### PR TITLE
Fix DEFAULT_REPO to lemma-platform for release manifest resolution

### DIFF
--- a/lemma-stack/lemma_stack/release/manifest.py
+++ b/lemma-stack/lemma_stack/release/manifest.py
@@ -21,7 +21,7 @@ from lemma_stack.output import AdminError, info
 from lemma_stack.paths import LocalPaths
 
 SCHEMA_VERSION = 1
-DEFAULT_REPO = "lemma-work/lemma-app"
+DEFAULT_REPO = "lemma-work/lemma-platform"
 MANIFEST_ASSET = "lemma-local.json"
 APP_IMAGE_KEYS = ("backend", "frontend", "agentbox", "agentbox_runtime")
 


### PR DESCRIPTION
The release-local-images workflow now runs in the lemma-platform repo and attaches the release manifest (lemma-local.json) to GitHub releases here. lemma-stack was still pointing at the old lemma-app repo for manifest resolution.

This fix ensures:
- `lemma-stack install` fetches the manifest from `lemma-work/lemma-platform/releases`
- The `curl | bash` installer works end-to-end after a release tag is pushed
- Image pulls resolve to `ghcr.io/lemma-work/lemma-*:v<version>`