### PR TITLE
fix(functions/connectors): idempotent sync retries, release DB conn across external I/O, clean run errors

### DIFF
--- a/agentbox/agentbox/function_executor.py
+++ b/agentbox/agentbox/function_executor.py
@@ -15,6 +15,7 @@ import subprocess
 import sys
 import time
 import traceback
+from collections import OrderedDict
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import ModuleType
@@ -283,6 +284,15 @@ class LemmaFunctionApiClient:
         return payload
 
 
+# Retention for the run_id idempotency cache. Comfortably longer than the
+# backend's full retry window for a single run (≈12 execute attempts + 3
+# sandbox-recovery attempts with backoff), after which a duplicate /execute can
+# no longer arrive for that run_id. The size cap bounds memory over a long-lived
+# sandbox that serves many runs.
+_RESULT_TTL_SECONDS = 600.0
+_MAX_COMPLETED_RESULTS = 1024
+
+
 class FunctionExecutor:
     def __init__(
         self,
@@ -296,6 +306,19 @@ class FunctionExecutor:
         self.invocation_lock = asyncio.Lock()
         # pip specs already installed in this container, so repeat runs don't reinstall.
         self._ensured_packages: set[str] = set()
+        # Idempotency by function run_id. A function run is non-idempotent (it can
+        # have side effects, e.g. creating an Outlook draft), so a re-POSTed
+        # /execute for the same run_id -- a backend transport-retry or any
+        # double-dispatch -- must NOT run the function again. `run_id` is a stable
+        # DB id reused on every retry, so it is a valid idempotency key. Per-run
+        # locks serialize same-run_id requests (the second awaits, then returns
+        # the cached result); `_completed` caches terminal sync results for the
+        # backend's full retry window; the async path dedupes against `self.jobs`.
+        self._run_locks: dict[UUID, asyncio.Lock] = {}
+        self._registry_lock = asyncio.Lock()
+        self._completed: "OrderedDict[UUID, tuple[float, FunctionInvokeResponse]]" = (
+            OrderedDict()
+        )
 
     def api_client(self, token: str) -> LemmaFunctionApiClient:
         return LemmaFunctionApiClient(base_url=self.lemma_base_url, token=token)
@@ -308,25 +331,84 @@ class FunctionExecutor:
         request: FunctionExecuteRequest,
         token: str,
     ) -> FunctionInvokeResponse | FunctionJobAcceptedResponse:
-        if request.async_job:
-            job = StoredJob(run_id=request.run_id, job_id=f"function:{request.run_id}")
-            self.jobs[request.run_id] = job
-            asyncio.create_task(
-                self._run_job(
-                    job,
-                    pod_id=pod_id,
-                    function_name=function_name,
-                    request=request,
-                    token=token,
+        # Gate every execute by a per-run_id lock so a re-POST for the same run
+        # (transport retry / double-dispatch) joins the original instead of
+        # starting a second invocation of a non-idempotent function.
+        run_lock = await self._run_lock_for(request.run_id)
+        async with run_lock:
+            if request.async_job:
+                # Async path dedup: if the job already exists (running or done),
+                # return the existing acceptance and let the backend poll it.
+                # Never launch a second _run_job for the same run_id.
+                existing = self.jobs.get(request.run_id)
+                if existing is not None:
+                    return FunctionJobAcceptedResponse(
+                        run_id=request.run_id, job_id=existing.job_id
+                    )
+                job = StoredJob(
+                    run_id=request.run_id, job_id=f"function:{request.run_id}"
                 )
+                self.jobs[request.run_id] = job
+                asyncio.create_task(
+                    self._run_job(
+                        job,
+                        pod_id=pod_id,
+                        function_name=function_name,
+                        request=request,
+                        token=token,
+                    )
+                )
+                return FunctionJobAcceptedResponse(
+                    run_id=request.run_id, job_id=job.job_id
+                )
+
+            # Sync path: return the cached terminal result on a duplicate, else
+            # run once and cache. Caches ALL terminal outcomes (completed/failed/
+            # timeout) so a function that ran its side effect then failed is never
+            # re-run.
+            cached = self._completed.get(request.run_id)
+            if cached is not None:
+                return cached[1]
+            response = await self._execute_sync(
+                pod_id=pod_id,
+                function_name=function_name,
+                request=request,
+                token=token,
             )
-            return FunctionJobAcceptedResponse(run_id=request.run_id, job_id=job.job_id)
-        return await self._execute_sync(
-            pod_id=pod_id,
-            function_name=function_name,
-            request=request,
-            token=token,
-        )
+            self._completed[request.run_id] = (time.monotonic(), response)
+            return response
+
+    async def _run_lock_for(self, run_id: UUID) -> asyncio.Lock:
+        """Get-or-create the per-run lock and opportunistically evict expired
+        idempotency state (no background task needed)."""
+        async with self._registry_lock:
+            self._sweep_expired()
+            lock = self._run_locks.get(run_id)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._run_locks[run_id] = lock
+            return lock
+
+    def _sweep_expired(self) -> None:
+        """Evict completed sync results past the TTL or over the size cap, and
+        drop per-run locks that are no longer needed. Never evicts a lock that is
+        currently held (an in-flight run -- timeout_seconds can be up to 3600)."""
+        now = time.monotonic()
+        while self._completed:
+            run_id, (completed_at, _response) = next(iter(self._completed.items()))
+            over_cap = len(self._completed) > _MAX_COMPLETED_RESULTS
+            if not over_cap and now - completed_at <= _RESULT_TTL_SECONDS:
+                break
+            self._completed.popitem(last=False)
+        # A lock is safe to drop once its run has no cached result and is not
+        # in-flight (not locked) and not a live async job.
+        for run_id, lock in list(self._run_locks.items()):
+            if (
+                run_id not in self._completed
+                and run_id not in self.jobs
+                and not lock.locked()
+            ):
+                self._run_locks.pop(run_id, None)
 
     async def schemas(
         self,

--- a/agentbox/agentbox/function_executor.py
+++ b/agentbox/agentbox/function_executor.py
@@ -284,13 +284,18 @@ class LemmaFunctionApiClient:
         return payload
 
 
-# Retention for the run_id idempotency cache. Comfortably longer than the
-# backend's full retry window for a single run (≈12 execute attempts + 3
+# Retention for the run_id idempotency cache. The TTL is comfortably longer than
+# the backend's full retry window for a single run (≈12 execute attempts + 3
 # sandbox-recovery attempts with backoff), after which a duplicate /execute can
-# no longer arrive for that run_id. The size cap bounds memory over a long-lived
-# sandbox that serves many runs.
+# no longer arrive for that run_id. The size cap keeps only the most-recent few
+# completed results so a long-lived sandbox never accumulates many cached
+# FunctionInvokeResponse objects (which carry logs/output) -- bounding RAM.
+# Retries arrive within seconds of the original, so the original is always among
+# the most-recent entries; if a result is evicted before a (much) later
+# duplicate, that duplicate simply re-runs (the pod-side guard still prevents a
+# duplicate side effect).
 _RESULT_TTL_SECONDS = 600.0
-_MAX_COMPLETED_RESULTS = 1024
+_MAX_COMPLETED_RESULTS = 32
 
 
 class FunctionExecutor:

--- a/agentbox/tests/e2e/conftest.py
+++ b/agentbox/tests/e2e/conftest.py
@@ -371,6 +371,50 @@ async def {function_name}(ctx, data: AgentBoxInput) -> AgentBoxOutput:
     yield from _serve_fake_function(fixture)
 
 
+@pytest.fixture
+def fake_lemma_counter_function_server() -> (
+    Generator[tuple[str, FakeLemmaFunction], None, None]
+):
+    """Serves a function with an OBSERVABLE side effect: it appends one line to a
+    per-marker file on every real invocation and returns the line count. The
+    returned count reveals whether a re-POSTed run_id actually re-ran the body --
+    the real-sandbox analogue of "did we create a second Outlook draft?"."""
+    from uuid import uuid4
+
+    function_name = f"agentbox_counter_{uuid4().hex[:8]}"
+    code = f"""#input_type_name: CounterInput
+#output_type_name: CounterOutput
+#function_name: {function_name}
+
+from pathlib import Path
+from pydantic import BaseModel
+
+class CounterInput(BaseModel):
+    marker: str
+
+class CounterOutput(BaseModel):
+    invocations: int
+
+async def {function_name}(ctx, data: CounterInput) -> CounterOutput:
+    log = Path("/tmp") / ("agentbox_invocations_" + data.marker + ".log")
+    with log.open("a") as handle:
+        handle.write("x\\n")
+    with log.open() as handle:
+        count = sum(1 for _ in handle)
+    print(f"invocation {{count}} for marker {{data.marker}}")
+    return CounterOutput(invocations=count)
+"""
+    fixture = FakeLemmaFunction(
+        pod_id=str(uuid4()),
+        function_id=str(uuid4()),
+        name=function_name,
+        code=code,
+        user_id=str(uuid4()),
+        organization_id=str(uuid4()),
+    )
+    yield from _serve_fake_function(fixture)
+
+
 def _serve_fake_function(
     fixture: FakeLemmaFunction,
 ) -> Generator[tuple[str, FakeLemmaFunction], None, None]:

--- a/agentbox/tests/e2e/test_function_executor_e2e.py
+++ b/agentbox/tests/e2e/test_function_executor_e2e.py
@@ -192,3 +192,137 @@ def test_private_function_executor_installs_declared_python_package(
     assert result["status"] == "completed", result
     assert "moo" in result["output_data"]["rendered"]
 
+
+
+# --- run_id idempotency against the real Docker AgentBox ---------------------
+#
+# A function run is non-idempotent (it can create an Outlook draft, etc.). These
+# exercise the real sandbox to prove a re-POSTed run_id never re-runs the body,
+# concurrent duplicates collapse to one run, and distinct run_ids each execute.
+
+import concurrent.futures
+from uuid import uuid4
+
+
+def _counter_headers(agentbox_server, sandbox_id, function, lemma_base_url):
+    created = agentbox_server.client.request_json(
+        "PUT",
+        f"/sandboxes/{sandbox_id}",
+        body={"env": {"LEMMA_BASE_URL": lemma_base_url}},
+        timeout=180,
+    )
+    assert created.status_code == HTTPStatus.OK, created.text
+    return {
+        "Authorization": f"Bearer {function.token}",
+        "X-API-Key": agentbox_server.api_key,
+    }
+
+
+def _post_execute(manager, sandbox_id, function, headers, *, run_id, marker, async_job=False):
+    return manager.request_json(
+        "POST",
+        f"/sandboxes/{sandbox_id}/apps/function_executor/"
+        f"pods/{function.pod_id}/functions/{function.name}/execute",
+        body={
+            "run_id": run_id,
+            "input_data": {"marker": marker},
+            "async_job": async_job,
+            "timeout_seconds": 120,
+        },
+        headers=headers,
+        timeout=180,
+    )
+
+
+def test_sync_execute_idempotent_on_run_id(
+    agentbox_server, sandbox_id, fake_lemma_counter_function_server
+):
+    lemma_base_url, function = fake_lemma_counter_function_server
+    manager = agentbox_server.client
+    headers = _counter_headers(agentbox_server, sandbox_id, function, lemma_base_url)
+    run_id = str(uuid4())
+    marker = uuid4().hex
+
+    first = _post_execute(manager, sandbox_id, function, headers, run_id=run_id, marker=marker)
+    # A backend transport-retry re-POSTs the SAME run_id.
+    second = _post_execute(manager, sandbox_id, function, headers, run_id=run_id, marker=marker)
+
+    assert first.status_code == HTTPStatus.OK, first.text
+    assert second.status_code == HTTPStatus.OK, second.text
+    assert first.json()["status"] == "completed"
+    # The function body ran exactly once: the side-effect counter stays at 1 and
+    # the retry returns the identical cached result.
+    assert first.json()["output_data"] == {"invocations": 1}
+    assert second.json()["output_data"] == {"invocations": 1}
+
+
+def test_distinct_run_ids_each_execute(
+    agentbox_server, sandbox_id, fake_lemma_counter_function_server
+):
+    lemma_base_url, function = fake_lemma_counter_function_server
+    manager = agentbox_server.client
+    headers = _counter_headers(agentbox_server, sandbox_id, function, lemma_base_url)
+    marker = uuid4().hex
+
+    first = _post_execute(manager, sandbox_id, function, headers, run_id=str(uuid4()), marker=marker)
+    second = _post_execute(manager, sandbox_id, function, headers, run_id=str(uuid4()), marker=marker)
+
+    # Distinct logical runs each execute (idempotency is per run_id, not global).
+    assert first.json()["output_data"] == {"invocations": 1}
+    assert second.json()["output_data"] == {"invocations": 2}
+
+
+def test_concurrent_same_run_id_runs_once(
+    agentbox_server, sandbox_id, fake_lemma_counter_function_server
+):
+    lemma_base_url, function = fake_lemma_counter_function_server
+    manager = agentbox_server.client
+    headers = _counter_headers(agentbox_server, sandbox_id, function, lemma_base_url)
+    run_id = str(uuid4())
+    marker = uuid4().hex
+
+    # Fire two executes for the SAME run_id concurrently (the backend's retry can
+    # race the original). The per-run lock must collapse them to a single run.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [
+            pool.submit(_post_execute, manager, sandbox_id, function, headers, run_id=run_id, marker=marker)
+            for _ in range(2)
+        ]
+        responses = [f.result() for f in futures]
+
+    for resp in responses:
+        assert resp.status_code == HTTPStatus.OK, resp.text
+        assert resp.json()["status"] == "completed"
+        assert resp.json()["output_data"] == {"invocations": 1}
+
+
+def test_async_execute_idempotent_on_run_id(
+    agentbox_server, sandbox_id, fake_lemma_counter_function_server
+):
+    lemma_base_url, function = fake_lemma_counter_function_server
+    manager = agentbox_server.client
+    headers = _counter_headers(agentbox_server, sandbox_id, function, lemma_base_url)
+    run_id = str(uuid4())
+    marker = uuid4().hex
+
+    first = _post_execute(manager, sandbox_id, function, headers, run_id=run_id, marker=marker, async_job=True)
+    second = _post_execute(manager, sandbox_id, function, headers, run_id=run_id, marker=marker, async_job=True)
+    assert first.json()["status"] == "accepted"
+    # A re-POST returns the same job, never launching a second run.
+    assert second.json()["job_id"] == first.json()["job_id"]
+
+    deadline = time.monotonic() + 30
+    status = None
+    while time.monotonic() < deadline:
+        resp = manager.request_json(
+            "GET",
+            f"/sandboxes/{sandbox_id}/apps/function_executor/runs/{run_id}",
+            headers={"X-API-Key": agentbox_server.api_key},
+            timeout=60,
+        )
+        status = resp.json()
+        if status["status"] == "completed":
+            break
+        time.sleep(0.5)
+    assert status is not None and status["status"] == "completed"
+    assert status["output_data"] == {"invocations": 1}

--- a/agentbox/tests/test_function_executor.py
+++ b/agentbox/tests/test_function_executor.py
@@ -373,6 +373,132 @@ async def test_executor_package_install_failure_fails_run(tmp_path, monkeypatch)
     assert "install" in (response.error.message or "").lower()
 
 
+# --- idempotency by run_id --------------------------------------------------
+
+FAILING_FUNCTION_CODE = """#input_type_name: InputModel
+#output_type_name: OutputModel
+#function_name: run_function
+from pydantic import BaseModel
+
+class InputModel(BaseModel):
+    x: int
+
+class OutputModel(BaseModel):
+    y: int
+
+async def run_function(ctx, data):
+    raise ValueError("boom -- side effect already happened")
+"""
+
+
+def _increment_executor(tmp_path, *, code: str = FUNCTION_CODE) -> _TestExecutor:
+    metadata = FunctionMetadata(
+        id=uuid4(),
+        name="increment",
+        pod_id=uuid4(),
+        code=code,
+        code_hash=function_code_hash(code),
+    )
+    client = _FakeLemmaClient(
+        verified=VerifiedToken(user_id=uuid4(), email="t@example.com"),
+        metadata=metadata,
+    )
+    return _TestExecutor(client=client, workspace_root=str(tmp_path))
+
+
+@pytest.mark.anyio
+async def test_sync_execute_is_idempotent_on_run_id(tmp_path):
+    executor = _increment_executor(tmp_path)
+    pod_id = executor.client.metadata.pod_id
+    run_id = uuid4()
+    req = FunctionExecuteRequest(run_id=run_id, input_data={"x": 2})
+
+    first = await executor.execute(
+        pod_id=pod_id, function_name="increment", request=req, token="token"
+    )
+    # A re-POST for the same run_id (a backend transport-retry) must NOT re-run.
+    second = await executor.execute(
+        pod_id=pod_id, function_name="increment", request=req, token="token"
+    )
+
+    assert first.status == "completed"
+    assert second.output_data == first.output_data == {"y": 3}
+    assert second is first  # the cached result is returned verbatim
+    assert executor.client.function_calls == 1  # the function body ran once
+
+
+@pytest.mark.anyio
+async def test_different_run_ids_are_not_deduped(tmp_path):
+    executor = _increment_executor(tmp_path)
+    pod_id = executor.client.metadata.pod_id
+
+    await executor.execute(
+        pod_id=pod_id,
+        function_name="increment",
+        request=FunctionExecuteRequest(run_id=uuid4(), input_data={"x": 2}),
+        token="token",
+    )
+    await executor.execute(
+        pod_id=pod_id,
+        function_name="increment",
+        request=FunctionExecuteRequest(run_id=uuid4(), input_data={"x": 2}),
+        token="token",
+    )
+
+    # Distinct logical runs each execute (idempotency is per run_id, not global).
+    assert executor.client.function_calls == 2
+
+
+@pytest.mark.anyio
+async def test_sync_execute_caches_failed_result(tmp_path):
+    # A function that ran its side effect then failed must not be re-run on retry.
+    executor = _increment_executor(tmp_path, code=FAILING_FUNCTION_CODE)
+    pod_id = executor.client.metadata.pod_id
+    run_id = uuid4()
+    req = FunctionExecuteRequest(run_id=run_id, input_data={"x": 2})
+
+    first = await executor.execute(
+        pod_id=pod_id, function_name="increment", request=req, token="token"
+    )
+    second = await executor.execute(
+        pod_id=pod_id, function_name="increment", request=req, token="token"
+    )
+
+    assert first.status == "failed"
+    assert second is first
+    assert executor.client.function_calls == 1
+
+
+@pytest.mark.anyio
+async def test_async_execute_dedups_on_run_id(tmp_path):
+    executor = _increment_executor(tmp_path)
+    pod_id = executor.client.metadata.pod_id
+    run_id = uuid4()
+    req = FunctionExecuteRequest(run_id=run_id, input_data={"x": 5}, async_job=True)
+
+    accepted1 = await executor.execute(
+        pod_id=pod_id, function_name="increment", request=req, token="token"
+    )
+    # A re-POST while the job exists must return the same acceptance, not launch
+    # a second _run_job.
+    accepted2 = await executor.execute(
+        pod_id=pod_id, function_name="increment", request=req, token="token"
+    )
+
+    assert accepted1.status == "accepted"
+    assert accepted2.job_id == accepted1.job_id
+
+    for _ in range(50):
+        if executor.job_status(run_id).status == "completed":
+            break
+        await asyncio.sleep(0.01)
+
+    status = executor.job_status(run_id)
+    assert status.status == "completed"
+    assert status.output_data == {"y": 6}
+    assert executor.client.function_calls == 1  # job body ran once
+
+
 @pytest.mark.anyio
 async def test_executor_rejects_invalid_package_spec(tmp_path, monkeypatch):
     installed = False

--- a/lemma-backend/app/core/authorization/dependencies.py
+++ b/lemma-backend/app/core/authorization/dependencies.py
@@ -24,6 +24,35 @@ def _is_default_pod_agent_claims(claims) -> bool:
     )
 
 
+async def resolve_current_context(
+    *,
+    session: AsyncSession,
+    request: Request,
+    user_id: UUID,
+) -> Context:
+    """Build the request's authorization ``Context`` on ``session``.
+
+    Pure resolution from the delegation claims (the path functions/pods take when
+    they call an endpoint with a delegated token) or the plain user context. Does
+    NOT consult/mutate ``request.state.ctx`` or bind the contextvar -- callers do
+    that. Extracted from ``get_current_context`` so the same logic can run inside
+    a short ``current_context_scope`` (release the pooled connection before slow
+    non-DB work) instead of only via the request-scoped dependency.
+    """
+    claims = getattr(request.state, "delegation_claims", None)
+    if claims is not None:
+        return await AuthorizationDataService(session).build_context_from_delegation_claims(
+            user_id=user_id,
+            claims=claims,
+            request_id=request.headers.get("x-request-id"),
+            is_default_pod_agent=_is_default_pod_agent_claims(claims),
+        )
+    return await AuthorizationDataService(session).build_user_context(
+        user_id=user_id,
+        request_id=request.headers.get("x-request-id"),
+    )
+
+
 async def get_current_context(
     request: Request,
     user: CurrentUser,
@@ -33,20 +62,8 @@ async def get_current_context(
     if existing is not None and existing.user_id == user.id:
         set_current_context(existing)
         return existing
-    claims = getattr(request.state, "delegation_claims", None)
-    if claims is not None:
-        ctx = await AuthorizationDataService(uow.session).build_context_from_delegation_claims(
-            user_id=user.id,
-            claims=claims,
-            request_id=request.headers.get("x-request-id"),
-            is_default_pod_agent=_is_default_pod_agent_claims(claims),
-        )
-        request.state.ctx = ctx
-        set_current_context(ctx)
-        return ctx
-    ctx = await AuthorizationDataService(uow.session).build_user_context(
-        user_id=user.id,
-        request_id=request.headers.get("x-request-id"),
+    ctx = await resolve_current_context(
+        session=uow.session, request=request, user_id=user.id
     )
     request.state.ctx = ctx
     set_current_context(ctx)

--- a/lemma-backend/app/core/authorization/scope.py
+++ b/lemma-backend/app/core/authorization/scope.py
@@ -32,7 +32,10 @@ from fastapi import Request
 
 from app.core.authorization.context import Context
 from app.core.authorization.current import reset_current_context, set_current_context
-from app.core.authorization.dependencies import resolve_pod_context
+from app.core.authorization.dependencies import (
+    resolve_current_context,
+    resolve_pod_context,
+)
 from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
 from app.core.infrastructure.db.uow_factory import UnitOfWorkFactory
 
@@ -82,6 +85,31 @@ async def pod_context_scope(
     async with uow_factory() as uow:
         ctx = await resolve_pod_context(
             session=uow.session, request=request, user_id=user_id, pod_id=pod_id
+        )
+        async with context_scope(ctx):
+            yield UowContext(uow=uow, ctx=ctx)
+
+
+@asynccontextmanager
+async def current_context_scope(
+    uow_factory: UnitOfWorkFactory,
+    *,
+    request: Request,
+    user_id: UUID,
+) -> AsyncIterator[UowContext]:
+    """Open one short UoW, build + bind the request's ``Context``, yield ``(uow,
+    ctx)``.
+
+    The org/delegation-aware counterpart of ``pod_context_scope`` for endpoints
+    that authorize via ``CurrentContextDep`` rather than a pod (e.g. the
+    organization-scoped connector-operation execute). The Context is built with
+    ``resolve_current_context`` (delegation-claims aware), bound for the block,
+    and the connection is released on exit so the slow non-DB tail (a Composio /
+    connector round-trip) runs with no pooled connection held.
+    """
+    async with uow_factory() as uow:
+        ctx = await resolve_current_context(
+            session=uow.session, request=request, user_id=user_id
         )
         async with context_scope(ctx):
             yield UowContext(uow=uow, ctx=ctx)

--- a/lemma-backend/app/core/config.py
+++ b/lemma-backend/app/core/config.py
@@ -229,12 +229,21 @@ class Settings(BaseSettings):
         ),
     )
     lemma_openai_default_model: str = Field(
-        default="gpt-4o",
-        description="Default model name for the OpenAI-compatible system model profile.",
+        default="",
+        description=(
+            "Default model name for the OpenAI-compatible system model profile. "
+            "No built-in default: when LEMMA_OPENAI_API_KEY is set the model(s) "
+            "must be provided via LEMMA_OPENAI_MODEL_NAMES / "
+            "LEMMA_OPENAI_DEFAULT_MODEL, otherwise the profile build fails loudly."
+        ),
     )
     lemma_openai_model_names: str = Field(
-        default="gpt-4o,gpt-4o-mini",
-        description="Comma-separated model names for the OpenAI-compatible system model profile.",
+        default="",
+        description=(
+            "Comma-separated model names for the OpenAI-compatible system model "
+            "profile. Required (via env) when LEMMA_OPENAI_API_KEY is set; there "
+            "is no built-in model default."
+        ),
     )
     lemma_openai_vision_model_names: str = Field(
         default="",

--- a/lemma-backend/app/modules/agent/services/runtime_profile_service.py
+++ b/lemma-backend/app/modules/agent/services/runtime_profile_service.py
@@ -492,6 +492,9 @@ def _system_lemma_openai_profile() -> AgentRuntimeProfile | None:
     api_key = _env_or_setting("LEMMA_OPENAI_API_KEY", settings.lemma_openai_api_key)
     if not api_key:
         return None
+    # _build_system_openai_catalog() -> _csv_setting() already raises a clean
+    # "requires at least one model" error when the key is set but no models are
+    # configured (there is no built-in model default).
     model_catalog = _build_system_openai_catalog()
     default_model_name = (
         os.getenv("LEMMA_OPENAI_DEFAULT_MODEL") or settings.lemma_openai_default_model

--- a/lemma-backend/app/modules/agent/tests/e2e/system_lemma_helpers.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/system_lemma_helpers.py
@@ -68,15 +68,24 @@ def system_lemma_api_key() -> str | None:
 
 
 def system_lemma_default_model() -> str:
-    """The configured default model for system:lemma (from .env or os.environ)."""
+    """The configured default model for system:lemma (from .env or os.environ).
+
+    Falls back to the app's own config default (``settings.lemma_openai_default_model``)
+    rather than a hard-coded literal, so the helper can never drift from what the
+    running app resolves when no LEMMA_OPENAI_* env is set.
+    """
+    from app.core.config import settings
+
     env = system_lemma_env_overlay()
-    return env.get("LEMMA_OPENAI_DEFAULT_MODEL") or "minimax-m3"
+    return env.get("LEMMA_OPENAI_DEFAULT_MODEL") or settings.lemma_openai_default_model
 
 
 def system_lemma_model_names() -> list[str]:
     """All configured model names for system:lemma."""
+    from app.core.config import settings
+
     env = system_lemma_env_overlay()
-    raw = env.get("LEMMA_OPENAI_MODEL_NAMES", "")
+    raw = env.get("LEMMA_OPENAI_MODEL_NAMES") or settings.lemma_openai_model_names
     models = [m.strip() for m in raw.split(",") if m.strip()]
     default = system_lemma_default_model()
     if default and default not in models:

--- a/lemma-backend/app/modules/agent/tests/e2e/test_agent_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_agent_e2e.py
@@ -1748,6 +1748,10 @@ class TestAgentRuntimeConfigApis:
         monkeypatch,
     ):
         monkeypatch.setenv("LEMMA_OPENAI_API_KEY", "system-lemma-secret")
+        # The system model profile has no built-in model default; the operator
+        # must configure the catalog via env when the key is set.
+        monkeypatch.setenv("LEMMA_OPENAI_MODEL_NAMES", "gpt-4o,gpt-4o-mini")
+        monkeypatch.setenv("LEMMA_OPENAI_DEFAULT_MODEL", "gpt-4o")
         monkeypatch.delenv("LEMMA_DEFAULT_MODEL_TYPE", raising=False)
         harnesses = await authenticated_client.get("/agent-runtime/harnesses")
         assert harnesses.status_code == 200, harnesses.text
@@ -1807,6 +1811,7 @@ class TestAgentRuntimeConfigApis:
                     "harness_kind": "CLAUDE_CODE",
                     "display_name": "Claude Code",
                     "models": [],
+                    "model_catalog": [],
                     "available": False,
                     "availability_status": "NOT_INSTALLED",
                     "daemon_id": missing_tool_daemon_id,
@@ -2183,18 +2188,22 @@ class TestAgentRuntimeConfigApis:
             for item in harnesses.json()["items"]
             if item.get("daemon_id") == daemon_id
         ]
-        assert daemon_items == [
-            {
-                "harness_kind": "CODEX",
-                "display_name": "Codex E2E",
-                "models": ["gpt-5.5", "gpt-5.5-mini"],
-                "available": True,
-                "availability_status": "READY",
-                "daemon_id": daemon_id,
-                "daemon_display_name": "Real E2E laptop",
-                "daemon_status": "ONLINE",
-            }
-        ]
+        assert len(daemon_items) == 1
+        daemon_item = daemon_items[0]
+        # model_catalog is derived from the flat models list (structured entry
+        # serialization); assert it by model name and check the rest exactly.
+        model_catalog = daemon_item.pop("model_catalog")
+        assert [entry["name"] for entry in model_catalog] == ["gpt-5.5", "gpt-5.5-mini"]
+        assert daemon_item == {
+            "harness_kind": "CODEX",
+            "display_name": "Codex E2E",
+            "models": ["gpt-5.5", "gpt-5.5-mini"],
+            "available": True,
+            "availability_status": "READY",
+            "daemon_id": daemon_id,
+            "daemon_display_name": "Real E2E laptop",
+            "daemon_status": "ONLINE",
+        }
 
         created = await authenticated_client.post(
             f"/organizations/{fixed_test_org['id']}/agent-runtime/profiles",
@@ -3032,6 +3041,8 @@ class TestAgentOpenApi:
             "CODEX",
             "CLAUDE_CODE",
             "OPENCODE",
+            "CURSOR",
+            "ANTIGRAVITY",
         ]
         assert "model_name" not in schemas["SendMessageRequest"]["properties"]
         assert "model_name" in schemas["AgentRuntimeConfig"]["properties"]

--- a/lemma-backend/app/modules/agent/tests/e2e/test_conversation_title_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_conversation_title_e2e.py
@@ -68,6 +68,10 @@ def _stub_llm(monkeypatch: pytest.MonkeyPatch, *, output: str) -> None:
     async def _noop_record(*, ctx, runtime_profile, result, status, reservation, metadata):
         return None
 
+    # The LLM title path is opt-in (settings.conversation_title_model); without
+    # it the service deliberately falls back to the first-message title. Enable
+    # it so the stubbed model boundary is exercised.
+    monkeypatch.setattr(cts.settings, "conversation_title_model", "deepseek-v4-flash")
     monkeypatch.setattr(cts, "PydanticAIAgent", _FakeLLMAgent)
     monkeypatch.setattr(cts, "AgentRuntimeProfileService", _FakeProfileService)
     monkeypatch.setattr(

--- a/lemma-backend/app/modules/agent/tests/unit/test_runtime_config_service.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_runtime_config_service.py
@@ -271,8 +271,13 @@ async def test_runtime_lists_configured_system_org_and_owned_personal_profiles(
 
     monkeypatch.setattr(settings, "environment", "development")
     monkeypatch.setattr(settings, "lemma_openai_api_key", "lemma-secret")
+    # The system model profile has no built-in model default; configure one.
+    monkeypatch.setattr(settings, "lemma_openai_model_names", "gpt-4o,gpt-4o-mini")
+    monkeypatch.setattr(settings, "lemma_openai_default_model", "gpt-4o")
     monkeypatch.delenv("LEMMA_DEFAULT_MODEL_TYPE", raising=False)
     monkeypatch.delenv("LEMMA_OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("LEMMA_OPENAI_MODEL_NAMES", raising=False)
+    monkeypatch.delenv("LEMMA_OPENAI_DEFAULT_MODEL", raising=False)
     org_id = uuid4()
     user_id = uuid4()
     other_org_id = uuid4()

--- a/lemma-backend/app/modules/connectors/api/connector_operation_controller.py
+++ b/lemma-backend/app/modules/connectors/api/connector_operation_controller.py
@@ -5,9 +5,10 @@ from uuid import UUID
 from fastapi import APIRouter, Query, Request
 
 from app.core.api.dependencies import CurrentUser
-from app.core.authorization.current import get_current_context
-from app.core.authorization.dependencies import CurrentContextDep
-from app.modules.connectors.api.dependencies import ConnectorOperationServiceDep
+from app.modules.connectors.api.dependencies import (
+    ConnectorOperationServiceDep,
+    ConnectorOperationUseCasesDep,
+)
 from app.modules.connectors.api.schemas.connector_operation_schemas import (
     OperationDetail,
     OperationDetailsBatchRequest,
@@ -101,23 +102,25 @@ async def execute_operation(
     body: OperationExecutionRequest,
     request: Request,
     user: CurrentUser,
-    ctx: CurrentContextDep,
-    service: ConnectorOperationServiceDep,
+    use_cases: ConnectorOperationUseCasesDep,
 ) -> OperationExecutionResponse:
-    _ = ctx
+    # No request-scoped service/context dependency: the use-case authorizes +
+    # resolves inside a short DB scope and runs the (1-45s) external operation
+    # call with no pooled connection held. Authorization is preserved -- the
+    # org/delegation Context is built in-scope and threaded as the actor.
     auth_header = request.headers.get("authorization") or ""
     auth_token = None
     if auth_header.lower().startswith("bearer "):
         auth_token = auth_header.split(" ", 1)[1].strip()
 
     account_id = UUID(body.account_id) if body.account_id else None
-    return await service.execute_operation_for_auth_config(
-        user_id=user.id,
+    return await use_cases.execute_operation_for_auth_config(
         organization_id=organization_id,
         auth_config_name=auth_config_name,
         operation_name=operation_name,
         payload=body.payload,
-        actor=get_current_context(),
+        user_id=user.id,
+        request=request,
         auth_token=auth_token,
         api_url=str(request.base_url).rstrip("/"),
         account_id=account_id,

--- a/lemma-backend/app/modules/connectors/api/dependencies.py
+++ b/lemma-backend/app/modules/connectors/api/dependencies.py
@@ -2,10 +2,14 @@ from typing import Annotated
 
 from fastapi import Depends
 
-from app.core.api.dependencies import UoWDep
+from app.core.api.dependencies import UoWDep, get_uow_factory
 from app.core.crypto import get_secret_cipher
+from app.core.infrastructure.db.uow_factory import UnitOfWorkFactory
 from app.core.infrastructure.events.message_bus import get_message_bus
 from app.modules.pod.services.authorization_factory import create_authorization_service
+from app.modules.connectors.application.connector_operation_use_cases import (
+    ConnectorOperationUseCases,
+)
 from app.modules.connectors.domain.connector import AuthProvider
 from app.modules.connectors.infrastructure.adapters.auth_provider_registry import (
     AuthProviderRegistry,
@@ -160,6 +164,26 @@ ConnectorTriggerServiceDep = Annotated[
 ]
 ConnectorOperationServiceDep = Annotated[
     ConnectorOperationService, Depends(get_connector_operation_service)
+]
+
+
+def build_connector_operation_use_cases(
+    uow_factory: UnitOfWorkFactory,
+) -> ConnectorOperationUseCases:
+    # Factory mode: the use-case opens its own short UoWs per phase (via
+    # build_connector_operation_service as the per-phase builder) so no pooled
+    # connection is held across the external operation call.
+    return ConnectorOperationUseCases(uow_factory, build_connector_operation_service)
+
+
+def get_connector_operation_use_cases(
+    uow_factory: UnitOfWorkFactory = Depends(get_uow_factory),
+) -> ConnectorOperationUseCases:
+    return build_connector_operation_use_cases(uow_factory)
+
+
+ConnectorOperationUseCasesDep = Annotated[
+    ConnectorOperationUseCases, Depends(get_connector_operation_use_cases)
 ]
 AccountResolutionServiceDep = Annotated[
     AccountResolutionService, Depends(get_account_resolution_service)

--- a/lemma-backend/app/modules/connectors/application/connector_operation_use_cases.py
+++ b/lemma-backend/app/modules/connectors/application/connector_operation_use_cases.py
@@ -1,0 +1,79 @@
+"""Connector-operation execution saga.
+
+Mirrors ``FunctionUseCases``: built from a ``uow_factory`` + a per-phase service
+builder so the DB/auth resolve phase runs inside a SHORT unit-of-work scope and
+the external Composio/Lemma operation call runs with NO pooled DB connection
+held. A request-scoped service/context dependency would otherwise pin one pooled
+connection per in-flight connector call (every ``pod.connectors.execute(...)``
+from a function routes through here), exhausting the pool under load.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+from uuid import UUID
+
+from fastapi import Request
+
+from app.core.authorization.scope import current_context_scope, uow_scope
+from app.core.infrastructure.db.uow_factory import UnitOfWorkFactory
+from app.modules.connectors.api.schemas.connector_operation_schemas import (
+    OperationExecutionResponse,
+)
+from app.modules.connectors.services.connector_operation_service import (
+    ConnectorOperationService,
+)
+
+
+class ConnectorOperationUseCases:
+    """Owns the connector-operation execution saga (factory mode)."""
+
+    def __init__(
+        self,
+        uow_factory: UnitOfWorkFactory,
+        service_builder: Callable[[Any], ConnectorOperationService],
+    ):
+        self._uow_factory = uow_factory
+        self._build = service_builder
+
+    async def execute_operation_for_auth_config(
+        self,
+        *,
+        organization_id: UUID,
+        auth_config_name: str,
+        operation_name: str,
+        payload: dict[str, Any],
+        user_id: UUID,
+        request: Request,
+        auth_token: str | None = None,
+        api_url: str | None = None,
+        account_id: UUID | None = None,
+    ) -> OperationExecutionResponse:
+        # Phase 1 (short scope): build + bind the request Context (org/delegation
+        # aware), resolve all DB state + authorize + resolve credentials. The
+        # scope commits any OAuth-token refresh and releases the connection on
+        # exit, before the external call.
+        async with current_context_scope(
+            self._uow_factory, request=request, user_id=user_id
+        ) as scope:
+            resolved = await self._build(scope.uow).resolve_execution_for_auth_config(
+                user_id=user_id,
+                organization_id=organization_id,
+                auth_config_name=auth_config_name,
+                operation_name=operation_name,
+                payload=payload,
+                actor=scope.ctx,
+                auth_token=auth_token,
+                api_url=api_url,
+                account_id=account_id,
+            )
+
+        # Phase 2: the external operation call, with NO pooled connection held.
+        # ``execute_resolved`` issues no DB I/O -- the gateway's connector
+        # validation is skipped (``resolved.provider`` is always set) and the
+        # concrete Lemma/Composio gateways are DB-free -- so this short uow never
+        # checks out a connection across the (1-45s) external call. The scope only
+        # supplies the service collaborator that owns the gateway + timeout +
+        # error-mapping logic.
+        async with uow_scope(self._uow_factory) as uow:
+            return await self._build(uow).execute_resolved(resolved)

--- a/lemma-backend/app/modules/connectors/infrastructure/adapters/routing_operation_gateway.py
+++ b/lemma-backend/app/modules/connectors/infrastructure/adapters/routing_operation_gateway.py
@@ -74,7 +74,15 @@ class RoutingOperationGateway(AppOperationGatewayPort):
         api_url: str | None = None,
         provider: str | None = None,
     ) -> Any:
-        await self._get_connector(connector_id)
+        # The connector lookup is pure existence-validation (the entity is
+        # discarded; routing uses ``provider``). When the caller already resolved
+        # ``provider`` -- the use-case resolve phase, which validated the
+        # connector under a short DB scope -- skip this read so the execute phase
+        # (this long external call) holds NO pooled DB connection. Concrete
+        # Lemma/Composio gateways are DB-free. When ``provider`` is unknown we
+        # still validate + derive the default route as before.
+        if provider is None:
+            await self._get_connector(connector_id)
         gateway = self._get_gateway_by_provider(provider or AuthProvider.LEMMA.value)
         # Hard-bound the upstream call. The LEMMA path is async (httpx.AsyncClient)
         # and the COMPOSIO path is offloaded via asyncio.to_thread, so neither

--- a/lemma-backend/app/modules/connectors/services/connector_operation_service.py
+++ b/lemma-backend/app/modules/connectors/services/connector_operation_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 
@@ -12,6 +13,7 @@ from app.modules.connectors.api.schemas.connector_operation_schemas import (
     OperationExecutionResponse,
     OperationSummary,
 )
+from app.modules.connectors.domain.connector import AuthProvider
 from app.modules.connectors.domain.errors import (
     AccountResolutionError,
     ConnectorNotFoundError,
@@ -29,6 +31,21 @@ from app.modules.connectors.services.account_resolution_service import (
     AccountResolutionService,
 )
 from app.modules.connectors.services.connector_service import ConnectorService
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedConnectorExecution:
+    """Session-free output of the connector-operation resolve phase, handed to
+    the external execute phase so the operation runs with no pooled DB connection
+    held. Carries only plain values -- never ORM/session-bound objects."""
+
+    connector_id: str
+    operation_execution_name: str
+    provider: str | None
+    third_party_credentials: dict[str, Any]
+    payload: dict[str, Any]
+    auth_token: str | None
+    api_url: str | None
 
 
 class ConnectorOperationService:
@@ -443,7 +460,15 @@ class ConnectorOperationService:
             provider=provider,
         )
 
-    async def execute_operation_for_auth_config(
+    # -- Resolve / execute split ------------------------------------------------
+    # ``resolve_execution*`` does all the DB reads + authorization + credential
+    # resolution and returns a session-free ``ResolvedConnectorExecution``;
+    # ``execute_resolved`` performs only the external gateway call. The
+    # ConnectorOperationUseCases runs resolve in a short DB scope and execute with
+    # no connection held. ``execute_operation*`` remain as thin wrappers
+    # (resolve + execute) for any single-shot internal callers.
+
+    async def resolve_execution_for_auth_config(
         self,
         *,
         user_id: UUID,
@@ -455,13 +480,13 @@ class ConnectorOperationService:
         auth_token: str | None = None,
         api_url: str | None = None,
         account_id: UUID | None = None,
-    ) -> OperationExecutionResponse:
+    ) -> ResolvedConnectorExecution:
         auth_config, connector_id, _provider = await self._resolve_auth_config_context(
             user_id=user_id,
             organization_id=organization_id,
             auth_config_name=auth_config_name,
         )
-        return await self.execute_operation(
+        return await self._resolve_execution(
             connector_id=connector_id,
             operation_name=operation_name,
             payload=payload,
@@ -473,7 +498,7 @@ class ConnectorOperationService:
             auth_config_id=auth_config.id,
         )
 
-    async def execute_operation(
+    async def _resolve_execution(
         self,
         *,
         connector_id: str,
@@ -485,7 +510,7 @@ class ConnectorOperationService:
         api_url: str | None = None,
         account_id: UUID | None = None,
         auth_config_id: UUID | None = None,
-    ) -> OperationExecutionResponse:
+    ) -> ResolvedConnectorExecution:
         await self._get_connector(connector_id)
         provider: str | None = None
         if auth_config_id is not None:
@@ -544,23 +569,97 @@ class ConnectorOperationService:
             account,
             user_id,
         )
+        return ResolvedConnectorExecution(
+            connector_id=connector_id,
+            operation_execution_name=operation.execution_name,
+            # Resolve the provider to a concrete value (the gateway already maps
+            # None -> LEMMA for routing). This guarantees the execute phase passes
+            # a non-None provider, so the gateway skips its connector-validation
+            # read and the external call holds NO DB connection.
+            provider=provider or AuthProvider.LEMMA.value,
+            third_party_credentials=third_party_credentials,
+            payload=payload or {},
+            auth_token=auth_token,
+            api_url=api_url,
+        )
+
+    async def execute_resolved(
+        self, resolved: ResolvedConnectorExecution
+    ) -> OperationExecutionResponse:
+        """Run the external operation for an already-resolved plan. Holds NO DB
+        connection: the gateway's connector-validation read is skipped because
+        ``provider`` is supplied (the connector was validated in the resolve
+        phase), and the concrete provider gateways are DB-free."""
         try:
             result = await self.operation_gateway.execute_operation(
-                connector_id=connector_id,
-                operation_name=operation.execution_name,
-                payload=payload or {},
-                third_party_credentials=third_party_credentials,
-                auth_token=auth_token,
-                api_url=api_url,
-                provider=provider,
+                connector_id=resolved.connector_id,
+                operation_name=resolved.operation_execution_name,
+                payload=resolved.payload or {},
+                third_party_credentials=resolved.third_party_credentials,
+                auth_token=resolved.auth_token,
+                api_url=resolved.api_url,
+                provider=resolved.provider,
             )
         except ConnectorDomainError:
             raise
         except Exception as exc:
             raise OperationExecutionInfrastructureError(
-                f"Failed to execute '{operation.execution_name}' for '{connector_id}'.",
+                f"Failed to execute '{resolved.operation_execution_name}' for "
+                f"'{resolved.connector_id}'.",
                 details=self._exception_details(exc),
             ) from exc
         return OperationExecutionResponse(
             result=self._normalize_execution_result(result)
         )
+
+    async def execute_operation_for_auth_config(
+        self,
+        *,
+        user_id: UUID,
+        organization_id: UUID,
+        auth_config_name: str,
+        operation_name: str,
+        payload: dict[str, Any],
+        actor: Context | None = None,
+        auth_token: str | None = None,
+        api_url: str | None = None,
+        account_id: UUID | None = None,
+    ) -> OperationExecutionResponse:
+        resolved = await self.resolve_execution_for_auth_config(
+            user_id=user_id,
+            organization_id=organization_id,
+            auth_config_name=auth_config_name,
+            operation_name=operation_name,
+            payload=payload,
+            actor=actor,
+            auth_token=auth_token,
+            api_url=api_url,
+            account_id=account_id,
+        )
+        return await self.execute_resolved(resolved)
+
+    async def execute_operation(
+        self,
+        *,
+        connector_id: str,
+        operation_name: str,
+        payload: dict[str, Any],
+        user_id: UUID,
+        actor: Context | None = None,
+        auth_token: str | None = None,
+        api_url: str | None = None,
+        account_id: UUID | None = None,
+        auth_config_id: UUID | None = None,
+    ) -> OperationExecutionResponse:
+        resolved = await self._resolve_execution(
+            connector_id=connector_id,
+            operation_name=operation_name,
+            payload=payload,
+            user_id=user_id,
+            actor=actor,
+            auth_token=auth_token,
+            api_url=api_url,
+            account_id=account_id,
+            auth_config_id=auth_config_id,
+        )
+        return await self.execute_resolved(resolved)

--- a/lemma-backend/app/modules/connectors/tests/unit/test_connector_operation_use_cases.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_connector_operation_use_cases.py
@@ -1,0 +1,105 @@
+"""Unit tests for ConnectorOperationUseCases — the saga that releases the pooled
+DB connection across the external connector/Composio operation call.
+
+The key guarantee: the DB/auth resolve phase runs (and its short scope closes,
+releasing the connection + committing any OAuth-token refresh) BEFORE the
+external execute phase runs.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass
+from uuid import uuid4
+
+import pytest
+
+from app.modules.connectors.application import connector_operation_use_cases as ucmod
+from app.modules.connectors.application.connector_operation_use_cases import (
+    ConnectorOperationUseCases,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+@dataclass
+class _FakeUowCtx:
+    uow: object
+    ctx: object
+
+
+@pytest.fixture
+def events():
+    return []
+
+
+@pytest.fixture(autouse=True)
+def _fake_scopes(monkeypatch, events):
+    @contextlib.asynccontextmanager
+    async def fake_current_context_scope(uow_factory, *, request, user_id):
+        events.append("p1_open")
+        try:
+            yield _FakeUowCtx(uow="uow1", ctx="ctx-actor")
+        finally:
+            events.append("p1_close")
+
+    @contextlib.asynccontextmanager
+    async def fake_uow_scope(uow_factory):
+        events.append("p2_open")
+        try:
+            yield "uow2"
+        finally:
+            events.append("p2_close")
+
+    monkeypatch.setattr(ucmod, "current_context_scope", fake_current_context_scope)
+    monkeypatch.setattr(ucmod, "uow_scope", fake_uow_scope)
+
+
+async def test_resolve_runs_in_phase1_and_execute_runs_after_release(events):
+    resolved_sentinel = object()
+    response_sentinel = object()
+
+    class _FakeService:
+        def __init__(self, uow):
+            self.uow = uow
+
+        async def resolve_execution_for_auth_config(self, **kwargs):
+            events.append(("resolve", self.uow, kwargs["actor"]))
+            return resolved_sentinel
+
+        async def execute_resolved(self, resolved):
+            events.append(("execute", self.uow, resolved))
+            return response_sentinel
+
+    uc = ConnectorOperationUseCases(uow_factory=object(), service_builder=_FakeService)
+
+    result = await uc.execute_operation_for_auth_config(
+        organization_id=uuid4(),
+        auth_config_name="outlook",
+        operation_name="OUTLOOK_CREATE_DRAFT_REPLY",
+        payload={"x": 1},
+        user_id=uuid4(),
+        request=object(),
+        auth_token="tok",
+        api_url="https://api",
+        account_id=None,
+    )
+
+    assert result is response_sentinel
+
+    names = [e if isinstance(e, str) else e[0] for e in events]
+    # Phase 1 fully closes (connection released) BEFORE the external execute runs.
+    assert names == [
+        "p1_open",
+        "resolve",
+        "p1_close",
+        "p2_open",
+        "execute",
+        "p2_close",
+    ]
+
+    resolve_evt = next(e for e in events if isinstance(e, tuple) and e[0] == "resolve")
+    execute_evt = next(e for e in events if isinstance(e, tuple) and e[0] == "execute")
+    # resolve authorizes with the in-scope ctx as actor; execute consumes the plan.
+    assert resolve_evt[1] == "uow1" and resolve_evt[2] == "ctx-actor"
+    assert execute_evt[1] == "uow2" and execute_evt[2] is resolved_sentinel

--- a/lemma-backend/app/modules/connectors/tests/unit/test_routing_operation_gateway.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_routing_operation_gateway.py
@@ -80,6 +80,59 @@ async def test_routes_composio_executor_apps_to_composio_gateway():
 
 
 @pytest.mark.asyncio
+async def test_preresolved_provider_skips_connector_validation_read():
+    # When the caller already resolved `provider` (the use-case resolve phase,
+    # which validated the connector under a short DB scope), the gateway must NOT
+    # touch the connector repository — so the external execute phase holds no DB
+    # connection.
+    connector_repository = AsyncMock(get=AsyncMock())
+    lemma_gateway = AsyncMock(execute_operation=AsyncMock(return_value={"ok": True}))
+
+    gateway = RoutingOperationGateway(
+        connector_repository=connector_repository,
+        lemma_gateway=lemma_gateway,
+        composio_gateway=AsyncMock(),
+    )
+
+    result = await gateway.execute_operation(
+        connector_id="gmail",
+        operation_name="drafts_list",
+        payload={},
+        third_party_credentials={"access_token": "t"},
+        provider=AuthProvider.LEMMA.value,
+    )
+
+    assert result == {"ok": True}
+    connector_repository.get.assert_not_awaited()
+    lemma_gateway.execute_operation.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_provider_still_validates_connector():
+    # Back-compat: callers that don't pre-resolve a provider keep the existence
+    # validation (and its DB read).
+    connector_repository = AsyncMock(
+        get=AsyncMock(return_value=ConnectorEntity(id="gmail"))
+    )
+    lemma_gateway = AsyncMock(execute_operation=AsyncMock(return_value={"ok": True}))
+
+    gateway = RoutingOperationGateway(
+        connector_repository=connector_repository,
+        lemma_gateway=lemma_gateway,
+        composio_gateway=AsyncMock(),
+    )
+
+    await gateway.execute_operation(
+        connector_id="gmail",
+        operation_name="drafts_list",
+        payload={},
+        third_party_credentials={"access_token": "t"},
+    )
+
+    connector_repository.get.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_execute_operation_times_out_instead_of_hanging(monkeypatch):
     """A slow/hung upstream must fail fast with a 504, not block indefinitely."""
     monkeypatch.setattr(connector_settings, "connector_operation_timeout_seconds", 0.2)

--- a/lemma-backend/app/modules/function/api/controllers/function_controller.py
+++ b/lemma-backend/app/modules/function/api/controllers/function_controller.py
@@ -46,7 +46,6 @@ from app.modules.function.api.dependencies import (
     FunctionResourceDeleteDep,
     FunctionResourceEditorDep,
     FunctionResourceAdminDep,
-    FunctionResourceExecuteDep,
     FunctionResourceViewerDep,
 )
 from app.modules.workspace.services.workspace_tool_runtime import (
@@ -331,7 +330,12 @@ async def delete_function(
     operation_id="function.run",
     summary="Execute Function",
     description="Execute a function",
-    dependencies=[FunctionResourceExecuteDep],
+    # No route-level FunctionResourceExecuteDep: that request-scoped dependency
+    # pins its pooled DB connection for the whole request, including the slow
+    # sandbox execution. Authorization happens instead inside the use-case's
+    # short pod_context_scope (function_service.resolve_execute ->
+    # ctx.require(FUNCTION_EXECUTE)), so the connection is released before the
+    # sandbox round-trip. Mirrors conversation_controller.send_message.
 )
 async def execute_function(
     request: Request,

--- a/lemma-backend/app/modules/function/application/function_run_executor.py
+++ b/lemma-backend/app/modules/function/application/function_run_executor.py
@@ -21,7 +21,6 @@ import contextlib
 import json
 import os
 import time
-import traceback
 from datetime import datetime
 from typing import Any
 from uuid import UUID
@@ -55,8 +54,11 @@ from app.modules.function.services.function_runtime_command import (
     function_workspace_cwd,
 )
 from app.modules.workspace.agentbox_retry import (
+    CONNECT_PHASE_TRANSPORT_ERRORS,
     RETRYABLE_HTTP_STATUS_CODES,
+    RETRYABLE_TRANSPORT_ERRORS,
     retry_on_transient_agentbox_error,
+    truncate_message,
 )
 from app.modules.workspace.services.agentbox_manager import agentbox_sandbox_id
 
@@ -113,6 +115,17 @@ _RECOVERABLE_SANDBOX_TRANSPORT_ERRORS = (
     httpx.WriteError,
     httpx.WriteTimeout,
 )
+# A synchronous (API) function execute is NON-IDEMPOTENT: re-running it re-runs
+# whatever side effect the function already performed (e.g. creating an Outlook
+# draft). Its sandbox-recovery may therefore only re-run on errors that prove the
+# request never reached a running app -- the pod is missing/conflicted (404/409)
+# or the connection was never established (ConnectError/ConnectTimeout). A 5xx or
+# a response-leg transport error (read/remote-protocol/write) is ambiguous (the
+# app may have already run), so it must surface as a failure rather than trigger
+# a re-run. Mirrors the inner ``CONNECT_PHASE_TRANSPORT_ERRORS`` / 504-drop logic
+# in ``_execute_via_function_executor``.
+_NON_IDEMPOTENT_RECOVERABLE_SANDBOX_STATUS_CODES = frozenset({404, 409})
+_NON_IDEMPOTENT_RECOVERABLE_SANDBOX_TRANSPORT_ERRORS = CONNECT_PHASE_TRANSPORT_ERRORS
 
 
 class FunctionRunExecutor:
@@ -221,7 +234,10 @@ class FunctionRunExecutor:
                 )
             except Exception as exc:
                 run.status = FunctionRunStatus.FAILED
-                run.error, run.logs = self._format_execution_exception(exc)
+                # Clean, user-facing error only; full server detail goes to
+                # logger.exception below. Leave run.logs as the container logs
+                # (if any) -- never append a server traceback.
+                run.error = self._user_facing_execution_error(exc)
                 run.completed_at = datetime.now()
                 await self._persist_terminal_run(function, run)
                 logger.exception("Function job run %s failed during execution", run.id)
@@ -237,10 +253,10 @@ class FunctionRunExecutor:
             )
         except Exception as exc:
             run.status = FunctionRunStatus.FAILED
-            run.error, exception_logs = self._format_execution_exception(exc)
-            run.logs = "\n".join(
-                part for part in [run.logs, exception_logs] if part
-            ) or None
+            # Clean, user-facing error only; full server detail goes to
+            # logger.exception below. Preserve any container logs already on the
+            # run -- never append a server traceback or raw HTTP body.
+            run.error = self._user_facing_execution_error(exc)
             logger.exception("Function run %s failed during execution", run.id)
 
         run.completed_at = datetime.now()
@@ -396,8 +412,16 @@ class FunctionRunExecutor:
                 if close is not None:
                     await close()
 
+        # A synchronous (API) execute is non-idempotent, so sandbox-recovery may
+        # only re-run on "the request provably never ran" errors (pod missing /
+        # connect-phase) -- never on an ambiguous 5xx or response-leg transport
+        # error that may have already executed the function and run its side
+        # effect (the cause of the duplicate-draft storm).
         executor_response = await self._execute_with_sandbox_recovery(
-            run=run, make_attempt=_attempt
+            run=run,
+            make_attempt=_attempt,
+            recoverable_status_codes=_NON_IDEMPOTENT_RECOVERABLE_SANDBOX_STATUS_CODES,
+            recoverable_transport_errors=_NON_IDEMPOTENT_RECOVERABLE_SANDBOX_TRANSPORT_ERRORS,
         )
         self._apply_executor_response_to_run(run, executor_response)
 
@@ -470,21 +494,32 @@ class FunctionRunExecutor:
     # -- Resilience helpers ------------------------------------------------
 
     @staticmethod
-    def _is_recoverable_sandbox_error(exc: BaseException) -> bool:
+    def _is_recoverable_sandbox_error(
+        exc: BaseException,
+        *,
+        status_codes: frozenset[int] = _RECOVERABLE_SANDBOX_STATUS_CODES,
+        transport_errors: tuple[type[BaseException], ...] = _RECOVERABLE_SANDBOX_TRANSPORT_ERRORS,
+    ) -> bool:
         """True for errors that mean "the sandbox is internally unavailable right
         now" -- a missing/not-running pod or a manager/transport blip -- as
         opposed to a real function failure (which comes back as a 200 response,
         never an exception) or a genuine function timeout (a builtin TimeoutError
-        from the poll, deliberately excluded so it stays terminal)."""
+        from the poll, deliberately excluded so it stays terminal).
+
+        ``status_codes``/``transport_errors`` are narrowed by the caller for a
+        non-idempotent (synchronous) execute so a request that may have already
+        run is not re-run."""
         if isinstance(exc, httpx.HTTPStatusError):
-            return exc.response.status_code in _RECOVERABLE_SANDBOX_STATUS_CODES
-        return isinstance(exc, _RECOVERABLE_SANDBOX_TRANSPORT_ERRORS)
+            return exc.response.status_code in status_codes
+        return isinstance(exc, transport_errors)
 
     async def _execute_with_sandbox_recovery(
         self,
         *,
         run: FunctionRunEntity,
         make_attempt,
+        recoverable_status_codes: frozenset[int] = _RECOVERABLE_SANDBOX_STATUS_CODES,
+        recoverable_transport_errors: tuple[type[BaseException], ...] = _RECOVERABLE_SANDBOX_TRANSPORT_ERRORS,
     ) -> FunctionInvokeResponse:
         """Run an execution attempt, recovering from transient sandbox failures.
 
@@ -496,6 +531,11 @@ class FunctionRunExecutor:
         200 response (status ``failed``/``timeout``) -- never an exception -- so it
         is returned and never retried. Only a sandbox that cannot be provisioned
         (the error persists across every attempt) surfaces as a run failure.
+
+        For a non-idempotent (synchronous) execute the caller narrows
+        ``recoverable_status_codes``/``recoverable_transport_errors`` to the
+        "request provably never ran" set, so an ambiguous failure does not re-run
+        the function and duplicate its side effect.
         """
         last_exc: BaseException | None = None
         for attempt in range(1, _SANDBOX_RECOVERY_MAX_ATTEMPTS + 1):
@@ -503,7 +543,11 @@ class FunctionRunExecutor:
                 return await make_attempt()
             except Exception as exc:
                 if (
-                    not self._is_recoverable_sandbox_error(exc)
+                    not self._is_recoverable_sandbox_error(
+                        exc,
+                        status_codes=recoverable_status_codes,
+                        transport_errors=recoverable_transport_errors,
+                    )
                     or attempt == _SANDBOX_RECOVERY_MAX_ATTEMPTS
                 ):
                     raise
@@ -614,19 +658,31 @@ class FunctionRunExecutor:
             # A synchronous execute is non-idempotent: a 504 means the request
             # reached the in-sandbox app and it ran past its budget without
             # responding, so re-sending could run the function again. Drop 504
-            # from the retryable set for sync and surface a timeout instead. An
-            # async_job execute returns immediately, so it keeps the full set
-            # (its retries only ever cover the cold-start "app not ready" race).
+            # from the retryable set for sync and surface a timeout instead. For
+            # the same reason, drop the response-leg transport errors (read /
+            # remote-protocol / write / OSError such as "connection reset by
+            # peer"): each can fire *after* the function already ran and produced
+            # its side effect, so retrying would duplicate it -- the bug behind
+            # the Outlook duplicate-draft storm. Only connect-phase errors
+            # (ConnectError/ConnectTimeout) are safe, and they still cover the
+            # cold-start "app not ready" race. An async_job execute returns
+            # immediately, so it keeps the full sets.
             retryable_status_codes = (
                 RETRYABLE_HTTP_STATUS_CODES
                 if async_job
                 else RETRYABLE_HTTP_STATUS_CODES - {504}
+            )
+            retryable_transport_errors = (
+                RETRYABLE_TRANSPORT_ERRORS
+                if async_job
+                else CONNECT_PHASE_TRANSPORT_ERRORS
             )
             try:
                 return await retry_on_transient_agentbox_error(
                     _do_execute,
                     max_attempts=_FUNCTION_EXECUTE_RETRY_MAX_ATTEMPTS,
                     retryable_status_codes=retryable_status_codes,
+                    retryable_transport_errors=retryable_transport_errors,
                     on_retry=lambda attempt, message: logger.info(
                         "function_executor execute not ready sandbox=%s run=%s attempt=%s: %s",
                         sandbox_id,
@@ -828,40 +884,35 @@ class FunctionRunExecutor:
 
         return "\n".join(part for part in parts if part) or None
 
-    def _format_execution_exception(self, exc: Exception) -> tuple[str, str | None]:
-        response = getattr(exc, "response", None)
-        if response is not None:
-            status_code = getattr(response, "status_code", None)
-            body = getattr(response, "text", None) or getattr(response, "content", b"")
-            if isinstance(body, bytes):
-                body = body.decode("utf-8", errors="replace")
-            body = str(body).strip()
-            request = getattr(response, "request", None)
-            request_label = ""
-            if request is not None:
-                request_label = f" {getattr(request, 'method', '')} {getattr(request, 'url', '')}".strip()
-            error = (
-                f"Function sandbox request failed with HTTP {status_code}"
-                if status_code is not None
-                else "Function sandbox request failed"
-            )
-            if body:
-                first_line = body.splitlines()[0]
-                error = f"{error}: {first_line}"
-            logs = "\n".join(
-                part
-                for part in [
-                    f"Sandbox request failed{': ' + request_label if request_label else ''}",
-                    f"HTTP status: {status_code}" if status_code is not None else None,
-                    body,
-                ]
-                if part
-            )
-            return error, logs or None
+    def _user_facing_execution_error(self, exc: Exception) -> str:
+        """A concise, user-facing message for a backend<->sandbox failure.
 
-        error = str(exc) or exc.__class__.__name__
-        logs = "".join(traceback.format_exception(type(exc), exc, exc.__traceback__))
-        return error, logs
+        ``run.error`` and ``run.logs`` are surfaced to pod authors (and embedded
+        in workflow node errors), so they must NOT carry server internals -- raw
+        HTTP response bodies, ``str(OSError)`` like ``[Errno 104] Connection reset
+        by peer``, or Python tracebacks. The full detail is captured server-side
+        via ``logger.exception`` at the call site; here we map the failure class
+        to a clean sentence. A real function failure never reaches this path (it
+        returns a 200 response whose structured ``error.message`` is used by
+        ``_apply_executor_response_to_run``); only backend<->sandbox transport /
+        HTTP / timeout failures and our own ``FunctionValidationError`` do.
+        """
+        if isinstance(exc, FunctionValidationError):
+            # Already authored to be user-facing (e.g. schema mismatch).
+            return truncate_message(str(exc)) or "Function validation failed."
+        if isinstance(exc, httpx.HTTPStatusError):
+            status_code = exc.response.status_code
+            if status_code in (502, 503, 504):
+                return "The function sandbox was temporarily unavailable. Please retry."
+            return "The function sandbox returned an unexpected error."
+        if isinstance(exc, (httpx.TimeoutException, TimeoutError)):
+            return "The function did not complete before the execution timeout."
+        if isinstance(exc, (httpx.TransportError, OSError)):
+            return (
+                "The function sandbox connection was interrupted; the function "
+                "may not have completed."
+            )
+        return "The function failed to execute due to an internal error."
 
     def _job_workspace_session_id(self, run_id: UUID) -> str:
         return f"function-run-{run_id}"

--- a/lemma-backend/app/modules/function/tests/unit/test_function_run_executor_resilience.py
+++ b/lemma-backend/app/modules/function/tests/unit/test_function_run_executor_resilience.py
@@ -1,0 +1,154 @@
+"""Unit tests for the function-run executor's resilience behaviour:
+
+* Fix 1 (outer): a synchronous (non-idempotent) execute does not re-run the
+  whole function on an ambiguous post-dispatch error, but still recovers from a
+  "request provably never ran" error.
+* Fix 3: backend<->sandbox failures surface a clean, user-facing ``run.error``
+  with no server tracebacks / raw HTTP bodies / ``Errno`` strings.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.core.log import log as _log_module  # noqa: F401  (ensure logging import OK)
+from app.modules.function.application import function_run_executor as fre
+from app.modules.function.application.function_run_executor import (
+    _NON_IDEMPOTENT_RECOVERABLE_SANDBOX_STATUS_CODES,
+    _NON_IDEMPOTENT_RECOVERABLE_SANDBOX_TRANSPORT_ERRORS,
+    FunctionRunExecutor,
+)
+from app.modules.function.domain.errors import FunctionValidationError
+
+pytestmark = pytest.mark.asyncio
+
+
+def _executor() -> FunctionRunExecutor:
+    return FunctionRunExecutor(workspace_service=None, storage_factory=None)
+
+
+def _http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "https://sandbox.test/execute")
+    response = httpx.Response(status_code, request=request, text="internal stack trace leak")
+    return httpx.HTTPStatusError("error", request=request, response=response)
+
+
+class _FakeRun:
+    id = "run-1"
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    async def _instant(_delay):
+        return None
+
+    monkeypatch.setattr(fre.asyncio, "sleep", _instant)
+
+
+# --------------------------------------------------------------------------
+# Fix 3 — clean, user-facing error mapping (no server internals)
+# --------------------------------------------------------------------------
+
+_LEAK_SUBSTRINGS = ("Traceback", "Errno", "104", "Connection reset", "stack trace", "sandbox.test")
+
+
+@pytest.mark.parametrize(
+    "exc,expected_fragment",
+    [
+        (ConnectionResetError(104, "Connection reset by peer"), "interrupted"),
+        (httpx.ReadError("boom"), "interrupted"),
+        (httpx.RemoteProtocolError("server disconnected"), "interrupted"),
+        (httpx.ReadTimeout("slow"), "timeout"),
+        (TimeoutError("deadline"), "timeout"),
+        (_http_status_error(503), "temporarily unavailable"),
+        (_http_status_error(500), "unexpected error"),
+        (ValueError("kaboom internal"), "internal error"),
+    ],
+)
+async def test_user_facing_error_is_clean(exc, expected_fragment):
+    msg = _executor()._user_facing_execution_error(exc)
+    assert expected_fragment in msg.lower()
+    for leak in _LEAK_SUBSTRINGS:
+        assert leak not in msg
+
+
+async def test_function_validation_error_message_passes_through():
+    msg = _executor()._user_facing_execution_error(
+        FunctionValidationError("Input does not match the declared schema.")
+    )
+    assert msg == "Input does not match the declared schema."
+
+
+# --------------------------------------------------------------------------
+# Fix 1 (outer) — sandbox-recovery is idempotency-aware for sync executes
+# --------------------------------------------------------------------------
+
+
+async def test_is_recoverable_matrix_default_vs_narrowed():
+    # Default (async-job / JOB path): the full set still recovers read errors + 5xx.
+    assert FunctionRunExecutor._is_recoverable_sandbox_error(httpx.ReadError("x")) is True
+    assert FunctionRunExecutor._is_recoverable_sandbox_error(_http_status_error(500)) is True
+
+    # Narrowed (sync / non-idempotent): only "request provably never ran" errors.
+    narrow = dict(
+        status_codes=_NON_IDEMPOTENT_RECOVERABLE_SANDBOX_STATUS_CODES,
+        transport_errors=_NON_IDEMPOTENT_RECOVERABLE_SANDBOX_TRANSPORT_ERRORS,
+    )
+    assert FunctionRunExecutor._is_recoverable_sandbox_error(httpx.ReadError("x"), **narrow) is False
+    assert FunctionRunExecutor._is_recoverable_sandbox_error(_http_status_error(500), **narrow) is False
+    assert FunctionRunExecutor._is_recoverable_sandbox_error(httpx.ConnectError("x"), **narrow) is True
+    assert FunctionRunExecutor._is_recoverable_sandbox_error(_http_status_error(404), **narrow) is True
+
+
+async def test_sync_recovery_does_not_rerun_on_post_dispatch_error():
+    calls = {"n": 0}
+
+    async def _attempt():
+        calls["n"] += 1
+        raise httpx.ReadError("response-leg failure after the function ran")
+
+    with pytest.raises(httpx.ReadError):
+        await _executor()._execute_with_sandbox_recovery(
+            run=_FakeRun(),
+            make_attempt=_attempt,
+            recoverable_status_codes=_NON_IDEMPOTENT_RECOVERABLE_SANDBOX_STATUS_CODES,
+            recoverable_transport_errors=_NON_IDEMPOTENT_RECOVERABLE_SANDBOX_TRANSPORT_ERRORS,
+        )
+    # No re-run — the function may already have executed its side effect.
+    assert calls["n"] == 1
+
+
+async def test_sync_recovery_still_recovers_when_request_never_ran():
+    calls = {"n": 0}
+
+    async def _attempt():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.ConnectError("pod missing / connection refused")
+        return "ok"
+
+    result = await _executor()._execute_with_sandbox_recovery(
+        run=_FakeRun(),
+        make_attempt=_attempt,
+        recoverable_status_codes=_NON_IDEMPOTENT_RECOVERABLE_SANDBOX_STATUS_CODES,
+        recoverable_transport_errors=_NON_IDEMPOTENT_RECOVERABLE_SANDBOX_TRANSPORT_ERRORS,
+    )
+    assert result == "ok"
+    assert calls["n"] == 2
+
+
+async def test_default_recovery_reruns_read_error_for_job_path():
+    # The JOB/async path keeps the full recoverable set (re-running an accepted
+    # job is safe because the sandbox dedupes by run_id).
+    calls = {"n": 0}
+
+    async def _attempt():
+        calls["n"] += 1
+        raise httpx.ReadError("blip")
+
+    with pytest.raises(httpx.ReadError):
+        await _executor()._execute_with_sandbox_recovery(
+            run=_FakeRun(), make_attempt=_attempt
+        )
+    assert calls["n"] == fre._SANDBOX_RECOVERY_MAX_ATTEMPTS

--- a/lemma-backend/app/modules/function/tests/unit/test_function_service.py
+++ b/lemma-backend/app/modules/function/tests/unit/test_function_service.py
@@ -671,7 +671,7 @@ async def test_execute_function_api_cache_hit_skips_code_fetch(
     assert fake_session.exec_calls == []
 
 
-async def test_execute_function_sandbox_http_error_is_persisted_on_run(
+async def test_execute_function_sandbox_http_error_surfaces_clean_error(
     service: FunctionService,
     function_repo: AsyncMock,
     run_repo: AsyncMock,
@@ -697,11 +697,15 @@ async def test_execute_function_sandbox_http_error_is_persisted_on_run(
     result = await _execute(service, function, run)
 
     assert result.status == FunctionRunStatus.FAILED
-    assert "HTTP 500" in result.error
-    assert "sandbox execution crashed" in result.logs
+    # Fix 3: the run carries a clean, user-facing error — never the HTTP status
+    # code or the raw sandbox/manager response body.
+    assert "unexpected error" in result.error.lower()
+    assert "HTTP 500" not in result.error
+    assert "sandbox execution crashed" not in result.error
+    assert "sandbox execution crashed" not in (result.logs or "")
     final_update = run_repo.update_run_and_collect.await_args.kwargs
     assert final_update["status"] == FunctionRunStatus.FAILED
-    assert "sandbox execution crashed" in final_update["logs"]
+    assert "sandbox execution crashed" not in (final_update.get("logs") or "")
 
 
 async def test_execute_function_recovers_from_transient_sandbox_error(

--- a/lemma-backend/app/modules/test_support/e2e/runtime.py
+++ b/lemma-backend/app/modules/test_support/e2e/runtime.py
@@ -479,8 +479,9 @@ async def full_stack(
         )
 
     # Inject the Fireworks key so both the in-process backend and the worker
-    # subprocess resolve the system:lemma OpenAI-compatible profile (its
-    # base_url/default model already default to Fireworks).
+    # subprocess resolve the system:lemma OpenAI-compatible profile. The model
+    # catalog has no built-in default, so the real-LLM env (.env / exported
+    # LEMMA_OPENAI_* vars) must provide LEMMA_OPENAI_BASE_URL + LEMMA_OPENAI_MODEL_NAMES.
     cred_env_keys = ("LEMMA_OPENAI_API_KEY", "lemma_openai_api_key")
     original_cred_env = {key: os.environ.get(key) for key in cred_env_keys}
     original_cred_setting = settings.lemma_openai_api_key

--- a/lemma-backend/app/modules/workflow/infrastructure/adapters/function_adapter.py
+++ b/lemma-backend/app/modules/workflow/infrastructure/adapters/function_adapter.py
@@ -47,7 +47,11 @@ class FunctionControlAdapter(FunctionPort):
         if run.status == FunctionRunStatus.COMPLETED:
             return run.output_data
         if run.status == FunctionRunStatus.FAILED:
-            raise RuntimeError(f"Function execution failed: {run.error}")
+            # run.error is already a clean, user-facing message; the stepper wraps
+            # this as "Node '<id>' execution failed: <message>", so don't add a
+            # redundant "Function execution failed:" prefix (the node is a
+            # function) or leak internal detail here.
+            raise RuntimeError(run.error or "The function failed to execute.")
 
         # A non-terminal run is a JOB dispatched to the worker; suspend the
         # workflow on the run id (API functions always complete inline or fail).

--- a/lemma-backend/app/modules/workspace/agentbox_retry.py
+++ b/lemma-backend/app/modules/workspace/agentbox_retry.py
@@ -33,6 +33,20 @@ RETRYABLE_TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
     OSError,
 )
 
+# A subset of the above that provably occur *before* the request is delivered to
+# the upstream app: the connection was never established, so the request could
+# not have run. These are the only transport errors safe to retry for a
+# NON-IDEMPOTENT call (e.g. a synchronous function execute that has a side
+# effect). The errors omitted here -- ReadError/ReadTimeout/RemoteProtocolError/
+# WriteError/WriteTimeout/OSError -- can all fire *after* the request reached and
+# ran in the app (the failure is only on the response leg), so re-sending would
+# run the side effect a second time. This mirrors why sync executes also drop
+# 504 from ``RETRYABLE_HTTP_STATUS_CODES``.
+CONNECT_PHASE_TRANSPORT_ERRORS: tuple[type[BaseException], ...] = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+)
+
 DEFAULT_MAX_ATTEMPTS = 12
 DEFAULT_INITIAL_RETRY_DELAY_SECONDS = 0.25
 DEFAULT_MAX_RETRY_DELAY_SECONDS = 2.0
@@ -80,6 +94,7 @@ async def retry_on_transient_agentbox_error(
     max_delay: float = DEFAULT_MAX_RETRY_DELAY_SECONDS,
     on_retry: Callable[[int, str], None] | None = None,
     retryable_status_codes: frozenset[int] = RETRYABLE_HTTP_STATUS_CODES,
+    retryable_transport_errors: tuple[type[BaseException], ...] = RETRYABLE_TRANSPORT_ERRORS,
 ) -> T:
     """Run ``operation`` retrying only transient transport / retryable-5xx errors.
 
@@ -89,7 +104,11 @@ async def retry_on_transient_agentbox_error(
     hook invoked before each backoff sleep. ``retryable_status_codes`` narrows
     which 5xx codes are retried -- e.g. a non-idempotent synchronous call drops
     504 (gateway timeout) so a request that already reached the app is not
-    re-sent.
+    re-sent. ``retryable_transport_errors`` narrows which transport exceptions
+    are retried for the same reason -- a non-idempotent call passes
+    ``CONNECT_PHASE_TRANSPORT_ERRORS`` so a request that may have already run in
+    the app (a response-leg failure) is not re-sent and its side effect not
+    duplicated.
     """
     delay = initial_delay
     for attempt in range(1, max_attempts + 1):
@@ -102,7 +121,7 @@ async def retry_on_transient_agentbox_error(
             ):
                 raise
             error = format_http_status_error(exc)
-        except RETRYABLE_TRANSPORT_ERRORS as exc:
+        except retryable_transport_errors as exc:
             if attempt == max_attempts:
                 raise
             error = format_transport_error(exc)

--- a/lemma-backend/app/modules/workspace/tests/unit/test_agentbox_retry.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_agentbox_retry.py
@@ -5,6 +5,7 @@ import pytest
 
 from app.modules.workspace import agentbox_retry
 from app.modules.workspace.agentbox_retry import (
+    CONNECT_PHASE_TRANSPORT_ERRORS,
     is_retryable_http_error,
     retry_on_transient_agentbox_error,
 )
@@ -105,3 +106,66 @@ async def test_is_retryable_http_error_matrix():
     assert is_retryable_http_error(_http_status_error(500))
     assert not is_retryable_http_error(_http_status_error(400))
     assert not is_retryable_http_error(_http_status_error(404))
+
+
+# --- non-idempotent (narrowed transport set) -------------------------------
+# A synchronous function execute passes CONNECT_PHASE_TRANSPORT_ERRORS so a
+# response-leg failure (which may have already run the function) is NOT re-sent.
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        httpx.ReadError("read failed"),
+        httpx.ReadTimeout("timed out"),
+        httpx.RemoteProtocolError("server disconnected"),
+        ConnectionResetError(104, "Connection reset by peer"),  # OSError subclass
+    ],
+)
+async def test_post_dispatch_transport_error_not_retried_when_narrowed(exc):
+    calls = {"n": 0}
+
+    async def _op():
+        calls["n"] += 1
+        raise exc
+
+    with pytest.raises(type(exc)):
+        await retry_on_transient_agentbox_error(
+            _op,
+            max_attempts=5,
+            retryable_transport_errors=CONNECT_PHASE_TRANSPORT_ERRORS,
+        )
+    # Surfaces immediately — the request may have already executed.
+    assert calls["n"] == 1
+
+
+async def test_connect_phase_error_still_retried_when_narrowed():
+    calls = {"n": 0}
+
+    async def _op():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.ConnectError("Connection refused")  # request never delivered
+        return "ok"
+
+    result = await retry_on_transient_agentbox_error(
+        _op,
+        max_attempts=3,
+        retryable_transport_errors=CONNECT_PHASE_TRANSPORT_ERRORS,
+    )
+    assert result == "ok"
+    assert calls["n"] == 2
+
+
+async def test_default_transport_set_still_retries_read_error():
+    # The default (async-job / non-narrowed) path keeps the full set.
+    calls = {"n": 0}
+
+    async def _op():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.ReadError("blip")
+        return "ok"
+
+    assert await retry_on_transient_agentbox_error(_op, max_attempts=3) == "ok"
+    assert calls["n"] == 2


### PR DESCRIPTION
## Why

Investigating a pod that produced **~200 duplicate Outlook drafts from only ~80 workflow runs** (the same reply appearing 8+ times within the same minute) surfaced one root-cause bug plus three adjacent issues on the function-execution and connector paths. All four are fixed here.

## Fixes

### 1. Idempotent sync (`API`) function-execute retries — *the duplicate-draft cause*
A synchronous function execute is **non-idempotent** (it can run a side effect like `OUTLOOK_CREATE_DRAFT_REPLY`), so it must not be re-sent on errors that can fire **after** the request already ran in the sandbox.

- `agentbox_retry.py`: add `CONNECT_PHASE_TRANSPORT_ERRORS` (`ConnectError`/`ConnectTimeout` — connection never established → request provably not delivered) and a `retryable_transport_errors` param.
- `function_run_executor.py`: for `async_job=False`, the **inner** execute retry uses the connect-phase set only, and the **outer** `_execute_with_sandbox_recovery` recovers only on "request provably never ran" errors (`404/409` + connect-phase). The `JOB`/async path keeps the full sets (the sandbox dedupes accepted jobs by `run_id`).

This closes the same non-idempotency hole the existing `- {504}` logic already acknowledged for status codes, now extended to the response-leg transport errors (`ReadError`/`ReadTimeout`/`RemoteProtocolError`/`OSError` such as *connection reset by peer*).

### 2. Don't pin a DB connection across the sandbox call
Remove the redundant route-level `FunctionResourceExecuteDep` on the function-execute endpoint — `function_service.resolve_execute` already enforces `FUNCTION_EXECUTE` inside the use-case's short `pod_context_scope`, so the route dep only served to pin a pooled connection across the multi-second sandbox call. **Audit outcome:** the file/app heavy-IO endpoints already use short-scoped use-cases; workspace/browser/icon use sandbox-token auth (no DB); flow-run is async CRUD.

### 3. Connector-operation use-case (release the connection across the Composio call)
Every `pod.connectors.execute(...)` from a function routed through an endpoint that pinned **one** request-scoped connection (shared by `get_current_context` + the service) across the always-present **1–45s** external operation call.

- New `ConnectorOperationUseCases` (factory mode, mirrors `FunctionUseCases`) + a reusable `current_context_scope` primitive (org/**delegation**-claims aware — functions hit this endpoint with delegated tokens).
- Split `ConnectorOperationService` into `resolve_execution` (DB + authz + credentials, short scope) and `execute_resolved` (external only, no DB). The routing gateway skips its connector-validation read when `provider` is pre-resolved (concrete Lemma/Composio gateways are DB-free).
- **Preserved exactly:** org + delegation authorization, the 45s operation timeout, result normalization, error mapping.
- **Follow-up (noted):** decomposing the *shared* `get_account_credentials` OAuth refresh so the conditional token refresh also releases the connection (benefits `account_controller` + `agent_surfaces/credential_resolver`). This PR fixes the always-present, longest hold.

### 4. Clean `run.error` / `run.logs`
Backend↔sandbox failures no longer dump Python tracebacks or raw HTTP response bodies into the run. `_user_facing_execution_error` maps the failure class to a concise message; full detail still goes to the server log via `logger.exception`. The workflow node-error prefix is de-nested (`Node 'x' execution failed: <clean message>`).

## Tests
- `test_agentbox_retry.py`: post-dispatch transport errors are **not** retried under the narrowed set; connect-phase still is; default set unchanged.
- `test_function_run_executor_resilience.py` (new): `_user_facing_execution_error` leaks no traceback/HTTP-body/`Errno`; sync recovery doesn't re-run on post-dispatch errors but recovers when the request never ran; JOB path unchanged.
- `test_routing_operation_gateway.py`: pre-resolved provider skips the connector read; no-provider still validates.
- `test_connector_operation_use_cases.py` (new): the resolve scope closes (connection released) **before** the external execute runs; authz actor threaded.
- `test_function_service.py`: updated to assert the clean (non-leaky) error.
- Full unit suite green: **1534 passed**.

## Authorization note
No authorization behavior changes. Function execute still enforces `FUNCTION_EXECUTE` (in-scope); connector execute still builds the org/delegation `Context` and threads it as the actor — just inside a short scope instead of a request-scoped dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)