### PR TITLE
feat(bundle): native pod share / import / export UI (the share→import→remix loop)

### DIFF
--- a/lemma-frontend/app/import/github/[owner]/[repo]/page.tsx
+++ b/lemma-frontend/app/import/github/[owner]/[repo]/page.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { use, useMemo, useState } from 'react';
+import { Download, Github, Plus } from 'lucide-react';
+
+import { ProtectedRoute } from '@/components/auth/protected-route';
+import { PlainPageShell } from '@/components/dashboard/plain-page-shell';
+import { Button } from '@/components/ui/button';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { ImportDialog } from '@/components/bundle/import-dialog';
+import { useAccessiblePods } from '@/lib/hooks/use-pods';
+
+export default function ImportGithubPage({
+    params,
+}: {
+    params: Promise<{ owner: string; repo: string }>;
+}) {
+    const raw = use(params);
+    const owner = decodeURIComponent(raw.owner);
+    const repo = decodeURIComponent(raw.repo);
+
+    return (
+        <ProtectedRoute>
+            <ImportGithubLanding owner={owner} repo={repo} />
+        </ProtectedRoute>
+    );
+}
+
+function ImportGithubLanding({ owner, repo }: { owner: string; repo: string }) {
+    const { data } = useAccessiblePods();
+    const organizations = data.organizations;
+    const pods = data.items;
+    const showOrgLabels = data.hasMultipleOrganizations;
+
+    const [orgId, setOrgId] = useState('');
+    const [podId, setPodId] = useState('');
+    const [dialog, setDialog] = useState<{ createNew?: { organizationId: string }; podId?: string } | null>(
+        null,
+    );
+
+    const presetGithub = useMemo(() => ({ owner, repo }), [owner, repo]);
+    const effectiveOrg = orgId || organizations[0]?.id || '';
+    const selectedPod = pods.find((p) => p.id === podId);
+
+    return (
+        <PlainPageShell
+            title="Import from GitHub"
+            backHref="/"
+            backLabel="Home"
+            contentWidthClassName="max-w-xl"
+            centerContent
+        >
+            <div className="space-y-5">
+                {/* Source card */}
+                <div className="flex flex-col items-center gap-3 rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-1)] p-8 text-center">
+                    <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-[var(--surface-2)]">
+                        <Github className="h-6 w-6 text-[var(--text-primary)]" />
+                    </div>
+                    <div>
+                        <h1 className="text-lg font-medium text-[var(--text-primary)]">{repo}</h1>
+                        <p className="text-sm text-[var(--text-tertiary)]">
+                            github.com/{owner}/{repo}
+                        </p>
+                    </div>
+                    <p className="max-w-sm text-sm text-[var(--text-secondary)]">
+                        Import this pod into your Lemma workspace — its tables, agents, workflows, apps and
+                        surfaces.
+                    </p>
+                </div>
+
+                {/* Create a new pod */}
+                <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-1)] p-4">
+                    <div className="flex items-start gap-2.5">
+                        <Plus className="mt-0.5 h-4 w-4 shrink-0 text-[var(--action-primary)]" />
+                        <div className="min-w-0 flex-1">
+                            <div className="text-sm font-medium text-[var(--text-primary)]">Create a new pod</div>
+                            <p className="text-xs text-[var(--text-tertiary)]">
+                                A fresh copy you fully own — recommended.
+                            </p>
+                        </div>
+                    </div>
+                    <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+                        {organizations.length > 1 ? (
+                            <Select value={effectiveOrg} onValueChange={setOrgId}>
+                                <SelectTrigger className="sm:flex-1">
+                                    <SelectValue placeholder="Choose a workspace" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {organizations.map((org) => (
+                                        <SelectItem key={org.id} value={org.id}>
+                                            {org.name}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        ) : null}
+                        <Button
+                            className="sm:w-auto"
+                            disabled={!effectiveOrg}
+                            onClick={() => setDialog({ createNew: { organizationId: effectiveOrg } })}
+                        >
+                            Create &amp; import
+                        </Button>
+                    </div>
+                </section>
+
+                {/* Install into an existing pod */}
+                <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-1)] p-4">
+                    <div className="flex items-start gap-2.5">
+                        <Download className="mt-0.5 h-4 w-4 shrink-0 text-[var(--text-tertiary)]" />
+                        <div className="min-w-0 flex-1">
+                            <div className="text-sm font-medium text-[var(--text-primary)]">
+                                Install into an existing pod
+                            </div>
+                            <p className="text-xs text-[var(--text-tertiary)]">
+                                Add these resources to a pod you already have.
+                            </p>
+                        </div>
+                    </div>
+                    <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+                        <Select value={podId} onValueChange={setPodId} disabled={pods.length === 0}>
+                            <SelectTrigger className="sm:flex-1">
+                                <SelectValue placeholder={pods.length ? 'Choose a pod' : 'No pods yet'} />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {pods.map((pod) => (
+                                    <SelectItem key={pod.id} value={pod.id}>
+                                        {pod.name}
+                                        {showOrgLabels && pod.organization_name
+                                            ? ` · ${pod.organization_name}`
+                                            : ''}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        <Button
+                            variant="secondary"
+                            className="sm:w-auto"
+                            disabled={!podId}
+                            onClick={() => setDialog({ podId })}
+                        >
+                            Install
+                        </Button>
+                    </div>
+                </section>
+            </div>
+
+            <ImportDialog
+                open={Boolean(dialog)}
+                onOpenChange={(nextOpen) => {
+                    if (!nextOpen) setDialog(null);
+                }}
+                presetGithub={presetGithub}
+                createNew={dialog?.createNew}
+                podId={dialog?.podId}
+                podName={selectedPod?.name}
+                onCompleted={() => setDialog(null)}
+            />
+        </PlainPageShell>
+    );
+}

--- a/lemma-frontend/app/import/github/[owner]/[repo]/page.tsx
+++ b/lemma-frontend/app/import/github/[owner]/[repo]/page.tsx
@@ -58,7 +58,7 @@ function ImportGithubLanding({ owner, repo }: { owner: string; repo: string }) {
         >
             <div className="space-y-5">
                 {/* Source card */}
-                <div className="flex flex-col items-center gap-3 rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-1)] p-8 text-center">
+                <div className="surface-panel flex flex-col items-center gap-3 p-8 text-center">
                     <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-[var(--surface-2)]">
                         <Github className="h-6 w-6 text-[var(--text-primary)]" />
                     </div>
@@ -75,7 +75,7 @@ function ImportGithubLanding({ owner, repo }: { owner: string; repo: string }) {
                 </div>
 
                 {/* Create a new pod */}
-                <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-1)] p-4">
+                <section className="surface-panel p-4">
                     <div className="flex items-start gap-2.5">
                         <Plus className="mt-0.5 h-4 w-4 shrink-0 text-[var(--action-primary)]" />
                         <div className="min-w-0 flex-1">
@@ -111,7 +111,7 @@ function ImportGithubLanding({ owner, repo }: { owner: string; repo: string }) {
                 </section>
 
                 {/* Install into an existing pod */}
-                <section className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-1)] p-4">
+                <section className="surface-panel p-4">
                     <div className="flex items-start gap-2.5">
                         <Download className="mt-0.5 h-4 w-4 shrink-0 text-[var(--text-tertiary)]" />
                         <div className="min-w-0 flex-1">

--- a/lemma-frontend/app/pod/[id]/data/page.tsx
+++ b/lemma-frontend/app/pod/[id]/data/page.tsx
@@ -7,6 +7,7 @@ import { Database, Loader2, Plus } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { DatastoreTableView } from '@/components/data/datastore-table-view';
+import { DatastoreTableSkeleton } from '@/components/data/datastore-table-skeleton';
 import { DocumentViewer } from '@/components/documents/document-viewer';
 import { ProductIcon } from '@/components/pod/product-icon';
 import { ConceptHint } from '@/components/education/concept-hint';
@@ -158,7 +159,9 @@ export default function DataHubPage({
             ? requestedTableTab
             : tables[0]?.name ?? null;
     const showingFiles = isFilesRoute;
-    const usesWorkbenchLayout = showingFiles || Boolean(activeTableName);
+    // Keep the tables loading state in the workbench layout so the skeleton fills
+    // the pane and matches the loaded table instead of collapsing to a small box.
+    const usesWorkbenchLayout = showingFiles || Boolean(activeTableName) || (!showingFiles && loadingTables);
 
     useEffect(() => {
         if (isFilesRoute && tabParam) {
@@ -1236,12 +1239,7 @@ export default function DataHubPage({
                         </>
                     )
                 ) : loadingTables ? (
-                    <EmptyState
-                        variant="panel"
-                        icon={<Loader2 className="h-5 w-5 animate-spin" />}
-                        title="Loading tables"
-                        description="Checking this pod's structured data."
-                    />
+                    <DatastoreTableSkeleton />
                 ) : activeTableName ? (
                     <DatastoreTableView
                         key={`${activeTableName}:${routeTableFiltersKey}`}

--- a/lemma-frontend/app/pod/[id]/settings/page.tsx
+++ b/lemma-frontend/app/pod/[id]/settings/page.tsx
@@ -11,6 +11,7 @@ import { ProtectedRoute } from '@/components/auth/protected-route';
 import { resolveDefaultAgentRuntime } from '@/components/agents/agent-runtime-helpers';
 import { RuntimeModelPicker } from '@/components/lemma/assistant/model-picker';
 import { PodSettingsPanel, PodSettingsShell } from '@/components/pod/pod-settings-shell';
+import { PodBundleSettingsPanel } from '@/components/bundle/pod-bundle-settings';
 import { SettingsChoiceList, SettingsHelpText } from '@/components/settings/settings-kit';
 import {
     useAgentRuntimes,
@@ -109,6 +110,13 @@ function PodSettingsPageContent({ params }: { params: Promise<{ id: string }> })
                 podId={podId}
                 currentPolicy={pod?.config?.join_policy ?? PodJoinPolicy.INVITE_ONLY}
                 canUpdate={canUpdatePod}
+            />
+
+            <PodBundleSettingsPanel
+                podId={podId}
+                podName={pod?.name}
+                canUpdate={canUpdatePod}
+                recipes={pod?.config?.recipes ?? []}
             />
             </div>
         </PodSettingsShell>

--- a/lemma-frontend/components/bundle/account-variable-field.tsx
+++ b/lemma-frontend/components/bundle/account-variable-field.tsx
@@ -1,0 +1,337 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Check, ExternalLink, Loader2, Plug, Plus, X } from 'lucide-react';
+import { buildSchemaFormPayload, buildSchemaFormValues } from 'lemma-sdk';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import {
+    useAccounts,
+    useAuthConfigs,
+    useConnectors,
+    useCreateConnectorAccount,
+    useCreateConnectRequest,
+    useEnableConnector,
+} from '@/lib/hooks/use-connectors';
+import { SchemaFields } from '@/components/connectors/schema-fields';
+import {
+    getAccountStatusMeta,
+    getCredentialSchema,
+    getPrimaryCapability,
+    hasSystemDefault,
+    schemaHasFields,
+    usesDirectCredentials,
+    type SchemaValues,
+} from '@/components/connectors/connector-utils';
+import type { Account, Connector } from '@/lib/types';
+
+interface AccountVariableFieldProps {
+    organizationId?: string;
+    podId?: string | null;
+    platform: string;
+    label: string;
+    description?: string | null;
+    required?: boolean;
+    value: string;
+    onChange: (value: string) => void;
+}
+
+function matchesPlatform(connector: Connector, platform: string): boolean {
+    const p = platform.toLowerCase();
+    const slug = (connector as { slug?: string }).slug;
+    return (
+        connector.name?.toLowerCase() === p ||
+        connector.title?.toLowerCase() === p ||
+        slug?.toLowerCase() === p
+    );
+}
+
+function accountLabel(account: Account): string {
+    return account.email || account.provider_account_id || 'Connected account';
+}
+
+export function AccountVariableField({
+    organizationId,
+    podId,
+    platform,
+    label,
+    description,
+    required,
+    value,
+    onChange,
+}: AccountVariableFieldProps) {
+    const { data: connectors = [] } = useConnectors({ limit: 200 });
+    const connector = useMemo(
+        () => connectors.find((c) => matchesPlatform(c, platform)) ?? null,
+        [connectors, platform],
+    );
+
+    const { data: accounts = [], refetch } = useAccounts({
+        organizationId,
+        connectorId: connector?.id,
+        limit: 100,
+        enabled: Boolean(organizationId && connector),
+    });
+    const { data: authConfigs = [] } = useAuthConfigs({
+        organizationId,
+        limit: 200,
+        enabled: Boolean(organizationId && connector),
+    });
+    const enableConnector = useEnableConnector(organizationId);
+    const createConnectRequest = useCreateConnectRequest(organizationId);
+    const createConnectorAccount = useCreateConnectorAccount(organizationId);
+
+    const capability = useMemo(() => getPrimaryCapability(connector), [connector]);
+    const credentialSchema = useMemo(() => getCredentialSchema(capability), [capability]);
+    const isOAuth = Boolean(capability && hasSystemDefault(capability) && !usesDirectCredentials(capability));
+    const canCredential = usesDirectCredentials(capability);
+
+    const [awaitingOAuth, setAwaitingOAuth] = useState(false);
+    const [showCredentials, setShowCredentials] = useState(false);
+    const [credValues, setCredValues] = useState<SchemaValues>({});
+    const [submitting, setSubmitting] = useState(false);
+
+    const seenIdsRef = useRef<Set<string>>(new Set());
+    const onChangeRef = useRef(onChange);
+    useEffect(() => {
+        onChangeRef.current = onChange;
+    }, [onChange]);
+
+    // Convenience: a single existing account satisfies a required field on its own.
+    useEffect(() => {
+        if (!value && accounts.length === 1) onChangeRef.current(accounts[0].id);
+    }, [accounts, value]);
+
+    // While an OAuth tab is open, poll for the new account and auto-select it.
+    useEffect(() => {
+        if (!awaitingOAuth) return;
+        const started = Date.now();
+        const timer = setInterval(async () => {
+            const res = await refetch();
+            const items = (res.data ?? []) as Account[];
+            const fresh = items.find((a) => !seenIdsRef.current.has(a.id));
+            if (fresh) {
+                onChangeRef.current(fresh.id);
+                setAwaitingOAuth(false);
+                toast.success(`Connected ${platform}`);
+            } else if (Date.now() - started > 120_000) {
+                setAwaitingOAuth(false);
+            }
+        }, 2500);
+        return () => clearInterval(timer);
+    }, [awaitingOAuth, refetch, platform]);
+
+    async function resolveAuthConfigId(): Promise<string> {
+        const active = authConfigs.find((cfg) => cfg.connector_id === connector!.id && cfg.status === 'ACTIVE');
+        if (active) return active.id;
+        if (!capability || !hasSystemDefault(capability)) {
+            throw new Error('This connector needs setup in Connectors first.');
+        }
+        const authConfig = await enableConnector.mutateAsync({
+            connectorId: connector!.id,
+            provider: capability.provider,
+            configSource: 'SYSTEM_DEFAULT',
+        });
+        return authConfig.id;
+    }
+
+    async function startOAuth() {
+        if (!connector) return;
+        seenIdsRef.current = new Set(accounts.map((a) => a.id));
+        setAwaitingOAuth(true);
+        try {
+            const authConfigId = await resolveAuthConfigId();
+            const resp = await createConnectRequest.mutateAsync({ connectorId: connector.id, authConfigId });
+            if (resp.authorization_url) {
+                window.open(resp.authorization_url, '_blank', 'noopener,noreferrer');
+            }
+        } catch (error) {
+            setAwaitingOAuth(false);
+            toast.error(error instanceof Error ? error.message : `Could not connect ${platform}`);
+        }
+    }
+
+    async function submitCredentials() {
+        if (!connector) return;
+        const payload = buildSchemaFormPayload(credentialSchema, credValues);
+        if (!payload.isValid) {
+            toast.error(Object.values(payload.errors)[0] || 'Credentials are incomplete');
+            return;
+        }
+        setSubmitting(true);
+        try {
+            const authConfigId = await resolveAuthConfigId();
+            const account = (await createConnectorAccount.mutateAsync({
+                authConfigId,
+                credentials: payload.data,
+            })) as { id?: string };
+            await refetch();
+            if (account?.id) onChange(account.id);
+            setShowCredentials(false);
+            toast.success(`Connected ${platform}`);
+        } catch (error) {
+            toast.error(error instanceof Error ? error.message : 'Could not save credentials');
+        } finally {
+            setSubmitting(false);
+        }
+    }
+
+    function handleConnectClick() {
+        if (isOAuth) {
+            void startOAuth();
+            return;
+        }
+        if (canCredential) {
+            // No fields to fill (e.g. NOAUTH) → connect directly.
+            if (!schemaHasFields(credentialSchema)) {
+                void submitCredentials();
+                return;
+            }
+            setCredValues(buildSchemaFormValues(credentialSchema));
+            setShowCredentials(true);
+            return;
+        }
+        // Fallback: unknown auth style — let them set it up in Connectors.
+        if (podId) window.open(`/pod/${podId}/connectors`, '_blank', 'noopener,noreferrer');
+    }
+
+    const title = platform.charAt(0).toUpperCase() + platform.slice(1);
+
+    return (
+        <div className="space-y-2">
+            <div>
+                <div className="flex items-center gap-1.5 text-xs font-medium text-[var(--text-secondary)]">
+                    <Plug className="h-3.5 w-3.5 text-[var(--text-tertiary)]" />
+                    {label}
+                    {required ? <span className="text-[var(--state-error)]">*</span> : null}
+                </div>
+                {description ? (
+                    <p className="mt-0.5 text-xs text-[var(--text-tertiary)]">{description}</p>
+                ) : null}
+            </div>
+
+            {/* No matching connector in the catalog — never block; let them paste an id. */}
+            {!connector ? (
+                <Input
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                    placeholder={`${platform} account id`}
+                />
+            ) : (
+                <div className="space-y-1.5">
+                    {accounts.map((account) => {
+                        const selected = value === account.id;
+                        const meta = getAccountStatusMeta(account.status);
+                        return (
+                            <button
+                                key={account.id}
+                                type="button"
+                                onClick={() => onChange(account.id)}
+                                className={cn(
+                                    'flex w-full items-center gap-2.5 rounded-lg border px-3 py-2 text-left transition-colors',
+                                    selected
+                                        ? 'border-[var(--action-primary)] bg-[var(--surface-2)]'
+                                        : 'border-[var(--border-subtle)] hover:bg-[var(--surface-2)]',
+                                )}
+                            >
+                                <span
+                                    className={cn(
+                                        'flex h-4 w-4 shrink-0 items-center justify-center rounded-full border',
+                                        selected
+                                            ? 'border-[var(--action-primary)] bg-[var(--action-primary)] text-[var(--button-primary-fg)]'
+                                            : 'border-[var(--border-strong)]',
+                                    )}
+                                >
+                                    {selected ? <Check className="h-3 w-3" /> : null}
+                                </span>
+                                <span className="min-w-0 flex-1 truncate text-sm text-[var(--text-primary)]">
+                                    {accountLabel(account)}
+                                </span>
+                                <span
+                                    className={cn(
+                                        'shrink-0 text-[10px] font-medium uppercase',
+                                        meta.needsAttention
+                                            ? 'text-[var(--state-warning)]'
+                                            : 'text-[var(--text-tertiary)]',
+                                    )}
+                                >
+                                    {meta.label}
+                                </span>
+                            </button>
+                        );
+                    })}
+
+                    {/* Inline credential form (bot token / API key) — no new tab. */}
+                    {showCredentials ? (
+                        <div className="space-y-3 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)] p-3">
+                            <div className="flex items-center justify-between">
+                                <span className="text-xs font-medium text-[var(--text-secondary)]">
+                                    Connect {title}
+                                </span>
+                                <button
+                                    type="button"
+                                    onClick={() => setShowCredentials(false)}
+                                    className="text-[var(--text-tertiary)] hover:text-[var(--text-primary)]"
+                                    aria-label="Cancel"
+                                >
+                                    <X className="h-3.5 w-3.5" />
+                                </button>
+                            </div>
+                            <SchemaFields
+                                schema={credentialSchema}
+                                values={credValues}
+                                onChange={setCredValues}
+                                emptyMessage="No credentials are required for this app."
+                                autoFocusFirst
+                            />
+                            <Button
+                                type="button"
+                                size="sm"
+                                className="w-full"
+                                onClick={submitCredentials}
+                                loading={submitting}
+                                loadingLabel="Connecting…"
+                            >
+                                Connect
+                            </Button>
+                        </div>
+                    ) : awaitingOAuth ? (
+                        <div className="flex items-center justify-between gap-2 rounded-lg border border-[var(--border-subtle)] px-3 py-2 text-sm text-[var(--text-secondary)]">
+                            <span className="flex items-center gap-2">
+                                <Loader2 className="h-3.5 w-3.5 animate-spin text-[var(--action-primary)]" />
+                                Waiting for {title} authorization…
+                            </span>
+                            <button
+                                type="button"
+                                onClick={() => setAwaitingOAuth(false)}
+                                className="text-xs text-[var(--text-tertiary)] hover:text-[var(--text-primary)]"
+                            >
+                                Cancel
+                            </button>
+                        </div>
+                    ) : (
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            size="sm"
+                            className="w-full"
+                            onClick={handleConnectClick}
+                        >
+                            {accounts.length > 0 ? (
+                                <Plus className="mr-2 h-3.5 w-3.5" />
+                            ) : isOAuth ? (
+                                <ExternalLink className="mr-2 h-3.5 w-3.5" />
+                            ) : (
+                                <Plug className="mr-2 h-3.5 w-3.5" />
+                            )}
+                            {accounts.length > 0 ? `Connect another ${title} account` : `Connect ${title}`}
+                        </Button>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/lemma-frontend/components/bundle/account-variable-field.tsx
+++ b/lemma-frontend/components/bundle/account-variable-field.tsx
@@ -252,7 +252,7 @@ export function AccountVariableField({
                                 </span>
                                 <span
                                     className={cn(
-                                        'shrink-0 text-[10px] font-medium uppercase',
+                                        'shrink-0 text-xs font-medium uppercase',
                                         meta.needsAttention
                                             ? 'text-[var(--state-warning)]'
                                             : 'text-[var(--text-tertiary)]',

--- a/lemma-frontend/components/bundle/bundle-progress.tsx
+++ b/lemma-frontend/components/bundle/bundle-progress.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+interface BundleProgressBarProps {
+    done: number;
+    total: number;
+    label?: string;
+    className?: string;
+}
+
+/**
+ * A determinate progress bar driven by a job's done/total counts. Falls back to
+ * an indeterminate pulse before the total is known.
+ */
+export function BundleProgressBar({ done, total, label, className }: BundleProgressBarProps) {
+    const pct = total > 0 ? Math.min(100, Math.round((done / total) * 100)) : null;
+
+    return (
+        <div className={cn('space-y-1.5', className)}>
+            {label ? (
+                <div className="flex items-center justify-between text-xs text-[var(--text-tertiary)]">
+                    <span>{label}</span>
+                    {pct !== null ? (
+                        <span className="tabular-nums">
+                            {done}/{total}
+                        </span>
+                    ) : null}
+                </div>
+            ) : null}
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-[var(--surface-2)]">
+                <div
+                    className={cn(
+                        'h-full rounded-full bg-[var(--action-primary)] transition-[width] duration-300 ease-out',
+                        pct === null && 'w-1/3 animate-pulse',
+                    )}
+                    /* eslint-disable-next-line no-restricted-syntax -- Runtime progress scale is data-driven geometry. */
+                    style={pct !== null ? { width: `${pct}%` } : undefined}
+                />
+            </div>
+        </div>
+    );
+}

--- a/lemma-frontend/components/bundle/home-import-button.tsx
+++ b/lemma-frontend/components/bundle/home-import-button.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useState } from 'react';
+import { Download } from 'lucide-react';
+
+import { useAccessiblePods } from '@/lib/hooks/use-pods';
+import { ImportDialog } from './import-dialog';
+
+/**
+ * "Import a pod" entry for the home sidebar — creates a brand-new pod from a
+ * bundle (a .zip or a public GitHub repo) in the user's default workspace.
+ */
+export function HomeImportButton({ onNavigate }: { onNavigate?: () => void }) {
+    const [open, setOpen] = useState(false);
+    const { data } = useAccessiblePods();
+    const orgId = data.organizations[0]?.id;
+
+    if (!orgId) return null;
+
+    return (
+        <>
+            <button
+                type="button"
+                onClick={() => {
+                    onNavigate?.();
+                    setOpen(true);
+                }}
+                className="lemma-sidebar-row lemma-sidebar-row-comfy w-full text-left"
+            >
+                <Download className="h-4 w-4" />
+                Import a pod
+            </button>
+            <ImportDialog open={open} onOpenChange={setOpen} createNew={{ organizationId: orgId }} />
+        </>
+    );
+}

--- a/lemma-frontend/components/bundle/import-dialog.tsx
+++ b/lemma-frontend/components/bundle/import-dialog.tsx
@@ -1,0 +1,814 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+    AlertTriangle,
+    ArrowRight,
+    CheckCircle2,
+    FileArchive,
+    Github,
+    Loader2,
+    MessageCircle,
+    PanelsTopLeft,
+    Share2,
+    Sparkles,
+    Upload,
+    Wrench,
+    X,
+} from 'lucide-react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import { showResourceErrorToast } from '@/components/shared/resource-feedback';
+import { BundleProgressBar } from '@/components/bundle/bundle-progress';
+import { AccountVariableField } from '@/components/bundle/account-variable-field';
+import { ShareSheet } from '@/components/bundle/share-sheet';
+import { getLemmaClient } from '@/lib/sdk/lemma-client';
+import { usePod } from '@/lib/hooks/use-pods';
+import { cn } from '@/lib/utils';
+import {
+    applyImport,
+    cancelImport,
+    getImport,
+    parseGithubRepo,
+    startImport,
+    trackBundleJob,
+    uploadBundle,
+    type BundleProgressView,
+    type ImportPlan,
+    type ImportStatusResponse,
+    type PlanStep,
+    type StepAction,
+} from '@/lib/hooks/use-pod-bundle';
+
+type Step = 'source' | 'planning' | 'review' | 'applying' | 'done' | 'error';
+type SourceMode = 'upload' | 'github';
+
+interface ImportDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    /** Install into an existing pod. */
+    podId?: string;
+    podName?: string | null;
+    /** Create a brand-new pod in this org, then import into it. */
+    createNew?: { organizationId: string };
+    /** Preset a GitHub source and skip the source step (e.g. from an import link). */
+    presetGithub?: { owner: string; repo: string; ref?: string };
+    onCompleted?: (podId: string) => void;
+}
+
+type ImportSource =
+    | { mode: 'upload'; file: File }
+    | { mode: 'github'; owner: string; repo: string; ref?: string };
+
+const ACTION_STYLES: Record<StepAction, { label: string; className: string }> = {
+    CREATE: { label: 'New', className: 'text-[var(--state-success)] bg-[color:color-mix(in_srgb,var(--state-success)_14%,transparent)]' },
+    UPDATE: { label: 'Update', className: 'text-[var(--state-warning)] bg-[color:color-mix(in_srgb,var(--state-warning)_14%,transparent)]' },
+    SKIP: { label: 'Skip', className: 'text-[var(--text-tertiary)] bg-[var(--surface-2)]' },
+};
+
+function fileBaseName(name: string): string {
+    return name.replace(/\.zip$/i, '').replace(/[_-]+/g, ' ').trim();
+}
+
+function StepRow({ step }: { step: PlanStep }) {
+    const action = ACTION_STYLES[step.action] ?? ACTION_STYLES.SKIP;
+    const running = step.status === 'RUNNING';
+    const done = step.status === 'DONE';
+    const failed = step.status === 'FAILED';
+    return (
+        <div className="flex items-center gap-2 py-1.5 text-sm">
+            <span className="flex h-4 w-4 shrink-0 items-center justify-center">
+                {running ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin text-[var(--action-primary)]" />
+                ) : done ? (
+                    <CheckCircle2 className="h-3.5 w-3.5 text-[var(--state-success)]" />
+                ) : failed ? (
+                    <AlertTriangle className="h-3.5 w-3.5 text-[var(--state-error)]" />
+                ) : (
+                    <span className="h-1.5 w-1.5 rounded-full bg-[var(--border-strong)]" />
+                )}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-[var(--text-secondary)]">
+                <span className="text-[var(--text-tertiary)]">{step.kind.toLowerCase()}</span>{' '}
+                <span className="text-[var(--text-primary)]">{step.name}</span>
+            </span>
+            {step.destructive ? (
+                <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-[var(--state-error)]" aria-label="Destructive" />
+            ) : null}
+            <span className={cn('shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase', action.className)}>
+                {action.label}
+            </span>
+        </div>
+    );
+}
+
+export function ImportDialog({
+    open,
+    onOpenChange,
+    podId,
+    podName,
+    createNew,
+    presetGithub,
+    onCompleted,
+}: ImportDialogProps) {
+    const router = useRouter();
+    const queryClient = useQueryClient();
+
+    const [step, setStep] = useState<Step>(presetGithub ? 'planning' : 'source');
+    const [targetPodId, setTargetPodId] = useState<string | null>(podId ?? null);
+    const [sourceMode, setSourceMode] = useState<SourceMode>('upload');
+    const [file, setFile] = useState<File | null>(null);
+    const [githubUrl, setGithubUrl] = useState('');
+    const [newPodName, setNewPodName] = useState('');
+    const [plan, setPlan] = useState<ImportPlan | null>(null);
+    const [variables, setVariables] = useState<Record<string, string>>({});
+    const [confirmDestructive, setConfirmDestructive] = useState(false);
+    const [busy, setBusy] = useState(false);
+    const [progressLabel, setProgressLabel] = useState<string | null>(null);
+    const [liveSteps, setLiveSteps] = useState<PlanStep[]>([]);
+    const [applyView, setApplyView] = useState<BundleProgressView | null>(null);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [shareOpen, setShareOpen] = useState(false);
+
+    // Refs for cleanup of a create-new pod / staged import that never finished.
+    const targetPodRef = useRef<string | null>(podId ?? null);
+    const createdPodRef = useRef<string | null>(null);
+    const importIdRef = useRef<string | null>(null);
+    const eventsUrlRef = useRef<string | null>(null);
+    const completedRef = useRef(false);
+    const abortRef = useRef<AbortController | null>(null);
+    const autoStartedRef = useRef(false);
+
+    const isCreateNew = Boolean(createNew);
+
+    const resetState = useCallback(() => {
+        setStep(presetGithub ? 'planning' : 'source');
+        setTargetPodId(podId ?? null);
+        setSourceMode('upload');
+        setFile(null);
+        setGithubUrl('');
+        setNewPodName('');
+        setPlan(null);
+        setVariables({});
+        setConfirmDestructive(false);
+        setBusy(false);
+        setProgressLabel(null);
+        setLiveSteps([]);
+        setApplyView(null);
+        setErrorMessage(null);
+        targetPodRef.current = podId ?? null;
+        createdPodRef.current = null;
+        importIdRef.current = null;
+        eventsUrlRef.current = null;
+        completedRef.current = false;
+        abortRef.current = null;
+    }, [podId, presetGithub]);
+
+    const cleanupUnfinished = useCallback(async () => {
+        abortRef.current?.abort();
+        const target = targetPodRef.current;
+        const importId = importIdRef.current;
+        if (target && importId && !completedRef.current) {
+            try {
+                await cancelImport(target, importId);
+            } catch {
+                /* best effort */
+            }
+        }
+        // Delete the throwaway pod we created for a create-new import that failed.
+        if (createdPodRef.current && !completedRef.current) {
+            try {
+                await getLemmaClient().pods.delete(createdPodRef.current);
+                queryClient.invalidateQueries({ queryKey: ['pods'] });
+            } catch {
+                /* best effort */
+            }
+        }
+    }, [queryClient]);
+
+    const handleOpenChange = useCallback(
+        (next: boolean) => {
+            if (!next) {
+                if (!completedRef.current) void cleanupUnfinished();
+                onOpenChange(false);
+                // Defer reset so the closing animation doesn't flash the source step.
+                setTimeout(resetState, 200);
+            } else {
+                resetState();
+                onOpenChange(true);
+            }
+        },
+        [cleanupUnfinished, onOpenChange, resetState],
+    );
+
+    async function resolveTargetPod(source: ImportSource): Promise<string> {
+        if (podId) {
+            targetPodRef.current = podId;
+            return podId;
+        }
+        if (!createNew) throw new Error('No import target');
+        const suggested =
+            newPodName.trim() ||
+            (source.mode === 'upload' ? fileBaseName(source.file.name) : source.repo) ||
+            'Imported pod';
+        const pod = (await getLemmaClient().pods.create({
+            name: suggested,
+            organization_id: createNew.organizationId,
+        })) as { id: string };
+        createdPodRef.current = pod.id;
+        targetPodRef.current = pod.id;
+        queryClient.invalidateQueries({ queryKey: ['pods'] });
+        return pod.id;
+    }
+
+    async function beginImport(source: ImportSource) {
+        if (busy) return;
+        setErrorMessage(null);
+        setBusy(true);
+        setStep('planning');
+        setProgressLabel(source.mode === 'github' ? 'Fetching repository…' : 'Uploading bundle…');
+        const abort = new AbortController();
+        abortRef.current = abort;
+        try {
+            const target = await resolveTargetPod(source);
+            setTargetPodId(target);
+
+            let started: ImportStatusResponse;
+            if (source.mode === 'upload') {
+                const uploaded = await uploadBundle(target, source.file);
+                started = await startImport(target, { kind: 'URL', url: uploaded.url });
+            } else {
+                started = await startImport(target, {
+                    kind: 'GITHUB',
+                    owner: source.owner,
+                    repo: source.repo,
+                    ref: source.ref,
+                });
+            }
+            importIdRef.current = started.import_id;
+            eventsUrlRef.current = started.events_url;
+
+            setProgressLabel('Planning changes…');
+            const planned = await trackBundleJob({
+                podId: target,
+                eventsUrl: started.events_url,
+                fetchStatus: () => getImport(target, started.import_id),
+                stopStatuses: ['AWAITING_CONFIRMATION', 'FAILED', 'CANCELLED'],
+                onProgress: (v) =>
+                    setProgressLabel(v.status === 'FETCHING' ? 'Fetching bundle…' : 'Planning changes…'),
+                signal: abort.signal,
+            });
+
+            if (planned.status !== 'AWAITING_CONFIRMATION' || !planned.plan) {
+                throw new Error(planned.error || 'Could not plan the import.');
+            }
+
+            // Seed variable defaults.
+            const seeded: Record<string, string> = {};
+            for (const v of planned.plan.variables) seeded[v.name] = v.default ?? '';
+            setVariables(seeded);
+            setPlan(planned.plan);
+            setLiveSteps(planned.plan.steps);
+            setStep('review');
+        } catch (error) {
+            if ((error as Error)?.name === 'AbortError') return;
+            const message = error instanceof Error ? error.message : 'Import failed';
+            setErrorMessage(message);
+            setStep('error');
+            showResourceErrorToast(error, 'Import failed');
+        } finally {
+            setBusy(false);
+            setProgressLabel(null);
+        }
+    }
+
+    function handleStart() {
+        setErrorMessage(null);
+        if (sourceMode === 'upload') {
+            if (!file) {
+                setErrorMessage('Choose a .zip bundle to import.');
+                return;
+            }
+            void beginImport({ mode: 'upload', file });
+            return;
+        }
+        const repo = parseGithubRepo(githubUrl);
+        if (!repo) {
+            setErrorMessage('Enter a GitHub repo, e.g. github.com/owner/repo.');
+            return;
+        }
+        void beginImport({ mode: 'github', owner: repo.owner, repo: repo.repo });
+    }
+
+    // Preset source (import link) → skip the picker and plan immediately on open.
+    useEffect(() => {
+        if (!open) {
+            autoStartedRef.current = false;
+            return;
+        }
+        if (presetGithub && !autoStartedRef.current) {
+            autoStartedRef.current = true;
+            void beginImport({
+                mode: 'github',
+                owner: presetGithub.owner,
+                repo: presetGithub.repo,
+                ref: presetGithub.ref,
+            });
+        }
+        // beginImport is intentionally excluded — it closes over fresh state each
+        // render; the autoStartedRef guard makes this fire exactly once per open.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [open, presetGithub]);
+
+    async function handleApply() {
+        const target = targetPodRef.current;
+        const importId = importIdRef.current;
+        const eventsUrl = eventsUrlRef.current;
+        if (!target || !importId || !eventsUrl || busy || !plan) return;
+
+        // Required variables must be filled.
+        const missing = plan.variables.filter((v) => v.required && !variables[v.name]?.trim());
+        if (missing.length > 0) {
+            setErrorMessage(`Fill required values: ${missing.map((v) => v.name).join(', ')}`);
+            return;
+        }
+        if (plan.has_destructive_steps && !confirmDestructive) {
+            setErrorMessage('Confirm the destructive changes to continue.');
+            return;
+        }
+
+        setBusy(true);
+        setErrorMessage(null);
+        setLiveSteps(plan.steps);
+        setApplyView({ status: 'APPLYING', done: 0, total: plan.steps.length });
+        const abort = new AbortController();
+        abortRef.current = abort;
+        try {
+            await applyImport(target, importId, {
+                variables,
+                confirm_destructive: confirmDestructive,
+            });
+            setStep('applying');
+            const final = await trackBundleJob({
+                podId: target,
+                eventsUrl,
+                fetchStatus: () => getImport(target, importId),
+                stopStatuses: ['COMPLETED', 'FAILED', 'CANCELLED'],
+                onProgress: setApplyView,
+                onFrame: (frame) => {
+                    if (frame.type === 'step' && typeof frame.step.index === 'number') {
+                        setLiveSteps((prev) =>
+                            prev.map((s) =>
+                                s.index === frame.step.index
+                                    ? { ...s, status: frame.step.status ?? s.status, error: frame.step.error ?? s.error }
+                                    : s,
+                            ),
+                        );
+                    }
+                },
+                signal: abort.signal,
+            });
+
+            if (final.status !== 'COMPLETED') {
+                throw new Error(final.error || 'Apply failed');
+            }
+            if (final.plan) setLiveSteps(final.plan.steps);
+
+            completedRef.current = true;
+            createdPodRef.current = null; // keep the pod — it's real now
+            queryClient.invalidateQueries({ queryKey: ['pods'] });
+            queryClient.invalidateQueries({ queryKey: ['pods', target] });
+            setStep('done');
+        } catch (error) {
+            if ((error as Error)?.name === 'AbortError') return;
+            const message = error instanceof Error ? error.message : 'Apply failed';
+            setErrorMessage(message);
+            setStep('error');
+            showResourceErrorToast(error, 'Apply failed');
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    function handleFinish() {
+        const target = targetPodRef.current;
+        completedRef.current = true;
+        onOpenChange(false);
+        setTimeout(resetState, 200);
+        if (target) {
+            onCompleted?.(target);
+            if (isCreateNew) router.push(`/pod/${target}`);
+            else router.refresh();
+        }
+    }
+
+    // Navigate somewhere inside the freshly-imported pod, closing the wizard.
+    function navigateTo(path: string) {
+        const target = targetPodRef.current;
+        completedRef.current = true;
+        onOpenChange(false);
+        setTimeout(resetState, 200);
+        if (target) {
+            onCompleted?.(target);
+            router.push(path);
+        }
+    }
+
+    // Organization for connector-account variables (create-new knows it upfront;
+    // install-here derives it from the target pod).
+    const { data: targetPod } = usePod(createNew ? undefined : targetPodId ?? undefined);
+    const organizationId = createNew?.organizationId ?? targetPod?.organization_id ?? undefined;
+
+    // ---- render helpers ----
+    const planSteps = liveSteps.length > 0 ? liveSteps : plan?.steps ?? [];
+    const counts = planSteps.reduce(
+        (acc, s) => {
+            acc[s.action] = (acc[s.action] ?? 0) + 1;
+            return acc;
+        },
+        {} as Record<string, number>,
+    );
+
+    return (
+        <>
+        <DialogPrimitive.Root open={open} onOpenChange={handleOpenChange}>
+            <DialogPrimitive.Portal>
+                <DialogPrimitive.Overlay className="scrim-overlay fixed inset-0 z-50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+                <DialogPrimitive.Content className="fixed inset-0 z-50 flex flex-col bg-[var(--surface-1)] text-[var(--text-primary)] outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
+                    <header className="flex h-14 shrink-0 items-center justify-between gap-4 border-b border-[var(--border-subtle)] px-4 sm:px-6">
+                        <div className="min-w-0">
+                            <DialogPrimitive.Title className="truncate text-sm font-medium text-[var(--text-primary)]">
+                                {isCreateNew ? 'Import a pod' : `Install into ${podName || 'this pod'}`}
+                            </DialogPrimitive.Title>
+                            <DialogPrimitive.Description className="truncate text-xs text-[var(--text-tertiary)]">
+                                {isCreateNew
+                                    ? 'Create a new pod from a bundle — a .zip or a GitHub repo.'
+                                    : 'Add resources from a bundle into this pod. Existing resources update in place.'}
+                            </DialogPrimitive.Description>
+                        </div>
+                        <DialogPrimitive.Close
+                            className="lemma-shell-icon-button custom-focus-ring h-9 w-9 shrink-0 text-[var(--text-tertiary)]"
+                            aria-label="Close"
+                        >
+                            <X className="h-4 w-4" />
+                        </DialogPrimitive.Close>
+                    </header>
+
+                    <div className="flex-1 overflow-y-auto">
+                        <div className="mx-auto w-full max-w-2xl px-4 py-8 sm:px-6">
+                    {/* --- SOURCE --- */}
+                    {step === 'source' ? (
+                        <div className="space-y-4">
+                            <div className="grid grid-cols-2 gap-2">
+                                <button
+                                    type="button"
+                                    onClick={() => setSourceMode('upload')}
+                                    className={cn(
+                                        'flex items-center gap-2 rounded-lg border p-3 text-sm transition-colors',
+                                        sourceMode === 'upload'
+                                            ? 'border-[var(--action-primary)] bg-[var(--surface-2)] text-[var(--text-primary)]'
+                                            : 'border-[var(--border-subtle)] text-[var(--text-secondary)] hover:bg-[var(--surface-2)]',
+                                    )}
+                                >
+                                    <FileArchive className="h-4 w-4" />
+                                    Upload .zip
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => setSourceMode('github')}
+                                    className={cn(
+                                        'flex items-center gap-2 rounded-lg border p-3 text-sm transition-colors',
+                                        sourceMode === 'github'
+                                            ? 'border-[var(--action-primary)] bg-[var(--surface-2)] text-[var(--text-primary)]'
+                                            : 'border-[var(--border-subtle)] text-[var(--text-secondary)] hover:bg-[var(--surface-2)]',
+                                    )}
+                                >
+                                    <Github className="h-4 w-4" />
+                                    From GitHub
+                                </button>
+                            </div>
+
+                            {sourceMode === 'upload' ? (
+                                <label className="flex cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-[var(--border-strong)] bg-[var(--surface-1)] px-4 py-8 text-center transition-colors hover:bg-[var(--surface-2)]">
+                                    <Upload className="h-6 w-6 text-[var(--text-tertiary)]" />
+                                    <span className="text-sm text-[var(--text-secondary)]">
+                                        {file ? file.name : 'Click to choose a .zip bundle'}
+                                    </span>
+                                    <input
+                                        type="file"
+                                        accept=".zip,application/zip"
+                                        className="hidden"
+                                        onChange={(e) => {
+                                            const chosen = e.target.files?.[0] ?? null;
+                                            setFile(chosen);
+                                            if (chosen && !newPodName) setNewPodName(fileBaseName(chosen.name));
+                                        }}
+                                    />
+                                </label>
+                            ) : (
+                                <div className="space-y-1.5">
+                                    <Label htmlFor="import-github-url" className="text-xs">
+                                        Public GitHub repository
+                                    </Label>
+                                    <Input
+                                        id="import-github-url"
+                                        value={githubUrl}
+                                        onChange={(e) => {
+                                            setGithubUrl(e.target.value);
+                                            const repo = parseGithubRepo(e.target.value);
+                                            if (repo && !newPodName) setNewPodName(repo.repo);
+                                        }}
+                                        placeholder="github.com/owner/repo"
+                                    />
+                                </div>
+                            )}
+
+                            {isCreateNew ? (
+                                <div className="space-y-1.5">
+                                    <Label htmlFor="import-pod-name" className="text-xs">
+                                        New pod name
+                                    </Label>
+                                    <Input
+                                        id="import-pod-name"
+                                        value={newPodName}
+                                        onChange={(e) => setNewPodName(e.target.value)}
+                                        placeholder="Imported pod"
+                                    />
+                                </div>
+                            ) : null}
+
+                            {errorMessage ? (
+                                <p className="text-sm text-[var(--state-error)]">{errorMessage}</p>
+                            ) : null}
+
+                            <Button className="w-full" onClick={handleStart} loading={busy} loadingLabel="Preparing…">
+                                Continue
+                                <ArrowRight className="ml-2 h-4 w-4" />
+                            </Button>
+                        </div>
+                    ) : null}
+
+                    {/* --- PLANNING --- */}
+                    {step === 'planning' ? (
+                        <div className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+                            <Loader2 className="h-6 w-6 animate-spin text-[var(--action-primary)]" />
+                            <p className="text-sm text-[var(--text-secondary)]">{progressLabel ?? 'Planning…'}</p>
+                        </div>
+                    ) : null}
+
+                    {/* --- REVIEW --- */}
+                    {step === 'review' && plan ? (
+                        <div className="space-y-4">
+                            <div className="flex flex-wrap gap-2 text-xs">
+                                {(['CREATE', 'UPDATE', 'SKIP'] as StepAction[]).map((a) =>
+                                    counts[a] ? (
+                                        <span
+                                            key={a}
+                                            className={cn('rounded px-2 py-0.5 font-medium', ACTION_STYLES[a].className)}
+                                        >
+                                            {counts[a]} {ACTION_STYLES[a].label.toLowerCase()}
+                                        </span>
+                                    ) : null,
+                                )}
+                            </div>
+
+                            <div className="max-h-52 divide-y divide-[var(--border-subtle)] overflow-y-auto rounded-lg border border-[var(--border-subtle)] px-3">
+                                {planSteps.map((s) => (
+                                    <StepRow key={`${s.kind}-${s.index}`} step={s} />
+                                ))}
+                            </div>
+
+                            {plan.warnings.length > 0 ? (
+                                <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--surface-2)] p-3 text-xs text-[var(--text-secondary)]">
+                                    {plan.warnings.map((w, i) => (
+                                        <p key={i}>{w}</p>
+                                    ))}
+                                </div>
+                            ) : null}
+
+                            {plan.variables.length > 0 ? (
+                                <div className="space-y-3">
+                                    <p className="text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">
+                                        Configuration
+                                    </p>
+                                    {plan.variables.map((v) => {
+                                        const setValue = (val: string) =>
+                                            setVariables((prev) => ({ ...prev, [v.name]: val }));
+
+                                        if (v.kind === 'account' && v.platform) {
+                                            return (
+                                                <AccountVariableField
+                                                    key={v.name}
+                                                    organizationId={organizationId}
+                                                    podId={targetPodId}
+                                                    platform={v.platform}
+                                                    label={v.name}
+                                                    description={v.description}
+                                                    required={v.required}
+                                                    value={variables[v.name] ?? ''}
+                                                    onChange={setValue}
+                                                />
+                                            );
+                                        }
+
+                                        const secret = /secret|password|token|key/i.test(v.kind);
+                                        return (
+                                            <div key={v.name} className="space-y-1">
+                                                <Label htmlFor={`var-${v.name}`} className="text-xs">
+                                                    {v.name}
+                                                    {v.required ? <span className="text-[var(--state-error)]"> *</span> : null}
+                                                </Label>
+                                                {v.description ? (
+                                                    <p className="text-xs text-[var(--text-tertiary)]">{v.description}</p>
+                                                ) : null}
+                                                <Input
+                                                    id={`var-${v.name}`}
+                                                    type={secret ? 'password' : 'text'}
+                                                    value={variables[v.name] ?? ''}
+                                                    onChange={(e) => setValue(e.target.value)}
+                                                    placeholder={v.default ?? ''}
+                                                />
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            ) : null}
+
+                            {plan.has_destructive_steps ? (
+                                <label className="flex items-start gap-2 rounded-md border border-[color:color-mix(in_srgb,var(--state-error)_40%,transparent)] bg-[color:color-mix(in_srgb,var(--state-error)_8%,transparent)] p-3">
+                                    <Checkbox
+                                        checked={confirmDestructive}
+                                        onCheckedChange={(v) => setConfirmDestructive(v === true)}
+                                        className="mt-0.5"
+                                    />
+                                    <span className="text-xs text-[var(--text-secondary)]">
+                                        Some steps remove columns or data that exist today. I understand and want to
+                                        proceed.
+                                    </span>
+                                </label>
+                            ) : null}
+
+                            {errorMessage ? (
+                                <p className="text-sm text-[var(--state-error)]">{errorMessage}</p>
+                            ) : null}
+
+                            <div className="flex gap-2">
+                                <Button variant="secondary" className="flex-1" onClick={() => handleOpenChange(false)}>
+                                    Cancel
+                                </Button>
+                                <Button
+                                    className="flex-1"
+                                    onClick={handleApply}
+                                    loading={busy}
+                                    loadingLabel="Applying…"
+                                    disabled={plan.has_destructive_steps && !confirmDestructive}
+                                >
+                                    {isCreateNew ? 'Create pod' : 'Apply'}
+                                </Button>
+                            </div>
+                        </div>
+                    ) : null}
+
+                    {/* --- APPLYING --- */}
+                    {step === 'applying' ? (
+                        <div className="space-y-4">
+                            <BundleProgressBar
+                                done={applyView?.done ?? 0}
+                                total={applyView?.total ?? planSteps.length}
+                                label="Applying resources…"
+                            />
+                            <div className="max-h-64 divide-y divide-[var(--border-subtle)] overflow-y-auto rounded-lg border border-[var(--border-subtle)] px-3">
+                                {planSteps.map((s) => (
+                                    <StepRow key={`${s.kind}-${s.index}`} step={s} />
+                                ))}
+                            </div>
+                        </div>
+                    ) : null}
+
+                    {/* --- DONE (the "it's yours" takeover) --- */}
+                    {step === 'done' ? (
+                        <div className="flex flex-col items-center gap-6 py-6 text-center">
+                            <div className="flex flex-col items-center gap-3">
+                                <div className="flex h-14 w-14 items-center justify-center rounded-full bg-[color:color-mix(in_srgb,var(--state-success)_16%,transparent)]">
+                                    <Sparkles className="h-7 w-7 text-[var(--state-success)]" />
+                                </div>
+                                <div>
+                                    <p className="text-xl font-medium text-[var(--text-primary)]">
+                                        {isCreateNew
+                                            ? `${plan?.bundle_name || podName || 'Your pod'} is yours`
+                                            : 'Installed'}
+                                    </p>
+                                    <p className="mt-1 text-sm text-[var(--text-tertiary)]">
+                                        {isCreateNew
+                                            ? 'Open it, make it your own, then pass it on.'
+                                            : 'The bundle was applied to this pod.'}
+                                    </p>
+                                </div>
+                            </div>
+
+                            {isCreateNew ? (
+                                <div className="grid w-full grid-cols-2 gap-3">
+                                    {[
+                                        {
+                                            icon: PanelsTopLeft,
+                                            title: 'Open the app',
+                                            hint: 'See what it does',
+                                            onClick: () => navigateTo(`/pod/${targetPodId}/app/pages`),
+                                        },
+                                        {
+                                            icon: MessageCircle,
+                                            title: 'Activate a surface',
+                                            hint: 'Slack, Telegram, more',
+                                            onClick: () => navigateTo(`/pod/${targetPodId}/surfaces`),
+                                        },
+                                        {
+                                            icon: Share2,
+                                            title: 'Share with a friend',
+                                            hint: 'Pass the pod on',
+                                            onClick: () => setShareOpen(true),
+                                        },
+                                        {
+                                            icon: Wrench,
+                                            title: 'Customize',
+                                            hint: 'Tweak it in chat',
+                                            onClick: () => navigateTo(`/pod/${targetPodId}`),
+                                        },
+                                    ].map((action) => (
+                                        <button
+                                            key={action.title}
+                                            type="button"
+                                            onClick={action.onClick}
+                                            className="flex flex-col items-start gap-2 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-1)] p-4 text-left transition-colors hover:border-[var(--action-primary)] hover:bg-[var(--surface-2)]"
+                                        >
+                                            <action.icon className="h-5 w-5 text-[var(--action-primary)]" />
+                                            <div>
+                                                <div className="text-sm font-medium text-[var(--text-primary)]">
+                                                    {action.title}
+                                                </div>
+                                                <div className="text-xs text-[var(--text-tertiary)]">{action.hint}</div>
+                                            </div>
+                                        </button>
+                                    ))}
+                                </div>
+                            ) : (
+                                <div className="flex w-full gap-2">
+                                    <Button variant="secondary" className="flex-1" onClick={() => setShareOpen(true)}>
+                                        <Share2 className="mr-2 h-4 w-4" />
+                                        Share
+                                    </Button>
+                                    <Button className="flex-1" onClick={handleFinish}>
+                                        Done
+                                        <ArrowRight className="ml-2 h-4 w-4" />
+                                    </Button>
+                                </div>
+                            )}
+                        </div>
+                    ) : null}
+
+                    {/* --- ERROR --- */}
+                    {step === 'error' ? (
+                        <div className="flex flex-col items-center gap-3 py-8 text-center">
+                            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[color:color-mix(in_srgb,var(--state-error)_14%,transparent)]">
+                                <AlertTriangle className="h-6 w-6 text-[var(--state-error)]" />
+                            </div>
+                            <p className="text-sm text-[var(--text-secondary)]">
+                                {errorMessage ?? 'Something went wrong.'}
+                            </p>
+                            <div className="flex w-full gap-2">
+                                <Button variant="secondary" className="flex-1" onClick={() => handleOpenChange(false)}>
+                                    Close
+                                </Button>
+                                <Button
+                                    className="flex-1"
+                                    onClick={() => {
+                                        setErrorMessage(null);
+                                        setStep('source');
+                                    }}
+                                >
+                                    Try again
+                                </Button>
+                            </div>
+                        </div>
+                    ) : null}
+                        </div>
+                    </div>
+                </DialogPrimitive.Content>
+            </DialogPrimitive.Portal>
+        </DialogPrimitive.Root>
+        {targetPodId ? (
+            <ShareSheet
+                podId={targetPodId}
+                podName={plan?.bundle_name ?? podName}
+                open={shareOpen}
+                onOpenChange={setShareOpen}
+            />
+        ) : null}
+        </>
+    );
+}

--- a/lemma-frontend/components/bundle/import-dialog.tsx
+++ b/lemma-frontend/components/bundle/import-dialog.tsx
@@ -67,8 +67,8 @@ type ImportSource =
     | { mode: 'github'; owner: string; repo: string; ref?: string };
 
 const ACTION_STYLES: Record<StepAction, { label: string; className: string }> = {
-    CREATE: { label: 'New', className: 'text-[var(--state-success)] bg-[color:color-mix(in_srgb,var(--state-success)_14%,transparent)]' },
-    UPDATE: { label: 'Update', className: 'text-[var(--state-warning)] bg-[color:color-mix(in_srgb,var(--state-warning)_14%,transparent)]' },
+    CREATE: { label: 'New', className: 'state-surface-success' },
+    UPDATE: { label: 'Update', className: 'state-surface-warning' },
     SKIP: { label: 'Skip', className: 'text-[var(--text-tertiary)] bg-[var(--surface-2)]' },
 };
 
@@ -101,7 +101,7 @@ function StepRow({ step }: { step: PlanStep }) {
             {step.destructive ? (
                 <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-[var(--state-error)]" aria-label="Destructive" />
             ) : null}
-            <span className={cn('shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium uppercase', action.className)}>
+            <span className={cn('shrink-0 rounded px-1.5 py-0.5 text-xs font-medium uppercase', action.className)}>
                 {action.label}
             </span>
         </div>
@@ -641,7 +641,7 @@ export function ImportDialog({
                             ) : null}
 
                             {plan.has_destructive_steps ? (
-                                <label className="flex items-start gap-2 rounded-md border border-[color:color-mix(in_srgb,var(--state-error)_40%,transparent)] bg-[color:color-mix(in_srgb,var(--state-error)_8%,transparent)] p-3">
+                                <label className="state-surface-error flex items-start gap-2 rounded-md p-3">
                                     <Checkbox
                                         checked={confirmDestructive}
                                         onCheckedChange={(v) => setConfirmDestructive(v === true)}
@@ -695,7 +695,7 @@ export function ImportDialog({
                     {step === 'done' ? (
                         <div className="flex flex-col items-center gap-6 py-6 text-center">
                             <div className="flex flex-col items-center gap-3">
-                                <div className="flex h-14 w-14 items-center justify-center rounded-full bg-[color:color-mix(in_srgb,var(--state-success)_16%,transparent)]">
+                                <div className="state-surface-success flex h-14 w-14 items-center justify-center rounded-full">
                                     <Sparkles className="h-7 w-7 text-[var(--state-success)]" />
                                 </div>
                                 <div>
@@ -744,7 +744,7 @@ export function ImportDialog({
                                             key={action.title}
                                             type="button"
                                             onClick={action.onClick}
-                                            className="flex flex-col items-start gap-2 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-1)] p-4 text-left transition-colors hover:border-[var(--action-primary)] hover:bg-[var(--surface-2)]"
+                                            className="flex flex-col items-start gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)] p-4 text-left transition-colors hover:border-[var(--action-primary)] hover:bg-[var(--surface-2)]"
                                         >
                                             <action.icon className="h-5 w-5 text-[var(--action-primary)]" />
                                             <div>
@@ -774,7 +774,7 @@ export function ImportDialog({
                     {/* --- ERROR --- */}
                     {step === 'error' ? (
                         <div className="flex flex-col items-center gap-3 py-8 text-center">
-                            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[color:color-mix(in_srgb,var(--state-error)_14%,transparent)]">
+                            <div className="state-surface-error flex h-12 w-12 items-center justify-center rounded-full">
                                 <AlertTriangle className="h-6 w-6 text-[var(--state-error)]" />
                             </div>
                             <p className="text-sm text-[var(--text-secondary)]">

--- a/lemma-frontend/components/bundle/pod-bundle-settings.tsx
+++ b/lemma-frontend/components/bundle/pod-bundle-settings.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useState } from 'react';
+import { ArrowUpRight, Github, PackageOpen, Share2, Upload } from 'lucide-react';
+import type { PodRecipe } from 'lemma-sdk';
+
+import { PodSettingsPanel } from '@/components/pod/pod-settings-shell';
+import { Button } from '@/components/ui/button';
+import { ShareSheet } from '@/components/bundle/share-sheet';
+import { ImportDialog } from '@/components/bundle/import-dialog';
+
+interface PodBundleSettingsPanelProps {
+    podId: string;
+    podName?: string | null;
+    canUpdate: boolean;
+    recipes: PodRecipe[];
+}
+
+function formatImportedAt(value: string): string {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '';
+    return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function RecipeRow({ recipe }: { recipe: PodRecipe }) {
+    const when = formatImportedAt(recipe.imported_at);
+    const isGithub = recipe.kind === 'github' && recipe.repo_url;
+
+    return (
+        <div className="flex items-center gap-2.5 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)] px-3 py-2">
+            <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[var(--surface-2)]">
+                {isGithub ? (
+                    <Github className="h-4 w-4 text-[var(--text-secondary)]" />
+                ) : (
+                    <PackageOpen className="h-4 w-4 text-[var(--text-secondary)]" />
+                )}
+            </span>
+            <div className="min-w-0 flex-1">
+                {isGithub ? (
+                    <a
+                        href={recipe.repo_url ?? '#'}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-1 truncate text-sm font-medium text-[var(--action-primary)] hover:underline"
+                    >
+                        {recipe.repo_url?.replace(/^https?:\/\//, '') ?? recipe.name}
+                        <ArrowUpRight className="h-3.5 w-3.5 shrink-0" />
+                    </a>
+                ) : (
+                    <div className="truncate text-sm font-medium text-[var(--text-primary)]">
+                        {recipe.name || 'Uploaded bundle'}
+                    </div>
+                )}
+                <div className="text-xs text-[var(--text-tertiary)]">
+                    {recipe.kind === 'github' ? 'From GitHub' : 'Uploaded'}
+                    {when ? ` · ${when}` : ''}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+/**
+ * The full "Share & bundles" home in pod Settings — export/publish, install a
+ * bundle, and the pod's provenance (which bundles were imported into it).
+ */
+export function PodBundleSettingsPanel({ podId, podName, canUpdate, recipes }: PodBundleSettingsPanelProps) {
+    const [shareOpen, setShareOpen] = useState(false);
+    const [importOpen, setImportOpen] = useState(false);
+
+    return (
+        <PodSettingsPanel
+            title="Share & bundles"
+            description="Export this pod as a portable bundle, publish it to GitHub, or install another bundle into it."
+        >
+            {recipes.length > 0 ? (
+                <div className="mb-4 space-y-2">
+                    <p className="text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">
+                        Provenance
+                    </p>
+                    {recipes.map((recipe, index) => (
+                        <RecipeRow key={`${recipe.kind}-${recipe.imported_at}-${index}`} recipe={recipe} />
+                    ))}
+                </div>
+            ) : null}
+
+            <div className="flex flex-wrap gap-2">
+                <Button variant="secondary" onClick={() => setShareOpen(true)}>
+                    <Share2 className="mr-2 h-4 w-4" />
+                    Share / export
+                </Button>
+                {canUpdate ? (
+                    <Button variant="secondary" onClick={() => setImportOpen(true)}>
+                        <Upload className="mr-2 h-4 w-4" />
+                        Install a bundle
+                    </Button>
+                ) : null}
+            </div>
+
+            <ShareSheet podId={podId} podName={podName} open={shareOpen} onOpenChange={setShareOpen} />
+            {canUpdate ? (
+                <ImportDialog
+                    podId={podId}
+                    podName={podName}
+                    open={importOpen}
+                    onOpenChange={setImportOpen}
+                />
+            ) : null}
+        </PodSettingsPanel>
+    );
+}

--- a/lemma-frontend/components/bundle/share-sheet.tsx
+++ b/lemma-frontend/components/bundle/share-sheet.tsx
@@ -1,0 +1,317 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { ArrowUpRight, Copy, Download, FileText, Github } from 'lucide-react';
+import { toast } from 'sonner';
+
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+} from '@/components/ui/sheet';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch, SwitchThumb, SwitchTrack } from '@/components/ui/switch';
+import { showResourceErrorToast } from '@/components/shared/resource-feedback';
+import { BundleProgressBar } from '@/components/bundle/bundle-progress';
+import {
+    getPublish,
+    pollExport,
+    startExport,
+    startPublish,
+    toRepoSlug,
+    trackBundleJob,
+    triggerBundleDownload,
+    type BundleProgressView,
+    type PublishStatusResponse,
+} from '@/lib/hooks/use-pod-bundle';
+
+interface ShareSheetProps {
+    podId: string;
+    podName?: string | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+/** The design-system Switch is headless — it needs a track + thumb to render. */
+function Toggle({
+    checked,
+    onCheckedChange,
+    disabled,
+}: {
+    checked: boolean;
+    onCheckedChange: (next: boolean) => void;
+    disabled?: boolean;
+}) {
+    return (
+        <Switch checked={checked} onCheckedChange={onCheckedChange} disabled={disabled}>
+            <SwitchTrack className={checked ? 'bg-[var(--action-primary)]' : undefined}>
+                <SwitchThumb className={checked ? 'translate-x-4' : undefined} />
+            </SwitchTrack>
+        </Switch>
+    );
+}
+
+function looksLikeNotConnected(message: string | null | undefined): boolean {
+    const text = (message || '').toLowerCase();
+    return text.includes('not_connected') || text.includes('connect') || text.includes('no github');
+}
+
+function publishPhaseLabel(status: string): string {
+    if (status === 'EXPORTING') return 'Packaging pod…';
+    if (status === 'PUBLISHING') return 'Pushing files to GitHub…';
+    return 'Starting…';
+}
+
+export function ShareSheet({ podId, podName, open, onOpenChange }: ShareSheetProps) {
+    const defaultRepo = useMemo(() => toRepoSlug(podName || 'my-pod') || 'my-pod', [podName]);
+
+    // Export
+    const [withData, setWithData] = useState(true);
+    const [exporting, setExporting] = useState(false);
+    const [exportView, setExportView] = useState<BundleProgressView | null>(null);
+
+    // Publish
+    const [repoName, setRepoName] = useState(defaultRepo);
+    const [isPrivate, setIsPrivate] = useState(false);
+    const [aiReadme, setAiReadme] = useState(true);
+    const [publishing, setPublishing] = useState(false);
+    const [publishView, setPublishView] = useState<BundleProgressView | null>(null);
+    const [published, setPublished] = useState<PublishStatusResponse | null>(null);
+    const [needsGithub, setNeedsGithub] = useState(false);
+
+    async function handleExport() {
+        if (exporting) return;
+        setExporting(true);
+        setExportView({ status: 'QUEUED', done: 0, total: 0 });
+        try {
+            const started = await startExport(podId, { with_data: withData });
+            const final = await pollExport(podId, started.export_id, {
+                onTick: (s) =>
+                    setExportView({ status: s.status, done: s.progress.done, total: s.progress.total }),
+            });
+            if (final.status === 'READY' && final.download_url) {
+                triggerBundleDownload(final.download_url, final.bundle_filename ?? undefined);
+                if (final.warnings.length > 0) {
+                    toast.warning('Bundle ready — with notes', {
+                        description: final.warnings.slice(0, 3).join(' · '),
+                    });
+                } else {
+                    toast.success('Bundle downloaded');
+                }
+            } else {
+                throw new Error(final.error || 'Export failed');
+            }
+        } catch (error) {
+            showResourceErrorToast(error, 'Export failed');
+        } finally {
+            setExporting(false);
+            setExportView(null);
+        }
+    }
+
+    async function handlePublish() {
+        const name = repoName.trim();
+        if (publishing || !name) return;
+        setPublishing(true);
+        setPublished(null);
+        setNeedsGithub(false);
+        setPublishView({ status: 'QUEUED', done: 0, total: 0 });
+        try {
+            const started = await startPublish(podId, {
+                repo_name: name,
+                private: isPrivate,
+                ai_readme: aiReadme,
+            });
+            const final = await trackBundleJob({
+                podId,
+                eventsUrl: started.events_url,
+                fetchStatus: () => getPublish(podId, started.publish_id),
+                stopStatuses: ['COMPLETED', 'FAILED'],
+                onProgress: setPublishView,
+            });
+            if (final.status === 'COMPLETED') {
+                setPublished(final);
+                toast.success('Published to GitHub');
+            } else if (looksLikeNotConnected(final.error)) {
+                setNeedsGithub(true);
+            } else {
+                throw new Error(final.error || 'Publish failed');
+            }
+        } catch (error) {
+            const message = error instanceof Error ? error.message : '';
+            if (looksLikeNotConnected(message)) {
+                setNeedsGithub(true);
+            } else {
+                showResourceErrorToast(error, 'Publish failed');
+            }
+        } finally {
+            setPublishing(false);
+            setPublishView(null);
+        }
+    }
+
+    async function copy(text: string, label: string) {
+        try {
+            await navigator.clipboard.writeText(text);
+            toast.success(`${label} copied`);
+        } catch {
+            toast.error('Could not copy to clipboard');
+        }
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={onOpenChange}>
+            <SheetContent side="right" className="flex w-full flex-col gap-0 sm:max-w-md">
+                <SheetHeader>
+                    <SheetTitle>Share this pod</SheetTitle>
+                    <SheetDescription>
+                        Package {podName ? <span className="font-medium">{podName}</span> : 'this pod'} as a
+                        portable bundle — download it, or publish it to GitHub with a one-click install badge.
+                    </SheetDescription>
+                </SheetHeader>
+
+                <div className="flex-1 space-y-6 overflow-y-auto px-1 py-6">
+                    {/* Download */}
+                    <section className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)] p-4">
+                        <div className="flex items-center gap-2 text-sm font-medium text-[var(--text-primary)]">
+                            <Download className="h-4 w-4 text-[var(--text-tertiary)]" />
+                            Download bundle
+                        </div>
+                        <p className="mt-1 text-xs text-[var(--text-tertiary)]">
+                            A <code>.zip</code> of the whole pod — tables, agents, functions, workflows, apps and
+                            surfaces. Anyone can import it from Lemma.
+                        </p>
+                        <div className="mt-4 flex items-center justify-between gap-3">
+                            <div className="text-sm text-[var(--text-secondary)]">
+                                Include table data
+                                <span className="block text-xs text-[var(--text-tertiary)]">
+                                    Off exports the schema only.
+                                </span>
+                            </div>
+                            <Toggle checked={withData} onCheckedChange={setWithData} disabled={exporting} />
+                        </div>
+                        {exporting && exportView ? (
+                            <BundleProgressBar
+                                className="mt-4"
+                                done={exportView.done}
+                                total={exportView.total}
+                                label="Packaging…"
+                            />
+                        ) : (
+                            <Button className="mt-4 w-full" variant="secondary" onClick={handleExport}>
+                                <Download className="mr-2 h-4 w-4" />
+                                Download .zip
+                            </Button>
+                        )}
+                    </section>
+
+                    {/* Publish to GitHub */}
+                    <section className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)] p-4">
+                        <div className="flex items-center gap-2 text-sm font-medium text-[var(--text-primary)]">
+                            <Github className="h-4 w-4 text-[var(--text-tertiary)]" />
+                            Publish to GitHub
+                        </div>
+                        <p className="mt-1 text-xs text-[var(--text-tertiary)]">
+                            Creates a repo with a README and an <span className="font-medium">Import to Lemma</span>{' '}
+                            badge — a durable, shareable install link.
+                        </p>
+
+                        {published ? (
+                            <div className="mt-4 space-y-3">
+                                <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--surface-2)] p-3">
+                                    <div className="text-xs text-[var(--text-tertiary)]">Published repository</div>
+                                    <a
+                                        href={published.repo_url ?? '#'}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="mt-0.5 flex items-center gap-1 text-sm font-medium text-[var(--action-primary)] hover:underline"
+                                    >
+                                        {published.repo_url?.replace(/^https?:\/\//, '') ?? published.repo_name}
+                                        <ArrowUpRight className="h-3.5 w-3.5" />
+                                    </a>
+                                </div>
+                                <div className="flex gap-2">
+                                    <Button
+                                        variant="secondary"
+                                        size="sm"
+                                        className="flex-1"
+                                        onClick={() => published.repo_url && copy(published.repo_url, 'Repo link')}
+                                    >
+                                        <Copy className="mr-2 h-3.5 w-3.5" />
+                                        Copy link
+                                    </Button>
+                                    <Button variant="secondary" size="sm" className="flex-1" onClick={() => setPublished(null)}>
+                                        Publish again
+                                    </Button>
+                                </div>
+                                <p className="text-xs text-[var(--text-tertiary)]">
+                                    Others import it from <span className="font-medium">Import → GitHub</span> by pasting
+                                    this URL.
+                                </p>
+                            </div>
+                        ) : publishing ? (
+                            <BundleProgressBar
+                                className="mt-4"
+                                done={publishView?.done ?? 0}
+                                total={publishView?.total ?? 0}
+                                label={publishPhaseLabel(publishView?.status ?? 'QUEUED')}
+                            />
+                        ) : (
+                            <div className="mt-4 space-y-4">
+                                <div className="space-y-1.5">
+                                    <Label htmlFor="bundle-repo-name" className="text-xs">
+                                        Repository name
+                                    </Label>
+                                    <Input
+                                        id="bundle-repo-name"
+                                        value={repoName}
+                                        onChange={(e) => setRepoName(e.target.value)}
+                                        placeholder="my-pod"
+                                    />
+                                </div>
+                                <div className="flex items-start justify-between gap-3 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-2)] p-3">
+                                    <div className="flex items-start gap-2">
+                                        <FileText className="mt-0.5 h-4 w-4 shrink-0 text-[var(--text-tertiary)]" />
+                                        <div className="text-sm text-[var(--text-secondary)]">
+                                            AI-written README
+                                            <span className="block text-xs text-[var(--text-tertiary)]">
+                                                Generates a README describing what the pod does.
+                                            </span>
+                                        </div>
+                                    </div>
+                                    <Toggle checked={aiReadme} onCheckedChange={setAiReadme} />
+                                </div>
+                                <div className="flex items-center justify-between gap-3">
+                                    <span className="text-sm text-[var(--text-secondary)]">Private repository</span>
+                                    <Toggle checked={isPrivate} onCheckedChange={setIsPrivate} />
+                                </div>
+
+                                {needsGithub ? (
+                                    <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--surface-2)] p-3 text-xs text-[var(--text-secondary)]">
+                                        Connect your GitHub account first, then publish.
+                                        <Link
+                                            href={`/pod/${podId}/connectors`}
+                                            className="ml-1 font-medium text-[var(--action-primary)] hover:underline"
+                                        >
+                                            Open connectors
+                                        </Link>
+                                    </div>
+                                ) : null}
+
+                                <Button className="w-full" onClick={handlePublish} disabled={!repoName.trim()}>
+                                    <Github className="mr-2 h-4 w-4" />
+                                    Publish to GitHub
+                                </Button>
+                            </div>
+                        )}
+                    </section>
+                </div>
+            </SheetContent>
+        </Sheet>
+    );
+}

--- a/lemma-frontend/components/data/datastore-table-skeleton.tsx
+++ b/lemma-frontend/components/data/datastore-table-skeleton.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+/**
+ * DatastoreTableSkeleton — loading placeholder that mirrors the embedded
+ * DatastoreTableView frame (toolbar + grid + footer) so the tables page loads
+ * into the same shape it settles on, instead of flashing a floating dashed box.
+ *
+ * It reuses the `.data-table-workbench` CSS structure, so the toolbar/grid/footer
+ * pick up the exact borders, radii, and spacing of the real table.
+ */
+const ROW_FADE = [
+    'opacity-100',
+    'opacity-90',
+    'opacity-80',
+    'opacity-70',
+    'opacity-60',
+    'opacity-50',
+    'opacity-40',
+];
+
+export function DatastoreTableSkeleton({ rows = 8 }: { rows?: number }) {
+    const columns = 4;
+
+    return (
+        <div
+            className="datastore-table-workbench lemma-workbench-panel data-table-workbench relative flex h-full min-h-0 flex-col overflow-hidden"
+            role="status"
+            aria-label="Loading table"
+        >
+            <div className="data-table-toolbar shrink-0">
+                <div className="flex w-full items-center justify-between gap-2">
+                    <div className="lemma-skeleton h-5 w-40 rounded-md" />
+                    <div className="flex items-center gap-1.5">
+                        <div className="lemma-skeleton h-8 w-16 rounded-md" />
+                        <div className="lemma-skeleton h-8 w-20 rounded-md" />
+                        <div className="lemma-skeleton h-8 w-24 rounded-md" />
+                    </div>
+                </div>
+            </div>
+
+            <div className="data-table-viewport relative flex-1 overflow-hidden bg-[var(--row-bg)]">
+                <div className="data-table-grid-frame h-full">
+                    <div className="h-full overflow-hidden">
+                        <div className="flex items-center gap-6 border-b border-[color:var(--row-border)] px-4 py-2.5">
+                            {Array.from({ length: columns }).map((_, index) => (
+                                <div key={index} className="lemma-skeleton h-3.5 flex-1 rounded-full" />
+                            ))}
+                        </div>
+                        <div className="divide-y divide-[color:color-mix(in_srgb,var(--border-subtle)_42%,transparent)]">
+                            {Array.from({ length: rows }).map((_, rowIndex) => (
+                                <div
+                                    key={rowIndex}
+                                    className={`flex items-center gap-6 px-4 py-3 ${ROW_FADE[Math.min(rowIndex, ROW_FADE.length - 1)]}`}
+                                >
+                                    {Array.from({ length: columns }).map((_, columnIndex) => (
+                                        <div key={columnIndex} className="lemma-skeleton h-3 flex-1 rounded-full" />
+                                    ))}
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div className="data-table-footer shrink-0">
+                <div className="flex items-center justify-between">
+                    <div className="lemma-skeleton h-3.5 w-48 rounded-full" />
+                    <div className="flex items-center gap-2">
+                        <div className="lemma-skeleton h-8 w-20 rounded-md" />
+                        <div className="lemma-skeleton h-8 w-16 rounded-md" />
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/lemma-frontend/components/data/datastore-table-view.tsx
+++ b/lemma-frontend/components/data/datastore-table-view.tsx
@@ -9,6 +9,7 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { DestructiveConfirmationDialog } from '@/components/shared/destructive-confirmation-dialog';
 import { QuietEmptyState } from '@/components/shared/empty-state';
+import { DatastoreTableSkeleton } from '@/components/data/datastore-table-skeleton';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -338,11 +339,7 @@ export function DatastoreTableView({
     };
 
     if (tableLoading) {
-        return (
-            <div className="surface-card flex h-64 items-center justify-center">
-                <div className="text-[var(--text-secondary)]">Loading table...</div>
-            </div>
-        );
+        return <DatastoreTableSkeleton />;
     }
 
     if (!table) {

--- a/lemma-frontend/components/home/home-sidebar-chrome.tsx
+++ b/lemma-frontend/components/home/home-sidebar-chrome.tsx
@@ -12,6 +12,7 @@ import {
     Plus,
 } from 'lucide-react';
 import { Logo } from '@/components/brand/logo';
+import { HomeImportButton } from '@/components/bundle/home-import-button';
 import { ProductIcon, type ProductIconTone } from '@/components/pod/product-icon';
 import { SidebarEmptyState } from '@/components/shared/empty-state';
 import { ThemeToggle } from '@/components/theme/theme-toggle';
@@ -100,6 +101,7 @@ function SidebarContent({
                         <Plus className="h-4 w-4" />
                         New pod
                     </Link>
+                    <HomeImportButton onNavigate={onNavigate} />
                 </nav>
 
                 <div className="mt-8 space-y-5">

--- a/lemma-frontend/components/pod/workspace-sidebar.tsx
+++ b/lemma-frontend/components/pod/workspace-sidebar.tsx
@@ -17,8 +17,10 @@ import {
     PanelsTopLeft,
     Plus,
     Plug,
+    Share2,
     ShieldCheck,
     Table2,
+    Upload,
     User,
     Workflow,
 } from 'lucide-react';
@@ -27,6 +29,8 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import { useAIAssistant } from '@/components/ai/ai-assistant-context';
 import { Logo } from '@/components/brand/logo';
 import { FileTypeIcon } from '@/components/documents/file-type-icon';
+import { ShareSheet } from '@/components/bundle/share-sheet';
+import { ImportDialog } from '@/components/bundle/import-dialog';
 import { usePodLayoutOptional } from '@/components/pod/pod-layout-context';
 import { ProductIcon, type ProductIconTone } from '@/components/pod/product-icon';
 import { SidebarEmptyState } from '@/components/shared/empty-state';
@@ -195,6 +199,8 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
     const searchParamsString = searchParams.toString();
     const [assistantCreationKind, setAssistantCreationKind] = useState<AssistantCreationKind | null>(null);
     const [assistantCreationPrompt, setAssistantCreationPrompt] = useState('');
+    const [bundleShareOpen, setBundleShareOpen] = useState(false);
+    const [bundleImportOpen, setBundleImportOpen] = useState(false);
     const { pages = [] } = useApp();
     const { data: podsData } = useAccessiblePods();
     const { data: profile } = useProfile();
@@ -647,6 +653,15 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
                         />
                     </DropdownMenu.Root>
                 </div>
+                <button
+                    type="button"
+                    onClick={() => setBundleShareOpen(true)}
+                    className="lemma-shell-icon-button custom-focus-ring h-9 w-9 shrink-0 self-center text-[var(--text-tertiary)] hover:text-[var(--action-primary)]"
+                    aria-label="Share pod"
+                    title="Share pod"
+                >
+                    <Share2 className="h-4 w-4" strokeWidth={1.8} />
+                </button>
                 {onCollapse ? (
                     <button
                         type="button"
@@ -751,6 +766,14 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
                                             Browse recipes
                                         </DropdownMenu.Item>
                                     ) : null}
+                                    <DropdownMenu.Separator className="my-1 h-px bg-[var(--border-subtle)]" />
+                                    <DropdownMenu.Item
+                                        onSelect={() => setBundleImportOpen(true)}
+                                        className="lemma-menu-row px-2"
+                                    >
+                                        <Upload className="h-3.5 w-3.5 shrink-0 text-[var(--text-tertiary)]" />
+                                        Install a bundle
+                                    </DropdownMenu.Item>
                                 </DropdownMenu.Content>
                             </DropdownMenu.Portal>
                         </DropdownMenu.Root>
@@ -839,6 +862,21 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
                     </DialogFooter>
                 </DialogContent>
             </Dialog>
+
+            <ShareSheet
+                podId={podId}
+                podName={podName}
+                open={bundleShareOpen}
+                onOpenChange={setBundleShareOpen}
+            />
+            {canShowCreateMenu ? (
+                <ImportDialog
+                    podId={podId}
+                    podName={podName}
+                    open={bundleImportOpen}
+                    onOpenChange={setBundleImportOpen}
+                />
+            ) : null}
 
             <div className="min-h-0 flex-1 overflow-y-auto px-3">
                 {routeWorktree}

--- a/lemma-frontend/lib/hooks/use-pod-bundle.ts
+++ b/lemma-frontend/lib/hooks/use-pod-bundle.ts
@@ -1,0 +1,442 @@
+'use client';
+
+/**
+ * Data layer for the pod bundle share/import/export experience.
+ *
+ * Mirrors `app/modules/pod_bundle/api/schemas.py`. The backend runs export /
+ * import / publish as streaq jobs and keeps ephemeral state in Redis; these
+ * helpers start a job (202) and then *poll* the Redis-backed status endpoint
+ * until it reaches a terminal state. Polling is the design's first-class
+ * progress path (SSE is an optimization we can layer on later).
+ */
+
+import { parseSSEJson, readSSE } from 'lemma-sdk';
+
+import { getLemmaApiBaseUrl, getLemmaClient } from '@/lib/sdk/lemma-client';
+
+// ---------------------------------------------------------------------------
+// Types (kept in sync with the backend response models)
+// ---------------------------------------------------------------------------
+
+export type ExportStatus = 'QUEUED' | 'EXPORTING' | 'READY' | 'FAILED';
+export type ImportStatus =
+    | 'QUEUED'
+    | 'FETCHING'
+    | 'PLANNING'
+    | 'AWAITING_CONFIRMATION'
+    | 'APPLYING'
+    | 'COMPLETED'
+    | 'FAILED'
+    | 'CANCELLED';
+export type PublishStatus = 'QUEUED' | 'EXPORTING' | 'PUBLISHING' | 'COMPLETED' | 'FAILED';
+export type StepAction = 'CREATE' | 'UPDATE' | 'SKIP';
+export type StepStatus = 'PENDING' | 'RUNNING' | 'DONE' | 'FAILED' | 'SKIPPED';
+export type BundleSourceKind = 'URL' | 'GITHUB';
+
+export interface BundleProgress {
+    done: number;
+    total: number;
+}
+
+export interface ExportStatusResponse {
+    export_id: string;
+    status: ExportStatus;
+    progress: BundleProgress;
+    bundle_filename: string | null;
+    download_url: string | null;
+    expires_at: string | null;
+    warnings: string[];
+    error: string | null;
+}
+
+export interface PlanStep {
+    index: number;
+    kind: string;
+    name: string;
+    action: StepAction;
+    destructive: boolean;
+    detail: Record<string, unknown>;
+    status: StepStatus;
+    error: string | null;
+}
+
+export interface VariableSpec {
+    name: string;
+    kind: string;
+    description: string | null;
+    required: boolean;
+    default: string | null;
+    /** For `account`-kind variables: the connector platform, e.g. "slack". */
+    platform?: string | null;
+}
+
+export interface ImportPlan {
+    format_version: number;
+    bundle_name: string | null;
+    steps: PlanStep[];
+    variables: VariableSpec[];
+    warnings: string[];
+    has_destructive_steps: boolean;
+}
+
+export interface ImportStatusResponse {
+    import_id: string;
+    pod_id: string;
+    status: ImportStatus;
+    source_kind: string;
+    plan: ImportPlan | null;
+    progress: BundleProgress;
+    events_url: string;
+    error: string | null;
+}
+
+export interface UploadResponse {
+    url: string;
+    expires_at: string;
+}
+
+export interface PublishStatusResponse {
+    publish_id: string;
+    pod_id: string;
+    status: PublishStatus;
+    repo_name: string;
+    repo_url: string | null;
+    progress: BundleProgress;
+    events_url: string;
+    error: string | null;
+}
+
+const EXPORT_TERMINAL: ExportStatus[] = ['READY', 'FAILED'];
+const IMPORT_TERMINAL: ImportStatus[] = ['COMPLETED', 'FAILED', 'CANCELLED'];
+const PUBLISH_TERMINAL: PublishStatus[] = ['COMPLETED', 'FAILED'];
+
+function client(podId: string) {
+    return getLemmaClient(podId);
+}
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+export function startExport(
+    podId: string,
+    body: { with_data?: boolean; include?: string[] | null } = {},
+): Promise<ExportStatusResponse> {
+    return client(podId).request('POST', `/pods/${podId}/bundle/exports`, { body });
+}
+
+export function getExport(podId: string, exportId: string): Promise<ExportStatusResponse> {
+    return client(podId).request('GET', `/pods/${podId}/bundle/exports/${exportId}`);
+}
+
+// ---------------------------------------------------------------------------
+// Upload + import
+// ---------------------------------------------------------------------------
+
+export function uploadBundle(podId: string, file: File): Promise<UploadResponse> {
+    const form = new FormData();
+    form.append('data', file, file.name);
+    return client(podId).request('POST', `/pods/${podId}/bundle/uploads`, {
+        body: form,
+        isFormData: true,
+    });
+}
+
+export interface StartImportBody {
+    kind: BundleSourceKind;
+    url?: string;
+    owner?: string;
+    repo?: string;
+    ref?: string;
+    account_id?: string;
+}
+
+export function startImport(podId: string, body: StartImportBody): Promise<ImportStatusResponse> {
+    return client(podId).request('POST', `/pods/${podId}/bundle/imports`, { body });
+}
+
+export function getImport(podId: string, importId: string): Promise<ImportStatusResponse> {
+    return client(podId).request('GET', `/pods/${podId}/bundle/imports/${importId}`);
+}
+
+export function applyImport(
+    podId: string,
+    importId: string,
+    body: { variables?: Record<string, string>; confirm_destructive?: boolean },
+): Promise<ImportStatusResponse> {
+    return client(podId).request('POST', `/pods/${podId}/bundle/imports/${importId}/apply`, { body });
+}
+
+export async function cancelImport(podId: string, importId: string): Promise<void> {
+    await client(podId).request('DELETE', `/pods/${podId}/bundle/imports/${importId}`);
+}
+
+// ---------------------------------------------------------------------------
+// Publish (GitHub)
+// ---------------------------------------------------------------------------
+
+export interface StartPublishBody {
+    repo_name: string;
+    private?: boolean;
+    account_id?: string;
+    ai_readme?: boolean;
+}
+
+export function startPublish(podId: string, body: StartPublishBody): Promise<PublishStatusResponse> {
+    return client(podId).request('POST', `/pods/${podId}/bundle/publishes`, { body });
+}
+
+export function getPublish(podId: string, publishId: string): Promise<PublishStatusResponse> {
+    return client(podId).request('GET', `/pods/${podId}/bundle/publishes/${publishId}`);
+}
+
+// ---------------------------------------------------------------------------
+// Polling
+// ---------------------------------------------------------------------------
+
+interface PollOptions<T> {
+    intervalMs?: number;
+    signal?: AbortSignal;
+    onTick?: (state: T) => void;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+    return new Promise((resolve, reject) => {
+        if (signal?.aborted) {
+            reject(new DOMException('Aborted', 'AbortError'));
+            return;
+        }
+        const timer = setTimeout(() => {
+            cleanup();
+            resolve();
+        }, ms);
+        const onAbort = () => {
+            cleanup();
+            reject(new DOMException('Aborted', 'AbortError'));
+        };
+        const cleanup = () => {
+            clearTimeout(timer);
+            signal?.removeEventListener('abort', onAbort);
+        };
+        signal?.addEventListener('abort', onAbort, { once: true });
+    });
+}
+
+async function poll<T extends { status: string }>(
+    fetcher: () => Promise<T>,
+    isTerminal: (state: T) => boolean,
+    opts: PollOptions<T> = {},
+): Promise<T> {
+    const interval = opts.intervalMs ?? 1200;
+    for (;;) {
+        if (opts.signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+        const state = await fetcher();
+        opts.onTick?.(state);
+        if (isTerminal(state)) return state;
+        await sleep(interval, opts.signal);
+    }
+}
+
+export function pollExport(
+    podId: string,
+    exportId: string,
+    opts?: PollOptions<ExportStatusResponse>,
+): Promise<ExportStatusResponse> {
+    return poll(() => getExport(podId, exportId), (s) => EXPORT_TERMINAL.includes(s.status), opts);
+}
+
+export function pollImport(
+    podId: string,
+    importId: string,
+    opts?: PollOptions<ImportStatusResponse> & { until?: (s: ImportStatusResponse) => boolean },
+): Promise<ImportStatusResponse> {
+    const until = opts?.until;
+    return poll(
+        () => getImport(podId, importId),
+        (s) => (until ? until(s) : IMPORT_TERMINAL.includes(s.status)),
+        opts,
+    );
+}
+
+export function pollPublish(
+    podId: string,
+    publishId: string,
+    opts?: PollOptions<PublishStatusResponse>,
+): Promise<PublishStatusResponse> {
+    return poll(() => getPublish(podId, publishId), (s) => PUBLISH_TERMINAL.includes(s.status), opts);
+}
+
+// ---------------------------------------------------------------------------
+// Realtime (SSE) — imports and publishes stream `.../events`; exports poll.
+// ---------------------------------------------------------------------------
+
+export type BundleFrame =
+    | { type: 'snapshot'; seq: number; state: { status: string; progress?: BundleProgress } }
+    | { type: 'status'; status: string; seq: number }
+    | { type: 'step'; step: Partial<PlanStep> & { index?: number }; seq: number }
+    | { type: 'progress'; done: number; total: number; seq: number }
+    | { type: 'completed'; status: string; seq: number }
+    | { type: 'error'; message: string; seq: number }
+    | { type: 'expired' };
+
+export interface BundleProgressView {
+    status: string;
+    done: number;
+    total: number;
+}
+
+/**
+ * Open a bundle events SSE stream and dispatch each parsed frame. Owns an abort
+ * controller so the underlying fetch is cancelled on every exit — important
+ * because we stop reading at non-terminal frames (e.g. AWAITING_CONFIRMATION),
+ * where the server keeps the stream open. `readSSE` has no teardown of its own.
+ */
+export async function streamBundleEvents(
+    podId: string,
+    eventsUrl: string,
+    onFrame: (frame: BundleFrame) => void,
+    signal?: AbortSignal,
+    stopWhen?: (frame: BundleFrame) => boolean,
+): Promise<void> {
+    const controller = new AbortController();
+    const relayAbort = () => controller.abort();
+    if (signal) {
+        if (signal.aborted) controller.abort();
+        else signal.addEventListener('abort', relayAbort, { once: true });
+    }
+    try {
+        const stream = await client(podId).stream(eventsUrl, {
+            headers: { Accept: 'text/event-stream' },
+            signal: controller.signal,
+        });
+        for await (const raw of readSSE(stream)) {
+            const frame = parseSSEJson<BundleFrame>(raw);
+            if (!frame) continue;
+            onFrame(frame);
+            const stop = stopWhen
+                ? stopWhen(frame)
+                : frame.type === 'completed' || frame.type === 'error' || frame.type === 'expired';
+            if (stop) return;
+        }
+    } finally {
+        controller.abort(); // cancel the fetch/stream on any exit (stop, error, terminal)
+        signal?.removeEventListener('abort', relayAbort);
+    }
+}
+
+/**
+ * Track a bundle job to a stopping state, driving live progress from SSE and
+ * confirming the authoritative final state with a status read. Falls back to
+ * polling if the stream can't be opened or drops.
+ *
+ * `stopStatuses` are the states that end this phase (e.g. AWAITING_CONFIRMATION
+ * for a plan, COMPLETED/FAILED for an apply/publish).
+ */
+export async function trackBundleJob<T extends { status: string; progress?: BundleProgress }>(opts: {
+    podId: string;
+    eventsUrl: string;
+    fetchStatus: () => Promise<T>;
+    stopStatuses: string[];
+    onProgress?: (view: BundleProgressView) => void;
+    onFrame?: (frame: BundleFrame) => void;
+    signal?: AbortSignal;
+}): Promise<T> {
+    const { podId, eventsUrl, fetchStatus, stopStatuses, onProgress, onFrame, signal } = opts;
+    const isTerminal = (s: T) => stopStatuses.includes(s.status);
+    const view: BundleProgressView = { status: 'QUEUED', done: 0, total: 0 };
+    const emit = () => onProgress?.({ ...view });
+
+    const shouldStop = (frame: BundleFrame): boolean => {
+        if (frame.type === 'snapshot') return stopStatuses.includes(frame.state.status);
+        if (frame.type === 'status') return stopStatuses.includes(frame.status);
+        if (frame.type === 'completed') return stopStatuses.includes(frame.status);
+        return frame.type === 'error' || frame.type === 'expired';
+    };
+
+    try {
+        await streamBundleEvents(
+            podId,
+            eventsUrl,
+            (frame) => {
+                onFrame?.(frame);
+                if (frame.type === 'snapshot') {
+                    view.status = frame.state.status;
+                    view.done = frame.state.progress?.done ?? view.done;
+                    view.total = frame.state.progress?.total ?? view.total;
+                } else if (frame.type === 'status') {
+                    view.status = frame.status;
+                } else if (frame.type === 'progress') {
+                    view.done = frame.done;
+                    view.total = frame.total;
+                } else if (frame.type === 'completed') {
+                    view.status = frame.status;
+                }
+                emit();
+            },
+            signal,
+            shouldStop,
+        );
+        // Stream reached a stop frame (or closed) — read the authoritative state.
+        return await poll(fetchStatus, isTerminal, { signal });
+    } catch (error) {
+        if ((error as Error)?.name === 'AbortError') throw error;
+        // SSE unavailable — degrade to polling, still surfacing progress.
+        return poll(fetchStatus, isTerminal, {
+            signal,
+            onTick: (s) => {
+                view.status = s.status;
+                view.done = s.progress?.done ?? 0;
+                view.total = s.progress?.total ?? 0;
+                emit();
+            },
+        });
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Download
+// ---------------------------------------------------------------------------
+
+/**
+ * Trigger a browser download of a signed bundle URL. The endpoint gates on the
+ * logged-in user (cookie session), so an anchor navigation carries auth; the
+ * server sets Content-Disposition to force the download.
+ */
+export function triggerBundleDownload(downloadUrl: string, filename?: string): void {
+    const href = /^https?:\/\//i.test(downloadUrl)
+        ? downloadUrl
+        : `${getLemmaApiBaseUrl().replace(/\/$/, '')}${downloadUrl.startsWith('/') ? '' : '/'}${downloadUrl}`;
+    const anchor = document.createElement('a');
+    anchor.href = href;
+    if (filename) anchor.download = filename;
+    anchor.rel = 'noopener';
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+}
+
+// ---------------------------------------------------------------------------
+// Small shared helpers
+// ---------------------------------------------------------------------------
+
+/** github.com/owner/repo (or owner/repo) → { owner, repo }. */
+export function parseGithubRepo(input: string): { owner: string; repo: string } | null {
+    const trimmed = input.trim();
+    if (!trimmed) return null;
+    const cleaned = trimmed
+        .replace(/^https?:\/\/(www\.)?github\.com\//i, '')
+        .replace(/\.git$/i, '')
+        .replace(/\/$/, '');
+    const parts = cleaned.split('/').filter(Boolean);
+    if (parts.length < 2) return null;
+    return { owner: parts[0], repo: parts[1] };
+}
+
+/** A human name → a safe-ish repo/slug (`My Pod!` → `my-pod`). */
+export function toRepoSlug(value: string): string {
+    return (value || '')
+        .toLowerCase()
+        .replace(/[^a-z0-9._-]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 90);
+}

--- a/lemma-frontend/scripts/design-audit-baseline.json
+++ b/lemma-frontend/scripts/design-audit-baseline.json
@@ -1,6 +1,6 @@
 {
   "informational": {
-    "rawButtonElements": 25,
+    "rawButtonElements": 31,
     "rawSwitchButtonElements": 0,
     "rawFieldElements": 3,
     "inlineEditableFieldElements": 1,

--- a/lemma-typescript/public/lemma-client.js
+++ b/lemma-typescript/public/lemma-client.js
@@ -15735,6 +15735,13 @@ var LemmaClient = (() => {
     request(method, path, options) {
       return this._http.request(method, path, options);
     }
+    /**
+     * Raw streaming request — escape hatch for `text/event-stream` (SSE) endpoints
+     * not covered by a namespace. Returns the response body; pair with `readSSE`.
+     */
+    stream(path, options) {
+      return this._http.stream(path, options);
+    }
   };
 
   // src/browser.ts

--- a/lemma-typescript/src/client.ts
+++ b/lemma-typescript/src/client.ts
@@ -176,4 +176,21 @@ export class LemmaClient {
   ): Promise<T> {
     return this._http.request<T>(method, path, options);
   }
+
+  /**
+   * Raw streaming request — escape hatch for `text/event-stream` (SSE) endpoints
+   * not covered by a namespace. Returns the response body; pair with `readSSE`.
+   */
+  stream(
+    path: string,
+    options?: {
+      method?: "GET" | "POST" | "PATCH";
+      params?: Record<string, string | number | boolean | undefined | null>;
+      body?: unknown;
+      headers?: HeadersInit;
+      signal?: AbortSignal;
+    },
+  ): Promise<ReadableStream<Uint8Array>> {
+    return this._http.stream(path, options);
+  }
 }


### PR DESCRIPTION
## What

Native frontend for the **share → import → remix** loop, built on the merged pod-bundle backend (#74). A pod can be exported as a bundle, published to GitHub with an install badge, and imported into a workspace — turning export/import into the product's growth flywheel.

```
make → SHARE → land → import → "it's yours" → share → …
```

## What & where

**Share** (outbound / growth CTA)
- **Sidebar header** — a Share icon button in the pod identity zone (a pod-level action, not a nav row).
- **`ShareSheet`** — download `.zip` (with-data toggle) + publish to GitHub (repo name, private, AI README), with live progress.

**Import** (inbound)
- **New menu → "Install a bundle"** — install into the current pod.
- **Home → "Import a pod"** — create a new pod from a bundle (workspace level).
- **`/import/github/[owner]/[repo]`** — global landing the published-repo badge deep-links to; offers *create a new pod* vs *install into an existing pod*, then launches the wizard with the GitHub source preset. Matches the backend badge target exactly.
- **`ImportDialog`** — full-screen wizard: source (upload / GitHub) → plan review (CREATE/UPDATE/SKIP, destructive confirm, `${var}` config) → apply with live steps → **"it's yours"** takeover (open app · activate surface · share · customize — share re-enters the loop).

**Settings → "Share & bundles"**
- The deep home for export/publish/install, plus **provenance**: renders `pod.config.recipes` ("imported from github.com/owner/repo" / uploaded bundle) — the only place a pod's bundle origin is shown.

**Connector accounts** — `account`-kind plan variables (e.g. a Slack/Telegram surface) render a picker: choose an existing connected account or **connect inline** (OAuth popup for OAuth apps, an in-place credential form for token apps), then the new account auto-selects. No bouncing to a separate connectors tab.

## How it works

- **Progress is SSE-driven** (`trackBundleJob` → `readSSE` over a new `LemmaClient.stream()`), with polling as a fallback and to read the authoritative terminal state. Exports poll (that endpoint has no `/events`).
- **Create-new-from-bundle** is frontend orchestration: create an empty pod, then import into it (the backend import API is pod-scoped). A throwaway pod from a failed import is best-effort cleaned up.

## Commits

1. `feat(sdk)` — add `LemmaClient.stream()` for SSE endpoints
2. `feat(bundle)` — share/export sheet + import wizard (data layer + UI)
3. `feat(bundle)` — GitHub import landing route + settings panel
4. `feat(bundle)` — sidebar & home entry points

## Testing

- **Exercised live in the browser against a running backend** — the GitHub landing round-trip, the connect-account inline flow, and SSE progress on real publish/import were verified. Several fixes came directly out of that testing: the headless `Switch` rendering, inline connect (vs. opening a new tab), progress display, and the account picker.
- `npm run typecheck` — clean; `eslint` — clean on all touched files.
- The design-audit strict gate fails identically on a clean `main` (pre-existing baseline drift); these changes add only informational items.

## Deferred (intentional follow-ups)

- Logged-out **sign-up-in-the-loop** on the landing (today `ProtectedRoute` just redirects to login) — the biggest lever for acquisition-inside-the-loop.
- `/import/p/[id]` shared-pod link route, and the gallery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
