### PR TITLE
feat(connectors): add GitHub to Composio catalog + fix WhatsApp webhook verification + fix agentbox first-run stall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SHELL := /bin/bash
 #   make coverage      full coverage report (unit + e2e per component)
 # ──────────────────────────────────────────────────────────────────────────────
 
-.PHONY: help init dev stop stop-all logs _ensure-databases \
+.PHONY: help init dev stop stop-all logs _ensure-databases _ensure-agentbox-image \
         test test-backend test-backend-unit test-backend-e2e \
         test-frontend test-cli test-cli-unit test-cli-e2e test-python \
         coverage coverage-backend coverage-backend-unit coverage-backend-e2e \
@@ -63,6 +63,13 @@ DEV_REDIS_URL         := redis://localhost:$(DEV_REDIS_PORT)/0
 DEV_SUPERTOKENS_URL   := http://localhost:$(DEV_SUPERTOKENS_PORT)
 DEV_AGENTBOX_URL      := http://127.0.0.1:$(DEV_AGENTBOX_PORT)
 DEV_AGENTBOX_API_KEY  ?= dev-agentbox-key
+# ~2.9GB image. docker run auto-pulls a missing image synchronously and
+# uncapped — the first sandbox creation after a fresh clone would otherwise
+# block on this pull with zero progress feedback, which looks exactly like a
+# hung agent ("stuck at exec command, no sandbox created"). Pre-pulling in
+# `make init`/`make dev` turns that invisible stall into a visible, one-time
+# download.
+AGENTBOX_RUNTIME_IMAGE := ghcr.io/lemma-work/lemma-agentbox-runtime:latest
 
 COMMON_DEV_ENV := \
 	DEV_POSTGRES_PORT=$(DEV_POSTGRES_PORT) \
@@ -83,7 +90,7 @@ AGENTBOX_DEV_ENV := \
 	AGENTBOX_PROVIDER=docker \
 	AGENTBOX_API_KEY=$(DEV_AGENTBOX_API_KEY) \
 	AGENTBOX_API_URL=$(DEV_AGENTBOX_URL) \
-	AGENTBOX_RUNTIME_IMAGE=ghcr.io/lemma-work/lemma-agentbox-runtime:latest \
+	AGENTBOX_RUNTIME_IMAGE=$(AGENTBOX_RUNTIME_IMAGE) \
 	AGENTBOX_STATE_DB_PATH=/tmp/agentbox-state.db \
 	AGENTBOX_STORAGE_ROOT=/tmp/agentbox-workspaces \
 	AGENTBOX_ENDPOINT_HOST=127.0.0.1 \
@@ -165,7 +172,18 @@ init:
 	@$(MAKE) --no-print-directory _init-backend-env
 	@$(MAKE) --no-print-directory _init-frontend-env
 	@echo ""
+	@$(MAKE) --no-print-directory _ensure-agentbox-image
+	@echo ""
 	@echo "Done. Run 'make dev' to start the stack."
+
+_ensure-agentbox-image:
+	@if docker image inspect "$(AGENTBOX_RUNTIME_IMAGE)" >/dev/null 2>&1; then \
+		echo "  ✓ AgentBox runtime image already present: $(AGENTBOX_RUNTIME_IMAGE)"; \
+	else \
+		echo "→ Pulling AgentBox runtime image (one-time, ~2.9GB): $(AGENTBOX_RUNTIME_IMAGE)…"; \
+		docker pull "$(AGENTBOX_RUNTIME_IMAGE)" && \
+		echo "  ✓ AgentBox runtime image ready"; \
+	fi
 
 _init-backend-env:
 	@if [ ! -f $(BACKEND_DIR)/.env ]; then \
@@ -267,6 +285,7 @@ dev:
 	@echo "→ Starting Lemma dev stack…"
 	@$(MAKE) --no-print-directory stop 2>/dev/null || true
 	@$(MAKE) --no-print-directory _ensure-init
+	@$(MAKE) --no-print-directory _ensure-agentbox-image
 	@$(MAKE) --no-print-directory _infra-up
 	@$(MAKE) --no-print-directory _wait-infra
 	@$(MAKE) --no-print-directory _ensure-databases

--- a/lemma-backend/app/modules/agent_surfaces/api/controllers/webhook_controller.py
+++ b/lemma-backend/app/modules/agent_surfaces/api/controllers/webhook_controller.py
@@ -127,17 +127,18 @@ async def handle_surface_webhook(
     return {"message": "Webhook received"}
 
 
-def _webhook_verification_response(platform: str, params: dict[str, str]) -> Response:
+def _webhook_verification_response(
+    platform: str, params: dict[str, str], *, whatsapp_verify_token: str | None = None
+) -> Response:
     """Shared GET-verification handshake (WhatsApp hub challenge / Telegram ok)."""
     if platform == "whatsapp":
         mode = params.get("hub.mode")
         challenge = params.get("hub.challenge")
         verify_token = params.get("hub.verify_token")
 
-        expected_token = surface_settings.whatsapp_verify_token
         security_enabled = bool(surface_settings.surface_webhook_security_enabled)
         if mode == "subscribe" and challenge and (
-            not security_enabled or verify_token == expected_token
+            not security_enabled or verify_token == whatsapp_verify_token
         ):
             return Response(content=challenge, media_type="text/plain")
 
@@ -157,7 +158,11 @@ async def verify_surface_webhook(
     request: Request,
 ):
     """Webhook verification endpoint for platforms that require it."""
-    return _webhook_verification_response(platform, dict(request.query_params))
+    return _webhook_verification_response(
+        platform,
+        dict(request.query_params),
+        whatsapp_verify_token=surface_settings.whatsapp_verify_token,
+    )
 
 
 @router.get(
@@ -168,12 +173,27 @@ async def verify_surface_webhook(
 async def verify_direct_surface_webhook(
     surface_id: UUID,
     request: Request,
+    security_service: SurfaceWebhookSecurityServiceDep,
     service: AgentSurfaceService = Depends(get_surface_service),
 ):
-    """Webhook verification endpoint for platforms that require it."""
+    """Webhook verification endpoint for platforms that require it.
+
+    WhatsApp surfaces bound to a connector account are verified against that
+    account's own ``verify_token`` (never the system-wide one) so each
+    customer's WhatsApp Business webhook config only has to match their own
+    credentials.
+    """
     surface = await service.get_surface(surface_id)
+    platform = surface.surface_type.value.lower()
+    whatsapp_verify_token = (
+        await security_service.resolve_whatsapp_verify_token(surface)
+        if platform == "whatsapp"
+        else surface_settings.whatsapp_verify_token
+    )
     return _webhook_verification_response(
-        surface.surface_type.value.lower(), dict(request.query_params)
+        platform,
+        dict(request.query_params),
+        whatsapp_verify_token=whatsapp_verify_token,
     )
 
 

--- a/lemma-backend/app/modules/agent_surfaces/api/dependencies.py
+++ b/lemma-backend/app/modules/agent_surfaces/api/dependencies.py
@@ -74,8 +74,15 @@ def get_surface_event_handler(
     )
 
 
-def get_surface_webhook_security_service() -> SurfaceWebhookSecurityService:
-    return SurfaceWebhookSecurityService()
+def get_surface_webhook_security_service(
+    uow: UoWDep,
+) -> SurfaceWebhookSecurityService:
+    return SurfaceWebhookSecurityService(
+        credential_resolver=SurfaceCredentialResolver(
+            session=uow.session,
+            connector_service=get_connector_service(uow),
+        )
+    )
 
 
 SurfaceServiceDep = Annotated[AgentSurfaceService, Depends(get_surface_service)]

--- a/lemma-backend/app/modules/agent_surfaces/platforms/common.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/common.py
@@ -43,15 +43,19 @@ def computed_webhook_url(surface: AgentSurfaceEntity) -> str | None:
 
     Shared by the surface response builder and the unified setup read. Returns
     None unless the surface uses WEBHOOK event mode and the API is publicly
-    reachable. Telegram with a connected account gets a surface-specific URL;
-    the other platform webhooks share a platform-level URL.
+    reachable. Telegram and WhatsApp with a connected account get a
+    surface-specific URL (each account has its own webhook secret/verify
+    token); the other platform webhooks share a platform-level URL.
     """
     if surface.event_mode is not SurfaceEventMode.WEBHOOK:
         return None
     if not public_https_api_url_available():
         return None
     base = settings.api_url.rstrip("/")
-    if surface.surface_type is SurfacePlatform.TELEGRAM and surface.account_id is not None:
+    if (
+        surface.surface_type in (SurfacePlatform.TELEGRAM, SurfacePlatform.WHATSAPP)
+        and surface.account_id is not None
+    ):
         return f"{base}/surfaces/{surface.id}/webhook"
     if surface.surface_type in _PLATFORM_WEBHOOK_TYPES:
         return f"{base}/surfaces/webhooks/{surface.surface_type.value.lower()}"

--- a/lemma-backend/app/modules/agent_surfaces/services/surface_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/surface_service.py
@@ -431,7 +431,7 @@ class AgentSurfaceService:
             is_custom_app=await self._surface_uses_org_custom_app(surface),
             webhook_url=webhook_url,
             slack_socket_mode=surface_settings.enable_slack_socket_mode,
-            whatsapp_verify_token=surface_settings.whatsapp_verify_token,
+            whatsapp_verify_token=await self._whatsapp_verify_token_for_setup(surface),
         )
         pending_consent = bool(
             admin_consent and admin_consent["required"] and not admin_consent["granted"]
@@ -450,16 +450,23 @@ class AgentSurfaceService:
     async def _surface_uses_org_custom_app(
         self, surface: AgentSurfaceEntity
     ) -> bool:
-        """True when the surface's account was set up with the org's own OAuth
-        app (auth config ``ORG_CUSTOM``), so the org must point that app's
-        webhook at Lemma. System/Lemma-managed auth configs need no setup."""
+        """True when the org must manually point a platform app's webhook at Lemma.
+
+        For OAuth platforms this means the account was set up with the org's
+        own app (auth config ``ORG_CUSTOM``) — Lemma's system app is already
+        wired up centrally. WhatsApp is credential-managed (API_KEY, no OAuth
+        app registration) so there is no Lemma-shared "system app" to fall
+        back to: any connected account is the org's own WhatsApp Business app
+        and always needs its webhook configured.
+        """
+        if surface.account_id is None:
+            return False
+        if surface.surface_type is SurfacePlatform.WHATSAPP:
+            return True
+
         from app.modules.connectors.domain.auth_config import AuthConfigSource
 
-        if (
-            surface.account_id is None
-            or self._account_port is None
-            or self._auth_config_port is None
-        ):
+        if self._account_port is None or self._auth_config_port is None:
             return False
         account = await self._account_port.get_account(surface.account_id)
         if account is None or account.auth_config_id is None:
@@ -471,6 +478,35 @@ class AgentSurfaceService:
             auth_config
             and auth_config.config_source == AuthConfigSource.ORG_CUSTOM.value
         )
+
+    async def _whatsapp_verify_token_for_setup(
+        self, surface: AgentSurfaceEntity
+    ) -> str | None:
+        """The verify token to show the user for pasting into Meta's console.
+
+        A connected account's own ``verify_token`` (from its stored
+        credentials) — the value the backend actually checks incoming
+        ``hub.verify_token`` requests against for that surface. Falls back to
+        the system-wide token for account-less (Lemma-managed) surfaces.
+        """
+        if (
+            surface.surface_type is SurfacePlatform.WHATSAPP
+            and surface.account_id is not None
+            and self._credential_resolver is not None
+        ):
+            try:
+                credentials = await self._credential_resolver.for_account(
+                    surface.account_id
+                )
+            except Exception:
+                logger.warning(
+                    "Could not resolve WhatsApp verify token for account %s",
+                    surface.account_id,
+                    exc_info=True,
+                )
+                return None
+            return credentials.get("verify_token")
+        return surface_settings.whatsapp_verify_token
 
     async def _surface_admin_consent(
         self, surface: AgentSurfaceEntity

--- a/lemma-backend/app/modules/agent_surfaces/services/webhook_security_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/webhook_security_service.py
@@ -4,7 +4,7 @@ import hashlib
 import hmac
 import json
 import time
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import jwt
@@ -13,8 +13,16 @@ from jwt.algorithms import RSAAlgorithm
 from app.core.config import settings
 from app.core.domain.errors import DomainError
 from app.core.infrastructure.cache.redis_json_cache import RedisJsonCache
+from app.core.log.log import get_logger
 from app.modules.agent_surfaces.config import surface_settings
 from app.modules.agent_surfaces.domain.entities import AgentSurfaceEntity, SurfacePlatform
+
+if TYPE_CHECKING:
+    from app.modules.agent_surfaces.services.credential_resolver import (
+        SurfaceCredentialResolver,
+    )
+
+logger = get_logger(__name__)
 _SLACK_SIGNATURE_VERSION = "v0"
 _SLACK_MAX_TIMESTAMP_SKEW_SECONDS = 60 * 5
 _BOT_FRAMEWORK_OPENID_CONFIG_URL = (
@@ -62,6 +70,11 @@ class SurfaceWebhookAuthenticationError(DomainError):
 
 
 class SurfaceWebhookSecurityService:
+    def __init__(
+        self, *, credential_resolver: "SurfaceCredentialResolver | None" = None
+    ):
+        self._credential_resolver = credential_resolver
+
     def verification_enabled(self) -> bool:
         return bool(surface_settings.surface_webhook_security_enabled)
 
@@ -128,11 +141,55 @@ class SurfaceWebhookSecurityService:
                 webhook_secret=surface.webhook_secret,
             )
             return
+        if surface.surface_type is SurfacePlatform.WHATSAPP:
+            app_secret, _ = await self._resolve_whatsapp_secrets(surface)
+            self._verify_whatsapp_signature(
+                headers=headers,
+                raw_body=raw_body,
+                app_secret=app_secret,
+            )
+            return
         await self.verify_platform_request(
             platform=surface.surface_type.value,
             headers=headers,
             raw_body=raw_body,
         )
+
+    async def _resolve_whatsapp_secrets(
+        self, surface: AgentSurfaceEntity | None
+    ) -> tuple[str | None, str | None]:
+        """Returns ``(app_secret, verify_token)`` to check a WhatsApp request against.
+
+        A surface bound to a connector account (the org's own WhatsApp Business
+        app) is verified against *that account's* stored ``app_secret`` /
+        ``verify_token`` — never the system fallback, so a misconfigured or
+        missing org credential fails closed instead of silently matching
+        Lemma's own managed number. Only account-less (Lemma-managed) surfaces
+        use the env-configured system credentials.
+        """
+        if surface is not None and surface.account_id is not None:
+            if self._credential_resolver is None:
+                return None, None
+            try:
+                credentials = await self._credential_resolver.for_account(
+                    surface.account_id
+                )
+            except Exception:
+                logger.warning(
+                    "Could not resolve WhatsApp credentials for account %s",
+                    surface.account_id,
+                    exc_info=True,
+                )
+                return None, None
+            return credentials.get("app_secret"), credentials.get("verify_token")
+        return surface_settings.whatsapp_app_secret, surface_settings.whatsapp_verify_token
+
+    async def resolve_whatsapp_verify_token(
+        self, surface: AgentSurfaceEntity | None
+    ) -> str | None:
+        """The verify token to check ``hub.verify_token`` against for this surface."""
+        _, verify_token = await self._resolve_whatsapp_secrets(surface)
+        return verify_token
 
     def _verify_slack_signature(
         self,

--- a/lemma-backend/scripts/import_connector_catalog.py
+++ b/lemma-backend/scripts/import_connector_catalog.py
@@ -148,6 +148,7 @@ DEFAULT_COMPOSIO_CONNECTOR_IDS: tuple[str, ...] = (
     "facebook",
     "figma",
     "freshdesk",
+    "github",
     "google_analytics",
     "google_chat",
     "googleads",


### PR DESCRIPTION
## Summary

**GitHub connector**
- GitHub was missing from `DEFAULT_COMPOSIO_CONNECTOR_IDS` in `lemma-backend/scripts/import_connector_catalog.py`, so it was never synced into the connector catalog even though `COMPOSIO_API_KEY` is set.
- Added `"github"` to the default allowlist. No toolkit slug override is needed since Composio's toolkit slug for GitHub is `github`, matching our connector id convention.

**WhatsApp surface webhook verification (per connected account)**
- The `whatsapp` connector's `credential_schema` already asks for `verify_token` and `app_secret` per connected account, but the webhook layer never read them back — every WhatsApp surface was verified against the system-wide `WHATSAPP_VERIFY_TOKEN`/`WHATSAPP_APP_SECRET` env vars regardless of which account it belonged to. An org connecting their own WhatsApp Business app could never pass Lemma's webhook checks.
- `platforms/common.py`: account-bound WhatsApp surfaces now get a surface-specific webhook URL (`/surfaces/{surface_id}/webhook`), same pattern as Telegram, instead of sharing the platform-level URL.
- `webhook_security_service.py`: resolves the `app_secret`/`verify_token` to check a WhatsApp request against from the bound account's stored credentials when present, falling back to system env vars only for account-less (Lemma-managed) surfaces. A connected account with missing/misconfigured secrets now fails closed instead of silently matching the system secret.
- `surface_service.py`: the setup-guide response now surfaces the *actual* per-account verify token (so what the user pastes into Meta's console is what the backend actually checks), and treats any connected WhatsApp account as needing its own webhook instructions — WhatsApp is credential-managed (API_KEY), not OAuth, so it has no Lemma-shared "system app" to exempt the way OAuth's `ORG_CUSTOM` gating does.
- **Note:** orgs that already pointed Meta's console at the old shared `/surfaces/webhooks/whatsapp` URL will need to update it to the new surface-specific URL from the setup response — the old shared URL never correctly enforced their own credentials anyway.

**`make dev`: fix silent first-run AgentBox stall**
- Root cause: `docker run` auto-pulls a missing image synchronously with no timeout. The AgentBox runtime image (~2.9GB) was never pre-pulled by `make init`/`make dev`, so the first agent action needing a sandbox (any bash/exec tool call) triggered an invisible multi-minute pull inside the manager's `docker run` call — no progress, no error, just a hung request. Looks exactly like "the agent got stuck at exec command, no docker sandbox was created."
- Added `_ensure-agentbox-image`, wired into both `make init` (visible download during one-time setup) and `make dev` (self-healing if the image was later removed, e.g. by `docker system prune`). Skips the pull when the image is already present.
- Verified against the actual failure mode: untagged the local runtime image to simulate a fresh clone, confirmed the new target detects it's missing and re-pulls it with visible progress, then confirmed a manual create-sandbox → create-session → exec-command flow against the real AgentBox manager works once the image is present — the gap was purely the missing pre-pull, not the exec mechanism itself.
- Also confirmed agentbox, the worker, and the scheduler are already started/wired correctly by `make dev` (`standalone_app.py` bundles API + worker + scheduler in one process; agentbox is a separate manager process started and health-waited before the backend) — nothing else was missing.

## Test plan
- [x] `uv run pytest app/modules/agent_surfaces -m "not e2e" -q` — 250 passed
- [x] `uv run pytest app/modules/agent_surfaces/tests/e2e/` — 31 passed, 2 skipped (no regressions vs. main)
- [x] `ruff check` on all touched files — clean
- [x] `make init` && `make dev` end-to-end on a real machine: databases created, migrations applied, AgentBox image check passes, backend/frontend/agentbox all return 200
- [x] Simulated a missing AgentBox runtime image and confirmed `make init`/`make dev` re-pulls it automatically with visible progress
- [ ] Run `python scripts/import_connector_catalog.py --provider composio --app github --dry-run` against an env with `COMPOSIO_API_KEY` set and confirm the GitHub toolkit, its operations, and triggers are fetched without errors.
- [ ] Connect a WhatsApp Business account with a custom `verify_token`/`app_secret`, confirm `GET /pods/{pod_id}/surfaces/whatsapp/setup` returns the surface-specific webhook URL and that same verify token, and that Meta's webhook verification handshake against that URL succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)