### PR TITLE
fix(dev): create supertokens/lemma_datastore DBs and run migrations in make dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SHELL := /bin/bash
 #   make coverage      full coverage report (unit + e2e per component)
 # ──────────────────────────────────────────────────────────────────────────────
 
-.PHONY: help init dev stop stop-all logs \
+.PHONY: help init dev stop stop-all logs _ensure-databases \
         test test-backend test-backend-unit test-backend-e2e \
         test-frontend test-cli test-cli-unit test-cli-e2e test-python \
         coverage coverage-backend coverage-backend-unit coverage-backend-e2e \
@@ -269,6 +269,8 @@ dev:
 	@$(MAKE) --no-print-directory _ensure-init
 	@$(MAKE) --no-print-directory _infra-up
 	@$(MAKE) --no-print-directory _wait-infra
+	@$(MAKE) --no-print-directory _ensure-databases
+	@$(MAKE) --no-print-directory migrate
 	@echo ""
 	@echo "  Frontend  →  $(DEV_FRONTEND_URL)"
 	@echo "  Auth UI   →  $(DEV_AUTH_FRONTEND_URL)"
@@ -310,6 +312,24 @@ _wait-infra:
 			pg_isready -h localhost -p $(DEV_POSTGRES_PORT) -q 2>/dev/null && echo "  ✓ Postgres ready" && break; \
 			sleep 1; \
 		done
+
+_ensure-databases:
+	@echo "  Ensuring extra databases (supertokens, lemma_datastore) exist…"
+	@cd $(BACKEND_DIR) && \
+		for db in supertokens lemma_datastore; do \
+			exists=$$(docker compose exec -T db psql -U postgres -tAc "SELECT 1 FROM pg_database WHERE datname = '$$db'" 2>/dev/null | tr -d '[:space:]'); \
+			if [ "$$exists" != "1" ]; then \
+				echo "    Creating database $$db…"; \
+				docker compose exec -T db psql -U postgres -c "CREATE DATABASE $$db" >/dev/null; \
+				if [ "$$db" = "supertokens" ]; then \
+					echo "    Restarting supertokens (picks up new database)…"; \
+					docker compose restart supertokens >/dev/null; \
+				fi; \
+			fi; \
+		done; \
+		docker compose exec -T db psql -U postgres -d lemma -c "CREATE EXTENSION IF NOT EXISTS vector" >/dev/null; \
+		docker compose exec -T db psql -U postgres -d lemma_datastore -c "CREATE EXTENSION IF NOT EXISTS vector" >/dev/null
+	@echo "  ✓ Databases ready"
 
 _run-backend:
 	@echo "  Starting backend ($(DEV_BACKEND_URL))…"


### PR DESCRIPTION
## Summary
- Root-caused the `Failed to ensure datastore query role grants` / `database "lemma_datastore" does not exist` warning on a fresh `make init && make dev`: docker-compose's `db` service only provisions `POSTGRES_DB=lemma`, so `supertokens` and `lemma_datastore` are never created. On a truly fresh clone the `supertokens` container was actually crash-looping for the same reason (its target database doesn't exist), and `alembic upgrade head` was never run against `lemma` either, leaving the app booting against an empty `public` schema.
- Added a `_ensure-databases` Makefile target, run as part of `make dev` right after infra is up: creates `supertokens` and `lemma_datastore` if missing (restarting `supertokens` so it picks up its new DB), and enables the `vector` extension on `lemma` and `lemma_datastore`.
- `make dev` now also runs `make migrate` before starting the backend/frontend, so a fresh clone gets a fully migrated schema without a manual step.

## Test plan
- [x] Dropped the `lemma-backend_postgres_data` volume to simulate a fresh clone, ran `make dev`, and confirmed in the logs: `supertokens` DB created + container restarted healthy, `lemma_datastore` DB created, `alembic upgrade head` applied the baseline migration, then backend + frontend + agentbox all started cleanly.
- [x] `curl http://localhost:8710/scalar` → 200, `curl http://localhost:3710` → 200 (full HTML render).
- [x] Backend logs show `Datastore query role grants ensured` instead of the previous warning/traceback.
- [x] Re-ran `make dev` against the now-existing databases to confirm the new step is idempotent (no errors, no unnecessary supertokens restart).

🤖 Generated with [Claude Code](https://claude.com/claude-code)