### PR TITLE
feat(usage): enforce monthly user spend limits

### DIFF
--- a/lemma-backend/app/modules/usage/api/schemas.py
+++ b/lemma-backend/app/modules/usage/api/schemas.py
@@ -117,4 +117,5 @@ class UsageLimitsResponse(BaseModel):
     user_id: UUID
     org_monthly: UsageLimitScopeResponse
     user_weekly: UsageLimitScopeResponse
+    user_monthly: UsageLimitScopeResponse
     allowed: bool

--- a/lemma-backend/app/modules/usage/domain/ports.py
+++ b/lemma-backend/app/modules/usage/domain/ports.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Protocol, Sequence
 from uuid import UUID
@@ -67,6 +68,18 @@ class UsageRepositoryPort(Protocol):
     ) -> Sequence[dict[str, object]]: ...
 
 
+@dataclass(frozen=True)
+class UsageLimitValues:
+    """Resolved system-spend limits for an org/user context.
+
+    ``None`` means unlimited for that window.
+    """
+
+    org_monthly_limit_usd: float | None = None
+    user_weekly_limit_usd: float | None = None
+    user_monthly_limit_usd: float | None = None
+
+
 class UsageLimitPort(Protocol):
     """What usage needs from an external billing/plan provider: the spend limits
     that apply to an org+user. Implemented by the billing module (dependency
@@ -78,6 +91,6 @@ class UsageLimitPort(Protocol):
         *,
         organization_id: UUID | None,
         user_id: UUID,
-    ) -> "tuple[float | None, float | None]":
-        """Return (org_monthly_limit_usd, user_weekly_limit_usd); None = unlimited."""
+    ) -> UsageLimitValues:
+        """Return applicable spend limits; ``None`` means unlimited."""
         ...

--- a/lemma-backend/app/modules/usage/services/usage_service.py
+++ b/lemma-backend/app/modules/usage/services/usage_service.py
@@ -11,7 +11,7 @@ from app.core.log.log import get_logger
 from app.modules.agent.domain.runtime_profiles import RuntimeProfileScope
 from app.modules.agent.domain.value_objects import AgentRunUsage
 from app.modules.usage.domain.entities import UsageRecord, UsageReservation
-from app.modules.usage.domain.ports import UsageLimitPort
+from app.modules.usage.domain.ports import UsageLimitPort, UsageLimitValues
 from app.modules.usage.domain.errors import UsageLimitExceededError
 from app.modules.usage.domain.events import ModelUsageEvent, UsageLimitDeniedEvent
 from app.modules.usage.infrastructure.repositories import UsageRepository
@@ -35,6 +35,7 @@ class UsageService:
 
     DEFAULT_ORG_MONTHLY_COST_LIMIT_USD: float | None = 50.0
     DEFAULT_USER_WEEKLY_COST_LIMIT_USD: float | None = 10.0
+    DEFAULT_USER_MONTHLY_COST_LIMIT_USD: float | None = None
     DEFAULT_RESERVATION_USD = 0.01
 
     # Per-model rates (USD per 1M tokens). Keyed by both the public model name
@@ -123,6 +124,18 @@ class UsageService:
                     window_kind="user_week",
                     window_start=user_weekly["window_start"],
                     window_end=user_weekly["reset_at"],
+                    amount_usd=amount,
+                )
+            )
+        user_monthly = limits["user_monthly"]
+        if user_monthly["limit_usd"] is not None:
+            counter_ids.append(
+                await self.usage_repository.reserve_counter(
+                    organization_id=organization_id,
+                    user_id=user_id,
+                    window_kind="user_month",
+                    window_start=user_monthly["window_start"],
+                    window_end=user_monthly["reset_at"],
                     amount_usd=amount,
                 )
             )
@@ -371,7 +384,7 @@ class UsageService:
             second=0,
             microsecond=0,
         )
-        org_limit_usd, user_limit_usd = await self._resolve_usage_limit_values(
+        limit_values = await self._resolve_usage_limit_values(
             organization_id=organization_id,
             user_id=user_id,
         )
@@ -390,38 +403,62 @@ class UsageService:
                 window_kind="org_month",
                 window_start=month_start,
             )
-        user_used = await self.usage_repository.get_system_cost(
+        user_weekly_used = await self.usage_repository.get_system_cost(
             organization_id=organization_id,
             user_id=user_id,
             start=week_start,
             end=now,
         )
-        user_reserved = await self.usage_repository.get_reserved_cost(
+        user_weekly_reserved = await self.usage_repository.get_reserved_cost(
             organization_id=organization_id,
             user_id=user_id,
             window_kind="user_week",
             window_start=week_start,
         )
+        user_monthly_used = await self.usage_repository.get_system_cost(
+            organization_id=organization_id,
+            user_id=user_id,
+            start=month_start,
+            end=now,
+        )
+        user_monthly_reserved = await self.usage_repository.get_reserved_cost(
+            organization_id=organization_id,
+            user_id=user_id,
+            window_kind="user_month",
+            window_start=month_start,
+        )
         org_scope = self._limit_scope(
-            limit_usd=org_limit_usd,
+            limit_usd=limit_values.org_monthly_limit_usd,
             used_usd=org_used,
             reserved_usd=org_reserved,
             reset_at=self._next_month_start(now),
             window_start=month_start,
         )
-        user_scope = self._limit_scope(
-            limit_usd=user_limit_usd,
-            used_usd=user_used,
-            reserved_usd=user_reserved,
+        user_weekly_scope = self._limit_scope(
+            limit_usd=limit_values.user_weekly_limit_usd,
+            used_usd=user_weekly_used,
+            reserved_usd=user_weekly_reserved,
             reset_at=week_start + timedelta(days=7),
             window_start=week_start,
+        )
+        user_monthly_scope = self._limit_scope(
+            limit_usd=limit_values.user_monthly_limit_usd,
+            used_usd=user_monthly_used,
+            reserved_usd=user_monthly_reserved,
+            reset_at=self._next_month_start(now),
+            window_start=month_start,
         )
         return {
             "organization_id": organization_id,
             "user_id": user_id,
             "org_monthly": org_scope,
-            "user_weekly": user_scope,
-            "allowed": bool(org_scope["allowed"] and user_scope["allowed"]),
+            "user_weekly": user_weekly_scope,
+            "user_monthly": user_monthly_scope,
+            "allowed": bool(
+                org_scope["allowed"]
+                and user_weekly_scope["allowed"]
+                and user_monthly_scope["allowed"]
+            ),
         }
 
     def _calculate_system_cost(
@@ -502,17 +539,32 @@ class UsageService:
         *,
         organization_id: UUID | None,
         user_id: UUID,
-    ) -> tuple[float | None, float | None]:
+    ) -> UsageLimitValues:
         # No external plan provider (e.g. no billing installed) -> built-in
         # defaults. A configured provider (billing) resolves plan-based limits.
         if self.usage_limit_port is None:
-            return (
-                self.DEFAULT_ORG_MONTHLY_COST_LIMIT_USD if organization_id else None,
-                self.DEFAULT_USER_WEEKLY_COST_LIMIT_USD,
+            return UsageLimitValues(
+                org_monthly_limit_usd=(
+                    self.DEFAULT_ORG_MONTHLY_COST_LIMIT_USD
+                    if organization_id
+                    else None
+                ),
+                user_weekly_limit_usd=self.DEFAULT_USER_WEEKLY_COST_LIMIT_USD,
+                user_monthly_limit_usd=self.DEFAULT_USER_MONTHLY_COST_LIMIT_USD,
             )
-        return await self.usage_limit_port.resolve_limits(
+        resolved = await self.usage_limit_port.resolve_limits(
             organization_id=organization_id,
             user_id=user_id,
+        )
+        if isinstance(resolved, UsageLimitValues):
+            return resolved
+        # Backwards-compatible guard for older tests/adapters returning
+        # ``(org_monthly, user_weekly)``.
+        org_monthly, user_weekly = resolved
+        return UsageLimitValues(
+            org_monthly_limit_usd=org_monthly,
+            user_weekly_limit_usd=user_weekly,
+            user_monthly_limit_usd=None,
         )
 
     def _limit_scope(

--- a/lemma-backend/app/modules/usage/tests/unit/test_usage_limits_fake_unit.py
+++ b/lemma-backend/app/modules/usage/tests/unit/test_usage_limits_fake_unit.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 import pytest
 
 from app.modules.test_support.fakes import FakeUnitOfWork
+from app.modules.usage.domain.ports import UsageLimitValues
 from app.modules.usage.services.usage_service import UsageService
 
 pytestmark = pytest.mark.unit
@@ -70,6 +71,30 @@ async def test_user_weekly_limit_blocks_when_exceeded():
     assert limits["user_weekly"]["remaining_usd"] == 0.0
 
 
+async def test_user_monthly_limit_blocks_when_exceeded():
+    class _MonthlyLimitPort:
+        async def resolve_limits(self, *, organization_id, user_id):
+            del organization_id, user_id
+            return UsageLimitValues(
+                org_monthly_limit_usd=None,
+                user_weekly_limit_usd=None,
+                user_monthly_limit_usd=10.0,
+            )
+
+    service = UsageService(
+        usage_repository=_StubUsageRepository(used_usd=12.0),
+        usage_limit_port=_MonthlyLimitPort(),
+    )
+
+    limits = await service.get_usage_limits(organization_id=None, user_id=uuid4())
+
+    assert limits["allowed"] is False
+    assert limits["user_weekly"]["allowed"] is True
+    assert limits["user_monthly"]["allowed"] is False
+    assert limits["user_monthly"]["limit_usd"] == 10.0
+    assert limits["user_monthly"]["remaining_usd"] == 0.0
+
+
 async def test_falls_back_to_builtin_defaults_without_billing():
     # No UsageLimitPort (the OSS build) -> usage's built-in default limits.
     service = UsageService(
@@ -83,3 +108,4 @@ async def test_falls_back_to_builtin_defaults_without_billing():
         limits["user_weekly"]["limit_usd"]
         == UsageService.DEFAULT_USER_WEEKLY_COST_LIMIT_USD
     )
+    assert limits["user_monthly"]["limit_usd"] is None


### PR DESCRIPTION
Summary:
- add a resolved usage limit value object with optional user monthly limits
- enforce and reserve user monthly spend windows alongside existing org monthly and user weekly windows
- expose user_monthly in the usage limits response

Tests:
- uv run pytest app/modules/usage/tests/unit/test_usage_limits_fake_unit.py