### PR TITLE
fix(surfaces): clean file deep links + drop lingering Teams "thinking" message

### DIFF
--- a/lemma-backend/app/modules/agent_surfaces/domain/models.py
+++ b/lemma-backend/app/modules/agent_surfaces/domain/models.py
@@ -81,6 +81,19 @@ class SurfaceDisplayRenderPlan(BaseModel):
             lines.append(f"{action.label}: {action.url}")
         return "\n".join(lines)
 
+    def to_caption(self) -> str:
+        """Title + summary + details, WITHOUT the action URL.
+
+        For surfaces where a card or button already carries the link (Teams
+        adaptive card, Slack blocks): the caption is used as the accompanying/
+        notification text so the raw URL is never dumped inline next to the card.
+        """
+        lines = [self.title]
+        if self.summary:
+            lines.append(self.summary)
+        lines.extend(line for line in self.detail_lines if line)
+        return "\n".join(lines)
+
 
 # Suffix marking a native "Other (type your own)" free-text input whose answer,
 # when filled, overrides the selected option for the question keyed by the prefix.

--- a/lemma-backend/app/modules/agent_surfaces/platforms/slack/service.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/slack/service.py
@@ -146,7 +146,9 @@ class SlackPlatformService:
         try:
             payload: dict[str, Any] = {
                 "channel": channel,
-                "text": render_plan.to_plain_text(),
+                # Notification-fallback text only (blocks carry the button). Use
+                # the caption so the raw URL isn't surfaced in the push preview.
+                "text": render_plan.to_caption(),
                 "blocks": _display_resource_blocks(render_plan),
             }
             thread_ts = event.reply_target.get("thread_ts")

--- a/lemma-backend/app/modules/agent_surfaces/platforms/teams/adapter.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/teams/adapter.py
@@ -316,10 +316,13 @@ class TeamsSurfaceAdapter(BaseSurfaceAdapter):
             f"{client.bf_service_url(event.reply_target.get('service_url'))}"
             f"/v3/conversations/{quote(str(conversation_id))}/activities"
         )
+        # The adaptive card carries the title/summary and the "Open file" button,
+        # so no inline ``text`` (which would dump the raw URL next to the card).
+        # ``summary`` is the Bot Framework notification field — shown in toasts,
+        # not as a message bubble — so the deep link is never rendered inline.
         body: dict[str, Any] = {
             "type": "message",
-            "text": render_plan.to_plain_text(),
-            "textFormat": "markdown",
+            "summary": render_plan.to_caption(),
             "attachments": [
                 {
                     "contentType": "application/vnd.microsoft.card.adaptive",
@@ -492,6 +495,41 @@ class TeamsSurfaceAdapter(BaseSurfaceAdapter):
             return {"activity_id": new_id} if new_id else progress_handle
         except Exception:
             return progress_handle
+
+    async def end_progress(
+        self,
+        *,
+        credentials: dict[str, Any],
+        event: ParsedInboundSurfaceEvent,
+        progress_handle: dict[str, Any] | None = None,
+    ) -> None:
+        """Delete the streamed progress ("thinking") activity at run end so it
+        does not linger next to the final answer (the final answer is delivered
+        separately). Mirrors Slack/Telegram end_progress. Best-effort."""
+        del credentials
+        activity_id = (progress_handle or {}).get("activity_id")
+        tenant_id = event.tenant_id
+        conversation_id = event.reply_target.get("conversation_id")
+        if not activity_id or not tenant_id or not conversation_id:
+            return
+        bot_token = await self._get_bot_token(tenant_id)
+        if not bot_token:
+            return
+        base = client.bf_service_url(event.reply_target.get("service_url"))
+        url = (
+            f"{base}/v3/conversations/{quote(str(conversation_id))}"
+            f"/activities/{quote(str(activity_id))}"
+        )
+        try:
+            async with aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=30)
+            ) as session:
+                async with session.delete(
+                    url, headers=client.auth_headers(bot_token)
+                ) as response:
+                    response.raise_for_status()
+        except Exception:
+            return
 
     async def download_attachment(
         self,

--- a/lemma-backend/app/modules/agent_surfaces/services/display_resource_renderer.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/display_resource_renderer.py
@@ -197,7 +197,7 @@ def build_display_resource_url(
             tool_call_id=tool_call_id,
         )
     if request.type is DisplayResourceType.FILE:
-        return _file_resource_url(pod_base, request, conversation_id)
+        return _file_resource_url(pod_base, request)
     if request.type is DisplayResourceType.TABLE:
         if request.query:
             return _conversation_url(pod_base, conversation_id, tool_call_id)
@@ -310,21 +310,17 @@ def _display_resource_kind(request: DisplayResourceRequest) -> str:
     return request.type.value.lower().replace("_", " ").title()
 
 
-def _file_resource_url(
-    pod_base: str,
-    request: DisplayResourceRequest,
-    conversation_id: UUID | None,
-) -> str:
+def _file_resource_url(pod_base: str, request: DisplayResourceRequest) -> str:
+    # A bare ``?file=<path>`` deep link is intentional. The in-app document
+    # viewer opens the file straight from the path and derives the parent folder
+    # from it, so ``folder`` is redundant. ``assistantConversationId`` is
+    # deliberately omitted too: when present it switches the viewer into a
+    # header-less "assistant presentation" mode, whereas the plain path opens the
+    # full file viewer (with header + back nav) — the better reading experience.
     if not request.path:
-        return _append_conversation(f"{pod_base}/files", conversation_id)
+        return f"{pod_base}/files"
     file_path = _normalize_pod_file_path(request.path)
-    params: dict[str, str] = {"file": file_path}
-    parent = _parent_path(file_path)
-    if parent:
-        params["folder"] = parent
-    return _append_conversation(
-        f"{pod_base}/files?{urlencode(params)}", conversation_id
-    )
+    return f"{pod_base}/files?{urlencode({'file': file_path})}"
 
 
 def _table_resource_url(
@@ -416,14 +412,6 @@ def _normalize_pod_file_path(path: str) -> str:
     if with_leading.startswith("/pod/"):
         return with_leading[len("/pod") :] or "/"
     return with_leading
-
-
-def _parent_path(path: str) -> str | None:
-    normalized = path.rstrip("/")
-    parts = [part for part in normalized.split("/") if part]
-    if len(parts) <= 1:
-        return None
-    return "/" + "/".join(parts[:-1])
 
 
 def _compact(value: object, max_length: int) -> str:

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_display_resource_renderer.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_display_resource_renderer.py
@@ -39,6 +39,32 @@ def test_display_resource_renderer_builds_table_filter_url(monkeypatch):
     assert "stage" in plan.to_plain_text()
 
 
+def test_display_resource_renderer_file_url_is_bare_path(monkeypatch):
+    monkeypatch.setattr(settings, "frontend_url", "https://app.example.test")
+    pod_id = uuid4()
+    conversation_id = uuid4()
+
+    plan = build_display_resource_render_plan(
+        pod_id=pod_id,
+        conversation_id=conversation_id,
+        tool_call_id="tool-file-1",
+        request=DisplayResourceRequest.model_validate(
+            {"type": "FILE", "path": "/LEDFLEX_SKILLS/product-catalog-reference.md"}
+        ),
+    )
+
+    assert plan.primary_action is not None
+    url = plan.primary_action.url
+    # File links carry ONLY the file path: no folder (the viewer derives it) and
+    # no assistantConversationId (which would trigger the header-less viewer).
+    assert url == (
+        f"https://app.example.test/pod/{pod_id}/files"
+        "?file=%2FLEDFLEX_SKILLS%2Fproduct-catalog-reference.md"
+    )
+    assert "assistantConversationId" not in url
+    assert "folder=" not in url
+
+
 def test_display_resource_renderer_reads_browser_url_from_model_output():
     pod_id = uuid4()
 

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_platform_adapters.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_platform_adapters.py
@@ -377,6 +377,71 @@ async def test_teams_send_display_resource_posts_adaptive_card(monkeypatch):
     assert attachment["content"]["type"] == "AdaptiveCard"
     assert attachment["content"]["actions"][0]["type"] == "Action.OpenUrl"
     assert posted["json"]["replyToId"] == "msg-1"
+    # No inline text bubble dumping the raw URL — the card carries the button and
+    # ``summary`` is notification-only.
+    assert "text" not in posted["json"]
+    assert posted["json"]["summary"].startswith("Table: deals")
+    assert "http" not in posted["json"]["summary"]
+
+
+@pytest.mark.asyncio
+async def test_teams_end_progress_deletes_activity(monkeypatch):
+    deleted: dict = {}
+
+    class _Response:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        def raise_for_status(self):
+            return None
+
+    class _Session:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        def delete(self, url, *, headers):
+            deleted["url"] = url
+            deleted["headers"] = headers
+            return _Response()
+
+    adapter = TeamsSurfaceAdapter()
+    adapter._get_bot_token = AsyncMock(return_value="bot-token")
+    monkeypatch.setattr(
+        teams_adapter_module.aiohttp,
+        "ClientSession",
+        lambda *args, **kwargs: _Session(),
+    )
+    event = ParsedInboundSurfaceEvent(
+        platform="TEAMS",
+        conversation_type=ConversationType.EXTERNAL_DM,
+        tenant_id="tenant-1",
+        external_channel_id="a:dm-conversation",
+        external_thread_id="a:dm-conversation",
+        external_message_id="msg-1",
+        sender_external_user_id="29:user",
+        message_text="hello",
+        is_dm=True,
+        reply_target={
+            "service_url": "https://smba.example.test/teams",
+            "conversation_id": "a:dm-conversation",
+        },
+    )
+
+    await adapter.end_progress(
+        credentials={},
+        event=event,
+        progress_handle={"activity_id": "act-99"},
+    )
+
+    assert deleted["url"].endswith("/activities/act-99")
+    assert "conversations/" in deleted["url"]
+    assert deleted["headers"]["Authorization"] == "Bearer bot-token"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What & why

Two things surfaced while testing the Teams bot, both affecting **all surfaces**:

### 1. File deep links were cluttered and opened the wrong viewer mode
The file "Open" link looked like:
```
https://asur.work/pod/<id>/files?file=%2FLEDFLEX_SKILLS%2Fproduct-catalog-reference.md&folder=%2FLEDFLEX_SKILLS&assistantConversationId=019f21ac-...
```
- `assistantConversationId` isn't just noise — the frontend (`DocumentSpace`) reads it and enters a header-less **"assistant presentation"** mode that hides the file viewer's header/back-nav. Dropping it opens the **full in-app viewer** (the better reading experience).
- `folder` is redundant: when a file is selected the viewer derives the parent from the file path itself.

File links now carry **only the path**: `…/files?file=<path>`.

### 2. Raw URL was dumped inline next to the card ("looks ugly")
Teams sent an adaptive card **and** a plain-text block repeating the title/summary + the raw URL. Now it's **card/button only**:
- **Teams**: adaptive card only (with the *Open file* button). The Bot Framework `summary` field carries notification text (shown in toasts, not as an inline bubble) — the raw URL is never rendered inline.
- **Slack**: the notification-fallback `text` uses a new caption (no raw URL); the in-message blocks already used a button.
- New `SurfaceDisplayRenderPlan.to_caption()` = title/summary/details **without** the action URL, for card-accompanying text.
- Telegram/WhatsApp/email already used buttons/links — unchanged. Email stays a single reply with links/attachments.

### 3. Teams "thinking" progress message lingered after the answer
Teams streams progress as an edited activity but had **no `end_progress`** — so it fell back to the base no-op and the last "thinking"/tool status stayed in the chat next to the final answer. Slack (`chat_delete`) and Telegram (`deleteMessage`) already delete theirs. Added a Teams `end_progress()` that deletes the streamed activity (`DELETE /v3/conversations/{id}/activities/{activityId}`), so it disappears like the others.

## Tests
- `test_display_resource_renderer_file_url_is_bare_path` — asserts `?file=` only, no `folder`/`assistantConversationId`.
- `test_teams_send_display_resource_posts_adaptive_card` — extended to assert no inline `text` and a URL-free `summary`.
- `test_teams_end_progress_deletes_activity` — asserts the streamed activity is DELETEd.
- Full `agent_surfaces` unit suite green (252 passed); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)