### PR TITLE
fix(connectors): org_id path-param bug breaking account delete + delegation gap

### DIFF
--- a/lemma-backend/app/core/authorization/dependencies.py
+++ b/lemma-backend/app/core/authorization/dependencies.py
@@ -79,8 +79,10 @@ async def get_org_context(
     user: CurrentUser,
     uow: UoWDep,
 ) -> Context:
-    raw_org_id = request.path_params.get("org_id") or request.query_params.get(
-        "organization_id"
+    raw_org_id = (
+        request.path_params.get("org_id")
+        or request.path_params.get("organization_id")
+        or request.query_params.get("organization_id")
     )
     if raw_org_id is None:
         raise HTTPException(

--- a/lemma-backend/app/modules/connectors/api/auth_config_controller.py
+++ b/lemma-backend/app/modules/connectors/api/auth_config_controller.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Query
 
 from app.core.api.dependencies import CurrentUser
 from app.core.api.pagination import parse_uuid_page_token
+from app.core.authorization.dependencies import reject_delegated_workload
 from app.modules.connectors.api.dependencies import ConnectorServiceDep
 from app.modules.connectors.api.schemas import (
     AuthConfigCreateSchema,
@@ -137,6 +138,7 @@ async def get_auth_config(
 @router.delete(
     "/{auth_config_name}",
     operation_id="connector.auth_config.delete",
+    dependencies=[reject_delegated_workload("delete an auth config")],
 )
 async def delete_auth_config(
     user: CurrentUser,

--- a/lemma-backend/app/modules/connectors/domain/connector.py
+++ b/lemma-backend/app/modules/connectors/domain/connector.py
@@ -62,6 +62,10 @@ class LemmaProviderCapability(BaseModel):
     supports_org_custom_oauth: bool = False
     system_default_available: bool = False
     package_name: str | None = None
+    # Catalog-curated operation names (tried in order) that fetch the
+    # connected account's own profile (email/name/workspace), so display_name
+    # resolution doesn't depend on the OAuth response alone.
+    profile_operation_names: list[str] | None = None
 
 
 class ComposioProviderCapability(BaseModel):
@@ -71,6 +75,7 @@ class ComposioProviderCapability(BaseModel):
     auth_config_schema: dict[str, Any] | None = None
     system_default_available: bool = True
     supports_org_custom_auth_config: bool = False
+    profile_operation_names: list[str] | None = None
 
 
 ProviderCapability = Annotated[

--- a/lemma-backend/app/modules/connectors/infrastructure/repositories/account_repository.py
+++ b/lemma-backend/app/modules/connectors/infrastructure/repositories/account_repository.py
@@ -2,13 +2,17 @@ from typing import Optional, Sequence
 from uuid import UUID
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import selectinload
 
 from app.core.domain.message_bus import MessageBus
 from app.core.infrastructure.db.repository import SqlAlchemyRepository
 from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
 from app.modules.connectors.domain.account import AccountEntity
-from app.modules.connectors.domain.errors import AccountNotFoundError
+from app.modules.connectors.domain.errors import (
+    AccountAlreadyConnectedError,
+    AccountNotFoundError,
+)
 from app.modules.connectors.domain.ports import AccountRepositoryPort, SecretEncryptionPort
 from app.modules.connectors.infrastructure.models import Account
 
@@ -48,6 +52,24 @@ class AccountRepository(
         )
         return self.model_cls(**data)
 
+    def _reraise_as_conflict_if_duplicate_identity(
+        self, exc: IntegrityError, connector_id: str
+    ) -> None:
+        """Translate a uq_accounts_provider_identity violation into a clean
+        409, rather than letting the raw IntegrityError propagate.
+
+        App-level dedup (``_reject_if_identity_already_connected`` in
+        ConnectorService) already rejects the common case before either
+        create/update runs, but that check-then-act has a TOCTOU gap under
+        concurrency (e.g. two near-simultaneous OAuth callbacks for the same
+        identity) -- this is the backstop at the DB boundary. Re-raises
+        unrelated IntegrityErrors untouched (the same table also has a
+        uq_accounts_default_per_auth_config constraint).
+        """
+        if "uq_accounts_provider_identity" in str(exc.orig):
+            raise AccountAlreadyConnectedError(connector_id) from exc
+        raise exc
+
     def _to_entity(self, instance: Account) -> AccountEntity:
         data = {
             "id": instance.id,
@@ -74,7 +96,10 @@ class AccountRepository(
         """Create new account with eager loaded connector."""
         instance = self._to_model(entity)
         self.session.add(instance)
-        await self.session.flush()
+        try:
+            await self.session.flush()
+        except IntegrityError as exc:
+            self._reraise_as_conflict_if_duplicate_identity(exc, entity.connector_id)
         await self.session.refresh(instance, attribute_names=["connector"])
         return self._to_entity(instance)
 
@@ -99,7 +124,10 @@ class AccountRepository(
         instance.display_name = entity.display_name
         instance.status = entity.status.value if hasattr(entity.status, "value") else str(entity.status)
 
-        await self.session.flush()
+        try:
+            await self.session.flush()
+        except IntegrityError as exc:
+            self._reraise_as_conflict_if_duplicate_identity(exc, entity.connector_id)
         return self._to_entity(instance)
 
     async def get(self, id: UUID) -> Optional[AccountEntity]:

--- a/lemma-backend/app/modules/connectors/services/account_identity.py
+++ b/lemma-backend/app/modules/connectors/services/account_identity.py
@@ -110,11 +110,12 @@ async def _telegram_identity(creds: dict) -> AccountIdentity:
         logger.warning("Telegram getMe failed while resolving account identity: %s", exc)
         return AccountIdentity()
     bot_id = result.get("id")
+    bot_id_str = str(bot_id) if bot_id is not None else None
     username = _str(result.get("username"))
     first_name = _str(result.get("first_name"))
-    display = f"@{username}" if username else first_name
+    display = f"@{username}" if username else (first_name or bot_id_str)
     return AccountIdentity(
-        provider_account_id=str(bot_id) if bot_id is not None else None,
+        provider_account_id=bot_id_str,
         display_name=display,
     )
 
@@ -149,10 +150,13 @@ def _email_identity(creds: dict, profile: dict, raw: dict, user_data: dict) -> A
         or _str(creds.get("email"))
     )
     provider_account_id = email or _nested(raw, "sub") or _nested(user_data, "sub")
+    # Rare, but scopes can be narrow enough that no profile call surfaces an
+    # email (e.g. a Drive-only grant) -- fall back to the id we do have so the
+    # account is still distinguishable rather than unlabeled.
     return AccountIdentity(
         provider_account_id=provider_account_id,
         email=email,
-        display_name=email,
+        display_name=email or provider_account_id,
     )
 
 
@@ -169,9 +173,10 @@ def _slack_identity(creds: dict, profile: dict, raw: dict, user_data: dict) -> A
         or _nested(profile, "user_id")
     )
     bot_user_id = _nested(raw, "bot_user_id") or _nested(profile, "bot_id")
+    provider_account_id = user_id or bot_user_id or team_id
     return AccountIdentity(
-        provider_account_id=user_id or bot_user_id or team_id,
-        display_name=team_name or team_id,
+        provider_account_id=provider_account_id,
+        display_name=team_name or team_id or provider_account_id,
     )
 
 
@@ -186,8 +191,29 @@ def _generic_identity(creds: dict, profile: dict, raw: dict, user_data: dict) ->
         or _nested(user_data, "sub")
         or email
     )
+    # This fallback covers most of the catalog: Composio-managed OAuth apps with
+    # no dedicated handler above. There's no universal email/name field across
+    # toolkits, so prefer (in order): a user-set Composio alias; a per-toolkit
+    # username/account label (subdomain/shop/site name/instance -- e.g. a
+    # Zendesk subdomain or Shopify store name); Composio's auto-generated,
+    # toolkit-agnostic word_id ("github_red-castle") purpose-built for
+    # telling multiple accounts of the same app apart; then the raw ids
+    # already resolved above.
+    labeled_fallback = (
+        _nested(raw, "alias")
+        or _nested(raw, "username")
+        or _nested(raw, "site_name")
+        or _nested(raw, "instance_name")
+        or _nested(raw, "shop")
+        or _nested(raw, "subdomain")
+        or _nested(raw, "domain")
+        or _nested(raw, "word_id")
+        or provider_account_id
+        or _nested(raw, "account_id")
+        or _nested(raw, "account_url")
+    )
     return AccountIdentity(
         provider_account_id=provider_account_id,
         email=email,
-        display_name=email or provider_account_id,
+        display_name=email or labeled_fallback,
     )

--- a/lemma-backend/app/modules/connectors/services/auth/composio_auth_provider.py
+++ b/lemma-backend/app/modules/connectors/services/auth/composio_auth_provider.py
@@ -142,9 +142,23 @@ class ComposioAuthProvider(AuthProviderInterface):
         state = getattr(connection_account, "state", None)
         value = getattr(state, "val", None)
         model_dump = getattr(value, "model_dump", None)
-        if callable(model_dump):
-            return model_dump(mode="json", by_alias=True, exclude_none=True)
-        return None
+        data = (
+            model_dump(mode="json", by_alias=True, exclude_none=True)
+            if callable(model_dump)
+            else {}
+        )
+        # word_id/alias live on the connected account itself, not state.val, and
+        # are the only toolkit-agnostic identity signal Composio gives us: a
+        # user-set alias, else a stable auto-generated label ("gmail_red-castle")
+        # meant for exactly this — telling multiple accounts of the same app
+        # apart when the toolkit's own fields (below) don't surface an email.
+        alias = getattr(connection_account, "alias", None)
+        word_id = getattr(connection_account, "word_id", None)
+        if alias:
+            data["alias"] = alias
+        if word_id:
+            data["word_id"] = word_id
+        return data or None
 
     def _composio_auth_scheme(self, connector: ConnectorEntity) -> AuthScheme:
         try:

--- a/lemma-backend/app/modules/connectors/services/connector_service.py
+++ b/lemma-backend/app/modules/connectors/services/connector_service.py
@@ -285,6 +285,14 @@ class ConnectorService:
                 )
                 continue
             profile = self._profile_to_dict(result)
+            # Composio wraps every tool execution result in
+            # {"data": ..., "successful": ..., "error": ...} (composio.tools.execute's
+            # ToolExecutionResponse); the toolkit's actual fields (email, name, ...)
+            # live one level down in `data`, not at the top level.
+            if isinstance(profile, dict) and provider.upper() == AuthProvider.COMPOSIO.value:
+                unwrapped = profile.get("data")
+                if isinstance(unwrapped, dict):
+                    profile = unwrapped
             if profile:
                 return profile
         return None

--- a/lemma-backend/app/modules/connectors/services/connector_service.py
+++ b/lemma-backend/app/modules/connectors/services/connector_service.py
@@ -63,15 +63,6 @@ from app.core.log.log import get_logger
 
 logger = get_logger(__name__)
 
-# Provider-agnostic profile operations that expose the account holder's email.
-# The operation repository resolves each candidate against the account's
-# provider, so only the matching one (e.g. composio GMAIL_GET_PROFILE vs native
-# get_profile) actually runs. Order is preference, not provider.
-_EMAIL_PROFILE_OPERATIONS: dict[str, tuple[str, ...]] = {
-    "gmail": ("GMAIL_GET_PROFILE", "get_profile"),
-    "outlook": ("OUTLOOK_GET_PROFILE",),
-}
-
 
 class ConnectorService:
     """Service for connector application/account OAuth flows."""
@@ -252,18 +243,24 @@ class ConnectorService:
             current = current.get(part)
         return current if isinstance(current, str) else None
 
-    async def _fetch_account_email_profile(
+    async def _fetch_account_profile(
         self,
-        connector_id: str,
+        connector: ConnectorEntity,
         provider: str,
         credentials: OAuthCredentials,
     ) -> dict | None:
-        """Fetch the account holder's profile via the provider's get-profile
-        operation, so the email is populated the same way for both Lemma-native
-        and Composio accounts (Gmail, Outlook, ...)."""
+        """Fetch the account holder's own profile via the catalog-curated
+        profile operation(s) for this connector+provider, so identity fields
+        (email, name, workspace, ...) are populated the same way for any app
+        the catalog has a profile operation for, not just a hardcoded few."""
         if self.operation_gateway is None or self.operation_repository is None:
             return None
-        for operation_name in _EMAIL_PROFILE_OPERATIONS.get(connector_id, ()):
+        connector_id = connector.id
+        try:
+            capability = connector.capability_for(provider)
+        except ValueError:
+            return None
+        for operation_name in capability.profile_operation_names or ():
             operation = (
                 await self.operation_repository.get_by_connector_provider_and_name(
                     connector_id, provider, operation_name
@@ -864,11 +861,21 @@ class ConnectorService:
             credentials=credentials,
         )
 
+        # Best-effort: fetch the account holder's own profile via the
+        # catalog-curated profile operation for this connector+provider (if
+        # any), so credential-managed accounts (e.g. a Notion integration
+        # token) get the same identity enrichment OAuth accounts do. A
+        # missing/failing operation just leaves profile=None; identity
+        # resolution falls back to whatever the credentials carry.
+        profile = await self._fetch_account_profile(
+            connector, provider.value, stored_credentials
+        )
+
         # Derive a stable identity + human-friendly label from the connected
         # credentials so the account is distinguishable and duplicates can be
         # rejected. A client-supplied provider_account_id/email takes precedence.
         identity = await resolve_account_identity(
-            connector_id=connector.id, credentials=stored_credentials
+            connector_id=connector.id, credentials=stored_credentials, profile=profile
         )
         provider_account_id = provider_account_id or identity.provider_account_id
         email = email or identity.email
@@ -980,8 +987,8 @@ class ConnectorService:
         provider_account_id = provider_account_id or self._extract_provider_account_id_from_profile(
             connector.id, native_profile
         )
-        email_profile = await self._fetch_account_email_profile(
-            connector.id,
+        email_profile = await self._fetch_account_profile(
+            connector,
             self._provider_value(auth_config),
             credentials,
         )
@@ -992,12 +999,15 @@ class ConnectorService:
         )
 
         # Human-friendly label for the account list (team name / mailbox / …),
-        # falling back to the email when the app has no better label.
+        # falling back to the email when the app has no better label. Prefer
+        # the catalog-driven profile (works for any app with a profile
+        # operation configured) over the Lemma-native one (Gmail/Drive/Slack
+        # only) since only one of the two is ever populated for a given app.
         display_name = (
             await resolve_account_identity(
                 connector_id=connector.id,
                 credentials=credentials,
-                profile=native_profile,
+                profile=email_profile or native_profile,
             )
         ).display_name or email
 

--- a/lemma-backend/app/modules/connectors/tests/e2e/test_accounts_connect_requests_e2e.py
+++ b/lemma-backend/app/modules/connectors/tests/e2e/test_accounts_connect_requests_e2e.py
@@ -4,13 +4,23 @@ from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid4
 
 import pytest
+from httpx import AsyncClient
+from starlette import status
 
+from app.core.authorization.delegation import (
+    DEFAULT_POD_AGENT_ID,
+    DEFAULT_POD_AGENT_NAME,
+)
 from app.modules.connectors.domain.account import OAuthCredentials
 from app.modules.connectors.domain.connector import AuthProvider
 from app.modules.connectors.infrastructure.models.account import Account
 from app.modules.connectors.infrastructure.models.auth_config import AuthConfig
 from app.modules.connectors.infrastructure.models.connector import Connector
 from app.modules.connectors.services.auth.lemma_auth_provider import LemmaAuthProvider
+from app.modules.identity.infrastructure.supertokens_auth.helpers import get_user_token
+from app.modules.identity.infrastructure.supertokens_auth.token_factory import (
+    build_delegation_claims,
+)
 
 # A native Gmail row as seeded by the catalog importer: a LEMMA OAuth2 capability
 # with NO stored oauth2_defaults. The Google OAuth endpoints/scopes are resolved
@@ -24,6 +34,33 @@ GMAIL_NATIVE_CAPABILITIES = [
     }
 ]
 GOOGLE_AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+
+
+async def _create_pod(owner_client, org_id: str, name: str) -> str:
+    response = await owner_client.post(
+        "/pods",
+        json={
+            "organization_id": org_id,
+            "name": f"{name} {uuid4().hex[:8]}",
+            "description": "connectors authz e2e",
+            "type": "HYBRID",
+        },
+    )
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+    return response.json()["id"]
+
+
+async def _default_pod_agent_headers(*, user_id: str, pod_id: str) -> dict[str, str]:
+    claims = build_delegation_claims(
+        workload_type="agent",
+        workload_id=DEFAULT_POD_AGENT_ID,
+        workload_name=DEFAULT_POD_AGENT_NAME,
+        pod_id=UUID(pod_id),
+        session_id=f"connectors-authz-e2e-{uuid4().hex}",
+        invoked_by_user_id=UUID(user_id),
+    )
+    token = await get_user_token(UUID(user_id), delegation_claims=claims)
+    return {"Authorization": f"Bearer {token}"}
 
 
 @pytest.mark.asyncio
@@ -599,6 +636,83 @@ async def test_gmail_connector_api_reflects_runtime_oauth_resolution(
 
 
 @pytest.mark.asyncio
+async def test_delete_account_removes_account_and_404s_on_repeat(
+    authenticated_client,
+    fixed_test_org,
+    db_session,
+):
+    """Regression: DELETE .../connectors/accounts/{account_id} previously 400'd
+    with "organization_id is required". The route's `reject_delegated_workload`
+    dependency resolves org context via `get_org_context`, which only read the
+    `{org_id}` path param while this router is mounted under
+    `{organization_id}` -- so the org id was never found. Exercised end-to-end
+    (real HTTP + real dependency chain) rather than via the service directly,
+    since the bug lived in path-param resolution, not the service layer.
+    """
+    connector_id = f"delete-app-{uuid4().hex[:8]}"
+    app = Connector(
+        id=connector_id,
+        title="Delete Test App",
+        description="Credential-managed delete test app",
+        provider_capabilities=[
+            {
+                "provider": "LEMMA",
+                "auth_scheme": "API_KEY",
+                "credential_schema": {
+                    "type": "object",
+                    "required": ["bot_token"],
+                    "properties": {"bot_token": {"type": "string", "format": "password"}},
+                },
+            }
+        ],
+        is_active=True,
+    )
+    db_session.add(app)
+    await db_session.commit()
+
+    org_id = fixed_test_org["id"]
+    auth_config_response = await authenticated_client.post(
+        f"/organizations/{org_id}/connectors/auth-configs",
+        json={
+            "connector_id": connector_id,
+            "provider": "LEMMA",
+            "config_source": "ORG_CUSTOM",
+            "name": connector_id,
+        },
+    )
+    assert auth_config_response.status_code == 200, auth_config_response.text
+
+    create_response = await authenticated_client.post(
+        f"/organizations/{org_id}/connectors/accounts",
+        json={
+            "auth_config_name": connector_id,
+            "credentials": {"bot_token": "delete-me-token"},
+        },
+    )
+    assert create_response.status_code == 200, create_response.text
+    account_id = create_response.json()["id"]
+
+    delete_response = await authenticated_client.delete(
+        f"/organizations/{org_id}/connectors/accounts/{account_id}"
+    )
+    assert delete_response.status_code == 200, delete_response.text
+    assert delete_response.json()["success"] is True
+
+    result = await db_session.execute(
+        Account.__table__.select().where(Account.id == UUID(account_id))
+    )
+    assert result.mappings().first() is None
+
+    # Deleting again 404s (account not found) rather than 400ing on org context
+    # resolution, confirming the org id is actually being read from the path.
+    second_delete = await authenticated_client.delete(
+        f"/organizations/{org_id}/connectors/accounts/{account_id}"
+    )
+    assert second_delete.status_code == 404, second_delete.text
+    assert second_delete.json()["code"] == "ACCOUNT_NOT_FOUND"
+
+
+@pytest.mark.asyncio
 async def test_credential_managed_account_rejects_duplicate_identity_and_exposes_display_name(
     authenticated_client,
     fixed_test_org,
@@ -676,3 +790,364 @@ async def test_credential_managed_account_rejects_duplicate_identity_and_exposes
     )
     assert other.status_code == 200, other.text
     assert other.json()["provider_account_id"] == "acc-beta"
+
+
+@pytest.mark.asyncio
+async def test_oauth_new_account_addition_and_reauth_flows(
+    authenticated_client,
+    fixed_test_org,
+    db_session,
+    monkeypatch,
+):
+    """End-to-end coverage for multi-account OAuth via the accounts API:
+
+    * connecting a second, distinct provider identity creates a NEW account
+      (not a duplicate/clobber of the first) and is not the default;
+    * re-authing an identity that already has an account (matched by
+      provider_account_id) updates that SAME account in place -- restoring it
+      to CONNECTED -- instead of creating a third account.
+    """
+    connector_id = f"oauth-multi-app-{uuid4().hex[:8]}"
+    app = Connector(
+        id=connector_id,
+        title="OAuth Multi App",
+        description="OAuth multi-account test app",
+        provider_capabilities=[
+            {
+                "provider": "LEMMA",
+                "auth_scheme": "OAUTH2",
+                "supports_org_custom_oauth": True,
+                "oauth2_defaults": {
+                    "default_scopes": ["openid"],
+                    "authorization_url": "https://mock.example.com/auth",
+                    "token_url": "https://mock.example.com/token",
+                },
+            }
+        ],
+        is_active=True,
+    )
+    db_session.add(app)
+    await db_session.commit()
+
+    org_id = fixed_test_org["id"]
+    auth_config_response = await authenticated_client.post(
+        f"/organizations/{org_id}/connectors/auth-configs",
+        json={
+            "connector_id": connector_id,
+            "provider": "LEMMA",
+            "config_source": "ORG_CUSTOM",
+            "credential_config": {
+                "oauth2_credentials": {
+                    "client_id": "client-id",
+                    "client_secret": "client-secret",
+                }
+            },
+        },
+    )
+    assert auth_config_response.status_code == 200, auth_config_response.text
+
+    async def _fake_get_authorization_url(self, connector, user_id, state, redirect_uri):
+        return ("https://mock.example.com/authorize", "provider_state")
+
+    # The callback URL's "code" query param stands in for the provider's actual
+    # authorization code; here it doubles as a way to pick which identity the
+    # exchange returns, so the test can drive distinct-identity vs same-identity
+    # callbacks without a real OAuth provider.
+    async def _fake_exchange_code_for_credentials(
+        self, connector, redirect_uri, user_id, state=None
+    ):
+        from urllib.parse import parse_qs, urlparse
+
+        code = (parse_qs(urlparse(redirect_uri).query).get("code") or [""])[0]
+        return OAuthCredentials(
+            access_token=f"access-token-{code}",
+            refresh_token=f"refresh-token-{code}",
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=30),
+            raw_response={"provider_account_id": code},
+        )
+
+    monkeypatch.setattr(
+        LemmaAuthProvider, "get_authorization_url", _fake_get_authorization_url
+    )
+    monkeypatch.setattr(
+        LemmaAuthProvider,
+        "exchange_code_for_credentials",
+        _fake_exchange_code_for_credentials,
+    )
+
+    async def _connect(identity_code: str) -> dict:
+        response = await authenticated_client.post(
+            f"/organizations/{org_id}/connectors/connect-requests",
+            json={"connector_id": connector_id},
+        )
+        assert response.status_code == 200, response.text
+        state = response.json()["attributes"]["state"]
+        callback = await authenticated_client.get(
+            "/connectors/connect-requests/oauth/callback",
+            params={"state": state, "code": identity_code, "format": "json"},
+        )
+        assert callback.status_code == 200, callback.text
+        return callback.json()
+
+    # New account addition flow: a first identity connects and becomes default.
+    first_account = await _connect("user-alpha")
+    assert first_account["provider_account_id"] == "user-alpha"
+    assert first_account["is_default"] is True
+    assert first_account["status"] == "CONNECTED"
+
+    # A second, distinct identity connects -> a NEW, non-default account.
+    second_account = await _connect("user-beta")
+    assert second_account["provider_account_id"] == "user-beta"
+    assert second_account["id"] != first_account["id"]
+    assert second_account["is_default"] is False
+    assert second_account["status"] == "CONNECTED"
+
+    list_response = await authenticated_client.get(
+        f"/organizations/{org_id}/connectors/accounts",
+        params={"connector_id": connector_id},
+    )
+    assert list_response.status_code == 200, list_response.text
+    assert {item["id"] for item in list_response.json()["items"]} == {
+        first_account["id"],
+        second_account["id"],
+    }
+
+    # Simulate the first account degrading (e.g. token revoked upstream).
+    result = await db_session.execute(
+        Account.__table__.select().where(Account.id == UUID(first_account["id"]))
+    )
+    stored = result.mappings().one()
+    await db_session.execute(
+        Account.__table__.update()
+        .where(Account.id == UUID(first_account["id"]))
+        .values(status="REAUTH_REQUIRED")
+    )
+    await db_session.commit()
+    assert stored["status"] == "CONNECTED"  # sanity: it really was healthy before
+
+    # Reauth flow: re-connecting the SAME identity updates the SAME account in
+    # place (no third account created) and restores it to CONNECTED.
+    reauth_account = await _connect("user-alpha")
+    assert reauth_account["id"] == first_account["id"]
+    assert reauth_account["status"] == "CONNECTED"
+
+    list_response = await authenticated_client.get(
+        f"/organizations/{org_id}/connectors/accounts",
+        params={"connector_id": connector_id},
+    )
+    assert list_response.status_code == 200, list_response.text
+    accounts_after_reauth = list_response.json()["items"]
+    assert len(accounts_after_reauth) == 2
+    assert {item["id"] for item in accounts_after_reauth} == {
+        first_account["id"],
+        second_account["id"],
+    }
+
+    credentials_response = await authenticated_client.get(
+        f"/organizations/{org_id}/connectors/accounts/{first_account['id']}/credentials"
+    )
+    assert credentials_response.status_code == 200, credentials_response.text
+    assert (
+        credentials_response.json()["data"]["access_token"]
+        == "access-token-user-alpha"
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_and_get_auth_config(
+    authenticated_client,
+    fixed_test_org,
+    db_session,
+):
+    """GET .../auth-configs (list) and GET .../auth-configs/{name} (single) had
+    no e2e coverage even though create/delete did."""
+    connector_id = f"read-auth-config-{uuid4().hex[:8]}"
+    app = Connector(
+        id=connector_id,
+        title="Read Auth Config App",
+        description="App for auth-config read coverage",
+        provider_capabilities=[
+            {
+                "provider": "LEMMA",
+                "auth_scheme": "API_KEY",
+                "credential_schema": {
+                    "type": "object",
+                    "required": ["bot_token"],
+                    "properties": {"bot_token": {"type": "string", "format": "password"}},
+                },
+            }
+        ],
+        is_active=True,
+    )
+    db_session.add(app)
+    await db_session.commit()
+
+    org_id = fixed_test_org["id"]
+    create_response = await authenticated_client.post(
+        f"/organizations/{org_id}/connectors/auth-configs",
+        json={
+            "connector_id": connector_id,
+            "provider": "LEMMA",
+            "config_source": "ORG_CUSTOM",
+            "name": connector_id,
+        },
+    )
+    assert create_response.status_code == 200, create_response.text
+    auth_config_id = create_response.json()["id"]
+
+    list_response = await authenticated_client.get(
+        f"/organizations/{org_id}/connectors/auth-configs"
+    )
+    assert list_response.status_code == 200, list_response.text
+    assert any(
+        item["id"] == auth_config_id for item in list_response.json()["items"]
+    )
+
+    get_response = await authenticated_client.get(
+        f"/organizations/{org_id}/connectors/auth-configs/{connector_id}"
+    )
+    assert get_response.status_code == 200, get_response.text
+    assert get_response.json()["id"] == auth_config_id
+    assert get_response.json()["connector_id"] == connector_id
+
+    missing_response = await authenticated_client.get(
+        f"/organizations/{org_id}/connectors/auth-configs/does-not-exist-{uuid4().hex[:8]}"
+    )
+    assert missing_response.status_code == 404, missing_response.text
+
+
+@pytest.mark.asyncio
+async def test_default_pod_agent_cannot_delete_account(
+    authenticated_client: AsyncClient,
+    async_client: AsyncClient,
+    fixed_test_org,
+    fixed_test_user,
+    db_session,
+):
+    """A delegated workload (the default pod agent) is denied outright on
+    account deletion -- this is an org-level, ownership-based action a
+    workload has no business performing on its own, not just a nuanced
+    grant/approval gate."""
+    connector_id = f"agent-delete-app-{uuid4().hex[:8]}"
+    app = Connector(
+        id=connector_id,
+        title="Agent Delete Test App",
+        description="Credential-managed agent-delete test app",
+        provider_capabilities=[
+            {
+                "provider": "LEMMA",
+                "auth_scheme": "API_KEY",
+                "credential_schema": {
+                    "type": "object",
+                    "required": ["bot_token"],
+                    "properties": {"bot_token": {"type": "string", "format": "password"}},
+                },
+            }
+        ],
+        is_active=True,
+    )
+    db_session.add(app)
+    await db_session.commit()
+
+    org_id = fixed_test_org["id"]
+    auth_config_response = await authenticated_client.post(
+        f"/organizations/{org_id}/connectors/auth-configs",
+        json={
+            "connector_id": connector_id,
+            "provider": "LEMMA",
+            "config_source": "ORG_CUSTOM",
+            "name": connector_id,
+        },
+    )
+    assert auth_config_response.status_code == 200, auth_config_response.text
+
+    create_response = await authenticated_client.post(
+        f"/organizations/{org_id}/connectors/accounts",
+        json={
+            "auth_config_name": connector_id,
+            "credentials": {"bot_token": "agent-delete-token"},
+        },
+    )
+    assert create_response.status_code == 200, create_response.text
+    account_id = create_response.json()["id"]
+
+    pod_id = await _create_pod(authenticated_client, org_id, "Agent Delete Pod")
+    agent_headers = await _default_pod_agent_headers(
+        user_id=fixed_test_user["id"], pod_id=pod_id
+    )
+
+    response = await async_client.delete(
+        f"/organizations/{org_id}/connectors/accounts/{account_id}",
+        headers=agent_headers,
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN, response.text
+    assert response.json()["code"] == "DESTRUCTIVE_ACTION_REQUIRES_APPROVAL"
+
+    # Control: the account is untouched and the human can still delete it.
+    still_there = await authenticated_client.get(
+        f"/organizations/{org_id}/connectors/accounts/{account_id}"
+    )
+    assert still_there.status_code == 200, still_there.text
+
+
+@pytest.mark.asyncio
+async def test_default_pod_agent_cannot_delete_auth_config(
+    authenticated_client: AsyncClient,
+    async_client: AsyncClient,
+    fixed_test_org,
+    fixed_test_user,
+    db_session,
+):
+    """Deleting an auth config cascades to delete every account under it for
+    every user in the org -- at least as destructive as deleting a single
+    account, so a delegated workload must be denied outright here too."""
+    connector_id = f"agent-delete-config-{uuid4().hex[:8]}"
+    app = Connector(
+        id=connector_id,
+        title="Agent Delete Config App",
+        description="App for auth-config delegated-delete coverage",
+        provider_capabilities=[
+            {
+                "provider": "LEMMA",
+                "auth_scheme": "API_KEY",
+                "credential_schema": {
+                    "type": "object",
+                    "required": ["bot_token"],
+                    "properties": {"bot_token": {"type": "string", "format": "password"}},
+                },
+            }
+        ],
+        is_active=True,
+    )
+    db_session.add(app)
+    await db_session.commit()
+
+    org_id = fixed_test_org["id"]
+    auth_config_response = await authenticated_client.post(
+        f"/organizations/{org_id}/connectors/auth-configs",
+        json={
+            "connector_id": connector_id,
+            "provider": "LEMMA",
+            "config_source": "ORG_CUSTOM",
+            "name": connector_id,
+        },
+    )
+    assert auth_config_response.status_code == 200, auth_config_response.text
+
+    pod_id = await _create_pod(authenticated_client, org_id, "Agent Delete Config Pod")
+    agent_headers = await _default_pod_agent_headers(
+        user_id=fixed_test_user["id"], pod_id=pod_id
+    )
+
+    response = await async_client.delete(
+        f"/organizations/{org_id}/connectors/auth-configs/{connector_id}",
+        headers=agent_headers,
+    )
+    assert response.status_code == status.HTTP_403_FORBIDDEN, response.text
+    assert response.json()["code"] == "DESTRUCTIVE_ACTION_REQUIRES_APPROVAL"
+
+    # Control: the auth config is untouched and the human can still delete it.
+    still_there = await authenticated_client.get(
+        f"/organizations/{org_id}/connectors/auth-configs/{connector_id}"
+    )
+    assert still_there.status_code == 200, still_there.text

--- a/lemma-backend/app/modules/connectors/tests/unit/test_account_identity.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_account_identity.py
@@ -21,6 +21,19 @@ async def test_gmail_identity_from_profile_email():
     assert identity.display_name == "rahul@gmail.com"
 
 
+async def test_gmail_identity_falls_back_to_sub_when_profile_has_no_email():
+    """A narrow-scope grant (e.g. Drive-only) can leave the profile call
+    without an email -- the account must still get a distinguishable label."""
+    identity = await resolve_account_identity(
+        connector_id="google_drive",
+        credentials={"raw_response": {"sub": "109876543210"}},
+        profile={},
+    )
+    assert identity.email is None
+    assert identity.provider_account_id == "109876543210"
+    assert identity.display_name == "109876543210"
+
+
 async def test_slack_identity_uses_team_name_and_user_id():
     identity = await resolve_account_identity(
         connector_id="slack",
@@ -34,6 +47,15 @@ async def test_slack_identity_uses_team_name_and_user_id():
     )
     assert identity.provider_account_id == "U777"
     assert identity.display_name == "Acme"
+
+
+async def test_slack_identity_falls_back_to_provider_account_id_without_team_name():
+    identity = await resolve_account_identity(
+        connector_id="slack",
+        credentials={"raw_response": {"authed_user": {"id": "U777"}}},
+    )
+    assert identity.provider_account_id == "U777"
+    assert identity.display_name == "U777"
 
 
 async def test_whatsapp_identity_from_phone_number_id():
@@ -61,6 +83,62 @@ async def test_generic_identity_falls_back_to_raw_user_id():
         credentials={"raw_response": {"user": {"id": "acc-1"}}},
     )
     assert identity.provider_account_id == "acc-1"
+
+
+async def test_generic_identity_falls_back_to_composio_word_id_when_no_email():
+    """Most of the catalog (Composio OAuth apps with no dedicated handler) has
+    no universal email/username field -- word_id is Composio's own
+    toolkit-agnostic label built for exactly this: telling multiple accounts
+    of the same app apart."""
+    identity = await resolve_account_identity(
+        connector_id="github",
+        credentials={"raw_response": {"word_id": "github_red-castle"}},
+    )
+    assert identity.email is None
+    assert identity.display_name == "github_red-castle"
+
+
+async def test_generic_identity_prefers_alias_over_word_id():
+    identity = await resolve_account_identity(
+        connector_id="notion",
+        credentials={
+            "raw_response": {
+                "alias": "Marketing workspace",
+                "word_id": "notion_blue-otter",
+                "account_id": "acc-9",
+            }
+        },
+    )
+    assert identity.display_name == "Marketing workspace"
+    # provider_account_id derivation is unaffected by the new label fallbacks.
+    assert identity.provider_account_id is None
+
+
+async def test_generic_identity_uses_per_toolkit_subdomain_fields():
+    identity = await resolve_account_identity(
+        connector_id="zendesk",
+        credentials={"raw_response": {"subdomain": "acme-support"}},
+    )
+    assert identity.display_name == "acme-support"
+
+
+async def test_generic_identity_email_still_wins_over_word_id():
+    identity = await resolve_account_identity(
+        connector_id="hubspot",
+        credentials={
+            "raw_response": {"word_id": "hubspot_green-fox"},
+            "email": "sales@acme.test",
+        },
+    )
+    assert identity.display_name == "sales@acme.test"
+
+
+async def test_generic_identity_falls_back_to_account_id_when_nothing_else():
+    identity = await resolve_account_identity(
+        connector_id="some-new-toolkit",
+        credentials={"raw_response": {"account_id": "acct_123"}},
+    )
+    assert identity.display_name == "acct_123"
 
 
 async def test_telegram_identity_calls_getme(monkeypatch):
@@ -94,6 +172,37 @@ async def test_telegram_identity_calls_getme(monkeypatch):
     assert identity.provider_account_id == "123"
     assert identity.display_name == "@lemmabot"
     assert _FakeClient.posted_url == "http://fake/bot111:AAA/getMe"
+
+
+async def test_telegram_identity_falls_back_to_bot_id_without_username_or_name(monkeypatch):
+    class _FakeResp:
+        def raise_for_status(self):  # noqa: D401
+            return None
+
+        def json(self):
+            return {"ok": True, "result": {"id": 456}}
+
+    class _FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url):
+            return _FakeResp()
+
+    monkeypatch.setattr(account_identity.httpx, "AsyncClient", _FakeClient)
+
+    identity = await resolve_account_identity(
+        connector_id="telegram",
+        credentials={"bot_token": "111:AAA", "api_base_url": "http://fake/bot"},
+    )
+    assert identity.provider_account_id == "456"
+    assert identity.display_name == "456"
 
 
 async def test_telegram_missing_token_returns_empty():

--- a/lemma-backend/app/modules/connectors/tests/unit/test_account_repository.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_account_repository.py
@@ -1,0 +1,156 @@
+"""AccountRepository's IntegrityError -> AccountAlreadyConnectedError translation.
+
+App-level dedup (ConnectorService._reject_if_identity_already_connected)
+rejects the common case before create/update ever runs, but that
+check-then-act has a TOCTOU gap under concurrency. These tests cover the
+repository-level backstop directly against a stubbed session so they don't
+need a real Postgres connection."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.modules.connectors.domain.account import AccountEntity, AccountStatus
+from app.modules.connectors.domain.errors import AccountAlreadyConnectedError
+from app.modules.connectors.infrastructure.repositories.account_repository import (
+    AccountRepository,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+class _FakeResult:
+    def __init__(self, instance):
+        self._instance = instance
+
+    def scalars(self):
+        return self
+
+    def first(self):
+        return self._instance
+
+
+class _FakeSession:
+    def __init__(self, *, flush_exc: Exception | None = None, existing=None):
+        self._flush_exc = flush_exc
+        self._existing = existing
+        self.added = []
+
+    def add(self, instance):
+        self.added.append(instance)
+
+    async def flush(self):
+        if self._flush_exc is not None:
+            raise self._flush_exc
+
+    async def refresh(self, instance, attribute_names=None):
+        return None
+
+    async def execute(self, stmt):
+        return _FakeResult(self._existing)
+
+
+class _FakeUow:
+    def __init__(self, session):
+        self.session = session
+
+
+class _NoopEncryption:
+    def encrypt_json(self, value):
+        return value
+
+    def decrypt_json(self, value):
+        return value
+
+
+def _account_entity(**overrides) -> AccountEntity:
+    defaults = dict(
+        user_id=uuid4(),
+        organization_id=uuid4(),
+        auth_config_id=uuid4(),
+        connector_id="asana",
+        status=AccountStatus.CONNECTED,
+        provider_account_id="acc-1",
+        credentials={"access_token": "tok"},
+    )
+    defaults.update(overrides)
+    return AccountEntity(**defaults)
+
+
+def _duplicate_identity_error() -> IntegrityError:
+    return IntegrityError(
+        "INSERT INTO accounts ...",
+        {},
+        Exception(
+            'duplicate key value violates unique constraint '
+            '"uq_accounts_provider_identity"'
+        ),
+    )
+
+
+def _unrelated_error() -> IntegrityError:
+    return IntegrityError(
+        "INSERT INTO accounts ...",
+        {},
+        Exception(
+            'duplicate key value violates unique constraint '
+            '"uq_accounts_default_per_auth_config"'
+        ),
+    )
+
+
+async def test_create_translates_duplicate_identity_violation():
+    session = _FakeSession(flush_exc=_duplicate_identity_error())
+    repo = AccountRepository(uow=_FakeUow(session), encryption=_NoopEncryption())
+
+    with pytest.raises(AccountAlreadyConnectedError):
+        await repo.create(_account_entity())
+
+
+async def test_create_reraises_unrelated_integrity_error():
+    session = _FakeSession(flush_exc=_unrelated_error())
+    repo = AccountRepository(uow=_FakeUow(session), encryption=_NoopEncryption())
+
+    with pytest.raises(IntegrityError):
+        await repo.create(_account_entity())
+
+
+async def test_update_translates_duplicate_identity_violation():
+    from app.modules.connectors.infrastructure.models import Account
+
+    existing = Account(
+        id=uuid4(),
+        user_id=uuid4(),
+        organization_id=uuid4(),
+        auth_config_id=uuid4(),
+        connector_id="asana",
+        status="CONNECTED",
+        credentials={"access_token": "tok"},
+    )
+    session = _FakeSession(flush_exc=_duplicate_identity_error(), existing=existing)
+    repo = AccountRepository(uow=_FakeUow(session), encryption=_NoopEncryption())
+
+    with pytest.raises(AccountAlreadyConnectedError):
+        await repo.update(_account_entity(id=existing.id))
+
+
+async def test_update_reraises_unrelated_integrity_error():
+    from app.modules.connectors.infrastructure.models import Account
+
+    existing = Account(
+        id=uuid4(),
+        user_id=uuid4(),
+        organization_id=uuid4(),
+        auth_config_id=uuid4(),
+        connector_id="asana",
+        status="CONNECTED",
+        credentials={"access_token": "tok"},
+    )
+    session = _FakeSession(flush_exc=_unrelated_error(), existing=existing)
+    repo = AccountRepository(uow=_FakeUow(session), encryption=_NoopEncryption())
+
+    with pytest.raises(IntegrityError):
+        await repo.update(_account_entity(id=existing.id))

--- a/lemma-backend/app/modules/connectors/tests/unit/test_composio_auth_provider.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_composio_auth_provider.py
@@ -45,12 +45,20 @@ def _connector(app_id: str = "google_calendar") -> ConnectorEntity:
     )
 
 
-def _provider(connection_state: BaseModel, status: str = "ACTIVE") -> ComposioAuthProvider:
+def _provider(
+    connection_state: BaseModel,
+    status: str = "ACTIVE",
+    *,
+    word_id: str | None = None,
+    alias: str | None = None,
+) -> ComposioAuthProvider:
     connected_accounts = SimpleNamespace(
         get=lambda _: SimpleNamespace(
             id="ca_test_connection",
             status=status,
             state=SimpleNamespace(val=connection_state),
+            word_id=word_id,
+            alias=alias,
         )
     )
     composio = SimpleNamespace(connected_accounts=connected_accounts)
@@ -92,6 +100,41 @@ async def test_exchange_code_uses_composio_expires_in_for_google_accounts():
     assert credentials.expires_at is not None
     assert credentials.expires_at > datetime.now(timezone.utc) + timedelta(minutes=50)
     provider._get_google_token_expiration.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_surfaces_word_id_and_alias_for_account_labeling():
+    """word_id/alias live on the connected account, not state.val -- they must
+    be threaded into raw_response so account_identity can use them as a
+    toolkit-agnostic display-name fallback (most toolkits have no email)."""
+    provider = _provider(
+        _FakeConnectionState(access_token="access-token"),
+        word_id="github_red-castle",
+        alias="Work GitHub",
+    )
+
+    credentials = await provider.exchange_code_for_credentials(
+        connector=_connector("github"),
+        redirect_uri="https://app.example.com/callback?connectedAccountId=ca_test_connection",
+        user_id=uuid4(),
+    )
+
+    assert credentials.raw_response["word_id"] == "github_red-castle"
+    assert credentials.raw_response["alias"] == "Work GitHub"
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_raw_response_omits_word_id_and_alias_when_absent():
+    provider = _provider(_FakeConnectionState(access_token="access-token"))
+
+    credentials = await provider.exchange_code_for_credentials(
+        connector=_connector("github"),
+        redirect_uri="https://app.example.com/callback?connectedAccountId=ca_test_connection",
+        user_id=uuid4(),
+    )
+
+    assert "word_id" not in credentials.raw_response
+    assert "alias" not in credentials.raw_response
 
 
 @pytest.mark.asyncio

--- a/lemma-backend/app/modules/connectors/tests/unit/test_connector_service.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_connector_service.py
@@ -910,7 +910,13 @@ def _profile_operation(
 
 async def test_handle_oauth_callback_populates_email_via_profile_operation():
     """Email is filled from a provider-agnostic get-profile operation, so a
-    Composio Outlook account gets its `mail`/`userPrincipalName` populated."""
+    Composio Outlook account gets its `mail`/`userPrincipalName` populated.
+
+    The mocked gateway result is wrapped in Composio's real envelope
+    (composio.tools.execute's ToolExecutionResponse: {data, error, successful})
+    rather than a flat dict, so this actually exercises the unwrapping in
+    _fetch_account_profile instead of accidentally passing regardless of it.
+    """
     user_id = uuid4()
     auth_config = _composio_auth_config("outlook")
     connect_request = ConnectRequestEntity(
@@ -931,9 +937,13 @@ async def test_handle_oauth_callback_populates_email_via_profile_operation():
 
     operation_gateway = AsyncMock()
     operation_gateway.execute_operation.return_value = {
-        "displayName": "Test User",
-        "mail": "user@lemma.work",
-        "userPrincipalName": "user@lemma.work",
+        "data": {
+            "displayName": "Test User",
+            "mail": "user@lemma.work",
+            "userPrincipalName": "user@lemma.work",
+        },
+        "error": None,
+        "successful": True,
     }
     operation_repository = AsyncMock()
     operation_repository.get_by_connector_provider_and_name.return_value = (
@@ -991,6 +1001,75 @@ async def test_fetch_account_profile_skips_when_gateway_absent():
         _connector("outlook"), "COMPOSIO", OAuthCredentials(access_token="tok")
     )
     assert result is None
+
+
+async def test_fetch_account_profile_unwraps_composio_data_envelope():
+    """Every composio.tools.execute() result is wrapped in
+    {"data": ..., "error": ..., "successful": ...} -- the toolkit's actual
+    fields live under `data`, not at the top level. Without unwrapping this,
+    email/identity extraction would never find anything for any Composio app."""
+    connector = ConnectorEntity(
+        id="asana",
+        provider_capabilities=[
+            ComposioProviderCapability(
+                toolkit_slug="asana",
+                profile_operation_names=["ASANA_GET_CURRENT_USER"],
+            ),
+        ],
+    )
+    operation_repository = AsyncMock()
+    operation_repository.get_by_connector_provider_and_name.return_value = (
+        _profile_operation("asana", "ASANA_GET_CURRENT_USER")
+    )
+    operation_gateway = AsyncMock()
+    operation_gateway.execute_operation.return_value = {
+        "data": {"email": "pm@acme.test", "name": "Project Manager"},
+        "error": None,
+        "successful": True,
+    }
+
+    service = _service(
+        operation_gateway=operation_gateway,
+        operation_repository=operation_repository,
+    )
+    result = await service._fetch_account_profile(
+        connector, "COMPOSIO", OAuthCredentials(access_token="tok")
+    )
+
+    assert result == {"email": "pm@acme.test", "name": "Project Manager"}
+
+
+async def test_fetch_account_profile_does_not_unwrap_for_lemma_provider():
+    """Native (Lemma) operation results are never Composio-wrapped -- a
+    coincidental top-level "data" key must be left alone."""
+    connector = ConnectorEntity(
+        id="gmail",
+        provider_capabilities=[
+            LemmaProviderCapability(profile_operation_names=["get_profile"]),
+        ],
+    )
+    operation_repository = AsyncMock()
+    operation_repository.get_by_connector_provider_and_name.return_value = (
+        _profile_operation("gmail", "get_profile")
+    )
+    operation_gateway = AsyncMock()
+    operation_gateway.execute_operation.return_value = {
+        "email_address": "user@gmail.com",
+        "data": "not an envelope",
+    }
+
+    service = _service(
+        operation_gateway=operation_gateway,
+        operation_repository=operation_repository,
+    )
+    result = await service._fetch_account_profile(
+        connector, "LEMMA", OAuthCredentials(access_token="tok")
+    )
+
+    assert result == {
+        "email_address": "user@gmail.com",
+        "data": "not an envelope",
+    }
 
 
 async def test_fetch_account_profile_skips_when_provider_unsupported():

--- a/lemma-backend/app/modules/connectors/tests/unit/test_connector_service.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_connector_service.py
@@ -297,6 +297,64 @@ async def test_create_account_composio_api_key_connects_via_provider():
     uow.commit.assert_awaited_once()
 
 
+async def test_create_account_enriches_identity_via_profile_operation():
+    """Credential-managed accounts (e.g. a Notion integration token) get the
+    same profile-operation enrichment OAuth accounts do -- best-effort, via
+    the catalog-curated profile_operation_names on the capability."""
+    user_id = uuid4()
+    app = ConnectorEntity(
+        id="notion",
+        provider_capabilities=[
+            ComposioProviderCapability(
+                toolkit_slug="notion",
+                auth_scheme=AuthScheme.API_KEY,
+                profile_operation_names=["NOTION_RETRIEVE_YOUR_TOKEN_S_BOT_USER"],
+            )
+        ],
+    )
+    auth_config = _composio_auth_config("notion")
+    stored = ComposioCredentials(connection_id="ca_notion")
+
+    auth_provider = AsyncMock()
+    auth_provider.connect_with_credentials.return_value = stored
+    registry = Mock()
+    registry.get.return_value = auth_provider
+
+    operation_repository = AsyncMock()
+    operation_repository.get_by_connector_provider_and_name.return_value = (
+        _profile_operation("notion", "NOTION_RETRIEVE_YOUR_TOKEN_S_BOT_USER")
+    )
+    operation_gateway = AsyncMock()
+    operation_gateway.execute_operation.return_value = {
+        "email": "eng@acme.test",
+        "name": "Acme Engineering",
+    }
+
+    account_repo = AsyncMock()
+    account_repo.get_by_user_and_auth_config.return_value = None
+    account_repo.get_by_user_auth_config_and_provider_account.return_value = None
+    account_repo.create.side_effect = lambda entity: entity
+
+    service = _service(
+        connector_repository=AsyncMock(get=AsyncMock(return_value=app)),
+        auth_config_repository=_auth_config_repo(auth_config),
+        account_repository=account_repo,
+        auth_provider_registry=registry,
+        operation_gateway=operation_gateway,
+        operation_repository=operation_repository,
+    )
+
+    account = await service.create_account(
+        user_id=user_id,
+        organization_id=ORG_ID,
+        auth_config_id=auth_config.id,
+        credentials={"integration_token": "secret"},
+    )
+
+    assert account.email == "eng@acme.test"
+    operation_gateway.execute_operation.assert_awaited_once()
+
+
 async def test_create_account_allows_multiple_and_sets_default():
     """Multiple credential-managed accounts are allowed; the first one
     connected is the default, later ones are not."""
@@ -893,7 +951,10 @@ async def test_handle_oauth_callback_populates_email_via_profile_operation():
     outlook_app = ConnectorEntity(
         id="outlook",
         provider_capabilities=[
-            ComposioProviderCapability(toolkit_slug="outlook"),
+            ComposioProviderCapability(
+                toolkit_slug="outlook",
+                profile_operation_names=["OUTLOOK_GET_PROFILE"],
+            ),
         ],
     )
     service = _service(
@@ -924,12 +985,54 @@ async def test_handle_oauth_callback_populates_email_via_profile_operation():
     assert execute_kwargs["third_party_credentials"]["connection_id"] == "ca_123"
 
 
-async def test_fetch_account_email_profile_skips_when_gateway_absent():
+async def test_fetch_account_profile_skips_when_gateway_absent():
     service = _service()
-    result = await service._fetch_account_email_profile(
-        "outlook", "COMPOSIO", OAuthCredentials(access_token="tok")
+    result = await service._fetch_account_profile(
+        _connector("outlook"), "COMPOSIO", OAuthCredentials(access_token="tok")
     )
     assert result is None
+
+
+async def test_fetch_account_profile_skips_when_provider_unsupported():
+    """capability_for raises for a provider the connector doesn't support --
+    must be swallowed, not propagated, since this is a best-effort lookup."""
+    service = _service(
+        operation_gateway=AsyncMock(), operation_repository=AsyncMock()
+    )
+    result = await service._fetch_account_profile(
+        _connector("slack"), "COMPOSIO", OAuthCredentials(access_token="tok")
+    )
+    assert result is None
+
+
+async def test_fetch_account_profile_tries_catalog_operation_names_in_order():
+    connector = ConnectorEntity(
+        id="asana",
+        provider_capabilities=[
+            ComposioProviderCapability(
+                toolkit_slug="asana",
+                profile_operation_names=["ASANA_MISSING_OP", "ASANA_GET_CURRENT_USER"],
+            ),
+        ],
+    )
+    operation_repository = AsyncMock()
+    operation_repository.get_by_connector_provider_and_name.side_effect = [
+        None,
+        _profile_operation("asana", "ASANA_GET_CURRENT_USER"),
+    ]
+    operation_gateway = AsyncMock()
+    operation_gateway.execute_operation.return_value = {"email": "pm@acme.test"}
+
+    service = _service(
+        operation_gateway=operation_gateway,
+        operation_repository=operation_repository,
+    )
+    result = await service._fetch_account_profile(
+        connector, "COMPOSIO", OAuthCredentials(access_token="tok")
+    )
+
+    assert result == {"email": "pm@acme.test"}
+    assert operation_repository.get_by_connector_provider_and_name.await_count == 2
 
 
 async def test_handle_oauth_callback_surfaces_upstream_error_details():

--- a/lemma-backend/app/modules/connectors/tests/unit/test_import_connector_catalog.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_import_connector_catalog.py
@@ -582,6 +582,133 @@ async def test_sync_composio_catalog_uses_lemma_auth_provider_for_native_auth_ap
 
 
 @pytest.mark.asyncio
+async def test_sync_composio_catalog_applies_curated_profile_operation_names():
+    """A connector with a curated entry in the profile-operations override
+    gets it threaded onto its ComposioProviderCapability during sync."""
+    connector_repository = SimpleNamespace(get=AsyncMock(return_value=None))
+    operation_repository = SimpleNamespace()
+    trigger_repository = SimpleNamespace()
+
+    toolkit_item = _toolkit("testapp", name="TestApp")
+    composio = SimpleNamespace(
+        toolkits=SimpleNamespace(get=MagicMock(return_value=_toolkit_detail()))
+    )
+
+    with (
+        patch.dict(os.environ, {"COMPOSIO_API_KEY": "test-api-key"}, clear=False),
+        patch.object(importer, "Composio", return_value=composio),
+        patch.object(importer, "_list_composio_toolkits", return_value=[toolkit_item]),
+        patch.object(importer, "_paginate_tools", return_value=iter([])),
+        patch.object(importer, "_paginate_triggers", return_value=iter([])),
+        patch.object(
+            importer,
+            "_load_connector_profile_operations",
+            return_value={"testapp": {"COMPOSIO": ["TESTAPP_GET_CURRENT_USER"]}},
+        ),
+        patch.object(importer, "_upsert_connector", AsyncMock()) as upsert_connector,
+        patch.object(importer, "_upsert_operation", AsyncMock()),
+        patch.object(importer, "_upsert_trigger", AsyncMock()),
+    ):
+        await importer._sync_composio_catalog(
+            connector_repository,
+            operation_repository,
+            trigger_repository,
+            app_filters={"testapp"},
+            managed_by="composio",
+            page_size=100,
+            max_composio_apps=10,
+        )
+
+    entity = upsert_connector.await_args.args[1]
+    capability = _capability(entity, AuthProvider.COMPOSIO)
+    assert capability.profile_operation_names == ["TESTAPP_GET_CURRENT_USER"]
+
+
+@pytest.mark.asyncio
+async def test_sync_composio_catalog_leaves_profile_operation_names_none_without_override():
+    """No regression for the ~50 apps with no curated entry yet: the field
+    stays None, identical to today's behavior before this feature existed."""
+    connector_repository = SimpleNamespace(get=AsyncMock(return_value=None))
+    operation_repository = SimpleNamespace()
+    trigger_repository = SimpleNamespace()
+
+    toolkit_item = _toolkit("uncurated_app", name="Uncurated App")
+    composio = SimpleNamespace(
+        toolkits=SimpleNamespace(get=MagicMock(return_value=_toolkit_detail()))
+    )
+
+    with (
+        patch.dict(os.environ, {"COMPOSIO_API_KEY": "test-api-key"}, clear=False),
+        patch.object(importer, "Composio", return_value=composio),
+        patch.object(importer, "_list_composio_toolkits", return_value=[toolkit_item]),
+        patch.object(importer, "_paginate_tools", return_value=iter([])),
+        patch.object(importer, "_paginate_triggers", return_value=iter([])),
+        patch.object(importer, "_load_connector_profile_operations", return_value={}),
+        patch.object(importer, "_upsert_connector", AsyncMock()) as upsert_connector,
+        patch.object(importer, "_upsert_operation", AsyncMock()),
+        patch.object(importer, "_upsert_trigger", AsyncMock()),
+    ):
+        await importer._sync_composio_catalog(
+            connector_repository,
+            operation_repository,
+            trigger_repository,
+            app_filters={"uncurated_app"},
+            managed_by="composio",
+            page_size=100,
+            max_composio_apps=10,
+        )
+
+    entity = upsert_connector.await_args.args[1]
+    capability = _capability(entity, AuthProvider.COMPOSIO)
+    assert capability.profile_operation_names is None
+
+
+@pytest.mark.asyncio
+async def test_sync_native_catalog_applies_curated_profile_operation_names():
+    """JSON-config Lemma apps (Slack, Jira, Confluence, ...) also get curated
+    profile operations threaded onto their LemmaProviderCapability."""
+    connector_repository = SimpleNamespace(get=AsyncMock(return_value=None))
+    operation_repository = SimpleNamespace()
+    trigger_repository = SimpleNamespace()
+    schema_compiler = SimpleNamespace(
+        to_json_schema=MagicMock(return_value={"type": "object"})
+    )
+
+    with (
+        patch.object(
+            importer,
+            "_load_lemma_apps_config",
+            return_value=[
+                {
+                    "name": "testapp",
+                    "title": "TestApp",
+                    "description": "TestApp connector",
+                    "auth_method": "OAUTH2",
+                    "triggers": [],
+                }
+            ],
+        ),
+        patch.object(
+            importer,
+            "_load_connector_profile_operations",
+            return_value={"testapp": {"LEMMA": ["get_profile"]}},
+        ),
+        patch.object(importer, "_upsert_connector", AsyncMock()) as upsert_connector,
+    ):
+        await importer._sync_native_catalog(
+            connector_repository,
+            operation_repository,
+            trigger_repository,
+            app_filters={"testapp"},
+            schema_compiler=schema_compiler,
+        )
+
+    entity = upsert_connector.await_args.args[1]
+    capability = _capability(entity, AuthProvider.LEMMA)
+    assert capability.profile_operation_names == ["get_profile"]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("toolkit_slug", "expected_app_id"),
     [

--- a/lemma-backend/scripts/connector_profile_operations.json
+++ b/lemma-backend/scripts/connector_profile_operations.json
@@ -1,0 +1,30 @@
+{
+  "gmail": {
+    "LEMMA": ["get_profile"],
+    "COMPOSIO": ["GMAIL_GET_PROFILE", "get_profile"]
+  },
+  "outlook": {
+    "COMPOSIO": ["OUTLOOK_GET_PROFILE"]
+  },
+  "asana": {
+    "COMPOSIO": ["ASANA_GET_CURRENT_USER"]
+  },
+  "notion": {
+    "COMPOSIO": ["NOTION_RETRIEVE_YOUR_TOKEN_S_BOT_USER"]
+  },
+  "hubspot": {
+    "COMPOSIO": ["HUBSPOT_GET_MY_HUBSPOT_ACCOUNT_DETAILS"]
+  },
+  "linear": {
+    "COMPOSIO": ["LINEAR_GET_CURRENT_USER"]
+  },
+  "github": {
+    "COMPOSIO": ["GITHUB_GET_THE_AUTHENTICATED_USER"]
+  },
+  "discord": {
+    "COMPOSIO": ["DISCORD_GET_MY_USER"]
+  },
+  "zendesk": {
+    "COMPOSIO": ["ZENDESK_SHOW_CURRENT_USER"]
+  }
+}

--- a/lemma-backend/scripts/connector_profile_operations.json
+++ b/lemma-backend/scripts/connector_profile_operations.json
@@ -10,10 +10,10 @@
     "COMPOSIO": ["ASANA_GET_CURRENT_USER"]
   },
   "notion": {
-    "COMPOSIO": ["NOTION_RETRIEVE_YOUR_TOKEN_S_BOT_USER"]
+    "COMPOSIO": ["NOTION_GET_ABOUT_ME"]
   },
   "hubspot": {
-    "COMPOSIO": ["HUBSPOT_GET_MY_HUBSPOT_ACCOUNT_DETAILS"]
+    "COMPOSIO": ["HUBSPOT_GET_ACCOUNT_INFO"]
   },
   "linear": {
     "COMPOSIO": ["LINEAR_GET_CURRENT_USER"]
@@ -23,8 +23,5 @@
   },
   "discord": {
     "COMPOSIO": ["DISCORD_GET_MY_USER"]
-  },
-  "zendesk": {
-    "COMPOSIO": ["ZENDESK_SHOW_CURRENT_USER"]
   }
 }

--- a/lemma-backend/scripts/import_connector_catalog.py
+++ b/lemma-backend/scripts/import_connector_catalog.py
@@ -215,6 +215,45 @@ def _load_lemma_apps_config() -> list[dict]:
         return json.load(f)
 
 
+# Curated map of connector_id -> {provider: [operation names]} for the
+# operation to call right after connecting an account to fetch its own
+# profile (email/name/workspace) -- so display_name resolution doesn't
+# depend solely on whatever the OAuth token-exchange response happens to
+# carry. Human-curated rather than auto-detected: Composio's operation
+# naming is not standardized across toolkits (GMAIL_GET_PROFILE vs
+# DISCORD_GET_MY_USER vs a generic about_get), so guessing by name alone
+# risks silently picking the wrong operation. Candidates are tried in order
+# by the service layer; a connector/provider with no entry here simply gets
+# no profile-operation enrichment (falls back to raw OAuth-response data).
+CONNECTOR_PROFILE_OPERATIONS_PATH = (
+    Path(__file__).parent / "connector_profile_operations.json"
+)
+
+
+def _load_connector_profile_operations() -> dict[str, dict[str, list[str]]]:
+    """Load the curated connector_id -> {provider: [operation names]} map."""
+    if not CONNECTOR_PROFILE_OPERATIONS_PATH.exists():
+        logger.warning(
+            "Connector profile operations config not found at %s",
+            CONNECTOR_PROFILE_OPERATIONS_PATH,
+        )
+        return {}
+    with open(CONNECTOR_PROFILE_OPERATIONS_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _profile_operation_names(
+    profile_operations: dict[str, dict[str, list[str]]],
+    connector_id: str,
+    provider: AuthProvider,
+) -> list[str] | None:
+    """Look up curated profile-operation candidates for a connector+provider."""
+    by_provider = profile_operations.get(_normalize_connector_id(connector_id))
+    if not by_provider:
+        return None
+    return by_provider.get(provider.value) or None
+
+
 def _build_operation_search_document(
     *,
     public_name: str,
@@ -479,13 +518,18 @@ def _merge_provider_capabilities(
 def _native_package_provider_capability(
     connector_id: str,
     existing: ConnectorEntity | None,
+    *,
+    profile_operation_names: list[str] | None = None,
 ) -> LemmaProviderCapability:
     auth_method = _infer_native_auth_method(connector_id, existing)
     if existing:
         try:
             capability = existing.capability_for(AuthProvider.LEMMA)
             if isinstance(capability, LemmaProviderCapability):
-                updates: dict[str, object] = {"auth_scheme": auth_method}
+                updates: dict[str, object] = {
+                    "auth_scheme": auth_method,
+                    "profile_operation_names": profile_operation_names,
+                }
                 if capability.auth_config_schema is None:
                     updates["auth_config_schema"] = _default_auth_config_schema(
                         auth_method
@@ -494,7 +538,9 @@ def _native_package_provider_capability(
         except ValueError:
             pass
 
-    return _lemma_provider_capability(auth_method=auth_method)
+    return _lemma_provider_capability(
+        auth_method=auth_method, profile_operation_names=profile_operation_names
+    )
 
 
 def _default_auth_config_schema(auth_method: AuthMethod) -> dict:
@@ -525,6 +571,7 @@ def _lemma_provider_capability(
     auth_config_schema: dict | None = None,
     credential_schema: dict | None = None,
     system_oauth: dict | None = None,
+    profile_operation_names: list[str] | None = None,
 ) -> LemmaProviderCapability:
     system_default_available = (
         auth_method != AuthMethod.OAUTH2 or _system_oauth_available(system_oauth)
@@ -543,6 +590,7 @@ def _lemma_provider_capability(
         else None,
         supports_org_custom_oauth=auth_method == AuthMethod.OAUTH2,
         system_default_available=system_default_available,
+        profile_operation_names=profile_operation_names,
     )
 
 
@@ -551,6 +599,7 @@ def _composio_provider_capability(
     auth_method: AuthMethod,
     toolkit_slug: str,
     auth_config_schema: dict | None = None,
+    profile_operation_names: list[str] | None = None,
 ) -> ComposioProviderCapability:
     return ComposioProviderCapability(
         auth_scheme=auth_method,
@@ -558,6 +607,7 @@ def _composio_provider_capability(
         auth_config_schema=auth_config_schema,
         system_default_available=True,
         supports_org_custom_auth_config=False,
+        profile_operation_names=profile_operation_names,
     )
 
 
@@ -942,6 +992,8 @@ async def _sync_native_catalog(
     total_operations = 0
     total_triggers = 0
 
+    profile_operations = _load_connector_profile_operations()
+
     # First sync Lemma-managed apps from JSON config (Slack, Jira, Confluence)
     lemma_apps = _load_lemma_apps_config()
     normalized_app_filters = (
@@ -975,6 +1027,9 @@ async def _sync_native_catalog(
                     auth_config_schema=app_config.get("auth_config_schema"),
                     credential_schema=app_config.get("credential_schema"),
                     system_oauth=app_config.get("system_oauth"),
+                    profile_operation_names=_profile_operation_names(
+                        profile_operations, connector_id, AuthProvider.LEMMA
+                    ),
                 ),
             ),
             agent_instruction=app_config.get("agent_instruction")
@@ -1060,7 +1115,13 @@ async def _sync_native_catalog(
             icon=existing.icon if existing else None,
             provider_capabilities=_merge_provider_capabilities(
                 existing,
-                _native_package_provider_capability(connector_id, existing),
+                _native_package_provider_capability(
+                    connector_id,
+                    existing,
+                    profile_operation_names=_profile_operation_names(
+                        profile_operations, connector_id, AuthProvider.LEMMA
+                    ),
+                ),
             ),
             agent_instruction=existing.agent_instruction if existing else None,
             is_active=True,
@@ -1201,15 +1262,24 @@ async def _sync_single_composio_toolkit(
     composio_auth_config_schema = _composio_credential_schema(
         toolkit_detail, composio_auth_method
     )
+    profile_operations = _load_connector_profile_operations()
     lemma_capability = None
     if supports_native:
+        lemma_profile_operation_names = _profile_operation_names(
+            profile_operations, connector_id, AuthProvider.LEMMA
+        )
         try:
             lemma_capability = existing.capability_for(AuthProvider.LEMMA) if existing else None
         except ValueError:
             lemma_capability = None
-        if lemma_capability is None:
+        if lemma_capability is not None:
+            lemma_capability = lemma_capability.model_copy(
+                update={"profile_operation_names": lemma_profile_operation_names}
+            )
+        else:
             lemma_capability = _lemma_provider_capability(
                 auth_method=_infer_native_auth_method(connector_id, existing),
+                profile_operation_names=lemma_profile_operation_names,
             )
 
     entity = ConnectorEntity(
@@ -1235,6 +1305,9 @@ async def _sync_single_composio_toolkit(
                 auth_method=composio_auth_method,
                 toolkit_slug=toolkit_item.slug,
                 auth_config_schema=composio_auth_config_schema,
+                profile_operation_names=_profile_operation_names(
+                    profile_operations, connector_id, AuthProvider.COMPOSIO
+                ),
             ),
             lemma_capability,
         ),


### PR DESCRIPTION
## Summary
- Fixes a 400 `"organization_id is required"` on `DELETE /organizations/{organization_id}/connectors/accounts/{account_id}`: `get_org_context` only read the `{org_id}` path param, but connectors routes mount under `{organization_id}`.
- Closes a related gap: `delete_auth_config` (which cascades to delete every account under it, org-wide) had no `reject_delegated_workload` gate, unlike the single-account delete.
- Improves `display_name` fallback (Composio's `word_id`/`alias` + common per-toolkit fields) for apps with no dedicated identity handler.
- Moves "which operation fetches this account's own profile" from a hardcoded Python dict (gmail/outlook only) onto the connector's provider capability itself — a catalog-owned setting via a curated override file (`scripts/connector_profile_operations.json`), instead of hand-editing `connector_service.py` per app. Wired into both the OAuth callback and `create_account`.
- Closes a TOCTOU gap in the "same identity can't connect twice" guarantee: a race under concurrent connects could surface as a raw 500 instead of a clean 409.
- **Found and fixed a real bug during verification**: every `composio.tools.execute()` result is wrapped in `{"data": ..., "error": ..., "successful": ...}` (confirmed against the installed SDK's `ToolExecutionResponse` type) — the toolkit's actual fields live one level down in `data`. The profile-fetch extraction never accounted for this, so it would have silently failed for every Composio profile operation, including the pre-existing gmail/outlook ones (their only test coverage used an unrealistic flat-dict mock). Fixed with provider-scoped unwrapping.
- Verified the 7 curated operation names against Composio's real docs: asana/linear/github/discord were correct; notion and hubspot were wrong and corrected; zendesk's exact slug couldn't be confirmed and was removed rather than guessed.

## Test plan
- [x] `test_delete_account_removes_account_and_404s_on_repeat` — reproduces the reported bug end-to-end; confirmed it fails without the fix and passes with it.
- [x] `test_oauth_new_account_addition_and_reauth_flows` / `test_list_and_get_auth_config` / `test_default_pod_agent_cannot_delete_account` / `test_default_pod_agent_cannot_delete_auth_config` — new e2e coverage.
- [x] Unit tests for `account_identity.py`/`composio_auth_provider.py` display-name fallbacks.
- [x] Unit tests for the importer's curated profile-operations wiring (native + Composio, with/without override).
- [x] Unit tests for `connector_service.py`'s catalog-driven profile fetch (OAuth callback + `create_account`) and the Composio envelope-unwrapping fix (including a negative case: Lemma-provider results are untouched).
- [x] Unit tests for `account_repository.py`'s IntegrityError → 409 translation.
- [x] Full unit suite (`pytest -m "not e2e"`): 1899 passed, 1 skipped (unrelated optional dependency).
- [x] Full fast e2e suite matching every `e2e.yml` shard: 324 passed, 1 skipped (real-GCS creds gated).
- [x] Full connectors module suite: 211 passed, 5 skipped (real-credential gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)