### PR TITLE
fix: make lemma-pod-bundle resolve for CI and PyPI installs of lemma-terminal

### DIFF
--- a/.github/workflows/release-lemma-terminal.yml
+++ b/.github/workflows/release-lemma-terminal.yml
@@ -73,6 +73,50 @@ jobs:
             fi
           done
 
+      - name: Vendor the shared pod-bundle package into the wheel
+        shell: python
+        run: |
+          import pathlib
+          import re
+          import shutil
+
+          # lemma-terminal imports lemma_pod_bundle at runtime, but that package
+          # is unpublished: locally/CI it resolves from the sibling monorepo
+          # checkout via [tool.uv.sources]. PyPI users have no such checkout, and
+          # setuptools ignores [tool.uv.sources], so the dependency would leak
+          # into the wheel's Requires-Dist and every `pip install lemma-terminal`
+          # would fail on the missing lemma-pod-bundle distribution. Vendor the
+          # (stdlib-only) package into the wheel and drop the runtime dependency.
+          src = pathlib.Path("lemma-pod-bundle/lemma_pod_bundle")
+          dst = pathlib.Path("lemma-cli/lemma_pod_bundle")
+          if not src.is_dir():
+              raise SystemExit(f"Vendor source not found: {src}")
+          if dst.exists():
+              shutil.rmtree(dst)
+          shutil.copytree(src, dst)
+
+          pyproject = pathlib.Path("lemma-cli/pyproject.toml")
+          text = pyproject.read_text()
+
+          # Drop the now-vendored dependency so it stays out of Requires-Dist.
+          text, dep_count = re.subn(
+              r'(?m)^\s*"lemma-pod-bundle>=[^"]+",\n', "", text, count=1
+          )
+          if dep_count != 1:
+              raise SystemExit("Could not find the lemma-pod-bundle dependency to strip")
+
+          # Ship the vendored package alongside lemma_cli in the wheel.
+          text, inc_count = re.subn(
+              r'(?m)^include = \["lemma_cli\*"\]$',
+              'include = ["lemma_cli*", "lemma_pod_bundle*"]',
+              text,
+              count=1,
+          )
+          if inc_count != 1:
+              raise SystemExit("Could not find the packages.find include list to extend")
+
+          pyproject.write_text(text)
+
       - name: Install build tools
         run: python -m pip install --upgrade build twine
 
@@ -88,6 +132,33 @@ jobs:
           count=$(python -c "import zipfile,glob; w=glob.glob('dist/*.whl')[0]; print(sum(1 for n in zipfile.ZipFile(w).namelist() if n.endswith('SKILL.md')))")
           echo "SKILL.md files in wheel: $count"
           test "$count" -ge 1 || { echo 'No skills bundled in the wheel — aborting release.'; exit 1; }
+
+      - name: Verify pod-bundle is vendored and not a PyPI dependency
+        working-directory: lemma-cli
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import glob, sys, zipfile
+
+          wheel = glob.glob("dist/*.whl")[0]
+          zf = zipfile.ZipFile(wheel)
+          names = zf.namelist()
+
+          if "lemma_pod_bundle/__init__.py" not in names:
+              sys.exit("lemma_pod_bundle is not vendored into the wheel — aborting release.")
+
+          meta = next(n for n in names if n.endswith(".dist-info/METADATA"))
+          leaked = [
+              line
+              for line in zf.read(meta).decode().splitlines()
+              if line.startswith("Requires-Dist:") and "lemma-pod-bundle" in line
+          ]
+          if leaked:
+              sys.exit(f"lemma-pod-bundle still declared as a dependency {leaked} — aborting release.")
+
+          print("pod-bundle vendored into the wheel, no PyPI dependency — ok")
+          PY
 
       - name: Check distribution
         working-directory: lemma-cli

--- a/.github/workflows/windows-daemon.yml
+++ b/.github/workflows/windows-daemon.yml
@@ -102,7 +102,11 @@ jobs:
       - name: Unit tests — cross-platform process helpers (real Windows)
         run: |
           $ErrorActionPreference = "Stop"
-          pip install -e ./lemma-python -e ./lemma-cli pytest pytest-asyncio
+          # Plain pip (unlike uv) ignores [tool.uv.sources], so it cannot resolve
+          # the CLI's local-only deps from their sibling checkouts. Install every
+          # unpublished path package explicitly (lemma-pod-bundle, lemma-sdk)
+          # alongside the CLI, or pip tries PyPI and fails on lemma-pod-bundle.
+          pip install -e ./lemma-pod-bundle -e ./lemma-python -e ./lemma-cli pytest pytest-asyncio
           pytest lemma-cli/tests/test_daemon_process.py -q
           if ($LASTEXITCODE -ne 0) { throw "daemon process unit tests failed ($LASTEXITCODE)" }
           exit 0


### PR DESCRIPTION
## Problem

The Pod bundles PR (#74) made the CLI depend on `lemma-pod-bundle>=0.1.0`, an **unpublished, local-only** package resolved from the sibling checkout via `[tool.uv.sources]`. That table is understood by `uv` only — plain `pip` and `setuptools`/`build` ignore it — which breaks in two places:

1. **CI (was already red):** the *Windows daemon smoke* workflow's unit-test step uses plain `pip install`, which tried to fetch `lemma-pod-bundle` from PyPI and failed → `pytest` never installed → *'pytest is not recognized'*. ([failing run](https://github.com/lemma-work/lemma-platform/actions/runs/28655550757/job/84983620735))
2. **PyPI users (would break on next release):** the built `lemma-terminal` wheel carries `Requires-Dist: lemma-pod-bundle>=0.1.0`, and that package isn't on PyPI (404, no release workflow). Every `uv tool install lemma-terminal` / `pip install lemma-terminal` would fail at install time with `No matching distribution found for lemma-pod-bundle>=0.1.0`.

## Fixes

**1. CI** ([windows-daemon.yml](.github/workflows/windows-daemon.yml)) — pass the local pod-bundle path explicitly, like `lemma-sdk` already is:
```
pip install -e ./lemma-pod-bundle -e ./lemma-python -e ./lemma-cli pytest pytest-asyncio
```

**2. Release** ([release-lemma-terminal.yml](.github/workflows/release-lemma-terminal.yml)) — vendor the stdlib-only `lemma_pod_bundle` package into the wheel (the same pattern as agent skills) and strip the runtime dependency during the release build, so the published wheel is self-contained. A new verify step fails the release if the package is missing or the dependency leaks into `Requires-Dist`.

## Verification

- **CI fix:** reproduced the exact error locally, then confirmed green on the real Windows runner (run [28657172390](https://github.com/lemma-work/lemma-platform/actions/runs/28657172390), all steps pass).
- **Release fix:** built the wheel with the new steps — `lemma_pod_bundle/*` is vendored and `Requires-Dist` no longer mentions it. Installed the wheel in a clean venv **with no monorepo checkout**: no pod-bundle error, and `import lemma_pod_bundle`, `lemma_cli.cli_app.pod_bundle`, and `lemma --version` all work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)