### PR TITLE
fix(desktop): refresh Stable runtime and install terminal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -464,11 +464,14 @@ jobs:
           set -euo pipefail
           app="desktop/target/release/bundle/macos/Lemma.app"
           sidecar="${app}/Contents/MacOS/lemma-supervisor"
+          uv="${app}/Contents/MacOS/uv"
 
           test -d "${app}"
           test -x "${sidecar}"
+          test -x "${uv}"
           codesign --verify --deep --strict --verbose=2 "${app}"
           codesign --verify --strict --verbose=2 "${sidecar}"
+          codesign --verify --strict --verbose=2 "${uv}"
 
           signature_info="$(codesign -dvvv "${app}" 2>&1)"
           printf '%s\n' "${signature_info}"

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -139,9 +139,12 @@ jobs:
           set -euo pipefail
           app="desktop/target/release/bundle/macos/Lemma.app"
           sidecar="${app}/Contents/MacOS/lemma-supervisor"
+          uv="${app}/Contents/MacOS/uv"
 
+          test -x "${uv}"
           codesign --verify --deep --strict --verbose=2 "${app}"
           codesign --verify --strict --verbose=2 "${sidecar}"
+          codesign --verify --strict --verbose=2 "${uv}"
           codesign -dvvv "${app}" 2>&1 | grep -F "Authority=Developer ID Application:"
           xcrun stapler validate "${app}"
 

--- a/.github/workflows/release-local-images.yml
+++ b/.github/workflows/release-local-images.yml
@@ -245,7 +245,7 @@ jobs:
               "infra": {
                   "postgres": "docker.io/pgvector/pgvector:0.8.3-pg16",
                   "redis": "docker.io/redis/redis-stack:7.2.0-v19",
-                  "supertokens": "docker.io/supertokens/supertokens-postgresql:11.1.0",
+                  "supertokens": "docker.io/supertokens/supertokens-postgresql:11.4.5",
                   "kreuzberg": "ghcr.io/kreuzberg-dev/kreuzberg:4.9.9",
               },
           }

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -34,7 +34,9 @@ Connection modes (persisted in `~/Library/Application Support/Lemma/desktop-conf
 - **undecided** (first launch): asks whether to connect to Lemma Cloud or run
   Lemma locally; local setup requires a second confirmation before installation
 - **local**: spawns the supervisor, shows the splash with live
-  startup phases, navigates to `http://localhost:3711` when ready
+  startup phases, refreshes Stable-channel images, installs the matching
+  `lemma-terminal` release and its curated agent skills, then navigates to
+  `http://localhost:3711` when ready. Explicit version channels stay pinned.
 - **hosted**: loads the hosted app directly, no local services
 
 ## Development
@@ -58,11 +60,13 @@ lemma-stack supervise --dry-run   # then type: {"cmd":"start"}
 
 ## Distribution pieces
 
-- `scripts/build-sidecar.sh` — compiles `lemma-stack` into a single
-  self-contained binary (`lemma-supervisor`) via PyInstaller from
+- `scripts/build-sidecar.sh` — compiles `lemma-stack` into a self-contained
+  binary (`lemma-supervisor`) via PyInstaller from
   `lemma-stack/lemma_stack/sidecar_main.py`. The sidecar runs `lemma-stack
   supervise`, which pulls the released container images itself — no runtime
-  checkout or tarball download is involved.
+  checkout or tarball download is involved. Distribution builds also bundle
+  the signed `uv` executable used to install or upgrade `lemma-terminal` when
+  the app was launched from Finder without a shell `PATH`.
 - `scripts/extract-concepts.mjs` — bakes the in-app education concept registry
   (`lemma-frontend/lib/education/concepts.ts`) into `ui/concepts.gen.json` for
   the splash tour.
@@ -70,7 +74,7 @@ lemma-stack supervise --dry-run   # then type: {"cmd":"start"}
   Podman runtime (krunkit entitlements in `krunkit-entitlements.plist`).
 
 A distribution build runs the sidecar build then bundles with
-`tauri.dist.conf.json` (adds the sidecar as externalBin):
+`tauri.dist.conf.json` (adds the supervisor and uv as external binaries):
 
 ```sh
 node desktop/scripts/extract-concepts.mjs

--- a/desktop/scripts/build-sidecar.sh
+++ b/desktop/scripts/build-sidecar.sh
@@ -4,8 +4,9 @@
 # `lemma-stack supervise`, which pulls the released images and brings the
 # stack up — no runtime checkout or download needed.
 #
-# Output: desktop/binaries/lemma-supervisor-<target-triple>, which
-# tauri.dist.conf.json picks up via externalBin.
+# Output: desktop/binaries/lemma-supervisor-<target-triple> plus the uv binary
+# used to install/update lemma-terminal for Finder-launched desktop sessions.
+# tauri.dist.conf.json picks up both via externalBin.
 set -euo pipefail
 
 cd "$(dirname "$0")/../.."
@@ -28,5 +29,10 @@ mkdir -p "$OUT_DIR"
     lemma_stack/sidecar_main.py )
 
 mv "$OUT_DIR/lemma-supervisor" "$OUT_DIR/lemma-supervisor-$TRIPLE"
+UV_BIN="$(command -v uv)"
+cp "$UV_BIN" "$OUT_DIR/uv-$TRIPLE"
+chmod 0755 "$OUT_DIR/uv-$TRIPLE"
 echo "sidecar: $OUT_DIR/lemma-supervisor-$TRIPLE"
+echo "uv: $OUT_DIR/uv-$TRIPLE"
 "$OUT_DIR/lemma-supervisor-$TRIPLE" --help >/dev/null && echo "sidecar: smoke ok"
+"$OUT_DIR/uv-$TRIPLE" --version >/dev/null && echo "uv: smoke ok"

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -337,8 +337,16 @@ fn handle_supervisor_event(app: &AppHandle, event: &Value) {
                 ui.ready = true;
                 ui.running = true;
                 ui.error = false;
-                if let Some(url) = event["url"].as_str() {
-                    ui.url = url.to_string();
+                // The stack advertises its wildcard sslip.io origin so pod apps
+                // can share cookies. Keep the desktop shell on localhost,
+                // however: WebKit treats plain-http localhost as trustworthy
+                // and exposes Web Crypto for the PKCE browser handoff.
+                if ui.mode != "local" {
+                    if let Some(url) = event["url"].as_str() {
+                        ui.url = url.to_string();
+                    }
+                } else {
+                    ui.url = local_url();
                 }
                 // Stay on the splash: the user proceeds via its CTA.
             }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -337,16 +337,12 @@ fn handle_supervisor_event(app: &AppHandle, event: &Value) {
                 ui.ready = true;
                 ui.running = true;
                 ui.error = false;
-                // The stack advertises its wildcard sslip.io origin so pod apps
-                // can share cookies. Keep the desktop shell on localhost,
-                // however: WebKit treats plain-http localhost as trustworthy
-                // and exposes Web Crypto for the PKCE browser handoff.
-                if ui.mode != "local" {
-                    if let Some(url) = event["url"].as_str() {
-                        ui.url = url.to_string();
-                    }
-                } else {
-                    ui.url = local_url();
+                // Use the stack's sslip.io origin in local mode so the app,
+                // browser-auth page, API, and pod subdomains share the same
+                // cookie boundary. The frontend supplies a SHA-256 fallback
+                // for WebKit, where Web Crypto is unavailable over plain HTTP.
+                if let Some(url) = event["url"].as_str() {
+                    ui.url = url.to_string();
                 }
                 // Stay on the splash: the user proceeds via its CTA.
             }

--- a/desktop/tauri.dist.conf.json
+++ b/desktop/tauri.dist.conf.json
@@ -1,6 +1,6 @@
 {
   "bundle": {
-    "externalBin": ["binaries/lemma-supervisor"],
+    "externalBin": ["binaries/lemma-supervisor", "binaries/uv"],
     "macOS": {
       "hardenedRuntime": true,
       "entitlements": "entitlements.plist"

--- a/lemma-backend/app/modules/agent/services/runtime_profile_service.py
+++ b/lemma-backend/app/modules/agent/services/runtime_profile_service.py
@@ -104,7 +104,9 @@ def register_system_openai_catalog_customizer(
     _system_openai_catalog_customizer = customizer
 
 
-def _build_system_openai_catalog() -> list[RuntimeModelCatalogEntry]:
+def _build_system_openai_catalog(
+    *, require_models: bool = True
+) -> list[RuntimeModelCatalogEntry]:
     """The env-configured system OpenAI catalog, after any registered customizer.
 
     Shared by the live profile and the pricing-coverage names so both reflect the
@@ -112,8 +114,13 @@ def _build_system_openai_catalog() -> list[RuntimeModelCatalogEntry]:
     import/startup.
     """
     _load_runtime_env()
-    model_names = _csv_setting(
+    raw_model_names = (
         os.getenv("LEMMA_OPENAI_MODEL_NAMES") or settings.lemma_openai_model_names
+    )
+    model_names = (
+        _csv_setting(raw_model_names)
+        if require_models
+        else _csv_setting_or_empty(raw_model_names)
     )
     default_model_name = (
         os.getenv("LEMMA_OPENAI_DEFAULT_MODEL") or settings.lemma_openai_default_model
@@ -149,7 +156,7 @@ def system_lemma_openai_catalog_model_names() -> list[tuple[str, str | None]]:
     """
     return [
         (entry.name, entry.provider_model_name)
-        for entry in _build_system_openai_catalog()
+        for entry in _build_system_openai_catalog(require_models=False)
     ]
 
 
@@ -161,6 +168,7 @@ def _openai_compat_model_capabilities(
     if model_name in vision_model_names:
         capabilities.append(RuntimeModelCapability.VISION)
     return capabilities
+
 
 USER_DAEMON_PROFILE_PROTOCOLS = {
     HarnessKind.CODEX: RuntimeProfileProtocol.CODEX_APP_SERVER,
@@ -578,13 +586,18 @@ def _env_or_setting(env_name: str, setting_value: object | None) -> str | None:
 
 
 def _csv_setting(value: str) -> list[str]:
+    model_names = _csv_setting_or_empty(value)
+    if not model_names:
+        raise RuntimeError("Lemma system model profile requires at least one model")
+    return model_names
+
+
+def _csv_setting_or_empty(value: str) -> list[str]:
     model_names: list[str] = []
     for raw_model_name in value.split(","):
         model_name = raw_model_name.strip()
         if model_name and model_name not in model_names:
             model_names.append(model_name)
-    if not model_names:
-        raise RuntimeError("Lemma system model profile requires at least one model")
     return model_names
 
 

--- a/lemma-backend/app/modules/agent/services/runtime_profile_service.py
+++ b/lemma-backend/app/modules/agent/services/runtime_profile_service.py
@@ -107,12 +107,7 @@ def register_system_openai_catalog_customizer(
 def _build_system_openai_catalog(
     *, require_models: bool = True
 ) -> list[RuntimeModelCatalogEntry]:
-    """The env-configured system OpenAI catalog, after any registered customizer.
-
-    Shared by the live profile and the pricing-coverage names so both reflect the
-    same (optionally remapped) catalog. Requires no credentials, so it can run at
-    import/startup.
-    """
+    """Build the configured system OpenAI catalog, then customize it."""
     _load_runtime_env()
     raw_model_names = (
         os.getenv("LEMMA_OPENAI_MODEL_NAMES") or settings.lemma_openai_model_names
@@ -147,13 +142,7 @@ def _build_system_openai_catalog(
 
 
 def system_lemma_openai_catalog_model_names() -> list[tuple[str, str | None]]:
-    """``(public_name, provider_model_name)`` for the configured system:lemma
-    OpenAI-compatible catalog.
-
-    Mirrors the catalog built by ``_system_lemma_openai_profile`` (including any
-    registered customizer) without requiring credentials, so it can drive the
-    usage-pricing coverage invariant at import/startup.
-    """
+    """Return public/provider model pairs for pricing coverage checks."""
     return [
         (entry.name, entry.provider_model_name)
         for entry in _build_system_openai_catalog(require_models=False)
@@ -500,9 +489,7 @@ def _system_lemma_openai_profile() -> AgentRuntimeProfile | None:
     api_key = _env_or_setting("LEMMA_OPENAI_API_KEY", settings.lemma_openai_api_key)
     if not api_key:
         return None
-    # _build_system_openai_catalog() -> _csv_setting() already raises a clean
-    # "requires at least one model" error when the key is set but no models are
-    # configured (there is no built-in model default).
+    # Configured credentials require at least one explicit model.
     model_catalog = _build_system_openai_catalog()
     default_model_name = (
         os.getenv("LEMMA_OPENAI_DEFAULT_MODEL") or settings.lemma_openai_default_model

--- a/lemma-backend/app/modules/agent/tests/unit/test_system_openai_catalog_customizer.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_system_openai_catalog_customizer.py
@@ -54,6 +54,18 @@ def test_default_catalog_uses_names_verbatim(openai_env):
         assert RuntimeModelCapability.VISION not in entry.capabilities
 
 
+def test_pricing_catalog_is_empty_when_no_models_are_configured(monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(runtime_profile_service, "_load_runtime_env", lambda: None)
+    monkeypatch.setattr(settings, "lemma_openai_model_names", "")
+    monkeypatch.setattr(settings, "lemma_openai_default_model", "")
+    monkeypatch.delenv("LEMMA_OPENAI_MODEL_NAMES", raising=False)
+    monkeypatch.delenv("LEMMA_OPENAI_DEFAULT_MODEL", raising=False)
+
+    assert system_lemma_openai_catalog_model_names() == []
+
+
 def test_customizer_remaps_provider_and_vision(openai_env):
     mapping = {
         "minimax-m3": ("accounts/fireworks/models/minimax-m3", True),

--- a/lemma-frontend/components/auth/portal/auth/desktop.test.ts
+++ b/lemma-frontend/components/auth/portal/auth/desktop.test.ts
@@ -55,6 +55,18 @@ describe("desktop auth helpers", () => {
     expect(verifier).toHaveLength(43);
     expect(challenge).toMatch(/^[A-Za-z0-9_-]{43}$/);
   });
+
+  it("creates the PKCE challenge when WebKit has no SubtleCrypto", async () => {
+    vi.stubGlobal("window", {
+      sessionStorage: new MemoryStorage(),
+      crypto: { getRandomValues: globalThis.crypto.getRandomValues.bind(globalThis.crypto) },
+      btoa: globalThis.btoa.bind(globalThis),
+    });
+
+    await expect(challengeForDesktopVerifier("test-verifier")).resolves.toBe(
+      "JBbiqONGWPaAmwXk_8bT6UnlPfrn65D32eZlJS-zGG0",
+    );
+  });
 });
 
 class MemoryStorage implements Storage {

--- a/lemma-frontend/components/auth/portal/auth/desktop.ts
+++ b/lemma-frontend/components/auth/portal/auth/desktop.ts
@@ -1,3 +1,5 @@
+import { sha256 } from "@noble/hashes/sha2.js";
+
 const DESKTOP_REQUEST_STORAGE_KEY = "lemma.desktop-auth.request-id";
 const DESKTOP_PENDING_STORAGE_KEY = "lemma.desktop-auth.pending";
 
@@ -84,11 +86,12 @@ export function createDesktopVerifier(): string {
 export async function challengeForDesktopVerifier(
   verifier: string,
 ): Promise<string> {
-  const digest = await window.crypto.subtle.digest(
-    "SHA-256",
-    new TextEncoder().encode(verifier),
-  );
-  return base64Url(new Uint8Array(digest));
+  const encoded = new TextEncoder().encode(verifier);
+  const subtle = window.crypto.subtle;
+  const digest = subtle
+    ? new Uint8Array(await subtle.digest("SHA-256", encoded))
+    : sha256(encoded);
+  return base64Url(digest);
 }
 
 function base64Url(bytes: Uint8Array): string {

--- a/lemma-frontend/package-lock.json
+++ b/lemma-frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
+        "@noble/hashes": "^2.2.0",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -1575,6 +1576,18 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/lemma-frontend/package.json
+++ b/lemma-frontend/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
+    "@noble/hashes": "^2.2.0",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/lemma-stack/lemma_stack/app.py
+++ b/lemma-stack/lemma_stack/app.py
@@ -24,7 +24,7 @@ from lemma_stack.output import (
     warn,
 )
 from lemma_stack.paths import LocalPaths, enrich_path
-from lemma_stack.register import install_lemma_cli, register_local_server
+from lemma_stack.register import install_lemma_cli_and_skills, register_local_server
 from lemma_stack.release import manifest as release_manifest
 from lemma_stack.runtime import detect
 from lemma_stack.stack import images, lifecycle
@@ -175,7 +175,7 @@ def install(
 
     # 7. install the lemma CLI and point it at this stack (server "local")
     if use_cli:
-        install_lemma_cli()
+        install_lemma_cli_and_skills(version=manifest.version)
         if not start_stack:
             register_local_server(
                 base_url=render.backend_origin(config),

--- a/lemma-stack/lemma_stack/orchestrate.py
+++ b/lemma-stack/lemma_stack/orchestrate.py
@@ -9,6 +9,7 @@ from tomlkit import TOMLDocument
 
 from lemma_stack.config import render, store
 from lemma_stack.context import AdminContext
+from lemma_stack.output import AdminError, warn
 from lemma_stack.paths import LocalPaths
 from lemma_stack.register import register_local_server
 from lemma_stack.release import manifest as release_manifest
@@ -36,9 +37,23 @@ def resolve_manifest(
 ) -> ReleaseManifest:
     if manifest_path is not None:
         return release_manifest.load_file(manifest_path)
-    if prefer_pinned and paths.release_file.exists():
+    selected_channel = channel or store.channel(config)
+    has_pin = paths.release_file.exists()
+
+    # Desktop starts follow the stable channel so replacing the app upgrades
+    # its local images. Explicit version channels remain pinned. If Stable is
+    # temporarily unreachable, use the last known-good manifest so local mode
+    # still works offline.
+    if prefer_pinned and has_pin and selected_channel != "stable":
         return release_manifest.load_pinned(paths)
-    return release_manifest.fetch(channel or store.channel(config))
+    try:
+        return release_manifest.fetch(selected_channel)
+    except AdminError:
+        if not (prefer_pinned and has_pin and selected_channel == "stable"):
+            raise
+        pinned = release_manifest.load_pinned(paths)
+        warn(f"could not refresh the stable release; continuing with pinned Lemma {pinned.version}")
+        return pinned
 
 
 def bring_up(

--- a/lemma-stack/lemma_stack/register.py
+++ b/lemma-stack/lemma_stack/register.py
@@ -11,11 +11,14 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
+from typing import Sequence
 
 from lemma_stack.output import info, ok, warn
 
 SERVER_NAME = "local"
+CLI_DISTRIBUTION = "lemma-terminal"
 
 
 def cli_config_path() -> Path:
@@ -73,33 +76,87 @@ def _detect_cli_source() -> str | None:
     return None
 
 
-def install_lemma_cli() -> bool:
-    """Best-effort install of the `lemma` CLI as a uv tool. Never fatal — the
-    server is registered regardless, so the CLI works once present."""
-    if shutil.which("uv") is None:
-        warn("uv not found; install the lemma CLI yourself: uv tool install lemma-cli")
-        return False
-    source = _detect_cli_source()
-    if source is None:
-        # End-user install: always force the latest PyPI release, replacing any
-        # previous installation (including one from a git source).
-        source = "lemma-cli"
-    elif shutil.which("lemma") is not None:
-        # Dev environment with a local checkout already on PATH — leave it alone.
-        return True
-    info(f"installing the lemma CLI from {source}")
-    proc = subprocess.run(
-        ["uv", "tool", "install", "--force", source],
+def _find_user_binary(name: str) -> str | None:
+    # Finder-launched macOS apps do not inherit the user's shell PATH. The
+    # signed desktop bundle includes uv next to the supervisor sidecar. Prefer
+    # uv's user tool directory over a stale system-wide CLI on PATH.
+    for directory in (
+        Path(sys.executable).resolve().parent,
+        Path.home() / ".local" / "bin",
+        Path.home() / ".cargo" / "bin",
+    ):
+        candidate = directory / name
+        if candidate.is_file():
+            return str(candidate)
+    return shutil.which(name)
+
+
+def _run(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(command),
         capture_output=True,
         text=True,
         check=False,
     )
+
+
+def _installed_cli_version(lemma: str) -> str | None:
+    proc = _run([lemma, "--version"])
+    if proc.returncode != 0:
+        return None
+    first_line = (proc.stdout or proc.stderr or "").splitlines()[0:1]
+    if not first_line:
+        return None
+    parts = first_line[0].strip().split()
+    return parts[1] if len(parts) >= 2 and parts[0] == "lemma" else None
+
+
+def install_lemma_cli(*, version: str | None = None) -> bool:
+    """Best-effort install of the `lemma` CLI as a uv tool. Never fatal — the
+    server is registered regardless, so the CLI works once present."""
+    uv = _find_user_binary("uv")
+    if uv is None:
+        warn("uv not found; install the Lemma terminal yourself: uv tool install lemma-terminal")
+        return False
+    source = _detect_cli_source()
+    if source is None:
+        source = f"{CLI_DISTRIBUTION}=={version}" if version else CLI_DISTRIBUTION
+        lemma = _find_user_binary("lemma")
+        if version and lemma and _installed_cli_version(lemma) == version:
+            return True
+    elif _find_user_binary("lemma") is not None:
+        # Dev environment with a local checkout already on PATH — leave it alone.
+        return True
+    info(f"installing the lemma CLI from {source}")
+    proc = _run([uv, "tool", "install", "--force", source])
     if proc.returncode != 0:
         detail = (proc.stderr or proc.stdout or "").strip()[-300:]
         warn(
             "could not auto-install the lemma CLI; install it with "
-            f"`uv tool install lemma-cli`.\n  {detail}"
+            f"`uv tool install {source}`.\n  {detail}"
         )
         return False
     ok("lemma CLI installed")
     return True
+
+
+def install_lemma_skills() -> bool:
+    """Upsert curated skills from lemma-terminal into user-level agent dirs."""
+    lemma = _find_user_binary("lemma")
+    if lemma is None:
+        warn("lemma CLI not found; skipping bundled skill installation")
+        return False
+    info("installing bundled Lemma skills")
+    proc = _run([lemma, "skills", "install", "--target", "all", "--yes"])
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()[-300:]
+        warn(f"could not install bundled Lemma skills.\n  {detail}")
+        return False
+    ok("Lemma skills installed")
+    return True
+
+
+def install_lemma_cli_and_skills(*, version: str | None = None) -> bool:
+    if not install_lemma_cli(version=version):
+        return False
+    return install_lemma_skills()

--- a/lemma-stack/lemma_stack/supervise.py
+++ b/lemma-stack/lemma_stack/supervise.py
@@ -183,6 +183,10 @@ class Supervisor:
             do_register=True,
             progress=progress,
         )
+        self._set_phase("workspace", "installing terminal and skills")
+        from lemma_stack.register import install_lemma_cli_and_skills
+
+        install_lemma_cli_and_skills(version=manifest.version)
         self._finish_ready(config)
 
     def _resolve_provider(self, config) -> str:

--- a/lemma-stack/tests/test_manifest.py
+++ b/lemma-stack/tests/test_manifest.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import re
+from pathlib import Path
 
 import pytest
 
@@ -33,6 +35,17 @@ def test_parse_and_pull_refs():
     # infra falls back to built-in defaults when missing from the manifest
     assert manifest.infra_image("postgres") == "docker.io/pgvector/pgvector:0.8.0-pg16"
     assert manifest.infra_image("redis") == m.DEFAULT_INFRA_IMAGES["redis"]
+
+
+def test_release_workflow_uses_the_stack_supertokens_version():
+    workflow = (
+        Path(__file__).resolve().parents[2]
+        / ".github/workflows/release-local-images.yml"
+    ).read_text(encoding="utf-8")
+    match = re.search(r'"supertokens": "([^"]+)"', workflow)
+
+    assert match is not None
+    assert match.group(1) == m.DEFAULT_INFRA_IMAGES["supertokens"]
 
 
 def test_kreuzberg_pull_only_when_enabled():

--- a/lemma-stack/tests/test_orchestrate.py
+++ b/lemma-stack/tests/test_orchestrate.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from lemma_stack import orchestrate
+from lemma_stack.config import store
+from lemma_stack.output import AdminError
+from lemma_stack.release import manifest as release_manifest
+
+
+def _manifest(version: str):
+    return release_manifest.parse(
+        {
+            "schema_version": 1,
+            "version": version,
+            "min_admin_version": "0",
+            "images": {
+                name: f"ghcr.io/lemma-work/lemma-{name}:v{version}"
+                for name in ("backend", "frontend", "agentbox", "agentbox_runtime")
+            },
+        }
+    )
+
+
+def test_desktop_stable_channel_refreshes_an_existing_pin(paths, monkeypatch):
+    config = store.new_document()
+    release_manifest.pin(paths, _manifest("0.5.1"))
+    latest = _manifest("0.6.1")
+    seen: list[str] = []
+
+    def fetch(channel: str):
+        seen.append(channel)
+        return latest
+
+    monkeypatch.setattr(orchestrate.release_manifest, "fetch", fetch)
+
+    resolved = orchestrate.resolve_manifest(config, paths, prefer_pinned=True)
+
+    assert resolved.version == "0.6.1"
+    assert seen == ["stable"]
+
+
+def test_desktop_explicit_version_channel_keeps_its_pin(paths, monkeypatch):
+    config = store.new_document()
+    config["install"]["channel"] = "0.5.1"
+    release_manifest.pin(paths, _manifest("0.5.1"))
+
+    def unexpected_fetch(_channel: str):
+        raise AssertionError("explicit version pins must not refresh")
+
+    monkeypatch.setattr(orchestrate.release_manifest, "fetch", unexpected_fetch)
+
+    resolved = orchestrate.resolve_manifest(config, paths, prefer_pinned=True)
+
+    assert resolved.version == "0.5.1"
+
+
+def test_desktop_stable_channel_falls_back_to_pin_offline(paths, monkeypatch, capsys):
+    config = store.new_document()
+    release_manifest.pin(paths, _manifest("0.5.1"))
+
+    def unavailable(_channel: str):
+        raise AdminError("offline")
+
+    monkeypatch.setattr(orchestrate.release_manifest, "fetch", unavailable)
+
+    resolved = orchestrate.resolve_manifest(config, paths, prefer_pinned=True)
+
+    assert resolved.version == "0.5.1"
+    assert "continuing with pinned Lemma 0.5.1" in capsys.readouterr().err

--- a/lemma-stack/tests/test_register.py
+++ b/lemma-stack/tests/test_register.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 
 from lemma_stack import register
 
@@ -61,3 +62,72 @@ def test_register_preserves_existing_servers_and_tokens(tmp_path, monkeypatch):
     assert local["base_url"] == "http://localhost:8711"
     assert local["token"] == "tok-local"
     assert local["defaults"] == {"pod_id": "p-1"}
+
+
+def test_cli_install_uses_release_aligned_terminal_distribution(monkeypatch):
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(register, "_detect_cli_source", lambda: None)
+    monkeypatch.setattr(
+        register,
+        "_find_user_binary",
+        lambda name: f"/tools/{name}" if name in {"uv", "lemma"} else None,
+    )
+
+    def run(command):
+        command = list(command)
+        commands.append(command)
+        if command[-1] == "--version":
+            return subprocess.CompletedProcess(command, 0, stdout="lemma 0.5.1\n", stderr="")
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(register, "_run", run)
+
+    assert register.install_lemma_cli(version="0.6.1") is True
+    assert commands[-1] == [
+        "/tools/uv",
+        "tool",
+        "install",
+        "--force",
+        "lemma-terminal==0.6.1",
+    ]
+
+
+def test_current_cli_version_is_not_reinstalled(monkeypatch):
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(register, "_detect_cli_source", lambda: None)
+    monkeypatch.setattr(
+        register,
+        "_find_user_binary",
+        lambda name: f"/tools/{name}" if name in {"uv", "lemma"} else None,
+    )
+
+    def run(command):
+        command = list(command)
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="lemma 0.6.1\n", stderr="")
+
+    monkeypatch.setattr(register, "_run", run)
+
+    assert register.install_lemma_cli(version="0.6.1") is True
+    assert commands == [["/tools/lemma", "--version"]]
+
+
+def test_skill_install_upserts_curated_bundle_for_all_user_agents(monkeypatch):
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        register,
+        "_find_user_binary",
+        lambda name: "/tools/lemma" if name == "lemma" else None,
+    )
+
+    def run(command):
+        command = list(command)
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(register, "_run", run)
+
+    assert register.install_lemma_skills() is True
+    assert commands == [["/tools/lemma", "skills", "install", "--target", "all", "--yes"]]


### PR DESCRIPTION
## Summary

- refresh the Stable release manifest when desktop Local mode starts, so replacing the app upgrades pinned local images
- preserve explicit version-channel pins and fall back to the last known-good Stable manifest when offline
- install the `lemma-terminal` version matching the resolved Local stack release
- upsert the terminal's curated Lemma skills into supported user-level agent directories
- bundle and sign `uv` inside the macOS app so Finder launches do not depend on shell `PATH`
- verify the bundled supervisor and uv signatures in PR and release CI

## Why

A newly installed Lemma Desktop 0.6.1 was still running a local frontend pinned to 0.5.1, so merged onboarding changes were not visible. Desktop also only wrote a local CLI profile; it never installed or upgraded `lemma-terminal` or its bundled skills.

## Behavior

- `channel = stable`: refresh online, use the old pin offline
- explicit `channel = X.Y.Z`: remain pinned
- matching terminal version already installed: skip reinstall, still refresh skills
- CLI/skill setup failure remains non-fatal to the local app startup and is surfaced in supervisor logs

## Verification

- lemma-stack tests: `52 passed, 3 skipped`
- changed-file Ruff formatting and lint: passed
- desktop Rust tests: `6 passed`
- sidecar build and uv smoke test: passed
- ad-hoc signed Tauri app bundle: passed
- strict codesign verification for app, supervisor, and uv: passed
- live read-only resolver check against the existing 0.5.1 pin: resolved Stable to `0.6.1`

No version bump or release is included.