### PR TITLE
Fix agent surface prompt and onboarding edge cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,10 @@ jobs:
     needs: changes
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
     defaults:
       run:
         working-directory: lemma-backend
@@ -83,6 +87,65 @@ jobs:
         run: make test-unit
         env:
           REDIS_URL: redis://localhost:6379
+      - name: Agent surfaces unit coverage
+        run: make coverage-agent-surfaces-unit
+        env:
+          REDIS_URL: redis://localhost:6379
+      - name: Add agent surfaces coverage to job summary
+        if: always()
+        run: |
+          if [ -f coverage-agent-surfaces/comment.md ]; then
+            cat coverage-agent-surfaces/comment.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Upload agent surfaces unit coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-surfaces-unit-coverage
+          path: |
+            lemma-backend/coverage-agent-surfaces/comment.md
+            lemma-backend/coverage-agent-surfaces/summary.json
+            lemma-backend/coverage-agent-surfaces/coverage.json
+            lemma-backend/coverage-agent-surfaces/coverage.xml
+            lemma-backend/coverage-agent-surfaces/html
+          if-no-files-found: ignore
+      - name: Update PR agent surfaces coverage comment
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          hashFiles('lemma-backend/coverage-agent-surfaces/comment.md') != ''
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- lemma-agent-surfaces-coverage -->';
+            const body = fs.readFileSync('lemma-backend/coverage-agent-surfaces/comment.md', 'utf8');
+            const issue_number = context.payload.pull_request.number;
+            const {owner, repo} = context.repo;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
 
   backend-lint:
     name: lemma-backend async-safety lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: read
       issues: write
     defaults:
       run:
@@ -83,43 +83,39 @@ jobs:
           enable-cache: true
       - name: Sync deps
         run: uv sync
-      - name: Unit tests
-        run: make test-unit
+      - name: Unit tests with coverage
+        run: make coverage-backend-unit
         env:
           REDIS_URL: redis://localhost:6379
-      - name: Agent surfaces unit coverage
-        run: make coverage-agent-surfaces-unit
-        env:
-          REDIS_URL: redis://localhost:6379
-      - name: Add agent surfaces coverage to job summary
+      - name: Add backend coverage to job summary
         if: always()
         run: |
-          if [ -f coverage-agent-surfaces/comment.md ]; then
-            cat coverage-agent-surfaces/comment.md >> "$GITHUB_STEP_SUMMARY"
+          if [ -f coverage-backend/comment.md ]; then
+            cat coverage-backend/comment.md >> "$GITHUB_STEP_SUMMARY"
           fi
-      - name: Upload agent surfaces unit coverage
+      - name: Upload backend unit coverage
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: agent-surfaces-unit-coverage
+          name: backend-unit-coverage
           path: |
-            lemma-backend/coverage-agent-surfaces/comment.md
-            lemma-backend/coverage-agent-surfaces/summary.json
-            lemma-backend/coverage-agent-surfaces/coverage.json
-            lemma-backend/coverage-agent-surfaces/coverage.xml
-            lemma-backend/coverage-agent-surfaces/html
+            lemma-backend/coverage-backend/comment.md
+            lemma-backend/coverage-backend/summary.json
+            lemma-backend/coverage-backend/coverage.json
+            lemma-backend/coverage-backend/coverage.xml
+            lemma-backend/coverage-backend/html
           if-no-files-found: ignore
-      - name: Update PR agent surfaces coverage comment
+      - name: Update PR backend coverage comment
         if: >-
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
-          hashFiles('lemma-backend/coverage-agent-surfaces/comment.md') != ''
+          hashFiles('lemma-backend/coverage-backend/comment.md') != ''
         uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
-            const marker = '<!-- lemma-agent-surfaces-coverage -->';
-            const body = fs.readFileSync('lemma-backend/coverage-agent-surfaces/comment.md', 'utf8');
+            const marker = '<!-- lemma-backend-coverage:unit -->';
+            const body = fs.readFileSync('lemma-backend/coverage-backend/comment.md', 'utf8');
             const issue_number = context.payload.pull_request.number;
             const {owner, repo} = context.repo;
             try {
@@ -148,7 +144,7 @@ jobs:
                 });
               }
             } catch (error) {
-              core.warning(`Could not update agent surfaces coverage PR comment: ${error.message}`);
+              core.warning(`Could not update backend coverage PR comment: ${error.message}`);
             }
 
   backend-lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
     defaults:
       run:
@@ -122,29 +122,33 @@ jobs:
             const body = fs.readFileSync('lemma-backend/coverage-agent-surfaces/comment.md', 'utf8');
             const issue_number = context.payload.pull_request.number;
             const {owner, repo} = context.repo;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-            const existing = comments.find((comment) =>
-              comment.user?.type === 'Bot' && comment.body?.includes(marker)
-            );
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner,
                 repo,
                 issue_number,
-                body,
+                per_page: 100,
               });
+              const existing = comments.find((comment) =>
+                comment.user?.type === 'Bot' && comment.body?.includes(marker)
+              );
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body,
+                });
+              }
+            } catch (error) {
+              core.warning(`Could not update agent surfaces coverage PR comment: ${error.message}`);
             }
 
   backend-lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
     defaults:
       run:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
     strategy:
       # Run every shard even if one fails, so one red shard doesn't mask others.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: read
       issues: write
     strategy:
       # Run every shard even if one fails, so one red shard doesn't mask others.
@@ -53,26 +53,22 @@ jobs:
         # The fast suite is sharded across runners, each serial (E2E_WORKERS=1):
         # parallelism is across machines, not xdist workers within one machine —
         # which sidesteps the shared-container contention that makes -n2 flaky.
-        # Each shard runs `test-e2e-shard` scoped by E2E_ARGS; the union of all
-        # shard args equals the whole fast suite, with `rest` a catch-all via
-        # --ignore so a new module's e2e tests are never silently skipped.
+        # Each shard runs the normal fast e2e command under coverage, scoped by
+        # E2E_ARGS; the union of all shard args equals the whole fast suite, with
+        # `rest` a catch-all via --ignore so a new module's e2e tests are never
+        # silently skipped.
         # Shards are balanced by test count (~50-75 each); wall-clock ≈ the
         # slowest shard (~3min).
         suite:
           - name: surfaces
-            target: test-e2e-shard
             args: app/modules/agent_surfaces/tests/e2e
           - name: pod
-            target: test-e2e-shard
             args: app/modules/pod/tests/e2e
           - name: datastore
-            target: test-e2e-shard
             args: app/modules/datastore/tests/e2e app/modules/apps/tests/e2e
           - name: connectors
-            target: test-e2e-shard
             args: app/modules/connectors/tests/e2e app/modules/schedule/tests/e2e
           - name: rest
-            target: test-e2e-shard
             args: >-
               app/modules app/core
               --ignore=app/modules/agent_surfaces/tests/e2e
@@ -98,41 +94,42 @@ jobs:
       # Every shard runs serially (E2E_WORKERS=1) on its own runner; the shards
       # run in parallel, so the gate's wall-clock is the slowest shard, not their
       # sum. E2E_ARGS scopes each shard to its module paths.
-      - name: E2E tests (mocked LLM + fake AgentBox)
-        if: matrix.suite.name != 'surfaces'
-        run: make ${{ matrix.suite.target }} E2E_ARGS="${{ matrix.suite.args }}" E2E_WORKERS=1
-      - name: Agent surfaces combined coverage
-        if: matrix.suite.name == 'surfaces'
-        run: make coverage-agent-surfaces-combined E2E_WORKERS=1
-      - name: Add agent surfaces coverage to job summary
-        if: always() && matrix.suite.name == 'surfaces'
+      - name: E2E tests with coverage (mocked LLM + fake AgentBox)
+        run: >-
+          make coverage-backend-e2e-shard
+          E2E_ARGS="${{ matrix.suite.args }}"
+          E2E_WORKERS=1
+          COVERAGE_PHASE=e2e-${{ matrix.suite.name }}
+      - name: Add backend coverage to job summary
+        if: always()
         run: |
-          if [ -f coverage-agent-surfaces/comment.md ]; then
-            cat coverage-agent-surfaces/comment.md >> "$GITHUB_STEP_SUMMARY"
+          if [ -f coverage-backend/comment.md ]; then
+            cat coverage-backend/comment.md >> "$GITHUB_STEP_SUMMARY"
           fi
-      - name: Upload agent surfaces combined coverage
-        if: always() && matrix.suite.name == 'surfaces'
+      - name: Upload backend e2e coverage
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: agent-surfaces-combined-coverage
+          name: backend-e2e-${{ matrix.suite.name }}-coverage
           path: |
-            lemma-backend/coverage-agent-surfaces/comment.md
-            lemma-backend/coverage-agent-surfaces/summary.json
-            lemma-backend/coverage-agent-surfaces/coverage.json
-            lemma-backend/coverage-agent-surfaces/coverage.xml
-            lemma-backend/coverage-agent-surfaces/html
+            lemma-backend/coverage-backend/comment.md
+            lemma-backend/coverage-backend/summary.json
+            lemma-backend/coverage-backend/coverage.json
+            lemma-backend/coverage-backend/coverage.xml
+            lemma-backend/coverage-backend/html
           if-no-files-found: ignore
-      - name: Update PR agent surfaces coverage comment
+      - name: Update PR backend coverage comment
         if: >-
           github.event_name == 'workflow_run' &&
-          matrix.suite.name == 'surfaces' &&
-          hashFiles('lemma-backend/coverage-agent-surfaces/comment.md') != ''
+          hashFiles('lemma-backend/coverage-backend/comment.md') != ''
         uses: actions/github-script@v8
+        env:
+          COVERAGE_PHASE: e2e-${{ matrix.suite.name }}
         with:
           script: |
             const fs = require('fs');
-            const marker = '<!-- lemma-agent-surfaces-coverage -->';
-            const body = fs.readFileSync('lemma-backend/coverage-agent-surfaces/comment.md', 'utf8');
+            const marker = `<!-- lemma-backend-coverage:${process.env.COVERAGE_PHASE} -->`;
+            const body = fs.readFileSync('lemma-backend/coverage-backend/comment.md', 'utf8');
             const pullRequests = context.payload.workflow_run.pull_requests || [];
             const pr = pullRequests[0];
             if (!pr) {
@@ -176,7 +173,7 @@ jobs:
                 });
               }
             } catch (error) {
-              core.warning(`Could not update agent surfaces coverage PR comment: ${error.message}`);
+              core.warning(`Could not update backend coverage PR comment: ${error.message}`);
             }
 
   surface-live-smoke:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,6 +20,8 @@ name: Backend E2E (mocked)
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [labeled, synchronize, reopened]
   workflow_run:
     workflows: ["CI"]
     types: [completed]
@@ -40,6 +42,10 @@ jobs:
       (github.event.workflow_run.event == 'pull_request' &&
        github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: write
     strategy:
       # Run every shard even if one fails, so one red shard doesn't mask others.
       fail-fast: false
@@ -93,4 +99,102 @@ jobs:
       # run in parallel, so the gate's wall-clock is the slowest shard, not their
       # sum. E2E_ARGS scopes each shard to its module paths.
       - name: E2E tests (mocked LLM + fake AgentBox)
+        if: matrix.suite.name != 'surfaces'
         run: make ${{ matrix.suite.target }} E2E_ARGS="${{ matrix.suite.args }}" E2E_WORKERS=1
+      - name: Agent surfaces combined coverage
+        if: matrix.suite.name == 'surfaces'
+        run: make coverage-agent-surfaces-combined E2E_WORKERS=1
+      - name: Add agent surfaces coverage to job summary
+        if: always() && matrix.suite.name == 'surfaces'
+        run: |
+          if [ -f coverage-agent-surfaces/comment.md ]; then
+            cat coverage-agent-surfaces/comment.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Upload agent surfaces combined coverage
+        if: always() && matrix.suite.name == 'surfaces'
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-surfaces-combined-coverage
+          path: |
+            lemma-backend/coverage-agent-surfaces/comment.md
+            lemma-backend/coverage-agent-surfaces/summary.json
+            lemma-backend/coverage-agent-surfaces/coverage.json
+            lemma-backend/coverage-agent-surfaces/coverage.xml
+            lemma-backend/coverage-agent-surfaces/html
+          if-no-files-found: ignore
+      - name: Update PR agent surfaces coverage comment
+        if: >-
+          github.event_name == 'workflow_run' &&
+          matrix.suite.name == 'surfaces' &&
+          hashFiles('lemma-backend/coverage-agent-surfaces/comment.md') != ''
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- lemma-agent-surfaces-coverage -->';
+            const body = fs.readFileSync('lemma-backend/coverage-agent-surfaces/comment.md', 'utf8');
+            const pullRequests = context.payload.workflow_run.pull_requests || [];
+            const pr = pullRequests[0];
+            if (!pr) {
+              core.info('No PR is associated with this workflow_run; skipping coverage comment.');
+              return;
+            }
+            const {owner, repo} = context.repo;
+            const {data: pull} = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pr.number,
+            });
+            if (pull.head.repo.full_name !== `${owner}/${repo}`) {
+              core.info(`Skipping coverage comment for fork PR ${pull.head.repo.full_name}.`);
+              return;
+            }
+            const issue_number = pr.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+  surface-live-smoke:
+    name: agent surfaces live smoke
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'surface-live'))
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: lemma-backend
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Sync deps
+        run: uv sync
+      - name: Live provider smoke tests
+        run: uv run pytest app/modules/agent_surfaces/tests/e2e/test_surface_live_smoke_e2e.py -m surface_live -o timeout=120
+        env:
+          LEMMA_RUN_SURFACE_LIVE_E2E: "1"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: write
     strategy:
       # Run every shard even if one fails, so one red shard doesn't mask others.
@@ -150,29 +150,33 @@ jobs:
               return;
             }
             const issue_number = pr.number;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-            const existing = comments.find((comment) =>
-              comment.user?.type === 'Bot' && comment.body?.includes(marker)
-            );
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 owner,
                 repo,
                 issue_number,
-                body,
+                per_page: 100,
               });
+              const existing = comments.find((comment) =>
+                comment.user?.type === 'Bot' && comment.body?.includes(marker)
+              );
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number,
+                  body,
+                });
+              }
+            } catch (error) {
+              core.warning(`Could not update agent surfaces coverage PR comment: ${error.message}`);
             }
 
   surface-live-smoke:

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ htmlcov/
 coverage/
 coverage-agent-surfaces/
 coverage-backend/
+lemma-backend/coverage-agent-surfaces/
+lemma-backend/coverage-backend/
 lcov.info
 *.lcov
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ coverage-*.xml
 htmlcov/
 coverage/
 coverage-agent-surfaces/
+coverage-backend/
 lcov.info
 *.lcov
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ coverage.xml
 coverage-*.xml
 htmlcov/
 coverage/
+coverage-agent-surfaces/
 lcov.info
 *.lcov
 

--- a/lemma-backend/.coveragerc
+++ b/lemma-backend/.coveragerc
@@ -1,0 +1,24 @@
+[run]
+source = app/modules/agent_surfaces
+omit =
+    */tests/*
+parallel = true
+relative_files = true
+sigterm = true
+concurrency =
+    multiprocessing
+    thread
+
+[report]
+show_missing = true
+skip_covered = false
+sort = Cover
+
+[html]
+directory = coverage-agent-surfaces/html
+
+[xml]
+output = coverage-agent-surfaces/coverage.xml
+
+[json]
+output = coverage-agent-surfaces/coverage.json

--- a/lemma-backend/.coveragerc
+++ b/lemma-backend/.coveragerc
@@ -1,7 +1,9 @@
 [run]
-source = app/modules/agent_surfaces
+source = app
 omit =
     */tests/*
+    */test_*.py
+    */conftest.py
 parallel = true
 relative_files = true
 sigterm = true
@@ -15,10 +17,10 @@ skip_covered = false
 sort = Cover
 
 [html]
-directory = coverage-agent-surfaces/html
+directory = coverage-backend/html
 
 [xml]
-output = coverage-agent-surfaces/coverage.xml
+output = coverage-backend/coverage.xml
 
 [json]
-output = coverage-agent-surfaces/coverage.json
+output = coverage-backend/coverage.json

--- a/lemma-backend/Makefile
+++ b/lemma-backend/Makefile
@@ -27,12 +27,12 @@ MAX_USERS         ?= 100
 THINK_MS          ?= 500
 LEMMA_API_URL     ?= http://localhost:8000
 
-AGENT_SURFACES_COVERAGE_DIR ?= coverage-agent-surfaces
-AGENT_SURFACES_COVERAGE_FILE ?= $(CURDIR)/.coverage.agent-surfaces
-AGENT_SURFACES_COVERAGE_RUN_ENV = COVERAGE_PROCESS_START=$(CURDIR)/.coveragerc COVERAGE_FILE=$(AGENT_SURFACES_COVERAGE_FILE)
-AGENT_SURFACES_COVERAGE_DATA_ENV = COVERAGE_FILE=$(AGENT_SURFACES_COVERAGE_FILE)
+BACKEND_COVERAGE_DIR ?= coverage-backend
+BACKEND_COVERAGE_FILE ?= $(CURDIR)/.coverage.backend
+BACKEND_COVERAGE_RUN_ENV = COVERAGE_PROCESS_START=$(CURDIR)/.coveragerc COVERAGE_FILE=$(BACKEND_COVERAGE_FILE)
+BACKEND_COVERAGE_DATA_ENV = COVERAGE_FILE=$(BACKEND_COVERAGE_FILE)
 
-.PHONY: help test test-unit test-e2e test-e2e-real test-e2e-fast test-e2e-runtime test-module coverage coverage-unit coverage-e2e coverage-agent-surfaces-unit coverage-agent-surfaces-combined coverage-agent-surfaces-report test-collect lint migrate docker-build docker-build-cloud docker-build-arm64 docker-build-amd64 agentbox-build teams-manifest-zip load-test-build load-test-up load-test-migrate load-test-setup load-test-run load-test-sse load-test-journey load-test-monitor load-test-down load-test
+.PHONY: help test test-unit test-e2e test-e2e-real test-e2e-fast test-e2e-runtime test-module coverage coverage-unit coverage-e2e coverage-backend-unit coverage-backend-e2e-shard coverage-backend-report test-collect lint migrate docker-build docker-build-cloud docker-build-arm64 docker-build-amd64 agentbox-build teams-manifest-zip load-test-build load-test-up load-test-migrate load-test-setup load-test-run load-test-sse load-test-journey load-test-monitor load-test-down load-test
 
 help:
 	@echo "Lemma backend:"
@@ -45,8 +45,8 @@ help:
 	@echo "  make test-module MODULE=pod"
 	@echo "  make coverage-unit     # unit coverage"
 	@echo "  make coverage-e2e      # e2e coverage"
-	@echo "  make coverage-agent-surfaces-unit     # agent_surfaces unit coverage + markdown"
-	@echo "  make coverage-agent-surfaces-combined # agent_surfaces unit+mocked-e2e coverage + markdown"
+	@echo "  make coverage-backend-unit     # backend unit coverage + markdown"
+	@echo "  make coverage-backend-e2e-shard # backend e2e shard coverage + markdown"
 	@echo "  make lint              # run ruff checks"
 	@echo "  make migrate           # apply database migrations"
 	@echo "  make docker-build-cloud  # build the lemma-cloud image"
@@ -128,47 +128,42 @@ coverage-unit:
 coverage-e2e:
 	uv run pytest -m e2e --cov=app --cov-report=term-missing --cov-report=xml:coverage-e2e.xml
 
-coverage-agent-surfaces-unit:
-	@mkdir -p $(AGENT_SURFACES_COVERAGE_DIR)
-	$(AGENT_SURFACES_COVERAGE_DATA_ENV) uv run coverage erase
-	$(AGENT_SURFACES_COVERAGE_RUN_ENV) uv run coverage run --parallel-mode -m pytest \
-		app/modules/agent_surfaces/tests/unit \
-		--junitxml=$(AGENT_SURFACES_COVERAGE_DIR)/junit-unit.xml
-	$(MAKE) coverage-agent-surfaces-report COVERAGE_PHASE=unit
+coverage-backend-unit:
+	@mkdir -p $(BACKEND_COVERAGE_DIR)
+	@rm -f $(BACKEND_COVERAGE_DIR)/junit-*.xml $(BACKEND_COVERAGE_DIR)/comment.md $(BACKEND_COVERAGE_DIR)/summary.json $(BACKEND_COVERAGE_DIR)/coverage.json $(BACKEND_COVERAGE_DIR)/coverage.xml
+	$(BACKEND_COVERAGE_DATA_ENV) uv run coverage erase
+	$(BACKEND_COVERAGE_RUN_ENV) uv run coverage run --parallel-mode -m pytest \
+		-m "not e2e" \
+		--junitxml=$(BACKEND_COVERAGE_DIR)/junit-unit.xml
+	$(MAKE) coverage-backend-report COVERAGE_PHASE=unit
 
-coverage-agent-surfaces-combined:
-	@mkdir -p $(AGENT_SURFACES_COVERAGE_DIR)
-	$(AGENT_SURFACES_COVERAGE_DATA_ENV) uv run coverage erase
-	$(AGENT_SURFACES_COVERAGE_RUN_ENV) uv run coverage run --parallel-mode -m pytest \
-		app/modules/agent_surfaces/tests/unit \
-		--junitxml=$(AGENT_SURFACES_COVERAGE_DIR)/junit-unit.xml
-	$(AGENT_SURFACES_COVERAGE_RUN_ENV) uv run coverage run --parallel-mode -m pytest \
-		app/modules/agent_surfaces/tests/e2e \
+coverage-backend-e2e-shard:
+	@test -n "$(E2E_ARGS)" || (echo "E2E_ARGS is required" && exit 1)
+	@test -n "$(COVERAGE_PHASE)" || (echo "COVERAGE_PHASE is required, e.g. e2e-surfaces" && exit 1)
+	@mkdir -p $(BACKEND_COVERAGE_DIR)
+	@rm -f $(BACKEND_COVERAGE_DIR)/junit-*.xml $(BACKEND_COVERAGE_DIR)/comment.md $(BACKEND_COVERAGE_DIR)/summary.json $(BACKEND_COVERAGE_DIR)/coverage.json $(BACKEND_COVERAGE_DIR)/coverage.xml
+	$(BACKEND_COVERAGE_DATA_ENV) uv run coverage erase
+	$(BACKEND_COVERAGE_RUN_ENV) uv run coverage run --parallel-mode -m pytest \
+		$(E2E_PARALLEL) $(E2E_ARGS) \
 		-m "e2e and not slow and not worker and not workspace and not provider and not local_cli and not indexing" \
 		-o timeout=120 \
-		--junitxml=$(AGENT_SURFACES_COVERAGE_DIR)/junit-e2e.xml
-	# Keep real-worker surface coverage, but isolate it from the fast non-worker shard.
-	$(AGENT_SURFACES_COVERAGE_RUN_ENV) uv run coverage run --parallel-mode -m pytest \
-		app/modules/agent_surfaces/tests/e2e/test_full_real_surface_e2e.py \
-		-m e2e \
-		-o timeout=180 \
-		--junitxml=$(AGENT_SURFACES_COVERAGE_DIR)/junit-e2e-worker.xml
-	$(MAKE) coverage-agent-surfaces-report COVERAGE_PHASE=combined
+		--junitxml=$(BACKEND_COVERAGE_DIR)/junit-$(COVERAGE_PHASE).xml
+	$(MAKE) coverage-backend-report COVERAGE_PHASE=$(COVERAGE_PHASE)
 
-coverage-agent-surfaces-report:
-	@test -n "$(COVERAGE_PHASE)" || (echo "COVERAGE_PHASE is required: unit or combined" && exit 1)
-	@mkdir -p $(AGENT_SURFACES_COVERAGE_DIR)
-	$(AGENT_SURFACES_COVERAGE_DATA_ENV) uv run coverage combine
-	$(AGENT_SURFACES_COVERAGE_DATA_ENV) uv run coverage report --skip-covered --sort=cover
-	$(AGENT_SURFACES_COVERAGE_DATA_ENV) uv run coverage json -o $(AGENT_SURFACES_COVERAGE_DIR)/coverage.json
-	$(AGENT_SURFACES_COVERAGE_DATA_ENV) uv run coverage xml -o $(AGENT_SURFACES_COVERAGE_DIR)/coverage.xml
-	$(AGENT_SURFACES_COVERAGE_DATA_ENV) uv run coverage html -d $(AGENT_SURFACES_COVERAGE_DIR)/html
-	uv run python scripts/agent_surfaces_coverage_report.py \
+coverage-backend-report:
+	@test -n "$(COVERAGE_PHASE)" || (echo "COVERAGE_PHASE is required" && exit 1)
+	@mkdir -p $(BACKEND_COVERAGE_DIR)
+	$(BACKEND_COVERAGE_DATA_ENV) uv run coverage combine
+	$(BACKEND_COVERAGE_DATA_ENV) uv run coverage report --skip-covered --sort=cover
+	$(BACKEND_COVERAGE_DATA_ENV) uv run coverage json -o $(BACKEND_COVERAGE_DIR)/coverage.json
+	$(BACKEND_COVERAGE_DATA_ENV) uv run coverage xml -o $(BACKEND_COVERAGE_DIR)/coverage.xml
+	$(BACKEND_COVERAGE_DATA_ENV) uv run coverage html -d $(BACKEND_COVERAGE_DIR)/html
+	uv run python scripts/backend_coverage_report.py \
 		--phase $(COVERAGE_PHASE) \
-		--coverage-json $(AGENT_SURFACES_COVERAGE_DIR)/coverage.json \
-		--junit-glob "$(AGENT_SURFACES_COVERAGE_DIR)/junit-*.xml" \
-		--markdown-out $(AGENT_SURFACES_COVERAGE_DIR)/comment.md \
-		--summary-json-out $(AGENT_SURFACES_COVERAGE_DIR)/summary.json
+		--coverage-json $(BACKEND_COVERAGE_DIR)/coverage.json \
+		--junit-glob "$(BACKEND_COVERAGE_DIR)/junit-*.xml" \
+		--markdown-out $(BACKEND_COVERAGE_DIR)/comment.md \
+		--summary-json-out $(BACKEND_COVERAGE_DIR)/summary.json
 
 coverage-module:
 	@test -n "$(MODULE)" || (echo "MODULE is required, e.g. make coverage-module MODULE=agent" && exit 1)

--- a/lemma-backend/Makefile
+++ b/lemma-backend/Makefile
@@ -147,6 +147,12 @@ coverage-agent-surfaces-combined:
 		-m "e2e and not slow and not worker and not workspace and not provider and not local_cli and not indexing" \
 		-o timeout=120 \
 		--junitxml=$(AGENT_SURFACES_COVERAGE_DIR)/junit-e2e.xml
+	# Keep real-worker surface coverage, but isolate it from the fast non-worker shard.
+	$(AGENT_SURFACES_COVERAGE_RUN_ENV) uv run coverage run --parallel-mode -m pytest \
+		app/modules/agent_surfaces/tests/e2e/test_full_real_surface_e2e.py \
+		-m e2e \
+		-o timeout=180 \
+		--junitxml=$(AGENT_SURFACES_COVERAGE_DIR)/junit-e2e-worker.xml
 	$(MAKE) coverage-agent-surfaces-report COVERAGE_PHASE=combined
 
 coverage-agent-surfaces-report:

--- a/lemma-backend/Makefile
+++ b/lemma-backend/Makefile
@@ -27,7 +27,12 @@ MAX_USERS         ?= 100
 THINK_MS          ?= 500
 LEMMA_API_URL     ?= http://localhost:8000
 
-.PHONY: help test test-unit test-e2e test-e2e-real test-e2e-fast test-e2e-runtime test-module coverage coverage-unit coverage-e2e test-collect lint migrate docker-build docker-build-cloud docker-build-arm64 docker-build-amd64 agentbox-build teams-manifest-zip load-test-build load-test-up load-test-migrate load-test-setup load-test-run load-test-sse load-test-journey load-test-monitor load-test-down load-test
+AGENT_SURFACES_COVERAGE_DIR ?= coverage-agent-surfaces
+AGENT_SURFACES_COVERAGE_FILE ?= $(CURDIR)/.coverage.agent-surfaces
+AGENT_SURFACES_COVERAGE_RUN_ENV = COVERAGE_PROCESS_START=$(CURDIR)/.coveragerc COVERAGE_FILE=$(AGENT_SURFACES_COVERAGE_FILE)
+AGENT_SURFACES_COVERAGE_DATA_ENV = COVERAGE_FILE=$(AGENT_SURFACES_COVERAGE_FILE)
+
+.PHONY: help test test-unit test-e2e test-e2e-real test-e2e-fast test-e2e-runtime test-module coverage coverage-unit coverage-e2e coverage-agent-surfaces-unit coverage-agent-surfaces-combined coverage-agent-surfaces-report test-collect lint migrate docker-build docker-build-cloud docker-build-arm64 docker-build-amd64 agentbox-build teams-manifest-zip load-test-build load-test-up load-test-migrate load-test-setup load-test-run load-test-sse load-test-journey load-test-monitor load-test-down load-test
 
 help:
 	@echo "Lemma backend:"
@@ -40,6 +45,8 @@ help:
 	@echo "  make test-module MODULE=pod"
 	@echo "  make coverage-unit     # unit coverage"
 	@echo "  make coverage-e2e      # e2e coverage"
+	@echo "  make coverage-agent-surfaces-unit     # agent_surfaces unit coverage + markdown"
+	@echo "  make coverage-agent-surfaces-combined # agent_surfaces unit+mocked-e2e coverage + markdown"
 	@echo "  make lint              # run ruff checks"
 	@echo "  make migrate           # apply database migrations"
 	@echo "  make docker-build-cloud  # build the lemma-cloud image"
@@ -120,6 +127,42 @@ coverage-unit:
 
 coverage-e2e:
 	uv run pytest -m e2e --cov=app --cov-report=term-missing --cov-report=xml:coverage-e2e.xml
+
+coverage-agent-surfaces-unit:
+	@mkdir -p $(AGENT_SURFACES_COVERAGE_DIR)
+	$(AGENT_SURFACES_COVERAGE_DATA_ENV) uv run coverage erase
+	$(AGENT_SURFACES_COVERAGE_RUN_ENV) uv run coverage run --parallel-mode -m pytest \
+		app/modules/agent_surfaces/tests/unit \
+		--junitxml=$(AGENT_SURFACES_COVERAGE_DIR)/junit-unit.xml
+	$(MAKE) coverage-agent-surfaces-report COVERAGE_PHASE=unit
+
+coverage-agent-surfaces-combined:
+	@mkdir -p $(AGENT_SURFACES_COVERAGE_DIR)
+	$(AGENT_SURFACES_COVERAGE_DATA_ENV) uv run coverage erase
+	$(AGENT_SURFACES_COVERAGE_RUN_ENV) uv run coverage run --parallel-mode -m pytest \
+		app/modules/agent_surfaces/tests/unit \
+		--junitxml=$(AGENT_SURFACES_COVERAGE_DIR)/junit-unit.xml
+	$(AGENT_SURFACES_COVERAGE_RUN_ENV) uv run coverage run --parallel-mode -m pytest \
+		app/modules/agent_surfaces/tests/e2e \
+		-m "e2e and not slow and not worker and not workspace and not provider and not local_cli and not indexing" \
+		-o timeout=120 \
+		--junitxml=$(AGENT_SURFACES_COVERAGE_DIR)/junit-e2e.xml
+	$(MAKE) coverage-agent-surfaces-report COVERAGE_PHASE=combined
+
+coverage-agent-surfaces-report:
+	@test -n "$(COVERAGE_PHASE)" || (echo "COVERAGE_PHASE is required: unit or combined" && exit 1)
+	@mkdir -p $(AGENT_SURFACES_COVERAGE_DIR)
+	$(AGENT_SURFACES_COVERAGE_DATA_ENV) uv run coverage combine
+	$(AGENT_SURFACES_COVERAGE_DATA_ENV) uv run coverage report --skip-covered --sort=cover
+	$(AGENT_SURFACES_COVERAGE_DATA_ENV) uv run coverage json -o $(AGENT_SURFACES_COVERAGE_DIR)/coverage.json
+	$(AGENT_SURFACES_COVERAGE_DATA_ENV) uv run coverage xml -o $(AGENT_SURFACES_COVERAGE_DIR)/coverage.xml
+	$(AGENT_SURFACES_COVERAGE_DATA_ENV) uv run coverage html -d $(AGENT_SURFACES_COVERAGE_DIR)/html
+	uv run python scripts/agent_surfaces_coverage_report.py \
+		--phase $(COVERAGE_PHASE) \
+		--coverage-json $(AGENT_SURFACES_COVERAGE_DIR)/coverage.json \
+		--junit-glob "$(AGENT_SURFACES_COVERAGE_DIR)/junit-*.xml" \
+		--markdown-out $(AGENT_SURFACES_COVERAGE_DIR)/comment.md \
+		--summary-json-out $(AGENT_SURFACES_COVERAGE_DIR)/summary.json
 
 coverage-module:
 	@test -n "$(MODULE)" || (echo "MODULE is required, e.g. make coverage-module MODULE=agent" && exit 1)
@@ -248,4 +291,3 @@ load-test-down:
 load-test: load-test-build load-test-up load-test-migrate load-test-setup load-test-run
 	@echo ""
 	@echo "Done. Run 'make load-test-down' to remove containers and credentials."
-

--- a/lemma-backend/app/core/tests/unit/test_backend_coverage_report.py
+++ b/lemma-backend/app/core/tests/unit/test_backend_coverage_report.py
@@ -6,37 +6,37 @@ from pathlib import Path
 
 
 def _load_reporter():
-    script = (
-        Path(__file__).resolve().parents[5]
-        / "scripts"
-        / "agent_surfaces_coverage_report.py"
-    )
-    spec = importlib.util.spec_from_file_location(
-        "agent_surfaces_coverage_report", script
-    )
+    script = Path(__file__).resolve().parents[4] / "scripts" / "backend_coverage_report.py"
+    spec = importlib.util.spec_from_file_location("backend_coverage_report", script)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
 
-def test_coverage_report_groups_modules_platforms_and_escapes_markdown(tmp_path):
+def test_backend_coverage_report_groups_modules_and_escapes_markdown(tmp_path):
     reporter = _load_reporter()
     coverage = {
         "files": {
             "app/modules/agent_surfaces/services/ingress_service.py": {
                 "summary": {"num_statements": 10, "missing_lines": 2}
             },
-            "app/modules/agent_surfaces/platforms/teams/service.py": {
+            "app/modules/agent/runtime.py": {
                 "summary": {"num_statements": 20, "missing_lines": 10}
             },
-            "app/modules/agent_surfaces/platforms/slack/service.py": {
+            "app/core/web_search/search_client.py": {
                 "summary": {"num_statements": 5, "missing_lines": 0}
             },
-            "app/modules/agent_surfaces/root|odd.py": {
+            "app/standalone|odd.py": {
                 "summary": {"num_statements": 4, "missing_lines": 1}
             },
             "app/modules/agent_surfaces/tests/unit/test_ignored.py": {
+                "summary": {"num_statements": 99, "missing_lines": 99}
+            },
+            "app/core/test_ignored.py": {
+                "summary": {"num_statements": 99, "missing_lines": 99}
+            },
+            "app/modules/agent/conftest.py": {
                 "summary": {"num_statements": 99, "missing_lines": 99}
             },
         },
@@ -52,41 +52,47 @@ def test_coverage_report_groups_modules_platforms_and_escapes_markdown(tmp_path)
         '<testsuite tests="3" failures="0" errors="0" skipped="1" time="1.2" />'
     )
 
-    summary = reporter.build_summary(coverage, phase="combined", junit_paths=[junit])
+    summary = reporter.build_summary(coverage, phase="e2e-surfaces", junit_paths=[junit])
     markdown = reporter.render_markdown(summary)
 
-    assert summary["top_level"] == [
+    assert summary["modules"] == [
         {
-            "name": "platforms",
-            "statements": 25,
+            "name": "agent",
+            "statements": 20,
             "missing": 10,
-            "covered": 15,
-            "coverage": 60.0,
+            "covered": 10,
+            "coverage": 50.0,
         },
         {
-            "name": "root",
-            "statements": 4,
-            "missing": 1,
-            "covered": 3,
-            "coverage": 75.0,
-        },
-        {
-            "name": "services",
+            "name": "agent_surfaces",
             "statements": 10,
             "missing": 2,
             "covered": 8,
             "coverage": 80.0,
         },
+        {
+            "name": "core",
+            "statements": 5,
+            "missing": 0,
+            "covered": 5,
+            "coverage": 100.0,
+        },
+        {
+            "name": "standalone|odd.py",
+            "statements": 4,
+            "missing": 1,
+            "covered": 3,
+            "coverage": 75.0,
+        },
     ]
-    assert [row["name"] for row in summary["platforms"]] == ["slack", "teams"]
     assert summary["tests"]["tests"] == 3
     assert summary["tests"]["skipped"] == 1
-    assert "root\\|odd.py" in markdown
+    assert "standalone\\|odd.py" in markdown
     assert "66.7%" in markdown
-    assert reporter.COMMENT_MARKER in markdown
+    assert reporter.comment_marker("e2e-surfaces") in markdown
 
 
-def test_coverage_report_missing_artifact_fallback(tmp_path):
+def test_backend_coverage_report_missing_artifact_fallback():
     reporter = _load_reporter()
     summary = reporter.build_summary(None, phase="unit", junit_paths=[])
 
@@ -96,7 +102,7 @@ def test_coverage_report_missing_artifact_fallback(tmp_path):
     assert "Coverage artifact was not found" in markdown
 
 
-def test_coverage_report_cli_writes_markdown_and_summary(tmp_path):
+def test_backend_coverage_report_cli_writes_markdown_and_summary(tmp_path):
     reporter = _load_reporter()
     coverage_json = tmp_path / "coverage.json"
     coverage_json.write_text(
@@ -118,9 +124,6 @@ def test_coverage_report_cli_writes_markdown_and_summary(tmp_path):
     )
     markdown_out = tmp_path / "comment.md"
     summary_out = tmp_path / "summary.json"
-
-    code = reporter.main.__globals__["argparse"]  # prove module loaded normally
-    assert code is not None
 
     import subprocess
     import sys

--- a/lemma-backend/app/core/tests/unit/test_web_search.py
+++ b/lemma-backend/app/core/tests/unit/test_web_search.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from app.core.web_search.search_client import DuckDuckGoHTMLParser
+
+
+def test_duckduckgo_html_parser_extracts_snippet_after_url_block() -> None:
+    parser = DuckDuckGoHTMLParser()
+
+    parser.feed(
+        """
+        <div class="result__body">
+          <h2>
+            <a class="result__a"
+               href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fexample.com%2Fdocs">
+              Example <b>Docs</b>
+            </a>
+          </h2>
+          <div class="result__extras">extra metadata</div>
+          <a class="result__snippet">
+            Official <b>API</b> docs and guides.
+          </a>
+        </div>
+        """
+    )
+
+    assert parser.results == [
+        {
+            "title": "Example Docs",
+            "url": "https://example.com/docs",
+            "snippet": "Official API docs and guides.",
+        }
+    ]

--- a/lemma-backend/app/modules/agent/tests/e2e/test_agent_usage_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_agent_usage_e2e.py
@@ -14,6 +14,7 @@ from app.modules.agent.infrastructure.models import AgentRuntimeProfileModel
 from app.modules.agent.services.runtime_profile_service import _load_runtime_env
 from app.modules.agent.tests.e2e.system_lemma_helpers import (
     SYSTEM_LEMMA_SKIP_REASON,
+    system_lemma_env_overlay,
     system_lemma_api_key,
     system_lemma_available,
     system_lemma_default_model,
@@ -315,29 +316,35 @@ async def test_non_default_model_run_records_nonzero_cost(
     os.getenv("LEMMA_RUN_PROVIDER_E2E") != "1",
     reason="Set LEMMA_RUN_PROVIDER_E2E=1 to run real provider-backed e2e tests.",
 )
-async def test_agent_run_uses_user_added_fireworks_openai_compatible_profile(
+async def test_agent_run_uses_user_added_openai_compatible_profile(
     authenticated_client,
     fixed_test_org,
     worker,
     db_session,
-    monkeypatch,
 ):
     _ = worker
     _load_runtime_env()
-    fireworks_api_key = os.getenv("FIREWORKS_API_KEY")
-    if not fireworks_api_key:
-        pytest.skip("FIREWORKS_API_KEY is required for real Fireworks profile e2e.")
-    monkeypatch.delenv("FIREWORKS_API_KEY", raising=False)
+    provider_env = system_lemma_env_overlay()
+    api_key = system_lemma_api_key()
+    if not api_key:
+        pytest.skip(SYSTEM_LEMMA_SKIP_REASON)
+    base_url = provider_env.get("LEMMA_OPENAI_BASE_URL")
+    if not base_url:
+        pytest.skip("LEMMA_OPENAI_BASE_URL is required for provider profile e2e.")
+    model_names = system_lemma_model_names()
+    if not model_names:
+        pytest.skip("LEMMA_OPENAI_MODEL_NAMES is required for provider profile e2e.")
+    default_model = system_lemma_default_model()
     pod_id = await _create_test_pod(authenticated_client, fixed_test_org)
     create_profile = await authenticated_client.post(
         f"/organizations/{fixed_test_org['id']}/agent-runtime/profiles",
         json={
             "source": "OPENAI_COMPATIBLE",
-            "name": f"Fireworks Custom {uuid4().hex[:8]}",
-            "base_url": "https://api.fireworks.ai/inference/v1",
-            "api_key": fireworks_api_key,
-            "default_model_name": "accounts/fireworks/models/kimi-k2p6",
-            "model_names": ["accounts/fireworks/models/kimi-k2p6"],
+            "name": f"Custom System Lemma Compatible {uuid4().hex[:8]}",
+            "base_url": base_url,
+            "api_key": api_key,
+            "default_model_name": default_model,
+            "model_names": model_names,
         },
     )
     assert create_profile.status_code == 201, create_profile.text
@@ -353,12 +360,12 @@ async def test_agent_run_uses_user_added_fireworks_openai_compatible_profile(
     )
     assert stored_profile is not None
     assert stored_profile.credentials["_encrypted"] == "lemma-secret-v2"
-    assert fireworks_api_key not in str(stored_profile.credentials)
+    assert api_key not in str(stored_profile.credentials)
 
     create_agent = await authenticated_client.post(
         f"/pods/{pod_id}/agents",
         json={
-            "name": "Custom Fireworks Agent",
+            "name": "Custom Provider Agent",
             "instruction": "Answer briefly and directly.",
             "agent_runtime": {"profile_id": profile_id},
         },
@@ -367,7 +374,7 @@ async def test_agent_run_uses_user_added_fireworks_openai_compatible_profile(
 
     create_conversation = await authenticated_client.post(
         f"/pods/{pod_id}/conversations",
-        json={"agent_name": "custom_fireworks_agent", "title": "Custom Fireworks"},
+        json={"agent_name": "custom_provider_agent", "title": "Custom Provider"},
     )
     assert create_conversation.status_code == 201, create_conversation.text
     conversation_id = create_conversation.json()["id"]
@@ -375,7 +382,7 @@ async def test_agent_run_uses_user_added_fireworks_openai_compatible_profile(
     events = await _post_sse(
         authenticated_client,
         f"/pods/{pod_id}/conversations/{conversation_id}/messages",
-        {"content": "Say only: custom fireworks profile works."},
+        {"content": "Say only: custom provider profile works."},
     )
 
     assert events[-1]["type"] == "completed", events

--- a/lemma-backend/app/modules/agent/tests/e2e/test_web_search_providers_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_web_search_providers_e2e.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from app.core.config import settings
 from app.core.web_search.web_search import WebSearchRequest, search_web
 
-pytestmark = pytest.mark.e2e
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.provider,
+    pytest.mark.skipif(
+        os.getenv("LEMMA_RUN_PROVIDER_E2E") != "1",
+        reason="Set LEMMA_RUN_PROVIDER_E2E=1 to run live web-search provider e2e.",
+    ),
+]
 
 
 @pytest.mark.asyncio

--- a/lemma-backend/app/modules/agent/tests/e2e/test_widget_submit_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_widget_submit_e2e.py
@@ -61,7 +61,7 @@ async def _create_agent(authenticated_client, pod_id: str) -> dict:
         json={
             "name": f"Widget Agent {uuid4().hex[:8]}",
             "instruction": "Reply briefly.",
-            "agent_runtime": {"profile_id": "system:fireworks", "model_name": "kimi-k2.6"},
+            "agent_runtime": {"profile_id": "system:lemma"},
             "toolsets": [],
         },
     )

--- a/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/service.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/service.py
@@ -111,6 +111,14 @@ class WhatsAppPlatformService:
             event.reply_target.get("phone_number_id") or self._phone_number_id
         )
         sender_wa_id = event.reply_target.get("sender_wa_id") or event.sender_phone
+        if not sender_wa_id or not phone_number_id or not self._access_token:
+            logger.warning(
+                "WhatsApp send_message skipped due to missing token/phone/sender "
+                "phone_number_id=%s sender=%s",
+                phone_number_id,
+                sender_wa_id,
+            )
+            return
 
         url = f"{self._api_base}/{phone_number_id}/messages"
         payload = {

--- a/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/service.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/service.py
@@ -101,6 +101,39 @@ class WhatsAppPlatformService:
             display_name=event.sender_display_name,
         )
 
+    async def get_display_phone_number(self) -> str | None:
+        """Return the human-messageable WhatsApp number for this phone_number_id.
+
+        ``phone_number_id`` is Meta's opaque Graph id; users need the display
+        phone number in surfaces list UI. Prefer already-stored account
+        credential metadata, then resolve it through Graph best-effort.
+        """
+        for key in ("display_phone_number", "phone_number"):
+            value = str(self.credentials.get(key) or "").strip()
+            if value:
+                return value
+        if not self._access_token or not self._phone_number_id:
+            return None
+
+        url = f"{self._api_base}/{self._phone_number_id}"
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    url,
+                    params={"fields": "display_phone_number"},
+                    headers={"Authorization": f"Bearer {self._access_token}"},
+                )
+                response.raise_for_status()
+                body = response.json() or {}
+        except Exception as exc:
+            logger.debug(
+                "WhatsApp display phone lookup failed phone_number_id=%s: %s",
+                self._phone_number_id,
+                exc,
+            )
+            return None
+        return str(body.get("display_phone_number") or "").strip() or None
+
     async def send_message(
         self,
         event: ParsedInboundSurfaceEvent,

--- a/lemma-backend/app/modules/agent_surfaces/services/ingress_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/ingress_service.py
@@ -222,6 +222,21 @@ class AgentSurfaceIngressService:
                     platform,
                 )
                 return None
+        elif platform in {
+            SurfacePlatform.TELEGRAM.value,
+            SurfacePlatform.WHATSAPP.value,
+        }:
+            # Platform-wide webhooks are shared system credentials. Custom/bound
+            # bots must arrive with receiver_surface_ids (native receiver) or via
+            # a direct surface webhook; otherwise continuity for the same external
+            # user/thread can accidentally pull a system-bot message into a
+            # custom-bot conversation.
+            surfaces = [
+                surface
+                for surface in surfaces
+                if surface.account_id is None
+                and surface.credential_mode is SurfaceCredentialMode.SYSTEM
+            ]
 
         # Mention verification for Telegram groups: the parser records any
         # @username / text_mention entities but does NOT set mentioned_agent for

--- a/lemma-backend/app/modules/agent_surfaces/services/ingress_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/ingress_service.py
@@ -30,6 +30,7 @@ from app.modules.agent_surfaces.domain.entities import (
     ParsedSurfaceInteraction,
     ResolvedSurfaceUser,
     SurfaceChannelRoute,
+    SurfaceCredentialMode,
     SurfaceMode,
     SurfacePlatform,
 )
@@ -1525,6 +1526,30 @@ class AgentSurfaceIngressService:
             f"Request access here: {base}/pods/{pod_id}"
         )
 
+    def _ambiguous_system_surface_access_message(self) -> str:
+        return (
+            "You're signed up, but this shared bot can't determine which "
+            "workspace to connect you to. Ask a workspace admin to add you, or "
+            "open Lemma and choose the workspace there."
+        )
+
+    def _can_disclose_pod_access_link(self, surface: AgentSurfaceEntity) -> bool:
+        """Whether a non-member DM can safely receive a pod-specific link.
+
+        Shared system chat identities (Telegram/WhatsApp) can fan into many pod
+        surfaces. Sending a pod-specific URL to a signed-up non-member on those
+        shared identities can disclose an unrelated pod id. A custom/bound
+        account has a surface-specific credential, so its pod target is clear.
+        """
+        if surface.credential_mode is not SurfaceCredentialMode.SYSTEM:
+            return True
+        if surface.account_id is not None:
+            return True
+        return surface.surface_type not in {
+            SurfacePlatform.TELEGRAM,
+            SurfacePlatform.WHATSAPP,
+        }
+
     def _reply_context(
         self,
         *,
@@ -1679,16 +1704,21 @@ class AgentSurfaceIngressService:
                 resolved_user.internal_user_id,
                 surface.pod_id,
             )
-            # Signed up but not a pod member: on any DM surface, point them to the
-            # pod home page to request access (instead of dropping). Safe for both
-            # system bots and custom/personal bots — a custom bot's token maps to
-            # exactly one surface (one pod), so the join target is unambiguous.
+            # Signed up but not a pod member: on a pod-specific DM surface,
+            # point them to the pod home page to request access. Shared system
+            # Telegram/WhatsApp identities can front many pods, so they receive
+            # a generic message that does not disclose this pod id.
             if parsed.is_dm:
+                reply_message = (
+                    self._pod_access_message(surface.pod_id)
+                    if self._can_disclose_pod_access_link(surface)
+                    else self._ambiguous_system_surface_access_message()
+                )
                 return self._reply_context(
                     surface=surface,
                     parsed=parsed,
                     agent_display_name=fallback_agent_display_name,
-                    reply=(self._pod_access_message(surface.pod_id), {}),
+                    reply=(reply_message, {}),
                 )
             return None
         if not surface.config.identity.allows_email(resolved_user.email):

--- a/lemma-backend/app/modules/agent_surfaces/services/progress_observer.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/progress_observer.py
@@ -106,6 +106,7 @@ class SurfaceAgentRunProgressObserver:
         # Opaque handle for the live progress message on streaming platforms
         # (Telegram/Teams), threaded across edits and cleared on finish.
         self._progress_handle: dict[str, Any] | None = None
+        self._rendered_waiting_tool_calls: set[tuple[str, str]] = set()
 
     async def on_run_started(
         self,
@@ -186,6 +187,20 @@ class SurfaceAgentRunProgressObserver:
         kind = data.get("kind")
         if kind not in ("ask_user", "request_approval"):
             return
+        tool_call_id = str(data.get("tool_call_id") or "")
+        rendered_key: tuple[str, str] | None = None
+        if tool_call_id:
+            rendered_key = (str(kind), tool_call_id)
+            if rendered_key in self._rendered_waiting_tool_calls:
+                logger.info(
+                    "Surface %s render skipped because tool call was already "
+                    "rendered conversation=%s tool_call_id=%s",
+                    kind,
+                    conversation.id,
+                    tool_call_id,
+                )
+                return
+            self._rendered_waiting_tool_calls.add(rendered_key)
         await self._clear_progress(conversation.id)
         # Deliver buffered narration (the lead-in to the question) exactly once.
         if not self._final_delivered:
@@ -207,21 +222,22 @@ class SurfaceAgentRunProgressObserver:
                             conversation.id,
                             exc,
                         )
-        tool_call_id = data.get("tool_call_id")
         async with self.uow_factory() as uow:
             service = self.service_factory(uow)
             try:
                 if kind == "ask_user":
                     await service.send_questions_for_conversation(
                         conversation_id=conversation.id,
-                        tool_call_id=str(tool_call_id) if tool_call_id else None,
+                        tool_call_id=tool_call_id or None,
                     )
                 else:
                     await service.send_approval_prompt_for_conversation(
                         conversation_id=conversation.id,
-                        tool_call_id=str(tool_call_id) if tool_call_id else None,
+                        tool_call_id=tool_call_id or None,
                     )
             except Exception as exc:
+                if rendered_key is not None:
+                    self._rendered_waiting_tool_calls.discard(rendered_key)
                 logger.warning(
                     "Surface %s render failed conversation=%s error=%s",
                     kind,

--- a/lemma-backend/app/modules/agent_surfaces/services/surface_reach_resolver.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/surface_reach_resolver.py
@@ -92,6 +92,8 @@ class SurfaceReachResolver:
             coro = self._teams_handle(surface)
         elif surface.surface_type is SurfacePlatform.TELEGRAM:
             coro = self._telegram_handle(surface, credential_resolver)
+        elif surface.surface_type is SurfacePlatform.WHATSAPP:
+            coro = self._whatsapp_handle(surface, credential_resolver)
         else:
             return None
         try:
@@ -135,6 +137,20 @@ class SurfaceReachResolver:
         credentials = await credential_resolver.for_surface(surface)
         username = await TelegramPlatformService(credentials).get_bot_username()
         return f"@{username}" if username else None
+
+    async def _whatsapp_handle(
+        self,
+        surface: AgentSurfaceEntity,
+        credential_resolver: "SurfaceCredentialResolver | None",
+    ) -> str | None:
+        if credential_resolver is None:
+            return None
+        from app.modules.agent_surfaces.platforms.whatsapp.service import (
+            WhatsAppPlatformService,
+        )
+
+        credentials = await credential_resolver.for_surface(surface)
+        return await WhatsAppPlatformService(credentials).get_display_phone_number()
 
     async def _teams_handle(self, surface: AgentSurfaceEntity) -> str | None:
         app_id = surface_settings.microsoft_bot_app_id

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/conftest.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/conftest.py
@@ -21,8 +21,12 @@ from app.modules.agent_surfaces.tests.e2e.helpers import (
     fake_whatsapp,
     message_store,
 )
+from app.modules.agent.tests.e2e.system_lemma_helpers import (
+    skip_unless_system_lemma,
+    system_lemma_api_key,
+    system_lemma_env_overlay,
+)
 from app.modules.test_support.e2e import fixtures as e2e_fixtures
-from app.modules.test_support.e2e.runtime import _read_root_env_value
 
 # Re-export shared E2E fixtures so this module can run with --confcutdir.
 test_network = e2e_fixtures.test_network
@@ -43,24 +47,13 @@ db_session = e2e_fixtures.db_session
 scenario = e2e_fixtures.scenario
 
 
-def _fireworks_credential() -> str | None:
-    return (
-        os.getenv("FIREWORKS_API_KEY")
-        or _read_root_env_value("FIREWORKS_API_KEY")
-        or _read_root_env_value("lemma_openai_api_key")
-    )
-
-
 @pytest_asyncio.fixture(scope="function")
-async def fireworks_worker(e2e_settings):
-    """Production streaq worker subprocess wired to the Fireworks ``system:lemma``
-    runtime, sharing the test's Postgres/Redis.
+async def system_lemma_worker(e2e_settings):
+    """Production streaq worker subprocess wired to ``system:lemma``.
 
-    This is what makes surface e2e fully real: the in-process app publishes the
-    webhook event to Redis, this worker consumes it, runs the agent on Fireworks,
-    and the observer delivers the reply — nothing is simulated except the inbound
-    webhook payload and the external platform API (a local fake). Skips when no
-    Fireworks credential is configured.
+    Default e2e mode uses the deterministic FunctionModel token source. When
+    ``E2E_LLM_MODE=real`` is set, the existing system:lemma helper gates on the
+    configured LEMMA_OPENAI_* credentials.
     """
     import asyncio
 
@@ -68,21 +61,19 @@ async def fireworks_worker(e2e_settings):
 
     from app.core.config import settings
 
-    key = _fireworks_credential()
-    if not key:
-        pytest.skip(
-            "Fireworks credential unavailable; set FIREWORKS_API_KEY to run "
-            "fully-real surface agent e2e tests."
-        )
+    skip_unless_system_lemma()
+    env_overlay = system_lemma_env_overlay()
+    key = system_lemma_api_key()
 
     previous_setting = settings.lemma_openai_api_key
-    settings.lemma_openai_api_key = key
+    if key:
+        settings.lemma_openai_api_key = key
 
     redis_client = redis.from_url(e2e_settings.redis_url, decode_responses=False)
     await redis_client.flushdb()
     await redis_client.aclose()
 
-    log_path = f"/tmp/lemma_surface_worker_{uuid4().hex}.log"
+    log_path = f"/tmp/lemma_system_lemma_surface_worker_{uuid4().hex}.log"
     backend_root = Path(__file__).resolve().parents[5]
 
     def _read_log() -> str:
@@ -101,6 +92,7 @@ async def fireworks_worker(e2e_settings):
             cwd=str(backend_root),
             env={
                 **os.environ,
+                **env_overlay,
                 "PYTHONPATH": ".",
                 "PYTHONUNBUFFERED": "1",
                 "DATABASE_URL": e2e_settings.database_url,
@@ -118,8 +110,6 @@ async def fireworks_worker(e2e_settings):
                 "LOCAL_OBJECT_STORAGE_ROOT": e2e_settings.local_object_storage_root,
                 "LOCAL_FILE_STORAGE_ROOT": e2e_settings.local_file_storage_root,
                 "COMPOSIO_CACHE_DIR": "/tmp/composio",
-                "LEMMA_OPENAI_API_KEY": key,
-                "lemma_openai_api_key": key,
             },
             stdout=log_writer,
             stderr=subprocess.STDOUT,
@@ -198,7 +188,6 @@ __all__ = [
     "fake_teams",
     "fake_telegram",
     "fake_whatsapp",
-    "fireworks_worker",
     "fixed_test_org",
     "fixed_test_user",
     "message_store",
@@ -211,5 +200,6 @@ __all__ = [
     "test_network",
     "test_pod",
     "test_redis_url",
+    "system_lemma_worker",
     "worker",
 ]

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/conftest.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/conftest.py
@@ -64,6 +64,11 @@ async def system_lemma_worker(e2e_settings):
     skip_unless_system_lemma()
     env_overlay = system_lemma_env_overlay()
     key = system_lemma_api_key()
+    coverage_env = {
+        name: value
+        for name in ("COVERAGE_PROCESS_START", "COVERAGE_FILE")
+        if (value := os.environ.get(name))
+    }
 
     previous_setting = settings.lemma_openai_api_key
     if key:
@@ -93,6 +98,7 @@ async def system_lemma_worker(e2e_settings):
             env={
                 **os.environ,
                 **env_overlay,
+                **coverage_env,
                 "PYTHONPATH": ".",
                 "PYTHONUNBUFFERED": "1",
                 "DATABASE_URL": e2e_settings.database_url,

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/helpers.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/helpers.py
@@ -226,8 +226,7 @@ async def _create_agent(
             "name": name or f"Surface Agent {uuid4().hex[:8]}",
             "instruction": "Reply briefly. Surface e2e will emulate the model.",
             "agent_runtime": {
-                "profile_id": "system:fireworks",
-                "model_name": "kimi-k2.6",
+                "profile_id": "system:lemma",
             },
             "toolsets": toolsets if toolsets is not None else [],
         },
@@ -254,6 +253,8 @@ async def _create_surface(
         payload["name"] = name
     if config.get("account_id"):
         payload["account_id"] = config["account_id"]
+    if config.get("credential_mode"):
+        payload["credential_mode"] = config["credential_mode"]
     if allowed_channel_ids:
         payload["config"] = {
             "channels": [{"channel_id": allowed_channel_ids[0]}]

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/mock_infrastructure.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/mock_infrastructure.py
@@ -24,6 +24,20 @@ from app.core.log.log import get_logger
 logger = get_logger(__name__)
 
 
+def _request_contract(request: web.Request) -> dict[str, str]:
+    metadata = {
+        "_method": request.method,
+        "_path": str(request.rel_url),
+    }
+    authorization = request.headers.get("Authorization")
+    if authorization:
+        metadata["_authorization"] = authorization
+    content_type = request.headers.get("Content-Type")
+    if content_type:
+        metadata["_content_type"] = content_type
+    return metadata
+
+
 class MockPlatformMessageStore:
     """Thread-safe store for messages sent via mock platform servers."""
 
@@ -89,8 +103,8 @@ class FakeSlackServer:
     def base_url(self) -> str:
         return f"http://127.0.0.1:{self._port}/api/"
 
-    async def _collect_params(self, request: web.Request) -> dict[str, str]:
-        payload = dict(request.query)
+    async def _collect_params(self, request: web.Request) -> dict[str, Any]:
+        payload: dict[str, Any] = dict(request.query)
         if request.can_read_body:
             with suppress(Exception):
                 data = await request.json()
@@ -101,6 +115,7 @@ class FakeSlackServer:
             with suppress(Exception):
                 form = await request.post()
                 payload.update({k: str(v) for k, v in form.items()})
+        payload.update(_request_contract(request))
         return payload
 
     async def _users_info(self, request: web.Request) -> web.Response:
@@ -270,7 +285,9 @@ class FakeTeamsServer:
 
     async def _post_activity(self, request: web.Request) -> web.Response:
         body = await request.json()
-        self._store.add("TEAMS", {"path": str(request.rel_url), "body": body})
+        self._store.add(
+            "TEAMS", {"path": str(request.rel_url), "body": body, **_request_contract(request)}
+        )
         return web.json_response(
             {"id": f"activity-{len(self._store.get_all('TEAMS'))}"}
         )
@@ -283,6 +300,7 @@ class FakeTeamsServer:
                 "path": str(request.rel_url),
                 "activity_id": request.match_info["activity_id"],
                 "body": body,
+                **_request_contract(request),
             },
         )
         return web.json_response({"id": request.match_info["activity_id"]})
@@ -351,13 +369,14 @@ class FakeWhatsAppServer:
                 "phone_number_id": request.match_info["phone_number_id"],
                 "filename": getattr(uploaded, "filename", None),
                 "media_id": media_id,
+                **_request_contract(request),
             },
         )
         return web.json_response({"id": media_id})
 
     async def _send_message(self, request: web.Request) -> web.Response:
         body = await request.json()
-        self._store.add("WHATSAPP", body)
+        self._store.add("WHATSAPP", {**body, **_request_contract(request)})
         return web.json_response(
             {
                 "messaging_product": "whatsapp",
@@ -441,7 +460,7 @@ class FakeTelegramServer:
                 {"ok": False, "error_code": 400, "description": "Bad Request: message is too long"},
                 status=400,
             )
-        self._store.add("TELEGRAM", body)
+        self._store.add("TELEGRAM", {**body, **_request_contract(request)})
         return web.json_response(
             {
                 "ok": True,
@@ -458,7 +477,7 @@ class FakeTelegramServer:
         if failure is not None:
             return failure
         body = await request.json()
-        self._store.add("TELEGRAM_EDIT", body)
+        self._store.add("TELEGRAM_EDIT", {**body, **_request_contract(request)})
         return web.json_response(
             {
                 "ok": True,
@@ -481,6 +500,7 @@ class FakeTelegramServer:
                 "caption": str(form.get("caption")) if form.get("caption") else None,
                 "has_voice": voice is not None,
                 "voice_filename": getattr(voice, "filename", None),
+                **_request_contract(request),
             },
         )
         return web.json_response(
@@ -502,6 +522,7 @@ class FakeTelegramServer:
                 "chat_id": str(form.get("chat_id")) if form.get("chat_id") else None,
                 "caption": str(form.get("caption")) if form.get("caption") else None,
                 "filename": getattr(document, "filename", None),
+                **_request_contract(request),
             },
         )
         return web.json_response(
@@ -539,6 +560,7 @@ class FakeTelegramServer:
                 "method": "setWebhook",
                 "token": request.match_info["token"],
                 "body": body,
+                **_request_contract(request),
             },
         )
         return web.json_response({"ok": True, "result": True})
@@ -555,6 +577,7 @@ class FakeTelegramServer:
                 "method": "deleteWebhook",
                 "token": request.match_info["token"],
                 "body": body,
+                **_request_contract(request),
             },
         )
         return web.json_response({"ok": True, "result": True})
@@ -603,7 +626,7 @@ class FakeGmailServer:
 
     async def _send_message(self, request: web.Request) -> web.Response:
         body = await request.json()
-        self._store.add("GMAIL", body)
+        self._store.add("GMAIL", {**body, **_request_contract(request)})
         return web.json_response({"id": "gmail-message-1"})
 
 
@@ -637,7 +660,7 @@ class FakeResendServer:
 
     async def _send_email(self, request: web.Request) -> web.Response:
         body = await request.json()
-        self._store.add("RESEND", body)
+        self._store.add("RESEND", {**body, **_request_contract(request)})
         return web.json_response({"id": f"resend-message-{len(self._store.get_all('RESEND'))}"})
 
 
@@ -692,13 +715,13 @@ class FakeOutlookServer:
             return web.json_response({"error": {"message": "Not found"}}, status=404)
         self._store.add(
             "OUTLOOK_FETCH",
-            {"message_id": message_id, "query": dict(request.query)},
+            {"message_id": message_id, "query": dict(request.query), **_request_contract(request)},
         )
         return web.json_response(payload)
 
     async def _send_mail(self, request: web.Request) -> web.Response:
         body = await request.json()
-        self._store.add("OUTLOOK", body)
+        self._store.add("OUTLOOK", {**body, **_request_contract(request)})
         return web.Response(status=202)
 
     async def _reply(self, request: web.Request) -> web.Response:
@@ -708,6 +731,7 @@ class FakeOutlookServer:
             {
                 "message_id": request.match_info["message_id"],
                 "body": body,
+                **_request_contract(request),
             },
         )
         return web.Response(status=202)
@@ -719,6 +743,7 @@ class FakeOutlookServer:
             {
                 "source_message_id": request.match_info["message_id"],
                 "draft_id": draft_id,
+                **_request_contract(request),
             },
         )
         return web.json_response({"id": draft_id})
@@ -730,6 +755,7 @@ class FakeOutlookServer:
             {
                 "message_id": request.match_info["message_id"],
                 "body": body,
+                **_request_contract(request),
             },
         )
         return web.Response(status=200)
@@ -741,6 +767,7 @@ class FakeOutlookServer:
             {
                 "message_id": request.match_info["message_id"],
                 "body": body,
+                **_request_contract(request),
             },
         )
         return web.json_response(
@@ -750,7 +777,7 @@ class FakeOutlookServer:
     async def _send_draft(self, request: web.Request) -> web.Response:
         self._store.add(
             "OUTLOOK_DRAFT_SEND",
-            {"message_id": request.match_info["message_id"]},
+            {"message_id": request.match_info["message_id"], **_request_contract(request)},
         )
         return web.Response(status=202)
 

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_full_real_surface_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_full_real_surface_e2e.py
@@ -69,9 +69,10 @@ async def test_telegram_webhook_surface_registers_and_replies_with_real_agent(
     fixed_test_user,
     fake_telegram,
     message_store,
-    system_lemma_worker,
+    worker,
     monkeypatch,
 ):
+    _ = worker  # real streaq worker subprocess consuming surface events
     from app.core.config import settings as app_settings
 
     # Webhook registration requires a public HTTPS api_url; the worker reaches
@@ -143,9 +144,10 @@ async def test_telegram_webhook_multi_turn_reuses_conversation_with_real_agent(
     fixed_test_user,
     fake_telegram,
     message_store,
-    system_lemma_worker,
+    worker,
     monkeypatch,
 ):
+    _ = worker  # real streaq worker subprocess consuming surface events
     from app.core.config import settings as app_settings
 
     monkeypatch.setattr(app_settings, "api_url", "https://surface-e2e.test")

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_full_real_surface_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_full_real_surface_e2e.py
@@ -1,19 +1,18 @@
-"""Fully-real agent surface e2e — real worker + real Fireworks agent.
+"""Full surface agent e2e — real worker + system:lemma runtime.
 
 Nothing is simulated except the inbound webhook payload (POSTed to the real,
 auth-excluded webhook endpoint) and the external platform's HTTP API (a local
 fake server that captures what the agent sends back — we cannot call the real
-Telegram Bot API from a test). The agent runs for real on Fireworks
-(``system:lemma``) inside the production streaq worker subprocess, and the full
-path is exercised: webhook → Redis → worker subscriber → agent run → progress
-observer → adapter → outbound delivery.
+Telegram Bot API from a test). The production streaq worker subprocess runs the
+agent through ``system:lemma``: deterministic FunctionModel by default, or the
+real configured provider only when ``E2E_LLM_MODE=real`` is requested.
 
 Run:
 
-    LEMMA_RUN_PROVIDER_E2E=1 uv run pytest \
+    uv run pytest \
         app/modules/agent_surfaces/tests/e2e/test_full_real_surface_e2e.py -m e2e
 
-Skips automatically when the Fireworks credential is absent.
+In real-LLM mode it skips automatically when system:lemma credentials are absent.
 """
 
 from __future__ import annotations
@@ -26,6 +25,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.crypto import get_secret_cipher
 from app.modules.agent_surfaces.infrastructure.models import AgentSurface
 from app.modules.agent_surfaces.tests.e2e.helpers import (
     _conversation_by_external_thread,
@@ -39,13 +39,13 @@ from app.modules.agent_surfaces.tests.e2e.mock_infrastructure import (
     wait_for_messages,
 )
 
-pytestmark = [pytest.mark.e2e, pytest.mark.provider]
+pytestmark = pytest.mark.e2e
 
-# Real Fireworks call + worker round-trip — give it room.
+# Worker + queued run round-trip. Real-LLM mode can be slower, so keep room.
 REAL_REPLY_TIMEOUT = 180.0
 
 
-async def _create_real_agent(client: AsyncClient, pod_id: str) -> str:
+async def _create_system_lemma_agent(client: AsyncClient, pod_id: str) -> str:
     response = await client.post(
         f"/pods/{pod_id}/agents",
         json={
@@ -69,7 +69,7 @@ async def test_telegram_webhook_surface_registers_and_replies_with_real_agent(
     fixed_test_user,
     fake_telegram,
     message_store,
-    fireworks_worker,
+    system_lemma_worker,
     monkeypatch,
 ):
     from app.core.config import settings as app_settings
@@ -92,7 +92,7 @@ async def test_telegram_webhook_surface_registers_and_replies_with_real_agent(
         },
     )
 
-    agent_name = await _create_real_agent(authenticated_client, pod_id)
+    agent_name = await _create_system_lemma_agent(authenticated_client, pod_id)
     surface = await _create_surface(
         authenticated_client,
         pod_id,
@@ -116,7 +116,7 @@ async def test_telegram_webhook_surface_registers_and_replies_with_real_agent(
 
     surface_row = await db_session.get(AgentSurface, UUID(surface_id))
     assert surface_row is not None and surface_row.webhook_secret
-    secret = surface_row.webhook_secret
+    secret = get_secret_cipher().decrypt_str(surface_row.webhook_secret)
 
     payload = _telegram_payload(text="Hi there!", message_id=1, sender_id=sender_id)
     response = await authenticated_client.post(
@@ -126,8 +126,8 @@ async def test_telegram_webhook_surface_registers_and_replies_with_real_agent(
     )
     assert response.status_code == 200, response.text
 
-    # The real agent ran on Fireworks and the observer delivered one reply to
-    # the (fake) Telegram API for the right chat.
+    # The worker ran the agent and the observer delivered one reply to the
+    # fake Telegram API for the right chat.
     messages = await wait_for_messages(
         message_store, "TELEGRAM", min_count=1, timeout_seconds=REAL_REPLY_TIMEOUT
     )
@@ -143,7 +143,7 @@ async def test_telegram_webhook_multi_turn_reuses_conversation_with_real_agent(
     fixed_test_user,
     fake_telegram,
     message_store,
-    fireworks_worker,
+    system_lemma_worker,
     monkeypatch,
 ):
     from app.core.config import settings as app_settings
@@ -162,7 +162,7 @@ async def test_telegram_webhook_multi_turn_reuses_conversation_with_real_agent(
             "api_base_url": f"{fake_telegram.api_base}/bot",
         },
     )
-    agent_name = await _create_real_agent(authenticated_client, pod_id)
+    agent_name = await _create_system_lemma_agent(authenticated_client, pod_id)
     surface = await _create_surface(
         authenticated_client,
         pod_id,
@@ -178,7 +178,8 @@ async def test_telegram_webhook_multi_turn_reuses_conversation_with_real_agent(
         resolved_user_id=UUID(fixed_test_user["id"]),
     )
     surface_row = await db_session.get(AgentSurface, UUID(surface_id))
-    secret = surface_row.webhook_secret
+    assert surface_row is not None and surface_row.webhook_secret
+    secret = get_secret_cipher().decrypt_str(surface_row.webhook_secret)
 
     async def _send(text: str, message_id: int) -> None:
         payload = _telegram_payload(text=text, message_id=message_id, sender_id=sender_id)

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_multi_pod_resolution_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_multi_pod_resolution_e2e.py
@@ -21,7 +21,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
 from app.modules.agent_surfaces.config import surface_settings
-from app.modules.agent_surfaces.domain.ingress_context import SurfaceChatContext
+from app.modules.agent_surfaces.domain.ingress_context import (
+    SurfaceChatContext,
+    SurfaceReplyContext,
+)
 from app.modules.agent_surfaces.domain.ingress_request import (
     SurfacePlatformWebhookIngress,
 )
@@ -29,12 +32,20 @@ from app.modules.agent_surfaces.events.handlers import build_surface_event_handl
 from app.modules.agent_surfaces.tests.e2e.helpers import (
     _conversation_by_external_thread,
     _create_surface,
+    _ensure_connector_account,
     _seed_external_user,
     _telegram_payload,
+    _whatsapp_payload,
 )
 from app.modules.test_support.e2e.builders import E2EScenario
+from app.modules.test_support.e2e_authz import auth_headers
 
 pytestmark = pytest.mark.e2e
+
+SYSTEM_WHATSAPP_PHONE_NUMBER_ID = "1234567890"
+SYSTEM_WHATSAPP_WABA_ID = "waba-routing-system"
+CUSTOM_WHATSAPP_PHONE_NUMBER_ID = "10987654321"
+CUSTOM_WHATSAPP_WABA_ID = "waba-routing-custom"
 
 
 async def _prepare_telegram_dm(db_session: AsyncSession, payload: dict):
@@ -46,6 +57,136 @@ async def _prepare_telegram_dm(db_session: AsyncSession, payload: dict):
     )
     await uow.commit()
     return context
+
+
+def _wire_shared_platform(monkeypatch, platform: str) -> None:
+    if platform == "TELEGRAM":
+        monkeypatch.setattr(surface_settings, "telegram_bot_token", "shared-native-bot")
+        monkeypatch.setattr(surface_settings, "enable_telegram_polling_mode", True)
+        return
+    monkeypatch.setattr(surface_settings, "whatsapp_access_token", "wa-token")
+    monkeypatch.setattr(
+        surface_settings, "whatsapp_phone_number_id", SYSTEM_WHATSAPP_PHONE_NUMBER_ID
+    )
+    monkeypatch.setattr(surface_settings, "whatsapp_waba_id", SYSTEM_WHATSAPP_WABA_ID)
+    monkeypatch.setattr(surface_settings, "whatsapp_app_secret", "wa-secret")
+
+
+def _external_id(platform: str, suffix: int) -> str:
+    if platform == "TELEGRAM":
+        return str(910000000 + suffix)
+    return f"1555{suffix:07d}"
+
+
+def _thread_id(platform: str, external_id: str, *, phone_number_id: str | None = None) -> str:
+    if platform == "TELEGRAM":
+        return external_id
+    return f"{external_id}@{phone_number_id or SYSTEM_WHATSAPP_PHONE_NUMBER_ID}"
+
+
+def _dm_payload(
+    platform: str,
+    *,
+    external_id: str,
+    text: str,
+    message_id: int,
+    phone_number_id: str | None = None,
+    waba_id: str | None = None,
+) -> dict:
+    if platform == "TELEGRAM":
+        return _telegram_payload(
+            text=text,
+            message_id=message_id,
+            sender_id=int(external_id),
+        )
+    return _whatsapp_payload(
+        text=text,
+        message_id=f"wamid-routing-{message_id}-{external_id}",
+        phone_number_id=phone_number_id or SYSTEM_WHATSAPP_PHONE_NUMBER_ID,
+        waba_id=waba_id or SYSTEM_WHATSAPP_WABA_ID,
+        sender_phone=external_id,
+    )
+
+
+async def _prepare_platform_dm(
+    db_session: AsyncSession,
+    platform: str,
+    payload: dict,
+    *,
+    receiver_surface_ids: list[UUID] | None = None,
+):
+    uow = SqlAlchemyUnitOfWork(db_session)
+    handler = build_surface_event_handler(uow)
+    context = await handler.prepare_ingress(
+        SurfacePlatformWebhookIngress(
+            source=platform.lower(),
+            payload=payload,
+            receiver_surface_ids=receiver_surface_ids,
+        )
+    )
+    await uow.commit()
+    return context
+
+
+async def _seed_platform_user(
+    db_session: AsyncSession,
+    *,
+    platform: str,
+    external_id: str,
+    user_id: str,
+    tenant_id: str | None = None,
+) -> None:
+    await _seed_external_user(
+        db_session,
+        platform=platform,
+        external_user_id=external_id,
+        resolved_user_id=UUID(user_id),
+        tenant_id=tenant_id if platform == "WHATSAPP" else None,
+    )
+
+
+async def _two_orgs_with_system_surfaces(
+    authenticated_client: AsyncClient,
+    async_client: AsyncClient,
+    owner_user: dict,
+    *,
+    platform: str,
+):
+    org_a = E2EScenario(
+        owner_client=authenticated_client,
+        async_client=async_client,
+        owner_user=owner_user,
+    )
+    await org_a.create_org_with_pod(name_prefix=f"{platform}MultiPodA")
+    org_b = E2EScenario(
+        owner_client=authenticated_client,
+        async_client=async_client,
+        owner_user=owner_user,
+    )
+    await org_b.create_org_with_pod(name_prefix=f"{platform}MultiPodB")
+
+    surface_a = await _create_surface(
+        authenticated_client, org_a.pod_id, config={"type": platform}
+    )
+    surface_b = await _create_surface(
+        authenticated_client, org_b.pod_id, config={"type": platform}
+    )
+    return org_a, org_b, surface_a, surface_b
+
+
+async def _set_user_default_surface(
+    async_client: AsyncClient,
+    *,
+    user: dict,
+    platform: str,
+    surface_id: str,
+) -> None:
+    put = await async_client.put(
+        "/surfaces/me/default",
+        json={"platform": platform, "surface_id": surface_id},
+        headers=auth_headers(user),
+    )
+    assert put.status_code == 200, put.text
 
 
 async def _two_orgs_with_telegram_surfaces(
@@ -158,3 +299,355 @@ async def test_shared_bot_routes_to_user_default_surface(
     assert isinstance(ctx, SurfaceChatContext)
     assert ctx.surface_id == UUID(surface_b["id"])
     assert str(ctx.pod_id) == org_b.pod_id
+
+
+@pytest.mark.parametrize("platform", ["TELEGRAM", "WHATSAPP"])
+async def test_shared_system_bot_multi_user_routing_matrix(
+    authenticated_client: AsyncClient,
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    fixed_test_user,
+    monkeypatch,
+    platform: str,
+):
+    """Five signed-up users per platform exercise the shared system-bot matrix.
+
+    Parameterized over Telegram and WhatsApp, this gives the 10-user shared
+    surface scenario: single-pod member, default, deterministic tiebreak,
+    continuity, duplicate delivery, and signed-up non-member no-leak behavior.
+    """
+    from app.core.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "api_url", "https://api.example.test")
+    _wire_shared_platform(monkeypatch, platform)
+    org_a, org_b, surface_a, surface_b = await _two_orgs_with_system_surfaces(
+        authenticated_client,
+        async_client,
+        fixed_test_user,
+        platform=platform,
+    )
+    tenant_id = SYSTEM_WHATSAPP_WABA_ID if platform == "WHATSAPP" else None
+
+    single_user = await org_a.create_user(f"{platform.lower()}-single")
+    await org_a.add_user_to_pod(user=single_user, role="POD_EDITOR")
+    single_external = _external_id(platform, 1)
+    await _seed_platform_user(
+        db_session,
+        platform=platform,
+        external_id=single_external,
+        user_id=single_user["id"],
+        tenant_id=tenant_id,
+    )
+    single_ctx = await _prepare_platform_dm(
+        db_session,
+        platform,
+        _dm_payload(
+            platform,
+            external_id=single_external,
+            text="single pod",
+            message_id=101,
+        ),
+    )
+    assert isinstance(single_ctx, SurfaceChatContext)
+    assert single_ctx.surface_id == UUID(surface_a["id"])
+    assert str(single_ctx.pod_id) == org_a.pod_id
+
+    default_user = await org_a.create_user(f"{platform.lower()}-default")
+    await org_a.add_user_to_pod(user=default_user, role="POD_EDITOR")
+    await org_b.add_user_to_pod(user=default_user, role="POD_EDITOR")
+    await _set_user_default_surface(
+        async_client,
+        user=default_user,
+        platform=platform,
+        surface_id=surface_b["id"],
+    )
+    default_external = _external_id(platform, 2)
+    await _seed_platform_user(
+        db_session,
+        platform=platform,
+        external_id=default_external,
+        user_id=default_user["id"],
+        tenant_id=tenant_id,
+    )
+    default_ctx = await _prepare_platform_dm(
+        db_session,
+        platform,
+        _dm_payload(
+            platform,
+            external_id=default_external,
+            text="use my default",
+            message_id=102,
+        ),
+    )
+    assert isinstance(default_ctx, SurfaceChatContext)
+    assert default_ctx.surface_id == UUID(surface_b["id"])
+    assert str(default_ctx.pod_id) == org_b.pod_id
+
+    tiebreak_user = await org_a.create_user(f"{platform.lower()}-tiebreak")
+    await org_a.add_user_to_pod(user=tiebreak_user, role="POD_EDITOR")
+    await org_b.add_user_to_pod(user=tiebreak_user, role="POD_EDITOR")
+    tiebreak_external = _external_id(platform, 3)
+    await _seed_platform_user(
+        db_session,
+        platform=platform,
+        external_id=tiebreak_external,
+        user_id=tiebreak_user["id"],
+        tenant_id=tenant_id,
+    )
+    tiebreak_ctx = await _prepare_platform_dm(
+        db_session,
+        platform,
+        _dm_payload(
+            platform,
+            external_id=tiebreak_external,
+            text="no default set",
+            message_id=103,
+        ),
+    )
+    assert isinstance(tiebreak_ctx, SurfaceChatContext)
+    assert tiebreak_ctx.surface_id == UUID(surface_a["id"])
+    assert str(tiebreak_ctx.pod_id) == org_a.pod_id
+
+    continuity_user = await org_a.create_user(f"{platform.lower()}-continuity")
+    await org_a.add_user_to_pod(user=continuity_user, role="POD_EDITOR")
+    await org_b.add_user_to_pod(user=continuity_user, role="POD_EDITOR")
+    continuity_external = _external_id(platform, 4)
+    await _seed_platform_user(
+        db_session,
+        platform=platform,
+        external_id=continuity_external,
+        user_id=continuity_user["id"],
+        tenant_id=tenant_id,
+    )
+    continuity_first = await _prepare_platform_dm(
+        db_session,
+        platform,
+        _dm_payload(
+            platform,
+            external_id=continuity_external,
+            text="start a thread",
+            message_id=104,
+        ),
+    )
+    assert isinstance(continuity_first, SurfaceChatContext)
+    opposite_surface = (
+        surface_b
+        if continuity_first.surface_id == UUID(surface_a["id"])
+        else surface_a
+    )
+    await _set_user_default_surface(
+        async_client,
+        user=continuity_user,
+        platform=platform,
+        surface_id=opposite_surface["id"],
+    )
+    continuity_second = await _prepare_platform_dm(
+        db_session,
+        platform,
+        _dm_payload(
+            platform,
+            external_id=continuity_external,
+            text="same thread wins",
+            message_id=105,
+        ),
+    )
+    assert isinstance(continuity_second, SurfaceChatContext)
+    assert continuity_second.surface_id == continuity_first.surface_id
+    assert continuity_second.conversation_id == continuity_first.conversation_id
+
+    duplicate_user = await org_a.create_user(f"{platform.lower()}-duplicate")
+    await org_a.add_user_to_pod(user=duplicate_user, role="POD_EDITOR")
+    duplicate_external = _external_id(platform, 5)
+    await _seed_platform_user(
+        db_session,
+        platform=platform,
+        external_id=duplicate_external,
+        user_id=duplicate_user["id"],
+        tenant_id=tenant_id,
+    )
+    duplicate_payload = _dm_payload(
+        platform,
+        external_id=duplicate_external,
+        text="deliver once",
+        message_id=106,
+    )
+    duplicate_first = await _prepare_platform_dm(
+        db_session, platform, duplicate_payload
+    )
+    duplicate_second = await _prepare_platform_dm(
+        db_session, platform, duplicate_payload
+    )
+    assert isinstance(duplicate_first, SurfaceChatContext)
+    assert duplicate_second is None
+
+    non_member = await org_a.create_user(f"{platform.lower()}-nonmember")
+    non_member_external = _external_id(platform, 6)
+    await _seed_platform_user(
+        db_session,
+        platform=platform,
+        external_id=non_member_external,
+        user_id=non_member["id"],
+        tenant_id=tenant_id,
+    )
+    non_member_ctx = await _prepare_platform_dm(
+        db_session,
+        platform,
+        _dm_payload(
+            platform,
+            external_id=non_member_external,
+            text="where do I go?",
+            message_id=107,
+        ),
+    )
+    if non_member_ctx is not None:
+        assert isinstance(non_member_ctx, SurfaceReplyContext)
+        message = non_member_ctx.reply_message or ""
+        assert f"/pods/{org_a.pod_id}" not in message
+        assert f"/pods/{org_b.pod_id}" not in message
+
+
+@pytest.mark.parametrize("platform", ["TELEGRAM", "WHATSAPP"])
+async def test_custom_bot_scope_and_system_bot_threads_do_not_cross(
+    authenticated_client: AsyncClient,
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    test_pod,
+    fixed_test_user,
+    monkeypatch,
+    platform: str,
+):
+    from app.core.config import settings as app_settings
+    from app.modules.test_support.e2e_authz import signup_user
+
+    monkeypatch.setattr(app_settings, "api_url", "https://api.example.test")
+    _wire_shared_platform(monkeypatch, platform)
+
+    pod_id = test_pod["id"]
+    system_surface = await _create_surface(
+        authenticated_client,
+        pod_id,
+        config={"type": platform},
+        name=f"{platform.lower()}-system",
+    )
+    connector_id = platform.lower()
+    credentials = (
+        {"bot_token": f"custom-{platform.lower()}-bot"}
+        if platform == "TELEGRAM"
+        else {
+            "access_token": "custom-wa-token",
+            "phone_number_id": CUSTOM_WHATSAPP_PHONE_NUMBER_ID,
+            "waba_id": CUSTOM_WHATSAPP_WABA_ID,
+        }
+    )
+    account = await _ensure_connector_account(
+        db_session,
+        user_id=fixed_test_user["id"],
+        connector_id=connector_id,
+        credentials=credentials,
+    )
+    custom_surface = await _create_surface(
+        authenticated_client,
+        pod_id,
+        config={
+            "type": platform,
+            "account_id": str(account.id),
+            "credential_mode": "CUSTOM",
+        },
+        name=f"{platform.lower()}-custom",
+    )
+    custom_surface_id = UUID(custom_surface["id"])
+
+    member_external = _external_id(platform, 701)
+    await _seed_platform_user(
+        db_session,
+        platform=platform,
+        external_id=member_external,
+        user_id=fixed_test_user["id"],
+        tenant_id=CUSTOM_WHATSAPP_WABA_ID if platform == "WHATSAPP" else None,
+    )
+    if platform == "WHATSAPP":
+        await _seed_platform_user(
+            db_session,
+            platform=platform,
+            external_id=member_external,
+            user_id=fixed_test_user["id"],
+            tenant_id=SYSTEM_WHATSAPP_WABA_ID,
+        )
+
+    custom_ctx = await _prepare_platform_dm(
+        db_session,
+        platform,
+        _dm_payload(
+            platform,
+            external_id=member_external,
+            text="custom bot thread",
+            message_id=701,
+            phone_number_id=CUSTOM_WHATSAPP_PHONE_NUMBER_ID,
+            waba_id=CUSTOM_WHATSAPP_WABA_ID,
+        ),
+        receiver_surface_ids=[custom_surface_id],
+    )
+    assert isinstance(custom_ctx, SurfaceChatContext)
+    assert custom_ctx.surface_id == custom_surface_id
+
+    system_ctx = await _prepare_platform_dm(
+        db_session,
+        platform,
+        _dm_payload(
+            platform,
+            external_id=member_external,
+            text="system bot thread",
+            message_id=702,
+        ),
+    )
+    assert isinstance(system_ctx, SurfaceChatContext)
+    assert system_ctx.surface_id == UUID(system_surface["id"])
+    assert system_ctx.conversation_id != custom_ctx.conversation_id
+
+    outsider = await signup_user(async_client, f"{platform.lower()}-custom-outsider")
+    outsider_external = _external_id(platform, 702)
+    await _seed_platform_user(
+        db_session,
+        platform=platform,
+        external_id=outsider_external,
+        user_id=outsider["id"],
+        tenant_id=CUSTOM_WHATSAPP_WABA_ID if platform == "WHATSAPP" else None,
+    )
+    non_member_ctx = await _prepare_platform_dm(
+        db_session,
+        platform,
+        _dm_payload(
+            platform,
+            external_id=outsider_external,
+            text="custom access?",
+            message_id=703,
+            phone_number_id=CUSTOM_WHATSAPP_PHONE_NUMBER_ID,
+            waba_id=CUSTOM_WHATSAPP_WABA_ID,
+        ),
+        receiver_surface_ids=[custom_surface_id],
+    )
+    assert isinstance(non_member_ctx, SurfaceReplyContext)
+    assert f"/pods/{pod_id}" in (non_member_ctx.reply_message or "")
+
+    unknown_external = _external_id(platform, 703)
+    unresolved_ctx = await _prepare_platform_dm(
+        db_session,
+        platform,
+        _dm_payload(
+            platform,
+            external_id=unknown_external,
+            text="new phone who dis",
+            message_id=704,
+            phone_number_id=CUSTOM_WHATSAPP_PHONE_NUMBER_ID,
+            waba_id=CUSTOM_WHATSAPP_WABA_ID,
+        ),
+        receiver_surface_ids=[custom_surface_id],
+    )
+    assert isinstance(unresolved_ctx, SurfaceReplyContext)
+    unresolved_message = (unresolved_ctx.reply_message or "").lower()
+    assert (
+        "sign up" in unresolved_message
+        or "contact" in unresolved_message
+        or "share your phone" in unresolved_message
+    )
+    assert "/pods/" not in (unresolved_ctx.reply_message or "")

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_onboarding_reply_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_onboarding_reply_e2e.py
@@ -1,9 +1,8 @@
 """E2E for surface onboarding replies (WS6 / concern #3).
 
 A signed-up user who is not a member of the surface's pod gets a pod-access
-(join-request) link — now for *custom* bots too, not just system surfaces,
-because a custom bot's token maps to exactly one pod (so the join target is
-unambiguous)."""
+link only when the bot credential is pod-specific. Shared system bots avoid
+disclosing a pod id to a non-member."""
 
 from __future__ import annotations
 
@@ -39,6 +38,38 @@ async def _prepare_telegram_dm(db_session: AsyncSession, payload: dict):
     )
     await uow.commit()
     return context
+
+
+async def test_system_bot_signed_up_non_member_does_not_get_pod_access_link(
+    authenticated_client: AsyncClient,
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    test_pod,
+    monkeypatch,
+):
+    monkeypatch.setattr(surface_settings, "telegram_bot_token", "system-onboarding-bot")
+    monkeypatch.setattr(surface_settings, "enable_telegram_polling_mode", True)
+    pod_id = test_pod["id"]
+
+    await _create_surface(authenticated_client, pod_id, config={"type": "TELEGRAM"})
+
+    outsider = await signup_user(async_client, "system-outsider")
+    await _seed_external_user(
+        db_session,
+        platform="TELEGRAM",
+        external_user_id="701701701",
+        resolved_user_id=UUID(outsider["id"]),
+    )
+
+    context = await _prepare_telegram_dm(
+        db_session,
+        _telegram_payload(text="let me in", message_id=6, sender_id=701701701),
+    )
+
+    assert isinstance(context, SurfaceReplyContext)
+    message = context.reply_message or ""
+    assert f"/pods/{pod_id}" not in message
+    assert "shared bot" in message.lower()
 
 
 async def test_custom_bot_signed_up_non_member_gets_pod_access_link(

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_onboarding_reply_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_onboarding_reply_e2e.py
@@ -30,11 +30,20 @@ from app.modules.test_support.e2e_authz import signup_user
 pytestmark = pytest.mark.e2e
 
 
-async def _prepare_telegram_dm(db_session: AsyncSession, payload: dict):
+async def _prepare_telegram_dm(
+    db_session: AsyncSession,
+    payload: dict,
+    *,
+    receiver_surface_ids: list[UUID] | None = None,
+):
     uow = SqlAlchemyUnitOfWork(db_session)
     handler = build_surface_event_handler(uow)
     context = await handler.prepare_ingress(
-        SurfacePlatformWebhookIngress(source="telegram", payload=payload)
+        SurfacePlatformWebhookIngress(
+            source="telegram",
+            payload=payload,
+            receiver_surface_ids=receiver_surface_ids,
+        )
     )
     await uow.commit()
     return context
@@ -90,7 +99,7 @@ async def test_custom_bot_signed_up_non_member_gets_pod_access_link(
         connector_id="telegram",
         credentials={"bot_token": "custom-onboarding-bot"},
     )
-    await _create_surface(
+    surface = await _create_surface(
         authenticated_client,
         pod_id,
         config={"type": "TELEGRAM", "account_id": str(account.id)},
@@ -108,6 +117,7 @@ async def test_custom_bot_signed_up_non_member_gets_pod_access_link(
     context = await _prepare_telegram_dm(
         db_session,
         _telegram_payload(text="let me in", message_id=5, sender_id=700700700),
+        receiver_surface_ids=[UUID(surface["id"])],
     )
 
     # Instead of being dropped, they get a pod-access / join-request link.

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_platform_contracts_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_platform_contracts_e2e.py
@@ -255,6 +255,31 @@ async def test_whatsapp_final_answer_contract(fake_whatsapp, message_store):
     assert payload["text"] == {"body": "Contract reply"}
 
 
+async def test_chat_surfaces_skip_outbound_when_credentials_are_missing(
+    fake_slack,
+    fake_whatsapp,
+    message_store,
+):
+    slack = SlackPlatformService(
+        credentials={
+            "scope": "chat:write",
+            "api_base_url": fake_slack.base_url,
+        }
+    )
+    whatsapp = WhatsAppPlatformService(
+        {
+            "phone_number_id": "phone-contract",
+            "api_base_url": f"{fake_whatsapp.api_base}/v21.0",
+        }
+    )
+
+    await slack.send_message(event=_slack_event(), message="should not send")
+    await whatsapp.send_message(event=_whatsapp_event(), message="should not send")
+
+    assert message_store.get_all("SLACK") == []
+    assert message_store.get_all("WHATSAPP") == []
+
+
 async def test_gmail_final_answer_contract(fake_gmail, message_store):
     service = GmailPlatformService(
         {

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_platform_contracts_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_platform_contracts_e2e.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+import base64
+from email import message_from_bytes
+
+import pytest
+
+from app.modules.agent_surfaces.domain.entities import (
+    ConversationType,
+    ParsedInboundSurfaceEvent,
+)
+from app.modules.agent_surfaces.platforms.gmail.service import GmailPlatformService
+from app.modules.agent_surfaces.platforms.outlook.service import OutlookPlatformService
+from app.modules.agent_surfaces.platforms.resend.service import ResendPlatformService
+from app.modules.agent_surfaces.platforms.slack.service import SlackPlatformService
+from app.modules.agent_surfaces.platforms.teams.adapter import TeamsSurfaceAdapter
+from app.modules.agent_surfaces.platforms.telegram.service import TelegramPlatformService
+from app.modules.agent_surfaces.platforms.whatsapp.service import WhatsAppPlatformService
+from app.modules.agent_surfaces.tests.e2e.mock_infrastructure import wait_for_messages
+
+pytestmark = pytest.mark.e2e
+
+
+def _slack_event() -> ParsedInboundSurfaceEvent:
+    return ParsedInboundSurfaceEvent(
+        platform="SLACK",
+        conversation_type=ConversationType.EXTERNAL_DM,
+        tenant_id="T-contract",
+        external_channel_id="D-contract",
+        external_thread_id="1700000000.000001",
+        external_message_id="1700000000.000001",
+        sender_external_user_id="U-contract",
+        sender_display_name="Contract User",
+        message_text="hello",
+        is_dm=True,
+        mentioned_agent=True,
+        reply_target={"channel": "D-contract", "thread_ts": "1700000000.000001"},
+    )
+
+
+def _teams_event(fake_teams) -> ParsedInboundSurfaceEvent:
+    return ParsedInboundSurfaceEvent(
+        platform="TEAMS",
+        conversation_type=ConversationType.EXTERNAL_GROUP,
+        tenant_id="tenant-contract",
+        external_channel_id="19:channel",
+        external_thread_id="activity-root",
+        external_message_id="activity-reply",
+        sender_external_user_id="29:user",
+        sender_display_name="Contract User",
+        message_text="hello",
+        is_dm=False,
+        mentioned_agent=True,
+        reply_target={
+            "service_url": fake_teams.service_url,
+            "conversation_id": "conversation-contract",
+            "reply_to_id": "activity-root",
+        },
+    )
+
+
+def _telegram_event() -> ParsedInboundSurfaceEvent:
+    return ParsedInboundSurfaceEvent(
+        platform="TELEGRAM",
+        conversation_type=ConversationType.EXTERNAL_DM,
+        external_channel_id="424242",
+        external_thread_id="424242",
+        external_message_id="111",
+        sender_external_user_id="424242",
+        sender_display_name="Contract User",
+        message_text="hello",
+        is_dm=True,
+        mentioned_agent=True,
+        reply_target={"chat_id": "424242", "message_id": 111},
+    )
+
+
+def _whatsapp_event() -> ParsedInboundSurfaceEvent:
+    return ParsedInboundSurfaceEvent(
+        platform="WHATSAPP",
+        conversation_type=ConversationType.EXTERNAL_DM,
+        tenant_id="waba-contract",
+        external_channel_id="phone-contract",
+        external_thread_id="15551234567@phone-contract",
+        external_message_id="wamid.contract",
+        sender_external_user_id="15551234567",
+        sender_phone="15551234567",
+        sender_display_name="Contract User",
+        message_text="hello",
+        is_dm=True,
+        mentioned_agent=True,
+        reply_target={
+            "phone_number_id": "phone-contract",
+            "sender_wa_id": "15551234567",
+        },
+    )
+
+
+def _gmail_event() -> ParsedInboundSurfaceEvent:
+    return ParsedInboundSurfaceEvent(
+        platform="GMAIL",
+        conversation_type=ConversationType.EXTERNAL_DM,
+        external_thread_id="gmail-thread-1",
+        external_message_id="gmail-message-1",
+        sender_external_user_id="sender@example.test",
+        sender_email="sender@example.test",
+        sender_display_name="Sender",
+        message_text="hello",
+        should_start_conversation=True,
+        reply_target={
+            "recipient_email": "sender@example.test",
+            "subject": "Contract Subject",
+            "thread_id": "gmail-thread-1",
+            "in_reply_to": "<gmail-message-1@example.test>",
+            "references": ["<gmail-root@example.test>"],
+        },
+    )
+
+
+def _outlook_event() -> ParsedInboundSurfaceEvent:
+    return ParsedInboundSurfaceEvent(
+        platform="OUTLOOK",
+        conversation_type=ConversationType.EXTERNAL_DM,
+        external_thread_id="outlook-thread-1",
+        external_message_id="outlook-message-1",
+        sender_external_user_id="sender@example.test",
+        sender_email="sender@example.test",
+        sender_display_name="Sender",
+        message_text="hello",
+        should_start_conversation=True,
+        reply_target={"message_id": "outlook-message-1"},
+    )
+
+
+def _resend_event() -> ParsedInboundSurfaceEvent:
+    return ParsedInboundSurfaceEvent(
+        platform="RESEND",
+        conversation_type=ConversationType.EXTERNAL_DM,
+        external_thread_id="resend-thread-1",
+        external_message_id="resend-message-1",
+        sender_external_user_id="sender@example.test",
+        sender_email="sender@example.test",
+        sender_display_name="Sender",
+        message_text="hello",
+        should_start_conversation=True,
+        reply_target={
+            "recipient_email": "sender@example.test",
+            "subject": "Contract Subject",
+            "in_reply_to": "<resend-message-1@example.test>",
+            "references": ["<resend-root@example.test>"],
+        },
+    )
+
+
+async def test_slack_final_answer_contract(fake_slack, message_store):
+    service = SlackPlatformService(
+        credentials={
+            "access_token": "xoxb-contract",
+            "scope": "chat:write,chat:write.customize",
+            "api_base_url": fake_slack.base_url,
+        }
+    )
+
+    await service.send_message(
+        event=_slack_event(),
+        message="*Contract* reply",
+        metadata={"agent_display_name": "Contract Agent"},
+    )
+
+    messages = await wait_for_messages(message_store, "SLACK", min_count=1)
+    payload = messages[-1]
+    assert payload["_method"] == "POST"
+    assert payload["_path"] == "/api/chat.postMessage"
+    assert payload["_authorization"] == "Bearer xoxb-contract"
+    assert payload["channel"] == "D-contract"
+    assert payload["thread_ts"] == "1700000000.000001"
+    assert payload["text"] == "*Contract* reply"
+    assert payload["username"] == "Contract Agent"
+
+
+async def test_teams_final_answer_contract(fake_teams, message_store, monkeypatch):
+    adapter = TeamsSurfaceAdapter()
+
+    async def _fake_bot_token(self, tenant_id=None):
+        assert tenant_id == "tenant-contract"
+        return "teams-contract-token"
+
+    monkeypatch.setattr(TeamsSurfaceAdapter, "_get_bot_token", _fake_bot_token)
+
+    await adapter.send_message(
+        credentials={},
+        event=_teams_event(fake_teams),
+        message="**Contract** reply",
+    )
+
+    messages = await wait_for_messages(message_store, "TEAMS", min_count=1)
+    payload = messages[-1]
+    assert payload["_method"] == "POST"
+    assert payload["_authorization"] == "Bearer teams-contract-token"
+    assert payload["_path"] == "/teams/v3/conversations/conversation-contract/activities"
+    assert payload["body"] == {
+        "type": "message",
+        "text": "**Contract** reply",
+        "textFormat": "markdown",
+        "replyToId": "activity-root",
+    }
+
+
+async def test_telegram_final_answer_contract_and_retry(fake_telegram, message_store):
+    service = TelegramPlatformService(
+        {
+            "bot_token": "telegram-contract-token",
+            "api_base_url": f"{fake_telegram.api_base}/bot",
+        }
+    )
+    fake_telegram.fail_next["sendMessage"] = 1
+
+    await service.send_message(
+        event=_telegram_event(),
+        message="Contract *reply*",
+    )
+
+    messages = await wait_for_messages(message_store, "TELEGRAM", min_count=1)
+    payload = messages[-1]
+    assert payload["_method"] == "POST"
+    assert payload["_path"] == "/bottelegram-contract-token/sendMessage"
+    assert payload["chat_id"] == "424242"
+    assert payload["reply_parameters"] == {
+        "message_id": 111,
+        "allow_sending_without_reply": True,
+    }
+    assert payload["parse_mode"] == "MarkdownV2"
+    assert "Contract" in payload["text"]
+
+
+async def test_whatsapp_final_answer_contract(fake_whatsapp, message_store):
+    service = WhatsAppPlatformService(
+        {
+            "access_token": "wa-contract-token",
+            "phone_number_id": "phone-contract",
+            "api_base_url": f"{fake_whatsapp.api_base}/v21.0",
+        }
+    )
+
+    await service.send_message(event=_whatsapp_event(), message="Contract reply")
+
+    messages = await wait_for_messages(message_store, "WHATSAPP", min_count=1)
+    payload = messages[-1]
+    assert payload["_method"] == "POST"
+    assert payload["_path"] == "/v21.0/phone-contract/messages"
+    assert payload["_authorization"] == "Bearer wa-contract-token"
+    assert payload["messaging_product"] == "whatsapp"
+    assert payload["to"] == "15551234567"
+    assert payload["type"] == "text"
+    assert payload["text"] == {"body": "Contract reply"}
+
+
+async def test_gmail_final_answer_contract(fake_gmail, message_store):
+    service = GmailPlatformService(
+        {
+            "access_token": "gmail-contract-token",
+            "api_base_url": fake_gmail.api_base,
+        }
+    )
+
+    await service.send_message(event=_gmail_event(), message="Contract reply")
+
+    messages = await wait_for_messages(message_store, "GMAIL", min_count=1)
+    payload = messages[-1]
+    assert payload["_method"] == "POST"
+    assert payload["_path"] == "/gmail/v1/users/me/messages/send"
+    assert payload["_authorization"] == "Bearer gmail-contract-token"
+    assert payload["threadId"] == "gmail-thread-1"
+
+    raw = payload["raw"]
+    padding = "=" * (-len(raw) % 4)
+    email = message_from_bytes(base64.urlsafe_b64decode(raw + padding))
+    assert email["To"] == "sender@example.test"
+    assert email["Subject"] == "Re: Contract Subject"
+    assert email["In-Reply-To"] == "<gmail-message-1@example.test>"
+    assert email["References"] == "<gmail-root@example.test>"
+    assert "Contract reply" in email.get_payload()
+
+
+async def test_outlook_final_answer_contract(fake_outlook, message_store):
+    service = OutlookPlatformService(
+        {
+            "access_token": "outlook-contract-token",
+            "api_base_url": fake_outlook.api_base,
+        }
+    )
+
+    await service.send_message(event=_outlook_event(), message="Contract reply")
+
+    messages = await wait_for_messages(message_store, "OUTLOOK_REPLY", min_count=1)
+    payload = messages[-1]
+    assert payload["_method"] == "POST"
+    assert payload["_path"] == "/v1.0/me/messages/outlook-message-1/reply"
+    assert payload["_authorization"] == "Bearer outlook-contract-token"
+    assert payload["message_id"] == "outlook-message-1"
+    assert payload["body"] == {
+        "message": {
+            "body": {
+                "contentType": "Text",
+                "content": "Contract reply",
+            }
+        }
+    }
+
+
+async def test_resend_final_answer_contract(fake_resend, message_store):
+    service = ResendPlatformService(
+        {
+            "api_key": "resend-contract-token",
+            "from_address": "assistant@example.test",
+            "from_name": "Lemma Contract",
+            "api_base_url": fake_resend.api_base,
+        }
+    )
+
+    await service.send_message(event=_resend_event(), message="Contract reply")
+
+    messages = await wait_for_messages(message_store, "RESEND", min_count=1)
+    payload = messages[-1]
+    assert payload["_method"] == "POST"
+    assert payload["_path"] == "/emails"
+    assert payload["_authorization"] == "Bearer resend-contract-token"
+    assert payload["from"] == "Lemma Contract <assistant@example.test>"
+    assert payload["to"] == ["sender@example.test"]
+    assert payload["subject"] == "Re: Contract Subject"
+    assert payload["headers"] == {
+        "In-Reply-To": "<resend-message-1@example.test>",
+        "References": "<resend-root@example.test>",
+    }
+    assert payload["text"] == "Contract reply"

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_request_approval_matrix_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_request_approval_matrix_e2e.py
@@ -104,7 +104,7 @@ async def _make_approved_tool_resolvable(
     ``request_approval``'s wrapped-tool execution (``ApprovalExecutor``) runs
     independently of the scripted-mock harness run and resolves the AGENT's
     (not the paused RUN's) runtime profile to decide tool availability — the
-    default test agent's "system:fireworks" profile isn't configured in this
+    default test agent's "system:lemma" profile isn't the scripted local runtime in this
     e2e environment, so that resolution must be redirected too.
     """
     runtime_profile_id = await _ensure_e2e_runtime_profile(

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_surface_live_smoke_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_surface_live_smoke_e2e.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from app.modules.agent_surfaces.domain.entities import (
+    ConversationType,
+    ParsedInboundSurfaceEvent,
+)
+from app.modules.agent_surfaces.platforms.gmail.service import GmailPlatformService
+from app.modules.agent_surfaces.platforms.outlook.service import OutlookPlatformService
+from app.modules.agent_surfaces.platforms.resend.service import ResendPlatformService
+from app.modules.agent_surfaces.platforms.slack.service import SlackPlatformService
+from app.modules.agent_surfaces.platforms.teams.adapter import TeamsSurfaceAdapter
+from app.modules.agent_surfaces.platforms.telegram.service import TelegramPlatformService
+from app.modules.agent_surfaces.platforms.whatsapp.service import WhatsAppPlatformService
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.provider,
+    pytest.mark.surface_live,
+    pytest.mark.skipif(
+        os.getenv("LEMMA_RUN_SURFACE_LIVE_E2E") != "1",
+        reason="Set LEMMA_RUN_SURFACE_LIVE_E2E=1 to run live surface smoke tests.",
+    ),
+]
+
+
+def _required_env(*names: str) -> dict[str, str]:
+    values = {name: os.getenv(name, "").strip() for name in names}
+    missing = [name for name, value in values.items() if not value]
+    if missing:
+        pytest.skip(f"Missing live surface env: {', '.join(missing)}")
+    return values
+
+
+def _event(
+    platform: str,
+    *,
+    target: dict,
+    thread_id: str = "surface-live-smoke",
+) -> ParsedInboundSurfaceEvent:
+    return ParsedInboundSurfaceEvent(
+        platform=platform,
+        conversation_type=ConversationType.EXTERNAL_DM,
+        external_channel_id=str(target.get("channel") or target.get("chat_id") or ""),
+        external_thread_id=thread_id,
+        external_message_id=f"{thread_id}-message",
+        sender_external_user_id=str(target.get("sender") or "surface-live-user"),
+        sender_email=target.get("sender_email"),
+        sender_phone=target.get("sender_phone"),
+        sender_display_name="Surface Live Smoke",
+        message_text="live smoke",
+        is_dm=True,
+        mentioned_agent=True,
+        should_start_conversation=True,
+        reply_target=target,
+    )
+
+
+async def test_live_telegram_minimal_send():
+    env = _required_env("TELEGRAM_BOT_TOKEN", "LEMMA_SURFACE_LIVE_TELEGRAM_CHAT_ID")
+    service = TelegramPlatformService({"bot_token": env["TELEGRAM_BOT_TOKEN"]})
+
+    await service.send_message(
+        event=_event(
+            "TELEGRAM",
+            target={"chat_id": env["LEMMA_SURFACE_LIVE_TELEGRAM_CHAT_ID"]},
+        ),
+        message="Lemma surface live smoke: Telegram",
+    )
+
+
+async def test_live_whatsapp_minimal_send():
+    env = _required_env(
+        "WHATSAPP_ACCESS_TOKEN",
+        "WHATSAPP_PHONE_NUMBER_ID",
+        "LEMMA_SURFACE_LIVE_WHATSAPP_TO",
+    )
+    service = WhatsAppPlatformService(
+        {
+            "access_token": env["WHATSAPP_ACCESS_TOKEN"],
+            "phone_number_id": env["WHATSAPP_PHONE_NUMBER_ID"],
+        }
+    )
+
+    await service.send_message(
+        event=_event(
+            "WHATSAPP",
+            target={
+                "phone_number_id": env["WHATSAPP_PHONE_NUMBER_ID"],
+                "sender_wa_id": env["LEMMA_SURFACE_LIVE_WHATSAPP_TO"],
+            },
+        ),
+        message="Lemma surface live smoke: WhatsApp",
+    )
+
+
+async def test_live_slack_minimal_send():
+    env = _required_env(
+        "LEMMA_SURFACE_LIVE_SLACK_BOT_TOKEN",
+        "LEMMA_SURFACE_LIVE_SLACK_CHANNEL_ID",
+    )
+    service = SlackPlatformService(
+        credentials={"access_token": env["LEMMA_SURFACE_LIVE_SLACK_BOT_TOKEN"]}
+    )
+
+    await service.send_message(
+        event=_event(
+            "SLACK",
+            target={"channel": env["LEMMA_SURFACE_LIVE_SLACK_CHANNEL_ID"]},
+        ),
+        message="Lemma surface live smoke: Slack",
+    )
+
+
+async def test_live_teams_minimal_send():
+    env = _required_env(
+        "LEMMA_SURFACE_LIVE_TEAMS_TENANT_ID",
+        "LEMMA_SURFACE_LIVE_TEAMS_SERVICE_URL",
+        "LEMMA_SURFACE_LIVE_TEAMS_CONVERSATION_ID",
+    )
+    adapter = TeamsSurfaceAdapter()
+
+    await adapter.send_message(
+        credentials={},
+        event=_event(
+            "TEAMS",
+            target={
+                "service_url": env["LEMMA_SURFACE_LIVE_TEAMS_SERVICE_URL"],
+                "conversation_id": env["LEMMA_SURFACE_LIVE_TEAMS_CONVERSATION_ID"],
+            },
+        ).model_copy(update={"tenant_id": env["LEMMA_SURFACE_LIVE_TEAMS_TENANT_ID"]}),
+        message="Lemma surface live smoke: Teams",
+    )
+
+
+async def test_live_gmail_minimal_send():
+    env = _required_env(
+        "LEMMA_SURFACE_LIVE_GMAIL_ACCESS_TOKEN",
+        "LEMMA_SURFACE_LIVE_EMAIL_TO",
+    )
+    service = GmailPlatformService(
+        {"access_token": env["LEMMA_SURFACE_LIVE_GMAIL_ACCESS_TOKEN"]}
+    )
+
+    await service.send_message(
+        event=_event(
+            "GMAIL",
+            target={
+                "recipient_email": env["LEMMA_SURFACE_LIVE_EMAIL_TO"],
+                "subject": "Lemma surface live smoke",
+            },
+        ),
+        message="Lemma surface live smoke: Gmail",
+    )
+
+
+async def test_live_outlook_minimal_reply():
+    env = _required_env(
+        "LEMMA_SURFACE_LIVE_OUTLOOK_ACCESS_TOKEN",
+        "LEMMA_SURFACE_LIVE_OUTLOOK_MESSAGE_ID",
+    )
+    service = OutlookPlatformService(
+        {"access_token": env["LEMMA_SURFACE_LIVE_OUTLOOK_ACCESS_TOKEN"]}
+    )
+
+    await service.send_message(
+        event=_event(
+            "OUTLOOK",
+            target={"message_id": env["LEMMA_SURFACE_LIVE_OUTLOOK_MESSAGE_ID"]},
+        ),
+        message="Lemma surface live smoke: Outlook",
+    )
+
+
+async def test_live_resend_minimal_send():
+    env = _required_env(
+        "RESEND_API_KEY",
+        "LEMMA_SURFACE_LIVE_RESEND_FROM",
+        "LEMMA_SURFACE_LIVE_EMAIL_TO",
+    )
+    service = ResendPlatformService(
+        {
+            "api_key": env["RESEND_API_KEY"],
+            "from_address": env["LEMMA_SURFACE_LIVE_RESEND_FROM"],
+            "from_name": "Lemma",
+        }
+    )
+
+    await service.send_message(
+        event=_event(
+            "RESEND",
+            target={
+                "recipient_email": env["LEMMA_SURFACE_LIVE_EMAIL_TO"],
+                "subject": "Lemma surface live smoke",
+            },
+        ),
+        message="Lemma surface live smoke: Resend",
+    )

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_telegram_surface_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_telegram_surface_e2e.py
@@ -187,6 +187,50 @@ async def test_telegram_group_mention_routes_and_replies(
     assert "E2E agent reply" in telegram_messages[-1]["text"]
 
 
+async def test_telegram_group_mention_from_non_member_is_ignored(
+    authenticated_client: AsyncClient,
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    test_pod,
+    fake_telegram,
+    message_store,
+    monkeypatch,
+):
+    """Group mentions stay pod-member gated and never post onboarding/access
+    prompts into the group."""
+    from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
+    from app.modules.agent_surfaces.events.handlers import (
+        build_surface_event_handler,
+    )
+    from app.modules.test_support.e2e_authz import signup_user
+
+    _wire_native_telegram(monkeypatch, fake_telegram)
+    pod_id = test_pod["id"]
+    await _create_surface(authenticated_client, pod_id, config={"type": "TELEGRAM"})
+
+    outsider = await signup_user(async_client, "telegram-group-outsider")
+    await _seed_external_user(
+        db_session,
+        platform="TELEGRAM",
+        external_user_id="900101",
+        resolved_user_id=UUID(outsider["id"]),
+    )
+
+    payload = _telegram_group_payload(
+        text="@lemmabot summarize this",
+        message_id=73,
+        sender_id=900101,
+        chat_id=-1004444444444,
+    )
+    handler = build_surface_event_handler(SqlAlchemyUnitOfWork(db_session))
+    context = await handler.prepare_ingress(
+        SurfacePlatformWebhookIngress(source="telegram", payload=payload, headers={})
+    )
+
+    assert context is None
+    assert message_store.get_all("TELEGRAM") == []
+
+
 async def test_telegram_group_reply_to_bot_continues_without_mention(
     authenticated_client: AsyncClient,
     db_session: AsyncSession,

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_coverage_report.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_coverage_report.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_reporter():
+    script = (
+        Path(__file__).resolve().parents[5]
+        / "scripts"
+        / "agent_surfaces_coverage_report.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "agent_surfaces_coverage_report", script
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_coverage_report_groups_modules_platforms_and_escapes_markdown(tmp_path):
+    reporter = _load_reporter()
+    coverage = {
+        "files": {
+            "app/modules/agent_surfaces/services/ingress_service.py": {
+                "summary": {"num_statements": 10, "missing_lines": 2}
+            },
+            "app/modules/agent_surfaces/platforms/teams/service.py": {
+                "summary": {"num_statements": 20, "missing_lines": 10}
+            },
+            "app/modules/agent_surfaces/platforms/slack/service.py": {
+                "summary": {"num_statements": 5, "missing_lines": 0}
+            },
+            "app/modules/agent_surfaces/root|odd.py": {
+                "summary": {"num_statements": 4, "missing_lines": 1}
+            },
+            "app/modules/agent_surfaces/tests/unit/test_ignored.py": {
+                "summary": {"num_statements": 99, "missing_lines": 99}
+            },
+        },
+        "totals": {
+            "covered_lines": 26,
+            "num_statements": 39,
+            "percent_covered": 66.666,
+            "missing_lines": 13,
+        },
+    }
+    junit = tmp_path / "junit.xml"
+    junit.write_text(
+        '<testsuite tests="3" failures="0" errors="0" skipped="1" time="1.2" />'
+    )
+
+    summary = reporter.build_summary(coverage, phase="combined", junit_paths=[junit])
+    markdown = reporter.render_markdown(summary)
+
+    assert summary["top_level"] == [
+        {
+            "name": "platforms",
+            "statements": 25,
+            "missing": 10,
+            "covered": 15,
+            "coverage": 60.0,
+        },
+        {
+            "name": "root",
+            "statements": 4,
+            "missing": 1,
+            "covered": 3,
+            "coverage": 75.0,
+        },
+        {
+            "name": "services",
+            "statements": 10,
+            "missing": 2,
+            "covered": 8,
+            "coverage": 80.0,
+        },
+    ]
+    assert [row["name"] for row in summary["platforms"]] == ["slack", "teams"]
+    assert summary["tests"]["tests"] == 3
+    assert summary["tests"]["skipped"] == 1
+    assert "root\\|odd.py" in markdown
+    assert "66.7%" in markdown
+    assert reporter.COMMENT_MARKER in markdown
+
+
+def test_coverage_report_missing_artifact_fallback(tmp_path):
+    reporter = _load_reporter()
+    summary = reporter.build_summary(None, phase="unit", junit_paths=[])
+
+    markdown = reporter.render_markdown(summary)
+
+    assert summary["missing_coverage"] is True
+    assert "Coverage artifact was not found" in markdown
+
+
+def test_coverage_report_cli_writes_markdown_and_summary(tmp_path):
+    reporter = _load_reporter()
+    coverage_json = tmp_path / "coverage.json"
+    coverage_json.write_text(
+        json.dumps(
+            {
+                "files": {
+                    "app/modules/agent_surfaces/domain/entities.py": {
+                        "summary": {"num_statements": 8, "missing_lines": 0}
+                    }
+                },
+                "totals": {
+                    "covered_lines": 8,
+                    "num_statements": 8,
+                    "percent_covered": 100.0,
+                    "missing_lines": 0,
+                },
+            }
+        )
+    )
+    markdown_out = tmp_path / "comment.md"
+    summary_out = tmp_path / "summary.json"
+
+    code = reporter.main.__globals__["argparse"]  # prove module loaded normally
+    assert code is not None
+
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(Path(reporter.__file__)),
+            "--coverage-json",
+            str(coverage_json),
+            "--phase",
+            "unit",
+            "--markdown-out",
+            str(markdown_out),
+            "--summary-json-out",
+            str(summary_out),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "100.0%" in result.stdout
+    assert "100.0%" in markdown_out.read_text()
+    assert json.loads(summary_out.read_text())["totals"]["covered_lines"] == 8

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_ingress_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_ingress_service.py
@@ -311,9 +311,9 @@ async def test_prepare_webhook_returns_signup_context_for_unresolved_user():
     service.conversation_service.create_conversation.assert_not_called()
 
 
-async def test_prepare_webhook_returns_pod_access_link_for_non_member():
-    """A signed-up user who isn't a pod member is pointed to the pod home page
-    (request access) on a DM system surface, instead of being dropped."""
+async def test_prepare_webhook_avoids_pod_access_link_for_system_non_member():
+    """A signed-up non-member on a shared system Telegram bot should not receive
+    a pod-specific URL, because the shared identity can front many pods."""
     surface = _telegram_surface()
     surface.credential_mode = SurfaceCredentialMode.SYSTEM
     event = ParsedInboundSurfaceEvent(
@@ -350,7 +350,52 @@ async def test_prepare_webhook_returns_pod_access_link_for_non_member():
     )
 
     assert isinstance(context, SurfaceReplyContext)
+    assert "Request access" not in (context.reply_message or "")
+    assert str(surface.pod_id) not in (context.reply_message or "")
+    assert "shared bot" in (context.reply_message or "")
+    service.conversation_service.create_conversation.assert_not_called()
+
+
+async def test_prepare_webhook_returns_pod_access_link_for_custom_non_member():
+    """A custom/bound bot maps to one configured surface, so the pod target is
+    explicit and the access link is safe to show."""
+    surface = _telegram_surface()
+    surface.credential_mode = SurfaceCredentialMode.CUSTOM
+    event = ParsedInboundSurfaceEvent(
+        platform=SurfacePlatform.TELEGRAM,
+        conversation_type=ConversationType.EXTERNAL_DM,
+        external_thread_id="123",
+        external_channel_id="123",
+        sender_external_user_id="999",
+        message_text="hi",
+        is_dm=True,
+        reply_target={"chat_id": "123"},
+    )
+    adapter = AsyncMock()
+    adapter.parse_inbound_event.return_value = event
+    adapter.unresolved_sender_reply.return_value = None
+    adapter.linked_sender_confirmation.return_value = None
+    service = _build_service(
+        adapter=adapter,
+        surfaces=[surface],
+        resolved_user=ResolvedSurfaceUser(
+            internal_user_id=uuid4(),
+            external_user_id="999",
+            email="member@example.com",
+            display_name="Member",
+        ),
+    )
+    service.pod_membership_port = SimpleNamespace(
+        get_user_pod_ids=AsyncMock(return_value=[])
+    )
+
+    context = await service.prepare_ingress(
+        SurfacePlatformWebhookIngress(source="telegram", payload={}, headers={})
+    )
+
+    assert isinstance(context, SurfaceReplyContext)
     assert "Request access" in (context.reply_message or "")
+    assert str(surface.pod_id) in (context.reply_message or "")
     service.conversation_service.create_conversation.assert_not_called()
 
 

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_ingress_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_ingress_service.py
@@ -149,6 +149,22 @@ def _slack_channel_event(*, channel_id: str = "C999") -> ParsedInboundSurfaceEve
     )
 
 
+def _telegram_event(*, chat_id: str, message_id: str) -> ParsedInboundSurfaceEvent:
+    return ParsedInboundSurfaceEvent(
+        platform="TELEGRAM",
+        conversation_type=ConversationType.EXTERNAL_DM,
+        external_channel_id=chat_id,
+        external_thread_id=chat_id,
+        external_message_id=message_id,
+        sender_external_user_id="777",
+        sender_display_name="Telegram User",
+        message_text="Hello from Telegram",
+        is_dm=True,
+        mentioned_agent=True,
+        reply_target={"chat_id": chat_id, "message_id": message_id},
+    )
+
+
 def _conversation(surface: AgentSurfaceEntity, user_id: UUID) -> Conversation:
     return Conversation(
         id=uuid4(),
@@ -390,7 +406,12 @@ async def test_prepare_webhook_returns_pod_access_link_for_custom_non_member():
     )
 
     context = await service.prepare_ingress(
-        SurfacePlatformWebhookIngress(source="telegram", payload={}, headers={})
+        SurfacePlatformWebhookIngress(
+            source="telegram",
+            payload={},
+            headers={},
+            receiver_surface_ids=[surface.id],
+        )
     )
 
     assert isinstance(context, SurfaceReplyContext)
@@ -1337,6 +1358,138 @@ async def test_send_to_member_reuses_existing_thread():
     )
     assert sent is True
     assert "Your report is ready." in adapter.send_message.await_args.kwargs["message"]
+
+
+async def test_send_to_member_uses_requested_surface_latest_thread():
+    surface = _telegram_surface()
+    user_id = uuid4()
+    older_link = AgentSurfaceConversationLink(
+        surface_id=surface.id,
+        conversation_id=uuid4(),
+        platform="TELEGRAM",
+        external_channel_id="older-chat",
+        external_thread_id="older-chat",
+        external_user_id="777",
+        last_event=_telegram_event(
+            chat_id="older-chat", message_id="older-message"
+        ).model_dump(mode="json"),
+    )
+    latest_link = AgentSurfaceConversationLink(
+        surface_id=surface.id,
+        conversation_id=uuid4(),
+        platform="TELEGRAM",
+        external_channel_id="latest-chat",
+        external_thread_id="latest-chat",
+        external_user_id="777",
+        last_event=_telegram_event(
+            chat_id="latest-chat", message_id="latest-message"
+        ).model_dump(mode="json"),
+    )
+    adapter = AsyncMock()
+    service = _build_service(adapter=adapter, surfaces=[surface], existing_link=older_link)
+    service.pod_membership_port = SimpleNamespace(
+        get_user_pod_ids=AsyncMock(return_value=[surface.pod_id])
+    )
+    service.external_user_repository = AsyncMock(
+        get_by_resolved_user=AsyncMock(
+            return_value=SimpleNamespace(external_user_id="777")
+        )
+    )
+    service.conversation_link_repository.get_latest_by_surface_and_external_user = (
+        AsyncMock(return_value=latest_link)
+    )
+    service.conversation_link_repository.get_by_conversation_id.return_value = latest_link
+
+    sent = await service.send_to_member(
+        surface=surface,
+        user_id=user_id,
+        message="Use the newest thread.",
+    )
+
+    assert sent is True
+    service.conversation_link_repository.get_latest_by_surface_and_external_user.assert_awaited_once_with(
+        surface_id=surface.id,
+        external_user_id="777",
+    )
+    event = adapter.send_message.await_args.kwargs["event"]
+    assert event.external_thread_id == "latest-chat"
+    assert event.reply_target["chat_id"] == "latest-chat"
+
+
+async def test_send_to_member_does_not_confuse_system_and_custom_threads():
+    system_surface = _telegram_surface()
+    custom_surface = _telegram_surface()
+    user_id = uuid4()
+    system_link = AgentSurfaceConversationLink(
+        surface_id=system_surface.id,
+        conversation_id=uuid4(),
+        platform="TELEGRAM",
+        external_channel_id="system-chat",
+        external_thread_id="system-chat",
+        external_user_id="777",
+        last_event=_telegram_event(
+            chat_id="system-chat", message_id="system-message"
+        ).model_dump(mode="json"),
+    )
+    custom_link = AgentSurfaceConversationLink(
+        surface_id=custom_surface.id,
+        conversation_id=uuid4(),
+        platform="TELEGRAM",
+        external_channel_id="custom-chat",
+        external_thread_id="custom-chat",
+        external_user_id="777",
+        last_event=_telegram_event(
+            chat_id="custom-chat", message_id="custom-message"
+        ).model_dump(mode="json"),
+    )
+    links_by_surface = {
+        system_surface.id: system_link,
+        custom_surface.id: custom_link,
+    }
+    links_by_conversation = {
+        system_link.conversation_id: system_link,
+        custom_link.conversation_id: custom_link,
+    }
+    adapter = AsyncMock()
+    service = _build_service(
+        adapter=adapter,
+        surfaces=[system_surface, custom_surface],
+        existing_link=system_link,
+    )
+    service.pod_membership_port = SimpleNamespace(
+        get_user_pod_ids=AsyncMock(
+            return_value=[system_surface.pod_id, custom_surface.pod_id]
+        )
+    )
+    service.external_user_repository = AsyncMock(
+        get_by_resolved_user=AsyncMock(
+            return_value=SimpleNamespace(external_user_id="777")
+        )
+    )
+    service.conversation_link_repository.get_latest_by_surface_and_external_user = (
+        AsyncMock(side_effect=lambda *, surface_id, external_user_id: links_by_surface[surface_id])
+    )
+    service.conversation_link_repository.get_by_conversation_id.side_effect = (
+        lambda conversation_id: links_by_conversation[conversation_id]
+    )
+
+    custom_sent = await service.send_to_member(
+        surface=custom_surface,
+        user_id=user_id,
+        message="custom only",
+    )
+    system_sent = await service.send_to_member(
+        surface=system_surface,
+        user_id=user_id,
+        message="system only",
+    )
+
+    assert custom_sent is True
+    assert system_sent is True
+    first_event = adapter.send_message.await_args_list[0].kwargs["event"]
+    second_event = adapter.send_message.await_args_list[1].kwargs["event"]
+    assert first_event.external_thread_id == "custom-chat"
+    assert second_event.external_thread_id == "system-chat"
 
 
 async def test_send_to_member_rejects_non_member():

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_native_questions.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_native_questions.py
@@ -1,9 +1,18 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
 from app.modules.agent_surfaces.domain.models import (
     SurfaceQuestion,
     SurfaceQuestionOption,
     SurfaceQuestionRenderPlan,
+)
+from app.modules.agent_surfaces.domain.entities import (
+    ConversationType,
+    ParsedInboundSurfaceEvent,
+    SurfacePlatform,
 )
 from app.modules.agent_surfaces.platforms.slack.service import _question_blocks
 from app.modules.agent_surfaces.platforms.slack.parser import SlackMessageParser
@@ -15,6 +24,9 @@ from app.modules.agent_surfaces.platforms.teams.parser import (
 from app.modules.agent_surfaces.api.controllers.webhook_controller import (
     _decode_webhook_payload,
 )
+from app.modules.agent_surfaces.platforms.telegram.adapter import TelegramSurfaceAdapter
+from app.modules.agent_surfaces.platforms.telegram.service import _OTHER_CALLBACK_VALUE
+from app.modules.agent_surfaces.platforms.whatsapp.adapter import WhatsAppSurfaceAdapter
 
 
 def _plan() -> SurfaceQuestionRenderPlan:
@@ -191,18 +203,6 @@ def test_decode_webhook_payload_handles_form_encoded_and_json():
 
 # ── Telegram native inline keyboards ─────────────────────────────────────────
 
-import pytest
-from unittest.mock import AsyncMock, patch
-
-from app.modules.agent_surfaces.domain.entities import (
-    ConversationType,
-    ParsedInboundSurfaceEvent,
-    SurfacePlatform,
-)
-from app.modules.agent_surfaces.platforms.telegram.adapter import TelegramSurfaceAdapter
-from app.modules.agent_surfaces.platforms.telegram.service import _OTHER_CALLBACK_VALUE
-
-
 def _single_question_plan() -> SurfaceQuestionRenderPlan:
     return SurfaceQuestionRenderPlan(
         title="Which country?",
@@ -327,9 +327,6 @@ async def test_telegram_parse_inbound_interaction_other_and_unknown_return_none(
 
 
 # ── WhatsApp native interactive replies ──────────────────────────────────────
-
-from app.modules.agent_surfaces.platforms.whatsapp.adapter import WhatsAppSurfaceAdapter
-
 
 def _whatsapp_event() -> ParsedInboundSurfaceEvent:
     return ParsedInboundSurfaceEvent(

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_platform_new_adapters.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_platform_new_adapters.py
@@ -203,6 +203,50 @@ async def test_whatsapp_send_display_resource_uses_cta_url_payload(monkeypatch):
     )
 
 
+@pytest.mark.asyncio
+async def test_whatsapp_display_phone_number_lookup_uses_graph_phone_id(monkeypatch):
+    requested: dict = {}
+
+    class _Response:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"display_phone_number": "+1 555 0100"}
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def get(self, url, *, params, headers):
+            requested["url"] = url
+            requested["params"] = params
+            requested["headers"] = headers
+            return _Response()
+
+    monkeypatch.setattr(
+        whatsapp_service_module.httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: _Client(),
+    )
+
+    number = await whatsapp_service_module.WhatsAppPlatformService(
+        {
+            "access_token": "wa-token",
+            "phone_number_id": "PN42",
+            "api_base_url": "https://graph.example.test/v21.0",
+        }
+    ).get_display_phone_number()
+
+    assert number == "+1 555 0100"
+    assert requested["url"] == "https://graph.example.test/v21.0/PN42"
+    assert requested["params"] == {"fields": "display_phone_number"}
+    assert requested["headers"]["Authorization"] == "Bearer wa-token"
+
+
 def _telegram_text_payload() -> dict:
     return {
         "update_id": 100000001,

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_pod_deleted_handler.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_pod_deleted_handler.py
@@ -10,6 +10,13 @@ from uuid import uuid4
 
 import pytest
 
+from app.modules.agent_surfaces.domain.entities import (
+    ConversationType,
+    ParsedInboundSurfaceEvent,
+    SurfacePlatform,
+)
+from app.modules.agent_surfaces.domain.events import SurfaceWebhookReceivedEvent
+from app.modules.agent_surfaces.domain.ingress_context import SurfaceReplyContext
 from app.modules.agent_surfaces.events import handlers
 
 
@@ -60,3 +67,83 @@ async def test_on_pod_deleted_ignores_non_delete_events(monkeypatch):
     )
 
     service.delete_all_surfaces_for_pod.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_surface_webhook_enqueues_prepared_context(monkeypatch):
+    handler = AsyncMock()
+    context = _reply_context()
+    handler.try_handle_interaction.return_value = False
+    handler.prepare_ingress.return_value = context
+    job_queue = AsyncMock()
+    uow_mock = AsyncMock()
+    monkeypatch.setattr(handlers, "build_surface_event_handler", lambda uow: handler)
+
+    await handlers.handle_surface_webhook(
+        SurfaceWebhookReceivedEvent(source="telegram", payload={"update_id": 1}),
+        logging.getLogger("test"),
+        uow_factory=partial(_mock_uow_factory, uow_mock),
+        job_queue=job_queue,
+    )
+
+    handler.try_handle_interaction.assert_awaited_once()
+    handler.prepare_ingress.assert_awaited_once()
+    job_queue.enqueue.assert_awaited_once()
+    assert job_queue.enqueue.await_args.kwargs["payload"]["context"]["mode"] == "reply"
+
+
+@pytest.mark.asyncio
+async def test_handle_surface_webhook_skips_queue_when_interaction_was_handled(
+    monkeypatch,
+):
+    handler = AsyncMock()
+    handler.try_handle_interaction.return_value = True
+    job_queue = AsyncMock()
+    uow_mock = AsyncMock()
+    monkeypatch.setattr(handlers, "build_surface_event_handler", lambda uow: handler)
+
+    await handlers.handle_surface_webhook(
+        SurfaceWebhookReceivedEvent(source="telegram", payload={"callback_query": {}}),
+        logging.getLogger("test"),
+        uow_factory=partial(_mock_uow_factory, uow_mock),
+        job_queue=job_queue,
+    )
+
+    handler.prepare_ingress.assert_not_awaited()
+    job_queue.enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_surface_webhook_skips_queue_when_no_context(monkeypatch):
+    handler = AsyncMock()
+    handler.try_handle_interaction.return_value = False
+    handler.prepare_ingress.return_value = None
+    job_queue = AsyncMock()
+    uow_mock = AsyncMock()
+    monkeypatch.setattr(handlers, "build_surface_event_handler", lambda uow: handler)
+
+    await handlers.handle_surface_webhook(
+        SurfaceWebhookReceivedEvent(source="telegram", payload={"update_id": 2}),
+        logging.getLogger("test"),
+        uow_factory=partial(_mock_uow_factory, uow_mock),
+        job_queue=job_queue,
+    )
+
+    handler.prepare_ingress.assert_awaited_once()
+    job_queue.enqueue.assert_not_awaited()
+
+
+def _reply_context() -> SurfaceReplyContext:
+    return SurfaceReplyContext(
+        platform=SurfacePlatform.TELEGRAM,
+        event=ParsedInboundSurfaceEvent(
+            platform=SurfacePlatform.TELEGRAM,
+            conversation_type=ConversationType.EXTERNAL_DM,
+            external_thread_id="123",
+            sender_external_user_id="123",
+            message_text="hi",
+            is_dm=True,
+            reply_target={"chat_id": "123"},
+        ),
+        reply_message="hello",
+    )

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_progress_observer.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_progress_observer.py
@@ -58,6 +58,14 @@ class _SurfaceService:
         self.messages.append({"display_resource": kwargs})
         return self.send_result
 
+    async def send_questions_for_conversation(self, **kwargs):
+        self.messages.append({"questions": kwargs})
+        return self.send_result
+
+    async def send_approval_prompt_for_conversation(self, **kwargs):
+        self.messages.append({"approval": kwargs})
+        return self.send_result
+
 
 def _observer(service: _SurfaceService) -> SurfaceAgentRunProgressObserver:
     return SurfaceAgentRunProgressObserver(
@@ -489,5 +497,29 @@ async def test_progress_observer_stops_when_indicator_cannot_be_sent(monkeypatch
         {
             "conversation_id": conversation.id,
             "metadata": None,
+        }
+    ]
+
+
+async def test_progress_observer_renders_waiting_tool_call_once():
+    """A repeated WAITING event for the same ask_user tool call must not send
+    the same native surface prompt several times."""
+    service = _SurfaceService()
+    observer = _observer(service)
+    conversation = SimpleNamespace(id=uuid4(), metadata={"surface_platform": "TELEGRAM"})
+    waiting = AgentEvent(
+        type=AgentEventType.WAITING,
+        data={"kind": "ask_user", "tool_call_id": "ask-1"},
+    )
+
+    await observer.on_event(waiting, conversation, SimpleNamespace())
+    await observer.on_event(waiting, conversation, SimpleNamespace())
+
+    assert service.messages == [
+        {
+            "questions": {
+                "conversation_id": conversation.id,
+                "tool_call_id": "ask-1",
+            }
         }
     ]

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_resend_surface.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_resend_surface.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_slack_stream_progress.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_slack_stream_progress.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from slack_sdk.errors import SlackApiError
 from slack_sdk.web.async_client import AsyncWebClient
 
 from app.modules.agent_surfaces.domain.entities import (
@@ -63,3 +64,66 @@ async def test_slack_stream_progress_posts_updates_then_deletes(monkeypatch):
     # end_progress deletes the placeholder.
     await svc.end_progress(event, handle)
     assert deletes and deletes[0]["ts"] == "200.5"
+
+
+async def test_slack_send_file_bytes_retries_without_customized_identity(monkeypatch):
+    completions: list[dict] = []
+    uploads: list[dict] = []
+
+    async def fake_upload_ticket(self, **kwargs):
+        uploads.append(kwargs)
+        return {"ok": True, "upload_url": "https://upload.example.test", "file_id": "F1"}
+
+    async def fake_complete(self, **kwargs):
+        completions.append(kwargs)
+        if len(completions) == 1:
+            raise SlackApiError(
+                "custom identity rejected",
+                {
+                    "ok": False,
+                    "error": "invalid_arguments",
+                    "response_metadata": {"messages": ["username is not allowed"]},
+                },
+            )
+        return {"ok": True}
+
+    class FakeUploadResponse:
+        def raise_for_status(self):
+            return None
+
+    class FakeHttpClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, files):
+            assert url == "https://upload.example.test"
+            assert files["file"][0] == "report.txt"
+            return FakeUploadResponse()
+
+    monkeypatch.setattr(AsyncWebClient, "files_getUploadURLExternal", fake_upload_ticket)
+    monkeypatch.setattr(AsyncWebClient, "files_completeUploadExternal", fake_complete)
+    monkeypatch.setattr(
+        "app.modules.agent_surfaces.platforms.slack.service.httpx.AsyncClient",
+        FakeHttpClient,
+    )
+
+    svc = SlackPlatformService(credentials={"access_token": "xoxb-test"})
+    sent = await svc.send_file_bytes(
+        _event(),
+        file_name="report.txt",
+        file_bytes=b"hello",
+        mime_type="text/plain",
+        caption="Report",
+    )
+
+    assert sent is True
+    assert uploads == [{"filename": "report.txt", "length": 5}]
+    assert len(completions) == 2
+    assert completions[0]["initial_comment"] == "Report"
+    assert completions[1]["files"] == [{"id": "F1", "title": "Report"}]

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_surface_reach_resolver.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_surface_reach_resolver.py
@@ -171,7 +171,32 @@ async def test_teams_handle_config_fallback(monkeypatch):
     assert surface.surface_identity_username == "Lemma (config)"
 
 
-async def test_whatsapp_falls_back_to_account_display_name():
+async def test_whatsapp_handle_resolves_display_phone_and_persists():
+    surface = _surface(
+        surface_type=SurfacePlatform.WHATSAPP,
+        surface_identity_id=None,
+    )
+    repo = FakeSurfaceRepository()
+
+    reach = await SurfaceReachResolver().resolve(
+        surface,
+        credential_resolver=FakeCredentialResolver(
+            {
+                "access_token": "wa-token",
+                "phone_number_id": "PN42",
+                "display_phone_number": "+1 555 0100",
+            }
+        ),
+        connector_service=FakeConnectorService("WhatsApp Account Label"),
+        surface_repository=repo,
+    )
+
+    assert reach.handle == "+1 555 0100"
+    assert surface.surface_identity_username == "+1 555 0100"
+    assert repo.updated == [surface]
+
+
+async def test_whatsapp_falls_back_to_account_display_name_when_number_unavailable():
     surface = _surface(
         surface_type=SurfacePlatform.WHATSAPP, surface_identity_id=None
     )

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_teams_tools.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_teams_tools.py
@@ -350,3 +350,61 @@ async def test_teams_get_recent_thread_messages_include_files(
     assert [message.text for message in response.messages] == ["[File shared: diagram.png]"]
     assert response.messages[0].attachments[0].download_url == "https://files.example/diagram.png"
     assert response.messages[0].attachments[0].content_type == "image/png"
+
+
+def test_teams_download_helper_classifies_urls_and_credentials():
+    from app.modules.agent_surfaces.platforms.teams.service import (
+        _is_raw_sharepoint_document_url,
+        _looks_like_bot_attachment_url,
+        _split_sharepoint_site_and_item_path,
+        _tenant_id_from_credentials,
+    )
+
+    assert (
+        _tenant_id_from_credentials({"user_data": {"tenant_id": "tenant-user"}})
+        == "tenant-user"
+    )
+    assert (
+        _tenant_id_from_credentials({"raw_response": {"tid": "tenant-raw"}})
+        == "tenant-raw"
+    )
+    assert _looks_like_bot_attachment_url(
+        "https://smba.trafficmanager.net/amer/v3/attachments/abc/views/original"
+    )
+    assert _is_raw_sharepoint_document_url(
+        "https://example.sharepoint.com/sites/Eng/Shared%20Documents/report.docx"
+    )
+    assert _split_sharepoint_site_and_item_path(
+        "/sites/Eng/Shared Documents/report.docx"
+    ) == ("/sites/Eng", "/Shared Documents/report.docx")
+
+
+@pytest.mark.asyncio
+async def test_teams_download_attachment_returns_none_without_tokens(monkeypatch):
+    from app.modules.agent_surfaces.domain.entities import (
+        ConversationType,
+        ParsedInboundSurfaceEvent,
+    )
+    from app.modules.agent_surfaces.platforms.teams.service import TeamsPlatformService
+
+    monkeypatch.setattr(
+        "app.modules.agent_surfaces.platforms.teams.client.get_bot_token",
+        AsyncMock(return_value=None),
+    )
+    service = TeamsPlatformService(credentials={"tenant_id": "tenant-1"})
+
+    result = await service.download_attachment_bytes(
+        ParsedInboundSurfaceEvent(
+            platform="TEAMS",
+            conversation_type=ConversationType.EXTERNAL_GROUP,
+            external_thread_id="thread",
+            message_text="file",
+        ),
+        {
+            "download_url": "https://smba.trafficmanager.net/amer/v3/attachments/abc",
+            "name": "file.txt",
+            "content_type": "text/plain",
+        },
+    )
+
+    assert result is None

--- a/lemma-backend/app/modules/test_support/e2e/runtime.py
+++ b/lemma-backend/app/modules/test_support/e2e/runtime.py
@@ -477,6 +477,11 @@ async def full_stack(
     skip_unless_system_lemma()
     env_overlay = system_lemma_env_overlay()
     system_lemma_key = system_lemma_api_key()
+    coverage_env = {
+        name: value
+        for name in ("COVERAGE_PROCESS_START", "COVERAGE_FILE")
+        if (value := os.environ.get(name))
+    }
 
     # Make the same system:lemma env visible to both the in-process backend and
     # the worker subprocess. In default mock mode this may be empty; in real mode
@@ -502,6 +507,7 @@ async def full_stack(
     worker_env = {
         **os.environ,
         **env_overlay,
+        **coverage_env,
         "PYTHONPATH": ".",
         "DATABASE_URL": settings.database_url,
         "DATASTORE_DATABASE_URL": settings.datastore_database_url,

--- a/lemma-backend/app/modules/test_support/e2e/runtime.py
+++ b/lemma-backend/app/modules/test_support/e2e/runtime.py
@@ -20,6 +20,11 @@ import httpx
 import uvicorn
 
 from app.core.config import settings
+from app.modules.agent.tests.e2e.system_lemma_helpers import (
+    skip_unless_system_lemma,
+    system_lemma_api_key,
+    system_lemma_env_overlay,
+)
 
 
 def _available_port() -> int:
@@ -459,36 +464,29 @@ async def full_stack(
 
     Combines the real backend + local Docker AgentBox (``configure_workspace_api_url``)
     and a real scheduler (``scheduler_api_server``) with the **production streaq
-    worker subprocess** wired to the AgentBox and the Fireworks-backed
-    ``system:lemma`` agent runtime. The worker is a fresh subprocess per test
-    (no shared in-process singletons), so triggered runs execute real functions
-    in Docker and real agents on Fireworks autonomously.
+    worker subprocess** wired to the AgentBox and the ``system:lemma`` agent
+    runtime. The worker is a fresh subprocess per test (no shared in-process
+    singletons), so triggered runs execute real functions in Docker and
+    deterministic mock agents by default. Set ``E2E_LLM_MODE=real`` to use the
+    configured live system:lemma provider.
 
-    Skips when the Fireworks credential is unavailable.
+    Skips only in real-LLM mode when system:lemma credentials are unavailable.
     """
     import redis.asyncio as redis
 
-    fireworks_key = (
-        os.getenv("FIREWORKS_API_KEY")
-        or _read_root_env_value("FIREWORKS_API_KEY")
-        or _read_root_env_value("lemma_openai_api_key")
-    )
-    if not fireworks_key:
-        pytest.skip(
-            "Fireworks credential unavailable; export FIREWORKS_API_KEY to run "
-            "fully-real agent e2e tests."
-        )
+    skip_unless_system_lemma()
+    env_overlay = system_lemma_env_overlay()
+    system_lemma_key = system_lemma_api_key()
 
-    # Inject the Fireworks key so both the in-process backend and the worker
-    # subprocess resolve the system:lemma OpenAI-compatible profile. The model
-    # catalog has no built-in default, so the real-LLM env (.env / exported
-    # LEMMA_OPENAI_* vars) must provide LEMMA_OPENAI_BASE_URL + LEMMA_OPENAI_MODEL_NAMES.
-    cred_env_keys = ("LEMMA_OPENAI_API_KEY", "lemma_openai_api_key")
-    original_cred_env = {key: os.environ.get(key) for key in cred_env_keys}
+    # Make the same system:lemma env visible to both the in-process backend and
+    # the worker subprocess. In default mock mode this may be empty; in real mode
+    # the helper has already verified that the key exists.
+    original_overlay_env = {key: os.environ.get(key) for key in env_overlay}
     original_cred_setting = settings.lemma_openai_api_key
-    for key in cred_env_keys:
-        os.environ[key] = fireworks_key
-    settings.lemma_openai_api_key = fireworks_key
+    for key, value in env_overlay.items():
+        os.environ[key] = value
+    if system_lemma_key:
+        settings.lemma_openai_api_key = system_lemma_key
 
     redis_url = settings.redis_url
     redis_client = redis.from_url(redis_url, decode_responses=False)
@@ -500,10 +498,10 @@ async def full_stack(
 
     # The worker subprocess inherits os.environ, which now carries AGENTBOX_API_URL/
     # KEY and API_URL (from configure_workspace_api_url), SCHEDULER_API_URL (from
-    # scheduler_api_server), and the Fireworks key. So it runs functions in the
-    # local Docker AgentBox and agents on Fireworks for real.
+    # scheduler_api_server), and any system:lemma provider env from .env/CI.
     worker_env = {
         **os.environ,
+        **env_overlay,
         "PYTHONPATH": ".",
         "DATABASE_URL": settings.database_url,
         "DATASTORE_DATABASE_URL": settings.datastore_database_url,
@@ -578,7 +576,7 @@ async def full_stack(
             await redis_client.flushdb()
             await redis_client.aclose()
             settings.lemma_openai_api_key = original_cred_setting
-            for key, value in original_cred_env.items():
+            for key, value in original_overlay_env.items():
                 if value is None:
                     os.environ.pop(key, None)
                 else:

--- a/lemma-backend/pytest.ini
+++ b/lemma-backend/pytest.ini
@@ -19,6 +19,7 @@ markers =
     workspace: Tests that require a docker workspace runtime image
     indexing: E2E tests that need the Kreuzberg document-extraction container (real indexing/search); split out of test-e2e-fast
     provider: Tests that require real third-party provider credentials or APIs
+    surface_live: Optional live agent-surface provider smoke tests; gated by LEMMA_RUN_SURFACE_LIVE_E2E=1
     human: Tests needing a human in the loop (e.g. live OAuth consent); opt-in only, never in CI
     local_cli: Tests that require local Codex/OpenCode/Claude CLI binaries
     real_llm: Tests that require the real model (skipped in mock e2e mode)

--- a/lemma-backend/scripts/agent_surfaces_coverage_report.py
+++ b/lemma-backend/scripts/agent_surfaces_coverage_report.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import argparse
+import glob
+import html
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree
+
+
+COMMENT_MARKER = "<!-- lemma-agent-surfaces-coverage -->"
+MODULE_PREFIX = "app/modules/agent_surfaces/"
+PLATFORM_ROOT = "platforms"
+
+
+def _pct(covered: int, statements: int) -> float:
+    if statements <= 0:
+        return 100.0
+    return (covered / statements) * 100
+
+
+def _format_pct(value: float) -> str:
+    return f"{value:.1f}%"
+
+
+def _escape_cell(value: object) -> str:
+    text = html.escape(str(value), quote=False)
+    return text.replace("|", "\\|")
+
+
+def _table(headers: list[str], rows: list[list[object]]) -> str:
+    lines = [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    for row in rows:
+        lines.append("| " + " | ".join(_escape_cell(item) for item in row) + " |")
+    return "\n".join(lines)
+
+
+def _load_coverage(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    return json.loads(path.read_text())
+
+
+def _module_name(filename: str) -> str:
+    rel = filename.split(MODULE_PREFIX, 1)[-1]
+    if "/" not in rel:
+        return "root"
+    return rel.split("/", 1)[0]
+
+
+def _platform_name(filename: str) -> str | None:
+    rel = filename.split(MODULE_PREFIX, 1)[-1]
+    parts = rel.split("/")
+    if not parts or parts[0] != PLATFORM_ROOT:
+        return None
+    if len(parts) == 2:
+        return "platforms_core"
+    return parts[1]
+
+
+def _accumulate_coverage(
+    coverage: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    top_level: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+    platforms: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+    files: list[dict[str, Any]] = []
+
+    for filename, meta in coverage.get("files", {}).items():
+        if "/tests/" in filename:
+            continue
+        summary = meta["summary"]
+        statements = int(summary["num_statements"])
+        missing = int(summary["missing_lines"])
+        covered = statements - missing
+        module = _module_name(filename)
+        top_level[module][0] += statements
+        top_level[module][1] += missing
+
+        platform = _platform_name(filename)
+        if platform:
+            platforms[platform][0] += statements
+            platforms[platform][1] += missing
+
+        files.append(
+            {
+                "file": filename.split(MODULE_PREFIX, 1)[-1],
+                "statements": statements,
+                "missing": missing,
+                "covered": covered,
+                "coverage": _pct(covered, statements),
+            }
+        )
+
+    def _rows(source: dict[str, list[int]]) -> list[dict[str, Any]]:
+        rows = []
+        for name, (statements, missing) in sorted(source.items()):
+            covered = statements - missing
+            rows.append(
+                {
+                    "name": name,
+                    "statements": statements,
+                    "missing": missing,
+                    "covered": covered,
+                    "coverage": _pct(covered, statements),
+                }
+            )
+        return rows
+
+    lowest = sorted(files, key=lambda row: (row["coverage"], -row["statements"]))[:10]
+    return _rows(top_level), _rows(platforms), lowest
+
+
+def _read_junit(path: Path) -> dict[str, float | int]:
+    if not path.exists():
+        return {"tests": 0, "failures": 0, "errors": 0, "skipped": 0, "time": 0.0}
+    root = ElementTree.fromstring(path.read_text())
+    suites = [root] if root.tag == "testsuite" else list(root.findall("testsuite"))
+    totals = {"tests": 0, "failures": 0, "errors": 0, "skipped": 0, "time": 0.0}
+    for suite in suites:
+        totals["tests"] += int(suite.attrib.get("tests", 0))
+        totals["failures"] += int(suite.attrib.get("failures", 0))
+        totals["errors"] += int(suite.attrib.get("errors", 0))
+        totals["skipped"] += int(suite.attrib.get("skipped", 0))
+        totals["time"] += float(suite.attrib.get("time", 0.0))
+    return totals
+
+
+def _read_junits(paths: list[Path]) -> dict[str, float | int]:
+    totals = {"tests": 0, "failures": 0, "errors": 0, "skipped": 0, "time": 0.0}
+    for path in paths:
+        one = _read_junit(path)
+        for key in totals:
+            totals[key] += one[key]  # type: ignore[operator]
+    return totals
+
+
+def build_summary(
+    coverage: dict[str, Any] | None,
+    *,
+    phase: str,
+    junit_paths: list[Path],
+) -> dict[str, Any]:
+    tests = _read_junits(junit_paths)
+    if coverage is None:
+        return {
+            "phase": phase,
+            "missing_coverage": True,
+            "tests": tests,
+            "totals": {},
+            "top_level": [],
+            "platforms": [],
+            "lowest_files": [],
+        }
+
+    top_level, platforms, lowest = _accumulate_coverage(coverage)
+    return {
+        "phase": phase,
+        "missing_coverage": False,
+        "tests": tests,
+        "totals": coverage.get("totals", {}),
+        "top_level": top_level,
+        "platforms": platforms,
+        "lowest_files": lowest,
+    }
+
+
+def render_markdown(summary: dict[str, Any]) -> str:
+    phase = summary["phase"]
+    title = "unit" if phase == "unit" else "combined unit + mocked e2e"
+    lines = [COMMENT_MARKER, f"## Agent Surfaces Coverage ({title})", ""]
+    lines.append("_Report-only: this PR does not fail on coverage thresholds yet._")
+    lines.append("")
+
+    tests = summary["tests"]
+    lines.append(
+        "**Tests:** "
+        f"{tests['tests']} collected, "
+        f"{tests['failures']} failed, "
+        f"{tests['errors']} errors, "
+        f"{tests['skipped']} skipped"
+    )
+
+    if summary["missing_coverage"]:
+        lines.extend(
+            [
+                "",
+                "Coverage artifact was not found, so module coverage could not be rendered.",
+            ]
+        )
+        return "\n".join(lines).rstrip() + "\n"
+
+    totals = summary["totals"]
+    statements = int(totals["num_statements"])
+    missing = int(totals["missing_lines"])
+    covered = int(totals["covered_lines"])
+    percent = float(totals["percent_covered"])
+    lines.append(
+        f"**Total:** {_format_pct(percent)} ({covered}/{statements} lines, "
+        f"{missing} missing)"
+    )
+    lines.append("")
+    lines.append("### Top-level modules")
+    lines.append(
+        _table(
+            ["Module", "Statements", "Missing", "Coverage"],
+            [
+                [
+                    row["name"],
+                    row["statements"],
+                    row["missing"],
+                    _format_pct(row["coverage"]),
+                ]
+                for row in summary["top_level"]
+            ],
+        )
+    )
+    lines.append("")
+    lines.append("### Platform areas")
+    lines.append(
+        _table(
+            ["Area", "Statements", "Missing", "Coverage"],
+            [
+                [
+                    row["name"],
+                    row["statements"],
+                    row["missing"],
+                    _format_pct(row["coverage"]),
+                ]
+                for row in summary["platforms"]
+            ],
+        )
+    )
+    lines.append("")
+    lines.append("### Lowest-covered files")
+    lines.append(
+        _table(
+            ["File", "Statements", "Missing", "Coverage"],
+            [
+                [
+                    row["file"],
+                    row["statements"],
+                    row["missing"],
+                    _format_pct(row["coverage"]),
+                ]
+                for row in summary["lowest_files"]
+            ],
+        )
+    )
+    lines.append("")
+    lines.append(
+        "Optional live-provider smoke tests remain separate behind "
+        "`LEMMA_RUN_SURFACE_LIVE_E2E=1` / `surface-live`."
+    )
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _paths_from_glob(patterns: list[str]) -> list[Path]:
+    paths: list[Path] = []
+    for pattern in patterns:
+        paths.extend(Path(path) for path in sorted(glob.glob(pattern)))
+    return paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--coverage-json", type=Path, required=True)
+    parser.add_argument("--phase", choices=["unit", "combined"], required=True)
+    parser.add_argument("--junit", action="append", type=Path, default=[])
+    parser.add_argument("--junit-glob", action="append", default=[])
+    parser.add_argument("--markdown-out", type=Path, required=True)
+    parser.add_argument("--summary-json-out", type=Path, required=True)
+    args = parser.parse_args()
+
+    junit_paths = list(args.junit) + _paths_from_glob(args.junit_glob)
+    summary = build_summary(
+        _load_coverage(args.coverage_json),
+        phase=args.phase,
+        junit_paths=junit_paths,
+    )
+    markdown = render_markdown(summary)
+
+    args.markdown_out.parent.mkdir(parents=True, exist_ok=True)
+    args.summary_json_out.parent.mkdir(parents=True, exist_ok=True)
+    args.markdown_out.write_text(markdown)
+    args.summary_json_out.write_text(json.dumps(summary, indent=2, sort_keys=True))
+    print(markdown)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lemma-backend/scripts/backend_coverage_report.py
+++ b/lemma-backend/scripts/backend_coverage_report.py
@@ -10,9 +10,11 @@ from typing import Any
 from xml.etree import ElementTree
 
 
-COMMENT_MARKER = "<!-- lemma-agent-surfaces-coverage -->"
-MODULE_PREFIX = "app/modules/agent_surfaces/"
-PLATFORM_ROOT = "platforms"
+COMMENT_MARKER_PREFIX = "lemma-backend-coverage"
+
+
+def comment_marker(phase: str) -> str:
+    return f"<!-- {COMMENT_MARKER_PREFIX}:{phase} -->"
 
 
 def _pct(covered: int, statements: int) -> float:
@@ -46,49 +48,48 @@ def _load_coverage(path: Path) -> dict[str, Any] | None:
     return json.loads(path.read_text())
 
 
+def _relative_app_file(filename: str) -> str:
+    return filename.split("app/", 1)[-1] if "app/" in filename else filename
+
+
 def _module_name(filename: str) -> str:
-    rel = filename.split(MODULE_PREFIX, 1)[-1]
-    if "/" not in rel:
-        return "root"
-    return rel.split("/", 1)[0]
-
-
-def _platform_name(filename: str) -> str | None:
-    rel = filename.split(MODULE_PREFIX, 1)[-1]
+    rel = _relative_app_file(filename)
     parts = rel.split("/")
-    if not parts or parts[0] != PLATFORM_ROOT:
-        return None
-    if len(parts) == 2:
-        return "platforms_core"
-    return parts[1]
+    if not parts:
+        return "root"
+    if parts[0] == "modules" and len(parts) > 1:
+        return parts[1]
+    if parts[0] == "core":
+        return "core"
+    return parts[0] or "root"
+
+
+def _should_skip_file(filename: str) -> bool:
+    rel = _relative_app_file(filename)
+    name = rel.rsplit("/", 1)[-1]
+    return "/tests/" in filename or name.startswith("test_") or name == "conftest.py"
 
 
 def _accumulate_coverage(
     coverage: dict[str, Any],
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
-    top_level: dict[str, list[int]] = defaultdict(lambda: [0, 0])
-    platforms: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    modules: dict[str, list[int]] = defaultdict(lambda: [0, 0])
     files: list[dict[str, Any]] = []
 
     for filename, meta in coverage.get("files", {}).items():
-        if "/tests/" in filename:
+        if _should_skip_file(filename):
             continue
         summary = meta["summary"]
         statements = int(summary["num_statements"])
         missing = int(summary["missing_lines"])
         covered = statements - missing
         module = _module_name(filename)
-        top_level[module][0] += statements
-        top_level[module][1] += missing
-
-        platform = _platform_name(filename)
-        if platform:
-            platforms[platform][0] += statements
-            platforms[platform][1] += missing
-
+        modules[module][0] += statements
+        modules[module][1] += missing
         files.append(
             {
-                "file": filename.split(MODULE_PREFIX, 1)[-1],
+                "file": _relative_app_file(filename),
+                "module": module,
                 "statements": statements,
                 "missing": missing,
                 "covered": covered,
@@ -96,23 +97,21 @@ def _accumulate_coverage(
             }
         )
 
-    def _rows(source: dict[str, list[int]]) -> list[dict[str, Any]]:
-        rows = []
-        for name, (statements, missing) in sorted(source.items()):
-            covered = statements - missing
-            rows.append(
-                {
-                    "name": name,
-                    "statements": statements,
-                    "missing": missing,
-                    "covered": covered,
-                    "coverage": _pct(covered, statements),
-                }
-            )
-        return rows
+    module_rows = []
+    for name, (statements, missing) in sorted(modules.items()):
+        covered = statements - missing
+        module_rows.append(
+            {
+                "name": name,
+                "statements": statements,
+                "missing": missing,
+                "covered": covered,
+                "coverage": _pct(covered, statements),
+            }
+        )
 
-    lowest = sorted(files, key=lambda row: (row["coverage"], -row["statements"]))[:10]
-    return _rows(top_level), _rows(platforms), lowest
+    lowest = sorted(files, key=lambda row: (row["coverage"], -row["statements"]))[:15]
+    return module_rows, lowest
 
 
 def _read_junit(path: Path) -> dict[str, float | int]:
@@ -152,34 +151,35 @@ def build_summary(
             "missing_coverage": True,
             "tests": tests,
             "totals": {},
-            "top_level": [],
-            "platforms": [],
+            "modules": [],
             "lowest_files": [],
         }
 
-    top_level, platforms, lowest = _accumulate_coverage(coverage)
+    modules, lowest = _accumulate_coverage(coverage)
     return {
         "phase": phase,
         "missing_coverage": False,
         "tests": tests,
         "totals": coverage.get("totals", {}),
-        "top_level": top_level,
-        "platforms": platforms,
+        "modules": modules,
         "lowest_files": lowest,
     }
 
 
+def _phase_title(phase: str) -> str:
+    return phase.replace("-", " ")
+
+
 def render_markdown(summary: dict[str, Any]) -> str:
     phase = summary["phase"]
-    title = "unit" if phase == "unit" else "combined unit + mocked e2e"
-    lines = [COMMENT_MARKER, f"## Agent Surfaces Coverage ({title})", ""]
+    lines = [comment_marker(phase), f"## Backend Coverage ({_phase_title(phase)})", ""]
     lines.append("_Report-only: this PR does not fail on coverage thresholds yet._")
     lines.append("")
 
     tests = summary["tests"]
     lines.append(
         "**Tests:** "
-        f"{tests['tests']} collected, "
+        f"{tests['tests']} run, "
         f"{tests['failures']} failed, "
         f"{tests['errors']} errors, "
         f"{tests['skipped']} skipped"
@@ -204,7 +204,7 @@ def render_markdown(summary: dict[str, Any]) -> str:
         f"{missing} missing)"
     )
     lines.append("")
-    lines.append("### Top-level modules")
+    lines.append("### Module Coverage")
     lines.append(
         _table(
             ["Module", "Statements", "Missing", "Coverage"],
@@ -215,34 +215,19 @@ def render_markdown(summary: dict[str, Any]) -> str:
                     row["missing"],
                     _format_pct(row["coverage"]),
                 ]
-                for row in summary["top_level"]
+                for row in summary["modules"]
             ],
         )
     )
     lines.append("")
-    lines.append("### Platform areas")
+    lines.append("### Lowest-Covered Files")
     lines.append(
         _table(
-            ["Area", "Statements", "Missing", "Coverage"],
-            [
-                [
-                    row["name"],
-                    row["statements"],
-                    row["missing"],
-                    _format_pct(row["coverage"]),
-                ]
-                for row in summary["platforms"]
-            ],
-        )
-    )
-    lines.append("")
-    lines.append("### Lowest-covered files")
-    lines.append(
-        _table(
-            ["File", "Statements", "Missing", "Coverage"],
+            ["File", "Module", "Statements", "Missing", "Coverage"],
             [
                 [
                     row["file"],
+                    row["module"],
                     row["statements"],
                     row["missing"],
                     _format_pct(row["coverage"]),
@@ -250,11 +235,6 @@ def render_markdown(summary: dict[str, Any]) -> str:
                 for row in summary["lowest_files"]
             ],
         )
-    )
-    lines.append("")
-    lines.append(
-        "Optional live-provider smoke tests remain separate behind "
-        "`LEMMA_RUN_SURFACE_LIVE_E2E=1` / `surface-live`."
     )
     return "\n".join(lines).rstrip() + "\n"
 
@@ -269,7 +249,7 @@ def _paths_from_glob(patterns: list[str]) -> list[Path]:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--coverage-json", type=Path, required=True)
-    parser.add_argument("--phase", choices=["unit", "combined"], required=True)
+    parser.add_argument("--phase", required=True)
     parser.add_argument("--junit", action="append", type=Path, default=[])
     parser.add_argument("--junit-glob", action="append", default=[])
     parser.add_argument("--markdown-out", type=Path, required=True)

--- a/lemma-backend/sitecustomize.py
+++ b/lemma-backend/sitecustomize.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import os
+
+
+if os.environ.get("COVERAGE_PROCESS_START"):
+    try:
+        import coverage
+
+        coverage.process_startup()
+    except Exception:
+        # Coverage must never prevent app/test subprocess startup.
+        pass


### PR DESCRIPTION
## Summary
- prevent repeated WAITING events from rendering duplicate ask_user/request_approval prompts on external surfaces
- avoid exposing pod-specific access links on shared system Telegram/WhatsApp surfaces for signed-up non-members
- keep custom/bound bot onboarding links working and add unit/e2e coverage for both paths

## Tests
- uv run ruff check app/modules/agent_surfaces/services/ingress_service.py app/modules/agent_surfaces/services/progress_observer.py app/modules/agent_surfaces/tests/unit/test_ingress_service.py app/modules/agent_surfaces/tests/unit/test_progress_observer.py app/modules/agent_surfaces/tests/e2e/test_onboarding_reply_e2e.py
- uv run pytest app/modules/agent_surfaces/tests/unit
- uv run pytest app/modules/agent_surfaces/tests/e2e (75 passed, 2 skipped: Fireworks credential unavailable)
