### PR TITLE
fix(dev): make `make init` + `make dev` work on a fresh clone

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,10 +144,6 @@ init:
 	@command -v node >/dev/null 2>&1 || (echo "  ✗ Node.js not found — install from https://nodejs.org/"; exit 1)
 	@echo "  ✓ Prerequisites OK"
 	@echo ""
-	@echo "→ Creating .env files (skipped if already present)…"
-	@$(MAKE) --no-print-directory _init-backend-env
-	@$(MAKE) --no-print-directory _init-frontend-env
-	@echo ""
 	@echo "→ Installing dependencies…"
 	@cd $(BACKEND_DIR) && uv sync --quiet
 	@cd $(CLI_DIR) && uv sync --quiet
@@ -160,6 +156,14 @@ init:
 	@echo "→ Building lemma-sdk (lemma-typescript)…"
 	@cd $(TS_DIR) && npm run build --silent
 	@echo "  ✓ lemma-sdk built — dist/ ready for frontend import"
+	@echo ""
+	@# Env files come AFTER install: _init-frontend-env runs the frontend's
+	@# gen:runtime-config, which imports @next/env from node_modules. Generating
+	@# env before `npm install` aborts a fresh-clone `make init` with
+	@# ERR_MODULE_NOT_FOUND before any dependency is installed.
+	@echo "→ Creating .env files (skipped if already present)…"
+	@$(MAKE) --no-print-directory _init-backend-env
+	@$(MAKE) --no-print-directory _init-frontend-env
 	@echo ""
 	@echo "Done. Run 'make dev' to start the stack."
 
@@ -265,10 +269,6 @@ dev:
 	@$(MAKE) --no-print-directory _ensure-init
 	@$(MAKE) --no-print-directory _infra-up
 	@$(MAKE) --no-print-directory _wait-infra
-	@$(MAKE) --no-print-directory _run-agentbox &
-	@$(MAKE) --no-print-directory _wait-agentbox
-	@$(MAKE) --no-print-directory _run-backend &
-	@$(MAKE) --no-print-directory _run-frontend &
 	@echo ""
 	@echo "  Frontend  →  $(DEV_FRONTEND_URL)"
 	@echo "  Auth UI   →  $(DEV_AUTH_FRONTEND_URL)"
@@ -278,7 +278,19 @@ dev:
 	@echo ""
 	@echo "  Tail backend logs : make logs"
 	@echo "  Press Ctrl-C or run 'make stop' to stop."
-	@wait
+	@echo ""
+	@# Launch all three dev servers and wait in ONE shell. Make runs each recipe
+	@# line in its own shell, so backgrounding with `&` on separate lines orphans
+	@# the jobs and a `wait` on the next line returns immediately (make dev would
+	@# exit while the servers kept running detached). Keeping the launches + wait
+	@# in a single backslash-joined line fixes that; the trap turns Ctrl-C into a
+	@# clean `make stop` of every server and port.
+	@trap '$(MAKE) --no-print-directory stop; exit 0' INT TERM; \
+		$(MAKE) --no-print-directory _run-agentbox & \
+		$(MAKE) --no-print-directory _wait-agentbox; \
+		$(MAKE) --no-print-directory _run-backend & \
+		$(MAKE) --no-print-directory _run-frontend & \
+		wait
 
 _ensure-init:
 	@test -f $(BACKEND_DIR)/.env  || { echo "  ! $(BACKEND_DIR)/.env missing — run 'make init'"; exit 1; }

--- a/lemma-backend/docker-compose.yml
+++ b/lemma-backend/docker-compose.yml
@@ -49,7 +49,14 @@ services:
       retries: 10
 
   kreuzberg:
-    image: ghcr.io/kreuzberg-dev/kreuzberg:4.9.9
+    # Document-extraction service (REST API: /health, /extract, /chunk). The
+    # project moved orgs (kreuzberg-dev → xberg-io), so the old
+    # ghcr.io/kreuzberg-dev/kreuzberg:4.9.9 path now denies pulls — a fresh
+    # `docker compose up` failed with "error from registry: denied" and took the
+    # whole stack down with it. This is the same 4.9.9 on the current public
+    # namespace. The -core image is smaller (~580MB) and downloads OCR models on
+    # first use into the kreuzberg_cache volume. Overridable via DEV_KREUZBERG_IMAGE.
+    image: ${DEV_KREUZBERG_IMAGE:-ghcr.io/xberg-io/kreuzberg:4.9.9-core}
     ports:
       - "${DEV_KREUZBERG_PORT:-8002}:8000"
     restart: unless-stopped


### PR DESCRIPTION
## Problem

A freshly-forked/cloned checkout could not be brought up with the documented `make init` && `make dev` flow. Three independent blockers:

1. **`make init` died before installing any dependencies.** The frontend env step runs `npm run gen:runtime-config`, whose script imports `@next/env` from `node_modules` — but init ran it **before** `npm install`. On a fresh clone this crashes with `ERR_MODULE_NOT_FOUND` right after writing the `.env` files, leaving the tree with `.env` present but no `node_modules` / `.venv` / `dist`.

2. **`docker compose up` could not pull the document-extraction image.** `ghcr.io/kreuzberg-dev/kreuzberg:4.9.9` now denies pulls (the project moved orgs: `kreuzberg-dev` → `xberg-io`). Because Compose aborts the entire `up` when any image fails, **postgres/redis/supertokens never started either** — the whole stack was down with `error from registry: denied`.

3. **`make dev` exited immediately and orphaned the servers.** Make runs each recipe line in its own shell, so backgrounding the servers with `&` on separate lines and `wait`-ing on the next line returned at once while the servers ran detached — and `Ctrl-C` did nothing.

## Fix

- **`Makefile` `init`** — install dependencies + build the SDK **before** generating env/runtime-config, so `gen:runtime-config` has `@next/env` available.
- **`docker-compose.yml` `kreuzberg`** — point at the same 4.9.9 on the current public namespace: `ghcr.io/xberg-io/kreuzberg:4.9.9-core` (smaller ~580 MB image; `/health`, `/extract`, `/chunk` all verified). Overridable via `DEV_KREUZBERG_IMAGE`.
- **`Makefile` `dev`** — launch all three servers + `wait` in a single shell so `make dev` stays attached, with a `trap` that turns `Ctrl-C` into a clean `make stop`.

## Verification

- `make init` from a wiped tree (no `node_modules` / `dist` / `.env`) → exits 0 and generates `runtime-config.js`.
- `make dev` → backend, frontend, agentbox, and kreuzberg all return **200**; stays in the foreground; tears down cleanly via both `Ctrl-C` and `make stop`.
- Kreuzberg `4.9.9-core` smoke-tested directly and under Compose: `/health` (v4.9.9), `/extract`, and `/chunk` all 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)