### PR TITLE
Fix WebSocket accept race in datastore changes endpoint

### DIFF
--- a/lemma-backend/app/modules/datastore/api/controllers/changes_controller.py
+++ b/lemma-backend/app/modules/datastore/api/controllers/changes_controller.py
@@ -249,7 +249,11 @@ async def datastore_changes_ws(
         )
         return
 
-    await websocket.accept()
+    try:
+        await websocket.accept()
+    except RuntimeError:
+        # Client disconnected before we could accept (race on connect).
+        return
 
     forwarder = asyncio.create_task(
         _forward_changes(

--- a/lemma-backend/app/modules/datastore/tests/e2e/test_changes_ws_e2e.py
+++ b/lemma-backend/app/modules/datastore/tests/e2e/test_changes_ws_e2e.py
@@ -198,3 +198,62 @@ async def test_changes_ws_rejects_unauthenticated(
     await communicator.send_input({"type": "websocket.connect"})
     closed = await communicator.receive_output(timeout=5)
     assert closed["type"] == "websocket.close"
+
+
+async def test_changes_ws_disconnect_immediately_after_connect(
+    notes_pod: DatastoreApi,
+    fixed_test_user,
+    test_app,
+):
+    """Client that disconnects immediately after the handshake must not crash the server.
+
+    Regression guard for the uvicorn accept-race: in production, a client that
+    closes the TCP connection between the HTTP upgrade and the server's
+    websocket.accept() causes uvicorn to raise RuntimeError.  The ASGI layer
+    should always complete cleanly regardless of when the client goes away.
+    """
+    communicator = _ws_communicator(
+        test_app, notes_pod.pod_id, fixed_test_user["token"]
+    )
+    # Connect, then immediately signal disconnect before consuming any output.
+    await communicator.send_input({"type": "websocket.connect"})
+    await communicator.send_input({"type": "websocket.disconnect", "code": 1001})
+
+    # Drain whatever the server sent (accept + ready frame) before it noticed
+    # the disconnect.  We don't assert on the exact sequence — both "accepted
+    # then closed" and "rejected with close" are valid outcomes.  What matters
+    # is that the application task finishes without raising.
+    for _ in range(5):
+        try:
+            msg = await communicator.receive_output(timeout=2)
+            if msg["type"] == "websocket.close":
+                break
+        except Exception:
+            break
+
+    # The ASGI app task must have exited cleanly (no unhandled exception).
+    await communicator.wait(timeout=3)
+
+
+async def test_changes_ws_disconnect_during_streaming(
+    notes_pod: DatastoreApi,
+    fixed_test_user,
+    test_app,
+):
+    """Client that disconnects mid-stream must not leave a runaway server task.
+
+    Once the server has accepted and started streaming, a sudden client
+    disconnect should be detected by _wait_for_disconnect and cause both the
+    forwarder task and the disconnect-watcher to be cancelled and awaited.
+    """
+    communicator = _ws_communicator(
+        test_app, notes_pod.pod_id, fixed_test_user["token"]
+    )
+    await communicator.send_input({"type": "websocket.connect"})
+    await _expect_accept_and_ready(communicator)
+
+    # Disconnect mid-stream without sending a change event.
+    await communicator.send_input({"type": "websocket.disconnect", "code": 1001})
+
+    # Server should finish within a short window.
+    await communicator.wait(timeout=3)

--- a/lemma-backend/app/modules/datastore/tests/unit/test_changes_ws_controller.py
+++ b/lemma-backend/app/modules/datastore/tests/unit/test_changes_ws_controller.py
@@ -1,0 +1,154 @@
+"""Unit tests for the datastore changes WebSocket controller.
+
+Focuses on error-handling paths that are hard to reproduce with the full
+E2E stack: specifically the client-disconnect race that surfaces as a
+RuntimeError when uvicorn's state machine rejects websocket.accept().
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from app.modules.datastore.api.controllers.changes_controller import (
+    datastore_changes_ws,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+_MODULE = "app.modules.datastore.api.controllers.changes_controller"
+
+
+def _mock_session(user_id=None):
+    s = MagicMock()
+    s.get_user_id.return_value = str(user_id or uuid4())
+    return s
+
+
+def _mock_uow_factory(uow):
+    """Return a SessionUnitOfWorkFactory-shaped mock that yields *uow*."""
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=uow)
+    cm.__aexit__ = AsyncMock(return_value=False)
+
+    factory_instance = MagicMock()
+    factory_instance.return_value = cm
+
+    factory_class = MagicMock(return_value=factory_instance)
+    return factory_class
+
+
+def _make_ws(**accept_kwargs):
+    ws = MagicMock()
+    ws.headers.get.return_value = None
+    ws.cookies.get.return_value = None
+    ws.query_params.get.return_value = "test-token"
+    ws.accept = AsyncMock(**accept_kwargs)
+    ws.close = AsyncMock()
+    ws.send_json = AsyncMock()
+    ws.receive = AsyncMock(side_effect=Exception("disconnected"))
+    return ws
+
+
+def _auth_patches(uow):
+    mock_ctx = MagicMock()
+    mock_ctx.require = AsyncMock()
+
+    mock_table_svc = AsyncMock()
+    mock_table_svc.list_tables = AsyncMock(return_value=([], None))
+
+    mock_auth_svc_instance = MagicMock()
+    mock_auth_svc_instance.build_user_context = AsyncMock(return_value=mock_ctx)
+
+    mock_auth_svc_class = MagicMock(return_value=mock_auth_svc_instance)
+
+    mock_build_ts = MagicMock(return_value=mock_table_svc)
+
+    return mock_ctx, mock_auth_svc_class, mock_build_ts
+
+
+async def test_accept_runtimeerror_does_not_crash():
+    """RuntimeError during websocket.accept() must not propagate to the ASGI layer.
+
+    Production uvicorn raises RuntimeError when the client disconnects between
+    routing and accept() — the state machine has already moved past the accept
+    window.  The handler must catch it and return cleanly.
+    """
+    pod_id = uuid4()
+    ws = _make_ws(side_effect=RuntimeError("Expected ASGI message 'websocket.send'"))
+
+    uow = MagicMock()
+    uow.session = MagicMock()
+    _, mock_auth_svc, mock_build_ts = _auth_patches(uow)
+    mock_factory = _mock_uow_factory(uow)
+
+    with (
+        patch(f"{_MODULE}._resolve_session", AsyncMock(return_value=_mock_session())),
+        patch(f"{_MODULE}.SessionUnitOfWorkFactory", mock_factory),
+        patch(f"{_MODULE}.AuthorizationDataService", mock_auth_svc),
+        patch(f"{_MODULE}.build_table_service", mock_build_ts),
+    ):
+        # Must return None — not raise, not propagate the RuntimeError.
+        result = await datastore_changes_ws(ws, pod_id=pod_id, table=None, since=None)
+
+    assert result is None
+    ws.accept.assert_awaited_once()
+    ws.send_json.assert_not_awaited()  # streaming never started
+
+
+async def test_accept_runtimeerror_specific_table_does_not_crash():
+    """Same race with a table= filter in the query params."""
+    pod_id = uuid4()
+    ws = _make_ws(side_effect=RuntimeError("websocket state machine"))
+
+    uow = MagicMock()
+    uow.session = MagicMock()
+    mock_ctx, mock_auth_svc, mock_build_ts = _auth_patches(uow)
+
+    mock_table_entity = MagicMock()
+    mock_table_entity.table_name = "notes"
+    mock_table_svc = mock_build_ts.return_value
+    mock_table_svc.get_table = AsyncMock(return_value=mock_table_entity)
+
+    mock_factory = _mock_uow_factory(uow)
+
+    with (
+        patch(f"{_MODULE}._resolve_session", AsyncMock(return_value=_mock_session())),
+        patch(f"{_MODULE}.SessionUnitOfWorkFactory", mock_factory),
+        patch(f"{_MODULE}.AuthorizationDataService", mock_auth_svc),
+        patch(f"{_MODULE}.build_table_service", mock_build_ts),
+    ):
+        result = await datastore_changes_ws(
+            ws, pod_id=pod_id, table="notes", since=None
+        )
+
+    assert result is None
+    ws.accept.assert_awaited_once()
+
+
+async def test_accept_succeeds_normally_starts_streaming():
+    """Sanity: when accept() succeeds the forwarder task is started."""
+    pod_id = uuid4()
+    ws = _make_ws()
+
+    uow = MagicMock()
+    uow.session = MagicMock()
+    _, mock_auth_svc, mock_build_ts = _auth_patches(uow)
+    mock_factory = _mock_uow_factory(uow)
+
+    async def _fake_forward_changes(websocket, *, pod_id, user_id, allowed_tables, since):
+        await websocket.send_json({"type": "ready", "since": "0-0"})
+
+    with (
+        patch(f"{_MODULE}._resolve_session", AsyncMock(return_value=_mock_session())),
+        patch(f"{_MODULE}.SessionUnitOfWorkFactory", mock_factory),
+        patch(f"{_MODULE}.AuthorizationDataService", mock_auth_svc),
+        patch(f"{_MODULE}.build_table_service", mock_build_ts),
+        patch(f"{_MODULE}._forward_changes", _fake_forward_changes),
+    ):
+        await datastore_changes_ws(ws, pod_id=pod_id, table=None, since=None)
+
+    ws.accept.assert_awaited_once()
+    ws.send_json.assert_awaited_once_with({"type": "ready", "since": "0-0"})


### PR DESCRIPTION
## Summary
- Wraps `websocket.accept()` in a `try/except RuntimeError` in the datastore changes WebSocket controller
- When a client disconnects immediately after initiating the handshake, uvicorn's state machine transitions past the accept window and raises `RuntimeError: Expected ASGI message 'websocket.send' or 'websocket.close', but got 'websocket.accept'`
- The fix catches this and returns cleanly instead of crashing with an unhandled ASGI exception visible in production logs

## Root cause
Client races: connects → disconnects before the server finishes auth checks and calls `accept()`. Uvicorn's WebSocket state machine rejects the late `accept` message.

## Test plan
- [ ] Reproduce by rapidly connecting + disconnecting to `/pods/{id}/datastore/changes` — no more `RuntimeError` in logs
- [ ] Normal WebSocket connections continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)