### PR TITLE
fix(desktop): restore first-run choice and browser auth handoff

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -1942,7 +1942,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lemma-desktop"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lemma-desktop"
-version = "0.6.0"
+version = "0.6.1"
 description = "Lemma desktop shell"
 edition = "2021"
 

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -20,6 +20,9 @@ use tauri_plugin_autostart::ManagerExt as _;
 
 const DEFAULT_HOSTED_URL: &str = "https://lemma.work";
 const DEFAULT_LOCAL_URL: &str = "http://localhost:3711";
+// Legacy development builds persisted a mode before the released chooser
+// contract was stable. Require that chooser once, then retain the new choice.
+const CONNECTION_MODE_PROMPT_REVISION: u64 = 1;
 
 #[derive(Clone, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -97,7 +100,14 @@ fn connection_mode() -> String {
             return mode;
         }
     }
-    match read_config()["connectionMode"].as_str() {
+    configured_connection_mode(&read_config())
+}
+
+fn configured_connection_mode(config: &Value) -> String {
+    if config["connectionModePromptRevision"].as_u64() != Some(CONNECTION_MODE_PROMPT_REVISION) {
+        return "undecided".into();
+    }
+    match config["connectionMode"].as_str() {
         Some("hosted") => "hosted".into(),
         Some("local") => "local".into(),
         // First launch: the splash asks the user to choose.
@@ -360,73 +370,6 @@ fn open_app_window(app: &AppHandle, url: &str) -> Result<(), String> {
     Ok(())
 }
 
-fn open_local_auth_window(app: &AppHandle, url: &str) -> Result<(), String> {
-    let target = tauri::Url::parse(url).map_err(|error| format!("invalid auth URL: {error}"))?;
-    let window = if let Some(window) = app.get_webview_window("auth") {
-        window
-            .navigate(target)
-            .map_err(|error| format!("could not open account setup: {error}"))?;
-        window
-    } else {
-        build_local_auth_window(app, target)?
-    };
-    window
-        .show()
-        .map_err(|error| format!("could not show account setup: {error}"))?;
-    window
-        .set_focus()
-        .map_err(|error| format!("could not focus account setup: {error}"))?;
-    if let Some(main) = app.get_webview_window("main") {
-        let _ = main.hide();
-    }
-    Ok(())
-}
-
-fn build_local_auth_window(
-    app: &AppHandle,
-    target: tauri::Url,
-) -> Result<tauri::WebviewWindow, String> {
-    let navigation_handle = app.clone();
-    let new_window_handle = app.clone();
-    let window = WebviewWindowBuilder::new(app, "auth", WebviewUrl::External(target))
-        .title("Lemma account setup")
-        .inner_size(1080.0, 780.0)
-        .min_inner_size(860.0, 620.0)
-        .on_navigation(move |url| {
-            if navigation_allowed_for_app(&navigation_handle, url) {
-                true
-            } else {
-                open_external(url.as_str());
-                false
-            }
-        })
-        .on_new_window(move |url, _features| {
-            if url.as_str() != "about:blank" {
-                if navigation_allowed_for_app(&new_window_handle, &url) {
-                    if let Some(auth) = new_window_handle.get_webview_window("auth") {
-                        let _ = auth.navigate(url);
-                    }
-                } else {
-                    open_external(url.as_str());
-                }
-            }
-            NewWindowResponse::Deny
-        })
-        .build()
-        .map_err(|error| format!("could not create account window: {error}"))?;
-
-    let close_handle = app.clone();
-    let close_window = window.clone();
-    window.on_window_event(move |event| {
-        if let tauri::WindowEvent::CloseRequested { api, .. } = event {
-            api.prevent_close();
-            let _ = close_window.hide();
-            show_splash(&close_handle);
-        }
-    });
-    Ok(window)
-}
-
 fn navigate_app_window(app: &AppHandle, url: &str) -> Result<(), String> {
     open_app_window(app, url)
 }
@@ -554,6 +497,7 @@ fn set_mode(app: &AppHandle, mode: &str) {
     }
     write_config(|config| {
         config["connectionMode"] = json!(mode);
+        config["connectionModePromptRevision"] = json!(CONNECTION_MODE_PROMPT_REVISION);
     });
 }
 
@@ -599,6 +543,11 @@ fn handle_deep_link(app: &AppHandle, url: &tauri::Url) {
         let _ = window.show();
         let _ = window.set_focus();
     }
+    // Older builds used a second native auth webview. Hide it if it still
+    // exists; the main window now owns the one-time session exchange.
+    if let Some(window) = app.get_webview_window("auth") {
+        let _ = window.hide();
+    }
 }
 
 fn desktop_context_script(mode: &str) -> String {
@@ -627,12 +576,11 @@ fn app_base_url(app: &AppHandle) -> String {
     }
 }
 
-fn local_auth_path(mode: &str) -> &'static str {
-    if mode == "signup" {
-        "auth/signup"
-    } else {
-        "auth"
-    }
+fn desktop_auth_url(base: &str, auth_mode: &str) -> String {
+    format!(
+        "{}/auth/desktop?mode={auth_mode}",
+        base.trim_end_matches('/'),
+    )
 }
 
 #[tauri::command]
@@ -643,24 +591,10 @@ async fn login(app: AppHandle, mode: Option<String>) -> Result<(), String> {
     } else {
         "signin"
     };
-    if current_mode(&app) == "local" {
-        open_local_auth_window(
-            &app,
-            &format!(
-                "{}/{}",
-                base.trim_end_matches('/'),
-                local_auth_path(auth_mode),
-            ),
-        )
-    } else {
-        open_app_window(
-            &app,
-            &format!(
-                "{}/auth/desktop?mode={auth_mode}",
-                base.trim_end_matches('/'),
-            ),
-        )
-    }
+    // Keep `main` as the waiting/exchange surface in both modes. The frontend
+    // creates a short-lived request, opens marked auth in the system browser,
+    // and consumes the result when `lemma://auth/complete` returns.
+    open_app_window(&app, &desktop_auth_url(&base, auth_mode))
 }
 
 fn build_tray(app: &AppHandle) -> tauri::Result<()> {
@@ -980,8 +914,29 @@ mod tests {
     }
 
     #[test]
-    fn local_account_creation_opens_the_supertokens_signup_route() {
-        assert_eq!(local_auth_path("signup"), "auth/signup");
-        assert_eq!(local_auth_path("signin"), "auth");
+    fn legacy_connection_preferences_require_the_released_chooser_once() {
+        assert_eq!(
+            configured_connection_mode(&json!({"connectionMode": "hosted"})),
+            "undecided"
+        );
+        assert_eq!(
+            configured_connection_mode(&json!({
+                "connectionMode": "local",
+                "connectionModePromptRevision": CONNECTION_MODE_PROMPT_REVISION,
+            })),
+            "local"
+        );
+    }
+
+    #[test]
+    fn desktop_auth_uses_the_browser_handoff_in_every_mode() {
+        assert_eq!(
+            desktop_auth_url("https://lemma.work", "signup"),
+            "https://lemma.work/auth/desktop?mode=signup"
+        );
+        assert_eq!(
+            desktop_auth_url("http://localhost:3711/", "signin"),
+            "http://localhost:3711/auth/desktop?mode=signin"
+        );
     }
 }

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Lemma",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "identifier": "work.lemma.desktop",
   "build": {
     "frontendDist": "ui"

--- a/lemma-cli/lemma_cli/__init__.py
+++ b/lemma-cli/lemma_cli/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 __all__ = ["__version__"]
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 if sys.platform == "win32":
     for _stream in (sys.stdout, sys.stderr):

--- a/lemma-cli/pyproject.toml
+++ b/lemma-cli/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   # >= the version that has the endpoints the current commands use, so a fresh
   # `uv tool install` upgrades an already-installed older lemma-sdk. The release
   # workflow rewrites this to the release version on every tagged build.
-  "lemma-sdk>=0.6.0",
+  "lemma-sdk>=0.6.1",
   # Shared pod bundle format vocabulary (layout/jsonc/diff/portability/
   # normalize/archive), extracted so the backend can consume the same format.
   "lemma-pod-bundle>=0.1.0",

--- a/lemma-cli/uv.lock
+++ b/lemma-cli/uv.lock
@@ -493,7 +493,7 @@ source = { directory = "../lemma-pod-bundle" }
 
 [[package]]
 name = "lemma-sdk"
-version = "0.6.0"
+version = "0.6.1"
 source = { directory = "../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/lemma-frontend/package-lock.json
+++ b/lemma-frontend/package-lock.json
@@ -71,7 +71,7 @@
     },
     "../lemma-typescript": {
       "name": "lemma-sdk",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "supertokens-web-js": "^0.16.0"

--- a/lemma-python/pyproject.toml
+++ b/lemma-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-sdk"
-version = "0.6.0"
+version = "0.6.1"
 description = "Python SDK for Lemma"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/lemma-python/uv.lock
+++ b/lemma-python/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "lemma-sdk"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },

--- a/lemma-typescript/package-lock.json
+++ b/lemma-typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemma-sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lemma-sdk",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "supertokens-web-js": "^0.16.0"

--- a/lemma-typescript/package.json
+++ b/lemma-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemma-sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Official TypeScript SDK for Lemma APIs, optimized around pod-scoped workflows",
   "license": "Apache-2.0",
   "author": "Lemma",

--- a/lemma-typescript/public/lemma-client.js
+++ b/lemma-typescript/public/lemma-client.js
@@ -9795,7 +9795,7 @@ var LemmaClient = (() => {
   }
 
   // src/version.ts
-  var SDK_VERSION = "0.6.0";
+  var SDK_VERSION = "0.6.1";
   var CLIENT_HEADER_NAME = "X-Lemma-Client";
   var CLIENT_HEADER_VALUE = `lemma-sdk-ts/${SDK_VERSION}`;
 

--- a/lemma-typescript/src/version.ts
+++ b/lemma-typescript/src/version.ts
@@ -1,6 +1,6 @@
 // Keep SDK_VERSION in sync with package.json "version". The CI codegen/drift
 // gate (workstream A) asserts they match so this can't silently drift.
-export const SDK_VERSION = "0.6.0";
+export const SDK_VERSION = "0.6.1";
 
 /** Sent as `X-Lemma-Client` on every request so the backend can log which client
  *  + version hit an endpoint (User-Agent is a forbidden header in browser fetch). */


### PR DESCRIPTION
## Summary

- prompt once for Local vs Cloud when upgrading from a legacy saved desktop preference
- route both local and hosted account creation through the system-browser desktop auth flow
- return through the registered `lemma://auth/complete` deep link and finish the one-time PKCE session exchange in the main app
- remove the orphaned secondary auth webview
- prepare coordinated `0.6.1` versions for desktop, Python SDK, npm SDK, and terminal CLI

## Security

The callback contains only the short-lived request ID. The verifier stays in the desktop webview, and no long-lived token is placed in the deep-link URL.

## Verification

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — 6 passed
- `npm run release:check`
- `npm run registry:check` — 20 registry items
- `npm test` — 115 passed
- package/version consistency checks for Python SDK and terminal CLI

The Docker-backed backend handoff E2E is covered by CI; this Mac does not have the Docker CLI required by that fixture.