### PR TITLE
Update AgentBox profile smoke assertion

### DIFF
--- a/lemma-backend/app/modules/workspace/tests/e2e/test_agentbox_browser_runtime_e2e.py
+++ b/lemma-backend/app/modules/workspace/tests/e2e/test_agentbox_browser_runtime_e2e.py
@@ -76,10 +76,8 @@ async def test_agentbox_runtime_supports_lemma_cli_browser_and_yielded_exec(
 
         profile = await _exec(session, "lemma --output json profile get", timeout=30)
         profile_json = json.loads(profile["stdout"])
-        assert profile_json["current_user"]["email"] == fixed_test_user["email"]
-        assert profile_json["current_user"]["id"] == fixed_test_user["id"]
-        assert profile_json["pod_id"]["value"] == pod["id"]
-        assert profile_json["org_id"]["value"] == fixed_test_org["id"]
+        assert profile_json["email"] == fixed_test_user["email"]
+        assert profile_json["id"] == fixed_test_user["id"]
 
         sleep_started = time.monotonic()
         yielded_sleep = await _exec(


### PR DESCRIPTION
## Summary
- align the AgentBox CLI smoke test with the current `lemma profile get` JSON contract
- retain delegated-user identity verification

## Verification
- focused Ruff check passes
- `git diff --check`

Protected run 29160290148 otherwise reached 73 passing tests, with three transient real-runtime infrastructure failures.