### PR TITLE
fix(authz): harden authorization flow (escalation, revocation, cross-org, gating)

### DIFF
--- a/lemma-backend/app/core/authorization/cache.py
+++ b/lemma-backend/app/core/authorization/cache.py
@@ -151,19 +151,29 @@ async def invalidate_role_snapshot_cache(
     pod_id: UUID | None = None,
     user_id: UUID | None = None,
 ) -> None:
-    """Drop cached role snapshots after a grant/role mutation.
+    """Drop cached role snapshots after a grant/role/membership mutation.
 
-    Clears the whole snapshot cache (a safe superset of the
-    organization/pod/user scope): role mutations are infrequent admin operations,
-    and over-clearing only forces a DB re-derivation on the next access — never
-    stale authorization. The scope args are accepted for call-site clarity.
+    When ``user_id`` is given, only that principal's snapshots are dropped — the
+    snapshot key is prefixed by the principal id (``{user_id}:{org}:{pod}``), so
+    a prefix delete removes every org/pod snapshot for that one principal without
+    flushing everyone. ``user_id`` here is the snapshot-key principal: a human
+    user id, or — for workload snapshots — the agent/function principal id.
+
+    Without ``user_id`` the whole snapshot cache is cleared (a safe superset) —
+    the right scope for role-definition changes that affect many principals at
+    once. Over-clearing only forces a DB re-derivation on next access, never
+    stale authorization. The ``organization_id``/``pod_id`` args are accepted for
+    call-site clarity.
     """
-    _ = (organization_id, pod_id, user_id)
+    _ = (organization_id, pod_id)
     cache = _get_role_cache()
     if cache is None:
         return
     try:
-        await cache.clear_prefix()
+        if user_id is not None:
+            await cache.delete_prefix(f"{user_id}:")
+        else:
+            await cache.clear_prefix()
     except Exception:
         logger.warning(
             "Role-snapshot cache invalidation failed; stale snapshots persist "

--- a/lemma-backend/app/core/authorization/delegation_revocation.py
+++ b/lemma-backend/app/core/authorization/delegation_revocation.py
@@ -1,0 +1,75 @@
+"""Delegation-token revocation set (Redis-backed).
+
+A delegated workload token (agent/function) is a signed session that stays valid
+until it expires. When the workload loses its standing authority — most
+importantly when the agent/function is deleted — its in-flight tokens must stop
+working before they expire on their own. Revoking the workload's actor id here
+blocks every delegated token minted for it until the entry's TTL (configured to
+be >= the max access-token lifetime) elapses.
+
+Redis-backed (shared across replicas, like the role-snapshot and session-approval
+caches). Redis being unavailable degrades to "not revoked" — availability over
+strictness, consistent with the other authz caches — but logs loudly so an
+outage is visible. (Resource-grant removal needs no revocation: workload grants
+are queried live on every check, so they take effect immediately.)
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.core.config import settings
+from app.core.infrastructure.cache.redis_json_cache import RedisJsonCache
+from app.core.log.log import get_logger
+
+logger = get_logger(__name__)
+
+_revocation_cache: RedisJsonCache | None = None
+
+
+def _get_revocation_cache() -> RedisJsonCache | None:
+    global _revocation_cache
+    ttl = settings.delegation_revocation_ttl_seconds
+    if ttl <= 0:
+        return None
+    if _revocation_cache is None or _revocation_cache._ttl_seconds != ttl:
+        _revocation_cache = RedisJsonCache(
+            redis_url=settings.redis_url,
+            key_prefix="authz:delegation-revoked",
+            ttl_seconds=ttl,
+        )
+    return _revocation_cache
+
+
+async def revoke_delegation(*, actor_id: UUID) -> None:
+    """Block every in-flight delegated token minted for ``actor_id``."""
+    cache = _get_revocation_cache()
+    if cache is None:
+        return
+    try:
+        await cache.set_json(str(actor_id), {"revoked": True})
+    except Exception:
+        logger.warning(
+            "Delegation-revocation store unavailable; workload %s not revoked "
+            "(its token will still expire naturally).",
+            actor_id,
+            exc_info=True,
+        )
+
+
+async def is_delegation_revoked(*, actor_id: UUID) -> bool:
+    """True when a delegated token for ``actor_id`` has been revoked."""
+    cache = _get_revocation_cache()
+    if cache is None:
+        return False
+    try:
+        payload = await cache.get_json(str(actor_id))
+    except Exception:
+        logger.warning(
+            "Delegation-revocation store unavailable; treating workload %s as "
+            "not revoked (safe for availability).",
+            actor_id,
+            exc_info=True,
+        )
+        return False
+    return payload is not None

--- a/lemma-backend/app/core/authorization/dependencies.py
+++ b/lemma-backend/app/core/authorization/dependencies.py
@@ -208,6 +208,28 @@ def reject_delegated_workload(action_label: str):
     return Depends(_dependency)
 
 
+def reject_delegated_workload_pod(action_label: str):
+    """Pod-scoped counterpart of :func:`reject_delegated_workload`.
+
+    For pod-routed ownership actions that mint membership (approving a join
+    request grants org/pod membership). There is no per-resource grant or session
+    approval that should let a workload confer membership on someone, so deny it
+    outright. Humans are unaffected.
+    """
+
+    async def _dependency(ctx: PodContextDep) -> None:
+        if ctx.actor_type == ActorType.DELEGATED_USER_WORKLOAD:
+            from app.core.domain.errors import DomainError
+
+            raise DomainError(
+                f"Delegated workloads may not {action_label}.",
+                code="DESTRUCTIVE_ACTION_REQUIRES_APPROVAL",
+                status_code=403,
+            )
+
+    return Depends(_dependency)
+
+
 async def pod_from_path(request: Request) -> ResourceRef:
     raw_pod_id = request.path_params.get("pod_id")
     if not raw_pod_id:

--- a/lemma-backend/app/core/authorization/service.py
+++ b/lemma-backend/app/core/authorization/service.py
@@ -31,6 +31,7 @@ from app.core.authorization.delegation import (
     WorkloadPrincipalType,
 )
 from app.core.authorization.session_approvals import has_session_approval
+from app.core.domain.errors import DomainError
 from app.core.authorization.grants import (
     delete_grantee_grants,
     grant_resource_type_values,
@@ -641,6 +642,16 @@ class AuthorizationDataService:
         request_id: str | None = None,
         is_default_pod_agent: bool = False,
     ) -> Context:
+        # Defense in depth: the claims and the session are minted together, so
+        # the claim's invoked_by_user_id must match the authenticated session
+        # user. A mismatch means the token was tampered with or mis-minted — never
+        # build a context that delegates for a different user than the token.
+        if claims.invoked_by_user_id != user_id:
+            raise DomainError(
+                "Delegation invoked_by_user_id does not match the session user",
+                code="DELEGATION_USER_MISMATCH",
+                status_code=403,
+            )
         return await self.build_delegated_workload_context(
             user_id=user_id,
             principal_type=claims.actor_type.value,

--- a/lemma-backend/app/core/authorization/service.py
+++ b/lemma-backend/app/core/authorization/service.py
@@ -83,6 +83,17 @@ _ENSURED_ROLE_SCOPES: set[tuple[UUID, UUID | None]] = set()
 
 
 @dataclass(frozen=True, slots=True)
+class MemberAuthorizationTargets:
+    """Authorization data tied to an org member, captured before removal so the
+    (FK-less, non-cascading) role assignments/grants can be purged afterward."""
+
+    user_id: UUID | None
+    organization_member_id: UUID
+    # (pod_member_id, pod_id) for each pod membership under this org member.
+    pod_memberships: tuple[tuple[UUID, UUID], ...]
+
+
+@dataclass(frozen=True, slots=True)
 class RoleSummary:
     id: UUID
     organization_id: UUID
@@ -360,8 +371,17 @@ class AuthorizationDataService:
                 )
             )
         await self.session.flush()
+        # Targeted invalidation: an assignment change touches exactly one
+        # principal, so drop only that principal's snapshots rather than flushing
+        # every user's. Falls back to a full clear when the principal can't be
+        # mapped to its snapshot key (safe superset).
+        snapshot_principal_id = await self._resolve_snapshot_principal_id(
+            principal_type, principal_id
+        )
         await invalidate_role_snapshot_cache(
-            organization_id=organization_id, pod_id=pod_id
+            organization_id=organization_id,
+            pod_id=pod_id,
+            user_id=snapshot_principal_id,
         )
         return normalized
 
@@ -818,6 +838,112 @@ class AuthorizationDataService:
             role_names.add(role_name)
             if permission_id is not None:
                 permission_ids.add(permission_id)
+
+    async def _resolve_snapshot_principal_id(
+        self, principal_type: str, principal_id: UUID
+    ) -> UUID | None:
+        """Map a role-assignment principal to the id its role snapshot is cached
+        under (see ``cache._snapshot_suffix``), or ``None`` when it can't be
+        resolved so the caller falls back to a full-cache invalidation.
+
+        Workload snapshots are cached under the workload principal id itself;
+        org/pod member snapshots are cached under the human ``user_id``.
+        """
+        normalized = principal_type.upper()
+        if normalized in ("AGENT", "FUNCTION"):
+            return principal_id
+        if normalized == "ORG_MEMBER":
+            return (
+                await self.session.execute(
+                    select(OrganizationMember.user_id).where(
+                        OrganizationMember.id == principal_id
+                    )
+                )
+            ).scalar_one_or_none()
+        if normalized == "POD_MEMBER":
+            return (
+                await self.session.execute(
+                    select(OrganizationMember.user_id)
+                    .join(
+                        PodMember,
+                        PodMember.organization_member_id == OrganizationMember.id,
+                    )
+                    .where(PodMember.id == principal_id)
+                )
+            ).scalar_one_or_none()
+        return None
+
+    async def delete_principal_role_assignments(
+        self, *, principal_type: str, principal_id: UUID
+    ) -> None:
+        """Delete every role assignment held by a principal.
+
+        ``RoleAssignmentModel.principal_id`` is polymorphic and carries no FK, so
+        these rows do not cascade when the underlying member/workload is deleted.
+        Call this on removal to avoid orphaned assignments. Parallel to
+        ``delete_grantee_grants`` for resource grants.
+        """
+        await self.session.execute(
+            delete(RoleAssignmentModel).where(
+                RoleAssignmentModel.principal_type == principal_type,
+                RoleAssignmentModel.principal_id == principal_id,
+            )
+        )
+        await self.session.flush()
+
+    async def member_authorization_targets(
+        self, *, organization_member_id: UUID
+    ) -> "MemberAuthorizationTargets | None":
+        """Snapshot the authorization data tied to an org member before it is
+        removed: the human ``user_id`` and the pod memberships that will
+        cascade-delete with it (their role assignments/grants do not cascade).
+
+        Returns ``None`` when the org member does not exist. Read-only, so it is
+        safe to call before the removal is authorized.
+        """
+        row = (
+            await self.session.execute(
+                select(OrganizationMember.user_id).where(
+                    OrganizationMember.id == organization_member_id
+                )
+            )
+        ).first()
+        if row is None:
+            return None
+        pod_rows = (
+            await self.session.execute(
+                select(PodMember.id, PodMember.pod_id).where(
+                    PodMember.organization_member_id == organization_member_id
+                )
+            )
+        ).all()
+        return MemberAuthorizationTargets(
+            user_id=row[0],
+            organization_member_id=organization_member_id,
+            pod_memberships=tuple((r[0], r[1]) for r in pod_rows),
+        )
+
+    async def purge_member_authorization(
+        self, targets: "MemberAuthorizationTargets"
+    ) -> None:
+        """Delete the role assignments + resource grants for a removed org member
+        and its (cascade-deleted) pod memberships, then invalidate the removed
+        user's cached role snapshots so access is revoked on the next request."""
+        for pod_member_id, pod_id in targets.pod_memberships:
+            await self.delete_principal_role_assignments(
+                principal_type="POD_MEMBER", principal_id=pod_member_id
+            )
+            await delete_grantee_grants(
+                self.session,
+                pod_id=pod_id,
+                grantee_type="POD_MEMBER",
+                grantee_id=pod_member_id,
+            )
+        await self.delete_principal_role_assignments(
+            principal_type="ORG_MEMBER",
+            principal_id=targets.organization_member_id,
+        )
+        await invalidate_role_snapshot_cache(user_id=targets.user_id)
 
 
 class Authorizer:

--- a/lemma-backend/app/core/authorization/tests/unit/test_delegation_context_guard.py
+++ b/lemma-backend/app/core/authorization/tests/unit/test_delegation_context_guard.py
@@ -1,0 +1,41 @@
+"""build_context_from_delegation_claims must refuse to delegate for a different
+user than the authenticated session (the claim's invoked_by_user_id and the
+session user are minted together, so a mismatch is tampering or a bug)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from app.core.authorization.delegation import DelegationClaims, WorkloadPrincipalType
+from app.core.authorization.service import AuthorizationDataService
+from app.core.domain.errors import DomainError
+
+
+def _claims(*, invoked_by_user_id) -> DelegationClaims:
+    return DelegationClaims(
+        actor_type=WorkloadPrincipalType.AGENT,
+        actor_id=uuid4(),
+        pod_id=uuid4(),
+        session_id="sess",
+        scope=[],
+        invoked_by_user_id=invoked_by_user_id,
+        delegation_version=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_rejects_when_invoked_by_does_not_match_session_user():
+    # The mismatch is caught before any DB work, so a mock session is fine.
+    service = AuthorizationDataService(AsyncMock())
+
+    with pytest.raises(DomainError) as exc:
+        await service.build_context_from_delegation_claims(
+            user_id=uuid4(),
+            claims=_claims(invoked_by_user_id=uuid4()),
+        )
+
+    assert exc.value.status_code == 403
+    assert exc.value.code == "DELEGATION_USER_MISMATCH"

--- a/lemma-backend/app/core/authorization/tests/unit/test_delegation_revocation.py
+++ b/lemma-backend/app/core/authorization/tests/unit/test_delegation_revocation.py
@@ -1,0 +1,48 @@
+"""Delegation revocation set: revoke_delegation marks an actor, and
+is_delegation_revoked reports it (degrading to not-revoked on Redis errors)."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from app.core.authorization import delegation_revocation as dr
+
+
+class _RecordingCache:
+    def __init__(self) -> None:
+        self.store: dict[str, object] = {}
+
+    async def set_json(self, suffix: str, value: object) -> None:
+        self.store[suffix] = value
+
+    async def get_json(self, suffix: str):
+        return self.store.get(suffix)
+
+
+class _BrokenCache:
+    async def set_json(self, suffix: str, value: object) -> None:
+        raise ConnectionError("redis down")
+
+    async def get_json(self, suffix: str):
+        raise ConnectionError("redis down")
+
+
+@pytest.mark.asyncio
+async def test_revoke_then_check_reports_revoked(monkeypatch):
+    recorder = _RecordingCache()
+    monkeypatch.setattr(dr, "_get_revocation_cache", lambda: recorder)
+    actor_id = uuid4()
+
+    assert await dr.is_delegation_revoked(actor_id=actor_id) is False
+    await dr.revoke_delegation(actor_id=actor_id)
+    assert await dr.is_delegation_revoked(actor_id=actor_id) is True
+
+
+@pytest.mark.asyncio
+async def test_redis_outage_degrades_to_not_revoked(monkeypatch):
+    monkeypatch.setattr(dr, "_get_revocation_cache", lambda: _BrokenCache())
+    # Neither call raises; a store outage must not fail the request.
+    await dr.revoke_delegation(actor_id=uuid4())
+    assert await dr.is_delegation_revoked(actor_id=uuid4()) is False

--- a/lemma-backend/app/core/authorization/tests/unit/test_role_snapshot_cache.py
+++ b/lemma-backend/app/core/authorization/tests/unit/test_role_snapshot_cache.py
@@ -77,3 +77,42 @@ async def test_redis_outage_degrades_to_miss_with_warning(monkeypatch, caplog):
     warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
     assert any("cache read failed" in m for m in warnings)
     assert any("cache write failed" in m for m in warnings)
+
+
+class _RecordingCache:
+    def __init__(self):
+        self.deleted_prefixes: list[str] = []
+        self.cleared = 0
+
+    async def delete_prefix(self, sub_prefix: str) -> None:
+        self.deleted_prefixes.append(sub_prefix)
+
+    async def clear_prefix(self) -> None:
+        self.cleared += 1
+
+
+@pytest.mark.asyncio
+async def test_invalidate_with_user_id_targets_only_that_principal(monkeypatch):
+    recorder = _RecordingCache()
+    monkeypatch.setattr(cache_module, "_get_role_cache", lambda: recorder)
+    user_id = uuid4()
+
+    await cache_module.invalidate_role_snapshot_cache(
+        organization_id=uuid4(), pod_id=uuid4(), user_id=user_id
+    )
+
+    assert recorder.deleted_prefixes == [f"{user_id}:"]
+    assert recorder.cleared == 0
+
+
+@pytest.mark.asyncio
+async def test_invalidate_without_user_id_clears_everything(monkeypatch):
+    recorder = _RecordingCache()
+    monkeypatch.setattr(cache_module, "_get_role_cache", lambda: recorder)
+
+    await cache_module.invalidate_role_snapshot_cache(
+        organization_id=uuid4(), pod_id=uuid4()
+    )
+
+    assert recorder.cleared == 1
+    assert recorder.deleted_prefixes == []

--- a/lemma-backend/app/core/authorization/tests/unit/test_role_snapshot_cache.py
+++ b/lemma-backend/app/core/authorization/tests/unit/test_role_snapshot_cache.py
@@ -7,6 +7,9 @@ including None scopes and the nested PrincipalRef sets.
 
 from uuid import uuid4
 
+import pytest
+
+from app.core.authorization import cache as cache_module
 from app.core.authorization.cache import RoleSnapshot, _deserialize, _serialize
 from app.core.authorization.context import PrincipalRef
 
@@ -37,11 +40,6 @@ def test_role_snapshot_serialization_handles_empty_and_none_scopes():
         grant_principal_sets=(),
     )
     assert _deserialize(_serialize(snapshot)) == snapshot
-
-
-import pytest
-
-from app.core.authorization import cache as cache_module
 
 
 class _BrokenCache:

--- a/lemma-backend/app/core/authorization/tests/unit/test_workload_gate.py
+++ b/lemma-backend/app/core/authorization/tests/unit/test_workload_gate.py
@@ -1,0 +1,37 @@
+"""The pod-scoped workload gate denies delegated workloads but not humans.
+
+Member-management / membership-minting endpoints route through
+``reject_delegated_workload_pod`` so a delegated agent cannot confer membership
+on the invoking user's behalf, while human admins are unaffected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.authorization.context import ActorType, Context
+from app.core.authorization.dependencies import reject_delegated_workload_pod
+from app.core.domain.errors import DomainError
+
+
+def _ctx(actor_type: ActorType) -> Context:
+    return Context(actor_type=actor_type, actor_id="actor", authorizer=object())
+
+
+@pytest.mark.asyncio
+async def test_pod_workload_gate_denies_delegated_workload():
+    dependency = reject_delegated_workload_pod("approve join requests").dependency
+
+    with pytest.raises(DomainError) as exc:
+        await dependency(_ctx(ActorType.DELEGATED_USER_WORKLOAD))
+
+    assert exc.value.status_code == 403
+    assert exc.value.code == "DESTRUCTIVE_ACTION_REQUIRES_APPROVAL"
+
+
+@pytest.mark.asyncio
+async def test_pod_workload_gate_allows_human_user():
+    dependency = reject_delegated_workload_pod("approve join requests").dependency
+
+    # No raise for a human actor.
+    await dependency(_ctx(ActorType.USER))

--- a/lemma-backend/app/core/config.py
+++ b/lemma-backend/app/core/config.py
@@ -335,6 +335,15 @@ class Settings(BaseSettings):
             "disable session approvals (every destructive action re-prompts)."
         ),
     )
+    delegation_revocation_ttl_seconds: int = Field(
+        default=3600,
+        description=(
+            "How long a revoked delegated workload (e.g. a deleted agent/function) "
+            "stays blocked. Must be >= the max access-token lifetime so an "
+            "in-flight delegated token cannot outlive its revocation. Set to 0 to "
+            "disable delegation revocation."
+        ),
+    )
     # Google OAuth Settings
     google_client_id: Optional[str] = Field(
         default=None, description="Google OAuth Client ID"

--- a/lemma-backend/app/core/infrastructure/cache/redis_json_cache.py
+++ b/lemma-backend/app/core/infrastructure/cache/redis_json_cache.py
@@ -60,11 +60,15 @@ class RedisJsonCache(Generic[T]):
         redis = await self._get_redis()
         await redis.delete(self.build_key(suffix))
 
-    async def clear_prefix(self) -> None:
-        """Delete every key under this cache's prefix (SCAN + DEL). Used by
-        invalidation hooks and test isolation; O(matched keys)."""
+    async def delete_prefix(self, sub_prefix: str) -> None:
+        """Delete every key under ``{key_prefix}:{sub_prefix}*`` (SCAN + DEL).
+
+        Narrower than :meth:`clear_prefix`: lets an invalidation target a single
+        logical group (e.g. all of one principal's role snapshots across orgs and
+        pods) instead of flushing the whole cache. O(matched keys).
+        """
         redis = await self._get_redis()
-        pattern = f"{self._key_prefix}:*"
+        pattern = f"{self._key_prefix}:{sub_prefix}*"
         cursor = 0
         while True:
             cursor, keys = await redis.scan(cursor, match=pattern, count=256)
@@ -72,6 +76,11 @@ class RedisJsonCache(Generic[T]):
                 await redis.delete(*keys)
             if cursor == 0:
                 break
+
+    async def clear_prefix(self) -> None:
+        """Delete every key under this cache's prefix (SCAN + DEL). Used by
+        invalidation hooks and test isolation; O(matched keys)."""
+        await self.delete_prefix("")
 
     async def close(self) -> None:
         if self._redis is None:

--- a/lemma-backend/app/core/security.py
+++ b/lemma-backend/app/core/security.py
@@ -7,6 +7,7 @@ from supertokens_python.recipe.session.exceptions import TryRefreshTokenError
 from app.core.authorization.current import set_current_context
 from app.core.config import settings
 from app.core.authorization.delegation import (
+    CLAIM_ACTOR_ID,
     DelegationClaimsError,
     parse_delegation_claims,
 )
@@ -125,6 +126,19 @@ async def verify_auth(connection: HTTPConnection):
                     ) from exc
 
                 connection.state.delegation_claims = delegation_claims
+            elif payload.get("isImpersonation") is True or payload.get(CLAIM_ACTOR_ID):
+                # Delegation is disabled, but a delegated/impersonation token
+                # (minted with isImpersonation + delegation claims) carries the
+                # workload's authority. Without the delegation layer to clamp it,
+                # honoring it would silently promote it to a full user session, so
+                # reject it — disabling the flag must fail safe, not escalate.
+                raise HTTPException(
+                    status_code=403,
+                    detail={
+                        "code": "IMPERSONATION_NOT_ALLOWED",
+                        "message": "Delegated tokens are disabled.",
+                    },
+                )
 
     except TryRefreshTokenError:
         # This exception is raised when the access token has expired.

--- a/lemma-backend/app/core/security.py
+++ b/lemma-backend/app/core/security.py
@@ -11,6 +11,7 @@ from app.core.authorization.delegation import (
     DelegationClaimsError,
     parse_delegation_claims,
 )
+from app.core.authorization.delegation_revocation import is_delegation_revoked
 from app.core.log.log import get_logger
 from app.modules.identity.domain.user_entities import AuthUserEntity
 
@@ -124,6 +125,20 @@ async def verify_auth(connection: HTTPConnection):
                             "message": str(exc),
                         },
                     ) from exc
+
+                if delegation_claims is not None and await is_delegation_revoked(
+                    actor_id=delegation_claims.actor_id
+                ):
+                    # The workload this token delegates for lost its authority
+                    # (e.g. the agent/function was deleted). Reject before it
+                    # expires on its own.
+                    raise HTTPException(
+                        status_code=403,
+                        detail={
+                            "code": "DELEGATION_REVOKED",
+                            "message": "Delegated workload has been revoked.",
+                        },
+                    )
 
                 connection.state.delegation_claims = delegation_claims
             elif payload.get("isImpersonation") is True or payload.get(CLAIM_ACTOR_ID):

--- a/lemma-backend/app/modules/agent/services/agent_service.py
+++ b/lemma-backend/app/modules/agent/services/agent_service.py
@@ -11,6 +11,7 @@ from app.core.authorization.context import (
     ResourceType,
     ResourceVisibility,
 )
+from app.core.authorization.delegation_revocation import revoke_delegation
 from app.core.authorization.permissions import Permissions
 from app.modules.agent.domain.entities import Agent
 from app.modules.agent.domain.errors import (
@@ -258,6 +259,9 @@ class AgentService:
                 ctx=ctx,
             )
         await self.agent_repository.delete(agent.id)
+        # Revoke any in-flight delegated token minted for this agent so it stops
+        # working immediately rather than lingering until the token expires.
+        await revoke_delegation(actor_id=agent.id)
 
     def _normalize_names(self, values: list[str], *, label: str) -> list[str]:
         normalized: list[str] = []

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_delete_revocation.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_delete_revocation.py
@@ -1,0 +1,29 @@
+"""Deleting an agent must revoke its in-flight delegated tokens."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from app.modules.agent.services import agent_service as agent_service_module
+from app.modules.agent.services.agent_service import AgentService
+
+
+@pytest.mark.asyncio
+async def test_delete_agent_revokes_delegation(monkeypatch):
+    agent = SimpleNamespace(id=uuid4(), user_id=uuid4())
+    repo = AsyncMock()
+    service = AgentService(agent_repository=repo, authorization_service=AsyncMock())
+    monkeypatch.setattr(service, "get_agent_by_name", AsyncMock(return_value=agent))
+    revoke_spy = AsyncMock()
+    monkeypatch.setattr(agent_service_module, "revoke_delegation", revoke_spy)
+
+    # requester_user_id/ctx omitted: authorization is exercised elsewhere; here we
+    # assert the revocation emit follows a successful delete.
+    await service.delete_agent(pod_id=uuid4(), name="reporter")
+
+    repo.delete.assert_awaited_once_with(agent.id)
+    revoke_spy.assert_awaited_once_with(actor_id=agent.id)

--- a/lemma-backend/app/modules/connectors/domain/ports.py
+++ b/lemma-backend/app/modules/connectors/domain/ports.py
@@ -48,6 +48,10 @@ class AccountRepositoryPort(Protocol):
         self, user_id: UUID, auth_config_id: UUID
     ) -> Optional[AccountEntity]: ...
 
+    async def get_by_user_org_and_auth_config(
+        self, user_id: UUID, organization_id: UUID, auth_config_id: UUID
+    ) -> Optional[AccountEntity]: ...
+
     async def get_by_user_auth_config_and_provider_account(
         self,
         user_id: UUID,

--- a/lemma-backend/app/modules/connectors/infrastructure/repositories/account_repository.py
+++ b/lemma-backend/app/modules/connectors/infrastructure/repositories/account_repository.py
@@ -130,6 +130,8 @@ class AccountRepository(
     async def get_by_user_org_and_app(
         self, user_id: UUID, organization_id: UUID, connector_id: str
     ) -> Optional[AccountEntity]:
+        """Org-scoped counterpart of :meth:`get_by_user_and_app` — the user's
+        default (or oldest) account for a connector within one organization."""
         stmt = (
             select(Account)
             .where(
@@ -137,6 +139,7 @@ class AccountRepository(
                 Account.organization_id == organization_id,
                 Account.connector_id == connector_id,
             )
+            .order_by(Account.is_default.desc(), Account.created_at)
             .options(selectinload(Account.connector))
         )
         result = await self.session.execute(stmt)
@@ -150,6 +153,24 @@ class AccountRepository(
         stmt = (
             select(Account)
             .where(Account.user_id == user_id, Account.auth_config_id == auth_config_id)
+            .order_by(Account.is_default.desc(), Account.created_at)
+            .options(selectinload(Account.connector))
+        )
+        result = await self.session.execute(stmt)
+        instance = result.scalars().first()
+        return self._to_entity(instance) if instance else None
+
+    async def get_by_user_org_and_auth_config(
+        self, user_id: UUID, organization_id: UUID, auth_config_id: UUID
+    ) -> Optional[AccountEntity]:
+        """Org-scoped counterpart of :meth:`get_by_user_and_auth_config`."""
+        stmt = (
+            select(Account)
+            .where(
+                Account.user_id == user_id,
+                Account.organization_id == organization_id,
+                Account.auth_config_id == auth_config_id,
+            )
             .order_by(Account.is_default.desc(), Account.created_at)
             .options(selectinload(Account.connector))
         )

--- a/lemma-backend/app/modules/connectors/services/account_resolution_service.py
+++ b/lemma-backend/app/modules/connectors/services/account_resolution_service.py
@@ -50,25 +50,42 @@ class AccountResolutionService:
         self.authz_read_port = authz_read_port
         self.authorization_service = authorization_service
 
+    @staticmethod
+    def _context_org_id(auth_ctx: Context | None) -> UUID | None:
+        return getattr(auth_ctx, "organization_id", None)
+
     async def _get_owned_account(
         self,
         *,
         user_id: UUID,
         connector_id: str,
         account_id: UUID | None,
+        organization_id: UUID | None = None,
     ) -> AccountEntity:
         if account_id is not None:
             account = await self._get_account_for_connector(
                 account_id=account_id,
                 connector_id=connector_id,
             )
-            if account.user_id != user_id:
+            if account.user_id != user_id or (
+                organization_id is not None
+                and account.organization_id != organization_id
+            ):
                 raise AccountResolutionError(
                     f"Account '{account_id}' is not available for this user."
                 )
             return account
 
-        account = await self.account_repo.get_by_user_and_app(user_id, connector_id)
+        # Scope to the caller's organization when known: a user may connect the
+        # same connector under several orgs, and one org's run must not resolve
+        # another org's account.
+        account = (
+            await self.account_repo.get_by_user_org_and_app(
+                user_id, organization_id, connector_id
+            )
+            if organization_id is not None
+            else await self.account_repo.get_by_user_and_app(user_id, connector_id)
+        )
         if not account:
             raise AccountResolutionError(
                 f"No account connected for '{connector_id}'. Connect your account first."
@@ -82,20 +99,34 @@ class AccountResolutionService:
         connector_id: str,
         auth_config_id: UUID,
         account_id: UUID | None,
+        organization_id: UUID | None = None,
     ) -> AccountEntity:
         if account_id is not None:
             account = await self._get_account_for_connector(
                 account_id=account_id,
                 connector_id=connector_id,
             )
-            if account.user_id != user_id or account.auth_config_id != auth_config_id:
+            if (
+                account.user_id != user_id
+                or account.auth_config_id != auth_config_id
+                or (
+                    organization_id is not None
+                    and account.organization_id != organization_id
+                )
+            ):
                 raise AccountResolutionError(
                     f"Account '{account_id}' is not available for this auth config."
                 )
             return account
 
-        account = await self.account_repo.get_by_user_and_auth_config(
-            user_id, auth_config_id
+        account = (
+            await self.account_repo.get_by_user_org_and_auth_config(
+                user_id, organization_id, auth_config_id
+            )
+            if organization_id is not None
+            else await self.account_repo.get_by_user_and_auth_config(
+                user_id, auth_config_id
+            )
         )
         if not account:
             raise AccountResolutionError(
@@ -129,12 +160,14 @@ class AccountResolutionService:
         auth_ctx = auth_actor or get_current_context()
         if auth_ctx is None or auth_ctx.delegated_by_user_id is None:
             raise ConnectorAccessDeniedError("Missing delegated workload context")
+        organization_id = self._context_org_id(auth_ctx)
 
         if self._is_default_pod_agent_delegation(auth_ctx):
             return await self._get_owned_account(
                 user_id=user_id,
                 connector_id=connector_id,
                 account_id=account_id,
+                organization_id=organization_id,
             )
 
         await self._require_delegated_access(
@@ -151,6 +184,15 @@ class AccountResolutionService:
                 account_id=account_id,
                 connector_id=connector_id,
             )
+            # A workload runs inside one pod (hence one org); an account from a
+            # different org is never in scope, even the invoker's own.
+            if (
+                organization_id is not None
+                and requested_account.organization_id != organization_id
+            ):
+                raise AccountResolutionError(
+                    f"Account '{account_id}' is not available in this organization."
+                )
             if requested_account.user_id == user_id:
                 return requested_account
             await self._require_delegated_access(
@@ -167,6 +209,7 @@ class AccountResolutionService:
             user_id=user_id,
             connector_id=connector_id,
             account_id=None,
+            organization_id=organization_id,
         )
 
     @staticmethod
@@ -217,6 +260,7 @@ class AccountResolutionService:
             user_id=user_id,
             connector_id=connector_id,
             account_id=account_id,
+            organization_id=self._context_org_id(auth_ctx),
         )
 
     async def resolve_account_for_auth_config(
@@ -247,4 +291,5 @@ class AccountResolutionService:
             connector_id=connector_id,
             auth_config_id=auth_config_id,
             account_id=account_id,
+            organization_id=self._context_org_id(auth_ctx),
         )

--- a/lemma-backend/app/modules/connectors/tests/unit/test_account_resolution_service.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_account_resolution_service.py
@@ -121,6 +121,85 @@ async def test_resolve_account_rejects_explicit_account_from_another_org():
         )
 
 
+async def test_resolve_for_auth_config_uses_org_scoped_lookup():
+    user_id = uuid4()
+    org_id = uuid4()
+    auth_config_id = uuid4()
+    account = _account(user_id=user_id, connector_id="slack")
+    repo = AsyncMock(
+        get_by_user_org_and_auth_config=AsyncMock(return_value=account),
+        get_by_user_and_auth_config=AsyncMock(
+            return_value=_account(user_id=user_id, connector_id="slack")
+        ),
+    )
+    service = AccountResolutionService(account_repository=repo)
+    auth_actor = SimpleNamespace(
+        organization_id=org_id,
+        delegated_by_user_id=None,
+        actor_type=ActorType.USER,
+    )
+
+    resolved = await service.resolve_account_for_auth_config(
+        user_id=user_id,
+        connector_id="slack",
+        auth_config_id=auth_config_id,
+        auth_actor=auth_actor,
+    )
+
+    assert resolved.id == account.id
+    repo.get_by_user_org_and_auth_config.assert_awaited_once_with(
+        user_id, org_id, auth_config_id
+    )
+    repo.get_by_user_and_auth_config.assert_not_called()
+
+
+async def test_resolve_for_auth_config_rejects_explicit_account_from_another_org():
+    user_id = uuid4()
+    org_id = uuid4()
+    account = _account(user_id=user_id, connector_id="slack")
+    repo = AsyncMock(get=AsyncMock(return_value=account))
+    service = AccountResolutionService(account_repository=repo)
+    auth_actor = SimpleNamespace(
+        organization_id=org_id,
+        delegated_by_user_id=None,
+        actor_type=ActorType.USER,
+    )
+
+    with pytest.raises(AccountResolutionError):
+        await service.resolve_account_for_auth_config(
+            user_id=user_id,
+            connector_id="slack",
+            auth_config_id=account.auth_config_id,
+            auth_actor=auth_actor,
+            account_id=account.id,
+        )
+
+
+async def test_workload_rejects_explicit_account_from_another_org():
+    # A workload runs inside one pod/org; an explicit account from a different
+    # org is out of scope even before grant checks would pass.
+    user_id = uuid4()
+    pod_id = uuid4()
+    org_id = uuid4()
+    account = _account(user_id=user_id, connector_id="slack")
+    repo = AsyncMock(get=AsyncMock(return_value=account))
+    service = AccountResolutionService(
+        account_repository=repo,
+        authz_read_port=AsyncMock(),
+        authorization_service=AsyncMock(),
+    )
+    auth_actor = _delegated_actor(user_id=user_id, pod_id=pod_id)
+    auth_actor.organization_id = org_id  # account.organization_id is a different org
+
+    with pytest.raises(AccountResolutionError):
+        await service.resolve_account(
+            user_id=user_id,
+            connector_id="slack",
+            auth_actor=auth_actor,
+            account_id=account.id,
+        )
+
+
 async def test_resolve_account_rejects_explicit_account_from_another_user():
     user_id = uuid4()
     account = _account(user_id=uuid4(), connector_id="slack")

--- a/lemma-backend/app/modules/connectors/tests/unit/test_account_resolution_service.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_account_resolution_service.py
@@ -69,6 +69,58 @@ async def test_resolve_account_returns_user_owned_account_for_plain_user():
     assert resolved.id == account.id
 
 
+async def test_resolve_account_scopes_owned_lookup_to_context_org():
+    # A plain-user resolution must look the account up within the caller's org,
+    # not across every org the user belongs to.
+    user_id = uuid4()
+    org_id = uuid4()
+    account = _account(user_id=user_id, connector_id="slack")
+    repo = AsyncMock(
+        get_by_user_org_and_app=AsyncMock(return_value=account),
+        get_by_user_and_app=AsyncMock(
+            return_value=_account(user_id=user_id, connector_id="slack")
+        ),
+    )
+    service = AccountResolutionService(account_repository=repo)
+    auth_actor = SimpleNamespace(
+        organization_id=org_id,
+        delegated_by_user_id=None,
+        actor_type=ActorType.USER,
+    )
+
+    resolved = await service.resolve_account(
+        user_id=user_id,
+        connector_id="slack",
+        auth_actor=auth_actor,
+    )
+
+    assert resolved.id == account.id
+    repo.get_by_user_org_and_app.assert_awaited_once_with(user_id, org_id, "slack")
+    repo.get_by_user_and_app.assert_not_called()
+
+
+async def test_resolve_account_rejects_explicit_account_from_another_org():
+    user_id = uuid4()
+    org_id = uuid4()
+    # account.organization_id is a different (random) org than the caller's.
+    account = _account(user_id=user_id, connector_id="slack")
+    repo = AsyncMock(get=AsyncMock(return_value=account))
+    service = AccountResolutionService(account_repository=repo)
+    auth_actor = SimpleNamespace(
+        organization_id=org_id,
+        delegated_by_user_id=None,
+        actor_type=ActorType.USER,
+    )
+
+    with pytest.raises(AccountResolutionError):
+        await service.resolve_account(
+            user_id=user_id,
+            connector_id="slack",
+            auth_actor=auth_actor,
+            account_id=account.id,
+        )
+
+
 async def test_resolve_account_rejects_explicit_account_from_another_user():
     user_id = uuid4()
     account = _account(user_id=uuid4(), connector_id="slack")

--- a/lemma-backend/app/modules/function/services/function_service.py
+++ b/lemma-backend/app/modules/function/services/function_service.py
@@ -14,6 +14,7 @@ from app.core.authorization.context import (
     ResourceType,
     ResourceVisibility,
 )
+from app.core.authorization.delegation_revocation import revoke_delegation
 from app.core.authorization.permissions import Permissions
 from app.core.helpers.slug import slugify
 from app.core.domain.job_queue import JobQueuePort
@@ -425,6 +426,9 @@ class FunctionService:
         deleted = await self._delete_function_row(function.id)
         if not deleted:
             raise FunctionNotFoundError(f"Function {name} not found")
+        # Revoke any in-flight delegated token minted for this function so it
+        # stops working immediately rather than lingering until the token expires.
+        await revoke_delegation(actor_id=function.id)
         # Icon cleanup is a storage call — run it after the DB session closes so
         # no pooled connection is held across it.
         if self.icon_service:

--- a/lemma-backend/app/modules/function/tests/unit/test_function_delete_revocation.py
+++ b/lemma-backend/app/modules/function/tests/unit/test_function_delete_revocation.py
@@ -1,0 +1,41 @@
+"""Deleting a function must revoke its in-flight delegated tokens."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from app.modules.function.services import function_service as function_service_module
+from app.modules.function.services.function_service import FunctionService
+
+
+def _service() -> FunctionService:
+    return FunctionService(
+        function_repository=AsyncMock(),
+        run_repository=AsyncMock(),
+        workspace_service=AsyncMock(),
+        storage_factory=AsyncMock(),
+        authorization_service=AsyncMock(),
+        icon_service=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_function_revokes_delegation(monkeypatch):
+    function = SimpleNamespace(id=uuid4(), pod_id=uuid4(), icon_url=None)
+    service = _service()
+    monkeypatch.setattr(
+        service, "_load_function_by_name", AsyncMock(return_value=function)
+    )
+    monkeypatch.setattr(service, "_delete_function_row", AsyncMock(return_value=True))
+    revoke_spy = AsyncMock()
+    monkeypatch.setattr(function_service_module, "revoke_delegation", revoke_spy)
+
+    ctx = SimpleNamespace(require=AsyncMock())
+    result = await service.delete_function(uuid4(), "reporter", uuid4(), ctx=ctx)
+
+    assert result is True
+    revoke_spy.assert_awaited_once_with(actor_id=function.id)

--- a/lemma-backend/app/modules/identity/api/controllers/organization_controller.py
+++ b/lemma-backend/app/modules/identity/api/controllers/organization_controller.py
@@ -532,11 +532,22 @@ async def remove_member(
     org_id: UUID,
     member_id: UUID,
     org_service: OrganizationServiceDep,
+    uow: UoWDep,
 ) -> None:
     """Remove a member from the organization."""
     user: UserEntity = request.state.user
+    authz = AuthorizationDataService(uow.session)
+    # Capture the member's authorization targets before removal: deleting the
+    # org member cascades its pod memberships away, but their (FK-less) role
+    # assignments and grants do not cascade. The read is harmless if the removal
+    # is subsequently denied.
+    targets = await authz.member_authorization_targets(
+        organization_member_id=member_id
+    )
     await org_service.remove_member(
         member_id=member_id,
         requester_user_id=user.id,
         organization_id=org_id,
     )
+    if targets is not None:
+        await authz.purge_member_authorization(targets)

--- a/lemma-backend/app/modules/identity/domain/organization_entities.py
+++ b/lemma-backend/app/modules/identity/domain/organization_entities.py
@@ -16,6 +16,34 @@ class OrganizationRole(str, Enum):
     ORG_MEMBER = "ORG_MEMBER"
 
 
+# Organization roles ordered from least to most privileged. Mirrors the implicit
+# hierarchy already relied on in organization_service (e.g. an editor cannot
+# remove an owner).
+ORG_ROLE_HIERARCHY: dict["OrganizationRole", int] = {
+    OrganizationRole.ORG_MEMBER: 1,
+    OrganizationRole.ORG_EDITOR: 2,
+    OrganizationRole.ORG_OWNER: 3,
+}
+
+
+def can_grant_org_role(
+    approver_role: "OrganizationRole", target_role: "OrganizationRole"
+) -> bool:
+    """Whether ``approver_role`` may grant ``target_role`` to another member.
+
+    Only an ORG_OWNER may grant an elevated role (ORG_OWNER/ORG_EDITOR); every
+    lesser approver is capped at ORG_MEMBER. This blocks an editor — or a pod
+    admin who is only an org member — from minting an org owner/editor through a
+    side channel such as approving a join request.
+    """
+    if approver_role == OrganizationRole.ORG_OWNER:
+        return True
+    return (
+        ORG_ROLE_HIERARCHY[target_role]
+        <= ORG_ROLE_HIERARCHY[OrganizationRole.ORG_MEMBER]
+    )
+
+
 class OrganizationJoinPolicy(str, Enum):
     """Who may self-join an organization, ordered from closed to open."""
 

--- a/lemma-backend/app/modules/identity/tests/unit/test_security_killswitch.py
+++ b/lemma-backend/app/modules/identity/tests/unit/test_security_killswitch.py
@@ -11,7 +11,15 @@ import pytest
 from fastapi import HTTPException
 
 from app.core import security
-from app.core.authorization.delegation import CLAIM_ACTOR_ID
+from app.core.authorization.delegation import (
+    CLAIM_ACTOR_ID,
+    CLAIM_ACTOR_TYPE,
+    CLAIM_DELEGATION_VERSION,
+    CLAIM_INVOKED_BY_USER_ID,
+    CLAIM_POD_ID,
+    CLAIM_SESSION_ID,
+    DELEGATION_VERSION,
+)
 
 
 class _FakeSession:
@@ -76,3 +84,65 @@ async def test_plain_user_token_accepted_when_delegation_disabled(monkeypatch):
 
     assert conn.state.user is not None
     assert conn.state.delegation_claims is None
+
+
+def _delegation_payload(*, user_id: str, actor_id: str) -> dict:
+    return {
+        CLAIM_ACTOR_TYPE: "AGENT",
+        CLAIM_ACTOR_ID: actor_id,
+        CLAIM_POD_ID: str(uuid4()),
+        CLAIM_SESSION_ID: "sess",
+        CLAIM_INVOKED_BY_USER_ID: user_id,
+        CLAIM_DELEGATION_VERSION: DELEGATION_VERSION,
+        "isImpersonation": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_revoked_delegation_token_rejected(monkeypatch):
+    user_id = str(uuid4())
+    actor_id = str(uuid4())
+    monkeypatch.setattr(
+        security.settings, "authz_delegated_tokens_enabled", True, raising=False
+    )
+    monkeypatch.setattr(
+        security,
+        "get_session",
+        AsyncMock(
+            return_value=_FakeSession(
+                user_id, _delegation_payload(user_id=user_id, actor_id=actor_id)
+            )
+        ),
+    )
+    monkeypatch.setattr(security, "is_delegation_revoked", AsyncMock(return_value=True))
+
+    with pytest.raises(HTTPException) as exc:
+        await security.verify_auth(_connection())
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail["code"] == "DELEGATION_REVOKED"
+
+
+@pytest.mark.asyncio
+async def test_live_delegation_token_accepted(monkeypatch):
+    conn = _connection()
+    user_id = str(uuid4())
+    actor_id = str(uuid4())
+    monkeypatch.setattr(
+        security.settings, "authz_delegated_tokens_enabled", True, raising=False
+    )
+    monkeypatch.setattr(
+        security,
+        "get_session",
+        AsyncMock(
+            return_value=_FakeSession(
+                user_id, _delegation_payload(user_id=user_id, actor_id=actor_id)
+            )
+        ),
+    )
+    monkeypatch.setattr(security, "is_delegation_revoked", AsyncMock(return_value=False))
+
+    await security.verify_auth(conn)
+
+    assert conn.state.delegation_claims is not None
+    assert str(conn.state.delegation_claims.actor_id) == actor_id

--- a/lemma-backend/app/modules/identity/tests/unit/test_security_killswitch.py
+++ b/lemma-backend/app/modules/identity/tests/unit/test_security_killswitch.py
@@ -1,0 +1,78 @@
+"""When delegated tokens are disabled, verify_auth must reject impersonation /
+delegation tokens rather than silently honoring them as full user sessions."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.core import security
+from app.core.authorization.delegation import CLAIM_ACTOR_ID
+
+
+class _FakeSession:
+    def __init__(self, user_id: str, payload: dict):
+        self._user_id = user_id
+        self._payload = payload
+
+    def get_user_id(self) -> str:
+        return self._user_id
+
+    def get_access_token_payload(self) -> dict:
+        return self._payload
+
+
+def _connection() -> SimpleNamespace:
+    return SimpleNamespace(
+        url=SimpleNamespace(path="/pods/does-not-matter"),
+        scope={"type": "http"},
+        state=SimpleNamespace(),
+    )
+
+
+def _patch(monkeypatch, *, flag: bool, payload: dict):
+    monkeypatch.setattr(
+        security.settings, "authz_delegated_tokens_enabled", flag, raising=False
+    )
+    monkeypatch.setattr(
+        security,
+        "get_session",
+        AsyncMock(return_value=_FakeSession(str(uuid4()), payload)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_impersonation_token_rejected_when_delegation_disabled(monkeypatch):
+    _patch(monkeypatch, flag=False, payload={"isImpersonation": True})
+
+    with pytest.raises(HTTPException) as exc:
+        await security.verify_auth(_connection())
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail["code"] == "IMPERSONATION_NOT_ALLOWED"
+
+
+@pytest.mark.asyncio
+async def test_delegation_claim_token_rejected_when_delegation_disabled(monkeypatch):
+    _patch(monkeypatch, flag=False, payload={CLAIM_ACTOR_ID: str(uuid4())})
+
+    with pytest.raises(HTTPException) as exc:
+        await security.verify_auth(_connection())
+
+    assert exc.value.status_code == 403
+    assert exc.value.detail["code"] == "IMPERSONATION_NOT_ALLOWED"
+
+
+@pytest.mark.asyncio
+async def test_plain_user_token_accepted_when_delegation_disabled(monkeypatch):
+    conn = _connection()
+    _patch(monkeypatch, flag=False, payload={"client": "lemma-cli"})
+
+    await security.verify_auth(conn)
+
+    assert conn.state.user is not None
+    assert conn.state.delegation_claims is None

--- a/lemma-backend/app/modules/pod/api/controllers/pod_join_request_controller.py
+++ b/lemma-backend/app/modules/pod/api/controllers/pod_join_request_controller.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, status
 
 from app.core.api.dependencies import CurrentUser, UoWDep
 from app.core.api.pagination import parse_uuid_page_token
+from app.core.authorization.dependencies import reject_delegated_workload_pod
 from app.core.authorization.service import AuthorizationDataService
 from app.modules.identity.domain.organization_entities import OrganizationRole
 from app.modules.pod.api.dependencies import PodJoinRequestServiceDep
@@ -110,6 +111,7 @@ async def list_join_requests(
     summary="Approve Pod Join Request",
     description="Approve a pending pod join request and add user to org/pod",
     response_model=PodJoinRequestCreateResponse,
+    dependencies=[reject_delegated_workload_pod("approve join requests")],
 )
 async def approve_join_request(
     pod_id: UUID,

--- a/lemma-backend/app/modules/pod/api/controllers/pod_member_controller.py
+++ b/lemma-backend/app/modules/pod/api/controllers/pod_member_controller.py
@@ -33,6 +33,7 @@ _PodMemberManageDep = require_action(Permissions.POD_MEMBER_MANAGE, pod_from_pat
     summary="Add Pod Member",
     description="Add a member to a pod",
     response_model=PodMemberResponse,
+    dependencies=[_PodMemberManageDep],
 )
 async def add_member(
     pod_id: UUID,

--- a/lemma-backend/app/modules/pod/api/controllers/resource_access_controller.py
+++ b/lemma-backend/app/modules/pod/api/controllers/resource_access_controller.py
@@ -18,6 +18,7 @@ from app.core.authorization.grants import (
     validate_pod_resource_grant_permissions,
 )
 from app.core.authorization.models import RoleModel
+from app.core.authorization.permissions import Permissions
 from app.core.authorization.resource_actions import RESOURCE_ACTIONS
 from app.core.authorization.resource_names import resolve_resource_id_by_name
 from app.core.authorization.service import AuthorizationDataService
@@ -50,7 +51,7 @@ class _GrantInput:
     response_model=ResourceAccessResponse,
     status_code=status.HTTP_200_OK,
     operation_id="pod.resource_access.get",
-    dependencies=[require_action("pod.role.manage")],
+    dependencies=[require_action(Permissions.POD_ROLE_MANAGE)],
 )
 async def get_resource_access(
     pod_id: UUID,
@@ -89,7 +90,7 @@ async def get_resource_access(
     response_model=ResourceAccessResponse,
     status_code=status.HTTP_200_OK,
     operation_id="pod.resource_access.grant.replace",
-    dependencies=[require_action("pod.role.manage")],
+    dependencies=[require_action(Permissions.POD_ROLE_MANAGE)],
 )
 async def replace_resource_access_grant(
     pod_id: UUID,
@@ -158,7 +159,7 @@ async def replace_resource_access_grant(
     response_model=ResourceAccessResponse,
     status_code=status.HTTP_200_OK,
     operation_id="pod.resource_access.grant.delete",
-    dependencies=[require_action("pod.role.manage")],
+    dependencies=[require_action(Permissions.POD_ROLE_MANAGE)],
 )
 async def delete_resource_access_grant(
     pod_id: UUID,

--- a/lemma-backend/app/modules/pod/services/pod_join_request_service.py
+++ b/lemma-backend/app/modules/pod/services/pod_join_request_service.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from app.modules.identity.domain.organization_entities import (
     OrganizationMemberEntity,
     OrganizationRole,
+    can_grant_org_role,
 )
 from app.modules.pod.domain.errors import (
     PodAccessDeniedError,
@@ -338,7 +339,7 @@ class PodJoinRequestService:
         if not pod:
             raise PodNotFoundError()
 
-        await self._require_manage_permission(
+        approver = await self._require_manage_permission(
             pod_id=pod.id,
             organization_id=pod.organization_id,
             requester_user_id=requester_user_id,
@@ -353,11 +354,22 @@ class PodJoinRequestService:
                 f"Join request is already {join_request.status.value.lower()}"
             )
 
+        approver_is_org_manager = approver.role in (
+            OrganizationRole.ORG_OWNER,
+            OrganizationRole.ORG_EDITOR,
+        )
+
         target_org_member = await self.organization_repository.get_member(
             join_request.user_id,
             pod.organization_id,
         )
         if not target_org_member:
+            # The org role is granted to a brand-new member here, so bound it to
+            # what the approver may confer: only an org owner mints owners/editors.
+            if not can_grant_org_role(approver.role, org_role):
+                raise PodAccessDeniedError(
+                    "You may not grant that organization role"
+                )
             target_org_member = await self.organization_repository.add_member(
                 OrganizationMemberEntity(
                     user_id=join_request.user_id,
@@ -378,6 +390,17 @@ class PodJoinRequestService:
             )
             created_member = await self.pod_member_repository.create(pod_member)
             if self.pod_role_service is not None:
+                # A pod-admin approver (not an org-level manager) may only confer
+                # pod roles within their own bounds. Org owners/editors manage the
+                # pod with org authority and are not pod members, so they skip the
+                # pod-membership-based bounds check.
+                if not approver_is_org_manager:
+                    await self.pod_role_service.require_role_manager_bounds(
+                        pod_id=pod_id,
+                        requester_user_id=requester_user_id,
+                        target_roles=[pod_role],
+                        target_user_id=join_request.user_id,
+                    )
                 await self.pod_role_service.sync_member_roles(
                     pod_id=pod_id,
                     pod_member_id=created_member.id,

--- a/lemma-backend/app/modules/pod/services/pod_member_service.py
+++ b/lemma-backend/app/modules/pod/services/pod_member_service.py
@@ -302,11 +302,13 @@ class PodMemberService:
                     "Only org owners or pod admins can remove members"
                 )
 
+        removed_user_id: UUID | None = None
         try:
             org_member_to_remove = await self.organization_repository.get_member_by_id(
                 pod_member.organization_member_id
             )
             if org_member_to_remove:
+                removed_user_id = org_member_to_remove.user_id
                 pod_member.mark_removed(user_id=org_member_to_remove.user_id)
         except Exception as e:
             logger.warning(f"Failed to fetch user info for event emission: {e}")
@@ -314,6 +316,16 @@ class PodMemberService:
         deleted = await self.pod_member_repository.delete_entity(pod_member)
         if not deleted:
             raise PodMemberNotFoundError()
+
+        # Revoke the removed member's cached authorization immediately (and clean
+        # up their role assignments / grants). Without this, a cached role
+        # snapshot would keep granting pod access until its TTL elapses.
+        if self.pod_role_service is not None:
+            await self.pod_role_service.revoke_member_authorization(
+                pod_id=pod_member.pod_id,
+                pod_member_id=pod_member.id,
+                user_id=removed_user_id,
+            )
 
         return True
 

--- a/lemma-backend/app/modules/pod/services/pod_role_service.py
+++ b/lemma-backend/app/modules/pod/services/pod_role_service.py
@@ -6,7 +6,9 @@ from uuid import UUID
 
 from fastapi import HTTPException, status
 
+from app.core.authorization.cache import invalidate_role_snapshot_cache
 from app.core.authorization.factory import create_authorization_data_service
+from app.core.authorization.grants import delete_grantee_grants
 from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
 from app.modules.pod.domain.role_entities import PodRoleEntity, SYSTEM_ROLE_NAMES
 from app.modules.pod.domain.roles import PodRole
@@ -144,6 +146,27 @@ class PodRoleService:
             assigned_by_user_id=added_by_user_id,
         )
         return normalized_roles
+
+    async def revoke_member_authorization(
+        self,
+        *,
+        pod_id: UUID,
+        pod_member_id: UUID,
+        user_id: UUID | None,
+    ) -> None:
+        """Drop a removed pod member's role assignments and resource grants and
+        invalidate their cached role snapshot, so pod access is revoked on the
+        next request instead of lingering until the snapshot TTL elapses."""
+        await self._authz.delete_principal_role_assignments(
+            principal_type="POD_MEMBER", principal_id=pod_member_id
+        )
+        await delete_grantee_grants(
+            self._authz.session,
+            pod_id=pod_id,
+            grantee_type="POD_MEMBER",
+            grantee_id=pod_member_id,
+        )
+        await invalidate_role_snapshot_cache(user_id=user_id)
 
     async def get_member_roles_by_user_id(
         self,

--- a/lemma-backend/app/modules/pod/tests/e2e/test_authz_hardening_e2e.py
+++ b/lemma-backend/app/modules/pod/tests/e2e/test_authz_hardening_e2e.py
@@ -1,0 +1,206 @@
+"""End-to-end coverage for the authorization-hardening fixes:
+
+- join-request approval cannot grant an org role above the approver's authority;
+- a removed pod member loses access on the very next request (no TTL wait);
+- a delegated workload cannot manage members or approve join requests.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from httpx import AsyncClient
+from starlette import status
+
+from app.core.authorization.delegation import (
+    DEFAULT_POD_AGENT_ID,
+    DEFAULT_POD_AGENT_NAME,
+)
+from app.modules.identity.infrastructure.supertokens_auth.helpers import get_user_token
+from app.modules.identity.infrastructure.supertokens_auth.token_factory import (
+    build_delegation_claims,
+)
+from app.modules.test_support.e2e_authz import (
+    add_pod_member,
+    auth_headers,
+    invite_org_member,
+    signup_user,
+)
+
+pytestmark = pytest.mark.e2e
+
+
+async def _create_pod(owner_client: AsyncClient, org_id: str, name: str) -> str:
+    response = await owner_client.post(
+        "/pods",
+        json={
+            "organization_id": org_id,
+            "name": f"{name} {uuid4().hex[:8]}",
+            "description": "authz hardening e2e",
+            "type": "HYBRID",
+        },
+    )
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+    return response.json()["id"]
+
+
+async def _default_pod_agent_headers(*, user_id: str, pod_id: str) -> dict[str, str]:
+    claims = build_delegation_claims(
+        workload_type="agent",
+        workload_id=DEFAULT_POD_AGENT_ID,
+        workload_name=DEFAULT_POD_AGENT_NAME,
+        pod_id=UUID(pod_id),
+        session_id=f"authz-hardening-e2e-{uuid4().hex}",
+        invoked_by_user_id=UUID(user_id),
+    )
+    token = await get_user_token(UUID(user_id), delegation_claims=claims)
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.mark.asyncio
+async def test_pod_admin_cannot_mint_org_owner_via_join_approval(
+    authenticated_client: AsyncClient,
+    async_client: AsyncClient,
+    fixed_test_org,
+):
+    """A POD_ADMIN who is only an ORG_MEMBER may approve join requests, but must
+    not be able to grant the joining user an elevated org role."""
+    org_id = fixed_test_org["id"]
+    pod_id = await _create_pod(authenticated_client, org_id, "Escalation Pod")
+
+    approver = await signup_user(async_client, "approver")
+    approver_org_member = await invite_org_member(
+        authenticated_client, async_client, org_id=org_id, user=approver
+    )
+    await add_pod_member(
+        authenticated_client,
+        pod_id=pod_id,
+        organization_member_id=approver_org_member["id"],
+        role="POD_ADMIN",
+        roles=["POD_ADMIN"],
+    )
+
+    requester = await signup_user(async_client, "requester")
+    create = await async_client.post(
+        f"/pods/{pod_id}/join-requests", headers=auth_headers(requester)
+    )
+    assert create.status_code == status.HTTP_201_CREATED, create.text
+    join_request_id = create.json()["id"]
+
+    # Escalation attempt: mint an org owner. Must be rejected.
+    escalate = await async_client.post(
+        f"/pods/{pod_id}/join-requests/{join_request_id}/approve",
+        json={"org_role": "ORG_OWNER", "pod_role": "POD_VIEWER"},
+        headers=auth_headers(approver),
+    )
+    assert escalate.status_code == status.HTTP_403_FORBIDDEN, escalate.text
+
+    # Control: a permitted org role still approves.
+    ok = await async_client.post(
+        f"/pods/{pod_id}/join-requests/{join_request_id}/approve",
+        json={"org_role": "ORG_MEMBER", "pod_role": "POD_VIEWER"},
+        headers=auth_headers(approver),
+    )
+    assert ok.status_code == status.HTTP_200_OK, ok.text
+    assert ok.json()["status"] == "APPROVED"
+
+
+@pytest.mark.asyncio
+async def test_removed_member_loses_access_immediately(
+    authenticated_client: AsyncClient,
+    async_client: AsyncClient,
+    fixed_test_org,
+):
+    """Removing a member invalidates their cached role snapshot, so the next
+    authorized request is denied rather than served from the stale snapshot."""
+    org_id = fixed_test_org["id"]
+    pod_id = await _create_pod(authenticated_client, org_id, "Removal Pod")
+
+    member = await signup_user(async_client, "removed")
+    member_org = await invite_org_member(
+        authenticated_client, async_client, org_id=org_id, user=member
+    )
+    pod_member = await add_pod_member(
+        authenticated_client,
+        pod_id=pod_id,
+        organization_member_id=member_org["id"],
+        role="POD_EDITOR",
+        roles=["POD_EDITOR"],
+    )
+
+    # A pod.read-gated endpoint (goes through the cached role snapshot). This
+    # first call populates the snapshot for the member.
+    catalog_url = f"/pods/{pod_id}/permissions/catalog"
+    before = await async_client.get(catalog_url, headers=auth_headers(member))
+    assert before.status_code == status.HTTP_200_OK, before.text
+
+    removed = await authenticated_client.delete(
+        f"/pods/{pod_id}/members/{pod_member['pod_member_id']}"
+    )
+    assert removed.status_code == status.HTTP_204_NO_CONTENT, removed.text
+
+    # Denied on the very next request — no waiting for the snapshot TTL.
+    after = await async_client.get(catalog_url, headers=auth_headers(member))
+    assert after.status_code == status.HTTP_403_FORBIDDEN, after.text
+
+
+@pytest.mark.asyncio
+async def test_default_pod_agent_cannot_add_member(
+    authenticated_client: AsyncClient,
+    async_client: AsyncClient,
+    fixed_test_org,
+    fixed_test_user,
+):
+    """A delegated workload hits the destructive-action gate on member add."""
+    org_id = fixed_test_org["id"]
+    pod_id = await _create_pod(authenticated_client, org_id, "Agent Add Pod")
+
+    candidate = await signup_user(async_client, "candidate")
+    candidate_org = await invite_org_member(
+        authenticated_client, async_client, org_id=org_id, user=candidate
+    )
+
+    agent_headers = await _default_pod_agent_headers(
+        user_id=fixed_test_user["id"], pod_id=pod_id
+    )
+    response = await async_client.post(
+        f"/pods/{pod_id}/members",
+        json={
+            "organization_member_id": candidate_org["id"],
+            "roles": ["POD_VIEWER"],
+        },
+        headers=agent_headers,
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN, response.text
+    assert response.json()["code"] == "DESTRUCTIVE_ACTION_REQUIRES_APPROVAL"
+
+
+@pytest.mark.asyncio
+async def test_default_pod_agent_cannot_approve_join_request(
+    authenticated_client: AsyncClient,
+    async_client: AsyncClient,
+    fixed_test_org,
+    fixed_test_user,
+):
+    """A delegated workload is denied outright on join-request approval."""
+    org_id = fixed_test_org["id"]
+    pod_id = await _create_pod(authenticated_client, org_id, "Agent Approve Pod")
+
+    requester = await signup_user(async_client, "agent-approve-req")
+    create = await async_client.post(
+        f"/pods/{pod_id}/join-requests", headers=auth_headers(requester)
+    )
+    assert create.status_code == status.HTTP_201_CREATED, create.text
+    join_request_id = create.json()["id"]
+
+    agent_headers = await _default_pod_agent_headers(
+        user_id=fixed_test_user["id"], pod_id=pod_id
+    )
+    response = await async_client.post(
+        f"/pods/{pod_id}/join-requests/{join_request_id}/approve",
+        json={"org_role": "ORG_MEMBER", "pod_role": "POD_VIEWER"},
+        headers=agent_headers,
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN, response.text
+    assert response.json()["code"] == "DESTRUCTIVE_ACTION_REQUIRES_APPROVAL"

--- a/lemma-backend/app/modules/pod/tests/unit/test_pod_join_request_service.py
+++ b/lemma-backend/app/modules/pod/tests/unit/test_pod_join_request_service.py
@@ -276,6 +276,120 @@ async def test_approve_join_request_adds_org_and_pod_membership_when_missing():
     pod_member_repo.create.assert_awaited_once()
 
 
+def _approve_setup(*, approver_role, requester_pod_roles=None):
+    """Wire mocks for an approve_join_request call that creates a NEW member.
+
+    ``approver_role`` is the approver's org role; ``requester_pod_roles`` (when
+    given) makes them a pod member with those roles so an ORG_MEMBER approver can
+    still pass ``_require_manage_permission`` via the pod-admin tier.
+    """
+    pod_id = uuid4()
+    org_id = uuid4()
+    requester_id = uuid4()
+    target_user_id = uuid4()
+
+    pod_repo = AsyncMock()
+    pod_repo.get.return_value = PodEntity(
+        id=pod_id, user_id=requester_id, organization_id=org_id, name="Pod"
+    )
+
+    join_request = PodJoinRequestEntity(
+        id=uuid4(),
+        pod_id=pod_id,
+        organization_id=org_id,
+        user_id=target_user_id,
+        status=PodJoinRequestStatus.PENDING,
+    )
+    join_repo = AsyncMock()
+    join_repo.get.return_value = join_request
+    join_repo.update.side_effect = lambda entity: entity
+
+    requester_org_member = _org_member(
+        member_id=uuid4(), role=approver_role, org_id=org_id, user_id=requester_id
+    )
+
+    pod_member_repo = AsyncMock()
+    if requester_pod_roles is not None:
+        pod_member_repo.get_by_pod_and_org_member.return_value = PodMemberEntity(
+            pod_id=pod_id,
+            organization_member_id=requester_org_member.id,
+            roles=requester_pod_roles,
+        )
+    else:
+        pod_member_repo.get_by_pod_and_org_member.return_value = None
+
+    org_repo = AsyncMock()
+    # First get_member: the approver (in _require_manage_permission); second: the
+    # target user (not yet an org member, so a new membership would be created).
+    org_repo.get_member.side_effect = [requester_org_member, None]
+    org_repo.add_member.side_effect = lambda entity: entity
+
+    service = PodJoinRequestService(
+        pod_join_request_repository=join_repo,
+        pod_member_repository=pod_member_repo,
+        pod_repository=pod_repo,
+        organization_repository=org_repo,
+    )
+    return service, join_request, requester_id, org_repo
+
+
+@pytest.mark.asyncio
+async def test_approve_join_request_org_editor_cannot_grant_org_owner():
+    service, join_request, requester_id, org_repo = _approve_setup(
+        approver_role=OrganizationRole.ORG_EDITOR
+    )
+
+    with pytest.raises(PodAccessDeniedError):
+        await service.approve_join_request(
+            join_request.pod_id,
+            join_request.id,
+            requester_id,
+            org_role=OrganizationRole.ORG_OWNER,
+            pod_role=PodRole.USER,
+        )
+    org_repo.add_member.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_approve_join_request_pod_admin_org_member_cannot_grant_org_owner():
+    # A pod admin who is only an ORG_MEMBER can approve join requests, but must
+    # not be able to mint an org owner through the approval.
+    service, join_request, requester_id, org_repo = _approve_setup(
+        approver_role=OrganizationRole.ORG_MEMBER,
+        requester_pod_roles=[PodRole.ADMIN.value],
+    )
+
+    with pytest.raises(PodAccessDeniedError):
+        await service.approve_join_request(
+            join_request.pod_id,
+            join_request.id,
+            requester_id,
+            org_role=OrganizationRole.ORG_OWNER,
+            pod_role=PodRole.USER,
+        )
+    org_repo.add_member.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_approve_join_request_org_owner_may_grant_org_owner():
+    service, join_request, requester_id, org_repo = _approve_setup(
+        approver_role=OrganizationRole.ORG_OWNER
+    )
+
+    result = await service.approve_join_request(
+        join_request.pod_id,
+        join_request.id,
+        requester_id,
+        org_role=OrganizationRole.ORG_OWNER,
+        pod_role=PodRole.USER,
+    )
+
+    assert result.status == PodJoinRequestStatus.APPROVED
+    org_repo.add_member.assert_awaited_once()
+    created = org_repo.add_member.await_args.args[0]
+    assert created.role == OrganizationRole.ORG_OWNER
+
+
 def _org_member(*, member_id, role, org_id, user_id):
     return OrganizationMemberEntity(
         id=member_id, user_id=user_id, organization_id=org_id, role=role

--- a/lemma-backend/app/modules/pod/tests/unit/test_pod_member_service.py
+++ b/lemma-backend/app/modules/pod/tests/unit/test_pod_member_service.py
@@ -275,6 +275,55 @@ async def test_remove_member_not_found_raises(
 
 
 @pytest.mark.asyncio
+async def test_remove_member_revokes_authorization():
+    # Removal must revoke the member's cached authorization immediately (targeted
+    # by the removed user's id), not leave it live until the snapshot TTL.
+    requester_id = uuid4()
+    target_user_id = uuid4()
+    pod = _make_pod(organization_id=uuid4(), user_id=uuid4())
+    member = PodMemberEntity(
+        pod_id=pod.id,
+        organization_member_id=uuid4(),
+        role=PodRole.EDITOR,
+        user_id=target_user_id,
+    )
+
+    pod_member_repo = AsyncMock()
+    pod_member_repo.get_by_pod_and_id.return_value = member
+    pod_member_repo.delete_entity.return_value = True
+    pod_repo = AsyncMock()
+    pod_repo.get.return_value = pod
+    org_repo = AsyncMock()
+    org_repo.get_member.return_value = _make_org_member(
+        user_id=requester_id,
+        organization_id=pod.organization_id,
+        role=OrganizationRole.ORG_OWNER,
+    )
+    org_repo.get_member_by_id.return_value = _make_org_member(
+        user_id=target_user_id,
+        organization_id=pod.organization_id,
+        role=OrganizationRole.ORG_MEMBER,
+    )
+    role_service = AsyncMock()
+
+    service = PodMemberService(
+        pod_member_repository=pod_member_repo,
+        pod_repository=pod_repo,
+        organization_repository=org_repo,
+        pod_role_service=role_service,
+    )
+
+    result = await service.remove_member_from_pod(pod.id, member.id, requester_id)
+
+    assert result is True
+    role_service.revoke_member_authorization.assert_awaited_once_with(
+        pod_id=member.pod_id,
+        pod_member_id=member.id,
+        user_id=target_user_id,
+    )
+
+
+@pytest.mark.asyncio
 async def test_update_member_role_sets_role(
     pod_member_service: PodMemberService,
     pod_repository_mock: AsyncMock,


### PR DESCRIPTION
## Summary

Hardens the authorization flow following a full review of the auth → core authorizer → delegation → datastore/pod/connectors path. Fixes one privilege-escalation bug, a revocation-correctness gap, several places where mutations skipped the delegated-workload gate, and caching/perf trade-offs.

Organized as independent commits so each slice is reviewable (and revertable) on its own. All new tests fail on `main` and pass here; the full unit suite is green (the 6 failing `test_surface_service.py` telegram tests are pre-existing on `main` and unrelated).

## What's fixed

| # | Severity | Fix |
|---|----------|-----|
| 1 | 🔴 P0 | **Join-request approval privilege escalation.** `approve_join_request` applied the client-supplied `org_role`/`pod_role` with no bounds check, so an ORG_EDITOR — or a POD_ADMIN who is only an ORG_MEMBER — could approve a sock-puppet join as `org_role=ORG_OWNER`. Now bounded by `can_grant_org_role` (only ORG_OWNER grants owner/editor) and the existing `require_role_manager_bounds` for the pod role. |
| 2 | 🟠 P1 / P2e | **Revocation latency on member removal.** Removing a pod/org member neither invalidated the role-snapshot cache nor deleted the member's (FK-less) role assignments, so access lingered up to the cache TTL (~300s). Now revokes + cleans up on removal, and invalidation is **targeted per-principal** (a single membership/role change no longer flushes every user's snapshot). |
| 3 | 🟡 P2a | **Member management skipped the delegated-workload gate.** `add_member` now carries the `pod.member.manage` gate its siblings already use; join-request approval rejects delegated workloads outright. |
| 4 | 🟡 P2c | **Cross-org connector accounts.** Account resolution ignored `organization_id`, so a user/workload in one org could resolve an account connected under another. Now scoped to the caller's org via the org-filtered repo lookups. |
| 5 | 🟡 P2d | **Delegation kill-switch footgun.** With `authz_delegated_tokens_enabled=False`, an impersonation/delegated token was honored as a full user session. Now rejected (403 `IMPERSONATION_NOT_ALLOWED`) so disabling the flag fails safe. |
| 6 | 🟢 P2b / P3 | **Delegation revocation** (deleted agent/function → in-flight tokens rejected via a Redis revocation set), **`invoked_by_user_id` assertion**, and the `pod.role.manage` enum cleanup. |

## ⚠️ Behavior changes to sign off

- **Commit 3**: `add_member` now requires `pod.member.manage` (admin / org-owner), matching the already-gated `update_member_roles` / `remove_member`. Pod **editors** can no longer add members via this endpoint.

## Decisions to confirm in review

- **Kill-switch (Commit 5)**: rejects any `isImpersonation`/delegation-claim token when delegation is disabled.
- **Revocation fail-mode (Commit 6)**: Redis down ⇒ treat as *not revoked* (availability over strictness), consistent with the other authz caches. TTL `delegation_revocation_ttl_seconds` (default 3600) must be ≥ max access-token lifetime.

## Deferred (follow-up)

- **OAuth PKCE** for the native connector flow: touches the live token-exchange path, needs per-connector opt-in (many providers don't support PKCE) and real provider round-trip testing. App-level CSRF (`state`/`get_by_state`) already covers the main threat. Tracked separately.

## Test plan

- `make test-unit` — green (pre-existing surface-service failures excepted).
- New regression tests per finding: join-request bounds, member-removal revocation + targeted invalidation, pod workload gate, cross-org account resolution, kill-switch, delegation revocation.
- `make test-e2e-fast` recommended before merge (auth/pod/connector flows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
