### PR TITLE
docs: add CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,32 @@
+# Contributors
+
+Thank you to everyone helping us build lemma-platform. 💚
+
+Contributions of every kind make this project better, whether that's a bug
+report, a fix, docs, or an idea. This file is our way of saying thanks.
+
+## Found a bug or have an idea?
+
+The easiest way to contribute is to [open an issue](https://github.com/lemma-work/lemma-platform/issues/new).
+A clear report with steps to reproduce is genuinely valuable, and it's often the
+first step toward a fix. From there, pull requests are always welcome.
+
+## Code Contributors
+
+- **[Karan Punja Patel](https://github.com/KaranPunjaPatel)** is our first external
+  code contributor! Fixed a `TypeError` in the Python SDK's connector
+  connect-request flow by sending the connector identifier in the request body
+  instead of the URL path. ([#52](https://github.com/lemma-work/lemma-platform/pull/52))
+
+## Issue Reporters
+
+Thank you to the people who took the time to file clear, actionable reports:
+
+- [@aniket866](https://github.com/aniket866)
+- [@ayushgautam-dev](https://github.com/ayushgautam-dev)
+- [@wineforyourplate](https://github.com/wineforyourplate)
+- [@tarungarg18](https://github.com/tarungarg18)
+- [@sidd-92](https://github.com/sidd-92)
+- [@nhemant2005](https://github.com/nhemant2005)
+- [@harshinsecurity](https://github.com/harshinsecurity)
+- [@ranasonakshi855-lab](https://github.com/ranasonakshi855-lab)


### PR DESCRIPTION
Adds a `CONTRIBUTORS.md` to credit the people helping us build lemma-platform.

- **Code Contributors**: starts with @KaranPunjaPatel, our first external code contributor ([#52](https://github.com/lemma-work/lemma-platform/pull/52)).
- **Issue Reporters**: credits the external folks who've filed clear, actionable bug reports.
- Includes a short nudge encouraging people to open issues as an easy first contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)