### PR TITLE
Build release images on native arch runners (~20min frontend build → minutes)

### DIFF
--- a/.github/workflows/release-local-images.yml
+++ b/.github/workflows/release-local-images.yml
@@ -5,6 +5,11 @@ name: Release Local Stack Images
 # to the GitHub release. lemma-stack resolves:
 #   stable  -> releases/latest/download/lemma-local.json
 #   <X.Y.Z> -> releases/download/v<X.Y.Z>/lemma-local.json
+#
+# Multi-arch is built on NATIVE runners (amd64 on ubuntu-latest, arm64 on
+# ubuntu-24.04-arm) and merged into a manifest list. Building arm64 natively
+# instead of under QEMU emulation cuts the frontend build from ~20 min to a
+# few minutes (an emulated Next.js build is pathologically slow).
 
 on:
   push:
@@ -31,8 +36,8 @@ concurrency:
 
 jobs:
   build:
-    name: Build ${{ matrix.image.name }}
-    runs-on: ubuntu-latest
+    name: Build ${{ matrix.image.name }} (${{ matrix.platform.arch }})
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -49,26 +54,14 @@ jobs:
           - name: lemma-agentbox-runtime
             context: .
             dockerfile: agentbox/Dockerfile.runtime
+        platform:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Resolve version
-        id: version
-        shell: bash
-        run: |
-          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            version="${GITHUB_REF#refs/tags/v}"
-          else
-            version="${{ inputs.version }}"
-          fi
-          # Tolerate a leading "v" in the workflow_dispatch input (e.g. "v0.5.0")
-          # so tags resolve to "v<version>", not "vv<version>".
-          version="${version#v}"
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -80,38 +73,48 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
-        id: push
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: ${{ matrix.image.context }}
           file: ${{ matrix.image.dockerfile }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ env.IMAGE_PREFIX }}/${{ matrix.image.name }}:v${{ steps.version.outputs.version }}
-            ${{ env.IMAGE_PREFIX }}/${{ matrix.image.name }}:latest
-          cache-from: type=gha,scope=local-${{ matrix.image.name }}
-          cache-to: type=gha,scope=local-${{ matrix.image.name }},mode=max
+          platforms: linux/${{ matrix.platform.arch }}
+          # Push by digest only; the merge job assembles the tagged manifest list.
+          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
+          # Per-(image, arch) cache scope so the two arch builds never clobber
+          # each other's cache. Layer reuse keys on the Dockerfile COPY order:
+          # npm ci / uv sync layers stay cached until package-lock / uv.lock changes.
+          cache-from: type=gha,scope=${{ matrix.image.name }}-${{ matrix.platform.arch }}
+          cache-to: type=gha,scope=${{ matrix.image.name }}-${{ matrix.platform.arch }},mode=max
 
-      - name: Record digest
+      - name: Export digest
         shell: bash
         run: |
-          mkdir -p digests
-          echo '{"name": "${{ matrix.image.name }}", "digest": "${{ steps.push.outputs.digest }}"}' \
-            > "digests/${{ matrix.image.name }}.json"
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digest-${{ matrix.image.name }}
-          path: digests/${{ matrix.image.name }}.json
+          name: digest-${{ matrix.image.name }}-${{ matrix.platform.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
           retention-days: 1
 
-  manifest:
-    name: Publish release manifest
+  merge:
+    name: Merge ${{ matrix.image }}
     runs-on: ubuntu-latest
     needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - lemma-backend
+          - lemma-frontend
+          - lemma-agentbox
+          - lemma-agentbox-runtime
     steps:
       - name: Resolve version
         id: version
@@ -122,15 +125,73 @@ jobs:
           else
             version="${{ inputs.version }}"
           fi
-          # Tolerate a leading "v" in the workflow_dispatch input (e.g. "v0.5.0")
-          # so tags resolve to "v<version>", not "vv<version>".
           version="${version#v}"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          pattern: digest-*
+          path: /tmp/digests
+          pattern: digest-${{ matrix.image }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest list
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:v${{ steps.version.outputs.version }} \
+            -t ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:latest \
+            $(printf '${{ env.IMAGE_PREFIX }}/${{ matrix.image }}@sha256:%s ' *)
+
+      - name: Record merged digest
+        id: digest
+        shell: bash
+        working-directory: /tmp/digests
+        run: |
+          mkdir -p digests-out
+          d=$(docker buildx imagetools inspect \
+            "${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:v${{ steps.version.outputs.version }}" \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "{\"name\": \"${{ matrix.image }}\", \"digest\": \"$d\"}" > "digests-out/${{ matrix.image }}.json"
+
+      - name: Upload merged digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: merged-digest-${{ matrix.image }}
+          path: /tmp/digests/digests-out/${{ matrix.image }}.json
+          retention-days: 1
+
+  manifest:
+    name: Publish release manifest
+    runs-on: ubuntu-latest
+    needs: merge
+    steps:
+      - name: Resolve version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            version="${GITHUB_REF#refs/tags/v}"
+          else
+            version="${{ inputs.version }}"
+          fi
+          version="${version#v}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Download merged digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: merged-digest-*
           path: digests
           merge-multiple: true
 


### PR DESCRIPTION
## Problem

The `lemma-frontend` image takes **~22 minutes** to build, vs ~4-5 min for backend/agentbox. Measured from the last run:

| image | build time |
| --- | --- |
| lemma-frontend | **~22 min** |
| lemma-agentbox-runtime | ~11 min |
| lemma-agentbox | ~5 min |
| lemma-backend | ~4.5 min |

**Cause:** the workflow built `linux/amd64,linux/arm64` in a single job, so the **arm64 image was built under QEMU emulation**. The frontend runs two `npm ci` + two `npm run build` passes (TS SDK + Next.js); an emulated Next.js build is pathologically slow.

## Fix: native per-arch runners

Build each architecture on its own native GitHub-hosted runner (no QEMU), then merge into a manifest list — the pattern Docker recommends for fast multi-arch:

- **amd64 → `ubuntu-latest`, arm64 → `ubuntu-24.04-arm`** (free for public repos)
- Each `build` job is single-arch and **pushes by digest**
- A `merge` job assembles the tagged manifest list (`v<version>` + `latest`) with `docker buildx imagetools create`
- The `manifest` job consumes the merged per-image digests to produce `lemma-local.json`, same as before

Expected: the arm64 frontend leg drops from emulated-slow to native, so the frontend build goes from ~22 min to a few minutes (both arches now build in parallel on their own runners).

## Cache policy (the part you asked about)

- **Per-(image, arch) GHA cache scope.** Previously both arches shared `scope=local-<image>` and **clobbered each other's cache every run**. Now: `scope=<image>-<arch>`.
- **Eviction keys on `package-lock` / `uv.lock`** — already correct via Dockerfile COPY order (deps copied before source, so the `npm ci` / `uv sync` layers stay cached until the lockfile changes, and rebuild when it does). `mode=max` keeps all stages cached; GHA evicts LRU at the 10 GB repo limit.

## Notes

- QEMU setup step removed (not needed for native builds).
- `fail-fast: false` retained so every image/arch combo reports independently.
- Independent of the GHCR `403` push issue — that's a registry-permission matter; this only changes *how fast* and *on what runners* the images build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)