### PR TITLE
Fix/design audit violations

### DIFF
--- a/lemma-frontend/app/pod/[id]/layout.tsx
+++ b/lemma-frontend/app/pod/[id]/layout.tsx
@@ -15,7 +15,7 @@ import { MobileSidebarDrawer } from "@/components/pod/mobile-sidebar-drawer";
 import { PodLayoutProvider, usePodLayout } from "@/components/pod/pod-layout-context";
 import { WorkspaceSidebar } from "@/components/pod/workspace-sidebar";
 import { Button } from "@/components/ui/button";
-import { ArrowLeft, Home, MessageSquare, PanelLeftOpen, Settings, X } from "lucide-react";
+import { ArrowLeft, Home, PanelLeftOpen, Settings, X } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { getLemmaClient } from "@/lib/sdk/lemma-client";
 import { usePod } from "@/lib/hooks/use-pods";
@@ -463,28 +463,6 @@ function PodShell({
         router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
     }, [closeAssistant, pathname, router, searchParams]);
 
-    // On a focus route the assistant can't dock, so its launcher opens it and
-    // returns to that section's companion list, where it docks beside the
-    // overview instead of crowding the editor.
-    const openAssistantFromFocus = useCallback(() => {
-        openAssistant();
-        const section = pathname.replace(`/pod/${pod.id}`, "").split("/").filter(Boolean)[0];
-        router.push(section ? `/pod/${pod.id}/${section}` : `/pod/${pod.id}/conversations`);
-    }, [openAssistant, pathname, pod.id, router]);
-
-    const focusLauncher = isFocusRoute ? (
-        <button
-            type="button"
-            onClick={openAssistantFromFocus}
-            className="pod-assistant-launcher custom-focus-ring fixed bottom-5 right-5 z-40 inline-flex h-11 items-center gap-2 rounded-full border border-[var(--border-subtle)] bg-[var(--pod-main-bg)] px-4 text-sm font-medium text-[var(--text-secondary)] shadow-[var(--shadow-lg)] transition-colors hover:text-[var(--text-primary)]"
-            aria-label="Open Lemma Assist"
-            title="Open Lemma Assist"
-        >
-            <MessageSquare className="h-4 w-4" strokeWidth={1.8} />
-            <span className="hidden sm:inline">Assistant</span>
-        </button>
-    ) : null;
-
     if (podAccess.isLoading) {
         return <PageLoader />;
     }
@@ -522,7 +500,6 @@ function PodShell({
                         {children}
                     </main>
                 </PodTopbarProvider>
-                {focusLauncher}
             </div>
         );
     }
@@ -719,7 +696,6 @@ function PodShell({
                     </div>
                 </PodTopbarProvider>
             </main>
-            {focusLauncher}
         </div>
     );
 }

--- a/lemma-frontend/app/pod/[id]/page.tsx
+++ b/lemma-frontend/app/pod/[id]/page.tsx
@@ -616,7 +616,7 @@ function PodAppsHomePanel({ podId }: { podId: string }) {
                                         {title}
                                     </Link>
                                     {page.url ? (
-                                        <p className="mt-0.5 truncate font-mono text-[11px] text-[var(--text-tertiary)]">
+                                        <p className="mt-0.5 truncate font-mono text-xs text-[var(--text-tertiary)]">
                                             {formatAppUrl(page.url)}
                                         </p>
                                     ) : null}
@@ -628,7 +628,7 @@ function PodAppsHomePanel({ podId }: { podId: string }) {
                                         rel="noreferrer"
                                         aria-label="Open live app"
                                         title="Open live app"
-                                        className="custom-focus-ring inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[var(--text-tertiary)] transition-colors hover:bg-[var(--surface-2)] hover:text-[var(--text-primary)]"
+                                        className="lemma-quiet-icon-button custom-focus-ring text-[var(--text-tertiary)]"
                                     >
                                         <ExternalLink className="h-3.5 w-3.5" />
                                     </a>
@@ -655,7 +655,7 @@ const SURFACE_STATUS_TONE: Record<'success' | 'warning' | 'danger' | 'muted', { 
     success: { text: 'text-[var(--state-success)]', dot: 'bg-[var(--state-success)]' },
     warning: { text: 'text-[var(--state-warning)]', dot: 'bg-[var(--state-warning)]' },
     danger: { text: 'text-[var(--state-error)]', dot: 'bg-[var(--state-error)]' },
-    muted: { text: 'text-[var(--text-tertiary)]', dot: 'bg-[var(--border-default)]' },
+    muted: { text: 'text-[var(--text-tertiary)]', dot: 'bg-[var(--text-tertiary)]' },
 };
 
 function surfaceStatusView(status?: string | null): { label: string; tone: 'success' | 'warning' | 'danger' | 'muted' } {
@@ -686,8 +686,8 @@ function PodSurfacesHomePanel({ podId }: { podId: string }) {
         return (
             <section className="w-full">
                 <h2 className="text-base font-medium text-[var(--text-primary)]">Reachable at</h2>
-                <div className="mt-3 flex items-start gap-4 rounded-xl border border-dashed border-[var(--border-subtle)] bg-[var(--surface-1)] px-5 py-5">
-                    <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[color:color-mix(in_srgb,var(--delight)_14%,var(--surface-2))] text-[var(--delight)]">
+                <div className="mt-3 flex items-start gap-4 surface-panel-dashed px-5 py-5">
+                    <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--delight-soft)] text-[var(--delight)]">
                         <MessageCircle className="h-5 w-5" strokeWidth={1.8} />
                     </span>
                     <div className="min-w-0 flex-1">
@@ -723,7 +723,7 @@ function PodSurfacesHomePanel({ podId }: { podId: string }) {
                     <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover/all:translate-x-0.5" />
                 </Link>
             </div>
-            <div className="mt-3 overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-1)]">
+            <div className="mt-3 overflow-hidden surface-panel surface-panel-quiet">
                 {sorted.map((surface) => {
                     const platform = String(surface.platform || '').toUpperCase();
                     const meta = SURFACE_META[platform] || { label: formatDisplayName(platform), logo: '' };

--- a/lemma-frontend/app/pod/[id]/settings/page.tsx
+++ b/lemma-frontend/app/pod/[id]/settings/page.tsx
@@ -192,7 +192,7 @@ function PodJoinPolicyPanel({
                                 className={cn(
                                     'mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-gentle',
                                     selected
-                                        ? 'border-[var(--state-success)] bg-[var(--state-success)] text-white'
+                                        ? 'border-[var(--state-success)] bg-[var(--state-success)] text-[var(--text-on-brand)]'
                                         : 'border-[var(--field-border)] text-transparent',
                                 )}
                             >

--- a/lemma-frontend/components/education/first-win-checklist.tsx
+++ b/lemma-frontend/components/education/first-win-checklist.tsx
@@ -113,7 +113,7 @@ export function FirstWinChecklist({ podId, agentCount, workflowCount, conversati
                 <DropdownMenu.Trigger asChild>
                     <button
                         type="button"
-                        className="pointer-events-auto inline-flex items-center gap-2 rounded-full border border-[var(--border-subtle)] bg-[var(--surface-1)] py-1 pl-1 pr-3 text-xs font-medium text-[var(--text-secondary)] shadow-[var(--shadow-xs)] transition-colors hover:border-[var(--border-default)] hover:text-[var(--text-primary)] focus-ring"
+                        className="pointer-events-auto inline-flex items-center gap-2 rounded-full border border-[var(--border-subtle)] bg-[var(--surface-1)] py-1 pl-1 pr-3 text-xs font-medium text-[var(--text-secondary)] shadow-[var(--shadow-xs)] transition-colors hover:border-[var(--field-border)] hover:text-[var(--text-primary)] focus-ring"
                         aria-label={`Pod setup, ${doneCount} of ${items.length} done`}
                     >
                         <ProgressRing done={doneCount} total={items.length} />

--- a/lemma-frontend/components/lemma/assistant/assistant-approval-cards.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-approval-cards.tsx
@@ -455,7 +455,7 @@ function AskUserQuestionsForm({
                   "flex w-full items-start gap-2 rounded-md border text-left transition-all",
                   optionPad,
                   isSelected
-                    ? "border-[var(--accent)] bg-[color:color-mix(in_srgb,var(--accent)_8%,transparent)] shadow-[0_0_0_1px_var(--accent)]"
+                    ? "border-[var(--accent)] bg-[color:color-mix(in_srgb,var(--accent)_8%,transparent)] ring-1 ring-[var(--action-primary)]"
                     : "border-[color:color-mix(in_srgb,var(--row-border)_86%,transparent)] hover:border-[color:color-mix(in_srgb,var(--accent)_40%,var(--row-border))] hover:bg-[var(--surface-2)]",
                 )}
                 data-selected={isSelected}
@@ -467,7 +467,7 @@ function AskUserQuestionsForm({
                   )}>
                     {option.label}
                     {option.recommended ? (
-                      <Badge variant="outline" className="h-4 px-1 text-[10px] uppercase tracking-wide">Recommended</Badge>
+                      <Badge variant="outline" className="h-4 px-1 text-xs uppercase tracking-wide">Recommended</Badge>
                     ) : null}
                   </span>
                   {option.description ? (
@@ -478,7 +478,7 @@ function AskUserQuestionsForm({
                   className={cn(
                     "mt-0.5 flex size-4 flex-shrink-0 items-center justify-center rounded-full border transition-colors",
                     isSelected
-                      ? "border-[var(--accent)] bg-[var(--accent)] text-[var(--accent-foreground,#fff)]"
+                      ? "border-[var(--accent)] bg-[var(--accent)] text-[var(--text-on-brand)]"
                       : "border-[color:color-mix(in_srgb,var(--row-border)_70%,transparent)]",
                   )}
                   aria-hidden="true"

--- a/lemma-frontend/scripts/design-audit-baseline.json
+++ b/lemma-frontend/scripts/design-audit-baseline.json
@@ -1,6 +1,6 @@
 {
   "informational": {
-    "rawButtonElements": 24,
+    "rawButtonElements": 23,
     "rawSwitchButtonElements": 0,
     "rawFieldElements": 3,
     "inlineEditableFieldElements": 1,


### PR DESCRIPTION
## What changed

### Fix all design-audit strict violations and advisory drift

Resolve 12 strict violations across 4 files and 3 advisory violations in `page.tsx` — the CI `design:audit:ci` gate was already red on `main`.

- **`app/pod/[id]/page.tsx`**: `text-[11px]`→`text-xs`, `bg-[var(--border-default)]`→`bg-[var(--text-tertiary)]`, inline icon-button recipe→`lemma-quiet-icon-button`, dashed/`rounded-xl` panels→`surface-panel-dashed`/`surface-panel-quiet`, `color-mix` delight tone→`--delight-soft` token
- **`assistant-approval-cards.tsx`**: `#fff`→`var(--text-on-brand)`, `text-[10px]`→`text-xs`, `shadow-[0_0_0_1px_var(--accent)]`→`ring-1 ring-[var(--action-primary)]`
- **`first-win-checklist.tsx`**: `hover:border-[var(--border-default)]`→`hover:border-[var(--field-border)]`
- **`settings/page.tsx`**: `text-white`→`text-[var(--text-on-brand)]`

Design audit now passes: `productStrict=0`, `advisory=0`.

### Remove floating assistant launcher from focus routes

The `pod-assistant-launcher` was a fixed bottom-right bubble that appeared on focus routes (agent/flow/function editors and their "new" builders). It's been removed from all 7 pages:

- `/pod/{id}/agents/{agentId}`, `/agents/new`
- `/pod/{id}/flows/{flowId}`, `/flows/{flowId}/runs/{runId}`, `/flows/new`
- `/pod/{id}/functions/{functionId}`, `/functions/new`

The `isFocusRoute` flag stays — it's still used by `canShowAssistantSidebar` and the workspace sidebar. Updated the design audit baseline (rawButtonElements 24→23).

### Verification

`npm run check` (design audit + lint + typecheck + edu-anchors) and `npm test` (16 tests) all pass. SDK bundles unchanged.