### PR TITLE
Release v0.4.4: bump all packages

### DIFF
--- a/lemma-cli/lemma_cli/__init__.py
+++ b/lemma-cli/lemma_cli/__init__.py
@@ -2,4 +2,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "0.4.2"
+__version__ = "0.4.4"

--- a/lemma-cli/pyproject.toml
+++ b/lemma-cli/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   # >= the version that has the endpoints the current commands use, so a fresh
   # `uv tool install` upgrades an already-installed older lemma-sdk. The release
   # workflow rewrites this to the release version on every tagged build.
-  "lemma-sdk>=0.4.2",
+  "lemma-sdk>=0.4.4",
   "click>=8.3.0",
   "typer>=0.12.5",
   "rich>=13.9.4",

--- a/lemma-python/pyproject.toml
+++ b/lemma-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-sdk"
-version = "0.4.3"
+version = "0.4.4"
 description = "Python SDK for Lemma"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/lemma-typescript/package.json
+++ b/lemma-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemma-sdk",
-  "version": "0.4.1",
+  "version": "0.4.4",
   "description": "Official TypeScript SDK for Lemma APIs, optimized around pod-scoped workflows",
   "license": "Apache-2.0",
   "author": "Lemma",

--- a/lemma-typescript/public/lemma-client.js
+++ b/lemma-typescript/public/lemma-client.js
@@ -9794,7 +9794,7 @@ var LemmaClient = (() => {
   }
 
   // src/version.ts
-  var SDK_VERSION = "0.4.1";
+  var SDK_VERSION = "0.4.4";
   var CLIENT_HEADER_NAME = "X-Lemma-Client";
   var CLIENT_HEADER_VALUE = `lemma-sdk-ts/${SDK_VERSION}`;
 

--- a/lemma-typescript/src/version.ts
+++ b/lemma-typescript/src/version.ts
@@ -1,6 +1,6 @@
 // Keep SDK_VERSION in sync with package.json "version". The CI codegen/drift
 // gate (workstream A) asserts they match so this can't silently drift.
-export const SDK_VERSION = "0.4.1";
+export const SDK_VERSION = "0.4.4";
 
 /** Sent as `X-Lemma-Client` on every request so the backend can log which client
  *  + version hit an endpoint (User-Agent is a forbidden header in browser fetch). */


### PR DESCRIPTION
## Release v0.4.4

Bump all package versions to 0.4.4 for the upcoming release.

| Package | Registry | Old | New |
|---------|----------|-----|-----|
| lemma-sdk (Python) | PyPI | 0.4.3 | 0.4.4 |
| lemma-sdk (TypeScript) | npm | 0.4.1 | 0.4.4 |
| lemma-terminal (CLI) | PyPI | 0.4.2 | 0.4.4 |

Also:
- CLI's `lemma-sdk` dependency pin bumped to `>=0.4.4`
- Browser bundle rebuilt with `SDK_VERSION = "0.4.4"`

After merge, create a GitHub release with tag `v0.4.4` to trigger:
- PyPI publish (Python SDK + CLI)
- npm publish (TypeScript SDK)
- ghcr.io image build + release manifest