### PR TITLE
fix(agent/mcp): inline $defs/$ref in MCP tool schemas for daemon harnesses

### DIFF
--- a/lemma-backend/app/modules/agent/services/conversation_mcp_service.py
+++ b/lemma-backend/app/modules/agent/services/conversation_mcp_service.py
@@ -30,6 +30,7 @@ from app.modules.agent.infrastructure.repositories import (
     AgentRepository,
     ConversationRepository,
 )
+from app.modules.agent.tools.callable_tool_factory import inline_tool_schema_refs
 from app.modules.agent.tools.context import BaseAgentContext
 from app.modules.agent.tools.dispatcher import AgentToolDispatcher
 from app.modules.agent.tools.tool_errors import (
@@ -84,7 +85,7 @@ class ConversationMCPService:
             Tool(
                 name=exported_tool_name(tool.name),
                 description=tool.description,
-                inputSchema=dict(tool.input_schema),
+                inputSchema=inline_tool_schema_refs(tool.input_schema),
                 _meta={
                     "lemma_tool_name": tool.name,
                     **(

--- a/lemma-backend/app/modules/agent/services/pod_mcp_service.py
+++ b/lemma-backend/app/modules/agent/services/pod_mcp_service.py
@@ -31,6 +31,7 @@ from app.modules.agent.infrastructure.mcp import (
     exported_tool_name,
     normalize_local_mcp_tool_name,
 )
+from app.modules.agent.tools.callable_tool_factory import inline_tool_schema_refs
 from app.modules.agent.tools.context import BaseAgentContext
 from app.modules.agent.tools.dispatcher import AgentToolDispatcher
 from app.modules.agent.tools.pod.pydantic_adapter import pod_toolset
@@ -60,7 +61,7 @@ class PodMCPService:
             Tool(
                 name=exported_tool_name(tool.name),
                 description=tool.description,
-                inputSchema=dict(tool.input_schema),
+                inputSchema=inline_tool_schema_refs(tool.input_schema),
                 _meta={"lemma_tool_name": tool.name},
             )
             for tool in tools

--- a/lemma-backend/app/modules/agent/tests/unit/test_tool_schema_compat.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_tool_schema_compat.py
@@ -207,3 +207,25 @@ def test_final_answer_tool_schema_clean_with_output_schema():
     )
     tool = Tool(get_final_answer_tool(agent), takes_ctx=True)
     assert not _typeless_default_nodes(tool.function_schema.json_schema)
+
+
+def test_inline_tool_schema_refs_removes_defs_and_refs():
+    from app.modules.agent.tools.callable_tool_factory import inline_tool_schema_refs
+
+    # MCP tool schemas are served to daemon harnesses (OpenCode/Cursor/...) whose
+    # providers (e.g. Fireworks GLM) can't resolve $ref server-side, so they must
+    # ship fully inlined. RecordFilter is flat (field/op/value), so it inlines.
+    schema = {
+        "type": "object",
+        "properties": {"filters": {"type": "array", "items": {"$ref": "#/$defs/RecordFilter"}}},
+        "$defs": {
+            "RecordFilter": {
+                "type": "object",
+                "properties": {"field": {"type": "string"}, "op": {"$ref": "#/$defs/Op"}},
+            },
+            "Op": {"enum": ["eq", "ne"]},
+        },
+    }
+    inlined = inline_tool_schema_refs(schema)
+    assert not _unresolved_refs(inlined), _unresolved_refs(inlined)
+    assert "$defs" not in inlined

--- a/lemma-backend/app/modules/agent/tools/callable_tool_factory.py
+++ b/lemma-backend/app/modules/agent/tools/callable_tool_factory.py
@@ -59,6 +59,25 @@ def _inline_schema(schema: dict[str, Any]) -> dict[str, Any]:
     return InlineDefsJsonSchemaTransformer(schema, strict=False).walk()
 
 
+def inline_tool_schema_refs(schema: dict[str, Any]) -> dict[str, Any]:
+    """Inline non-recursive ``$defs``/``$ref`` in a tool's input schema.
+
+    OpenAI-compatible providers (notably Fireworks' GLM) can't resolve
+    ``$ref`` -> ``#/$defs/...`` server-side and reject the request with
+    ``Error resolving schema reference ... AttributeError("'NoneType' ... lookup")``.
+    The pydantic-ai model path already inlines refs via a model profile, but tool
+    schemas served over MCP to daemon harnesses (Claude Code, Cursor, OpenCode,
+    ...) were passed through raw. Inline them here too. Best-effort: a schema the
+    transformer can't process falls back to the original.
+    """
+    if not isinstance(schema, dict):
+        return schema
+    try:
+        return InlineDefsJsonSchemaTransformer(dict(schema), strict=False).walk()
+    except Exception:  # noqa: BLE001 -- never break tool listing over a schema quirk
+        return dict(schema)
+
+
 # Plain agents (no input_schema) are exposed as a single-string-input tool.
 _SINGLE_INPUT_FIELD = "input"
 


### PR DESCRIPTION
## What & why

Daemon-harness runs (OpenCode, Cursor, …) using an OpenAI-compatible provider that can't resolve `$ref` server-side — notably **Fireworks GLM**, the default OpenCode model — failed with:

```
RuntimeError: OpenCode error: Error resolving schema reference '#/$defs/RecordFilter':
AttributeError("'NoneType' object has no attribute 'lookup'")
```

**Root cause:** the MCP services served tool schemas **raw** (`inputSchema=dict(tool.input_schema)`), keeping pydantic's `$defs`/`$ref`. The in-process pydantic-ai model path already inlines refs via a model profile ([openai_schema_compat.py](app/modules/agent/services/openai_schema_compat.py)), but the MCP/daemon path didn't — so any tool whose args include a pydantic model/enum (e.g. the datastore query tool's `RecordFilter`, `display_resource`'s `DisplayResourceType`) broke on those providers.

## Fix

- Add `inline_tool_schema_refs` (best-effort `InlineDefsJsonSchemaTransformer`, falls back to the original schema on any quirk).
- Apply it in `pod_mcp_service.list_tools` and `conversation_mcp_service.list_tools` so daemon harnesses receive fully-inlined, provider-agnostic schemas.

`RecordFilter` is flat (field/op/value), so it inlines completely. (Genuinely recursive schemas keep a minimal `$defs`/`$ref` per the transformer's contract — unchanged.)

## Tests
- New regression test asserts `inline_tool_schema_refs` removes `$defs`/`$ref`.
- `test_tool_schema_compat` + `test_conversation_mcp_service` green; agent unit suite 268 green.

Independent of the harness PRs; applies to all daemon harnesses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)