### PR TITLE
fix(workflow,schedule,datastore): idempotency, sidecar auth, memory safety, circuit breaker

### DIFF
--- a/lemma-backend/app/core/config.py
+++ b/lemma-backend/app/core/config.py
@@ -475,6 +475,27 @@ class Settings(BaseSettings):
     scheduler_api_url: str = Field(
         default="http://localhost:8711", description="Scheduler API URL"
     )
+    schedule_max_consecutive_failures: int = Field(
+        default=5,
+        description=(
+            "Circuit breaker: after this many consecutive failed fires, a schedule "
+            "is auto-deactivated (is_active=False) so it stops firing and filling "
+            "the DB with failing runs, and a ScheduleDeactivated event is emitted "
+            "(notifies the creator). A successful fire resets the count. Env: "
+            "``SCHEDULE_MAX_CONSECUTIVE_FAILURES``."
+        ),
+    )
+    scheduler_internal_token: Optional[SecretStr] = Field(
+        default=None,
+        description=(
+            "Shared secret for service-to-service auth on the scheduler sidecar's "
+            "/scheduler/jobs API. The backend sends it as a bearer token and the "
+            "sidecar requires it. When unset (e.g. local single-process dev where "
+            "nothing else can reach the router) the sidecar does not enforce auth. "
+            "Set it in every deployment where the sidecar runs as its own reachable "
+            "service. Env: ``SCHEDULER_INTERNAL_TOKEN``."
+        ),
+    )
     supertokens_core_url: str = Field(
         default="http://localhost:3567", description="Supertokens core URL"
     )

--- a/lemma-backend/app/modules/datastore/config.py
+++ b/lemma-backend/app/modules/datastore/config.py
@@ -51,13 +51,14 @@ class DatastoreSettings(BaseSettings):
     document_processing_max_concurrency: int = Field(
         default=2,
         description=(
-            "Maximum concurrent document extraction jobs per worker process. This "
-            "is the one guaranteed lever on Kreuzberg's peak RAM: each extraction "
-            "carries a ~1.5GB model+runtime floor plus a per-doc working set, so "
-            "the multiplier matters. Kept at 2 so a mixed native+scanned load "
-            "stays under a 4GB kreuzberg instance (measured ~3.9GB peak at 2; OOM "
-            "at higher concurrency or 4 CPU). Lower to 1 for more headroom; pair "
-            "with the kreuzberg container held at cpus=2."
+            "Maximum concurrent document extractions per worker process. This is "
+            "the primary lever on a worker's peak RAM during ingestion: each "
+            "extraction holds the source document plus the extractor's response "
+            "(markdown + chunks + any extracted images) in memory at once, so peak "
+            "memory scales with this multiplier. Keep it low enough that "
+            "concurrency times the largest expected per-document working set stays "
+            "within the worker's memory budget; tune per deployment. Env: "
+            "``DOCUMENT_PROCESSING_MAX_CONCURRENCY``."
         ),
     )
     document_processing_debounce_seconds: int = Field(
@@ -144,16 +145,24 @@ class DatastoreSettings(BaseSettings):
         description="HTTP timeout (seconds) for Kreuzberg extract and chunk requests",
     )
     kreuzberg_transient_retry_attempts: int = Field(
-        default=5,
+        default=6,
         description=(
             "Attempts for transient (connection/timeout) Kreuzberg failures before "
-            "giving up. Bump in resource-constrained CI/e2e where a single shared "
-            "Kreuzberg can briefly stall under concurrent load."
+            "giving up. Combined with the base delay below the exponential backoff "
+            "totals base*(2^(attempts-1)-1) seconds of waiting, so the default "
+            "6/1.0s rides out ~30s of unavailability — enough to survive a backend "
+            "restart or a scale-from-zero cold start rather than failing the "
+            "extraction (which would mark the file FAILED). Raise for a backend "
+            "with longer cold starts. Env: ``KREUZBERG_TRANSIENT_RETRY_ATTEMPTS``."
         ),
     )
     kreuzberg_transient_retry_base_delay_seconds: float = Field(
-        default=0.5,
-        description="Base delay (seconds) for exponential backoff between Kreuzberg retries.",
+        default=1.0,
+        description=(
+            "Base delay (seconds) for exponential backoff between transient "
+            "Kreuzberg retries; total wait is base*(2^(attempts-1)-1). Env: "
+            "``KREUZBERG_TRANSIENT_RETRY_BASE_DELAY_SECONDS``."
+        ),
     )
 
     # PDF page rendering (on-demand, in-backend via pypdfium2 + Pillow)

--- a/lemma-backend/app/modules/datastore/infrastructure/kreuzberg_helper.py
+++ b/lemma-backend/app/modules/datastore/infrastructure/kreuzberg_helper.py
@@ -26,13 +26,14 @@ logger = get_logger(__name__)
 # outright (which would mark the file FAILED and wait on the recovery cron).
 # HTTP 4xx/5xx responses are NOT retried here; those are handled by the
 # config-fallback layer.
-# Defaults: 5 attempts with 0.5s base ⇒ backoff 0.5+1+2+4 = 7.5s of waiting,
-# enough to ride out a Kreuzberg container restart (e.g. after an OOM kill under
-# burst load). Both are overridable via datastore_settings (read at call time)
-# so resource-constrained CI/e2e — where a single shared Kreuzberg serves several
-# parallel workers — can wait longer instead of failing the extraction outright.
-_TRANSIENT_RETRY_ATTEMPTS = 5
-_TRANSIENT_RETRY_BASE_DELAY_SECONDS = 0.5
+# Defaults: 6 attempts with 1.0s base ⇒ backoff 1+2+4+8+16 = 31s of waiting
+# (total = base*(2^(attempts-1)-1)), enough to ride out a Kreuzberg restart or a
+# scale-from-zero cold start rather than failing the extraction outright (which
+# would mark the file FAILED and wait on the recovery cron). Both are overridable
+# via datastore_settings (read at call time) so a backend with longer cold starts
+# can wait longer.
+_TRANSIENT_RETRY_ATTEMPTS = 6
+_TRANSIENT_RETRY_BASE_DELAY_SECONDS = 1.0
 
 
 class KreuzbergExtractionResult:

--- a/lemma-backend/app/modules/datastore/services/file_processing_service.py
+++ b/lemma-backend/app/modules/datastore/services/file_processing_service.py
@@ -436,7 +436,14 @@ class DatastoreFileProcessingService:
             "search_metadata": search_metadata,
         }
 
-        for image in extraction.images:
+        # Drain the list rather than iterating it: each image's ``content`` bytes
+        # can be large (base64-decoded figures from a scanned doc), and holding the
+        # whole list resident until this method returns is the biggest avoidable
+        # chunk of steady-state memory during ingestion. Popping each image before
+        # uploading lets the GC reclaim its bytes as soon as the upload completes,
+        # so only one image's bytes are held at a time instead of all of them.
+        while extraction.images:
+            image = extraction.images.pop(0)
             await self.storage.upload_file(
                 build_datastore_child_artifact_key(
                     self.pod_id,

--- a/lemma-backend/app/modules/datastore/tests/unit/test_datastore_config.py
+++ b/lemma-backend/app/modules/datastore/tests/unit/test_datastore_config.py
@@ -23,11 +23,11 @@ EXPECTED = [
     ("docling_request_timeout_seconds", "DOCLING_REQUEST_TIMEOUT_SECONDS", 300.0),
     ("kreuzberg_url", "KREUZBERG_URL", "http://localhost:8002"),
     ("kreuzberg_request_timeout_seconds", "KREUZBERG_REQUEST_TIMEOUT_SECONDS", 180.0),
-    ("kreuzberg_transient_retry_attempts", "KREUZBERG_TRANSIENT_RETRY_ATTEMPTS", 5),
+    ("kreuzberg_transient_retry_attempts", "KREUZBERG_TRANSIENT_RETRY_ATTEMPTS", 6),
     (
         "kreuzberg_transient_retry_base_delay_seconds",
         "KREUZBERG_TRANSIENT_RETRY_BASE_DELAY_SECONDS",
-        0.5,
+        1.0,
     ),
     ("pdf_render_dpi", "PDF_RENDER_DPI", 150),
     ("pdf_render_max_long_edge", "PDF_RENDER_MAX_LONG_EDGE", 1568),

--- a/lemma-backend/app/modules/schedule/api/controllers/webhook_controller.py
+++ b/lemma-backend/app/modules/schedule/api/controllers/webhook_controller.py
@@ -103,11 +103,21 @@ async def handle_webhook(
                 detail="Invalid webhook signature",
             )
     else:
-        # For other sources, parse JSON
-        try:
-            payload = await request.json()
-        except Exception:
-            payload = {}  # Maybe just raw body handling if needed? But handler expects dict payload.
+        # SECURITY (interim): every source other than `composio` is unauthenticated
+        # here — the request body is attacker-controllable and flows straight into
+        # schedule matching + the started run's trigger context. Composio is the
+        # only source with real signature verification, so reject everything else
+        # until per-account verified webhook routing lands (see plan Part D). This
+        # deliberately disables the legacy shared Slack/generic ingress path.
+        logger.warning(
+            "Rejecting unauthenticated webhook for source %s; only composio is "
+            "verified on this endpoint.",
+            source,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Unsupported or unverified webhook source",
+        )
 
     await log_raw_webhook_event(source=source, payload=payload, headers=headers)
 

--- a/lemma-backend/app/modules/schedule/domain/events/schedule.py
+++ b/lemma-backend/app/modules/schedule/domain/events/schedule.py
@@ -24,6 +24,20 @@ class ScheduleDeleted(ScheduleEvent):
     event_type: str = "schedule.deleted"
 
 
+class ScheduleDeactivated(ScheduleEvent):
+    """A schedule was auto-deactivated by the failure circuit breaker.
+
+    Emitted when a schedule hits the consecutive-failure threshold and is set
+    inactive. Consumed today to notify the creator; the event is the extension
+    point for future reactions (in-app notification, admin alerting) without
+    changing the breaker.
+    """
+
+    event_type: str = "schedule.deactivated"
+    consecutive_failures: int
+    reason: str = "consecutive_failures"
+
+
 class ScheduleFired(ScheduleEvent):
     """Event emitted when any schedule source fires.
 
@@ -49,4 +63,4 @@ class ScheduleEvents:
     # from being dropped when a consumer's group was lost (flush/failover) and is
     # otherwise only recreated later at "$". The workflow pod consumes via this
     # group; the surface subscriber reads group-less (fan-out) and needs none.
-    CONSUMER_GROUPS = ("workflow-schedule-events",)
+    CONSUMER_GROUPS = ("workflow-schedule-events", "schedule-notifications")

--- a/lemma-backend/app/modules/schedule/handlers/schedule_notification_consumer.py
+++ b/lemma-backend/app/modules/schedule/handlers/schedule_notification_consumer.py
@@ -1,0 +1,92 @@
+"""Schedule notification handlers.
+
+Consumes ``schedule_events`` (own consumer group) and, on a
+``ScheduleDeactivated`` event from the failure circuit breaker, emails the
+schedule's creator. This subscriber is the extension point for reacting to
+deactivation — future consumers (in-app notification, admin alerting) add their
+own subscriber without touching the breaker.
+"""
+
+from __future__ import annotations
+
+from faststream import Depends, Logger
+from faststream.redis import RedisRouter
+
+from app.core.infrastructure.db.session import async_session_maker
+from app.core.infrastructure.db.uow_factory import (
+    SessionUnitOfWorkFactory,
+    UnitOfWorkFactory,
+)
+from app.core.infrastructure.events.stream_subscriber import redis_stream_sub
+from app.modules.schedule.domain.events.schedule import (
+    ScheduleDeactivated,
+    ScheduleEvents,
+)
+
+router = RedisRouter()
+
+
+def provide_uow_factory() -> UnitOfWorkFactory:
+    return SessionUnitOfWorkFactory(async_session_maker)
+
+
+@router.subscriber(
+    stream=redis_stream_sub(
+        ScheduleEvents.STREAM,
+        group="schedule-notifications",
+        consumer="schedule-notifications-consumer",
+    )
+)
+async def on_schedule_deactivated(
+    event: dict,
+    fs_logger: Logger,
+    uow_factory: UnitOfWorkFactory = Depends(provide_uow_factory),
+) -> None:
+    """Email the creator when their schedule is auto-deactivated."""
+    if event.get("event_type") != ScheduleDeactivated.get_event_type():
+        return
+
+    parsed = ScheduleDeactivated.model_validate(event)
+
+    # Resolve the creator's email.
+    from app.modules.identity.infrastructure.user_repositories import UserRepository
+
+    async with uow_factory() as uow:
+        user = await UserRepository(uow).get(parsed.user_id)
+
+    if user is None or not getattr(user, "email", None):
+        fs_logger.warning(
+            "ScheduleDeactivated for %s: no email for user %s; skipping notification",
+            parsed.schedule_id,
+            parsed.user_id,
+        )
+        return
+
+    subject = "A scheduled automation was paused after repeated failures"
+    html_content = (
+        "<p>One of your scheduled automations was automatically paused because it "
+        f"failed {parsed.consecutive_failures} times in a row.</p>"
+        f"<p>Schedule ID: <code>{parsed.schedule_id}</code></p>"
+        "<p>Re-enable it once you've addressed the cause; it will start fresh.</p>"
+    )
+
+    try:
+        from app.core.email.email_sender import EmailSender
+
+        sender = EmailSender.from_settings()
+        await sender.send_email(
+            to_email=str(user.email),
+            subject=subject,
+            html_content=html_content,
+        )
+        fs_logger.info(
+            "Sent deactivation notice for schedule %s to %s",
+            parsed.schedule_id,
+            user.email,
+        )
+    except Exception:
+        # Best-effort: the deactivation itself is already durable; a missed email
+        # must not crash the consumer or wedge the stream.
+        fs_logger.exception(
+            "Failed to send deactivation email for schedule %s", parsed.schedule_id
+        )

--- a/lemma-backend/app/modules/schedule/module.py
+++ b/lemma-backend/app/modules/schedule/module.py
@@ -21,12 +21,14 @@ def _event_routers():
         datastore_consumer,
         pod_lifecycle_consumer,
         schedule_consumer,
+        schedule_notification_consumer,
     )
 
     return [
         schedule_consumer.router,
         datastore_consumer.router,
         pod_lifecycle_consumer.router,
+        schedule_notification_consumer.router,
     ]
 
 

--- a/lemma-backend/app/modules/schedule/scheduler/api/scheduler_controller.py
+++ b/lemma-backend/app/modules/schedule/scheduler/api/scheduler_controller.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import hmac
 from uuid import UUID
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, Header, HTTPException, status
 from fastapi.responses import Response
 
 from app.modules.schedule.scheduler.scheduler_service import get_scheduler_service
@@ -15,11 +16,42 @@ from app.modules.schedule.scheduler.api.schemas import (
     JobListResponse,
     JobStatusResponse,
 )
+from app.core.config import reveal_secret, settings
 from app.core.log.log import get_logger
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/scheduler/jobs", tags=["Scheduler"])
+
+async def require_scheduler_token(
+    authorization: str | None = Header(default=None),
+) -> None:
+    """Service-to-service auth for the scheduler sidecar's job API.
+
+    The sidecar is an internal singleton reached only by the backend's
+    ``SchedulerAPIClient``. When ``scheduler_internal_token`` is configured the
+    caller must present it as a bearer token; when it is unset (e.g. local
+    single-process dev) the check is skipped so nothing breaks out of the box.
+    """
+    expected = reveal_secret(settings.scheduler_internal_token)
+    if not expected:
+        return
+
+    provided: str | None = None
+    if authorization and authorization.lower().startswith("bearer "):
+        provided = authorization[7:]
+
+    if not provided or not hmac.compare_digest(provided, expected):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing scheduler token",
+        )
+
+
+router = APIRouter(
+    prefix="/scheduler/jobs",
+    tags=["Scheduler"],
+    dependencies=[Depends(require_scheduler_token)],
+)
 
 
 @router.post(

--- a/lemma-backend/app/modules/schedule/scheduler/api_client.py
+++ b/lemma-backend/app/modules/schedule/scheduler/api_client.py
@@ -16,7 +16,7 @@ from app.modules.schedule.scheduler.api.schemas import (
     JobListResponse,
     JobStatusResponse,
 )
-from app.core.config import settings
+from app.core.config import reveal_secret, settings
 from app.core.log.log import get_logger
 
 from app.modules.schedule.domain.interfaces import SchedulerService
@@ -171,11 +171,17 @@ class SchedulerAPIClient(SchedulerService):
         Returns:
             Response JSON data
         """
+        headers: dict[str, str] = {}
+        token = reveal_secret(settings.scheduler_internal_token)
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
         try:
             async with session.request(
                 method=method,
                 url=url,
                 json=json_data,
+                headers=headers or None,
             ) as response:
                 response.raise_for_status()
 

--- a/lemma-backend/app/modules/schedule/services/schedule_fire_store.py
+++ b/lemma-backend/app/modules/schedule/services/schedule_fire_store.py
@@ -1,0 +1,128 @@
+"""Redis-backed idempotency + failure tracking for schedule fires.
+
+Two concerns, both keyed by schedule, both best-effort (a Redis blip must never
+drop or wrongly duplicate a legitimate fire):
+
+- Agent-target fire dedup: agent schedules have no DB uniqueness constraint to gate
+  duplicate side effects (unlike workflow runs, gated by
+  ``(flow_id, user_id, schedule_event_id)``), so a redelivered ``schedule.fired``
+  could start a second conversation. A ``SET NX EX`` claim keyed on the fire's event
+  id is the durable guard, layered under streaq's in-flight ``_job_id`` dedup.
+- Consecutive-failure counter for the circuit breaker: a schedule whose runs keep
+  erroring is auto-deactivated after N consecutive failures so it stops firing and
+  filling the DB with failed runs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID
+
+from redis.asyncio import Redis
+
+from app.core.config import settings
+from app.core.log.log import get_logger
+
+logger = get_logger(__name__)
+
+# Just needs to comfortably outlast the at-least-once redelivery window for a single
+# fire; schedule fires are low-volume so a generous window is cheap.
+_AGENT_FIRE_DEDUP_TTL_SECONDS = 6 * 60 * 60  # 6h
+
+# Refreshed on each failure, so a schedule that stops firing entirely eventually
+# drops its counter instead of leaking a key forever. Any schedule firing more
+# often than this is, by definition, not dormant.
+_FAILURE_COUNTER_TTL_SECONDS = 30 * 24 * 60 * 60  # 30d
+
+
+class ScheduleFireStore:
+    """Redis-backed idempotency + failure tracking for schedule fires."""
+
+    def __init__(self, redis_url: str | None = None) -> None:
+        self._redis_url = redis_url or settings.redis_url
+        self._redis: Redis | None = None
+        self._lock = asyncio.Lock()
+
+    async def _get_redis(self) -> Redis:
+        if self._redis is not None:
+            return self._redis
+        async with self._lock:
+            if self._redis is None:
+                self._redis = Redis.from_url(self._redis_url, decode_responses=True)
+        return self._redis
+
+    def _agent_fire_key(self, schedule_id: str, event_id: str) -> str:
+        return f"schedule:agent-fire:{schedule_id}:{event_id}"
+
+    def _failure_key(self, schedule_id: str) -> str:
+        return f"schedule:consec-fail:{schedule_id}"
+
+    async def claim_agent_fire(
+        self, *, schedule_id: UUID | str, event_id: str | None
+    ) -> bool:
+        """Claim a single agent-target fire.
+
+        Returns True the first time a given ``(schedule_id, event_id)`` is seen
+        (caller should dispatch) and False for a duplicate (caller should skip).
+        With no stable ``event_id`` there is nothing to dedup on, so it returns
+        True (matches prior behavior). Fails open (True) on any Redis error so a
+        transient blip never silently drops a legitimate fire.
+        """
+        if not event_id:
+            return True
+        try:
+            redis = await self._get_redis()
+            claimed = await redis.set(
+                self._agent_fire_key(str(schedule_id), str(event_id)),
+                "1",
+                ex=_AGENT_FIRE_DEDUP_TTL_SECONDS,
+                nx=True,
+            )
+            return bool(claimed)
+        except Exception as exc:  # noqa: BLE001 — dedup is best-effort
+            logger.warning(
+                "Schedule agent-fire dedup unavailable for %s:%s (%s); proceeding",
+                schedule_id,
+                event_id,
+                exc,
+            )
+            return True
+
+    async def record_failure(self, *, schedule_id: UUID | str) -> int:
+        """Increment and return the consecutive-failure count for a schedule.
+
+        Returns 0 on any Redis error so a blip never trips the breaker.
+        """
+        try:
+            redis = await self._get_redis()
+            key = self._failure_key(str(schedule_id))
+            count = await redis.incr(key)
+            await redis.expire(key, _FAILURE_COUNTER_TTL_SECONDS)
+            return int(count)
+        except Exception as exc:  # noqa: BLE001 — breaker is best-effort
+            logger.warning(
+                "Schedule failure counter unavailable for %s (%s)", schedule_id, exc
+            )
+            return 0
+
+    async def reset_failures(self, *, schedule_id: UUID | str) -> None:
+        """Clear the consecutive-failure count (on success or reactivation)."""
+        try:
+            redis = await self._get_redis()
+            await redis.delete(self._failure_key(str(schedule_id)))
+        except Exception as exc:  # noqa: BLE001 — best-effort
+            logger.warning(
+                "Failed clearing schedule failure counter for %s (%s)",
+                schedule_id,
+                exc,
+            )
+
+
+_store: ScheduleFireStore | None = None
+
+
+def get_schedule_fire_store() -> ScheduleFireStore:
+    global _store
+    if _store is None:
+        _store = ScheduleFireStore()
+    return _store

--- a/lemma-backend/app/modules/schedule/services/schedule_service.py
+++ b/lemma-backend/app/modules/schedule/services/schedule_service.py
@@ -449,6 +449,16 @@ class ScheduleService:
                     )
         updated = await self.schedule_repository.update(schedule_id, **update_data)
 
+        if updated and update_data.get("is_active") is True:
+            # Reactivating a schedule clears its circuit-breaker failure streak so
+            # a re-enabled schedule starts fresh instead of tripping again on the
+            # next failure.
+            from app.modules.schedule.services.schedule_fire_store import (
+                get_schedule_fire_store,
+            )
+
+            await get_schedule_fire_store().reset_failures(schedule_id=schedule_id)
+
         if updated and updated.schedule_type == ScheduleType.TIME:
             if "config" in update_data or "is_active" in update_data:
                 if updated.is_active:

--- a/lemma-backend/app/modules/workflow/events/handlers.py
+++ b/lemma-backend/app/modules/workflow/events/handlers.py
@@ -246,6 +246,20 @@ async def on_schedule_fired(
 
     fs_logger.info(f"Workflow: Received ScheduleFired for {schedule_id}")
 
+    # Dedup redelivered schedule fires: streaq drops a duplicate enqueue while a
+    # task with the same _job_id is still queued/running (its lock releases on
+    # completion), which covers the common at-least-once redelivery window between
+    # this handler receiving the event and ack-ing it. Durable idempotency across
+    # the full window still rests on the run's unique constraint (workflow target)
+    # and the Redis dedup key (agent target) inside handle_schedule_fired. Only set
+    # a _job_id when we have a stable event id to key on; otherwise fall back to
+    # streaq's random id (matches prior behavior).
+    dedup_kwargs: dict[str, str] = {}
+    if schedule_event_id:
+        dedup_kwargs["_job_id"] = (
+            f"workflow-schedule-fire:{schedule_id}:{schedule_event_id}"
+        )
+
     try:
         await job_queue.enqueue(
             "check_and_start_flows_for_schedule",
@@ -254,6 +268,7 @@ async def on_schedule_fired(
             metadata=metadata or {},
             llm_output=llm_output,
             schedule_event_id=str(schedule_event_id) if schedule_event_id else None,
+            **dedup_kwargs,
         )
     except Exception as e:
         fs_logger.error(

--- a/lemma-backend/app/modules/workflow/execution/engine.py
+++ b/lemma-backend/app/modules/workflow/execution/engine.py
@@ -170,18 +170,30 @@ class WorkflowEngine:
             schedule_event_id=schedule_event_id,
         )
 
-        result = await self._stepper(ctx).advance(run, flow)
-
+        # Persist the run row BEFORE advancing. The (flow_id, user_id,
+        # schedule_event_id) unique constraint must gate node side effects, not just
+        # the row: create() flushes, so a redelivered scheduled fire raises
+        # IntegrityError here — we convert it to WorkflowConflictError WITHOUT ever
+        # calling advance(), so a duplicate can never double-run entry-node side
+        # effects (start a conversation, invoke a function). We deliberately keep the
+        # in-memory `run` rather than create()'s return value, which is a summary
+        # entity missing the execution context/stack/step history the stepper needs.
         try:
-            run = await self.run_repo.create(run)
-            await self._persist_wait(run, result)
-            await self.uow.commit()
+            await self.run_repo.create(run)
         except IntegrityError as exc:
             if schedule_event_id is None:
                 raise
             raise WorkflowConflictError(
                 "Workflow run already exists for this schedule event"
             ) from exc
+
+        result = await self._stepper(ctx).advance(run, flow)
+
+        # create() persisted only the entry-node state; write the post-advance state
+        # (final node, status, step history, context) before committing.
+        run = await self.run_repo.update(run)
+        await self._persist_wait(run, result)
+        await self.uow.commit()
 
         return run
 

--- a/lemma-backend/app/modules/workflow/infrastructure/adapters/schedule_adapter.py
+++ b/lemma-backend/app/modules/workflow/infrastructure/adapters/schedule_adapter.py
@@ -1,7 +1,7 @@
 """Schedule adapter for the workflow module."""
 
 from datetime import datetime
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
 from app.modules.workflow.domain.ports import SchedulePort
@@ -17,16 +17,27 @@ class ScheduleControlAdapter(SchedulePort):
     async def schedule_workflow_wake(
         self, run_id: UUID, scheduled_at: str, pod_id: UUID, user_id: UUID
     ) -> UUID:
-        """Ask the scheduler to wake this workflow run at a specific time."""
+        """Ask the scheduler to wake this workflow run at a specific time.
+
+        The wake is keyed to a fresh per-wait token, NOT the run id. A run with
+        several sequential WAIT_UNTIL nodes would otherwise register every timer
+        under the same run-id key, so a duplicate or late wake could resume the
+        wrong timer (LP-059). The returned token becomes the wait's external_ref,
+        and it rides in the fired payload as ``wait_ref`` so the wake resolves to
+        exactly this wait. ``workflow_run_id`` is still included so the wake
+        handler can build the run's authorization context.
+        """
         _ = (pod_id, user_id)
+        timer_id = uuid4()
         await self.scheduler.schedule_once_job(
-            schedule_id=run_id,
+            schedule_id=timer_id,
             run_date=datetime.fromisoformat(scheduled_at),
             payload={
                 "workflow_run_id": str(run_id),
+                "wait_ref": str(timer_id),
                 "scheduled_at": scheduled_at,
                 "source": "workflow_wait_until",
             },
             replace_existing=True,
         )
-        return run_id
+        return timer_id

--- a/lemma-backend/app/modules/workflow/services/run_resume_service.py
+++ b/lemma-backend/app/modules/workflow/services/run_resume_service.py
@@ -107,16 +107,22 @@ class RunResumeService:
             reset_current_context(ctx_token)
 
     async def reconcile_stale_waits(self) -> int:
-        """Self-heal runs whose completion events were lost.
+        """Self-heal runs whose completion/wake events were lost.
 
         For ACTIVE AGENT/FUNCTION waits older than RECONCILE_AFTER, ask the
         source of truth: finished work resumes the run, failed/vanished work
-        fails it, in-progress work is left alone. Returns the number of
-        waits acted on.
+        fails it, in-progress work is left alone. TIME waits are also swept —
+        there is no external source to poll (a timer just needs to fire), so a
+        past-due TIME wait whose scheduler wake was lost is fired here. Returns
+        the number of waits acted on.
         """
         cutoff = datetime.now(timezone.utc) - RECONCILE_AFTER
         waits = await self._engine.wait_repo.list_active_older_than(
-            wait_types=[WorkflowRunWaitType.AGENT, WorkflowRunWaitType.FUNCTION],
+            wait_types=[
+                WorkflowRunWaitType.AGENT,
+                WorkflowRunWaitType.FUNCTION,
+                WorkflowRunWaitType.TIME,
+            ],
             created_before=cutoff,
             limit=RECONCILE_BATCH,
         )
@@ -132,6 +138,8 @@ class RunResumeService:
                     handled = await self._apply_agent_status(
                         wait, wait.external_ref, status, reconciled=True
                     )
+                elif wait.wait_type == WorkflowRunWaitType.TIME:
+                    handled = await self._fire_time_wait_if_due(wait)
                 else:
                     status = await self._engine.function_adapter.get_run_status(
                         UUID(wait.external_ref)
@@ -209,6 +217,50 @@ class RunResumeService:
             return True
         finally:
             reset_current_context(ctx_token)
+
+    async def _fire_time_wait_if_due(self, wait: WorkflowRunWaitEntity) -> bool:
+        """Fire a TIME wait whose scheduler wake was lost, once it is past due.
+
+        Unlike AGENT/FUNCTION waits there is no external system to poll — a timer
+        just needs to elapse. We only fire once ``scheduled_at`` has passed so a
+        wait legitimately scheduled far in the future is left alone; resume is a
+        no-op if the wait already completed (a duplicate with the primary wake).
+        """
+        scheduled_at_raw = (wait.payload or {}).get("scheduled_at")
+        if not scheduled_at_raw:
+            return False
+        try:
+            scheduled_at = datetime.fromisoformat(scheduled_at_raw)
+        except (TypeError, ValueError):
+            logger.warning(
+                "workflow.reconcile.time_wait_bad_scheduled_at",
+                wait_id=str(wait.id),
+                scheduled_at=scheduled_at_raw,
+            )
+            return False
+        if scheduled_at.tzinfo is None:
+            scheduled_at = scheduled_at.replace(tzinfo=timezone.utc)
+        if scheduled_at > datetime.now(timezone.utc):
+            return False  # not due yet
+
+        logger.warning(
+            "workflow.reconcile.firing_lost_timer",
+            run_id=str(wait.run_id),
+            wait_id=str(wait.id),
+            external_ref=wait.external_ref,
+        )
+        ctx = await self._run_context_for_wait(wait)
+        ctx_token = set_current_context(ctx)
+        try:
+            await self._engine.resume_internal(
+                WorkflowRunWaitType.TIME,
+                wait.external_ref,
+                {"payload": {}, "metadata": {}, "llm_output": {}},
+                ctx=ctx,
+            )
+        finally:
+            reset_current_context(ctx_token)
+        return True
 
     async def _apply_function_status(
         self, wait: WorkflowRunWaitEntity, status: dict

--- a/lemma-backend/app/modules/workflow/services/schedule_start_service.py
+++ b/lemma-backend/app/modules/workflow/services/schedule_start_service.py
@@ -44,11 +44,14 @@ class ScheduleStartService:
         )
         from app.modules.schedule.domain.schedule import ScheduleFireStatus
 
-        # 1. A wake for a specific run (wait_until timers carry the run id).
+        # 1. A wake for a specific run (wait_until timers carry the run id, and —
+        # for timers scheduled after the per-wait-token change — a wait_ref that
+        # resolves to the exact wait so sequential timers can't cross-resume).
         workflow_run_id = payload.get("workflow_run_id") or payload.get("flow_run_id")
         if workflow_run_id:
             await self._wake_run(
                 run_id=str(workflow_run_id),
+                external_ref=payload.get("wait_ref"),
                 payload=payload,
                 metadata=metadata,
                 llm_output=llm_output,
@@ -81,12 +84,30 @@ class ScheduleStartService:
                 schedule_event_id=schedule_event_id,
             )
             if run_id is not None:
-                await self._record_fire(
-                    schedule_repo, schedule.id, run_id=run_id
-                )
+                await self._record_fire(schedule_repo, schedule, run_id=run_id)
             return
 
         if schedule.agent_id is not None:
+            # Durable dedup for agent-target fires: unlike the workflow path (gated
+            # by the run's (flow_id, user_id, schedule_event_id) unique constraint),
+            # starting an agent conversation has no DB uniqueness guard, so a
+            # redelivered schedule.fired after the task already completed would start
+            # a second conversation. Claim the fire in Redis first; a duplicate skips.
+            from app.modules.schedule.services.schedule_fire_store import (
+                get_schedule_fire_store,
+            )
+
+            claimed = await get_schedule_fire_store().claim_agent_fire(
+                schedule_id=schedule.id, event_id=schedule_event_id
+            )
+            if not claimed:
+                logger.info(
+                    "Duplicate agent schedule fire %s:%s — skipping dispatch",
+                    schedule_id,
+                    schedule_event_id,
+                )
+                return
+
             try:
                 conversation_id = await self._engine.agent_adapter.run_agent_by_id(
                     agent_id=schedule.agent_id,
@@ -97,7 +118,7 @@ class ScheduleStartService:
                     conversation_metadata={"schedule_id": str(schedule_id)},
                 )
                 await self._record_fire(
-                    schedule_repo, schedule.id, run_id=str(conversation_id)
+                    schedule_repo, schedule, run_id=str(conversation_id)
                 )
             except Exception as exc:
                 logger.error(
@@ -108,7 +129,7 @@ class ScheduleStartService:
                 )
                 await self._record_fire(
                     schedule_repo,
-                    schedule.id,
+                    schedule,
                     status=ScheduleFireStatus.ERROR,
                     error=str(exc),
                 )
@@ -139,11 +160,16 @@ class ScheduleStartService:
         self,
         *,
         run_id: str,
+        external_ref: str | None = None,
         payload: dict,
         metadata: dict | None,
         llm_output: dict | None,
     ) -> None:
-        logger.info("Waking workflow run %s from scheduler", run_id)
+        # Resume the specific wait keyed by its own token when present; fall back
+        # to the run id for timers scheduled before the per-wait-token change (so
+        # in-flight waits created by the old code path still wake correctly).
+        resume_ref = external_ref or run_id
+        logger.info("Waking workflow run %s from scheduler (wait %s)", run_id, resume_ref)
         run = await self._engine.run_repo.get(UUID(run_id))
         if run is None:
             logger.info("No workflow run found for scheduler wake %s", run_id)
@@ -153,7 +179,7 @@ class ScheduleStartService:
         try:
             await self._engine.resume_internal(
                 WorkflowRunWaitType.TIME,
-                external_ref=run_id,
+                external_ref=resume_ref,
                 output={
                     "payload": payload,
                     "metadata": metadata or {},
@@ -212,7 +238,7 @@ class ScheduleStartService:
 
             await self._record_fire(
                 ScheduleRepository(self._uow),
-                schedule.id,
+                schedule,
                 status=ScheduleFireStatus.ERROR,
                 error=str(exc),
             )
@@ -221,7 +247,7 @@ class ScheduleStartService:
     async def _record_fire(
         self,
         schedule_repo,
-        schedule_id: UUID,
+        schedule,
         *,
         run_id: str | None = None,
         status=None,
@@ -229,15 +255,88 @@ class ScheduleStartService:
     ) -> None:
         from app.modules.schedule.domain.schedule import ScheduleFireStatus
 
+        resolved = status or ScheduleFireStatus.TRIGGERED
+        tripped_count: int | None = None
         try:
             await schedule_repo.record_fire(
-                schedule_id,
-                status=status or ScheduleFireStatus.TRIGGERED,
+                schedule.id,
+                status=resolved,
                 run_id=run_id,
                 error=error,
+            )
+            tripped_count = await self._apply_failure_policy(
+                schedule_repo, schedule, resolved
             )
             await self._uow.commit()
         except Exception:
             logger.exception(
-                "Failed to record fire telemetry for schedule %s", schedule_id
+                "Failed to record fire telemetry for schedule %s", schedule.id
+            )
+            return
+        # Emit only after the deactivation is durably committed, so a consumer
+        # (e.g. the creator-notification email) never fires for a state that
+        # rolled back.
+        if tripped_count is not None:
+            await self._emit_deactivated(schedule, tripped_count)
+
+    async def _apply_failure_policy(self, schedule_repo, schedule, status) -> int | None:
+        """Circuit breaker: count consecutive failures and deactivate on threshold.
+
+        ERROR increments the Redis counter; a success (TRIGGERED) resets it;
+        anything else (e.g. FILTERED, which never reaches this execution choke
+        point anyway) is a no-op. Returns the failure count when it trips the
+        breaker, else None. Best-effort — the Redis store swallows its own errors.
+        """
+        from app.core.config import settings
+        from app.modules.schedule.domain.schedule import ScheduleFireStatus
+        from app.modules.schedule.services.schedule_fire_store import (
+            get_schedule_fire_store,
+        )
+
+        store = get_schedule_fire_store()
+        if status == ScheduleFireStatus.TRIGGERED:
+            await store.reset_failures(schedule_id=schedule.id)
+            return None
+        if status != ScheduleFireStatus.ERROR:
+            return None
+
+        count = await store.record_failure(schedule_id=schedule.id)
+        threshold = settings.schedule_max_consecutive_failures
+        if threshold <= 0 or count < threshold:
+            return None
+
+        # Trip: stop the schedule from firing (all matcher queries filter is_active)
+        # and clear the counter so a later reactivation starts clean.
+        await schedule_repo.update(schedule.id, is_active=False)
+        await store.reset_failures(schedule_id=schedule.id)
+        logger.warning(
+            "Circuit breaker deactivated schedule %s after %d consecutive failures",
+            schedule.id,
+            count,
+        )
+        return count
+
+    async def _emit_deactivated(self, schedule, count: int) -> None:
+        from app.core.pubsub.publisher import PubSubPublisher
+        from app.modules.schedule.domain.events.schedule import (
+            ScheduleDeactivated,
+            ScheduleEvents,
+        )
+
+        try:
+            event = ScheduleDeactivated(
+                schedule_id=schedule.id,
+                user_id=schedule.user_id,
+                schedule_type=schedule.schedule_type,
+                consecutive_failures=count,
+            )
+            async with PubSubPublisher() as publisher:
+                await publisher.publish(
+                    ScheduleEvents.STREAM,
+                    event,
+                    ensure_groups=ScheduleEvents.CONSUMER_GROUPS,
+                )
+        except Exception:
+            logger.exception(
+                "Failed to emit ScheduleDeactivated for schedule %s", schedule.id
             )

--- a/lemma-backend/app/modules/workflow/tests/unit/test_schedule_idempotency_regression.py
+++ b/lemma-backend/app/modules/workflow/tests/unit/test_schedule_idempotency_regression.py
@@ -1,0 +1,153 @@
+"""Regression tests for the workflow+schedule idempotency fixes.
+
+Covers:
+- C1 (LP-057): start_run persists the run row BEFORE advancing, so the
+  schedule-event unique constraint gates node side effects.
+- C3 (LP-102): a duplicate agent-target schedule fire is skipped via the Redis
+  claim, so the agent conversation is not started twice.
+- E: the failure circuit breaker counts ERROR fires, resets on success, and
+  deactivates the schedule at the threshold.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import pytest
+
+from app.modules.schedule.domain.schedule import ScheduleFireStatus
+from app.modules.workflow.execution.engine import WorkflowEngine
+from app.modules.workflow.services.schedule_start_service import ScheduleStartService
+
+
+def _engine_with_mocks() -> WorkflowEngine:
+    uow = Mock()
+    uow.commit = AsyncMock()
+    uow.session = Mock()
+    engine = WorkflowEngine(
+        uow,
+        agent_adapter=Mock(),
+        function_adapter=Mock(),
+        schedule_adapter=Mock(),
+    )
+    return engine
+
+
+@pytest.mark.anyio
+async def test_start_run_persists_row_before_advancing():
+    """The run row must be created/flushed (under the unique constraint) before
+    stepper.advance runs any node side effects (LP-057)."""
+    engine = _engine_with_mocks()
+
+    flow_id, pod_id, user_id = uuid4(), uuid4(), uuid4()
+    engine.flow_repo.get = AsyncMock(
+        return_value=SimpleNamespace(id=flow_id, pod_id=pod_id)
+    )
+    engine._require_action = AsyncMock(return_value=None)
+    engine._entry_node_id = Mock(return_value="entry")
+
+    engine.run_repo = AsyncMock()
+    engine.run_repo.update.return_value = SimpleNamespace(wait=None)
+
+    stepper = Mock()
+    stepper.advance = AsyncMock(return_value=SimpleNamespace(wait=None))
+    engine._stepper = Mock(return_value=stepper)
+
+    # Record the relative order of create vs advance.
+    order = Mock()
+    order.attach_mock(engine.run_repo.create, "create")
+    order.attach_mock(stepper.advance, "advance")
+
+    await engine.start_run(flow_id, user_id)
+
+    engine.run_repo.create.assert_awaited_once()
+    stepper.advance.assert_awaited_once()
+    call_names = [c[0] for c in order.mock_calls]
+    assert call_names.index("create") < call_names.index("advance"), (
+        "run row must be persisted before node side effects run"
+    )
+
+
+@pytest.mark.anyio
+async def test_duplicate_agent_schedule_fire_is_skipped(monkeypatch):
+    """A redelivered agent-target fire whose Redis claim fails must not start a
+    second conversation (LP-102)."""
+    engine = _engine_with_mocks()
+    engine.agent_adapter.run_agent_by_id = AsyncMock(return_value=uuid4())
+
+    schedule = SimpleNamespace(
+        id=uuid4(),
+        pod_id=uuid4(),
+        user_id=uuid4(),
+        workflow_id=None,
+        agent_id=uuid4(),
+        is_active=True,
+        schedule_type=SimpleNamespace(value="TIME"),
+    )
+
+    svc = ScheduleStartService(engine)
+
+    # Schedule lookup returns our agent-target schedule.
+    import app.modules.schedule.repositories.schedule_repository as repo_mod
+
+    monkeypatch.setattr(
+        repo_mod, "ScheduleRepository", lambda uow: Mock(get=AsyncMock(return_value=schedule))
+    )
+
+    # The dedup claim reports "already fired".
+    import app.modules.schedule.services.schedule_fire_store as store_mod
+
+    store = Mock()
+    store.claim_agent_fire = AsyncMock(return_value=False)
+    monkeypatch.setattr(store_mod, "get_schedule_fire_store", lambda: store)
+
+    await svc.handle_schedule_fired(
+        schedule_id=str(schedule.id),
+        payload={},
+        schedule_event_id="evt-1",
+    )
+
+    store.claim_agent_fire.assert_awaited_once()
+    engine.agent_adapter.run_agent_by_id.assert_not_awaited()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "status,counts,expect_deactivate",
+    [
+        (ScheduleFireStatus.TRIGGERED, None, False),
+        (ScheduleFireStatus.ERROR, 2, False),
+        (ScheduleFireStatus.ERROR, 3, True),
+    ],
+)
+async def test_failure_circuit_breaker(monkeypatch, status, counts, expect_deactivate):
+    """ERROR increments and trips at the threshold; TRIGGERED resets."""
+    monkeypatch.setattr(
+        "app.core.config.settings.schedule_max_consecutive_failures", 3
+    )
+
+    import app.modules.schedule.services.schedule_fire_store as store_mod
+
+    store = Mock()
+    store.record_failure = AsyncMock(return_value=counts or 0)
+    store.reset_failures = AsyncMock()
+    monkeypatch.setattr(store_mod, "get_schedule_fire_store", lambda: store)
+
+    svc = ScheduleStartService(_engine_with_mocks())
+    schedule = SimpleNamespace(id=uuid4(), user_id=uuid4(), schedule_type="TIME")
+    schedule_repo = Mock()
+    schedule_repo.update = AsyncMock()
+
+    tripped = await svc._apply_failure_policy(schedule_repo, schedule, status)
+
+    if status == ScheduleFireStatus.TRIGGERED:
+        store.reset_failures.assert_awaited_once()
+        assert tripped is None
+    elif expect_deactivate:
+        schedule_repo.update.assert_awaited_once_with(schedule.id, is_active=False)
+        assert tripped == counts
+    else:
+        schedule_repo.update.assert_not_awaited()
+        assert tripped is None

--- a/lemma-backend/app/scheduler.py
+++ b/lemma-backend/app/scheduler.py
@@ -50,11 +50,15 @@ app = FastAPI(
     version=API_VERSION,
     description="API for managing scheduled jobs. Jobs emit events via FastStream when they fire.",
     lifespan=lifespan,
-    debug=settings.debug,
+    # Never enable FastAPI debug on the scheduler sidecar: it is an internal
+    # service and debug=True would leak tracebacks on error responses.
+    debug=False,
 )
 
 # Configure CORS
-# Check if settings.cors_origins is a list or string, typically list in Pydantic settings
+# This is an internal service-to-service API (only the backend's SchedulerAPIClient
+# calls it); no browser talks to it, so keep the surface minimal rather than the
+# previous wildcard methods/headers.
 origins = settings.cors_origins
 if isinstance(origins, str):
     origins = [o.strip() for o in origins.split(",")]
@@ -63,8 +67,8 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "DELETE", "PATCH"],
+    allow_headers=["Authorization", "Content-Type"],
 )
 
 


### PR DESCRIPTION
## Summary

Fixes a family of bugs found while investigating repeated schedule-triggered workflow starts and a dev `lemma-worker` OOM crash-loop. Design principle throughout: use Redis/streaq-native primitives (`_job_id`, `SET NX EX`, existing DB unique constraints) rather than new tables/migrations, and keep the scheduler sidecar (it's a deliberate singleton — the API/worker scale to multiple replicas, so recurring cron evaluation needs one owner).

Companion infra PR: gappyai/gappy-infra (dev configmap concurrency fix + stale prod comment).

### Datastore / Kreuzberg resilience
- Drain `extraction.images` per-upload in `_write_converted_projection` instead of holding the whole list resident — releases bytes as soon as each image uploads.
- Raise generic retry defaults (6 attempts / 1.0s base, ~31s total) so transient Kreuzberg failures ride out a backend restart or serverless cold start instead of cascading to FAILED.
- Keep `document_processing_max_concurrency`'s docstring deployment-agnostic (no infra-specific numbers in the OSS repo).

### Security
- Authenticate the scheduler sidecar's `/scheduler/jobs` API with a shared bearer token (service-to-service; unenforced when `scheduler_internal_token` is unset, so local dev keeps working).
- Force `debug=False` and narrow CORS (`allow_methods`/`allow_headers`) on the scheduler app.
- Hard-403 non-Composio webhook sources on `/webhooks/{source}` — today's code parses-and-trusts any other source with zero signature verification, letting attacker-controlled payload reach a started workflow's trigger context. Interim fix pending a per-account webhook routing follow-up.

### Workflow/schedule idempotency (zero schema change)
- `start_run` now persists the run row (under the existing `(flow_id, user_id, schedule_event_id)` unique constraint) **before** calling `stepper.advance()`, so a redelivered schedule fire can no longer double-run entry-node side effects before the DB catches the duplicate.
- Add a streaq `_job_id` to the schedule-fire enqueue for cheap in-flight dedup.
- Durable Redis `SET NX EX` dedup for agent-target schedule fires (`schedule_fire_store.py`) — agent dispatch has no DB row to gate on the way workflow runs do.
- Key `WAIT_UNTIL` timers to a fresh per-wait token instead of `run_id`, so a run with sequential timers can't have one wake resume the wrong wait; add `TIME` waits to the existing stale-wait reconcile sweep as a safety net for a lost wake.

### Schedule failure circuit breaker
- Redis consecutive-failure counter per schedule (`ERROR` increments, `TRIGGERED` resets, `FILTERED` is a no-op). At the configurable threshold (`schedule_max_consecutive_failures`, default 5) the schedule is auto-deactivated (`is_active=False`) and a new `ScheduleDeactivated` event is emitted, consumed by a new subscriber that emails the creator. Reactivation clears the counter.

## Test plan
- [x] All edited files pass `py_compile` + `ruff check --select F`
- [x] Import-smoke test on every touched module (no circular imports)
- [x] 160 existing unit/integration tests pass (`app/modules/schedule/tests`, `app/modules/workflow/tests/unit`)
- [x] 5 new regression tests added (`test_schedule_idempotency_regression.py`): create-before-advance ordering, duplicate-agent-fire skip, circuit-breaker increment/reset/trip
- [ ] e2e suite requiring a live worker subprocess not runnable in this sandbox — needs a real run before merge
- [ ] Manual dev-cluster check: replay a captured `schedule.fired` twice against a side-effecting workflow, confirm exactly one run/one side effect
- [ ] Manual: `curl /scheduler/jobs` without the bearer header → 401 (after the paired infra PR adds `SCHEDULER_INTERNAL_TOKEN` to `backend-secrets`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)