### PR TITLE
feat(pod): show requester identity in join-request approval + home surface

### DIFF
--- a/lemma-frontend/app/pod/[id]/page.tsx
+++ b/lemma-frontend/app/pod/[id]/page.tsx
@@ -4,7 +4,7 @@ import { use, useEffect, useMemo, useRef, useState, type CSSProperties } from 'r
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { ArrowRight, ArrowUp, ExternalLink, Loader2, MessageCircle, Plus, X } from 'lucide-react';
+import { ArrowRight, ArrowUp, ExternalLink, Loader2, MessageCircle, Plus, UserPlus, X } from 'lucide-react';
 
 import { useAIAssistant } from '@/components/ai/ai-assistant-context';
 import { StepLoader } from '@/components/brand/loader';
@@ -29,6 +29,7 @@ import {
 import { getAppAccent } from '@/lib/app/app-accent';
 import { usePod } from '@/lib/hooks/use-pods';
 import { usePodAccess } from '@/lib/hooks/use-pod-access';
+import { usePodJoinRequests } from '@/lib/hooks/use-pod-join-requests';
 import { usePodSurfaces } from '@/lib/hooks/use-pod-surfaces';
 import { useSchedules } from '@/lib/hooks/use-schedules';
 import { cn } from '@/lib/utils';
@@ -330,6 +331,51 @@ function PodBlankChatHome({ podId }: { podId: string }) {
     );
 }
 
+function PodJoinRequestsHomePanel({ podId }: { podId: string }) {
+    const podAccess = usePodAccess(podId);
+    const canManageMembers = podAccess.can('pod.member.manage');
+    const { data, isLoading } = usePodJoinRequests(podId, 'PENDING');
+    const requests = data?.items || [];
+
+    if (!canManageMembers || isLoading || requests.length === 0) return null;
+
+    const first = requests[0];
+    const firstLabel = first.user_name || first.user_email || first.user_id;
+    const headline =
+        requests.length === 1
+            ? `${firstLabel} wants to join this pod`
+            : `${requests.length} people are waiting to join`;
+    const detail =
+        requests.length === 1
+            ? first.user_email && first.user_email !== firstLabel
+                ? first.user_email
+                : 'Review and approve their access request.'
+            : `Including ${firstLabel} and ${requests.length - 1} more.`;
+
+    return (
+        <section className="lemma-pop-card w-full p-4 sm:p-5">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex min-w-0 items-start gap-3">
+                    <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border border-[var(--row-border)] bg-[var(--delight-soft)] text-[var(--delight)]">
+                        <UserPlus className="h-5 w-5" />
+                    </div>
+                    <div className="min-w-0">
+                        <p className="truncate text-sm font-semibold text-[var(--text-primary)]">{headline}</p>
+                        <p className="mt-1 truncate text-sm leading-6 text-[var(--text-secondary)]">{detail}</p>
+                    </div>
+                </div>
+                <Link
+                    href={`/pod/${podId}/settings/members?view=requests`}
+                    className="custom-focus-ring inline-flex shrink-0 items-center justify-center gap-2 rounded-lg bg-[var(--action-primary)] px-3.5 py-2 text-sm font-medium text-[var(--text-on-brand)] transition-colors hover:bg-[var(--action-primary-hover)]"
+                >
+                    Review requests
+                    <ArrowRight className="h-4 w-4" />
+                </Link>
+            </div>
+        </section>
+    );
+}
+
 type KanbanItem = {
     id: string;
     kind: 'agent' | 'workflow';
@@ -472,6 +518,7 @@ function PodAgentWorkflowKanban({ podId }: { podId: string }) {
                 />
             ) : null}
             <div className="mt-10 w-full space-y-5">
+                <PodJoinRequestsHomePanel podId={podId} />
                 <PodAppsHomePanel podId={podId} />
                 <PodSurfacesHomePanel podId={podId} />
             {isLoading || hasKanbanItems ? (

--- a/lemma-frontend/app/pod/[id]/settings/members/page.tsx
+++ b/lemma-frontend/app/pod/[id]/settings/members/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { use, useMemo, useState } from 'react';
-import { ArrowRight, CheckCircle2, Loader2, Mail, Plus, ShieldCheck, UserPlus, Users } from 'lucide-react';
+import { useSearchParams } from 'next/navigation';
+import { ArrowRight, CheckCircle2, Loader2, Mail, Plus, ShieldCheck, Users } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
 import { toast } from 'sonner';
 
 import { ProtectedRoute } from '@/components/auth/protected-route';
@@ -53,6 +55,12 @@ import { buildPodInviteRedirectUri, getPodInviteRedirectOptions } from '@/lib/ut
 
 type AccessView = 'people' | 'invites' | 'requests' | 'roles' | 'available';
 
+function formatRequestedAt(value: string): string {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return 'recently';
+    return formatDistanceToNow(date, { addSuffix: true });
+}
+
 export default function PodMembersPage({ params }: { params: Promise<{ id: string }> }) {
     return (
         <ProtectedRoute>
@@ -63,6 +71,7 @@ export default function PodMembersPage({ params }: { params: Promise<{ id: strin
 
 function PodMembersPageContent({ params }: { params: Promise<{ id: string }> }) {
     const { id: podId } = use(params);
+    const searchParams = useSearchParams();
     const podAccess = usePodAccess(podId);
     const { data: pod } = usePod(podId);
     const { data: profile } = useProfile();
@@ -117,7 +126,12 @@ function PodMembersPageContent({ params }: { params: Promise<{ id: string }> }) 
     const [memberPendingRemove, setMemberPendingRemove] = useState<{ id: string; label: string } | null>(null);
     const [invitationPendingRevoke, setInvitationPendingRevoke] = useState<{ id: string; email: string } | null>(null);
     const [approvingRequestId, setApprovingRequestId] = useState<string | null>(null);
-    const [activeView, setActiveView] = useState<AccessView>('people');
+    const initialView = ((): AccessView => {
+        const requested = searchParams.get('view');
+        const allowed: AccessView[] = ['people', 'invites', 'requests', 'roles', 'available'];
+        return allowed.includes(requested as AccessView) ? (requested as AccessView) : 'people';
+    })();
+    const [activeView, setActiveView] = useState<AccessView>(initialView);
     const [editingRoleName, setEditingRoleName] = useState<string | null>(null);
     const [newRoleName, setNewRoleName] = useState('');
     const [newRoleDescription, setNewRoleDescription] = useState('');
@@ -677,24 +691,33 @@ function PodMembersPageContent({ params }: { params: Promise<{ id: string }> }) 
                                 {pendingJoinRequests.map((request) => {
                                     const requesterOrgMember = orgMembers.find((member) => member.user_id === request.user_id);
                                     const requester = requesterOrgMember?.user;
-                                    const requesterLabel = requester?.full_name || requester?.email || request.user_id;
+                                    // Requesters are typically not org members yet, so prefer the
+                                    // name/email the join-request API returns over the org-member lookup.
+                                    const requesterName = request.user_name || requester?.full_name || null;
+                                    const requesterEmail = request.user_email || requester?.email || null;
+                                    const requesterLabel = requesterName || requesterEmail || request.user_id;
+                                    const requesterSecondary = requesterEmail && requesterEmail !== requesterLabel ? requesterEmail : null;
+                                    const requesterInitial = (requesterName?.[0] || requesterEmail?.[0] || 'U').toUpperCase();
+                                    const requestedAgo = formatRequestedAt(request.requested_at);
                                     const approvalConfig = resolveApprovalConfig(request.id);
                                     const isApprovingThis = isApprovingJoinRequest && approvingRequestId === request.id;
 
                                     return (
                                         <div key={request.id} className="lemma-index-row group flex flex-col gap-3 py-3">
-                                            <div className="flex min-w-0 items-center gap-2">
-                                                <UserPlus className="h-3.5 w-3.5 shrink-0 text-[var(--text-tertiary)]" />
-                                                <div className="flex min-w-0 flex-1 items-baseline gap-2">
+                                            <div className="flex min-w-0 items-center gap-3">
+                                                <Avatar className="h-8 w-8 shrink-0 border border-[color:var(--border-subtle)]">
+                                                    <AvatarFallback>{requesterInitial}</AvatarFallback>
+                                                </Avatar>
+                                                <div className="flex min-w-0 flex-1 flex-col">
                                                     <p className="truncate text-sm font-medium text-[var(--text-primary)]">{requesterLabel}</p>
-                                                    <p className="hidden truncate text-xs text-[var(--text-secondary)] md:block">
-                                                        Requested {new Date(request.requested_at).toLocaleString()}
+                                                    <p className="truncate text-xs text-[var(--text-secondary)]">
+                                                        {requesterSecondary ? `${requesterSecondary} · ` : ''}Requested {requestedAgo}
                                                     </p>
                                                 </div>
                                             </div>
 
                                             {canManageMembers ? (
-                                                <div className="grid gap-2 pl-5 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] sm:items-end">
+                                                <div className="grid gap-2 pl-11 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] sm:items-end">
                                                     <div className="space-y-1.5">
                                                         <p className="type-eyebrow-medium">Organization role</p>
                                                         <Select

--- a/lemma-frontend/lib/hooks/use-pod-join-requests.ts
+++ b/lemma-frontend/lib/hooks/use-pod-join-requests.ts
@@ -19,6 +19,8 @@ export interface PodJoinRequest {
     status: PodJoinRequestStatus;
     updated_at: string;
     user_id: string;
+    user_email?: string | null;
+    user_name?: string | null;
 }
 
 interface PodJoinRequestListResponse {


### PR DESCRIPTION
## Problem

The pod **Access requests** approval UI showed a raw `user_id` (UUID) instead of the requester's name/email. Root cause: the label was resolved by looking the requester up in the **org-members** list — but a join requester is by definition *not* an org member yet (that's what they're requesting), so the lookup always fell through to the UUID.

The backend already returns `user_name` and `user_email` on each join request; the frontend just wasn't consuming them.

## Changes

- **Fix identity:** add `user_name`/`user_email` to the `PodJoinRequest` interface and prefer them (over the org-member lookup) when building the requester label — so the approver sees a real name + email.
- **Polish the row:** avatar with initials, stacked name + email, and a relative `requested … ago` timestamp (via `date-fns`, already used elsewhere).
- **Home surface:** pending access requests now show as a card on the pod home page for members who can manage membership, deep-linking to the requests tab. Admins no longer have to dig into settings to notice a waiting request.
- **Deep-link:** the members page accepts `?view=<tab>` so the home banner can open the **Access requests** tab directly.

## Scope notes

- Purely frontend — no backend/API changes.
- **Reject/decline is intentionally out of scope:** there is no reject endpoint yet, so a request can only be resolved by approving it. This also means the home banner can't be dismissed without approving — a server-side reject endpoint would be the proper follow-up.

## Verification

- `npm run check` (design audit + lint + typecheck + edu-anchors) passes locally.

## Screenshot

Before: row showed only the UUID. After: `Ayush Gautam · ayush@gappy.ai · Requested … ago` with avatar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)