### PR TITLE
fix(cli/daemon): make process lifecycle Windows-compatible

### DIFF
--- a/.github/workflows/windows-daemon.yml
+++ b/.github/workflows/windows-daemon.yml
@@ -1,0 +1,108 @@
+name: Windows daemon smoke
+
+# Validates that the lemma CLI's user-daemon works on a real Windows kernel —
+# the install path plus the full `daemon start --background` / `status` / `stop`
+# lifecycle. This exercises the Windows-specific code that cannot be run on the
+# Linux/macOS dev machines: the detached process-group spawn and the ctypes
+# process-liveness probe.
+#
+# Triggers:
+#   * push to main           — post-merge gate (only when CLI files change)
+#   * PR labelled `windows-ci`— opt-in per-PR run (add the label to test a branch)
+#   * manual workflow_dispatch
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'lemma-cli/**'
+      - 'lemma-skills/**'
+      - '.github/workflows/windows-daemon.yml'
+  pull_request:
+    types: [labeled, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-daemon-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows-daemon:
+    name: Windows daemon lifecycle
+    # Always on push/dispatch; on PRs only when the `windows-ci` label is present.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'windows-ci'))
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install lemma-cli (uv tool — the real user install path)
+        run: uv tool install --force ./lemma-cli
+
+      - name: Put lemma on PATH
+        run: Add-Content -Path $env:GITHUB_PATH -Value (uv tool dir --bin)
+
+      - name: Smoke — version / servers / auth status
+        run: |
+          $ErrorActionPreference = "Stop"
+          lemma --version
+          if ($LASTEXITCODE -ne 0) { throw "lemma --version exited $LASTEXITCODE" }
+          lemma servers list
+          if ($LASTEXITCODE -ne 0) { throw "lemma servers list exited $LASTEXITCODE" }
+          # auth status exits 1 when logged out — that is expected; it just must
+          # not crash with a Windows-incompatibility error.
+          lemma auth status
+          if ($LASTEXITCODE -notin 0, 1) { throw "lemma auth status exited $LASTEXITCODE" }
+          Write-Host "smoke commands ok"
+          exit 0
+
+      - name: Daemon lifecycle — start --background / status / stop
+        run: |
+          $ErrorActionPreference = "Stop"
+          # A dummy --token makes session refresh a no-op (no browser login), and
+          # an unreachable --base-url keeps the daemon alive in its reconnect loop,
+          # so we get a live, detached pid to probe and then stop. Fully offline.
+          lemma --base-url http://127.0.0.1:9 --token ci-dummy-token daemon start --background
+          if ($LASTEXITCODE -ne 0) { throw "daemon start --background exited $LASTEXITCODE" }
+
+          Start-Sleep -Seconds 6
+          $status = (lemma daemon status | Out-String)
+          Write-Host "status after start:`n$status"
+          if ($status -notmatch '"running":\s*true') {
+            Write-Host "--- daemon log ---"
+            lemma daemon logs
+            throw "daemon was not running after background start"
+          }
+
+          lemma daemon stop
+          if ($LASTEXITCODE -ne 0) { throw "daemon stop exited $LASTEXITCODE" }
+
+          Start-Sleep -Seconds 3
+          $after = (lemma daemon status | Out-String)
+          Write-Host "status after stop:`n$after"
+          if ($after -match '"running":\s*true') { throw "daemon still running after stop" }
+          Write-Host "daemon lifecycle ok"
+          exit 0
+
+      - name: Unit tests — cross-platform process helpers (real Windows)
+        run: |
+          $ErrorActionPreference = "Stop"
+          pip install -e ./lemma-python -e ./lemma-cli pytest pytest-asyncio
+          pytest lemma-cli/tests/test_daemon_process.py -q
+          if ($LASTEXITCODE -ne 0) { throw "daemon process unit tests failed ($LASTEXITCODE)" }
+          exit 0

--- a/lemma-cli/lemma_cli/daemon/commands.py
+++ b/lemma-cli/lemma_cli/daemon/commands.py
@@ -135,6 +135,25 @@ def logs_daemon() -> None:
     _console().print(DAEMON_LOG_PATH.read_text())
 
 
+def _detach_kwargs() -> dict:
+    """Popen kwargs that detach the daemon from this CLI invocation.
+
+    POSIX uses a new session (setsid). Windows has no setsid and silently ignores
+    ``start_new_session``, so the equivalent is a detached, console-less new
+    process group. The ``subprocess.*`` flag constants below only exist on
+    Windows, so this branch is reached only where they are defined.
+    """
+    if sys.platform == "win32":
+        return {
+            "creationflags": (
+                subprocess.DETACHED_PROCESS
+                | subprocess.CREATE_NEW_PROCESS_GROUP
+                | subprocess.CREATE_NO_WINDOW
+            )
+        }
+    return {"start_new_session": True}
+
+
 def start_background(ctx: typer.Context, *, debug: bool = False) -> None:
     state = _state_from_ctx(ctx)
     DAEMON_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -160,12 +179,14 @@ def start_background(ctx: typer.Context, *, debug: bool = False) -> None:
     command.extend(["--config-file", str(state.config_path), "daemon", "start"])
     if debug:
         command.append("--debug")
+    # Detach the daemon so it outlives this CLI invocation (POSIX setsid /
+    # Windows detached process group — see _detach_kwargs).
     with DAEMON_LOG_PATH.open("ab") as log_file:
         process = subprocess.Popen(  # noqa: S603
             command,
             stdout=log_file,
             stderr=subprocess.STDOUT,
-            start_new_session=True,
+            **_detach_kwargs(),
         )
     write_daemon_status(process.pid, base_url=resolved_base_url, server=state.server)
     _console().print(f"Started daemon in background with pid {process.pid}.")

--- a/lemma-cli/lemma_cli/daemon/config.py
+++ b/lemma-cli/lemma_cli/daemon/config.py
@@ -4,6 +4,7 @@ import json
 import os
 import platform
 import socket
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import uuid4
@@ -115,8 +116,53 @@ def clear_daemon_status() -> None:
 
 
 def process_is_running(pid: int) -> bool:
+    """Return True if a process with ``pid`` is currently alive.
+
+    POSIX uses the classic ``kill(pid, 0)`` probe, which sends no signal and just
+    checks that the process exists. That probe is wrong on Windows — signal ``0``
+    maps to ``CTRL_C_EVENT`` there, not a no-op — so Windows queries the process
+    handle directly instead.
+    """
+    if pid <= 0:
+        return False
+    if sys.platform == "win32":
+        return _windows_process_is_running(pid)
     try:
         os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # The process exists but is owned by another user.
+        return True
     except OSError:
         return False
     return True
+
+
+def _windows_process_is_running(pid: int) -> bool:
+    import ctypes  # noqa: PLC0415
+    from ctypes import wintypes  # noqa: PLC0415
+
+    SYNCHRONIZE = 0x00100000
+    WAIT_TIMEOUT = 0x00000102
+    ERROR_ACCESS_DENIED = 5
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    kernel32.OpenProcess.restype = wintypes.HANDLE
+    kernel32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+    kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    kernel32.CloseHandle.restype = wintypes.BOOL
+
+    handle = kernel32.OpenProcess(SYNCHRONIZE, False, pid)
+    if not handle:
+        # No handle: the pid is gone, unless we were merely denied access — in
+        # which case the process does exist and is treated as running.
+        return ctypes.get_last_error() == ERROR_ACCESS_DENIED
+    try:
+        # A live process never becomes signaled, so a zero-timeout wait reports
+        # WAIT_TIMEOUT; an exited process reports WAIT_OBJECT_0 (0).
+        return kernel32.WaitForSingleObject(handle, 0) == WAIT_TIMEOUT
+    finally:
+        kernel32.CloseHandle(handle)

--- a/lemma-cli/tests/test_daemon_process.py
+++ b/lemma-cli/tests/test_daemon_process.py
@@ -1,0 +1,76 @@
+"""Cross-platform process-lifecycle helpers for the daemon.
+
+These guard the Windows-compatibility fixes: the liveness probe must not rely on
+POSIX ``kill(pid, 0)`` semantics (signal 0 is ``CTRL_C_EVENT`` on Windows), and
+the background daemon must detach via a new process group on Windows rather than
+the POSIX-only ``start_new_session``.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+from lemma_cli.daemon import commands as daemon_commands
+from lemma_cli.daemon import config as daemon_config
+
+
+def test_process_is_running_true_for_current_process():
+    assert daemon_config.process_is_running(os.getpid()) is True
+
+
+def test_process_is_running_false_for_unused_pid():
+    # A pid this large is effectively never allocated on POSIX or Windows.
+    assert daemon_config.process_is_running(2_000_000_000) is False
+
+
+@pytest.mark.parametrize("pid", [0, -1, -1234])
+def test_process_is_running_false_for_nonpositive_pid(pid):
+    assert daemon_config.process_is_running(pid) is False
+
+
+def test_process_is_running_delegates_to_windows_helper(monkeypatch):
+    seen = {}
+
+    def fake_windows(pid: int) -> bool:
+        seen["pid"] = pid
+        return True
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(daemon_config, "_windows_process_is_running", fake_windows)
+    # On the Windows path the POSIX kill(pid, 0) probe must never run.
+    monkeypatch.setattr(
+        daemon_config.os,
+        "kill",
+        lambda *args, **kwargs: pytest.fail("os.kill must not be used on win32"),
+    )
+
+    assert daemon_config.process_is_running(4321) is True
+    assert seen["pid"] == 4321
+
+
+def test_detach_kwargs_posix_uses_new_session(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert daemon_commands._detach_kwargs() == {"start_new_session": True}
+
+
+def test_detach_kwargs_windows_uses_detached_process_group(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    # These flag constants only exist on Windows; provide them (using their real
+    # values) so the branch is exercisable on any host running the suite.
+    monkeypatch.setattr(
+        daemon_commands.subprocess, "DETACHED_PROCESS", 0x00000008, raising=False
+    )
+    monkeypatch.setattr(
+        daemon_commands.subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200, raising=False
+    )
+    monkeypatch.setattr(
+        daemon_commands.subprocess, "CREATE_NO_WINDOW", 0x08000000, raising=False
+    )
+
+    kwargs = daemon_commands._detach_kwargs()
+
+    assert set(kwargs) == {"creationflags"}
+    assert kwargs["creationflags"] == 0x00000008 | 0x00000200 | 0x08000000
+    assert "start_new_session" not in kwargs


### PR DESCRIPTION
## What & why

Two POSIX-only patterns in the `lemma` user-daemon's process management misbehave on Windows. Found while auditing the CLI for Windows compatibility.

### 1. `process_is_running` — `daemon/config.py`
Used `os.kill(pid, 0)` as a liveness probe. On Windows, signal `0` is `CTRL_C_EVENT` (not a no-op existence check), so the probe is unreliable — `lemma daemon status` and the "already running?" guard in `daemon start` could be wrong.

**Fix:** Windows branch queries the process handle via `OpenProcess(SYNCHRONIZE)` + `WaitForSingleObject` (handle `restype` set so 64-bit handles aren't truncated). POSIX path keeps `kill(pid, 0)` but now distinguishes `ProcessLookupError` (dead) from `PermissionError` (alive, other user). Non-positive pids short-circuit to `False`.

### 2. `start_background` — `daemon/commands.py`
Detached the background daemon with `start_new_session=True`, which is **POSIX-only** ([docs: "Availability: POSIX"](https://docs.python.org/3/library/subprocess.html#subprocess.Popen)) and silently ignored on Windows — so `lemma daemon start --background` never actually detached.

**Fix:** new `_detach_kwargs()` helper — POSIX keeps `setsid`; Windows uses `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW`.

### Not changed
- `stop_daemon`'s `os.kill(pid, signal.SIGTERM)` already works on Windows (any non-CTRL signal routes to `TerminateProcess`, and `signal.SIGTERM` is defined on Windows), so it's left as-is.
- The OpenCode skills path (`~/.config/opencode/skills`) is **correct on Windows** — OpenCode uses `~/.config/opencode` on all platforms ([docs](https://opencode.ai/docs/config/)); `%APPDATA%` is a known misconception. No change.

## Testing
- New `tests/test_daemon_process.py` covers the liveness probe (current pid, unused pid, non-positive pids, Windows delegation) and the platform-specific detach kwargs.
- `pytest tests/test_daemon_process.py tests/test_daemon_cli.py` → **50 passed**; `ruff check` clean.
- Windows-specific `ctypes`/`creationflags` paths verified by code + the Python docs cited above (no Windows host available in CI here — a `windows-latest` smoke job would close that gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)