### PR TITLE
fix: resolve remaining connector, daemon, and local-stack issues

### DIFF
--- a/.github/workflows/windows-daemon.yml
+++ b/.github/workflows/windows-daemon.yml
@@ -100,7 +100,7 @@ jobs:
           Write-Host "daemon lifecycle ok"
           exit 0
 
-      - name: Unit tests — cross-platform process helpers (real Windows)
+      - name: Unit tests — process lifecycle and command shims (real Windows)
         run: |
           $ErrorActionPreference = "Stop"
           # Plain pip (unlike uv) ignores [tool.uv.sources], so it cannot resolve

--- a/lemma-backend/app/modules/connectors/tests/unit/test_import_connector_catalog.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_import_connector_catalog.py
@@ -430,6 +430,93 @@ async def test_sync_composio_catalog_keeps_composio_operations_for_non_native_ap
 
 
 @pytest.mark.asyncio
+async def test_sync_composio_catalog_imports_apollo_api_key_and_contact_operations():
+    connector_repository = SimpleNamespace(get=AsyncMock(return_value=None))
+    operation_repository = SimpleNamespace()
+    trigger_repository = SimpleNamespace()
+
+    toolkit_item = _toolkit("apollo", name="Apollo")
+    toolkit_item.auth_schemes = ["API_KEY"]
+    api_key_field = SimpleNamespace(
+        name="generic_api_key",
+        display_name="API Key",
+        description="Apollo API key",
+        type="string",
+        default=None,
+        is_secret=True,
+        required=True,
+    )
+    toolkit_detail = SimpleNamespace(
+        auth_config_details=[
+            SimpleNamespace(
+                mode="API_KEY",
+                fields=SimpleNamespace(
+                    connected_account_initiation=SimpleNamespace(
+                        required=[api_key_field],
+                        optional=[],
+                    )
+                ),
+            )
+        ]
+    )
+    operation_names = [
+        "APOLLO_SEARCH_CONTACTS",
+        "APOLLO_PEOPLE_SEARCH",
+        "APOLLO_PEOPLE_ENRICHMENT",
+        "APOLLO_LIST_EMAIL_ACCOUNTS",
+    ]
+    composio = SimpleNamespace(
+        toolkits=SimpleNamespace(get=MagicMock(return_value=toolkit_detail))
+    )
+
+    with (
+        patch.dict(os.environ, {"COMPOSIO_API_KEY": "test-api-key"}, clear=False),
+        patch.object(importer, "Composio", return_value=composio),
+        patch.object(importer, "_list_composio_toolkits", return_value=[toolkit_item]),
+        patch.object(
+            importer,
+            "_paginate_tools",
+            return_value=iter([_tool(name) for name in operation_names]),
+        ),
+        patch.object(importer, "_paginate_triggers", return_value=iter([])),
+        patch.object(importer, "_upsert_connector", AsyncMock()) as upsert_connector,
+        patch.object(importer, "_upsert_operation", AsyncMock()) as upsert_operation,
+    ):
+        totals = await importer._sync_composio_catalog(
+            connector_repository,
+            operation_repository,
+            trigger_repository,
+            app_filters={"apollo"},
+            managed_by="composio",
+            page_size=100,
+            max_composio_apps=10,
+        )
+
+    assert totals == (1, 4, 0)
+    entity = upsert_connector.await_args.args[1]
+    assert entity.id == "apollo"
+    capability = _capability(entity, AuthProvider.COMPOSIO)
+    assert capability.auth_scheme == AuthMethod.API_KEY
+    assert capability.auth_config_schema == {
+        "type": "object",
+        "properties": {
+            "generic_api_key": {
+                "type": "string",
+                "title": "API Key",
+                "description": "Apollo API key",
+                "format": "password",
+            }
+        },
+        "additionalProperties": False,
+        "required": ["generic_api_key"],
+    }
+    imported_operations = {
+        call.kwargs["public_name"] for call in upsert_operation.await_args_list
+    }
+    assert imported_operations == set(operation_names)
+
+
+@pytest.mark.asyncio
 async def test_sync_composio_catalog_preserves_exact_composio_app_and_operation_names():
     connector_repository = SimpleNamespace(get=AsyncMock(return_value=None))
     operation_repository = SimpleNamespace()
@@ -907,6 +994,7 @@ def test_list_composio_toolkits_uses_curated_allowlist_and_env_append():
     assert "metaads" in fetched_slugs
     assert "zoho_mail" in fetched_slugs
     assert "asana" in fetched_slugs
+    assert "apollo" in fetched_slugs
     assert "custom_app" in fetched_slugs
     assert "composio" not in fetched_slugs
     composio.toolkits.get.assert_any_call("custom_app")

--- a/lemma-backend/scripts/import_connector_catalog.py
+++ b/lemma-backend/scripts/import_connector_catalog.py
@@ -144,6 +144,7 @@ DEFAULT_COMPOSIO_CONNECTOR_IDS: tuple[str, ...] = (
     "googledocs",
     "googlesheets",
     "airtable",
+    "apollo",
     "asana",
     "box",
     "cal",

--- a/lemma-cli/lemma_cli/cli_core/commands/connectors.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/connectors.py
@@ -256,23 +256,30 @@ def create_account(
     ),
 ) -> None:
     """Connect an account with credentials."""
+    if bool(auth_config) == bool(auth_config_id):
+        raise typer.BadParameter(
+            "Use exactly one: --auth-config or --auth-config-id",
+        )
     credentials = read_json(credentials_json, credentials_file, required=True)
     preferences = read_json(preferences_json, preferences_file, required=False) or None
+    request_data = {
+        "credentials": credentials,
+        "provider_account_id": provider_account_id,
+        "email": email,
+        "preferences": preferences,
+        "allowed_scopes": allowed_scope or None,
+    }
+    if auth_config:
+        request_data["auth_config_name"] = auth_config
+    if auth_config_id:
+        request_data["auth_config_id"] = auth_config_id
     state = state_from_ctx(ctx)
     result = run_with_client(
         ctx,
         lambda client, s: (
             client.connectors.accounts.create(
                 auth_config or auth_config_id or "",
-                AccountCreateSchema.from_dict(
-                    {
-                        "credentials": credentials,
-                        "provider_account_id": provider_account_id,
-                        "email": email,
-                        "preferences": preferences,
-                        "allowed_scopes": allowed_scope or None,
-                    }
-                ),
+                AccountCreateSchema.from_dict(request_data),
             )
             if hasattr(client.connectors, "accounts")
             else client.connectors.create_account(

--- a/lemma-cli/lemma_cli/daemon/harnesses/antigravity.py
+++ b/lemma-cli/lemma_cli/daemon/harnesses/antigravity.py
@@ -14,7 +14,7 @@ from ..mcp import (
     provider_environment,
     write_provider_mcp_files,
 )
-from ..process import STREAM_READER_LIMIT, terminate_gracefully
+from ..process import create_subprocess, terminate_gracefully
 
 
 class AntigravityHarness:
@@ -55,14 +55,12 @@ class AntigravityHarness:
         write_provider_mcp_files("ANTIGRAVITY", cwd, mcp)
         env = provider_environment(harness_kind="ANTIGRAVITY", mcp=mcp)
         daemon_log("start antigravity provider", {"harness_kind": "ANTIGRAVITY", "command": command, "cwd": str(cwd)})
-        process = await asyncio.create_subprocess_exec(
-            *command,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=str(cwd),
+        process = await create_subprocess(
+            command,
+            cwd=cwd,
             env=env,
-            limit=STREAM_READER_LIMIT,
+            harness_kind="ANTIGRAVITY",
+            stdin=True,
         )
         try:
             async with asyncio.timeout(daemon_turn_timeout_seconds()):

--- a/lemma-cli/lemma_cli/daemon/harnesses/claude_code.py
+++ b/lemma-cli/lemma_cli/daemon/harnesses/claude_code.py
@@ -20,7 +20,7 @@ from ..mcp import (
     provider_environment,
     write_provider_mcp_files,
 )
-from ..process import STREAM_READER_LIMIT, drain_stream, terminate_gracefully
+from ..process import create_subprocess, drain_stream, terminate_gracefully
 
 
 class ClaudeCodeHarness:
@@ -82,14 +82,12 @@ async def _run_claude_code_provider(
     write_provider_mcp_files(harness_kind, cwd, mcp)
     env = provider_environment(harness_kind=harness_kind, mcp=mcp)
     daemon_log("start stream provider", {"harness_kind": harness_kind, "command": command, "cwd": str(cwd)})
-    process = await asyncio.create_subprocess_exec(
-        *command,
-        stdin=asyncio.subprocess.PIPE if stdin_text is not None else None,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        cwd=str(cwd),
+    process = await create_subprocess(
+        command,
+        cwd=cwd,
         env=env,
-        limit=STREAM_READER_LIMIT,
+        harness_kind=harness_kind,
+        stdin=stdin_text is not None,
     )
     stdout_parts: list[str] = []
     raw_stdout_parts: list[str] = []

--- a/lemma-cli/lemma_cli/daemon/harnesses/codex.py
+++ b/lemma-cli/lemma_cli/daemon/harnesses/codex.py
@@ -24,7 +24,7 @@ from ..mcp import (
     provider_cwd_for_run,
     provider_environment,
 )
-from ..process import STREAM_READER_LIMIT
+from ..process import create_subprocess
 
 CODEX_WORKER_TTL_SECONDS_ENV = "LEMMA_DAEMON_CODEX_WORKER_TTL_SECONDS"
 DAEMON_TURN_TIMEOUT_SECONDS_ENV = "LEMMA_DAEMON_TURN_TIMEOUT_SECONDS"
@@ -78,14 +78,12 @@ class JsonRpcProcess:
 
     async def start(self) -> None:
         daemon_log("jsonrpc process start", {"command": self.command, "cwd": str(self.cwd)})
-        self.process = await asyncio.create_subprocess_exec(
-            *self.command,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=str(self.cwd),
+        self.process = await create_subprocess(
+            self.command,
+            cwd=self.cwd,
             env=self.env,
-            limit=STREAM_READER_LIMIT,
+            harness_kind="CODEX",
+            stdin=True,
         )
         self._tasks = [
             asyncio.create_task(self._read_stdout()),

--- a/lemma-cli/lemma_cli/daemon/harnesses/opencode.py
+++ b/lemma-cli/lemma_cli/daemon/harnesses/opencode.py
@@ -24,7 +24,7 @@ from ..mcp import (
     provider_cwd_for_run,
     provider_environment,
 )
-from ..process import STREAM_READER_LIMIT
+from ..process import create_subprocess
 
 
 def _opencode_debug_logs_enabled() -> bool:
@@ -103,13 +103,11 @@ async def _run_opencode_server_provider(
             "opencode_config": env.get("OPENCODE_CONFIG_CONTENT"),
         },
     )
-    process = await asyncio.create_subprocess_exec(
-        *command,
-        cwd=str(cwd),
+    process = await create_subprocess(
+        command,
+        cwd=cwd,
         env=env,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        limit=STREAM_READER_LIMIT,
+        harness_kind="OPENCODE",
     )
     server_output: list[str] = []
     log_tasks: list[asyncio.Task[None]] = []

--- a/lemma-cli/lemma_cli/daemon/process.py
+++ b/lemma-cli/lemma_cli/daemon/process.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
+import shutil
 from pathlib import Path
 
 # Fixes "ValueError: Separator is found, but chunk is longer than limit".
@@ -10,16 +12,45 @@ from pathlib import Path
 STREAM_READER_LIMIT = 10 * 1024 * 1024  # 10 MB
 
 
+def resolve_executable(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    harness_kind: str,
+) -> list[str]:
+    """Resolve a provider binary against the child PATH before spawning it."""
+    if not command:
+        raise RuntimeError(f"No provider command configured for {harness_kind}")
+    binary = command[0]
+    lookup = binary
+    if not os.path.isabs(binary) and os.path.dirname(binary):
+        lookup = str(cwd / binary)
+    executable = shutil.which(lookup, path=env.get("PATH"))
+    if executable is None:
+        raise FileNotFoundError(
+            f"{harness_kind} executable '{command[0]}' was not found on PATH"
+        )
+    return [executable, *command[1:]]
+
+
 async def create_subprocess(
     command: list[str],
     *,
     cwd: Path,
     env: dict[str, str],
+    harness_kind: str,
     stdin: bool = False,
 ) -> asyncio.subprocess.Process:
     """Create a subprocess with a 10 MB StreamReader limit on stdout/stderr."""
+    resolved_command = resolve_executable(
+        command,
+        cwd=cwd,
+        env=env,
+        harness_kind=harness_kind,
+    )
     return await asyncio.create_subprocess_exec(
-        *command,
+        *resolved_command,
         stdin=asyncio.subprocess.PIPE if stdin else None,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,

--- a/lemma-cli/lemma_cli/daemon/runner.py
+++ b/lemma-cli/lemma_cli/daemon/runner.py
@@ -21,6 +21,7 @@ from .mcp import (
     provider_cwd_for_run,
     provider_environment,
 )
+from .process import create_subprocess
 
 # Reconnect backoff: a dropped backend connection must not kill the daemon — it
 # should wait and reconnect so it keeps serving runs. Full-jitter exponential
@@ -745,13 +746,12 @@ async def run_provider_command(
     cwd = provider_cwd_for_run(harness_kind, mcp)
     env = provider_environment(harness_kind=harness_kind, mcp=mcp)
     daemon_log("start one-shot provider", {"harness_kind": harness_kind, "command": command, "cwd": str(cwd)})
-    process = await asyncio.create_subprocess_exec(
-        *command,
-        stdin=asyncio.subprocess.PIPE if stdin_text is not None else None,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        cwd=str(cwd),
+    process = await create_subprocess(
+        command,
+        cwd=cwd,
         env=env,
+        harness_kind=harness_kind,
+        stdin=stdin_text is not None,
     )
     try:
         stdout_bytes, stderr_bytes = await process.communicate(

--- a/lemma-cli/tests/test_cli_v2.py
+++ b/lemma-cli/tests/test_cli_v2.py
@@ -1845,6 +1845,95 @@ def test_connectors_account_create_forwards_credentials(monkeypatch):
     assert captured["credentials"] == {"bot_token": "token"}
 
 
+@pytest.mark.parametrize(
+    ("selector_args", "expected_selector"),
+    [
+        (["--auth-config", "telegram"], {"auth_config_name": "telegram"}),
+        (
+            ["--auth-config-id", "00000000-0000-0000-0000-000000000002"],
+            {"auth_config_id": "00000000-0000-0000-0000-000000000002"},
+        ),
+    ],
+)
+def test_connectors_account_create_modern_facade_preserves_selector(
+    monkeypatch, selector_args, expected_selector
+):
+    captured: dict[str, object] = {}
+
+    class FakeAccounts:
+        def create(self, auth_config, request):
+            captured["auth_config"] = auth_config
+            captured["request"] = request.to_dict()
+            return {"id": "account-1"}
+
+    fake_client = SimpleNamespace(
+        connectors=SimpleNamespace(accounts=FakeAccounts())
+    )
+
+    def fake_run_with_client(ctx, fn):
+        return fn(fake_client, SimpleNamespace(config={"_runtime": {"org": "org-1"}}))
+
+    monkeypatch.setattr(connectors, "run_with_client", fake_run_with_client)
+
+    result = runner.invoke(
+        app,
+        [
+            "--org",
+            "org-1",
+            "connectors",
+            "accounts",
+            "create",
+            *selector_args,
+            "--data",
+            json.dumps({"bot_token": "token"}),
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    request = captured["request"]
+    assert isinstance(request, dict)
+    for key, value in expected_selector.items():
+        assert request[key] == value
+    other_key = (
+        "auth_config_id"
+        if "auth_config_name" in expected_selector
+        else "auth_config_name"
+    )
+    assert other_key not in request
+
+
+@pytest.mark.parametrize(
+    "selector_args",
+    [
+        [],
+        [
+            "--auth-config",
+            "telegram",
+            "--auth-config-id",
+            "00000000-0000-0000-0000-000000000002",
+        ],
+    ],
+)
+def test_connectors_account_create_requires_exactly_one_selector(selector_args):
+    result = runner.invoke(
+        app,
+        [
+            "--org",
+            "org-1",
+            "connectors",
+            "accounts",
+            "create",
+            *selector_args,
+            "--data",
+            json.dumps({"bot_token": "token"}),
+        ],
+        terminal_width=200,
+    )
+
+    assert result.exit_code != 0
+    assert "Use exactly one: --auth-config or --auth-config-id" in result.output
+
+
 def test_connectors_triggers_list_passes_auth_config(monkeypatch):
     captured: dict[str, object] = {}
 

--- a/lemma-cli/tests/test_cli_v2.py
+++ b/lemma-cli/tests/test_cli_v2.py
@@ -4,6 +4,7 @@ import json
 
 import pytest
 import typer
+from click import unstyle
 from types import SimpleNamespace
 
 from typer.testing import CliRunner
@@ -1931,7 +1932,7 @@ def test_connectors_account_create_requires_exactly_one_selector(selector_args):
     )
 
     assert result.exit_code != 0
-    assert "Use exactly one: --auth-config or --auth-config-id" in result.output
+    assert "Use exactly one: --auth-config or --auth-config-id" in unstyle(result.output)
 
 
 def test_connectors_triggers_list_passes_auth_config(monkeypatch):

--- a/lemma-cli/tests/test_daemon_process.py
+++ b/lemma-cli/tests/test_daemon_process.py
@@ -9,11 +9,86 @@ from __future__ import annotations
 
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
 from lemma_cli.daemon import commands as daemon_commands
 from lemma_cli.daemon import config as daemon_config
+from lemma_cli.daemon import process as daemon_process
+
+
+def test_resolve_executable_uses_child_path(monkeypatch):
+    captured = {}
+
+    def fake_which(binary, *, path):
+        captured["binary"] = binary
+        captured["path"] = path
+        return "/resolved/codex"
+
+    monkeypatch.setattr(daemon_process.shutil, "which", fake_which)
+
+    command = daemon_process.resolve_executable(
+        ["codex", "app-server"],
+        cwd=Path("/workspace"),
+        env={"PATH": "/child/bin"},
+        harness_kind="CODEX",
+    )
+
+    assert command == ["/resolved/codex", "app-server"]
+    assert captured == {"binary": "codex", "path": "/child/bin"}
+
+
+def test_resolve_executable_reports_harness(monkeypatch):
+    monkeypatch.setattr(daemon_process.shutil, "which", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(
+        FileNotFoundError,
+        match="CODEX executable 'codex' was not found on PATH",
+    ):
+        daemon_process.resolve_executable(
+            ["codex", "app-server"],
+            cwd=Path("/workspace"),
+            env={"PATH": ""},
+            harness_kind="CODEX",
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_subprocess_runs_resolved_executable(tmp_path):
+    process = await daemon_process.create_subprocess(
+        [sys.executable, "-c", "print('provider-ok')"],
+        cwd=tmp_path,
+        env=os.environ.copy(),
+        harness_kind="TEST",
+    )
+    stdout, stderr = await process.communicate()
+
+    assert process.returncode == 0, stderr.decode(errors="replace")
+    assert stdout.decode().strip() == "provider-ok"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="requires Windows command shims")
+@pytest.mark.asyncio
+async def test_create_subprocess_runs_windows_cmd_shim(tmp_path):
+    shim = tmp_path / "codex.cmd"
+    shim.write_text(
+        '@echo off\r\npython -c "print(\'codex-shim-ok\')"\r\n',
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["PATH"] = f"{tmp_path}{os.pathsep}{env.get('PATH', '')}"
+
+    process = await daemon_process.create_subprocess(
+        ["codex"],
+        cwd=tmp_path,
+        env=env,
+        harness_kind="CODEX",
+    )
+    stdout, stderr = await process.communicate()
+
+    assert process.returncode == 0, stderr.decode(errors="replace")
+    assert stdout.decode().strip() == "codex-shim-ok"
 
 
 def test_process_is_running_true_for_current_process():

--- a/lemma-python/lemma_sdk/resources/connectors.py
+++ b/lemma-python/lemma_sdk/resources/connectors.py
@@ -125,10 +125,19 @@ class ConnectorAccounts:
         )
 
     def create(self, auth_config: str, request: AccountCreateSchema) -> AccountResponseSchema:
+        body = request.to_dict()
+        auth_config_name = body.get("auth_config_name")
+        auth_config_id = body.get("auth_config_id")
+        if auth_config_name and auth_config_id:
+            raise ValueError("Specify only one of auth_config_name or auth_config_id")
+        if not auth_config_name and not auth_config_id:
+            if not auth_config:
+                raise ValueError("Either auth_config_name or auth_config_id is required")
+            body["auth_config_name"] = auth_config
+        request = AccountCreateSchema.from_dict(body)
         return self._parent._call(
             connector_account_create,
             self._parent._org_uuid(),
-            auth_config,
             body=request,
         )
 

--- a/lemma-python/tests/test_sdk_connectors.py
+++ b/lemma-python/tests/test_sdk_connectors.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from lemma_sdk.openapi_client.api.connectors import connector_account_create
+from lemma_sdk.openapi_client.models.account_create_schema import AccountCreateSchema
+from lemma_sdk.resources.connectors import BoundConnectors
+from lemma_sdk.transport import LemmaTransport
+
+
+ORG_ID = "00000000-0000-0000-0000-000000000001"
+AUTH_CONFIG_ID = "00000000-0000-0000-0000-000000000002"
+
+
+def _request(**values: Any) -> AccountCreateSchema:
+    return AccountCreateSchema.from_dict({"credentials": {}, **values})
+
+
+def _resource(
+    monkeypatch: pytest.MonkeyPatch, captured: dict[str, Any]
+) -> BoundConnectors:
+    def sync_detailed(organization_id, *, client, body):  # type: ignore[no-untyped-def]
+        captured["organization_id"] = organization_id
+        captured["body"] = body.to_dict()
+        return type(
+            "Response",
+            (),
+            {"status_code": 200, "parsed": {"id": "account-1"}, "headers": {}},
+        )()
+
+    monkeypatch.setattr(connector_account_create, "sync_detailed", sync_detailed)
+    transport = LemmaTransport(base_url="https://api.example.test", token="test")
+    return BoundConnectors(transport, org_id=ORG_ID)
+
+
+def test_account_create_legacy_name_is_merged_into_body_without_extra_path_arg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    resource = _resource(monkeypatch, captured)
+
+    result = resource.accounts.create("workspace-slack", _request())
+
+    assert result == {"id": "account-1"}
+    assert str(captured["organization_id"]) == ORG_ID
+    assert captured["body"]["auth_config_name"] == "workspace-slack"
+    assert "auth_config_id" not in captured["body"]
+
+
+def test_account_create_request_name_takes_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    resource = _resource(monkeypatch, captured)
+
+    resource.accounts.create("legacy-name", _request(auth_config_name="request-name"))
+
+    assert captured["body"]["auth_config_name"] == "request-name"
+
+
+def test_account_create_preserves_auth_config_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+    resource = _resource(monkeypatch, captured)
+
+    resource.accounts.create("ignored", _request(auth_config_id=AUTH_CONFIG_ID))
+
+    assert captured["body"]["auth_config_id"] == AUTH_CONFIG_ID
+    assert "auth_config_name" not in captured["body"]
+
+
+def test_account_create_rejects_conflicting_selectors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resource = _resource(monkeypatch, {})
+
+    with pytest.raises(ValueError, match="Specify only one"):
+        resource.accounts.create(
+            "legacy-name",
+            _request(auth_config_name="request-name", auth_config_id=AUTH_CONFIG_ID),
+        )
+
+
+def test_account_create_rejects_missing_selector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resource = _resource(monkeypatch, {})
+
+    with pytest.raises(ValueError, match="Either auth_config_name or auth_config_id"):
+        resource.accounts.create("", _request())

--- a/lemma-stack/lemma_stack/stack/specs.py
+++ b/lemma-stack/lemma_stack/stack/specs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import platform
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -77,7 +78,19 @@ class ServiceSpec:
 
 
 def selinux_enforcing() -> bool:
+    """Return whether the host Linux kernel reports SELinux support."""
     return Path("/sys/fs/selinux/enforce").exists()
+
+
+def agentbox_socket_requires_label_disable(provider: str) -> bool:
+    """Return whether the nested runtime socket needs an unconfined label.
+
+    Podman on macOS and Windows runs containers inside an SELinux-enforcing
+    Fedora CoreOS VM, so checking only the host filesystem misses that case.
+    """
+    if selinux_enforcing():
+        return True
+    return provider == "podman" and platform.system() in {"Darwin", "Windows"}
 
 
 def run_args(spec: ServiceSpec, *, selinux: bool | None = None) -> list[str]:
@@ -219,7 +232,9 @@ def build_specs(
             ),
             user="root",
             # the mounted API socket must not be relabeled by SELinux
-            security_opts=("label=disable",) if selinux_enforcing() else (),
+            security_opts=("label=disable",)
+            if agentbox_socket_requires_label_disable(provider)
+            else (),
         )
     )
 

--- a/lemma-stack/tests/test_specs.py
+++ b/lemma-stack/tests/test_specs.py
@@ -126,6 +126,48 @@ def test_agentbox_docker_wiring(config, paths, manifest):
     assert mounts["/var/run/docker.sock"] == "/var/run/docker.sock"
 
 
+@pytest.mark.parametrize(
+    ("host_platform", "host_selinux", "provider", "expected"),
+    [
+        ("Linux", True, "podman", ("label=disable",)),
+        ("Linux", True, "docker", ("label=disable",)),
+        ("Linux", False, "podman", ()),
+        ("Darwin", False, "podman", ("label=disable",)),
+        ("Windows", False, "podman", ("label=disable",)),
+        ("Darwin", False, "docker", ()),
+        ("Windows", False, "docker", ()),
+    ],
+)
+def test_agentbox_socket_selinux_guard_matrix(
+    monkeypatch,
+    config,
+    paths,
+    manifest,
+    host_platform,
+    host_selinux,
+    provider,
+    expected,
+):
+    monkeypatch.setattr(specs_mod.platform, "system", lambda: host_platform)
+    monkeypatch.setattr(specs_mod, "selinux_enforcing", lambda: host_selinux)
+
+    spec = by_name(build(config, paths, manifest, provider=provider), "agentbox")
+
+    assert spec.security_opts == expected
+
+
+def test_agentbox_security_opts_change_config_hash(config, paths, manifest, monkeypatch):
+    monkeypatch.setattr(specs_mod.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(specs_mod, "selinux_enforcing", lambda: False)
+    unconfined = by_name(build(config, paths, manifest, provider="podman"), "agentbox")
+    monkeypatch.setattr(specs_mod.platform, "system", lambda: "Darwin")
+    guarded = by_name(build(config, paths, manifest, provider="podman"), "agentbox")
+
+    assert unconfined.security_opts == ()
+    assert guarded.security_opts == ("label=disable",)
+    assert unconfined.config_hash() != guarded.config_hash()
+
+
 def test_config_hash_changes_with_image_and_env(config, paths, manifest):
     spec = by_name(build(config, paths, manifest), "backend")
     base_hash = spec.config_hash()


### PR DESCRIPTION
## Summary

- fix connector account creation so auth config names and IDs are sent in the request body without the invalid generated-client positional argument
- resolve daemon harness executables against the child PATH before spawning, including Windows command shims
- apply the agentbox SELinux socket guard for Podman VMs on macOS and Windows while preserving Docker Desktop behavior
- enable Apollo in the default Composio catalog with API-key and contact/email operation coverage

## Testing

- lemma-python: 52 passed
- lemma-cli unit: 591 passed, 1 skipped, 24 deselected
- lemma-stack unit: 45 passed, 4 install-experience tests deselected
- backend connector catalog, credential-account, and Resend: 39 passed
- Ruff checks passed for all changed Python files
- strict type check passed for the new shared process helper and stack implementation; broader touched legacy modules retain pre-existing type debt outside these changes

## Environment-only validation

- the real Windows command-shim test is included in the windows-daemon workflow
- Apollo live dry-run requires COMPOSIO_API_KEY, which was unavailable locally
- macOS Podman smoke requires a running Podman VM, which was stopped locally

Fixes #56
Fixes #59
Fixes #60
Fixes #61
Fixes #62