### PR TITLE
chore: prepare 0.6.0 release

### DIFF
--- a/.github/actions/setup-apple-signing/action.yml
+++ b/.github/actions/setup-apple-signing/action.yml
@@ -1,0 +1,71 @@
+name: Setup Apple code signing
+description: Import a Developer ID Application certificate into an ephemeral macOS keychain.
+
+inputs:
+  certificate:
+    description: Base64-encoded Developer ID Application certificate in PKCS#12 format.
+    required: true
+  certificate-password:
+    description: Password used when exporting the PKCS#12 certificate.
+    required: true
+
+outputs:
+  signing-identity:
+    description: Developer ID Application identity imported into the temporary keychain.
+    value: ${{ steps.import.outputs.signing-identity }}
+  keychain-path:
+    description: Temporary keychain path to delete after the build.
+    value: ${{ steps.import.outputs.keychain-path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Import Developer ID certificate
+      id: import
+      shell: bash
+      env:
+        APPLE_CERTIFICATE: ${{ inputs.certificate }}
+        APPLE_CERTIFICATE_PASSWORD: ${{ inputs.certificate-password }}
+      run: |
+        set -euo pipefail
+
+        if [[ -z "${APPLE_CERTIFICATE}" || -z "${APPLE_CERTIFICATE_PASSWORD}" ]]; then
+          echo "::error::APPLE_CERTIFICATE and APPLE_CERTIFICATE_PASSWORD are required for Developer ID signing."
+          exit 1
+        fi
+
+        certificate_path="${RUNNER_TEMP}/lemma-developer-id.p12"
+        keychain_path="${RUNNER_TEMP}/lemma-signing.keychain-db"
+        keychain_password="$(openssl rand -hex 32)"
+
+        printf '%s' "${APPLE_CERTIFICATE}" | base64 --decode > "${certificate_path}"
+        security create-keychain -p "${keychain_password}" "${keychain_path}"
+        security default-keychain -s "${keychain_path}"
+        security set-keychain-settings -lut 21600 "${keychain_path}"
+        security unlock-keychain -p "${keychain_password}" "${keychain_path}"
+        security import "${certificate_path}" \
+          -k "${keychain_path}" \
+          -P "${APPLE_CERTIFICATE_PASSWORD}" \
+          -T /usr/bin/codesign
+        security set-key-partition-list \
+          -S apple-tool:,apple:,codesign: \
+          -s \
+          -k "${keychain_password}" \
+          "${keychain_path}"
+        security list-keychains -d user -s "${keychain_path}"
+
+        signing_identity="$(
+          security find-identity -v -p codesigning "${keychain_path}" \
+            | sed -n 's/.*"\(Developer ID Application:[^"]*\)".*/\1/p' \
+            | head -n 1
+        )"
+        if [[ -z "${signing_identity}" ]]; then
+          echo "::error::The imported certificate does not contain a Developer ID Application identity."
+          security find-identity -v -p codesigning "${keychain_path}"
+          exit 1
+        fi
+
+        echo "Imported ${signing_identity}"
+        echo "signing-identity=${signing_identity}" >> "${GITHUB_OUTPUT}"
+        echo "keychain-path=${keychain_path}" >> "${GITHUB_OUTPUT}"
+        rm -f "${certificate_path}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       typescript: ${{ steps.filter.outputs.typescript }}
       frontend: ${{ steps.filter.outputs.frontend }}
       codegen: ${{ steps.filter.outputs.codegen }}
+      desktop: ${{ steps.filter.outputs.desktop }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
@@ -58,6 +59,13 @@ jobs:
               - 'lemma-typescript/scripts/generate_l2.mjs'
               - 'lemma-typescript/scripts/patch_generated_imports.mjs'
               - '.github/workflows/ci.yml'
+            desktop:
+              - 'desktop/**'
+              - 'lemma-stack/**'
+              - 'lemma-frontend/lib/education/concepts.ts'
+              - '.github/actions/setup-apple-signing/**'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/release-desktop.yml'
 
   backend-unit:
     name: lemma-backend unit
@@ -383,6 +391,105 @@ jobs:
           if ($content -notmatch "ErrorActionPreference") { Write-Error "install.ps1 missing error handling"; exit 1 }
           Write-Host "install.ps1 validation passed"
 
+  desktop:
+    name: macOS desktop build + codesign
+    needs: changes
+    if: needs.changes.outputs.desktop == 'true'
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            desktop/target
+          key: desktop-ci-cargo-${{ runner.os }}-${{ hashFiles('desktop/Cargo.lock') }}
+          restore-keys: desktop-ci-cargo-${{ runner.os }}-
+
+      - name: Import Developer ID certificate
+        id: apple-signing
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        uses: ./.github/actions/setup-apple-signing
+        with:
+          certificate: ${{ secrets.APPLE_CERTIFICATE }}
+          certificate-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+
+      - name: Select Developer ID signing
+        if: steps.apple-signing.outcome == 'success'
+        env:
+          SIGNING_IDENTITY: ${{ steps.apple-signing.outputs.signing-identity }}
+        run: |
+          echo "APPLE_SIGNING_IDENTITY=${SIGNING_IDENTITY}" >> "${GITHUB_ENV}"
+          echo "LEMMA_EXPECTED_SIGNING=developer-id" >> "${GITHUB_ENV}"
+
+      - name: Select ad-hoc signing for untrusted builds
+        if: steps.apple-signing.outcome == 'skipped'
+        run: |
+          echo "APPLE_SIGNING_IDENTITY=-" >> "${GITHUB_ENV}"
+          echo "LEMMA_EXPECTED_SIGNING=adhoc" >> "${GITHUB_ENV}"
+
+      - name: Bake splash concepts
+        run: node desktop/scripts/extract-concepts.mjs
+
+      - name: Verify baked splash concepts are committed
+        run: git diff --exit-code desktop/ui/concepts.gen.json
+
+      - name: Build supervisor sidecar
+        run: desktop/scripts/build-sidecar.sh
+
+      - name: Run desktop tests
+        working-directory: desktop
+        run: cargo test --locked
+
+      - name: Build and codesign DMG
+        working-directory: desktop
+        run: npx -y @tauri-apps/cli@2.11.4 build --config tauri.dist.conf.json
+
+      - name: Verify application signature
+        shell: bash
+        run: |
+          set -euo pipefail
+          app="desktop/target/release/bundle/macos/Lemma.app"
+          sidecar="${app}/Contents/MacOS/lemma-supervisor"
+
+          test -d "${app}"
+          test -x "${sidecar}"
+          codesign --verify --deep --strict --verbose=2 "${app}"
+          codesign --verify --strict --verbose=2 "${sidecar}"
+
+          signature_info="$(codesign -dvvv "${app}" 2>&1)"
+          printf '%s\n' "${signature_info}"
+          if [[ "${LEMMA_EXPECTED_SIGNING}" == "developer-id" ]]; then
+            grep -F "Authority=Developer ID Application:" <<< "${signature_info}"
+          else
+            grep -F "Signature=adhoc" <<< "${signature_info}"
+          fi
+
+      - name: Upload macOS DMG
+        uses: actions/upload-artifact@v4
+        with:
+          name: lemma-desktop-macos-${{ github.sha }}
+          path: desktop/target/release/bundle/dmg/Lemma_*_aarch64.dmg
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Remove temporary signing keychain
+        if: always() && steps.apple-signing.outcome == 'success'
+        run: security delete-keychain "${{ steps.apple-signing.outputs.keychain-path }}"
+
   ci:
     name: CI passed
     if: always()
@@ -398,6 +505,7 @@ jobs:
       - frontend-build
       - install-experience
       - windows-cli
+      - desktop
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any required suite failed

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -2,9 +2,8 @@ name: Release Lemma Desktop
 
 # Builds the Tauri macOS app (arm64) and attaches the DMG to the GitHub
 # release. The DMG contains the thin Rust shell + the compiled lemma-stack
-# supervisor sidecar (PyInstaller). Signing/notarization happens only when
-# the APPLE_* secrets are present; otherwise the DMG is built unsigned
-# (still hardened-runtime, just not notarized).
+# supervisor sidecar (PyInstaller). Public releases require Developer ID
+# signing and Apple notarization; missing credentials fail before the build.
 
 on:
   release:
@@ -13,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to build, for example 0.2.1 or v0.2.1"
+        description: "Version to build, for example 0.6.0 or v0.6.0"
         required: true
 
 permissions:
@@ -37,6 +36,26 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ github.sha }}
+
+      - name: Import Developer ID certificate
+        id: apple-signing
+        uses: ./.github/actions/setup-apple-signing
+        with:
+          certificate: ${{ secrets.APPLE_CERTIFICATE }}
+          certificate-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+
+      - name: Require notarization credentials
+        shell: bash
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${APPLE_ID}" || -z "${APPLE_PASSWORD}" || -z "${APPLE_TEAM_ID}" ]]; then
+            echo "::error::APPLE_ID, APPLE_PASSWORD, and APPLE_TEAM_ID are required for notarized macOS releases."
+            exit 1
+          fi
 
       - name: Resolve version
         id: version
@@ -99,20 +118,38 @@ jobs:
       - name: Bake splash concepts
         run: node desktop/scripts/extract-concepts.mjs
 
+      - name: Verify baked splash concepts are committed
+        run: git diff --exit-code desktop/ui/concepts.gen.json
+
       - name: Build supervisor sidecar
         run: desktop/scripts/build-sidecar.sh
 
       - name: Build DMG
         working-directory: desktop
-        run: npx -y @tauri-apps/cli@latest build --config tauri.dist.conf.json
+        run: npx -y @tauri-apps/cli@2.11.4 build --config tauri.dist.conf.json
         env:
-          # Signing/notarization only when secrets are present.
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_SIGNING_IDENTITY: ${{ steps.apple-signing.outputs.signing-identity }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Verify Developer ID signature and notarization staple
+        shell: bash
+        run: |
+          set -euo pipefail
+          app="desktop/target/release/bundle/macos/Lemma.app"
+          sidecar="${app}/Contents/MacOS/lemma-supervisor"
+
+          codesign --verify --deep --strict --verbose=2 "${app}"
+          codesign --verify --strict --verbose=2 "${sidecar}"
+          codesign -dvvv "${app}" 2>&1 | grep -F "Authority=Developer ID Application:"
+          xcrun stapler validate "${app}"
 
       - name: Upload DMG to release
         uses: softprops/action-gh-release@v2
         with:
           files: desktop/target/release/bundle/dmg/Lemma_*_aarch64.dmg
+
+      - name: Remove temporary signing keychain
+        if: always() && steps.apple-signing.outcome == 'success'
+        run: security delete-keychain "${{ steps.apple-signing.outputs.keychain-path }}"

--- a/.github/workflows/release-lemma-typescript.yml
+++ b/.github/workflows/release-lemma-typescript.yml
@@ -16,6 +16,7 @@ env:
 permissions:
   actions: read
   contents: read
+  id-token: write
 
 concurrency:
   group: release-lemma-typescript-${{ github.event.release.tag_name || inputs.version }}
@@ -42,9 +43,11 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 24
-          registry-url: https://registry.npmjs.org
           cache: npm
           cache-dependency-path: lemma-typescript/package-lock.json
+
+      - name: Use npm with trusted publishing support
+        run: npm install --global npm@11.18.0
 
       - name: Set package version from release tag
         id: version
@@ -59,6 +62,12 @@ jobs:
           fi
 
           npm version "${version}" --no-git-tag-version --allow-same-version
+
+          source_version="$(node -e 'const fs=require("fs"); const m=fs.readFileSync("src/version.ts","utf8").match(/SDK_VERSION = "([^"]+)"/); if (!m) process.exit(1); process.stdout.write(m[1])')"
+          if [[ "${source_version}" != "${version}" ]]; then
+            echo "src/version.ts SDK_VERSION (${source_version}) must match release version ${version}. Commit the release version before publishing." >&2
+            exit 1
+          fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
@@ -66,6 +75,12 @@ jobs:
 
       - name: Build package
         run: npm run build
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Verify registry blocks
+        run: npm run registry:check
 
       - name: Check whether version is already published
         id: published
@@ -87,6 +102,4 @@ jobs:
 
       - name: Publish package
         if: steps.published.outputs.should_publish == 'true'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -1942,7 +1942,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lemma-desktop"
-version = "0.2.1"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lemma-desktop"
-version = "0.2.1"
+version = "0.6.0"
 description = "Lemma desktop shell"
 edition = "2021"
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -75,8 +75,28 @@ A distribution build runs the sidecar build then bundles with
 ```sh
 node desktop/scripts/extract-concepts.mjs
 desktop/scripts/build-sidecar.sh
-cd desktop && npx -y @tauri-apps/cli@latest build --config tauri.dist.conf.json
+cd desktop && npx -y @tauri-apps/cli@2.11.4 build --config tauri.dist.conf.json
 ```
+
+## CI and code signing
+
+The main CI workflow builds the supervisor sidecar and DMG, then verifies the
+application and bundled sidecar signatures. Pull requests use Tauri's ad-hoc
+signing identity (`-`) so untrusted code never receives Apple credentials.
+Trusted runs from `main` import a Developer ID Application certificate into an
+ephemeral keychain and verify that the resulting app has a Developer ID
+authority.
+
+Developer ID signing requires these Actions secrets:
+
+- `APPLE_CERTIFICATE` — base64-encoded `.p12` export containing the certificate
+  and private key
+- `APPLE_CERTIFICATE_PASSWORD` — password used when exporting the `.p12`
+
+The release workflow uses the same certificate import path and additionally
+requires `APPLE_ID`, `APPLE_PASSWORD` (an app-specific password), and
+`APPLE_TEAM_ID` for notarization. It verifies the Developer ID signature and
+notarization staple before uploading the DMG.
 
 Supervisor resolution order in the shell: `LEMMA_DESKTOP_SUPERVISOR_BIN` →
 bundled sidecar next to the app executable → `uv run --project lemma-stack

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Lemma",
-  "version": "0.2.1",
+  "version": "0.6.0",
   "identifier": "work.lemma.desktop",
   "build": {
     "frontendDist": "ui"

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_display_resource_matrix_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_display_resource_matrix_e2e.py
@@ -290,9 +290,6 @@ async def test_display_resource_slack_routes_pod_resource_catalog_to_deep_links(
             tool_call_id="tool-invalid-loading",
         ),
         script_display_resource(
-            type="AGENT", interactive=True, tool_call_id="tool-invalid-interactive"
-        ),
-        script_display_resource(
             type="FILE",
             path="/private/tmp/report.pdf",
             tool_call_id="tool-invalid-private-file",

--- a/lemma-cli/lemma_cli/__init__.py
+++ b/lemma-cli/lemma_cli/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 __all__ = ["__version__"]
 
-__version__ = "0.5.7"
+__version__ = "0.6.0"
 
 if sys.platform == "win32":
     for _stream in (sys.stdout, sys.stderr):

--- a/lemma-cli/pyproject.toml
+++ b/lemma-cli/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   # >= the version that has the endpoints the current commands use, so a fresh
   # `uv tool install` upgrades an already-installed older lemma-sdk. The release
   # workflow rewrites this to the release version on every tagged build.
-  "lemma-sdk>=0.5.7",
+  "lemma-sdk>=0.6.0",
   # Shared pod bundle format vocabulary (layout/jsonc/diff/portability/
   # normalize/archive), extracted so the backend can consume the same format.
   "lemma-pod-bundle>=0.1.0",

--- a/lemma-cli/uv.lock
+++ b/lemma-cli/uv.lock
@@ -493,7 +493,7 @@ source = { directory = "../lemma-pod-bundle" }
 
 [[package]]
 name = "lemma-sdk"
-version = "0.5.7"
+version = "0.6.0"
 source = { directory = "../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/lemma-frontend/package-lock.json
+++ b/lemma-frontend/package-lock.json
@@ -71,7 +71,7 @@
     },
     "../lemma-typescript": {
       "name": "lemma-sdk",
-      "version": "0.5.7",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "supertokens-web-js": "^0.16.0"

--- a/lemma-python/pyproject.toml
+++ b/lemma-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-sdk"
-version = "0.5.7"
+version = "0.6.0"
 description = "Python SDK for Lemma"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/lemma-python/uv.lock
+++ b/lemma-python/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "lemma-sdk"
-version = "0.5.7"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },

--- a/lemma-typescript/package-lock.json
+++ b/lemma-typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemma-sdk",
-  "version": "0.5.7",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lemma-sdk",
-      "version": "0.5.7",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "supertokens-web-js": "^0.16.0"

--- a/lemma-typescript/package.json
+++ b/lemma-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemma-sdk",
-  "version": "0.5.7",
+  "version": "0.6.0",
   "description": "Official TypeScript SDK for Lemma APIs, optimized around pod-scoped workflows",
   "license": "Apache-2.0",
   "author": "Lemma",
@@ -8,11 +8,11 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": {
-    "lemma-sdk": "./bin/lemma-sdk.js"
+    "lemma-sdk": "bin/lemma-sdk.js"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/lemma-work/lemma-platform.git",
+    "url": "git+https://github.com/lemma-work/lemma-platform.git",
     "directory": "lemma-typescript"
   },
   "homepage": "https://github.com/lemma-work/lemma-platform/tree/main/lemma-typescript#readme",

--- a/lemma-typescript/public/lemma-client.js
+++ b/lemma-typescript/public/lemma-client.js
@@ -9795,7 +9795,7 @@ var LemmaClient = (() => {
   }
 
   // src/version.ts
-  var SDK_VERSION = "0.5.7";
+  var SDK_VERSION = "0.6.0";
   var CLIENT_HEADER_NAME = "X-Lemma-Client";
   var CLIENT_HEADER_VALUE = `lemma-sdk-ts/${SDK_VERSION}`;
 

--- a/lemma-typescript/src/version.ts
+++ b/lemma-typescript/src/version.ts
@@ -1,6 +1,6 @@
 // Keep SDK_VERSION in sync with package.json "version". The CI codegen/drift
 // gate (workstream A) asserts they match so this can't silently drift.
-export const SDK_VERSION = "0.5.7";
+export const SDK_VERSION = "0.6.0";
 
 /** Sent as `X-Lemma-Client` on every request so the backend can log which client
  *  + version hit an endpoint (User-Agent is a forbidden header in browser fetch). */


### PR DESCRIPTION
## Summary

- align lemma-terminal, Python SDK, npm SDK, and macOS desktop at 0.6.0
- build and codesign the desktop app and DMG in CI, using ad-hoc signatures for pull requests and Developer ID on trusted main runs
- require Developer ID signing, notarization, and staple verification for desktop releases
- publish lemma-sdk to npm through GitHub OIDC trusted publishing with build, test, registry, and version gates
- remove a stale display-resource E2E case that contradicted the current public request model

## Validation

- lemma-terminal: 585 passed
- Python SDK: 47 passed, 1 skipped
- TypeScript SDK: 115 passed; 20 registry items validated; 0.6.0 package dry-run passed
- desktop: 5 passed; local Developer ID app, sidecar, and DMG signatures verified
- backend display-resource units: 61 passed; corrected E2E file passes Ruff
- GitHub Actions workflows pass actionlint

## Release prerequisites after merge

- add APPLE_ID and APPLE_PASSWORD repository secrets for notarization
- add LEMMA_OPENAI_API_KEY to the backend-protected-e2e environment
- run Backend protected E2E against the exact merged commit before publishing v0.6.0