### PR TITLE
Support scoped user usage limits

### DIFF
--- a/lemma-backend/app/modules/usage/api/schemas.py
+++ b/lemma-backend/app/modules/usage/api/schemas.py
@@ -104,6 +104,7 @@ class UsageStatsResponse(BaseModel):
 
 class UsageLimitScopeResponse(BaseModel):
     limit_usd: float | None = None
+    scope: str
     used_usd: float
     reserved_usd: float
     remaining_usd: float | None = None

--- a/lemma-backend/app/modules/usage/domain/ports.py
+++ b/lemma-backend/app/modules/usage/domain/ports.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Protocol, Sequence
+from typing import Literal, Protocol, Sequence
 from uuid import UUID
 
 from app.modules.usage.domain.entities import UsageRecord, UsageSummary
@@ -78,6 +78,8 @@ class UsageLimitValues:
     org_monthly_limit_usd: float | None = None
     user_weekly_limit_usd: float | None = None
     user_monthly_limit_usd: float | None = None
+    user_limit_scope: Literal["organization", "global"] = "organization"
+    excluded_organization_ids: tuple[UUID, ...] = ()
 
 
 class UsageLimitPort(Protocol):

--- a/lemma-backend/app/modules/usage/infrastructure/repositories.py
+++ b/lemma-backend/app/modules/usage/infrastructure/repositories.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Sequence
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 
 from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
 from app.modules.usage.domain.entities import UsageRecord, UsageSummary
@@ -167,6 +167,7 @@ class UsageRepository(UsageRepositoryPort):
         user_id: UUID | None,
         start: datetime,
         end: datetime,
+        exclude_organization_ids: Sequence[UUID] = (),
     ) -> float:
         stmt = select(func.coalesce(func.sum(UsageRecordModel.cost_usd), 0.0)).where(
             UsageRecordModel.occurred_at >= start,
@@ -178,6 +179,15 @@ class UsageRepository(UsageRepositoryPort):
             user_id=user_id,
             system_cost_only=True,
         )
+        if exclude_organization_ids:
+            stmt = stmt.where(
+                or_(
+                    UsageRecordModel.organization_id.is_(None),
+                    UsageRecordModel.organization_id.notin_(
+                        tuple(exclude_organization_ids)
+                    ),
+                )
+            )
         result = await self.session.execute(stmt)
         return float(result.scalar_one() or 0.0)
 

--- a/lemma-backend/app/modules/usage/services/usage_service.py
+++ b/lemma-backend/app/modules/usage/services/usage_service.py
@@ -114,12 +114,12 @@ class UsageService:
                     window_end=org_monthly["reset_at"],
                     amount_usd=amount,
                 )
-            )
+        )
         user_weekly = limits["user_weekly"]
         if user_weekly["limit_usd"] is not None:
             counter_ids.append(
                 await self.usage_repository.reserve_counter(
-                    organization_id=organization_id,
+                    organization_id=user_weekly["counter_organization_id"],
                     user_id=user_id,
                     window_kind="user_week",
                     window_start=user_weekly["window_start"],
@@ -131,7 +131,7 @@ class UsageService:
         if user_monthly["limit_usd"] is not None:
             counter_ids.append(
                 await self.usage_repository.reserve_counter(
-                    organization_id=organization_id,
+                    organization_id=user_monthly["counter_organization_id"],
                     user_id=user_id,
                     window_kind="user_month",
                     window_start=user_monthly["window_start"],
@@ -388,6 +388,16 @@ class UsageService:
             organization_id=organization_id,
             user_id=user_id,
         )
+        user_limit_organization_id = (
+            organization_id
+            if limit_values.user_limit_scope == "organization"
+            else None
+        )
+        excluded_organization_ids = (
+            limit_values.excluded_organization_ids
+            if limit_values.user_limit_scope == "global"
+            else ()
+        )
         org_used = 0.0
         org_reserved = 0.0
         if organization_id is not None:
@@ -404,25 +414,27 @@ class UsageService:
                 window_start=month_start,
             )
         user_weekly_used = await self.usage_repository.get_system_cost(
-            organization_id=organization_id,
+            organization_id=user_limit_organization_id,
             user_id=user_id,
             start=week_start,
             end=now,
+            exclude_organization_ids=excluded_organization_ids,
         )
         user_weekly_reserved = await self.usage_repository.get_reserved_cost(
-            organization_id=organization_id,
+            organization_id=user_limit_organization_id,
             user_id=user_id,
             window_kind="user_week",
             window_start=week_start,
         )
         user_monthly_used = await self.usage_repository.get_system_cost(
-            organization_id=organization_id,
+            organization_id=user_limit_organization_id,
             user_id=user_id,
             start=month_start,
             end=now,
+            exclude_organization_ids=excluded_organization_ids,
         )
         user_monthly_reserved = await self.usage_repository.get_reserved_cost(
-            organization_id=organization_id,
+            organization_id=user_limit_organization_id,
             user_id=user_id,
             window_kind="user_month",
             window_start=month_start,
@@ -433,6 +445,8 @@ class UsageService:
             reserved_usd=org_reserved,
             reset_at=self._next_month_start(now),
             window_start=month_start,
+            scope="organization",
+            counter_organization_id=organization_id,
         )
         user_weekly_scope = self._limit_scope(
             limit_usd=limit_values.user_weekly_limit_usd,
@@ -440,6 +454,8 @@ class UsageService:
             reserved_usd=user_weekly_reserved,
             reset_at=week_start + timedelta(days=7),
             window_start=week_start,
+            scope=limit_values.user_limit_scope,
+            counter_organization_id=user_limit_organization_id,
         )
         user_monthly_scope = self._limit_scope(
             limit_usd=limit_values.user_monthly_limit_usd,
@@ -447,6 +463,8 @@ class UsageService:
             reserved_usd=user_monthly_reserved,
             reset_at=self._next_month_start(now),
             window_start=month_start,
+            scope=limit_values.user_limit_scope,
+            counter_organization_id=user_limit_organization_id,
         )
         return {
             "organization_id": organization_id,
@@ -551,6 +569,7 @@ class UsageService:
                 ),
                 user_weekly_limit_usd=self.DEFAULT_USER_WEEKLY_COST_LIMIT_USD,
                 user_monthly_limit_usd=self.DEFAULT_USER_MONTHLY_COST_LIMIT_USD,
+                user_limit_scope="organization",
             )
         resolved = await self.usage_limit_port.resolve_limits(
             organization_id=organization_id,
@@ -565,6 +584,7 @@ class UsageService:
             org_monthly_limit_usd=org_monthly,
             user_weekly_limit_usd=user_weekly,
             user_monthly_limit_usd=None,
+            user_limit_scope="organization",
         )
 
     def _limit_scope(
@@ -575,17 +595,21 @@ class UsageService:
         reserved_usd: float,
         reset_at: datetime,
         window_start: datetime,
+        scope: str,
+        counter_organization_id: UUID | None,
     ) -> dict[str, object]:
         consumed = used_usd + reserved_usd
         remaining = None if limit_usd is None else max(0.0, limit_usd - consumed)
         return {
             "limit_usd": limit_usd,
+            "scope": scope,
             "used_usd": used_usd,
             "reserved_usd": reserved_usd,
             "remaining_usd": remaining,
             "allowed": limit_usd is None or consumed < limit_usd,
             "reset_at": reset_at,
             "window_start": window_start,
+            "counter_organization_id": counter_organization_id,
         }
 
     def _next_month_start(self, now: datetime) -> datetime:

--- a/lemma-backend/app/modules/usage/tests/unit/test_usage_limits_fake_unit.py
+++ b/lemma-backend/app/modules/usage/tests/unit/test_usage_limits_fake_unit.py
@@ -25,11 +25,15 @@ class _StubUsageRepository:
     def __init__(self, *, used_usd: float) -> None:
         self.uow = FakeUnitOfWork()
         self._used = used_usd
+        self.system_cost_calls: list[dict[str, object]] = []
+        self.reserved_cost_calls: list[dict[str, object]] = []
 
-    async def get_system_cost(self, **_kwargs) -> float:
+    async def get_system_cost(self, **kwargs) -> float:
+        self.system_cost_calls.append(kwargs)
         return self._used
 
-    async def get_reserved_cost(self, **_kwargs) -> float:
+    async def get_reserved_cost(self, **kwargs) -> float:
+        self.reserved_cost_calls.append(kwargs)
         return 0.0
 
 
@@ -38,6 +42,15 @@ class _FakeUsageLimitPort:
 
     def __init__(self, *, org_limit, user_limit) -> None:
         self._limits = (org_limit, user_limit)
+
+    async def resolve_limits(self, *, organization_id, user_id):
+        del organization_id, user_id
+        return self._limits
+
+
+class _StaticUsageLimitPort:
+    def __init__(self, limits: UsageLimitValues) -> None:
+        self._limits = limits
 
     async def resolve_limits(self, *, organization_id, user_id):
         del organization_id, user_id
@@ -109,3 +122,72 @@ async def test_falls_back_to_builtin_defaults_without_billing():
         == UsageService.DEFAULT_USER_WEEKLY_COST_LIMIT_USD
     )
     assert limits["user_monthly"]["limit_usd"] is None
+
+
+async def test_org_scoped_user_limits_count_only_selected_org():
+    organization_id = uuid4()
+    repository = _StubUsageRepository(used_usd=2.0)
+    service = UsageService(
+        usage_repository=repository,
+        usage_limit_port=_StaticUsageLimitPort(
+            UsageLimitValues(
+                org_monthly_limit_usd=50.0,
+                user_weekly_limit_usd=10.0,
+                user_monthly_limit_usd=20.0,
+                user_limit_scope="organization",
+            )
+        ),
+    )
+
+    limits = await service.get_usage_limits(
+        organization_id=organization_id,
+        user_id=uuid4(),
+    )
+
+    assert limits["user_weekly"]["scope"] == "organization"
+    assert limits["user_monthly"]["scope"] == "organization"
+    user_cost_calls = [
+        call for call in repository.system_cost_calls if call["user_id"] is not None
+    ]
+    assert len(user_cost_calls) == 2
+    assert all(call["organization_id"] == organization_id for call in user_cost_calls)
+    assert all(call["exclude_organization_ids"] == () for call in user_cost_calls)
+
+
+async def test_global_user_limits_count_all_orgs_except_exclusions():
+    excluded_org_id = uuid4()
+    repository = _StubUsageRepository(used_usd=2.0)
+    service = UsageService(
+        usage_repository=repository,
+        usage_limit_port=_StaticUsageLimitPort(
+            UsageLimitValues(
+                org_monthly_limit_usd=None,
+                user_weekly_limit_usd=10.0,
+                user_monthly_limit_usd=20.0,
+                user_limit_scope="global",
+                excluded_organization_ids=(excluded_org_id,),
+            )
+        ),
+    )
+
+    limits = await service.get_usage_limits(
+        organization_id=uuid4(),
+        user_id=uuid4(),
+    )
+
+    assert limits["user_weekly"]["scope"] == "global"
+    assert limits["user_monthly"]["scope"] == "global"
+    user_cost_calls = [
+        call for call in repository.system_cost_calls if call["user_id"] is not None
+    ]
+    assert len(user_cost_calls) == 2
+    assert all(call["organization_id"] is None for call in user_cost_calls)
+    assert all(
+        call["exclude_organization_ids"] == (excluded_org_id,)
+        for call in user_cost_calls
+    )
+    user_reserved_calls = [
+        call for call in repository.reserved_cost_calls if call["user_id"] is not None
+    ]
+    assert len(user_reserved_calls) == 2
+    assert all(call["organization_id"] is None for call in user_reserved_calls)


### PR DESCRIPTION
## Summary
- add user-limit scope metadata to resolved usage limits
- support global user aggregation with excluded paid organization ids
- expose limit scope in usage limit API responses
- reserve/check user limit counters using the resolved scope

## Tests
- uv run pytest app/modules/usage/tests/unit/test_usage_limits_fake_unit.py
- uv run ruff check app/modules/usage/domain/ports.py app/modules/usage/services/usage_service.py app/modules/usage/infrastructure/repositories.py app/modules/usage/api/schemas.py app/modules/usage/tests/unit/test_usage_limits_fake_unit.py