### PR TITLE
fix(connectors): remove splitwise, fix Composio connect, API-key auth, account status

### DIFF
--- a/lemma-backend/app/modules/connectors/api/account_controller.py
+++ b/lemma-backend/app/modules/connectors/api/account_controller.py
@@ -125,6 +125,7 @@ async def get_credentials(
             expires_at=credentials.expires_at
             if hasattr(credentials, "expires_at")
             else None,
+            connection_id=getattr(credentials, "connection_id", None),
         ),
         user_data=credentials.user_data if hasattr(credentials, "user_data") else None,
     )

--- a/lemma-backend/app/modules/connectors/api/schemas/__init__.py
+++ b/lemma-backend/app/modules/connectors/api/schemas/__init__.py
@@ -241,8 +241,11 @@ class CredentialTypes(Enum):
 class OauthCredentialsResponseSchema(BaseModel):
     """Schema for OAuth credentials response."""
 
-    access_token: str
+    # Optional: Composio-managed connections are addressed by connection_id and
+    # may not surface a raw access token.
+    access_token: Optional[str] = None
     expires_at: Optional[datetime.datetime] = None
+    connection_id: Optional[str] = None
 
 
 class ApiKeyCredentialsResponseSchema(BaseModel):

--- a/lemma-backend/app/modules/connectors/application/connector_operation_use_cases.py
+++ b/lemma-backend/app/modules/connectors/application/connector_operation_use_cases.py
@@ -20,8 +20,13 @@ from app.core.infrastructure.db.uow_factory import UnitOfWorkFactory
 from app.modules.connectors.api.schemas.connector_operation_schemas import (
     OperationExecutionResponse,
 )
+from app.modules.connectors.domain.errors import (
+    OperationExecutionAccessDeniedError,
+    OperationExecutionUnauthorizedError,
+)
 from app.modules.connectors.services.connector_operation_service import (
     ConnectorOperationService,
+    ResolvedConnectorExecution,
 )
 
 
@@ -75,5 +80,31 @@ class ConnectorOperationUseCases:
         # checks out a connection across the (1-45s) external call. The scope only
         # supplies the service collaborator that owns the gateway + timeout +
         # error-mapping logic.
+        try:
+            async with uow_scope(self._uow_factory) as uow:
+                return await self._build(uow).execute_resolved(resolved)
+        except (
+            OperationExecutionUnauthorizedError,
+            OperationExecutionAccessDeniedError,
+        ):
+            # The provider rejected our credentials: the account is unusable until
+            # the user reconnects. Flag it in a fresh short scope (the external
+            # call already finished, so no connection was held across it), then
+            # re-raise the original error unchanged.
+            await self._flag_account_reauth_required(resolved)
+            raise
+
+    async def _flag_account_reauth_required(
+        self, resolved: ResolvedConnectorExecution
+    ) -> None:
+        if resolved.account_id is None or resolved.account_user_id is None:
+            return
         async with uow_scope(self._uow_factory) as uow:
-            return await self._build(uow).execute_resolved(resolved)
+            connector_service = self._build(uow).connector_service
+            if connector_service is None:
+                return
+            await connector_service.mark_account_reauth_required(
+                resolved.account_id,
+                resolved.account_user_id,
+                resolved.organization_id,
+            )

--- a/lemma-backend/app/modules/connectors/domain/account.py
+++ b/lemma-backend/app/modules/connectors/domain/account.py
@@ -16,7 +16,13 @@ class OAuthCredentials(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    access_token: str = Field(..., description="OAuth access token")
+    access_token: Optional[str] = Field(
+        None,
+        description=(
+            "OAuth access token. Optional because Composio-managed connections "
+            "are addressed by connection_id and may not surface a raw token."
+        ),
+    )
     refresh_token: Optional[str] = Field(None, description="OAuth refresh token")
     token_type: str = Field(default="Bearer", description="Type of the token")
     expires_at: Optional[datetime] = Field(

--- a/lemma-backend/app/modules/connectors/infrastructure/adapters/composio_operation_gateway.py
+++ b/lemma-backend/app/modules/connectors/infrastructure/adapters/composio_operation_gateway.py
@@ -105,29 +105,46 @@ class ComposioOperationGateway(AppOperationGatewayPort):
                 "error": error,
                 "response": response,
             }
+            message = f"Composio tool execution failed for '{operation_name}': {error}"
             normalized_error = str(error).lower()
-            if normalized_error in {"not_found", "tool_not_found"}:
-                raise OperationExecutionNotFoundError(
-                    f"Composio tool execution failed for '{operation_name}': {error}",
-                    details=details,
-                )
-            if normalized_error in {"unauthorized", "not_authed", "invalid_auth"}:
-                raise OperationExecutionUnauthorizedError(
-                    f"Composio tool execution failed for '{operation_name}': {error}",
-                    details=details,
-                )
-            if normalized_error in {"forbidden", "missing_scope"}:
-                raise OperationExecutionAccessDeniedError(
-                    f"Composio tool execution failed for '{operation_name}': {error}",
-                    details=details,
-                )
-            if normalized_error in {"invalid_arguments", "validation_error", "bad_request"}:
-                raise OperationExecutionValidationError(
-                    f"Composio tool execution failed for '{operation_name}': {error}",
-                    details=details,
-                )
-            raise OperationExecutionInfrastructureError(
-                f"Composio tool execution failed for '{operation_name}': {error}",
-                details=details,
-            )
+            # Composio surfaces failures two ways: a structured token (e.g.
+            # "unauthorized") or a provider passthrough whose HTTP status lives in
+            # the response data (e.g. OpenWeather "HTTP 401"). Classify on both so
+            # a revoked/invalid credential maps to Unauthorized (triggering the
+            # account reauth flow) rather than a generic 500.
+            status_code = self._error_status_code(response)
+            if normalized_error in {"not_found", "tool_not_found"} or status_code == 404:
+                raise OperationExecutionNotFoundError(message, details=details)
+            if (
+                normalized_error in {"unauthorized", "not_authed", "invalid_auth"}
+                or status_code == 401
+            ):
+                raise OperationExecutionUnauthorizedError(message, details=details)
+            if (
+                normalized_error in {"forbidden", "missing_scope"}
+                or status_code == 403
+            ):
+                raise OperationExecutionAccessDeniedError(message, details=details)
+            if (
+                normalized_error in {"invalid_arguments", "validation_error", "bad_request"}
+                or status_code in {400, 422}
+            ):
+                raise OperationExecutionValidationError(message, details=details)
+            raise OperationExecutionInfrastructureError(message, details=details)
         return response.get("data")
+
+    @staticmethod
+    def _error_status_code(response: dict[str, Any]) -> int | None:
+        """Best-effort HTTP status from a failed Composio tool response."""
+        candidates: list[Any] = [response.get("status_code")]
+        data = response.get("data")
+        if isinstance(data, dict):
+            candidates.append(data.get("status_code"))
+        for candidate in candidates:
+            if isinstance(candidate, bool):
+                continue
+            if isinstance(candidate, int):
+                return candidate
+            if isinstance(candidate, str) and candidate.isdigit():
+                return int(candidate)
+        return None

--- a/lemma-backend/app/modules/connectors/services/auth/auth_provider.py
+++ b/lemma-backend/app/modules/connectors/services/auth/auth_provider.py
@@ -1,4 +1,4 @@
-from app.modules.connectors.domain.account import OAuthCredentials
+from app.modules.connectors.domain.account import CredentialTypes, OAuthCredentials
 from abc import ABC, abstractmethod
 from typing import Tuple, Optional
 from uuid import UUID
@@ -7,6 +7,29 @@ from app.modules.connectors.domain.connector import ConnectorEntity
 
 class AuthProviderInterface(ABC):
     """Abstract interface for authentication providers."""
+
+    @abstractmethod
+    async def connect_with_credentials(
+        self,
+        connector: ConnectorEntity,
+        user_id: UUID,
+        credentials: dict,
+    ) -> CredentialTypes:
+        """
+        Connect an account directly from user-supplied credentials (non-OAuth).
+
+        Used for credential-managed schemes (API key, etc.) where there is no
+        redirect/callback flow.
+
+        Args:
+            connector: The connector (effective connector with provider config)
+            user_id: The user ID
+            credentials: Raw credential fields submitted by the user
+
+        Returns:
+            The credentials to persist on the account.
+        """
+        pass
 
     @abstractmethod
     async def get_authorization_url(

--- a/lemma-backend/app/modules/connectors/services/auth/composio_auth_provider.py
+++ b/lemma-backend/app/modules/connectors/services/auth/composio_auth_provider.py
@@ -9,10 +9,11 @@ import aiohttp
 os.environ.setdefault("COMPOSIO_CACHE_DIR", "/tmp/composio")
 
 from composio import Composio
+from composio.types import auth_scheme as composio_auth_scheme
 
 from app.modules.connectors.config import connector_settings
-from app.modules.connectors.domain.account import OAuthCredentials
-from app.modules.connectors.domain.connector import ConnectorEntity
+from app.modules.connectors.domain.account import ComposioCredentials, OAuthCredentials
+from app.modules.connectors.domain.connector import AuthScheme, ConnectorEntity
 from app.modules.connectors.domain.errors import ConnectorValidationError
 from app.modules.connectors.domain.ports import ConnectorRepositoryPort
 from app.modules.connectors.services.auth.auth_provider import AuthProviderInterface
@@ -22,6 +23,12 @@ logger = get_logger(__name__)
 
 ComposioClientFactory = Callable[[], Any]
 HttpSessionFactory = Callable[[], aiohttp.ClientSession]
+
+# Mirrors the Composio SDK's terminal connection states (INACTIVE is excluded
+# on purpose — it can recover to ACTIVE).
+_TERMINAL_CONNECTION_STATES: frozenset[str] = frozenset(
+    {"FAILED", "EXPIRED", "REVOKED"}
+)
 
 
 class ComposioAuthProvider(AuthProviderInterface):
@@ -139,6 +146,68 @@ class ComposioAuthProvider(AuthProviderInterface):
             return model_dump(mode="json", by_alias=True, exclude_none=True)
         return None
 
+    def _composio_auth_scheme(self, connector: ConnectorEntity) -> AuthScheme:
+        try:
+            capability = connector.capability_for("COMPOSIO")
+        except ValueError:
+            return AuthScheme.OAUTH2
+        return getattr(capability, "auth_scheme", AuthScheme.OAUTH2)
+
+    def _resolve_auth_config_id(
+        self,
+        connector: ConnectorEntity,
+        composio: Any,
+    ) -> str:
+        auth_config_id = connector.composio_auth_config_id
+        if auth_config_id:
+            return auth_config_id
+        auth_config = composio.auth_configs.create(
+            toolkit=self._toolkit_slug(connector),
+            options={
+                "type": "use_composio_managed_auth",
+            },
+        )
+        logger.info(
+            "Created Composio auth config ID: %s for app %s",
+            auth_config.id,
+            connector.id,
+        )
+        return auth_config.id
+
+    async def connect_with_credentials(
+        self,
+        connector: ConnectorEntity,
+        user_id: UUID,
+        credentials: dict,
+    ) -> ComposioCredentials:
+        if not credentials:
+            raise ConnectorValidationError(
+                "Credentials are required to connect this Composio app."
+            )
+
+        scheme = self._composio_auth_scheme(connector)
+        if scheme == AuthScheme.OAUTH2:
+            raise ConnectorValidationError(
+                "OAuth2 Composio apps must be connected with a connect request, "
+                "not direct credentials."
+            )
+
+        composio = self._composio_client_factory()
+        auth_config_id = self._resolve_auth_config_id(connector, composio)
+
+        if scheme == AuthScheme.NOAUTH:
+            config = composio_auth_scheme.no_auth(credentials)
+        else:
+            config = composio_auth_scheme.api_key(credentials)
+
+        connection_request = composio.connected_accounts.initiate(
+            user_id=str(user_id),
+            auth_config_id=auth_config_id,
+            config=config,
+        )
+
+        return ComposioCredentials(connection_id=connection_request.id)
+
     async def get_authorization_url(
         self,
         connector: ConnectorEntity,
@@ -146,22 +215,9 @@ class ComposioAuthProvider(AuthProviderInterface):
         state: str,
         redirect_uri: str,
     ) -> Tuple[str, str]:
-        composio_app_name = self._toolkit_slug(connector)
-
         composio = self._composio_client_factory()
 
-        auth_config_id = connector.composio_auth_config_id
-        if not auth_config_id:
-            auth_config = composio.auth_configs.create(
-                toolkit=composio_app_name,
-                options={
-                    "type": "use_composio_managed_auth",
-                },
-            )
-            auth_config_id = auth_config.id
-            logger.info(
-                f"Created Composio auth config ID: {auth_config_id} for app {connector.id}"
-            )
+        auth_config_id = self._resolve_auth_config_id(connector, composio)
 
         redirect_url = f"{redirect_uri}?state={state}"
 
@@ -197,6 +253,13 @@ class ComposioAuthProvider(AuthProviderInterface):
 
         composio = self._composio_client_factory()
         connection_account = composio.connected_accounts.get(connected_account_id)
+
+        status = str(getattr(connection_account, "status", "") or "").upper()
+        if status in _TERMINAL_CONNECTION_STATES:
+            raise ConnectorValidationError(
+                f"Composio connection {connected_account_id} is in terminal state "
+                f"{status}; the account could not be connected."
+            )
 
         state_value = connection_account.state.val
         access_token = getattr(state_value, "access_token", None)

--- a/lemma-backend/app/modules/connectors/services/auth/composio_auth_provider.py
+++ b/lemma-backend/app/modules/connectors/services/auth/composio_auth_provider.py
@@ -153,19 +153,40 @@ class ComposioAuthProvider(AuthProviderInterface):
             return AuthScheme.OAUTH2
         return getattr(capability, "auth_scheme", AuthScheme.OAUTH2)
 
+    # Maps our auth scheme to the Composio custom-auth scheme string used when a
+    # toolkit has no Composio-managed credentials (bring-your-own API key, etc.).
+    _CUSTOM_AUTH_SCHEME = {
+        AuthScheme.API_KEY: "API_KEY",
+        AuthScheme.NOAUTH: "NO_AUTH",
+    }
+
     def _resolve_auth_config_id(
         self,
         connector: ConnectorEntity,
         composio: Any,
+        *,
+        custom_auth_scheme: str | None = None,
     ) -> str:
+        """Reuse the connector's Composio auth config, else create one.
+
+        OAuth apps use Composio-managed credentials (``use_composio_managed_auth``).
+        Credential-managed apps (API key / no-auth) have no managed credentials, so
+        they need ``use_custom_auth`` with the explicit scheme; the per-account key
+        is supplied at ``initiate`` time.
+        """
         auth_config_id = connector.composio_auth_config_id
         if auth_config_id:
             return auth_config_id
+        if custom_auth_scheme is not None:
+            options: dict[str, Any] = {
+                "type": "use_custom_auth",
+                "auth_scheme": custom_auth_scheme,
+            }
+        else:
+            options = {"type": "use_composio_managed_auth"}
         auth_config = composio.auth_configs.create(
             toolkit=self._toolkit_slug(connector),
-            options={
-                "type": "use_composio_managed_auth",
-            },
+            options=options,
         )
         logger.info(
             "Created Composio auth config ID: %s for app %s",
@@ -193,7 +214,11 @@ class ComposioAuthProvider(AuthProviderInterface):
             )
 
         composio = self._composio_client_factory()
-        auth_config_id = self._resolve_auth_config_id(connector, composio)
+        auth_config_id = self._resolve_auth_config_id(
+            connector,
+            composio,
+            custom_auth_scheme=self._CUSTOM_AUTH_SCHEME.get(scheme, "API_KEY"),
+        )
 
         if scheme == AuthScheme.NOAUTH:
             config = composio_auth_scheme.no_auth(credentials)

--- a/lemma-backend/app/modules/connectors/services/auth/lemma_auth_provider.py
+++ b/lemma-backend/app/modules/connectors/services/auth/lemma_auth_provider.py
@@ -29,6 +29,16 @@ class LemmaAuthProvider(AuthProviderInterface):
         self._oauth_session_factory = oauth_session_factory
         self._cloud_id_resolver = cloud_id_resolver
 
+    async def connect_with_credentials(
+        self,
+        connector: ConnectorEntity,
+        user_id: UUID,
+        credentials: dict,
+    ) -> dict:
+        # Native credential-managed accounts store the submitted credentials
+        # verbatim — there is no provider-side connection to establish.
+        return credentials
+
     async def get_authorization_url(
         self,
         connector: ConnectorEntity,

--- a/lemma-backend/app/modules/connectors/services/connector_operation_service.py
+++ b/lemma-backend/app/modules/connectors/services/connector_operation_service.py
@@ -46,6 +46,11 @@ class ResolvedConnectorExecution:
     payload: dict[str, Any]
     auth_token: str | None
     api_url: str | None
+    # Plain identifiers (never session-bound) so the execute phase can flag the
+    # account for re-auth on an unauthorized failure without re-resolving it.
+    account_id: UUID | None = None
+    account_user_id: UUID | None = None
+    organization_id: UUID | None = None
 
 
 class ConnectorOperationService:
@@ -581,6 +586,9 @@ class ConnectorOperationService:
             payload=payload or {},
             auth_token=auth_token,
             api_url=api_url,
+            account_id=getattr(account, "id", None),
+            account_user_id=getattr(account, "user_id", None),
+            organization_id=getattr(account, "organization_id", None),
         )
 
     async def execute_resolved(

--- a/lemma-backend/app/modules/connectors/services/connector_service.py
+++ b/lemma-backend/app/modules/connectors/services/connector_service.py
@@ -5,7 +5,11 @@ from uuid import UUID
 
 from app.core.domain.uow import IUnitOfWork
 from app.core.domain.errors import DomainError
-from app.modules.connectors.domain.account import AccountEntity, OAuthCredentials
+from app.modules.connectors.domain.account import (
+    AccountEntity,
+    AccountStatus,
+    OAuthCredentials,
+)
 from app.modules.connectors.domain.auth_config import (
     AuthConfigEntity,
     AuthConfigSource,
@@ -739,17 +743,26 @@ class ConnectorService:
             auth_config_id=auth_config_id,
         )
         connector = await self.get_connector(auth_config.connector_id)
-        if self._provider_value(auth_config) == AuthProvider.LEMMA.value:
+        provider_value = self._provider_value(auth_config)
+        if provider_value == AuthProvider.LEMMA.value:
             capability = self._lemma_capability(connector)
             if capability.auth_scheme != AuthScheme.OAUTH2:
                 raise ConnectorValidationError(
                     "Credential-managed native accounts must be connected with the accounts API."
                 )
+        elif provider_value == AuthProvider.COMPOSIO.value:
+            if self._composio_capability(connector).auth_scheme != AuthScheme.OAUTH2:
+                raise ConnectorValidationError(
+                    "Credential-managed Composio accounts must be connected with the accounts API."
+                )
 
         existing_account = await self.account_repository.get_by_user_and_auth_config(
             user_id, auth_config.id
         )
-        if existing_account:
+        # Allow re-running OAuth on an existing account that has become unusable
+        # (preserving its account_id); only a healthy CONNECTED account blocks a
+        # new connect request.
+        if existing_account and existing_account.status == AccountStatus.CONNECTED:
             raise AccountAlreadyConnectedError(connector.id)
 
         effective_connector = self._build_effective_connector(connector, auth_config)
@@ -819,13 +832,14 @@ class ConnectorService:
         )
         connector = await self.get_connector(auth_config.connector_id)
         provider = AuthProvider(self._provider_value(auth_config))
-        if provider != AuthProvider.LEMMA:
-            raise ConnectorValidationError(
-                "Direct credential account creation is only supported for Lemma native auth configs."
-            )
+        if provider == AuthProvider.LEMMA:
+            auth_scheme = self._lemma_capability(connector).auth_scheme
+        elif provider == AuthProvider.COMPOSIO:
+            auth_scheme = self._composio_capability(connector).auth_scheme
+        else:
+            raise UnsupportedAuthProviderError(provider.value)
 
-        capability = self._lemma_capability(connector)
-        if capability.auth_scheme == AuthScheme.OAUTH2:
+        if auth_scheme == AuthScheme.OAUTH2:
             raise ConnectorValidationError(
                 "OAuth2 accounts must be connected with an OAuth connect request."
             )
@@ -841,13 +855,23 @@ class ConnectorService:
         if existing_account:
             raise AccountAlreadyConnectedError(connector.id)
 
+        # Composio credential-managed apps must establish a connected account on
+        # Composio's side; native (Lemma) apps store the credentials verbatim.
+        effective_connector = self._build_effective_connector(connector, auth_config)
+        auth_provider = self._get_auth_provider_by_name(provider.value)
+        stored_credentials = await auth_provider.connect_with_credentials(
+            connector=effective_connector,
+            user_id=user_id,
+            credentials=credentials,
+        )
+
         account = await self.account_repository.create(
             AccountEntity(
                 user_id=user_id,
                 organization_id=organization_id,
                 auth_config_id=auth_config.id,
                 connector_id=connector.id,
-                credentials=credentials,
+                credentials=stored_credentials,
                 provider_account_id=provider_account_id,
                 email=email,
                 preferences=preferences,
@@ -933,6 +957,8 @@ class ConnectorService:
                 account.provider_account_id = provider_account_id
             if email:
                 account.email = email
+            # A successful (re-)auth restores the account to a usable state.
+            account.status = AccountStatus.CONNECTED
             account = await self.account_repository.update(account)
         else:
             account = await self.account_repository.create(
@@ -1041,14 +1067,21 @@ class ConnectorService:
                         credentials=oauth_credentials,
                         user_id=account.user_id,
                     )
-                except DomainError:
-                    raise
                 except Exception as exc:
+                    # An expired token we cannot refresh means the account is
+                    # unusable until the user reconnects.
                     if is_expired:
+                        await self._persist_account_status(
+                            account, AccountStatus.REAUTH_REQUIRED
+                        )
+                        if isinstance(exc, DomainError):
+                            raise
                         raise OAuthFlowError(
                             f"Failed to refresh credentials: {exc}",
                             details=self._exception_details(exc),
                         ) from exc
+                    if isinstance(exc, DomainError):
+                        raise
                     logger.warning(
                         "Credential refresh failed for account %s; using stored token. %s",
                         account_id,
@@ -1056,15 +1089,48 @@ class ConnectorService:
                     )
                 else:
                     account.credentials = new_credentials
+                    # A successful refresh restores a previously-degraded account.
+                    account.status = AccountStatus.CONNECTED
                     account = await self.account_repository.update(account)
                     await self.uow.commit()
                     credentials = account.credentials
             elif is_expired:
+                await self._persist_account_status(
+                    account, AccountStatus.REAUTH_REQUIRED
+                )
                 raise OAuthFlowError(
                     "Credentials are expired and cannot be refreshed for this account."
                 )
 
         return self._to_oauth_credentials(credentials)
+
+    async def _persist_account_status(
+        self, account: AccountEntity, status: AccountStatus
+    ) -> AccountEntity:
+        """Persist an account status transition (idempotent)."""
+        if account.status == status:
+            return account
+        account.status = status
+        account = await self.account_repository.update(account)
+        await self.uow.commit()
+        return account
+
+    async def mark_account_reauth_required(
+        self,
+        account_id: UUID,
+        user_id: UUID,
+        organization_id: UUID | None = None,
+    ) -> None:
+        """Flag an account as needing re-authentication.
+
+        Best-effort: a missing/inaccessible account is silently ignored so this
+        never masks the original auth failure that triggered it.
+        """
+        try:
+            account = await self.get_account(account_id, user_id, organization_id)
+        except DomainError:
+            return
+        await self._persist_account_status(account, AccountStatus.REAUTH_REQUIRED)
 
     async def delete_account(
         self,

--- a/lemma-backend/app/modules/connectors/services/connector_service.py
+++ b/lemma-backend/app/modules/connectors/services/connector_service.py
@@ -1223,6 +1223,11 @@ class ConnectorService:
     def _to_oauth_credentials(self, credentials: object) -> OAuthCredentials:
         if isinstance(credentials, OAuthCredentials):
             return credentials
+        # Coerce any other pydantic credential model (e.g. ComposioCredentials)
+        # to a dict so its fields — crucially connection_id — are preserved.
+        if not isinstance(credentials, dict):
+            model_dump = getattr(credentials, "model_dump", None)
+            credentials = model_dump() if callable(model_dump) else {}
         if isinstance(credentials, dict):
             return OAuthCredentials(
                 access_token=credentials.get("access_token", ""),

--- a/lemma-backend/app/modules/connectors/tests/e2e/test_composio_real_e2e.py
+++ b/lemma-backend/app/modules/connectors/tests/e2e/test_composio_real_e2e.py
@@ -1,0 +1,417 @@
+"""Real Composio e2e tests for the connector connect/execute/status flows.
+
+These hit the live Composio API and are gated on real credentials, so they are
+skipped by default (CI). Three tiers:
+
+* **Tier 1 (``provider`` marker, no browser):** API-key connect + operation
+  (needs ``COMPOSIO_API_KEY`` + ``TEST_OPENWEATHER_API_KEY``) and the
+  reauth-flip-on-bad-credential path (needs only ``COMPOSIO_API_KEY``).
+* **Tier 2 (``provider`` + ``human`` markers, opt-in):** real OAuth consent in a
+  browser, the Canva exchange fix, and in-place reconnect. Opt in with
+  ``RUN_HUMAN_OAUTH=1``; a human completes consent while the test polls Composio.
+* **Webhook (``provider`` marker):** Composio webhook signature verification with
+  ``COMPOSIO_WEBHOOK_SECRET`` (local crypto, no network).
+
+Run examples::
+
+    # Tier 1 reauth (only needs the Composio platform key)
+    pytest -m provider app/modules/connectors/tests/e2e/test_composio_real_e2e.py \
+        -k reauth -s
+
+    # Human OAuth (opens your browser; you consent live)
+    RUN_HUMAN_OAUTH=1 pytest -m "provider and human" \
+        app/modules/connectors/tests/e2e/test_composio_real_e2e.py -s
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import importlib.util
+import json
+import os
+import sys
+import time
+import webbrowser
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+from composio import Composio
+from httpx import AsyncClient
+from sqlalchemy import delete
+
+sys.path.append(str(Path(__file__).resolve().parents[5]))
+
+from app.modules.connectors.config import connector_settings
+from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
+from app.modules.connectors.domain.account import AccountStatus
+from app.modules.connectors.domain.auth_config import AuthConfigSource
+from app.modules.connectors.domain.connector import AuthProvider
+from app.modules.connectors.infrastructure.models.account import Account
+from app.modules.connectors.infrastructure.models.auth_config import AuthConfig
+from app.modules.connectors.infrastructure.models.connector import Connector
+from app.modules.connectors.infrastructure.models.connector_operation import (
+    ConnectorOperation,
+)
+from app.modules.connectors.infrastructure.models.connector_trigger import (
+    ConnectorTrigger,
+)
+from app.modules.connectors.infrastructure.repositories.connector_operation_repository import (
+    ConnectorOperationRepository,
+)
+from app.modules.connectors.infrastructure.repositories.connector_repository import (
+    ConnectorRepository,
+)
+from app.modules.connectors.infrastructure.repositories.connector_trigger_repository import (
+    ConnectorTriggerRepository,
+)
+
+# --- load the import script as a module (real catalog sync helpers) -----------
+_IMPORTER_PATH = Path(__file__).resolve().parents[5] / "scripts" / "import_connector_catalog.py"
+_IMPORTER_SPEC = importlib.util.spec_from_file_location("import_connector_catalog", _IMPORTER_PATH)
+assert _IMPORTER_SPEC and _IMPORTER_SPEC.loader
+importer = importlib.util.module_from_spec(_IMPORTER_SPEC)
+_IMPORTER_SPEC.loader.exec_module(importer)
+
+OPENWEATHER_SLUG = "openweather_api"
+OPENWEATHER_OP = "OPENWEATHER_API_GET_CURRENT_WEATHER"
+
+
+def _env_value(name: str) -> str | None:
+    """Read an env var, falling back to lemma-backend/.env."""
+    value = os.getenv(name)
+    if value:
+        return value
+    env_path = Path(__file__).resolve().parents[5] / ".env"
+    if not env_path.exists():
+        return None
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        if not line or line.lstrip().startswith("#") or "=" not in line:
+            continue
+        key, raw = line.split("=", 1)
+        if key.strip() == name:
+            return raw.strip().strip('"').strip("'")
+    return None
+
+
+def _composio_api_key() -> str | None:
+    return connector_settings.composio_api_key or _env_value("COMPOSIO_API_KEY")
+
+
+def _require_composio() -> str:
+    key = _composio_api_key()
+    if not key:
+        pytest.skip("Real Composio e2e requires COMPOSIO_API_KEY.")
+    return key
+
+
+def _composio_client() -> Composio:
+    return Composio(api_key=_require_composio())
+
+
+async def _reseed_composio_app(db_session, connector_id: str) -> None:
+    """Re-import a single Composio app's catalog (connector + ops + capability)."""
+    await db_session.execute(
+        delete(ConnectorTrigger).where(ConnectorTrigger.connector_id == connector_id)
+    )
+    await db_session.execute(
+        delete(ConnectorOperation).where(ConnectorOperation.connector_id == connector_id)
+    )
+    await db_session.execute(delete(Connector).where(Connector.id == connector_id))
+    await db_session.commit()
+
+    uow = SqlAlchemyUnitOfWork(db_session)
+    await importer._sync_composio_catalog(
+        ConnectorRepository(uow),
+        ConnectorOperationRepository(uow),
+        ConnectorTriggerRepository(uow),
+        app_filters={connector_id},
+        managed_by="composio",
+        page_size=100,
+        max_composio_apps=10,
+    )
+    await uow.commit()
+
+
+async def _seed_composio_auth_config(db_session, connector_id: str, org_id) -> AuthConfig:
+    auth_config = AuthConfig(
+        organization_id=org_id,
+        connector_id=connector_id,
+        provider=AuthProvider.COMPOSIO.value,
+        config_source=AuthConfigSource.SYSTEM_DEFAULT.value,
+        name=f"{connector_id}-{uuid4().hex[:8]}",
+    )
+    db_session.add(auth_config)
+    await db_session.flush()
+    await db_session.commit()
+    return auth_config
+
+
+def _cleanup_user_accounts(user_id) -> None:
+    """Best-effort: delete every Composio connected account for the test user."""
+    try:
+        composio = Composio(api_key=_composio_api_key() or "")
+        accounts = composio.connected_accounts.list(user_ids=[str(user_id)])
+        for item in getattr(accounts, "items", []) or []:
+            try:
+                composio.connected_accounts.delete(item.id)
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+
+# =============================================================================
+# Tier 1a — API-key connect + real operation (needs a real OpenWeather key)
+# =============================================================================
+@pytest.mark.provider
+@pytest.mark.asyncio
+async def test_composio_api_key_connect_and_execute(
+    authenticated_client: AsyncClient,
+    fixed_test_user,
+    fixed_test_org,
+    db_session,
+):
+    _require_composio()
+    api_key = _env_value("TEST_OPENWEATHER_API_KEY")
+    if not api_key:
+        pytest.skip("Real OpenWeather connect requires TEST_OPENWEATHER_API_KEY.")
+
+    org_id = fixed_test_org["id"]
+    await _reseed_composio_app(db_session, OPENWEATHER_SLUG)
+
+    # The import populated the API-key credential schema (generic_api_key).
+    connector = await db_session.get(Connector, OPENWEATHER_SLUG)
+    assert connector is not None
+    capability = connector.to_entity().capability_for(AuthProvider.COMPOSIO)
+    assert capability.auth_config_schema is not None
+    assert "generic_api_key" in capability.auth_config_schema["properties"]
+
+    auth_config = await _seed_composio_auth_config(db_session, OPENWEATHER_SLUG, org_id)
+    accounts_url = f"/organizations/{org_id}/connectors/accounts"
+
+    try:
+        resp = await authenticated_client.post(
+            accounts_url,
+            json={
+                "auth_config_id": str(auth_config.id),
+                "credentials": {"generic_api_key": api_key},
+            },
+        )
+        assert resp.status_code == 200, resp.text
+        account = resp.json()
+        assert account["status"] == AccountStatus.CONNECTED.value
+        account_id = account["id"]
+
+        # A real connected account was created on Composio's side.
+        creds_resp = await authenticated_client.get(
+            f"{accounts_url}/{account_id}/credentials"
+        )
+        assert creds_resp.status_code == 200, creds_resp.text
+        assert creds_resp.json().get("connection_id")
+
+        ops_url = (
+            f"/organizations/{org_id}/connectors/{auth_config.name}/operations/"
+            f"{OPENWEATHER_OP}/execute"
+        )
+        exec_resp = await authenticated_client.post(
+            ops_url,
+            json={"payload": {"q": "London", "units": "metric"}, "account_id": account_id},
+        )
+        assert exec_resp.status_code == 200, exec_resp.text
+        # OpenWeather echoes the resolved city in the response.
+        assert "London" in json.dumps(exec_resp.json())
+    finally:
+        _cleanup_user_accounts(fixed_test_user["id"])
+
+
+# =============================================================================
+# Tier 1b — account auto-flips to REAUTH_REQUIRED on a provider auth failure
+# =============================================================================
+@pytest.mark.provider
+@pytest.mark.asyncio
+async def test_composio_account_flips_to_reauth_on_unauthorized(
+    authenticated_client: AsyncClient,
+    fixed_test_user,
+    fixed_test_org,
+    db_session,
+):
+    _require_composio()
+    org_id = fixed_test_org["id"]
+    await _reseed_composio_app(db_session, OPENWEATHER_SLUG)
+    auth_config = await _seed_composio_auth_config(db_session, OPENWEATHER_SLUG, org_id)
+    accounts_url = f"/organizations/{org_id}/connectors/accounts"
+
+    try:
+        resp = await authenticated_client.post(
+            accounts_url,
+            json={
+                "auth_config_id": str(auth_config.id),
+                "credentials": {"generic_api_key": "deliberately-invalid-key"},
+            },
+        )
+        if resp.status_code != 200:
+            pytest.skip(
+                "Composio rejected the bad API key at connect time; the "
+                f"execute-time reauth path is not reachable for this app: {resp.text}"
+            )
+        account_id = resp.json()["id"]
+
+        ops_url = (
+            f"/organizations/{org_id}/connectors/{auth_config.name}/operations/"
+            f"{OPENWEATHER_OP}/execute"
+        )
+        exec_resp = await authenticated_client.post(
+            ops_url,
+            json={"payload": {"q": "London"}, "account_id": account_id},
+        )
+        # The provider rejects the bad key; our API surfaces an auth failure.
+        assert exec_resp.status_code in (401, 403), exec_resp.text
+
+        # ...and the account is auto-flagged for re-authentication.
+        get_resp = await authenticated_client.get(f"{accounts_url}/{account_id}")
+        assert get_resp.status_code == 200, get_resp.text
+        assert get_resp.json()["status"] == AccountStatus.REAUTH_REQUIRED.value
+    finally:
+        _cleanup_user_accounts(fixed_test_user["id"])
+
+
+# =============================================================================
+# Tier 2 — human-orchestrated real OAuth: connect (Canva fix) + reconnect
+# =============================================================================
+def _human_oauth_enabled() -> bool:
+    return bool(os.getenv("RUN_HUMAN_OAUTH"))
+
+
+def _wait_for_active_connection(composio: Composio, connection_id: str, timeout: float = 300.0):
+    deadline = time.time() + timeout
+    last_status = None
+    while time.time() < deadline:
+        try:
+            account = composio.connected_accounts.get(connection_id)
+            last_status = getattr(account, "status", None)
+            if str(last_status).upper() == "ACTIVE":
+                return account
+            if str(last_status).upper() in {"FAILED", "EXPIRED", "REVOKED"}:
+                pytest.fail(f"Connection {connection_id} entered terminal state {last_status}")
+        except Exception:
+            pass
+        time.sleep(3)
+    pytest.fail(f"Timed out waiting for {connection_id} to become ACTIVE (last={last_status})")
+
+
+@pytest.mark.provider
+@pytest.mark.human
+@pytest.mark.asyncio
+async def test_composio_oauth_connect_and_reconnect_human(
+    authenticated_client: AsyncClient,
+    fixed_test_user,
+    fixed_test_org,
+    db_session,
+):
+    if not _human_oauth_enabled():
+        pytest.skip("Set RUN_HUMAN_OAUTH=1 to run the human-in-the-loop OAuth test.")
+    composio = _composio_client()
+
+    org_id = fixed_test_org["id"]
+    app = os.getenv("TEST_OAUTH_APP", "canva")
+    await _reseed_composio_app(db_session, app)
+    auth_config = await _seed_composio_auth_config(db_session, app, org_id)
+    cr_url = f"/organizations/{org_id}/connectors/connect-requests"
+    callback_url = "/connectors/connect-requests/oauth/callback"
+
+    async def _consent_and_complete() -> dict:
+        resp = await authenticated_client.post(
+            cr_url, json={"auth_config_id": str(auth_config.id)}
+        )
+        assert resp.status_code == 200, resp.text
+        connect_request = resp.json()
+        authorization_url = connect_request["authorization_url"]
+        attributes = connect_request["attributes"] or {}
+        state = attributes["state"]
+        connection_id = attributes["provider_state"]
+
+        print(f"\n\n=== HUMAN ACTION REQUIRED: authorize {app} in your browser ===")
+        print(authorization_url)
+        print("Waiting for you to complete consent...\n")
+        try:
+            webbrowser.open(authorization_url)
+        except Exception:
+            pass
+
+        _wait_for_active_connection(composio, connection_id)
+
+        # Drive our real callback in-process (the e2e app is ASGI, not on a
+        # reachable port) — this exercises exchange_code_for_credentials for real.
+        cb = await authenticated_client.get(
+            callback_url,
+            params={"state": state, "connectedAccountId": connection_id, "format": "json"},
+        )
+        assert cb.status_code == 200, cb.text
+        return cb.json()
+
+    try:
+        # First connect — the Canva fix: succeeds even when no raw access_token
+        # is surfaced (the connection_id is the authoritative credential).
+        account = await _consent_and_complete()
+        assert account["status"] == AccountStatus.CONNECTED.value
+        original_account_id = account["id"]
+
+        # Simulate the account becoming unusable.
+        row = await db_session.get(Account, original_account_id)
+        row.status = AccountStatus.REAUTH_REQUIRED.value
+        await db_session.commit()
+
+        # Reconnect must be allowed (no 409) for an unusable account...
+        reconnect = await _consent_and_complete()
+        # ...and must reuse the SAME account_id (preserving downstream references).
+        assert reconnect["id"] == original_account_id
+        assert reconnect["status"] == AccountStatus.CONNECTED.value
+    finally:
+        _cleanup_user_accounts(fixed_test_user["id"])
+
+
+# =============================================================================
+# Webhook — Composio webhook signature verification
+# =============================================================================
+@pytest.mark.provider
+def test_composio_webhook_signature_verification():
+    secret = connector_settings.composio_webhook_secret or _env_value("COMPOSIO_WEBHOOK_SECRET")
+    if not secret:
+        pytest.skip("Webhook verification requires COMPOSIO_WEBHOOK_SECRET.")
+
+    from app.modules.schedule.infrastructure.adapters.composio_webhook_verifier import (
+        ComposioWebhookVerifier,
+    )
+
+    payload = json.dumps(
+        {
+            "trigger_name": "GMAIL_NEW_GMAIL_MESSAGE",
+            "connection_id": "ca_test_connection",
+            "trigger_id": "ti_test_trigger",
+            "payload": {"message_id": "m1", "subject": "hello"},
+            "log_id": "log_test",
+        }
+    )
+    webhook_id = "msg_test_123"
+    timestamp = str(int(time.time()))
+    to_sign = f"{webhook_id}.{timestamp}.{payload}"
+    digest = hmac.new(secret.encode("utf-8"), to_sign.encode("utf-8"), hashlib.sha256).digest()
+    signature = "v1," + base64.b64encode(digest).decode("utf-8")
+
+    headers = {
+        "webhook-id": webhook_id,
+        "webhook-timestamp": timestamp,
+        "webhook-signature": signature,
+    }
+
+    verifier = ComposioWebhookVerifier()
+    result = verifier.verify(payload, headers)
+    assert result["raw_payload"]["connection_id"] == "ca_test_connection"
+
+    # A tampered signature is rejected.
+    bad_headers = {**headers, "webhook-signature": "v1," + base64.b64encode(b"wrong").decode()}
+    with pytest.raises(Exception):
+        verifier.verify(payload, bad_headers)

--- a/lemma-backend/app/modules/connectors/tests/e2e/test_composio_real_e2e.py
+++ b/lemma-backend/app/modules/connectors/tests/e2e/test_composio_real_e2e.py
@@ -285,6 +285,14 @@ def _human_oauth_enabled() -> bool:
     return bool(os.getenv("RUN_HUMAN_OAUTH"))
 
 
+# Read-only "smoke" operations per OAuth app, to prove the connected account
+# actually works for real execution. (slug, payload).
+_SMOKE_OPS: dict[str, tuple[str, dict]] = {
+    "google_calendar": ("GOOGLECALENDAR_LIST_CALENDARS", {}),
+    "gmail": ("GMAIL_GET_PROFILE", {}),
+}
+
+
 def _wait_for_active_connection(composio: Composio, connection_id: str, timeout: float = 300.0):
     deadline = time.time() + timeout
     last_status = None
@@ -304,6 +312,7 @@ def _wait_for_active_connection(composio: Composio, connection_id: str, timeout:
 
 @pytest.mark.provider
 @pytest.mark.human
+@pytest.mark.timeout(900)
 @pytest.mark.asyncio
 async def test_composio_oauth_connect_and_reconnect_human(
     authenticated_client: AsyncClient,
@@ -316,33 +325,36 @@ async def test_composio_oauth_connect_and_reconnect_human(
     composio = _composio_client()
 
     org_id = fixed_test_org["id"]
-    app = os.getenv("TEST_OAUTH_APP", "canva")
+    app = os.getenv("TEST_OAUTH_APP", "google_calendar")
     await _reseed_composio_app(db_session, app)
     auth_config = await _seed_composio_auth_config(db_session, app, org_id)
     cr_url = f"/organizations/{org_id}/connectors/connect-requests"
     callback_url = "/connectors/connect-requests/oauth/callback"
 
-    async def _consent_and_complete() -> dict:
+    async def _run_smoke_op(account_id: str) -> None:
+        smoke = _SMOKE_OPS.get(app)
+        if not smoke:
+            return
+        op_name, payload = smoke
+        exec_resp = await authenticated_client.post(
+            f"/organizations/{org_id}/connectors/{auth_config.name}/operations/"
+            f"{op_name}/execute",
+            json={"payload": payload, "account_id": account_id},
+        )
+        assert exec_resp.status_code == 200, exec_resp.text
+        print(f"\n=== {op_name} succeeded: {json.dumps(exec_resp.json())[:300]} ===\n")
+
+    async def _initiate() -> tuple[str, str, str]:
+        """POST a connect request; return (state, connection_id, authorization_url)."""
         resp = await authenticated_client.post(
             cr_url, json={"auth_config_id": str(auth_config.id)}
         )
         assert resp.status_code == 200, resp.text
-        connect_request = resp.json()
-        authorization_url = connect_request["authorization_url"]
-        attributes = connect_request["attributes"] or {}
-        state = attributes["state"]
-        connection_id = attributes["provider_state"]
+        body = resp.json()
+        attributes = body["attributes"] or {}
+        return attributes["state"], attributes["provider_state"], body["authorization_url"]
 
-        print(f"\n\n=== HUMAN ACTION REQUIRED: authorize {app} in your browser ===")
-        print(authorization_url)
-        print("Waiting for you to complete consent...\n")
-        try:
-            webbrowser.open(authorization_url)
-        except Exception:
-            pass
-
-        _wait_for_active_connection(composio, connection_id)
-
+    async def _complete(state: str, connection_id: str) -> dict:
         # Drive our real callback in-process (the e2e app is ASGI, not on a
         # reachable port) — this exercises exchange_code_for_credentials for real.
         cb = await authenticated_client.get(
@@ -353,22 +365,41 @@ async def test_composio_oauth_connect_and_reconnect_human(
         return cb.json()
 
     try:
-        # First connect — the Canva fix: succeeds even when no raw access_token
-        # is surfaced (the connection_id is the authoritative credential).
-        account = await _consent_and_complete()
+        # --- First connect (the only human consent needed) ------------------
+        state, connection_id, authorization_url = await _initiate()
+        print(f"\n\n=== HUMAN ACTION REQUIRED: authorize {app} in your browser ===")
+        print(authorization_url)
+        print("Waiting for you to complete consent...\n")
+        try:
+            webbrowser.open(authorization_url)
+        except Exception:
+            pass
+
+        _wait_for_active_connection(composio, connection_id)
+        account = await _complete(state, connection_id)
+        # The Canva fix: succeeds even when no raw access_token is surfaced.
         assert account["status"] == AccountStatus.CONNECTED.value
         original_account_id = account["id"]
 
-        # Simulate the account becoming unusable.
+        # The connected account works for a real operation.
+        await _run_smoke_op(original_account_id)
+
+        # --- Reconnect on the same account_id (no second consent) -----------
+        # Mark the account unusable, then re-initiate: this must be ALLOWED
+        # (no 409). We complete the callback by reusing the still-active first
+        # connection, so no second browser consent is required.
         row = await db_session.get(Account, original_account_id)
         row.status = AccountStatus.REAUTH_REQUIRED.value
         await db_session.commit()
 
-        # Reconnect must be allowed (no 409) for an unusable account...
-        reconnect = await _consent_and_complete()
-        # ...and must reuse the SAME account_id (preserving downstream references).
+        reconnect_state, _new_connection_id, _ = await _initiate()  # 200 == allowed
+        reconnect = await _complete(reconnect_state, connection_id)
+        # Must reuse the SAME account_id (preserving downstream references).
         assert reconnect["id"] == original_account_id
         assert reconnect["status"] == AccountStatus.CONNECTED.value
+
+        # The reconnected account still works.
+        await _run_smoke_op(original_account_id)
     finally:
         _cleanup_user_accounts(fixed_test_user["id"])
 

--- a/lemma-backend/app/modules/connectors/tests/e2e/test_composio_real_e2e.py
+++ b/lemma-backend/app/modules/connectors/tests/e2e/test_composio_real_e2e.py
@@ -210,7 +210,7 @@ async def test_composio_api_key_connect_and_execute(
             f"{accounts_url}/{account_id}/credentials"
         )
         assert creds_resp.status_code == 200, creds_resp.text
-        assert creds_resp.json().get("connection_id")
+        assert creds_resp.json()["data"].get("connection_id")
 
         ops_url = (
             f"/organizations/{org_id}/connectors/{auth_config.name}/operations/"

--- a/lemma-backend/app/modules/connectors/tests/unit/test_composio_auth_provider.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_composio_auth_provider.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
@@ -11,11 +11,16 @@ from pydantic import BaseModel
 
 os.environ.setdefault("COMPOSIO_CACHE_DIR", "/tmp/composio")
 
-from app.modules.connectors.domain.account import OAuthCredentials
+from app.modules.connectors.domain.account import (
+    ComposioCredentials,
+    OAuthCredentials,
+)
 from app.modules.connectors.domain.connector import (
+    AuthScheme,
     ConnectorEntity,
     ComposioProviderCapability,
 )
+from app.modules.connectors.domain.errors import ConnectorValidationError
 from app.modules.connectors.infrastructure.repositories.account_repository import (
     AccountRepository,
 )
@@ -40,10 +45,11 @@ def _connector(app_id: str = "google_calendar") -> ConnectorEntity:
     )
 
 
-def _provider(connection_state: BaseModel) -> ComposioAuthProvider:
+def _provider(connection_state: BaseModel, status: str = "ACTIVE") -> ComposioAuthProvider:
     connected_accounts = SimpleNamespace(
         get=lambda _: SimpleNamespace(
             id="ca_test_connection",
+            status=status,
             state=SimpleNamespace(val=connection_state),
         )
     )
@@ -52,6 +58,15 @@ def _provider(connection_state: BaseModel) -> ComposioAuthProvider:
         connector_repository=AsyncMock(),
         composio_client_factory=lambda: composio,
     )
+
+
+class _TokenlessConnectionState(BaseModel):
+    """A Composio connection state that surfaces no raw access_token (e.g. Canva)."""
+
+    access_token: str | None = None
+    refresh_token: str | None = None
+    expires_in: str | float | None = None
+    token_type: str | None = None
 
 
 @pytest.mark.asyncio
@@ -103,6 +118,101 @@ async def test_refresh_credentials_falls_back_to_default_expiry_when_missing():
     assert credentials.expires_at is not None
     assert credentials.expires_at > datetime.now(timezone.utc) + timedelta(minutes=4)
     provider._get_google_token_expiration.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_succeeds_when_access_token_missing():
+    # Canva-style: the connected account is created/active but exposes no raw
+    # access_token. The connection_id is the authoritative credential, so this
+    # must succeed rather than raise on a missing token.
+    provider = _provider(
+        _TokenlessConnectionState(token_type="Bearer"),
+        status="ACTIVE",
+    )
+
+    credentials = await provider.exchange_code_for_credentials(
+        connector=_connector("canva"),
+        redirect_uri="https://app.example.com/callback?connectedAccountId=ca_test_connection",
+        user_id=uuid4(),
+    )
+
+    assert credentials.access_token is None
+    assert credentials.connection_id == "ca_test_connection"
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_raises_on_terminal_connection_state():
+    provider = _provider(
+        _TokenlessConnectionState(),
+        status="FAILED",
+    )
+
+    with pytest.raises(ConnectorValidationError):
+        await provider.exchange_code_for_credentials(
+            connector=_connector("canva"),
+            redirect_uri="https://app.example.com/callback?connectedAccountId=ca_test_connection",
+            user_id=uuid4(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_connect_with_credentials_initiates_api_key_connection():
+    connector = ConnectorEntity(
+        id="airtable",
+        provider_capabilities=[
+            ComposioProviderCapability(
+                toolkit_slug="airtable",
+                auth_scheme=AuthScheme.API_KEY,
+            )
+        ],
+        composio_auth_config_id="ac_existing",
+    )
+
+    initiate = MagicMock(return_value=SimpleNamespace(id="ca_new_connection"))
+    auth_configs = SimpleNamespace(create=MagicMock())
+    composio = SimpleNamespace(
+        connected_accounts=SimpleNamespace(initiate=initiate),
+        auth_configs=auth_configs,
+    )
+    provider = ComposioAuthProvider(
+        connector_repository=AsyncMock(),
+        composio_client_factory=lambda: composio,
+    )
+
+    user_id = uuid4()
+    credentials = await provider.connect_with_credentials(
+        connector=connector,
+        user_id=user_id,
+        credentials={"api_key": "secret-key"},
+    )
+
+    assert isinstance(credentials, ComposioCredentials)
+    assert credentials.connection_id == "ca_new_connection"
+    # Reused the existing auth config (no create call) and passed an API_KEY config
+    # with no callback_url (non-OAuth flow).
+    auth_configs.create.assert_not_called()
+    initiate.assert_called_once()
+    _, kwargs = initiate.call_args
+    assert kwargs["auth_config_id"] == "ac_existing"
+    assert kwargs["user_id"] == str(user_id)
+    assert "callback_url" not in kwargs
+    assert kwargs["config"]["auth_scheme"] == "API_KEY"
+    assert kwargs["config"]["val"]["api_key"] == "secret-key"
+
+
+@pytest.mark.asyncio
+async def test_connect_with_credentials_rejects_oauth_apps():
+    provider = ComposioAuthProvider(
+        connector_repository=AsyncMock(),
+        composio_client_factory=lambda: SimpleNamespace(),
+    )
+
+    with pytest.raises(ConnectorValidationError):
+        await provider.connect_with_credentials(
+            connector=_connector("canva"),  # defaults to OAUTH2
+            user_id=uuid4(),
+            credentials={"api_key": "x"},
+        )
 
 
 def test_account_repository_serializes_expires_at_as_json_string():

--- a/lemma-backend/app/modules/connectors/tests/unit/test_composio_auth_provider.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_composio_auth_provider.py
@@ -201,6 +201,44 @@ async def test_connect_with_credentials_initiates_api_key_connection():
 
 
 @pytest.mark.asyncio
+async def test_connect_with_credentials_creates_custom_auth_config():
+    # No pre-existing auth config id -> must create a use_custom_auth config
+    # (API-key toolkits have no Composio-managed credentials).
+    connector = ConnectorEntity(
+        id="tavily",
+        provider_capabilities=[
+            ComposioProviderCapability(
+                toolkit_slug="tavily",
+                auth_scheme=AuthScheme.API_KEY,
+            )
+        ],
+    )
+    create = MagicMock(return_value=SimpleNamespace(id="ac_created"))
+    initiate = MagicMock(return_value=SimpleNamespace(id="ca_created"))
+    composio = SimpleNamespace(
+        auth_configs=SimpleNamespace(create=create),
+        connected_accounts=SimpleNamespace(initiate=initiate),
+    )
+    provider = ComposioAuthProvider(
+        connector_repository=AsyncMock(),
+        composio_client_factory=lambda: composio,
+    )
+
+    creds = await provider.connect_with_credentials(
+        connector=connector,
+        user_id=uuid4(),
+        credentials={"generic_api_key": "k"},
+    )
+
+    assert creds.connection_id == "ca_created"
+    create.assert_called_once()
+    _, kwargs = create.call_args
+    assert kwargs["options"]["type"] == "use_custom_auth"
+    assert kwargs["options"]["auth_scheme"] == "API_KEY"
+    assert initiate.call_args.kwargs["auth_config_id"] == "ac_created"
+
+
+@pytest.mark.asyncio
 async def test_connect_with_credentials_rejects_oauth_apps():
     provider = ComposioAuthProvider(
         connector_repository=AsyncMock(),

--- a/lemma-backend/app/modules/connectors/tests/unit/test_composio_operation_gateway.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_composio_operation_gateway.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault("COMPOSIO_CACHE_DIR", "/tmp/composio")
+
+from app.modules.connectors.domain.errors import (
+    OperationExecutionAccessDeniedError,
+    OperationExecutionInfrastructureError,
+    OperationExecutionUnauthorizedError,
+)
+from app.modules.connectors.infrastructure.adapters.composio_operation_gateway import (
+    ComposioOperationGateway,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _gateway(execute_response):
+    composio = SimpleNamespace(
+        tools=SimpleNamespace(execute=lambda *a, **k: execute_response)
+    )
+    return ComposioOperationGateway(composio_client_factory=lambda: composio)
+
+
+async def _run(gateway):
+    return await gateway.execute_operation(
+        connector_id="openweather_api",
+        operation_name="OPENWEATHER_API_GET_CURRENT_WEATHER",
+        payload={"q": "London"},
+        third_party_credentials={"connection_id": "ca_test"},
+        provider="COMPOSIO",
+    )
+
+
+async def test_provider_passthrough_401_maps_to_unauthorized():
+    # Mirrors a real OpenWeather bad-key failure surfaced by Composio: free-text
+    # error, HTTP status nested in `data.status_code`.
+    response = {
+        "successful": False,
+        "error": "Error fetching current weather: HTTP 401. Invalid API key.",
+        "data": {"status_code": 401, "message": "Invalid API key."},
+    }
+    with pytest.raises(OperationExecutionUnauthorizedError):
+        await _run(_gateway(response))
+
+
+async def test_provider_passthrough_403_maps_to_access_denied():
+    response = {
+        "successful": False,
+        "error": "Forbidden",
+        "data": {"status_code": 403},
+    }
+    with pytest.raises(OperationExecutionAccessDeniedError):
+        await _run(_gateway(response))
+
+
+async def test_structured_unauthorized_token_still_maps():
+    response = {"successful": False, "error": "unauthorized"}
+    with pytest.raises(OperationExecutionUnauthorizedError):
+        await _run(_gateway(response))
+
+
+async def test_unclassified_error_remains_infrastructure():
+    response = {
+        "successful": False,
+        "error": "upstream exploded",
+        "data": {"status_code": 502},
+    }
+    with pytest.raises(OperationExecutionInfrastructureError):
+        await _run(_gateway(response))
+
+
+async def test_successful_response_returns_data():
+    response = {"successful": True, "data": {"name": "London"}}
+    result = await _run(_gateway(response))
+    assert result == {"name": "London"}

--- a/lemma-backend/app/modules/connectors/tests/unit/test_connector_operation_use_cases.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_connector_operation_use_cases.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass
+from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
@@ -17,6 +18,10 @@ import pytest
 from app.modules.connectors.application import connector_operation_use_cases as ucmod
 from app.modules.connectors.application.connector_operation_use_cases import (
     ConnectorOperationUseCases,
+)
+from app.modules.connectors.domain.errors import OperationExecutionUnauthorizedError
+from app.modules.connectors.services.connector_operation_service import (
+    ResolvedConnectorExecution,
 )
 
 pytestmark = pytest.mark.asyncio
@@ -103,3 +108,52 @@ async def test_resolve_runs_in_phase1_and_execute_runs_after_release(events):
     # resolve authorizes with the in-scope ctx as actor; execute consumes the plan.
     assert resolve_evt[1] == "uow1" and resolve_evt[2] == "ctx-actor"
     assert execute_evt[1] == "uow2" and execute_evt[2] is resolved_sentinel
+
+
+async def test_unauthorized_execution_flags_account_for_reauth(events):
+    account_id = uuid4()
+    user_id = uuid4()
+    org_id = uuid4()
+    resolved = ResolvedConnectorExecution(
+        connector_id="airtable",
+        operation_execution_name="AIRTABLE_LIST_BASES",
+        provider="COMPOSIO",
+        third_party_credentials={"connection_id": "ca_x"},
+        payload={},
+        auth_token=None,
+        api_url=None,
+        account_id=account_id,
+        account_user_id=user_id,
+        organization_id=org_id,
+    )
+    connector_service = AsyncMock()
+
+    class _FakeService:
+        def __init__(self, uow):
+            self.uow = uow
+            self.connector_service = connector_service
+
+        async def resolve_execution_for_auth_config(self, **kwargs):
+            return resolved
+
+        async def execute_resolved(self, resolved):
+            raise OperationExecutionUnauthorizedError("unauthorized")
+
+    uc = ConnectorOperationUseCases(uow_factory=object(), service_builder=_FakeService)
+
+    with pytest.raises(OperationExecutionUnauthorizedError):
+        await uc.execute_operation_for_auth_config(
+            organization_id=org_id,
+            auth_config_name="airtable",
+            operation_name="AIRTABLE_LIST_BASES",
+            payload={},
+            user_id=user_id,
+            request=object(),
+            account_id=account_id,
+        )
+
+    # A fresh phase-2 scope opens for the flagging write after the failed call.
+    assert events.count("p2_open") == 2
+    connector_service.mark_account_reauth_required.assert_awaited_once_with(
+        account_id, user_id, org_id
+    )

--- a/lemma-backend/app/modules/connectors/tests/unit/test_connector_service.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_connector_service.py
@@ -6,8 +6,14 @@ from uuid import uuid4
 
 import pytest
 
-from app.modules.connectors.domain.account import AccountEntity, OAuthCredentials
+from app.modules.connectors.domain.account import (
+    AccountEntity,
+    AccountStatus,
+    ComposioCredentials,
+    OAuthCredentials,
+)
 from app.modules.connectors.domain.connector import (
+    AuthScheme,
     ConnectorEntity,
     AuthProvider,
     ComposioProviderCapability,
@@ -22,6 +28,7 @@ from app.modules.connectors.domain.connect_request import ConnectRequestStatus
 from app.modules.connectors.domain.errors import (
     AccountAlreadyConnectedError,
     ConnectorNotFoundError,
+    ConnectorValidationError,
     ConnectRequestStateRequiredError,
     OAuthFlowError,
 )
@@ -190,6 +197,202 @@ async def test_create_composio_auth_config_allows_system_default_without_env_key
     assert result.config_source == AuthConfigSource.SYSTEM_DEFAULT
     auth_config_repo.create.assert_awaited_once()
     uow.commit.assert_awaited_once()
+
+
+async def test_initiate_connect_request_allows_reauth_for_unusable_account():
+    # An account that has become unusable (REAUTH_REQUIRED) must not block a new
+    # connect request — the user reconnects in place, preserving account_id.
+    user_id = uuid4()
+    auth_config = _auth_config()
+    unusable = _account(user_id)
+    unusable.status = AccountStatus.REAUTH_REQUIRED
+
+    auth_provider = AsyncMock()
+    auth_provider.get_authorization_url.return_value = ("https://auth", "provider_state")
+    registry = Mock()
+    registry.get.return_value = auth_provider
+    connect_repo = AsyncMock()
+    connect_repo.create.side_effect = lambda req: req
+    redirect_builder = Mock()
+    redirect_builder.build.return_value = "https://callback"
+
+    service = _service(
+        connector_repository=AsyncMock(get=AsyncMock(return_value=_connector())),
+        auth_config_repository=_auth_config_repo(auth_config),
+        account_repository=AsyncMock(
+            get_by_user_and_auth_config=AsyncMock(return_value=unusable)
+        ),
+        connect_request_repository=connect_repo,
+        auth_provider_registry=registry,
+        redirect_uri_builder=redirect_builder,
+    )
+
+    result = await service.initiate_connect_request(
+        user_id=user_id, organization_id=ORG_ID, connector_id="slack"
+    )
+
+    assert isinstance(result, ConnectRequestEntity)
+
+
+async def test_create_account_composio_api_key_connects_via_provider():
+    user_id = uuid4()
+    app = ConnectorEntity(
+        id="airtable",
+        provider_capabilities=[
+            ComposioProviderCapability(
+                toolkit_slug="airtable",
+                auth_scheme=AuthScheme.API_KEY,
+            )
+        ],
+    )
+    auth_config = _composio_auth_config("airtable")
+    stored = ComposioCredentials(connection_id="ca_airtable")
+
+    auth_provider = AsyncMock()
+    auth_provider.connect_with_credentials.return_value = stored
+    registry = Mock()
+    registry.get.return_value = auth_provider
+
+    account_repo = AsyncMock()
+    account_repo.get_by_user_and_auth_config.return_value = None
+    account_repo.create.side_effect = lambda entity: entity
+    uow = AsyncMock()
+
+    service = _service(
+        uow=uow,
+        connector_repository=AsyncMock(get=AsyncMock(return_value=app)),
+        auth_config_repository=_auth_config_repo(auth_config),
+        account_repository=account_repo,
+        auth_provider_registry=registry,
+    )
+
+    account = await service.create_account(
+        user_id=user_id,
+        organization_id=ORG_ID,
+        auth_config_id=auth_config.id,
+        credentials={"api_key": "secret"},
+    )
+
+    assert account.credentials == stored
+    auth_provider.connect_with_credentials.assert_awaited_once()
+    account_repo.create.assert_awaited_once()
+    uow.commit.assert_awaited_once()
+
+
+async def test_create_account_rejects_oauth2_scheme():
+    user_id = uuid4()
+    service = _service(
+        connector_repository=AsyncMock(get=AsyncMock(return_value=_connector())),
+        auth_config_repository=_auth_config_repo(_auth_config()),
+    )
+
+    with pytest.raises(ConnectorValidationError):
+        await service.create_account(
+            user_id=user_id,
+            organization_id=ORG_ID,
+            auth_config_id=_auth_config().id,
+            credentials={"api_key": "secret"},
+        )
+
+
+async def test_get_account_credentials_marks_reauth_required_on_refresh_failure():
+    user_id = uuid4()
+    expired = OAuthCredentials(
+        access_token="old",
+        refresh_token="refresh",
+        expires_at=datetime.now() - timedelta(minutes=5),
+    )
+    account = AccountEntity(
+        id=uuid4(),
+        user_id=user_id,
+        organization_id=ORG_ID,
+        auth_config_id=uuid4(),
+        connector_id="slack",
+        credentials=expired,
+    )
+    account_repo = AsyncMock()
+    account_repo.get.return_value = account
+    account_repo.update.side_effect = lambda entity: entity
+    auth_provider = AsyncMock()
+    auth_provider.refresh_credentials.side_effect = RuntimeError("token revoked")
+    registry = Mock()
+    registry.get.return_value = auth_provider
+    uow = AsyncMock()
+
+    service = _service(
+        uow=uow,
+        connector_repository=AsyncMock(get=AsyncMock(return_value=_connector())),
+        auth_config_repository=_auth_config_repo(
+            AuthConfigEntity(
+                id=account.auth_config_id,
+                organization_id=ORG_ID,
+                connector_id="slack",
+                provider="LEMMA",
+                config_source=AuthConfigSource.SYSTEM_DEFAULT,
+                name="slack",
+            )
+        ),
+        account_repository=account_repo,
+        auth_provider_registry=registry,
+    )
+
+    with pytest.raises(OAuthFlowError):
+        await service.get_account_credentials(account.id, user_id)
+
+    assert account.status == AccountStatus.REAUTH_REQUIRED
+    account_repo.update.assert_awaited()
+
+
+async def test_handle_oauth_callback_resets_status_to_connected():
+    user_id = uuid4()
+    auth_config = _auth_config("slack")
+    connect_request = ConnectRequestEntity(
+        id=uuid4(),
+        user_id=user_id,
+        organization_id=ORG_ID,
+        auth_config_id=auth_config.id,
+        connector_id="slack",
+        authorization_url="https://auth",
+        status=ConnectRequestStatus.PENDING,
+        attributes={"state": "state-reauth"},
+    )
+    existing = AccountEntity(
+        id=uuid4(),
+        user_id=user_id,
+        organization_id=ORG_ID,
+        auth_config_id=auth_config.id,
+        connector_id="slack",
+        status=AccountStatus.REAUTH_REQUIRED,
+        credentials=OAuthCredentials(access_token="old"),
+    )
+    credentials = OAuthCredentials(access_token="xoxb-token")
+    auth_provider = AsyncMock()
+    auth_provider.exchange_code_for_credentials.return_value = credentials
+    registry = Mock()
+    registry.get.return_value = auth_provider
+
+    account_repo = AsyncMock()
+    account_repo.get_by_user_and_auth_config.return_value = existing
+    account_repo.update.side_effect = lambda entity: entity
+    connect_repo = AsyncMock()
+    connect_repo.get_by_state.return_value = connect_request
+    connect_repo.update.side_effect = lambda req: req
+
+    service = _service(
+        connector_repository=AsyncMock(get=AsyncMock(return_value=_connector("slack"))),
+        auth_config_repository=_auth_config_repo(auth_config),
+        account_repository=account_repo,
+        connect_request_repository=connect_repo,
+        auth_provider_registry=registry,
+    )
+
+    with patch.object(service, "_load_native_account_profile", AsyncMock(return_value=None)):
+        account = await service.handle_oauth_callback(
+            redirect_uri="https://cb?state=state-reauth&code=abc",
+            state="state-reauth",
+        )
+
+    assert account.status == AccountStatus.CONNECTED
 
 
 async def test_handle_oauth_callback_requires_state():

--- a/lemma-backend/app/modules/connectors/tests/unit/test_import_connector_catalog.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_import_connector_catalog.py
@@ -834,7 +834,12 @@ async def test_deactivate_excluded_composio_connectors_deactivates_microsoft_tea
         is_active=True,
     )
     connector_repository = SimpleNamespace(
-        get=AsyncMock(return_value=existing),
+        # Only microsoft_teams exists in the DB; other excluded ids resolve to None.
+        get=AsyncMock(
+            side_effect=lambda connector_id: existing
+            if connector_id == "microsoft_teams"
+            else None
+        ),
         update=AsyncMock(),
     )
 
@@ -843,7 +848,7 @@ async def test_deactivate_excluded_composio_connectors_deactivates_microsoft_tea
     )
 
     assert count == 1
-    connector_repository.get.assert_awaited_once_with("microsoft_teams")
+    connector_repository.get.assert_any_await("microsoft_teams")
     connector_repository.update.assert_awaited_once()
     updated = connector_repository.update.await_args.args[0]
     assert updated.id == "microsoft_teams"

--- a/lemma-backend/pytest.ini
+++ b/lemma-backend/pytest.ini
@@ -18,6 +18,7 @@ markers =
     worker: Tests that require the real streaq worker
     workspace: Tests that require a docker workspace runtime image
     provider: Tests that require real third-party provider credentials or APIs
+    human: Tests needing a human in the loop (e.g. live OAuth consent); opt-in only, never in CI
     local_cli: Tests that require local Codex/OpenCode/Claude CLI binaries
     real_llm: Tests that require the real model (skipped in mock e2e mode)
     real_sandbox: Tests that require the real Docker AgentBox (skipped in fake e2e mode)

--- a/lemma-backend/scripts/import_connector_catalog.py
+++ b/lemma-backend/scripts/import_connector_catalog.py
@@ -127,6 +127,7 @@ NATIVE_AUTH_METHOD_OVERRIDES: dict[str, AuthMethod] = {
 LEMMA_AUTH_PROVIDER_CONNECTOR_IDS = NATIVE_OPERATION_CONNECTOR_IDS | {"confluence"}
 COMPOSIO_EXCLUDED_CONNECTOR_IDS = {
     "microsoft_teams",
+    "splitwise",
 }
 DEFAULT_COMPOSIO_CONNECTOR_IDS: tuple[str, ...] = (
     "gmail",
@@ -183,7 +184,6 @@ DEFAULT_COMPOSIO_CONNECTOR_IDS: tuple[str, ...] = (
     "semrush",
     "sentry",
     "servicenow",
-    "splitwise",
     "spotify",
     "square",
     "stripe",
@@ -335,6 +335,88 @@ def _infer_composio_auth_method(toolkit_item, toolkit_detail) -> AuthMethod:
     if schemes & {"OAUTH1", "OAUTH2", "COMPOSIO_LINK"}:
         return AuthMethod.OAUTH2
     return AuthMethod.API_KEY
+
+
+_COMPOSIO_FIELD_TYPE_TO_JSON = {
+    "string": "string",
+    "number": "number",
+    "integer": "integer",
+    "boolean": "boolean",
+    "object": "object",
+}
+_COMPOSIO_OAUTH_MODES = {"OAUTH1", "OAUTH2", "COMPOSIO_LINK", "DCR_OAUTH", "S2S_OAUTH2"}
+
+
+def _composio_field_json_type(field_type: object) -> str:
+    return _COMPOSIO_FIELD_TYPE_TO_JSON.get(str(field_type).lower(), "string")
+
+
+def _composio_credential_schema(
+    toolkit_detail, auth_method: AuthMethod
+) -> dict | None:
+    """Build a JSON Schema describing the credentials a user must submit to
+    connect a non-OAuth Composio app, derived from the toolkit's
+    ``connected_account_initiation`` fields so the UI can render the form."""
+    if auth_method == AuthMethod.OAUTH2:
+        return None
+
+    details = getattr(toolkit_detail, "auth_config_details", None) or []
+    target_mode = auth_method.value.upper()
+    selected = None
+    for detail in details:
+        if str(getattr(detail, "mode", "")).upper() == target_mode:
+            selected = detail
+            break
+    if selected is None:
+        for detail in details:
+            if str(getattr(detail, "mode", "")).upper() not in _COMPOSIO_OAUTH_MODES:
+                selected = detail
+                break
+    if selected is None:
+        return None
+
+    fields_group = getattr(
+        getattr(selected, "fields", None), "connected_account_initiation", None
+    )
+    if fields_group is None:
+        return None
+
+    properties: dict[str, dict] = {}
+    required: list[str] = []
+    all_fields = list(getattr(fields_group, "required", None) or []) + list(
+        getattr(fields_group, "optional", None) or []
+    )
+    for field in all_fields:
+        name = getattr(field, "name", None)
+        if not name or name in properties:
+            continue
+        prop: dict[str, object] = {
+            "type": _composio_field_json_type(getattr(field, "type", "string")),
+            "title": getattr(field, "display_name", None) or name,
+        }
+        description = getattr(field, "description", None)
+        if description:
+            prop["description"] = description
+        default = getattr(field, "default", None)
+        if default is not None:
+            prop["default"] = default
+        if getattr(field, "is_secret", False):
+            prop["format"] = "password"
+        properties[name] = prop
+        if getattr(field, "required", False):
+            required.append(name)
+
+    if not properties:
+        return None
+
+    schema: dict[str, object] = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": False,
+    }
+    if required:
+        schema["required"] = required
+    return schema
 
 
 def _infer_native_auth_method(
@@ -1115,6 +1197,9 @@ async def _sync_single_composio_toolkit(
     existing = await connector_repository.get(connector_id)
     toolkit_detail = composio.toolkits.get(toolkit_item.slug)
     composio_auth_method = _infer_composio_auth_method(toolkit_item, toolkit_detail)
+    composio_auth_config_schema = _composio_credential_schema(
+        toolkit_detail, composio_auth_method
+    )
     lemma_capability = None
     if supports_native:
         try:
@@ -1148,6 +1233,7 @@ async def _sync_single_composio_toolkit(
             _composio_provider_capability(
                 auth_method=composio_auth_method,
                 toolkit_slug=toolkit_item.slug,
+                auth_config_schema=composio_auth_config_schema,
             ),
             lemma_capability,
         ),


### PR DESCRIPTION
## Summary

Four fixes to the Composio connector integration, surfaced from broken "connect" experiences.

### 1. Remove the splitwise app
It doesn't work, so drop it from the default import allowlist and add it to `COMPOSIO_EXCLUDED_CONNECTOR_IDS` — `_deactivate_excluded_composio_connectors` deactivates any already-imported row on the next sync.

### 2. Fix Canva "connection failed" despite a created Composio account
`OAuthCredentials.access_token` was a **required** field, but Composio addresses connections by `connection_id` and doesn't always surface a raw token at callback time. The `None` token raised a pydantic `ValidationError` that the OAuth callback turned into a "Connection failed" page — even though the Composio account existed and was usable. Now `access_token` is optional, and `exchange_code_for_credentials` only fails on **terminal** Composio states (`FAILED`/`EXPIRED`/`REVOKED`).

### 3. API-key (non-OAuth) Composio apps
Previously impossible — the connect flow always assumed an OAuth redirect. Now:
- The import script derives a credential **field schema** from the toolkit's `connected_account_initiation` fields (so the UI can render the form).
- New `AuthProviderInterface.connect_with_credentials`: Composio creates the connected account via `connected_accounts.initiate(config=auth_scheme.api_key(...))` and stores the `connection_id`; Lemma stores credentials verbatim.
- `create_account` routes Composio non-OAuth auth configs through the provider (same accounts endpoint native API-key apps use).

### 4. Account usability tracking + in-place reconnect
`AccountStatus` existed but was never set/read. Now:
- Accounts are auto-flagged `REAUTH_REQUIRED` when credentials become unusable — on refresh failure (`get_account_credentials`) and on a provider 401/403 at execution time. The execution-time write happens in a **fresh short scope** in the operation use-case, so it respects #53's "no DB connection held across the external call" guarantee.
- Successful (re-)auth resets the account to `CONNECTED`.
- `initiate_connect_request` only blocks a `CONNECTED` account, so an unusable account can re-run OAuth **on the same `account_id`** — preserving the references that schedules (webhook triggers), agents (`AGENT_OWNED`), and pods hold by ID.

## Testing
- `pytest app/modules/connectors/tests` → **158 passed, 1 skipped** (skip needs a real Google account).
- New unit tests cover: tokenless/terminal Composio exchange, API-key `connect_with_credentials`, Composio API-key `create_account` + OAuth2 rejection, reconnect status gating, refresh-failure flagging, callback status reset, and execution-time reauth flagging.
- `ruff` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)