### PR TITLE
fix(daemon): drop stale Claude Code tool names from --disallowedTools

### DIFF
--- a/lemma-cli/lemma_cli/daemon/mcp.py
+++ b/lemma-cli/lemma_cli/daemon/mcp.py
@@ -30,18 +30,22 @@ DEFAULT_CWD_DIRS = {
     "OPENCODE": "lemma-opencode",
 }
 
+# Claude Code's own (non-MCP) tools, passed via --disallowedTools so the agent
+# uses the pod's MCP tools instead of the harness's local file/shell tools.
+# Each name must match a tool that the installed Claude Code actually exposes:
+# an unknown name makes Claude Code print
+#   Permission deny rule "<name>" matches no known tool — check for typos.
+# on every run. LS, MultiEdit, NotebookRead, and TodoRead were removed in
+# Claude Code 2.x (folded into Glob/Bash, Edit, Read, and TodoWrite), so they
+# are intentionally absent here — keep this list in sync as Claude Code evolves.
 CLAUDE_CODE_NATIVE_TOOLS = (
     "Agent",
     "Bash",
     "Edit",
     "Glob",
     "Grep",
-    "LS",
-    "MultiEdit",
     "NotebookEdit",
-    "NotebookRead",
     "Read",
-    "TodoRead",
     "TodoWrite",
     "Write",
 )

--- a/lemma-cli/tests/test_daemon_cli.py
+++ b/lemma-cli/tests/test_daemon_cli.py
@@ -1266,6 +1266,10 @@ def test_claude_mcp_args_disable_native_tools_by_default(monkeypatch):
     assert "Bash" in disallowed_tools
     assert "Read" in disallowed_tools
     assert "WebSearch" not in disallowed_tools
+    # Stale names removed in Claude Code 2.x must not return: each one Claude Code
+    # doesn't recognize prints a "matches no known tool" warning on every run.
+    for stale in ("LS", "MultiEdit", "NotebookRead", "TodoRead"):
+        assert stale not in disallowed_tools
 
 
 def test_claude_command_resumes_saved_session():


### PR DESCRIPTION
## Summary

Addresses **Bug 1** of #25: `CLAUDE_CODE_NATIVE_TOOLS` (in
`lemma_cli/daemon/mcp.py`, passed to Claude Code via `--disallowedTools`) still
listed `LS`, `MultiEdit`, `NotebookRead`, and `TodoRead` — all removed in
Claude Code 2.x. Claude Code prints one warning per name it doesn't recognize:

```
Permission deny rule "LS" matches no known tool — check for typos.
Permission deny rule "MultiEdit" matches no known tool — check for typos.
Permission deny rule "NotebookRead" matches no known tool — check for typos.
Permission deny rule "TodoRead" matches no known tool — check for typos.
```

So a brand-new user wiring up Claude Code sees four alarming "permission deny"
lines on their very first conversation — a working setup that looks broken.

## Fix

- Remove the four dead names. The tools they were folded into are already
  disallowed (`LS`→`Glob`/`Bash`, `MultiEdit`→`Edit`, `NotebookRead`→`Read`,
  `TodoRead`→`TodoWrite`), so the set of tools actually disabled is unchanged —
  only the spurious warnings go away.
- Document that the list must track Claude Code's real tool names (an unknown
  name re-introduces the warning), so it doesn't silently drift again.
- Add a regression assertion in `test_claude_mcp_args_disable_native_tools_by_default`
  that the stale names never come back.

## Testing

- `pytest tests/test_daemon_cli.py` — **42 passed**; ruff clean.

## Out of scope

Bug 2 of #25 (the **sonnet** model selecting the 1M-context variant and failing
without usage credits) is an account/billing setting rather than a daemon
change, so #25 is intentionally **not** auto-closed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)