### PR TITLE
fix(daemon): reliable websocket reconnect + concurrency control

### DIFF
--- a/lemma-backend/app/core/config.py
+++ b/lemma-backend/app/core/config.py
@@ -203,6 +203,27 @@ class Settings(BaseSettings):
             "disable the background reconcile loop."
         ),
     )
+    daemon_ws_ping_stale_after_seconds: float = Field(
+        default=90.0,
+        description=(
+            "If a connected user daemon sends no daemon.ping for this long, the "
+            "backend closes the websocket proactively instead of waiting for a "
+            "TCP-level disconnect (handles a half-open connection the daemon "
+            "itself doesn't notice). Should comfortably exceed the daemon's own "
+            "self-declared-dead threshold (ping interval * missed-pong limit, "
+            "default 15s * 3 = 45s)."
+        ),
+    )
+    daemon_reconnect_grace_seconds: float = Field(
+        default=120.0,
+        description=(
+            "How long DaemonHarness.run() waits for a disconnected user daemon "
+            "to reattach an in-flight run before failing it. Bounded and "
+            "orthogonal to DEFAULT_DAEMON_EVENT_TIMEOUT_SECONDS (7200s), which "
+            "governs a *live* connection's max silent gap between events, not "
+            "disconnect recovery."
+        ),
+    )
     local_agent_runtime_config_path: str = Field(
         default_factory=lambda: str(
             _default_local_root() / "lemma" / "agent-runtime.json"

--- a/lemma-backend/app/modules/agent/api/controllers/runtime_config_controller.py
+++ b/lemma-backend/app/modules/agent/api/controllers/runtime_config_controller.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import time
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect, status
@@ -12,8 +15,10 @@ from app.core.api.dependencies import CurrentUser, UoWDep
 from app.core.authorization.context import ResourceRef
 from app.core.authorization.dependencies import OrgContextDep
 from app.core.authorization.permissions import Permissions
+from app.core.config import settings
 from app.core.infrastructure.db.session import async_session_maker
 from app.core.infrastructure.db.uow_factory import SessionUnitOfWorkFactory
+from app.core.log.log import get_logger
 from app.modules.agent.api.schemas import (
     AgentHarnessInfo,
     AgentHarnessListResponse,
@@ -31,7 +36,11 @@ from app.modules.agent.domain.runtime_profiles import (
     RuntimeModelCapability,
     RuntimeModelCatalogEntry,
 )
-from app.modules.agent.infrastructure.daemon_hub import agent_runtime_daemon_hub
+from app.modules.agent.infrastructure.daemon_hub import (
+    agent_runtime_daemon_hub,
+    clear_daemon_capacity,
+    set_daemon_capacity,
+)
 from app.modules.agent.infrastructure.repositories import (
     AgentRuntimeDaemonRepository,
     AgentRuntimeProfileRepository,
@@ -41,6 +50,8 @@ from app.modules.identity.infrastructure.organization_repositories import (
     OrganizationRepository,
 )
 from app.core.crypto import get_secret_cipher
+
+logger = get_logger(__name__)
 
 router = APIRouter(tags=["agent_runtime"])
 
@@ -270,6 +281,7 @@ async def daemon_websocket(websocket: WebSocket) -> None:
     await websocket.accept()
     uow_factory = SessionUnitOfWorkFactory(async_session_maker)
     daemon_id: UUID | None = None
+    stale_reaper_task: asyncio.Task[None] | None = None
     try:
         ready_message = await websocket.receive_json()
         if ready_message.get("type") != "daemon.ready":
@@ -297,11 +309,27 @@ async def daemon_websocket(websocket: WebSocket) -> None:
             user_id=user_id,
             websocket=websocket,
         )
+        await _store_capacity_if_present(daemon_id, payload.get("capacity"))
+        # Reattach any runs the daemon says it's still holding from a prior
+        # connection BEFORE acking readiness, so a run.start/run.stop that
+        # arrives right after can find the reattached queue rather than racing
+        # ahead of this.
+        reattach_run_ids = _reattach_agent_run_ids(payload.get("reattach_runs"))
+        if reattach_run_ids:
+            await agent_runtime_daemon_hub.reattach_runs(
+                daemon_id=daemon_id,
+                user_id=user_id,
+                agent_run_ids=reattach_run_ids,
+            )
         await websocket.send_json(
             {
                 "type": "daemon.ready_ack",
                 "daemon_id": str(daemon_id),
             }
+        )
+        last_ping_monotonic = _MutableMonotonic()
+        stale_reaper_task = asyncio.create_task(
+            _close_if_ping_stale(websocket, last_ping_monotonic, daemon_id=daemon_id)
         )
         while True:
             message = await websocket.receive_json()
@@ -314,6 +342,7 @@ async def daemon_websocket(websocket: WebSocket) -> None:
                         user_id=user_id,
                         harness_catalog=catalog,
                     )
+                await _store_capacity_if_present(daemon_id, message.get("capacity"))
                 continue
             if message_type == "run.event":
                 await agent_runtime_daemon_hub.handle_run_event(
@@ -323,20 +352,34 @@ async def daemon_websocket(websocket: WebSocket) -> None:
                 )
                 continue
             if message_type == "daemon.ping":
+                last_ping_monotonic.value = time.monotonic()
                 async with uow_factory() as uow:
                     await AgentRuntimeDaemonRepository(uow).mark_seen(
                         daemon_id=daemon_id,
                         user_id=user_id,
                     )
+                await _store_capacity_if_present(
+                    daemon_id, _json_object(message.get("payload")).get("capacity")
+                )
                 await websocket.send_json({"type": "daemon.pong"})
     except WebSocketDisconnect:
         pass
     finally:
+        if stale_reaper_task is not None:
+            stale_reaper_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await stale_reaper_task
         if daemon_id is not None:
             await agent_runtime_daemon_hub.unregister(
                 daemon_id=daemon_id,
                 user_id=user_id,
             )
+            # A disconnected daemon's last-known capacity has no actionable
+            # meaning -- clear it immediately rather than relying solely on
+            # the Redis TTL, which would let start_run() see stale
+            # not-at-capacity data for up to _DAEMON_CAPACITY_TTL_SECONDS
+            # after a crash.
+            await clear_daemon_capacity(daemon_id=daemon_id)
             async with uow_factory() as uow:
                 await AgentRuntimeDaemonRepository(uow).mark_offline(
                     daemon_id=daemon_id,
@@ -344,8 +387,75 @@ async def daemon_websocket(websocket: WebSocket) -> None:
                 )
 
 
+class _MutableMonotonic:
+    """Tiny mutable holder so the reaper task can observe ping updates.
+
+    Plain closures over a local variable can't be reassigned from another
+    task without ``nonlocal`` plumbing across two separate coroutines; a
+    one-field object is simpler than threading an ``asyncio.Event`` for this.
+    """
+
+    __slots__ = ("value",)
+
+    def __init__(self) -> None:
+        self.value = time.monotonic()
+
+
+async def _close_if_ping_stale(
+    websocket: WebSocket,
+    last_ping_monotonic: _MutableMonotonic,
+    *,
+    daemon_id: UUID,
+) -> None:
+    """Proactively close a daemon websocket that's gone quiet on ``daemon.ping``.
+
+    Backstop for a half-open connection the daemon's own client-side heartbeat
+    doesn't notice (e.g. one direction of the socket is silently dropped by a
+    middlebox). Normal disconnects are already detected instantly via
+    ``WebSocketDisconnect`` elsewhere in this route -- this only fires when the
+    transport looks alive but has stopped carrying heartbeats.
+    """
+    threshold = settings.daemon_ws_ping_stale_after_seconds
+    poll_interval = max(1.0, threshold / 3)
+    while True:
+        await asyncio.sleep(poll_interval)
+        if time.monotonic() - last_ping_monotonic.value > threshold:
+            logger.warning(
+                "Daemon websocket stale (no daemon.ping); closing",
+                daemon_id=str(daemon_id),
+                threshold_seconds=threshold,
+            )
+            with contextlib.suppress(Exception):
+                await websocket.close(code=status.WS_1001_GOING_AWAY, reason="Heartbeat timeout")
+            return
+
+
 def _json_object(value: object) -> dict[str, object]:
     return value if isinstance(value, dict) else {}
+
+
+def _reattach_agent_run_ids(raw: object) -> list[UUID]:
+    if not isinstance(raw, list):
+        return []
+    agent_run_ids: list[UUID] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        try:
+            agent_run_ids.append(UUID(str(item.get("agent_run_id"))))
+        except ValueError:
+            continue
+    return agent_run_ids
+
+
+async def _store_capacity_if_present(daemon_id: UUID, raw_capacity: object) -> None:
+    if not isinstance(raw_capacity, dict):
+        return
+    active = raw_capacity.get("active_run_count")
+    cap = raw_capacity.get("max_concurrent_runs")
+    if not isinstance(active, int) or not isinstance(cap, int):
+        return
+    await set_daemon_capacity(daemon_id=daemon_id, active_run_count=active, max_concurrent_runs=cap)
 
 
 async def _daemon_websocket_session(websocket: WebSocket):

--- a/lemma-backend/app/modules/agent/domain/value_objects.py
+++ b/lemma-backend/app/modules/agent/domain/value_objects.py
@@ -392,6 +392,19 @@ class AgentEventType(str, Enum):
     # The run paused waiting for the user (ask_user / request_approval). Terminal
     # for this run; the user's submission starts a fresh run that resumes.
     WAITING = "WAITING"
+    # Internal only -- never sent by the daemon. Synthesized by
+    # AgentRuntimeDaemonHub when a daemon's websocket drops, so a
+    # DaemonHarness.run() consumer blocked on its run's queue wakes up
+    # immediately instead of waiting out the (much longer)
+    # DEFAULT_DAEMON_EVENT_TIMEOUT_SECONDS silence budget. Not terminal: the
+    # harness intercepts it, starts a bounded reconnect-grace window, and
+    # either resumes normally or fails the run once the grace window elapses.
+    RECONNECTING = "RECONNECTING"
+    # The daemon explicitly refused a run.start because it's already running
+    # max_concurrent_runs turns. Terminal, like ERROR, but kept as its own
+    # member (not folded into ERROR) so callers can distinguish "busy, retry"
+    # from "the provider crashed" and surface a more actionable message.
+    REJECTED = "REJECTED"
 
     @classmethod
     def _missing_(cls, value: object) -> "AgentEventType | None":

--- a/lemma-backend/app/modules/agent/events/handlers.py
+++ b/lemma-backend/app/modules/agent/events/handlers.py
@@ -9,6 +9,7 @@ from faststream import Depends, Logger
 from faststream.redis import RedisRouter
 from streaq.task import TaskStatus
 
+from app.core.config import settings
 from app.core.infrastructure.db.session import async_session_maker
 from app.core.infrastructure.db.uow_factory import (
     SessionUnitOfWorkFactory,
@@ -71,14 +72,15 @@ def provide_uow_factory() -> UnitOfWorkFactory:
 
 
 def build_harness_registry() -> HarnessRegistry:
+    reconnect_grace_seconds = settings.daemon_reconnect_grace_seconds
     return HarnessRegistry(
         [
             PydanticAIHarness(),
-            DaemonHarness(HarnessKind.CODEX),
-            DaemonHarness(HarnessKind.CLAUDE_CODE),
-            DaemonHarness(HarnessKind.OPENCODE),
-            DaemonHarness(HarnessKind.CURSOR),
-            DaemonHarness(HarnessKind.ANTIGRAVITY),
+            DaemonHarness(HarnessKind.CODEX, reconnect_grace_seconds=reconnect_grace_seconds),
+            DaemonHarness(HarnessKind.CLAUDE_CODE, reconnect_grace_seconds=reconnect_grace_seconds),
+            DaemonHarness(HarnessKind.OPENCODE, reconnect_grace_seconds=reconnect_grace_seconds),
+            DaemonHarness(HarnessKind.CURSOR, reconnect_grace_seconds=reconnect_grace_seconds),
+            DaemonHarness(HarnessKind.ANTIGRAVITY, reconnect_grace_seconds=reconnect_grace_seconds),
         ]
     )
 

--- a/lemma-backend/app/modules/agent/infrastructure/daemon_hub.py
+++ b/lemma-backend/app/modules/agent/infrastructure/daemon_hub.py
@@ -52,6 +52,15 @@ class AgentRuntimeDaemonHub:
     def __init__(self) -> None:
         self._connections: dict[UUID, _DaemonConnection] = {}
         self._remote_runs: dict[UUID, _RemoteRunSubscription] = {}
+        # Run queues salvaged from a connection that just died, keyed by
+        # agent_run_id. A DaemonHarness.run() consumer for one of these runs
+        # is still reading from the SAME queue object (it never lets go of
+        # its reference), sitting in a bounded reconnect-grace wait after
+        # seeing the RECONNECTING sentinel pushed below -- this dict is what
+        # lets a future reattach hand the queue back to a live connection.
+        # Entries are removed either by finish_run() (the run resolved, one
+        # way or another) or, once implemented, by a reattach reclaiming them.
+        self._orphaned_run_queues: dict[UUID, asyncio.Queue[AgentEvent]] = {}
         self._lock = asyncio.Lock()
 
     async def register(
@@ -74,6 +83,10 @@ class AgentRuntimeDaemonHub:
             if old_connection is not None and old_connection.command_task is not None:
                 old_connection.command_task.cancel()
             self._connections[daemon_id] = connection
+            if old_connection is not None:
+                self._orphan_connection_runs_locked(old_connection)
+        if old_connection is not None:
+            self._notify_connection_runs_reconnecting(old_connection, reason="daemon_superseded")
         with contextlib.suppress(TimeoutError):
             await asyncio.wait_for(connection.command_ready.wait(), timeout=2)
 
@@ -84,9 +97,73 @@ class AgentRuntimeDaemonHub:
                 del self._connections[daemon_id]
                 if connection.command_task is not None:
                     connection.command_task.cancel()
+                self._orphan_connection_runs_locked(connection)
+        if connection is not None and connection.user_id == user_id:
+            self._notify_connection_runs_reconnecting(connection, reason="daemon_disconnected")
         if connection is not None and connection.command_task is not None:
             with contextlib.suppress(asyncio.CancelledError):
                 await connection.command_task
+
+    def _orphan_connection_runs_locked(self, connection: _DaemonConnection) -> None:
+        """Move a dying connection's run queues into ``_orphaned_run_queues``.
+
+        Must be called while holding ``self._lock`` (it mutates the shared
+        dict). Only preserves queues; pushing the RECONNECTING sentinel
+        happens separately (outside the lock -- ``queue.put_nowait`` doesn't
+        need it and there's no reason to hold the hub lock across N queue
+        pushes).
+        """
+        self._orphaned_run_queues.update(connection.run_queues)
+
+    def _notify_connection_runs_reconnecting(
+        self,
+        connection: _DaemonConnection,
+        *,
+        reason: str,
+    ) -> None:
+        for agent_run_id, queue in list(connection.run_queues.items()):
+            with contextlib.suppress(asyncio.QueueFull):
+                queue.put_nowait(
+                    AgentEvent(
+                        type=AgentEventType.RECONNECTING,
+                        data={"reason": reason},
+                        agent_run_id=agent_run_id,
+                    )
+                )
+
+    async def reattach_runs(
+        self,
+        *,
+        daemon_id: UUID,
+        user_id: UUID,
+        agent_run_ids: list[UUID],
+    ) -> None:
+        """Re-link surviving ``DaemonHarness.run()`` consumers to a new connection.
+
+        Each ``agent_run_id`` here was registered via ``start_run()`` on a now-dead
+        connection; its ``asyncio.Queue`` is still being read by a
+        ``DaemonHarness.run()`` sitting in its bounded reconnect-grace window
+        (see ``harnesses/daemon.py``). This does NOT create a new queue -- it
+        hands the SAME queue object to the new connection, so the harness's
+        already-running consumer starts receiving events again transparently
+        the moment the daemon flushes its buffered backlog and resumes live
+        sends, with no protocol-visible "resume" step needed on the consumer
+        side (it just sees ordinary events arrive after the RECONNECTING
+        sentinel it already saw).
+
+        Must be called before the connection is told to consider itself fully
+        ready (e.g. before ``daemon.ready_ack``), so a run.start/run.stop for
+        one of these ids that arrives right after can find the reattached
+        queue rather than racing ahead of this.
+        """
+        connection = await self._connection_for(daemon_id=daemon_id, user_id=user_id)
+        if connection is None:
+            return
+        async with self._lock:
+            for agent_run_id in agent_run_ids:
+                queue = self._orphaned_run_queues.pop(agent_run_id, None)
+                if queue is not None:
+                    connection.run_queues[agent_run_id] = queue
 
     async def connected(self, *, daemon_id: UUID, user_id: UUID) -> bool:
         return await self._connection_for(daemon_id=daemon_id, user_id=user_id) is not None
@@ -99,6 +176,15 @@ class AgentRuntimeDaemonHub:
         agent_run_id: UUID,
         payload: JsonObject,
     ) -> asyncio.Queue[AgentEvent]:
+        capacity = await get_daemon_capacity(daemon_id=daemon_id)
+        if capacity is not None:
+            active = capacity.get("active_run_count")
+            cap = capacity.get("max_concurrent_runs")
+            if isinstance(active, int) and isinstance(cap, int) and active >= cap:
+                raise RuntimeError(
+                    f"User daemon is at capacity ({active}/{cap} runs active). "
+                    "Try again shortly."
+                )
         connection = await self._connection_for(daemon_id=daemon_id, user_id=user_id)
         queue: asyncio.Queue[AgentEvent] = asyncio.Queue()
         if connection is None:
@@ -135,6 +221,18 @@ class AgentRuntimeDaemonHub:
                 },
             )
             return queue
+
+        if agent_run_id in connection.run_queues:
+            # Defense in depth: the CLI daemon itself guards against a
+            # redelivered run.start for an id it's already running, but this
+            # would otherwise silently clobber the first queue reference here
+            # too (same shape of bug) if some other caller ever double-dispatched.
+            logger.warning(
+                "start_run called for an agent_run_id already registered on this connection",
+                daemon_id=str(daemon_id),
+                agent_run_id=str(agent_run_id),
+            )
+            return connection.run_queues[agent_run_id]
 
         connection.run_queues[agent_run_id] = queue
         await self._send(
@@ -187,6 +285,12 @@ class AgentRuntimeDaemonHub:
             connection.run_queues.pop(agent_run_id, None)
         async with self._lock:
             subscription = self._remote_runs.pop(agent_run_id, None)
+            # A run that resolved (completed/failed/stopped) while its queue was
+            # sitting in _orphaned_run_queues (disconnected, never reattached)
+            # must not linger there forever -- DaemonHarness.run() always calls
+            # finish_run() in its `finally`, so this is the guaranteed cleanup
+            # path for orphaned entries nothing ever reattached.
+            self._orphaned_run_queues.pop(agent_run_id, None)
         if subscription is not None:
             subscription.task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -364,6 +468,45 @@ def _run_event_channel(agent_run_id: UUID) -> str:
 
 def _daemon_online_key(daemon_id: UUID) -> str:
     return f"agent-runtime:daemon:{daemon_id}:online"
+
+
+def _daemon_capacity_key(daemon_id: UUID) -> str:
+    return f"agent-runtime:daemon:{daemon_id}:capacity"
+
+
+# Ephemeral, presence-scoped data (same category as _daemon_online_key above)
+# -- lives in Redis, not a DB column, because it's a live fact that changes on
+# every heartbeat and is meaningless the instant the daemon disconnects. The
+# TTL is a safety net only; the heartbeat refreshes it far more often, and
+# _clear_daemon_capacity() below removes it immediately on a clean disconnect.
+_DAEMON_CAPACITY_TTL_SECONDS = 120
+
+
+async def set_daemon_capacity(
+    *, daemon_id: UUID, active_run_count: int, max_concurrent_runs: int
+) -> None:
+    await _get_redis().set(
+        _daemon_capacity_key(daemon_id),
+        json.dumps(
+            {"active_run_count": active_run_count, "max_concurrent_runs": max_concurrent_runs}
+        ),
+        ex=_DAEMON_CAPACITY_TTL_SECONDS,
+    )
+
+
+async def get_daemon_capacity(*, daemon_id: UUID) -> JsonObject | None:
+    raw = await _get_redis().get(_daemon_capacity_key(daemon_id))
+    if raw is None:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+async def clear_daemon_capacity(*, daemon_id: UUID) -> None:
+    await _get_redis().delete(_daemon_capacity_key(daemon_id))
 
 
 _redis_pool: ConnectionPool | None = None

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/daemon.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/daemon.py
@@ -39,6 +39,12 @@ from pydantic_ai.usage import RunUsage
 
 
 DEFAULT_DAEMON_EVENT_TIMEOUT_SECONDS = 7200.0
+# Bounded and orthogonal to DEFAULT_DAEMON_EVENT_TIMEOUT_SECONDS above: that one
+# tolerates a *live* connection's long silent gap between events (a slow tool
+# call); this one bounds how long a disconnected run waits for its daemon to
+# reconnect before giving up. Kept far shorter on purpose -- see run()'s
+# RECONNECTING handling below.
+DEFAULT_RECONNECT_GRACE_SECONDS = 120.0
 
 
 class DaemonHarness:
@@ -49,9 +55,11 @@ class DaemonHarness:
         kind: HarnessKind,
         *,
         event_timeout_seconds: float = DEFAULT_DAEMON_EVENT_TIMEOUT_SECONDS,
+        reconnect_grace_seconds: float = DEFAULT_RECONNECT_GRACE_SECONDS,
     ):
         self.kind = kind
         self.event_timeout_seconds = event_timeout_seconds
+        self.reconnect_grace_seconds = reconnect_grace_seconds
 
     async def run(
         self,
@@ -97,6 +105,10 @@ class DaemonHarness:
             return
 
         stop_sent = False
+        # Set the moment a RECONNECTING sentinel is first seen; cleared once a
+        # real event arrives again. Bounds how long this run waits out a dead
+        # connection, independent of (and much shorter than) event_timeout_seconds.
+        reconnecting_since: float | None = None
         try:
             while True:
                 if (
@@ -114,6 +126,18 @@ class DaemonHarness:
                 try:
                     while True:
                         remaining = deadline - time.monotonic()
+                        if reconnecting_since is not None:
+                            grace_remaining = (
+                                reconnecting_since + self.reconnect_grace_seconds
+                            ) - time.monotonic()
+                            if grace_remaining <= 0:
+                                yield AgentEvent(
+                                    type=AgentEventType.ERROR,
+                                    data="User daemon did not reconnect within the grace period",
+                                    agent_run_id=agent_run_id,
+                                )
+                                return
+                            remaining = min(remaining, grace_remaining)
                         if remaining <= 0:
                             raise TimeoutError
                         try:
@@ -142,11 +166,34 @@ class DaemonHarness:
                         agent_run_id=agent_run_id,
                     )
                     return
+
+                if event.type == AgentEventType.RECONNECTING:
+                    if reconnecting_since is None:
+                        reconnecting_since = time.monotonic()
+                        yield AgentEvent(
+                            type=AgentEventType.STATUS,
+                            data={
+                                "status": "Connection to your machine dropped; waiting to reconnect…",
+                                "phase": "reconnecting",
+                            },
+                            agent_run_id=agent_run_id,
+                        )
+                    continue
+
+                if reconnecting_since is not None:
+                    reconnecting_since = None
+                    yield AgentEvent(
+                        type=AgentEventType.STATUS,
+                        data={"status": "Reconnected.", "phase": "reconnected"},
+                        agent_run_id=agent_run_id,
+                    )
+
                 yield event
                 if event.type in {
                     AgentEventType.COMPLETED,
                     AgentEventType.STOPPED,
                     AgentEventType.ERROR,
+                    AgentEventType.REJECTED,
                 }:
                     return
         finally:

--- a/lemma-backend/app/modules/agent/services/agent_runner_service.py
+++ b/lemma-backend/app/modules/agent/services/agent_runner_service.py
@@ -116,6 +116,25 @@ async def _finalize_safely(coro: Awaitable[None], *, agent_run_id: UUID) -> None
         )
 
 
+def _rejected_run_error_message(data: object) -> str:
+    """Build a user-facing message for a daemon-capacity REJECTED event.
+
+    Falls back to a generic message if the structured shape the daemon sends
+    (``{"reason", "active_run_count", "max_concurrent_runs"}``) isn't present
+    -- keeps this robust against an older/newer daemon sending a different
+    payload shape.
+    """
+    if isinstance(data, dict) and data.get("reason") == "daemon_at_capacity":
+        active = data.get("active_run_count")
+        cap = data.get("max_concurrent_runs")
+        if isinstance(active, int) and isinstance(cap, int):
+            return (
+                f"Daemon busy: {active}/{cap} runs already active. "
+                "Try again in a moment."
+            )
+    return "Daemon rejected this run (at capacity). Try again in a moment."
+
+
 def _profile_model_settings(
     runtime_profile_snapshot: dict[str, object | None] | None,
 ) -> JsonObject | None:
@@ -645,6 +664,26 @@ class AgentRunnerService:
                 agent_run_id=agent_run_id,
                 status=AgentRunStatus.FAILED,
                 error=str(event.data),
+                usage_data=usage_data,
+                organization_id=organization_id,
+                pod_id=pod_id,
+                user_id=user_id,
+                agent_id=agent_id,
+                started_at=started_at,
+                runtime_profile=runtime_profile,
+                usage_reservation=usage_reservation,
+            )
+            return True
+
+        if event.type == AgentEventType.REJECTED:
+            # The daemon explicitly refused this run (already at
+            # max_concurrent_runs) -- terminal, like ERROR, but with a more
+            # actionable message built from the event's structured data.
+            await self._finish_agent_run(
+                conversation_id=conversation_id,
+                agent_run_id=agent_run_id,
+                status=AgentRunStatus.FAILED,
+                error=_rejected_run_error_message(event.data),
                 usage_data=usage_data,
                 organization_id=organization_id,
                 pod_id=pod_id,

--- a/lemma-backend/app/modules/agent/tests/e2e/test_daemon_reliability_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_daemon_reliability_e2e.py
@@ -1,0 +1,585 @@
+"""Holistic e2e tests for the daemon websocket reliability/concurrency redesign.
+
+Unlike the per-harness happy-path tests (test_daemon_claude_code_e2e.py etc.),
+these drive real disruption scenarios against real daemon subprocesses, a real
+backend, and real LLM calls:
+
+- Two different harnesses (Claude Code + Codex) running truly concurrently on
+  one daemon, with no cross-talk between their conversations.
+- The backend's websocket connection to the daemon being torn down and
+  re-established mid-run (a server-side restart/connection reset), while the
+  daemon holds the in-flight run and reattaches once reconnected.
+- The daemon process itself going unresponsive for an extended window (SIGSTOP,
+  simulating the client machine losing network connectivity) long enough to
+  trip the backend's staleness detection, then coming back -- verifying the
+  same provider subprocess resumes with no duplicate tool execution.
+- Concurrent runs beyond the daemon's configured capacity being rejected
+  immediately rather than silently competing for host resources.
+
+Most of these need a real tool call (`sleep N` via lemma_exec_command) to
+create a controllable time window to act within, so -- like the other
+real-daemon e2e tests -- they need the real local AgentBox
+(configure_workspace_api_url). The backend-restart test is the one exception:
+it deliberately avoids any tool call, since restarting the backend also
+severs any live MCP tool-call session regardless of timing -- see
+_long_text_reply_prompt for why.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import shutil
+import signal
+import socket
+
+import pytest
+import uvicorn
+
+from app.modules.agent.domain.value_objects import MessageRole
+from app.modules.agent.tests.e2e.daemon_harness_e2e_helpers import (
+    BINARY,
+    assert_latest_assistant_contains,
+    create_daemon_profile,
+    create_test_pod,
+    create_workspace_agent_and_conversation,
+    post_sse,
+    start_real_daemon_process,
+    stop_process,
+    wait_for_daemon_harness,
+)
+
+pytestmark = [pytest.mark.e2e, pytest.mark.slow, pytest.mark.local_cli, pytest.mark.provider]
+
+
+def _skip_unless_installed(*harness_kinds: str) -> None:
+    for harness_kind in harness_kinds:
+        binary = BINARY[harness_kind]
+        if shutil.which(binary) is None:
+            pytest.skip(f"{binary} CLI is not installed")
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+async def _start_controllable_backend(app, port: int) -> tuple[uvicorn.Server, "asyncio.Task[None]"]:
+    """Start a real, restartable uvicorn server wrapping ``app`` on ``port``.
+
+    Mirrors app.modules.test_support.e2e.runtime's `backend_server` fixture
+    internals, but keeps the Server/Task under the caller's control instead of
+    hiding them behind a fixture -- needed here specifically to stop and
+    restart the SAME port mid-test to simulate a server-side connection reset.
+    """
+    config = uvicorn.Config(
+        app=app,
+        host="0.0.0.0",
+        port=port,
+        log_level="warning",
+        access_log=False,
+        lifespan="on",
+        ws="websockets-sansio",
+    )
+    server = uvicorn.Server(config)
+    task = asyncio.create_task(server.serve())
+    for _ in range(100):
+        if server.started:
+            break
+        if task.done():
+            raise RuntimeError("Backend server exited before startup") from task.exception()
+        await asyncio.sleep(0.1)
+    else:
+        raise RuntimeError("Timed out starting backend server")
+    return server, task
+
+
+async def _stop_controllable_backend(server: uvicorn.Server, task: "asyncio.Task[None]") -> None:
+    server.should_exit = True
+    try:
+        await asyncio.wait_for(task, timeout=10)
+    except asyncio.TimeoutError:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+def _sleep_and_echo_prompt(*, seconds: int, marker: str) -> str:
+    return (
+        "Use lemma_exec_command to run exactly: "
+        f"`printf START_{marker}; sleep {seconds}; printf END_{marker}`. "
+        "Wait for it to finish, then reply with the exact combined output and "
+        "nothing else."
+    )
+
+
+def _long_text_reply_prompt(*, marker: str) -> str:
+    """A tool-free prompt shaped to create a long, disruptable streaming window.
+
+    Deliberately uses NO tool call. Claude Code's CLI holds its MCP client
+    session open against the backend's MCP endpoint for as long as any tool
+    use is live in the conversation -- restarting the backend severs that
+    session outright (a real, separate limitation of synchronous MCP calls
+    tied to the same connection, confirmed empirically: it surfaces as an
+    "error" stream event, "Connection closed by server.", regardless of
+    exactly when the restart lands relative to an individual tool call).
+    That is not what this test wants to isolate.
+
+    A pure text reply only ever touches the websocket (daemon -> backend),
+    which IS what the hold/reattach redesign covers -- so restart during
+    token streaming here has no other connection to accidentally take down.
+    "No duplicate tool execution" across a restart is covered separately by
+    test_daemon_survives_client_network_loss_and_resumes_without_duplicate_tool_execution,
+    which disrupts only the daemon's own websocket (SIGSTOP on the daemon
+    process) while the provider subprocess's own MCP session stays live.
+    """
+    return (
+        "Without calling any tools, write out the numbers from 1 to 60 in "
+        "words (one, two, three, ...), each on its own line, and finish "
+        f"with a final line containing exactly DONE_{marker}."
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Concurrent runs across two different harnesses on one daemon
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(180)
+async def test_concurrent_runs_across_claude_code_and_codex_harnesses(
+    authenticated_client,
+    fixed_test_org,
+    fixed_test_user,
+    backend_server,
+    configure_workspace_api_url,
+    tmp_path,
+    worker,
+):
+    """One daemon process serving two concurrent conversations on two
+    different harnesses at once -- the core promise of the redesign: a single
+    websocket reliably multiplexing many concurrent runs with no cross-talk.
+    """
+    del configure_workspace_api_url
+    _skip_unless_installed("CLAUDE_CODE", "CODEX")
+
+    daemon_dir = tmp_path / "daemon-state"
+    process = start_real_daemon_process(
+        backend_server=backend_server,
+        fixed_test_user=fixed_test_user,
+        tmp_path=tmp_path,
+    )
+    try:
+        claude_harness = await wait_for_daemon_harness(
+            authenticated_client, harness_kind="CLAUDE_CODE", process=process
+        )
+        codex_harness = await wait_for_daemon_harness(
+            authenticated_client, harness_kind="CODEX", process=process
+        )
+        assert claude_harness["daemon_id"] == codex_harness["daemon_id"], (
+            "expected one daemon process to serve both harnesses"
+        )
+
+        conversations = {}
+        for harness_kind, harness in (("CLAUDE_CODE", claude_harness), ("CODEX", codex_harness)):
+            profile_id, model_name = await create_daemon_profile(
+                authenticated_client,
+                fixed_test_org,
+                daemon_id=harness["daemon_id"],
+                harness_kind=harness_kind,
+                models=harness["models"],
+            )
+            pod_id = await create_test_pod(authenticated_client, fixed_test_org, harness_kind)
+            _, conversation_id = await create_workspace_agent_and_conversation(
+                authenticated_client,
+                pod_id=pod_id,
+                profile_id=profile_id,
+                model_name=model_name,
+                harness_kind=harness_kind,
+            )
+            conversations[harness_kind] = (pod_id, conversation_id)
+
+        claude_pod_id, claude_conversation_id = conversations["CLAUDE_CODE"]
+        codex_pod_id, codex_conversation_id = conversations["CODEX"]
+
+        claude_task = asyncio.create_task(
+            post_sse(
+                authenticated_client,
+                f"/pods/{claude_pod_id}/conversations/{claude_conversation_id}/messages",
+                {"content": _sleep_and_echo_prompt(seconds=8, marker="CLAUDE")},
+            )
+        )
+        codex_task = asyncio.create_task(
+            post_sse(
+                authenticated_client,
+                f"/pods/{codex_pod_id}/conversations/{codex_conversation_id}/messages",
+                {"content": _sleep_and_echo_prompt(seconds=8, marker="CODEX")},
+            )
+        )
+
+        claude_events, codex_events = await asyncio.gather(claude_task, codex_task)
+
+        for events in (claude_events, codex_events):
+            assert events, "SSE stream produced no events"
+            assert not [e for e in events if e["type"] == "error"], events
+            assert events[-1]["type"] == "completed", events
+
+        claude_text = await assert_latest_assistant_contains(
+            authenticated_client,
+            pod_id=claude_pod_id,
+            conversation_id=claude_conversation_id,
+            markers=["START_CLAUDE", "END_CLAUDE"],
+        )
+        codex_text = await assert_latest_assistant_contains(
+            authenticated_client,
+            pod_id=codex_pod_id,
+            conversation_id=codex_conversation_id,
+            markers=["START_CODEX", "END_CODEX"],
+        )
+
+        # The actual point of this test: the OTHER conversation's markers must
+        # never leak across, which would indicate queue/event cross-talk
+        # between the two concurrent runs sharing one daemon connection.
+        assert "START_CODEX" not in claude_text and "END_CODEX" not in claude_text
+        assert "START_CLAUDE" not in codex_text and "END_CLAUDE" not in codex_text
+    finally:
+        stop_process(process, daemon_dir=daemon_dir)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. Backend restart mid-run
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(180)
+async def test_daemon_reconnects_after_backend_restart_mid_run(
+    test_app,
+    authenticated_client,
+    fixed_test_org,
+    fixed_test_user,
+    configure_workspace_api_url,
+    tmp_path,
+    worker,
+):
+    """Simulates a server-side restart (e.g. a rolling deploy / LB connection
+    drain) of the process the daemon's websocket is attached to: stop the real
+    uvicorn server, wait briefly, start a fresh one on the SAME port. The
+    daemon must notice the drop, reconnect with backoff, and the in-flight run
+    must resume and complete via the same provider subprocess.
+    """
+    del configure_workspace_api_url
+    _skip_unless_installed("CLAUDE_CODE")
+
+    port = _free_port()
+    server, server_task = await _start_controllable_backend(test_app, port)
+    daemon_backend = {
+        "host_base_url": f"http://127.0.0.1:{port}",
+        "docker_base_url": f"http://host.docker.internal:{port}",
+    }
+
+    daemon_dir = tmp_path / "daemon-state"
+    process = start_real_daemon_process(
+        backend_server=daemon_backend,
+        fixed_test_user=fixed_test_user,
+        tmp_path=tmp_path,
+    )
+    try:
+        harness = await wait_for_daemon_harness(
+            authenticated_client, harness_kind="CLAUDE_CODE", process=process
+        )
+        profile_id, model_name = await create_daemon_profile(
+            authenticated_client,
+            fixed_test_org,
+            daemon_id=harness["daemon_id"],
+            harness_kind="CLAUDE_CODE",
+            models=harness["models"],
+        )
+        pod_id = await create_test_pod(authenticated_client, fixed_test_org, "CLAUDE_CODE")
+        _, conversation_id = await create_workspace_agent_and_conversation(
+            authenticated_client,
+            pod_id=pod_id,
+            profile_id=profile_id,
+            model_name=model_name,
+            harness_kind="CLAUDE_CODE",
+        )
+
+        events: list[dict] = []
+
+        async def _drive_run() -> list[dict]:
+            async with authenticated_client.stream(
+                "POST",
+                f"/pods/{pod_id}/conversations/{conversation_id}/messages",
+                json={"content": _long_text_reply_prompt(marker="RESTART")},
+                timeout=120,
+            ) as response:
+                assert response.status_code == 200
+                async with asyncio.timeout(120):
+                    async for line in response.aiter_lines():
+                        if not line.startswith("data: "):
+                            continue
+                        payload = json.loads(line.removeprefix("data: "))
+                        events.append(payload)
+                        if payload["type"] in {"completed", "stopped", "error"}:
+                            break
+            return events
+
+        run_task = asyncio.create_task(_drive_run())
+
+        # Wait for the first real TOKEN event -- proof the LLM has started
+        # streaming text -- then restart immediately. No tool call is
+        # involved (see _long_text_reply_prompt), so the only thing at risk
+        # is the websocket itself, and a ~60-line reply leaves a wide,
+        # comfortably-real window of remaining streaming to disrupt into.
+        async with asyncio.timeout(30):
+            while not any(e.get("type") == "token" for e in events):
+                await asyncio.sleep(0.1)
+
+        await _stop_controllable_backend(server, server_task)
+        await asyncio.sleep(2)  # simulated downtime window
+        server, server_task = await _start_controllable_backend(test_app, port)
+
+        result_events = await run_task
+        assert result_events, "SSE stream produced no events"
+        assert not [e for e in result_events if e["type"] == "error"], result_events
+        assert result_events[-1]["type"] == "completed", result_events
+
+        await assert_latest_assistant_contains(
+            authenticated_client,
+            pod_id=pod_id,
+            conversation_id=conversation_id,
+            markers=["DONE_RESTART"],
+        )
+    finally:
+        stop_process(process, daemon_dir=daemon_dir)
+        await _stop_controllable_backend(server, server_task)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Client (daemon) network unavailable for an extended window
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(120)
+async def test_daemon_survives_client_network_loss_and_resumes_without_duplicate_tool_execution(
+    monkeypatch,
+    authenticated_client,
+    fixed_test_org,
+    fixed_test_user,
+    backend_server,
+    configure_workspace_api_url,
+    tmp_path,
+    worker,
+):
+    """Freezes the daemon PROCESS itself (SIGSTOP) for long enough to trip the
+    backend's staleness detection -- simulating the client machine losing
+    network connectivity, not just a clean disconnect. On SIGCONT, the SAME
+    provider subprocess must resume (buffered output flushed, live streaming
+    restored) and complete with the tool call executed exactly once.
+
+    The staleness threshold is monkeypatched down from its 90s production
+    default to a few seconds (same pattern as
+    test_daemon_websocket_route.py's unit tests) so the whole scenario runs
+    on a short, real timescale -- a real 90s+ freeze around a real long-running
+    exec_command was found to unreliably trip an unrelated limit in the local
+    AgentBox test runtime (a "Remote end closed connection" transport failure
+    on the sandbox's own command endpoint for commands this long), which is
+    not what this test targets.
+    """
+    del configure_workspace_api_url
+    _skip_unless_installed("CLAUDE_CODE")
+
+    import app.modules.agent.api.controllers.runtime_config_controller as controller
+
+    monkeypatch.setattr(controller.settings, "daemon_ws_ping_stale_after_seconds", 8.0)
+
+    daemon_dir = tmp_path / "daemon-state"
+    process = start_real_daemon_process(
+        backend_server=backend_server,
+        fixed_test_user=fixed_test_user,
+        tmp_path=tmp_path,
+    )
+    try:
+        harness = await wait_for_daemon_harness(
+            authenticated_client, harness_kind="CLAUDE_CODE", process=process
+        )
+        profile_id, model_name = await create_daemon_profile(
+            authenticated_client,
+            fixed_test_org,
+            daemon_id=harness["daemon_id"],
+            harness_kind="CLAUDE_CODE",
+            models=harness["models"],
+        )
+        pod_id = await create_test_pod(authenticated_client, fixed_test_org, "CLAUDE_CODE")
+        _, conversation_id = await create_workspace_agent_and_conversation(
+            authenticated_client,
+            pod_id=pod_id,
+            profile_id=profile_id,
+            model_name=model_name,
+            harness_kind="CLAUDE_CODE",
+        )
+
+        run_task = asyncio.create_task(
+            post_sse(
+                authenticated_client,
+                f"/pods/{pod_id}/conversations/{conversation_id}/messages",
+                {"content": _sleep_and_echo_prompt(seconds=30, marker="FREEZE")},
+                timeout=90,
+            )
+        )
+
+        await asyncio.sleep(4)  # let the tool call actually start
+
+        os.kill(process.pid, signal.SIGSTOP)
+        try:
+            # Comfortably past the monkeypatched 8s staleness threshold, so
+            # the backend's reaper actually closes the connection from its
+            # side (a frozen process can't run its own timers to notice on
+            # its own -- this is what makes the freeze meaningfully
+            # different from a clean, instantly-detected disconnect).
+            await asyncio.sleep(15)
+        finally:
+            os.kill(process.pid, signal.SIGCONT)
+
+        events = await run_task
+        assert events, "SSE stream produced no events"
+        assert not [e for e in events if e["type"] == "error"], events
+        assert events[-1]["type"] == "completed", events
+
+        final_text = await assert_latest_assistant_contains(
+            authenticated_client,
+            pod_id=pod_id,
+            conversation_id=conversation_id,
+            markers=["START_FREEZE", "END_FREEZE"],
+        )
+        # A genuine duplicate run/re-dispatch of the whole turn (the actual
+        # redesign risk this test targets) would re-run the full prompt and
+        # duplicate these markers in the final reply.
+        assert final_text.count("START_FREEZE") == 1, final_text
+        assert final_text.count("END_FREEZE") == 1, final_text
+
+        response = await authenticated_client.get(
+            f"/pods/{pod_id}/conversations/{conversation_id}/messages"
+        )
+        items = response.json()["items"]
+        # CLAUDE_CODE's daemon harness never persists a TOOL_RETURN message
+        # (only codex.py/OpenCode's base.py emit one) and Claude Code's CLI
+        # namespaces MCP tools as mcp__<server_label>__<tool_name>. Also, for
+        # a long-running command sitting near Claude Code's own client-side
+        # synchronous-wait budget (empirically ~150s), the CLI may legitimately
+        # issue a SECOND tool_call to check in on the same backgrounded
+        # command (distinct tool_call_id, tty/yield_time_ms polling args) --
+        # not a re-execution. So "no duplicate execution" is proven by every
+        # call referencing the same underlying shell command, not a strict
+        # call count of 1.
+        tool_calls = [
+            item
+            for item in items
+            if item["role"] == MessageRole.ASSISTANT.value
+            and item["kind"] == "TOOL_CALL"
+            and (item["tool_name"] or "").endswith("lemma_exec_command")
+        ]
+        assert tool_calls, items
+        commands = {(call.get("tool_args") or {}).get("cmd") for call in tool_calls}
+        assert commands == {"printf START_FREEZE; sleep 30; printf END_FREEZE"}, tool_calls
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            os.kill(process.pid, signal.SIGCONT)  # in case a failure left it stopped
+        stop_process(process, daemon_dir=daemon_dir)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Concurrent runs beyond daemon capacity
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(120)
+async def test_concurrent_runs_beyond_daemon_capacity_are_rejected(
+    monkeypatch,
+    authenticated_client,
+    fixed_test_org,
+    fixed_test_user,
+    backend_server,
+    configure_workspace_api_url,
+    tmp_path,
+    worker,
+):
+    """A daemon capped at 2 concurrent runs must immediately reject a 3rd
+    rather than silently letting it compete for host resources -- the admission
+    control added in the concurrency redesign, exercised against a real daemon
+    dispatch (not the fakes used by the unit tests).
+    """
+    del configure_workspace_api_url
+    _skip_unless_installed("CLAUDE_CODE")
+    monkeypatch.setenv("LEMMA_DAEMON_MAX_CONCURRENT_RUNS", "2")
+
+    daemon_dir = tmp_path / "daemon-state"
+    process = start_real_daemon_process(
+        backend_server=backend_server,
+        fixed_test_user=fixed_test_user,
+        tmp_path=tmp_path,
+    )
+    try:
+        harness = await wait_for_daemon_harness(
+            authenticated_client, harness_kind="CLAUDE_CODE", process=process
+        )
+        profile_id, model_name = await create_daemon_profile(
+            authenticated_client,
+            fixed_test_org,
+            daemon_id=harness["daemon_id"],
+            harness_kind="CLAUDE_CODE",
+            models=harness["models"],
+        )
+        pod_id = await create_test_pod(authenticated_client, fixed_test_org, "CLAUDE_CODE")
+
+        conversation_ids = []
+        for _ in range(3):
+            _, conversation_id = await create_workspace_agent_and_conversation(
+                authenticated_client,
+                pod_id=pod_id,
+                profile_id=profile_id,
+                model_name=model_name,
+                harness_kind="CLAUDE_CODE",
+            )
+            conversation_ids.append(conversation_id)
+
+        tasks = [
+            asyncio.create_task(
+                post_sse(
+                    authenticated_client,
+                    f"/pods/{pod_id}/conversations/{conversation_id}/messages",
+                    {"content": _sleep_and_echo_prompt(seconds=10, marker=f"CAP{i}")},
+                )
+            )
+            for i, conversation_id in enumerate(conversation_ids)
+        ]
+        results = await asyncio.gather(*tasks)
+
+        terminal_types = [events[-1]["type"] for events in results]
+        completed = [t for t in terminal_types if t == "completed"]
+        errored = [t for t in terminal_types if t == "error"]
+        assert len(completed) == 2, terminal_types
+        assert len(errored) == 1, terminal_types
+
+        rejected_index = terminal_types.index("error")
+        rejected_events = results[rejected_index]
+        # Exact wording from _rejected_run_error_message (agent_runner_service.py):
+        # "Daemon busy: N/M runs already active. Try again in a moment."
+        assert "busy" in str(rejected_events[-1]["data"]).lower(), rejected_events
+
+        # The rejected conversation must be finalized (FAILED), not stuck
+        # RUNNING -- the exact gap found and fixed during live verification of
+        # the redesign (AgentRunnerService previously had no branch for the
+        # REJECTED event type).
+        rejected_conversation_id = conversation_ids[rejected_index]
+        conversation = await authenticated_client.get(
+            f"/pods/{pod_id}/conversations/{rejected_conversation_id}"
+        )
+        assert conversation.json()["last_run_status"] == "FAILED", conversation.text
+    finally:
+        stop_process(process, daemon_dir=daemon_dir)

--- a/lemma-backend/app/modules/agent/tests/e2e/test_daemon_reliability_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_daemon_reliability_e2e.py
@@ -23,6 +23,14 @@ real-daemon e2e tests -- they need the real local AgentBox
 it deliberately avoids any tool call, since restarting the backend also
 severs any live MCP tool-call session regardless of timing -- see
 _long_text_reply_prompt for why.
+
+All four tests carry a generous 300s timeout even though each one's own
+logic runs in well under a minute: the shared `workspace_image` fixture
+(module-scoped, but keyed off a content-addressed Docker tag that persists
+across separate pytest invocations too) builds the AgentBox runtime image
+from scratch the first time any test needs it in a given environment --
+whichever test runs first in a fresh checkout/CI run pays that cold-build
+cost, which can take a few minutes.
 """
 
 from __future__ import annotations
@@ -149,7 +157,7 @@ def _long_text_reply_prompt(*, marker: str) -> str:
 
 
 @pytest.mark.asyncio
-@pytest.mark.timeout(180)
+@pytest.mark.timeout(300)
 async def test_concurrent_runs_across_claude_code_and_codex_harnesses(
     authenticated_client,
     fixed_test_org,
@@ -255,7 +263,7 @@ async def test_concurrent_runs_across_claude_code_and_codex_harnesses(
 
 
 @pytest.mark.asyncio
-@pytest.mark.timeout(180)
+@pytest.mark.timeout(300)
 async def test_daemon_reconnects_after_backend_restart_mid_run(
     test_app,
     authenticated_client,
@@ -364,7 +372,7 @@ async def test_daemon_reconnects_after_backend_restart_mid_run(
 
 
 @pytest.mark.asyncio
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(300)
 async def test_daemon_survives_client_network_loss_and_resumes_without_duplicate_tool_execution(
     monkeypatch,
     authenticated_client,
@@ -498,7 +506,7 @@ async def test_daemon_survives_client_network_loss_and_resumes_without_duplicate
 
 
 @pytest.mark.asyncio
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(300)
 async def test_concurrent_runs_beyond_daemon_capacity_are_rejected(
     monkeypatch,
     authenticated_client,

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_runner_service.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_runner_service.py
@@ -11,7 +11,27 @@ from app.modules.agent.infrastructure.harnesses.registry import HarnessRegistry
 from app.modules.agent.services.agent_runner_service import (
     AgentRunnerService,
     _finalize_safely,
+    _rejected_run_error_message,
 )
+
+
+def test_rejected_run_error_message_uses_structured_capacity_data():
+    message = _rejected_run_error_message(
+        {"reason": "daemon_at_capacity", "active_run_count": 2, "max_concurrent_runs": 2}
+    )
+    assert message == "Daemon busy: 2/2 runs already active. Try again in a moment."
+
+
+def test_rejected_run_error_message_falls_back_for_malformed_data():
+    assert _rejected_run_error_message("not-a-dict") == (
+        "Daemon rejected this run (at capacity). Try again in a moment."
+    )
+    assert _rejected_run_error_message({"reason": "something_else"}) == (
+        "Daemon rejected this run (at capacity). Try again in a moment."
+    )
+    assert _rejected_run_error_message(
+        {"reason": "daemon_at_capacity", "active_run_count": "two"}
+    ) == "Daemon rejected this run (at capacity). Try again in a moment."
 
 
 class _FailingContextManager:

--- a/lemma-backend/app/modules/agent/tests/unit/test_daemon_harness.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_daemon_harness.py
@@ -10,15 +10,20 @@ from pydantic_ai.toolsets import FunctionToolset
 from app.modules.agent.domain.context import AgentContext
 from app.modules.agent.domain.entities import Agent, Conversation, Message
 from app.modules.agent.domain.value_objects import (
+    AgentEvent,
     AgentEventType,
     HarnessKind,
     HarnessOptions,
     MessageKind,
     MessageRole,
 )
-from app.modules.agent.infrastructure.daemon_hub import agent_runtime_daemon_hub
+from app.modules.agent.infrastructure.daemon_hub import (
+    AgentRuntimeDaemonHub,
+    agent_runtime_daemon_hub,
+)
 from app.modules.agent.infrastructure.harnesses.daemon import (
     DEFAULT_DAEMON_EVENT_TIMEOUT_SECONDS,
+    DEFAULT_RECONNECT_GRACE_SECONDS,
     DaemonHarness,
     _mcp_payload,
     _run_start_payload,
@@ -343,3 +348,498 @@ def test_daemon_harness_attaches_cached_session_and_recovery_prompt():
     assert "Stay concise." in recovery_prompt
     assert "You are running through a Lemma user daemon." in recovery_prompt
     assert payload["prompt"]["user_prompt"] == "USER:\ncontinue"
+
+
+def test_daemon_harness_default_reconnect_grace_is_two_minutes():
+    harness = DaemonHarness(HarnessKind.CODEX)
+
+    assert harness.reconnect_grace_seconds == DEFAULT_RECONNECT_GRACE_SECONDS
+    assert harness.reconnect_grace_seconds == 120.0
+
+
+def _build_minimal_run_args(
+    *, daemon_id, daemon_user_id, agent_run_id
+) -> tuple[Agent, Conversation, Message, AgentContext, HarnessOptions]:
+    pod_id = uuid4()
+    actor_user_id = uuid4()
+    agent = Agent(
+        pod_id=pod_id,
+        user_id=actor_user_id,
+        name="Daemon Agent",
+        instruction="Answer through the daemon.",
+    )
+    conversation = Conversation(
+        user_id=actor_user_id,
+        pod_id=pod_id,
+        organization_id=uuid4(),
+        title="Daemon run",
+    )
+    message = Message.create(
+        conversation_id=conversation.id,
+        sequence=0,
+        agent_run_id=None,
+        role=MessageRole.USER,
+        text="hello",
+    )
+    ctx = AgentContext(
+        user_id=actor_user_id,
+        pod_id=pod_id,
+        conversation_id=conversation.id,
+        agent_run_id=agent_run_id,
+    )
+    options = HarnessOptions(
+        model_name="gpt-5.5",
+        extra={
+            "runtime_profile": {
+                "user_id": str(daemon_user_id),
+                "daemon_id": str(daemon_id),
+                "scope": "ORGANIZATION",
+                "config": {},
+            }
+        },
+    )
+    return agent, conversation, message, ctx, options
+
+
+@pytest.mark.asyncio
+async def test_daemon_harness_resumes_after_reconnecting_within_grace(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        "app.modules.agent.infrastructure.harnesses.daemon.WorkspaceSandboxService",
+        _FakeWorkspaceSandboxService,
+    )
+    daemon_id = uuid4()
+    daemon_user_id = uuid4()
+    agent_run_id = uuid4()
+    queue: asyncio.Queue = asyncio.Queue()
+
+    async def _fake_start_run(**_kwargs):
+        return queue
+
+    async def _fake_finish_run(**_kwargs):
+        return None
+
+    monkeypatch.setattr(agent_runtime_daemon_hub, "start_run", _fake_start_run)
+    monkeypatch.setattr(agent_runtime_daemon_hub, "finish_run", _fake_finish_run)
+
+    agent, conversation, message, ctx, options = _build_minimal_run_args(
+        daemon_id=daemon_id, daemon_user_id=daemon_user_id, agent_run_id=agent_run_id
+    )
+    # event_timeout_seconds is generous here on purpose: this test proves the
+    # grace-period path resolves the run WITHOUT ever touching that (much
+    # longer) budget -- if it wrongly fell back onto the 2s event_timeout, the
+    # overall asyncio.wait_for(task, timeout=1) below would fail the test.
+    harness = DaemonHarness(
+        HarnessKind.CODEX, event_timeout_seconds=2.0, reconnect_grace_seconds=2.0
+    )
+
+    events: list[AgentEvent] = []
+
+    async def collect_events() -> None:
+        async for event in harness.run(
+            agent=agent,
+            conversation=conversation,
+            messages=[message],
+            ctx=ctx,
+            options=options,
+            agent_run_id=agent_run_id,
+        ):
+            events.append(event)
+
+    task = asyncio.create_task(collect_events())
+    await asyncio.sleep(0.01)
+    await queue.put(
+        AgentEvent(
+            type=AgentEventType.RECONNECTING,
+            data={"reason": "daemon_disconnected"},
+            agent_run_id=agent_run_id,
+        )
+    )
+    await asyncio.sleep(0.01)
+    await queue.put(
+        AgentEvent(type=AgentEventType.COMPLETED, data={}, agent_run_id=agent_run_id)
+    )
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert [event.type for event in events] == [
+        AgentEventType.STATUS,
+        AgentEventType.STATUS,
+        AgentEventType.COMPLETED,
+    ]
+    assert events[0].data["phase"] == "reconnecting"
+    assert events[1].data["phase"] == "reconnected"
+
+
+@pytest.mark.asyncio
+async def test_daemon_harness_fails_fast_when_reconnect_grace_expires(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        "app.modules.agent.infrastructure.harnesses.daemon.WorkspaceSandboxService",
+        _FakeWorkspaceSandboxService,
+    )
+    daemon_id = uuid4()
+    daemon_user_id = uuid4()
+    agent_run_id = uuid4()
+    queue: asyncio.Queue = asyncio.Queue()
+
+    async def _fake_start_run(**_kwargs):
+        return queue
+
+    async def _fake_finish_run(**_kwargs):
+        return None
+
+    monkeypatch.setattr(agent_runtime_daemon_hub, "start_run", _fake_start_run)
+    monkeypatch.setattr(agent_runtime_daemon_hub, "finish_run", _fake_finish_run)
+
+    agent, conversation, message, ctx, options = _build_minimal_run_args(
+        daemon_id=daemon_id, daemon_user_id=daemon_user_id, agent_run_id=agent_run_id
+    )
+    # event_timeout_seconds is deliberately much larger than reconnect_grace_seconds:
+    # the whole point of this test is proving the fast-fail path fires from the
+    # short grace deadline, not the (here, intentionally unreachable-in-test-time)
+    # long silence budget.
+    harness = DaemonHarness(
+        HarnessKind.CODEX, event_timeout_seconds=30.0, reconnect_grace_seconds=0.05
+    )
+
+    events: list[AgentEvent] = []
+
+    async def collect_events() -> None:
+        async for event in harness.run(
+            agent=agent,
+            conversation=conversation,
+            messages=[message],
+            ctx=ctx,
+            options=options,
+            agent_run_id=agent_run_id,
+        ):
+            events.append(event)
+
+    task = asyncio.create_task(collect_events())
+    await asyncio.sleep(0.01)
+    await queue.put(
+        AgentEvent(
+            type=AgentEventType.RECONNECTING,
+            data={"reason": "daemon_disconnected"},
+            agent_run_id=agent_run_id,
+        )
+    )
+    # Nothing else is ever put on the queue -- the grace period must expire on
+    # its own. Bounded well under event_timeout_seconds=30s.
+    await asyncio.wait_for(task, timeout=2.0)
+
+    assert [event.type for event in events] == [
+        AgentEventType.STATUS,
+        AgentEventType.ERROR,
+    ]
+    assert events[0].data["phase"] == "reconnecting"
+    assert "did not reconnect within the grace period" in events[1].data
+
+
+@pytest.mark.asyncio
+async def test_hub_unregister_pushes_reconnecting_and_preserves_queue():
+    hub = AgentRuntimeDaemonHub()
+    daemon_id = uuid4()
+    daemon_user_id = uuid4()
+    agent_run_id = uuid4()
+    websocket = _FakeWebSocket()
+
+    await hub.register(daemon_id=daemon_id, user_id=daemon_user_id, websocket=websocket)  # type: ignore[arg-type]
+    queue = await hub.start_run(
+        daemon_id=daemon_id,
+        user_id=daemon_user_id,
+        agent_run_id=agent_run_id,
+        payload={},
+    )
+
+    await hub.unregister(daemon_id=daemon_id, user_id=daemon_user_id)
+
+    event = queue.get_nowait()
+    assert event.type == AgentEventType.RECONNECTING
+    assert event.agent_run_id == agent_run_id
+    assert event.data["reason"] == "daemon_disconnected"
+    assert hub._orphaned_run_queues.get(agent_run_id) is queue
+
+
+@pytest.mark.asyncio
+async def test_hub_finish_run_clears_orphaned_queue():
+    hub = AgentRuntimeDaemonHub()
+    daemon_id = uuid4()
+    daemon_user_id = uuid4()
+    agent_run_id = uuid4()
+    websocket = _FakeWebSocket()
+
+    await hub.register(daemon_id=daemon_id, user_id=daemon_user_id, websocket=websocket)  # type: ignore[arg-type]
+    await hub.start_run(
+        daemon_id=daemon_id,
+        user_id=daemon_user_id,
+        agent_run_id=agent_run_id,
+        payload={},
+    )
+    await hub.unregister(daemon_id=daemon_id, user_id=daemon_user_id)
+    assert agent_run_id in hub._orphaned_run_queues
+
+    await hub.finish_run(
+        daemon_id=daemon_id, user_id=daemon_user_id, agent_run_id=agent_run_id
+    )
+
+    assert agent_run_id not in hub._orphaned_run_queues
+
+
+@pytest.mark.asyncio
+async def test_hub_register_supersedes_connection_orphans_old_runs():
+    hub = AgentRuntimeDaemonHub()
+    daemon_id = uuid4()
+    daemon_user_id = uuid4()
+    agent_run_id = uuid4()
+    old_websocket = _FakeWebSocket()
+    new_websocket = _FakeWebSocket()
+
+    await hub.register(daemon_id=daemon_id, user_id=daemon_user_id, websocket=old_websocket)  # type: ignore[arg-type]
+    queue = await hub.start_run(
+        daemon_id=daemon_id,
+        user_id=daemon_user_id,
+        agent_run_id=agent_run_id,
+        payload={},
+    )
+
+    # A second connection for the same daemon_id supersedes the first (e.g. the
+    # daemon reconnected before the backend noticed the old socket was dead) --
+    # the old connection's runs must be orphaned exactly like a clean
+    # unregister() would, not silently dropped.
+    await hub.register(daemon_id=daemon_id, user_id=daemon_user_id, websocket=new_websocket)  # type: ignore[arg-type]
+
+    event = queue.get_nowait()
+    assert event.type == AgentEventType.RECONNECTING
+    assert event.data["reason"] == "daemon_superseded"
+    assert hub._orphaned_run_queues.get(agent_run_id) is queue
+
+    await hub.unregister(daemon_id=daemon_id, user_id=daemon_user_id)
+
+
+@pytest.mark.asyncio
+async def test_hub_reattach_runs_relinks_orphaned_queue_to_new_connection():
+    hub = AgentRuntimeDaemonHub()
+    daemon_id = uuid4()
+    daemon_user_id = uuid4()
+    agent_run_id = uuid4()
+    old_websocket = _FakeWebSocket()
+    new_websocket = _FakeWebSocket()
+
+    await hub.register(daemon_id=daemon_id, user_id=daemon_user_id, websocket=old_websocket)  # type: ignore[arg-type]
+    queue = await hub.start_run(
+        daemon_id=daemon_id,
+        user_id=daemon_user_id,
+        agent_run_id=agent_run_id,
+        payload={},
+    )
+    await hub.unregister(daemon_id=daemon_id, user_id=daemon_user_id)
+    assert agent_run_id in hub._orphaned_run_queues
+
+    await hub.register(daemon_id=daemon_id, user_id=daemon_user_id, websocket=new_websocket)  # type: ignore[arg-type]
+    await hub.reattach_runs(
+        daemon_id=daemon_id, user_id=daemon_user_id, agent_run_ids=[agent_run_id]
+    )
+
+    # The SAME queue object is handed to the new connection -- a
+    # DaemonHarness.run() consumer still holding a reference to it (waiting
+    # out its reconnect grace) starts receiving events again transparently.
+    connection = hub._connections[daemon_id]
+    assert connection.run_queues.get(agent_run_id) is queue
+    assert agent_run_id not in hub._orphaned_run_queues
+
+    await hub.unregister(daemon_id=daemon_id, user_id=daemon_user_id)
+
+
+@pytest.mark.asyncio
+async def test_hub_reattach_runs_is_noop_for_unknown_run_id():
+    hub = AgentRuntimeDaemonHub()
+    daemon_id = uuid4()
+    daemon_user_id = uuid4()
+    websocket = _FakeWebSocket()
+
+    await hub.register(daemon_id=daemon_id, user_id=daemon_user_id, websocket=websocket)  # type: ignore[arg-type]
+
+    # No matching orphaned queue exists -- must not raise, must not create a
+    # spurious run_queues entry.
+    await hub.reattach_runs(daemon_id=daemon_id, user_id=daemon_user_id, agent_run_ids=[uuid4()])
+
+    connection = hub._connections[daemon_id]
+    assert connection.run_queues == {}
+
+    await hub.unregister(daemon_id=daemon_id, user_id=daemon_user_id)
+
+
+@pytest.mark.asyncio
+async def test_hub_reattach_runs_is_noop_when_daemon_not_connected():
+    hub = AgentRuntimeDaemonHub()
+    # No register() call at all -- reattach_runs must handle a daemon that
+    # isn't (or is no longer) connected without raising.
+    await hub.reattach_runs(
+        daemon_id=uuid4(), user_id=uuid4(), agent_run_ids=[uuid4()]
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_run_for_already_active_run_returns_existing_queue_without_resending():
+    hub = AgentRuntimeDaemonHub()
+    daemon_id = uuid4()
+    daemon_user_id = uuid4()
+    agent_run_id = uuid4()
+    websocket = _FakeWebSocket()
+
+    await hub.register(daemon_id=daemon_id, user_id=daemon_user_id, websocket=websocket)  # type: ignore[arg-type]
+    first_queue = await hub.start_run(
+        daemon_id=daemon_id, user_id=daemon_user_id, agent_run_id=agent_run_id, payload={}
+    )
+    assert len(websocket.sent) == 1
+
+    second_queue = await hub.start_run(
+        daemon_id=daemon_id, user_id=daemon_user_id, agent_run_id=agent_run_id, payload={}
+    )
+
+    assert second_queue is first_queue
+    # No second run.start was sent for the same agent_run_id.
+    assert len(websocket.sent) == 1
+
+    await hub.unregister(daemon_id=daemon_id, user_id=daemon_user_id)
+
+
+@pytest.mark.asyncio
+async def test_start_run_raises_when_daemon_at_capacity(monkeypatch):
+    import app.modules.agent.infrastructure.daemon_hub as daemon_hub_module
+
+    async def _fake_get_capacity(*, daemon_id):
+        del daemon_id
+        return {"active_run_count": 4, "max_concurrent_runs": 4}
+
+    monkeypatch.setattr(daemon_hub_module, "get_daemon_capacity", _fake_get_capacity)
+
+    hub = AgentRuntimeDaemonHub()
+    daemon_id = uuid4()
+    daemon_user_id = uuid4()
+    websocket = _FakeWebSocket()
+    await hub.register(daemon_id=daemon_id, user_id=daemon_user_id, websocket=websocket)  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError, match=r"at capacity \(4/4"):
+        await hub.start_run(
+            daemon_id=daemon_id, user_id=daemon_user_id, agent_run_id=uuid4(), payload={}
+        )
+
+    # The capacity check short-circuits before any dispatch attempt.
+    assert websocket.sent == []
+
+    await hub.unregister(daemon_id=daemon_id, user_id=daemon_user_id)
+
+
+@pytest.mark.asyncio
+async def test_start_run_proceeds_when_below_capacity(monkeypatch):
+    import app.modules.agent.infrastructure.daemon_hub as daemon_hub_module
+
+    async def _fake_get_capacity(*, daemon_id):
+        del daemon_id
+        return {"active_run_count": 1, "max_concurrent_runs": 4}
+
+    monkeypatch.setattr(daemon_hub_module, "get_daemon_capacity", _fake_get_capacity)
+
+    hub = AgentRuntimeDaemonHub()
+    daemon_id = uuid4()
+    daemon_user_id = uuid4()
+    websocket = _FakeWebSocket()
+    await hub.register(daemon_id=daemon_id, user_id=daemon_user_id, websocket=websocket)  # type: ignore[arg-type]
+
+    await hub.start_run(
+        daemon_id=daemon_id, user_id=daemon_user_id, agent_run_id=uuid4(), payload={}
+    )
+
+    assert len(websocket.sent) == 1
+
+    await hub.unregister(daemon_id=daemon_id, user_id=daemon_user_id)
+
+
+@pytest.mark.asyncio
+async def test_start_run_proceeds_when_capacity_unknown(monkeypatch):
+    """Fail-open: a daemon that hasn't reported capacity yet (fresh connection,
+    or an older CLI binary that predates this field) must never be treated as
+    blocked -- upgrading the backend must not brick daemons on an older
+    version that never sends `capacity` at all.
+    """
+    import app.modules.agent.infrastructure.daemon_hub as daemon_hub_module
+
+    async def _fake_get_capacity(*, daemon_id):
+        del daemon_id
+        return None
+
+    monkeypatch.setattr(daemon_hub_module, "get_daemon_capacity", _fake_get_capacity)
+
+    hub = AgentRuntimeDaemonHub()
+    daemon_id = uuid4()
+    daemon_user_id = uuid4()
+    websocket = _FakeWebSocket()
+    await hub.register(daemon_id=daemon_id, user_id=daemon_user_id, websocket=websocket)  # type: ignore[arg-type]
+
+    await hub.start_run(
+        daemon_id=daemon_id, user_id=daemon_user_id, agent_run_id=uuid4(), payload={}
+    )
+
+    assert len(websocket.sent) == 1
+
+    await hub.unregister(daemon_id=daemon_id, user_id=daemon_user_id)
+
+
+@pytest.mark.asyncio
+async def test_daemon_harness_treats_rejected_event_as_terminal(monkeypatch):
+    monkeypatch.setattr(
+        "app.modules.agent.infrastructure.harnesses.daemon.WorkspaceSandboxService",
+        _FakeWorkspaceSandboxService,
+    )
+    daemon_id = uuid4()
+    daemon_user_id = uuid4()
+    agent_run_id = uuid4()
+    queue: asyncio.Queue = asyncio.Queue()
+
+    async def _fake_start_run(**_kwargs):
+        return queue
+
+    async def _fake_finish_run(**_kwargs):
+        return None
+
+    monkeypatch.setattr(agent_runtime_daemon_hub, "start_run", _fake_start_run)
+    monkeypatch.setattr(agent_runtime_daemon_hub, "finish_run", _fake_finish_run)
+
+    agent, conversation, message, ctx, options = _build_minimal_run_args(
+        daemon_id=daemon_id, daemon_user_id=daemon_user_id, agent_run_id=agent_run_id
+    )
+    harness = DaemonHarness(HarnessKind.CODEX, event_timeout_seconds=2.0)
+
+    events: list[AgentEvent] = []
+
+    async def collect_events() -> None:
+        async for event in harness.run(
+            agent=agent,
+            conversation=conversation,
+            messages=[message],
+            ctx=ctx,
+            options=options,
+            agent_run_id=agent_run_id,
+        ):
+            events.append(event)
+
+    task = asyncio.create_task(collect_events())
+    await asyncio.sleep(0.01)
+    await queue.put(
+        AgentEvent(
+            type=AgentEventType.REJECTED,
+            data={
+                "reason": "daemon_at_capacity",
+                "active_run_count": 4,
+                "max_concurrent_runs": 4,
+            },
+            agent_run_id=agent_run_id,
+        )
+    )
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert [event.type for event in events] == [AgentEventType.REJECTED]

--- a/lemma-backend/app/modules/agent/tests/unit/test_daemon_websocket_route.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_daemon_websocket_route.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from uuid import uuid4
+
+import pytest
+
+from app.modules.agent.api.controllers.runtime_config_controller import (
+    _MutableMonotonic,
+    _close_if_ping_stale,
+    _reattach_agent_run_ids,
+    _store_capacity_if_present,
+)
+
+
+class _FakeWebSocket:
+    def __init__(self) -> None:
+        self.closed_with: dict | None = None
+
+    async def close(self, *, code=None, reason=None) -> None:
+        self.closed_with = {"code": code, "reason": reason}
+
+
+def test_reattach_agent_run_ids_parses_valid_entries():
+    run_id_1 = uuid4()
+    run_id_2 = uuid4()
+
+    result = _reattach_agent_run_ids(
+        [
+            {"agent_run_id": str(run_id_1), "buffered_event_count": 3, "overflowed": False},
+            {"agent_run_id": str(run_id_2), "buffered_event_count": 0, "overflowed": False},
+        ]
+    )
+
+    assert result == [run_id_1, run_id_2]
+
+
+def test_reattach_agent_run_ids_skips_malformed_entries():
+    run_id = uuid4()
+
+    result = _reattach_agent_run_ids(
+        [
+            {"agent_run_id": str(run_id)},
+            {"agent_run_id": "not-a-uuid"},
+            {"no_agent_run_id": "here"},
+            "not-even-a-dict",
+        ]
+    )
+
+    assert result == [run_id]
+
+
+def test_reattach_agent_run_ids_handles_non_list_input():
+    assert _reattach_agent_run_ids(None) == []
+    assert _reattach_agent_run_ids("garbage") == []
+    assert _reattach_agent_run_ids({}) == []
+
+
+@pytest.mark.asyncio
+async def test_close_if_ping_stale_closes_after_threshold(monkeypatch):
+    import app.modules.agent.api.controllers.runtime_config_controller as controller
+
+    # The reaper's poll interval is max(1.0, threshold/3) -- it can't fire
+    # faster than ~1s regardless of how small the threshold is, so the test
+    # timeout must clear that floor with margin.
+    monkeypatch.setattr(controller.settings, "daemon_ws_ping_stale_after_seconds", 0.03)
+    websocket = _FakeWebSocket()
+    last_ping = _MutableMonotonic()
+
+    await asyncio.wait_for(
+        _close_if_ping_stale(websocket, last_ping, daemon_id=uuid4()), timeout=2.0
+    )
+
+    assert websocket.closed_with is not None
+
+
+@pytest.mark.asyncio
+async def test_close_if_ping_stale_does_not_close_while_pings_keep_arriving(monkeypatch):
+    import app.modules.agent.api.controllers.runtime_config_controller as controller
+    import time
+
+    monkeypatch.setattr(controller.settings, "daemon_ws_ping_stale_after_seconds", 0.05)
+    websocket = _FakeWebSocket()
+    last_ping = _MutableMonotonic()
+
+    reaper = asyncio.create_task(_close_if_ping_stale(websocket, last_ping, daemon_id=uuid4()))
+    for _ in range(10):
+        await asyncio.sleep(0.02)
+        last_ping.value = time.monotonic()  # simulate a fresh daemon.ping arriving
+
+    reaper.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await reaper
+
+    assert websocket.closed_with is None
+
+
+@pytest.mark.asyncio
+async def test_store_capacity_if_present_stores_well_formed_payload(monkeypatch):
+    import app.modules.agent.api.controllers.runtime_config_controller as controller
+
+    stored = {}
+
+    async def _fake_set_capacity(*, daemon_id, active_run_count, max_concurrent_runs):
+        stored["daemon_id"] = daemon_id
+        stored["active_run_count"] = active_run_count
+        stored["max_concurrent_runs"] = max_concurrent_runs
+
+    monkeypatch.setattr(controller, "set_daemon_capacity", _fake_set_capacity)
+    daemon_id = uuid4()
+
+    await _store_capacity_if_present(
+        daemon_id, {"active_run_count": 2, "max_concurrent_runs": 4}
+    )
+
+    assert stored == {"daemon_id": daemon_id, "active_run_count": 2, "max_concurrent_runs": 4}
+
+
+@pytest.mark.asyncio
+async def test_store_capacity_if_present_ignores_malformed_payload(monkeypatch):
+    import app.modules.agent.api.controllers.runtime_config_controller as controller
+
+    calls = []
+
+    async def _fake_set_capacity(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(controller, "set_daemon_capacity", _fake_set_capacity)
+
+    await _store_capacity_if_present(uuid4(), None)
+    await _store_capacity_if_present(uuid4(), "not-a-dict")
+    await _store_capacity_if_present(uuid4(), {"active_run_count": "two", "max_concurrent_runs": 4})
+    await _store_capacity_if_present(uuid4(), {"active_run_count": 2})
+
+    assert calls == []

--- a/lemma-backend/app/modules/agent/tools/user_interaction/models.py
+++ b/lemma-backend/app/modules/agent/tools/user_interaction/models.py
@@ -107,17 +107,20 @@ def validate_display_payload(request: "DisplayResourceRequest") -> str | None:
     by both the model and the frontend) instead of a retry / validation error.
     """
     if request.type == DisplayResourceType.BROWSER:
-        if any(
-            value is not None
-            for value in (
-                request.name,
-                request.path,
-                request.public_url,
-                request.content,
-                request.filters,
-                request.query,
+        if (
+            any(
+                value is not None
+                for value in (
+                    request.name,
+                    request.path,
+                    request.public_url,
+                    request.content,
+                    request.filters,
+                    request.query,
+                )
             )
-        ) or request.loading_messages:
+            or request.loading_messages
+        ):
             return "BROWSER resources only accept type."
         return None
 
@@ -148,10 +151,7 @@ def validate_display_payload(request: "DisplayResourceRequest") -> str | None:
             for value in (request.public_url, request.content)
         )
         if payload_count != 1:
-            return (
-                "WIDGET resources must provide exactly one of public_url or "
-                "content."
-            )
+            return "WIDGET resources must provide exactly one of public_url or content."
 
     if request.type != DisplayResourceType.TABLE and (
         request.filters is not None or request.query is not None

--- a/lemma-backend/app/modules/agent_surfaces/services/progress_observer.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/progress_observer.py
@@ -118,7 +118,7 @@ class SurfaceAgentRunProgressObserver:
         ctx: ConversationContext,
     ) -> None:
         del ctx
-        if event.type == AgentEventType.ERROR:
+        if event.type in {AgentEventType.ERROR, AgentEventType.REJECTED}:
             self._run_errored = True
             return
 

--- a/lemma-cli/lemma_cli/cli_core/commands/daemon.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/daemon.py
@@ -29,6 +29,8 @@ from lemma_cli.daemon.runner import (
     _prompt_text_preview,
     _strip_prompt_echo_from_stdout,
     _stop_active_run,
+    _RunEventSink,
+    _HeldRun,
 )
 
 # ── Logging helpers ───────────────────────────────────────────────────────────
@@ -141,6 +143,8 @@ __all__ = [
     "_prompt_text_preview",
     "_strip_prompt_echo_from_stdout",
     "_stop_active_run",
+    "_RunEventSink",
+    "_HeldRun",
     # logging
     "_daemon_log",
     "_set_daemon_debug",

--- a/lemma-cli/lemma_cli/daemon/commands.py
+++ b/lemma-cli/lemma_cli/daemon/commands.py
@@ -90,7 +90,7 @@ def start_daemon(
 
     from lemma_sdk.config import resolve_base_url, resolve_token, resolve_verify_ssl  # noqa: PLC0415
 
-    from .runner import run_daemon  # noqa: PLC0415
+    from .runner import run_daemon_with_graceful_shutdown  # noqa: PLC0415
 
     resolved_base_url = resolve_base_url(
         state.base_url, state.config, use_env=state.server_source == "env",
@@ -98,7 +98,7 @@ def start_daemon(
     write_daemon_status(os.getpid(), base_url=resolved_base_url, server=state.server)
     try:
         asyncio.run(
-            run_daemon(
+            run_daemon_with_graceful_shutdown(
                 base_url=resolved_base_url,
                 token=resolve_token(
                     state.token,

--- a/lemma-cli/lemma_cli/daemon/config.py
+++ b/lemma-cli/lemma_cli/daemon/config.py
@@ -14,6 +14,24 @@ DAEMON_CONFIG_PATH = DAEMON_DIR / "config.json"
 DAEMON_PID_PATH = DAEMON_DIR / "daemon.pid"
 DAEMON_LOG_PATH = DAEMON_DIR / "logs" / "daemon.log"
 
+# Admission-control cap on concurrent runs -- defined here (not alongside the
+# other daemon tunables in runner.py) so ensure_config() can lazy-fill it into
+# the persisted config without a circular import (runner.py already imports
+# from this module). The persisted value is for discoverability only; the
+# actual enforcement in runner.py always reads the env var fresh via this
+# function, so an env var change takes effect on the next daemon start without
+# needing to edit config.json.
+MAX_CONCURRENT_RUNS_ENV = "LEMMA_DAEMON_MAX_CONCURRENT_RUNS"
+DEFAULT_MAX_CONCURRENT_RUNS = 4
+
+
+def max_concurrent_runs() -> int:
+    raw = os.getenv(MAX_CONCURRENT_RUNS_ENV, str(DEFAULT_MAX_CONCURRENT_RUNS))
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return DEFAULT_MAX_CONCURRENT_RUNS
+
 
 def ensure_config() -> dict:
     DAEMON_DIR.mkdir(parents=True, exist_ok=True)
@@ -22,6 +40,8 @@ def ensure_config() -> dict:
         config["device_key"] = str(uuid4())
     if not config.get("display_name"):
         config["display_name"] = socket.gethostname()
+    if not config.get("max_concurrent_runs"):
+        config["max_concurrent_runs"] = max_concurrent_runs()
     save_config(config)
     return config
 

--- a/lemma-cli/lemma_cli/daemon/harnesses/codex.py
+++ b/lemma-cli/lemma_cli/daemon/harnesses/codex.py
@@ -30,6 +30,23 @@ CODEX_WORKER_TTL_SECONDS_ENV = "LEMMA_DAEMON_CODEX_WORKER_TTL_SECONDS"
 DAEMON_TURN_TIMEOUT_SECONDS_ENV = "LEMMA_DAEMON_TURN_TIMEOUT_SECONDS"
 DEFAULT_DAEMON_TURN_TIMEOUT_SECONDS = 7200.0
 DEFAULT_CODEX_WORKER_TTL_SECONDS = DEFAULT_DAEMON_TURN_TIMEOUT_SECONDS
+# Bounds how many distinct conversations can have a live codex app-server
+# subprocess at once. Unlike the daemon-wide run cap (runner.py's
+# max_concurrent_runs, admission-control/reject), this one QUEUES a new
+# conversation's first turn when full rather than rejecting it: an unrelated
+# stale-but-still-warm conversation shouldn't fail a brand new one on a
+# single-user laptop with no peers to redistribute to, and the daemon-wide cap
+# already bounds total exposure.
+CODEX_POOL_MAX_WORKERS_ENV = "LEMMA_DAEMON_CODEX_POOL_MAX_WORKERS"
+DEFAULT_CODEX_POOL_MAX_WORKERS = 4
+
+
+def codex_pool_max_workers() -> int:
+    raw = os.getenv(CODEX_POOL_MAX_WORKERS_ENV, str(DEFAULT_CODEX_POOL_MAX_WORKERS))
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return DEFAULT_CODEX_POOL_MAX_WORKERS
 
 
 class JsonRpcRequestError(RuntimeError):
@@ -287,12 +304,19 @@ class CodexWorker:
 
 
 class CodexWorkerPool:
-    """Manages a pool of CodexWorkers with TTL-based idle cleanup."""
+    """Manages a pool of CodexWorkers with TTL-based idle cleanup.
+
+    Bounded by ``codex_pool_max_workers()``: acquiring a semaphore slot is
+    required only to *create* a new worker, never to reuse an existing one for
+    an already-pooled conversation, so a single conversation's turns never
+    block on the pool being "full" of itself.
+    """
 
     def __init__(self) -> None:
         self._workers: dict[str, CodexWorker] = {}
         self._ttl_tasks: dict[str, asyncio.Task[None]] = {}
         self._lock = asyncio.Lock()
+        self._slots = asyncio.Semaphore(codex_pool_max_workers())
 
     async def run(
         self,
@@ -345,20 +369,37 @@ class CodexWorkerPool:
             if task is not None:
                 task.cancel()
             worker = self._workers.get(conversation_id)
-            if worker is None:
-                worker = CodexWorker(conversation_id=conversation_id)
-                self._workers[conversation_id] = worker
+            if worker is not None:
+                return worker  # existing conversation -- no new slot needed
+        # New conversation: acquire a pool slot. This await is what makes a
+        # full pool queue a new conversation's first turn rather than reject
+        # it -- it simply waits here until a slot frees.
+        await self._slots.acquire()
+        async with self._lock:
+            worker = self._workers.get(conversation_id)
+            if worker is not None:
+                # Lost the race to a concurrent call for the same
+                # conversation_id while waiting on the semaphore -- release
+                # the slot we don't need and reuse the winner's worker.
+                self._slots.release()
+                return worker
+            worker = CodexWorker(conversation_id=conversation_id)
+            self._workers[conversation_id] = worker
             return worker
 
     async def _retire_worker(self, conversation_id: str, worker: CodexWorker) -> None:
+        removed = False
         async with self._lock:
             current = self._workers.get(conversation_id)
             if current is worker:
                 self._workers.pop(conversation_id, None)
+                removed = True
             task = self._ttl_tasks.pop(conversation_id, None)
             if task is not None:
                 task.cancel()
         await worker.close()
+        if removed:
+            self._slots.release()
 
     def _schedule_idle_close(self, conversation_id: str, worker: CodexWorker) -> None:
         existing = self._ttl_tasks.pop(conversation_id, None)
@@ -378,10 +419,13 @@ class CodexWorkerPool:
         async with self._lock:
             current = self._workers.get(conversation_id)
             if current is not worker or worker.last_used_at != last_used_at:
+                # Reused since this close was scheduled -- the worker is still
+                # live and its slot still legitimately held; do not release.
                 return
             self._workers.pop(conversation_id, None)
             self._ttl_tasks.pop(conversation_id, None)
         await worker.close()
+        self._slots.release()
 
 
 _CODEX_APP_SERVER_POOL = CodexWorkerPool()

--- a/lemma-cli/lemma_cli/daemon/runner.py
+++ b/lemma-cli/lemma_cli/daemon/runner.py
@@ -286,9 +286,47 @@ async def run_daemon(
         reaper_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await reaper_task
-        for held in held_runs.values():
-            if not held.task.done():
-                held.task.cancel()
+        pending = [held.task for held in held_runs.values() if not held.task.done()]
+        for task in pending:
+            task.cancel()
+        if pending:
+            # Await, not just request, cancellation -- each task's own
+            # CancelledError handler (harness-specific, e.g. claude_code.py's
+            # terminate_gracefully) is what actually tears down its
+            # subprocess. Returning before that finishes would let
+            # run_daemon() exit (and the process die, if this is on the
+            # graceful-shutdown path) while a provider subprocess is still
+            # orphaned mid-teardown.
+            await asyncio.gather(*pending, return_exceptions=True)
+
+
+async def run_daemon_with_graceful_shutdown(**kwargs: Any) -> None:
+    """Run ``run_daemon`` with SIGTERM/SIGINT cancelling it instead of killing
+    the process outright.
+
+    With no signal handler installed, the interpreter's default SIGTERM
+    behavior tears the process down immediately -- none of ``run_daemon``'s
+    own cleanup (terminating active/held provider subprocesses) gets a
+    chance to run, orphaning them. `lemma daemon stop` and a plain `kill`
+    both send SIGTERM; this makes both paths shut down the same way a
+    reconnect-triggered hold/cancel already does.
+    """
+    import signal
+
+    loop = asyncio.get_running_loop()
+    task = asyncio.ensure_future(run_daemon(**kwargs))
+
+    def _request_shutdown(sig_name: str) -> None:
+        daemon_log("received shutdown signal; stopping gracefully", {"signal": sig_name})
+        task.cancel()
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        with contextlib.suppress(NotImplementedError):
+            # Not implemented on Windows -- falls back to default handling there.
+            loop.add_signal_handler(sig, _request_shutdown, sig.name)
+
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
 
 
 def _capacity_payload(active_run_count: int) -> dict[str, int]:

--- a/lemma-cli/lemma_cli/daemon/runner.py
+++ b/lemma-cli/lemma_cli/daemon/runner.py
@@ -101,9 +101,25 @@ class _RunEventSink:
         self._buffer: collections.deque[dict[str, Any]] | None = None
         self.overflowed = False
 
-    def go_buffered(self, buffer: "collections.deque[dict[str, Any]]") -> None:
+    def go_buffered(
+        self, buffer: "collections.deque[dict[str, Any]]"
+    ) -> "collections.deque[dict[str, Any]]":
+        """Switch to buffered mode; returns the buffer actually in use.
+
+        If a live send already failed and self-buffered (see ``__call__``),
+        that buffer -- and whatever it already accumulated while this daemon
+        process couldn't run _serve_connection's own disconnect handling
+        (e.g. it was SIGSTOP-frozen when the peer closed the socket) -- is
+        kept as-is; the freshly allocated ``buffer`` argument is only used if
+        this sink was still live. Callers must use the returned buffer (not
+        necessarily the one passed in) for anything that reads buffered
+        events later (e.g. a _HeldRun's own ``buffer`` field).
+        """
+        if self._buffer is not None:
+            return self._buffer
         self._buffer = buffer
         self.overflowed = False
+        return self._buffer
 
     def go_live(self, websocket: Any, send_lock: asyncio.Lock) -> None:
         self._websocket = websocket
@@ -116,9 +132,30 @@ class _RunEventSink:
                 self.overflowed = True
             self._buffer.append({"type": event_type, "data": data})
             return
-        await send_run_event(
-            self._websocket, self._agent_run_id, event_type, data, lock=self._send_lock
-        )
+        try:
+            await send_run_event(
+                self._websocket,
+                self._agent_run_id,
+                event_type,
+                data,
+                lock=self._send_lock,
+                reraise=True,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 - transport guard
+            # The live send failed -- most likely the peer closed the socket
+            # while this daemon process was itself unresponsive (SIGSTOP),
+            # so _serve_connection's own disconnect handling never got a
+            # chance to redirect this sink to buffered mode first. Buffer
+            # this event now rather than losing it; _serve_connection's
+            # later disconnect handling reuses this same buffer via
+            # go_buffered() instead of overwriting it with an empty one.
+            if self._buffer is None:
+                self._buffer = collections.deque(maxlen=max_buffered_events_per_run())
+            if len(self._buffer) == self._buffer.maxlen:
+                self.overflowed = True
+            self._buffer.append({"type": event_type, "data": data})
 
 
 @dataclass
@@ -564,10 +601,10 @@ async def _serve_connection(
                 # cancel-on-disconnect behavior rather than holding it blind.
                 task.cancel()
                 continue
-            buffer: "collections.deque[dict[str, Any]]" = collections.deque(
+            fresh_buffer: "collections.deque[dict[str, Any]]" = collections.deque(
                 maxlen=max_buffered_events_per_run()
             )
-            sink.go_buffered(buffer)
+            buffer = sink.go_buffered(fresh_buffer)
             held_runs[agent_run_id] = _HeldRun(
                 task=task, sink=sink, buffer=buffer, disconnected_at=disconnected_at
             )
@@ -747,6 +784,7 @@ async def send_run_event(
     data: Any,
     *,
     lock: asyncio.Lock | None = None,
+    reraise: bool = False,
 ) -> None:
     daemon_log("send run event", {"agent_run_id": agent_run_id, "event_type": event_type, "data": data})
     await _send_json(
@@ -757,6 +795,7 @@ async def send_run_event(
             "event": {"type": event_type, "data": data},
         },
         lock=lock,
+        reraise=reraise,
     )
 
 
@@ -765,11 +804,21 @@ async def _send_json(
     payload: dict[str, Any],
     *,
     lock: asyncio.Lock | None = None,
+    reraise: bool = False,
 ) -> None:
-    """Send a JSON message, tolerating a dropped socket.
+    """Send a JSON message, by default tolerating a dropped socket.
 
     A failed send (e.g. the connection dropped mid-run) must not crash the daemon —
     the reconnect loop re-establishes the connection; the dropped event is logged.
+    This is the right default for fire-and-forget sends (heartbeat pings,
+    handshake messages) with no buffering fallback available.
+
+    ``reraise=True`` lets a caller that DOES have a buffering fallback (a run's
+    ``_RunEventSink``) find out the send failed instead of the event being
+    silently lost -- this matters specifically because ``_serve_connection``'s
+    own disconnect handling (which normally redirects a sink to buffered mode)
+    can't run at all while the daemon process itself is unresponsive (e.g.
+    SIGSTOP) at the moment the peer closes the socket.
 
     ``lock`` serializes concurrent senders on one websocket (the heartbeat task
     and N run tasks can all be sending at once) — ``websockets``' ``send()`` is
@@ -785,9 +834,11 @@ async def _send_json(
         raise
     except Exception as exc:  # noqa: BLE001 - transport guard
         daemon_log(
-            "websocket send failed; dropping message",
-            {"type": payload.get("type"), "error": str(exc)},
+            "websocket send failed",
+            {"type": payload.get("type"), "error": str(exc), "reraise": reraise},
         )
+        if reraise:
+            raise
 
 
 def _prompt_parts(

--- a/lemma-cli/lemma_cli/daemon/runner.py
+++ b/lemma-cli/lemma_cli/daemon/runner.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
 import asyncio
+import collections
 import contextlib
 import json
+import os
 import random
+import time
+from dataclasses import dataclass
 from typing import Any, Callable
 
 from ._logging import log as daemon_log, preview as _preview, redact as _redact
 from ._utils import bounded_error_detail
 from .catalog import discover_harness_catalog
-from .config import ensure_config, save_config, daemon_ws_url, device_info
+from .config import ensure_config, save_config, daemon_ws_url, device_info, max_concurrent_runs
 from .harnesses.registry import get_harness
 from .mcp import (
     payload_with_reachable_mcp_urls,
@@ -23,6 +27,133 @@ from .mcp import (
 # backoff, capped, to avoid hammering the server on a sustained outage.
 _RECONNECT_BASE_DELAY_SECONDS = 1.0
 _RECONNECT_MAX_DELAY_SECONDS = 30.0
+
+# App-level heartbeat: sent on its own asyncio task, independent of run-handling
+# tasks, so a busy/slow run can never delay it. This is the primary liveness
+# signal (the low-level websockets ping/pong stays at library defaults as a
+# coarser secondary safety net) because it's the only one that can distinguish
+# "connection is actually dead" from "the daemon process is just busy."
+_PING_INTERVAL_SECONDS_ENV = "LEMMA_DAEMON_PING_INTERVAL_SECONDS"
+_DEFAULT_PING_INTERVAL_SECONDS = 15.0
+_PONG_MISS_LIMIT_ENV = "LEMMA_DAEMON_PONG_MISS_LIMIT"
+_DEFAULT_PONG_MISS_LIMIT = 3
+
+
+def ping_interval_seconds() -> float:
+    raw = os.getenv(_PING_INTERVAL_SECONDS_ENV, str(_DEFAULT_PING_INTERVAL_SECONDS))
+    try:
+        return max(1.0, float(raw))
+    except ValueError:
+        return _DEFAULT_PING_INTERVAL_SECONDS
+
+
+def pong_miss_limit() -> int:
+    raw = os.getenv(_PONG_MISS_LIMIT_ENV, str(_DEFAULT_PONG_MISS_LIMIT))
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return _DEFAULT_PONG_MISS_LIMIT
+
+
+# Hold-not-kill: a transport drop must not kill an in-flight run's subprocess --
+# it's an independent OS process that keeps running regardless of the
+# websocket. Its events are buffered locally and flushed once a new connection
+# reattaches; if nothing reattaches within the grace window, the daemon gives
+# up and terminates the subprocess itself (bounds resource use on an abandoned
+# laptop). Kept >= the backend's own reconnect grace (daemon_reconnect_grace_seconds,
+# default 120s) so the daemon never kills a run the backend might still reattach to.
+_HOLD_GRACE_SECONDS_ENV = "LEMMA_DAEMON_HOLD_GRACE_SECONDS"
+_DEFAULT_HOLD_GRACE_SECONDS = 150.0
+_MAX_BUFFERED_EVENTS_ENV = "LEMMA_DAEMON_MAX_BUFFERED_EVENTS"
+_DEFAULT_MAX_BUFFERED_EVENTS = 2000
+
+
+def hold_grace_seconds() -> float:
+    raw = os.getenv(_HOLD_GRACE_SECONDS_ENV, str(_DEFAULT_HOLD_GRACE_SECONDS))
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return _DEFAULT_HOLD_GRACE_SECONDS
+
+
+def max_buffered_events_per_run() -> int:
+    raw = os.getenv(_MAX_BUFFERED_EVENTS_ENV, str(_DEFAULT_MAX_BUFFERED_EVENTS))
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return _DEFAULT_MAX_BUFFERED_EVENTS
+
+
+class _RunEventSink:
+    """Indirection for where a run's events go: a live websocket, or a capped
+    local buffer while the connection is down.
+
+    Letting this be redirected in place (instead of threading a fresh closure
+    through a fresh task) is what lets a held run's subprocess keep running
+    across a disconnect without being restarted -- only its event destination
+    changes.
+    """
+
+    def __init__(self, websocket: Any, agent_run_id: str, send_lock: asyncio.Lock) -> None:
+        self._websocket = websocket
+        self._agent_run_id = agent_run_id
+        self._send_lock = send_lock
+        self._buffer: collections.deque[dict[str, Any]] | None = None
+        self.overflowed = False
+
+    def go_buffered(self, buffer: "collections.deque[dict[str, Any]]") -> None:
+        self._buffer = buffer
+        self.overflowed = False
+
+    def go_live(self, websocket: Any, send_lock: asyncio.Lock) -> None:
+        self._websocket = websocket
+        self._send_lock = send_lock
+        self._buffer = None
+
+    async def __call__(self, event_type: str, data: Any) -> None:
+        if self._buffer is not None:
+            if len(self._buffer) == self._buffer.maxlen:
+                self.overflowed = True
+            self._buffer.append({"type": event_type, "data": data})
+            return
+        await send_run_event(
+            self._websocket, self._agent_run_id, event_type, data, lock=self._send_lock
+        )
+
+
+@dataclass
+class _HeldRun:
+    task: "asyncio.Task[None]"
+    sink: _RunEventSink
+    buffer: "collections.deque[dict[str, Any]]"
+    disconnected_at: float
+
+
+_HELD_RUN_REAP_POLL_INTERVAL_SECONDS = 5.0
+
+
+async def _reap_expired_held_runs(held_runs: dict[str, _HeldRun]) -> None:
+    """Terminate a held run's subprocess once nothing reattaches in time.
+
+    Runs for the daemon's whole lifetime (a sibling to the reconnect loop, not
+    scoped to one connection) since a held run must stay watched across
+    however many failed reconnect attempts happen before the grace window
+    elapses.
+    """
+    while True:
+        await asyncio.sleep(_HELD_RUN_REAP_POLL_INTERVAL_SECONDS)
+        grace = hold_grace_seconds()
+        now = time.monotonic()
+        for agent_run_id, held in list(held_runs.items()):
+            if now - held.disconnected_at < grace:
+                continue
+            daemon_log(
+                "hold grace period expired; terminating held run",
+                {"agent_run_id": agent_run_id},
+            )
+            if not held.task.done():
+                held.task.cancel()
+            held_runs.pop(agent_run_id, None)
 
 
 def reconnect_delay_seconds(attempt: int) -> float:
@@ -98,49 +229,117 @@ async def run_daemon(
                 ssl=ssl_option,
             )
 
-    # `backoff_attempt` grows the delay while we can't stay connected and resets
-    # once a connection is established; `reconnects` is a monotonic count of
-    # reconnect cycles used only to bound the loop in tests.
-    backoff_attempt = 0
-    reconnects = 0
-    while True:
-        current_token = token_provider() if token_provider is not None else token
-        daemon_log("connecting websocket", {"url": ws_url, "attempt": backoff_attempt})
-        try:
-            async with connect_factory(current_token) as websocket:
-                backoff_attempt = 0  # reset backoff once we're connected
-                await _serve_connection(
-                    websocket,
-                    config=config,
-                    catalog=catalog,
-                    base_url=base_url,
-                )
-            # _serve_connection returned: the server closed the socket cleanly.
-            daemon_log("websocket closed; reconnecting", {})
-        except asyncio.CancelledError:
-            raise
-        except InvalidStatus as exc:
-            status_code = getattr(getattr(exc, "response", None), "status_code", None)
-            if status_code in {401, 403}:
-                import click
-                raise click.ClickException(
-                    "Daemon websocket authentication failed. Run `lemma auth login` and try again."
-                ) from exc
-            daemon_log("websocket rejected; will retry", {"status": status_code})
-        except (OSError, WebSocketException) as exc:
-            daemon_log("websocket connection error; will retry", {"error": str(exc)})
+    # `held_runs` survives across reconnects (unlike `_serve_connection`'s local
+    # `active_runs`, which is fresh per connection) -- it's how a run's
+    # subprocess keeps running, buffering its events, while the daemon is
+    # between connections. The reaper is a sibling task for the daemon's whole
+    # lifetime so a held run stays watched across however many reconnect
+    # attempts happen before its grace window elapses.
+    held_runs: dict[str, _HeldRun] = {}
+    reaper_task = asyncio.create_task(_reap_expired_held_runs(held_runs))
+    try:
+        # `backoff_attempt` grows the delay while we can't stay connected and resets
+        # once a connection is established; `reconnects` is a monotonic count of
+        # reconnect cycles used only to bound the loop in tests.
+        backoff_attempt = 0
+        reconnects = 0
+        while True:
+            current_token = token_provider() if token_provider is not None else token
+            daemon_log("connecting websocket", {"url": ws_url, "attempt": backoff_attempt})
+            try:
+                async with connect_factory(current_token) as websocket:
+                    backoff_attempt = 0  # reset backoff once we're connected
+                    await _serve_connection(
+                        websocket,
+                        config=config,
+                        catalog=catalog,
+                        base_url=base_url,
+                        held_runs=held_runs,
+                    )
+                # _serve_connection returned: the server closed the socket cleanly.
+                daemon_log("websocket closed; reconnecting", {})
+            except asyncio.CancelledError:
+                raise
+            except InvalidStatus as exc:
+                status_code = getattr(getattr(exc, "response", None), "status_code", None)
+                if status_code in {401, 403}:
+                    import click
+                    raise click.ClickException(
+                        "Daemon websocket authentication failed. Run `lemma auth login` and try again."
+                    ) from exc
+                daemon_log("websocket rejected; will retry", {"status": status_code})
+            except (OSError, WebSocketException) as exc:
+                daemon_log("websocket connection error; will retry", {"error": str(exc)})
 
-        reconnects += 1
-        if max_reconnect_attempts is not None and reconnects > max_reconnect_attempts:
-            daemon_log("giving up reconnect", {"reconnects": reconnects})
-            return
-        delay = reconnect_delay_seconds(backoff_attempt)
-        backoff_attempt += 1
-        daemon_log(
-            "reconnecting after backoff",
-            {"delay_seconds": round(delay, 2), "reconnects": reconnects},
+            reconnects += 1
+            if max_reconnect_attempts is not None and reconnects > max_reconnect_attempts:
+                daemon_log("giving up reconnect", {"reconnects": reconnects})
+                return
+            delay = reconnect_delay_seconds(backoff_attempt)
+            backoff_attempt += 1
+            daemon_log(
+                "reconnecting after backoff",
+                {"delay_seconds": round(delay, 2), "reconnects": reconnects},
+            )
+            await asyncio.sleep(delay)
+    finally:
+        reaper_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await reaper_task
+        for held in held_runs.values():
+            if not held.task.done():
+                held.task.cancel()
+
+
+def _capacity_payload(active_run_count: int) -> dict[str, int]:
+    return {
+        "max_concurrent_runs": max_concurrent_runs(),
+        "active_run_count": active_run_count,
+    }
+
+
+async def _heartbeat_loop(
+    websocket: Any,
+    *,
+    send_lock: asyncio.Lock,
+    pong_seen: asyncio.Event,
+    active_runs: dict[str, Any],
+) -> None:
+    """Send ``daemon.ping`` on its own task, independent of run-handling tasks.
+
+    A busy/slow run task must never delay this — that decoupling is the actual
+    fix for connections dying under load. Detects a dead peer by counting
+    consecutive un-answered pings and closes the socket itself; that closure
+    unblocks ``_serve_connection``'s ``async for`` message loop via the normal
+    ``ConnectionClosed`` path, so no restructuring of that loop is needed.
+
+    Also carries the daemon's live capacity (``active_run_count`` /
+    ``max_concurrent_runs``) on every ping -- this is the most frequent signal
+    the backend gets, so it's the natural carrier for a fact that can change
+    every few seconds as runs start/finish.
+    """
+    interval = ping_interval_seconds()
+    limit = pong_miss_limit()
+    misses = 0
+    while True:
+        await asyncio.sleep(interval)
+        pong_seen.clear()
+        await _send_json(
+            websocket,
+            {"type": "daemon.ping", "payload": {"capacity": _capacity_payload(len(active_runs))}},
+            lock=send_lock,
         )
-        await asyncio.sleep(delay)
+        try:
+            await asyncio.wait_for(pong_seen.wait(), timeout=interval)
+            misses = 0
+        except asyncio.TimeoutError:
+            misses += 1
+            daemon_log("daemon.pong missed", {"misses": misses, "limit": limit})
+            if misses >= limit:
+                daemon_log("heartbeat stale; closing connection", {"misses": misses})
+                with contextlib.suppress(Exception):
+                    await websocket.close()
+                return
 
 
 async def _serve_connection(
@@ -149,12 +348,29 @@ async def _serve_connection(
     config: dict[str, Any],
     catalog: Any,
     base_url: str,
+    held_runs: dict[str, _HeldRun],
 ) -> None:
     """Run the ready handshake + message loop until the connection closes.
 
-    In-flight run tasks are cancelled when the connection drops so they don't leak
-    across reconnects.
+    In-flight run tasks are NOT cancelled when the connection drops -- their
+    subprocesses are independent OS processes that keep running regardless of
+    the websocket. Each is moved into ``held_runs`` with its event sink
+    redirected to a local buffer, then reattached (buffered events flushed,
+    sink pointed live again) the next time a connection comes up. Only the
+    daemon-wide reaper (``_reap_expired_held_runs``) or an explicit
+    ``run.stop`` actually terminates a run's subprocess.
     """
+    send_lock = asyncio.Lock()
+
+    reattach_runs = [
+        {
+            "agent_run_id": agent_run_id,
+            "buffered_event_count": len(held.buffer),
+            "overflowed": held.sink.overflowed,
+        }
+        for agent_run_id, held in held_runs.items()
+        if not held.task.done()
+    ]
     await _send_json(
         websocket,
         {
@@ -165,11 +381,52 @@ async def _serve_connection(
                 or __import__("socket").gethostname(),
                 "device_info": device_info(),
                 "harness_catalog": catalog,
+                "reattach_runs": reattach_runs,
+                # Runs about to be reattached (below) already count against
+                # capacity even though they haven't been re-added to
+                # active_runs yet at this point in the handshake.
+                "capacity": _capacity_payload(len(reattach_runs)),
             },
         },
+        lock=send_lock,
     )
-    daemon_log("connected; waiting for runs", {"catalog": catalog})
+    daemon_log(
+        "connected; waiting for runs",
+        {"catalog": catalog, "reattached": len(reattach_runs)},
+    )
+
     active_runs: dict[str, asyncio.Task[None]] = {}
+    active_sinks: dict[str, _RunEventSink] = {}
+
+    # Reattach: flush each held run's buffered events (oldest first) over the
+    # new connection, THEN point its sink live -- in that order, so buffered
+    # history can never race ahead of (or behind) events emitted after
+    # reattachment.
+    for agent_run_id, held in list(held_runs.items()):
+        held_runs.pop(agent_run_id, None)
+        if held.task.done():
+            continue
+        for buffered in list(held.buffer):
+            await send_run_event(
+                websocket, agent_run_id, buffered["type"], buffered["data"], lock=send_lock
+            )
+        held.buffer.clear()
+        held.sink.go_live(websocket, send_lock)
+        active_runs[agent_run_id] = held.task
+        active_sinks[agent_run_id] = held.sink
+
+        def _on_reattached_run_done(_task: Any, run_id: str = agent_run_id) -> None:
+            active_runs.pop(run_id, None)
+            active_sinks.pop(run_id, None)
+
+        held.task.add_done_callback(_on_reattached_run_done)
+
+    pong_seen = asyncio.Event()
+    heartbeat_task = asyncio.create_task(
+        _heartbeat_loop(
+            websocket, send_lock=send_lock, pong_seen=pong_seen, active_runs=active_runs
+        )
+    )
     try:
         async for raw_message in websocket:
             message = json.loads(raw_message)
@@ -180,22 +437,69 @@ async def _serve_connection(
                 save_config(config)
                 daemon_log("ready ack", {"daemon_id": config["daemon_id"]})
                 continue
+            if message_type == "daemon.pong":
+                pong_seen.set()
+                continue
             if message_type == "catalog.refresh":
                 catalog = discover_harness_catalog()
                 await _send_json(
-                    websocket, {"type": "daemon.catalog", "payload": catalog}
+                    websocket,
+                    {
+                        "type": "daemon.catalog",
+                        "payload": catalog,
+                        "capacity": _capacity_payload(len(active_runs)),
+                    },
+                    lock=send_lock,
                 )
                 daemon_log("catalog refreshed", catalog)
                 continue
             if message_type == "run.start":
                 agent_run_id = str(message.get("agent_run_id") or "")
+                if agent_run_id in active_runs:
+                    # Redelivered run.start for a run already in flight (e.g. a
+                    # race during reconnect) -- ack, don't spawn a second
+                    # subprocess for the same id.
+                    daemon_log(
+                        "duplicate run.start ignored", {"agent_run_id": agent_run_id}
+                    )
+                    continue
+                cap = max_concurrent_runs()
+                if len(active_runs) >= cap:
+                    # Explicit, immediate rejection -- not a silent queue.
+                    # Queuing here would look identical, from the backend's
+                    # DaemonHarness.run() side, to a run that's legitimately
+                    # just slow to emit its first event, and both would sit
+                    # silently until event_timeout_seconds (2h) eventually
+                    # fired. Rejecting up front also means this run never
+                    # starts a timeout clock at all.
+                    daemon_log(
+                        "run.start rejected: daemon at capacity",
+                        {"agent_run_id": agent_run_id, "active": len(active_runs), "cap": cap},
+                    )
+                    await send_run_event(
+                        websocket,
+                        agent_run_id,
+                        "rejected",
+                        {
+                            "reason": "daemon_at_capacity",
+                            "active_run_count": len(active_runs),
+                            "max_concurrent_runs": cap,
+                        },
+                        lock=send_lock,
+                    )
+                    continue
+                sink = _RunEventSink(websocket, agent_run_id, send_lock)
                 task = asyncio.create_task(
-                    handle_run_start(websocket, message, base_url=base_url)
+                    handle_run_start(message, base_url=base_url, sink=sink)
                 )
                 active_runs[agent_run_id] = task
-                task.add_done_callback(
-                    lambda _task, run_id=agent_run_id: active_runs.pop(run_id, None)
-                )
+                active_sinks[agent_run_id] = sink
+
+                def _on_run_done(_task: Any, run_id: str = agent_run_id) -> None:
+                    active_runs.pop(run_id, None)
+                    active_sinks.pop(run_id, None)
+
+                task.add_done_callback(_on_run_done)
                 continue
             if message_type == "run.stop":
                 agent_run_id = str(message.get("agent_run_id") or "")
@@ -203,12 +507,32 @@ async def _serve_connection(
                     websocket=websocket,
                     active_runs=active_runs,
                     agent_run_id=agent_run_id,
+                    send_lock=send_lock,
                 )
                 continue
     finally:
-        for task in list(active_runs.values()):
-            if not task.done():
+        heartbeat_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await heartbeat_task
+        disconnected_at = time.monotonic()
+        for agent_run_id, task in list(active_runs.items()):
+            if task.done():
+                continue
+            sink = active_sinks.get(agent_run_id)
+            if sink is None:
+                # Should never happen -- sinks are added at the same time as
+                # active_runs entries. Without a sink there's nowhere sane to
+                # redirect this run's output, so fall back to the old
+                # cancel-on-disconnect behavior rather than holding it blind.
                 task.cancel()
+                continue
+            buffer: "collections.deque[dict[str, Any]]" = collections.deque(
+                maxlen=max_buffered_events_per_run()
+            )
+            sink.go_buffered(buffer)
+            held_runs[agent_run_id] = _HeldRun(
+                task=task, sink=sink, buffer=buffer, disconnected_at=disconnected_at
+            )
 
 
 async def _stop_active_run(
@@ -216,21 +540,29 @@ async def _stop_active_run(
     websocket: Any,
     active_runs: dict[str, asyncio.Task[None]],
     agent_run_id: str,
+    send_lock: asyncio.Lock | None = None,
 ) -> None:
     task = active_runs.get(agent_run_id)
     if task is not None:
         task.cancel()
         return
     if agent_run_id:
-        await send_run_event(websocket, agent_run_id, "stopped", {})
+        await send_run_event(websocket, agent_run_id, "stopped", {}, lock=send_lock)
 
 
 async def handle_run_start(
-    websocket: Any,
     message: dict[str, Any],
     *,
+    sink: _RunEventSink,
     base_url: str | None = None,
 ) -> None:
+    """Run one provider turn, sending every event through ``sink``.
+
+    ``sink`` is an indirection, not a fixed destination: it can be redirected
+    between "send live" and "buffer locally" by ``_serve_connection`` across a
+    disconnect/reconnect without this function (or the subprocess it drives)
+    ever being restarted.
+    """
     agent_run_id = str(message.get("agent_run_id") or "")
     payload = message.get("payload") if isinstance(message.get("payload"), dict) else {}
     if base_url:
@@ -246,25 +578,19 @@ async def handle_run_start(
             "prompt_preview": _preview(_prompt_text_preview(payload)),
         },
     )
-    await send_run_event(
-        websocket,
-        agent_run_id,
-        "status",
-        {"status": "daemon provider process starting", "harness_kind": harness_kind},
+    await sink(
+        "status", {"status": "daemon provider process starting", "harness_kind": harness_kind}
     )
     try:
-        result = await run_provider_command(
-            payload,
-            event_sink=lambda event_type, data: send_run_event(websocket, agent_run_id, event_type, data),
-        )
+        result = await run_provider_command(payload, event_sink=sink)
     except asyncio.CancelledError:
         daemon_log("run cancelled", {"agent_run_id": agent_run_id})
-        await send_run_event(websocket, agent_run_id, "stopped", {})
+        await sink("stopped", {})
         raise
     except Exception as exc:
         error_detail = _exception_detail(exc)
         daemon_log("run failed", {"agent_run_id": agent_run_id, "error": error_detail})
-        await send_run_event(websocket, agent_run_id, "error", error_detail)
+        await sink("error", error_detail)
         return
     daemon_log(
         "provider result",
@@ -280,11 +606,9 @@ async def handle_run_start(
     if result["stdout"]:
         redacted_command = _redact(result["command"])
         if not result.get("streamed_tokens"):
-            await send_run_event(websocket, agent_run_id, "token", result["stdout"])
+            await sink("token", result["stdout"])
         if not result.get("streamed_messages"):
-            await send_run_event(
-                websocket,
-                agent_run_id,
+            await sink(
                 "message",
                 {
                     "role": "assistant",
@@ -298,16 +622,9 @@ async def handle_run_start(
                 },
             )
     if result["returncode"] == 0:
-        await send_run_event(
-            websocket,
-            agent_run_id,
-            "completed",
-            {"returncode": result["returncode"], "stderr": result["stderr"]},
-        )
+        await sink("completed", {"returncode": result["returncode"], "stderr": result["stderr"]})
         return
-    await send_run_event(
-        websocket,
-        agent_run_id,
+    await sink(
         "error",
         result["stderr"] or f"Provider command failed with exit code {result['returncode']}",
     )
@@ -390,6 +707,8 @@ async def send_run_event(
     agent_run_id: str,
     event_type: str,
     data: Any,
+    *,
+    lock: asyncio.Lock | None = None,
 ) -> None:
     daemon_log("send run event", {"agent_run_id": agent_run_id, "event_type": event_type, "data": data})
     await _send_json(
@@ -399,17 +718,31 @@ async def send_run_event(
             "agent_run_id": agent_run_id,
             "event": {"type": event_type, "data": data},
         },
+        lock=lock,
     )
 
 
-async def _send_json(websocket: Any, payload: dict[str, Any]) -> None:
+async def _send_json(
+    websocket: Any,
+    payload: dict[str, Any],
+    *,
+    lock: asyncio.Lock | None = None,
+) -> None:
     """Send a JSON message, tolerating a dropped socket.
 
     A failed send (e.g. the connection dropped mid-run) must not crash the daemon —
     the reconnect loop re-establishes the connection; the dropped event is logged.
+
+    ``lock`` serializes concurrent senders on one websocket (the heartbeat task
+    and N run tasks can all be sending at once) — ``websockets``' ``send()`` is
+    not safe to call concurrently from multiple tasks without one.
     """
     try:
-        await websocket.send(json.dumps(payload))
+        if lock is not None:
+            async with lock:
+                await websocket.send(json.dumps(payload))
+        else:
+            await websocket.send(json.dumps(payload))
     except asyncio.CancelledError:
         raise
     except Exception as exc:  # noqa: BLE001 - transport guard

--- a/lemma-cli/tests/test_codex_pool_bounding.py
+++ b/lemma-cli/tests/test_codex_pool_bounding.py
@@ -1,0 +1,166 @@
+"""Tests for CodexWorkerPool's per-daemon concurrency bounding (slot semaphore).
+
+Drives the pool's internal ``_worker_for_conversation``/``_retire_worker``/
+``_close_after_ttl`` directly rather than through a full simulated codex
+app-server turn -- those methods are exactly where the slot-accounting logic
+lives, and the full turn machinery (JsonRpcProcess protocol, etc.) is already
+covered by the existing tests in test_daemon_cli.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from lemma_cli.daemon.harnesses import codex
+
+
+def test_codex_pool_max_workers_defaults(monkeypatch):
+    monkeypatch.delenv(codex.CODEX_POOL_MAX_WORKERS_ENV, raising=False)
+    assert codex.codex_pool_max_workers() == 4
+
+
+def test_codex_pool_max_workers_env_override(monkeypatch):
+    monkeypatch.setenv(codex.CODEX_POOL_MAX_WORKERS_ENV, "2")
+    assert codex.codex_pool_max_workers() == 2
+
+
+def test_codex_pool_max_workers_invalid_env_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv(codex.CODEX_POOL_MAX_WORKERS_ENV, "not-a-number")
+    assert codex.codex_pool_max_workers() == 4
+
+
+@pytest.mark.asyncio
+async def test_worker_for_conversation_reuses_existing_without_consuming_new_slot(monkeypatch):
+    monkeypatch.setattr(codex, "codex_pool_max_workers", lambda: 1)
+    pool = codex.CodexWorkerPool()
+
+    worker1 = await pool._worker_for_conversation("conv-1")
+    # The pool is at capacity (1/1) via conv-1's slot -- a second call for the
+    # SAME conversation must reuse it without blocking on the semaphore (the
+    # fast path in _worker_for_conversation returns before ever touching
+    # self._slots).
+    worker2 = await asyncio.wait_for(pool._worker_for_conversation("conv-1"), timeout=0.2)
+
+    assert worker1 is worker2
+
+
+@pytest.mark.asyncio
+async def test_worker_for_new_conversation_blocks_when_pool_full(monkeypatch):
+    monkeypatch.setattr(codex, "codex_pool_max_workers", lambda: 1)
+    pool = codex.CodexWorkerPool()
+
+    await pool._worker_for_conversation("conv-1")  # consumes the only slot
+
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(pool._worker_for_conversation("conv-2"), timeout=0.1)
+
+
+@pytest.mark.asyncio
+async def test_worker_for_new_conversation_proceeds_once_a_slot_frees(monkeypatch):
+    monkeypatch.setattr(codex, "codex_pool_max_workers", lambda: 1)
+    pool = codex.CodexWorkerPool()
+
+    worker1 = await pool._worker_for_conversation("conv-1")
+    waiter = asyncio.create_task(pool._worker_for_conversation("conv-2"))
+    await asyncio.sleep(0.05)
+    assert not waiter.done()  # still queued, pool is full
+
+    await pool._retire_worker("conv-1", worker1)  # frees the slot
+
+    worker2 = await asyncio.wait_for(waiter, timeout=1.0)
+    assert worker2.conversation_id == "conv-2"
+
+
+@pytest.mark.asyncio
+async def test_slot_released_on_worker_retirement_after_error(monkeypatch):
+    monkeypatch.setattr(codex, "codex_pool_max_workers", lambda: 1)
+    pool = codex.CodexWorkerPool()
+
+    worker1 = await pool._worker_for_conversation("conv-1")
+    # Simulates the error path in CodexWorkerPool.run(): a turn raises, the
+    # worker is retired immediately (not left to idle-TTL out).
+    await pool._retire_worker("conv-1", worker1)
+
+    # A distinct-conversation call must proceed immediately -- the freed slot
+    # let it straight through, and it's a genuinely different worker object.
+    worker2 = await asyncio.wait_for(pool._worker_for_conversation("conv-2"), timeout=0.2)
+    assert worker2 is not worker1
+    assert worker2.conversation_id == "conv-2"
+
+
+@pytest.mark.asyncio
+async def test_retire_worker_is_a_noop_if_already_retired(monkeypatch):
+    monkeypatch.setattr(codex, "codex_pool_max_workers", lambda: 1)
+    pool = codex.CodexWorkerPool()
+
+    worker1 = await pool._worker_for_conversation("conv-1")
+    await pool._retire_worker("conv-1", worker1)
+    worker2 = await pool._worker_for_conversation("conv-2")  # takes the freed slot
+
+    # Retiring the ALREADY-retired conv-1 worker a second time (e.g. a
+    # duplicate error-path call) must not release a slot that isn't rightfully
+    # held anymore -- if it did, a third distinct conversation would
+    # incorrectly get through despite the pool's cap of 1.
+    await pool._retire_worker("conv-1", worker1)
+
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(pool._worker_for_conversation("conv-3"), timeout=0.1)
+
+    # Sanity: conv-2's own slot is unaffected by any of this.
+    assert (await pool._worker_for_conversation("conv-2")) is worker2
+
+
+@pytest.mark.asyncio
+async def test_slot_released_on_idle_ttl_eviction(monkeypatch):
+    monkeypatch.setattr(codex, "codex_pool_max_workers", lambda: 1)
+    monkeypatch.setattr(codex, "codex_worker_ttl_seconds", lambda: 0.02)
+    pool = codex.CodexWorkerPool()
+
+    worker1 = await pool._worker_for_conversation("conv-1")
+    pool._schedule_idle_close("conv-1", worker1)
+
+    # Before the TTL fires, the pool is still full.
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(pool._worker_for_conversation("conv-2"), timeout=0.01)
+
+    # After it fires, the slot is free.
+    worker2 = await asyncio.wait_for(pool._worker_for_conversation("conv-2"), timeout=1.0)
+    assert worker2.conversation_id == "conv-2"
+
+
+@pytest.mark.asyncio
+async def test_slot_not_double_released_when_worker_reused_before_ttl_fires(monkeypatch):
+    """Regression test for the trickiest edge case: reusing a conversation's
+    worker before its scheduled idle-close fires must NOT cause the eventual
+    real close to release a slot the reuse never re-consumed (a double
+    release would let one extra conversation through beyond the cap).
+    """
+    monkeypatch.setattr(codex, "codex_pool_max_workers", lambda: 1)
+    monkeypatch.setattr(codex, "codex_worker_ttl_seconds", lambda: 0.05)
+    pool = codex.CodexWorkerPool()
+
+    worker1 = await pool._worker_for_conversation("conv-1")
+    pool._schedule_idle_close("conv-1", worker1)  # simulates turn #1 finishing
+
+    await asyncio.sleep(0.01)
+    # Reuse before the TTL fires -- cancels + (via the next line) reschedules
+    # the pending close, exactly like a second turn on the same conversation.
+    worker1_again = await pool._worker_for_conversation("conv-1")
+    assert worker1_again is worker1
+    pool._schedule_idle_close("conv-1", worker1)  # simulates turn #2 finishing
+
+    # Let the (rescheduled) TTL close actually fire.
+    await asyncio.sleep(0.15)
+
+    # The slot was released exactly once by the real close -- a second
+    # conversation can now get in...
+    worker2 = await asyncio.wait_for(pool._worker_for_conversation("conv-2"), timeout=0.5)
+    assert worker2.conversation_id == "conv-2"
+
+    # ...but a THIRD must NOT, because the pool is still only 1-wide. If the
+    # stale (cancelled) close had also released a slot, both conv-2 and
+    # conv-3 would get through here.
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(pool._worker_for_conversation("conv-3"), timeout=0.1)

--- a/lemma-cli/tests/test_daemon_cli.py
+++ b/lemma-cli/tests/test_daemon_cli.py
@@ -103,6 +103,22 @@ class _FakeWebSocket:
         self.messages.append(json.loads(payload))
 
 
+async def _handle_run_start(websocket, message, **kwargs):
+    """Back-compat wrapper for tests written against the pre-hold-not-kill
+    ``handle_run_start(websocket, message, ...)`` signature.
+
+    Production code now threads a redirectable ``_RunEventSink`` instead of a
+    raw websocket + lock, so a held run's subprocess can survive a disconnect
+    without being restarted. The sink defaults to "live" (not buffered), so
+    routing through it here still populates ``websocket.messages`` exactly as
+    the old direct-websocket calls did.
+    """
+    sink = daemon._RunEventSink(
+        websocket, str(message.get("agent_run_id") or ""), asyncio.Lock()
+    )
+    return await daemon.handle_run_start(message, sink=sink, **kwargs)
+
+
 @pytest.mark.asyncio
 async def test_stop_active_run_acks_orphaned_run():
     websocket = _FakeWebSocket()
@@ -149,7 +165,7 @@ async def test_daemon_run_start_executes_configured_provider_command(monkeypatch
         f"{sys.executable} -c \"print('assistant ok')\"",
     )
 
-    await daemon.handle_run_start(
+    await _handle_run_start(
         websocket,
         {
             "type": "run.start",
@@ -187,7 +203,7 @@ async def test_daemon_does_not_emit_prompt_echo_from_provider_stdout(monkeypatch
         f"{sys.executable} -c \"import sys; print(sys.stdin.read())\"",
     )
 
-    await daemon.handle_run_start(
+    await _handle_run_start(
         websocket,
         {
             "type": "run.start",
@@ -227,7 +243,7 @@ async def test_daemon_strips_prompt_echo_prefix_from_provider_stdout(monkeypatch
         ),
     )
 
-    await daemon.handle_run_start(
+    await _handle_run_start(
         websocket,
         {
             "type": "run.start",
@@ -268,7 +284,7 @@ async def test_codex_app_server_tool_events_stream_as_agent_tokens_and_messages(
     monkeypatch.setattr(daemon, "_JsonRpcProcess", _FakeCodexJsonRpcProcess)
 
     try:
-        await daemon.handle_run_start(
+        await _handle_run_start(
             websocket,
             {
                 "type": "run.start",
@@ -367,7 +383,7 @@ async def test_codex_app_server_pool_allows_parallel_runs(monkeypatch, tmp_path)
     monkeypatch.setattr(daemon, "_JsonRpcProcess", _SlowFakeCodexJsonRpcProcess)
 
     async def run(websocket: _FakeWebSocket, run_id: str) -> None:
-        await daemon.handle_run_start(
+        await _handle_run_start(
             websocket,
             {
                 "type": "run.start",
@@ -442,7 +458,7 @@ async def test_codex_app_server_pool_reuses_worker_with_saved_thread(
         },
     }
     try:
-        await daemon.handle_run_start(
+        await _handle_run_start(
             websocket_one,
             {"type": "run.start", "agent_run_id": "run-one", "payload": payload},
         )
@@ -453,7 +469,7 @@ async def test_codex_app_server_pool_reuses_worker_with_saved_thread(
                 "user_prompt": "USER:\nwhat is my code word?",
             },
         }
-        await daemon.handle_run_start(
+        await _handle_run_start(
             websocket_two,
             {"type": "run.start", "agent_run_id": "run-two", "payload": payload},
         )
@@ -517,7 +533,7 @@ async def test_codex_app_server_worker_closes_after_cancelled_turn(
     }
 
     task = asyncio.create_task(
-        daemon.handle_run_start(
+        _handle_run_start(
             websocket_one,
             {"type": "run.start", "agent_run_id": "run-cancel", "payload": payload},
         )
@@ -537,7 +553,7 @@ async def test_codex_app_server_worker_closes_after_cancelled_turn(
         assert _HangingFakeCodexJsonRpcProcess.instances[0].closed is True
 
         monkeypatch.setattr(daemon, "_JsonRpcProcess", _FakeCodexJsonRpcProcess)
-        await daemon.handle_run_start(
+        await _handle_run_start(
             websocket_two,
             {"type": "run.start", "agent_run_id": "run-resume", "payload": payload},
         )
@@ -571,7 +587,7 @@ async def test_codex_app_server_recovers_from_stale_saved_session(
     monkeypatch.setattr(daemon, "_JsonRpcProcess", _FailingTurnFakeCodexJsonRpcProcess)
 
     try:
-        await daemon.handle_run_start(
+        await _handle_run_start(
             websocket,
             {
                 "type": "run.start",
@@ -645,7 +661,7 @@ async def test_codex_app_server_flushes_completed_agent_message_items(
     monkeypatch.setattr(daemon, "_JsonRpcProcess", _MultiMessageFakeCodexJsonRpcProcess)
 
     try:
-        await daemon.handle_run_start(
+        await _handle_run_start(
             websocket,
             {
                 "type": "run.start",
@@ -697,7 +713,7 @@ async def test_codex_app_server_strips_submitted_prompt_echo_from_stream(
     monkeypatch.setattr(daemon, "_JsonRpcProcess", _PromptEchoFakeCodexJsonRpcProcess)
 
     try:
-        await daemon.handle_run_start(
+        await _handle_run_start(
             websocket,
             {
                 "type": "run.start",
@@ -754,7 +770,7 @@ async def test_codex_app_server_pool_uses_separate_threads_for_separate_conversa
     monkeypatch.setattr(daemon, "_JsonRpcProcess", _FakeCodexJsonRpcProcess)
 
     async def run(conversation_id: str, text: str) -> None:
-        await daemon.handle_run_start(
+        await _handle_run_start(
             _FakeWebSocket(),
             {
                 "type": "run.start",
@@ -803,7 +819,7 @@ async def test_codex_app_server_pool_closes_idle_worker_after_ttl(monkeypatch, t
     monkeypatch.setattr(daemon, "_JsonRpcProcess", _FakeCodexJsonRpcProcess)
 
     try:
-        await daemon.handle_run_start(
+        await _handle_run_start(
             websocket,
             {
                 "type": "run.start",
@@ -928,7 +944,7 @@ async def test_claude_stream_persists_assistant_text_before_tool_call(monkeypatc
         f"{sys.executable} {script_path}",
     )
 
-    await daemon.handle_run_start(
+    await _handle_run_start(
         websocket,
         {
             "type": "run.start",
@@ -984,7 +1000,7 @@ async def test_daemon_persists_claude_stream_session_id(monkeypatch, tmp_path):
         f"{sys.executable} {script_path}",
     )
 
-    await daemon.handle_run_start(
+    await _handle_run_start(
         websocket,
         {
             "type": "run.start",
@@ -1050,7 +1066,7 @@ async def test_daemon_recovers_from_stale_claude_session(monkeypatch, tmp_path):
         f"{sys.executable} {script_path}",
     )
 
-    await daemon.handle_run_start(
+    await _handle_run_start(
         websocket,
         {
             "type": "run.start",

--- a/lemma-cli/tests/test_daemon_resiliency.py
+++ b/lemma-cli/tests/test_daemon_resiliency.py
@@ -6,6 +6,8 @@ import asyncio
 import collections
 import contextlib
 import json
+import os
+import signal
 import time
 
 import pytest
@@ -845,3 +847,86 @@ async def test_heartbeat_ping_includes_capacity_payload(monkeypatch):
 
     ping = _pings_sent(ws)[0]
     assert ping["payload"]["capacity"] == {"max_concurrent_runs": 4, "active_run_count": 1}
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name == "nt", reason="add_signal_handler is POSIX-only")
+async def test_graceful_shutdown_cancels_run_daemon_on_sigterm(monkeypatch):
+    """`lemma daemon stop` / a plain `kill` send SIGTERM. With no handler at
+    all, the interpreter's default behavior tears the process down before
+    run_daemon()'s own subprocess-teardown cleanup gets a chance to run,
+    orphaning any active/held provider subprocess. The wrapper must turn
+    that into a cancellation of the daemon task instead.
+    """
+    cleanup_ran = asyncio.Event()
+
+    async def _fake_run_daemon(**kwargs):
+        del kwargs
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            cleanup_ran.set()
+            raise
+
+    monkeypatch.setattr(runner, "run_daemon", _fake_run_daemon)
+
+    task = asyncio.create_task(runner.run_daemon_with_graceful_shutdown())
+    # Handler registration is synchronous, before the wrapper's first
+    # `await` -- yielding back to the loop a few times is enough for that
+    # setup to have run.
+    await asyncio.sleep(0.05)
+    os.kill(os.getpid(), signal.SIGTERM)
+
+    await asyncio.wait_for(task, timeout=2)
+    assert cleanup_ran.is_set()
+    assert task.done() and not task.cancelled()  # CancelledError is suppressed, not propagated
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(os.name == "nt", reason="add_signal_handler is POSIX-only")
+async def test_graceful_shutdown_awaits_held_run_cancellation_before_returning(monkeypatch):
+    """run_daemon()'s own finally block must AWAIT cancelled held-run tasks,
+    not just call .cancel() and move on -- otherwise the process can still
+    exit (via the graceful-shutdown wrapper returning) before a held
+    subprocess's own CancelledError-triggered teardown actually finishes.
+    """
+    torn_down = asyncio.Event()
+
+    async def _held_task_body():
+        try:
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            await asyncio.sleep(0.05)  # simulate terminate-then-wait teardown work
+            torn_down.set()
+            raise
+
+    # run_daemon() owns `held_runs` internally and only ever hands it to
+    # _serve_connection() by reference -- inject the pre-populated entry from
+    # inside the fake so it lands in the SAME dict run_daemon()'s own
+    # `finally` later inspects.
+    async def _fake_serve_connection(*args, held_runs, **kwargs):
+        del args, kwargs
+        held_runs["run-1"] = runner._HeldRun(
+            task=asyncio.create_task(_held_task_body()),
+            sink=runner._RunEventSink(_FakeWS(), "run-1", asyncio.Lock()),
+            buffer=collections.deque(),
+            disconnected_at=time.monotonic(),
+        )
+        await asyncio.sleep(10)
+
+    monkeypatch.setattr(runner, "_serve_connection", _fake_serve_connection)
+
+    daemon_task = asyncio.create_task(
+        runner.run_daemon(
+            base_url="http://x",
+            token="t",
+            verify_ssl=False,
+            connect_factory=lambda _token: _FakeConn(_FakeWS()),
+        )
+    )
+    await asyncio.sleep(0.05)
+    daemon_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await asyncio.wait_for(daemon_task, timeout=2)
+
+    assert torn_down.is_set()

--- a/lemma-cli/tests/test_daemon_resiliency.py
+++ b/lemma-cli/tests/test_daemon_resiliency.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import collections
+import contextlib
 import json
+import time
 
 import pytest
 
@@ -43,20 +46,51 @@ def test_ssl_for_wss_without_verify_is_unverified_context():
 
 
 class _FakeWS:
-    def __init__(self, incoming=None):
+    """Fake websocket.
+
+    Default mode (``hang_when_empty=False``) preserves the original behavior:
+    once ``incoming`` is exhausted, iteration ends with ``StopAsyncIteration``
+    (simulates a connection the peer already closed).
+
+    ``hang_when_empty=True`` instead backs iteration with an ``asyncio.Queue``,
+    so the "connection" stays open indefinitely and a test can push more
+    messages later via ``push_incoming()`` and have a pending ``__anext__()``
+    wake up for them -- needed to test behavior that only shows up while a
+    connection is genuinely still live (e.g. a heartbeat ticking alongside a
+    busy run task).
+    """
+
+    def __init__(self, incoming=None, *, hang_when_empty: bool = False):
         self.sent: list[str] = []
-        self._incoming = list(incoming or [])
         self.send_should_fail = False
+        self.closed = False
+        if hang_when_empty:
+            self._queue: asyncio.Queue[str] | None = asyncio.Queue()
+            for item in list(incoming or []):
+                self._queue.put_nowait(item)
+            self._incoming = None
+        else:
+            self._queue = None
+            self._incoming = list(incoming or [])
 
     async def send(self, data):
         if self.send_should_fail:
             raise ConnectionError("socket closed")
         self.sent.append(data)
 
+    async def close(self, *_args, **_kwargs):
+        self.closed = True
+
+    def push_incoming(self, data: str) -> None:
+        assert self._queue is not None, "push_incoming requires hang_when_empty=True"
+        self._queue.put_nowait(data)
+
     def __aiter__(self):
         return self
 
     async def __anext__(self):
+        if self._queue is not None:
+            return await self._queue.get()
         if self._incoming:
             return self._incoming.pop(0)
         raise StopAsyncIteration
@@ -219,3 +253,595 @@ async def test_opencode_post_does_not_retry(monkeypatch):
             _Client(), "POST", "http://x", "/session", params={}
         )
     assert calls["n"] == 1  # POSTs are never auto-retried
+
+
+def _pings_sent(ws: _FakeWS) -> list[dict]:
+    return [json.loads(m) for m in ws.sent if json.loads(m).get("type") == "daemon.ping"]
+
+
+def test_ping_interval_seconds_defaults(monkeypatch):
+    monkeypatch.delenv(runner._PING_INTERVAL_SECONDS_ENV, raising=False)
+    assert runner.ping_interval_seconds() == 15.0
+
+
+def test_ping_interval_seconds_env_override(monkeypatch):
+    monkeypatch.setenv(runner._PING_INTERVAL_SECONDS_ENV, "5")
+    assert runner.ping_interval_seconds() == 5.0
+
+
+def test_ping_interval_seconds_invalid_env_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv(runner._PING_INTERVAL_SECONDS_ENV, "not-a-number")
+    assert runner.ping_interval_seconds() == 15.0
+
+
+def test_pong_miss_limit_defaults(monkeypatch):
+    monkeypatch.delenv(runner._PONG_MISS_LIMIT_ENV, raising=False)
+    assert runner.pong_miss_limit() == 3
+
+
+def test_pong_miss_limit_env_override(monkeypatch):
+    monkeypatch.setenv(runner._PONG_MISS_LIMIT_ENV, "5")
+    assert runner.pong_miss_limit() == 5
+
+
+def test_pong_miss_limit_invalid_env_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv(runner._PONG_MISS_LIMIT_ENV, "not-a-number")
+    assert runner.pong_miss_limit() == 3
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_closes_connection_after_missed_pongs(monkeypatch):
+    monkeypatch.setattr(runner, "ping_interval_seconds", lambda: 0.01)
+    monkeypatch.setattr(runner, "pong_miss_limit", lambda: 2)
+    ws = _FakeWS()
+    pong_seen = asyncio.Event()  # never set -- every ping counts as a miss
+
+    await asyncio.wait_for(
+        runner._heartbeat_loop(ws, send_lock=asyncio.Lock(), pong_seen=pong_seen, active_runs={}),
+        timeout=1.0,
+    )
+
+    assert len(_pings_sent(ws)) == 2  # closes right after the 2nd consecutive miss
+    assert ws.closed is True
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_keeps_running_while_pongs_answered(monkeypatch):
+    monkeypatch.setattr(runner, "ping_interval_seconds", lambda: 0.01)
+    monkeypatch.setattr(runner, "pong_miss_limit", lambda: 2)
+    ws = _FakeWS()
+    pong_seen = asyncio.Event()
+
+    async def _answer_every_ping():
+        while True:
+            await asyncio.sleep(0.001)
+            if ws.sent:
+                pong_seen.set()
+
+    responder = asyncio.create_task(_answer_every_ping())
+    heartbeat = asyncio.create_task(
+        runner._heartbeat_loop(ws, send_lock=asyncio.Lock(), pong_seen=pong_seen, active_runs={})
+    )
+    await asyncio.sleep(0.08)
+    heartbeat.cancel()
+    responder.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await heartbeat
+    with contextlib.suppress(asyncio.CancelledError):
+        await responder
+
+    assert len(_pings_sent(ws)) >= 3
+    assert ws.closed is False
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_independent_of_busy_run_task(monkeypatch):
+    """Regression guard: a slow/long run task must never delay the heartbeat.
+
+    This is the actual fix for the reported bug -- the heartbeat runs on its
+    own asyncio task, decoupled from run-handling tasks, so it can detect and
+    react to a dead connection even while a run is in flight.
+    """
+    monkeypatch.setattr(runner, "ping_interval_seconds", lambda: 0.01)
+    monkeypatch.setattr(runner, "pong_miss_limit", lambda: 1000)  # never self-declare dead here
+
+    busy_started = asyncio.Event()
+
+    async def _busy_handle_run_start(message, *, sink, base_url=None):
+        busy_started.set()
+        await asyncio.sleep(1.0)
+
+    monkeypatch.setattr(runner, "handle_run_start", _busy_handle_run_start)
+
+    ws = _FakeWS(
+        incoming=[json.dumps({"type": "run.start", "agent_run_id": "run-1", "payload": {}})],
+        hang_when_empty=True,
+    )
+
+    serve_task = asyncio.create_task(
+        runner._serve_connection(
+            ws, config={"device_key": "k"}, catalog={}, base_url="http://x", held_runs={}
+        )
+    )
+    await asyncio.wait_for(busy_started.wait(), timeout=1.0)
+    await asyncio.sleep(0.1)  # several heartbeat intervals while the run task sleeps
+    serve_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await serve_task
+
+    assert len(_pings_sent(ws)) >= 3
+
+
+@pytest.mark.asyncio
+async def test_serve_connection_routes_daemon_pong_to_heartbeat(monkeypatch):
+    """Regression guard for the message-loop <-> heartbeat wiring itself."""
+    monkeypatch.setattr(runner, "ping_interval_seconds", lambda: 0.01)
+    monkeypatch.setattr(runner, "pong_miss_limit", lambda: 2)
+
+    ws = _FakeWS(hang_when_empty=True)
+    original_send = ws.send
+
+    async def _send_with_auto_pong(data):
+        await original_send(data)
+        if json.loads(data).get("type") == "daemon.ping":
+            ws.push_incoming(json.dumps({"type": "daemon.pong"}))
+
+    ws.send = _send_with_auto_pong
+
+    serve_task = asyncio.create_task(
+        runner._serve_connection(
+            ws, config={"device_key": "k"}, catalog={}, base_url="http://x", held_runs={}
+        )
+    )
+    await asyncio.sleep(0.15)
+    serve_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await serve_task
+
+    assert len(_pings_sent(ws)) >= 3  # never self-declared dead: every ping got its pong
+    assert ws.closed is False
+
+
+def _run_events(ws: _FakeWS) -> list[dict]:
+    return [json.loads(m) for m in ws.sent if json.loads(m).get("type") == "run.event"]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_run_start_for_active_run_is_ignored(monkeypatch):
+    monkeypatch.setattr(runner, "ping_interval_seconds", lambda: 1000.0)
+
+    calls = {"n": 0}
+
+    async def _fake_handle_run_start(message, *, sink, base_url=None):
+        calls["n"] += 1
+        await asyncio.sleep(10)  # stays "active" for the duration of the test
+
+    monkeypatch.setattr(runner, "handle_run_start", _fake_handle_run_start)
+
+    ws = _FakeWS(
+        incoming=[
+            json.dumps({"type": "run.start", "agent_run_id": "run-1", "payload": {}}),
+            json.dumps({"type": "run.start", "agent_run_id": "run-1", "payload": {}}),
+        ],
+        hang_when_empty=True,
+    )
+    serve_task = asyncio.create_task(
+        runner._serve_connection(
+            ws, config={"device_key": "k"}, catalog={}, base_url="http://x", held_runs={}
+        )
+    )
+    for _ in range(100):
+        if calls["n"] >= 1:
+            break
+        await asyncio.sleep(0.01)
+    await asyncio.sleep(0.05)  # give the (would-be) second dispatch a chance to fire
+    serve_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await serve_task
+
+    assert calls["n"] == 1  # the redelivered run.start never spawned a second task
+
+
+@pytest.mark.asyncio
+async def test_held_run_reaper_terminates_after_grace_expires(monkeypatch):
+    monkeypatch.setattr(runner, "hold_grace_seconds", lambda: 0.02)
+    monkeypatch.setattr(runner, "_HELD_RUN_REAP_POLL_INTERVAL_SECONDS", 0.01)
+
+    async def _never_finishes():
+        await asyncio.sleep(10)
+
+    task = asyncio.create_task(_never_finishes())
+    sink = runner._RunEventSink(_FakeWS(), "run-held", asyncio.Lock())
+    buffer: "collections.deque" = collections.deque(maxlen=10)
+    held_runs = {
+        "run-held": runner._HeldRun(
+            task=task, sink=sink, buffer=buffer, disconnected_at=time.monotonic()
+        )
+    }
+
+    reaper = asyncio.create_task(runner._reap_expired_held_runs(held_runs))
+    for _ in range(200):
+        if "run-held" not in held_runs:
+            break
+        await asyncio.sleep(0.01)
+    reaper.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await reaper
+
+    assert "run-held" not in held_runs
+    assert task.cancelled() or task.cancelling()
+
+
+@pytest.mark.asyncio
+async def test_held_run_not_reaped_before_grace_expires(monkeypatch):
+    monkeypatch.setattr(runner, "hold_grace_seconds", lambda: 10.0)
+    monkeypatch.setattr(runner, "_HELD_RUN_REAP_POLL_INTERVAL_SECONDS", 0.01)
+
+    async def _never_finishes():
+        await asyncio.sleep(10)
+
+    task = asyncio.create_task(_never_finishes())
+    sink = runner._RunEventSink(_FakeWS(), "run-held", asyncio.Lock())
+    buffer: "collections.deque" = collections.deque(maxlen=10)
+    held_runs = {
+        "run-held": runner._HeldRun(
+            task=task, sink=sink, buffer=buffer, disconnected_at=time.monotonic()
+        )
+    }
+
+    reaper = asyncio.create_task(runner._reap_expired_held_runs(held_runs))
+    await asyncio.sleep(0.1)
+    reaper.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await reaper
+
+    assert "run-held" in held_runs
+    assert not task.done()
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_run_survives_disconnect_and_reattaches_with_buffered_events(monkeypatch):
+    """End-to-end CLI-side hold-not-kill + reattach: a run's subprocess is not
+    cancelled when its connection drops, events emitted while disconnected are
+    buffered, and reconnecting flushes them + resumes live streaming -- all
+    without the run task itself ever being restarted.
+    """
+    monkeypatch.setattr(runner, "ping_interval_seconds", lambda: 1000.0)
+
+    emit_more = asyncio.Event()
+    emitted_second_event = asyncio.Event()
+
+    async def _fake_handle_run_start(message, *, sink, base_url=None):
+        await sink("status", {"status": "starting"})
+        await emit_more.wait()
+        await sink("token", "emitted-while-disconnected")
+        emitted_second_event.set()
+        await asyncio.sleep(10)
+
+    monkeypatch.setattr(runner, "handle_run_start", _fake_handle_run_start)
+
+    held_runs: dict[str, runner._HeldRun] = {}
+    ws1 = _FakeWS(
+        incoming=[json.dumps({"type": "run.start", "agent_run_id": "run-1", "payload": {}})],
+        hang_when_empty=True,
+    )
+    conn1 = asyncio.create_task(
+        runner._serve_connection(
+            ws1, config={"device_key": "k"}, catalog={}, base_url="http://x", held_runs=held_runs
+        )
+    )
+    for _ in range(100):
+        if _run_events(ws1):
+            break
+        await asyncio.sleep(0.01)
+    assert _run_events(ws1)[0]["event"]["type"] == "status"
+
+    # Simulate the connection dropping (same code path a real ConnectionClosed
+    # would hit: _serve_connection's finally block runs regardless of why the
+    # `async for` loop stopped).
+    conn1.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await conn1
+
+    assert "run-1" in held_runs
+    assert not held_runs["run-1"].task.done()
+
+    # While "disconnected," the run keeps going and emits another event -- it
+    # must land in the buffer, not be lost or crash anything.
+    emit_more.set()
+    await asyncio.wait_for(emitted_second_event.wait(), timeout=1.0)
+    for _ in range(100):
+        if held_runs["run-1"].buffer:
+            break
+        await asyncio.sleep(0.01)
+    assert len(held_runs["run-1"].buffer) == 1
+    assert held_runs["run-1"].buffer[0] == {"type": "token", "data": "emitted-while-disconnected"}
+
+    # Reconnect: a fresh connection sharing the SAME held_runs dict.
+    ws2 = _FakeWS(hang_when_empty=True)
+    conn2 = asyncio.create_task(
+        runner._serve_connection(
+            ws2, config={"device_key": "k"}, catalog={}, base_url="http://x", held_runs=held_runs
+        )
+    )
+    try:
+        for _ in range(200):
+            if _run_events(ws2):
+                break
+            await asyncio.sleep(0.01)
+
+        ready_payload = json.loads(ws2.sent[0])["payload"]
+        assert ready_payload["reattach_runs"] == [
+            {"agent_run_id": "run-1", "buffered_event_count": 1, "overflowed": False}
+        ]
+        flushed = _run_events(ws2)
+        assert flushed[0]["agent_run_id"] == "run-1"
+        assert flushed[0]["event"] == {"type": "token", "data": "emitted-while-disconnected"}
+        # Reattachment reclaims the run -- it's no longer "held" once live again.
+        assert held_runs == {}
+    finally:
+        conn2.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await conn2
+
+
+def test_hold_grace_seconds_defaults(monkeypatch):
+    monkeypatch.delenv(runner._HOLD_GRACE_SECONDS_ENV, raising=False)
+    assert runner.hold_grace_seconds() == 150.0
+
+
+def test_hold_grace_seconds_env_override(monkeypatch):
+    monkeypatch.setenv(runner._HOLD_GRACE_SECONDS_ENV, "30")
+    assert runner.hold_grace_seconds() == 30.0
+
+
+def test_hold_grace_seconds_invalid_env_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv(runner._HOLD_GRACE_SECONDS_ENV, "not-a-number")
+    assert runner.hold_grace_seconds() == 150.0
+
+
+def test_max_buffered_events_per_run_defaults(monkeypatch):
+    monkeypatch.delenv(runner._MAX_BUFFERED_EVENTS_ENV, raising=False)
+    assert runner.max_buffered_events_per_run() == 2000
+
+
+def test_max_buffered_events_per_run_env_override(monkeypatch):
+    monkeypatch.setenv(runner._MAX_BUFFERED_EVENTS_ENV, "50")
+    assert runner.max_buffered_events_per_run() == 50
+
+
+def test_max_buffered_events_per_run_invalid_env_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv(runner._MAX_BUFFERED_EVENTS_ENV, "not-a-number")
+    assert runner.max_buffered_events_per_run() == 2000
+
+
+@pytest.mark.asyncio
+async def test_run_event_sink_buffer_overflow_sets_flag_and_drops_oldest():
+    buffer: "collections.deque" = collections.deque(maxlen=2)
+    sink = runner._RunEventSink(_FakeWS(), "run-1", asyncio.Lock())
+    sink.go_buffered(buffer)
+
+    await sink("token", "one")
+    await sink("token", "two")
+    assert sink.overflowed is False
+    await sink("token", "three")
+
+    assert sink.overflowed is True
+    assert list(buffer) == [
+        {"type": "token", "data": "two"},
+        {"type": "token", "data": "three"},
+    ]
+
+
+def test_max_concurrent_runs_defaults(monkeypatch):
+    from lemma_cli.daemon import config as daemon_config
+
+    monkeypatch.delenv(daemon_config.MAX_CONCURRENT_RUNS_ENV, raising=False)
+    assert daemon_config.max_concurrent_runs() == 4
+
+
+def test_max_concurrent_runs_env_override(monkeypatch):
+    from lemma_cli.daemon import config as daemon_config
+
+    monkeypatch.setenv(daemon_config.MAX_CONCURRENT_RUNS_ENV, "8")
+    assert daemon_config.max_concurrent_runs() == 8
+
+
+def test_max_concurrent_runs_invalid_env_falls_back_to_default(monkeypatch):
+    from lemma_cli.daemon import config as daemon_config
+
+    monkeypatch.setenv(daemon_config.MAX_CONCURRENT_RUNS_ENV, "not-a-number")
+    assert daemon_config.max_concurrent_runs() == 4
+
+
+def test_ensure_config_persists_max_concurrent_runs(tmp_path, monkeypatch):
+    from lemma_cli.daemon import config as daemon_config
+
+    monkeypatch.setattr(daemon_config, "DAEMON_DIR", tmp_path)
+    monkeypatch.setattr(daemon_config, "DAEMON_CONFIG_PATH", tmp_path / "config.json")
+    monkeypatch.delenv(daemon_config.MAX_CONCURRENT_RUNS_ENV, raising=False)
+
+    config = daemon_config.ensure_config()
+    assert config["max_concurrent_runs"] == 4
+
+    # A pre-existing value is preserved across calls (matching device_key's
+    # idempotency), even if the env default would differ now.
+    config["max_concurrent_runs"] = 99
+    daemon_config.save_config(config)
+    reloaded = daemon_config.ensure_config()
+    assert reloaded["max_concurrent_runs"] == 99
+
+
+@pytest.mark.asyncio
+async def test_run_start_rejected_when_at_capacity(monkeypatch):
+    monkeypatch.setattr(runner, "ping_interval_seconds", lambda: 1000.0)
+    monkeypatch.setattr(runner, "max_concurrent_runs", lambda: 2)
+
+    async def _never_finishes(message, *, sink, base_url=None):
+        await asyncio.sleep(10)
+
+    monkeypatch.setattr(runner, "handle_run_start", _never_finishes)
+
+    ws = _FakeWS(
+        incoming=[
+            json.dumps({"type": "run.start", "agent_run_id": "run-1", "payload": {}}),
+            json.dumps({"type": "run.start", "agent_run_id": "run-2", "payload": {}}),
+            json.dumps({"type": "run.start", "agent_run_id": "run-3", "payload": {}}),
+        ],
+        hang_when_empty=True,
+    )
+    serve_task = asyncio.create_task(
+        runner._serve_connection(
+            ws, config={"device_key": "k"}, catalog={}, base_url="http://x", held_runs={}
+        )
+    )
+    for _ in range(200):
+        if len(_run_events(ws)) >= 1:
+            break
+        await asyncio.sleep(0.01)
+    await asyncio.sleep(0.05)
+    serve_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await serve_task
+
+    events = _run_events(ws)
+    rejected = [e for e in events if e["event"]["type"] == "rejected"]
+    assert len(rejected) == 1
+    assert rejected[0]["agent_run_id"] == "run-3"
+    assert rejected[0]["event"]["data"] == {
+        "reason": "daemon_at_capacity",
+        "active_run_count": 2,
+        "max_concurrent_runs": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_rejected_run_never_starts_a_task(monkeypatch):
+    monkeypatch.setattr(runner, "ping_interval_seconds", lambda: 1000.0)
+    monkeypatch.setattr(runner, "max_concurrent_runs", lambda: 1)
+
+    calls: list[str] = []
+
+    async def _record_and_hang(message, *, sink, base_url=None):
+        calls.append(str(message.get("agent_run_id")))
+        await asyncio.sleep(10)
+
+    monkeypatch.setattr(runner, "handle_run_start", _record_and_hang)
+
+    ws = _FakeWS(
+        incoming=[
+            json.dumps({"type": "run.start", "agent_run_id": "run-1", "payload": {}}),
+            json.dumps({"type": "run.start", "agent_run_id": "run-2", "payload": {}}),
+        ],
+        hang_when_empty=True,
+    )
+    serve_task = asyncio.create_task(
+        runner._serve_connection(
+            ws, config={"device_key": "k"}, catalog={}, base_url="http://x", held_runs={}
+        )
+    )
+    for _ in range(200):
+        if calls:
+            break
+        await asyncio.sleep(0.01)
+    await asyncio.sleep(0.05)
+    serve_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await serve_task
+
+    # Only the first (admitted) run ever reached handle_run_start -- the
+    # rejected one never started a task, so it can never accidentally start a
+    # timeout clock for work that never ran.
+    assert calls == ["run-1"]
+
+
+@pytest.mark.asyncio
+async def test_daemon_ready_includes_capacity_payload(monkeypatch):
+    monkeypatch.setattr(runner, "ping_interval_seconds", lambda: 1000.0)
+    monkeypatch.setattr(runner, "max_concurrent_runs", lambda: 4)
+
+    ws = _FakeWS(hang_when_empty=True)
+    serve_task = asyncio.create_task(
+        runner._serve_connection(
+            ws, config={"device_key": "k"}, catalog={}, base_url="http://x", held_runs={}
+        )
+    )
+    for _ in range(200):
+        if ws.sent:
+            break
+        await asyncio.sleep(0.01)
+    serve_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await serve_task
+
+    ready = json.loads(ws.sent[0])
+    assert ready["payload"]["capacity"] == {"max_concurrent_runs": 4, "active_run_count": 0}
+
+
+@pytest.mark.asyncio
+async def test_daemon_catalog_refresh_includes_live_active_run_count(monkeypatch):
+    monkeypatch.setattr(runner, "ping_interval_seconds", lambda: 1000.0)
+    monkeypatch.setattr(runner, "max_concurrent_runs", lambda: 4)
+
+    async def _never_finishes(message, *, sink, base_url=None):
+        await asyncio.sleep(10)
+
+    monkeypatch.setattr(runner, "handle_run_start", _never_finishes)
+
+    ws = _FakeWS(
+        incoming=[
+            json.dumps({"type": "run.start", "agent_run_id": "run-1", "payload": {}}),
+            json.dumps({"type": "catalog.refresh"}),
+        ],
+        hang_when_empty=True,
+    )
+    serve_task = asyncio.create_task(
+        runner._serve_connection(
+            ws, config={"device_key": "k"}, catalog={}, base_url="http://x", held_runs={}
+        )
+    )
+    for _ in range(200):
+        if any(json.loads(m).get("type") == "daemon.catalog" for m in ws.sent):
+            break
+        await asyncio.sleep(0.01)
+    serve_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await serve_task
+
+    catalog_msg = next(json.loads(m) for m in ws.sent if json.loads(m).get("type") == "daemon.catalog")
+    assert catalog_msg["capacity"] == {"max_concurrent_runs": 4, "active_run_count": 1}
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_ping_includes_capacity_payload(monkeypatch):
+    monkeypatch.setattr(runner, "ping_interval_seconds", lambda: 0.02)
+    monkeypatch.setattr(runner, "pong_miss_limit", lambda: 1000)
+    monkeypatch.setattr(runner, "max_concurrent_runs", lambda: 4)
+
+    async def _never_finishes(message, *, sink, base_url=None):
+        await asyncio.sleep(10)
+
+    monkeypatch.setattr(runner, "handle_run_start", _never_finishes)
+
+    ws = _FakeWS(
+        incoming=[json.dumps({"type": "run.start", "agent_run_id": "run-1", "payload": {}})],
+        hang_when_empty=True,
+    )
+    serve_task = asyncio.create_task(
+        runner._serve_connection(
+            ws, config={"device_key": "k"}, catalog={}, base_url="http://x", held_runs={}
+        )
+    )
+    for _ in range(200):
+        if _pings_sent(ws):
+            break
+        await asyncio.sleep(0.01)
+    serve_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await serve_task
+
+    ping = _pings_sent(ws)[0]
+    assert ping["payload"]["capacity"] == {"max_concurrent_runs": 4, "active_run_count": 1}

--- a/lemma-cli/tests/test_daemon_resiliency.py
+++ b/lemma-cli/tests/test_daemon_resiliency.py
@@ -638,6 +638,51 @@ async def test_run_event_sink_buffer_overflow_sets_flag_and_drops_oldest():
     ]
 
 
+@pytest.mark.asyncio
+async def test_run_event_sink_self_buffers_on_live_send_failure():
+    """If a live send fails -- e.g. the peer closed the socket while this
+    daemon process was itself frozen/unresponsive (SIGSTOP) and never got a
+    chance to run _serve_connection's own disconnect handling first -- the
+    event must be buffered, not silently dropped. Found via a real SIGSTOP
+    e2e test where the daemon resumed and the assistant's final reply never
+    included the tool-call message, because it had been dropped by
+    `_send_json`'s swallow-all-exceptions behavior on a still-"live" sink.
+    """
+    ws = _FakeWS()
+    ws.send_should_fail = True
+    sink = runner._RunEventSink(ws, "run-1", asyncio.Lock())
+
+    await sink("token", "lost-without-the-fix")
+
+    assert sink._buffer is not None
+    assert list(sink._buffer) == [{"type": "token", "data": "lost-without-the-fix"}]
+
+
+@pytest.mark.asyncio
+async def test_go_buffered_preserves_events_already_self_buffered():
+    """_serve_connection's disconnect handling always allocates a fresh
+    buffer and calls go_buffered() with it -- that must not clobber events a
+    sink already self-buffered after a live send failure (see previous
+    test).
+    """
+    ws = _FakeWS()
+    ws.send_should_fail = True
+    sink = runner._RunEventSink(ws, "run-1", asyncio.Lock())
+    await sink("token", "already-buffered")
+
+    fresh_buffer = collections.deque(maxlen=runner.max_buffered_events_per_run())
+    buffer = sink.go_buffered(fresh_buffer)
+
+    assert buffer is not fresh_buffer
+    assert list(buffer) == [{"type": "token", "data": "already-buffered"}]
+
+    await sink("token", "buffered-after-reconnect-handling-too")
+    assert list(buffer) == [
+        {"type": "token", "data": "already-buffered"},
+        {"type": "token", "data": "buffered-after-reconnect-handling-too"},
+    ]
+
+
 def test_max_concurrent_runs_defaults(monkeypatch):
     from lemma_cli.daemon import config as daemon_config
 


### PR DESCRIPTION
## Summary

Two bugs were reported for pod agents running on the lemma-cli daemon:
1. A long-running daemon run appeared to have no MCP tools / unrestricted Bash — investigated live, turned out **not** to be a real bug (toolset resolution works correctly for both pod-default and named agents).
2. The daemon's websocket to the backend drops mid-run ("keepalive ping timeout"), orphaning the run — the backend shows it `RUNNING` forever (or until a ~35–45 min backstop cron fires), while the daemon streaming it is gone.

Root-cause investigation found bug 2 is real, and a naive timeout bump would paper over a deeper gap: the protocol had no heartbeat actually in use, no distinction between "connection is dead" vs "provider is silently busy," no reconnect-with-resume, no redelivery/dedup, and no concurrency admission control. This PR redesigns the protocol ground-up in three phases:

**Phase 1 — Heartbeat + fast-fail**
- The CLI daemon now actually sends `daemon.ping` (the backend's `daemon.pong` handler already existed but was dead code — the client never called it), on its own `asyncio` task independent of run-handling tasks, so a busy run can never delay it.
- Backend pushes a `RECONNECTING` sentinel into a run's queue the instant a daemon disconnects, and `DaemonHarness.run()` shows a "reconnecting…" status and waits a bounded grace window (~2 min, configurable) before failing — decoupled from the existing 7200s `event_timeout_seconds`, which still correctly tolerates one legitimately long silent tool call on a *live* connection.
- Backend also gets a staleness reaper as a backstop for half-open connections.

**Phase 2 — Hold-not-kill + reattach**
- A run's subprocess is no longer cancelled just because the transport drops — it's an independent OS process that keeps running. Its events buffer locally (capped ring buffer) and flush once a new connection reattaches, with the buffered daemon-side session preserved across reconnects.
- Closes a real duplicate-execution gap: a redelivered `run.start` for an already-active `agent_run_id` is now a no-op on both sides instead of spawning a second concurrent subprocess.

**Phase 3 — Concurrency admission control**
- Per-daemon concurrency cap (`LEMMA_DAEMON_MAX_CONCURRENT_RUNS`, default 4) rejects new runs immediately when at capacity instead of silently competing for host CPU/subprocess slots — explicit rejection, not a silent queue that would look identical to a slow-but-legitimate run.
- Codex's per-conversation app-server pool is bounded the same way (queues rather than rejects, since an unrelated warm conversation shouldn't fail a brand-new one on a single-user laptop).
- Daemon capacity is signaled to the backend via the heartbeat and stored in Redis (ephemeral, like the existing online-presence key), so the backend can fail fast with a clear "daemon busy" message.

Live verification caught two real integration gaps that unit tests alone missed (both fixed): `AgentRunnerService`'s harness-event consumer and the surfaces `ProgressObserver` never had a branch for the new `REJECTED` event type, so a rejected run silently stayed `RUNNING` forever until I added explicit handling.

## Test plan

- [x] `lemma-cli`: 554 unit tests pass (up from 524 baseline; +30 new tests covering heartbeat scheduling/independence, grace-period resume/fail-fast, held-run buffering/reattach, concurrency-cap rejection, codex pool slot accounting including the double-release edge case)
- [x] `lemma-backend`: full suite (1580 tests across all modules) passes with zero regressions; +31 new tests covering hub disconnect/reattach bookkeeping, `DaemonHarness` grace-period state machine, capacity storage gate, `REJECTED` finalization
- [x] Ruff clean on every touched file, both repos
- [x] Live-verified against a local `make dev` stack with a real daemon + real Claude Code harness:
  - Killed the daemon process outright mid-run → conversation reached `FAILED` with a clear error within the grace window, not the 2-hour timeout or the ~40min cron
  - Fired 3 concurrent conversations at a daemon capped at 2 → 2 completed, 1 got an immediate `Daemon busy: 2/2 runs already active` error, conversation correctly finalized as `FAILED` (not stuck `RUNNING`)
  - `SIGSTOP`'d the daemon process for 35s mid-tool-call (long enough to trip the backend's staleness reaper) → chat UI showed "Connection to your machine dropped; waiting to reconnect…" → "Reconnected." → same `claude` subprocess resumed (never restarted) → correct final answer → confirmed via conversation message history that the tool executed **exactly once**, no duplication

🤖 Generated with [Claude Code](https://claude.com/claude-code)