### PR TITLE
fix(agent): accept JSON-string data in pod_write_record to prevent empty writes

### DIFF
--- a/lemma-backend/app/modules/agent/tests/unit/test_pod_tools.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_pod_tools.py
@@ -194,6 +194,52 @@ async def test_pod_write_record_rejects_empty_data(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_pod_write_record_accepts_json_string_data(monkeypatch):
+    # Models on OpenAI-compatible providers commonly pass `data` as a JSON-encoded
+    # string rather than a native object (the free-form object schema carries an
+    # empty `properties` map, which weaker models fill with `{}`, dropping the
+    # row). The string form must decode to a dict and write through unchanged.
+    record = SimpleNamespace(data={"id": "1", "name": "Ada"})
+    services = SimpleNamespace(
+        record=SimpleNamespace(create_record=AsyncMock(return_value=record)),
+        table=SimpleNamespace(get_table=AsyncMock()),
+        ctx=SimpleNamespace(pod_id=uuid4(), user_id=uuid4()),
+    )
+    _patch_services(monkeypatch, services)
+    monkeypatch.setattr(
+        pod_adapter, "_table_context", AsyncMock(return_value=SimpleNamespace())
+    )
+
+    request = PodWriteRecordRequest(
+        action="create",
+        table_name="t",
+        data='{"name": "Ada", "age": 36, "tags": ["x"]}',
+    )
+    # The validator normalizes the JSON string to a dict before the tool runs.
+    assert request.data == {"name": "Ada", "age": 36, "tags": ["x"]}
+
+    result = await pod_adapter.pod_write_record(_run_ctx(), request)
+    assert result["success"] is True
+    # The datastore receives a decoded dict (positional arg), never the raw string.
+    written = services.record.create_record.await_args.args[1]
+    assert written == {"name": "Ada", "age": 36, "tags": ["x"]}
+
+
+def test_pod_write_record_data_string_validation():
+    from pydantic import ValidationError
+
+    # A blank string is treated as no data (caught later by the non-empty guard).
+    blank = PodWriteRecordRequest(action="create", table_name="t", data="   ")
+    assert blank.data is None
+
+    # A string that is not valid JSON, or that decodes to a non-object, is a
+    # validation error — not a silently-dropped or blank write.
+    for bad in ("not json", "[1, 2, 3]", '"just a string"', "42"):
+        with pytest.raises(ValidationError):
+            PodWriteRecordRequest(action="create", table_name="t", data=bad)
+
+
+@pytest.mark.asyncio
 async def test_pod_get_records_single_vs_list(monkeypatch):
     record = SimpleNamespace(data={"id": "1", "name": "Ada"})
     services = SimpleNamespace(

--- a/lemma-backend/app/modules/agent/tests/unit/test_tool_schema_compat.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_tool_schema_compat.py
@@ -143,6 +143,29 @@ def test_openai_compatible_transformer_inlines_all_defs():
     assert not offenders, f"unresolved $ref/$defs after inlining: {offenders}"
 
 
+def test_pod_write_record_data_advertises_object_or_json_string():
+    """`pod_write_record.data` must offer a JSON-string form alongside the object.
+
+    OpenAI requires every object schema to carry a `properties` map, so a
+    free-form (dynamic-column) object necessarily serializes with
+    `properties: {}` — which many models read as "no fields" and fill with `{}`,
+    silently dropping the row. The JSON-string branch is the escape hatch that
+    lets those models write data, so the transformed tool schema must keep both
+    branches (and never collapse `data` to a strict, closed empty object).
+    """
+    from app.modules.agent.services.openai_schema_compat import (
+        InlineDefsOpenAIJsonSchemaTransformer,
+    )
+    from app.modules.agent.tools.pod.pydantic_adapter import pod_toolset
+
+    raw = _tool_schema(pod_toolset.tools["pod_write_record"])
+    assert raw is not None
+    transformed = InlineDefsOpenAIJsonSchemaTransformer(raw, strict=None).walk()
+    data_schema = transformed["properties"]["data"]
+    branch_types = {branch.get("type") for branch in data_schema.get("anyOf", [])}
+    assert {"object", "string"} <= branch_types, data_schema
+
+
 def test_record_filter_value_is_typed_not_bare_any():
     from app.modules.agent.tools.pod.models import RecordFilter
 

--- a/lemma-backend/app/modules/agent/tools/pod/models.py
+++ b/lemma-backend/app/modules/agent/tools/pod/models.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from app.modules.agent.domain.value_objects import JsonObject
 
@@ -58,16 +59,56 @@ class PodWriteRecordRequest(BaseModel):
         default=None,
         description="Target record id. Required for 'update' and 'delete'.",
     )
-    data: JsonObject | None = Field(
+    # Accepts a JSON object OR a JSON-encoded string of that object. The `str`
+    # member exists so the tool schema advertises the string form: OpenAI
+    # requires every object schema to carry a `properties` map, and a free-form
+    # (dynamic-column) object necessarily serializes with `properties: {}` —
+    # which many models read as "no fields" and fill with `{}`, silently
+    # dropping the row. The string form is an unambiguous escape hatch. The
+    # `_coerce_data` validator decodes any string back to a dict, so downstream
+    # code only ever sees `dict | None`.
+    data: JsonObject | str | None = Field(
         default=None,
         description=(
-            "An object mapping column name -> value, e.g. "
-            '{"title": "Q3 report", "amount": 42, "tags": ["a", "b"]}. Values may '
-            "be scalars, nested objects, or arrays. REQUIRED and must be non-empty "
-            "for 'create' and 'update' — an empty object writes nothing and is "
-            "rejected."
+            "The row's column name -> value mapping. Pass EITHER a JSON object, "
+            'e.g. {"title": "Q3 report", "amount": 42, "tags": ["a", "b"]}, OR a '
+            "JSON-encoded string of that same object if you cannot emit a "
+            'populated object directly, e.g. "{\\"title\\": \\"Q3 report\\", '
+            '\\"amount\\": 42}". Values may be scalars, nested objects, or '
+            "arrays. REQUIRED and must be non-empty for 'create' and 'update' — "
+            "an empty object writes nothing and is rejected."
         ),
     )
+
+    @field_validator("data", mode="before")
+    @classmethod
+    def _coerce_data(cls, value: object) -> object:
+        """Decode a JSON-encoded string payload into an object.
+
+        Models on OpenAI-compatible providers often pass ``data`` as a JSON
+        string instead of a native object (see the field comment). Parse it here
+        so the rest of the toolset always receives a ``dict``; a blank string
+        becomes ``None`` (caught by the non-empty guard), and a string that is
+        not a JSON object is rejected with an actionable message.
+        """
+        if not isinstance(value, str):
+            return value
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            parsed = json.loads(text)
+        except (ValueError, TypeError) as exc:
+            raise ValueError(
+                '`data` was a string but not valid JSON; pass a JSON object like '
+                '{"title": "Q3 report"} (or a JSON-encoded string of it).'
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise ValueError(
+                "`data` must be (or JSON-decode to) an object of column->value, "
+                f"not {type(parsed).__name__}."
+            )
+        return parsed
 
 
 class QueryRequest(BaseModel):


### PR DESCRIPTION
## Summary

Fixes the agent `pod_write_record` (toolset `POD`) bug where a write could
silently persist nothing even when the agent built a fully populated payload,
failing with:

> data must be a non-empty object of column->value ... the payload was empty

## Root cause

On the **default OpenAI-compatible runtime**, `data` is a free-form
(dynamic-column) object. OpenAI requires every object schema to carry a
`properties` map, so pydantic-ai's transformer emits `properties: {}` for it
("OpenAI drops objects without it"). The tool runs **non-strict**, so nothing
is stripped in transport — but a schema advertising *zero properties* leads
weaker OpenAI-compatible models to emit `data: {}`, which trips the existing
non-empty guard. This matches that guard's own comment ("a frequent failure on
smaller models"). The Anthropic path gets a clean object (no `properties: {}`)
and was unaffected.

The pydantic-ai v1.107 / pydantic 2.13.4 tool-definition pipeline was
reproduced for both providers to confirm this before changing code.

## Fix

Let `data` also be a **JSON-encoded string** (`JsonObject | str | None`),
advertised in the tool schema as an unambiguous escape hatch, and decode it
back to a dict in a `field_validator(mode="before")` so downstream code still
only ever sees `dict | None`.

- Backward compatible — native objects still work (Anthropic, strong models).
- Strict-safe and provider-agnostic.
- Invalid or non-object strings are rejected with actionable messages; blank
  strings fall through to the existing non-empty guard.

## Testing

- New regression tests for the coercion behavior (`test_pod_tools.py`) and the
  schema contract (`test_tool_schema_compat.py`).
- Full agent unit suite: **263 passed**; ruff clean.

Fixes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)