### PR TITLE
feat(pod): keep app iframes alive across tab switches

### DIFF
--- a/lemma-frontend/app/pod/[id]/app/view/page.tsx
+++ b/lemma-frontend/app/pod/[id]/app/view/page.tsx
@@ -1,80 +1,16 @@
 'use client';
 
-import { use } from 'react';
-import { useSearchParams } from 'next/navigation';
-import { PanelsTopLeft } from 'lucide-react';
-import { useAppPage } from '@/lib/hooks/use-app';
-import { resourceAllows } from '@/lib/authz/resource-actions';
-import { usePodAccess } from '@/lib/hooks/use-pod-access';
-import { RecoveryState } from '@/components/shared/empty-state';
-import { AppFrame } from '@/components/app/app-launch';
 import { ProtectedRoute } from '@/components/auth/protected-route';
-import { StepLoader } from '@/components/brand/loader';
 
-export default function AppViewPage({ params }: { params: Promise<{ id: string }> }) {
-    const { id: podId } = use(params);
-    const searchParams = useSearchParams();
-    const requestedPageSlug = searchParams.get('page');
-    const podAccess = usePodAccess(podId);
-
-    const { data: page, isLoading } = useAppPage(podId, requestedPageSlug, null, { mode: 'view' });
-
-    if (!requestedPageSlug) {
-        return (
-            <ProtectedRoute>
-                <div className="h-full flex items-center justify-center">
-                    <RecoveryState
-                        icon={<PanelsTopLeft className="h-5 w-5" />}
-                        title="Missing app page"
-                        description="Open an app from the Apps list so Lemma knows which workspace to show."
-                    />
-                </div>
-            </ProtectedRoute>
-        );
-    }
-
-    if (isLoading) {
-        return (
-            <div className="h-full flex items-center justify-center">
-                <StepLoader size="sm" />
-            </div>
-        );
-    }
-
-    if (!page) {
-        return (
-            <div className="h-full flex items-center justify-center">
-                <RecoveryState
-                    icon={<PanelsTopLeft className="h-5 w-5" />}
-                    title="App unavailable"
-                    description="The selected app could not be loaded. Try opening it again from the Apps list."
-                />
-            </div>
-        );
-    }
-
+// The live app iframe is owned by the pod shell's keep-alive AppFrameHost, which
+// is mounted above the router so it survives tab switches. This route only
+// anchors the URL (?page=slug); the host reads the active slug from it and shows
+// the matching (already-running) iframe. Keeping this a thin placeholder avoids
+// mounting a second iframe that would cold-boot the app on every navigation.
+export default function AppViewPage() {
     return (
         <ProtectedRoute>
-            <div className="h-full w-full overflow-hidden">
-                {page.url ? (
-                    <AppFrame
-                        podId={podId}
-                        appId={page.id}
-                        appName={page.title}
-                        title={page.title}
-                        url={page.url}
-                        visibility={page.visibility}
-                        canShare={resourceAllows(page, 'app.update', podAccess.can('app.update'))}
-                    />
-                ) : (
-                    <div className="state-surface-warning h-full p-4">
-                        <p className="mb-2 text-sm font-semibold text-[var(--state-warning)]">App link not available</p>
-                        <p className="text-xs text-[var(--text-secondary)]">
-                            This app app did not return a web app URL from the server.
-                        </p>
-                    </div>
-                )}
-            </div>
+            <div className="h-full w-full" />
         </ProtectedRoute>
     );
 }

--- a/lemma-frontend/app/pod/[id]/layout.tsx
+++ b/lemma-frontend/app/pod/[id]/layout.tsx
@@ -9,6 +9,7 @@ import { HelpMenu } from "@/components/education/help-menu";
 import { PodAssistantSidebar } from "@/components/ai/pod-assistant";
 import { InlineLoader, PageLoader } from "@/components/brand/loader";
 import { AppProvider, useApp } from "@/components/app/app-context";
+import { AppFrameHost } from "@/components/app/app-frame-host";
 import { PodAppTabs } from "@/components/pod/pod-app-tabs";
 import { useOrganization } from "@/components/dashboard/org-context";
 import { PodTopbarProvider, type PodTopbarState } from "@/components/pod/pod-topbar-context";
@@ -736,6 +737,7 @@ function PodShell({
                         )}
                     </header>
                 ) : null}
+                <div className="relative flex min-h-0 flex-1 flex-col">
                 <PodTopbarProvider value={topbarContextValue}>
                     <div
                         className={cn(
@@ -759,6 +761,13 @@ function PodShell({
                         </div>
                     </div>
                 </PodTopbarProvider>
+                <AppFrameHost
+                    podId={pod.id}
+                    visible={isAppViewRoute}
+                    activeSlug={isAppViewRoute ? (searchParams.get("page") || null) : null}
+                    canUpdateApp={podAccess.can("app.update")}
+                />
+                </div>
             </main>
         </div>
     );

--- a/lemma-frontend/components/app/app-frame-host.tsx
+++ b/lemma-frontend/components/app/app-frame-host.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+import { PanelsTopLeft } from 'lucide-react';
+import { useApp } from '@/components/app/app-context';
+import { AppFrame } from '@/components/app/app-launch';
+import { StepLoader } from '@/components/brand/loader';
+import { RecoveryState } from '@/components/shared/empty-state';
+import { resourceAllows } from '@/lib/authz/resource-actions';
+import { cn } from '@/lib/utils';
+
+// Keep at most this many app iframes alive at once; opening a further app evicts
+// the oldest (FIFO). The active app is always the newest insertion, so it is
+// never the one evicted.
+const MAX_LIVE_APPS = 4;
+
+// Keep-alive host for the pod's app iframes. It is mounted once in the pod shell
+// — above the router — so it survives route changes. It lazily mounts an iframe
+// the first time each app tab is opened, then keeps it mounted, hiding the
+// inactive ones with `display:none` rather than unmounting them. A hidden iframe
+// keeps running (its state and live connections persist), so switching between
+// app tabs is instant with no cold reboot. Only the app matching the current
+// `/app/view?page=slug` route is shown.
+export function AppFrameHost({
+    podId,
+    visible,
+    activeSlug,
+    canUpdateApp,
+}: {
+    podId: string;
+    visible: boolean;
+    activeSlug: string | null;
+    canUpdateApp: boolean;
+}) {
+    const { pages } = useApp();
+    const [activated, setActivated] = useState<string[]>([]);
+
+    // Mark a slug live the first time its tab is opened and keep it mounted
+    // (hidden) until it's evicted by the FIFO cap. Adjusting state during render
+    // (guarded so it runs once per new slug) derives this from the active-slug
+    // prop without an effect + cascading re-render.
+    if (activeSlug && !activated.includes(activeSlug)) {
+        setActivated((prev) => {
+            if (prev.includes(activeSlug)) return prev;
+            const next = [...prev, activeSlug];
+            return next.length > MAX_LIVE_APPS ? next.slice(next.length - MAX_LIVE_APPS) : next;
+        });
+    }
+
+    const livePages = pages.filter((page) => activated.includes(page.slug) && page.url);
+    const activePage = activeSlug ? pages.find((page) => page.slug === activeSlug) : null;
+    const hasActiveFrame = livePages.some((page) => page.slug === activeSlug);
+
+    const missingSlug = visible && !activeSlug;
+    const unavailable = visible && !!activeSlug && pages.length > 0 && (!activePage || !activePage.url);
+    const loading = visible && !!activeSlug && !hasActiveFrame && !unavailable;
+
+    return (
+        <div aria-hidden={!visible} className={cn('absolute inset-0 z-20', visible ? 'block' : 'hidden')}>
+            {livePages.map((page) => (
+                <div
+                    key={page.slug}
+                    className={cn('absolute inset-0', page.slug === activeSlug ? 'block' : 'hidden')}
+                >
+                    <AppFrame
+                        podId={podId}
+                        appId={page.id}
+                        appName={page.title}
+                        title={page.title}
+                        url={page.url as string}
+                        visibility={page.visibility}
+                        canShare={resourceAllows(page, 'app.update', canUpdateApp)}
+                    />
+                </div>
+            ))}
+
+            {loading ? (
+                <div className="absolute inset-0 flex items-center justify-center">
+                    <StepLoader size="sm" />
+                </div>
+            ) : null}
+
+            {missingSlug ? (
+                <div className="absolute inset-0 flex items-center justify-center">
+                    <RecoveryState
+                        icon={<PanelsTopLeft className="h-5 w-5" />}
+                        title="Missing app page"
+                        description="Open an app from the Apps list so Lemma knows which workspace to show."
+                    />
+                </div>
+            ) : null}
+
+            {unavailable ? (
+                <div className="absolute inset-0 flex items-center justify-center">
+                    <RecoveryState
+                        icon={<PanelsTopLeft className="h-5 w-5" />}
+                        title="App unavailable"
+                        description="This app didn't return a web app URL. Try opening it again from the Apps list."
+                    />
+                </div>
+            ) : null}
+        </div>
+    );
+}


### PR DESCRIPTION
## What I changed

I made the pod's app iframes keep-alive so switching between app tabs no longer cold-boots each app.

- I added `AppFrameHost`, a small pool mounted once in the pod shell — above the router — so it survives route changes. It lazily mounts an app's iframe the first time I open that tab, then keeps it mounted, hiding the inactive ones with `display:none` instead of unmounting them. A hidden iframe keeps running, so the app's state and live connections survive the switch and coming back is instant, with no refetch.
- I capped the pool at 4, FIFO — opening a 5th app evicts the oldest. The active app is always the newest entry, so it's never the one dropped; an evicted app just reloads once on its next visit.
- I wired the host into the shell (it overlays the content area only on `/app/view`) and slimmed that route down to a thin placeholder, so it no longer mounts a second, route-scoped iframe that reloaded on every navigation.

## Why

Every tab switch re-navigated the route, which unmounted the iframe and re-fetched the app's data / re-opened its connections. Keeping the iframes mounted above the router fixes that. This builds on the app tabs from #86 (already merged).

## How to check

Open an app, change something stateful in it (scroll, a filter, an open panel), switch to another app and back — it should be exactly as I left it, with no reload. Same going to home and back. Past 4 apps, the oldest one reloads when I return to it.

## One caveat

Entering a fullscreen workflow editor/run unmounts the shell's normal layout, so the pool resets there — returning to an app reloads it once. Rare path; I'm flagging it rather than hiding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
