### PR TITLE
Fix install.sh + add CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,264 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      run_e2e:
+        description: "Run the gated backend e2e suite (testcontainers)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      python_sdk: ${{ steps.filter.outputs.python_sdk }}
+      typescript: ${{ steps.filter.outputs.typescript }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      codegen: ${{ steps.filter.outputs.codegen }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'lemma-backend/**'
+              - '.github/workflows/ci.yml'
+            python_sdk:
+              - 'lemma-python/**'
+              - 'lemma-cli/**'
+              - 'lemma-skills/**'
+              - '.github/workflows/ci.yml'
+            typescript:
+              - 'lemma-typescript/**'
+              - '.github/workflows/ci.yml'
+            frontend:
+              - 'lemma-frontend/**'
+            codegen:
+              - 'lemma-python/**'
+              - 'lemma-typescript/**'
+              - 'lemma-backend/app/**'
+              - 'scripts/**'
+              - '.github/workflows/ci.yml'
+
+  backend-unit:
+    name: lemma-backend unit
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: lemma-backend
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Sync deps
+        run: uv sync
+      - name: Unit tests
+        run: make test-unit
+        env:
+          REDIS_URL: redis://localhost:6379
+
+  python-sdk:
+    name: Python SDK + CLI tests
+    needs: changes
+    if: needs.changes.outputs.python_sdk == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install SDK + CLI
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ./lemma-python
+          pip install -e ./lemma-cli
+          pip install pytest pytest-asyncio
+      - name: Test (CLI + Python SDK, offline only)
+        run: pytest lemma-cli/tests lemma-python/tests -m "not integration"
+
+  typescript-sdk:
+    name: TypeScript SDK checks
+    needs: changes
+    if: needs.changes.outputs.typescript == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: lemma-typescript
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      - run: npm ci
+      - name: Typecheck (src)
+        run: npx tsc --noEmit -p tsconfig.json
+      - name: Typecheck (tests)
+        run: npx tsc --noEmit -p tsconfig.test.json
+      - name: SDK_VERSION matches package.json
+        run: |
+          PKG=$(node -p "require('./package.json').version")
+          SRC=$(grep -oE '"[0-9]+\.[0-9]+\.[0-9]+"' src/version.ts | head -1 | tr -d '"')
+          echo "package.json=$PKG version.ts=$SRC"
+          test "$PKG" = "$SRC" || { echo "::error::src/version.ts SDK_VERSION ($SRC) != package.json version ($PKG)"; exit 1; }
+      - name: Browser bundle is fresh
+        run: |
+          npm run build:bundle
+          git diff --exit-code public/lemma-client.js \
+            || { echo "::error::Committed public/lemma-client.js is stale — run 'npm run build:bundle' and commit"; exit 1; }
+      - name: Unit tests
+        run: npx vitest run
+
+  codegen-drift:
+    name: Codegen drift gate
+    needs: changes
+    if: needs.changes.outputs.codegen == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      - name: Install uv
+        run: pip install uv
+      - name: Regenerate Python client from committed spec
+        working-directory: lemma-python
+        run: OPENAPI_FILE=lemma_sdk/openapi_spec.json bash scripts/generate_openapi_client.sh
+      - name: Fail on Python drift
+        run: |
+          git diff --exit-code lemma-python/lemma_sdk/openapi_client lemma-python/lemma_sdk/_spec_info.py \
+            || { echo "::error::Committed Python client is out of sync — run scripts/generate_openapi_client.sh and commit"; exit 1; }
+      - name: Regenerate TypeScript client from committed spec
+        working-directory: lemma-typescript
+        run: OPENAPI_FILE=../lemma-python/lemma_sdk/openapi_spec.json bash scripts/generate_openapi_client.sh
+      - name: Fail on TypeScript drift
+        run: |
+          git diff --exit-code lemma-typescript/src/openapi_client \
+            || { echo "::error::Committed TypeScript client is out of sync — run scripts/generate_openapi_client.sh and commit"; exit 1; }
+      - name: Regenerate L2 hooks from x-lemma metadata
+        working-directory: lemma-typescript
+        run: node scripts/generate_l2.mjs
+      - name: Fail on L2 hook drift
+        run: |
+          git diff --exit-code lemma-typescript/src/react/generated \
+            || { echo "::error::Generated L2 hooks are stale — run 'npm run generate:l2' and commit"; exit 1; }
+
+  frontend-check:
+    name: Frontend lint, design audit, test
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            lemma-typescript/package-lock.json
+            lemma-frontend/package-lock.json
+      - name: Install TypeScript SDK dependencies
+        working-directory: lemma-typescript
+        run: npm ci
+      - name: Install frontend dependencies
+        working-directory: lemma-frontend
+        run: npm ci
+      - name: Lint, typecheck, design audit
+        working-directory: lemma-frontend
+        run: npm run check
+      - name: Frontend unit tests
+        working-directory: lemma-frontend
+        run: npm test
+
+  frontend-build:
+    name: Frontend build (SDK integration)
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.typescript == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            lemma-typescript/package-lock.json
+            lemma-frontend/package-lock.json
+      - name: Install TypeScript SDK dependencies
+        working-directory: lemma-typescript
+        run: npm ci
+      - name: Install frontend dependencies
+        working-directory: lemma-frontend
+        run: npm ci
+      - name: Build frontend (builds the SDK via prebuild)
+        working-directory: lemma-frontend
+        run: npm run build
+      - name: Verify generated SDK browser bundles are committed
+        run: git diff --exit-code -- lemma-typescript/public/lemma-client.js lemma-typescript/public/lemma-ui.js
+
+  backend-e2e:
+    name: lemma-backend e2e (gated)
+    if: github.event_name == 'workflow_dispatch' && inputs.run_e2e
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: lemma-backend
+    steps:
+      - uses: actions/checkout@v5
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Sync deps
+        run: uv sync
+      - name: E2E tests (fast API suite, parallel)
+        run: make test-e2e-fast E2E_WORKERS=2
+
+  ci:
+    name: CI passed
+    if: always()
+    needs:
+      - changes
+      - backend-unit
+      - python-sdk
+      - typescript-sdk
+      - codegen-drift
+      - frontend-check
+      - frontend-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any required suite failed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "::error::One or more required CI suites failed or were cancelled."
+          exit 1
+      - run: echo "All required CI suites passed (or were skipped as unaffected)."

--- a/.github/workflows/deploy-registry-pages.yml
+++ b/.github/workflows/deploy-registry-pages.yml
@@ -1,0 +1,66 @@
+name: Deploy Registry to GitHub Pages
+
+on:
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: lemma-typescript
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: lemma-typescript/package-lock.json
+
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: ${{ secrets.PAGES_ENABLEMENT_TOKEN != '' && 'true' || 'false' }}
+          token: ${{ secrets.PAGES_ENABLEMENT_TOKEN != '' && secrets.PAGES_ENABLEMENT_TOKEN || github.token }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build registry
+        run: npm run registry:build
+
+      - name: Prevent Jekyll processing
+        run: touch ./public/.nojekyll
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: lemma-typescript/public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release-lemma-python.yml
+++ b/.github/workflows/release-lemma-python.yml
@@ -1,0 +1,67 @@
+name: Release Lemma Python SDK
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish, for example 1.2.3 or v1.2.3"
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-lemma-python-${{ github.event.release.tag_name || inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: lemma-python
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set package version from release tag
+        shell: python
+        env:
+          RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.version }}
+        run: |
+          import os
+          import pathlib
+          import re
+
+          version = os.environ["RELEASE_VERSION"].removeprefix("v")
+          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?", version):
+              raise SystemExit(f"Invalid semver release tag: {os.environ['RELEASE_VERSION']}")
+
+          path = pathlib.Path("pyproject.toml")
+          text = path.read_text()
+          text = re.sub(r'(?m)^version = "[^"]+"$', f'version = "{version}"', text, count=1)
+          path.write_text(text)
+
+      - name: Install build tools
+        run: python -m pip install --upgrade build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Check distribution
+        run: python -m twine check dist/*
+
+      - name: Publish package
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload --skip-existing dist/*

--- a/.github/workflows/release-lemma-terminal.yml
+++ b/.github/workflows/release-lemma-terminal.yml
@@ -1,0 +1,101 @@
+name: Release Lemma Terminal CLI
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish, for example 1.2.3 or v1.2.3"
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-lemma-terminal-${{ github.event.release.tag_name || inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set package version from release tag
+        shell: python
+        env:
+          RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.version }}
+        run: |
+          import os
+          import pathlib
+          import re
+
+          version = os.environ["RELEASE_VERSION"].removeprefix("v")
+          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?", version):
+              raise SystemExit(f"Invalid semver release tag: {os.environ['RELEASE_VERSION']}")
+
+          path = pathlib.Path("lemma-cli/lemma_cli/__init__.py")
+          text = path.read_text()
+          text, count = re.subn(
+              r'(?m)^__version__ = "[^"]+"$', f'__version__ = "{version}"', text, count=1
+          )
+          if count != 1:
+              raise SystemExit("Could not find __version__ in lemma-cli/lemma_cli/__init__.py")
+          path.write_text(text)
+
+          pyproject = pathlib.Path("lemma-cli/pyproject.toml")
+          pp_text = pyproject.read_text()
+          pp_text, pp_count = re.subn(
+              r'(?m)^(\s*)"lemma-sdk>=[^"]+",',
+              rf'\g<1>"lemma-sdk>={version}",',
+              pp_text,
+              count=1,
+          )
+          if pp_count != 1:
+              raise SystemExit("Could not find the lemma-sdk pin in lemma-cli/pyproject.toml")
+          pyproject.write_text(pp_text)
+
+      - name: Vendor agent skills into the package
+        run: |
+          mkdir -p lemma-cli/lemma_cli/skills
+          for d in lemma-skills/*/; do
+            if [ -f "$d/SKILL.md" ]; then
+              cp -r "$d" "lemma-cli/lemma_cli/skills/"
+            fi
+          done
+
+      - name: Install build tools
+        run: python -m pip install --upgrade build twine
+
+      - name: Build package
+        working-directory: lemma-cli
+        run: python -m build
+
+      - name: Verify skills are bundled
+        working-directory: lemma-cli
+        shell: bash
+        run: |
+          set -euo pipefail
+          count=$(python -c "import zipfile,glob; w=glob.glob('dist/*.whl')[0]; print(sum(1 for n in zipfile.ZipFile(w).namelist() if n.endswith('SKILL.md')))")
+          echo "SKILL.md files in wheel: $count"
+          test "$count" -ge 1 || { echo 'No skills bundled in the wheel — aborting release.'; exit 1; }
+
+      - name: Check distribution
+        working-directory: lemma-cli
+        run: python -m twine check dist/*
+
+      - name: Publish package
+        working-directory: lemma-cli
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload --skip-existing dist/*

--- a/.github/workflows/release-lemma-typescript.yml
+++ b/.github/workflows/release-lemma-typescript.yml
@@ -1,0 +1,85 @@
+name: Release Lemma TypeScript SDK
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish, for example 1.2.3 or v1.2.3"
+        required: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-lemma-typescript-${{ github.event.release.tag_name || inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: lemma-typescript
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: lemma-typescript/package-lock.json
+
+      - name: Set package version from release tag
+        id: version
+        shell: bash
+        env:
+          RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.version }}
+        run: |
+          version="${RELEASE_VERSION#v}"
+          if [[ ! "${version}" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid semver release tag: ${RELEASE_VERSION}" >&2
+            exit 1
+          fi
+
+          npm version "${version}" --no-git-tag-version --allow-same-version
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+
+      - name: Check whether version is already published
+        id: published
+        shell: bash
+        run: |
+          package_name="$(node -p "require('./package.json').name")"
+          package_version="${{ steps.version.outputs.version }}"
+
+          if npm view "${package_name}@${package_version}" version >/dev/null 2>&1; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "${package_name}@${package_version} is already published."
+          else
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Pack package
+        if: steps.published.outputs.should_publish == 'true'
+        run: npm pack --dry-run
+
+      - name: Publish package
+        if: steps.published.outputs.should_publish == 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish

--- a/.github/workflows/release-local-images.yml
+++ b/.github/workflows/release-local-images.yml
@@ -1,0 +1,177 @@
+name: Release Local Stack Images
+
+# Builds the four images the local-stack installer (lemma-stack) consumes,
+# pushes them to ghcr.io, and attaches a release manifest (lemma-local.json)
+# to the GitHub release. lemma-stack resolves:
+#   stable  -> releases/latest/download/lemma-local.json
+#   <X.Y.Z> -> releases/download/v<X.Y.Z>/lemma-local.json
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 0.1.0). Uses tag v<version>."
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: release-local-images-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build ${{ matrix.image.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - name: lemma-backend
+            context: .
+            dockerfile: lemma-backend/Dockerfile
+          - name: lemma-frontend
+            context: .
+            dockerfile: lemma-frontend/Dockerfile
+          - name: lemma-agentbox
+            context: agentbox
+            dockerfile: agentbox/Dockerfile
+          - name: lemma-agentbox-runtime
+            context: .
+            dockerfile: agentbox/Dockerfile.runtime
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Resolve version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.image.context }}
+          file: ${{ matrix.image.dockerfile }}
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.image.name }}:v${{ steps.version.outputs.version }}
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.image.name }}:latest
+          cache-from: type=gha,scope=local-${{ matrix.image.name }}
+          cache-to: type=gha,scope=local-${{ matrix.image.name }},mode=max
+
+      - name: Record digest
+        shell: bash
+        run: |
+          mkdir -p digests
+          echo '{"name": "${{ matrix.image.name }}", "digest": "${{ steps.push.outputs.digest }}"}' \
+            > "digests/${{ matrix.image.name }}.json"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.image.name }}
+          path: digests/${{ matrix.image.name }}.json
+          retention-days: 1
+
+  manifest:
+    name: Publish release manifest
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Resolve version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digest-*
+          path: digests
+          merge-multiple: true
+
+      - name: Generate lemma-local.json
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          PREFIX: ${{ env.IMAGE_PREFIX }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          version = os.environ["VERSION"]
+          prefix = os.environ["PREFIX"]
+          digests = {}
+          for path in Path("digests").glob("*.json"):
+              entry = json.loads(path.read_text())
+              digests[entry["name"]] = entry["digest"]
+
+          def image(name: str) -> dict:
+              return {"ref": f"{prefix}/{name}:v{version}", "digest": digests[name]}
+
+          manifest = {
+              "schema_version": 1,
+              "version": version,
+              "released_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+              "min_admin_version": "0.1.0",
+              "images": {
+                  "backend": image("lemma-backend"),
+                  "frontend": image("lemma-frontend"),
+                  "agentbox": image("lemma-agentbox"),
+                  "agentbox_runtime": image("lemma-agentbox-runtime"),
+              },
+              "infra": {
+                  "postgres": "docker.io/pgvector/pgvector:0.8.3-pg16",
+                  "redis": "docker.io/redis/redis-stack:7.2.0-v19",
+                  "supertokens": "docker.io/supertokens/supertokens-postgresql:11.1.0",
+                  "kreuzberg": "ghcr.io/kreuzberg-dev/kreuzberg:4.9.9",
+              },
+          }
+          Path("lemma-local.json").write_text(json.dumps(manifest, indent=2) + "\n")
+          print(json.dumps(manifest, indent=2))
+          PY
+
+      - name: Attach manifest to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          files: lemma-local.json
+          generate_release_notes: true

--- a/install.sh
+++ b/install.sh
@@ -27,9 +27,10 @@ if ! command -v uv >/dev/null 2>&1; then
   command -v uv >/dev/null 2>&1 || fail "uv installed but not on PATH; open a new shell and re-run"
 fi
 
-# LEMMA_STACK_SOURCE lets developers bootstrap from a checkout instead of PyPI:
+# LEMMA_STACK_SOURCE lets developers bootstrap from a local checkout:
 #   LEMMA_STACK_SOURCE=$PWD/lemma-stack ./install.sh -y
-LEMMA_STACK_SPEC="${LEMMA_STACK_SOURCE:-lemma-stack}"
+# When unset, install from the git repo (the package is not on PyPI yet).
+LEMMA_STACK_SPEC="${LEMMA_STACK_SOURCE:-git+https://github.com/lemma-work/lemma-platform.git#subdirectory=lemma-stack}"
 
 say "Installing lemma-stack…"
 uv tool install --force "$LEMMA_STACK_SPEC" >/dev/null

--- a/lemma-typescript/public/lemma-client.js
+++ b/lemma-typescript/public/lemma-client.js
@@ -9794,7 +9794,7 @@ var LemmaClient = (() => {
   }
 
   // src/version.ts
-  var SDK_VERSION = "0.4.0";
+  var SDK_VERSION = "0.4.1";
   var CLIENT_HEADER_NAME = "X-Lemma-Client";
   var CLIENT_HEADER_VALUE = `lemma-sdk-ts/${SDK_VERSION}`;
 

--- a/scripts/prepare_client_openapi.py
+++ b/scripts/prepare_client_openapi.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+HTTP_METHODS = {"get", "put", "post", "delete", "options", "head", "patch", "trace"}
+
+
+def _operation_is_excluded(operation: Mapping[str, Any], path: str, excluded_tags: set[str], excluded_prefixes: tuple[str, ...]) -> bool:
+    tags = {str(tag).lower() for tag in operation.get("tags", [])}
+    if tags & excluded_tags:
+        return True
+    return path.startswith(excluded_prefixes)
+
+
+def _collect_schema_refs(value: Any, refs: set[str]) -> None:
+    if isinstance(value, Mapping):
+        ref = value.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/components/schemas/"):
+            refs.add(ref.rsplit("/", 1)[-1])
+        for item in value.values():
+            _collect_schema_refs(item, refs)
+    elif isinstance(value, list):
+        for item in value:
+            _collect_schema_refs(item, refs)
+
+
+def _retain_referenced_schemas(schema: dict[str, Any]) -> None:
+    components = schema.get("components")
+    if not isinstance(components, dict):
+        return
+    schemas = components.get("schemas")
+    if not isinstance(schemas, dict):
+        return
+
+    referenced: set[str] = set()
+    _collect_schema_refs(schema.get("paths", {}), referenced)
+
+    changed = True
+    while changed:
+        changed = False
+        for name in list(referenced):
+            model = schemas.get(name)
+            before = len(referenced)
+            _collect_schema_refs(model, referenced)
+            changed = changed or len(referenced) != before
+
+    for name in list(schemas):
+        if name not in referenced:
+            schemas.pop(name, None)
+
+
+def prepare_client_openapi(
+    schema: dict[str, Any],
+    *,
+    excluded_tags: set[str],
+    excluded_prefixes: tuple[str, ...],
+    prune_unreferenced_schemas: bool,
+) -> dict[str, Any]:
+    paths = schema.get("paths")
+    if isinstance(paths, dict):
+        for path in list(paths):
+            path_item = paths[path]
+            if not isinstance(path_item, dict):
+                continue
+            for method in list(path_item):
+                if method.lower() not in HTTP_METHODS:
+                    continue
+                operation = path_item[method]
+                if isinstance(operation, Mapping) and _operation_is_excluded(
+                    operation,
+                    path,
+                    excluded_tags,
+                    excluded_prefixes,
+                ):
+                    path_item.pop(method, None)
+            if not any(method.lower() in HTTP_METHODS for method in path_item):
+                paths.pop(path, None)
+
+    if prune_unreferenced_schemas:
+        _retain_referenced_schemas(schema)
+
+    return schema
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Prepare Lemma OpenAPI for public SDK generation.")
+    parser.add_argument("input", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument(
+        "--exclude-tag",
+        action="append",
+        default=[],
+        help="OpenAPI tag to exclude. Case-insensitive. Can be provided multiple times.",
+    )
+    parser.add_argument(
+        "--exclude-prefix",
+        action="append",
+        default=[],
+        help="Path prefix to exclude. Can be provided multiple times.",
+    )
+    parser.add_argument(
+        "--keep-unreferenced-schemas",
+        action="store_true",
+        help="Keep component schemas that are no longer referenced after endpoint filtering.",
+    )
+    args = parser.parse_args()
+
+    schema = json.loads(args.input.read_text(encoding="utf-8"))
+    prepared = prepare_client_openapi(
+        schema,
+        excluded_tags={tag.lower() for tag in args.exclude_tag},
+        excluded_prefixes=tuple(args.exclude_prefix),
+        prune_unreferenced_schemas=not args.keep_unreferenced_schemas,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(prepared, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stamp_lemma_metadata.py
+++ b/scripts/stamp_lemma_metadata.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Stamp x-lemma metadata onto the committed OpenAPI spec (Wave 3, CG-4).
+
+The live backend injects x-lemma in `custom_openapi()`. This script applies the *same*
+`apply_lemma_metadata` function to the committed `lemma-python/lemma_sdk/openapi_spec.json`
+so the committed artifact equals what a fresh regen would produce — without needing a
+running backend. It re-emits with the exact formatting the spec pipeline uses
+(`indent=2, sort_keys=True`, trailing newline) so there are no spurious diffs.
+
+Usage:
+    python scripts/stamp_lemma_metadata.py [--check]
+
+`--check` exits non-zero if the spec is missing/incomplete x-lemma or would change,
+for use as a CI gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "lemma-backend"))
+
+from app.core.openapi_extensions import apply_lemma_metadata, validate_metadata_coverage  # noqa: E402
+
+SPEC_PATH = ROOT / "lemma-python" / "lemma_sdk" / "openapi_spec.json"
+
+
+def _render(spec: dict) -> str:
+    return json.dumps(spec, indent=2, sort_keys=True) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="Fail if the spec would change or is incomplete.")
+    args = parser.parse_args()
+
+    original = SPEC_PATH.read_text(encoding="utf-8")
+    spec = json.loads(original)
+    apply_lemma_metadata(spec)
+
+    problems = validate_metadata_coverage(spec)
+    if problems:
+        print(f"x-lemma metadata incomplete ({len(problems)} problem(s)):", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+
+    rendered = _render(spec)
+    annotated = sum(1 for _ in _iter_x_lemma(spec))
+
+    if args.check:
+        if rendered != original:
+            print("Committed openapi_spec.json is stale — run: python scripts/stamp_lemma_metadata.py", file=sys.stderr)
+            return 1
+        print(f"x-lemma metadata up to date ({annotated} operations annotated).")
+        return 0
+
+    SPEC_PATH.write_text(rendered, encoding="utf-8")
+    print(f"Stamped x-lemma metadata onto {annotated} operations in {SPEC_PATH.relative_to(ROOT)}.")
+    return 0
+
+
+def _iter_x_lemma(spec: dict):
+    for item in spec.get("paths", {}).values():
+        if not isinstance(item, dict):
+            continue
+        for operation in item.values():
+            if isinstance(operation, dict) and "x-lemma" in operation:
+                yield operation
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What this does

### install.sh fix
- Install `lemma-stack` from `git+https://github.com/lemma-work/lemma-platform.git#subdirectory=lemma-stack` instead of PyPI (the package is not published yet). The `curl | bash` one-liner now works for everyone.

### CI workflows added
- **ci.yml** — OSS test suite: backend unit tests, Python SDK + CLI tests, TypeScript SDK checks, codegen drift gate, frontend lint/build, gated backend e2e
- **release-local-images.yml** — Build 4 images (backend, frontend, agentbox, agentbox-runtime) and push to ghcr.io with a release manifest
- **release-lemma-python.yml** — Publish Python SDK to PyPI on release
- **release-lemma-terminal.yml** — Publish CLI to PyPI (skills vendored inline from the repo)
- **release-lemma-typescript.yml** — Publish TS SDK to npm on release
- **deploy-registry-pages.yml** — Deploy shadcn registry to GitHub Pages