### PR TITLE
fix(pod-bundle): landing-page README, real AI polish, branded install button

### DIFF
--- a/lemma-backend/app/modules/pod_bundle/events/handlers.py
+++ b/lemma-backend/app/modules/pod_bundle/events/handlers.py
@@ -521,7 +521,10 @@ async def publish_pod_github(context: dict[str, str | None]) -> None:
     if state is None or state.status == PublishStatus.COMPLETED:
         return
 
-    from app.modules.pod_bundle.infrastructure.ai_readme import polish_readme
+    from app.modules.pod_bundle.infrastructure.ai_readme import (
+        build_system_polish_fn,
+        polish_readme,
+    )
     from app.modules.pod_bundle.infrastructure.exporter import BundleExporter
     from app.modules.pod_bundle.infrastructure.github_publisher import (
         ComposioGithubOps,
@@ -538,10 +541,12 @@ async def publish_pod_github(context: dict[str, str | None]) -> None:
         async def _noop_progress(done: int, total: int) -> None:
             return None
 
+        organization_id = None
         async with uow_scope(worker_ctx.uow_factory) as uow:
             ctx = await AuthorizationDataService(uow.session).build_user_context(
                 user_id=user_id, pod_id=pod_id
             )
+            organization_id = ctx.organization_id
             async with context_scope(ctx):
                 pod_name, zip_bytes, _warnings = await BundleExporter().export(
                     pod_id=pod_id,
@@ -555,17 +560,8 @@ async def publish_pod_github(context: dict[str, str | None]) -> None:
 
         files = _zip_to_files(zip_bytes)
         counts = _resource_counts(files)
-        owner_guess = state.repo_name  # refined from the created repo below
-        readme = render_readme(
-            pod_name=pod_name.removesuffix(".zip"),
-            description=None,
-            resource_counts=counts,
-            owner=owner_guess,
-            repo=state.repo_name,
-        )
-        if state.ai_readme:
-            readme = await polish_readme(readme, polish_fn=None)
-        state.readme = readme
+        pod_meta = _pod_meta_from_files(files)
+        repo_description = pod_meta.get("description")
 
         # (2) PUBLISHING — create the repo + push files via Composio (no DB held
         # across the HTTP calls beyond each short per-operation scope).
@@ -597,6 +593,36 @@ async def publish_pod_github(context: dict[str, str | None]) -> None:
 
         publisher = GithubPublisher(ComposioGithubOps(_run_op))
 
+        # Create the repo first so the README's install button carries the real
+        # GitHub owner (not the repo name), then render + optionally AI-polish the
+        # README and push everything.
+        repo = await publisher.create_repo(
+            repo_name=state.repo_name,
+            private=state.private,
+            description=repo_description,
+        )
+        state.repo_url = repo.html_url
+        state.repo_created = True
+        await store.save_publish(state)
+
+        readme = render_readme(
+            pod_name=pod_meta.get("name") or pod_name.removesuffix(".zip"),
+            description=repo_description,
+            resource_counts=counts,
+            owner=repo.owner,
+            repo=repo.repo,
+            icon_url=pod_meta.get("icon_url"),
+        )
+        if state.ai_readme:
+            polish_fn = build_system_polish_fn(
+                user_id=user_id,
+                organization_id=organization_id,
+                pod_id=pod_id,
+            )
+            readme = await polish_readme(readme, polish_fn=polish_fn)
+        state.readme = readme
+        await store.save_publish(state)
+
         async def _on_file(path: str, done: int, total: int) -> None:
             state.progress.done = done
             state.progress.total = total
@@ -608,10 +634,11 @@ async def publish_pod_github(context: dict[str, str | None]) -> None:
         repo = await publisher.publish(
             repo_name=state.repo_name,
             private=state.private,
-            description=None,
+            description=repo_description,
             files=files,
             readme=readme,
             on_progress=_on_file,
+            already_created=repo,
         )
 
         state.status = PublishStatus.COMPLETED
@@ -659,6 +686,27 @@ def _zip_to_files(zip_bytes: bytes) -> dict[str, bytes]:
                 continue
             files[name] = zf.read(info)
     return files
+
+
+def _pod_meta_from_files(files: dict[str, bytes]) -> dict[str, str | None]:
+    """Read the pod's name/description/icon_url from the bundle's ``pod.json`` so
+    the README uses the real pod identity (not the export filename)."""
+    import json
+
+    raw = files.get("pod.json")
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw.decode("utf-8"))
+    except Exception:  # noqa: BLE001 - a malformed manifest just yields no meta
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {
+        "name": data.get("name"),
+        "description": data.get("description"),
+        "icon_url": data.get("icon_url"),
+    }
 
 
 def _resource_counts(files: dict[str, bytes]) -> dict[str, int]:

--- a/lemma-backend/app/modules/pod_bundle/infrastructure/ai_readme.py
+++ b/lemma-backend/app/modules/pod_bundle/infrastructure/ai_readme.py
@@ -5,14 +5,15 @@ model is slow, unavailable, or errors. When ``ai_readme`` is requested we attemp
 a single system-model rewrite; any problem falls back to the deterministic
 README from :mod:`readme`.
 
-The model call is injected (``polish_fn``) so the publish job can wire the
-metered system model and tests can supply a fake; when no runner is available
-this returns the input unchanged.
+The model call is injected (``polish_fn``) so tests can supply a fake; the publish
+job wires the metered system model via :func:`build_system_polish_fn`. When no
+``polish_fn`` is given this returns the input unchanged.
 """
 
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from uuid import UUID
 
 from app.core.log.log import get_logger
 
@@ -21,9 +22,17 @@ logger = get_logger(__name__)
 PolishFn = Callable[[str], Awaitable[str]]
 
 _PROMPT = (
-    "Polish this project README for a shared Lemma pod. Keep every install "
-    "badge, link, and heading intact; improve only wording and flow. Return "
-    "Markdown only."
+    "You are polishing the README landing page for a shared Lemma pod (a "
+    "published GitHub repo someone can one-click install). Improve the wording, "
+    "flow, and the tagline so it reads like an inviting product page, and you may "
+    "add a short intro sentence or lightly reorganize prose.\n\n"
+    "Hard constraints — do NOT change these:\n"
+    "- Keep the centered install button exactly as-is: the `<a>`/`<img>` block "
+    "whose image is the `https://img.shields.io/...Install%20to%20Lemma...` badge.\n"
+    "- Keep every link, the `<div align=\"center\">` header, the '## Install' "
+    "instructions, and the resource counts in 'What's inside'.\n"
+    "- Do not invent resources, features, or links that are not already present.\n"
+    "Return only the Markdown, no code fences, no commentary."
 )
 
 
@@ -35,8 +44,98 @@ async def polish_readme(readme: str, *, polish_fn: PolishFn | None = None) -> st
     except Exception as exc:  # noqa: BLE001 - never fail a publish over polish
         logger.warning("README AI polish failed; using deterministic README: %s", exc)
         return readme
-    polished = (polished or "").strip()
+    polished = _strip_code_fence((polished or "").strip())
     # A model that returns nothing or drops the install badge is not trusted.
     if not polished or "img.shields.io" not in polished:
         return readme
     return polished
+
+
+def _strip_code_fence(text: str) -> str:
+    """Peel a wrapping ```markdown … ``` fence a model sometimes adds."""
+    if text.startswith("```"):
+        lines = text.splitlines()
+        if len(lines) >= 2:
+            lines = lines[1:]
+            if lines and lines[-1].strip().startswith("```"):
+                lines = lines[:-1]
+            return "\n".join(lines).strip()
+    return text
+
+
+def build_system_polish_fn(
+    *,
+    user_id: UUID,
+    organization_id: UUID | None,
+    pod_id: UUID,
+) -> PolishFn:
+    """A ``polish_fn`` that rewrites the README with the metered **system** model,
+    mirroring ``ConversationTitleService`` (resolve the system runtime → run a
+    one-shot pydantic-ai agent → record usage). Any failure propagates so
+    :func:`polish_readme` falls back to the deterministic README."""
+
+    async def _polish(readme: str) -> str:
+        from pydantic_ai import Agent as PydanticAIAgent
+
+        from app.modules.agent.domain.value_objects import AgentRuntimeConfig
+        from app.modules.agent.services.runtime_model_factory import (
+            require_pydantic_ai_model_from_runtime_profile,
+        )
+        from app.modules.agent.services.runtime_profile_service import (
+            DEFAULT_SYSTEM_AGENT_RUNTIME_PROFILE_ID,
+            AgentRuntimeProfileService,
+        )
+        from app.modules.usage.services.pydantic_ai_tracking import (
+            record_pydantic_ai_result_usage,
+            reserve_usage_for_runtime,
+        )
+        from app.modules.usage.services.usage_context import UsageExecutionContext
+
+        resolved = await AgentRuntimeProfileService().resolve(
+            runtime=AgentRuntimeConfig(profile_id=DEFAULT_SYSTEM_AGENT_RUNTIME_PROFILE_ID),
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        runtime_profile = resolved.public_snapshot()
+        model = require_pydantic_ai_model_from_runtime_profile(
+            runtime_profile=runtime_profile,
+            runtime_credentials=resolved.credentials or {},
+            fallback_model_name=resolved.model_name_for_harness,
+        )
+        agent = PydanticAIAgent(model, system_prompt=_PROMPT)
+
+        usage_context = UsageExecutionContext(
+            user_id=user_id,
+            organization_id=organization_id,
+            pod_id=pod_id,
+            source_type="pod_bundle_readme",
+        )
+        reservation = await reserve_usage_for_runtime(
+            organization_id=organization_id,
+            user_id=user_id,
+            runtime_profile=runtime_profile,
+        )
+        result = None
+        try:
+            result = await agent.run(readme)
+            await record_pydantic_ai_result_usage(
+                ctx=usage_context,
+                runtime_profile=runtime_profile,
+                result=result,
+                status="COMPLETED",
+                reservation=reservation,
+                metadata={"helper": "pod_bundle_readme"},
+            )
+        except Exception:
+            await record_pydantic_ai_result_usage(
+                ctx=usage_context,
+                runtime_profile=runtime_profile,
+                result=result,
+                status="FAILED",
+                reservation=reservation,
+                metadata={"helper": "pod_bundle_readme"},
+            )
+            raise
+        return str(result.output)
+
+    return _polish

--- a/lemma-backend/app/modules/pod_bundle/infrastructure/github_publisher.py
+++ b/lemma-backend/app/modules/pod_bundle/infrastructure/github_publisher.py
@@ -53,6 +53,20 @@ class GithubPublisher:
     def __init__(self, ops: GithubOps):
         self._ops = ops
 
+    async def create_repo(
+        self, *, repo_name: str, private: bool, description: str | None
+    ) -> RepoCreateResult:
+        """Create the repo and return its location (owner/repo/url). Split out from
+        :meth:`publish` so a caller that needs the real GitHub **owner** before
+        pushing — e.g. to render an install link into the README — can create
+        first, then push with ``already_created=repo``."""
+        try:
+            return await self._ops.create_repo(
+                name=repo_name, private=private, description=description
+            )
+        except Exception as exc:  # noqa: BLE001
+            raise GithubPublishError(f"Could not create GitHub repo: {exc}") from exc
+
     async def publish(
         self,
         *,
@@ -66,14 +80,9 @@ class GithubPublisher:
     ) -> RepoCreateResult:
         """Create the repo (tolerating an existing one we already made) and push
         every file plus the README. Returns the repo location."""
-        repo = already_created
-        if repo is None:
-            try:
-                repo = await self._ops.create_repo(
-                    name=repo_name, private=private, description=description
-                )
-            except Exception as exc:  # noqa: BLE001
-                raise GithubPublishError(f"Could not create GitHub repo: {exc}") from exc
+        repo = already_created or await self.create_repo(
+            repo_name=repo_name, private=private, description=description
+        )
 
         payload = {"README.md": readme.encode("utf-8"), **files}
         total = len(payload)

--- a/lemma-backend/app/modules/pod_bundle/infrastructure/readme.py
+++ b/lemma-backend/app/modules/pod_bundle/infrastructure/readme.py
@@ -1,23 +1,50 @@
-"""Render a bundle's README (deterministic; optional AI polish lives elsewhere).
+"""Render a bundle's README as a human-facing landing page for the pod.
 
-The README documents what the published pod contains and carries an install
-badge that deep-links to the importing UI (``/import/github/{owner}/{repo}``), so
-anyone viewing the repo can one-click install it into their own workspace.
+The README is what someone sees when they land on the published GitHub repo, so
+it reads like a product page: a centered header, a big **Install to Lemma**
+button (a shields.io ``for-the-badge`` badge carrying the Lemma mark) that
+deep-links to the one-click importer (``/import/github/{owner}/{repo}``), a
+"What's inside" summary, and install instructions. Deterministic; the optional AI
+polish (:mod:`ai_readme`) only refines the copy of this same structure.
 """
 
 from __future__ import annotations
 
+import base64
+from urllib.parse import urlencode
+
 from app.core.config import settings
 
-_RESOURCE_LABELS = [
-    ("tables", "Tables"),
-    ("agents", "Agents"),
-    ("functions", "Functions"),
-    ("workflows", "Workflows"),
-    ("schedules", "Schedules"),
-    ("apps", "Apps"),
-    ("surfaces", "Surfaces"),
+# Lemma brand purple.
+_BRAND = "6D3BEB"
+
+# Display order + emoji for the "What's inside" table (surfaces read as
+# "Connectors", the user-facing term).
+_RESOURCE_META = [
+    ("apps", "Apps", "🧩"),
+    ("agents", "Agents", "🤖"),
+    ("workflows", "Workflows", "🔀"),
+    ("functions", "Functions", "⚙️"),
+    ("tables", "Tables", "🗃️"),
+    ("schedules", "Schedules", "⏰"),
+    ("surfaces", "Connectors", "🔌"),
 ]
+
+# The Lemma bar-chart mark, in white, used as the install badge's logo. Kept tiny
+# and inline so the README is self-contained: shields.io bakes the data-URI logo
+# into the badge it serves, so it renders on GitHub (which would otherwise strip a
+# raw ``data:`` image).
+_LEMMA_MARK_SVG = (
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">'
+    '<rect x="2" y="13" width="5" height="9" rx="1" fill="#fff"/>'
+    '<rect x="9.5" y="8" width="5" height="14" rx="1" fill="#fff"/>'
+    '<rect x="17" y="3" width="5" height="19" rx="1" fill="#fff"/></svg>'
+)
+
+_DEFAULT_TAGLINE = (
+    "A shareable Lemma pod — agents, data, workflows, and connectors, "
+    "ready to install in one click."
+)
 
 
 def _app_base_url() -> str:
@@ -27,11 +54,36 @@ def _app_base_url() -> str:
     return str(base).rstrip("/") if base else "https://lemma.work"
 
 
+def _lemma_logo_data_uri() -> str:
+    encoded = base64.b64encode(_LEMMA_MARK_SVG.encode("utf-8")).decode("ascii")
+    return f"data:image/svg+xml;base64,{encoded}"
+
+
+def install_badge_url() -> str:
+    """The shields.io badge image URL: a large ``for-the-badge`` pill in the Lemma
+    brand color with the Lemma mark as its logo."""
+    query = urlencode(
+        {
+            "style": "for-the-badge",
+            "logo": _lemma_logo_data_uri(),
+            "logoColor": "white",
+        }
+    )
+    return f"https://img.shields.io/badge/Install%20to%20Lemma-{_BRAND}?{query}"
+
+
+def install_target(owner: str, repo: str) -> str:
+    return f"{_app_base_url()}/import/github/{owner}/{repo}"
+
+
 def install_badge(owner: str, repo: str) -> str:
-    app = _app_base_url()
-    target = f"{app}/import/github/{owner}/{repo}"
-    badge = "https://img.shields.io/badge/Install%20to-Lemma-6D3BEB"
-    return f"[![Install to Lemma]({badge})]({target})"
+    """A big, clickable install button: the branded badge linked to the one-click
+    GitHub import route, sized up with an explicit height."""
+    return (
+        f'<a href="{install_target(owner, repo)}">'
+        f'<img src="{install_badge_url()}" height="44" alt="Install to Lemma" />'
+        "</a>"
+    )
 
 
 def render_readme(
@@ -41,32 +93,62 @@ def render_readme(
     resource_counts: dict[str, int],
     owner: str,
     repo: str,
+    icon_url: str | None = None,
 ) -> str:
-    lines: list[str] = [f"# {pod_name}", ""]
-    if description:
-        lines += [description.strip(), ""]
-    lines += [install_badge(owner, repo), ""]
+    name = (pod_name or "Lemma Pod").strip() or "Lemma Pod"
+    tagline = (description or "").strip() or _DEFAULT_TAGLINE
 
     present = [
-        (label, resource_counts.get(key, 0))
-        for key, label in _RESOURCE_LABELS
+        (label, emoji, resource_counts.get(key, 0))
+        for key, label, emoji in _RESOURCE_META
         if resource_counts.get(key, 0) > 0
     ]
+
+    lines: list[str] = ['<div align="center">', ""]
+    if icon_url:
+        lines += [f'<img src="{icon_url}" width="88" height="88" alt="{name}" />', ""]
+    lines += [
+        f"# {name}",
+        "",
+        f"### {tagline}",
+        "",
+        install_badge(owner, repo),
+        "",
+        "</div>",
+        "",
+    ]
+
     if present:
-        lines += ["## What's inside", ""]
-        lines += [f"- **{label}:** {count}" for label, count in present]
+        lines += [
+            "## ✨ What's inside",
+            "",
+            "|  | Resource | Count |",
+            "| :-: | :-- | --: |",
+        ]
+        lines += [f"| {emoji} | **{label}** | {count} |" for label, emoji, count in present]
         lines += [""]
 
     lines += [
-        "## Install",
+        "## 🚀 Install",
         "",
-        "Click the badge above, or import this repo from Lemma: "
-        "**Settings → Share & Export → Import from GitHub**.",
+        f"**One click** — press **Install to Lemma** above "
+        f"(or [open the installer]({install_target(owner, repo)})).",
+        "",
+        "**From inside Lemma** — go to **Settings → Share & Export → Import from "
+        f"GitHub** and paste `{owner}/{repo}`.",
+        "",
+        "Everything installs into *your own* workspace — your data, your model keys. "
+        "Connectors reconnect to *your* accounts and apps rebuild for your pod on "
+        "import, so nothing is shared but the recipe.",
         "",
         "---",
         "",
-        "_Exported from [Lemma](https://lemma.work) — the open workspace for "
-        "humans and AI agents._",
+        '<div align="center">',
+        "",
+        '<sub>Exported from <a href="https://lemma.work">Lemma</a> — the open '
+        "workspace for humans and AI agents.</sub>",
+        "",
+        "</div>",
         "",
     ]
     return "\n".join(lines)

--- a/lemma-backend/app/modules/pod_bundle/tests/unit/test_publisher.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/unit/test_publisher.py
@@ -15,6 +15,7 @@ from app.modules.pod_bundle.infrastructure.readme import install_badge, render_r
 class FakeOps:
     def __init__(self, *, create_error=False, put_error_on=None):
         self.created = None
+        self.create_calls = 0
         self.puts: list[tuple[str, int]] = []
         self._create_error = create_error
         self._put_error_on = put_error_on
@@ -22,6 +23,7 @@ class FakeOps:
     async def create_repo(self, *, name, private, description):
         if self._create_error:
             raise RuntimeError("boom")
+        self.create_calls += 1
         self.created = (name, private)
         return RepoCreateResult(owner="acme", repo=name, html_url=f"https://github.com/acme/{name}")
 
@@ -43,15 +45,41 @@ def test_render_readme_has_badge_and_counts():
         repo="crm",
     )
     assert "# CRM" in r
-    assert "Leads pod" in r
+    assert "Leads pod" in r  # the description becomes the tagline
     assert "img.shields.io" in r
-    assert "**Tables:** 2" in r and "**Agents:** 1" in r
+    # "What's inside" is a table of the present resources.
+    assert "**Tables** | 2 |" in r and "**Agents** | 1 |" in r
     assert "Functions" not in r  # zero-count types omitted
 
 
-def test_install_badge_links_to_import_route():
+def test_render_readme_default_tagline_when_no_description():
+    r = render_readme(
+        pod_name="CRM", description=None, resource_counts={}, owner="acme", repo="crm"
+    )
+    assert "ready to install" in r  # falls back to a friendly default tagline
+
+
+def test_render_readme_includes_icon_when_provided():
+    r = render_readme(
+        pod_name="CRM",
+        description="Leads pod",
+        resource_counts={},
+        owner="acme",
+        repo="crm",
+        icon_url="https://cdn.example/icon.png",
+    )
+    assert '<img src="https://cdn.example/icon.png"' in r
+
+
+def test_install_button_is_big_branded_badge():
     badge = install_badge("acme", "crm")
+    # Links to the one-click importer for the real owner/repo...
     assert "/import/github/acme/crm" in badge
+    # ...as a big for-the-badge pill carrying the Lemma mark, sized up.
+    assert "img.shields.io" in badge
+    assert "for-the-badge" in badge
+    assert "logo=data%3Aimage" in badge  # url-encoded data: logo (the Lemma mark)
+    assert 'height="44"' in badge
 
 
 # --- publisher ---------------------------------------------------------------
@@ -71,6 +99,24 @@ async def test_publish_creates_repo_and_uploads_readme_first():
     paths = [p for p, _ in ops.puts]
     assert paths[0] == "README.md"
     assert "pod.json" in paths and "tables/leads/leads.json" in paths
+
+
+async def test_create_repo_then_publish_reuses_repo_without_recreating():
+    # The publish handler creates the repo first (to know the owner for the README),
+    # then pushes with already_created — the repo must not be created twice.
+    ops = FakeOps()
+    publisher = GithubPublisher(ops)
+    repo = await publisher.create_repo(repo_name="crm", private=False, description="d")
+    assert repo.owner == "acme"
+    await publisher.publish(
+        repo_name="crm",
+        private=False,
+        description="d",
+        files={"pod.json": b"{}"},
+        readme="img.shields.io",
+        already_created=repo,
+    )
+    assert ops.create_calls == 1  # created once, reused for the push
 
 
 async def test_publish_chunks_large_files():
@@ -147,3 +193,11 @@ async def test_polish_accepts_good_output():
 
     out = await polish_readme("original img.shields.io", polish_fn=good)
     assert "polished" in out
+
+
+async def test_polish_strips_wrapping_code_fence():
+    async def fenced(_):
+        return "```markdown\n# Polished img.shields.io\n```"
+
+    out = await polish_readme("original img.shields.io", polish_fn=fenced)
+    assert out == "# Polished img.shields.io"


### PR DESCRIPTION
## Why

Reported on the GitHub-publish flow: **the `ai_readme` flag does nothing, the default README is bare, and the install badge is small with no Lemma icon.** While fixing those I also found the install link used the repo name as the GitHub *owner* (so it 404'd) and the pod's real description was dropped.

## What

**Landing-page README** — `render_readme` now reads like a product page:
- Centered header (with the pod's icon when it has one), the pod's real **name + description** as the tagline.
- A big **Install to Lemma** button, a `✨ What's inside` table (with emoji, "surfaces" shown as *Connectors*), and clear `🚀 Install` steps.

**Bigger, branded install button** — a shields.io `for-the-badge` pill in the Lemma brand purple carrying the **Lemma bar-chart mark** as its logo (base64 data-URI, so it renders on GitHub which strips raw `data:` images), sized up with an explicit `height`. Verified it renders (`INSTALL TO LEMMA` + embedded mark, HTTP 200 from shields).

**`ai_readme` actually works now** — it was calling `polish_readme(polish_fn=None)`, a guaranteed no-op. Added `build_system_polish_fn`, which calls the **metered system model** (mirrors `ConversationTitleService`: resolve the system runtime → one-shot pydantic-ai agent → record usage), wired into the publish job. It only *refines the copy* (prompt pins the badge/links/structure) and **degrades to the deterministic README** on any failure. Also strips a wrapping ```` ```markdown ```` fence a model sometimes adds.

**Fixed the install-link owner bug** — the README was rendered with `owner=repo_name` before the repo existed. Now `GithubPublisher.create_repo` creates the repo first (returning the real owner), the README is rendered/polished with the correct `owner/repo`, then pushed via `publish(already_created=repo)` (no double-create).

The repo also gets the pod's description now (was `None`).

## Tests

Render/badge/icon/tagline assertions, code-fence stripping, and a create-then-publish-reuse test (repo created exactly once). Full pod_bundle unit suite + publish e2e green; ruff clean. The live model call can't run in unit CI (needs a provider), but it mirrors the proven title-service path and falls back safely.

## Notes

- Independent of #80 (connector-platform var) — non-overlapping files.
- `ai_readme` still **defaults to `false`** (opt-in); the deterministic template is now good on its own. Happy to flip the default to always-polish if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)