### PR TITLE
fix(agent): Claude models resolve to standard context + nicer picker (#25 Bug 2)

### DIFF
--- a/lemma-backend/app/modules/agent/api/controllers/runtime_config_controller.py
+++ b/lemma-backend/app/modules/agent/api/controllers/runtime_config_controller.py
@@ -26,7 +26,11 @@ from app.modules.agent.api.schemas import (
 )
 from app.modules.agent.agent_runtime_defaults import AgentRuntimeDefaultService
 from app.modules.agent.domain.value_objects import HarnessKind
-from app.modules.agent.domain.runtime_profiles import AgentRuntimeProfile
+from app.modules.agent.domain.runtime_profiles import (
+    AgentRuntimeProfile,
+    RuntimeModelCapability,
+    RuntimeModelCatalogEntry,
+)
 from app.modules.agent.infrastructure.daemon_hub import agent_runtime_daemon_hub
 from app.modules.agent.infrastructure.repositories import (
     AgentRuntimeDaemonRepository,
@@ -378,6 +382,9 @@ def _harness_infos_from_daemons(daemons: list[object]) -> list[AgentHarnessInfo]
                 for item in raw_models
                 if available and str(item).strip()
             ]
+            model_catalog = (
+                _harness_model_catalog(raw_info) if available else []
+            )
             items.append(
                 AgentHarnessInfo(
                     harness_kind=harness_kind,
@@ -386,6 +393,7 @@ def _harness_infos_from_daemons(daemons: list[object]) -> list[AgentHarnessInfo]
                         or f"{harness_kind.value} on {daemon.display_name}"
                     ),
                     models=models,
+                    model_catalog=model_catalog,
                     available=available,
                     availability_status="READY" if available else "NOT_INSTALLED",
                     daemon_id=daemon.id,
@@ -394,3 +402,47 @@ def _harness_infos_from_daemons(daemons: list[object]) -> list[AgentHarnessInfo]
                 )
             )
     return items
+
+
+def _harness_model_catalog(raw_info: dict) -> list[RuntimeModelCatalogEntry]:
+    """Structured model entries for a detected harness.
+
+    Uses the daemon's ``model_catalog`` (display name + provider model id +
+    metadata) when present, falling back to the flat ``models`` aliases for
+    daemons that predate the structured catalog.
+    """
+    capabilities = [RuntimeModelCapability.TEXT, RuntimeModelCapability.TOOLS]
+    raw_catalog = raw_info.get("model_catalog")
+    entries: list[RuntimeModelCatalogEntry] = []
+    if isinstance(raw_catalog, list):
+        for item in raw_catalog:
+            if not isinstance(item, dict):
+                continue
+            name = str(item.get("name") or "").strip()
+            if not name:
+                continue
+            provider_model_name = str(item.get("provider_model_name") or name).strip() or name
+            display_name = str(item.get("display_name") or "").strip() or name
+            metadata = item.get("metadata")
+            entries.append(
+                RuntimeModelCatalogEntry(
+                    name=name,
+                    display_name=display_name,
+                    provider_model_name=provider_model_name,
+                    capabilities=capabilities,
+                    metadata=metadata if isinstance(metadata, dict) else {},
+                )
+            )
+    if entries:
+        return entries
+    # Back-compat: build plain entries from the flat models list.
+    return [
+        RuntimeModelCatalogEntry(
+            name=str(model).strip(),
+            display_name=str(model).strip(),
+            provider_model_name=str(model).strip(),
+            capabilities=capabilities,
+        )
+        for model in (raw_info.get("models") or [])
+        if str(model).strip()
+    ]

--- a/lemma-backend/app/modules/agent/api/schemas.py
+++ b/lemma-backend/app/modules/agent/api/schemas.py
@@ -247,6 +247,10 @@ class AgentHarnessInfo(BaseModel):
     harness_kind: HarnessKind
     display_name: str
     models: list[str] = Field(default_factory=list)
+    # Structured model entries (display name, provider model id, context
+    # metadata) so the picker can advertise detected models nicely — not just
+    # the flat ``models`` aliases.
+    model_catalog: list[RuntimeModelCatalogEntry] = Field(default_factory=list)
     available: bool = True
     availability_status: str | None = None
     daemon_id: UUID | None = None

--- a/lemma-backend/app/modules/agent/services/runtime_profile_service.py
+++ b/lemma-backend/app/modules/agent/services/runtime_profile_service.py
@@ -9,6 +9,7 @@ import socket
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 from uuid import UUID, uuid4
 
@@ -258,15 +259,16 @@ class AgentRuntimeProfileService:
         if daemon is None:
             raise ValueError("Daemon is not available for the current user")
 
-        detected_models = _daemon_harness_model_names(
+        detected_catalog = _daemon_harness_model_catalog(
             harness_catalog=getattr(daemon, "harness_catalog", {}) or {},
             harness_kind=harness_kind,
         )
-        if detected_models is None:
+        if detected_catalog is None:
             raise ValueError(
                 f"{harness_kind.value} is not available from daemon {daemon_id}"
             )
-        model_names = _user_daemon_model_names(detected_models)
+        model_catalog = _user_daemon_model_catalog(detected_catalog)
+        model_names = [entry.name for entry in model_catalog]
         selected_default_model = _select_user_daemon_default_model(
             requested_model_name=default_model_name,
             model_names=model_names,
@@ -282,18 +284,7 @@ class AgentRuntimeProfileService:
             name=normalized_name,
             description=description.strip() if description else None,
             default_model_name=selected_default_model,
-            model_catalog=[
-                RuntimeModelCatalogEntry(
-                    name=model_name,
-                    display_name=model_name,
-                    provider_model_name=model_name,
-                    capabilities=[
-                        RuntimeModelCapability.TEXT,
-                        RuntimeModelCapability.TOOLS,
-                    ],
-                )
-                for model_name in model_names
-            ],
+            model_catalog=model_catalog,
             config={},
             status=RuntimeProfileStatus.ACTIVE,
             metadata={
@@ -593,20 +584,65 @@ def _display_model_name(model_name: str) -> str:
     return model_name.replace("-", " ").replace("_", " ").title()
 
 
-def _user_daemon_model_names(detected_models: list[str]) -> list[str]:
-    model_names = ["default"]
-    for model_name in detected_models:
-        normalized = model_name.strip()
-        if normalized and normalized not in model_names:
-            model_names.append(normalized)
-    return model_names
+def _user_daemon_model_catalog(
+    detected_models: list[dict[str, Any]],
+) -> list[RuntimeModelCatalogEntry]:
+    """Build the saved profile's model catalog from the daemon's entries.
+
+    Always leads with a ``default`` entry (the account's standard-context
+    default), then carries each detected model through with its display name,
+    provider model id, and metadata so the picker can advertise them.
+    """
+    entries = [_default_daemon_model_entry()]
+    seen = {"default"}
+    for item in detected_models:
+        name = str(item.get("name") or "").strip()
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        provider_model_name = str(item.get("provider_model_name") or name).strip() or name
+        display_name = str(item.get("display_name") or "").strip() or name
+        metadata = item.get("metadata")
+        entries.append(
+            RuntimeModelCatalogEntry(
+                name=name,
+                display_name=display_name,
+                provider_model_name=provider_model_name,
+                capabilities=[
+                    RuntimeModelCapability.TEXT,
+                    RuntimeModelCapability.TOOLS,
+                ],
+                metadata=metadata if isinstance(metadata, dict) else {},
+            )
+        )
+    return entries
 
 
-def _daemon_harness_model_names(
+def _default_daemon_model_entry() -> RuntimeModelCatalogEntry:
+    return RuntimeModelCatalogEntry(
+        name="default",
+        display_name="Default",
+        provider_model_name="default",
+        capabilities=[
+            RuntimeModelCapability.TEXT,
+            RuntimeModelCapability.TOOLS,
+        ],
+        metadata={"context_window": "standard"},
+    )
+
+
+def _daemon_harness_model_catalog(
     *,
     harness_catalog: object,
     harness_kind: HarnessKind,
-) -> list[str] | None:
+) -> list[dict[str, Any]] | None:
+    """Structured model entries reported by the daemon for a harness.
+
+    Prefers the daemon's ``model_catalog`` (name/display_name/
+    provider_model_name/metadata); falls back to the flat ``models`` string
+    list for daemons that predate the structured catalog. Returns ``None`` when
+    the harness is unavailable.
+    """
     if not isinstance(harness_catalog, dict):
         return None
     entry = harness_catalog.get(harness_kind.value)
@@ -614,10 +650,29 @@ def _daemon_harness_model_names(
         return None
     if entry.get("available") is False:
         return None
+    raw_catalog = entry.get("model_catalog")
+    if isinstance(raw_catalog, list):
+        structured = [
+            item
+            for item in raw_catalog
+            if isinstance(item, dict) and str(item.get("name") or "").strip()
+        ]
+        if structured:
+            return structured
+    # Back-compat: older daemons only report a flat ``models`` list of strings.
     raw_models = entry.get("models")
     if not isinstance(raw_models, list):
         return []
-    return [model for model in raw_models if isinstance(model, str)]
+    return [
+        {
+            "name": model,
+            "display_name": model,
+            "provider_model_name": model,
+            "metadata": {},
+        }
+        for model in raw_models
+        if isinstance(model, str) and model.strip()
+    ]
 
 
 def _select_user_daemon_default_model(

--- a/lemma-backend/app/modules/agent/tests/unit/test_runtime_config_service.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_runtime_config_service.py
@@ -572,6 +572,70 @@ async def test_create_user_daemon_profile_from_catalog():
 
 
 @pytest.mark.asyncio
+async def test_create_user_daemon_profile_maps_claude_standard_context_models():
+    org_id = uuid4()
+    user_id = uuid4()
+    daemon_id = uuid4()
+    repo = _ProfileRepository([])
+    daemon_repo = _DaemonRepository(
+        [
+            SimpleNamespace(
+                id=daemon_id,
+                user_id=user_id,
+                harness_catalog={
+                    "CLAUDE_CODE": {
+                        "available": True,
+                        "models": ["sonnet", "opus"],
+                        "model_catalog": [
+                            {
+                                "name": "sonnet",
+                                "display_name": "Claude Sonnet 4.6",
+                                "provider_model_name": "claude-sonnet-4-6",
+                                "metadata": {"context_window": "standard"},
+                            },
+                            {
+                                "name": "opus",
+                                "display_name": "Claude Opus 4.8",
+                                "provider_model_name": "claude-opus-4-8",
+                                "metadata": {"context_window": "standard"},
+                            },
+                        ],
+                    }
+                },
+            )
+        ]
+    )
+    service = AgentRuntimeProfileService(repo, daemon_repository=daemon_repo)
+
+    profile = await service.create_user_daemon_profile(
+        organization_id=org_id,
+        user_id=user_id,
+        daemon_id=daemon_id,
+        harness_kind=HarnessKind.CLAUDE_CODE,
+        name="Claude Code daemon",
+        default_model_name="sonnet",
+    )
+
+    by_name = {entry.name: entry for entry in profile.model_catalog}
+    # Default leads the catalog; the friendly alias stays the selection name but
+    # carries the full standard-context id + advertising metadata.
+    assert profile.model_catalog[0].name == "default"
+    assert by_name["sonnet"].provider_model_name == "claude-sonnet-4-6"
+    assert by_name["sonnet"].display_name == "Claude Sonnet 4.6"
+    assert by_name["sonnet"].metadata["context_window"] == "standard"
+    assert by_name["opus"].provider_model_name == "claude-opus-4-8"
+
+    # Resolving the alias hands the harness the standard-context id, so a user
+    # without usage credits never hits the 1M-context failure.
+    resolved = await service.resolve(
+        runtime=AgentRuntimeConfig(profile_id=profile.id, model_name="sonnet"),
+        organization_id=org_id,
+        user_id=user_id,
+    )
+    assert resolved.model_name_for_harness == "claude-sonnet-4-6"
+
+
+@pytest.mark.asyncio
 async def test_create_user_daemon_profile_rejects_unavailable_harness():
     user_id = uuid4()
     daemon_id = uuid4()

--- a/lemma-cli/lemma_cli/cli_core/commands/daemon.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/daemon.py
@@ -59,9 +59,13 @@ from lemma_cli.daemon.config import (
 # ── Catalog ───────────────────────────────────────────────────────────────────
 from lemma_cli.daemon.catalog import (
     HARNESS_BINARIES,
+    CLAUDE_CODE_MODEL_CATALOG,
+    CLAUDE_CODE_STANDARD_MODEL_BY_ALIAS,
     discover_harness_catalog,
     discover_harness,
     discover_harness_models,
+    discover_harness_model_entries,
+    normalize_provider_model_name,
     configured_harness_models,
     binary_version,
     run_catalog_command,
@@ -158,9 +162,13 @@ __all__ = [
     "clear_daemon_status",
     # catalog
     "HARNESS_BINARIES",
+    "CLAUDE_CODE_MODEL_CATALOG",
+    "CLAUDE_CODE_STANDARD_MODEL_BY_ALIAS",
     "discover_harness_catalog",
     "discover_harness",
     "discover_harness_models",
+    "discover_harness_model_entries",
+    "normalize_provider_model_name",
     "configured_harness_models",
     "binary_version",
     "run_catalog_command",

--- a/lemma-cli/lemma_cli/daemon/catalog.py
+++ b/lemma-cli/lemma_cli/daemon/catalog.py
@@ -12,6 +12,39 @@ HARNESS_BINARIES = {
     "OPENCODE": "opencode",
 }
 
+# Claude Code's bare ``sonnet``/``opus`` aliases resolve to the *latest* model,
+# which currently defaults to the 1M-context beta variant. That variant requires
+# usage-based billing credits, so a user on a plain Pro/Max plan who picks
+# "sonnet" gets a hard "Usage credits required for 1M context" failure on their
+# first message. We instead advertise the full, standard-context model ids so
+# the default path never opts into the paid 1M window.
+#
+# ``provider_model_name`` is what we hand to ``claude --model``; ``name`` stays
+# the friendly alias so it remains a stable selection key and existing saved
+# profiles keep working. Update these ids when Claude Code ships a newer model
+# (the alias->id mapping is the one spot that drifts with the CLI version).
+CLAUDE_CODE_MODEL_CATALOG: tuple[dict[str, Any], ...] = (
+    {
+        "name": "sonnet",
+        "display_name": "Claude Sonnet 4.6",
+        "provider_model_name": "claude-sonnet-4-6",
+        "metadata": {"alias": "sonnet", "context_window": "standard"},
+    },
+    {
+        "name": "opus",
+        "display_name": "Claude Opus 4.8",
+        "provider_model_name": "claude-opus-4-8",
+        "metadata": {"alias": "opus", "context_window": "standard"},
+    },
+)
+
+# Bare alias -> standard-context model id, used to rewrite ``--model`` for
+# already-saved profiles (and any caller) that still send the raw alias.
+CLAUDE_CODE_STANDARD_MODEL_BY_ALIAS: dict[str, str] = {
+    str(entry["name"]): str(entry["provider_model_name"])
+    for entry in CLAUDE_CODE_MODEL_CATALOG
+}
+
 
 def discover_harness_catalog() -> dict[str, dict[str, Any]]:
     return {
@@ -24,13 +57,17 @@ def discover_harness(harness_kind: str, binary: str) -> dict[str, Any]:
     path = shutil.which(binary)
     if path is None:
         return {"available": False, "binary": binary, "models": []}
-    models, model_discovery_error = discover_harness_models(harness_kind, binary)
+    model_catalog, model_discovery_error = discover_harness_model_entries(harness_kind, binary)
     payload: dict[str, Any] = {
         "available": True,
         "binary": binary,
         "path": path,
         "version": binary_version(binary),
-        "models": models,
+        # Flat list kept for backward compatibility with older readers.
+        "models": [str(entry["name"]) for entry in model_catalog],
+        # Structured entries carry display names, the provider model id we hand
+        # to the harness, and metadata (context window, etc.) for the picker.
+        "model_catalog": model_catalog,
         "display_name": harness_kind.replace("_", " ").title(),
     }
     if model_discovery_error:
@@ -38,20 +75,58 @@ def discover_harness(harness_kind: str, binary: str) -> dict[str, Any]:
     return payload
 
 
-def discover_harness_models(harness_kind: str, binary: str) -> tuple[list[str], str | None]:
+def discover_harness_model_entries(
+    harness_kind: str, binary: str
+) -> tuple[list[dict[str, Any]], str | None]:
+    """Structured model catalog for a harness.
+
+    Each entry is ``{name, display_name, provider_model_name, metadata}``.
+    ``name`` is the user-facing/selection key; ``provider_model_name`` is what
+    gets passed to the harness CLI. For most harnesses these are identical, but
+    Claude Code maps friendly aliases to full standard-context model ids.
+    """
     configured = configured_harness_models(harness_kind)
     if configured is not None:
-        return configured, None
+        return [_plain_model_entry(name) for name in configured], None
     try:
         if harness_kind == "CODEX":
-            return discover_codex_models(binary), None
+            return [_plain_model_entry(name) for name in discover_codex_models(binary)], None
         if harness_kind == "OPENCODE":
-            return discover_opencode_models(binary), None
+            return [_plain_model_entry(name) for name in discover_opencode_models(binary)], None
         if harness_kind == "CLAUDE_CODE":
-            return discover_claude_code_models(binary), None
+            return discover_claude_code_model_entries(binary), None
     except Exception as exc:  # noqa: BLE001
         return [], str(exc)
     return [], None
+
+
+def discover_harness_models(harness_kind: str, binary: str) -> tuple[list[str], str | None]:
+    entries, error = discover_harness_model_entries(harness_kind, binary)
+    return [str(entry["name"]) for entry in entries], error
+
+
+def _plain_model_entry(name: str) -> dict[str, Any]:
+    """A catalog entry whose selection name and provider id are the same."""
+    return {
+        "name": name,
+        "display_name": name,
+        "provider_model_name": name,
+        "metadata": {},
+    }
+
+
+def normalize_provider_model_name(harness_kind: str, model_name: str) -> str:
+    """Rewrite a model name to the string we actually hand the harness CLI.
+
+    For Claude Code this maps the bare ``sonnet``/``opus`` aliases to their
+    full standard-context model ids, so callers that send the raw alias (e.g.
+    profiles saved before this change) don't fall into the paid 1M-context
+    variant. Unknown names (full ids, ``default``, other harnesses) pass
+    through unchanged.
+    """
+    if harness_kind == "CLAUDE_CODE":
+        return CLAUDE_CODE_STANDARD_MODEL_BY_ALIAS.get(model_name.strip(), model_name)
+    return model_name
 
 
 def configured_harness_models(harness_kind: str) -> list[str] | None:
@@ -96,15 +171,29 @@ def discover_opencode_models(binary: str) -> list[str]:
     return _opencode_models_from_text(text)
 
 
-def discover_claude_code_models(binary: str) -> list[str]:
+def discover_claude_code_model_entries(binary: str) -> list[dict[str, Any]]:
     completed = run_catalog_command([binary, "--help"])
     text = f"{completed.stdout}\n{completed.stderr}"
-    aliases = [
-        model
-        for model in ("sonnet", "opus")
-        if f"'{model}'" in text or f'"{model}"' in text or f" {model}" in text
+    entries = [
+        _copy_model_entry(entry)
+        for entry in CLAUDE_CODE_MODEL_CATALOG
+        if _claude_alias_advertised(str(entry["name"]), text)
     ]
-    return aliases or ["sonnet", "opus"]
+    return entries or [_copy_model_entry(entry) for entry in CLAUDE_CODE_MODEL_CATALOG]
+
+
+def _claude_alias_advertised(alias: str, help_text: str) -> bool:
+    return (
+        f"'{alias}'" in help_text
+        or f'"{alias}"' in help_text
+        or f" {alias}" in help_text
+    )
+
+
+def _copy_model_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    copied = dict(entry)
+    copied["metadata"] = dict(entry.get("metadata") or {})
+    return copied
 
 
 def run_catalog_command(command: list[str]) -> subprocess.CompletedProcess[str]:

--- a/lemma-cli/lemma_cli/daemon/mcp.py
+++ b/lemma-cli/lemma_cli/daemon/mcp.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
+from .catalog import normalize_provider_model_name
+
 
 LEMMA_MCP_SERVER_NAME = "lemma_tools"
 LEMMA_MCP_TOKEN_ENV = "LEMMA_MCP_TOKEN"
@@ -74,6 +76,10 @@ def provider_command(
 ) -> list[str]:
     template = provider_command_template(harness_kind)
     mcp_config_args = provider_mcp_command_args(harness_kind=harness_kind, mcp=mcp)
+    # Rewrite bare aliases (e.g. Claude Code's "sonnet") to the standard-context
+    # model id before they reach the CLI, so profiles saved with the raw alias
+    # don't opt into the paid 1M-context variant.
+    model_name = normalize_provider_model_name(harness_kind, model_name)
     values = {
         "model": shlex.quote(model_name),
         "prompt": shlex.quote(prompt_text),

--- a/lemma-cli/tests/test_daemon_cli.py
+++ b/lemma-cli/tests/test_daemon_cli.py
@@ -1581,6 +1581,17 @@ def test_discover_harness_catalog_uses_real_cli_model_commands(monkeypatch, tmp_
         "anthropic/claude-sonnet-4-5",
     ]
     assert catalog["CLAUDE_CODE"]["models"] == ["sonnet", "opus"]
+    # Claude Code aliases are advertised with full standard-context model ids so
+    # the default path never opts into the paid 1M-context variant.
+    claude_catalog = catalog["CLAUDE_CODE"]["model_catalog"]
+    by_name = {entry["name"]: entry for entry in claude_catalog}
+    assert by_name["sonnet"]["provider_model_name"] == "claude-sonnet-4-6"
+    assert by_name["sonnet"]["display_name"] == "Claude Sonnet 4.6"
+    assert by_name["sonnet"]["metadata"]["context_window"] == "standard"
+    assert by_name["opus"]["provider_model_name"] == "claude-opus-4-8"
+    # Other harnesses keep selection name == provider model name.
+    codex_catalog = {entry["name"]: entry for entry in catalog["CODEX"]["model_catalog"]}
+    assert codex_catalog["gpt-5.5"]["provider_model_name"] == "gpt-5.5"
 
 
 def test_discover_harness_models_allows_explicit_override(monkeypatch):
@@ -1590,6 +1601,30 @@ def test_discover_harness_models_allows_explicit_override(monkeypatch):
         ["gpt-5.5", "gpt-5.4"],
         None,
     )
+
+
+def test_normalize_provider_model_name_maps_claude_aliases():
+    # Bare aliases resolve to standard-context full ids.
+    assert daemon.normalize_provider_model_name("CLAUDE_CODE", "sonnet") == "claude-sonnet-4-6"
+    assert daemon.normalize_provider_model_name("CLAUDE_CODE", " opus ") == "claude-opus-4-8"
+    # Full ids, "default", and unknown names pass through untouched.
+    assert daemon.normalize_provider_model_name("CLAUDE_CODE", "claude-sonnet-4-6") == "claude-sonnet-4-6"
+    assert daemon.normalize_provider_model_name("CLAUDE_CODE", "default") == "default"
+    # Aliases only get rewritten for Claude Code, not other harnesses.
+    assert daemon.normalize_provider_model_name("OPENCODE", "sonnet") == "sonnet"
+
+
+def test_claude_command_normalizes_alias_to_standard_context_model():
+    command = daemon.provider_command(
+        harness_kind="CLAUDE_CODE",
+        model_name="sonnet",
+        prompt_text="hello",
+        mcp={},
+    )
+
+    assert "--model" in command
+    assert command[command.index("--model") + 1] == "claude-sonnet-4-6"
+    assert "sonnet" not in command
 
 
 def _write_executable(path, content: str) -> None:

--- a/lemma-frontend/components/agents/agent-runtime-helpers.ts
+++ b/lemma-frontend/components/agents/agent-runtime-helpers.ts
@@ -149,6 +149,23 @@ export function formatAgentRuntime(
     return includeModel && modelName ? `${prefix} · ${shortModelName(modelName)}` : prefix;
 }
 
+// A short advisory drawn from a model's catalog metadata — e.g. a credits
+// requirement or a non-standard context window. Returns null for plain
+// standard-context models so the picker stays uncluttered.
+export function modelAdvisory(model: Pick<RuntimeModelCatalogEntry, 'metadata'>): string | null {
+    const metadata = (model.metadata ?? {}) as Record<string, unknown>;
+    if (metadata.requires_credits) return 'Requires usage credits';
+    const note = typeof metadata.note === 'string' ? metadata.note.trim() : '';
+    if (note) return note;
+    const contextWindow = typeof metadata.context_window === 'string'
+        ? metadata.context_window.trim()
+        : '';
+    if (contextWindow && contextWindow.toLowerCase() !== 'standard') {
+        return `${contextWindow} context`;
+    }
+    return null;
+}
+
 export function shortModelName(modelName: string): string {
     const normalized = modelName.replace(/\/$/, '');
     const markerMatch = normalized.match(/\/(?:models|routers)\/([^/]+)$/);
@@ -171,6 +188,11 @@ export function harnessLogo(harnessKind?: HarnessKind): string | undefined {
 }
 
 export function harnessModelOptions(harness: AgentHarnessInfo): RuntimeModelOption[] {
+    // Prefer the structured catalog (nice display names + context metadata);
+    // fall back to the flat model aliases for older daemons.
+    if (harness.model_catalog && harness.model_catalog.length > 0) {
+        return harness.model_catalog as RuntimeModelOption[];
+    }
     return (harness.models ?? []).map((modelName) => ({
         name: modelName,
         display_name: null,

--- a/lemma-frontend/components/agents/agent-runtime-rows.tsx
+++ b/lemma-frontend/components/agents/agent-runtime-rows.tsx
@@ -139,12 +139,14 @@ export function HarnessChoiceRow({
 export function RuntimeChoiceRow({
     title,
     subtitle,
+    trailing,
     selected,
     disabled = false,
     onClick,
 }: {
     title: string;
     subtitle?: string | null;
+    trailing?: ReactNode;
     selected: boolean;
     disabled?: boolean;
     onClick: () => void;
@@ -165,6 +167,7 @@ export function RuntimeChoiceRow({
                     <span className="block truncate font-mono text-xs leading-4 text-[var(--text-tertiary)]">{subtitle}</span>
                 ) : null}
             </span>
+            {trailing ? <span className="shrink-0">{trailing}</span> : null}
             <span
                 className={cn(
                     'flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border',

--- a/lemma-frontend/components/agents/agent-runtime-views.tsx
+++ b/lemma-frontend/components/agents/agent-runtime-views.tsx
@@ -16,6 +16,7 @@ import { cn } from '@/lib/utils';
 import {
     availableHarnessKey,
     harnessLogo,
+    modelAdvisory,
     modelPathHint,
     runtimeAvailabilityLabel,
     runtimeKey,
@@ -198,12 +199,18 @@ export function AvailableHarnessDetail({
                     <Label className="text-[var(--text-secondary)]">Default model</Label>
                     <div className="space-y-1">
                         {(harness.models ?? []).map((model) => {
-                            const hint = modelPathHint(model.provider_model_name ?? model.name);
+                            const hint = model.display_name && model.display_name !== model.name
+                                ? model.name
+                                : modelPathHint(model.provider_model_name ?? model.name);
+                            const advisory = modelAdvisory(model);
                             return (
                                 <RuntimeChoiceRow
                                     key={`${harness.harness_kind}-${model.name}`}
                                     title={model.display_name ?? shortModelName(model.name)}
                                     subtitle={hint}
+                                    trailing={advisory ? (
+                                        <span className="chip chip-sm chip-pill chip-muted">{advisory}</span>
+                                    ) : null}
                                     selected={activeModelName === model.name}
                                     disabled={isPending}
                                     onClick={() => onSelectModel(model.name)}
@@ -267,11 +274,15 @@ export function HarnessModelList({
                 const hint = model.display_name && model.display_name !== model.name
                     ? model.name
                     : modelPathHint(model.provider_model_name ?? modelName);
+                const advisory = modelAdvisory(model);
                 return (
                     <RuntimeChoiceRow
                         key={runtimeKey(runtime)}
                         title={model.display_name ?? shortModelName(modelName)}
                         subtitle={hint}
+                        trailing={advisory ? (
+                            <span className="chip chip-sm chip-pill chip-muted">{advisory}</span>
+                        ) : null}
                         selected={pendingKey === runtimeKey(runtime)}
                         onClick={() => onSelectRuntime(runtime)}
                     />

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -13,4 +13,4 @@ SDK and the server it is talking to.
 from __future__ import annotations
 
 API_VERSION = "3.1.0"
-SPEC_SHA256 = "7b9d508218a764962537b7a1622257d9e1da682e4069b65db543edf89073b4c3"
+SPEC_SHA256 = "fabd0acfbf1cf04a482a7c4b2663500e69fdb66213bf6997fc3a0d0fbe2b781f"

--- a/lemma-python/lemma_sdk/openapi_client/models/agent_harness_info.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/agent_harness_info.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 from uuid import UUID
 
 from attrs import define as _attrs_define
@@ -9,6 +9,10 @@ from attrs import field as _attrs_field
 
 from ..models.harness_kind import HarnessKind
 from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.runtime_model_catalog_entry import RuntimeModelCatalogEntry
+
 
 T = TypeVar("T", bound="AgentHarnessInfo")
 
@@ -24,6 +28,7 @@ class AgentHarnessInfo:
         daemon_display_name (None | str | Unset):
         daemon_id (None | Unset | UUID):
         daemon_status (None | str | Unset):
+        model_catalog (list[RuntimeModelCatalogEntry] | Unset):
         models (list[str] | Unset):
     """
 
@@ -34,6 +39,7 @@ class AgentHarnessInfo:
     daemon_display_name: None | str | Unset = UNSET
     daemon_id: None | Unset | UUID = UNSET
     daemon_status: None | str | Unset = UNSET
+    model_catalog: list[RuntimeModelCatalogEntry] | Unset = UNSET
     models: list[str] | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -70,6 +76,13 @@ class AgentHarnessInfo:
         else:
             daemon_status = self.daemon_status
 
+        model_catalog: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.model_catalog, Unset):
+            model_catalog = []
+            for model_catalog_item_data in self.model_catalog:
+                model_catalog_item = model_catalog_item_data.to_dict()
+                model_catalog.append(model_catalog_item)
+
         models: list[str] | Unset = UNSET
         if not isinstance(self.models, Unset):
             models = self.models
@@ -92,6 +105,8 @@ class AgentHarnessInfo:
             field_dict["daemon_id"] = daemon_id
         if daemon_status is not UNSET:
             field_dict["daemon_status"] = daemon_status
+        if model_catalog is not UNSET:
+            field_dict["model_catalog"] = model_catalog
         if models is not UNSET:
             field_dict["models"] = models
 
@@ -99,6 +114,8 @@ class AgentHarnessInfo:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.runtime_model_catalog_entry import RuntimeModelCatalogEntry
+
         d = dict(src_dict)
         display_name = d.pop("display_name")
 
@@ -154,6 +171,17 @@ class AgentHarnessInfo:
 
         daemon_status = _parse_daemon_status(d.pop("daemon_status", UNSET))
 
+        _model_catalog = d.pop("model_catalog", UNSET)
+        model_catalog: list[RuntimeModelCatalogEntry] | Unset = UNSET
+        if _model_catalog is not UNSET:
+            model_catalog = []
+            for model_catalog_item_data in _model_catalog:
+                model_catalog_item = RuntimeModelCatalogEntry.from_dict(
+                    model_catalog_item_data
+                )
+
+                model_catalog.append(model_catalog_item)
+
         models = cast(list[str], d.pop("models", UNSET))
 
         agent_harness_info = cls(
@@ -164,6 +192,7 @@ class AgentHarnessInfo:
             daemon_display_name=daemon_display_name,
             daemon_id=daemon_id,
             daemon_status=daemon_status,
+            model_catalog=model_catalog,
             models=models,
         )
 

--- a/lemma-python/lemma_sdk/openapi_spec.json
+++ b/lemma-python/lemma_sdk/openapi_spec.json
@@ -619,6 +619,13 @@
           "harness_kind": {
             "$ref": "#/components/schemas/HarnessKind"
           },
+          "model_catalog": {
+            "items": {
+              "$ref": "#/components/schemas/RuntimeModelCatalogEntry"
+            },
+            "title": "Model Catalog",
+            "type": "array"
+          },
           "models": {
             "items": {
               "type": "string"

--- a/lemma-typescript/src/openapi_client/models/AgentHarnessInfo.ts
+++ b/lemma-typescript/src/openapi_client/models/AgentHarnessInfo.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 import type { HarnessKind } from './HarnessKind.js';
+import type { RuntimeModelCatalogEntry } from './RuntimeModelCatalogEntry.js';
 export type AgentHarnessInfo = {
     availability_status?: (string | null);
     available?: boolean;
@@ -11,6 +12,7 @@ export type AgentHarnessInfo = {
     daemon_status?: (string | null);
     display_name: string;
     harness_kind: HarnessKind;
+    model_catalog?: Array<RuntimeModelCatalogEntry>;
     models?: Array<string>;
 };
 


### PR DESCRIPTION
## What & why

Closes the second half of #25. Picking **sonnet** in the model picker sent the bare alias to `claude --model sonnet`, which resolves to the **1M-context beta** and hard-fails for any user without usage credits:

> API Error: Usage credits required for 1M context

Root cause: the model-catalog seam collapsed `name` / `display_name` / `provider_model_name` to the same bare alias with empty metadata, so the daemon was handed `--model sonnet`.

## Changes

**Daemon (`lemma-cli`)**
- Emit a structured `model_catalog` (`name` / `display_name` / `provider_model_name` / `metadata`) alongside the flat `models` list (back-compat preserved).
- Curated Claude entries use **standard-context full ids** — `sonnet → claude-sonnet-4-6`, `opus → claude-opus-4-8` (verified against the installed binary's own model strings).
- `normalize_provider_model_name` rewrites bare aliases → standard ids before `--model`, so **already-saved** profiles can't hit the 1M error either (safety net).

**Backend**
- `create_user_daemon_profile` builds `RuntimeModelCatalogEntry` from the daemon's structured catalog (display name + provider id + metadata) instead of collapsing fields.
- `AgentHarnessInfo` gains `model_catalog` so the *detected-harness* picker can advertise nicely too (flat-list fallback for older daemons).

**Frontend**
- Picker shows `display_name` + a context/credits advisory for both detected harnesses and saved runtimes.

Standard context is the default; **nothing opts into the paid 1M variant**.

## Tests
- `lemma-cli`: structured catalog output + alias→standard normalization + `provider_command` rewrite.
- `lemma-backend`: catalog mapping + end-to-end resolution (`sonnet` resolves to `claude-sonnet-4-6`).
- Full suites green; frontend typecheck + eslint clean.

## Notes
- Bug 1 of #25 (stale `--disallowedTools` names) is handled separately in #41.
- The one SDK line (`AgentHarnessInfo.model_catalog`) is the only generated-client change; a separate regen surfaced unrelated stale endpoints (Scheduler/Webhooks) which were deliberately excluded — that staleness is its own follow-up.
- A `1M`-context opt-in entry was intentionally **not** added (Claude's deliberate-1M syntax isn't confirmed); the catalog is structured so adding variants later is a one-line data change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)