### PR TITLE
Fix flows page dead play button, missing create button, and function …

### DIFF
--- a/lemma-frontend/app/pod/[id]/flows/page.tsx
+++ b/lemma-frontend/app/pod/[id]/flows/page.tsx
@@ -33,7 +33,6 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { ResourceVisibilityBadge } from '@/components/shared/resource-visibility';
 import {
     useDeleteFlow,
@@ -293,18 +292,15 @@ export default function FlowsIndexPage({
                 productIconTone="workflows"
                 meta={<ConceptHint concept="flow" />}
                 actions={(
-                    <TooltipProvider>
-                    <>
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <Button asChild variant="ghost" size="icon" className="h-8 w-8 rounded" aria-label="Runs">
-                                    <Link href={`/pod/${podId}/flows?view=runs`}>
-                                        <Play className="h-4 w-4" />
-                                    </Link>
+                    <div className="flex items-center gap-2">
+                        {canCreateFunction ? (
+                            <Link href={`/pod/${podId}/functions/new`}>
+                                <Button variant="outline" className="gap-2" size="sm">
+                                    <Plus className="h-4 w-4" />
+                                    New function
                                 </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>Runs</TooltipContent>
-                        </Tooltip>
+                            </Link>
+                        ) : null}
                         {canCreateWorkflow ? (
                             <Link href={`/pod/${podId}/flows/new`}>
                                 <Button className="gap-2" size="sm">
@@ -313,8 +309,7 @@ export default function FlowsIndexPage({
                                 </Button>
                             </Link>
                         ) : null}
-                    </>
-                    </TooltipProvider>
+                    </div>
                 )}
             />
 

--- a/lemma-frontend/app/pod/[id]/functions/new/page.tsx
+++ b/lemma-frontend/app/pod/[id]/functions/new/page.tsx
@@ -28,9 +28,27 @@ export default function NewFunctionPage({
     const [panelTab, setPanelTab] = useState<FunctionPanelTab>('code');
 
     const [localData, setLocalData] = useState<Partial<FunctionType>>({
-        name: 'Untitled Function',
+        name: 'untitled_function',
         icon_url: null,
-        code: `# Write your Python function here\n\ndef main(input_data):\n    \"\"\"\n    Main entry point for the function.\n    \"\"\"\n    return {}`,
+        code: `#input_type_name: FunctionInput
+#output_type_name: FunctionOutput
+#function_name: untitled_function
+
+from pydantic import BaseModel
+from lemma_sdk import FunctionContext
+
+
+class FunctionInput(BaseModel):
+    message: str = ""
+
+
+class FunctionOutput(BaseModel):
+    result: str
+
+
+async def untitled_function(ctx: FunctionContext, data: FunctionInput) -> FunctionOutput:
+    return FunctionOutput(result=f"Processed: {data.message}")
+`,
         config: null,
         input_schema: {},
         output_schema: {},

--- a/lemma-frontend/components/shared/resource-feedback.tsx
+++ b/lemma-frontend/components/shared/resource-feedback.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { AlertCircle, CheckCircle2, X } from 'lucide-react';
 import { toast } from 'sonner';
+import { ApiError } from 'lemma-sdk';
 
 import { cn } from '@/lib/utils';
 
@@ -16,7 +17,34 @@ export type ResourceFeedbackAction = {
     variant?: 'primary' | 'secondary' | 'ghost' | 'outline';
 };
 
+function formatErrorDetails(details: unknown): string | null {
+    if (!Array.isArray(details) || details.length === 0) return null;
+    const MAX = 4;
+    const parts: string[] = [];
+    for (const entry of details) {
+        if (!entry || typeof entry !== 'object') continue;
+        const record = entry as Record<string, unknown>;
+        const msg = typeof record.msg === 'string' ? record.msg.trim() : '';
+        if (!msg) continue;
+        const loc = Array.isArray(record.loc) ? record.loc.filter((s): s is string => typeof s === 'string') : null;
+        const field = loc && loc.length > 0 ? loc.filter((segment) => segment !== 'body').join('.') : '';
+        parts.push(field ? `${field}: ${msg}` : msg);
+    }
+    if (parts.length === 0) return null;
+    const shown = parts.slice(0, MAX);
+    const remainder = parts.length - shown.length;
+    let text = shown.join('; ');
+    if (remainder > 0) text += `; +${remainder} more`;
+    return text;
+}
+
 export function getResourceErrorMessage(error: unknown, fallback: string) {
+    if (error instanceof ApiError) {
+        const base = error.message?.trim() || fallback;
+        const detailsText = formatErrorDetails(error.details);
+        if (detailsText) return `${base} — ${detailsText}`;
+        return base || fallback;
+    }
     if (error instanceof Error && error.message.trim()) return error.message;
     if (typeof error === 'string' && error.trim()) return error;
     return fallback;

--- a/lemma-frontend/lib/hooks/use-functions.ts
+++ b/lemma-frontend/lib/hooks/use-functions.ts
@@ -91,6 +91,9 @@ function toSdkFunctionPayload<T extends CreateFunctionData | UpdateFunctionData>
     delete rest.accessible_connectors;
     delete rest.accessible_folders;
     delete rest.accessible_tables;
+    delete rest.input_schema;
+    delete rest.output_schema;
+    delete rest.config_schema;
     return rest;
 }
 


### PR DESCRIPTION
…creation errors

- Remove non-functional Play button from flows header (linked to ?view=runs which matched no tab) and drop now-unused Tooltip import
- Add persistent 'New function' button to flows header actions so it no longer vanishes once workflows/functions exist
- Surface ApiError.details in error toasts so validation failures show the actual field-level errors (e.g. extra_forbidden on input_schema)
- Strip server-derived schema fields (input_schema/output_schema/config_schema) from create/update payloads in toSdkFunctionPayload — these are derived from code by the backend and were rejected with VALIDATION_ERROR
- Replace placeholder default function code with valid Lemma Python syntax (required headers, pydantic models, FunctionContext handler) and a valid snake_case default name