### PR TITLE
chore(deps): reduce Dependabot PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 version: 2
 
-# Version updates are intentionally low-frequency and grouped. Security updates
-# remain immediate, but are grouped per ecosystem instead of opening one PR per
-# vulnerable transitive dependency.
+# Version updates are intentionally low-frequency and grouped into one PR per
+# ecosystem, including major updates. Security updates remain immediate, but are
+# grouped per ecosystem instead of opening one PR per vulnerable dependency.
 updates:
   - package-ecosystem: uv
     directories:
@@ -18,12 +18,11 @@ updates:
       interval: monthly
       time: "04:00"
       timezone: Asia/Kolkata
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 1
     groups:
       python-routine-updates:
         applies-to: version-updates
         patterns: ["*"]
-        update-types: [minor, patch]
       python-security-updates:
         applies-to: security-updates
         patterns: ["*"]
@@ -36,12 +35,11 @@ updates:
       interval: monthly
       time: "04:15"
       timezone: Asia/Kolkata
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 1
     groups:
       javascript-routine-updates:
         applies-to: version-updates
         patterns: ["*"]
-        update-types: [minor, patch]
       javascript-security-updates:
         applies-to: security-updates
         patterns: ["*"]


### PR DESCRIPTION
## Summary

- group all Python and JavaScript version updates, including majors, into one routine PR per ecosystem
- cap concurrent routine version-update PRs at one per ecosystem
- preserve monthly scans and immediate grouped security updates

## Why

Major updates were excluded from the routine groups, so Dependabot opened a separate PR for each affected monorepo directory. This keeps the low-frequency schedule while preventing that fan-out.

## Validation

- parsed .github/dependabot.yml successfully as YAML
- git diff --check

## Follow-up

After merge, the old-config PRs and superseded individual setuptools PRs can be closed to clear the existing queue.