### PR TITLE
feat(agent): add system OpenAI catalog customizer hook

### DIFF
--- a/lemma-backend/app/modules/agent/services/runtime_profile_service.py
+++ b/lemma-backend/app/modules/agent/services/runtime_profile_service.py
@@ -6,6 +6,7 @@ import asyncio
 import ipaddress
 import os
 import socket
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
@@ -70,16 +71,41 @@ def _openai_compat_vision_model_names() -> set[str]:
     return {name.strip() for name in (raw or "").split(",") if name.strip()}
 
 
-def system_lemma_openai_catalog_model_names() -> list[tuple[str, str | None]]:
-    """``(public_name, provider_model_name)`` for the configured system:lemma
-    OpenAI-compatible catalog.
+# Optional hook: an extension (e.g. a cloud provider module) may register a
+# customizer that rewrites the system OpenAI-compatible model catalog before it
+# is published — typically to map short public names to provider model IDs and
+# declare per-model capabilities (vision). The core stays env-driven: without a
+# customizer the catalog is used verbatim (public name == provider model name).
+SystemOpenAICatalogCustomizer = Callable[
+    [list[RuntimeModelCatalogEntry]], list[RuntimeModelCatalogEntry]
+]
 
-    The system profile uses model names verbatim — the operator configures the
-    exact provider model IDs via ``LEMMA_OPENAI_MODEL_NAMES`` — so the public and
-    provider names are identical. Mirrors the catalog built by
-    ``_system_lemma_openai_profile`` (configured model list plus the default
-    model) without requiring credentials, so it can drive the usage-pricing
-    coverage invariant at import/startup.
+_system_openai_catalog_customizer: SystemOpenAICatalogCustomizer | None = None
+
+
+def register_system_openai_catalog_customizer(
+    customizer: SystemOpenAICatalogCustomizer | None,
+) -> None:
+    """Register (or clear with ``None``) the system OpenAI catalog customizer.
+
+    Call once at application startup from an extension module. The customizer
+    receives the env-built catalog — each entry with ``provider_model_name ==
+    name`` and the TEXT+TOOLS baseline (plus any env-declared vision) — and
+    returns a rewritten catalog. This is the supported seam for a provider
+    overlay to keep short public model names user-facing while sending the real
+    provider model ID to the API and declaring per-model vision, without the
+    operator hand-configuring provider IDs in the environment.
+    """
+    global _system_openai_catalog_customizer
+    _system_openai_catalog_customizer = customizer
+
+
+def _build_system_openai_catalog() -> list[RuntimeModelCatalogEntry]:
+    """The env-configured system OpenAI catalog, after any registered customizer.
+
+    Shared by the live profile and the pricing-coverage names so both reflect the
+    same (optionally remapped) catalog. Requires no credentials, so it can run at
+    import/startup.
     """
     _load_runtime_env()
     model_names = _csv_setting(
@@ -90,7 +116,37 @@ def system_lemma_openai_catalog_model_names() -> list[tuple[str, str | None]]:
     ).strip()
     if default_model_name and default_model_name not in model_names:
         model_names.insert(0, default_model_name)
-    return [(model_name, model_name) for model_name in model_names]
+    vision_model_names = _openai_compat_vision_model_names()
+    catalog = [
+        RuntimeModelCatalogEntry(
+            name=model_name,
+            display_name=_display_model_name(model_name),
+            # The operator configures the exact provider model IDs, so the public
+            # name is the provider name unless a customizer remaps it.
+            provider_model_name=model_name,
+            capabilities=_openai_compat_model_capabilities(
+                model_name, vision_model_names
+            ),
+        )
+        for model_name in model_names
+    ]
+    if _system_openai_catalog_customizer is not None:
+        catalog = _system_openai_catalog_customizer(catalog)
+    return catalog
+
+
+def system_lemma_openai_catalog_model_names() -> list[tuple[str, str | None]]:
+    """``(public_name, provider_model_name)`` for the configured system:lemma
+    OpenAI-compatible catalog.
+
+    Mirrors the catalog built by ``_system_lemma_openai_profile`` (including any
+    registered customizer) without requiring credentials, so it can drive the
+    usage-pricing coverage invariant at import/startup.
+    """
+    return [
+        (entry.name, entry.provider_model_name)
+        for entry in _build_system_openai_catalog()
+    ]
 
 
 def _openai_compat_model_capabilities(
@@ -440,15 +496,10 @@ def _system_lemma_openai_profile() -> AgentRuntimeProfile | None:
     api_key = _env_or_setting("LEMMA_OPENAI_API_KEY", settings.lemma_openai_api_key)
     if not api_key:
         return None
-    model_names = _csv_setting(
-        os.getenv("LEMMA_OPENAI_MODEL_NAMES") or settings.lemma_openai_model_names
-    )
+    model_catalog = _build_system_openai_catalog()
     default_model_name = (
         os.getenv("LEMMA_OPENAI_DEFAULT_MODEL") or settings.lemma_openai_default_model
     ).strip()
-    if default_model_name and default_model_name not in model_names:
-        model_names.insert(0, default_model_name)
-    vision_model_names = _openai_compat_vision_model_names()
     return AgentRuntimeProfile(
         id=SYSTEM_LEMMA_PROFILE_ID,
         scope=RuntimeProfileScope.SYSTEM,
@@ -456,20 +507,8 @@ def _system_lemma_openai_profile() -> AgentRuntimeProfile | None:
         protocol=RuntimeProfileProtocol.OPENAI_COMPATIBLE,
         name="Lemma",
         description="System Lemma model provider",
-        default_model_name=default_model_name or model_names[0],
-        model_catalog=[
-            RuntimeModelCatalogEntry(
-                name=model_name,
-                display_name=_display_model_name(model_name),
-                # The operator configures the exact provider model IDs, so the
-                # public name is the provider name (no translation layer).
-                provider_model_name=model_name,
-                capabilities=_openai_compat_model_capabilities(
-                    model_name, vision_model_names
-                ),
-            )
-            for model_name in model_names
-        ],
+        default_model_name=default_model_name or model_catalog[0].name,
+        model_catalog=model_catalog,
         config=OpenAICompatibleRuntimeConfig(
             base_url=os.getenv("LEMMA_OPENAI_BASE_URL")
             or settings.lemma_openai_base_url,

--- a/lemma-backend/app/modules/agent/tests/unit/test_system_openai_catalog_customizer.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_system_openai_catalog_customizer.py
@@ -1,0 +1,119 @@
+"""The system OpenAI catalog customizer hook.
+
+The core builds the system OpenAI-compatible catalog from env (public name ==
+provider model name, no vision). A provider overlay can register a customizer to
+remap provider model IDs and declare per-model vision while keeping the short
+public names. These tests pin that seam and its default (no-op) behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.modules.agent.domain.runtime_profiles import (
+    RuntimeModelCapability,
+    RuntimeModelCatalogEntry,
+)
+from app.modules.agent.services import runtime_profile_service
+from app.modules.agent.services.runtime_profile_service import (
+    AgentRuntimeProfileService,
+    register_system_openai_catalog_customizer,
+    system_lemma_openai_catalog_model_names,
+)
+
+
+@pytest.fixture
+def openai_env(monkeypatch):
+    monkeypatch.setenv("LEMMA_OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("LEMMA_OPENAI_BASE_URL", "https://provider.test/v1")
+    monkeypatch.setenv("LEMMA_OPENAI_MODEL_NAMES", "minimax-m3,glm-5.2")
+    monkeypatch.setenv("LEMMA_OPENAI_DEFAULT_MODEL", "minimax-m3")
+    monkeypatch.setenv("LEMMA_DEFAULT_MODEL_TYPE", "openai_compat")
+
+
+@pytest.fixture(autouse=True)
+def _clear_customizer():
+    # Always start and end with no customizer so global state never leaks.
+    register_system_openai_catalog_customizer(None)
+    yield
+    register_system_openai_catalog_customizer(None)
+
+
+def _system_catalog() -> dict[str, RuntimeModelCatalogEntry]:
+    profiles = AgentRuntimeProfileService().system_profiles()
+    assert profiles, "system profile should exist when the API key is set"
+    return {entry.name: entry for entry in profiles[0].model_catalog}
+
+
+def test_default_catalog_uses_names_verbatim(openai_env):
+    catalog = _system_catalog()
+    assert set(catalog) == {"minimax-m3", "glm-5.2"}
+    for name, entry in catalog.items():
+        # No customizer: public name == provider model name, no vision.
+        assert entry.provider_model_name == name
+        assert RuntimeModelCapability.VISION not in entry.capabilities
+
+
+def test_customizer_remaps_provider_and_vision(openai_env):
+    mapping = {
+        "minimax-m3": ("accounts/fireworks/models/minimax-m3", True),
+        "glm-5.2": ("accounts/fireworks/models/glm-5p2", False),
+    }
+
+    def customizer(entries):
+        out = []
+        for entry in entries:
+            provider, vision = mapping.get(entry.name, (entry.provider_model_name, False))
+            caps = [RuntimeModelCapability.TEXT, RuntimeModelCapability.TOOLS]
+            if vision:
+                caps.append(RuntimeModelCapability.VISION)
+            out.append(
+                entry.model_copy(
+                    update={"provider_model_name": provider, "capabilities": caps}
+                )
+            )
+        return out
+
+    register_system_openai_catalog_customizer(customizer)
+    catalog = _system_catalog()
+
+    # Public names stay; provider IDs + vision come from the customizer.
+    assert set(catalog) == {"minimax-m3", "glm-5.2"}
+    assert (
+        catalog["minimax-m3"].provider_model_name
+        == "accounts/fireworks/models/minimax-m3"
+    )
+    assert RuntimeModelCapability.VISION in catalog["minimax-m3"].capabilities
+    assert RuntimeModelCapability.VISION not in catalog["glm-5.2"].capabilities
+
+    # The pricing-coverage names reflect the same remap.
+    pairs = dict(system_lemma_openai_catalog_model_names())
+    assert pairs["minimax-m3"] == "accounts/fireworks/models/minimax-m3"
+    assert pairs["glm-5.2"] == "accounts/fireworks/models/glm-5p2"
+
+
+def test_public_dict_masks_remapped_provider_id(openai_env):
+    """SYSTEM profiles hide the provider model ID behind the public name, so the
+    remap never leaks to clients (the catalog name stays the identity)."""
+    register_system_openai_catalog_customizer(
+        lambda entries: [
+            e.model_copy(update={"provider_model_name": f"accounts/x/{e.name}"})
+            for e in entries
+        ]
+    )
+    profiles = AgentRuntimeProfileService().system_profiles()
+    payload = profiles[0].public_dict()
+    for model in payload["model_catalog"]:
+        assert model["provider_model_name"] == model["name"]
+
+
+def test_clear_customizer_restores_default(openai_env):
+    register_system_openai_catalog_customizer(
+        lambda entries: [
+            e.model_copy(update={"provider_model_name": "accounts/x/y"}) for e in entries
+        ]
+    )
+    register_system_openai_catalog_customizer(None)
+    catalog = _system_catalog()
+    assert catalog["minimax-m3"].provider_model_name == "minimax-m3"
+    assert runtime_profile_service._system_openai_catalog_customizer is None


### PR DESCRIPTION
## Why

The system OpenAI-compatible profile is built from env, using the public model name **verbatim as the provider model id** (the `register_openai_compat_models()` translation layer was removed in #28). A provider overlay — e.g. the lemma-cloud Fireworks module — needs to keep short public names (`minimax-m3`) user-facing while sending the real provider id (`accounts/fireworks/models/minimax-m3`) to the API and declaring per-model vision, **without** forcing the operator to hand-configure full provider ids in `.env` (which would also make the full id the client-facing identity).

Today the only way to do that is to monkeypatch the private `_system_lemma_openai_profile`, which couples the overlay to internals and breaks on sync.

## What

Add a single, optional extension seam:

```python
register_system_openai_catalog_customizer(fn)  # fn: list[RuntimeModelCatalogEntry] -> list[RuntimeModelCatalogEntry]
```

- An extension registers **one** callback at startup. It receives the env-built catalog (each entry `provider_model_name == name`, TEXT+TOOLS baseline plus any env vision) and returns a rewritten catalog — typically remapping provider ids and adding vision.
- **Core stays env-driven**: with no customizer registered, behavior is unchanged (names used verbatim).
- The live system profile and `system_lemma_openai_catalog_model_names()` (the usage pricing-coverage source) now both route through a shared `_build_system_openai_catalog()`, so a remap is reflected consistently — including the startup pricing-coverage check.
- `AgentRuntimeProfile.public_dict()` already masks the provider model id behind the public name for SYSTEM-scope profiles, so a remap **never leaks to clients** — the short name stays the identity end-to-end.

This is intentionally *not* a re-add of the removed model registry: the core holds no provider data; the extension owns all of it via the callback.

## Tests

- New `test_system_openai_catalog_customizer.py`: default no-op behavior, provider+vision remap, `public_dict` masking, and clear-restores-default (with autouse teardown so the global never leaks).
- Existing `test_runtime_config_service.py` (35) and usage `test_system_pricing_unit.py` (12) stay green.

```
39 passed  (agent runtime + customizer)
12 passed  (usage system pricing)
```

## Consumer

lemma-cloud's Fireworks module will register a customizer here instead of monkeypatching, keeping `.env` on short names (no data migration). Paired PR: lemma-work/lemma-app#152.

🤖 Generated with [Claude Code](https://claude.com/claude-code)