### PR TITLE
Fix Docker build paths that broke the v0.5.0 release image build

### DIFF
--- a/.github/workflows/release-local-images.yml
+++ b/.github/workflows/release-local-images.yml
@@ -34,6 +34,7 @@ jobs:
     name: Build ${{ matrix.image.name }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         image:
           - name: lemma-backend

--- a/agentbox/Dockerfile
+++ b/agentbox/Dockerfile
@@ -25,7 +25,7 @@ RUN groupadd --gid 10001 appuser \
     && useradd --uid 10001 --gid 10001 -d /home/appuser -m appuser
 
 COPY agentbox ./agentbox
-COPY agentbox/pyproject.toml ./
+COPY pyproject.toml ./
 RUN pip install --no-cache-dir .
 
 USER 10001:10001

--- a/lemma-backend/Dockerfile
+++ b/lemma-backend/Dockerfile
@@ -22,7 +22,7 @@ COPY lemma-backend/pyproject.toml lemma-backend/uv.lock ./
 
 # Copy local path dependencies and repo-native skills.
 COPY agentbox-client /agentbox-client
-COPY lemma-backend/lemma-integrations ./lemma-integrations
+COPY lemma-backend/lemma-connectors ./lemma-connectors
 COPY lemma-skills ./lemma-skills
 
 # Install dependencies into /app/.venv


### PR DESCRIPTION
## Problem

The [v0.5.0 **Release Local Stack Images** run](https://github.com/lemma-work/lemma-platform/actions/runs/28080194471) failed. The `lemma-agentbox` image errored with:

```
ERROR: failed to compute cache key: failed to calculate checksum of ref ...:
"/agentbox/pyproject.toml": not found
```

…and the other three image jobs (`lemma-backend`, `lemma-frontend`, `lemma-agentbox-runtime`) were **cancelled** by the matrix `fail-fast` before they could run — hiding a second, independent bug in the backend image.

## Root causes & fixes

**1. `agentbox/Dockerfile` — wrong pyproject path.**
The workflow builds this image with `context: agentbox`. The line `COPY agentbox/pyproject.toml ./` resolves to `agentbox/agentbox/pyproject.toml`, but the pyproject sits at the context root. The sibling `COPY agentbox ./agentbox` already correctly assumes `context=agentbox`.
→ `COPY agentbox/pyproject.toml ./` → `COPY pyproject.toml ./`

**2. `lemma-backend/Dockerfile` — stale directory name.**
`COPY lemma-backend/lemma-integrations ./lemma-integrations` references a directory that was renamed to **`lemma-connectors`** (the editable path dependency recorded in `lemma-backend/uv.lock` as `editable = "lemma-connectors"`). The old name no longer exists, so the COPY fails and `uv sync` would miss the path dep.
→ `COPY lemma-backend/lemma-integrations ./lemma-integrations` → `COPY lemma-backend/lemma-connectors ./lemma-connectors`

**3. `release-local-images.yml` — `fail-fast` hid the second bug.**
Added `fail-fast: false` to the build matrix so all four image builds report independently instead of cancelling each other on the first failure.

## Verification

Built locally with real Docker builds (single-platform):

- **agentbox manager** (`docker build -f agentbox/Dockerfile agentbox`): builds and installs `agentbox-0.1.0`, image exported. ✅
- **lemma-backend builder stage** (`docker build -f lemma-backend/Dockerfile --target builder .`): `COPY lemma-backend/lemma-connectors` succeeds and both `uv sync --frozen` steps complete. ✅

Also confirmed every COPY source path in the `lemma-frontend` and `lemma-agentbox-runtime` Dockerfiles exists in the repo (those jobs were only cancelled, not failing); with `fail-fast: false` they now run on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)