### PR TITLE
feat(connectors): Composio-first connectors UX with account status & reconnect

### DIFF
--- a/lemma-frontend/components/connectors/advanced-config.tsx
+++ b/lemma-frontend/components/connectors/advanced-config.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Loader2 } from 'lucide-react';
+import { buildSchemaFormPayload, buildSchemaFormValues } from 'lemma-sdk';
+import { toast } from 'sonner';
+import type { Connector } from '@/lib/types';
+import { SchemaFields } from './schema-fields';
+import {
+    getAppLabel,
+    getAuthConfigSchema,
+    getManagedConfigCopy,
+    getPrimaryProvider,
+    getProviderCapability,
+    getProviderDescription,
+    getProviderLabel,
+    getSupportedProviders,
+    hasSystemDefault,
+    supportsCustomConfig,
+    type AuthConfigMode,
+    type SchemaValues,
+} from './connector-utils';
+
+export interface AdvancedEnablePayload {
+    provider: string;
+    configSource: 'SYSTEM_DEFAULT' | 'ORG_CUSTOM';
+    credentialConfig?: Record<string, unknown> | null;
+    name?: string | null;
+}
+
+export function AdvancedConfigDialog({
+    app,
+    isEnabling,
+    onOpenChange,
+    onEnable,
+}: {
+    app: Connector | null;
+    isEnabling: boolean;
+    onOpenChange: (open: boolean) => void;
+    onEnable: (payload: AdvancedEnablePayload) => void;
+}) {
+    const [provider, setProvider] = useState<string>('LEMMA');
+    const [mode, setMode] = useState<AuthConfigMode>('MANAGED');
+    const [showCustomForm, setShowCustomForm] = useState(false);
+    const [values, setValues] = useState<SchemaValues>({});
+    const [customName, setCustomName] = useState('');
+
+    useEffect(() => {
+        if (!app) return;
+        const initialProvider = getPrimaryProvider(app);
+        const capability = getProviderCapability(app, initialProvider);
+        setProvider(initialProvider);
+        setMode(hasSystemDefault(capability) ? 'MANAGED' : 'CUSTOM');
+        setShowCustomForm(!hasSystemDefault(capability) && supportsCustomConfig(capability));
+        setValues(buildSchemaFormValues(getAuthConfigSchema(capability)));
+        setCustomName('');
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [app?.id]);
+
+    const capability = getProviderCapability(app, provider);
+    const schema = getAuthConfigSchema(capability);
+    const systemDefault = hasSystemDefault(capability);
+    const customSupported = supportsCustomConfig(capability);
+    const providers = getSupportedProviders(app);
+
+    const handleProviderChange = (nextProvider: string) => {
+        const nextCapability = getProviderCapability(app, nextProvider);
+        const hasDefault = hasSystemDefault(nextCapability);
+        setProvider(nextProvider);
+        setMode(hasDefault ? 'MANAGED' : 'CUSTOM');
+        setShowCustomForm(!hasDefault && supportsCustomConfig(nextCapability));
+        setValues(buildSchemaFormValues(getAuthConfigSchema(nextCapability)));
+        setCustomName('');
+    };
+
+    const canEnable = Boolean(
+        app && ((mode === 'MANAGED' && systemDefault) || (mode === 'CUSTOM' && customSupported)),
+    );
+
+    const handleEnable = () => {
+        if (!app) return;
+        if (mode === 'MANAGED') {
+            if (!systemDefault) {
+                toast.error('This provider does not expose managed credentials for this app');
+                return;
+            }
+            onEnable({ provider, configSource: 'SYSTEM_DEFAULT' });
+            return;
+        }
+
+        const payload = buildSchemaFormPayload(schema, values);
+        if (!payload.isValid) {
+            toast.error(Object.values(payload.errors)[0] || 'Custom config is incomplete');
+            return;
+        }
+        onEnable({
+            provider,
+            configSource: 'ORG_CUSTOM',
+            credentialConfig: payload.data,
+            name: customName.trim() || null,
+        });
+    };
+
+    return (
+        <Dialog open={Boolean(app)} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Advanced setup</DialogTitle>
+                    <DialogDescription>
+                        Choose how {getAppLabel(app)} should be authorized for this organization. Most apps work with the
+                        recommended default — you only need this to use a different provider or your own credentials.
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-4 py-2">
+                    {app && providers.length > 1 ? (
+                        <div className="space-y-2">
+                            <Label>Provider</Label>
+                            <RadioGroup
+                                value={provider}
+                                onValueChange={handleProviderChange}
+                                className="grid gap-2 sm:grid-cols-2"
+                            >
+                                {providers.map((option) => (
+                                    <Label
+                                        key={option}
+                                        className="flex cursor-pointer items-start gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)] p-3 text-[var(--text-primary)]"
+                                        data-selected={provider === option}
+                                    >
+                                        <RadioGroupItem value={option} className="mt-0.5" />
+                                        <span className="grid gap-1">
+                                            <span className="text-sm font-medium text-[var(--text-primary)]">
+                                                {getProviderLabel(option, getProviderCapability(app, option))}
+                                            </span>
+                                            <span className="text-xs leading-5 text-[var(--text-secondary)]">
+                                                {getProviderDescription(option, getProviderCapability(app, option))}
+                                            </span>
+                                        </span>
+                                    </Label>
+                                ))}
+                            </RadioGroup>
+                        </div>
+                    ) : null}
+
+                    {systemDefault ? (
+                        <div className="flex items-start justify-between gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)] p-3">
+                            <span className="grid gap-1">
+                                <span className="text-sm font-medium text-[var(--text-primary)]">System default</span>
+                                <span className="text-xs leading-5 text-[var(--text-secondary)]">
+                                    {getManagedConfigCopy(provider, capability)}
+                                </span>
+                            </span>
+                            {customSupported ? (
+                                <Button
+                                    type="button"
+                                    size="sm"
+                                    variant="ghost"
+                                    className="h-7 shrink-0 px-2 text-xs"
+                                    onClick={() => {
+                                        setMode('CUSTOM');
+                                        setShowCustomForm(true);
+                                    }}
+                                >
+                                    Use custom config
+                                </Button>
+                            ) : null}
+                        </div>
+                    ) : customSupported ? (
+                        <div className="surface-panel-muted px-3 py-2 text-sm text-[var(--text-secondary)]">
+                            Add an organization configuration to enable this app.
+                        </div>
+                    ) : (
+                        <div className="state-surface-error rounded-lg px-3 py-3 text-sm text-[var(--text-secondary)]">
+                            This provider does not have an available auth configuration yet.
+                        </div>
+                    )}
+
+                    {mode === 'CUSTOM' && showCustomForm ? (
+                        <div className="space-y-3">
+                            <div className="flex items-center justify-between gap-3">
+                                <Label>Custom configuration</Label>
+                                {systemDefault ? (
+                                    <Button
+                                        type="button"
+                                        size="sm"
+                                        variant="ghost"
+                                        className="h-7 px-2 text-xs"
+                                        onClick={() => {
+                                            setMode('MANAGED');
+                                            setShowCustomForm(false);
+                                        }}
+                                    >
+                                        Use default
+                                    </Button>
+                                ) : null}
+                            </div>
+                            <Input
+                                placeholder="Config name"
+                                value={customName}
+                                onChange={(event) => setCustomName(event.target.value)}
+                            />
+                            <SchemaFields
+                                schema={schema}
+                                values={values}
+                                onChange={setValues}
+                                emptyMessage="No custom configuration fields are available for this provider."
+                            />
+                        </div>
+                    ) : null}
+                </div>
+                <DialogFooter>
+                    <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isEnabling}>
+                        Cancel
+                    </Button>
+                    <Button onClick={handleEnable} disabled={!canEnable || isEnabling}>
+                        {isEnabling ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                        Enable
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/lemma-frontend/components/connectors/connect-account-dialog.tsx
+++ b/lemma-frontend/components/connectors/connect-account-dialog.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { AlertTriangle, Loader2 } from 'lucide-react';
+import { buildSchemaFormPayload, buildSchemaFormValues } from 'lemma-sdk';
+import { toast } from 'sonner';
+import type { Connector } from '@/lib/types';
+import { SchemaFields } from './schema-fields';
+import { getAppLabel, getCredentialSchema, type ProviderCapability, type SchemaValues } from './connector-utils';
+
+export interface CredentialTarget {
+    connector: Connector;
+    capability: ProviderCapability | null;
+    authConfigId: string | null;
+    mode: 'connect' | 'reconnect';
+    accountId?: string;
+}
+
+export function ConnectAccountDialog({
+    target,
+    isSubmitting,
+    onOpenChange,
+    onSubmit,
+}: {
+    target: CredentialTarget | null;
+    isSubmitting: boolean;
+    onOpenChange: (open: boolean) => void;
+    onSubmit: (data: Record<string, unknown>) => void;
+}) {
+    const schema = getCredentialSchema(target?.capability ?? null);
+    const [values, setValues] = useState<SchemaValues>({});
+
+    // Reset the form whenever the dialog opens for a different app / mode.
+    useEffect(() => {
+        if (target) {
+            setValues(buildSchemaFormValues(schema));
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [target?.connector.id, target?.mode]);
+
+    const isReconnect = target?.mode === 'reconnect';
+
+    const handleSubmit = () => {
+        const payload = buildSchemaFormPayload(schema, values);
+        if (!payload.isValid) {
+            toast.error(Object.values(payload.errors)[0] || 'Credentials are incomplete');
+            return;
+        }
+        onSubmit(payload.data);
+    };
+
+    return (
+        <Dialog open={Boolean(target)} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>{isReconnect ? 'Reconnect account' : 'Connect account'}</DialogTitle>
+                    <DialogDescription>
+                        Enter the credentials for {getAppLabel(target?.connector)}. Fields come from the connector credential schema.
+                    </DialogDescription>
+                </DialogHeader>
+
+                {isReconnect ? (
+                    <div className="state-surface-warning flex items-start gap-2 rounded-lg px-3 py-2.5 text-xs leading-5 text-[var(--text-secondary)]">
+                        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-[var(--state-warning)]" />
+                        <span>
+                            Reconnecting re-links this account. Agents, workflows, and schedules that reference it may need
+                            to be pointed at the new connection.
+                        </span>
+                    </div>
+                ) : null}
+
+                <div className="py-2">
+                    <SchemaFields
+                        schema={schema}
+                        values={values}
+                        onChange={setValues}
+                        emptyMessage="No credential fields are required for this app."
+                        autoFocusFirst
+                    />
+                </div>
+                <DialogFooter>
+                    <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
+                        Cancel
+                    </Button>
+                    <Button onClick={handleSubmit} disabled={isSubmitting}>
+                        {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                        {isReconnect ? 'Reconnect' : 'Connect'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/lemma-frontend/components/connectors/connector-card.tsx
+++ b/lemma-frontend/components/connectors/connector-card.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { DestructiveResourceActionItem, ResourceActionsMenu } from '@/components/shared/resource-actions-menu';
+import { CheckCircle2, ExternalLink, Loader2, Plug, RefreshCw } from 'lucide-react';
+import Image from 'next/image';
+import type { Account, Connector } from '@/lib/types';
+import {
+    getAccountStatusMeta,
+    getAppLabel,
+    getPrimaryCapability,
+    usesDirectCredentials,
+} from './connector-utils';
+
+function ConnectorIcon({ icon, alt }: { icon?: string | null; alt: string }) {
+    if (icon) {
+        return (
+            <div className="relative h-10 w-10 shrink-0 rounded-lg bg-transparent p-1.5">
+                <Image src={icon} alt={alt} fill className="object-contain p-1" />
+            </div>
+        );
+    }
+    return (
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[color:color-mix(in_srgb,var(--surface-2)_46%,transparent)]">
+            <Plug className="h-5 w-5 text-[var(--text-tertiary)]" />
+        </div>
+    );
+}
+
+export function ConnectorCard({
+    app,
+    isConnected,
+    isBusy,
+    hasAdvanced,
+    onConnect,
+    onAdvanced,
+}: {
+    app: Connector;
+    isConnected: boolean;
+    isBusy: boolean;
+    hasAdvanced: boolean;
+    onConnect: (app: Connector) => void;
+    onAdvanced: (app: Connector) => void;
+}) {
+    const capability = getPrimaryCapability(app);
+    const connectsWithCredentials = usesDirectCredentials(capability);
+
+    return (
+        <div className="resource-index-card group p-4">
+            <div className="mb-3 flex items-start justify-between gap-3">
+                <div className="flex items-center gap-3">
+                    <ConnectorIcon icon={app.icon} alt={getAppLabel(app)} />
+                    <div>
+                        <p className="text-sm font-normal text-[var(--text-primary)]">{app.title || app.name}</p>
+                    </div>
+                </div>
+                {isConnected ? (
+                    <span className="inline-flex shrink-0 items-center gap-1.5 py-1 text-xs font-medium text-[var(--state-success)]">
+                        <CheckCircle2 className="h-3.5 w-3.5" />
+                        Connected
+                    </span>
+                ) : null}
+            </div>
+
+            <p className="mb-4 min-h-[44px] line-clamp-2 text-sm leading-6 text-[var(--text-secondary)]">
+                {app.description || `Connect ${getAppLabel(app)} to your workflows.`}
+            </p>
+
+            <div className="flex items-center gap-2">
+                <Button
+                    className="flex-1 justify-center"
+                    variant={isConnected ? 'outline' : 'primary'}
+                    onClick={() => onConnect(app)}
+                    disabled={isBusy || isConnected}
+                >
+                    {isBusy ? (
+                        <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            Connecting...
+                        </>
+                    ) : isConnected ? (
+                        'Connected'
+                    ) : (
+                        <>
+                            Connect
+                            {connectsWithCredentials ? null : <ExternalLink className="ml-2 h-4 w-4" />}
+                        </>
+                    )}
+                </Button>
+                {hasAdvanced && !isConnected ? (
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-9 px-2 text-xs text-[var(--text-tertiary)]"
+                        onClick={() => onAdvanced(app)}
+                        disabled={isBusy}
+                    >
+                        Advanced
+                    </Button>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+export function ConnectedAccountCard({
+    account,
+    isBusy,
+    onReconnect,
+    onDisconnect,
+}: {
+    account: Account;
+    isBusy: boolean;
+    onReconnect: (account: Account) => void;
+    onDisconnect: (account: Account) => void;
+}) {
+    const status = getAccountStatusMeta(account.status);
+    const appName = account.connector?.title || account.connector?.name || 'Unknown app';
+
+    return (
+        <div className="resource-index-card group p-4">
+            <div className="flex items-start justify-between gap-3">
+                <div className="flex min-w-0 items-center gap-3">
+                    <ConnectorIcon icon={account.connector?.icon} alt={appName} />
+                    <div className="min-w-0">
+                        <p className="truncate text-sm font-normal text-[var(--text-primary)]">{appName}</p>
+                        <p className="truncate text-xs text-[var(--text-tertiary)]">{account.email || 'Connected'}</p>
+                    </div>
+                </div>
+                <ResourceActionsMenu
+                    ariaLabel={`Open actions for ${appName}`}
+                    triggerClassName="h-8 w-8 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+                >
+                    <DestructiveResourceActionItem disabled={isBusy} onSelect={() => onDisconnect(account)}>
+                        Disconnect
+                    </DestructiveResourceActionItem>
+                </ResourceActionsMenu>
+            </div>
+
+            <div className="mt-3 flex items-center justify-between gap-2">
+                <Badge variant={status.variant} title={status.hint}>
+                    {status.label}
+                </Badge>
+                {status.needsAttention ? (
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-8"
+                        onClick={() => onReconnect(account)}
+                        disabled={isBusy}
+                    >
+                        {isBusy ? (
+                            <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                        ) : (
+                            <RefreshCw className="mr-2 h-3.5 w-3.5" />
+                        )}
+                        Reconnect
+                    </Button>
+                ) : null}
+            </div>
+        </div>
+    );
+}

--- a/lemma-frontend/components/connectors/connector-grid.tsx
+++ b/lemma-frontend/components/connectors/connector-grid.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { EmptyState } from '@/components/shared/empty-state';
+import { Plug } from 'lucide-react';
+import type { Connector } from '@/lib/types';
+import { ConnectorCard } from './connector-card';
+import { hasAdvancedOptions } from './connector-utils';
+
+export function ConnectorGrid({
+    connectors,
+    connectedAppIds,
+    busyAppId,
+    searchTerm,
+    onConnect,
+    onAdvanced,
+}: {
+    connectors: Connector[];
+    connectedAppIds: Set<string>;
+    busyAppId: string | null;
+    searchTerm: string;
+    onConnect: (app: Connector) => void;
+    onAdvanced: (app: Connector) => void;
+}) {
+    return (
+        <div className="resource-index-grid resource-index-grid-md-2 resource-index-grid-xl-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
+            {connectors.map((app) => (
+                <ConnectorCard
+                    key={app.id}
+                    app={app}
+                    isConnected={connectedAppIds.has(app.id)}
+                    isBusy={busyAppId === app.id}
+                    hasAdvanced={hasAdvancedOptions(app)}
+                    onConnect={onConnect}
+                    onAdvanced={onAdvanced}
+                />
+            ))}
+
+            {connectors.length === 0 && (
+                <EmptyState
+                    variant="panel"
+                    icon={<Plug className="h-4 w-4" />}
+                    title="No connectors match this search"
+                    description={`Try a different app name${searchTerm ? ` than "${searchTerm}"` : ''}.`}
+                    className="col-span-full"
+                />
+            )}
+        </div>
+    );
+}

--- a/lemma-frontend/components/connectors/connector-utils.ts
+++ b/lemma-frontend/components/connectors/connector-utils.ts
@@ -1,0 +1,181 @@
+import type { Account, AuthConfig, Connector } from '@/lib/types';
+import { buildSchemaFormFields, type JsonSchemaLike } from 'lemma-sdk';
+
+export type ProviderCapability = NonNullable<Connector['provider_capabilities']>[number];
+export type SchemaValues = Record<string, unknown>;
+export type AuthConfigMode = 'MANAGED' | 'CUSTOM';
+
+export const PROVIDER = {
+    LEMMA: 'LEMMA',
+    COMPOSIO: 'COMPOSIO',
+} as const;
+
+export const ACCOUNT_STATUS = {
+    CONNECTED: 'CONNECTED',
+    REAUTH_REQUIRED: 'REAUTH_REQUIRED',
+    DISCONNECTED: 'DISCONNECTED',
+} as const;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+    Boolean(value && typeof value === 'object' && !Array.isArray(value));
+
+export const getAppLabel = (app: Connector | null | undefined) =>
+    app?.title || app?.name || app?.id || 'this app';
+
+export const getProviderCapabilities = (app: Connector | null | undefined): ProviderCapability[] =>
+    (app?.provider_capabilities || []) as ProviderCapability[];
+
+export const getSupportedProviders = (app: Connector | null | undefined): string[] => {
+    const providers = getProviderCapabilities(app)
+        .map((capability) => capability.provider)
+        .filter((provider): provider is string => typeof provider === 'string');
+    return providers.length > 0 ? providers : [PROVIDER.LEMMA];
+};
+
+export const getProviderCapability = (
+    app: Connector | null | undefined,
+    provider: string | null | undefined,
+): ProviderCapability | null =>
+    getProviderCapabilities(app).find((capability) => capability.provider === provider) ?? null;
+
+/**
+ * Composio-first: when a connector exposes a Composio capability we prefer it as
+ * the default connect path. Native (Lemma) auth stays available under Advanced.
+ */
+export const getPrimaryCapability = (app: Connector | null | undefined): ProviderCapability | null => {
+    const capabilities = getProviderCapabilities(app);
+    return (
+        capabilities.find((capability) => capability.provider === PROVIDER.COMPOSIO) ??
+        capabilities[0] ??
+        null
+    );
+};
+
+export const getPrimaryProvider = (app: Connector | null | undefined): string =>
+    getPrimaryCapability(app)?.provider || getSupportedProviders(app)[0] || PROVIDER.LEMMA;
+
+export const getAuthConfigSchema = (capability: ProviderCapability | null): JsonSchemaLike | null => {
+    const schema = capability?.auth_config_schema;
+    return isRecord(schema) ? (schema as JsonSchemaLike) : null;
+};
+
+export const usesDirectCredentials = (capability: ProviderCapability | null): boolean => {
+    if (!capability) return false;
+    if (capability.auth_scheme === 'API_KEY' || capability.auth_scheme === 'NOAUTH') return true;
+    const direct = 'credential_schema' in capability ? capability.credential_schema : null;
+    return isRecord(direct);
+};
+
+/**
+ * Resolves the credential form for direct-credential (API key / bot token) apps.
+ * Native Lemma apps carry it on `credential_schema`; Composio non-OAuth toolkits
+ * expose the derived initiation fields on `auth_config_schema`.
+ */
+export const getCredentialSchema = (capability: ProviderCapability | null): JsonSchemaLike | null => {
+    if (!capability) return null;
+    const direct = 'credential_schema' in capability ? capability.credential_schema : null;
+    if (isRecord(direct)) return direct as JsonSchemaLike;
+    if (usesDirectCredentials(capability)) {
+        return getAuthConfigSchema(capability);
+    }
+    return null;
+};
+
+export const schemaHasFields = (schema: JsonSchemaLike | null): boolean =>
+    buildSchemaFormFields(schema).length > 0;
+
+export const hasSystemDefault = (capability: ProviderCapability | null): boolean =>
+    Boolean(capability?.system_default_available);
+
+export const supportsCustomConfig = (capability: ProviderCapability | null): boolean => {
+    if (!capability) return false;
+    const hasConfigFields = schemaHasFields(getAuthConfigSchema(capability));
+    if ('supports_org_custom_oauth' in capability) {
+        return Boolean(capability.supports_org_custom_oauth && hasConfigFields);
+    }
+    if ('supports_org_custom_auth_config' in capability) {
+        return Boolean(capability.supports_org_custom_auth_config && hasConfigFields);
+    }
+    return hasConfigFields;
+};
+
+/** True when this connector has any Advanced (non-default provider / custom config) option worth surfacing. */
+export const hasAdvancedOptions = (app: Connector | null | undefined): boolean => {
+    if (getSupportedProviders(app).length > 1) return true;
+    return getProviderCapabilities(app).some((capability) => supportsCustomConfig(capability));
+};
+
+export const formatProviderName = (provider: string): string => {
+    if (provider === PROVIDER.LEMMA) return 'Native';
+    if (provider === PROVIDER.COMPOSIO) return 'Composio';
+    return provider
+        .toLowerCase()
+        .split('_')
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
+};
+
+export const getProviderLabel = (provider: string, capability: ProviderCapability | null): string => {
+    if (provider === PROVIDER.COMPOSIO) return 'Composio (recommended)';
+    if (provider === PROVIDER.LEMMA && usesDirectCredentials(capability)) return 'Native credentials';
+    if (provider === PROVIDER.LEMMA) return 'Native OAuth';
+    return formatProviderName(provider);
+};
+
+export const getProviderDescription = (provider: string, capability: ProviderCapability | null): string => {
+    if (provider === PROVIDER.COMPOSIO) return 'Composio-managed auth with trigger-backed workflows. Recommended.';
+    if (usesDirectCredentials(capability)) return 'Connect with credentials from this app, such as an API key or bot token.';
+    if (provider === PROVIDER.LEMMA) return 'Use OAuth with Lemma-managed or organization-managed credentials.';
+    return 'Use this provider for the connector connection.';
+};
+
+export const getManagedConfigCopy = (provider: string, capability: ProviderCapability | null): string => {
+    if (usesDirectCredentials(capability)) return 'Use the default credential setup for this app. Account credentials are added after enabling it.';
+    if (provider === PROVIDER.COMPOSIO) return 'Composio uses the system default configuration and supports triggers.';
+    if (provider === PROVIDER.LEMMA) return 'Use the system default OAuth configuration for this app.';
+    return `Use the default ${formatProviderName(provider)} auth configuration for this app.`;
+};
+
+export interface AccountStatusMeta {
+    label: string;
+    variant: 'success' | 'warning' | 'error';
+    needsAttention: boolean;
+    hint: string;
+}
+
+export const getAccountStatusMeta = (status: string | null | undefined): AccountStatusMeta => {
+    switch (status) {
+        case ACCOUNT_STATUS.REAUTH_REQUIRED:
+            return {
+                label: 'Reconnect needed',
+                variant: 'warning',
+                needsAttention: true,
+                hint: 'This account’s credentials stopped working. Reconnect to restore access.',
+            };
+        case ACCOUNT_STATUS.DISCONNECTED:
+            return {
+                label: 'Disconnected',
+                variant: 'error',
+                needsAttention: true,
+                hint: 'This account is disconnected. Reconnect to use it again.',
+            };
+        case ACCOUNT_STATUS.CONNECTED:
+        default:
+            return {
+                label: 'Connected',
+                variant: 'success',
+                needsAttention: false,
+                hint: 'This account is connected and ready to use.',
+            };
+    }
+};
+
+export const findAuthConfigForAccount = (
+    account: Account,
+    authConfigs: AuthConfig[] | undefined,
+): AuthConfig | null =>
+    (authConfigs || []).find((config) => config.id === account.auth_config_id) ??
+    (authConfigs || []).find(
+        (config) => config.connector_id === account.connector_id && config.status === 'ACTIVE',
+    ) ??
+    null;

--- a/lemma-frontend/components/connectors/connectors-view.tsx
+++ b/lemma-frontend/components/connectors/connectors-view.tsx
@@ -7,120 +7,30 @@ import {
     useCreateConnectRequest,
     useCreateConnectorAccount,
     useDeleteAccount,
-    useEnableConnector
+    useEnableConnector,
 } from '@/lib/hooks/use-connectors';
-import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/shared/empty-state';
 import { DestructiveConfirmationDialog } from '@/components/shared/destructive-confirmation-dialog';
-import { DestructiveResourceActionItem, ResourceActionsMenu } from '@/components/shared/resource-actions-menu';
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { Label } from '@/components/ui/label';
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { Checkbox } from '@/components/ui/checkbox';
-import { Switch, SwitchThumb, SwitchTrack } from '@/components/ui/switch';
-import { Plug, ExternalLink, CheckCircle2, Search, Loader2 } from 'lucide-react';
-import Image from 'next/image';
-import { useMemo, useState } from 'react';
 import { Input } from '@/components/ui/input';
-import { Textarea } from '@/components/ui/textarea';
+import { CheckCircle2, Loader2, Plug, Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
-import type { Connector } from '@/lib/types';
+import type { Account, Connector } from '@/lib/types';
 import { useOrganization } from '@/components/dashboard/org-context';
+import { ConnectorGrid } from './connector-grid';
+import { ConnectedAccountCard } from './connector-card';
+import { ConnectAccountDialog, type CredentialTarget } from './connect-account-dialog';
+import { AdvancedConfigDialog, type AdvancedEnablePayload } from './advanced-config';
 import {
-    buildSchemaFormFields,
-    buildSchemaFormPayload,
-    buildSchemaFormValues,
-    type JsonSchemaLike,
-    type SchemaFormField
-} from 'lemma-sdk';
-
-type AuthConfigMode = 'MANAGED' | 'CUSTOM';
-type ProviderCapability = NonNullable<Connector['provider_capabilities']>[number];
-type SchemaValues = Record<string, unknown>;
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-    Boolean(value && typeof value === 'object' && !Array.isArray(value));
-
-const getAppLabel = (app: Connector | null | undefined) => app?.title || app?.name || app?.id || 'this app';
-
-const getProviderCapabilities = (app: Connector | null | undefined): ProviderCapability[] => {
-    return (app?.provider_capabilities || []) as ProviderCapability[];
-};
-
-const getSupportedProviders = (app: Connector): string[] => {
-    const providers = getProviderCapabilities(app)
-        .map((capability) => capability.provider)
-        .filter((provider): provider is string => typeof provider === 'string');
-    return providers.length > 0 ? providers : ['LEMMA'];
-};
-
-const getPreferredProvider = (app: Connector): string => {
-    const providers = getSupportedProviders(app);
-    return providers[0] || 'LEMMA';
-};
-
-const getProviderCapability = (app: Connector | null | undefined, provider: string): ProviderCapability | null => {
-    return getProviderCapabilities(app).find((capability) => capability.provider === provider) ?? null;
-};
-
-const getAuthConfigSchema = (capability: ProviderCapability | null): JsonSchemaLike | null => {
-    const schema = capability?.auth_config_schema;
-    return isRecord(schema) ? schema as JsonSchemaLike : null;
-};
-
-const getCredentialSchema = (capability: ProviderCapability | null): JsonSchemaLike | null => {
-    if (!capability || !('credential_schema' in capability)) return null;
-    const schema = capability.credential_schema;
-    return isRecord(schema) ? schema as JsonSchemaLike : null;
-};
-
-const schemaHasFields = (schema: JsonSchemaLike | null): boolean =>
-    buildSchemaFormFields(schema).length > 0;
-
-const hasSystemDefault = (capability: ProviderCapability | null): boolean =>
-    Boolean(capability?.system_default_available);
-
-const supportsCustomConfig = (capability: ProviderCapability | null): boolean => {
-    if (!capability) return false;
-    const hasConfigFields = schemaHasFields(getAuthConfigSchema(capability));
-    if ('supports_org_custom_oauth' in capability) return Boolean(capability.supports_org_custom_oauth && hasConfigFields);
-    if ('supports_org_custom_auth_config' in capability) return Boolean(capability.supports_org_custom_auth_config && hasConfigFields);
-    return hasConfigFields;
-};
-
-const usesDirectCredentials = (capability: ProviderCapability | null): boolean =>
-    Boolean(getCredentialSchema(capability) || capability?.auth_scheme === 'API_KEY');
-
-const formatProviderName = (provider: string): string => {
-    if (provider === 'LEMMA') return 'OAuth';
-    if (provider === 'COMPOSIO') return 'Composio';
-    return provider
-        .toLowerCase()
-        .split('_')
-        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-        .join(' ');
-};
-
-const getProviderLabel = (provider: string, capability: ProviderCapability | null): string => {
-    if (provider === 'LEMMA' && usesDirectCredentials(capability)) return 'Credentials';
-    if (provider === 'LEMMA') return 'OAuth';
-    return formatProviderName(provider);
-};
-
-const getProviderDescription = (provider: string, capability: ProviderCapability | null): string => {
-    if (usesDirectCredentials(capability)) return 'Connect with credentials from this app, such as an API key or bot token.';
-    if (provider === 'COMPOSIO') return 'Use Composio-managed auth for trigger-backed workflows.';
-    if (provider === 'LEMMA') return 'Use OAuth with Lemma-managed or organization-managed credentials.';
-    return 'Use this provider for the connector connection.';
-};
-
-const getManagedConfigCopy = (provider: string, capability: ProviderCapability | null): string => {
-    if (usesDirectCredentials(capability)) return 'Use the default credential setup for this app. Account credentials are added after enabling it.';
-    if (provider === 'COMPOSIO') return 'Composio uses the system default configuration and supports triggers.';
-    if (provider === 'LEMMA') return 'Use the system default OAuth configuration for this app.';
-    return `Use the default ${formatProviderName(provider)} auth configuration for this app.`;
-};
+    findAuthConfigForAccount,
+    getAccountStatusMeta,
+    getAppLabel,
+    getPrimaryCapability,
+    getProviderCapability,
+    hasSystemDefault,
+    usesDirectCredentials,
+    type ProviderCapability,
+} from './connector-utils';
 
 interface ConnectorsViewProps {
     organizationId?: string;
@@ -129,6 +39,10 @@ interface ConnectorsViewProps {
     showHeader?: boolean;
 }
 
+const openAuthorization = (url?: string | null) => {
+    if (url) window.open(url, '_blank', 'noopener,noreferrer');
+};
+
 export function ConnectorsView({ organizationId, organizationName, embedded = false, showHeader = true }: ConnectorsViewProps) {
     const { currentOrg, organizations } = useOrganization();
     const effectiveOrganizationId = organizationId || currentOrg?.id;
@@ -136,6 +50,7 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
         organizationName ||
         organizations.find((org) => org.id === effectiveOrganizationId)?.name ||
         currentOrg?.name;
+
     const { data: accounts, isLoading: isLoadingAccounts } = useAccounts({ organizationId: effectiveOrganizationId, limit: 200 });
     const { data: authConfigs, isLoading: isLoadingAuthConfigs } = useAuthConfigs({ organizationId: effectiveOrganizationId, limit: 200 });
     const { data: connectors, isLoading: isLoadingApps } = useConnectors({ limit: 200 });
@@ -143,162 +58,209 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
     const enableConnector = useEnableConnector(effectiveOrganizationId);
     const createConnectRequest = useCreateConnectRequest(effectiveOrganizationId);
     const createConnectorAccount = useCreateConnectorAccount(effectiveOrganizationId);
+
     const [searchTerm, setSearchTerm] = useState('');
-    const [connectingAppId, setConnectingAppId] = useState<string | null>(null);
-    const [enablingAppId, setEnablingAppId] = useState<string | null>(null);
+    const [busyAppId, setBusyAppId] = useState<string | null>(null);
+    const [reconnectAccountId, setReconnectAccountId] = useState<string | null>(null);
     const [deletingAccountId, setDeletingAccountId] = useState<string | null>(null);
-    const [authConfigApp, setAuthConfigApp] = useState<Connector | null>(null);
-    const [authConfigMode, setAuthConfigMode] = useState<AuthConfigMode>('MANAGED');
-    const [authConfigProvider, setAuthConfigProvider] = useState('LEMMA');
-    const [showCustomConfigForm, setShowCustomConfigForm] = useState(false);
-    const [authConfigValues, setAuthConfigValues] = useState<SchemaValues>({});
-    const [customConfigName, setCustomConfigName] = useState('');
-    const [credentialApp, setCredentialApp] = useState<Connector | null>(null);
-    const [credentialValues, setCredentialValues] = useState<SchemaValues>({});
+    const [advancedApp, setAdvancedApp] = useState<Connector | null>(null);
+    const [isEnabling, setIsEnabling] = useState(false);
+    const [credentialTarget, setCredentialTarget] = useState<CredentialTarget | null>(null);
+    const [isSubmittingCredentials, setIsSubmittingCredentials] = useState(false);
     const [accountPendingDisconnect, setAccountPendingDisconnect] = useState<{
         id: string;
         appName: string;
         accountLabel: string;
     } | null>(null);
 
-    const enabledConfigByAppId = useMemo(() => {
-        return new Map((authConfigs || [])
-            .filter((config) => config.status === 'ACTIVE')
-            .map((config) => [config.connector_id, config]));
-    }, [authConfigs]);
+    const connectorsById = useMemo(
+        () => new Map((connectors || []).map((connector) => [connector.id, connector])),
+        [connectors],
+    );
+
+    const enabledConfigByAppId = useMemo(
+        () =>
+            new Map(
+                (authConfigs || [])
+                    .filter((config) => config.status === 'ACTIVE')
+                    .map((config) => [config.connector_id, config]),
+            ),
+        [authConfigs],
+    );
+
+    const connectedAppIds = useMemo(
+        () => new Set((accounts || []).map((account) => account.connector_id)),
+        [accounts],
+    );
+
+    const filteredApps = useMemo(() => {
+        const query = searchTerm.toLowerCase();
+        const matches = (connectors || []).filter(
+            (app) =>
+                (app.title && app.title.toLowerCase().includes(query)) ||
+                (app.name && app.name.toLowerCase().includes(query)) ||
+                (app.description && app.description.toLowerCase().includes(query)),
+        );
+        // Float connected connectors to the top, then enabled ones, keeping the
+        // original order stable within each group.
+        const rank = (app: Connector) =>
+            connectedAppIds.has(app.id) ? 0 : enabledConfigByAppId.has(app.id) ? 1 : 2;
+        return matches
+            .map((app, index) => ({ app, index }))
+            .sort((a, b) => rank(a.app) - rank(b.app) || a.index - b.index)
+            .map((entry) => entry.app);
+    }, [connectors, searchTerm, connectedAppIds, enabledConfigByAppId]);
+
+    const attentionCount = useMemo(
+        () => (accounts || []).filter((account) => getAccountStatusMeta(account.status).needsAttention).length,
+        [accounts],
+    );
+
+    const openCredentialDialog = (
+        app: Connector,
+        capability: ProviderCapability | null,
+        authConfigId: string | null,
+        mode: 'connect' | 'reconnect' = 'connect',
+        accountId?: string,
+    ) => {
+        setCredentialTarget({ connector: app, capability, authConfigId, mode, accountId });
+    };
+
+    // OAuth needs a round-trip to fetch the authorization URL before we can act.
+    const startOAuth = async (connectorId: string, authConfigId: string) => {
+        const response = await createConnectRequest.mutateAsync({ connectorId, authConfigId });
+        openAuthorization(response.authorization_url);
+    };
 
     const handleConnect = async (app: Connector) => {
-        const appId = app.id;
-        const authConfig = enabledConfigByAppId.get(appId);
-        if (!authConfig) {
-            toast.error('Enable this app before connecting an account');
+        const existing = enabledConfigByAppId.get(app.id) ?? null;
+        const capability = existing ? getProviderCapability(app, existing.provider) : getPrimaryCapability(app);
+        if (!capability) {
+            toast.error('This connector is not available yet');
             return;
         }
 
-        const capability = getProviderCapability(app, authConfig.provider);
-        const credentialSchema = getCredentialSchema(capability);
-        if (usesDirectCredentials(capability) && credentialSchema) {
-            setCredentialApp(app);
-            setCredentialValues(buildSchemaFormValues(credentialSchema));
-            return;
-        }
-
-        try {
-            setConnectingAppId(appId);
-            const response = await createConnectRequest.mutateAsync({
-                connectorId: appId,
-                authConfigId: authConfig.id,
-            });
-            if (response.authorization_url) {
-                window.open(response.authorization_url, '_blank', 'noopener,noreferrer');
+        // Credential apps: open the form immediately so keystrokes land in the field,
+        // not the page. Enabling (if needed) is deferred to submit time.
+        if (usesDirectCredentials(capability)) {
+            if (!existing && !hasSystemDefault(capability)) {
+                setAdvancedApp(app);
+                return;
             }
-        } catch (error) {
-            console.error('Failed to connect:', error);
-            toast.error('Failed to initiate connection');
-        } finally {
-            setConnectingAppId(null);
+            openCredentialDialog(app, capability, existing?.id ?? null, 'connect');
+            return;
         }
-    };
 
-    const openEnableDialog = (app: Connector) => {
-        const provider = getPreferredProvider(app);
-        const capability = getProviderCapability(app, provider);
-        setAuthConfigApp(app);
-        setAuthConfigProvider(provider);
-        setAuthConfigMode(hasSystemDefault(capability) ? 'MANAGED' : 'CUSTOM');
-        setShowCustomConfigForm(!hasSystemDefault(capability) && supportsCustomConfig(capability));
-        setAuthConfigValues(buildSchemaFormValues(getAuthConfigSchema(capability)));
-        setCustomConfigName('');
-    };
-
-    const handleAuthConfigProviderChange = (provider: string) => {
-        const capability = getProviderCapability(authConfigApp, provider);
-        const hasDefault = hasSystemDefault(capability);
-        const canUseCustom = supportsCustomConfig(capability);
-
-        setAuthConfigProvider(provider);
-        setAuthConfigMode(hasDefault ? 'MANAGED' : 'CUSTOM');
-        setShowCustomConfigForm(!hasDefault && canUseCustom);
-        setAuthConfigValues(buildSchemaFormValues(getAuthConfigSchema(capability)));
-        setCustomConfigName('');
-    };
-
-    const handleEnableFromDialog = async () => {
-        if (!authConfigApp) return;
-        const capability = getProviderCapability(authConfigApp, authConfigProvider);
-
+        // OAuth apps: auto-enable the managed default (if needed), then open the flow.
+        setBusyAppId(app.id);
         try {
-            setEnablingAppId(authConfigApp.id);
-
-            if (authConfigMode === 'MANAGED') {
+            let authConfig = existing;
+            if (!authConfig) {
                 if (!hasSystemDefault(capability)) {
-                    toast.error(`${formatProviderName(authConfigProvider)} does not expose managed credentials for this app`);
+                    setAdvancedApp(app);
                     return;
                 }
-                await enableConnector.mutateAsync({
-                    connectorId: authConfigApp.id,
-                    provider: authConfigProvider,
+                authConfig = await enableConnector.mutateAsync({
+                    connectorId: app.id,
+                    provider: capability.provider,
                     configSource: 'SYSTEM_DEFAULT',
                 });
-                toast.success('Connector enabled');
-                setAuthConfigApp(null);
-                return;
             }
+            await startOAuth(app.id, authConfig.id);
+        } catch (error) {
+            console.error('Failed to connect:', error);
+            toast.error('Failed to connect');
+        } finally {
+            setBusyAppId(null);
+        }
+    };
 
-            const schema = getAuthConfigSchema(capability);
-            const payload = buildSchemaFormPayload(schema, authConfigValues);
-            if (!payload.isValid) {
-                toast.error(Object.values(payload.errors)[0] || 'Custom config is incomplete');
-                return;
-            }
-
-            await enableConnector.mutateAsync({
-                connectorId: authConfigApp.id,
-                provider: authConfigProvider,
-                configSource: 'ORG_CUSTOM',
-                credentialConfig: payload.data,
-                name: customConfigName.trim() || null,
+    const handleAdvancedEnable = async (payload: AdvancedEnablePayload) => {
+        if (!advancedApp) return;
+        const app = advancedApp;
+        setIsEnabling(true);
+        try {
+            const authConfig = await enableConnector.mutateAsync({
+                connectorId: app.id,
+                provider: payload.provider,
+                configSource: payload.configSource,
+                credentialConfig: payload.credentialConfig,
+                name: payload.name,
             });
             toast.success('Connector enabled');
-            setAuthConfigApp(null);
+            setAdvancedApp(null);
+
+            const capability = getProviderCapability(app, authConfig.provider);
+            if (usesDirectCredentials(capability)) {
+                openCredentialDialog(app, capability, authConfig.id, 'connect');
+                return;
+            }
+            await startOAuth(app.id, authConfig.id);
         } catch (error) {
             console.error('Failed to enable connector:', error);
             toast.error('Failed to enable connector');
         } finally {
-            setEnablingAppId(null);
+            setIsEnabling(false);
         }
     };
 
-    const handleCreateCredentialAccount = async () => {
-        if (!credentialApp) return;
-        const authConfig = enabledConfigByAppId.get(credentialApp.id);
-        if (!authConfig) {
-            toast.error('Enable this app before adding credentials');
+    const handleReconnect = async (account: Account) => {
+        const app = connectorsById.get(account.connector_id) ?? (account.connector as Connector | undefined) ?? null;
+        const authConfig = findAuthConfigForAccount(account, authConfigs);
+        if (!app || !authConfig) {
+            toast.error('Unable to reconnect this account');
+            return;
+        }
+        const capability = getProviderCapability(app, authConfig.provider);
+
+        // Credential accounts re-link via the form (delete + recreate). OAuth accounts
+        // re-run the flow on the same account_id — the backend only blocks CONNECTED.
+        if (usesDirectCredentials(capability)) {
+            openCredentialDialog(app, capability, authConfig.id, 'reconnect', account.id);
             return;
         }
 
-        const capability = getProviderCapability(credentialApp, authConfig.provider);
-        const schema = getCredentialSchema(capability);
-        const payload = buildSchemaFormPayload(schema, credentialValues);
-        if (!payload.isValid) {
-            toast.error(Object.values(payload.errors)[0] || 'Credentials are incomplete');
-            return;
-        }
-
+        setReconnectAccountId(account.id);
         try {
-            setConnectingAppId(credentialApp.id);
-            await createConnectorAccount.mutateAsync({
-                authConfigId: authConfig.id,
-                credentials: payload.data,
-            });
-            toast.success(`${getAppLabel(credentialApp)} connected`);
-            setCredentialApp(null);
-            setCredentialValues({});
+            await startOAuth(account.connector_id, authConfig.id);
         } catch (error) {
-            console.error('Failed to connect credential account:', error);
+            console.error('Failed to reconnect:', error);
+            toast.error('Failed to start reconnect');
+        } finally {
+            setReconnectAccountId(null);
+        }
+    };
+
+    const handleCredentialSubmit = async (data: Record<string, unknown>) => {
+        const target = credentialTarget;
+        if (!target) return;
+        setIsSubmittingCredentials(true);
+        try {
+            // Enable the managed default now if the org hasn't configured this connector yet.
+            let authConfigId = target.authConfigId;
+            if (!authConfigId) {
+                if (!target.capability || !hasSystemDefault(target.capability)) {
+                    throw new Error('Connector is not configured for direct credentials');
+                }
+                const authConfig = await enableConnector.mutateAsync({
+                    connectorId: target.connector.id,
+                    provider: target.capability.provider,
+                    configSource: 'SYSTEM_DEFAULT',
+                });
+                authConfigId = authConfig.id;
+            }
+
+            if (target.mode === 'reconnect' && target.accountId) {
+                await deleteAccount.mutateAsync(target.accountId);
+            }
+            await createConnectorAccount.mutateAsync({ authConfigId, credentials: data });
+            toast.success(`${getAppLabel(target.connector)} ${target.mode === 'reconnect' ? 'reconnected' : 'connected'}`);
+            setCredentialTarget(null);
+        } catch (error) {
+            console.error('Failed to save credentials:', error);
             toast.error('Failed to save credentials');
         } finally {
-            setConnectingAppId(null);
+            setIsSubmittingCredentials(false);
         }
     };
 
@@ -317,120 +279,6 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
         }
     };
 
-    const connectedAppIds = useMemo(() => new Set((accounts || []).map((acc) => acc.connector_id)), [accounts]);
-
-    const filteredApps = (connectors || []).filter(app =>
-        (app.title && app.title.toLowerCase().includes(searchTerm.toLowerCase())) ||
-        (app.name && app.name.toLowerCase().includes(searchTerm.toLowerCase())) ||
-        (app.description && app.description.toLowerCase().includes(searchTerm.toLowerCase()))
-    );
-    const enabledConnectors = filteredApps.filter((app) => enabledConfigByAppId.has(app.id));
-    const availableConnectors = filteredApps.filter((app) => !enabledConfigByAppId.has(app.id));
-    const authConfigCapability = getProviderCapability(authConfigApp, authConfigProvider);
-    const authConfigProviderLabel = getProviderLabel(authConfigProvider, authConfigCapability);
-    const authConfigSchema = getAuthConfigSchema(authConfigCapability);
-    const authConfigHasSystemDefault = hasSystemDefault(authConfigCapability);
-    const authConfigSupportsCustom = supportsCustomConfig(authConfigCapability);
-    const canEnableAuthConfig = Boolean(
-        authConfigApp &&
-        (
-            (authConfigMode === 'MANAGED' && authConfigHasSystemDefault) ||
-            (authConfigMode === 'CUSTOM' && authConfigSupportsCustom)
-        )
-    );
-    const credentialCapability = credentialApp
-        ? getProviderCapability(credentialApp, enabledConfigByAppId.get(credentialApp.id)?.provider || getPreferredProvider(credentialApp))
-        : null;
-    const credentialSchema = getCredentialSchema(credentialCapability);
-
-    const renderConnectorCard = (app: Connector) => {
-        const authConfig = enabledConfigByAppId.get(app.id);
-        const isEnabled = Boolean(authConfig);
-        const isConnected = connectedAppIds.has(app.id);
-        const isBusy = enablingAppId === app.id || connectingAppId === app.id;
-        const activeCapability = authConfig ? getProviderCapability(app, authConfig.provider) : null;
-        const connectsWithCredentials = usesDirectCredentials(activeCapability);
-
-        return (
-            <div
-                key={app.id}
-                className="resource-index-card group p-4"
-            >
-                <div className="mb-3 flex items-start justify-between gap-3">
-                    <div className="flex items-center gap-3">
-                        {app.icon ? (
-                            <div className="relative h-10 w-10 rounded-lg bg-transparent p-1.5">
-                                <Image
-                                    src={app.icon}
-                                    alt={app.title || app.name || 'App'}
-                                    fill
-                                    className="object-contain p-1"
-                                />
-                            </div>
-                        ) : (
-                            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[color:color-mix(in_srgb,var(--surface-2)_46%,transparent)]">
-                                <Plug className="h-5 w-5 text-[var(--text-tertiary)]" />
-                            </div>
-                        )}
-                        <div>
-                            <p className="text-sm font-normal text-[var(--text-primary)]">{app.title || app.name}</p>
-                        </div>
-                    </div>
-                    {isEnabled ? (
-                        <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-transparent py-1 text-xs font-medium text-[var(--state-success)]">
-                            <CheckCircle2 className="h-3.5 w-3.5" />
-                            Enabled
-                        </span>
-                    ) : (
-                        <Switch
-                            checked={false}
-                            aria-label={`Enable ${app.title || app.name || app.id}`}
-                            className="flex shrink-0 items-center gap-2 rounded-full bg-transparent px-0 py-1 text-xs font-medium text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)] disabled:cursor-default disabled:opacity-80"
-                            onClick={() => openEnableDialog(app)}
-                            disabled={isBusy}
-                        >
-                            {isBusy && !isConnected ? (
-                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                            ) : (
-                                <SwitchTrack>
-                                    <SwitchThumb />
-                                </SwitchTrack>
-                            )}
-                            <span>Enable</span>
-                        </Switch>
-                    )}
-                </div>
-
-                <p className="mb-4 min-h-[44px] line-clamp-2 text-sm leading-6 text-[var(--text-secondary)]">
-                    {app.description || `Connect ${app.title || app.name} to your workflows.`}
-                </p>
-
-                {isEnabled ? (
-                    <Button
-                        className="w-full justify-center"
-                        variant={isConnected ? 'outline' : 'primary'}
-                        onClick={() => handleConnect(app)}
-                        disabled={isBusy || isConnected}
-                    >
-                        {isBusy ? (
-                            <>
-                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                                Connecting...
-                            </>
-                        ) : isConnected ? (
-                            'Connected'
-                        ) : (
-                            <>
-                                Connect account
-                                {connectsWithCredentials ? null : <ExternalLink className="ml-2 h-4 w-4" />}
-                            </>
-                        )}
-                    </Button>
-                ) : null}
-            </div>
-        );
-    };
-
     if (!effectiveOrganizationId) {
         return (
             <EmptyState
@@ -444,14 +292,31 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
 
     if (isLoadingAccounts || isLoadingApps || isLoadingAuthConfigs) {
         return (
-            <div className={embedded ? "flex min-h-[30vh] items-center justify-center bg-transparent" : "context-shell flex min-h-full items-center justify-center bg-transparent pb-8"}>
+            <div className={embedded ? 'flex min-h-[30vh] items-center justify-center bg-transparent' : 'context-shell flex min-h-full items-center justify-center bg-transparent pb-8'}>
                 <Loader2 className="h-8 w-8 animate-spin text-[var(--text-tertiary)]" />
             </div>
         );
     }
 
+    const searchField = (
+        <div className="relative w-full max-w-sm">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-tertiary)]" />
+            <Input
+                type="search"
+                name="connector-search"
+                autoComplete="off"
+                data-1p-ignore
+                data-lpignore="true"
+                placeholder="Search apps"
+                className="pl-9"
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+            />
+        </div>
+    );
+
     return (
-        <div className={embedded ? "min-h-full bg-transparent" : "context-shell min-h-full bg-transparent pb-8"}>
+        <div className={embedded ? 'min-h-full bg-transparent' : 'context-shell min-h-full bg-transparent pb-8'}>
             {showHeader ? (
                 <>
                     <div className="context-header">
@@ -459,39 +324,22 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
                             <p className="section-label">Connectors</p>
                             <h1 className="font-display text-4xl font-normal text-[var(--text-primary)]">Connectors</h1>
                             <p className="mt-2 max-w-2xl text-sm text-[var(--text-secondary)]">
-                                Enabled connectors and connected accounts are available to you across every pod in {effectiveOrganizationName || 'this organization'}.
+                                Connect the apps you use, and they’re available to you across every pod in {effectiveOrganizationName || 'this organization'}.
                             </p>
                         </div>
-
-                        <div className="relative w-full max-w-sm">
-                            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-tertiary)]" />
-                            <Input
-                                placeholder="Search apps"
-                                className="pl-9"
-                                value={searchTerm}
-                                onChange={(e) => setSearchTerm(e.target.value)}
-                            />
-                        </div>
+                        {searchField}
                     </div>
-
                     <p className="context-inline-note">
-                        Enable an connector once for the organization. Each user still connects their own account per organization.
+                        Click Connect and we’ll set up the recommended integration automatically. Use Advanced only to pick a
+                        different provider or your own credentials.
                     </p>
                 </>
             ) : (
                 <div className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                     <p className="max-w-2xl text-sm leading-6 text-[var(--text-secondary)]">
-                        Connectors you enable, and accounts you connect, are available to you across every pod in {effectiveOrganizationName || 'this organization'}.
+                        Connect the apps you use, and they’re available to you across every pod in {effectiveOrganizationName || 'this organization'}.
                     </p>
-                    <div className="relative w-full max-w-sm">
-                        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--text-tertiary)]" />
-                        <Input
-                            placeholder="Search apps"
-                            className="pl-9"
-                            value={searchTerm}
-                            onChange={(e) => setSearchTerm(e.target.value)}
-                        />
-                    </div>
+                    {searchField}
                 </div>
             )}
 
@@ -499,61 +347,67 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
                 <section className="context-section">
                     <div className="mb-3 flex items-center gap-2">
                         <CheckCircle2 className="h-4 w-4 text-[var(--state-success)]" />
-                        <h2 className="text-base font-normal text-[var(--text-primary)]">Connected accounts</h2>
+                        <h2 className="text-base font-normal text-[var(--text-primary)]">Your accounts</h2>
                         <span className="text-xs text-[var(--text-tertiary)]">{accounts.length}</span>
+                        {attentionCount > 0 ? (
+                            <span className="text-xs font-medium text-[var(--state-warning)]">
+                                · {attentionCount} need{attentionCount === 1 ? 's' : ''} attention
+                            </span>
+                        ) : null}
                     </div>
                     <div className="resource-index-grid resource-index-grid-md-2 resource-index-grid-xl-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
-                        {(accounts || []).map((account) => (
-                            <div
+                        {accounts.map((account) => (
+                            <ConnectedAccountCard
                                 key={account.id}
-                                className="resource-index-card group p-4"
-                            >
-                                <div className="flex items-center justify-between">
-                                    <div className="flex items-center gap-3">
-                                        {account.connector?.icon ? (
-                                            <div className="relative h-10 w-10 rounded-lg bg-transparent p-1.5">
-                                                <Image
-                                                    src={account.connector.icon}
-                                                    alt={account.connector.title || account.connector.name || 'App'}
-                                                    fill
-                                                    className="object-contain p-1"
-                                                />
-                                            </div>
-                                        ) : (
-                                            <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-[color:color-mix(in_srgb,var(--surface-2)_46%,transparent)]">
-                                                <Plug className="h-5 w-5 text-[var(--text-tertiary)]" />
-                                            </div>
-                                        )}
-                                        <div className="min-w-0">
-                                            <p className="truncate text-sm font-normal text-[var(--text-primary)]">
-                                                {account.connector?.title || account.connector?.name || 'Unknown App'}
-                                            </p>
-                                            <p className="truncate text-xs text-[var(--text-tertiary)]">
-                                                {account.email || 'Connected'}
-                                            </p>
-                                        </div>
-                                    </div>
-                                    <ResourceActionsMenu
-                                        ariaLabel={`Open actions for ${account.connector?.title || account.connector?.name || 'connected account'}`}
-                                        triggerClassName="h-8 w-8 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
-                                    >
-                                        <DestructiveResourceActionItem
-                                            disabled={deletingAccountId === account.id}
-                                            onSelect={() => setAccountPendingDisconnect({
-                                                id: account.id,
-                                                appName: account.connector?.title || account.connector?.name || 'this app',
-                                                accountLabel: account.email || account.connector?.title || account.connector?.name || 'Connected account',
-                                            })}
-                                        >
-                                            Disconnect
-                                        </DestructiveResourceActionItem>
-                                    </ResourceActionsMenu>
-                                </div>
-                            </div>
+                                account={account}
+                                isBusy={reconnectAccountId === account.id || deletingAccountId === account.id}
+                                onReconnect={handleReconnect}
+                                onDisconnect={(acc) =>
+                                    setAccountPendingDisconnect({
+                                        id: acc.id,
+                                        appName: acc.connector?.title || acc.connector?.name || 'this app',
+                                        accountLabel: acc.email || acc.connector?.title || acc.connector?.name || 'Connected account',
+                                    })
+                                }
+                            />
                         ))}
                     </div>
                 </section>
             )}
+
+            <section>
+                <div className="mb-3 flex items-center gap-2">
+                    <Plug className="h-4 w-4 text-[var(--text-tertiary)]" />
+                    <h2 className="text-base font-normal text-[var(--text-primary)]">All connectors</h2>
+                    <span className="text-xs text-[var(--text-tertiary)]">{filteredApps.length}</span>
+                </div>
+                <ConnectorGrid
+                    connectors={filteredApps}
+                    connectedAppIds={connectedAppIds}
+                    busyAppId={busyAppId}
+                    searchTerm={searchTerm}
+                    onConnect={handleConnect}
+                    onAdvanced={setAdvancedApp}
+                />
+            </section>
+
+            <AdvancedConfigDialog
+                app={advancedApp}
+                isEnabling={isEnabling}
+                onOpenChange={(open) => {
+                    if (!open) setAdvancedApp(null);
+                }}
+                onEnable={handleAdvancedEnable}
+            />
+
+            <ConnectAccountDialog
+                target={credentialTarget}
+                isSubmitting={isSubmittingCredentials}
+                onOpenChange={(open) => {
+                    if (!open) setCredentialTarget(null);
+                }}
+                onSubmit={handleCredentialSubmit}
+            />
 
             <DestructiveConfirmationDialog
                 open={Boolean(accountPendingDisconnect)}
@@ -573,322 +427,6 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
                 isPending={Boolean(deletingAccountId)}
                 onConfirm={() => void handleDisconnect()}
             />
-
-            {enabledConnectors.length > 0 ? (
-                <section className="context-section">
-                    <div className="mb-3 flex items-center gap-2">
-                        <CheckCircle2 className="h-4 w-4 text-[var(--state-success)]" />
-                        <h2 className="text-base font-normal text-[var(--text-primary)]">Enabled connectors</h2>
-                        <span className="text-xs text-[var(--text-tertiary)]">{enabledConnectors.length}</span>
-                    </div>
-                    <div className="resource-index-grid resource-index-grid-md-2 resource-index-grid-xl-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
-                        {enabledConnectors.map(renderConnectorCard)}
-                    </div>
-                </section>
-            ) : null}
-
-            <section>
-                <div className="mb-3 flex items-center gap-2">
-                    <Plug className="h-4 w-4 text-[var(--text-tertiary)]" />
-                    <h2 className="text-base font-normal text-[var(--text-primary)]">All connectors</h2>
-                    <span className="text-xs text-[var(--text-tertiary)]">{availableConnectors.length}</span>
-                </div>
-
-                <div className="resource-index-grid resource-index-grid-md-2 resource-index-grid-xl-3 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
-                    {availableConnectors.map(renderConnectorCard)}
-
-                    {filteredApps.length === 0 && (
-                        <EmptyState
-                            variant="panel"
-                            icon={<Plug className="h-4 w-4" />}
-                            title="No connectors match this search"
-                            description={`Try a different app name${searchTerm ? ` than "${searchTerm}"` : ''}.`}
-                            className="col-span-full"
-                        />
-                    )}
-                </div>
-            </section>
-
-            <Dialog open={Boolean(authConfigApp)} onOpenChange={(open) => {
-                if (!open) {
-                    setAuthConfigApp(null);
-                    setAuthConfigMode('MANAGED');
-                    setAuthConfigProvider('LEMMA');
-                    setShowCustomConfigForm(false);
-                    setAuthConfigValues({});
-                    setCustomConfigName('');
-                }
-            }}>
-                <DialogContent>
-                    <DialogHeader>
-                        <DialogTitle>Enable connector</DialogTitle>
-                        <DialogDescription>
-                            {usesDirectCredentials(authConfigCapability)
-                                ? `Enable ${getAppLabel(authConfigApp)} for this organization. Account credentials are connected after enabling it.`
-                                : `Choose how ${getAppLabel(authConfigApp)} should be authorized for this organization.`}
-                        </DialogDescription>
-                    </DialogHeader>
-                    <div className="space-y-4 py-2">
-                        {authConfigApp && getSupportedProviders(authConfigApp).length > 1 ? (
-                            <div className="space-y-2">
-                                <Label>Provider</Label>
-                                <RadioGroup
-                                    value={authConfigProvider}
-                                    onValueChange={handleAuthConfigProviderChange}
-                                    className="grid gap-2 sm:grid-cols-2"
-                                >
-                                    {getSupportedProviders(authConfigApp).map((provider) => (
-                                        <Label
-                                            key={provider}
-                                            className="flex cursor-pointer items-start gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)] p-3 text-[var(--text-primary)]"
-                                            data-selected={authConfigProvider === provider}
-                                        >
-                                            <RadioGroupItem value={provider} className="mt-0.5" />
-                                            <span className="grid gap-1">
-                                                <span className="text-sm font-medium text-[var(--text-primary)]">
-                                                    {getProviderLabel(provider, getProviderCapability(authConfigApp, provider))}
-                                                </span>
-                                                <span className="text-xs leading-5 text-[var(--text-secondary)]">
-                                                    {getProviderDescription(provider, getProviderCapability(authConfigApp, provider))}
-                                                </span>
-                                            </span>
-                                        </Label>
-                                    ))}
-                                </RadioGroup>
-                            </div>
-                        ) : authConfigApp ? (
-                            <div className="surface-panel-muted px-3 py-2 text-sm text-[var(--text-secondary)]">
-                                {authConfigProviderLabel}
-                            </div>
-                        ) : null}
-
-                        {authConfigHasSystemDefault ? (
-                            <div className="flex items-start justify-between gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)] p-3">
-                                <span className="grid gap-1">
-                                    <span className="text-sm font-medium text-[var(--text-primary)]">System default</span>
-                                    <span className="text-xs leading-5 text-[var(--text-secondary)]">
-                                        {getManagedConfigCopy(authConfigProvider, authConfigCapability)}
-                                    </span>
-                                </span>
-                                {authConfigSupportsCustom ? (
-                                    <Button
-                                        type="button"
-                                        size="sm"
-                                        variant="ghost"
-                                        className="h-7 shrink-0 px-2 text-xs"
-                                        onClick={() => {
-                                            setAuthConfigMode('CUSTOM');
-                                            setShowCustomConfigForm(true);
-                                        }}
-                                    >
-                                        Add custom config
-                                    </Button>
-                                ) : null}
-                            </div>
-                        ) : authConfigSupportsCustom ? (
-                            <div className="surface-panel-muted px-3 py-2 text-sm text-[var(--text-secondary)]">
-                                Add an organization OAuth configuration to enable this app.
-                            </div>
-                        ) : (
-                            <div className="state-surface-error rounded-lg px-3 py-3 text-sm text-[var(--text-secondary)]">
-                                This provider does not have an available auth configuration yet.
-                            </div>
-                        )}
-
-                        {authConfigMode === 'CUSTOM' && showCustomConfigForm ? (
-                            <div className="space-y-3">
-                                <div className="flex items-center justify-between gap-3">
-                                    <Label>Custom configuration</Label>
-                                    {authConfigHasSystemDefault ? (
-                                        <Button
-                                            type="button"
-                                            size="sm"
-                                            variant="ghost"
-                                            className="h-7 px-2 text-xs"
-                                            onClick={() => {
-                                                setAuthConfigMode('MANAGED');
-                                                setShowCustomConfigForm(false);
-                                            }}
-                                        >
-                                            Use default
-                                        </Button>
-                                    ) : null}
-                                </div>
-                                <Input
-                                    placeholder="Config name"
-                                    value={customConfigName}
-                                    onChange={(event) => setCustomConfigName(event.target.value)}
-                                />
-                                <SchemaFields
-                                    schema={authConfigSchema}
-                                    values={authConfigValues}
-                                    onChange={setAuthConfigValues}
-                                    emptyMessage="No custom configuration fields are available for this provider."
-                                />
-                            </div>
-                        ) : null}
-                    </div>
-                    <DialogFooter>
-                        <Button variant="outline" onClick={() => setAuthConfigApp(null)}>
-                            Cancel
-                        </Button>
-                        <Button
-                            onClick={() => void handleEnableFromDialog()}
-                            disabled={!canEnableAuthConfig || Boolean(authConfigApp && enablingAppId === authConfigApp.id)}
-                        >
-                            {authConfigApp && enablingAppId === authConfigApp.id ? (
-                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                            ) : null}
-                            Enable
-                        </Button>
-                    </DialogFooter>
-                </DialogContent>
-            </Dialog>
-
-            <Dialog open={Boolean(credentialApp)} onOpenChange={(open) => {
-                if (!open) {
-                    setCredentialApp(null);
-                    setCredentialValues({});
-                }
-            }}>
-                <DialogContent>
-                    <DialogHeader>
-                        <DialogTitle>Connect account</DialogTitle>
-                        <DialogDescription>
-                            Enter the credentials for {getAppLabel(credentialApp)}. Fields come from the connector credential schema.
-                        </DialogDescription>
-                    </DialogHeader>
-                    <div className="py-2">
-                        <SchemaFields
-                            schema={credentialSchema}
-                            values={credentialValues}
-                            onChange={setCredentialValues}
-                            emptyMessage="No credential fields are required for this app."
-                        />
-                    </div>
-                    <DialogFooter>
-                        <Button variant="outline" onClick={() => setCredentialApp(null)}>
-                            Cancel
-                        </Button>
-                        <Button onClick={() => void handleCreateCredentialAccount()} disabled={Boolean(credentialApp && connectingAppId === credentialApp.id)}>
-                            {credentialApp && connectingAppId === credentialApp.id ? (
-                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                            ) : null}
-                            Connect
-                        </Button>
-                    </DialogFooter>
-                </DialogContent>
-            </Dialog>
-        </div>
-    );
-}
-
-function SchemaFields({
-    schema,
-    values,
-    onChange,
-    emptyMessage = 'No configurable fields are required for this provider.',
-}: {
-    schema: JsonSchemaLike | null;
-    values: SchemaValues;
-    onChange: (values: SchemaValues) => void;
-    emptyMessage?: string;
-}) {
-    const fields = buildSchemaFormFields(schema);
-
-    if (fields.length === 0) {
-        return (
-            <div className="surface-panel-muted p-3 text-sm text-[var(--text-secondary)]">
-                {emptyMessage}
-            </div>
-        );
-    }
-
-    const updateField = (name: string, value: unknown) => {
-        onChange({ ...values, [name]: value });
-    };
-
-    return (
-        <div className="space-y-3">
-            {fields.map((field) => (
-                <SchemaField
-                    key={field.name}
-                    field={field}
-                    value={values[field.name]}
-                    onChange={(value) => updateField(field.name, value)}
-                />
-            ))}
-        </div>
-    );
-}
-
-function SchemaField({
-    field,
-    value,
-    onChange,
-}: {
-    field: SchemaFormField;
-    value: unknown;
-    onChange: (value: unknown) => void;
-}) {
-    const fieldId = `connector-schema-${field.name}`;
-    const label = `${field.label}${field.required ? ' *' : ''}`;
-    const stringValue = typeof value === 'string' ? value : value == null ? '' : String(value);
-
-    if (field.kind === 'boolean') {
-        return (
-            <Label htmlFor={fieldId} className="flex cursor-pointer items-start gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)] p-3">
-                <Checkbox
-                    id={fieldId}
-                    checked={Boolean(value)}
-                    onCheckedChange={(checked) => onChange(Boolean(checked))}
-                    className="mt-0.5"
-                />
-                <span className="grid gap-1">
-                    <span className="text-sm font-medium text-[var(--text-primary)]">{label}</span>
-                    {field.description ? (
-                        <span className="text-xs leading-5 text-[var(--text-secondary)]">{field.description}</span>
-                    ) : null}
-                </span>
-            </Label>
-        );
-    }
-
-    return (
-        <div className="space-y-1.5">
-            <Label htmlFor={fieldId}>{label}</Label>
-            {field.kind === 'select' ? (
-                <Select value={stringValue} onValueChange={onChange}>
-                    <SelectTrigger id={fieldId}>
-                        <SelectValue placeholder={`Select ${field.label}`} />
-                    </SelectTrigger>
-                    <SelectContent>
-                        {field.options.map((option) => (
-                            <SelectItem key={option.value} value={option.value}>
-                                {option.label}
-                            </SelectItem>
-                        ))}
-                    </SelectContent>
-                </Select>
-            ) : field.kind === 'textarea' || field.kind === 'json' ? (
-                <Textarea
-                    id={fieldId}
-                    className="form-field-control-flat min-h-28 p-3"
-                    value={stringValue}
-                    onChange={(event) => onChange(event.target.value)}
-                    spellCheck={field.kind !== 'json'}
-                />
-            ) : (
-                <Input
-                    id={fieldId}
-                    type={field.kind === 'number' ? 'number' : field.kind === 'email' ? 'email' : field.format === 'password' ? 'password' : 'text'}
-                    value={stringValue}
-                    onChange={(event) => onChange(event.target.value)}
-                />
-            )}
-            {field.description ? (
-                <p className="text-xs leading-5 text-[var(--text-tertiary)]">{field.description}</p>
-            ) : null}
         </div>
     );
 }

--- a/lemma-frontend/components/connectors/schema-fields.tsx
+++ b/lemma-frontend/components/connectors/schema-fields.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import { buildSchemaFormFields, type JsonSchemaLike, type SchemaFormField } from 'lemma-sdk';
+import type { SchemaValues } from './connector-utils';
+
+export function SchemaFields({
+    schema,
+    values,
+    onChange,
+    emptyMessage = 'No configurable fields are required for this provider.',
+    autoFocusFirst = false,
+}: {
+    schema: JsonSchemaLike | null;
+    values: SchemaValues;
+    onChange: (values: SchemaValues) => void;
+    emptyMessage?: string;
+    autoFocusFirst?: boolean;
+}) {
+    const fields = buildSchemaFormFields(schema);
+
+    if (fields.length === 0) {
+        return (
+            <div className="surface-panel-muted p-3 text-sm text-[var(--text-secondary)]">
+                {emptyMessage}
+            </div>
+        );
+    }
+
+    const updateField = (name: string, value: unknown) => {
+        onChange({ ...values, [name]: value });
+    };
+
+    return (
+        <div className="space-y-3">
+            {fields.map((field, index) => (
+                <SchemaField
+                    key={field.name}
+                    field={field}
+                    value={values[field.name]}
+                    onChange={(value) => updateField(field.name, value)}
+                    autoFocus={autoFocusFirst && index === 0}
+                />
+            ))}
+        </div>
+    );
+}
+
+function SchemaField({
+    field,
+    value,
+    onChange,
+    autoFocus = false,
+}: {
+    field: SchemaFormField;
+    value: unknown;
+    onChange: (value: unknown) => void;
+    autoFocus?: boolean;
+}) {
+    const fieldId = `connector-schema-${field.name}`;
+    const label = `${field.label}${field.required ? ' *' : ''}`;
+    const stringValue = typeof value === 'string' ? value : value == null ? '' : String(value);
+
+    if (field.kind === 'boolean') {
+        return (
+            <Label htmlFor={fieldId} className="flex cursor-pointer items-start gap-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)] p-3">
+                <Checkbox
+                    id={fieldId}
+                    autoFocus={autoFocus}
+                    checked={Boolean(value)}
+                    onCheckedChange={(checked) => onChange(Boolean(checked))}
+                    className="mt-0.5"
+                />
+                <span className="grid gap-1">
+                    <span className="text-sm font-medium text-[var(--text-primary)]">{label}</span>
+                    {field.description ? (
+                        <span className="text-xs leading-5 text-[var(--text-secondary)]">{field.description}</span>
+                    ) : null}
+                </span>
+            </Label>
+        );
+    }
+
+    return (
+        <div className="space-y-1.5">
+            <Label htmlFor={fieldId}>{label}</Label>
+            {field.kind === 'select' ? (
+                <Select value={stringValue} onValueChange={onChange}>
+                    <SelectTrigger id={fieldId} autoFocus={autoFocus}>
+                        <SelectValue placeholder={`Select ${field.label}`} />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {field.options.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            ) : field.kind === 'textarea' || field.kind === 'json' ? (
+                <Textarea
+                    id={fieldId}
+                    name={fieldId}
+                    autoFocus={autoFocus}
+                    autoComplete="off"
+                    data-1p-ignore
+                    data-lpignore="true"
+                    className="form-field-control-flat min-h-28 p-3"
+                    value={stringValue}
+                    onChange={(event) => onChange(event.target.value)}
+                    spellCheck={field.kind !== 'json'}
+                />
+            ) : (
+                <Input
+                    id={fieldId}
+                    name={fieldId}
+                    autoFocus={autoFocus}
+                    // API keys / tokens are not login credentials — "new-password" stops
+                    // Chrome from treating this as a login and autofilling the saved
+                    // username into another text field on the page (e.g. the search box).
+                    autoComplete={field.format === 'password' ? 'new-password' : 'off'}
+                    data-1p-ignore
+                    data-lpignore="true"
+                    type={field.kind === 'number' ? 'number' : field.kind === 'email' ? 'email' : field.format === 'password' ? 'password' : 'text'}
+                    value={stringValue}
+                    onChange={(event) => onChange(event.target.value)}
+                />
+            )}
+            {field.description ? (
+                <p className="text-xs leading-5 text-[var(--text-tertiary)]">{field.description}</p>
+            ) : null}
+        </div>
+    );
+}


### PR DESCRIPTION
## Why

The connectors page leaked backend internals (provider pickers, "auth config", managed-vs-custom) into the UI, connection status was fetched but never shown, and Composio API-key apps couldn't actually be connected from the UI. This reworks the page around the common path.

## What changed

- **Composio-first.** When a connector exposes a Composio capability it becomes the default connect path; native OAuth / custom config moves behind a small **Advanced** affordance instead of a provider radio.
- **One-click Connect.** Clicking Connect auto-creates the `SYSTEM_DEFAULT` auth config when the org has none, then opens OAuth or the credential form — the org-level "enable" step disappears from the normal flow. An existing org auth config is always reused (backend allows one per org+connector), so an admin's custom config wins over the managed default.
- **Account status + in-place reconnect.** Cards read `account.status` — `CONNECTED` / `REAUTH_REQUIRED` / `DISCONNECTED` — with an inline **Reconnect**. OAuth reconnect re-runs the flow on the same `account_id` (preserving references from schedules/agents/pods); credential accounts re-link via the form with a warning.
- **API-key via Composio.** The credential form is sourced from the Composio capability's `auth_config_schema` (Composio caps carry no `credential_schema`) and submitted through `create_account`.
- **Sorting.** Connected → enabled → the rest, stable within each tier.
- **Autofill fix.** API-key connectors render a `type="password"` field, which made Chrome autofill a saved email into the page's search box. Credential inputs now use `autocomplete="new-password"` and the search box is shielded, so nothing leaks.

## Structure

The 894-line monolith is split into `connector-utils` · `schema-fields` · `connector-card` · `connector-grid` · `connect-account-dialog` · `advanced-config`, with `connectors-view` as a slim container.

## Out of scope

- Backend upsert so credential (API-key) reconnect can preserve `account_id` — for now credential reconnect is delete-then-recreate (documented in the reconnect warning).
- OAuth return polling (card auto-flips to Connected after the popup completes).

## Testing

Frontend-only change. `npm run check` (design audit, lint, typecheck), `npm test` (16/16), and `npm run build` all pass locally; no SDK bundle drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)