### PR TITLE
Fix agentbox manifest merge: use -- separator to prevent runtime digest cross-contamination

### DIFF
--- a/.github/workflows/release-local-images.yml
+++ b/.github/workflows/release-local-images.yml
@@ -244,4 +244,7 @@ jobs:
         with:
           tag_name: v${{ steps.version.outputs.version }}
           files: lemma-local.json
-          generate_release_notes: true
+          # Only generate release notes on a real tag push; workflow_dispatch
+          # re-runs are used to repair an existing release (backfill the
+          # lemma-local.json asset) and must not overwrite the release body.
+          generate_release_notes: ${{ github.event_name == 'push' }}

--- a/.github/workflows/release-local-images.yml
+++ b/.github/workflows/release-local-images.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digest-${{ matrix.image.name }}-${{ matrix.platform.arch }}
+          name: digest-${{ matrix.image.name }}--${{ matrix.platform.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -132,7 +132,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digest-${{ matrix.image }}-*
+          pattern: digest-${{ matrix.image }}--*
           merge-multiple: true
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Summary

- The \`Merge lemma-agentbox\` job in \`release-local-images.yml\` was failing with \`ghcr.io/lemma-work/lemma-agentbox@sha256:...: not found\`
- **Root cause:** the artifact download pattern \`digest-lemma-agentbox-*\` also matched \`digest-lemma-agentbox-runtime-arm64\` and \`digest-lemma-agentbox-runtime-amd64\` (the glob \`*\` matches \`runtime-...\` because it's a suffix of \`lemma-agentbox\`). The merge job then tried to push those runtime digests as \`lemma-agentbox\`, which don't exist under that image name → \`not found\`
- Because \`Merge lemma-agentbox\` failed, the \`Publish release manifest\` job was skipped → **\`lemma-local.json\` was never attached to the v0.5.1 release** → the installer gets a 404

## Fixes

1. **Artifact separator changed to \`--\`:** \`digest-lemma-agentbox--*\` is now disjoint from \`digest-lemma-agentbox-runtime--*\` — the pattern can never cross-contaminate between the two images.

2. **\`generate_release_notes\` only fires on tag pushes:** \`workflow_dispatch\` re-runs are used to repair existing releases (backfill the \`lemma-local.json\` asset); generating release notes on those runs would overwrite the existing release body.

## To repair v0.5.1 after merging this PR

Once merged, go to [Actions → Release Local Stack Images](https://github.com/lemma-work/lemma-platform/actions/workflows/release-local-images.yml) → **Run workflow** → set version to \`0.5.1\`. This will rebuild all images (GHA cache makes it fast), create the multi-arch manifest for \`lemma-agentbox\`, generate \`lemma-local.json\`, and attach it to the existing v0.5.1 release without touching the release body.

## Test plan

- [ ] Merge and run \`workflow_dispatch\` with version \`0.5.1\` — all 4 merge jobs should pass
- [ ] Verify \`lemma-local.json\` appears as a release asset under v0.5.1
- [ ] Confirm the installer works: \`curl -fsSL https://raw.githubusercontent.com/lemma-work/lemma-platform/main/install.sh | bash\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)