### PR TITLE
feat(agent): pod-native toolsets for user agents, default view_image, pretty cwd

### DIFF
--- a/lemma-backend/app/modules/agent/capabilities/assembler.py
+++ b/lemma-backend/app/modules/agent/capabilities/assembler.py
@@ -87,7 +87,18 @@ def _agent_has_toolset(agent: Agent, toolset: AgentToolset) -> bool:
 
 def _partition_core_extra(
     toolsets: list[object],
+    *,
+    is_pod_default: bool,
 ) -> tuple[list[object], list[object]]:
+    """Split toolsets into core (prompt-visible) vs extra (deferred via ToolSearch).
+
+    Deferral only applies to the pod-default agent, which otherwise accumulates
+    every optional toolset in its prompt prefix. User-created agents already
+    chose a deliberately scoped toolset, so POD/SUBAGENTS are injected directly
+    for them like any other configured toolset.
+    """
+    if not is_pod_default:
+        return list(toolsets), []
     core: list[object] = []
     extra: list[object] = []
     for toolset in toolsets:
@@ -165,7 +176,9 @@ async def build_lemma_harness_tooling(
     # agent/uow_factory/run-id reserved: tool selection (incl. todo) now happens in
     # RunToolAssembler, so full_toolsets already reflects the agent's toolsets.
     _ = (agent, uow_factory, agent_run_id, model_name)
-    core, extra = _partition_core_extra(full_toolsets)
+    core, extra = _partition_core_extra(
+        full_toolsets, is_pod_default=ctx.is_pod_default_agent
+    )
 
     # The todo toolset (if the agent has TODO) already arrives in `full_toolsets`
     # from RunToolAssembler and is wrapped by `_visible_capability` above.

--- a/lemma-backend/app/modules/agent/domain/context.py
+++ b/lemma-backend/app/modules/agent/domain/context.py
@@ -19,6 +19,12 @@ class AgentContext(BaseModel):
     agent_name: str | None = None
     agent_run_id: UUID | None = None
     metadata: JsonObject | None = None
+    # True only for the pod-default assistant (no user-created Agent entity).
+    # Gates the deferred-tool (ToolSearch) partitioning in the LEMMA capability
+    # assembler: the pod-default agent keeps POD/SUBAGENTS deferred to avoid
+    # overloading its prompt prefix, while user-created agents that deliberately
+    # configured those toolsets get them injected directly.
+    is_pod_default_agent: bool = False
     # Rendered runtime brief (pod/user/granted resources) appended to the system
     # prompt. Built once per run by the runner; harness-neutral so it just rides
     # along on the context.

--- a/lemma-backend/app/modules/agent/domain/value_objects.py
+++ b/lemma-backend/app/modules/agent/domain/value_objects.py
@@ -63,6 +63,10 @@ class AgentToolset(str, Enum):
     POD = "POD"
     SUBAGENTS = "SUBAGENTS"
     TODO = "TODO"
+    # Reserved: never persisted on Agent.toolsets. Auto-appended at run time for
+    # any agent whose resolved model declares VISION capability, regardless of
+    # its configured toolsets — see `agent_runner_service.py`.
+    VIEW_IMAGE = "VIEW_IMAGE"
 
 
 class ConnectorMode(str, Enum):

--- a/lemma-backend/app/modules/agent/services/agent_runner_service.py
+++ b/lemma-backend/app/modules/agent/services/agent_runner_service.py
@@ -72,14 +72,15 @@ from app.modules.agent.services.realtime import (
 from app.modules.agent.services.agent_context_brief import AgentContextBriefBuilder
 from app.modules.agent.services.run_message_writer import RunMessageWriter
 from app.modules.agent.services.run_usage_recorder import RunUsageRecorder
-from app.modules.agent.services.workspace_location import resolve_workspace_location
+from app.modules.agent.services.workspace_location import (
+    resolve_pod_cwd,
+    resolve_workspace_location,
+)
 from app.modules.agent.tools.context import ConversationContext
 from app.modules.agent.tools.callable_tool_factory import AgentCallableToolFactory
 from app.modules.agent.tools.final_answer import get_final_answer_tool
-from app.modules.agent.tools.registry import (
-    POD_DEFAULT_AGENT_TOOLSETS,
-    adapt_toolsets_for_vision,
-)
+from app.modules.agent.tools.registry import POD_DEFAULT_AGENT_TOOLSETS
+from app.modules.agent.tools.workspace_cli.pydantic_adapter import view_image_toolset
 from app.modules.agent.tools.tool_assembler import RunToolAssembler
 from app.core.crypto import get_secret_cipher
 from app.core.authorization.delegation import DEFAULT_POD_AGENT_NAME
@@ -213,6 +214,7 @@ class AgentRunnerService:
             runtime_profile_snapshot = resolved_runtime.public_snapshot()
             runtime_credentials = resolved_runtime.credentials or {}
             workspace_location = resolve_workspace_location(conversation)
+            pod_cwd = resolve_pod_cwd(conversation)
             ctx = ConversationContext(
                 user_id=user_id,
                 org_id=conversation.organization_id,
@@ -230,6 +232,7 @@ class AgentRunnerService:
                 runtime_credentials=runtime_credentials,
                 workspace_id=workspace_location.workspace_id,
                 workspace_cwd=workspace_location.cwd,
+                pod_cwd=pod_cwd,
                 # Only the in-process pydantic (LEMMA) harness catches the
                 # ask_user/request_approval pause signal; daemon harnesses run the
                 # tools over MCP and own their own session, so they can't be paused
@@ -237,6 +240,7 @@ class AgentRunnerService:
                 supports_pause_signal=(
                     resolved_runtime.harness_kind == HarnessKind.LEMMA
                 ),
+                is_pod_default_agent=(agent.id == _POD_ASSISTANT_AGENT_ID),
                 **surface_context,
             )
             try:
@@ -254,6 +258,15 @@ class AgentRunnerService:
                 agent=agent,
                 conversation=conversation,
             )
+            # `view_image` is a standalone toolset, appended for any agent/harness
+            # whose resolved model declares VISION support — independent of the
+            # agent's configured toolsets (see AgentToolset.VIEW_IMAGE).
+            supports_vision = (
+                resolved_runtime.model is not None
+                and RuntimeModelCapability.VISION in resolved_runtime.model.capabilities
+            )
+            if supports_vision and view_image_toolset not in full_toolsets:
+                full_toolsets = [*full_toolsets, view_image_toolset]
             # Daemon harnesses (Codex/Claude-Code) reach every tool through the MCP
             # server, so they keep the full toolset list. The in-process LEMMA
             # harness instead shows core tools directly and defers the heavy "extra"
@@ -265,28 +278,13 @@ class AgentRunnerService:
                 harness_model_settings = _profile_model_settings(
                     runtime_profile_snapshot
                 )
-                # The in-process pydantic-ai harness drives the model directly and
-                # owns the message history, so a model without vision support
-                # breaks when `view_image` returns image content. Withhold the
-                # image-returning tools unless the resolved model declares VISION.
-                # (Daemon harnesses run their own external multimodal models and
-                # keep the full toolset.)
-                supports_vision = (
-                    resolved_runtime.model is not None
-                    and RuntimeModelCapability.VISION
-                    in resolved_runtime.model.capabilities
-                )
-                lemma_toolsets = adapt_toolsets_for_vision(
-                    full_toolsets,
-                    supports_vision=supports_vision,
-                )
                 # The in-process harness realizes every tool surface as a
                 # capability, so its toolset list is empty.
                 harness_capabilities = await build_lemma_harness_tooling(
                     uow_factory=self.uow_factory,
                     agent=agent,
                     ctx=ctx,
-                    full_toolsets=lemma_toolsets,
+                    full_toolsets=full_toolsets,
                     agent_run_id=agent_run_id,
                     model_name=resolved_runtime.model_name_for_harness,
                     enable_prompt_caching=(

--- a/lemma-backend/app/modules/agent/services/conversation_service.py
+++ b/lemma-backend/app/modules/agent/services/conversation_service.py
@@ -191,8 +191,12 @@ class ConversationService:
         A child (``parent_id`` set — a sub-agent OR a conversation pinned under a
         PROJECT) inherits the parent's resolved cwd + workspace selection, so it
         shares the parent's directory instead of getting its own. A root
-        conversation gets its own ``/workspace/conversations/{id}`` cwd. An
-        explicit ``cwd`` already in metadata always wins.
+        conversation gets its own ``/workspace/c/{date}/{slug}`` cwd. An explicit
+        ``cwd`` already in metadata always wins.
+
+        The cwd is the single source of truth for both filesystems: the pod
+        working directory (``/me/{suffix}``) is derived from it at read time
+        (``resolve_pod_cwd``), so nothing pod-specific is persisted here.
         """
         metadata = conversation.metadata if isinstance(conversation.metadata, dict) else {}
         if metadata.get("cwd"):
@@ -749,6 +753,7 @@ class ConversationService:
         )
         from app.modules.agent.tools.context import ConversationContext
         from app.core.crypto import get_secret_cipher
+        from app.modules.agent.services.workspace_location import resolve_pod_cwd
 
         uow_factory = SessionUnitOfWorkFactory(async_session_maker)
         agent = await self._resolve_agent(conversation=conversation, user_id=user_id)
@@ -786,6 +791,7 @@ class ConversationService:
             runtime_credentials=resolved.credentials or {},
             workspace_id=workspace_location.workspace_id,
             workspace_cwd=workspace_location.cwd,
+            pod_cwd=resolve_pod_cwd(conversation),
         )
 
     async def _pending_user_approval_from_messages(

--- a/lemma-backend/app/modules/agent/services/workspace_location.py
+++ b/lemma-backend/app/modules/agent/services/workspace_location.py
@@ -4,23 +4,54 @@ Both the agent run and the approval executor must run in the *same* workspace
 session and cwd, so the resolution lives here instead of being duplicated. The
 location is configurable per conversation via ``metadata``:
 
-- ``cwd`` — explicit working directory; defaults to ``/workspace/conversations/{id}``.
+- ``cwd`` — explicit working directory; a fresh root conversation gets a default
+  of ``/workspace/c/{date}/{slug}``. Stamped into metadata at creation
+  (``ConversationService._apply_inherited_cwd``) and read back thereafter.
 - ``workspace_name`` / ``workspace_id`` — selects the workspace; defaults to the
   single per-user workspace today. Kept metadata-driven so multi-workspace
   switching becomes a metadata-only change later.
+
+The pod filesystem's working directory (``/me/{suffix}``) is derived from the
+workspace cwd by swapping the ``/workspace`` prefix for ``/me`` — so an agent's
+scratchpad (``/workspace/c/{date}/{slug}``) and its pod filesystem
+(``/me/c/{date}/{slug}``) line up under the same short, human-readable path
+instead of a raw conversation UUID. No extra persisted field is needed: the cwd
+already lives in conversation metadata.
 """
 
 from __future__ import annotations
 
+import secrets
+import string
 from dataclasses import dataclass
 
 from app.modules.agent.domain.entities import Conversation
+
+_SLUG_ALPHABET = string.ascii_lowercase + string.digits
+_SLUG_LENGTH = 8
+_WORKSPACE_ROOT = "/workspace"
+_POD_ROOT = "/me"
 
 
 @dataclass(slots=True)
 class WorkspaceLocation:
     workspace_id: str
     cwd: str
+
+
+def generate_cwd_slug() -> str:
+    """A short random alphanumeric slug for conversation cwd paths."""
+    return "".join(secrets.choice(_SLUG_ALPHABET) for _ in range(_SLUG_LENGTH))
+
+
+def default_workspace_cwd(conversation: Conversation) -> str:
+    """The default ``/workspace/c/{date}/{slug}`` cwd for a root conversation.
+
+    Generates a fresh slug; callers persist the result into conversation
+    metadata (at creation) so it stays stable across later runs.
+    """
+    date = conversation.created_at.date().isoformat()
+    return f"{_WORKSPACE_ROOT}/c/{date}/{generate_cwd_slug()}"
 
 
 def resolve_workspace_location(conversation: Conversation) -> WorkspaceLocation:
@@ -36,6 +67,25 @@ def resolve_workspace_location(conversation: Conversation) -> WorkspaceLocation:
     cwd = str(
         workspace.get("cwd")
         or metadata.get("cwd")
-        or f"/workspace/conversations/{conversation.id}"
+        or default_workspace_cwd(conversation)
     )
     return WorkspaceLocation(workspace_id=workspace_id, cwd=cwd)
+
+
+def pod_cwd_from_workspace_cwd(workspace_cwd: str) -> str:
+    """Mirror a workspace cwd into the pod filesystem under ``/me``.
+
+    ``/workspace/c/{date}/{slug}`` -> ``/me/c/{date}/{slug}``. A cwd not under
+    ``/workspace`` is placed under ``/me`` as-is (defensive; overrides today are
+    always under ``/workspace``).
+    """
+    if workspace_cwd == _WORKSPACE_ROOT:
+        return _POD_ROOT
+    if workspace_cwd.startswith(f"{_WORKSPACE_ROOT}/"):
+        return f"{_POD_ROOT}/{workspace_cwd[len(_WORKSPACE_ROOT) + 1:]}"
+    return f"{_POD_ROOT}/{workspace_cwd.lstrip('/')}"
+
+
+def resolve_pod_cwd(conversation: Conversation) -> str:
+    """Default pod-filesystem cwd, sharing the workspace cwd's suffix."""
+    return pod_cwd_from_workspace_cwd(resolve_workspace_location(conversation).cwd)

--- a/lemma-backend/app/modules/agent/tests/e2e/test_projects_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_projects_e2e.py
@@ -54,7 +54,7 @@ async def test_project_groups_children_and_shares_cwd(
     assert project["id"] in await _list_ids(authenticated_client, pod_id, type="PROJECT")
 
     # A conversation pinned under the project inherits the project's cwd instead of
-    # getting its own /workspace/conversations/{id} directory.
+    # getting its own c/{date}/{slug} directory.
     child = await _create_conversation(
         authenticated_client,
         pod_id,
@@ -79,5 +79,8 @@ async def test_root_conversation_records_own_cwd(authenticated_client, fixed_tes
     convo = await _create_conversation(
         authenticated_client, pod_id, {"title": "root", "type": "CHAT"}
     )
-    # cwd is always recorded in metadata; a root gets its own conversation dir.
-    assert convo["metadata"]["cwd"] == f"/workspace/conversations/{convo['id']}"
+    # cwd is always recorded in metadata; a root gets its own c/{date}/{slug} dir,
+    # sharing its suffix with the pod filesystem default (`/me/{suffix}`).
+    cwd = convo["metadata"]["cwd"]
+    assert cwd.startswith("/workspace/c/")
+    assert cwd.count("/") == 4  # /workspace/c/{date}/{slug}

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_tools.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_tools.py
@@ -1148,7 +1148,11 @@ async def test_root_conversation_gets_own_cwd():
     convo = Conversation(pod_id=uuid4(), user_id=uuid4())
     await service._apply_inherited_cwd(convo, parent_id=None)
 
-    assert convo.metadata["cwd"] == f"/workspace/conversations/{convo.id}"
+    # A root gets its own pretty c/{date}/{slug} cwd stamped into metadata.
+    date = convo.created_at.date().isoformat()
+    cwd = convo.metadata["cwd"]
+    assert cwd.startswith(f"/workspace/c/{date}/")
+    assert cwd.count("/") == 4  # /workspace/c/{date}/{slug}
 
 
 @pytest.mark.asyncio

--- a/lemma-backend/app/modules/agent/tests/unit/test_capabilities.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_capabilities.py
@@ -32,9 +32,10 @@ from app.modules.agent.tools.registry import (
 )
 
 
-def test_partition_core_extra_splits_pod_into_extra():
+def test_partition_core_extra_splits_pod_into_extra_for_pod_default():
     core, extra = _partition_core_extra(
-        [workspace_cli_toolset, pod_toolset, web_search_toolset]
+        [workspace_cli_toolset, pod_toolset, web_search_toolset],
+        is_pod_default=True,
     )
     assert pod_toolset in extra
     assert workspace_cli_toolset in core
@@ -42,27 +43,17 @@ def test_partition_core_extra_splits_pod_into_extra():
     assert pod_toolset not in core
 
 
-def test_adapt_toolsets_for_vision_swaps_only_when_no_vision():
-    from app.modules.agent.tools.registry import adapt_toolsets_for_vision
-    from app.modules.agent.tools.workspace_cli.pydantic_adapter import (
-        workspace_cli_text_only_toolset,
+def test_partition_core_extra_keeps_everything_core_for_user_created_agent():
+    """User-created agents that configured POD/SUBAGENTS get them injected
+    directly (no ToolSearch round-trip) — only the pod-default agent defers."""
+    core, extra = _partition_core_extra(
+        [workspace_cli_toolset, pod_toolset, web_search_toolset],
+        is_pod_default=False,
     )
-
-    # Vision model: list is returned unchanged (view_image stays).
-    kept = adapt_toolsets_for_vision(
-        [workspace_cli_toolset, web_search_toolset], supports_vision=True
-    )
-    assert kept[0] is workspace_cli_toolset
-
-    # No-vision model: the workspace CLI toolset is swapped for the text-only
-    # variant (no view_image); other toolsets are untouched.
-    swapped = adapt_toolsets_for_vision(
-        [workspace_cli_toolset, web_search_toolset], supports_vision=False
-    )
-    assert swapped[0] is workspace_cli_text_only_toolset
-    assert swapped[1] is web_search_toolset
-    assert "view_image" not in workspace_cli_text_only_toolset.tools
-    assert "exec_command" in workspace_cli_text_only_toolset.tools
+    assert extra == []
+    assert pod_toolset in core
+    assert workspace_cli_toolset in core
+    assert web_search_toolset in core
 
 
 def test_prompt_caching_keys_on_conversation_id():
@@ -120,7 +111,7 @@ async def test_assembler_returns_capabilities_for_every_visible_toolset():
         agent=SimpleNamespace(
             toolsets=[AgentToolset.WEB_SEARCH, AgentToolset.WORKSPACE_CLI]
         ),
-        ctx=SimpleNamespace(conversation_id=uuid4()),
+        ctx=SimpleNamespace(conversation_id=uuid4(), is_pod_default_agent=True),
         full_toolsets=[web_search_toolset, workspace_cli_toolset],
         agent_run_id=uuid4(),
         model_name="m",
@@ -341,14 +332,16 @@ async def test_current_time_and_deferral_in_real_run():
     assert captured["settings"].get("openai_user") == str(conversation_id)
 
 
-# The 13 user-facing function tools. ToolSearch adds a 14th tool (`search_tools`)
-# at the discovery layer for the live provider adapter; it isn't reported in
-# FunctionModel's AgentInfo.function_tools, so it's asserted separately below.
+# The 12 user-facing function tools (view_image is a separate, vision-gated
+# toolset appended by the runner, not part of an agent's configured toolsets —
+# see test_pod_default_gains_view_image_toolset_when_vision_supported).
+# ToolSearch adds a 13th tool (`search_tools`) at the discovery layer for the
+# live provider adapter; it isn't reported in FunctionModel's
+# AgentInfo.function_tools, so it's asserted separately below.
 _EXPECTED_VISIBLE_POD_DEFAULT_TOOLS = {
     "exec_command",
     "manage_process",
     "execute_python",
-    "view_image",
     "web_search",
     "list_skills",
     "load_skill",
@@ -376,7 +369,8 @@ async def test_pod_default_visible_toolset_is_slim(monkeypatch):
     )
 
     deps = BaseAgentContext(
-        user_id=uuid4(), pod_id=uuid4(), conversation_id=uuid4()
+        user_id=uuid4(), pod_id=uuid4(), conversation_id=uuid4(),
+        is_pod_default_agent=True,
     )
     # Assemble through the real RunToolAssembler so the pod-default toolset
     # (including the conversation-scoped TODO toolset) is resolved exactly as in a
@@ -450,7 +444,10 @@ async def test_pod_default_speech_capability_carries_its_prompt(monkeypatch):
         storage_mod, "ConversationRepository", lambda _uow: _FakeRepo({})
     )
 
-    deps = BaseAgentContext(user_id=uuid4(), pod_id=uuid4(), conversation_id=uuid4())
+    deps = BaseAgentContext(
+        user_id=uuid4(), pod_id=uuid4(), conversation_id=uuid4(),
+        is_pod_default_agent=True,
+    )
     full_toolsets = await RunToolAssembler(lambda: _FakeUoW()).assemble(
         agent=None,
         conversation=SimpleNamespace(id=deps.conversation_id, metadata={}),
@@ -479,60 +476,75 @@ async def test_pod_default_speech_capability_carries_its_prompt(monkeypatch):
 
 
 @pytest.mark.anyio
-async def test_pod_default_without_vision_omits_view_image(monkeypatch):
-    """On a non-vision model the runner swaps in the text-only workspace toolset,
-    so view_image disappears while the other workspace tools and the workspace_cli
-    usage instructions are preserved."""
-    from app.modules.agent.capabilities import todo_storage as storage_mod
+async def test_pod_default_gains_view_image_toolset_when_vision_supported():
+    """`view_image` is not part of workspace_cli or any configured toolset — the
+    runner appends the standalone `view_image_toolset` only when the resolved
+    model supports vision (mirroring the vision-gated append in
+    `agent_runner_service.py`)."""
     from app.modules.agent.capabilities.assembler import build_lemma_harness_tooling
     from app.modules.agent.capabilities.instructed_toolset import (
         InstructedToolsetCapability,
     )
     from app.modules.agent.tools.context import BaseAgentContext
-    from app.modules.agent.tools.registry import (
-        POD_DEFAULT_AGENT_TOOLSETS,
-        adapt_toolsets_for_vision,
-    )
+    from app.modules.agent.tools.registry import POD_DEFAULT_AGENT_TOOLSETS
     from app.modules.agent.tools.tool_assembler import RunToolAssembler
-
-    monkeypatch.setattr(
-        storage_mod, "ConversationRepository", lambda _uow: _FakeRepo({})
+    from app.modules.agent.tools.workspace_cli.pydantic_adapter import (
+        view_image_toolset,
     )
 
-    deps = BaseAgentContext(user_id=uuid4(), pod_id=uuid4(), conversation_id=uuid4())
+    deps = BaseAgentContext(
+        user_id=uuid4(), pod_id=uuid4(), conversation_id=uuid4(),
+        is_pod_default_agent=True,
+    )
     full_toolsets = await RunToolAssembler(lambda: _FakeUoW()).assemble(
         agent=None,
         conversation=SimpleNamespace(id=deps.conversation_id, metadata={}),
     )
-    # Mirror the runner's LEMMA branch for a model that lacks VISION.
-    lemma_toolsets = adapt_toolsets_for_vision(full_toolsets, supports_vision=False)
-    capabilities = await build_lemma_harness_tooling(
-        uow_factory=lambda: _FakeUoW(),
-        agent=SimpleNamespace(toolsets=list(POD_DEFAULT_AGENT_TOOLSETS)),
-        ctx=deps,
-        full_toolsets=lemma_toolsets,
-        agent_run_id=uuid4(),
-        model_name="m",
-        enable_prompt_caching=False,
+
+    async def build_capabilities(*, supports_vision: bool) -> list[object]:
+        toolsets = full_toolsets
+        if supports_vision:
+            toolsets = [*full_toolsets, view_image_toolset]
+        return await build_lemma_harness_tooling(
+            uow_factory=lambda: _FakeUoW(),
+            agent=SimpleNamespace(toolsets=list(POD_DEFAULT_AGENT_TOOLSETS)),
+            ctx=deps,
+            full_toolsets=toolsets,
+            agent_run_id=uuid4(),
+            model_name="m",
+            enable_prompt_caching=False,
+        )
+
+    async def visible_tool_names(capabilities: list[object]) -> set[str]:
+        captured: dict = {}
+
+        def model_fn(messages, info: AgentInfo):
+            captured["visible"] = {
+                t.name for t in info.function_tools if not t.defer_loading
+            }
+            return ModelResponse(parts=[TextPart("done")])
+
+        agent = Agent(FunctionModel(model_fn), capabilities=capabilities)
+        await agent.run("hi", deps=deps)
+        return captured["visible"]
+
+    # No vision → view_image absent; everything else is unaffected.
+    no_vision_caps = await build_capabilities(supports_vision=False)
+    assert (
+        await visible_tool_names(no_vision_caps) == _EXPECTED_VISIBLE_POD_DEFAULT_TOOLS
     )
 
-    captured: dict = {}
-
-    def model_fn(messages, info: AgentInfo):
-        captured["visible"] = {
-            t.name for t in info.function_tools if not t.defer_loading
-        }
-        return ModelResponse(parts=[TextPart("done")])
-
-    agent = Agent(FunctionModel(model_fn), capabilities=capabilities)
-    await agent.run("hi", deps=deps)
-
-    # view_image is gone; the remaining workspace tools (and everything else) stay.
-    assert captured["visible"] == _EXPECTED_VISIBLE_POD_DEFAULT_TOOLS - {"view_image"}
-    # The workspace_cli usage instructions still ride along (text-only variant is
-    # recognised as the workspace CLI toolset).
+    # Vision supported → view_image appended as a plain core toolset capability
+    # (no bespoke instructions needed; the tool's own docstring carries guidance).
+    vision_caps = await build_capabilities(supports_vision=True)
+    assert (
+        await visible_tool_names(vision_caps)
+        == _EXPECTED_VISIBLE_POD_DEFAULT_TOOLS | {"view_image"}
+    )
+    # The workspace_cli usage instructions still ride along, unaffected by
+    # whether view_image is present.
     assert any(
         isinstance(c, InstructedToolsetCapability)
         and c.get_serialization_name() == "workspace_cli"
-        for c in capabilities
+        for c in vision_caps
     )

--- a/lemma-backend/app/modules/agent/tests/unit/test_pod_tools.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_pod_tools.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock
 from uuid import uuid4
 
 import pytest
@@ -24,18 +24,21 @@ from app.modules.agent.tools.pod.models import (
     PodGetRecordsRequest,
     PodReadFileRequest,
     PodTablesRequest,
+    PodWriteFileRequest,
     PodWriteRecordRequest,
     ViewDocumentPagesRequest,
 )
 from app.modules.agent.tools.registry import resolve_agent_toolsets
+from app.modules.datastore.domain.errors import DatastoreConflictError
 
 
-def _run_ctx() -> SimpleNamespace:
+def _run_ctx(*, pod_cwd: str | None = None) -> SimpleNamespace:
     return SimpleNamespace(
         deps=BaseAgentContext(
             user_id=uuid4(),
             pod_id=uuid4(),
             conversation_id=uuid4(),
+            pod_cwd=pod_cwd,
         )
     )
 
@@ -54,7 +57,7 @@ def test_pod_toolset_is_registered_under_pod_toolset_enum():
     assert pod_adapter.pod_toolset in toolsets
 
 
-def test_pod_toolset_exposes_exactly_the_nine_tools():
+def test_pod_toolset_exposes_exactly_the_ten_tools():
     names = set(pod_adapter.pod_toolset.tools.keys())
     assert names == {
         "pod_tables",
@@ -63,6 +66,7 @@ def test_pod_toolset_exposes_exactly_the_nine_tools():
         "pod_query",
         "pod_list_files",
         "pod_read_file",
+        "pod_write_file",
         "pod_view_document_pages",
         "pod_get_file_url",
         "pod_search_files",
@@ -443,3 +447,103 @@ async def test_pod_get_file_url_public_mints_signed_url(monkeypatch):
     create_signed_url.assert_awaited_once()
     _entity_args, kwargs = create_signed_url.call_args
     assert kwargs == {"expires_seconds": 3600, "max_hits": 5}
+
+
+@pytest.mark.asyncio
+async def test_pod_write_file_creates_new_file(monkeypatch):
+    entity = SimpleNamespace(path="/me/report.md", size_bytes=5)
+    services = SimpleNamespace(
+        file=SimpleNamespace(create_file=AsyncMock(return_value=entity)),
+        ctx=SimpleNamespace(pod_id=uuid4(), user_id=uuid4()),
+    )
+    _patch_services(monkeypatch, services)
+
+    result = await pod_adapter.pod_write_file(
+        _run_ctx(), PodWriteFileRequest(path="/me/report.md", content="hello")
+    )
+
+    assert result == {
+        "success": True,
+        "path": "/me/report.md",
+        "size_bytes": 5,
+        "created": True,
+    }
+    services.file.create_file.assert_awaited_once()
+    args, kwargs = services.file.create_file.call_args
+    assert args[1] == "report.md"
+    assert args[2] == b"hello"
+    assert kwargs["directory_path"] == "/me"
+
+
+@pytest.mark.asyncio
+async def test_pod_write_file_relative_path_resolves_against_pod_cwd(monkeypatch):
+    entity = SimpleNamespace(path="/me/c/2026-07-02/ab3f2k7q/notes.md", size_bytes=3)
+    services = SimpleNamespace(
+        file=SimpleNamespace(create_file=AsyncMock(return_value=entity)),
+        ctx=SimpleNamespace(pod_id=uuid4(), user_id=uuid4()),
+    )
+    _patch_services(monkeypatch, services)
+
+    ctx = _run_ctx(pod_cwd="/me/c/2026-07-02/ab3f2k7q")
+    result = await pod_adapter.pod_write_file(
+        ctx, PodWriteFileRequest(path="notes.md", content="hey")
+    )
+
+    assert result["success"] is True
+    args, kwargs = services.file.create_file.call_args
+    assert args[1] == "notes.md"
+    assert kwargs["directory_path"] == "/me/c/2026-07-02/ab3f2k7q"
+
+
+@pytest.mark.asyncio
+async def test_pod_write_file_conflict_without_overwrite_returns_error(monkeypatch):
+    services = SimpleNamespace(
+        file=SimpleNamespace(
+            create_file=AsyncMock(side_effect=DatastoreConflictError("exists")),
+            resolve_update_file=AsyncMock(),
+        ),
+        ctx=SimpleNamespace(pod_id=uuid4(), user_id=uuid4()),
+    )
+    _patch_services(monkeypatch, services)
+
+    result = await pod_adapter.pod_write_file(
+        _run_ctx(),
+        PodWriteFileRequest(path="/me/report.md", content="hello", overwrite=False),
+    )
+
+    assert result["success"] is False
+    assert "already exists" in result["error"]
+    services.file.resolve_update_file.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pod_write_file_conflict_with_overwrite_updates_existing(monkeypatch):
+    plan = object()
+    updated = SimpleNamespace(path="/me/report.md", size_bytes=7)
+    services = SimpleNamespace(
+        file=SimpleNamespace(
+            create_file=AsyncMock(side_effect=DatastoreConflictError("exists")),
+            resolve_update_file=AsyncMock(return_value=plan),
+            write_update_storage=AsyncMock(),
+            persist_update_file=AsyncMock(return_value=updated),
+            finalize_update_file=AsyncMock(),
+        ),
+        ctx=SimpleNamespace(pod_id=uuid4(), user_id=uuid4()),
+    )
+    _patch_services(monkeypatch, services)
+
+    result = await pod_adapter.pod_write_file(
+        _run_ctx(),
+        PodWriteFileRequest(path="/me/report.md", content="hello", overwrite=True),
+    )
+
+    assert result == {
+        "success": True,
+        "path": "/me/report.md",
+        "size_bytes": 7,
+        "created": False,
+    }
+    services.file.resolve_update_file.assert_awaited_once()
+    services.file.write_update_storage.assert_awaited_once_with(plan, ANY)
+    services.file.persist_update_file.assert_awaited_once_with(plan)
+    services.file.finalize_update_file.assert_awaited_once_with(plan, updated)

--- a/lemma-backend/app/modules/agent/tests/unit/test_workspace_location.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_workspace_location.py
@@ -1,19 +1,27 @@
-"""Unit tests for conversation workspace/cwd resolution."""
+"""Unit tests for conversation workspace/pod cwd resolution."""
 
 from __future__ import annotations
 
 from uuid import uuid4
 
 from app.modules.agent.domain.entities import Conversation
-from app.modules.agent.services.workspace_location import resolve_workspace_location
+from app.modules.agent.services.workspace_location import (
+    generate_cwd_slug,
+    pod_cwd_from_workspace_cwd,
+    resolve_pod_cwd,
+    resolve_workspace_location,
+)
 
 
-def test_defaults_to_conversation_scoped_cwd_and_single_workspace():
+def test_defaults_to_pretty_conversation_scoped_cwd_and_single_workspace():
     conversation = Conversation(pod_id=uuid4(), user_id=uuid4())
 
     location = resolve_workspace_location(conversation)
 
-    assert location.cwd == f"/workspace/conversations/{conversation.id}"
+    date = conversation.created_at.date().isoformat()
+    assert location.cwd.startswith(f"/workspace/c/{date}/")
+    # /workspace/c/{date}/{slug}
+    assert location.cwd.count("/") == 4
     assert location.workspace_id == "default"
 
 
@@ -41,3 +49,38 @@ def test_nested_workspace_block_takes_precedence():
 
     assert location.workspace_id == "ws-7"
     assert location.cwd == "/workspace/ws7"
+
+
+def test_pod_cwd_mirrors_persisted_workspace_cwd_under_me():
+    conversation = Conversation(
+        pod_id=uuid4(),
+        user_id=uuid4(),
+        metadata={"cwd": "/workspace/c/2026-07-02/ab3f2k7q"},
+    )
+
+    assert resolve_pod_cwd(conversation) == "/me/c/2026-07-02/ab3f2k7q"
+
+
+def test_pod_cwd_mirrors_overridden_workspace_cwd():
+    conversation = Conversation(
+        pod_id=uuid4(),
+        user_id=uuid4(),
+        metadata={"cwd": "/workspace/project"},
+    )
+
+    assert resolve_pod_cwd(conversation) == "/me/project"
+
+
+def test_pod_cwd_from_workspace_cwd_edge_cases():
+    assert pod_cwd_from_workspace_cwd("/workspace") == "/me"
+    assert pod_cwd_from_workspace_cwd("/workspace/a/b") == "/me/a/b"
+    # A cwd not under /workspace is placed under /me as-is (defensive).
+    assert pod_cwd_from_workspace_cwd("/other/x") == "/me/other/x"
+
+
+def test_generate_cwd_slug_is_short_and_alphanumeric():
+    slug = generate_cwd_slug()
+
+    assert len(slug) == 8
+    assert slug.isalnum()
+    assert slug == slug.lower()

--- a/lemma-backend/app/modules/agent/tools/context.py
+++ b/lemma-backend/app/modules/agent/tools/context.py
@@ -39,6 +39,9 @@ class BaseAgentContext(AgentContext):
     runtime_credentials: dict[str, object] = Field(default_factory=dict)
     workspace_id: str = "default"
     workspace_cwd: str | None = None
+    # Default pod-filesystem working directory for this conversation, e.g.
+    # `/me/c/{date}/{slug}`. Relative pod tool paths resolve against this.
+    pod_cwd: str | None = None
 
     # True only when this tool runs inside the in-process pydantic harness, which
     # catches the AgentInputRequired pause signal and turns it into a clean run
@@ -64,6 +67,12 @@ class BaseAgentContext(AgentContext):
 
     def get_workspace_cwd(self) -> str:
         return self.workspace_cwd or f"/workspace/conversations/{self.conversation_id}"
+
+    def get_pod_cwd(self) -> str:
+        # Callers on the main run path always set `pod_cwd` explicitly (see
+        # `resolve_pod_cwd`); this conversation_id-based fallback only covers
+        # secondary context-construction sites that haven't set it.
+        return self.pod_cwd or f"/me/conversations/{self.conversation_id}"
 
     def get_workspace_scope_key(self) -> str:
         return f"workspace:{self.workspace_id}:conversation:{self.conversation_id}"

--- a/lemma-backend/app/modules/agent/tools/pod/models.py
+++ b/lemma-backend/app/modules/agent/tools/pod/models.py
@@ -126,7 +126,14 @@ class QueryRequest(BaseModel):
 
 
 class PodListFilesRequest(BaseModel):
-    path: str = Field(default="/", description="Folder path, e.g. /pod or /me.")
+    path: str = Field(
+        default="/",
+        description=(
+            "Folder path, e.g. /pod or /me. An absolute path is used as-is; a "
+            "relative path (e.g. '' or 'notes') is resolved against your "
+            "default pod working directory (`/me/c/{date}/{slug}`)."
+        ),
+    )
     recursive: bool = Field(
         default=False,
         description=(
@@ -142,8 +149,33 @@ class PodListFilesRequest(BaseModel):
     )
 
 
+class PodWriteFileRequest(BaseModel):
+    path: str = Field(
+        ...,
+        description=(
+            "Pod file path to write. An absolute path (e.g. /me/report.md) is "
+            "used as-is; a relative path (e.g. report.md) is resolved against "
+            "your default pod working directory (`/me/c/{date}/{slug}`) — write "
+            "there when you don't need a specific shared location."
+        ),
+    )
+    content: str = Field(..., description="UTF-8 text content to write.")
+    overwrite: bool = Field(
+        default=True,
+        description="If false and the file already exists, the write is rejected instead of replacing it.",
+    )
+    description: str | None = Field(default=None, description="Optional file description.")
+
+
 class PodReadFileRequest(BaseModel):
-    path: str = Field(..., description="Absolute pod file path, e.g. /pod/notes.txt.")
+    path: str = Field(
+        ...,
+        description=(
+            "Pod file path to read. An absolute path (e.g. /pod/notes.txt) is "
+            "used as-is; a relative path is resolved against your default pod "
+            "working directory (`/me/c/{date}/{slug}`)."
+        ),
+    )
     format: Literal["text", "markdown"] = Field(
         default="text",
         description=(

--- a/lemma-backend/app/modules/agent/tools/pod/pydantic_adapter.py
+++ b/lemma-backend/app/modules/agent/tools/pod/pydantic_adapter.py
@@ -24,6 +24,7 @@ from app.modules.agent.tools.pod.models import (
     PodListFilesRequest,
     PodReadFileRequest,
     PodTablesRequest,
+    PodWriteFileRequest,
     PodWriteRecordRequest,
     QueryRequest,
     SearchFilesRequest,
@@ -31,11 +32,31 @@ from app.modules.agent.tools.pod.models import (
 )
 from app.modules.agent.tools.pod.pod_data_access import PodServices, pod_services
 from app.modules.agent.tools.tool_errors import approval_error_result
+from app.modules.datastore.domain.errors import DatastoreConflictError
+from app.modules.datastore.domain.file_entities import DatastoreFileUpdateEntity
 from app.modules.datastore.services.files.file_url import (
     build_file_app_url,
     build_object_url,
 )
 from app.modules.datastore.services.table_context import TableContext
+
+
+def _resolve_pod_path(deps: BaseAgentContext, path: str) -> str:
+    """Resolve a possibly-relative pod path against the agent's pod cwd."""
+    if path.startswith("/"):
+        return path
+    cwd = deps.get_pod_cwd().rstrip("/")
+    return f"{cwd}/{path}" if path else cwd
+
+
+def _split_pod_path(path: str) -> tuple[str, str]:
+    """Split an absolute pod path into (directory_path, name)."""
+    normalized = path if path.startswith("/") else f"/{path}"
+    trimmed = normalized.rstrip("/") or "/"
+    if trimmed == "/":
+        raise ValueError("A file path must include a file name.")
+    directory, _, name = trimmed.rpartition("/")
+    return (directory or "/", name)
 
 
 def _has_meaningful_data(data: JsonObject | None) -> bool:
@@ -280,6 +301,70 @@ async def pod_query(
 # --- Files ------------------------------------------------------------------
 
 
+async def pod_write_file(
+    ctx: RunContext[BaseAgentContext],
+    request: PodWriteFileRequest,
+) -> JsonObject:
+    """Write text content to a pod file, creating or overwriting it.
+
+    Without an absolute path, the file lands in your default pod working
+    directory (`/me/c/{date}/{slug}`) — a stable, private location scoped to
+    this conversation. Writes under your own `/me/...` (including that default
+    location) never need approval; writes to a shared pod path may.
+    """
+
+    async def op(services: PodServices) -> JsonObject:
+        resolved_path = _resolve_pod_path(ctx.deps, request.path)
+        directory_path, name = _split_pod_path(resolved_path)
+        content_bytes = request.content.encode("utf-8")
+        try:
+            entity = await services.file.create_file(
+                services.ctx.pod_id,
+                name,
+                content_bytes,
+                services.ctx,
+                description=request.description,
+                directory_path=directory_path,
+            )
+            return {
+                "success": True,
+                "path": entity.path,
+                "size_bytes": entity.size_bytes,
+                "created": True,
+            }
+        except DatastoreConflictError:
+            if not request.overwrite:
+                return {
+                    "success": False,
+                    "path": resolved_path,
+                    "error": (
+                        f"A file already exists at '{resolved_path}'. Pass "
+                        "overwrite=true to replace it."
+                    ),
+                }
+            update_entity = DatastoreFileUpdateEntity(
+                path=resolved_path,
+                content=content_bytes,
+                description=request.description,
+            )
+            plan = await services.file.resolve_update_file(
+                services.ctx.pod_id, update_entity, services.ctx
+            )
+            await services.file.write_update_storage(plan, update_entity)
+            updated = await services.file.persist_update_file(plan)
+            await services.file.finalize_update_file(plan, updated)
+            return {
+                "success": True,
+                "path": updated.path,
+                "size_bytes": updated.size_bytes,
+                "created": False,
+            }
+
+    return await _run(
+        ctx.deps, tool_name="pod_write_file", args=request.model_dump(), op=op
+    )
+
+
 async def pod_list_files(
     ctx: RunContext[BaseAgentContext],
     request: PodListFilesRequest,
@@ -288,22 +373,24 @@ async def pod_list_files(
 
     ``recursive=false`` (default) lists the immediate files and folders in
     ``path``. ``recursive=true`` returns a file tree rooted at ``path`` (folders
-    plus a sample of files per directory).
+    plus a sample of files per directory). Without an absolute path, resolves
+    against your default pod working directory (`/me/c/{date}/{slug}`).
     """
 
     async def op(services: PodServices) -> JsonObject:
+        resolved_path = _resolve_pod_path(ctx.deps, request.path)
         if request.recursive:
             tree = await services.file.get_directory_tree(
                 services.ctx.pod_id,
                 services.ctx,
-                root_path=request.path,
+                root_path=resolved_path,
                 files_per_directory=request.files_per_directory,
             )
             return {"success": True, "tree": to_json_value(tree)}
         files, cursor = await services.file.list_files(
             services.ctx.pod_id,
             services.ctx,
-            directory_path=request.path,
+            directory_path=resolved_path,
             limit=request.limit,
         )
         return {
@@ -339,10 +426,11 @@ async def pod_read_file(
     """
 
     async def op(services: PodServices) -> JsonObject:
+        resolved_path = _resolve_pod_path(ctx.deps, request.path)
         if request.format == "markdown":
             entity, markdown, page_count = await services.file.get_document_markdown(
                 services.ctx.pod_id,
-                request.path,
+                resolved_path,
                 services.ctx,
                 page_start=request.page_start,
                 page_end=request.page_end,
@@ -359,7 +447,7 @@ async def pod_read_file(
             }
 
         entity, content = await services.file.download_file_content_by_path(
-            services.ctx.pod_id, request.path, services.ctx
+            services.ctx.pod_id, resolved_path, services.ctx
         )
         try:
             text = content.decode("utf-8")
@@ -530,6 +618,7 @@ pod_toolset = FunctionToolset[BaseAgentContext](
         pod_query,
         pod_list_files,
         pod_read_file,
+        pod_write_file,
         pod_view_document_pages,
         pod_get_file_url,
         pod_search_files,

--- a/lemma-backend/app/modules/agent/tools/registry.py
+++ b/lemma-backend/app/modules/agent/tools/registry.py
@@ -14,7 +14,7 @@ from app.modules.agent.tools.user_interaction.pydantic_adapter import (
 )
 from app.modules.agent.tools.web.pydantic_adapter import web_search_toolset
 from app.modules.agent.tools.workspace_cli.pydantic_adapter import (
-    workspace_cli_text_only_toolset,
+    view_image_toolset,
     workspace_cli_toolset,
 )
 
@@ -40,6 +40,7 @@ _TOOLSET_BY_NAME: dict[AgentToolset, object] = {
     AgentToolset.SPEECH: speech_toolset,
     AgentToolset.POD: pod_toolset,
     AgentToolset.SUBAGENTS: subagents_toolset,
+    AgentToolset.VIEW_IMAGE: view_image_toolset,
 }
 
 # Toolsets that are NOT static singletons — they are realized per-conversation as
@@ -83,30 +84,9 @@ def resolve_agent_toolsets(
     return resolved
 
 
-def adapt_toolsets_for_vision(
-    toolsets: list[object],
-    *,
-    supports_vision: bool,
-) -> list[object]:
-    """Drop image-returning tools when the resolved model has no vision support.
-
-    Swaps the workspace CLI toolset for its text-only variant (no ``view_image``)
-    so a non-vision model never receives image content in its history — which
-    otherwise breaks the conversation. When the model supports vision the list is
-    returned unchanged.
-    """
-    if supports_vision:
-        return toolsets
-    return [
-        workspace_cli_text_only_toolset if t is workspace_cli_toolset else t
-        for t in toolsets
-    ]
-
-
 __all__ = [
     "POD_DEFAULT_AGENT_TOOLSETS",
     "EXTRA_TOOLSETS",
     "EXTRA_TOOLSET_OBJECTS",
     "resolve_agent_toolsets",
-    "adapt_toolsets_for_vision",
 ]

--- a/lemma-backend/app/modules/agent/tools/workspace_cli/pydantic_adapter.py
+++ b/lemma-backend/app/modules/agent/tools/workspace_cli/pydantic_adapter.py
@@ -144,9 +144,6 @@ async def view_image(
     return await workspace_cli.view_image(ctx.deps, request)
 
 
-# Tools every model can use. `view_image` is kept out of this base list because
-# it returns image bytes (BinaryContent) into the message history, which breaks
-# models without vision support.
 _WORKSPACE_CLI_BASE_TOOLS = [
     exec_command,
     manage_process,
@@ -154,20 +151,16 @@ _WORKSPACE_CLI_BASE_TOOLS = [
 ]
 
 workspace_cli_toolset = FunctionToolset[BaseAgentContext](
-    tools=[*_WORKSPACE_CLI_BASE_TOOLS, view_image]
-)
-
-# Variant for text-only models: identical to the full toolset minus `view_image`,
-# so a non-vision model never receives image content it cannot process.
-workspace_cli_text_only_toolset = FunctionToolset[BaseAgentContext](
     tools=list(_WORKSPACE_CLI_BASE_TOOLS)
 )
 
+# `view_image` lives in its own always-on-when-supported toolset (see
+# `registry.py`'s VIEW_IMAGE toolset) rather than workspace_cli, so it reaches
+# any agent with a vision-capable model regardless of configured toolsets.
+view_image_toolset = FunctionToolset[BaseAgentContext](tools=[view_image])
+
 
 def is_workspace_cli_toolset(toolset: object) -> bool:
-    """True for either workspace CLI variant (full or text-only).
-
-    The capability assembler keys workspace-CLI special handling (its usage
-    prompt) off the toolset identity, so both variants must be recognised.
-    """
-    return toolset is workspace_cli_toolset or toolset is workspace_cli_text_only_toolset
+    """True for the workspace CLI toolset (the capability assembler keys its
+    usage-prompt special handling off this identity check)."""
+    return toolset is workspace_cli_toolset


### PR DESCRIPTION
## Why

User-created (specialist) agents should work natively with the **pod filesystem** — read/write pod files and markdown, query tables — without the pod tools being hidden behind a `ToolSearch` round-trip. Today the deferred-tool mechanism is applied uniformly to every agent, so even a custom agent that deliberately enabled the `POD` toolset has to *discover* its tools before using them. This PR makes deferral a pod-default-assistant-only concern, adds pod file writing with a conversation-scoped working directory, and cleans up how the vision tool is attached.

## What changed

### 1. Deferred (`ToolSearch`) tools scoped to the pod-default agent only
- Deferring `POD`/`SUBAGENTS` behind `ToolSearch` (to keep the prompt slim) now applies **only** to the pod-default assistant. A user-created agent that configured `POD`/`SUBAGENTS` gets them injected **directly** as core tools — better tool-calling reliability, no discovery hop.
- Implemented with a new `is_pod_default_agent` flag on `AgentContext`; `_partition_core_extra` returns everything-core when it's `False`.
- **LEMMA-harness-only** by construction — daemon harnesses (Codex/Claude Code) already receive the full, unfiltered toolset list and are unaffected.

### 2. Pod file write + conversation-scoped pod cwd
- **New `pod_write_file` tool** (text/UTF-8 for v1): writes into the pod filesystem, defaulting to the agent's pod working directory. Creates the file, or updates it in place when `overwrite=true` (via the existing datastore update saga). Writes under the caller's own `/me/...` never need approval; writes to shared pod paths still return `needs_approval`, consistent with the other pod mutating tools.
- `pod_write_file` / `pod_list_files` / `pod_read_file` now resolve **relative paths** against a new `pod_cwd` on the run context.
- **Pretty, human-readable cwd.** Root conversations default to `/workspace/c/{date}/{slug}` instead of `/workspace/conversations/{uuid}`. The pod cwd (`/me/c/{date}/{slug}`) is **derived** from the workspace cwd by swapping the `/workspace` prefix for `/me`, so an agent's scratchpad and its pod filesystem line up under the same short path.
- **No schema change.** The cwd already lives in `conversation.metadata["cwd"]` (stamped at creation for every conversation). The pod cwd is derived at read time — **no new column, no migration.** A metadata `cwd` override (or a child inheriting a parent's directory) flows through to the pod cwd automatically.

### 3. `WORKSPACE_CLI` slimmed + `view_image` as a default vision toolset
- `WORKSPACE_CLI` is now just `exec_command` / `manage_process` / `execute_python`.
- `view_image` moves into its **own toolset**, auto-appended for any agent (pod-default **or** user-created) whose resolved model declares `VISION` capability — regardless of the agent's configured toolsets. This replaces the old full ↔ text-only `workspace_cli` swap (`adapt_toolsets_for_vision`), and applies to both LEMMA and daemon harnesses.

> QA-style direct table access (`pod_tables`, `pod_get_records`, `pod_query`, `pod_write_record`) already existed in the `POD` toolset — this PR just makes it (and the rest of the pod tools) reach user-created agents directly.

## Behavior summary

| Agent | POD/SUBAGENTS tools | `view_image` |
|---|---|---|
| Pod-default assistant | Deferred behind `ToolSearch` (unchanged) | Present iff model supports vision |
| User-created agent with POD/SUBAGENTS | **Injected directly (new)** | Present iff model supports vision |
| Any agent, non-vision model | — | Absent |

## Testing
- `app/modules/agent/tests/unit` — **284 passed**.
- Agent e2e suite — **44 passed** / 22 skipped (skips need Docker AgentBox / real provider creds). `test_projects_e2e.py` + `test_pod_tools_e2e.py` exercise the new cwd stamping and pod tools against real Postgres, confirming no migration is required.

New/updated unit coverage: `_partition_core_extra` core-vs-deferred per agent type; `pod_write_file` create / relative-path / conflict-without-overwrite / conflict-with-overwrite-updates; pod/workspace cwd derivation; vision-gated `view_image` append.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
