### PR TITLE
Fix pod home & apps page loading every app in a live iframe

### DIFF
--- a/lemma-frontend/app/pod/[id]/app/pages/page.tsx
+++ b/lemma-frontend/app/pod/[id]/app/pages/page.tsx
@@ -225,39 +225,9 @@ export default function AppPagesRoute({ params }: { params: Promise<{ id: string
                             <article
                                 key={page.slug}
                                 data-accent={accent}
-                                className="resource-index-card app-tile group relative overflow-hidden p-0"
+                                className="resource-index-card app-tile group"
                             >
-                                {page.url ? (
-                                    <Link href={viewHref} aria-label={`Open ${title}`} className="block">
-                                        <div className="app-preview">
-                                            <iframe
-                                                src={page.url}
-                                                title={`${title} preview`}
-                                                className="pointer-events-none absolute left-0 top-0 h-[160%] w-[160%] origin-top-left scale-[0.625] border-0"
-                                                loading="lazy"
-                                                tabIndex={-1}
-                                                aria-hidden="true"
-                                                sandbox="allow-same-origin allow-scripts allow-forms"
-                                            />
-                                        </div>
-                                    </Link>
-                                ) : (
-                                    <div className="app-cover h-10" />
-                                )}
-                                {canManageApp ? (
-                                    <div className="absolute right-2 top-2">
-                                        <ResourceActionsMenu
-                                            ariaLabel={`Open actions for ${title}`}
-                                            triggerClassName="h-7 w-7 shrink-0 rounded-md bg-[color:color-mix(in_srgb,var(--surface-1)_80%,transparent)] text-[var(--text-tertiary)] opacity-0 backdrop-blur-sm transition-opacity hover:bg-[var(--surface-2)] group-hover:opacity-100 group-focus-within:opacity-100"
-                                        >
-                                            <DestructiveResourceActionItem onSelect={() => setAppPendingDelete(page)}>
-                                                Delete app
-                                            </DestructiveResourceActionItem>
-                                        </ResourceActionsMenu>
-                                    </div>
-                                ) : null}
-
-                                <div className="app-foot flex items-center gap-3 px-3.5 py-3">
+                                <div className="flex items-center gap-3">
                                     <Link href={viewHref} aria-label={`Open ${title}`} className="shrink-0">
                                         <span className="app-icon flex h-10 w-10 items-center justify-center rounded-xl text-sm font-medium">
                                             {page.icon || title.charAt(0)}
@@ -287,6 +257,16 @@ export default function AppPagesRoute({ params }: { params: Promise<{ id: string
                                                 <ExternalLink className="h-3.5 w-3.5" />
                                             </a>
                                         </Button>
+                                    ) : null}
+                                    {canManageApp ? (
+                                        <ResourceActionsMenu
+                                            ariaLabel={`Open actions for ${title}`}
+                                            triggerClassName="h-8 w-8 shrink-0 rounded-md text-[var(--text-tertiary)] hover:bg-[var(--surface-2)]"
+                                        >
+                                            <DestructiveResourceActionItem onSelect={() => setAppPendingDelete(page)}>
+                                                Delete app
+                                            </DestructiveResourceActionItem>
+                                        </ResourceActionsMenu>
                                     ) : null}
                                 </div>
                             </article>

--- a/lemma-frontend/app/pod/[id]/page.tsx
+++ b/lemma-frontend/app/pod/[id]/page.tsx
@@ -587,25 +587,8 @@ function PodAppsHomePanel({ podId }: { podId: string }) {
                     const accent = getAppAccent(page.slug);
 
                     return (
-                        <article key={page.slug} data-accent={accent} className="resource-index-card app-tile group relative overflow-hidden p-0">
-                            {page.url ? (
-                                <Link href={viewHref} aria-label={`Open ${title}`} className="block">
-                                    <div className="app-preview">
-                                        <iframe
-                                            src={page.url}
-                                            title={`${title} preview`}
-                                            className="pointer-events-none absolute left-0 top-0 h-[160%] w-[160%] origin-top-left scale-[0.625] border-0"
-                                            loading="lazy"
-                                            tabIndex={-1}
-                                            aria-hidden="true"
-                                            sandbox="allow-same-origin allow-scripts allow-forms"
-                                        />
-                                    </div>
-                                </Link>
-                            ) : (
-                                <div className="app-cover h-10" />
-                            )}
-                            <div className="app-foot flex items-center gap-3 px-3.5 py-3">
+                        <article key={page.slug} data-accent={accent} className="resource-index-card app-tile group">
+                            <div className="flex items-center gap-3">
                                 <Link href={viewHref} aria-label={`Open ${title}`} className="shrink-0">
                                     <span className="app-icon flex h-10 w-10 items-center justify-center rounded-xl text-sm font-medium">
                                         {page.icon || title.charAt(0)}

--- a/lemma-frontend/styles/features/resource-ledgers.css
+++ b/lemma-frontend/styles/features/resource-ledgers.css
@@ -219,21 +219,11 @@
 }
 
 
-/* App cards — a short accent cover + overlapping squircle avatar. The accent is
-   per-app (see lib/app/app-accent.ts) and derives every shade from one semantic
-   token via color-mix, so it adapts to light/dark automatically. */
+/* App cards — a compact accent row. The accent is per-app (see
+   lib/app/app-accent.ts) and derives every shade from one semantic token via
+   color-mix, so it adapts to light/dark automatically. */
 .app-tile {
   --app-accent: var(--action-primary);
-}
-/* Full-bleed: the base card's 1rem padding would inset the preview. */
-.resource-index-card.app-tile {
-  padding: 0;
-}
-/* Footer sits on a slightly different surface than the preview/card so the text
-   area reads as its own band — close, but distinct. */
-.app-foot {
-  background: color-mix(in srgb, var(--app-accent) 5%, var(--surface-2));
-  border-top: 1px solid color-mix(in srgb, var(--border-subtle) 26%, transparent);
 }
 .app-tile[data-accent="brand"] { --app-accent: var(--action-primary); }
 .app-tile[data-accent="intelligence"] { --app-accent: var(--intelligence); }
@@ -242,18 +232,10 @@
 .app-tile[data-accent="success"] { --app-accent: var(--state-success); }
 .app-tile[data-accent="delight"] { --app-accent: var(--delight); }
 
-.app-cover {
-  background: color-mix(in srgb, var(--app-accent) 15%, var(--surface-1));
-}
-
-/* Live preview acts as the card's cover — a 16:9 laptop-shaped window into the
-   app. Short enough to stay tidy at any width (phone to wide desktop to docked
-   single-column). Retune the ratio here. */
-.app-preview {
-  position: relative;
-  aspect-ratio: 16 / 9;
-  overflow: hidden;
-  background: color-mix(in srgb, var(--app-accent) 10%, var(--surface-1));
+/* Faint accent wash across the whole card so tiles stay visually distinct
+   without a large cover hero. */
+.resource-index-card.app-tile {
+  background: color-mix(in srgb, var(--app-accent) 6%, var(--surface-1));
 }
 
 .app-icon {


### PR DESCRIPTION
## What
Pod home and the Apps page each rendered a scaled-down **live iframe** (`src={page.url}`) for every app tile — so opening the pod home (or the apps page) would spin up a full app instance per tile, hammering the browser and breaking the page.

## Fix
Removed the live iframe previews entirely. App tiles are now compact single-row cards: accent squircle icon + title + URL + actions. No app instances load until you actually open one.

### Changed
- **Pod home** (`PodAppsHomePanel`) — compact accent row, no hero/footer split, no iframe
- **Apps page** — same compact row, inline Open button + actions menu (no absolute overlay)
- **CSS** — dropped `.app-preview`, `.app-cover-hero`, `.app-cover-mark`, `.app-foot`; card now uses a faint per-app accent wash (`color-mix` 6%) to stay visually distinct

### Before / after
- **Before:** up to 6 full iframes on pod home, all apps as iframes on the apps page
- **After:** 0 iframes on either page; the full app only loads at `/pod/[id]/app/view?page=<slug>`

Lint + typecheck pass.