### PR TITLE
fix: pass app parameter in body instead of path for connect request

### DIFF
--- a/lemma-python/lemma_sdk/resources/connectors.py
+++ b/lemma-python/lemma_sdk/resources/connectors.py
@@ -270,7 +270,7 @@ class BoundConnectors(BoundResource):
         return self._call(
             connector_connect_request_create,
             self._org_uuid(),
-            body=compact({"app": app, "auth_config_id": auth_config_id}),
+            body=compact({"connector_id": app, "auth_config_id": auth_config_id}),
             body_model=ConnectRequestInitiateSchema,
         )
 

--- a/lemma-python/lemma_sdk/resources/connectors.py
+++ b/lemma-python/lemma_sdk/resources/connectors.py
@@ -270,8 +270,7 @@ class BoundConnectors(BoundResource):
         return self._call(
             connector_connect_request_create,
             self._org_uuid(),
-            app,
-            body=compact({"auth_config_id": auth_config_id}),
+            body=compact({"app": app, "auth_config_id": auth_config_id}),
             body_model=ConnectRequestInitiateSchema,
         )
 


### PR DESCRIPTION
When attempting to start an account connect request via the CLI, the command crashes with a TypeError. The app parameter is being passed as a positional argument to the underlying generated API client instead of being included in the request body.

Steps to Reproduce
Run the following CLI command (with a valid auth-config-id):
```
lemma connectors connect-requests create slack --auth-config-id <your-auth-config-id>
```
Expected Behavior
The connect request is created successfully.

Actual Behavior
The CLI crashes with the following traceback:

```
╭────────────────────────────────────────────────────────────── Traceback (most recent call last) ───────────────────────────────────────────────────────────────╮
...
│ /home/karan_linux/.local/share/uv/tools/lemma-terminal/lib/python3.14/site-packages/lemma_sdk/resources/connectors.py:270 in connect_request                   │
│                                                                                                                                                                │
│   267 │   │   *,                                                                                                                                               │
│   268 │   │   auth_config_id: str | None = None,                                                                                                               │
│   269 │   ) -> ConnectRequestResponseSchema:                                                                                                                   │
│ ❱ 270 │   │   return self._call(                                                                                                                               │
│   271 │   │   │   connector_connect_request_create,                                                                                                            │
│   272 │   │   │   self._org_uuid(),                                                                                                                            │
│   273 │   │   │   app,                                                                                                                                         │
...
│ /home/karan_linux/.local/share/uv/tools/lemma-terminal/lib/python3.14/site-packages/lemma_sdk/transport.py:83 in call                                          │
│                                                                                                                                                                │
│    80 │   │   attempt = 0                                                                                                                                      │
│    81 │   │   while True:                                                                                                                                      │
│    82 │   │   │   try:                                                                                                                                         │
│ ❱  83 │   │   │   │   response = endpoint.sync_detailed(                                                                                                       │
│    84 │   │   │   │   │   *path_args, client=self.generated, **kwargs                                                                                          │
│    85 │   │   │   │   )                                                                                                                                        │
...
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: sync_detailed() takes 1 positional argument but 2 positional arguments (and 2 keyword-only arguments) were given
```

Root Cause & Proposed Fix
In lemma_sdk/resources/connectors.py, the connect_request method is incorrectly passing app as a positional argument to self._call, which forwards it as a path argument to sync_detailed()

Current Code:
```
def connect_request(
        self,
        app: str,
        *,
        auth_config_id: str | None = None,
    ) -> ConnectRequestResponseSchema:
        return self._call(
            connector_connect_request_create,
            self._org_uuid(),
            app,  # <--- Incorrect positional argument
            body=compact({"auth_config_id": auth_config_id}),
            body_model=ConnectRequestInitiateSchema,
        )
```

Fix: Move app into the body dictionary (Fixed for me)
```
def connect_request(
        self,
        app: str,
        *,
        auth_config_id: str | None = None,
    ) -> ConnectRequestResponseSchema:
        return self._call(
            connector_connect_request_create,
            self._org_uuid(),
            body=compact({"app": app, "auth_config_id": auth_config_id}),
            body_model=ConnectRequestInitiateSchema,
        )
```


Environment OS: Windoes in WSL Linux (Ubuntu/Debian)
Installation Method: uv
