### PR TITLE
feat(pod): app tabs in the workspace header + pod home cleanup

### DIFF
--- a/lemma-frontend/app/pod/[id]/layout.tsx
+++ b/lemma-frontend/app/pod/[id]/layout.tsx
@@ -8,7 +8,8 @@ import { AIAssistantProvider, useAIAssistant } from "@/components/ai/ai-assistan
 import { HelpMenu } from "@/components/education/help-menu";
 import { PodAssistantSidebar } from "@/components/ai/pod-assistant";
 import { InlineLoader, PageLoader } from "@/components/brand/loader";
-import { AppProvider } from "@/components/app/app-context";
+import { AppProvider, useApp } from "@/components/app/app-context";
+import { PodAppTabs } from "@/components/pod/pod-app-tabs";
 import { useOrganization } from "@/components/dashboard/org-context";
 import { PodTopbarProvider, type PodTopbarState } from "@/components/pod/pod-topbar-context";
 import { MobileSidebarDrawer } from "@/components/pod/mobile-sidebar-drawer";
@@ -280,6 +281,7 @@ function PodShell({
         assistantDockWidth,
         setAssistantDockWidth,
     } = usePodLayout();
+    const { pages: appPages } = useApp();
     const [topbar, setTopbar] = useState<PodTopbarState>({});
     const [previousScreen, setPreviousScreen] = useState<PodHistoryScreen | null>(null);
     const [isPresentedClosing, setIsPresentedClosing] = useState(false);
@@ -318,6 +320,18 @@ function PodShell({
         !pathname.includes("/runs/") &&
         searchParams.get("mode") === "edit";
     const isPodHome = pathname === `/pod/${pod.id}` || pathname === `/pod/${pod.id}/`;
+    const isAppViewRoute = pathname.startsWith(`/pod/${pod.id}/app/view`);
+    // Show the workspace tab strip (Home + app tabs) on home and while viewing an
+    // app, but only once the pod actually has apps — a pod with none keeps the
+    // clean, header-less home canvas.
+    const showAppTabsBar = (isPodHome || isAppViewRoute) && appPages.length > 0;
+    // A stable key for the "which app-workspace view is this" decision below:
+    // changes when you switch apps, land on home, or leave for another section.
+    const appNavIntent = isAppViewRoute
+        ? `app:${searchParams.get("page") || ""}`
+        : isPodHome
+            ? "home"
+            : "other";
     const isConversationRoute = pathname === `/pod/${pod.id}/conversations` || pathname.startsWith(`/pod/${pod.id}/conversations/`);
     const isPresentedInteractionRoute =
         pathname === `/pod/${pod.id}/forms/view` || pathname === `/pod/${pod.id}/widgets/view`;
@@ -373,6 +387,20 @@ function PodShell({
     useEffect(() => {
         writeLastOpenedPodId(pod.id);
     }, [pod.id]);
+
+    // Selecting an app collapses the workspace nav so the app gets the full
+    // surface; landing back on home restores it. Desktop only — compact viewports
+    // use an off-canvas drawer this must not fight. Keyed on the view intent so it
+    // fires on genuine transitions (and app→app switches), leaving a user's manual
+    // toggle within the same view untouched.
+    useEffect(() => {
+        if (isCompact) return;
+        if (appNavIntent.startsWith("app:")) {
+            closeNav();
+        } else if (appNavIntent === "home") {
+            openNav();
+        }
+    }, [appNavIntent, isCompact, closeNav, openNav]);
 
     useLayoutEffect(() => {
         const nextScreen = { href: currentHref, label: currentScreenLabel };
@@ -516,7 +544,7 @@ function PodShell({
                     />
                 </div>
             </MobileSidebarDrawer>
-            {isPodHome && isCompact ? (
+            {isPodHome && isCompact && !showAppTabsBar ? (
                 <button
                     type="button"
                     onClick={() => setMobileNavOpen(true)}
@@ -564,7 +592,43 @@ function PodShell({
             ) : null}
 
             <main className="pod-workspace-main flex min-w-0 flex-1 flex-col overflow-hidden">
-                {!isPodHome && !isConversationRoute ? (
+                {showAppTabsBar ? (
+                    <header className="pod-shell-topbar flex h-14 shrink-0 items-center justify-between gap-4 bg-[var(--pod-main-bg)] px-4">
+                        <div className="flex h-7 min-w-0 flex-1 items-center gap-2">
+                            {showMobileNavTrigger ? (
+                                <button
+                                    type="button"
+                                    onClick={toggleNav}
+                                    className="lemma-shell-icon-button custom-focus-ring h-7 w-7 shrink-0 text-[var(--text-tertiary)]"
+                                    aria-label="Open navigation"
+                                    title="Open navigation"
+                                >
+                                    <PanelLeftOpen className="h-4 w-4" strokeWidth={1.8} />
+                                </button>
+                            ) : null}
+                            <PodAppTabs podId={pod.id} />
+                        </div>
+                        <div className="pod-shell-topbar-actions flex h-7 shrink-0 items-center gap-1.5">
+                            <TooltipProvider>
+                                <HelpMenu />
+                                {canUseSettings ? (
+                                    <Tooltip>
+                                        <TooltipTrigger asChild>
+                                            <Link
+                                                href={`/pod/${pod.id}/settings`}
+                                                className="lemma-shell-icon-button custom-focus-ring"
+                                                aria-label="Pod settings"
+                                            >
+                                                <Settings className="h-4 w-4" strokeWidth={1.8} />
+                                            </Link>
+                                        </TooltipTrigger>
+                                        <TooltipContent>Pod settings</TooltipContent>
+                                    </Tooltip>
+                                ) : null}
+                            </TooltipProvider>
+                        </div>
+                    </header>
+                ) : !isPodHome && !isConversationRoute ? (
                     <header
                         className={cn(
                             "pod-shell-topbar flex h-14 shrink-0 items-center justify-between gap-4 bg-[var(--pod-main-bg)] px-4",

--- a/lemma-frontend/app/pod/[id]/page.tsx
+++ b/lemma-frontend/app/pod/[id]/page.tsx
@@ -4,18 +4,15 @@ import { use, useEffect, useMemo, useRef, useState, type CSSProperties } from 'r
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { ArrowRight, ArrowUp, ExternalLink, Loader2, MessageCircle, Plus, UserPlus, X } from 'lucide-react';
+import { ArrowRight, ArrowUp, Loader2, MessageCircle, Plus, UserPlus, X } from 'lucide-react';
 
 import { useAIAssistant } from '@/components/ai/ai-assistant-context';
 import { StepLoader } from '@/components/brand/loader';
 import { ProtectedRoute } from '@/components/auth/protected-route';
 import { FirstWinChecklist } from '@/components/education/first-win-checklist';
-import { ResourceIcon } from '@/components/shared/resource-icon';
-import { ProductIcon } from '@/components/pod/product-icon';
 import { resolveDefaultAgentRuntime } from '@/components/agents/agent-runtime-helpers';
 import { RuntimeModelPicker } from '@/components/lemma/assistant/model-picker';
 import { RecipeFeatureCard } from '@/components/recipes/recipe-card';
-import { useAppPages } from '@/lib/hooks/use-app';
 import { featuredRecipes } from '@/lib/recipes/recipes';
 import { useLaunchRecipe } from '@/lib/recipes/use-launch-recipe';
 import { useAgents } from '@/lib/hooks/use-agents';
@@ -26,7 +23,6 @@ import {
     useFlows,
     useWorkflowRunSnapshots,
 } from '@/lib/hooks/use-flows';
-import { getAppAccent } from '@/lib/app/app-accent';
 import { usePod } from '@/lib/hooks/use-pods';
 import { usePodAccess } from '@/lib/hooks/use-pod-access';
 import { usePodJoinRequests } from '@/lib/hooks/use-pod-join-requests';
@@ -519,7 +515,6 @@ function PodAgentWorkflowKanban({ podId }: { podId: string }) {
             ) : null}
             <div className="mt-10 w-full space-y-5">
                 <PodJoinRequestsHomePanel podId={podId} />
-                <PodAppsHomePanel podId={podId} />
                 <PodSurfacesHomePanel podId={podId} />
             {isLoading || hasKanbanItems ? (
                 <section className="pod-home-work-section">
@@ -581,82 +576,6 @@ function PodAgentWorkflowKanban({ podId }: { podId: string }) {
     );
 }
 
-function formatAppTitle(value: string | null | undefined) {
-    const cleaned = (value || '').replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
-    if (!cleaned) return 'Untitled';
-    return cleaned.split(' ').map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(' ');
-}
-
-function formatAppUrl(value: string | null | undefined) {
-    if (!value) return '';
-    return value.replace(/^https?:\/\//, '').replace(/\/$/, '');
-}
-
-function PodAppsHomePanel({ podId }: { podId: string }) {
-    const { pages, isLoading } = useAppPages(podId);
-
-    if (isLoading || pages.length === 0) return null;
-
-    const featured = pages.slice(0, 6);
-
-    return (
-        <section className="w-full">
-            <div className="flex items-center justify-between gap-4">
-                <h2 className="text-base font-medium text-[var(--text-primary)]">Your apps</h2>
-                <Link
-                    href={`/pod/${podId}/app/pages`}
-                    className="custom-focus-ring group/all inline-flex shrink-0 items-center gap-1.5 text-sm font-medium text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-primary)]"
-                >
-                    All apps
-                    <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover/all:translate-x-0.5" />
-                </Link>
-            </div>
-
-            <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-                {featured.map((page) => {
-                    const title = formatAppTitle(page.title || page.slug);
-                    const viewHref = `/pod/${podId}/app/view?page=${encodeURIComponent(page.slug)}`;
-                    const accent = getAppAccent(page.slug);
-
-                    return (
-                        <article key={page.slug} data-accent={accent} className="resource-index-card app-tile group">
-                            <div className="flex items-center gap-3">
-                                <Link href={viewHref} aria-label={`Open ${title}`} className="shrink-0">
-                                    <span className="app-icon flex h-10 w-10 items-center justify-center rounded-xl text-sm font-medium">
-                                        {page.icon || title.charAt(0)}
-                                    </span>
-                                </Link>
-                                <div className="min-w-0 flex-1">
-                                    <Link href={viewHref} className="block truncate text-sm font-medium text-[var(--text-primary)]">
-                                        {title}
-                                    </Link>
-                                    {page.url ? (
-                                        <p className="mt-0.5 truncate font-mono text-xs text-[var(--text-tertiary)]">
-                                            {formatAppUrl(page.url)}
-                                        </p>
-                                    ) : null}
-                                </div>
-                                {page.url ? (
-                                    <a
-                                        href={page.url}
-                                        target="_blank"
-                                        rel="noreferrer"
-                                        aria-label="Open live app"
-                                        title="Open live app"
-                                        className="lemma-quiet-icon-button custom-focus-ring text-[var(--text-tertiary)]"
-                                    >
-                                        <ExternalLink className="h-3.5 w-3.5" />
-                                    </a>
-                                ) : null}
-                            </div>
-                        </article>
-                    );
-                })}
-            </div>
-        </section>
-    );
-}
-
 const SURFACE_META: Record<string, { label: string; logo: string }> = {
     SLACK: { label: 'Slack', logo: '/surfaces/slack.png' },
     TEAMS: { label: 'Teams', logo: '/surfaces/teams.png' },
@@ -700,23 +619,28 @@ function PodSurfacesHomePanel({ podId }: { podId: string }) {
     if (surfaces.length === 0) {
         return (
             <section className="w-full">
-                <h2 className="text-base font-medium text-[var(--text-primary)]">Reachable at</h2>
-                <div className="mt-3 flex items-start gap-4 surface-panel-dashed px-5 py-5">
-                    <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--delight-soft)] text-[var(--delight)]">
-                        <MessageCircle className="h-5 w-5" strokeWidth={1.8} />
+                <h2 className="text-base font-normal text-[var(--text-secondary)]">Surfaces</h2>
+                <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-2">
+                    <span className="flex items-center gap-1.5">
+                        {(['SLACK', 'GMAIL', 'TELEGRAM'] as const).map((key) => (
+                            <span
+                                key={key}
+                                className="flex h-7 w-7 items-center justify-center rounded-md border border-[color:color-mix(in_srgb,var(--border-subtle)_50%,transparent)] bg-[var(--surface-2)]"
+                            >
+                                <Image src={SURFACE_META[key].logo} alt={SURFACE_META[key].label} width={16} height={16} className="object-contain" />
+                            </span>
+                        ))}
                     </span>
-                    <div className="min-w-0 flex-1">
-                        <p className="text-sm font-medium text-[var(--text-primary)]">Let work reach this pod</p>
-                        <p className="mt-1 max-w-xl text-sm leading-6 text-[var(--text-secondary)]">
-                            Connect Slack, Gmail, Telegram and more — the pod picks up messages and an agent replies where your team already works.
-                        </p>
+                    <p className="text-sm leading-6 text-[var(--text-secondary)]">
+                        No surfaces yet —{' '}
                         <Link
                             href={surfacesHref}
-                            className="custom-focus-ring mt-3 inline-flex h-9 items-center justify-center gap-2 rounded-md border border-[color:var(--button-secondary-border)] bg-[var(--button-secondary-bg)] px-3 text-sm font-medium text-[var(--button-secondary-fg)] transition-colors hover:border-[var(--field-border-hover)] hover:bg-[var(--button-secondary-bg-hover)]"
+                            className="custom-focus-ring font-medium text-[var(--text-primary)] underline-offset-2 hover:underline"
                         >
-                            Connect a channel
-                        </Link>
-                    </div>
+                            connect one
+                        </Link>{' '}
+                        so this pod can answer messages.
+                    </p>
                 </div>
             </section>
         );
@@ -728,55 +652,56 @@ function PodSurfacesHomePanel({ podId }: { podId: string }) {
 
     return (
         <section className="w-full">
-            <div className="flex items-center justify-between gap-4">
-                <h2 className="text-base font-medium text-[var(--text-primary)]">Reachable at</h2>
+            <div className="flex items-center justify-between gap-3">
+                <h2 className="text-base font-normal text-[var(--text-secondary)]">Surfaces</h2>
                 <Link
                     href={surfacesHref}
-                    className="custom-focus-ring group/all inline-flex shrink-0 items-center gap-1.5 text-sm font-medium text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-primary)]"
+                    className="custom-focus-ring shrink-0 text-sm font-medium text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-primary)]"
                 >
-                    All channels
-                    <ArrowRight className="h-3.5 w-3.5 transition-transform group-hover/all:translate-x-0.5" />
+                    Manage
                 </Link>
             </div>
-            <div className="mt-3 overflow-hidden surface-panel surface-panel-quiet">
+            <ul className="mt-2 flex flex-col gap-0.5">
                 {sorted.map((surface) => {
                     const platform = String(surface.platform || '').toUpperCase();
-                    const meta = SURFACE_META[platform] || { label: formatDisplayName(platform), logo: '' };
+                    const meta = SURFACE_META[platform];
+                    const label = meta?.label || formatDisplayName(platform);
                     const status = surfaceStatusView(surface.status);
                     const tone = SURFACE_STATUS_TONE[status.tone];
                     const address = surfaceAddress(surface);
                     const responder = surface.agent_name?.trim() || 'Pod default';
 
                     return (
-                        <Link
-                            key={surface.id}
-                            href={surfacesHref}
-                            className="group flex items-center gap-3 border-b border-[color:color-mix(in_srgb,var(--border-subtle)_55%,transparent)] px-4 py-3 transition-colors last:border-b-0 hover:bg-[var(--surface-2)]"
-                        >
-                            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[var(--surface-2)]">
-                                {meta.logo ? (
-                                    <Image src={meta.logo} alt="" width={18} height={18} className="object-contain" />
-                                ) : (
-                                    <MessageCircle className="h-4 w-4 text-[var(--text-secondary)]" />
-                                )}
-                            </span>
-                            <div className="min-w-0 flex-1">
-                                <p className="truncate text-sm text-[var(--text-primary)]">
-                                    <span className="font-medium">{meta.label}</span>
-                                    {address ? <span className="text-[var(--text-tertiary)]"> · {address}</span> : null}
-                                </p>
-                                <p className="mt-0.5 truncate text-xs text-[var(--text-secondary)]">
-                                    {responder} answers
-                                </p>
-                            </div>
-                            <span className={cn('inline-flex shrink-0 items-center gap-1.5 text-xs', tone.text)}>
-                                <span className={cn('h-1.5 w-1.5 rounded-full', tone.dot)} />
-                                {status.label}
-                            </span>
-                        </Link>
+                        <li key={surface.id}>
+                            <Link
+                                href={surfacesHref}
+                                className="group flex items-center gap-3 rounded-lg px-2 py-2 transition-colors hover:bg-[color:color-mix(in_srgb,var(--surface-2)_55%,transparent)]"
+                            >
+                                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-[color:color-mix(in_srgb,var(--border-subtle)_50%,transparent)] bg-[var(--surface-2)]">
+                                    {meta?.logo ? (
+                                        <Image src={meta.logo} alt="" width={16} height={16} className="object-contain" />
+                                    ) : (
+                                        <MessageCircle className="h-4 w-4 text-[var(--text-secondary)]" />
+                                    )}
+                                </span>
+                                <div className="min-w-0 flex-1">
+                                    <p className="truncate text-sm text-[var(--text-primary)]">
+                                        <span className="font-normal">{label}</span>
+                                        {address ? <span className="text-[var(--text-tertiary)]"> · {address}</span> : null}
+                                    </p>
+                                    <p className="truncate text-xs text-[var(--text-secondary)]">
+                                        {responder} answers
+                                    </p>
+                                </div>
+                                <span className={cn('inline-flex shrink-0 items-center gap-1.5 text-xs', tone.text)}>
+                                    <span className={cn('h-1.5 w-1.5 rounded-full', tone.dot)} />
+                                    {status.label}
+                                </span>
+                            </Link>
+                        </li>
                     );
                 })}
-            </div>
+            </ul>
         </section>
     );
 }
@@ -788,7 +713,7 @@ function PodRecipesHomePanel({ podId }: { podId: string }) {
     if (featured.length === 0) return null;
 
     return (
-        <section className="w-full py-4">
+        <section className="w-full">
             <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
                 <div className="max-w-2xl">
                     <p className="type-eyebrow-mono">
@@ -828,44 +753,23 @@ function KanbanCard({ item }: { item: KanbanItem }) {
     return (
         <Link
             href={item.href}
-            className={cn(
-                'pod-home-work-card group block rounded-md px-2 py-3 transition-gentle'
-            )}
+            className="group flex items-center gap-2.5 rounded-md px-2 py-1.5 transition-colors hover:bg-[color:color-mix(in_srgb,var(--surface-2)_50%,transparent)]"
         >
-            <div className="pod-home-work-card-content">
-                <span className="pod-home-work-row-icon">
-                    <ResourceIcon
-                        iconUrl={item.kind === 'agent' ? item.iconUrl : null}
-                        alt={`${item.title} icon`}
-                        label={item.title}
-                        fallback={<ProductIcon tone={item.kind === 'agent' ? 'agents' : 'workflows'} size="sm" />}
-                        className="pod-home-work-resource-icon"
-                        imageClassName="object-contain p-1"
-                    />
-                </span>
-                <div className="min-w-0">
-                    <div className="pod-home-work-card-title block truncate text-sm font-normal leading-snug text-[var(--text-primary)]">
-                        {item.title}
-                    </div>
-                    <div className="pod-home-work-card-detail mt-0.5 block truncate text-xs leading-5 text-[var(--text-tertiary)]">
-                        {item.detail}
-                    </div>
-                </div>
-                <ArrowRight className="mt-1 h-4 w-4 shrink-0 text-[var(--text-tertiary)] transition-transform group-hover:translate-x-0.5 group-hover:text-[var(--text-primary)]" />
-            </div>
-            <StatusMarker status={item.status} tone={item.statusTone} />
+            <span
+                className={cn(
+                    'h-1.5 w-1.5 shrink-0 rounded-full',
+                    item.statusTone === 'live' && 'animate-pulse',
+                    kanbanDotClass(item.statusTone),
+                )}
+                aria-hidden="true"
+            />
+            <span className="min-w-0 flex-1 truncate text-sm text-[var(--text-primary)]">
+                {item.title}
+            </span>
+            <span className="max-w-[55%] shrink-0 truncate text-xs text-[var(--text-tertiary)]">
+                {item.detail}
+            </span>
         </Link>
-    );
-}
-
-function StatusMarker({ status, tone }: { status: string; tone: KanbanItem['statusTone'] }) {
-    if (tone !== 'live') return null;
-
-    return (
-        <span className={cn('pod-home-work-status', getStatusToneClass(tone))}>
-            <span className="h-1.5 w-1.5 rounded-full bg-current" />
-            {status}
-        </span>
     );
 }
 
@@ -920,12 +824,12 @@ function formatRelativeTime(value: string | null | undefined) {
     return `${diffDays}d ago`;
 }
 
-function getStatusToneClass(tone: KanbanItem['statusTone']) {
-    if (tone === 'danger') return 'text-[var(--state-error)]';
-    if (tone === 'warning') return 'text-[var(--delight)]';
-    if (tone === 'success') return 'text-[var(--state-success)]';
-    if (tone === 'live') return 'text-[var(--state-info)]';
-    return 'text-[var(--text-tertiary)]';
+function kanbanDotClass(tone: KanbanItem['statusTone']) {
+    if (tone === 'danger') return 'bg-[var(--state-error)]';
+    if (tone === 'warning') return 'bg-[var(--delight)]';
+    if (tone === 'success') return 'bg-[var(--state-success)]';
+    if (tone === 'live') return 'bg-[var(--state-info)]';
+    return 'bg-[var(--text-tertiary)]';
 }
 
 function formatDisplayName(value: string | null | undefined) {

--- a/lemma-frontend/components/pod/pod-app-tabs.tsx
+++ b/lemma-frontend/components/pod/pod-app-tabs.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { ExternalLink, Home } from 'lucide-react';
+import { useApp } from '@/components/app/app-context';
+import { getAppAccent } from '@/lib/app/app-accent';
+
+function formatAppTitle(value: string | null | undefined) {
+    const cleaned = (value || '').replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
+    if (!cleaned) return 'Untitled';
+    return cleaned
+        .split(' ')
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
+}
+
+// Pod workspace tab strip: "Home" is the leftmost anchor (always a way back to
+// the blank-canvas home), a divider sets it off from the app set, and each app
+// page is a peer tab. Tabs carry the same accent chip (emoji or initial,
+// `.app-icon` colored by `getAppAccent`) the home app cards use, kept small so
+// the strip stays light. Inactive tabs are muted and lift on hover; the selected
+// tab fills into a pill and reveals an "open in new tab" shortcut to its live URL.
+export function PodAppTabs({ podId }: { podId: string }) {
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+    const { pages } = useApp();
+
+    if (pages.length === 0) return null;
+
+    const isHomeActive = pathname === `/pod/${podId}` || pathname === `/pod/${podId}/`;
+    const activeSlug = pathname.startsWith(`/pod/${podId}/app/view`)
+        ? searchParams.get('page')
+        : null;
+
+    return (
+        <nav className="no-scrollbar flex min-w-0 flex-nowrap items-center gap-0.5 overflow-x-auto" aria-label="Pod apps">
+            <Link
+                href={`/pod/${podId}`}
+                data-state={isHomeActive ? 'active' : undefined}
+                aria-current={isHomeActive ? 'page' : undefined}
+                className="inline-flex h-8 shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-2 text-sm text-[var(--text-secondary)] transition-colors hover:bg-[color:color-mix(in_srgb,var(--surface-2)_60%,transparent)] hover:text-[var(--text-primary)] data-[state=active]:bg-[var(--surface-2)] data-[state=active]:font-medium data-[state=active]:text-[var(--text-primary)]"
+            >
+                <Home className="h-3.5 w-3.5 shrink-0" strokeWidth={1.8} />
+                Home
+            </Link>
+
+            <span className="mx-1 h-5 w-px shrink-0 bg-[var(--border-subtle)]" aria-hidden="true" />
+
+            {pages.map((page) => {
+                const title = formatAppTitle(page.title || page.slug);
+                const active = activeSlug === page.slug;
+                const accent = getAppAccent(page.slug);
+                const viewHref = `/pod/${podId}/app/view?page=${encodeURIComponent(page.slug)}`;
+
+                return (
+                    <div
+                        key={page.slug}
+                        data-state={active ? 'active' : undefined}
+                        className="group inline-flex h-8 shrink-0 items-center rounded-md transition-colors hover:bg-[color:color-mix(in_srgb,var(--surface-2)_60%,transparent)] data-[state=active]:bg-[var(--surface-2)]"
+                    >
+                        <Link
+                            href={viewHref}
+                            aria-current={active ? 'page' : undefined}
+                            title={title}
+                            className="inline-flex h-8 min-w-0 cursor-pointer items-center gap-1.5 rounded-md pl-1.5 pr-2 text-sm text-[var(--text-secondary)] transition-colors group-hover:text-[var(--text-primary)] group-data-[state=active]:font-medium group-data-[state=active]:text-[var(--text-primary)]"
+                        >
+                            <span
+                                data-accent={accent}
+                                className="app-tile app-icon flex h-5 w-5 shrink-0 items-center justify-center rounded-md text-xs font-medium leading-none"
+                            >
+                                {page.icon || title.charAt(0)}
+                            </span>
+                            <span className="max-w-[10rem] truncate">{title}</span>
+                        </Link>
+                        {active && page.url ? (
+                            <a
+                                href={page.url}
+                                target="_blank"
+                                rel="noreferrer"
+                                aria-label={`Open ${title} in new tab`}
+                                title="Open in new tab"
+                                className="mr-1 inline-flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-primary)]"
+                            >
+                                <ExternalLink className="h-3.5 w-3.5" />
+                            </a>
+                        ) : null}
+                    </div>
+                );
+            })}
+        </nav>
+    );
+}

--- a/lemma-frontend/components/pod/workspace-sidebar.tsx
+++ b/lemma-frontend/components/pod/workspace-sidebar.tsx
@@ -979,34 +979,36 @@ function PodSwitcherMenu({
                 align="start"
                 side={side}
                 sideOffset={8}
-                className="surface-panel z-50 w-72 p-1 shadow-[var(--shadow-lg)]"
+                className="surface-panel z-50 flex w-72 flex-col p-1 shadow-[var(--shadow-lg)]"
             >
-                <div className="px-2 py-1.5 type-eyebrow">
+                <div className="shrink-0 px-2 py-1.5 type-eyebrow">
                     Pods
                 </div>
-                {pods.length === 0 ? (
-                    <div className="px-2 py-2 text-sm text-[var(--text-tertiary)]">No pods yet.</div>
-                ) : null}
-                {showOrganizationLabels ? (
-                    podGroups.map((group) => group.pods.length > 0 ? (
-                        <div key={group.organization.id}>
-                            <div className="px-2 pt-2 pb-1 text-xs font-medium uppercase tracking-normal text-[var(--text-tertiary)]">
-                                {group.organization.name}
+                <div className="min-h-0 max-h-96 overflow-y-auto">
+                    {pods.length === 0 ? (
+                        <div className="px-2 py-2 text-sm text-[var(--text-tertiary)]">No pods yet.</div>
+                    ) : null}
+                    {showOrganizationLabels ? (
+                        podGroups.map((group) => group.pods.length > 0 ? (
+                            <div key={group.organization.id}>
+                                <div className="px-2 pt-2 pb-1 text-xs font-medium uppercase tracking-normal text-[var(--text-tertiary)]">
+                                    {group.organization.name}
+                                </div>
+                                {group.pods.map((pod) => (
+                                    <PodSwitcherMenuItem key={pod.id} pod={pod} podId={podId} />
+                                ))}
                             </div>
-                            {group.pods.map((pod) => (
-                                <PodSwitcherMenuItem key={pod.id} pod={pod} podId={podId} />
-                            ))}
-                        </div>
-                    ) : null)
-                ) : (
-                    pods.map((pod) => (
-                        <PodSwitcherMenuItem key={pod.id} pod={pod} podId={podId} />
-                    ))
-                )}
-                <DropdownMenu.Separator className="my-1 h-px bg-[var(--border-subtle)]" />
+                        ) : null)
+                    ) : (
+                        pods.map((pod) => (
+                            <PodSwitcherMenuItem key={pod.id} pod={pod} podId={podId} />
+                        ))
+                    )}
+                </div>
+                <DropdownMenu.Separator className="my-1 h-px shrink-0 bg-[var(--border-subtle)]" />
                 <DropdownMenu.Item
                     onSelect={() => router.push('/create-pod')}
-                    className="flex cursor-pointer items-center gap-2 rounded-lg px-2 py-2 text-sm font-medium text-[var(--delight)] outline-none transition-colors hover:bg-[var(--delight-soft)]"
+                    className="flex shrink-0 cursor-pointer items-center gap-2 rounded-lg px-2 py-2 text-sm font-medium text-[var(--delight)] outline-none transition-colors hover:bg-[var(--delight-soft)]"
                 >
                     <Plus className="h-3.5 w-3.5" />
                     New pod

--- a/lemma-frontend/styles/features/pod-home.css
+++ b/lemma-frontend/styles/features/pod-home.css
@@ -111,7 +111,7 @@
 }
 
 .pod-home-work-section {
-  padding-top: var(--space-8);
+  padding-top: var(--space-4);
   border-top: 0 !important;
   box-shadow: none !important;
 }
@@ -131,9 +131,9 @@
 }
 
 .pod-home-work-title {
-  color: var(--text-primary);
+  color: var(--text-secondary);
   font-size: 1rem;
-  font-weight: 500;
+  font-weight: 400;
   line-height: 1.4;
   letter-spacing: 0;
 }
@@ -180,7 +180,7 @@
 .pod-home-work-section-label {
   font-family: var(--font-mono-family);
   font-size: 0.656rem;
-  font-weight: 600;
+  font-weight: 500;
   letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--text-tertiary);

--- a/lemma-frontend/styles/primitives.css
+++ b/lemma-frontend/styles/primitives.css
@@ -1544,4 +1544,13 @@
    UTILITY LAYER
    ──────────────────────────────────────────── */
 
+  /* Hide scrollbar chrome while keeping the element scrollable — used by
+     horizontally scrolling strips like the pod app tabs. */
+  .no-scrollbar {
+    scrollbar-width: none;
+  }
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+
 }


### PR DESCRIPTION
## Summary

Adds an app tab strip to the pod workspace header and cleans up the pod home around it.

- **App tabs** — `Home` + one tab per app page in the shell header, shown on the pod home and app-view routes once the pod has apps. Tabs reuse the app-card accent chips; the active tab fills into a pill and reveals an open-in-new-tab shortcut to the app's live URL. Selecting an app auto-collapses the workspace nav on desktop for room; landing on home restores it.
- **Pod home cleanup** — removed the now-redundant "Your apps" cards (apps live in the tabs); reworked the surfaces panel into a light **Surfaces** list (platform logos, status dots, answering agent); collapsed activity items to single lines with status dots instead of avatar icons; lightened header weights/colors and tightened spacing for a calmer column.
- **Pod switcher fix** — bounded the switcher menu height (`max-h-96` + scroll) so long / multi-org pod lists no longer run to full viewport height; pinned the "Pods" header and "New pod" action.

Also adds a small `.no-scrollbar` utility used by the tab strip.

## Testing

Verified locally by the author on the running dev server (hot reload): tab switching, active + open-in-new-tab states, sidebar auto-collapse on an app / auto-expand on home, switcher scrolling with a long list, and both the connected and empty states of the reworked Surfaces panel.

## Notes

Branch was cut just before #83 (bundle share/import UI) merged to `main`. The only overlapping file is `workspace-sidebar.tsx`, in a non-overlapping region, so this merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
