### PR TITLE
fix(pod-bundle): harden export/import + per-user daily rate limit

### DIFF
--- a/lemma-backend/app/modules/agent_surfaces/api/controllers/surface_controller.py
+++ b/lemma-backend/app/modules/agent_surfaces/api/controllers/surface_controller.py
@@ -20,6 +20,7 @@ from app.modules.agent_surfaces.api.schemas import (
     AgentSurfaceResponse,
     AvailableSurfaceChannelResponse,
     AvailableSurfaceChannelsResponse,
+    AvailableSurfacesResponse,
     SurfaceBehaviorConfigInput,
     SurfaceConfigResponse,
     SurfaceCreateRequest,
@@ -39,9 +40,13 @@ from app.modules.agent_surfaces.domain.entities import (
 )
 from app.modules.agent_surfaces.domain.setup_guides import SurfacePlatformSetupGuide
 from app.modules.agent_surfaces.platforms.common import computed_webhook_url
+from app.modules.agent_surfaces.services.available_surfaces_builder import (
+    build_available_surfaces,
+)
 from app.modules.agent_surfaces.services.surface_service import (
     AgentSurfaceService,
 )
+from app.modules.connectors.api.dependencies import ConnectorServiceDep
 
 router = APIRouter(prefix="/pods/{pod_id}/surfaces", tags=["Agent Surfaces"])
 
@@ -49,6 +54,13 @@ router = APIRouter(prefix="/pods/{pod_id}/surfaces", tags=["Agent Surfaces"])
 # surface to exist yet, so it lives outside the surface-resource router.
 setup_guide_router = APIRouter(
     prefix="/pods/{pod_id}/surface-setup", tags=["Agent Surfaces"]
+)
+
+# The connectable-surface catalog (platform -> connector + supported credential
+# modes + connect schema) — also platform-level, needs no surface to exist. Kept
+# on its own path so it never collides with GET /surfaces/{surface_name}.
+available_surfaces_router = APIRouter(
+    prefix="/pods/{pod_id}/available-surfaces", tags=["Agent Surfaces"]
 )
 
 
@@ -551,3 +563,20 @@ async def get_surface_setup_guide(
     prerequisites) — works before any surface of this platform exists."""
     del user, pod_id
     return service.get_platform_setup_guide(platform)
+
+
+@available_surfaces_router.get(
+    "",
+    operation_id="agent.surface.available",
+    dependencies=[require_action(Permissions.AGENT_READ)],
+)
+async def list_available_surfaces(
+    pod_id: UUID,
+    user: CurrentUser,
+    connector_service: ConnectorServiceDep,
+) -> AvailableSurfacesResponse:
+    """The connectable-surface catalog: every surface platform with its connector,
+    supported credential modes, and the schema to connect an account. Platform-
+    level (no surface need exist); the pod scopes authorization only."""
+    del user, pod_id
+    return await build_available_surfaces(connector_service=connector_service)

--- a/lemma-backend/app/modules/agent_surfaces/api/controllers/surface_controller.py
+++ b/lemma-backend/app/modules/agent_surfaces/api/controllers/surface_controller.py
@@ -24,6 +24,7 @@ from app.modules.agent_surfaces.api.schemas import (
     SurfaceBehaviorConfigInput,
     SurfaceConfigResponse,
     SurfaceCreateRequest,
+    SurfaceReach,
     SurfaceSendRequest,
     SurfaceSendResponse,
     SurfaceSetupResponse,
@@ -42,6 +43,9 @@ from app.modules.agent_surfaces.domain.setup_guides import SurfacePlatformSetupG
 from app.modules.agent_surfaces.platforms.common import computed_webhook_url
 from app.modules.agent_surfaces.services.available_surfaces_builder import (
     build_available_surfaces,
+)
+from app.modules.agent_surfaces.services.surface_reach_resolver import (
+    SurfaceReachResolver,
 )
 from app.modules.agent_surfaces.services.surface_service import (
     AgentSurfaceService,
@@ -87,6 +91,7 @@ def _surface_response(
     surface: AgentSurfaceEntity,
     *,
     agent_name: str | None = None,
+    reach: SurfaceReach | None = None,
 ) -> AgentSurfaceResponse:
     return AgentSurfaceResponse(
         id=surface.id,
@@ -100,10 +105,30 @@ def _surface_response(
         account_id=surface.account_id,
         surface_identity_id=surface.surface_identity_id,
         surface_identity_username=surface.surface_identity_username,
+        surface_identity_email=surface.surface_identity_email,
         webhook_url=computed_webhook_url(surface),
+        reach=reach,
         config=SurfaceConfigResponse.from_domain(surface.config),
         status=surface.status,
     )
+
+
+async def _resolve_surface_reach(
+    surface: AgentSurfaceEntity,
+    *,
+    service: AgentSurfaceService,
+    connector_service,
+) -> SurfaceReach | None:
+    """Best-effort ``reach`` for a surface (never breaks the response)."""
+    try:
+        return await SurfaceReachResolver().resolve(
+            surface,
+            credential_resolver=service._credential_resolver,
+            connector_service=connector_service,
+            surface_repository=service.surface_repository,
+        )
+    except Exception:
+        return None
 
 
 def _surface_platform_from_ref(platform: str) -> SurfacePlatform:
@@ -232,6 +257,7 @@ async def list_surfaces(
     user: CurrentUser,
     agent_service: AgentServiceDep,
     ctx: PodContextDep,
+    connector_service: ConnectorServiceDep,
     service: AgentSurfaceService = Depends(get_surface_service),
     limit: int = 100,
     page_token: str | None = None,
@@ -273,7 +299,14 @@ async def list_surfaces(
             resolved_agent_name = await _resolve_agent_display_name(
                 agent_service, surface.agent_id
             )
-        items.append(_surface_response(surface, agent_name=resolved_agent_name))
+        reach = await _resolve_surface_reach(
+            surface, service=service, connector_service=connector_service
+        )
+        items.append(
+            _surface_response(
+                surface, agent_name=resolved_agent_name, reach=reach
+            )
+        )
     return AgentSurfaceListResponse(
         items=items,
         limit=limit,
@@ -292,6 +325,7 @@ async def create_surface(
     user: CurrentUser,
     agent_service: AgentServiceDep,
     ctx: PodContextDep,
+    connector_service: ConnectorServiceDep,
     service: AgentSurfaceService = Depends(get_surface_service),
 ) -> AgentSurfaceResponse:
     """Create a surface. ``name`` defaults to the lowercased platform — pass an
@@ -333,8 +367,13 @@ async def create_surface(
             is_active=False,
             ctx=ctx,
         )
+    reach = await _resolve_surface_reach(
+        surface, service=service, connector_service=connector_service
+    )
     del user
-    return _surface_response(surface, agent_name=agent.name if agent else None)
+    return _surface_response(
+        surface, agent_name=agent.name if agent else None, reach=reach
+    )
 
 
 @router.get(
@@ -348,6 +387,7 @@ async def get_surface(
     user: CurrentUser,
     agent_service: AgentServiceDep,
     ctx: PodContextDep,
+    connector_service: ConnectorServiceDep,
     service: AgentSurfaceService = Depends(get_surface_service),
 ) -> AgentSurfaceResponse:
     surface = await service.get_surface_by_name_in_pod(pod_id=pod_id, name=surface_name)
@@ -358,8 +398,11 @@ async def get_surface(
         action=Permissions.AGENT_READ,
     )
     agent_name = await _resolve_agent_display_name(agent_service, surface.agent_id)
+    reach = await _resolve_surface_reach(
+        surface, service=service, connector_service=connector_service
+    )
     del user
-    return _surface_response(surface, agent_name=agent_name)
+    return _surface_response(surface, agent_name=agent_name, reach=reach)
 
 
 @router.patch(
@@ -374,6 +417,7 @@ async def update_surface(
     user: CurrentUser,
     agent_service: AgentServiceDep,
     ctx: PodContextDep,
+    connector_service: ConnectorServiceDep,
     service: AgentSurfaceService = Depends(get_surface_service),
 ) -> AgentSurfaceResponse:
     """Partially update a surface. Only fields present in the request are
@@ -419,11 +463,16 @@ async def update_surface(
         ),
         ctx=ctx,
     )
-    del user
     resolved_agent_name = agent.name if agent else await _resolve_agent_display_name(
         agent_service, updated.agent_id
     )
-    return _surface_response(updated, agent_name=resolved_agent_name)
+    reach = await _resolve_surface_reach(
+        updated, service=service, connector_service=connector_service
+    )
+    del user
+    return _surface_response(
+        updated, agent_name=resolved_agent_name, reach=reach
+    )
 
 
 @router.delete(

--- a/lemma-backend/app/modules/agent_surfaces/api/schemas.py
+++ b/lemma-backend/app/modules/agent_surfaces/api/schemas.py
@@ -155,6 +155,19 @@ class SurfaceUpdateRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class SurfaceReach(BaseModel):
+    """How a human reaches this surface.
+
+    ``handle`` is the platform-native name a person types/sees to message the
+    bot (Slack/Teams bot display name, Telegram ``@username``, WhatsApp phone,
+    or the account/email for email surfaces). ``email`` is the surface's email
+    address, when it has one.
+    """
+
+    handle: str | None = None
+    email: str | None = None
+
+
 class AgentSurfaceResponse(BaseModel):
     id: UUID
     pod_id: UUID
@@ -167,7 +180,9 @@ class AgentSurfaceResponse(BaseModel):
     account_id: UUID | None = None
     surface_identity_id: str | None = None
     surface_identity_username: str | None = None
+    surface_identity_email: str | None = None
     webhook_url: str | None = None
+    reach: SurfaceReach | None = None
     config: SurfaceConfigResponse
     status: AgentSurfaceStatus = AgentSurfaceStatus.ACTIVE
 

--- a/lemma-backend/app/modules/agent_surfaces/api/schemas.py
+++ b/lemma-backend/app/modules/agent_surfaces/api/schemas.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from app.modules.connectors.domain.connector import AuthScheme
 from app.modules.agent_surfaces.domain.entities import (
     AgentSurfaceStatus,
     SurfaceChannelRoute,
@@ -250,3 +252,39 @@ class SurfaceSetupResponse(BaseModel):
     admin_consent: SurfaceAdminConsentInfo | None = None
     actions: list[SurfaceSetupAction] = Field(default_factory=list)
     guide: SurfacePlatformSetupGuide
+
+
+class SurfaceConnectDescriptor(BaseModel):
+    """What the frontend needs to render the "connect an account" (CUSTOM) flow
+    for a surface's connector — a slim projection of the connector's LEMMA
+    capability. ``system_oauth_available`` means the platform supplies the OAuth
+    app so the user connects without registering their own (distinct from whether
+    a fully-managed SYSTEM bot exists — that's ``supported_credential_modes``)."""
+
+    auth_scheme: AuthScheme
+    auth_config_schema: dict[str, Any] | None = None
+    credential_schema: dict[str, Any] | None = None
+    system_oauth_available: bool = False
+    supports_org_custom_oauth: bool = False
+
+
+class AvailableSurface(BaseModel):
+    """One connectable surface platform. ``supported_credential_modes`` is the
+    single source of truth for how it can be set up: ``[CUSTOM]`` means an account
+    must be connected; ``[CUSTOM, SYSTEM]`` means a Lemma-managed bot can also run
+    with no account. The frontend derives ``account_needed = SYSTEM not in modes``
+    and ``system_bot_available = SYSTEM in modes``."""
+
+    platform: SurfacePlatform
+    connector_id: str
+    provider: str
+    title: str | None = None
+    description: str | None = None
+    icon: str | None = None
+    supported_credential_modes: list[SurfaceCredentialMode]
+    connector_available: bool = True
+    connect: SurfaceConnectDescriptor | None = None
+
+
+class AvailableSurfacesResponse(BaseModel):
+    surfaces: list[AvailableSurface] = Field(default_factory=list)

--- a/lemma-backend/app/modules/agent_surfaces/config.py
+++ b/lemma-backend/app/modules/agent_surfaces/config.py
@@ -48,6 +48,14 @@ class SurfaceSettings(BaseSettings):
             "Useful for local testing of Teams webhook JWT validation."
         ),
     )
+    microsoft_bot_app_name: Optional[str] = Field(
+        default=None,
+        description=(
+            "Human-friendly display name of the Lemma Teams bot, used as the "
+            "surface reach handle when the Graph servicePrincipal lookup is "
+            "unavailable (e.g. Application.Read.All not consented)."
+        ),
+    )
 
     # Slack
     slack_signing_secret: Optional[str] = Field(

--- a/lemma-backend/app/modules/agent_surfaces/domain/surface_connectors.py
+++ b/lemma-backend/app/modules/agent_surfaces/domain/surface_connectors.py
@@ -1,0 +1,84 @@
+"""Canonical mapping from a surface platform to its connector.
+
+Every surface that runs on a "bring your own bot" account binds a connector
+account, and several places need to agree on *which* connector a given platform
+maps to and how its credentials behave: account binding (validating the bound
+account), credential resolution (OAuth-refresh vs. static key), and connector
+identity in general. Historically each of those hardcoded the connector id
+inline (``"teams"``, ``platform.value.lower()``, a per-module ``_APP_ID``), which
+drifted — most visibly Teams, whose connector is ``microsoft_teams`` (matching
+the Composio toolkit slug) even though the platform enum is ``TEAMS``.
+
+This module is the single source of truth. Add a platform here and the binding /
+credential / setup layers pick it up instead of re-deriving the id.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.modules.agent_surfaces.domain.entities import SurfacePlatform
+
+
+@dataclass(frozen=True)
+class SurfaceConnectorBinding:
+    """How a surface platform maps to a connector.
+
+    ``connector_id`` — the connector an account bound to this surface must belong
+    to (matches the id in the connector catalog / ``lemma_apps_config.json``).
+    ``provider`` — the auth provider that connector authenticates through; surface
+    bots are LEMMA-native. ``self_managed_credentials`` — the account stores a
+    static key/secret rather than a refreshable OAuth token, so credential
+    resolution must pass the stored credentials through untouched.
+    """
+
+    connector_id: str
+    provider: str
+    self_managed_credentials: bool
+
+
+# Keyed by platform; the connector_id is the catalog id (NOT necessarily the
+# lowercased platform — Teams is the deliberate exception).
+SURFACE_CONNECTOR_BINDINGS: dict[SurfacePlatform, SurfaceConnectorBinding] = {
+    SurfacePlatform.SLACK: SurfaceConnectorBinding(
+        connector_id="slack", provider="LEMMA", self_managed_credentials=False
+    ),
+    SurfacePlatform.TEAMS: SurfaceConnectorBinding(
+        connector_id="microsoft_teams", provider="LEMMA", self_managed_credentials=True
+    ),
+    SurfacePlatform.WHATSAPP: SurfaceConnectorBinding(
+        connector_id="whatsapp", provider="LEMMA", self_managed_credentials=True
+    ),
+    SurfacePlatform.TELEGRAM: SurfaceConnectorBinding(
+        connector_id="telegram", provider="LEMMA", self_managed_credentials=True
+    ),
+    SurfacePlatform.GMAIL: SurfaceConnectorBinding(
+        connector_id="gmail", provider="LEMMA", self_managed_credentials=False
+    ),
+    SurfacePlatform.OUTLOOK: SurfaceConnectorBinding(
+        connector_id="outlook", provider="LEMMA", self_managed_credentials=False
+    ),
+    SurfacePlatform.RESEND: SurfaceConnectorBinding(
+        connector_id="resend", provider="LEMMA", self_managed_credentials=True
+    ),
+}
+
+
+def surface_connector_binding(platform: SurfacePlatform) -> SurfaceConnectorBinding:
+    """The connector binding for a platform. Raises ``KeyError`` for an unmapped
+    platform — a new SurfacePlatform must declare its connector here."""
+    return SURFACE_CONNECTOR_BINDINGS[platform]
+
+
+def surface_connector_id(platform: SurfacePlatform) -> str:
+    """The connector id an account for ``platform`` must belong to."""
+    return SURFACE_CONNECTOR_BINDINGS[platform].connector_id
+
+
+# Connectors whose accounts hold service-level/static credentials (no OAuth
+# refresh flow). Derived from the registry so it can't drift from the bindings.
+SELF_MANAGED_CREDENTIAL_CONNECTOR_IDS: frozenset[str] = frozenset(
+    binding.connector_id
+    for binding in SURFACE_CONNECTOR_BINDINGS.values()
+    if binding.self_managed_credentials
+)

--- a/lemma-backend/app/modules/agent_surfaces/infrastructure/adapters/account_binding.py
+++ b/lemma-backend/app/modules/agent_surfaces/infrastructure/adapters/account_binding.py
@@ -7,6 +7,7 @@ from app.modules.agent_surfaces.domain.entities import SurfacePlatform
 from app.modules.agent_surfaces.domain.errors import (
     AgentSurfaceValidationError,
 )
+from app.modules.agent_surfaces.domain.surface_connectors import surface_connector_id
 from app.modules.agent_surfaces.domain.ports import (
     SurfaceAccountBindingPort,
     SurfaceAccountInfo,
@@ -37,14 +38,16 @@ class SurfaceAccountBindingResolver(SurfaceAccountBindingPort):
             # connector account is optional.
             if account_id is not None:
                 await self._require_account_app(
-                    account_id, label="Resend", expected_connector_id="resend"
+                    account_id,
+                    label="Resend",
+                    expected_connector_id=surface_connector_id(platform),
                 )
             return None, None, None
         if platform.is_email:
             await self._require_account_app(
                 account_id,
                 label=platform.value.title(),
-                expected_connector_id=platform.value.lower(),
+                expected_connector_id=surface_connector_id(platform),
             )
             return None, None, None
         if account_id is not None:
@@ -52,7 +55,7 @@ class SurfaceAccountBindingResolver(SurfaceAccountBindingPort):
             await self._require_account_app(
                 account_id,
                 label=platform.value.title(),
-                expected_connector_id=platform.value.lower(),
+                expected_connector_id=surface_connector_id(platform),
             )
         return None, None, None
 
@@ -85,7 +88,7 @@ class SurfaceAccountBindingResolver(SurfaceAccountBindingPort):
         account = await self._require_account_app(
             account_id,
             label="Slack",
-            expected_connector_id="slack",
+            expected_connector_id=surface_connector_id(SurfacePlatform.SLACK),
         )
         raw_response = account.credentials.get("raw_response") or {}
         workspace_id = (
@@ -104,7 +107,7 @@ class SurfaceAccountBindingResolver(SurfaceAccountBindingPort):
         account = await self._require_account_app(
             account_id,
             label="Teams",
-            expected_connector_id="teams",
+            expected_connector_id=surface_connector_id(SurfacePlatform.TEAMS),
         )
         raw_response = account.credentials.get("raw_response") or {}
         user_data = account.credentials.get("user_data") or {}

--- a/lemma-backend/app/modules/agent_surfaces/module.py
+++ b/lemma-backend/app/modules/agent_surfaces/module.py
@@ -10,6 +10,7 @@ logger = get_logger(__name__)
 
 def _routers():
     from app.modules.agent_surfaces.api.controllers.surface_controller import (
+        available_surfaces_router as surface_catalog,
         router as surface,
         setup_guide_router as surface_setup_guide,
     )
@@ -20,7 +21,13 @@ def _routers():
         router as surface_public,
     )
 
-    return [surface, surface_setup_guide, user_surfaces, surface_public]
+    return [
+        surface,
+        surface_setup_guide,
+        surface_catalog,
+        user_surfaces,
+        surface_public,
+    ]
 
 
 def _event_routers():

--- a/lemma-backend/app/modules/agent_surfaces/platforms/slack/service.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/slack/service.py
@@ -88,6 +88,28 @@ class SlackPlatformService:
             )
             raise
 
+    async def get_user_display_name(self, user_id: str) -> str | None:
+        """Return a user's Slack display name (best-effort).
+
+        Used to surface the bot's own human-facing name for the reach handle.
+        Returns None when the token or user id is missing, or on any API error.
+        """
+        token = slack_access_token(self.credentials)
+        if not user_id or not token:
+            return None
+        try:
+            client = build_slack_client(self.credentials)
+            response = await client.users_info(user=user_id)
+            user = response.get("user") or {}
+            profile = user.get("profile") or {}
+            name = profile.get("display_name") or profile.get("real_name")
+            return str(name).strip() or None if name else None
+        except Exception as exc:
+            logger.debug(
+                "Slack get_user_display_name failed for user=%s: %s", user_id, exc
+            )
+            return None
+
     async def send_message(
         self,
         *,

--- a/lemma-backend/app/modules/agent_surfaces/services/available_surfaces_builder.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/available_surfaces_builder.py
@@ -1,0 +1,107 @@
+"""Builds the read-only "available surfaces" catalog for the frontend.
+
+Joins the canonical surface->connector registry (``SURFACE_CONNECTOR_BINDINGS``)
+with the connector catalog and the platform's system-credential availability, so
+the frontend can render the setup UI and orchestrate account connection
+generically — and adding a new surface (e.g. Discord) is a backend-only change,
+picked up automatically by iterating the registry.
+
+Kept out of ``AgentSurfaceService`` on purpose: that service doesn't hold a
+connector service, and this is a pure catalog join with no surface state. The
+controller injects the connector service and calls this builder directly.
+"""
+
+from __future__ import annotations
+
+from app.core.log.log import get_logger
+from app.modules.agent_surfaces.api.schemas import (
+    AvailableSurface,
+    AvailableSurfacesResponse,
+    SurfaceConnectDescriptor,
+)
+from app.modules.agent_surfaces.domain.entities import (
+    SurfaceCredentialMode,
+    SurfacePlatform,
+)
+from app.modules.agent_surfaces.domain.surface_connectors import (
+    SURFACE_CONNECTOR_BINDINGS,
+)
+from app.modules.agent_surfaces.services.credential_resolver import (
+    has_native_credentials,
+)
+from app.modules.connectors.domain.connector import AuthProvider
+from app.modules.connectors.domain.errors import ConnectorNotFoundError
+from app.modules.connectors.services.connector_service import ConnectorService
+
+logger = get_logger(__name__)
+
+
+def _supported_credential_modes(platform: SurfacePlatform) -> list[SurfaceCredentialMode]:
+    """CUSTOM (connect an account) is always possible; SYSTEM (a Lemma-managed bot
+    that runs with no account) only when the platform's native credentials are
+    actually configured in this environment."""
+    modes = [SurfaceCredentialMode.CUSTOM]
+    if has_native_credentials(platform):
+        modes.append(SurfaceCredentialMode.SYSTEM)
+    return modes
+
+
+async def _connect_descriptor(
+    connector_service: ConnectorService, connector_id: str
+) -> tuple[SurfaceConnectDescriptor | None, bool, str | None, str | None, str | None]:
+    """Resolve the connector's LEMMA capability into a connect descriptor plus its
+    catalog display fields. Returns ``(descriptor, available, title, description,
+    icon)``; ``available`` is False (and descriptor None) when the connector is
+    missing, inactive, or exposes no LEMMA capability — so a mis-configured or
+    not-yet-catalogued surface degrades to a visible "unavailable" row instead of
+    500-ing the whole endpoint."""
+    try:
+        connector = await connector_service.get_connector(connector_id)
+    except ConnectorNotFoundError:
+        return None, False, None, None, None
+    if not connector.is_active:
+        return None, False, connector.title, connector.description, connector.icon
+    try:
+        capability = connector.capability_for(AuthProvider.LEMMA)
+    except ValueError:
+        logger.warning(
+            "Surface connector %s has no LEMMA capability; marking unavailable",
+            connector_id,
+        )
+        return None, False, connector.title, connector.description, connector.icon
+
+    descriptor = SurfaceConnectDescriptor(
+        auth_scheme=capability.auth_scheme,
+        auth_config_schema=capability.auth_config_schema,
+        credential_schema=capability.credential_schema,
+        system_oauth_available=bool(getattr(capability, "system_default_available", False)),
+        supports_org_custom_oauth=bool(
+            getattr(capability, "supports_org_custom_oauth", False)
+        ),
+    )
+    return descriptor, True, connector.title, connector.description, connector.icon
+
+
+async def build_available_surfaces(
+    *, connector_service: ConnectorService
+) -> AvailableSurfacesResponse:
+    """The connectable-surface catalog: one row per registry platform."""
+    surfaces: list[AvailableSurface] = []
+    for platform, binding in SURFACE_CONNECTOR_BINDINGS.items():
+        connect, available, title, description, icon = await _connect_descriptor(
+            connector_service, binding.connector_id
+        )
+        surfaces.append(
+            AvailableSurface(
+                platform=platform,
+                connector_id=binding.connector_id,
+                provider=binding.provider,
+                title=title,
+                description=description,
+                icon=icon,
+                supported_credential_modes=_supported_credential_modes(platform),
+                connector_available=available,
+                connect=connect,
+            )
+        )
+    return AvailableSurfacesResponse(surfaces=surfaces)

--- a/lemma-backend/app/modules/agent_surfaces/services/credential_resolver.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/credential_resolver.py
@@ -23,18 +23,22 @@ from app.modules.agent_surfaces.domain.entities import (
     AgentSurfaceEntity,
     SurfacePlatform,
 )
+from app.modules.agent_surfaces.domain.surface_connectors import (
+    SELF_MANAGED_CREDENTIAL_CONNECTOR_IDS,
+)
 from app.modules.connectors.infrastructure.models.account import Account
 from app.modules.connectors.services.connector_service import ConnectorService
 
 logger = get_logger(__name__)
 
-# Connectors that manage service-level credentials (no OAuth refresh flow).
-# Resend uses a static API key, not a 3-legged OAuth token — routing it through
-# the OAuth refresh flow would silently drop `api_key` (ConnectorService's
-# `_to_oauth_credentials` only carries access_token/refresh_token/token_type/
-# expires_at/raw_response/connection_id; `api_key` isn't one of them, and it
-# isn't in `_CONTEXT_KEYS` below either, so nothing rescues it afterward).
-_SELF_MANAGED_CREDENTIAL_APPS = frozenset({"teams", "whatsapp", "telegram", "resend"})
+# Connectors that manage service-level credentials (no OAuth refresh flow),
+# derived from the surface-connector registry so it can't drift from the
+# bindings. Resend, for one, uses a static API key, not a 3-legged OAuth token —
+# routing it through the OAuth refresh flow would silently drop `api_key`
+# (ConnectorService's `_to_oauth_credentials` only carries access_token/
+# refresh_token/token_type/expires_at/raw_response/connection_id; `api_key` isn't
+# one of them, and it isn't in `_CONTEXT_KEYS` below either, so nothing rescues it).
+_SELF_MANAGED_CREDENTIAL_APPS = SELF_MANAGED_CREDENTIAL_CONNECTOR_IDS
 
 # Non-secret keys platform adapters read for identity/routing context.
 _CONTEXT_KEYS = ("scope", "scopes", "api_base_url", "raw_response", "user_data")

--- a/lemma-backend/app/modules/agent_surfaces/services/surface_reach_resolver.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/surface_reach_resolver.py
@@ -1,0 +1,206 @@
+"""Resolve how a human reaches a configured surface (its ``reach.handle``).
+
+The handle is the platform-native name a person types or sees to message the
+bot: a Slack/Teams bot display name, a Telegram ``@username``, a WhatsApp phone,
+or the connected account / email address for email surfaces.
+
+Resolution is **lazy write-through**: the first read that needs a live call
+(Slack/Teams/Telegram) fetches the value once and persists it onto the surface's
+``surface_identity_username`` column, so every later read reuses the stored value
+with no external call. Everything here is best-effort — a GET must always
+succeed, so failures degrade to a fallback handle (or None) and never raise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import aiohttp
+
+from app.core.log.log import get_logger
+from app.modules.agent_surfaces.api.schemas import SurfaceReach
+from app.modules.agent_surfaces.config import surface_settings
+from app.modules.agent_surfaces.domain.entities import (
+    AgentSurfaceEntity,
+    SurfacePlatform,
+)
+from app.modules.agent_surfaces.platforms.teams.client import (
+    GRAPH_BASE,
+    auth_headers,
+    get_graph_token,
+)
+
+if TYPE_CHECKING:
+    from app.modules.agent_surfaces.services.credential_resolver import (
+        SurfaceCredentialResolver,
+    )
+    from app.modules.connectors.services.connector_service import ConnectorService
+
+logger = get_logger(__name__)
+
+# Hard ceiling on a single surface's live identity lookup so one slow/hung
+# provider (notably the Teams Graph call, which has no client-level timeout) can
+# never stall a surfaces list. On timeout we degrade to the fallback handle.
+_LIVE_HANDLE_TIMEOUT_SECONDS = 6.0
+
+
+class SurfaceReachResolver:
+    async def resolve(
+        self,
+        surface: AgentSurfaceEntity,
+        *,
+        credential_resolver: "SurfaceCredentialResolver | None" = None,
+        connector_service: "ConnectorService | None" = None,
+        surface_repository=None,
+    ) -> SurfaceReach:
+        email = surface.surface_identity_email
+
+        # Already resolved (lazy cache hit): reuse the stored handle, no live call.
+        if surface.surface_identity_username:
+            return SurfaceReach(handle=surface.surface_identity_username, email=email)
+
+        handle = await self._resolve_live_handle(
+            surface, credential_resolver=credential_resolver
+        )
+
+        # Write-through: a live call produced a NEW username → persist it once so
+        # later reads short-circuit above. Idempotent + best-effort.
+        if handle and surface_repository is not None:
+            await self._persist_username(surface, handle, surface_repository)
+
+        if handle is None:
+            handle = await self._fallback_handle(
+                surface, connector_service=connector_service
+            )
+
+        return SurfaceReach(handle=handle, email=email)
+
+    async def _resolve_live_handle(
+        self,
+        surface: AgentSurfaceEntity,
+        *,
+        credential_resolver: "SurfaceCredentialResolver | None",
+    ) -> str | None:
+        """Per-platform live handle lookup (best-effort → None on any failure).
+
+        Bounded by ``_LIVE_HANDLE_TIMEOUT_SECONDS`` so a hung provider can't stall
+        the caller; a timeout is treated like any other failure (→ fallback)."""
+        if surface.surface_type is SurfacePlatform.SLACK:
+            coro = self._slack_handle(surface, credential_resolver)
+        elif surface.surface_type is SurfacePlatform.TEAMS:
+            coro = self._teams_handle(surface)
+        elif surface.surface_type is SurfacePlatform.TELEGRAM:
+            coro = self._telegram_handle(surface, credential_resolver)
+        else:
+            return None
+        try:
+            return await asyncio.wait_for(coro, timeout=_LIVE_HANDLE_TIMEOUT_SECONDS)
+        except Exception as exc:  # timeout / API failure — never break the request
+            logger.debug(
+                "Surface reach live handle failed for surface=%s platform=%s: %s",
+                surface.id,
+                surface.surface_type,
+                exc,
+            )
+        return None
+
+    async def _slack_handle(
+        self,
+        surface: AgentSurfaceEntity,
+        credential_resolver: "SurfaceCredentialResolver | None",
+    ) -> str | None:
+        if credential_resolver is None or not surface.surface_identity_id:
+            return None
+        from app.modules.agent_surfaces.platforms.slack.service import (
+            SlackPlatformService,
+        )
+
+        credentials = await credential_resolver.for_surface(surface)
+        return await SlackPlatformService(
+            credentials=credentials
+        ).get_user_display_name(surface.surface_identity_id)
+
+    async def _telegram_handle(
+        self,
+        surface: AgentSurfaceEntity,
+        credential_resolver: "SurfaceCredentialResolver | None",
+    ) -> str | None:
+        if credential_resolver is None:
+            return None
+        from app.modules.agent_surfaces.platforms.telegram.service import (
+            TelegramPlatformService,
+        )
+
+        credentials = await credential_resolver.for_surface(surface)
+        username = await TelegramPlatformService(credentials).get_bot_username()
+        return f"@{username}" if username else None
+
+    async def _teams_handle(self, surface: AgentSurfaceEntity) -> str | None:
+        app_id = surface_settings.microsoft_bot_app_id
+        if app_id:
+            try:
+                tenant_id = surface.external_tenant_id or "botframework.com"
+                token = await get_graph_token(tenant_id)
+                if token:
+                    url = (
+                        f"{GRAPH_BASE}/servicePrincipals(appId='{app_id}')"
+                        "?$select=displayName"
+                    )
+                    async with aiohttp.ClientSession() as session:
+                        async with session.get(
+                            url, headers=auth_headers(token)
+                        ) as response:
+                            if response.status < 400:
+                                body = await response.json()
+                                name = str(body.get("displayName") or "").strip()
+                                if name:
+                                    return name
+            except Exception as exc:  # Application.Read.All may 403 — fall back
+                logger.debug(
+                    "Teams servicePrincipal lookup failed for surface=%s: %s",
+                    surface.id,
+                    exc,
+                )
+        # Fallback: configured bot display name (still a live-derived handle for
+        # write-through purposes, but requires no external call).
+        return surface_settings.microsoft_bot_app_name or None
+
+    async def _fallback_handle(
+        self,
+        surface: AgentSurfaceEntity,
+        *,
+        connector_service: "ConnectorService | None",
+    ) -> str | None:
+        """account.display_name → surface_identity_email → None."""
+        if surface.account_id is not None and connector_service is not None:
+            try:
+                account = await connector_service.account_repository.get(
+                    surface.account_id
+                )
+                if account and account.display_name:
+                    return account.display_name
+            except Exception as exc:
+                logger.debug(
+                    "Surface reach account fallback failed for surface=%s: %s",
+                    surface.id,
+                    exc,
+                )
+        return surface.surface_identity_email or None
+
+    async def _persist_username(
+        self,
+        surface: AgentSurfaceEntity,
+        handle: str,
+        surface_repository,
+    ) -> None:
+        """Write-through the resolved handle; best-effort (never fails the read)."""
+        try:
+            surface.surface_identity_username = handle
+            await surface_repository.update(surface)
+        except Exception as exc:
+            logger.debug(
+                "Surface reach write-through failed for surface=%s: %s",
+                surface.id,
+                exc,
+            )

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_ask_user_matrix_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_ask_user_matrix_e2e.py
@@ -268,7 +268,7 @@ async def test_ask_user_native_teams_adaptive_card_then_resumes_with_answer(
     account = await _ensure_connector_account(
         db_session,
         user_id=fixed_test_user["id"],
-        connector_id="teams",
+        connector_id="microsoft_teams",
         credentials={
             "access_token": "teams-token",
             "user_data": {"tenant_id": REAL_TEAMS_TENANT_ID},

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_display_resource_matrix_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_display_resource_matrix_e2e.py
@@ -260,7 +260,7 @@ async def test_display_resource_teams_file_always_falls_back_to_link(
     account = await _ensure_connector_account(
         db_session,
         user_id=fixed_test_user["id"],
-        connector_id="teams",
+        connector_id="microsoft_teams",
         credentials={
             "access_token": "teams-token",
             "user_data": {"tenant_id": REAL_TEAMS_TENANT_ID},

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_multi_tool_turn_matrix_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_multi_tool_turn_matrix_e2e.py
@@ -164,7 +164,7 @@ async def test_multi_tool_turn_teams_two_widgets_then_one_final_answer(
     account = await _ensure_connector_account(
         db_session,
         user_id=fixed_test_user["id"],
-        connector_id="teams",
+        connector_id="microsoft_teams",
         credentials={
             "access_token": "teams-token",
             "user_data": {"tenant_id": REAL_TEAMS_TENANT_ID},

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_progress_streaming_matrix_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_progress_streaming_matrix_e2e.py
@@ -196,7 +196,7 @@ async def test_progress_streams_via_put_activity_on_teams(
     account = await _ensure_connector_account(
         db_session,
         user_id=fixed_test_user["id"],
-        connector_id="teams",
+        connector_id="microsoft_teams",
         credentials={
             "access_token": "teams-token",
             "user_data": {"tenant_id": REAL_TEAMS_TENANT_ID},

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_request_approval_matrix_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_request_approval_matrix_e2e.py
@@ -336,7 +336,7 @@ async def test_request_approval_teams_text_prompt_then_resumes_on_approve(
     account = await _ensure_connector_account(
         db_session,
         user_id=fixed_test_user["id"],
-        connector_id="teams",
+        connector_id="microsoft_teams",
         credentials={
             "access_token": "teams-token",
             "user_data": {"tenant_id": REAL_TEAMS_TENANT_ID},

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_say_voice_matrix_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_say_voice_matrix_e2e.py
@@ -280,7 +280,7 @@ async def test_say_falls_back_to_link_card_on_teams(
     account = await _ensure_connector_account(
         db_session,
         user_id=fixed_test_user["id"],
-        connector_id="teams",
+        connector_id="microsoft_teams",
         credentials={
             "access_token": "teams-token",
             "user_data": {"tenant_id": REAL_TEAMS_TENANT_ID},

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_teams_surface_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_teams_surface_e2e.py
@@ -62,7 +62,7 @@ async def test_teams_channel_surface_handles_platform_payload_and_replies(
     account = await _ensure_connector_account(
         db_session,
         user_id=fixed_test_user["id"],
-        connector_id="teams",
+        connector_id="microsoft_teams",
         credentials={
             "access_token": "teams-token",
             "user_data": {"tenant_id": REAL_TEAMS_TENANT_ID},

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_account_binding.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_account_binding.py
@@ -73,7 +73,7 @@ async def test_teams_binding_extracts_tenant_id_from_account():
         SurfaceAccountInfo(
             id=account_id,
             user_id=uuid4(),
-            connector_id="teams",
+            connector_id="microsoft_teams",
             credentials={"user_data": {"tenant_id": "tenant-from-account"}},
         )
     )

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_available_surfaces.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_available_surfaces.py
@@ -1,0 +1,160 @@
+"""The available-surfaces catalog builder joins registry + connector + native creds."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from app.modules.agent_surfaces.domain.entities import (
+    SurfaceCredentialMode,
+    SurfacePlatform,
+)
+from app.modules.agent_surfaces.domain.surface_connectors import (
+    SURFACE_CONNECTOR_BINDINGS,
+    surface_connector_id,
+)
+from app.modules.agent_surfaces.services import available_surfaces_builder as mod
+from app.modules.agent_surfaces.services.available_surfaces_builder import (
+    build_available_surfaces,
+)
+from app.modules.connectors.domain.connector import (
+    AuthScheme,
+    ConnectorEntity,
+    LemmaProviderCapability,
+)
+from app.modules.connectors.domain.errors import ConnectorNotFoundError
+
+_CUSTOM = SurfaceCredentialMode.CUSTOM
+_SYSTEM = SurfaceCredentialMode.SYSTEM
+_NATIVE = {SurfacePlatform.WHATSAPP, SurfacePlatform.TELEGRAM, SurfacePlatform.RESEND}
+
+
+def _connector(connector_id: str, *, is_active=True, capability=None) -> ConnectorEntity:
+    return ConnectorEntity(
+        id=connector_id,
+        title=connector_id.replace("_", " ").title(),
+        icon=f"{connector_id}.png",
+        is_active=is_active,
+        provider_capabilities=[] if capability is None else [capability],
+    )
+
+
+def _default_cap() -> LemmaProviderCapability:
+    return LemmaProviderCapability(
+        auth_scheme=AuthScheme.OAUTH2, system_default_available=True
+    )
+
+
+def _connector_service(
+    *, missing=(), inactive=(), no_lemma=(), capability=None
+) -> AsyncMock:
+    cap = capability or _default_cap()
+
+    def _get(connector_id: str) -> ConnectorEntity:
+        if connector_id in missing:
+            raise ConnectorNotFoundError(connector_id)
+        if connector_id in no_lemma:
+            return _connector(connector_id, capability=None)  # no LEMMA capability
+        if connector_id in inactive:
+            return _connector(connector_id, is_active=False, capability=cap)
+        return _connector(connector_id, capability=cap)
+
+    svc = AsyncMock()
+    svc.get_connector.side_effect = _get
+    return svc
+
+
+def _by_platform(resp) -> dict[SurfacePlatform, object]:
+    return {s.platform: s for s in resp.surfaces}
+
+
+async def test_modes_reflect_native_credentials(monkeypatch):
+    monkeypatch.setattr(mod, "has_native_credentials", lambda p: p in _NATIVE)
+    surfaces = _by_platform(
+        await build_available_surfaces(connector_service=_connector_service())
+    )
+    for platform in _NATIVE:
+        assert surfaces[platform].supported_credential_modes == [_CUSTOM, _SYSTEM]
+    for platform in (
+        SurfacePlatform.SLACK,
+        SurfacePlatform.TEAMS,
+        SurfacePlatform.GMAIL,
+        SurfacePlatform.OUTLOOK,
+    ):
+        assert surfaces[platform].supported_credential_modes == [_CUSTOM]
+
+
+async def test_modes_drop_system_when_no_native_credentials(monkeypatch):
+    monkeypatch.setattr(mod, "has_native_credentials", lambda p: False)
+    resp = await build_available_surfaces(connector_service=_connector_service())
+    for surface in resp.surfaces:
+        assert surface.supported_credential_modes == [_CUSTOM]
+
+
+async def test_connect_descriptor_maps_capability(monkeypatch):
+    monkeypatch.setattr(mod, "has_native_credentials", lambda p: False)
+    cap = LemmaProviderCapability(
+        auth_scheme=AuthScheme.API_KEY,
+        credential_schema={"type": "object"},
+        auth_config_schema={"x": 1},
+        system_default_available=True,
+        supports_org_custom_oauth=True,
+    )
+    resp = await build_available_surfaces(
+        connector_service=_connector_service(capability=cap)
+    )
+    teams = _by_platform(resp)[SurfacePlatform.TEAMS]
+    assert teams.connector_id == "microsoft_teams"
+    assert teams.connector_available is True
+    assert teams.connect is not None
+    assert teams.connect.auth_scheme == AuthScheme.API_KEY
+    assert teams.connect.credential_schema == {"type": "object"}
+    assert teams.connect.auth_config_schema == {"x": 1}
+    assert teams.connect.system_oauth_available is True
+    assert teams.connect.supports_org_custom_oauth is True
+
+
+async def test_missing_connector_marked_unavailable(monkeypatch):
+    monkeypatch.setattr(mod, "has_native_credentials", lambda p: False)
+    telegram = surface_connector_id(SurfacePlatform.TELEGRAM)
+    resp = await build_available_surfaces(
+        connector_service=_connector_service(missing={telegram})
+    )
+    surface = _by_platform(resp)[SurfacePlatform.TELEGRAM]
+    assert surface.connector_available is False
+    assert surface.connect is None
+    # Registry-derived fields survive so the platform is still visible.
+    assert surface.connector_id == telegram
+    assert surface.supported_credential_modes == [_CUSTOM]
+    assert len(resp.surfaces) == len(SURFACE_CONNECTOR_BINDINGS)
+
+
+async def test_inactive_connector_marked_unavailable(monkeypatch):
+    monkeypatch.setattr(mod, "has_native_credentials", lambda p: False)
+    slack = surface_connector_id(SurfacePlatform.SLACK)
+    resp = await build_available_surfaces(
+        connector_service=_connector_service(inactive={slack})
+    )
+    surface = _by_platform(resp)[SurfacePlatform.SLACK]
+    assert surface.connector_available is False
+    assert surface.connect is None
+
+
+async def test_no_lemma_capability_does_not_raise(monkeypatch):
+    monkeypatch.setattr(mod, "has_native_credentials", lambda p: False)
+    gmail = surface_connector_id(SurfacePlatform.GMAIL)
+    resp = await build_available_surfaces(
+        connector_service=_connector_service(no_lemma={gmail})
+    )
+    surface = _by_platform(resp)[SurfacePlatform.GMAIL]
+    assert surface.connector_available is False
+    assert surface.connect is None
+
+
+async def test_one_row_per_registry_platform(monkeypatch):
+    # The endpoint is registry-driven, so a newly-registered surface (Discord)
+    # appears with no builder change.
+    monkeypatch.setattr(mod, "has_native_credentials", lambda p: False)
+    resp = await build_available_surfaces(connector_service=_connector_service())
+    platforms = [s.platform for s in resp.surfaces]
+    assert set(platforms) == set(SURFACE_CONNECTOR_BINDINGS)
+    assert len(platforms) == len(SURFACE_CONNECTOR_BINDINGS)

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_surface_config.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_surface_config.py
@@ -14,6 +14,7 @@ EXPECTED = [
     ("microsoft_bot_app_password", "MICROSOFT_BOT_APP_PASSWORD", None),
     ("microsoft_bot_tenant_id", "MICROSOFT_BOT_TENANT_ID", None),
     ("microsoft_bot_openid_config_url", "MICROSOFT_BOT_OPENID_CONFIG_URL", None),
+    ("microsoft_bot_app_name", "MICROSOFT_BOT_APP_NAME", None),
     ("slack_signing_secret", "SLACK_SIGNING_SECRET", None),
     ("slack_app_token", "SLACK_APP_TOKEN", None),
     ("slack_bot_token", "SLACK_BOT_TOKEN", None),

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_surface_connectors.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_surface_connectors.py
@@ -1,0 +1,37 @@
+"""The surface-platform -> connector registry is the single source of truth."""
+
+from __future__ import annotations
+
+from app.modules.agent_surfaces.domain.entities import SurfacePlatform
+from app.modules.agent_surfaces.domain.surface_connectors import (
+    SELF_MANAGED_CREDENTIAL_CONNECTOR_IDS,
+    SURFACE_CONNECTOR_BINDINGS,
+    surface_connector_binding,
+    surface_connector_id,
+)
+
+
+def test_every_platform_has_a_binding():
+    # A new SurfacePlatform must declare its connector here, or binding/credential
+    # resolution has nothing to map it to.
+    for platform in SurfacePlatform:
+        assert platform in SURFACE_CONNECTOR_BINDINGS
+
+
+def test_teams_maps_to_microsoft_teams():
+    assert surface_connector_id(SurfacePlatform.TEAMS) == "microsoft_teams"
+    assert surface_connector_binding(SurfacePlatform.TEAMS).provider == "LEMMA"
+
+
+def test_slack_maps_to_slack():
+    assert surface_connector_id(SurfacePlatform.SLACK) == "slack"
+
+
+def test_self_managed_set_tracks_the_bindings_and_new_teams_id():
+    # Renamed teams -> microsoft_teams must be reflected here (derived, not hardcoded).
+    assert "microsoft_teams" in SELF_MANAGED_CREDENTIAL_CONNECTOR_IDS
+    assert "teams" not in SELF_MANAGED_CREDENTIAL_CONNECTOR_IDS
+    # WhatsApp/Telegram/Resend hold static keys; Slack/email are OAuth-refresh.
+    assert {"whatsapp", "telegram", "resend"} <= SELF_MANAGED_CREDENTIAL_CONNECTOR_IDS
+    assert "slack" not in SELF_MANAGED_CREDENTIAL_CONNECTOR_IDS
+    assert "gmail" not in SELF_MANAGED_CREDENTIAL_CONNECTOR_IDS

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_surface_reach_resolver.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_surface_reach_resolver.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from app.modules.agent_surfaces.api.schemas import AgentSurfaceResponse, SurfaceReach
+from app.modules.agent_surfaces.config import surface_settings
+from app.modules.agent_surfaces.domain.entities import (
+    AgentSurfaceEntity,
+    SurfaceConfig,
+    SurfacePlatform,
+)
+from app.modules.agent_surfaces.platforms.slack.service import SlackPlatformService
+from app.modules.agent_surfaces.platforms.telegram.service import (
+    TelegramPlatformService,
+)
+from app.modules.agent_surfaces.services import surface_reach_resolver
+from app.modules.agent_surfaces.services.surface_reach_resolver import (
+    SurfaceReachResolver,
+)
+
+
+def _surface(**overrides) -> AgentSurfaceEntity:
+    payload = {
+        "id": uuid4(),
+        "pod_id": uuid4(),
+        "name": "slack",
+        "agent_id": uuid4(),
+        "surface_type": SurfacePlatform.SLACK,
+        "account_id": uuid4(),
+        "config": SurfaceConfig(),
+        "surface_identity_id": "U123BOT",
+    }
+    payload.update(overrides)
+    return AgentSurfaceEntity(**payload)
+
+
+class FakeCredentialResolver:
+    def __init__(self, credentials: dict | None = None):
+        self.credentials = credentials or {"bot_token": "xoxb-test"}
+        self.calls = 0
+
+    async def for_surface(self, surface, **kwargs):
+        self.calls += 1
+        return self.credentials
+
+
+class FakeAccountRepository:
+    def __init__(self, display_name: str | None = "Support Bot Account"):
+        self._display_name = display_name
+
+    async def get(self, account_id):
+        return SimpleNamespace(display_name=self._display_name)
+
+
+class FakeConnectorService:
+    def __init__(self, display_name: str | None = "Support Bot Account"):
+        self.account_repository = FakeAccountRepository(display_name)
+
+
+class FakeSurfaceRepository:
+    def __init__(self):
+        self.updated: list[AgentSurfaceEntity] = []
+
+    async def update(self, surface):
+        self.updated.append(surface)
+        return surface
+
+
+# ---------------------------------------------------------------------------
+# 1. Per-platform handle resolution
+# ---------------------------------------------------------------------------
+
+
+async def test_slack_handle_resolved_and_persisted(monkeypatch):
+    async def fake_display_name(self, user_id):
+        return "lemma-bot"
+
+    monkeypatch.setattr(
+        SlackPlatformService, "get_user_display_name", fake_display_name
+    )
+    surface = _surface(surface_type=SurfacePlatform.SLACK)
+    cred = FakeCredentialResolver()
+    repo = FakeSurfaceRepository()
+
+    reach = await SurfaceReachResolver().resolve(
+        surface,
+        credential_resolver=cred,
+        connector_service=FakeConnectorService(),
+        surface_repository=repo,
+    )
+
+    assert reach.handle == "lemma-bot"
+    assert surface.surface_identity_username == "lemma-bot"
+    assert repo.updated == [surface]
+
+
+async def test_telegram_handle_prefixes_at_and_persists(monkeypatch):
+    async def fake_username(self):
+        return "lemma_bot"
+
+    monkeypatch.setattr(TelegramPlatformService, "get_bot_username", fake_username)
+    surface = _surface(surface_type=SurfacePlatform.TELEGRAM)
+    repo = FakeSurfaceRepository()
+
+    reach = await SurfaceReachResolver().resolve(
+        surface,
+        credential_resolver=FakeCredentialResolver({"bot_token": "123:abc"}),
+        connector_service=FakeConnectorService(),
+        surface_repository=repo,
+    )
+
+    assert reach.handle == "@lemma_bot"
+    assert surface.surface_identity_username == "@lemma_bot"
+    assert repo.updated == [surface]
+
+
+async def test_teams_handle_from_graph(monkeypatch):
+    async def fake_teams_handle(self, surface):
+        # Simulate a successful graph servicePrincipal lookup at the seam.
+        return "Lemma Teams Bot"
+
+    monkeypatch.setattr(
+        SurfaceReachResolver, "_teams_handle", fake_teams_handle
+    )
+    surface = _surface(
+        surface_type=SurfacePlatform.TEAMS,
+        surface_identity_id=None,
+        external_tenant_id="tenant-1",
+    )
+    repo = FakeSurfaceRepository()
+
+    reach = await SurfaceReachResolver().resolve(
+        surface,
+        credential_resolver=FakeCredentialResolver(),
+        connector_service=FakeConnectorService(),
+        surface_repository=repo,
+    )
+
+    assert reach.handle == "Lemma Teams Bot"
+    assert surface.surface_identity_username == "Lemma Teams Bot"
+
+
+async def test_teams_handle_config_fallback(monkeypatch):
+    # Graph token unavailable → falls back to configured bot app name.
+    async def fake_token(tenant_id):
+        return None
+
+    monkeypatch.setattr(surface_reach_resolver, "get_graph_token", fake_token)
+    monkeypatch.setattr(
+        surface_settings, "microsoft_bot_app_id", "app-123"
+    )
+    monkeypatch.setattr(
+        surface_settings, "microsoft_bot_app_name", "Lemma (config)"
+    )
+    surface = _surface(
+        surface_type=SurfacePlatform.TEAMS,
+        surface_identity_id=None,
+        external_tenant_id="tenant-1",
+    )
+    repo = FakeSurfaceRepository()
+
+    reach = await SurfaceReachResolver().resolve(
+        surface,
+        credential_resolver=FakeCredentialResolver(),
+        connector_service=FakeConnectorService(),
+        surface_repository=repo,
+    )
+
+    assert reach.handle == "Lemma (config)"
+    assert surface.surface_identity_username == "Lemma (config)"
+
+
+async def test_whatsapp_falls_back_to_account_display_name():
+    surface = _surface(
+        surface_type=SurfacePlatform.WHATSAPP, surface_identity_id=None
+    )
+    repo = FakeSurfaceRepository()
+
+    reach = await SurfaceReachResolver().resolve(
+        surface,
+        credential_resolver=FakeCredentialResolver(),
+        connector_service=FakeConnectorService("WhatsApp +1 555"),
+        surface_repository=repo,
+    )
+
+    assert reach.handle == "WhatsApp +1 555"
+    # Fallback is not a live-resolved username → nothing persisted.
+    assert repo.updated == []
+
+
+async def test_gmail_falls_back_to_account_display_name():
+    surface = _surface(
+        surface_type=SurfacePlatform.GMAIL,
+        surface_identity_id=None,
+        surface_identity_email="bot@example.com",
+    )
+    repo = FakeSurfaceRepository()
+
+    reach = await SurfaceReachResolver().resolve(
+        surface,
+        credential_resolver=FakeCredentialResolver(),
+        connector_service=FakeConnectorService("Gmail Mailbox"),
+        surface_repository=repo,
+    )
+
+    assert reach.handle == "Gmail Mailbox"
+    assert repo.updated == []
+
+
+async def test_outlook_falls_back_to_account_display_name():
+    surface = _surface(
+        surface_type=SurfacePlatform.OUTLOOK, surface_identity_id=None
+    )
+
+    reach = await SurfaceReachResolver().resolve(
+        surface,
+        credential_resolver=FakeCredentialResolver(),
+        connector_service=FakeConnectorService("Outlook Mailbox"),
+        surface_repository=FakeSurfaceRepository(),
+    )
+
+    assert reach.handle == "Outlook Mailbox"
+
+
+async def test_resend_falls_back_to_surface_email():
+    surface = _surface(
+        surface_type=SurfacePlatform.RESEND,
+        account_id=None,
+        surface_identity_id=None,
+        surface_identity_email="pod-abc@ops.lemma.work",
+    )
+
+    reach = await SurfaceReachResolver().resolve(
+        surface,
+        credential_resolver=FakeCredentialResolver(),
+        connector_service=FakeConnectorService(),
+        surface_repository=FakeSurfaceRepository(),
+    )
+
+    assert reach.handle == "pod-abc@ops.lemma.work"
+    assert reach.email == "pod-abc@ops.lemma.work"
+
+
+# ---------------------------------------------------------------------------
+# 2. Lazy write-through
+# ---------------------------------------------------------------------------
+
+
+async def test_lazy_write_through_second_read_makes_no_call(monkeypatch):
+    call_count = {"n": 0}
+
+    async def fake_display_name(self, user_id):
+        call_count["n"] += 1
+        return "lemma-bot"
+
+    monkeypatch.setattr(
+        SlackPlatformService, "get_user_display_name", fake_display_name
+    )
+    surface = _surface(surface_type=SurfacePlatform.SLACK)
+    cred = FakeCredentialResolver()
+    repo = FakeSurfaceRepository()
+    resolver = SurfaceReachResolver()
+
+    first = await resolver.resolve(
+        surface,
+        credential_resolver=cred,
+        connector_service=FakeConnectorService(),
+        surface_repository=repo,
+    )
+    assert first.handle == "lemma-bot"
+    assert call_count["n"] == 1
+    assert cred.calls == 1
+    assert len(repo.updated) == 1
+
+    # Second read: surface now HAS surface_identity_username → no platform/cred
+    # call, no new persist, returns the stored value.
+    second = await resolver.resolve(
+        surface,
+        credential_resolver=cred,
+        connector_service=FakeConnectorService(),
+        surface_repository=repo,
+    )
+    assert second.handle == "lemma-bot"
+    assert call_count["n"] == 1
+    assert cred.calls == 1
+    assert len(repo.updated) == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. Best-effort: platform raises → fall back, no exception
+# ---------------------------------------------------------------------------
+
+
+async def test_platform_failure_falls_back_to_account_display_name(monkeypatch):
+    async def boom(self, user_id):
+        raise RuntimeError("slack down")
+
+    monkeypatch.setattr(SlackPlatformService, "get_user_display_name", boom)
+    surface = _surface(surface_type=SurfacePlatform.SLACK)
+    repo = FakeSurfaceRepository()
+
+    reach = await SurfaceReachResolver().resolve(
+        surface,
+        credential_resolver=FakeCredentialResolver(),
+        connector_service=FakeConnectorService("Fallback Account"),
+        surface_repository=repo,
+    )
+
+    assert reach.handle == "Fallback Account"
+    # No live username resolved → nothing persisted.
+    assert repo.updated == []
+
+
+async def test_no_handle_when_everything_missing(monkeypatch):
+    async def none_name(self, user_id):
+        return None
+
+    monkeypatch.setattr(SlackPlatformService, "get_user_display_name", none_name)
+    surface = _surface(
+        surface_type=SurfacePlatform.SLACK,
+        account_id=None,
+        surface_identity_email=None,
+    )
+
+    reach = await SurfaceReachResolver().resolve(
+        surface,
+        credential_resolver=FakeCredentialResolver(),
+        connector_service=None,
+        surface_repository=FakeSurfaceRepository(),
+    )
+
+    assert reach.handle is None
+    assert reach.email is None
+
+
+# ---------------------------------------------------------------------------
+# 4. reach.email + response exposure
+# ---------------------------------------------------------------------------
+
+
+async def test_reach_email_matches_surface_identity_email(monkeypatch):
+    async def fake_display_name(self, user_id):
+        return "lemma-bot"
+
+    monkeypatch.setattr(
+        SlackPlatformService, "get_user_display_name", fake_display_name
+    )
+    surface = _surface(
+        surface_type=SurfacePlatform.SLACK,
+        surface_identity_email="ident@example.com",
+    )
+
+    reach = await SurfaceReachResolver().resolve(
+        surface,
+        credential_resolver=FakeCredentialResolver(),
+        connector_service=FakeConnectorService(),
+        surface_repository=FakeSurfaceRepository(),
+    )
+
+    assert reach.email == "ident@example.com"
+
+
+async def test_live_handle_timeout_falls_back(monkeypatch):
+    # A hung provider must not stall the read — it times out and degrades to the
+    # account fallback (and persists nothing).
+    import asyncio
+
+    monkeypatch.setattr(
+        surface_reach_resolver, "_LIVE_HANDLE_TIMEOUT_SECONDS", 0.01
+    )
+
+    async def slow_name(self, user_id):
+        await asyncio.sleep(0.5)
+        return "too-slow"
+
+    monkeypatch.setattr(SlackPlatformService, "get_user_display_name", slow_name)
+    surface = _surface(surface_type=SurfacePlatform.SLACK)
+    repo = FakeSurfaceRepository()
+
+    reach = await SurfaceReachResolver().resolve(
+        surface,
+        credential_resolver=FakeCredentialResolver(),
+        connector_service=FakeConnectorService("Fallback Account"),
+        surface_repository=repo,
+    )
+
+    assert reach.handle == "Fallback Account"
+    assert repo.updated == []
+
+
+async def test_response_schema_includes_surface_identity_email_and_reach():
+    response = AgentSurfaceResponse(
+        id=uuid4(),
+        pod_id=uuid4(),
+        platform=SurfacePlatform.SLACK,
+        name="slack",
+        surface_identity_email="bot@example.com",
+        reach=SurfaceReach(handle="lemma-bot", email="bot@example.com"),
+        config={},
+    )
+
+    assert response.surface_identity_email == "bot@example.com"
+    assert response.reach is not None
+    assert response.reach.handle == "lemma-bot"
+    assert response.reach.email == "bot@example.com"

--- a/lemma-backend/app/modules/connectors/services/auth/lemma_auth_provider.py
+++ b/lemma-backend/app/modules/connectors/services/auth/lemma_auth_provider.py
@@ -176,7 +176,7 @@ class LemmaAuthProvider(AuthProviderInterface):
             expires_at = datetime.now().replace(microsecond=0) + timedelta(
                 seconds=token_data["expires_in"]
             )
-        if connector.id == "teams":
+        if connector.id == "microsoft_teams":
             import base64
             import json as _json
 

--- a/lemma-backend/app/modules/connectors/tests/unit/test_import_connector_catalog.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_import_connector_catalog.py
@@ -1049,3 +1049,69 @@ async def test_upsert_trigger_tags_provider():
     assert entity.provider == AuthProvider.COMPOSIO
     assert entity.id == "gmail:composio:new_message"
     assert entity.event_type == "new_message"
+
+
+# --- connector id rename migration -------------------------------------------
+
+
+class _FakeRenameResult:
+    rowcount = 1
+
+
+class _FakeRenameSession:
+    """Records executed statements so tests can assert the re-point-then-delete
+    order without a real database."""
+
+    def __init__(self) -> None:
+        self.executed: list = []
+
+    async def execute(self, statement, params=None):
+        self.executed.append((str(statement), params))
+        return _FakeRenameResult()
+
+
+class _FakeConnectorRepoForRename:
+    def __init__(self, existing_ids: set[str]) -> None:
+        self._existing = existing_ids
+
+    async def get(self, connector_id: str):
+        return object() if connector_id in self._existing else None
+
+
+def _rename_ops(session: _FakeRenameSession) -> list[str]:
+    return [" ".join(sql.split()[:2]) for sql, _ in session.executed]
+
+
+async def test_apply_connector_renames_repoints_then_deletes():
+    session = _FakeRenameSession()
+    repo = _FakeConnectorRepoForRename({"teams", "microsoft_teams"})
+    with patch.object(importer, "CONNECTOR_ID_RENAMES", {"teams": "microsoft_teams"}):
+        renamed = await importer._apply_connector_renames(repo, session)
+    assert renamed == 1
+    # Accounts + auth_configs are re-pointed BEFORE the old connector is deleted;
+    # deleting first would cascade-delete every connected account.
+    assert _rename_ops(session) == ["UPDATE accounts", "UPDATE auth_configs", "DELETE FROM"]
+    for _, params in session.executed:
+        assert params["old"] == "teams"
+        assert params.get("new", "microsoft_teams") == "microsoft_teams"
+
+
+async def test_apply_connector_renames_skips_when_old_absent():
+    session = _FakeRenameSession()
+    repo = _FakeConnectorRepoForRename({"microsoft_teams"})  # already migrated
+    with patch.object(importer, "CONNECTOR_ID_RENAMES", {"teams": "microsoft_teams"}):
+        renamed = await importer._apply_connector_renames(repo, session)
+    assert renamed == 0
+    assert session.executed == []
+
+
+async def test_apply_connector_renames_skips_when_target_not_synced():
+    # Safety: if the new connector isn't in the catalog yet, do NOT touch/delete
+    # the old one — re-pointing to a missing FK target or deleting the old row
+    # (ON DELETE CASCADE) would break or destroy live accounts.
+    session = _FakeRenameSession()
+    repo = _FakeConnectorRepoForRename({"teams"})
+    with patch.object(importer, "CONNECTOR_ID_RENAMES", {"teams": "microsoft_teams"}):
+        renamed = await importer._apply_connector_renames(repo, session)
+    assert renamed == 0
+    assert session.executed == []

--- a/lemma-backend/app/modules/pod_bundle/application/export_use_cases.py
+++ b/lemma-backend/app/modules/pod_bundle/application/export_use_cases.py
@@ -29,6 +29,10 @@ from app.modules.pod_bundle.domain.errors import (
 )
 from app.modules.pod_bundle.domain.state import ExportState, ExportStatus
 from app.modules.pod_bundle.infrastructure.download_url import verify_download_token
+from app.modules.pod_bundle.infrastructure.rate_limiter import (
+    BundleRateLimiter,
+    get_bundle_rate_limiter,
+)
 from app.modules.pod_bundle.infrastructure.staging import BundleStagingStorage
 from app.modules.pod_bundle.infrastructure.state_store import (
     PodBundleStateStore,
@@ -53,11 +57,13 @@ class ExportUseCases:
         state_store: PodBundleStateStore | None = None,
         staging: BundleStagingStorage | None = None,
         job_queue=None,
+        rate_limiter: BundleRateLimiter | None = None,
     ):
         self._uow_factory = uow_factory
         self._state_store = state_store or get_pod_bundle_state_store()
         self._staging = staging or BundleStagingStorage()
         self._job_queue = job_queue or get_streaq_job_queue()
+        self._rate_limiter = rate_limiter or get_bundle_rate_limiter()
 
     async def start_export(
         self,
@@ -79,6 +85,14 @@ class ExportUseCases:
             )
             async with context_scope(ctx):
                 await ctx.require(Permissions.POD_READ)
+
+        # Abuse guard: count this export against the user's daily cap only after
+        # they've proven POD_READ, so an unauthorized probe never burns quota.
+        await self._rate_limiter.check_and_increment(
+            user_id=user_id,
+            operation="export",
+            limit=pod_bundle_settings.pod_bundle_daily_export_limit,
+        )
 
         resolved_ttl = _clamp_ttl(ttl_seconds)
         export_id = uuid4()

--- a/lemma-backend/app/modules/pod_bundle/application/import_use_cases.py
+++ b/lemma-backend/app/modules/pod_bundle/application/import_use_cases.py
@@ -34,6 +34,10 @@ from app.modules.pod_bundle.domain.state import (
     ImportStatus,
     StepStatus,
 )
+from app.modules.pod_bundle.infrastructure.rate_limiter import (
+    BundleRateLimiter,
+    get_bundle_rate_limiter,
+)
 from app.modules.pod_bundle.infrastructure.staging import BundleStagingStorage
 from app.modules.pod_bundle.infrastructure.state_store import (
     PodBundleStateStore,
@@ -91,11 +95,13 @@ class ImportUseCases:
         state_store: PodBundleStateStore | None = None,
         staging: BundleStagingStorage | None = None,
         job_queue=None,
+        rate_limiter: BundleRateLimiter | None = None,
     ):
         self._uow_factory = uow_factory
         self._state_store = state_store or get_pod_bundle_state_store()
         self._staging = staging or BundleStagingStorage()
         self._job_queue = job_queue or get_streaq_job_queue()
+        self._rate_limiter = rate_limiter or get_bundle_rate_limiter()
 
     async def stage_upload(
         self, *, pod_id: UUID, user_id: UUID, filename: str | None, data: bytes
@@ -146,6 +152,16 @@ class ImportUseCases:
         The request carries no bytes either way.
         """
         await self._authorize(pod_id=pod_id, user_id=user_id, action=Permissions.POD_UPDATE)
+
+        # Abuse guard: count this import against the user's daily cap (separate
+        # bucket from exports) once POD_UPDATE is authorized. Staging an upload
+        # is not counted — only starting the plan/apply pipeline is.
+        await self._rate_limiter.check_and_increment(
+            user_id=user_id,
+            operation="import",
+            limit=pod_bundle_settings.pod_bundle_daily_import_limit,
+        )
+
         import_id = uuid4()
 
         if kind == BundleSourceKind.URL:

--- a/lemma-backend/app/modules/pod_bundle/config.py
+++ b/lemma-backend/app/modules/pod_bundle/config.py
@@ -58,6 +58,26 @@ class PodBundleSettings(BaseSettings):
         description="HTTP timeout (seconds) for fetching a GitHub repo zipball.",
     )
 
+    # --- Per-user daily abuse guard --------------------------------------
+    # Export and import are long-running jobs (archive assembly, agentbox app
+    # builds, multi-resource apply). A generous per-user daily cap stops a
+    # single account from hammering the workers; buckets are independent so a
+    # day of exports never blocks imports (and vice versa). 0 disables the cap.
+    pod_bundle_daily_export_limit: int = Field(
+        default=5,
+        description=(
+            "Max export jobs a single user may start per UTC day "
+            "(env: POD_BUNDLE_DAILY_EXPORT_LIMIT). 0 disables the limit."
+        ),
+    )
+    pod_bundle_daily_import_limit: int = Field(
+        default=5,
+        description=(
+            "Max import jobs a single user may start per UTC day "
+            "(env: POD_BUNDLE_DAILY_IMPORT_LIMIT). 0 disables the limit."
+        ),
+    )
+
     # --- Export download URL retention -----------------------------------
     pod_bundle_export_url_ttl_seconds: int = Field(
         default=24 * 60 * 60,

--- a/lemma-backend/app/modules/pod_bundle/domain/errors.py
+++ b/lemma-backend/app/modules/pod_bundle/domain/errors.py
@@ -43,6 +43,20 @@ class BundleJobConflictError(PodBundleDomainError):
         super().__init__(message, code="POD_BUNDLE_CONFLICT", status_code=409)
 
 
+class BundleRateLimitExceededError(PodBundleDomainError):
+    """The user hit their per-UTC-day cap on export or import jobs. Retriable
+    tomorrow (or once an operator raises the limit) — not a bug, so 429 with a
+    clear message rather than a generic 400."""
+
+    def __init__(self, message: str, details: object | None = None):
+        super().__init__(
+            message,
+            code="POD_BUNDLE_RATE_LIMITED",
+            status_code=429,
+            details=details,
+        )
+
+
 class BundleConfirmationRequiredError(PodBundleDomainError):
     """Destructive steps present without ``confirm_destructive``, or required
     variables missing."""

--- a/lemma-backend/app/modules/pod_bundle/events/handlers.py
+++ b/lemma-backend/app/modules/pod_bundle/events/handlers.py
@@ -397,6 +397,23 @@ async def apply_pod_import(context: dict[str, str | None]) -> None:
         }
         replacements.update(state.variables_provided or {})
 
+        # A pod_member (``${..._assignee}``) variable auto-resolves to the
+        # importing user's own membership unless they supplied one — otherwise the
+        # placeholder is left unresolved and the workflow silently loses its
+        # assignee. Resolve once and reuse for every such variable.
+        unresolved_member_vars = [
+            v.name
+            for v in state.plan.variables
+            if v.kind == "pod_member" and not replacements.get(v.name)
+        ]
+        if unresolved_member_vars:
+            member_id = await _resolve_importer_pod_member_id(
+                worker_ctx, pod_id=pod_id, user_id=user_id
+            )
+            if member_id is not None:
+                for name in unresolved_member_vars:
+                    replacements[name] = member_id
+
         # APP steps build in the agentbox and must not hold a pooled DB connection,
         # so they run through a self-scoped runner instead of the per-step uow_scope.
         app_runner = AppStepRunner(uow_factory=worker_ctx.uow_factory)
@@ -728,6 +745,40 @@ def _resource_counts(files: dict[str, bytes]) -> dict[str, int]:
         if len(parts) >= 2:
             seen.setdefault(parts[0], set()).add(parts[1])
     return {k: len(v) for k, v in seen.items()}
+
+
+async def _resolve_importer_pod_member_id(
+    worker_ctx: AppWorkerContext, *, pod_id: UUID, user_id: UUID
+) -> str | None:
+    """The importing user's own pod-member id in the target pod — what a
+    ``pod_member`` (``${..._assignee}``) variable resolves to when the importer
+    doesn't supply one explicitly, matching the CLI's assignee resolution.
+
+    Best-effort: returns ``None`` (leaving the placeholder unresolved, so the
+    service drops the assignee) if the user has no membership or the lookup
+    fails, rather than failing the whole apply over one workflow assignee."""
+    from app.modules.pod.api.dependencies import get_pod_member_service
+
+    try:
+        async with uow_scope(worker_ctx.uow_factory) as uow:
+            ctx = await AuthorizationDataService(uow.session).build_user_context(
+                user_id=user_id, pod_id=pod_id
+            )
+            async with context_scope(ctx):
+                service = get_pod_member_service(uow)
+                member = await service.get_pod_member_by_user_id(
+                    pod_id, user_id, requester_user_id=user_id
+                )
+                return str(member.id)
+    except Exception as exc:  # noqa: BLE001 — assignee auto-resolution is best-effort
+        logger.warning(
+            "Could not resolve importer pod-member id for pod %s user %s (%s); "
+            "workflow assignees left unresolved",
+            pod_id,
+            user_id,
+            exc,
+        )
+        return None
 
 
 async def _record_recipe(worker_ctx: AppWorkerContext, state: ImportState) -> None:

--- a/lemma-backend/app/modules/pod_bundle/infrastructure/applier.py
+++ b/lemma-backend/app/modules/pod_bundle/infrastructure/applier.py
@@ -364,6 +364,59 @@ class BundleApplier:
 
     # --- schedules -------------------------------------------------------
 
+    async def _validate_account_binding(
+        self,
+        *,
+        account_id: object,
+        expected_connector: object,
+        expected_provider: object,
+        resource_label: str,
+    ) -> None:
+        """Guard against a surface/schedule being wired to the wrong connector
+        account on import.
+
+        The bundle stamps every account reference with the ``connector_id`` (and
+        ``provider``) it was exported against; the importer supplies one of *their
+        own* org's account ids for the ``${..._account}`` variable. Here we confirm
+        that supplied account actually exists in the target org and belongs to the
+        expected connector — otherwise the resource is created pointing at a
+        missing/mismatched account and only fails opaquely when it next runs. The
+        connector match mirrors the surface account-binding rule
+        (``SurfaceAccountBindingResolver``), so an imported surface is held to the
+        same contract as a hand-configured one.
+        """
+        if not account_id or not expected_connector:
+            return
+        try:
+            account_uuid = (
+                account_id if isinstance(account_id, UUID) else UUID(str(account_id))
+            )
+        except (ValueError, TypeError) as exc:
+            raise PodBundleDomainError(
+                f"{resource_label} was given an invalid connector account id "
+                f"'{account_id}'.",
+                code="POD_BUNDLE_ACCOUNT_INVALID",
+            ) from exc
+
+        from app.modules.connectors.api.dependencies import get_connector_service
+
+        service = get_connector_service(self._uow)
+        account = await service.account_repository.get(account_uuid)
+        if account is None:
+            raise PodBundleDomainError(
+                f"{resource_label} references a connector account that does not "
+                f"exist in this org. Connect a '{expected_connector}' account and "
+                "supply its id for this import.",
+                code="POD_BUNDLE_ACCOUNT_NOT_FOUND",
+            )
+        if str(account.connector_id).lower() != str(expected_connector).lower():
+            raise PodBundleDomainError(
+                f"{resource_label} needs a '{expected_connector}' account, but the "
+                f"supplied account is for '{account.connector_id}'. Connect a "
+                f"'{expected_connector}' account and re-run the import.",
+                code="POD_BUNDLE_ACCOUNT_CONNECTOR_MISMATCH",
+            )
+
     async def _apply_schedule(self, step: PlanStep) -> None:
         from app.modules.schedule.api.dependencies import get_schedule_service
         from app.modules.schedule.domain.schedule import (
@@ -388,6 +441,12 @@ class BundleApplier:
         fields["name"] = step.name
         fields["schedule_type"] = ScheduleType(str(payload.get("schedule_type")))
         fields["config"] = payload.get("config") or {}
+        await self._validate_account_binding(
+            account_id=fields.get("account_id"),
+            expected_connector=payload.get("connector_id"),
+            expected_provider=payload.get("provider"),
+            resource_label=f"Schedule '{step.name}'",
+        )
         entity = ScheduleCreateEntity(
             user_id=self._user_id,
             pod_id=self._pod_id,
@@ -488,6 +547,13 @@ class BundleApplier:
                     }
                 },
             }
+        )
+
+        await self._validate_account_binding(
+            account_id=request.account_id,
+            expected_connector=payload.get("connector_id"),
+            expected_provider=payload.get("provider"),
+            resource_label=f"Surface '{resolved_name}'",
         )
 
         agent_service = get_agent_service(self._uow)

--- a/lemma-backend/app/modules/pod_bundle/infrastructure/exporter.py
+++ b/lemma-backend/app/modules/pod_bundle/infrastructure/exporter.py
@@ -35,6 +35,7 @@ from lemma_pod_bundle.layout import (
     _write_json,
 )
 from lemma_pod_bundle.normalize import (
+    _attach_permissions_payload,
     _normalize_agent_payload,
     _normalize_app_payload,
     _normalize_function_payload,
@@ -330,6 +331,16 @@ class BundleExporter:
                     payload = _normalize_function_payload(
                         _function_response_dict(function)
                     )
+                    grantee_id = getattr(function, "id", None)
+                    if grantee_id is not None:
+                        grants = await _resource_grants_payload(
+                            uow,
+                            pod_id=pod_id,
+                            grantee_type="FUNCTION",
+                            grantee_id=grantee_id,
+                        )
+                        if grants:
+                            payload = _attach_permissions_payload(payload, grants)
                     payload = _extract_large_text(
                         payload, field_name="code", file_name="code.py", resource_dir=dir_
                     )
@@ -354,6 +365,16 @@ class BundleExporter:
                     dir_ = root / "agents" / agent_name
                     dir_.mkdir(parents=True, exist_ok=True)
                     payload = _normalize_agent_payload(_agent_response_dict(agent))
+                    grantee_id = getattr(agent, "id", None)
+                    if grantee_id is not None:
+                        grants = await _resource_grants_payload(
+                            uow,
+                            pod_id=pod_id,
+                            grantee_type="AGENT",
+                            grantee_id=grantee_id,
+                        )
+                        if grants:
+                            payload = _attach_permissions_payload(payload, grants)
                     payload = _extract_large_text(
                         payload,
                         field_name="instruction",
@@ -550,7 +571,7 @@ class BundleExporter:
             logger.warning("Skipping surface export for pod %s: %s", pod_id, exc)
             return
 
-        seen_platforms: set[str] = set()
+        seen_names: set[str] = set()
         for surface in surfaces:
             try:
                 raw_surface = _dump_response(_surface_response(surface))
@@ -567,10 +588,12 @@ class BundleExporter:
                     raw_surface["connector_id"], raw_surface["provider"] = info
                 payload = _normalize_surface_payload(raw_surface)
                 platform = str(payload.get("platform") or "")
-                if not platform or platform in seen_platforms:
+                # De-dup by the surface's pod-unique name (not platform), so a pod
+                # with several surfaces of one platform exports all of them.
+                surface_name = str(payload.get("name") or "")
+                if not platform or not surface_name or surface_name in seen_names:
                     continue
-                seen_platforms.add(platform)
-                surface_name = str(payload["name"])
+                seen_names.add(surface_name)
                 dir_ = root / "surfaces" / surface_name
                 dir_.mkdir(parents=True, exist_ok=True)
                 _write_json(dir_ / f"{surface_name}.json", payload)
@@ -751,6 +774,54 @@ class BundleExporter:
 
 
 # --- response-dict adapters (per-module GET serialization) -------------------
+
+
+async def _resource_grants_payload(
+    uow: SqlAlchemyUnitOfWork,
+    *,
+    pod_id: UUID,
+    grantee_type: str,
+    grantee_id: UUID,
+) -> dict[str, Any] | None:
+    """Serialize an agent's/function's resource grants into the bundle's portable
+    ``{"grants": [...]}`` shape (keyed by ``resource_name``, never a source-org id).
+
+    Mirrors the ``…/permissions`` GET endpoint the CLI exporter reads, so a pod
+    exported through the async backend keeps the same executable grants a
+    CLI-exported one does — without them, an imported agent/function can be created
+    but can't call the tables/functions it was granted. ``list_grantee_resource_grants``
+    already drops grants whose resource no longer resolves to a name, and the applier
+    skips any that don't resolve in the target pod, so this stays best-effort/portable.
+    Best-effort: a failure to read grants logs and returns ``None`` (the resource
+    still exports, just without its grants) rather than sinking the whole export,
+    matching the surfaces/files/apps best-effort policy. Returns ``None`` when the
+    grantee has no grants (so nothing is attached)."""
+    from app.core.authorization.grants import list_grantee_resource_grants
+
+    try:
+        grouped = await list_grantee_resource_grants(
+            uow.session,
+            pod_id=pod_id,
+            grantee_type=grantee_type,
+            grantee_id=grantee_id,
+        )
+    except Exception as exc:  # noqa: BLE001 - grant export is best-effort
+        logger.warning(
+            "Skipping grant export for %s %s: %s", grantee_type, grantee_id, exc
+        )
+        return None
+    if not grouped:
+        return None
+    return {
+        "grants": [
+            {
+                "resource_type": resource_type.value,
+                "resource_name": resource_name,
+                "permission_ids": sorted(set(permission_ids)),
+            }
+            for (resource_type, resource_name), permission_ids in grouped.items()
+        ]
+    }
 
 
 def _pod_response_dict(pod: Any) -> dict[str, Any]:

--- a/lemma-backend/app/modules/pod_bundle/infrastructure/rate_limiter.py
+++ b/lemma-backend/app/modules/pod_bundle/infrastructure/rate_limiter.py
@@ -1,0 +1,101 @@
+"""Per-user daily rate limiting for pod-bundle export/import jobs.
+
+Export and import kick off long-running worker jobs (archive assembly, agentbox
+app builds, multi-resource apply). Without a cap a single account can enqueue
+them without bound and starve the workers, so we count job *starts* per user per
+UTC day in Redis and reject once the configured limit is hit.
+
+Design notes:
+
+- The counter is a plain ``INCR`` on a date-stamped key (``…:{YYYYMMDD}``) with a
+  short TTL, so each UTC day gets its own self-expiring key — no cron cleanup and
+  no stale reads across days. The same ``INCR``/``EXPIRE`` pattern the schedule
+  circuit breaker uses (:mod:`app.modules.schedule.services.schedule_fire_store`).
+- **Fails open**: a Redis blip must never block a legitimate export/import, so any
+  Redis error is logged and treated as "under the limit". The cap is an abuse
+  guard, not a correctness invariant.
+- The increment happens on the *accepted* path only (the caller invokes this after
+  authorization, before enqueue), so a rejected over-limit attempt still counts —
+  which is the desired behavior: hammering the endpoint keeps you rejected rather
+  than resetting your quota.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+from redis.asyncio import Redis
+
+from app.core.config import settings
+from app.core.log.log import get_logger
+from app.modules.pod_bundle.domain.errors import BundleRateLimitExceededError
+
+logger = get_logger(__name__)
+
+# Comfortably outlives a single UTC day (keys are date-stamped, so this is only
+# for cleanup of a day's key after it stops being written).
+_COUNTER_TTL_SECONDS = 2 * 24 * 60 * 60  # 48h
+
+
+class BundleRateLimiter:
+    """Redis-backed per-user daily counter for bundle export/import starts."""
+
+    def __init__(self, redis_url: str | None = None) -> None:
+        self._redis_url = redis_url or settings.redis_url
+        self._redis: Redis | None = None
+        self._lock = asyncio.Lock()
+
+    async def _get_redis(self) -> Redis:
+        if self._redis is not None:
+            return self._redis
+        async with self._lock:
+            if self._redis is None:
+                self._redis = Redis.from_url(self._redis_url, decode_responses=True)
+        return self._redis
+
+    @staticmethod
+    def _key(operation: str, user_id: object) -> str:
+        day = datetime.now(timezone.utc).strftime("%Y%m%d")
+        return f"pod-bundle:ratelimit:{operation}:{user_id}:{day}"
+
+    async def check_and_increment(
+        self, *, user_id: object, operation: str, limit: int
+    ) -> None:
+        """Count one ``operation`` (``"export"``/``"import"``) start for ``user_id``
+        and raise :class:`BundleRateLimitExceededError` if it exceeds ``limit``.
+
+        A non-positive ``limit`` disables the cap. Fails open on any Redis error.
+        """
+        if limit <= 0:
+            return
+        try:
+            redis = await self._get_redis()
+            key = self._key(operation, user_id)
+            count = await redis.incr(key)
+            if count == 1:
+                await redis.expire(key, _COUNTER_TTL_SECONDS)
+        except Exception as exc:  # noqa: BLE001 — the cap is best-effort
+            logger.warning(
+                "Bundle rate-limit counter unavailable for %s %s (%s); allowing",
+                operation,
+                user_id,
+                exc,
+            )
+            return
+        if count > limit:
+            raise BundleRateLimitExceededError(
+                f"Daily {operation} limit reached ({limit} per day). "
+                "Try again tomorrow (UTC) or ask an admin to raise the limit.",
+                details={"operation": operation, "limit": limit},
+            )
+
+
+_limiter: BundleRateLimiter | None = None
+
+
+def get_bundle_rate_limiter() -> BundleRateLimiter:
+    global _limiter
+    if _limiter is None:
+        _limiter = BundleRateLimiter()
+    return _limiter

--- a/lemma-backend/app/modules/pod_bundle/tests/unit/test_applier.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/unit/test_applier.py
@@ -643,3 +643,125 @@ async def test_surface_apply_rejects_missing_platform(tmp_path, monkeypatch):
     )
     with pytest.raises(PodBundleDomainError, match="platform"):
         await _applier(root).apply_step(_step(StepKind.SURFACE, "slack"))
+
+
+# --- account-binding validation on import ------------------------------------
+
+
+class _FakeConnectorService:
+    """Stand-in for the connectors service the applier consults to confirm a
+    supplied account matches the connector the bundle declared."""
+
+    def __init__(self, account, provider: str = "LEMMA"):
+        from types import SimpleNamespace
+
+        self.account_repository = SimpleNamespace(get=self._get_account)
+        self.auth_config_repository = SimpleNamespace(get=self._get_auth_config)
+        self._account = account
+        self._provider = provider
+
+    async def _get_account(self, account_id):
+        return self._account
+
+    async def _get_auth_config(self, auth_config_id):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(provider=SimpleNamespace(value=self._provider))
+
+
+def _patch_surface_deps(monkeypatch, surface_service, connector_service) -> None:
+    monkeypatch.setattr(
+        "app.modules.agent_surfaces.api.dependencies.get_surface_service",
+        lambda uow: surface_service,
+    )
+    monkeypatch.setattr(
+        "app.modules.agent.api.dependencies.get_agent_service",
+        lambda uow: FakeAgentService(),
+    )
+    monkeypatch.setattr(
+        "app.modules.connectors.api.dependencies.get_connector_service",
+        lambda uow: connector_service,
+    )
+
+
+async def test_surface_apply_accepts_matching_connector_account(tmp_path, monkeypatch):
+    """A supplied account whose connector matches the bundle's declared
+    connector_id passes validation and the surface is created."""
+    from types import SimpleNamespace
+
+    account = uuid4()
+    root = tmp_path / "bundle"
+    _write(
+        root / "surfaces" / "teams" / "teams.json",
+        {
+            "name": "teams",
+            "platform": "TEAMS",
+            "account_id": "${teams_account}",
+            "connector_id": "teams",
+            "provider": "LEMMA",
+            "is_enabled": True,
+        },
+    )
+    surface_fake = FakeSurfaceService()
+    connector_account = SimpleNamespace(connector_id="teams", auth_config_id=uuid4())
+    _patch_surface_deps(monkeypatch, surface_fake, _FakeConnectorService(connector_account))
+
+    applier = _applier(root, replacements={"teams_account": str(account)})
+    await applier.apply_step(_step(StepKind.SURFACE, "teams"))
+    assert surface_fake.created is not None
+    assert surface_fake.created["account_id"] == account
+
+
+async def test_surface_apply_rejects_wrong_connector_account(tmp_path, monkeypatch):
+    """A supplied account for the wrong connector is rejected with a clear error
+    instead of silently binding a mismatched account."""
+    from types import SimpleNamespace
+
+    from app.modules.pod_bundle.domain.errors import PodBundleDomainError
+
+    root = tmp_path / "bundle"
+    _write(
+        root / "surfaces" / "teams" / "teams.json",
+        {
+            "name": "teams",
+            "platform": "TEAMS",
+            "account_id": "${teams_account}",
+            "connector_id": "teams",
+            "provider": "LEMMA",
+            "is_enabled": True,
+        },
+    )
+    # User supplied a slack account for a teams surface.
+    connector_account = SimpleNamespace(connector_id="slack", auth_config_id=uuid4())
+    _patch_surface_deps(
+        monkeypatch, FakeSurfaceService(), _FakeConnectorService(connector_account)
+    )
+
+    applier = _applier(root, replacements={"teams_account": str(uuid4())})
+    with pytest.raises(PodBundleDomainError, match="teams"):
+        await applier.apply_step(_step(StepKind.SURFACE, "teams"))
+
+
+async def test_surface_apply_rejects_missing_account(tmp_path, monkeypatch):
+    """A supplied account id that doesn't exist in the target org is rejected."""
+    from app.modules.pod_bundle.domain.errors import PodBundleDomainError
+
+    root = tmp_path / "bundle"
+    _write(
+        root / "surfaces" / "teams" / "teams.json",
+        {
+            "name": "teams",
+            "platform": "TEAMS",
+            "account_id": "${teams_account}",
+            "connector_id": "teams",
+            "provider": "LEMMA",
+            "is_enabled": True,
+        },
+    )
+    _patch_surface_deps(
+        monkeypatch, FakeSurfaceService(), _FakeConnectorService(None)
+    )
+
+    applier = _applier(root, replacements={"teams_account": str(uuid4())})
+    with pytest.raises(PodBundleDomainError, match="does not exist"):
+        await applier.apply_step(_step(StepKind.SURFACE, "teams"))

--- a/lemma-backend/app/modules/pod_bundle/tests/unit/test_applier.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/unit/test_applier.py
@@ -697,13 +697,13 @@ async def test_surface_apply_accepts_matching_connector_account(tmp_path, monkey
             "name": "teams",
             "platform": "TEAMS",
             "account_id": "${teams_account}",
-            "connector_id": "teams",
+            "connector_id": "microsoft_teams",
             "provider": "LEMMA",
             "is_enabled": True,
         },
     )
     surface_fake = FakeSurfaceService()
-    connector_account = SimpleNamespace(connector_id="teams", auth_config_id=uuid4())
+    connector_account = SimpleNamespace(connector_id="microsoft_teams", auth_config_id=uuid4())
     _patch_surface_deps(monkeypatch, surface_fake, _FakeConnectorService(connector_account))
 
     applier = _applier(root, replacements={"teams_account": str(account)})
@@ -726,7 +726,7 @@ async def test_surface_apply_rejects_wrong_connector_account(tmp_path, monkeypat
             "name": "teams",
             "platform": "TEAMS",
             "account_id": "${teams_account}",
-            "connector_id": "teams",
+            "connector_id": "microsoft_teams",
             "provider": "LEMMA",
             "is_enabled": True,
         },
@@ -753,7 +753,7 @@ async def test_surface_apply_rejects_missing_account(tmp_path, monkeypatch):
             "name": "teams",
             "platform": "TEAMS",
             "account_id": "${teams_account}",
-            "connector_id": "teams",
+            "connector_id": "microsoft_teams",
             "provider": "LEMMA",
             "is_enabled": True,
         },

--- a/lemma-backend/app/modules/pod_bundle/tests/unit/test_exporter.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/unit/test_exporter.py
@@ -581,3 +581,69 @@ async def test_app_asset_over_byte_budget_is_skipped(
     assert (root / "apps" / "big_app" / "big_app.json").is_file()
     assert not (root / "apps" / "big_app" / "source").exists()
     assert any("per-item limit" in w for w in warnings)
+
+
+# --- resource-grant export ---------------------------------------------------
+
+
+async def test_resource_grants_payload_serializes_grants_by_name(monkeypatch):
+    """Grants export in the portable ``{"grants": [...]}`` shape the applier +
+    CLI consume, keyed by resource_name (never a source-org id)."""
+    from app.core.authorization.context import ResourceType
+
+    async def _fake_list(session, *, pod_id, grantee_type, grantee_id):
+        return {(ResourceType.DATASTORE_TABLE, "leads"): ["write", "read", "read"]}
+
+    monkeypatch.setattr(
+        "app.core.authorization.grants.list_grantee_resource_grants", _fake_list
+    )
+    out = await exporter_mod._resource_grants_payload(
+        SimpleNamespace(session=object()),
+        pod_id=uuid4(),
+        grantee_type="AGENT",
+        grantee_id=uuid4(),
+    )
+    assert out == {
+        "grants": [
+            {
+                "resource_type": "datastore_table",
+                "resource_name": "leads",
+                "permission_ids": ["read", "write"],
+            }
+        ]
+    }
+
+
+async def test_resource_grants_payload_none_when_no_grants(monkeypatch):
+    async def _fake_list(session, *, pod_id, grantee_type, grantee_id):
+        return {}
+
+    monkeypatch.setattr(
+        "app.core.authorization.grants.list_grantee_resource_grants", _fake_list
+    )
+    out = await exporter_mod._resource_grants_payload(
+        SimpleNamespace(session=object()),
+        pod_id=uuid4(),
+        grantee_type="FUNCTION",
+        grantee_id=uuid4(),
+    )
+    assert out is None
+
+
+async def test_resource_grants_payload_is_best_effort_on_error(monkeypatch):
+    """A grant-read failure must not sink the whole export — it degrades to no
+    grants for that resource."""
+
+    async def _boom(session, *, pod_id, grantee_type, grantee_id):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(
+        "app.core.authorization.grants.list_grantee_resource_grants", _boom
+    )
+    out = await exporter_mod._resource_grants_payload(
+        SimpleNamespace(session=object()),
+        pod_id=uuid4(),
+        grantee_type="AGENT",
+        grantee_id=uuid4(),
+    )
+    assert out is None

--- a/lemma-backend/app/modules/pod_bundle/tests/unit/test_rate_limiter.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/unit/test_rate_limiter.py
@@ -1,0 +1,83 @@
+"""Per-user daily rate limiter semantics with a fake Redis (no real Redis)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.modules.pod_bundle.domain.errors import BundleRateLimitExceededError
+from app.modules.pod_bundle.infrastructure.rate_limiter import BundleRateLimiter
+
+
+class _FakeRedis:
+    def __init__(self) -> None:
+        self.counts: dict[str, int] = {}
+        self.expires: dict[str, int] = {}
+
+    async def incr(self, key: str) -> int:
+        self.counts[key] = self.counts.get(key, 0) + 1
+        return self.counts[key]
+
+    async def expire(self, key: str, ttl: int) -> None:
+        self.expires[key] = ttl
+
+
+class _BrokenRedis:
+    async def incr(self, key: str) -> int:
+        raise RuntimeError("redis down")
+
+    async def expire(self, key: str, ttl: int) -> None:  # pragma: no cover
+        raise RuntimeError("redis down")
+
+
+def _limiter(redis) -> BundleRateLimiter:
+    limiter = BundleRateLimiter()
+    limiter._redis = redis  # bypass Redis.from_url
+    return limiter
+
+
+async def test_allows_up_to_limit_then_raises_429():
+    limiter = _limiter(_FakeRedis())
+    for _ in range(5):
+        await limiter.check_and_increment(user_id="u1", operation="export", limit=5)
+    with pytest.raises(BundleRateLimitExceededError) as exc:
+        await limiter.check_and_increment(user_id="u1", operation="export", limit=5)
+    assert exc.value.status_code == 429
+
+
+async def test_export_and_import_buckets_are_independent():
+    redis = _FakeRedis()
+    limiter = _limiter(redis)
+    for _ in range(5):
+        await limiter.check_and_increment(user_id="u1", operation="export", limit=5)
+    # Import bucket is untouched by a day of exports.
+    await limiter.check_and_increment(user_id="u1", operation="import", limit=5)
+
+
+async def test_users_do_not_share_a_bucket():
+    limiter = _limiter(_FakeRedis())
+    for _ in range(5):
+        await limiter.check_and_increment(user_id="u1", operation="export", limit=5)
+    # A different user starts fresh.
+    await limiter.check_and_increment(user_id="u2", operation="export", limit=5)
+
+
+async def test_zero_limit_disables_the_cap():
+    limiter = _limiter(_FakeRedis())
+    for _ in range(50):
+        await limiter.check_and_increment(user_id="u1", operation="export", limit=0)
+
+
+async def test_ttl_is_set_only_on_first_increment():
+    redis = _FakeRedis()
+    limiter = _limiter(redis)
+    await limiter.check_and_increment(user_id="u1", operation="export", limit=5)
+    assert len(redis.expires) == 1
+    await limiter.check_and_increment(user_id="u1", operation="export", limit=5)
+    assert len(redis.expires) == 1  # not refreshed on every call
+
+
+async def test_fails_open_when_redis_errors():
+    limiter = _limiter(_BrokenRedis())
+    # Well past any limit, but a Redis blip must never block a legitimate job.
+    await limiter.check_and_increment(user_id="u1", operation="export", limit=1)
+    await limiter.check_and_increment(user_id="u1", operation="export", limit=1)

--- a/lemma-backend/scripts/import_connector_catalog.py
+++ b/lemma-backend/scripts/import_connector_catalog.py
@@ -129,6 +129,14 @@ COMPOSIO_EXCLUDED_CONNECTOR_IDS = {
     "microsoft_teams",
     "splitwise",
 }
+# One-time id renames applied on catalog import: the value connector is synced
+# from config first, then existing accounts/auth-configs are re-pointed to it and
+# the old (key) connector is removed. ``teams`` -> ``microsoft_teams`` aligns the
+# native Teams surface connector with the Composio toolkit slug so every surface
+# platform maps to a single, consistently-named connector.
+CONNECTOR_ID_RENAMES: dict[str, str] = {
+    "teams": "microsoft_teams",
+}
 DEFAULT_COMPOSIO_CONNECTOR_IDS: tuple[str, ...] = (
     "gmail",
     "googlecalendar",
@@ -1400,6 +1408,84 @@ async def _run_in_session_batch(
             raise
 
 
+# Child tables that hold a live per-org/user reference to a connector and must be
+# re-pointed to the new id before the old connector row is deleted. Operations and
+# triggers are intentionally NOT here — they belong to the connector definition and
+# cascade-delete with the old row (the new connector already re-synced its own).
+_CONNECTOR_RENAME_REPOINT_TABLES = ("accounts", "auth_configs")
+
+
+async def _apply_connector_renames(connector_repository, session) -> int:
+    """Apply :data:`CONNECTOR_ID_RENAMES` as a safe, idempotent data migration.
+
+    ``connectors.id`` is a string primary key that ``accounts``, ``auth_configs``,
+    ``connector_operations`` and ``connector_triggers`` reference with
+    ``ON DELETE CASCADE`` — so this must (1) confirm the new connector already
+    exists (synced from config), (2) re-point accounts + auth configs off the old
+    id, then (3) delete the old connector (its stale operations/triggers cascade
+    away; the new connector carries its own freshly-synced set). Deleting the old
+    row *before* re-pointing would cascade-delete every connected account.
+
+    Idempotent: a rename whose old connector is already gone (or whose target
+    hasn't been synced yet) is skipped. Returns the number of renames applied.
+    """
+    from sqlalchemy import text
+
+    renamed = 0
+    for old_id, new_id in CONNECTOR_ID_RENAMES.items():
+        old = await connector_repository.get(old_id)
+        if old is None:
+            continue  # already migrated (or never existed)
+        new = await connector_repository.get(new_id)
+        if new is None:
+            logger.warning(
+                "Skipping connector rename %s -> %s: target connector is not "
+                "synced yet (run a native/full import first).",
+                old_id,
+                new_id,
+            )
+            continue
+        for table in _CONNECTOR_RENAME_REPOINT_TABLES:
+            result = await session.execute(
+                text(
+                    f"UPDATE {table} SET connector_id = :new "  # noqa: S608 - table names are a fixed literal allow-list
+                    "WHERE connector_id = :old"
+                ),
+                {"new": new_id, "old": old_id},
+            )
+            logger.info(
+                "Re-pointed %s %s row(s) from %s to %s",
+                getattr(result, "rowcount", "?"),
+                table,
+                old_id,
+                new_id,
+            )
+        await session.execute(
+            text("DELETE FROM connectors WHERE id = :old"),
+            {"old": old_id},
+        )
+        renamed += 1
+        logger.info("Renamed connector %s -> %s", old_id, new_id)
+    return renamed
+
+
+async def _run_connector_id_renames(*, dry_run: bool) -> int:
+    """Session wrapper around :func:`_apply_connector_renames` (commit unless dry-run)."""
+    async with async_session_maker() as session:
+        uow = SqlAlchemyUnitOfWork(session)
+        connector_repository = ConnectorRepository(uow)
+        try:
+            renamed = await _apply_connector_renames(connector_repository, session)
+            if dry_run:
+                await uow.rollback()
+            else:
+                await uow.commit()
+            return renamed
+        except Exception:
+            await uow.rollback()
+            raise
+
+
 async def _sync_native_catalog_batched(
     *,
     app_filters: set[str] | None,
@@ -1720,6 +1806,12 @@ async def main() -> None:
             max_composio_apps=args.max_composio_apps,
             dry_run=args.dry_run,
         )
+
+    # Apply any one-time connector id renames now that the target connectors have
+    # been synced (idempotent; skips renames whose old connector is already gone).
+    renamed_connectors = await _run_connector_id_renames(dry_run=args.dry_run)
+    if renamed_connectors:
+        logger.info("Applied %s connector id rename(s).", renamed_connectors)
 
     if args.dry_run:
         logger.info(

--- a/lemma-backend/scripts/lemma_apps_config.json
+++ b/lemma-backend/scripts/lemma_apps_config.json
@@ -650,7 +650,7 @@
     "triggers": []
   },
   {
-    "name": "teams",
+    "name": "microsoft_teams",
     "title": "Microsoft Teams",
     "description": "Connect Lemma assistants to Microsoft Teams. Chat with the bot in direct messages or @mention it in channels.",
     "auth_method": "OAUTH2",

--- a/lemma-cli/lemma_cli/cli_app/pod_bundle.py
+++ b/lemma-cli/lemma_cli/cli_app/pod_bundle.py
@@ -483,8 +483,16 @@ def _build_variable_applier(
             if default_id:
                 try:
                     client.connectors.accounts.get(str(default_id))
-                except LemmaAPIError:
-                    resolved = None
+                except LemmaAPIError as exc:
+                    # A 404/403 means the recorded source account isn't ours to
+                    # reuse — leave the variable unresolved. But a 429 (rate
+                    # limited) or 5xx is transient/systemic: treating it as
+                    # "account gone" would silently drop the binding and import a
+                    # half-wired resource, so surface it instead.
+                    if getattr(exc, "status_code", None) in (403, 404):
+                        resolved = None
+                    else:
+                        raise
                 else:
                     resolved = str(default_id)
             account_default_cache[name] = resolved

--- a/lemma-cli/lemma_cli/cli_core/state.py
+++ b/lemma-cli/lemma_cli/cli_core/state.py
@@ -140,6 +140,12 @@ def humanize_error(exc: Exception) -> str:
         key = exc.args[0] if exc.args else ""
         return f"Missing required field: {key}." if key else "Missing required field."
     if isinstance(exc, LemmaAPIError):
+        if getattr(exc, "status_code", None) == 429:
+            return (
+                str(exc)
+                + "\nYou've hit a rate limit — export/import are capped per day. "
+                "Wait and try again, or ask an admin to raise the limit."
+            )
         fields = _extract_field_errors(exc.details)
         if fields:
             return str(exc) + "\n" + "\n".join(f"  - {line}" for line in fields)

--- a/lemma-pod-bundle/lemma_pod_bundle/normalize.py
+++ b/lemma-pod-bundle/lemma_pod_bundle/normalize.py
@@ -233,8 +233,13 @@ def _normalize_surface_payload(surface: dict[str, Any]) -> dict[str, Any]:
         behavior_config["identity"] = identity_entry
 
     status = str(surface.get("status") or "").upper()
+    # Prefer the surface's own pod-unique name so several surfaces of the same
+    # platform (e.g. two Slack bots) round-trip as distinct resources instead of
+    # collapsing onto the platform slug and dropping all but one. Falls back to the
+    # lowercased platform for a legacy surface with no explicit name.
+    resolved_name = str(surface.get("name") or "").strip() or platform.lower()
     payload: dict[str, Any] = {
-        "name": platform.lower(),
+        "name": resolved_name,
         "platform": platform,
         "default_agent_name": surface.get("agent_name"),
         "credential_mode": surface.get("credential_mode"),


### PR DESCRIPTION
## Summary

A review of the pod bundle export/import flow surfaced correctness gaps in recreating a pod in a **new org for a new user**, plus no abuse guard on these long-running operations. This PR fixes all of them, then follows up with a consistent surface→connector mapping and two frontend-facing surface APIs.

## Part 1 — Export/import hardening
- **Per-user daily rate limit** — separate export/import buckets (default `5`, env `POD_BUNDLE_DAILY_EXPORT_LIMIT`/`_IMPORT_LIMIT`, `0` disables), Redis `INCR`+TTL, fails open, **429** on exceed.
- **Account validation on import**, **agent/function grant export** (was silently dropped), **`pod_member` auto-resolve** to the importer, **all surfaces round-trip** (name-based, not platform-collapsed), CLI 429 UX.

## Part 2 — Canonical surface→connector mapping + `teams` → `microsoft_teams`
- New `agent_surfaces/domain/surface_connectors.py` registry (single source of truth for `account_binding` + `credential_resolver`).
- Rename the native Teams connector `teams` → `microsoft_teams`; idempotent data migration in `import_connector_catalog.py` (re-point accounts/auth_configs, then delete old — ordered around the `ON DELETE CASCADE` FK).

## Part 3 — Available-surfaces catalog API
`GET /pods/{pod_id}/available-surfaces` — registry-driven catalog so adding a surface (Discord soon) is backend-only. Per platform: connector, provider, title/icon, `supported_credential_modes` (single source: `[CUSTOM]` = account required; `[CUSTOM, SYSTEM]` = managed bot available), and a slim `connect` descriptor (auth schema + `system_oauth_available`).

## Part 4 — Per-surface reach handle
`GET /pods/{pod_id}/surfaces` (list + single + create/update) now returns `reach: { handle, email }` + the previously-hidden `surface_identity_email`, so the UI can show **how a user reaches each surface**:
- `handle` = Slack/Teams bot name, Telegram `@username`, WhatsApp phone, or account/email address.
- Reuses the connectors `account.display_name` (computed at connect time) as the fallback; Slack/Teams/Telegram bot names are fetched live (Slack `users.info`, Teams Graph servicePrincipal with a `microsoft_bot_app_name` config fallback, Telegram `getMe`) and **lazily written through** to `surface_identity_username` on first read — later reads make no external call. No backfill migration.
- Best-effort with a per-call timeout: any failure/timeout degrades to the fallback handle; a GET never breaks.

## Testing
- Backend unit **green** across affected suites: pod_bundle 157, connectors (incl. rename-migration guards), agent_surfaces **403 passed / 2 Fireworks-skipped** (incl. 14 available-surfaces + reach-handle tests).
- Full backend e2e run: **384 passed / 88 env-gated skips**; the only failures were pre-existing live-external (Composio/OpenWeather) + load-sensitive benchmarks — none related to this branch.
- CLI **609 passed** · ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)