### PR TITLE
feat(connectors): add PKCE (S256) to native Lemma OAuth flow

### DIFF
--- a/lemma-backend/app/modules/connectors/domain/connector.py
+++ b/lemma-backend/app/modules/connectors/domain/connector.py
@@ -25,6 +25,13 @@ class OAuth2Defaults(BaseModel):
     extra_params: dict[str, Any] = Field(default_factory=dict)
     access_token_path: str = "access_token"
     refresh_token_path: str = "refresh_token"
+    use_pkce: bool = Field(
+        default=False,
+        description=(
+            "Opt in to PKCE (RFC 7636, S256) for the authorization-code flow. "
+            "Off by default because not every provider supports it."
+        ),
+    )
 
 
 class OAuth2Config(OAuth2Defaults):

--- a/lemma-backend/app/modules/connectors/domain/ports.py
+++ b/lemma-backend/app/modules/connectors/domain/ports.py
@@ -154,7 +154,7 @@ class AuthProviderPort(Protocol):
         user_id: UUID,
         state: str,
         redirect_uri: str,
-    ) -> tuple[str, str]: ...
+    ) -> tuple[str, str, Optional[str]]: ...
 
     async def exchange_code_for_credentials(
         self,
@@ -162,6 +162,7 @@ class AuthProviderPort(Protocol):
         redirect_uri: str,
         user_id: UUID,
         state: Optional[str] = None,
+        code_verifier: Optional[str] = None,
     ) -> OAuthCredentials: ...
 
     async def refresh_credentials(

--- a/lemma-backend/app/modules/connectors/services/auth/auth_provider.py
+++ b/lemma-backend/app/modules/connectors/services/auth/auth_provider.py
@@ -38,7 +38,7 @@ class AuthProviderInterface(ABC):
         user_id: UUID,
         state: str,
         redirect_uri: str,
-    ) -> Tuple[str, str]:
+    ) -> Tuple[str, str, Optional[str]]:
         """
         Get authorization URL for OAuth flow.
 
@@ -49,7 +49,9 @@ class AuthProviderInterface(ABC):
             redirect_uri: OAuth redirect URI
 
         Returns:
-            Tuple of (authorization_url, state)
+            Tuple of (authorization_url, state, code_verifier). ``code_verifier``
+            is the PKCE (RFC 7636) verifier that must be replayed at token
+            exchange, or ``None`` when the flow does not use PKCE.
         """
         pass
 
@@ -60,6 +62,7 @@ class AuthProviderInterface(ABC):
         redirect_uri: str,
         user_id: UUID,
         state: Optional[str] = None,
+        code_verifier: Optional[str] = None,
     ) -> OAuthCredentials:
         """
         Exchange authorization code for OAuth credentials.
@@ -69,6 +72,7 @@ class AuthProviderInterface(ABC):
             redirect_uri: The redirect URI with authorization code
             user_id: The user ID
             state: Optional OAuth state parameter
+            code_verifier: Optional PKCE (RFC 7636) code verifier to replay
 
         Returns:
             OAuthCredentials object

--- a/lemma-backend/app/modules/connectors/services/auth/composio_auth_provider.py
+++ b/lemma-backend/app/modules/connectors/services/auth/composio_auth_provider.py
@@ -239,7 +239,7 @@ class ComposioAuthProvider(AuthProviderInterface):
         user_id: UUID,
         state: str,
         redirect_uri: str,
-    ) -> Tuple[str, str]:
+    ) -> Tuple[str, str, Optional[str]]:
         composio = self._composio_client_factory()
 
         auth_config_id = self._resolve_auth_config_id(connector, composio)
@@ -255,7 +255,9 @@ class ComposioAuthProvider(AuthProviderInterface):
         if not connection_request.redirect_url:
             raise ConnectorValidationError("No redirect URL found for Composio app")
 
-        return connection_request.redirect_url, connection_request.id
+        # Composio manages the OAuth handshake (PKCE included) on its side, so
+        # there is no verifier for Lemma to persist and replay.
+        return connection_request.redirect_url, connection_request.id, None
 
     async def exchange_code_for_credentials(
         self,
@@ -263,6 +265,7 @@ class ComposioAuthProvider(AuthProviderInterface):
         redirect_uri: str,
         user_id: UUID,
         state: Optional[str] = None,
+        code_verifier: Optional[str] = None,
     ) -> OAuthCredentials:
         composio_app_name = self._toolkit_slug(connector)
 

--- a/lemma-backend/app/modules/connectors/services/auth/lemma_auth_provider.py
+++ b/lemma-backend/app/modules/connectors/services/auth/lemma_auth_provider.py
@@ -4,6 +4,7 @@ from typing import Awaitable, Callable, Optional, Tuple
 from urllib.parse import urlsplit, urlunsplit
 from uuid import UUID
 
+from authlib.common.security import generate_token
 from authlib.integrations.requests_client import OAuth2Session
 
 from app.modules.connectors.domain.account import OAuthCredentials
@@ -16,6 +17,10 @@ from app.core.log.log import get_logger
 logger = get_logger(__name__)
 
 CloudIdResolver = Callable[[str], Awaitable[str]]
+
+# RFC 7636 recommends a 43–128 char verifier; 48 random bytes → a 64-char
+# base64url token, comfortably inside that range.
+_PKCE_VERIFIER_BYTES = 48
 
 
 class LemmaAuthProvider(AuthProviderInterface):
@@ -45,7 +50,7 @@ class LemmaAuthProvider(AuthProviderInterface):
         user_id: UUID,
         state: str,
         redirect_uri: str,
-    ) -> Tuple[str, str]:
+    ) -> Tuple[str, str, Optional[str]]:
         if not connector.oauth2_config:
             raise ConnectorValidationError(
                 "OAuth2 configuration not found for connector"
@@ -53,21 +58,29 @@ class LemmaAuthProvider(AuthProviderInterface):
 
         oauth_config = connector.oauth2_config
 
+        # PKCE is opt-in per connector: only providers that advertise S256
+        # support get a code challenge, so existing flows are untouched.
+        code_verifier = generate_token(_PKCE_VERIFIER_BYTES) if oauth_config.use_pkce else None
+
         oauth = self._oauth_session_factory(
             client_id=oauth_config.client_id,
             client_secret=oauth_config.client_secret,
             redirect_uri=redirect_uri,
             scope=oauth_config.default_scopes,
+            code_challenge_method="S256" if oauth_config.use_pkce else None,
         )
 
+        # authlib derives the S256 challenge from the verifier and appends
+        # ``code_challenge``/``code_challenge_method`` to the URL for us.
         authorization_url, provider_state = await asyncio.to_thread(
             oauth.create_authorization_url,
             url=oauth_config.authorization_url,
             state=state,
+            code_verifier=code_verifier,
             **(oauth_config.extra_params or {})
         )
 
-        return authorization_url, provider_state
+        return authorization_url, provider_state, code_verifier
 
     async def exchange_code_for_credentials(
         self,
@@ -75,6 +88,7 @@ class LemmaAuthProvider(AuthProviderInterface):
         redirect_uri: str,
         user_id: UUID,
         state: Optional[str] = None,
+        code_verifier: Optional[str] = None,
     ) -> OAuthCredentials:
         if not connector.oauth2_config:
             raise ConnectorValidationError(
@@ -92,11 +106,21 @@ class LemmaAuthProvider(AuthProviderInterface):
             scope=oauth_config.default_scopes,
         )
 
-        token_data = await asyncio.to_thread(
-            oauth.fetch_token,
-            url=oauth_config.token_url,
-            authorization_response=authorization_response,
-        )
+        fetch_kwargs: dict[str, object] = {
+            "url": oauth_config.token_url,
+            "authorization_response": authorization_response,
+        }
+        # Pass the validated state so authlib re-checks it against the value
+        # echoed back in the callback URL (defence in depth on top of the
+        # connect-request lookup by state).
+        if state is not None:
+            fetch_kwargs["state"] = state
+        # Replay the PKCE verifier so the provider can match it against the
+        # challenge from the authorization request (RFC 7636).
+        if code_verifier is not None:
+            fetch_kwargs["code_verifier"] = code_verifier
+
+        token_data = await asyncio.to_thread(oauth.fetch_token, **fetch_kwargs)
 
         return await self._create_oauth_credentials(token_data, connector)
 

--- a/lemma-backend/app/modules/connectors/services/connector_service.py
+++ b/lemma-backend/app/modules/connectors/services/connector_service.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 import secrets
-from typing import Optional
+from typing import Any, Optional
 from uuid import UUID
 
 from app.core.domain.uow import IUnitOfWork
@@ -772,6 +772,7 @@ class ConnectorService:
             (
                 authorization_url,
                 provider_state,
+                code_verifier,
             ) = await auth_provider.get_authorization_url(
                 connector=effective_connector,
                 user_id=user_id,
@@ -787,6 +788,15 @@ class ConnectorService:
                 details=self._exception_details(exc),
             ) from exc
 
+        attributes: dict[str, Any] = {
+            "state": state,
+            "provider_state": provider_state,
+        }
+        # Stash the PKCE verifier alongside the state so it can be replayed at
+        # token exchange; absent for non-PKCE flows.
+        if code_verifier is not None:
+            attributes["code_verifier"] = code_verifier
+
         connect_request = ConnectRequestEntity(
             user_id=user_id,
             organization_id=organization_id,
@@ -794,7 +804,7 @@ class ConnectorService:
             connector_id=connector.id,
             authorization_url=authorization_url,
             status=ConnectRequestStatus.PENDING,
-            attributes={"state": state, "provider_state": provider_state},
+            attributes=attributes,
         )
         connect_request = await self.connect_request_repository.create(connect_request)
         await self.uow.commit()
@@ -946,12 +956,15 @@ class ConnectorService:
         effective_connector = self._build_effective_connector(connector, auth_config)
         auth_provider = self._get_auth_provider_by_name(self._provider_value(auth_config))
 
+        code_verifier = (pending_request.attributes or {}).get("code_verifier")
+
         try:
             credentials = await auth_provider.exchange_code_for_credentials(
                 connector=effective_connector,
                 redirect_uri=redirect_uri,
                 user_id=user_id,
-                state=None,
+                state=state,
+                code_verifier=code_verifier,
             )
         except DomainError:
             raise

--- a/lemma-backend/app/modules/connectors/tests/e2e/test_accounts_connect_requests_e2e.py
+++ b/lemma-backend/app/modules/connectors/tests/e2e/test_accounts_connect_requests_e2e.py
@@ -80,10 +80,10 @@ async def test_connect_request_and_accounts_lifecycle(
 
     async def _fake_get_authorization_url(self, connector, user_id, state, redirect_uri):
         assert connector.oauth2_config.client_secret == "client-secret"
-        return ("https://mock.example.com/authorize", "provider_state")
+        return ("https://mock.example.com/authorize", "provider_state", None)
 
     async def _fake_exchange_code_for_credentials(
-        self, connector, redirect_uri, user_id, state=None
+        self, connector, redirect_uri, user_id, state=None, code_verifier=None
     ):
         return OAuthCredentials(
             access_token="access-token",

--- a/lemma-backend/app/modules/connectors/tests/unit/test_connector_service.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_connector_service.py
@@ -121,7 +121,7 @@ async def test_initiate_connect_request_allowed_when_account_exists():
     user_id = uuid4()
     auth_config = _auth_config()
     auth_provider = AsyncMock()
-    auth_provider.get_authorization_url.return_value = ("https://auth", "provider_state")
+    auth_provider.get_authorization_url.return_value = ("https://auth", "provider_state", None)
     registry = Mock()
     registry.get.return_value = auth_provider
     uow = AsyncMock()
@@ -152,7 +152,7 @@ async def test_initiate_connect_request_allowed_when_account_exists():
 async def test_initiate_connect_request_success():
     user_id = uuid4()
     auth_provider = AsyncMock()
-    auth_provider.get_authorization_url.return_value = ("https://auth", "provider_state")
+    auth_provider.get_authorization_url.return_value = ("https://auth", "provider_state", None)
     registry = Mock()
     registry.get.return_value = auth_provider
     uow = AsyncMock()
@@ -225,7 +225,7 @@ async def test_initiate_connect_request_allows_reauth_for_unusable_account():
     unusable.status = AccountStatus.REAUTH_REQUIRED
 
     auth_provider = AsyncMock()
-    auth_provider.get_authorization_url.return_value = ("https://auth", "provider_state")
+    auth_provider.get_authorization_url.return_value = ("https://auth", "provider_state", None)
     registry = Mock()
     registry.get.return_value = auth_provider
     connect_repo = AsyncMock()
@@ -1146,3 +1146,169 @@ async def test_create_account_allows_when_existing_identity_unhealthy():
     )
     account_repo.create.assert_awaited_once()
     assert account.provider_account_id == "acc-dup"
+
+
+async def test_initiate_connect_request_stores_pkce_verifier_in_attributes():
+    """A PKCE verifier returned by the provider is persisted on the connect
+    request so it can be replayed at token exchange."""
+    user_id = uuid4()
+    auth_provider = AsyncMock()
+    auth_provider.get_authorization_url.return_value = (
+        "https://auth",
+        "provider_state",
+        "pkce-verifier-xyz",
+    )
+    registry = Mock()
+    registry.get.return_value = auth_provider
+    connect_repo = AsyncMock()
+    connect_repo.create.side_effect = lambda req: req
+    redirect_builder = Mock()
+    redirect_builder.build.return_value = "https://callback"
+
+    service = _service(
+        connector_repository=AsyncMock(get=AsyncMock(return_value=_connector())),
+        auth_config_repository=_auth_config_repo(),
+        account_repository=AsyncMock(
+            get_by_user_and_auth_config=AsyncMock(return_value=None)
+        ),
+        connect_request_repository=connect_repo,
+        auth_provider_registry=registry,
+        redirect_uri_builder=redirect_builder,
+    )
+
+    result = await service.initiate_connect_request(
+        user_id=user_id, organization_id=ORG_ID, connector_id="slack"
+    )
+
+    assert result.attributes["code_verifier"] == "pkce-verifier-xyz"
+
+
+async def test_initiate_connect_request_omits_verifier_for_non_pkce_provider():
+    """Non-PKCE providers return no verifier, so none is stored (existing
+    connect requests keep their original attribute shape)."""
+    user_id = uuid4()
+    auth_provider = AsyncMock()
+    auth_provider.get_authorization_url.return_value = (
+        "https://auth",
+        "provider_state",
+        None,
+    )
+    registry = Mock()
+    registry.get.return_value = auth_provider
+    connect_repo = AsyncMock()
+    connect_repo.create.side_effect = lambda req: req
+    redirect_builder = Mock()
+    redirect_builder.build.return_value = "https://callback"
+
+    service = _service(
+        connector_repository=AsyncMock(get=AsyncMock(return_value=_connector())),
+        auth_config_repository=_auth_config_repo(),
+        account_repository=AsyncMock(
+            get_by_user_and_auth_config=AsyncMock(return_value=None)
+        ),
+        connect_request_repository=connect_repo,
+        auth_provider_registry=registry,
+        redirect_uri_builder=redirect_builder,
+    )
+
+    result = await service.initiate_connect_request(
+        user_id=user_id, organization_id=ORG_ID, connector_id="slack"
+    )
+
+    assert "code_verifier" not in result.attributes
+
+
+async def test_handle_oauth_callback_replays_stored_pkce_verifier():
+    """The stored verifier and validated state are forwarded to the token
+    exchange at callback time."""
+    user_id = uuid4()
+    auth_config = _auth_config("slack")
+    connect_request = ConnectRequestEntity(
+        id=uuid4(),
+        user_id=user_id,
+        organization_id=ORG_ID,
+        auth_config_id=auth_config.id,
+        connector_id="slack",
+        authorization_url="https://auth",
+        status=ConnectRequestStatus.PENDING,
+        attributes={"state": "state-pkce", "code_verifier": "stored-verifier"},
+    )
+    credentials = OAuthCredentials(access_token="xoxb-token")
+    auth_provider = AsyncMock()
+    auth_provider.exchange_code_for_credentials.return_value = credentials
+    registry = Mock()
+    registry.get.return_value = auth_provider
+
+    account_repo = AsyncMock()
+    account_repo.get_by_user_and_auth_config.return_value = None
+    account_repo.get_by_user_auth_config_and_provider_account.return_value = None
+    account_repo.create.side_effect = lambda entity: entity
+    connect_repo = AsyncMock()
+    connect_repo.get_by_state.return_value = connect_request
+    connect_repo.update.side_effect = lambda req: req
+
+    service = _service(
+        connector_repository=AsyncMock(get=AsyncMock(return_value=_connector("slack"))),
+        auth_config_repository=_auth_config_repo(auth_config),
+        account_repository=account_repo,
+        connect_request_repository=connect_repo,
+        auth_provider_registry=registry,
+    )
+
+    with patch.object(service, "_load_native_account_profile", AsyncMock(return_value=None)):
+        await service.handle_oauth_callback(
+            redirect_uri="https://cb?state=state-pkce&code=abc",
+            state="state-pkce",
+        )
+
+    _, kwargs = auth_provider.exchange_code_for_credentials.await_args
+    assert kwargs["code_verifier"] == "stored-verifier"
+    assert kwargs["state"] == "state-pkce"
+
+
+async def test_handle_oauth_callback_passes_none_verifier_for_non_pkce():
+    """A connect request with no stored verifier forwards ``None`` (Composio and
+    other non-PKCE flows are unaffected)."""
+    user_id = uuid4()
+    auth_config = _auth_config("slack")
+    connect_request = ConnectRequestEntity(
+        id=uuid4(),
+        user_id=user_id,
+        organization_id=ORG_ID,
+        auth_config_id=auth_config.id,
+        connector_id="slack",
+        authorization_url="https://auth",
+        status=ConnectRequestStatus.PENDING,
+        attributes={"state": "state-nopkce"},
+    )
+    credentials = OAuthCredentials(access_token="xoxb-token")
+    auth_provider = AsyncMock()
+    auth_provider.exchange_code_for_credentials.return_value = credentials
+    registry = Mock()
+    registry.get.return_value = auth_provider
+
+    account_repo = AsyncMock()
+    account_repo.get_by_user_and_auth_config.return_value = None
+    account_repo.get_by_user_auth_config_and_provider_account.return_value = None
+    account_repo.create.side_effect = lambda entity: entity
+    connect_repo = AsyncMock()
+    connect_repo.get_by_state.return_value = connect_request
+    connect_repo.update.side_effect = lambda req: req
+
+    service = _service(
+        connector_repository=AsyncMock(get=AsyncMock(return_value=_connector("slack"))),
+        auth_config_repository=_auth_config_repo(auth_config),
+        account_repository=account_repo,
+        connect_request_repository=connect_repo,
+        auth_provider_registry=registry,
+    )
+
+    with patch.object(service, "_load_native_account_profile", AsyncMock(return_value=None)):
+        await service.handle_oauth_callback(
+            redirect_uri="https://cb?state=state-nopkce&code=abc",
+            state="state-nopkce",
+        )
+
+    _, kwargs = auth_provider.exchange_code_for_credentials.await_args
+    assert kwargs["code_verifier"] is None
+    assert kwargs["state"] == "state-nopkce"

--- a/lemma-backend/app/modules/connectors/tests/unit/test_lemma_auth_provider.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_lemma_auth_provider.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from urllib.parse import parse_qs, urlsplit
 from uuid import uuid4
 
 import pytest
+from authlib.oauth2.rfc7636 import create_s256_code_challenge
 
 from app.modules.connectors.domain.connector import ConnectorEntity, OAuth2Config
 from app.modules.connectors.services.auth.lemma_auth_provider import LemmaAuthProvider
@@ -52,7 +54,7 @@ class FakeSlackOAuth2Session(FakeOAuth2Session):
         }
 
 
-def _connector() -> ConnectorEntity:
+def _connector(*, use_pkce: bool = False) -> ConnectorEntity:
     return ConnectorEntity(
         id="slack",
         oauth2_config=OAuth2Config(
@@ -61,6 +63,7 @@ def _connector() -> ConnectorEntity:
             default_scopes=["chat:write"],
             authorization_url="https://slack.com/oauth/v2/authorize",
             token_url="https://slack.com/api/oauth.v2.access",
+            use_pkce=use_pkce,
         ),
     )
 
@@ -104,3 +107,83 @@ async def test_exchange_code_normalizes_slack_token_type_to_bearer():
 
     assert credentials.access_token == "xoxp-user-token"
     assert credentials.token_type == "Bearer"
+
+
+# --- PKCE (RFC 7636, S256) ---------------------------------------------------
+
+
+async def test_authorization_url_adds_s256_challenge_and_returns_verifier():
+    # Real authlib session so the actual S256 derivation is exercised.
+    provider = LemmaAuthProvider()
+
+    url, state, code_verifier = await provider.get_authorization_url(
+        connector=_connector(use_pkce=True),
+        user_id=uuid4(),
+        state="csrf-state",
+        redirect_uri="https://cb.example.com/callback",
+    )
+
+    assert state == "csrf-state"
+    assert code_verifier is not None
+    # RFC 7636 requires a 43–128 char verifier from the unreserved set.
+    assert 43 <= len(code_verifier) <= 128
+
+    params = parse_qs(urlsplit(url).query)
+    assert params["code_challenge_method"] == ["S256"]
+    # The challenge on the wire must be S256(verifier), never the raw verifier.
+    assert params["code_challenge"] == [create_s256_code_challenge(code_verifier)]
+    assert code_verifier not in params.get("code_challenge", [])
+
+
+async def test_authorization_url_omits_challenge_when_pkce_disabled():
+    provider = LemmaAuthProvider()
+
+    url, _state, code_verifier = await provider.get_authorization_url(
+        connector=_connector(use_pkce=False),
+        user_id=uuid4(),
+        state="csrf-state",
+        redirect_uri="https://cb.example.com/callback",
+    )
+
+    assert code_verifier is None
+    params = parse_qs(urlsplit(url).query)
+    assert "code_challenge" not in params
+    assert "code_challenge_method" not in params
+
+
+async def test_exchange_code_replays_verifier_to_token_endpoint():
+    provider = LemmaAuthProvider(oauth_session_factory=FakeOAuth2Session)
+    callback_url = (
+        "https://example.ngrok.app/connectors/connect-requests/oauth/callback"
+        "?code=abc&state=xyz"
+    )
+
+    await provider.exchange_code_for_credentials(
+        connector=_connector(use_pkce=True),
+        redirect_uri=callback_url,
+        user_id=uuid4(),
+        state="xyz",
+        code_verifier="the-stored-verifier",
+    )
+
+    assert FakeOAuth2Session.last_fetch_token["code_verifier"] == "the-stored-verifier"
+    # State is forwarded so authlib re-validates it against the callback URL.
+    assert FakeOAuth2Session.last_fetch_token["state"] == "xyz"
+
+
+async def test_exchange_code_omits_verifier_and_state_when_absent():
+    provider = LemmaAuthProvider(oauth_session_factory=FakeOAuth2Session)
+    callback_url = (
+        "https://example.ngrok.app/connectors/connect-requests/oauth/callback"
+        "?code=abc&state=xyz"
+    )
+
+    await provider.exchange_code_for_credentials(
+        connector=_connector(use_pkce=False),
+        redirect_uri=callback_url,
+        user_id=uuid4(),
+    )
+
+    # Non-PKCE providers must see an unchanged token request.
+    assert "code_verifier" not in FakeOAuth2Session.last_fetch_token
+    assert "state" not in FakeOAuth2Session.last_fetch_token


### PR DESCRIPTION
## Summary

Adds PKCE (RFC 7636, S256) to the native Lemma OAuth2 connector flow, deferred from the authz-hardening PR (#90) because it touches the live token-exchange path and needed real provider round-trip testing.

**What changed:**
- `LemmaAuthProvider.get_authorization_url` generates a `code_verifier` + S256 `code_challenge` and returns the verifier alongside the authorization URL and provider state.
- `LemmaAuthProvider.exchange_code_for_credentials` accepts a `code_verifier` and replays it to authlib's `fetch_token`. It also now forwards the validated `state` to `fetch_token` (previously hardcoded to `None`), so authlib re-checks state against the callback URL as defence-in-depth on top of the existing `ConnectRequest.get_by_state` lookup.
- `ConnectorService.initiate_connect_request` stores the verifier in `ConnectRequest.attributes["code_verifier"]` next to `state`; `handle_oauth_callback` retrieves it and passes it through to the token exchange.
- PKCE is **opt-in per connector** via a new `OAuth2Defaults.use_pkce` flag (default `False`) — some providers don't support it, and this avoids breaking existing connections. No connector has it enabled yet; that's a follow-up once a provider is verified against a real token endpoint.
- `AuthProviderInterface`/`AuthProviderPort` signatures updated to the new 3-tuple / extra-param shape. `ComposioAuthProvider` gets the minimal mechanical alignment (returns `None` for the verifier, accepts and ignores `code_verifier`) — Composio manages its own OAuth handshake, so no PKCE logic was added there.

**Why:**
App-level CSRF protection via `state` + `get_by_state` already exists. PKCE adds a second, independent layer that protects the authorization code itself from interception/replay (e.g. a leaked redirect or a malicious app on the same device intercepting the callback), per RFC 7636. It was scoped out of the authz-hardening PR specifically to keep that PR's blast radius to authorization logic and out of the OAuth token-exchange path, which needs care and provider-specific verification.

## Test plan
- [x] `test_lemma_auth_provider.py`: authorization URL carries `code_challenge_method=S256` and `code_challenge == S256(verifier)` (never the raw verifier) when `use_pkce=True`; both omitted when `use_pkce=False`; verifier + state replayed to `fetch_token` when present, omitted when absent.
- [x] `test_connector_service.py`: verifier stored in `ConnectRequest.attributes` when returned by the provider, omitted when `None`; callback retrieves and forwards the stored verifier + validated state to `exchange_code_for_credentials`; non-PKCE connect requests pass `code_verifier=None` unchanged.
- [x] Full connectors unit suite (153 tests) + connect-requests e2e suite (18 tests) pass.
- [ ] Real provider round-trip test once a specific connector opts in via `use_pkce=True` (out of scope for this PR — see "opt-in per connector" above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)