### PR TITLE
feat(agentbox): per-user /workspace persistence via directory-scoped …

### DIFF
--- a/agentbox/Dockerfile.runtime
+++ b/agentbox/Dockerfile.runtime
@@ -59,6 +59,15 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     xvfb \
     && rm -rf /var/lib/apt/lists/*
 
+# azcopy — start-runtime.sh uses it to sync /workspace to the user's per-user
+# object-storage directory (restore on boot, periodic + on-teardown save).
+RUN curl -sL https://aka.ms/downloadazcopy-v10-linux -o /tmp/azcopy.tgz \
+    && tar -xzf /tmp/azcopy.tgz -C /tmp \
+    && cp /tmp/azcopy_linux_amd64_*/azcopy /usr/local/bin/azcopy \
+    && chmod +x /usr/local/bin/azcopy \
+    && rm -rf /tmp/azcopy.tgz /tmp/azcopy_linux_amd64_* \
+    && azcopy --version
+
 COPY --from=node-runtime /usr/local/bin/node /usr/local/bin/node
 COPY --from=node-runtime /usr/local/lib/node_modules /usr/local/lib/node_modules
 RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \

--- a/agentbox/scripts/start-runtime.sh
+++ b/agentbox/scripts/start-runtime.sh
@@ -76,4 +76,68 @@ fi
 # early user command instead of helping it.
 nohup bash -c 'sleep 15; lemma --help >/dev/null 2>&1' >/dev/null 2>&1 &
 
-exec python -m agentbox.runtime_server
+# ── Per-user /workspace persistence (best-effort; never blocks boot) ──────────
+# The backend injects WORKSPACE_SYNC_URL + WORKSPACE_SYNC_SAS scoped to this
+# user's object-storage directory. /workspace stays on the local container FS
+# (fast, native inotify for Vite); we mirror it to storage: restore on boot,
+# then a background push loop + a final push on SIGTERM. azcopy failures only
+# cost persistence, never the sandbox — so nothing here runs under `set -e`.
+export AZCOPY_LOG_LOCATION="${AZCOPY_LOG_LOCATION:-/tmp/azcopy}"
+export AZCOPY_JOB_PLAN_LOCATION="${AZCOPY_JOB_PLAN_LOCATION:-/tmp/azcopy}"
+WORKSPACE_SYNC_INTERVAL="${WORKSPACE_SYNC_INTERVAL:-20}"
+WORKSPACE_SYNC_EXCLUDE_PATHS="${WORKSPACE_SYNC_EXCLUDE_PATHS:-node_modules;dist;.vite;coverage;.vitest-attachments;.browser-profile;.cache}"
+WORKSPACE_SYNC_EXCLUDE_PATTERN="${WORKSPACE_SYNC_EXCLUDE_PATTERN:-*.tsbuildinfo}"
+_RESTORE_OK=0
+
+workspace_persist_enabled() {
+  [ -n "${WORKSPACE_SYNC_URL:-}" ] && [ -n "${WORKSPACE_SYNC_SAS:-}" ] && command -v azcopy >/dev/null 2>&1
+}
+
+workspace_restore() {
+  echo "workspace: restoring /workspace from remote..." >&2
+  if azcopy sync "${WORKSPACE_SYNC_URL}?${WORKSPACE_SYNC_SAS}" "/workspace" \
+      --delete-destination=false >/tmp/azcopy-restore.log 2>&1; then
+    _RESTORE_OK=1
+    echo "workspace: restore complete" >&2
+  else
+    echo "workspace: restore FAILED — starting from current state (see /tmp/azcopy-restore.log)" >&2
+  fi
+}
+
+workspace_save() {
+  workspace_persist_enabled || return 0
+  # Only let the push delete remote files once we've successfully restored, so a
+  # boot that failed to restore never wipes the user's saved workspace.
+  local del=false
+  [ "$_RESTORE_OK" = "1" ] && del=true
+  azcopy sync "/workspace" "${WORKSPACE_SYNC_URL}?${WORKSPACE_SYNC_SAS}" \
+    --delete-destination="$del" \
+    --exclude-path="$WORKSPACE_SYNC_EXCLUDE_PATHS" \
+    --exclude-pattern="$WORKSPACE_SYNC_EXCLUDE_PATTERN" \
+    >/tmp/azcopy-save.log 2>&1 || echo "workspace: save failed (see /tmp/azcopy-save.log)" >&2
+}
+
+if workspace_persist_enabled; then
+  workspace_restore
+  ( while sleep "$WORKSPACE_SYNC_INTERVAL"; do workspace_save; done ) &
+  _SYNC_LOOP_PID=$!
+
+  term_handler() {
+    echo "workspace: SIGTERM — final save" >&2
+    workspace_save
+    [ -n "${_SYNC_LOOP_PID:-}" ] && kill "$_SYNC_LOOP_PID" 2>/dev/null || true
+    [ -n "${_RUNTIME_PID:-}" ] && kill -TERM "$_RUNTIME_PID" 2>/dev/null || true
+  }
+  trap term_handler TERM INT
+
+  # Run the runtime server as a child (not exec) so the trap can fire a final
+  # save on pod teardown. tini (PID 1) forwards SIGTERM here.
+  python -m agentbox.runtime_server &
+  _RUNTIME_PID=$!
+  wait "$_RUNTIME_PID" || true
+else
+  if [ -n "${WORKSPACE_SYNC_URL:-}" ]; then
+    echo "workspace: WORKSPACE_SYNC_URL set but azcopy/SAS unavailable — persistence disabled" >&2
+  fi
+  exec python -m agentbox.runtime_server
+fi

--- a/lemma-backend/app/modules/workspace/services/workspace_sandbox_service.py
+++ b/lemma-backend/app/modules/workspace/services/workspace_sandbox_service.py
@@ -20,6 +20,7 @@ from app.modules.workspace.services.agentbox_manager import AgentBoxSandbox, age
 from app.modules.workspace.services.interfaces import ISandbox, IWorkspaceSession
 from app.modules.workspace.services.workspace_activity_store import WorkspaceActivityStore
 from app.modules.workspace.services.workspace_state_store import WorkspaceStateStore
+from app.modules.workspace.services.workspace_sync import workspace_sync_env
 from app.core.log.log import get_logger
 
 logger = get_logger(__name__)
@@ -100,7 +101,7 @@ class WorkspaceSandboxService:
     async def _ensure_sandbox_info(self, user_id: UUID) -> SandboxInfo:
         return await self.sandbox.ensure_sandbox(
             user_id,
-            env=self._get_sandbox_app_env(),
+            env=self._get_sandbox_app_env(user_id),
         )
 
     async def _ensure_sandbox_info_with_retry(self, user_id: UUID) -> SandboxInfo:
@@ -125,10 +126,16 @@ class WorkspaceSandboxService:
             on_retry=_log_retry,
         )
 
-    def _get_sandbox_app_env(self) -> dict[str, str]:
-        return {
+    def _get_sandbox_app_env(self, user_id: UUID) -> dict[str, str]:
+        env = {
             "LEMMA_BASE_URL": self._resolve_workspace_api_url(),
         }
+        # Per-user /workspace persistence: a deployment may register a provider
+        # that returns a scoped object-storage URL + credential for this user's
+        # workspace directory (keyed on the sandbox id == user_id.hex). No-op in
+        # the OSS/local build. Never blocks sandbox creation on failure.
+        env.update(workspace_sync_env(agentbox_sandbox_id(user_id)))
+        return env
 
     def _resolve_workspace_api_url(self) -> str:
         return self.resolve_workspace_api_url_for_runtime(self.runtime)

--- a/lemma-backend/app/modules/workspace/services/workspace_sync.py
+++ b/lemma-backend/app/modules/workspace/services/workspace_sync.py
@@ -1,0 +1,45 @@
+"""Per-user /workspace persistence: optional sync-credential provider.
+
+The OSS/local build has no cloud workspace persistence. A deployment (e.g.
+lemma-cloud) can register a provider that, given a sandbox id, returns the env a
+sandbox needs to sync its `/workspace` to a per-user object-storage directory
+(a scoped URL + credential). Kept as a tiny registry so the OSS core stays
+cloud-agnostic — mirroring the `install_azure_storage_shim` pattern.
+
+The env keys are consumed by the sandbox runtime entrypoint (`start-runtime.sh`):
+  WORKSPACE_SYNC_URL  — object-storage directory URL for this user
+  WORKSPACE_SYNC_SAS  — scoped credential (SAS/query string) for that directory
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from app.core.log.log import get_logger
+
+logger = get_logger(__name__)
+
+WorkspaceSyncProvider = Callable[[str], dict[str, str]]
+
+_provider: WorkspaceSyncProvider | None = None
+
+
+def register_workspace_sync_provider(provider: WorkspaceSyncProvider) -> None:
+    """Register the deployment's sync-credential provider (called once at startup)."""
+    global _provider
+    _provider = provider
+
+
+def workspace_sync_env(sandbox_id: str) -> dict[str, str]:
+    """Return the sync env for `sandbox_id`, or {} if persistence isn't configured.
+
+    Never raises: a failure to mint sync credentials must not block sandbox
+    creation — the sandbox just starts without persistence.
+    """
+    if _provider is None:
+        return {}
+    try:
+        return _provider(sandbox_id) or {}
+    except Exception:
+        logger.exception("workspace sync provider failed for sandbox=%s", sandbox_id)
+        return {}


### PR DESCRIPTION
…sync

Sandbox /workspace on the Kubernetes provider was ephemeral — lost on every idle teardown. Add best-effort object-storage sync driven by two env vars the backend injects (WORKSPACE_SYNC_URL/SAS, scoped to the user's own storage directory):

- start-runtime.sh: restore /workspace on boot, background push loop, and a final push on SIGTERM (runs the runtime server as a child so the trap can fire). Never blocks boot; guards remote-delete behind a successful restore.
- Dockerfile.runtime: install azcopy.
- backend: WorkspaceSandboxService injects the per-user sync env (keyed on sandbox_id == user_id.hex) via a cloud-agnostic provider registry, so the OSS core stays storage-agnostic and the cloud build registers the Azure signer.