### PR TITLE
Pod bundles: executable-import hardening (grants + toolsets) + real use-case e2e

### DIFF
--- a/docs/design/pod-bundle-share-import.md
+++ b/docs/design/pod-bundle-share-import.md
@@ -137,3 +137,44 @@ Everything format-shaped moves out of `lemma-cli/lemma_cli/cli_app/pod_bundle.py
 - **Unit:** shared-lib format matrix (diff, FK order, `${var}` round-trip, zip-slip rejection); plan builder CREATE/UPDATE/SKIP + destructive matrix against fake snapshots; applier idempotency (apply twice; crash between commit and checkpoint); state store TTL/seq/expiry; publisher against a fake Composio client (repo-exists, chunk fallback); recipe round-trip through `PodConfig.from_raw` + `update_pod`; controller status-code semantics with faked queue/store.
 - **E2E** (real ASGI app + the real streaq worker subprocess from `test_support/e2e_base.py`): upload→plan→apply roundtrip into an existing pod; update-in-place with destructive confirmation; new-pod install; resume after a failed step; expiry (410); GitHub import from a fixture zipball (Composio faked); publish (Composio faked; README + badge + repo_url); SSE snapshot-then-live coherence.
 - **Pool-safety regression check:** during a large e2e apply, `pg_stat_activity` shows no long-held / idle-in-transaction connections — the failure mode this design exists to prevent.
+
+## Executable-import hardening (grants, toolsets, durability)
+
+The first slice made resources *appear*; this hardening makes them *work* — an
+imported function can reach its tables, an imported agent can use its tools, and
+every step is durably committed.
+
+- **Function + agent grants apply on import.** A resource manifest may carry
+  `permissions.grants` (`resource_type` / `resource_name` / `permission_ids`).
+  The applier validates, normalizes (name → id), and replaces the grantee's
+  resource grants in the step's own UoW — the same inline-grants path the
+  function/agent controllers use — so an imported function's datastore reads and
+  writes are authorized immediately. Function grants apply inline with the create
+  (then the delegated-token env cache is dropped); agent grants apply in the
+  deferred `AGENT_GRANTS` step, after every resource they reference exists.
+- **Agent toolsets travel with the agent.** The manifest's `toolsets` are applied
+  on create/update; without them a granted agent still can't act.
+- **Every apply step commits.** The bare per-step UoW rolls back on error but does
+  **not** auto-commit on success, so a step whose service didn't commit
+  internally (e.g. workflow create) was silently lost — and a DONE checkpoint on
+  lost data breaks crash-resume. The apply loop now commits each step before
+  checkpointing it. Two applier bugs surfaced by the executable e2e were fixed
+  alongside: `_apply_function`'s update path built the wrong `update_function`
+  call, and `_flow_exists` treated a `None` "not found" as "exists" and skipped
+  workflow creation.
+- **Real use-case bundle fixtures + execution e2e.** Three hand-authored bundles
+  live in the module (`tests/e2e/bundles/`): **support_inbox** (tickets table +
+  `triage_ticket` function + `support_agent`), **lead_scoring** (leads table +
+  `score_lead` function + `score_flow` workflow), and **moderation_queue**
+  (submissions table + `flag_content` function + `reviewer_agent` +
+  `screen_flow` workflow). Each e2e imports the bundle and then *runs* the
+  imported function against the real datastore — proving the grants were applied,
+  since without them the write returns a real 403 — and asserts the agent's
+  toolsets/grants and the workflow's function cross-reference survived the import.
+  A gated `real_llm` variant points `support_agent` at the real `system:lemma`
+  runtime and asserts it files a ticket by calling the imported function tool
+  (skipped without provider creds).
+- **Not covered here:** schedule *firing* needs the full scheduler stack (a live
+  scheduler API the session-scoped e2e worker can't reach), so schedule import is
+  covered at the applier unit level and firing by the schedule module's own
+  full-stack e2e.

--- a/lemma-backend/app/modules/pod_bundle/events/handlers.py
+++ b/lemma-backend/app/modules/pod_bundle/events/handlers.py
@@ -415,6 +415,14 @@ async def apply_pod_import(context: dict[str, str | None]) -> None:
                                 replacements=replacements,
                             )
                             await applier.apply_step(step)
+                            # Commit the step before checkpointing it DONE: the
+                            # bare UoW rolls back on error but does NOT auto-commit
+                            # on success, so uncommitted writes (e.g. a workflow a
+                            # later schedule step must resolve) would otherwise be
+                            # lost — and a DONE checkpoint on lost data would break
+                            # crash-resume. Idempotent when the service already
+                            # committed internally.
+                            await uow.commit()
                     step.status = StepStatus.DONE
                 except StepNotApplicableError as exc:
                     # Deferred kind (app/surface/grants) — skip, don't fail.

--- a/lemma-backend/app/modules/pod_bundle/infrastructure/applier.py
+++ b/lemma-backend/app/modules/pod_bundle/infrastructure/applier.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 
 import csv
 import io
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from lemma_pod_bundle import load_resource_payload
@@ -23,6 +24,9 @@ from lemma_pod_bundle.layout import TABLE_DATA_FILE
 from app.core.log.log import get_logger
 from app.modules.pod_bundle.domain.errors import PodBundleDomainError
 from app.modules.pod_bundle.domain.state import PlanStep, StepKind
+
+if TYPE_CHECKING:
+    from app.core.authorization.context import ResourceType
 
 logger = get_logger(__name__)
 
@@ -59,13 +63,14 @@ class BundleApplier:
             StepKind.TABLE_DATA: self._apply_table_data,
             StepKind.FUNCTION: self._apply_function,
             StepKind.AGENT: self._apply_agent,
+            StepKind.AGENT_GRANTS: self._apply_agent_grants,
             StepKind.SCHEDULE: self._apply_schedule,
             StepKind.WORKFLOW: self._apply_workflow,
         }.get(step.kind)
         if handler is None:
-            # app / surface / agent_grants are deferred: the connector/runtime
-            # dependencies they need are out of scope for this slice. Mark the
-            # step skipped-with-reason instead of failing the import.
+            # app / surface are deferred: the connector/runtime dependencies they
+            # need are out of scope for this slice. Mark the step
+            # skipped-with-reason instead of failing the import.
             raise StepNotApplicableError(
                 f"{step.kind.value} import is not supported yet; skipped."
             )
@@ -155,7 +160,10 @@ class BundleApplier:
 
     async def _apply_function(self, step: PlanStep) -> None:
         from app.modules.function.api.dependencies import build_function_service
-        from app.modules.function.domain.entities import FunctionEntity
+        from app.modules.function.domain.entities import (
+            FunctionEntity,
+            FunctionUpdateEntity,
+        )
 
         service = build_function_service(self._uow)
         payload = self._load("functions", step.name)
@@ -174,17 +182,40 @@ class BundleApplier:
                 config=payload.get("config"),
                 visibility=payload.get("visibility") or "POD",
             )
-            await service.create_function(
+            function = await service.create_function(
                 entity, self._user_id, code=code, ctx=self._ctx
             )
         else:
-            await service.update_function(
-                pod_id=self._pod_id,
-                name=step.name,
-                code=code,
-                description=payload.get("description"),
-                requester_user_id=self._user_id,
+            function = await service.update_function(
+                self._pod_id,
+                step.name,
+                FunctionUpdateEntity(
+                    description=payload.get("description"),
+                    icon_url=payload.get("icon_url"),
+                    code=code,
+                    config=payload.get("config"),
+                    visibility=payload.get("visibility"),
+                ),
+                self._user_id,
                 ctx=self._ctx,
+            )
+
+        # Resource grants (e.g. datastore-table read/write) are what let the
+        # function's LemmaDataStoreClient actually reach its tables at run time.
+        # Apply them in the same short UoW as the create/update so an imported
+        # function is executable immediately, then drop the delegated-token env
+        # cache so the new scopes take effect on the next run.
+        grants = _grants_from_payload(payload)
+        if grants and function.id is not None:
+            from app.modules.workspace.services.workspace_tool_runtime import (
+                invalidate_function_workspace_env_cache,
+            )
+
+            await self._apply_grants(
+                grantee_type="FUNCTION", grantee_id=function.id, grants=grants
+            )
+            await invalidate_function_workspace_env_cache(
+                pod_id=self._pod_id, function_id=function.id
             )
 
     # --- agents ----------------------------------------------------------
@@ -195,6 +226,10 @@ class BundleApplier:
         service = get_agent_service(self._uow)
         payload = self._load("agents", step.name)
         runtime = _agent_runtime(payload)
+        # Toolsets are what let an imported agent actually *use* tools (POD,
+        # WEB_SEARCH, …). Without them, a granted agent still can't act — so they
+        # travel with the agent, not the deferred grants step.
+        toolsets = _agent_toolsets(payload)
         existing = await _get_agent(service, self._pod_id, step.name, self._ctx)
         if existing is None:
             await service.create_agent(
@@ -205,6 +240,7 @@ class BundleApplier:
                 description=payload.get("description"),
                 icon_url=payload.get("icon_url"),
                 agent_runtime=runtime,
+                toolsets=toolsets,
                 input_schema=payload.get("input_schema"),
                 output_schema=payload.get("output_schema"),
                 visibility=payload.get("visibility"),
@@ -219,12 +255,63 @@ class BundleApplier:
                 description=payload.get("description"),
                 icon_url=payload.get("icon_url"),
                 agent_runtime=runtime,
+                toolsets=toolsets,
                 input_schema=payload.get("input_schema"),
                 output_schema=payload.get("output_schema"),
                 metadata=payload.get("metadata"),
                 requester_user_id=self._user_id,
                 ctx=self._ctx,
             )
+
+    async def _apply_agent_grants(self, step: PlanStep) -> None:
+        """Deferred grant step: replace an agent's resource permission grants once
+        every resource it references (tables, functions) has been applied."""
+        from app.modules.agent.api.dependencies import get_agent_service
+
+        payload = self._load("agents", step.name)
+        grants = _grants_from_payload(payload)
+        if not grants:
+            return
+        service = get_agent_service(self._uow)
+        agent = await _get_agent(service, self._pod_id, step.name, self._ctx)
+        if agent is None or agent.id is None:
+            raise PodBundleDomainError(
+                f"Agent '{step.name}' must exist before applying its grants.",
+                code="POD_BUNDLE_STEP_ORDER",
+            )
+        await self._apply_grants(
+            grantee_type="AGENT", grantee_id=agent.id, grants=grants
+        )
+
+    # --- grants ----------------------------------------------------------
+
+    async def _apply_grants(
+        self, *, grantee_type: str, grantee_id: UUID, grants: list[_GrantInput]
+    ) -> None:
+        """Validate + normalize (resource_name -> id) + replace the grantee's
+        resource grants, on the step's own short UoW session. Mirrors the
+        function/agent controllers' inline-grants path so imported workloads get
+        the same executable permissions a hand-authored one would."""
+        if not grants:
+            return
+        from app.core.authorization.grants import (
+            normalize_pod_resource_grants,
+            replace_grantee_resource_grants,
+            validate_pod_resource_grant_permissions,
+        )
+
+        validate_pod_resource_grant_permissions(grants)
+        normalized = await normalize_pod_resource_grants(
+            self._uow.session, pod_id=self._pod_id, grants=grants
+        )
+        await replace_grantee_resource_grants(
+            self._uow.session,
+            pod_id=self._pod_id,
+            grantee_type=grantee_type,
+            grantee_id=grantee_id,
+            grants=normalized,
+            created_by_user_id=self._user_id,
+        )
 
     # --- schedules -------------------------------------------------------
 
@@ -279,6 +366,52 @@ class BundleApplier:
 # --- module helpers ----------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class _GrantInput:
+    """Adapts a bundle manifest grant entry to the ``ResourceGrantInputProtocol``
+    the shared authorization layer expects (``resource_type`` / ``resource_name``
+    / ``permission_ids``). ``resource_type`` holds a ``ResourceType`` enum — the
+    annotation stays a string thanks to ``from __future__ import annotations`` so
+    the module import stays lazy/cycle-free."""
+
+    resource_type: ResourceType
+    resource_name: str
+    permission_ids: list[str]
+
+
+def _grants_from_payload(payload: dict[str, Any]) -> list[_GrantInput]:
+    """Read ``permissions.grants`` (or a bare top-level ``grants`` list) off a
+    resource manifest into typed grant inputs. Entries whose ``resource_type`` is
+    not a known :class:`ResourceType` or that omit a ``resource_name`` are
+    skipped with a warning rather than failing the whole import."""
+    from app.core.authorization.context import ResourceType
+
+    perms = payload.get("permissions")
+    raw = perms.get("grants") if isinstance(perms, dict) else payload.get("grants")
+    grants: list[_GrantInput] = []
+    for entry in raw or []:
+        if not isinstance(entry, dict):
+            continue
+        raw_type = entry.get("resource_type")
+        try:
+            resource_type = ResourceType(str(raw_type))
+        except ValueError:
+            logger.warning("Skipping grant with unknown resource_type %r", raw_type)
+            continue
+        resource_name = entry.get("resource_name")
+        if not resource_name:
+            logger.warning("Skipping grant without a resource_name: %r", entry)
+            continue
+        grants.append(
+            _GrantInput(
+                resource_type=resource_type,
+                resource_name=str(resource_name),
+                permission_ids=[str(p) for p in entry.get("permission_ids") or []],
+            )
+        )
+    return grants
+
+
 def _is_system_column(column: dict[str, Any]) -> bool:
     from lemma_pod_bundle.diff import _is_system_table_column
 
@@ -292,6 +425,25 @@ def _agent_runtime(payload: dict[str, Any]):
     if isinstance(raw, dict) and raw.get("profile_id"):
         return AgentRuntimeConfig.model_validate(raw)
     return None
+
+
+def _agent_toolsets(payload: dict[str, Any]) -> list[Any]:
+    """Map the manifest's ``toolsets`` list to :class:`AgentToolset` values,
+    dropping any the runtime doesn't recognize (forward-compat) and the reserved
+    ``VIEW_IMAGE`` toolset, which is never persisted."""
+    from app.modules.agent.domain.value_objects import AgentToolset
+
+    toolsets: list[AgentToolset] = []
+    for raw in payload.get("toolsets") or []:
+        try:
+            toolset = AgentToolset(str(raw))
+        except ValueError:
+            logger.warning("Skipping unknown agent toolset %r", raw)
+            continue
+        if toolset is AgentToolset.VIEW_IMAGE:
+            continue
+        toolsets.append(toolset)
+    return toolsets
 
 
 async def _get_table(service, pod_id, name, ctx):
@@ -319,9 +471,10 @@ async def _get_schedule(service, pod_id, name, ctx):
 
 
 async def _flow_exists(service, pod_id, name, ctx) -> bool:
+    # get_flow_by_name RETURNS None for a missing flow (it does not raise), so a
+    # bare try/except would treat "not found" as "exists" and skip the create.
     try:
-        await service.get_flow_by_name(pod_id, name, ctx=ctx)
-        return True
+        return await service.get_flow_by_name(pod_id, name, ctx=ctx) is not None
     except Exception:
         return False
 

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundle_e2e_helpers.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundle_e2e_helpers.py
@@ -1,0 +1,151 @@
+"""Shared helpers for the pod-bundle *use-case* e2e tests.
+
+These tests pack a real, hand-authored bundle from ``bundles/<name>/`` on disk,
+import it through the URL-based flow (upload -> signed URL -> import -> apply),
+and then *execute* the imported resources (run functions, fire schedules, run
+workflows) to prove the import produced working — not just present — resources.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from uuid import uuid4
+
+from fastapi import status
+
+from lemma_pod_bundle import pack_bundle
+
+BUNDLES_DIR = Path(__file__).parent / "bundles"
+
+
+def pack_fixture_bundle(name: str) -> bytes:
+    """Zip the on-disk fixture bundle ``bundles/<name>/`` into importable bytes."""
+    root = BUNDLES_DIR / name
+    assert (root / "pod.json").is_file(), f"no fixture bundle {name!r} at {root}"
+    return pack_bundle(root)
+
+
+async def provision_workspace(client, pod_id: str) -> None:
+    """Warm the pod owner's workspace sandbox *through the backend* before an
+    import runs a worker-created function against it.
+
+    Why this exists: the shared e2e ``worker`` fixture is session-scoped and
+    freezes ``API_URL`` at spawn, while ``backend_server`` binds a fresh port per
+    test. A sandbox first provisioned by the import worker therefore bakes a
+    callback URL that can't reach *this* test's backend, so the imported
+    function's datastore calls fail with a network error. Provisioning the
+    sandbox from the in-process backend first (which knows the current port)
+    makes the worker reuse a reachable sandbox — and mirrors reality, where a
+    user's workspace is already provisioned by the time they run an import.
+
+    Creating a function triggers synchronous schema extraction, which is what
+    provisions the sandbox; the probe is deleted afterwards.
+    """
+    probe = f"provision_probe_{uuid4().hex[:8]}"
+    code = (
+        "#input_type_name: In\n"
+        "#output_type_name: Out\n"
+        f"#function_name: {probe}\n\n"
+        "from pydantic import BaseModel\n"
+        "from lemma_sdk import FunctionContext\n\n"
+        "class In(BaseModel):\n    x: int = 0\n\n"
+        "class Out(BaseModel):\n    x: int = 0\n\n"
+        f"async def {probe}(ctx: FunctionContext, data: In) -> Out:\n"
+        "    return Out(x=data.x)\n"
+    )
+    created = await client.post(
+        f"/pods/{pod_id}/functions",
+        json={"name": probe, "description": "workspace warm-up probe", "code": code},
+        follow_redirects=True,
+    )
+    assert created.status_code == status.HTTP_201_CREATED, created.text
+    await client.delete(f"/pods/{pod_id}/functions/{probe}")
+
+
+async def new_pod(client, org_id: str, *, label: str = "Use Case") -> str:
+    res = await client.post(
+        "/pods",
+        json={
+            "name": f"{label} {uuid4()}",
+            "slug": f"{label.lower().replace(' ', '-')}-{uuid4().hex[:8]}",
+            "type": "ASSISTANT",
+            "organization_id": org_id,
+        },
+        follow_redirects=True,
+    )
+    assert res.status_code == status.HTTP_201_CREATED, res.text
+    return res.json()["id"]
+
+
+async def wait_import(client, pod_id: str, import_id: str, *, until, timeout: int = 120) -> dict:
+    body: dict | None = None
+    for _ in range(timeout):
+        res = await client.get(f"/pods/{pod_id}/bundle/imports/{import_id}")
+        assert res.status_code == status.HTTP_200_OK, res.text
+        body = res.json()
+        if body["status"] in until:
+            return body
+        await asyncio.sleep(1)
+    raise AssertionError(f"Import stuck at {body and body['status']} (wanted {until})")
+
+
+async def import_and_apply(
+    client, pod_id: str, zip_bytes: bytes, *, timeout: int = 120
+) -> dict:
+    """Full happy path: upload the zip, import from its signed URL, wait for the
+    plan, apply, and wait for COMPLETED. Returns the final import status body."""
+    up = await client.post(
+        f"/pods/{pod_id}/bundle/uploads",
+        files={"data": ("bundle.zip", zip_bytes, "application/zip")},
+    )
+    assert up.status_code == status.HTTP_201_CREATED, up.text
+    url = up.json()["url"]
+
+    res = await client.post(
+        f"/pods/{pod_id}/bundle/imports", json={"kind": "URL", "url": url}
+    )
+    assert res.status_code == status.HTTP_202_ACCEPTED, res.text
+    import_id = res.json()["import_id"]
+
+    await wait_import(client, pod_id, import_id, until={"AWAITING_CONFIRMATION"}, timeout=timeout)
+    apply = await client.post(
+        f"/pods/{pod_id}/bundle/imports/{import_id}/apply", json={}
+    )
+    assert apply.status_code == status.HTTP_202_ACCEPTED, apply.text
+    final = await wait_import(
+        client, pod_id, import_id, until={"COMPLETED", "FAILED"}, timeout=timeout
+    )
+    assert final["status"] == "COMPLETED", final
+    return final
+
+
+async def run_function(
+    client,
+    pod_id: str,
+    function_name: str,
+    input_data: dict,
+    *,
+    expected_status: str = "COMPLETED",
+    timeout: int = 90,
+) -> dict:
+    """POST a function run and poll to a terminal state. Returns the run body."""
+    res = await client.post(
+        f"/pods/{pod_id}/functions/{function_name}/runs",
+        json={"input_data": input_data},
+        follow_redirects=True,
+    )
+    assert res.status_code == status.HTTP_200_OK, res.text
+    run_id = res.json()["id"]
+    run: dict | None = None
+    for _ in range(timeout):
+        got = await client.get(
+            f"/pods/{pod_id}/functions/{function_name}/runs/{run_id}"
+        )
+        assert got.status_code == status.HTTP_200_OK, got.text
+        run = got.json()
+        if run["status"] in ("COMPLETED", "FAILED"):
+            break
+        await asyncio.sleep(1)
+    assert run is not None and run["status"] == expected_status, run
+    return run

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/lead_scoring/functions/score_lead/code.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/lead_scoring/functions/score_lead/code.py
@@ -1,0 +1,58 @@
+#input_type_name: ScoreInput
+#output_type_name: ScoreResult
+#function_name: score_lead
+
+from typing import Optional
+
+from pydantic import BaseModel
+from lemma_sdk import FunctionContext, Pod
+from lemma_sdk.errors import LemmaAPIError
+
+# Deterministic firmographic scoring so the e2e can assert exact numbers.
+_PLAN_BONUS = {"enterprise": 40, "pro": 20}
+
+
+class ScoreInput(BaseModel):
+    company: str
+    employees: int = 0
+    plan_interest: str = ""
+
+
+class ScoreResult(BaseModel):
+    denied: bool = False
+    status_code: Optional[int] = None
+    error_code: Optional[str] = None
+    lead_id: Optional[str] = None
+    score: Optional[int] = None
+    tier: Optional[str] = None
+
+
+def _tier(score: int) -> str:
+    if score >= 70:
+        return "HIGH"
+    if score >= 40:
+        return "MEDIUM"
+    return "LOW"
+
+
+async def score_lead(ctx: FunctionContext, data: ScoreInput) -> ScoreResult:
+    size_points = min(60, max(0, data.employees) // 5)
+    bonus = _PLAN_BONUS.get(data.plan_interest.strip().lower(), 0)
+    score = min(100, size_points + bonus)
+    tier = _tier(score)
+    pod = Pod.from_env()
+    try:
+        record = pod.table("leads").create(
+            {
+                "company": data.company,
+                "employees": data.employees,
+                "plan_interest": data.plan_interest,
+                "score": score,
+                "tier": tier,
+            }
+        )
+    except LemmaAPIError as exc:
+        return ScoreResult(
+            denied=True, status_code=exc.status_code, error_code=exc.code
+        )
+    return ScoreResult(lead_id=str(record["id"]), score=score, tier=tier)

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/lead_scoring/functions/score_lead/score_lead.json
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/lead_scoring/functions/score_lead/score_lead.json
@@ -1,0 +1,19 @@
+{
+  "name": "score_lead",
+  "description": "Score a sales lead by size + plan interest and record it in the leads table.",
+  "code": {"$file": "code.py"},
+  "visibility": "POD",
+  "permissions": {
+    "grants": [
+      {
+        "resource_type": "datastore_table",
+        "resource_name": "leads",
+        "permission_ids": [
+          "datastore.table.read",
+          "datastore.record.read",
+          "datastore.record.write"
+        ]
+      }
+    ]
+  }
+}

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/lead_scoring/pod.json
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/lead_scoring/pod.json
@@ -1,0 +1,6 @@
+{
+  "name": "Lead Scoring",
+  "description": "Score inbound sales leads by firmographics and plan interest, record them, and re-score nightly.",
+  "format_version": 2,
+  "variables": {}
+}

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/lead_scoring/tables/leads/leads.json
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/lead_scoring/tables/leads/leads.json
@@ -1,0 +1,13 @@
+{
+  "name": "leads",
+  "primary_key_column": "id",
+  "enable_rls": false,
+  "columns": [
+    {"name": "id", "type": "UUID", "required": true, "auto": true},
+    {"name": "company", "type": "TEXT", "required": true},
+    {"name": "employees", "type": "INTEGER", "required": false},
+    {"name": "plan_interest", "type": "TEXT", "required": false},
+    {"name": "score", "type": "INTEGER", "required": false},
+    {"name": "tier", "type": "TEXT", "required": false}
+  ]
+}

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/lead_scoring/workflows/score_flow/score_flow.json
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/lead_scoring/workflows/score_flow/score_flow.json
@@ -1,0 +1,22 @@
+{
+  "name": "score_flow",
+  "description": "Score a single lead supplied in the run payload.",
+  "start": {"type": "MANUAL"},
+  "nodes": [
+    {
+      "id": "score",
+      "type": "FUNCTION",
+      "label": "Score lead",
+      "config": {
+        "function_name": "score_lead",
+        "input_mapping": {
+          "company": {"type": "expression", "value": "start.payload.company"},
+          "employees": {"type": "expression", "value": "start.payload.employees"},
+          "plan_interest": {"type": "expression", "value": "start.payload.plan_interest"}
+        }
+      }
+    },
+    {"id": "end", "type": "END", "label": "Done"}
+  ],
+  "edges": [{"id": "e1", "source": "score", "target": "end"}]
+}

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/moderation_queue/agents/reviewer_agent/instruction.md
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/moderation_queue/agents/reviewer_agent/instruction.md
@@ -1,0 +1,12 @@
+# Content moderation reviewer
+
+You help a human moderator triage user submissions. For each submission:
+
+1. Call `flag_content` with the submission's content and author. It records the
+   submission and returns a status (`FLAGGED` or `APPROVED`) and, when flagged,
+   the reason.
+2. If the submission is `FLAGGED`, summarize why in one sentence and recommend a
+   next action (remove, warn, or escalate).
+3. If the submission is `APPROVED`, confirm it passed automated screening.
+
+Only rely on the status returned by `flag_content`; never invent a verdict.

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/moderation_queue/agents/reviewer_agent/reviewer_agent.json
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/moderation_queue/agents/reviewer_agent/reviewer_agent.json
@@ -1,0 +1,21 @@
+{
+  "name": "reviewer_agent",
+  "description": "Moderation reviewer that screens submissions and recommends actions.",
+  "instruction": {"$file": "instruction.md"},
+  "toolsets": ["POD", "USER_INTERACTION"],
+  "visibility": "POD",
+  "permissions": {
+    "grants": [
+      {
+        "resource_type": "function",
+        "resource_name": "flag_content",
+        "permission_ids": ["function.read", "function.execute"]
+      },
+      {
+        "resource_type": "datastore_table",
+        "resource_name": "submissions",
+        "permission_ids": ["datastore.table.read", "datastore.record.read"]
+      }
+    ]
+  }
+}

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/moderation_queue/functions/flag_content/code.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/moderation_queue/functions/flag_content/code.py
@@ -1,0 +1,48 @@
+#input_type_name: FlagInput
+#output_type_name: FlagResult
+#function_name: flag_content
+
+from typing import Optional
+
+from pydantic import BaseModel
+from lemma_sdk import FunctionContext, Pod
+from lemma_sdk.errors import LemmaAPIError
+
+# Deterministic banned-term screen so the e2e can assert the exact verdict.
+_BANNED = ("spam", "scam", "phishing", "malware")
+
+
+class FlagInput(BaseModel):
+    content: str
+    author: str = ""
+
+
+class FlagResult(BaseModel):
+    denied: bool = False
+    status_code: Optional[int] = None
+    error_code: Optional[str] = None
+    submission_id: Optional[str] = None
+    status: Optional[str] = None
+    reason: Optional[str] = None
+
+
+async def flag_content(ctx: FunctionContext, data: FlagInput) -> FlagResult:
+    lowered = data.content.lower()
+    hit = next((term for term in _BANNED if term in lowered), None)
+    status = "FLAGGED" if hit else "APPROVED"
+    reason = f"contains banned term '{hit}'" if hit else ""
+    pod = Pod.from_env()
+    try:
+        record = pod.table("submissions").create(
+            {
+                "author": data.author,
+                "content": data.content,
+                "status": status,
+                "reason": reason,
+            }
+        )
+    except LemmaAPIError as exc:
+        return FlagResult(
+            denied=True, status_code=exc.status_code, error_code=exc.code
+        )
+    return FlagResult(submission_id=str(record["id"]), status=status, reason=reason)

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/moderation_queue/functions/flag_content/flag_content.json
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/moderation_queue/functions/flag_content/flag_content.json
@@ -1,0 +1,19 @@
+{
+  "name": "flag_content",
+  "description": "Screen a submission for banned terms and record its moderation status.",
+  "code": {"$file": "code.py"},
+  "visibility": "POD",
+  "permissions": {
+    "grants": [
+      {
+        "resource_type": "datastore_table",
+        "resource_name": "submissions",
+        "permission_ids": [
+          "datastore.table.read",
+          "datastore.record.read",
+          "datastore.record.write"
+        ]
+      }
+    ]
+  }
+}

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/moderation_queue/pod.json
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/moderation_queue/pod.json
@@ -1,0 +1,6 @@
+{
+  "name": "Moderation Queue",
+  "description": "Screen user-generated submissions for banned content and queue the flagged ones for human review.",
+  "format_version": 2,
+  "variables": {}
+}

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/moderation_queue/tables/submissions/submissions.json
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/moderation_queue/tables/submissions/submissions.json
@@ -1,0 +1,12 @@
+{
+  "name": "submissions",
+  "primary_key_column": "id",
+  "enable_rls": false,
+  "columns": [
+    {"name": "id", "type": "UUID", "required": true, "auto": true},
+    {"name": "author", "type": "TEXT", "required": false},
+    {"name": "content", "type": "TEXT", "required": true},
+    {"name": "status", "type": "TEXT", "required": false},
+    {"name": "reason", "type": "TEXT", "required": false}
+  ]
+}

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/moderation_queue/workflows/screen_flow/screen_flow.json
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/moderation_queue/workflows/screen_flow/screen_flow.json
@@ -1,0 +1,21 @@
+{
+  "name": "screen_flow",
+  "description": "Screen a single submission supplied in the run payload.",
+  "start": {"type": "MANUAL"},
+  "nodes": [
+    {
+      "id": "screen",
+      "type": "FUNCTION",
+      "label": "Screen submission",
+      "config": {
+        "function_name": "flag_content",
+        "input_mapping": {
+          "content": {"type": "expression", "value": "start.payload.content"},
+          "author": {"type": "expression", "value": "start.payload.author"}
+        }
+      }
+    },
+    {"id": "end", "type": "END", "label": "Done"}
+  ],
+  "edges": [{"id": "e1", "source": "screen", "target": "end"}]
+}

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/support_inbox/agents/support_agent/instruction.md
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/support_inbox/agents/support_agent/instruction.md
@@ -1,0 +1,13 @@
+# Support triage assistant
+
+You are the front line of the customer-support inbox. For every inbound message:
+
+1. Read the customer's email (subject + body).
+2. Call the `triage_ticket` function with the subject and body. It files the
+   message as a ticket and returns the ticket id and a priority (`HIGH` or
+   `LOW`).
+3. Reply to the user with a short acknowledgement that includes the ticket id
+   and the priority it was filed under.
+
+Always file exactly one ticket per inbound message. Never invent a ticket id —
+use the one returned by `triage_ticket`.

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/support_inbox/agents/support_agent/support_agent.json
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/support_inbox/agents/support_agent/support_agent.json
@@ -1,0 +1,21 @@
+{
+  "name": "support_agent",
+  "description": "Customer-support assistant that triages inbound email into tickets.",
+  "instruction": {"$file": "instruction.md"},
+  "toolsets": ["POD", "USER_INTERACTION"],
+  "visibility": "POD",
+  "permissions": {
+    "grants": [
+      {
+        "resource_type": "function",
+        "resource_name": "triage_ticket",
+        "permission_ids": ["function.read", "function.execute"]
+      },
+      {
+        "resource_type": "datastore_table",
+        "resource_name": "tickets",
+        "permission_ids": ["datastore.table.read", "datastore.record.read"]
+      }
+    ]
+  }
+}

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/support_inbox/functions/triage_ticket/code.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/support_inbox/functions/triage_ticket/code.py
@@ -1,0 +1,48 @@
+#input_type_name: TriageInput
+#output_type_name: TriageResult
+#function_name: triage_ticket
+
+from typing import Optional
+
+from pydantic import BaseModel
+from lemma_sdk import FunctionContext, Pod
+from lemma_sdk.errors import LemmaAPIError
+
+# Words that push an inbound message to the top of the queue. Deterministic so
+# the e2e can assert the exact priority without an LLM in the loop.
+_URGENT_MARKERS = ("urgent", "refund", "broken", "asap", "immediately", "down")
+
+
+class TriageInput(BaseModel):
+    subject: str
+    body: str = ""
+
+
+class TriageResult(BaseModel):
+    denied: bool = False
+    status_code: Optional[int] = None
+    error_code: Optional[str] = None
+    ticket_id: Optional[str] = None
+    priority: Optional[str] = None
+
+
+async def triage_ticket(ctx: FunctionContext, data: TriageInput) -> TriageResult:
+    haystack = f"{data.subject}\n{data.body}".lower()
+    priority = "HIGH" if any(marker in haystack for marker in _URGENT_MARKERS) else "LOW"
+    pod = Pod.from_env()
+    try:
+        record = pod.table("tickets").create(
+            {
+                "subject": data.subject,
+                "body": data.body,
+                "priority": priority,
+                "status": "OPEN",
+            }
+        )
+    except LemmaAPIError as exc:
+        # Surface an authorization failure as structured output so the test can
+        # assert on the real status/code instead of an opaque run failure.
+        return TriageResult(
+            denied=True, status_code=exc.status_code, error_code=exc.code
+        )
+    return TriageResult(ticket_id=str(record["id"]), priority=priority)

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/support_inbox/functions/triage_ticket/triage_ticket.json
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/support_inbox/functions/triage_ticket/triage_ticket.json
@@ -1,0 +1,19 @@
+{
+  "name": "triage_ticket",
+  "description": "Classify an inbound support email by urgency and file it as a ticket.",
+  "code": {"$file": "code.py"},
+  "visibility": "POD",
+  "permissions": {
+    "grants": [
+      {
+        "resource_type": "datastore_table",
+        "resource_name": "tickets",
+        "permission_ids": [
+          "datastore.table.read",
+          "datastore.record.read",
+          "datastore.record.write"
+        ]
+      }
+    ]
+  }
+}

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/support_inbox/pod.json
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/support_inbox/pod.json
@@ -1,0 +1,6 @@
+{
+  "name": "Support Inbox",
+  "description": "Triage inbound customer-support email into a tickets table, with an assistant that can file and prioritize tickets.",
+  "format_version": 2,
+  "variables": {}
+}

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/support_inbox/tables/tickets/tickets.json
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/bundles/support_inbox/tables/tickets/tickets.json
@@ -1,0 +1,12 @@
+{
+  "name": "tickets",
+  "primary_key_column": "id",
+  "enable_rls": false,
+  "columns": [
+    {"name": "id", "type": "UUID", "required": true, "auto": true},
+    {"name": "subject", "type": "TEXT", "required": true},
+    {"name": "body", "type": "TEXT", "required": false},
+    {"name": "priority", "type": "TEXT", "required": false},
+    {"name": "status", "type": "TEXT", "required": false}
+  ]
+}

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/test_lead_scoring_e2e.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/test_lead_scoring_e2e.py
@@ -1,0 +1,83 @@
+"""Use-case e2e: the ``lead_scoring`` fixture bundle.
+
+Covers a richer bundle — table + function + workflow — and proves the imported
+``score_lead`` function actually runs against the datastore (its record grants
+were applied on import), while the workflow imports with its function
+cross-reference intact.
+
+(Schedules aren't exercised here: a TIME schedule's ``schedule_job`` needs a live
+scheduler API the session-scoped e2e worker can't reach. Schedule *import
+mapping* is covered by the applier unit tests, and schedule *firing* by the
+schedule module's own full-stack e2e.)
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import status
+
+from app.modules.pod_bundle.tests.e2e.bundle_e2e_helpers import (
+    import_and_apply,
+    pack_fixture_bundle,
+    provision_workspace,
+    run_function,
+)
+
+pytestmark = [pytest.mark.e2e, pytest.mark.worker, pytest.mark.workspace]
+
+
+async def test_lead_scoring_imports_function_workflow_and_schedule(
+    authenticated_client, test_pod, worker, workspace_api
+):
+    pod_id = test_pod["id"]
+    zip_bytes = pack_fixture_bundle("lead_scoring")
+
+    await provision_workspace(authenticated_client, pod_id)
+    await import_and_apply(authenticated_client, pod_id, zip_bytes)
+
+    # --- resources exist -------------------------------------------------
+    assert (
+        await authenticated_client.get(f"/pods/{pod_id}/datastore/tables/leads")
+    ).status_code == status.HTTP_200_OK
+    assert (
+        await authenticated_client.get(f"/pods/{pod_id}/functions/score_lead")
+    ).status_code == status.HTTP_200_OK
+
+    # --- the imported function runs (record grants applied on import) ----
+    hot = await run_function(
+        authenticated_client,
+        pod_id,
+        "score_lead",
+        {"company": "BigCo", "employees": 300, "plan_interest": "enterprise"},
+    )
+    hot_out = hot["output_data"]
+    assert hot_out["denied"] is False, hot_out
+    assert hot_out["score"] == 100, hot_out  # min(60, 300//5) + 40, capped at 100
+    assert hot_out["tier"] == "HIGH", hot_out
+
+    cold = await run_function(
+        authenticated_client,
+        pod_id,
+        "score_lead",
+        {"company": "SmallCo", "employees": 10, "plan_interest": "free"},
+    )
+    cold_out = cold["output_data"]
+    assert cold_out["denied"] is False, cold_out
+    assert cold_out["score"] == 2, cold_out  # 10//5 + 0
+    assert cold_out["tier"] == "LOW", cold_out
+
+    rows = (
+        await authenticated_client.get(f"/pods/{pod_id}/datastore/tables/leads/records")
+    ).json()["items"]
+    assert {r["tier"] for r in rows} == {"HIGH", "LOW"}, rows
+
+    # --- workflow imported with its FUNCTION node referencing score_lead --
+    wf = await authenticated_client.get(f"/pods/{pod_id}/workflows/score_flow")
+    assert wf.status_code == status.HTTP_200_OK, wf.text
+    wf_json = wf.json()
+    node_types = {n.get("type") for n in wf_json.get("nodes", [])}
+    assert "FUNCTION" in node_types, wf_json
+    # The function cross-reference survived the round trip.
+    assert "score_lead" in json.dumps(wf_json), wf_json

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/test_moderation_queue_e2e.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/test_moderation_queue_e2e.py
@@ -1,0 +1,93 @@
+"""Use-case e2e: the ``moderation_queue`` fixture bundle.
+
+The richest bundle — table + function + agent + workflow. Proves the imported
+``flag_content`` function really screens submissions and writes records (its
+grants were applied on import), that the ``reviewer_agent`` imports with its
+toolsets + grants, and that the ``screen_flow`` workflow imports with its
+function cross-reference intact.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import status
+
+from app.modules.pod_bundle.tests.e2e.bundle_e2e_helpers import (
+    import_and_apply,
+    pack_fixture_bundle,
+    provision_workspace,
+    run_function,
+)
+
+pytestmark = [pytest.mark.e2e, pytest.mark.worker, pytest.mark.workspace]
+
+
+async def test_moderation_queue_imports_and_screens_submissions(
+    authenticated_client, test_pod, worker, workspace_api
+):
+    pod_id = test_pod["id"]
+    zip_bytes = pack_fixture_bundle("moderation_queue")
+
+    await provision_workspace(authenticated_client, pod_id)
+    await import_and_apply(authenticated_client, pod_id, zip_bytes)
+
+    # --- resources exist -------------------------------------------------
+    for path in (
+        "datastore/tables/submissions",
+        "functions/flag_content",
+        "agents/reviewer_agent",
+        "workflows/screen_flow",
+    ):
+        resp = await authenticated_client.get(f"/pods/{pod_id}/{path}")
+        assert resp.status_code == status.HTTP_200_OK, (path, resp.text)
+
+    # --- agent imported with toolsets + grants ---------------------------
+    agent = await authenticated_client.get(f"/pods/{pod_id}/agents/reviewer_agent")
+    assert set(agent.json().get("toolsets") or []) >= {"POD", "USER_INTERACTION"}
+    perms = await authenticated_client.get(
+        f"/pods/{pod_id}/agents/reviewer_agent/permissions"
+    )
+    grant_by_resource = {
+        (g["resource_type"], g["resource_name"]): set(g["permission_ids"])
+        for g in perms.json()["grants"]
+    }
+    assert grant_by_resource.get(("function", "flag_content"), set()) >= {
+        "function.execute"
+    }
+
+    # --- imported function screens for real (record grants applied) ------
+    flagged = await run_function(
+        authenticated_client,
+        pod_id,
+        "flag_content",
+        {"author": "bot123", "content": "Buy now, this is not a scam at all"},
+    )
+    flagged_out = flagged["output_data"]
+    assert flagged_out["denied"] is False, flagged_out
+    assert flagged_out["status"] == "FLAGGED", flagged_out
+    assert "scam" in flagged_out["reason"], flagged_out
+
+    clean = await run_function(
+        authenticated_client,
+        pod_id,
+        "flag_content",
+        {"author": "alice", "content": "Thanks for the helpful walkthrough!"},
+    )
+    clean_out = clean["output_data"]
+    assert clean_out["denied"] is False, clean_out
+    assert clean_out["status"] == "APPROVED", clean_out
+
+    rows = (
+        await authenticated_client.get(
+            f"/pods/{pod_id}/datastore/tables/submissions/records"
+        )
+    ).json()["items"]
+    assert {r["status"] for r in rows} == {"FLAGGED", "APPROVED"}, rows
+
+    # --- workflow imported referencing flag_content ----------------------
+    wf = await authenticated_client.get(f"/pods/{pod_id}/workflows/screen_flow")
+    wf_json = wf.json()
+    assert "FUNCTION" in {n.get("type") for n in wf_json.get("nodes", [])}, wf_json
+    assert "flag_content" in json.dumps(wf_json), wf_json

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/test_support_inbox_e2e.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/test_support_inbox_e2e.py
@@ -1,0 +1,101 @@
+"""Use-case e2e: the ``support_inbox`` fixture bundle imports into a real pod and
+its resources actually *work*.
+
+The import applies a ``tickets`` table, a ``triage_ticket`` function (with the
+datastore grants that let it write records), and a ``support_agent`` (with its
+toolsets + grants). The test then runs the imported function to prove the grants
+were applied on import — without them the function's datastore write returns a
+real 403 instead of a ticket.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import status
+
+from app.modules.pod_bundle.tests.e2e.bundle_e2e_helpers import (
+    import_and_apply,
+    pack_fixture_bundle,
+    provision_workspace,
+    run_function,
+)
+
+pytestmark = [pytest.mark.e2e, pytest.mark.worker, pytest.mark.workspace]
+
+
+async def test_support_inbox_imports_and_function_executes(
+    authenticated_client, test_pod, worker, workspace_api
+):
+    pod_id = test_pod["id"]
+    zip_bytes = pack_fixture_bundle("support_inbox")
+
+    # Provision the workspace from the backend first (see helper docstring), then
+    # import so the worker reuses a sandbox that can reach this test's backend.
+    await provision_workspace(authenticated_client, pod_id)
+    await import_and_apply(authenticated_client, pod_id, zip_bytes)
+
+    # --- resources exist -------------------------------------------------
+    tbl = await authenticated_client.get(f"/pods/{pod_id}/datastore/tables/tickets")
+    assert tbl.status_code == status.HTTP_200_OK, tbl.text
+    assert {c["name"] for c in tbl.json()["columns"]} >= {
+        "subject",
+        "body",
+        "priority",
+        "status",
+    }
+
+    func = await authenticated_client.get(f"/pods/{pod_id}/functions/triage_ticket")
+    assert func.status_code == status.HTTP_200_OK, func.text
+
+    agent = await authenticated_client.get(f"/pods/{pod_id}/agents/support_agent")
+    assert agent.status_code == status.HTTP_200_OK, agent.text
+    # Toolsets travelled with the agent on import.
+    assert set(agent.json().get("toolsets") or []) >= {"POD", "USER_INTERACTION"}
+
+    # --- the imported grants were applied --------------------------------
+    agent_perms = await authenticated_client.get(
+        f"/pods/{pod_id}/agents/support_agent/permissions"
+    )
+    assert agent_perms.status_code == status.HTTP_200_OK, agent_perms.text
+    grant_by_resource = {
+        (g["resource_type"], g["resource_name"]): set(g["permission_ids"])
+        for g in agent_perms.json()["grants"]
+    }
+    assert grant_by_resource.get(("function", "triage_ticket"), set()) >= {
+        "function.execute"
+    }
+    assert grant_by_resource.get(("datastore_table", "tickets"), set()) >= {
+        "datastore.record.read"
+    }
+
+    # --- the imported function actually runs (proves its table grants) ---
+    urgent = await run_function(
+        authenticated_client,
+        pod_id,
+        "triage_ticket",
+        {"subject": "URGENT: checkout is broken", "body": "Customers can't pay."},
+    )
+    urgent_out = urgent["output_data"]
+    assert urgent_out["denied"] is False, urgent_out
+    assert urgent_out["priority"] == "HIGH", urgent_out
+    assert urgent_out["ticket_id"], urgent_out
+
+    normal = await run_function(
+        authenticated_client,
+        pod_id,
+        "triage_ticket",
+        {"subject": "Question about billing", "body": "How do I update my card?"},
+    )
+    normal_out = normal["output_data"]
+    assert normal_out["denied"] is False, normal_out
+    assert normal_out["priority"] == "LOW", normal_out
+
+    # --- both tickets landed in the table --------------------------------
+    records = await authenticated_client.get(
+        f"/pods/{pod_id}/datastore/tables/tickets/records"
+    )
+    assert records.status_code == status.HTTP_200_OK, records.text
+    rows = records.json()["items"]
+    by_priority = {r["priority"] for r in rows}
+    assert by_priority == {"HIGH", "LOW"}, rows
+    assert all(r["status"] == "OPEN" for r in rows), rows

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/test_support_inbox_real_llm_e2e.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/test_support_inbox_real_llm_e2e.py
@@ -1,0 +1,97 @@
+"""Gated real-LLM e2e: an imported agent runs on a real model and uses the
+imported function end to end.
+
+Imports the ``support_inbox`` bundle, points ``support_agent`` at the real
+``system:lemma`` runtime, and gives it a customer email. With a real model the
+agent must call the imported ``triage_ticket`` tool (which it can only do because
+the import applied its POD toolset + ``function.execute`` grant), and that
+function writes a ticket to the imported table (its own record grants). We assert
+the ticket landed — the whole imported pod working under a real model.
+
+Gated: needs real provider creds (``system_lemma_available``) + the Docker
+AgentBox (run under ``E2E_REAL=1``); skipped in the mock e2e gate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import status
+
+from app.modules.agent.tests.e2e.system_lemma_helpers import (
+    SYSTEM_LEMMA_SKIP_REASON,
+    system_lemma_available,
+)
+from app.modules.agent.tests.e2e.test_agent_e2e import (
+    DEFAULT_AGENT_RUNTIME,
+    _assert_completed_without_error,
+    _post_sse,
+)
+from app.modules.pod_bundle.tests.e2e.bundle_e2e_helpers import (
+    import_and_apply,
+    pack_fixture_bundle,
+    provision_workspace,
+)
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.worker,
+    pytest.mark.workspace,
+    pytest.mark.real_llm,
+    pytest.mark.skipif(not system_lemma_available(), reason=SYSTEM_LEMMA_SKIP_REASON),
+]
+
+
+async def _tickets(client, pod_id: str) -> list[dict]:
+    resp = await client.get(f"/pods/{pod_id}/datastore/tables/tickets/records")
+    assert resp.status_code == status.HTTP_200_OK, resp.text
+    return resp.json()["items"]
+
+
+async def test_imported_support_agent_files_ticket_with_real_model(
+    authenticated_client, test_pod, worker, workspace_api
+):
+    pod_id = test_pod["id"]
+
+    await provision_workspace(authenticated_client, pod_id)
+    await import_and_apply(authenticated_client, pod_id, pack_fixture_bundle("support_inbox"))
+
+    # Point the imported agent at the real runtime (the bundle is runtime-agnostic).
+    patch = await authenticated_client.patch(
+        f"/pods/{pod_id}/agents/support_agent",
+        json={"agent_runtime": DEFAULT_AGENT_RUNTIME},
+    )
+    assert patch.status_code == status.HTTP_200_OK, patch.text
+
+    convo = await authenticated_client.post(
+        f"/pods/{pod_id}/conversations",
+        json={"agent_name": "support_agent", "title": "support e2e", "type": "CHAT"},
+    )
+    assert convo.status_code == status.HTTP_201_CREATED, convo.text
+    conversation_id = convo.json()["id"]
+
+    events = await _post_sse(
+        authenticated_client,
+        f"/pods/{pod_id}/conversations/{conversation_id}/messages",
+        {
+            "content": (
+                "A customer just emailed. Subject: 'URGENT: I was double charged'. "
+                "Body: 'You billed my card twice and I need a refund today.' "
+                "Please file this support ticket."
+            )
+        },
+    )
+    _assert_completed_without_error(events)
+
+    # The agent had only the imported POD toolset + function.execute grant to work
+    # with, so a filed ticket proves the imported function ran with its imported
+    # grants under a real model. Poll briefly for the tool's write to settle.
+    rows: list[dict] = []
+    for _ in range(10):
+        rows = await _tickets(authenticated_client, pod_id)
+        if rows:
+            break
+        await asyncio.sleep(1)
+    assert rows, "support_agent did not file any ticket"
+    assert any(r.get("priority") == "HIGH" for r in rows), rows

--- a/lemma-backend/app/modules/pod_bundle/tests/unit/test_applier.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/unit/test_applier.py
@@ -9,6 +9,7 @@ from app.modules.pod_bundle.domain.state import PlanStep, StepAction, StepKind
 from app.modules.pod_bundle.infrastructure.applier import (
     BundleApplier,
     StepNotApplicableError,
+    _grants_from_payload,
     _read_csv,
     _substitute,
 )
@@ -138,3 +139,306 @@ async def test_table_update_adds_new_columns_only(tmp_path, monkeypatch):
     )
     assert fake.added == ["score"]
     assert fake.created == []
+
+
+# --- grants ------------------------------------------------------------------
+
+
+_FUNC_ID = uuid4()
+_AGENT_ID = uuid4()
+
+
+class _FakeUow:
+    """Applier grant paths need ``uow.session``; the bare ``object()`` used by
+    the table tests has none."""
+
+    def __init__(self):
+        self.session = object()
+
+
+def _grant_applier(root: Path) -> BundleApplier:
+    return BundleApplier(
+        uow=_FakeUow(), ctx=object(), pod_id=_UUID, user_id=_UUID, bundle_root=root
+    )
+
+
+def _patch_grant_layer(monkeypatch) -> dict:
+    """Stub the shared authorization grant functions (imported lazily inside the
+    applier) and record the calls. Returns the recorder dict."""
+    calls: dict = {}
+
+    def _validate(grants):
+        calls["validated"] = list(grants)
+
+    async def _normalize(session, *, pod_id, grants):
+        calls["normalized"] = list(grants)
+        calls["normalize_pod_id"] = pod_id
+        return ["NORMALIZED"]
+
+    async def _replace(
+        session, *, pod_id, grantee_type, grantee_id, grants, created_by_user_id
+    ):
+        calls["replace"] = {
+            "grantee_type": grantee_type,
+            "grantee_id": grantee_id,
+            "grants": grants,
+            "created_by_user_id": created_by_user_id,
+        }
+
+    monkeypatch.setattr(
+        "app.core.authorization.grants.validate_pod_resource_grant_permissions",
+        _validate,
+    )
+    monkeypatch.setattr(
+        "app.core.authorization.grants.normalize_pod_resource_grants", _normalize
+    )
+    monkeypatch.setattr(
+        "app.core.authorization.grants.replace_grantee_resource_grants", _replace
+    )
+    return calls
+
+
+def test_grants_from_payload_parses_and_skips_invalid():
+    from app.core.authorization.context import ResourceType
+
+    grants = _grants_from_payload(
+        {
+            "permissions": {
+                "grants": [
+                    {
+                        "resource_type": "datastore_table",
+                        "resource_name": "tickets",
+                        "permission_ids": [
+                            "datastore.record.read",
+                            "datastore.record.write",
+                        ],
+                    },
+                    # Unknown resource_type -> skipped, not fatal.
+                    {"resource_type": "nonsense", "resource_name": "x"},
+                    # Missing resource_name -> skipped.
+                    {"resource_type": "function", "permission_ids": []},
+                ]
+            }
+        }
+    )
+    assert len(grants) == 1
+    assert grants[0].resource_type == ResourceType.DATASTORE_TABLE
+    assert grants[0].resource_name == "tickets"
+    assert grants[0].permission_ids == [
+        "datastore.record.read",
+        "datastore.record.write",
+    ]
+
+
+def test_grants_from_payload_accepts_bare_grants_list():
+    from app.core.authorization.context import ResourceType
+
+    grants = _grants_from_payload(
+        {
+            "grants": [
+                {
+                    "resource_type": "function",
+                    "resource_name": "triage",
+                    "permission_ids": ["function.execute"],
+                }
+            ]
+        }
+    )
+    assert len(grants) == 1
+    assert grants[0].resource_type == ResourceType.FUNCTION
+    assert _grants_from_payload({}) == []
+
+
+class FakeFunctionService:
+    def __init__(self):
+        self.created = []
+        self.updated = []
+
+    async def get_function_by_name(
+        self, pod_id, name, user_id, *, raise_not_found=False, ctx=None
+    ):
+        return None
+
+    async def create_function(self, entity, user_id, code=None, ctx=None):
+        entity.id = _FUNC_ID
+        self.created.append(entity.name)
+        return entity
+
+
+async def test_function_apply_applies_grants_and_invalidates(tmp_path, monkeypatch):
+    from app.core.authorization.context import ResourceType
+
+    root = tmp_path / "bundle"
+    _write(
+        root / "functions" / "triage" / "triage.json",
+        {
+            "name": "triage",
+            "code": "def main():\n    return {}\n",
+            "permissions": {
+                "grants": [
+                    {
+                        "resource_type": "datastore_table",
+                        "resource_name": "tickets",
+                        "permission_ids": ["datastore.record.read"],
+                    }
+                ]
+            },
+        },
+    )
+    fake = FakeFunctionService()
+    monkeypatch.setattr(
+        "app.modules.function.api.dependencies.build_function_service",
+        lambda uow: fake,
+    )
+    calls = _patch_grant_layer(monkeypatch)
+    invalidated: dict = {}
+
+    async def _invalidate(*, pod_id, function_id):
+        invalidated["function_id"] = function_id
+
+    monkeypatch.setattr(
+        "app.modules.workspace.services.workspace_tool_runtime."
+        "invalidate_function_workspace_env_cache",
+        _invalidate,
+    )
+
+    await _grant_applier(root).apply_step(_step(StepKind.FUNCTION, "triage"))
+
+    assert fake.created == ["triage"]
+    assert calls["replace"]["grantee_type"] == "FUNCTION"
+    assert calls["replace"]["grantee_id"] == _FUNC_ID
+    assert calls["replace"]["grants"] == ["NORMALIZED"]
+    grant = calls["validated"][0]
+    assert grant.resource_type == ResourceType.DATASTORE_TABLE
+    assert grant.resource_name == "tickets"
+    # Cache dropped so the new scopes take effect on the next run.
+    assert invalidated["function_id"] == _FUNC_ID
+
+
+async def test_function_apply_without_grants_skips_grant_layer(tmp_path, monkeypatch):
+    root = tmp_path / "bundle"
+    _write(
+        root / "functions" / "noop" / "noop.json",
+        {"name": "noop", "code": "def main():\n    return {}\n"},
+    )
+    fake = FakeFunctionService()
+    monkeypatch.setattr(
+        "app.modules.function.api.dependencies.build_function_service",
+        lambda uow: fake,
+    )
+    calls = _patch_grant_layer(monkeypatch)
+    await _grant_applier(root).apply_step(_step(StepKind.FUNCTION, "noop"))
+    assert fake.created == ["noop"]
+    assert "replace" not in calls  # no grants -> grant layer untouched
+
+
+class FakeAgentService:
+    class _Agent:
+        id = _AGENT_ID
+
+    async def get_agent_by_name(self, *, pod_id, name, ctx=None):
+        return self._Agent()
+
+
+async def test_agent_grants_step_applies_grants(tmp_path, monkeypatch):
+    root = tmp_path / "bundle"
+    _write(
+        root / "agents" / "support" / "support.json",
+        {
+            "name": "support",
+            "permissions": {
+                "grants": [
+                    {
+                        "resource_type": "function",
+                        "resource_name": "triage",
+                        "permission_ids": ["function.execute"],
+                    }
+                ]
+            },
+        },
+    )
+    monkeypatch.setattr(
+        "app.modules.agent.api.dependencies.get_agent_service",
+        lambda uow: FakeAgentService(),
+    )
+    calls = _patch_grant_layer(monkeypatch)
+
+    await _grant_applier(root).apply_step(
+        _step(StepKind.AGENT_GRANTS, "support", action=StepAction.UPDATE)
+    )
+
+    assert calls["replace"]["grantee_type"] == "AGENT"
+    assert calls["replace"]["grantee_id"] == _AGENT_ID
+    assert calls["replace"]["grants"] == ["NORMALIZED"]
+
+
+# --- workflows + schedules ---------------------------------------------------
+
+
+class FakeFlowService:
+    def __init__(self):
+        self.created = []
+
+    async def get_flow_by_name(self, pod_id, name, requester_user_id=None, ctx=None):
+        # A missing flow returns None (does NOT raise) — the applier must treat
+        # that as "create", not "already exists".
+        return None
+
+    async def create_flow(self, **kwargs):
+        self.created.append(kwargs["name"])
+
+
+async def test_workflow_apply_creates_when_absent(tmp_path, monkeypatch):
+    root = tmp_path / "bundle"
+    _write(
+        root / "workflows" / "score_flow" / "score_flow.json",
+        {
+            "name": "score_flow",
+            "start": {"type": "MANUAL"},
+            "nodes": [{"id": "n", "type": "END"}],
+            "edges": [],
+        },
+    )
+    fake = FakeFlowService()
+    monkeypatch.setattr(
+        "app.modules.workflow.api.dependencies.get_flow_service", lambda uow: fake
+    )
+    await _grant_applier(root).apply_step(_step(StepKind.WORKFLOW, "score_flow"))
+    # Regression: get_flow_by_name returning None must not be read as "exists".
+    assert fake.created == ["score_flow"]
+
+
+class FakeScheduleService:
+    def __init__(self):
+        self.created = []
+
+    async def list_schedules(self, *, pod_id, name=None, ctx=None, **kwargs):
+        return [], None
+
+    async def create_schedule(self, entity, ctx):
+        self.created.append(entity)
+
+
+async def test_schedule_apply_maps_manifest_to_entity(tmp_path, monkeypatch):
+    root = tmp_path / "bundle"
+    _write(
+        root / "schedules" / "nightly" / "nightly.json",
+        {
+            "name": "nightly",
+            "schedule_type": "TIME",
+            "workflow_name": "score_flow",
+            "config": {"cron": "0 2 * * *"},
+        },
+    )
+    fake = FakeScheduleService()
+    monkeypatch.setattr(
+        "app.modules.schedule.api.dependencies.get_schedule_service",
+        lambda uow: fake,
+    )
+    await _grant_applier(root).apply_step(_step(StepKind.SCHEDULE, "nightly"))
+    assert len(fake.created) == 1
+    entity = fake.created[0]
+    assert entity.name == "nightly"
+    assert entity.schedule_type.value == "TIME"
+    assert entity.workflow_name == "score_flow"
+    assert entity.config == {"cron": "0 2 * * *"}


### PR DESCRIPTION
## What

Follows the merged pod-bundle feature (#74) with **hardening that makes imported resources actually work** (not just appear) plus **real use-case e2e** that import a bundle and then *run* the imported resources.

### Hardening
- **Function + agent grants apply on import.** A manifest's `permissions.grants` (`resource_type` / `resource_name` / `permission_ids`) are validated, normalized (name → id), and applied via the same inline-grants path the controllers use. Function grants apply inline with create (then the delegated-token env cache is dropped); agent grants apply in the deferred `AGENT_GRANTS` step once referenced resources exist. This is what lets an imported function's datastore reads/writes be authorized immediately.
- **Agent toolsets travel with the agent** on create/update — a granted agent can't act without them.
- **Every apply step commits before its DONE checkpoint.** The bare per-step UoW rolls back on error but does **not** auto-commit on success, so a step whose service didn't commit internally (e.g. workflow create) was silently lost — and a DONE checkpoint on lost data broke crash-resume.

Two applier bugs the executable e2e surfaced, fixed here:
- `_apply_function`'s update path called `update_function` with the wrong signature (`code=`/`description=`/`requester_user_id=` instead of a `FunctionUpdateEntity`), TypeError-ing on any re-import.
- `_flow_exists` treated `get_flow_by_name` returning `None` ("not found") as "exists" and skipped workflow creation entirely.

### Real use-case bundles + execution e2e
Three hand-authored bundles live in the module (`tests/e2e/bundles/`) and are imported end to end, then executed:
- **support_inbox** — tickets table + `triage_ticket` function + `support_agent`
- **lead_scoring** — leads table + `score_lead` function + `score_flow` workflow
- **moderation_queue** — submissions table + `flag_content` function + `reviewer_agent` + `screen_flow` workflow

Each e2e imports the bundle and then **runs the imported function against the real datastore** (real AgentBox) — proving the record grants were applied, since without them the write returns a real 403 — and asserts the agent's toolsets/grants and the workflow's function cross-reference survived the import. A gated `real_llm` variant points `support_agent` at the real `system:lemma` runtime and asserts it files a ticket by calling the imported function tool.

## Tests
- Applier **unit** tests (13): grant parse/skip-invalid, function + agent grant application, no-grants no-op, workflow create-when-absent (the `_flow_exists` regression), schedule entity mapping. Full pod_bundle unit suite: 105 green.
- **E2E** (real worker + Docker AgentBox, `E2E_REAL=1`): support_inbox / lead_scoring / moderation_queue all green; the 5 pre-existing apply e2e tests still green (per-step-commit regression check). The `real_llm` variant skips without provider creds.

## Notes
- No API surface change → no version bump / SDK regen.
- Schedule *firing* needs the full scheduler stack (a live scheduler API the session-scoped e2e worker can't reach), so schedule import is covered at the applier unit level and firing by the schedule module's own full-stack e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)