### PR TITLE
fix(agent): self-healing approval flow + stop agents over-asking

### DIFF
--- a/lemma-backend/app/modules/agent/api/controllers/conversation_controller.py
+++ b/lemma-backend/app/modules/agent/api/controllers/conversation_controller.py
@@ -325,20 +325,22 @@ async def resolve_approval(
     ctx: PodContextDep,
 ) -> ApprovalDecisionResponse:
     _ = ctx
-    try:
-        await service.resolve_user_approval(
-            conversation_id=conversation_id,
-            approval_id=approval_id,
-            user_id=user.id,
-            pod_id=pod_id,
-            decision=data.decision,
-            response=data.response,
-        )
-    except RuntimeError as exc:
-        # Deliberate remap: the service raises RuntimeError when the approval is
-        # already resolved / the run is no longer waiting (a conflict, not a 500).
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
-    return ApprovalDecisionResponse(approval_id=approval_id, decision=data.decision)
+    # Idempotent + self-healing: resolving an already-recorded approval reconciles
+    # its half-finished resume instead of erroring (status "reconciled"). A truly
+    # unknown approval raises UnknownApprovalError -> 404 via the domain handler.
+    resolution = await service.resolve_user_approval(
+        conversation_id=conversation_id,
+        approval_id=approval_id,
+        user_id=user.id,
+        pod_id=pod_id,
+        decision=data.decision,
+        response=data.response,
+    )
+    return ApprovalDecisionResponse(
+        approval_id=approval_id,
+        decision=resolution.decision,
+        status=resolution.status,
+    )
 
 
 @router.post(

--- a/lemma-backend/app/modules/agent/domain/errors.py
+++ b/lemma-backend/app/modules/agent/domain/errors.py
@@ -59,6 +59,18 @@ class ConversationStateError(AgentModuleError):
         super().__init__(message, code="CONVERSATION_STATE_ERROR", status_code=409)
 
 
+class UnknownApprovalError(AgentModuleError):
+    """No pending approval and no recorded decision for this approval id.
+
+    The approval genuinely does not exist (or its call was never persisted), so
+    it can neither be resolved nor reconciled. Distinct from a resolvable
+    already-recorded decision, which self-heals instead of erroring.
+    """
+
+    def __init__(self, message: str = "Unknown or expired approval"):
+        super().__init__(message, code="UNKNOWN_APPROVAL", status_code=404)
+
+
 class HarnessNotFoundError(AgentModuleError):
     """No harness is registered for the requested kind.
 

--- a/lemma-backend/app/modules/agent/infrastructure/repositories.py
+++ b/lemma-backend/app/modules/agent/infrastructure/repositories.py
@@ -49,6 +49,7 @@ from app.modules.agent.domain.value_objects import (
     JsonObject,
     JsonValue,
     MessageDraft,
+    MessageKind,
     to_json_value,
 )
 from app.modules.agent.infrastructure.models import (
@@ -1025,6 +1026,55 @@ class ConversationRepository:
             return None
         response = row.response if isinstance(row.response, dict) else {}
         return AgentRunApprovalDecision(row.decision), response
+
+    async def get_tool_call(
+        self,
+        *,
+        conversation_id: UUID,
+        tool_call_id: str,
+    ) -> MessageEntity | None:
+        """The pausing tool CALL for an approval, addressed by tool_call_id.
+
+        Looked up directly (not through a message-window scan) so a long
+        conversation can't push the original request_approval/ask_user call out
+        of view during resume reconciliation.
+        """
+        result = await self.session.execute(
+            select(MessageModel)
+            .where(
+                MessageModel.conversation_id == conversation_id,
+                MessageModel.tool_call_id == tool_call_id,
+                MessageModel.kind == MessageKind.TOOL_CALL.value,
+            )
+            .order_by(MessageModel.sequence.asc())
+            .limit(1)
+        )
+        row = result.scalar_one_or_none()
+        return row.to_entity() if row is not None else None
+
+    async def get_tool_return(
+        self,
+        *,
+        conversation_id: UUID,
+        tool_call_id: str,
+    ) -> MessageEntity | None:
+        """The synthesized tool RETURN for an approval, or None.
+
+        This is the idempotency guard for approval resume: if a return already
+        exists, the approved tool has already run and must NOT be re-executed.
+        """
+        result = await self.session.execute(
+            select(MessageModel)
+            .where(
+                MessageModel.conversation_id == conversation_id,
+                MessageModel.tool_call_id == tool_call_id,
+                MessageModel.kind == MessageKind.TOOL_RETURN.value,
+            )
+            .order_by(MessageModel.sequence.asc())
+            .limit(1)
+        )
+        row = result.scalar_one_or_none()
+        return row.to_entity() if row is not None else None
 
     async def list_resolved_approval_ids(
         self,

--- a/lemma-backend/app/modules/agent/prompts/agent_base.md
+++ b/lemma-backend/app/modules/agent/prompts/agent_base.md
@@ -2,6 +2,6 @@ You are a Lemma agent operating inside a pod-aware execution sandbox.
 
 Use the current pod's resources — its tables, files, functions, agents, workflows, schedules, and connected connectors — to accomplish the user's goal. Treat pod resources as an allow-list: prefer real pod data, file contents, and tool results over assumptions. When a task is actionable, take the next useful step and report the result plainly rather than describing what you would do.
 
-Two rules hold across every pod: keep durable state in tables (status, owner, lifecycle) and knowledge in files (playbooks, preferences, reference) — never let state rot in chat; and pause for confirmation before anything that sends, spends, deletes, or commits on someone's behalf.
+Two rules hold across every pod. First, keep durable state in tables (status, owner, lifecycle) and knowledge in files (playbooks, preferences, reference) — never let state rot in chat. Second, act on the resources you've been granted (see Granted Resources below) directly, without asking — only call `request_approval` when a tool returns a permission error (403), or for an explicitly destructive action (deleting data or resources, changing access).
 
 Your specific instructions and the tools available to you are described below. Follow your instructions closely; they take precedence when they narrow or override this guidance.

--- a/lemma-backend/app/modules/agent/prompts/pod_assistant.md
+++ b/lemma-backend/app/modules/agent/prompts/pod_assistant.md
@@ -10,7 +10,7 @@ Help the user get real work done with the pod's own resources — its tables, fi
 ## How to act
 
 - **Be proactive about the queue.** When it helps, surface what's pending and what needs the user's call — approvals waiting on them, stale rows, due work — instead of waiting to be asked item by item.
-- **Pause before the irreversible.** Anything that sends, spends, deletes, or commits on someone's behalf waits for the user's go-ahead: draft it, show it, then act on their confirmation. Reversible, low-stakes steps — just do them and report.
+- **Act first; pause only for the destructive.** You run with this user's own permissions — so do the work and report it: build, deploy, publish, create, update, write rows and files, run commands. Don't ask permission for reversible actions. Stop to confirm only before something destructive or hard to undo — deleting data or resources, changing who can access the pod, or sending messages/email or spending money on someone's behalf: draft it, show it, act on their go-ahead. If a tool call returns a permission error (403), that's your cue to `request_approval` — otherwise just proceed.
 - **Offer to build when the work recurs.** If the user is describing an ongoing process or system rather than a one-off task, say so and offer to build it into the pod — a table, an agent, a workflow, an app — so it stops living in chat. Load the `lemma-builder` skill for that.
 
 ## Voice

--- a/lemma-backend/app/modules/agent/services/agent_context_brief.py
+++ b/lemma-backend/app/modules/agent/services/agent_context_brief.py
@@ -224,7 +224,12 @@ class AgentContextBriefBuilder:
             repo = AgentContextBriefRepository(uow)
             rows = await repo.get_agent_grants(pod_id=pod_id, agent_id=agent.id)
             if not rows:
-                return ["\n## Granted Resources\n- (none)"]
+                return [
+                    "\n## Granted Resources",
+                    "- (none) — you have no resource grants yet. If a tool returns "
+                    "a permission error (403), call request_approval so the user "
+                    "can grant access or run it for you.",
+                ]
 
             refs: list[tuple[ResourceType, UUID]] = []
             perms_by_ref: dict[tuple[str, UUID], set[str]] = {}
@@ -266,7 +271,13 @@ class AgentContextBriefBuilder:
                 finally:
                     reset_current_context(token)
 
-        lines = ["\n## Granted Resources"]
+        lines = [
+            "\n## Granted Resources",
+            "These are pre-authorized for you — read, query, and act on them "
+            "directly without asking for approval. Only call request_approval if a "
+            "tool returns a permission error (403), or for an explicitly "
+            "destructive action.",
+        ]
         for (resource_type, resource_id), perms in list(perms_by_ref.items())[
             :_MAX_RESOURCES
         ]:

--- a/lemma-backend/app/modules/agent/services/conversation_service.py
+++ b/lemma-backend/app/modules/agent/services/conversation_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
+from typing import NamedTuple
 from uuid import UUID
 
 
@@ -26,6 +27,7 @@ from app.modules.agent.domain.entities import (
 from app.modules.agent.domain.errors import (
     AgentNotFoundError,
     ConversationNotFoundError,
+    UnknownApprovalError,
 )
 from app.modules.agent.domain.events import (
     AGENT_EVENTS_STREAM,
@@ -67,6 +69,20 @@ _POD_ASSISTANT_AGENT_ID = DEFAULT_POD_AGENT_ID
 # as a card by the client) and are resolved via the approvals endpoint, which
 # synthesizes their tool return and resumes the run.
 _PAUSING_TOOL_NAMES = ("ask_user", "request_approval")
+
+
+class ApprovalResolution(NamedTuple):
+    """Outcome of resolving an approval.
+
+    ``status`` is ``"resolved"`` when this call recorded the decision, or
+    ``"reconciled"`` when the decision already existed and this call only
+    finished (or re-finished) the resume — the self-heal path. ``decision`` is
+    the authoritative (stored) decision, which may differ from what a late
+    caller submitted.
+    """
+
+    status: str
+    decision: AgentRunApprovalDecision
 
 
 # When set, starting a new agent run does NOT publish the AgentRunStartedEvent
@@ -439,7 +455,7 @@ class ConversationService:
         decision: AgentRunApprovalDecision,
         response: dict[str, object] | None = None,
         agent_name: str | None = None,
-    ) -> None:
+    ) -> ApprovalResolution:
         """Record the user's decision and resume the paused agent run.
 
         ``ask_user`` / ``request_approval`` end their run when called (conversation
@@ -460,7 +476,7 @@ class ConversationService:
             agent_name=agent_name,
             action=Permissions.AGENT_EXECUTE,
         )
-        await self.resolve_user_approval_internal(
+        return await self.resolve_user_approval_internal(
             conversation=conversation,
             approval_id=approval_id,
             user_id=user_id,
@@ -480,81 +496,171 @@ class ConversationService:
         decision: AgentRunApprovalDecision,
         response: dict[str, object] | None = None,
         agent_name: str | None = None,
-    ) -> None:
+    ) -> ApprovalResolution:
         """Resume a paused run for an already-authorized + loaded conversation.
 
-        Carries the safety-critical core of :meth:`resolve_user_approval` (the
-        unique decision-record lock, the synthesized tool return, the
-        all-siblings-resolved resume gate). Callers MUST have authorized the
-        resolver against this conversation first. The caller's current auth
-        context must be the conversation owner's, since an approved
-        ``request_approval`` runs the wrapped tool with that authority.
+        Idempotent and self-healing. Classifies the approval three ways:
+          * neither a paused call nor a recorded decision exists -> it is unknown
+            (``UnknownApprovalError`` -> 404);
+          * no decision yet -> record it (the unique (conversation, approval) row
+            is the double-submit lock), then reconcile;
+          * a decision already exists -> adopt it and reconcile (the retry /
+            self-heal path) instead of erroring.
+
+        The reconcile step is safe to call repeatedly: the approved tool runs at
+        most once (guarded by an existing tool return) and the resume run starts
+        at most once. Callers MUST have authorized the resolver against this
+        conversation first. The caller's current auth context must be the
+        conversation owner's, since an approved ``request_approval`` runs the
+        wrapped tool with that authority.
         """
-        pending = await self._pending_user_approval_from_messages(
+        decision_row = await self.conversation_repository.get_approval_decision(
             conversation_id=conversation.id,
             approval_id=approval_id,
         )
-        if pending is None:
-            raise RuntimeError("Approval is not pending or no longer live")
-        kind = str(pending["kind"])
-        tool_args = pending["tool_args"] if isinstance(pending["tool_args"], dict) else {}
-
-        # Record the decision first so the unique (conversation, approval) row locks
-        # out a concurrent double-submit before any side-effecting tool runs.
-        decision_tool_name = (
-            "ask_user"
-            if kind == "ask_user"
-            else str(tool_args.get("tool_name") or "request_approval")
-        )
-        recorded = await self.conversation_repository.record_approval_decision(
+        paused = await self._paused_call_from_messages(
             conversation_id=conversation.id,
             approval_id=approval_id,
-            agent_run_id=pending["agent_run_id"],
-            tool_name=decision_tool_name,
-            decision=decision,
-            response=response or {},
-            resolved_by_user_id=user_id,
         )
-        if not recorded:
-            raise RuntimeError("Approval already resolved")
-        await self.uow.commit()
+        if decision_row is None and paused is None:
+            # Nothing to resolve and nothing to heal — the approval never existed
+            # or its call was never persisted.
+            raise UnknownApprovalError()
 
-        # Synthesize the tool return the resumed run will replay, and persist it under
-        # the *paused* run (the one that made the call). For an approved
-        # request_approval this runs the wrapped tool as the user. History is
-        # reconstructed per conversation, so _build_tool_batch pairs this return with
-        # its call regardless of which run each lives in.
-        paused_run_id = pending["agent_run_id"]
-        return_tool_name, tool_result = await self._build_resume_tool_return(
+        if paused is None:
+            # Unreachable in practice: the pausing tool call message is never
+            # deleted, so a recorded decision always has its call. Guard anyway —
+            # we cannot faithfully rebuild a resume without the original call.
+            raise UnknownApprovalError()
+        kind = str(paused["kind"])
+        tool_args = paused["tool_args"] if isinstance(paused["tool_args"], dict) else {}
+        paused_run_id = paused["agent_run_id"]
+
+        if decision_row is None:
+            # Fresh resolve: record the decision. The unique (conversation,
+            # approval) row locks out a concurrent double-submit before any
+            # side-effecting tool runs.
+            decision_tool_name = (
+                "ask_user"
+                if kind == "ask_user"
+                else str(tool_args.get("tool_name") or "request_approval")
+            )
+            recorded = await self.conversation_repository.record_approval_decision(
+                conversation_id=conversation.id,
+                approval_id=approval_id,
+                agent_run_id=paused_run_id,
+                tool_name=decision_tool_name,
+                decision=decision,
+                response=response or {},
+                resolved_by_user_id=user_id,
+            )
+            await self.uow.commit()
+            if recorded:
+                effective_decision, effective_response, status = (
+                    decision,
+                    response or {},
+                    "resolved",
+                )
+            else:
+                # A concurrent resolve won the race; adopt its stored decision and
+                # reconcile (idempotent) rather than raising "already resolved".
+                stored = await self.conversation_repository.get_approval_decision(
+                    conversation_id=conversation.id,
+                    approval_id=approval_id,
+                )
+                effective_decision, effective_response = (
+                    stored if stored is not None else (decision, response or {})
+                )
+                status = "reconciled"
+        else:
+            # Decision already recorded (retry / self-heal). Do NOT re-record or
+            # re-run the tool; adopt the stored decision and finish whatever the
+            # prior attempt left undone.
+            effective_decision, effective_response = decision_row
+            status = "reconciled"
+
+        await self._reconcile_approval_resume(
             conversation=conversation,
-            user_id=user_id,
+            approval_id=approval_id,
+            paused_run_id=paused_run_id,
             kind=kind,
             tool_args=tool_args,
-            decision=decision,
-            response=response or {},
-            paused_agent_run_id=paused_run_id,
+            decision=effective_decision,
+            response=effective_response,
+            user_id=user_id,
+            pod_id=pod_id,
+            agent_name=agent_name,
         )
-        saved_return = await self.conversation_repository.append_message(
+        return ApprovalResolution(status=status, decision=effective_decision)
+
+    async def _reconcile_approval_resume(
+        self,
+        *,
+        conversation: Conversation,
+        approval_id: str,
+        paused_run_id: UUID,
+        kind: str,
+        tool_args: dict[str, object],
+        decision: AgentRunApprovalDecision,
+        response: dict[str, object],
+        user_id: UUID,
+        pod_id: UUID,
+        agent_name: str | None,
+    ) -> None:
+        """Finish (or re-finish) an approval's resume; safe to call repeatedly.
+
+        Two idempotent halves:
+          1. Synthesize + persist the paused call's tool return exactly once. If a
+             return already exists the approved tool has already run, so we skip
+             the rebuild entirely — re-executing it (e.g. re-deploying an app, or
+             re-recording session grants) would be a correctness bug.
+          2. Start the resume run only once every pausing call in the paused run is
+             resolved and no run is already active. The conversation lock
+             serializes this so two near-simultaneous resolves don't each start a
+             run.
+
+        A resolve that died mid-flight (decision committed, return not appended,
+        or run not started) self-heals when this runs again on the user's retry.
+        """
+        existing_return = await self.conversation_repository.get_tool_return(
             conversation_id=conversation.id,
-            agent_run_id=paused_run_id,
-            draft=MessageDraft.of_tool_return(
-                tool_call_id=approval_id,
-                tool_name=return_tool_name,
-                tool_result=tool_result,
-            ),
+            tool_call_id=approval_id,
         )
-        await self.uow.commit()
-        await publish_conversation_event(
-            conversation.id,
-            message_payload(paused_run_id, message_to_payload(saved_return)),
-        )
+        if existing_return is None:
+            # Synthesize the tool return the resumed run will replay, and persist it
+            # under the *paused* run (the one that made the call). For an approved
+            # request_approval this runs the wrapped tool as the user. History is
+            # reconstructed per conversation, so _build_tool_batch pairs this return
+            # with its call regardless of which run each lives in.
+            return_tool_name, tool_result = await self._build_resume_tool_return(
+                conversation=conversation,
+                user_id=user_id,
+                kind=kind,
+                tool_args=tool_args,
+                decision=decision,
+                response=response,
+                paused_agent_run_id=paused_run_id,
+            )
+            saved_return = await self.conversation_repository.append_message(
+                conversation_id=conversation.id,
+                agent_run_id=paused_run_id,
+                draft=MessageDraft.of_tool_return(
+                    tool_call_id=approval_id,
+                    tool_name=return_tool_name,
+                    tool_result=tool_result,
+                ),
+            )
+            await self.uow.commit()
+            await publish_conversation_event(
+                conversation.id,
+                message_payload(paused_run_id, message_to_payload(saved_return)),
+            )
 
         # A turn can pause with several pending interactions (e.g. request_approval +
         # ask_user in one assistant turn). Resume only once every pausing tool call in
         # the paused run is resolved — otherwise the unresolved sibling would be
         # orphaned (no return) and dropped from the resumed run's history, making the
-        # agent re-ask it. The conversation lock serializes the resume decision so two
-        # near-simultaneous resolves don't each start a run.
+        # agent re-ask it.
         await self.conversation_repository.lock_conversation(conversation.id)
         remaining = await self._unresolved_pausing_call_ids(
             conversation_id=conversation.id,
@@ -838,39 +944,52 @@ class ConversationService:
             pod_cwd=resolve_pod_cwd(conversation),
         )
 
+    async def _paused_call_from_messages(
+        self,
+        *,
+        conversation_id: UUID,
+        approval_id: str,
+    ) -> dict[str, object] | None:
+        """The pausing tool call for an approval, regardless of decision state.
+
+        Addressed directly by ``tool_call_id`` (not a message-window scan) so a
+        long conversation can't hide the original call during resume
+        reconciliation. Returns ``{agent_run_id, kind, tool_args}`` or ``None``.
+        """
+        message = await self.conversation_repository.get_tool_call(
+            conversation_id=conversation_id,
+            tool_call_id=approval_id,
+        )
+        if (
+            message is None
+            or message.tool_name not in _PAUSING_TOOL_NAMES
+            or message.agent_run_id is None
+        ):
+            return None
+        tool_args = message.tool_args if isinstance(message.tool_args, dict) else {}
+        return {
+            "agent_run_id": message.agent_run_id,
+            "kind": message.tool_name,
+            "tool_args": tool_args,
+        }
+
     async def _pending_user_approval_from_messages(
         self,
         *,
         conversation_id: UUID,
         approval_id: str,
     ) -> dict[str, object] | None:
+        """The paused call only if it has NOT been resolved yet (else ``None``)."""
         already_resolved = await self.conversation_repository.get_approval_decision(
             conversation_id=conversation_id,
             approval_id=approval_id,
         )
         if already_resolved is not None:
             return None
-        messages, _ = await self.conversation_repository.list_messages(
+        return await self._paused_call_from_messages(
             conversation_id=conversation_id,
-            limit=500,
+            approval_id=approval_id,
         )
-        for message in messages:
-            if (
-                message.kind != MessageKind.TOOL_CALL
-                or message.tool_name not in _PAUSING_TOOL_NAMES
-                or message.tool_call_id != approval_id
-                or message.agent_run_id is None
-            ):
-                continue
-            tool_args = (
-                message.tool_args if isinstance(message.tool_args, dict) else {}
-            )
-            return {
-                "agent_run_id": message.agent_run_id,
-                "kind": message.tool_name,
-                "tool_args": tool_args,
-            }
-        return None
 
     async def get_pending_ask_user(
         self,

--- a/lemma-backend/app/modules/agent/tests/e2e/test_agent_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_agent_e2e.py
@@ -808,12 +808,17 @@ class TestPodAgentLifecycle:
         )
         assert approvals_after.json()["items"] == []
 
+        # Re-deciding an already-resolved call self-heals idempotently: it
+        # reconciles (no new run, no re-execution) and reports the stored decision
+        # instead of erroring with a conflict.
         duplicate = await authenticated_client.post(
             f"/pods/{pod_id}/conversations/{conversation_id}"
             f"/approvals/{approval_id}/decision",
             json={"decision": "DENY", "response": {}},
         )
-        assert duplicate.status_code == status.HTTP_409_CONFLICT
+        assert duplicate.status_code == 200, duplicate.text
+        assert duplicate.json()["status"] == "reconciled"
+        assert duplicate.json()["decision"] == "APPROVE_ONCE"
 
     async def test_request_approval_denial_resumes_without_executing(
         self,
@@ -859,12 +864,116 @@ class TestPodAgentLifecycle:
         )
         assert approvals_after.json()["items"] == []
 
+        # A retry after a resolved denial reconciles idempotently (stored DENY),
+        # never re-running the wrapped tool.
         duplicate = await authenticated_client.post(
             f"/pods/{pod_id}/conversations/{conversation_id}"
             f"/approvals/{approval_id}/decision",
             json={"decision": "APPROVE_ONCE", "response": {}},
         )
-        assert duplicate.status_code == status.HTTP_409_CONFLICT
+        assert duplicate.status_code == 200, duplicate.text
+        assert duplicate.json()["status"] == "reconciled"
+        assert duplicate.json()["decision"] == "DENY"
+
+    async def test_resolution_self_heals_after_recorded_but_unfinished_resume(
+        self,
+        authenticated_client,
+        fixed_test_org,
+        fixed_test_user,
+    ):
+        """Regression for the stuck approval loop.
+
+        Reproduces the exact wedge: a decision was committed but its resume died
+        before appending the synthesized return or starting the resume run (no
+        TTL, no reaper). The next resolve must SELF-HEAL — finish the resume and
+        report ``reconciled`` — instead of raising "Approval is not pending or no
+        longer live" forever.
+        """
+        pod_id, conversation_id, _agent, paused_run, approval_id = (
+            await _seed_paused_interaction(
+                authenticated_client,
+                fixed_test_org,
+                tool_name="ask_user",
+                tool_args={
+                    "questions": [
+                        {
+                            "question": "Which auth method?",
+                            "header": "Auth",
+                            "options": [{"label": "OAuth"}, {"label": "API key"}],
+                        }
+                    ]
+                },
+            )
+        )
+
+        # Simulate the wedge: decision committed, resume never finished.
+        async with create_uow_from_session_maker(async_session_maker) as uow:
+            recorded = await ConversationRepository(uow).record_approval_decision(
+                conversation_id=conversation_id,
+                approval_id=approval_id,
+                agent_run_id=paused_run.id,
+                tool_name="ask_user",
+                decision=AgentRunApprovalDecision.APPROVE_ONCE,
+                response={"answers": {"Auth": "OAuth"}},
+                resolved_by_user_id=UUID(fixed_test_user["id"]),
+            )
+            assert recorded is True
+            await uow.commit()
+
+        # Precondition: genuinely stuck — no synthesized return, no resume run.
+        resume_run, tool_return = await _resume_run_and_tool_return(
+            conversation_id, paused_run.id, approval_id
+        )
+        assert resume_run is None
+        assert tool_return is None
+
+        # The user clicks approve again -> self-heals (no 409/RuntimeError).
+        healed = await authenticated_client.post(
+            f"/pods/{pod_id}/conversations/{conversation_id}"
+            f"/approvals/{approval_id}/decision",
+            json={"decision": "APPROVE_ONCE", "response": {"answers": {"Auth": "OAuth"}}},
+        )
+        assert healed.status_code == 200, healed.text
+        assert healed.json()["status"] == "reconciled"
+
+        resume_run, tool_return = await _resume_run_and_tool_return(
+            conversation_id, paused_run.id, approval_id
+        )
+        assert resume_run is not None
+        assert resume_run.status == AgentRunStatus.RUNNING
+        assert tool_return is not None
+        # The stored decision/answers drive the synthesized return, not the (empty)
+        # ones a late caller might resend.
+        assert tool_return.tool_result["answers"] == {"Auth": "OAuth"}
+
+    async def test_unknown_approval_id_returns_404(
+        self,
+        authenticated_client,
+        fixed_test_org,
+    ):
+        """An approval id with no paused call and no decision is a 404, not a 409."""
+        pod_id, conversation_id, _agent, _paused_run, _approval_id = (
+            await _seed_paused_interaction(
+                authenticated_client,
+                fixed_test_org,
+                tool_name="ask_user",
+                tool_args={
+                    "questions": [
+                        {
+                            "question": "Which auth method?",
+                            "header": "Auth",
+                            "options": [{"label": "OAuth"}, {"label": "API key"}],
+                        }
+                    ]
+                },
+            )
+        )
+        missing = await authenticated_client.post(
+            f"/pods/{pod_id}/conversations/{conversation_id}"
+            f"/approvals/does-not-exist/decision",
+            json={"decision": "APPROVE_ONCE", "response": {}},
+        )
+        assert missing.status_code == status.HTTP_404_NOT_FOUND, missing.text
 
     async def test_request_approval_approval_runs_tool_as_user_on_resume(
         self,
@@ -874,12 +983,13 @@ class TestPodAgentLifecycle:
     ):
         """An approved request_approval runs the wrapped tool as the user during
         resume and feeds its result back as the synthesized tool return."""
-        captured: dict[str, object] = {}
+        captured: dict[str, object] = {"calls": 0}
 
         async def fake_execute_as_user(
             self, *, conversation, user_id, agent_run_id, tool_name, args
         ):  # noqa: ANN001 - test stub matching the service signature
             del self, conversation, user_id, agent_run_id
+            captured["calls"] = int(captured["calls"]) + 1
             captured["tool_name"] = tool_name
             captured["args"] = args
             return {"ok": True, "value": {"stdout": "deleted", "success": True}}
@@ -921,6 +1031,18 @@ class TestPodAgentLifecycle:
         assert tool_return.tool_result["result"] == {"stdout": "deleted", "success": True}
         assert captured["tool_name"] == "exec_command"
         assert captured["args"] == {"cmd": "lemma records delete orders --id 42"}
+        assert captured["calls"] == 1
+
+        # Re-execution guard: a duplicate resolve reconciles idempotently and must
+        # NOT run the (destructive) wrapped tool a second time.
+        duplicate = await authenticated_client.post(
+            f"/pods/{pod_id}/conversations/{conversation_id}"
+            f"/approvals/{approval_id}/decision",
+            json={"decision": "APPROVE_ONCE", "response": {}},
+        )
+        assert duplicate.status_code == 200, duplicate.text
+        assert duplicate.json()["status"] == "reconciled"
+        assert captured["calls"] == 1
 
     async def test_multiple_pending_interactions_resume_only_after_all_resolved(
         self,

--- a/lemma-typescript/src/react/useAssistantController.ts
+++ b/lemma-typescript/src/react/useAssistantController.ts
@@ -511,6 +511,19 @@ function sortMessagesByCreatedAt(messages: AssistantApiConversationMessage[]): A
   });
 }
 
+/** True when a synthesized tool return exists for this approval — i.e. the
+ *  server recorded + resumed it, so the card is resolved even if the HTTP
+ *  response the client saw failed. */
+function approvalResultPresent(
+  items: AssistantApiConversationMessage[] | null,
+  approvalId: string,
+): boolean {
+  if (!items) return false;
+  return items.some(
+    (msg) => msg.kind === "TOOL_RETURN" && msg.tool_call_id === approvalId,
+  );
+}
+
 function isConversationRunning(status: unknown): boolean {
   if (typeof status !== "string") return false;
   const normalized = status.trim().toLowerCase();
@@ -641,7 +654,7 @@ export function useAssistantController({
   const lastAutoLoadedConversationIdRef = useRef<string | null>(null);
   const loadingConversationIdRef = useRef<string | null>(null);
   const skipInitialLoadConversationIdsRef = useRef<Set<string>>(new Set());
-  const loadConversationMessagesRef = useRef<((conversationId: string) => Promise<void>) | null>(null);
+  const loadConversationMessagesRef = useRef<((conversationId: string) => Promise<AssistantApiConversationMessage[] | null>) | null>(null);
   const resumeIfRunningRef = useRef<((conversationId?: string | null) => Promise<boolean>) | null>(null);
 
   const scope = useMemo<AssistantConversationScope>(() => ({
@@ -841,7 +854,9 @@ export function useAssistantController({
     }
   }, [client, scope.organizationId]);
 
-  const loadConversationMessages = useCallback(async (conversationId: string) => {
+  const loadConversationMessages = useCallback(async (
+    conversationId: string,
+  ): Promise<AssistantApiConversationMessage[] | null> => {
     setIsLoadingMessages(true);
     try {
       const response = await sessionLoadMessages({
@@ -849,14 +864,16 @@ export function useAssistantController({
         limit: 100,
       });
       if (activeConversationIdRef.current !== conversationId) {
-        return;
+        return null;
       }
       const sorted = sortMessagesByCreatedAt((response.items || []) as AssistantApiConversationMessage[]);
       replaceLoadedMessages(sorted);
       setOlderMessagesCursor(response.next_page_token ?? null);
+      return sorted;
     } catch (err) {
       setLocalError((prev) => prev || (err instanceof Error ? err.message : "Failed to load messages"));
       setOlderMessagesCursor(null);
+      return null;
     } finally {
       setIsLoadingMessages(false);
     }
@@ -1361,6 +1378,15 @@ export function useAssistantController({
         setLocalError((prev) => prev || (error instanceof Error ? error.message : "Failed to resume conversation"));
       });
     } catch (err) {
+      // The resolve may have partially completed on the server (decision recorded,
+      // tool return appended) before the response failed. Reload and only surface
+      // the error if the approval is still genuinely pending — otherwise the card
+      // self-clears and the user can keep chatting instead of retrying a dead card.
+      const items = await loadConversationMessages(conversationId);
+      if (approvalResultPresent(items, approvalId)) {
+        void sessionResumeIfRunning(conversationId).catch(() => {});
+        return;
+      }
       setLocalError(err instanceof Error ? err.message : "Failed to resolve approval");
       throw err;
     }


### PR DESCRIPTION
## Why

Three issues reported from a pod chat:

1. **Stuck approval.** A user requested an approval (deploy an app), came back later, clicked *Approve*, and got **"Approval is not pending or no longer live."** On reload the card kept showing *pending* and the chat couldn't continue — a permanent loop.
2. **Pod default agent over-asks** — it requested approval for low-stakes actions (deploy/publish/write) instead of only destructive actions or a real 403.
3. **User agents over-ask** even though the backend already lists their granted resources.

## Root cause (approval bug)

`resolve_user_approval_internal` was **commit-then-side-effect**: it committed the decision row *first*, then ran the approved tool → appended the synthesized tool-return → started the resume run. If any later step threw, the decision persisted but the resume never finished. The conversation stayed `WAITING`, and every retry hit the `already_resolved` short-circuit → the same error forever. The frontend never reconciled the dead card. (It surfaced as HTTP 409 — the controller already remapped the bare `RuntimeError`.)

## What changed

**Self-healing resolution (backend)**
- New repo lookups `get_tool_call` / `get_tool_return` keyed by `tool_call_id` (not the newest-500 window). `get_tool_return` is the **re-execution guard**.
- Split `_paused_call_from_messages` out of the decision check.
- New re-entrant `_reconcile_approval_resume`: the approved tool + its synthesized return run **at most once** (skipped when a return already exists — so retries never re-deploy), and the resume run starts at most once.
- `resolve` classifies three ways: **unknown → `UnknownApprovalError` (404)**; no decision → record; **decision already exists → adopt + reconcile (self-heal)** instead of 409. Double-submit falls through to reconcile.
- Controller returns the typed result (`status: "resolved" | "reconciled"`) and drops the blanket `RuntimeError → 409` remap.

**Frontend (SDK)**
- On a resolve error, reload messages first and only surface the error if the approval is *still* pending; a healed/partial resume clears the card so the user can keep chatting.

**Stop over-asking**
- Pod default + user agent prompts: act on granted/authorized resources; pause only for genuinely destructive actions or a real 403/needs_approval.
- Context brief: granted resources are explicitly **pre-authorized** (act without asking; escalate only on a 403).

## Tests
- `test_resolution_self_heals_after_recorded_but_unfinished_resume` — reproduces the wedge and asserts self-heal.
- `test_unknown_approval_id_returns_404`.
- Idempotent duplicate-resolve asserts **no wrapped-tool re-execution** (`calls == 1`); existing 409-on-duplicate assertions updated to the new reconcile behavior.
- Green on this branch (rebased on `main`): approval e2e (6), backend ruff clean, SDK `tsc` clean. Also verified on first pass: ingress unit (35), fast agent module (313), SDK 115 tests.

## Not included (per scope)
No TTL/expiry column or cron reaper — self-heal on resolve + reload covers the return-and-retry case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)