### PR TITLE
fix(pod-bundle): surface connector platform on account import variables

### DIFF
--- a/lemma-backend/app/modules/pod_bundle/api/schemas.py
+++ b/lemma-backend/app/modules/pod_bundle/api/schemas.py
@@ -109,6 +109,14 @@ class VariableSpecResponse(BaseModel):
     description: str | None = None
     required: bool = False
     default: str | None = None
+    platform: str | None = Field(
+        default=None,
+        description=(
+            "For a connector account variable, the platform the account must "
+            "belong to (e.g. 'slack'), so the importer can connect the right "
+            "connector. Null for non-connector variables."
+        ),
+    )
 
 
 class ImportPlanResponse(BaseModel):
@@ -144,6 +152,7 @@ class ImportPlanResponse(BaseModel):
                     description=v.description,
                     required=v.required,
                     default=v.default,
+                    platform=v.platform,
                 )
                 for v in plan.variables
             ],

--- a/lemma-backend/app/modules/pod_bundle/domain/state.py
+++ b/lemma-backend/app/modules/pod_bundle/domain/state.py
@@ -112,6 +112,11 @@ class VariableSpec(BaseModel):
     description: str | None = None
     required: bool = False
     default: str | None = None
+    # For ``kind="account"`` surfaced connectors: the connector platform the
+    # account must belong to (e.g. "slack", "telegram"), so the importer UI can
+    # prompt for — and connect — the right connector. None for accounts with no
+    # platform context (e.g. a schedule's account) or non-account variables.
+    platform: str | None = None
 
 
 class ImportPlan(BaseModel):

--- a/lemma-backend/app/modules/pod_bundle/infrastructure/plan_builder.py
+++ b/lemma-backend/app/modules/pod_bundle/infrastructure/plan_builder.py
@@ -326,6 +326,7 @@ def _variables_from_manifest(pod_manifest: dict[str, Any]) -> list[VariableSpec]
         else:
             kind = "free"
         default = (meta or {}).get("default")
+        platform = (meta or {}).get("platform")
         specs.append(
             VariableSpec(
                 name=str(name),
@@ -333,6 +334,7 @@ def _variables_from_manifest(pod_manifest: dict[str, Any]) -> list[VariableSpec]
                 description=(meta or {}).get("description"),
                 required=(kind == "account") or (kind == "free" and default is None),
                 default=str(default) if default is not None else None,
+                platform=str(platform) if platform else None,
             )
         )
     return specs

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/test_connector_import_e2e.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/test_connector_import_e2e.py
@@ -40,6 +40,8 @@ async def test_connector_account_is_required_and_enforced(
     assert account_var is not None, plan["variables"]
     assert account_var["kind"] == "account"
     assert account_var["required"] is True
+    # The connector platform is sent so the UI can prompt for the right connector.
+    assert account_var["platform"] == "slack"
 
     # ...and there is a SURFACE step to apply.
     assert any(s["kind"] == "SURFACE" for s in plan["steps"]), plan["steps"]

--- a/lemma-backend/app/modules/pod_bundle/tests/unit/test_plan_builder.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/unit/test_plan_builder.py
@@ -153,7 +153,7 @@ async def test_variables_classified(tmp):
     root = _build_bundle(
         tmp,
         variables={
-            "acct": {"type": "account", "source_value": "x"},
+            "acct": {"type": "account", "source_value": "x", "platform": "slack"},
             "owner": {"type": "member", "source_value": "y"},
             "region": {"type": "string", "source_value": "z"},
             "app_slug": {"type": "app_slug", "source_value": "s", "default": "s"},
@@ -161,9 +161,13 @@ async def test_variables_classified(tmp):
     )
     plan = await PlanBuilder(FakeExisting()).build_plan(bundle_root=root)
     by_name = {v.name: v for v in plan.variables}
-    # Connector accounts must be supplied by the importer -> required.
+    # Connector accounts must be supplied by the importer -> required, and carry
+    # the platform so the UI can prompt for the right connector.
     assert by_name["acct"].kind == "account"
     assert by_name["acct"].required is True
+    assert by_name["acct"].platform == "slack"
+    # A variable with no platform context leaves it None.
+    assert by_name["region"].platform is None
     # Pod members auto-resolve to the importing user -> not required.
     assert by_name["owner"].kind == "pod_member"
     assert by_name["owner"].required is False


### PR DESCRIPTION
## Why

Follow-up to #78. The import plan's connector **account** variables are marked required, but they were sent to the frontend without the **platform**:

```json
{ "name": "slack_account", "kind": "account", "required": true, "default": null }
```

So the importer UI has no way to know *which* connector each account belongs to — it can't prompt the user to connect the right connector (Slack vs. Telegram) before applying.

The platform is already recorded in the `pod.json` variable meta by the exporter (`portability.py` tokenizes a surface's `account_id` with `{"platform": owner}`); it just wasn't plumbed through to `VariableSpec` / the API response.

## What

- Add `platform: str | None` to `VariableSpec` (domain) and `VariableSpecResponse` (API), populated from the variable meta in `_variables_from_manifest`.
- The account variables now serialize as `{"name": "slack_account", "kind": "account", "required": true, "platform": "slack", ...}` on `GET …/imports/{id}` (and the SSE snapshot), so the UI can prompt for + connect the right connector.
- Additive optional field — no breaking API change; a schedule account (no platform context) and non-account variables stay `null`.

## Tests

- Unit: `test_variables_classified` asserts the account variable carries `platform == "slack"` and a non-connector variable stays `None`.
- E2E: `test_connector_account_is_required_and_enforced` now asserts the plan response includes `platform == "slack"`.
- Full pod_bundle unit suite (121) + connector e2e green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)