### PR TITLE
Fix daemon tool completion and refine tool call UI

### DIFF
--- a/lemma-backend/agent_tool_schemas.json
+++ b/lemma-backend/agent_tool_schemas.json
@@ -111,6 +111,11 @@
           "additionalProperties": true,
           "description": "The user's answers keyed by each question's header. Each value is the chosen option label(s) or the custom text they typed for 'Other'.",
           "type": "object"
+        },
+        "interaction_fallback": {
+          "default": false,
+          "description": "True when a daemon runtime could not pause and the model must ask the question conversationally instead.",
+          "type": "boolean"
         }
       },
       "title": "AskUserResponse",
@@ -2363,6 +2368,11 @@
           "additionalProperties": true,
           "description": "Optional structured response submitted with the decision.",
           "type": "object"
+        },
+        "interaction_fallback": {
+          "default": false,
+          "description": "True when a daemon runtime could not pause and the model must ask for confirmation conversationally instead.",
+          "type": "boolean"
         }
       },
       "title": "RequestApprovalResponse",

--- a/lemma-backend/app/modules/agent/infrastructure/daemon_hub.py
+++ b/lemma-backend/app/modules/agent/infrastructure/daemon_hub.py
@@ -25,6 +25,7 @@ from app.modules.agent.infrastructure.agent_runtime_redis import (
     publish_json as _publish_json,
     run_event_channel as _run_event_channel,
 )
+from app.modules.agent.infrastructure.mcp import normalize_local_mcp_tool_name
 from app.modules.agent.domain.value_objects import (
     AgentEvent,
     AgentEventType,
@@ -538,6 +539,8 @@ def _event_from_payload(payload: object, *, agent_run_id: UUID) -> AgentEvent:
 def _normalize_event_data(event_type: AgentEventType, data: object) -> object:
     if event_type == AgentEventType.MESSAGE and isinstance(data, dict):
         return _message_draft_from_payload(data)
+    if event_type == AgentEventType.TOKEN and isinstance(data, dict):
+        return _normalize_tool_token(data)
     if event_type == AgentEventType.USAGE and isinstance(data, dict):
         return AgentRunUsage.model_validate(data)
     if isinstance(data, BaseModel):
@@ -549,7 +552,7 @@ def _message_draft_from_payload(data: dict) -> MessageDraft:
     """Build a flat MessageDraft from a daemon MESSAGE payload."""
 
     role = MessageRole(data.get("role", MessageRole.ASSISTANT.value))
-    metadata = data.get("metadata") if isinstance(data.get("metadata"), dict) else None
+    metadata = dict(data["metadata"]) if isinstance(data.get("metadata"), dict) else {}
     raw_kind = data.get("kind")
 
     if raw_kind is None:
@@ -560,32 +563,60 @@ def _message_draft_from_payload(data: dict) -> MessageDraft:
         return MessageDraft.of_text(
             body if isinstance(body, str) else ("" if body is None else str(body)),
             role=role,
-            metadata=metadata,
+            metadata=metadata or None,
         )
 
     kind = MessageKind(raw_kind)
     if kind == MessageKind.TOOL_CALL:
+        raw_tool_name = str(data.get("tool_name") or "unknown_tool")
+        tool_name = normalize_local_mcp_tool_name(raw_tool_name)
+        if tool_name != raw_tool_name:
+            metadata.setdefault("provider_tool_name", raw_tool_name)
         return MessageDraft.of_tool_call(
-            tool_name=str(data.get("tool_name") or "unknown_tool"),
+            tool_name=tool_name,
             tool_call_id=str(data.get("tool_call_id") or ""),
             tool_args=data.get("tool_args"),
             role=role,
-            metadata=metadata,
+            metadata=metadata or None,
         )
     if kind == MessageKind.TOOL_RETURN:
+        raw_tool_name = data.get("tool_name")
+        tool_name = (
+            normalize_local_mcp_tool_name(raw_tool_name)
+            if isinstance(raw_tool_name, str)
+            else None
+        )
+        if tool_name is not None and tool_name != raw_tool_name:
+            metadata.setdefault("provider_tool_name", raw_tool_name)
         return MessageDraft.of_tool_return(
-            tool_name=data.get("tool_name"),
+            tool_name=tool_name,
             tool_call_id=str(data.get("tool_call_id") or ""),
             tool_result=data.get("tool_result"),
             role=role,
-            metadata=metadata,
+            metadata=metadata or None,
         )
     return MessageDraft(
         role=role,
         kind=kind,
         text=data.get("text"),
-        metadata=metadata,
+        metadata=metadata or None,
     )
+
+
+def _normalize_tool_token(data: dict) -> dict:
+    if data.get("kind") != "tool" or not isinstance(data.get("data"), str):
+        return data
+    try:
+        payload = json.loads(data["data"])
+    except json.JSONDecodeError:
+        return data
+    if not isinstance(payload, dict) or not isinstance(payload.get("tool_name"), str):
+        return data
+    normalized = normalize_local_mcp_tool_name(payload["tool_name"])
+    if normalized == payload["tool_name"]:
+        return data
+    payload["tool_name"] = normalized
+    return {**data, "data": json.dumps(payload, separators=(",", ":"))}
 
 
 agent_runtime_daemon_hub = AgentRuntimeDaemonHub()

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/daemon.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/daemon.py
@@ -18,6 +18,7 @@ from app.modules.agent.domain.value_objects import (
     HarnessKind,
     HarnessOptions,
     JsonObject,
+    MessageDraft,
     MessageKind,
     MessageRole,
     to_json_value,
@@ -105,6 +106,7 @@ class DaemonHarness:
             return
 
         stop_sent = False
+        outstanding_tool_calls: dict[str, str] = {}
         # Set the moment a RECONNECTING sentinel is first seen; cleared once a
         # real event arrives again. Bounds how long this run waits out a dead
         # connection, independent of (and much shorter than) event_timeout_seconds.
@@ -131,11 +133,17 @@ class DaemonHarness:
                                 reconnecting_since + self.reconnect_grace_seconds
                             ) - time.monotonic()
                             if grace_remaining <= 0:
-                                yield AgentEvent(
+                                terminal_event = AgentEvent(
                                     type=AgentEventType.ERROR,
                                     data="User daemon did not reconnect within the grace period",
                                     agent_run_id=agent_run_id,
                                 )
+                                for missing_return in _missing_tool_return_events(
+                                    outstanding_tool_calls=outstanding_tool_calls,
+                                    terminal_event=terminal_event,
+                                ):
+                                    yield missing_return
+                                yield terminal_event
                                 return
                             remaining = min(remaining, grace_remaining)
                         if remaining <= 0:
@@ -160,11 +168,17 @@ class DaemonHarness:
                             )
                             stop_sent = True
                 except TimeoutError:
-                    yield AgentEvent(
+                    terminal_event = AgentEvent(
                         type=AgentEventType.ERROR,
                         data="User daemon did not emit a run event before timeout",
                         agent_run_id=agent_run_id,
                     )
+                    for missing_return in _missing_tool_return_events(
+                        outstanding_tool_calls=outstanding_tool_calls,
+                        terminal_event=terminal_event,
+                    ):
+                        yield missing_return
+                    yield terminal_event
                     return
 
                 if event.type == AgentEventType.RECONNECTING:
@@ -188,6 +202,31 @@ class DaemonHarness:
                         agent_run_id=agent_run_id,
                     )
 
+                if event.type == AgentEventType.MESSAGE and isinstance(
+                    event.data, MessageDraft
+                ):
+                    message = event.data
+                    if (
+                        message.kind == MessageKind.TOOL_CALL
+                        and message.tool_call_id
+                        and message.tool_name
+                    ):
+                        outstanding_tool_calls[message.tool_call_id] = message.tool_name
+                    elif message.kind == MessageKind.TOOL_RETURN and message.tool_call_id:
+                        outstanding_tool_calls.pop(message.tool_call_id, None)
+
+                if event.type in {
+                    AgentEventType.COMPLETED,
+                    AgentEventType.STOPPED,
+                    AgentEventType.ERROR,
+                    AgentEventType.REJECTED,
+                }:
+                    for missing_return in _missing_tool_return_events(
+                        outstanding_tool_calls=outstanding_tool_calls,
+                        terminal_event=event,
+                    ):
+                        yield missing_return
+
                 yield event
                 if event.type in {
                     AgentEventType.COMPLETED,
@@ -202,6 +241,49 @@ class DaemonHarness:
                 user_id=daemon_user_id,
                 agent_run_id=agent_run_id,
             )
+
+
+def _missing_tool_return_error(event_type: AgentEventType) -> str:
+    if event_type == AgentEventType.STOPPED:
+        return "Daemon run stopped before the tool returned a result."
+    if event_type == AgentEventType.ERROR:
+        return "Daemon run failed before the tool returned a result."
+    if event_type == AgentEventType.REJECTED:
+        return "Daemon run was rejected before the tool returned a result."
+    return "Daemon run completed without a tool return."
+
+
+def _missing_tool_return_events(
+    *,
+    outstanding_tool_calls: dict[str, str],
+    terminal_event: AgentEvent,
+) -> list[AgentEvent]:
+    events = [
+        AgentEvent(
+            type=AgentEventType.MESSAGE,
+            data=MessageDraft.of_tool_return(
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                tool_result={
+                    "success": False,
+                    "error": _missing_tool_return_error(terminal_event.type),
+                    **(
+                        {"interaction_fallback": True}
+                        if tool_name in {"ask_user", "request_approval"}
+                        else {}
+                    ),
+                },
+                metadata={
+                    "synthetic_tool_return": True,
+                    "terminal_event": terminal_event.type.value,
+                },
+            ),
+            agent_run_id=terminal_event.agent_run_id,
+        )
+        for tool_call_id, tool_name in outstanding_tool_calls.items()
+    ]
+    outstanding_tool_calls.clear()
+    return events
 
 
 def _daemon_id_from_options(options: HarnessOptions) -> UUID:

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_tools.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_tools.py
@@ -647,6 +647,7 @@ async def test_interaction_tools_guide_instead_of_pausing_on_daemon_harness():
         _one_question(),
     )
     assert ask.success is False
+    assert ask.interaction_fallback is True
     assert "continue this conversation" in (ask.message or "")
 
     approval = await request_approval(
@@ -656,6 +657,7 @@ async def test_interaction_tools_guide_instead_of_pausing_on_daemon_harness():
         title="List files?",
     )
     assert approval.success is False
+    assert approval.interaction_fallback is True
     assert "can't run a tool with the user's approval" in (approval.message or "")
 
 

--- a/lemma-backend/app/modules/agent/tests/unit/test_daemon_harness.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_daemon_harness.py
@@ -26,6 +26,7 @@ from app.modules.agent.infrastructure.harnesses.daemon import (
     DEFAULT_RECONNECT_GRACE_SECONDS,
     DaemonHarness,
     _mcp_payload,
+    _missing_tool_return_events,
     _run_start_payload,
 )
 
@@ -56,6 +57,39 @@ def test_daemon_harness_default_event_timeout_is_two_hours():
 
     assert harness.event_timeout_seconds == DEFAULT_DAEMON_EVENT_TIMEOUT_SECONDS
     assert harness.event_timeout_seconds == 7200.0
+
+
+@pytest.mark.parametrize(
+    ("terminal_type", "expected_error"),
+    [
+        (AgentEventType.COMPLETED, "Daemon run completed without a tool return."),
+        (AgentEventType.ERROR, "Daemon run failed before the tool returned a result."),
+        (AgentEventType.STOPPED, "Daemon run stopped before the tool returned a result."),
+    ],
+)
+def test_missing_tool_returns_are_closed_for_every_terminal_status(
+    terminal_type: AgentEventType, expected_error: str
+) -> None:
+    run_id = uuid4()
+    outstanding = {"call-1": "display_resource"}
+
+    events = _missing_tool_return_events(
+        outstanding_tool_calls=outstanding,
+        terminal_event=AgentEvent(
+            type=terminal_type,
+            data={},
+            agent_run_id=run_id,
+        ),
+    )
+
+    assert outstanding == {}
+    assert len(events) == 1
+    assert events[0].agent_run_id == run_id
+    assert events[0].data.tool_call_id == "call-1"
+    assert events[0].data.tool_result == {
+        "success": False,
+        "error": expected_error,
+    }
 
 
 class _FakeWebSocket:
@@ -225,6 +259,24 @@ async def test_daemon_harness_forwards_run_start_and_yields_events(
         message={
             "type": "run.event",
             "agent_run_id": str(agent_run_id),
+            "event": {
+                "type": "message",
+                "data": {
+                    "role": "assistant",
+                    "kind": "tool_call",
+                    "tool_name": "mcp__lemma_tools__lemma_exec_command",
+                    "tool_call_id": "unfinished-1",
+                    "tool_args": {"cmd": "pwd"},
+                },
+            },
+        },
+    )
+    await agent_runtime_daemon_hub.handle_run_event(
+        daemon_id=daemon_id,
+        user_id=daemon_user_id,
+        message={
+            "type": "run.event",
+            "agent_run_id": str(agent_run_id),
             "event": {"type": "completed", "data": {}},
         },
     )
@@ -232,10 +284,24 @@ async def test_daemon_harness_forwards_run_start_and_yields_events(
 
     assert [event.type for event in events] == [
         AgentEventType.MESSAGE,
+        AgentEventType.MESSAGE,
+        AgentEventType.MESSAGE,
         AgentEventType.COMPLETED,
     ]
     assert events[0].data.kind == MessageKind.TEXT
     assert events[0].data.text == "hi from daemon"
+    assert events[1].data.kind == MessageKind.TOOL_CALL
+    assert events[1].data.tool_name == "exec_command"
+    assert events[2].data.kind == MessageKind.TOOL_RETURN
+    assert events[2].data.tool_call_id == "unfinished-1"
+    assert events[2].data.tool_result == {
+        "success": False,
+        "error": "Daemon run completed without a tool return.",
+    }
+    assert events[2].data.metadata == {
+        "synthetic_tool_return": True,
+        "terminal_event": "COMPLETED",
+    }
     await agent_runtime_daemon_hub.unregister(
         daemon_id=daemon_id,
         user_id=daemon_user_id,

--- a/lemma-backend/app/modules/agent/tests/unit/test_daemon_hub_realtime.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_daemon_hub_realtime.py
@@ -7,7 +7,7 @@ from uuid import uuid4
 
 import pytest
 
-from app.modules.agent.domain.value_objects import AgentEventType
+from app.modules.agent.domain.value_objects import AgentEventType, MessageKind
 from app.modules.agent.infrastructure import daemon_hub
 
 
@@ -48,6 +48,83 @@ class _WebSocket:
 
     async def send_json(self, payload: dict[str, object]) -> None:
         self.sent.append(payload)
+
+
+@pytest.mark.parametrize(
+    ("provider_name", "canonical_name"),
+    [
+        ("mcp__lemma_tools__lemma_display_resource", "display_resource"),
+        ("mcp.lemma_tools.lemma_ask_user", "ask_user"),
+        ("lemma_tools_lemma_exec_command", "exec_command"),
+        ("lemma_display_resource", "display_resource"),
+        ("commandExecution", "commandExecution"),
+    ],
+)
+def test_daemon_message_tool_names_are_canonicalized(
+    provider_name: str, canonical_name: str
+) -> None:
+    event = daemon_hub._event_from_payload(
+        {
+            "type": "message",
+            "data": {
+                "role": "assistant",
+                "kind": "tool_call",
+                "tool_name": provider_name,
+                "tool_call_id": "call-1",
+                "tool_args": {"value": 1},
+            },
+        },
+        agent_run_id=uuid4(),
+    )
+
+    assert event.data.kind == MessageKind.TOOL_CALL
+    assert event.data.tool_name == canonical_name
+    if provider_name == canonical_name:
+        assert not (event.data.metadata or {}).get("provider_tool_name")
+    else:
+        assert event.data.metadata == {"provider_tool_name": provider_name}
+
+
+def test_daemon_tool_token_name_is_canonicalized() -> None:
+    event = daemon_hub._event_from_payload(
+        {
+            "type": "token",
+            "data": {
+                "kind": "tool",
+                "data": '{"tool_name":"mcp__lemma_tools__lemma_exec_command","args":{"cmd":"pwd"}}',
+            },
+        },
+        agent_run_id=uuid4(),
+    )
+
+    assert event.data == {
+        "kind": "tool",
+        "data": '{"tool_name":"exec_command","args":{"cmd":"pwd"}}',
+    }
+
+
+def test_daemon_tool_return_keeps_call_id_and_result_while_normalizing_name() -> None:
+    event = daemon_hub._event_from_payload(
+        {
+            "type": "message",
+            "data": {
+                "role": "tool",
+                "kind": "tool_return",
+                "tool_name": "mcp__lemma_tools__lemma_display_resource",
+                "tool_call_id": "display-1",
+                "tool_result": {"success": True, "url": "/widgets/1"},
+            },
+        },
+        agent_run_id=uuid4(),
+    )
+
+    assert event.data.kind == MessageKind.TOOL_RETURN
+    assert event.data.tool_name == "display_resource"
+    assert event.data.tool_call_id == "display-1"
+    assert event.data.tool_result == {"success": True, "url": "/widgets/1"}
+    assert event.data.metadata == {
+        "provider_tool_name": "mcp__lemma_tools__lemma_display_resource"
+    }
 
 
 @pytest.mark.asyncio

--- a/lemma-backend/app/modules/agent/tools/user_interaction/models.py
+++ b/lemma-backend/app/modules/agent/tools/user_interaction/models.py
@@ -209,6 +209,13 @@ class RequestApprovalResponse(BaseToolResponse):
         default_factory=dict,
         description="Optional structured response submitted with the decision.",
     )
+    interaction_fallback: bool = Field(
+        default=False,
+        description=(
+            "True when a daemon runtime could not pause and the model must ask "
+            "for confirmation conversationally instead."
+        ),
+    )
 
 
 class AskUserOption(BaseModel):
@@ -261,5 +268,12 @@ class AskUserResponse(BaseToolResponse):
         description=(
             "The user's answers keyed by each question's header. Each value is the "
             "chosen option label(s) or the custom text they typed for 'Other'."
+        ),
+    )
+    interaction_fallback: bool = Field(
+        default=False,
+        description=(
+            "True when a daemon runtime could not pause and the model must ask "
+            "the question conversationally instead."
         ),
     )

--- a/lemma-backend/app/modules/agent/tools/user_interaction/pydantic_adapter.py
+++ b/lemma-backend/app/modules/agent/tools/user_interaction/pydantic_adapter.py
@@ -265,6 +265,7 @@ async def request_approval(
         # the conversational fallback instead of hanging or aborting the run.
         return RequestApprovalResponse(
             success=False,
+            interaction_fallback=True,
             message=(
                 "This runtime can't run a tool with the user's approval mid-turn. "
                 f"Explain what you need to do ({tool_name}) and why it needs their "
@@ -396,6 +397,7 @@ async def ask_user(
         # Guide the model to ask conversationally instead of hanging/aborting.
         return AskUserResponse(
             success=False,
+            interaction_fallback=True,
             message=(
                 "This runtime can't pause to collect a multiple-choice answer. Ask "
                 "the user your question(s) directly in your reply and end your turn; "

--- a/lemma-cli/lemma_cli/daemon/harnesses/base.py
+++ b/lemma-cli/lemma_cli/daemon/harnesses/base.py
@@ -22,6 +22,7 @@ class StreamTextState:
         self.streamed_messages = False
         self.emitted_tool_call_ids: set[str] = set()
         self.emitted_tool_return_ids: set[str] = set()
+        self.tool_names_by_call_id: dict[str, str] = {}
 
     @property
     def full_text(self) -> str:
@@ -82,6 +83,7 @@ class StreamTextState:
             status = str(state.get("status") or "")
             if call_id not in self.emitted_tool_call_ids:
                 self.emitted_tool_call_ids.add(call_id)
+                self.tool_names_by_call_id[call_id] = tool_name
                 # Flush buffered text first so ordering reads text -> tool -> text.
                 await self.flush(is_final=False)
                 self.streamed_tokens = True

--- a/lemma-cli/lemma_cli/daemon/harnesses/claude_code.py
+++ b/lemma-cli/lemma_cli/daemon/harnesses/claude_code.py
@@ -6,7 +6,7 @@ import json
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from .base import StreamTextState
+from .base import StreamTextState, emit_tool_return
 from .codex import (
     _daemon_session_invalid_payload,
     _daemon_session_started_payload,
@@ -21,6 +21,7 @@ from ..mcp import (
     write_provider_mcp_files,
 )
 from ..process import create_subprocess, drain_stream, terminate_gracefully
+from .._utils import parse_jsonish
 
 
 class ClaudeCodeHarness:
@@ -200,6 +201,17 @@ async def _handle_claude_stream_event(
                 await state.flush(is_final=False)
                 await _emit_claude_tool_call(part, state)
         return text
+    if event_type == "user":
+        message = event.get("message")
+        if not isinstance(message, dict):
+            return ""
+        content = message.get("content")
+        if not isinstance(content, list):
+            return ""
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "tool_result":
+                await _emit_claude_tool_return(part, state)
+        return ""
     if event_type == "tool_call":
         # Cursor reports tool activity as top-level tool_call events
         # (subtype started/completed) rather than Claude's tool_use content
@@ -228,6 +240,7 @@ async def _emit_cursor_tool_call(event: dict[str, Any], state: StreamTextState) 
         if call_id in state.emitted_tool_call_ids:
             return
         state.emitted_tool_call_ids.add(call_id)
+        state.tool_names_by_call_id[call_id] = tool_name
         message = {
             "role": "assistant",
             "kind": "tool_call",
@@ -237,12 +250,14 @@ async def _emit_cursor_tool_call(event: dict[str, Any], state: StreamTextState) 
             "metadata": {"tool_name": tool_name, "provider": state.harness_kind},
         }
         state.streamed_tokens = True
+        state.streamed_messages = True
         await state.event_sink("token", codex_tool_token(message))
         await state.event_sink("message", message)
     elif subtype == "completed":
         if call_id in state.emitted_tool_return_ids:
             return
         state.emitted_tool_return_ids.add(call_id)
+        state.tool_names_by_call_id.setdefault(call_id, tool_name)
         state.streamed_messages = True
         await state.event_sink(
             "message",
@@ -293,7 +308,7 @@ async def _emit_claude_tool_call(part: dict[str, Any], state: StreamTextState) -
     if tool_call_id in state.emitted_tool_call_ids:
         return
     state.emitted_tool_call_ids.add(tool_call_id)
-    from .._utils import parse_jsonish
+    state.tool_names_by_call_id[tool_call_id] = tool_name
     tool_call = {
         "role": "assistant",
         "kind": "tool_call",
@@ -307,8 +322,60 @@ async def _emit_claude_tool_call(part: dict[str, Any], state: StreamTextState) -
     }
     if state.event_sink is not None:
         state.streamed_tokens = True
+        state.streamed_messages = True
         await state.event_sink("token", codex_tool_token(tool_call))
         await state.event_sink("message", tool_call)
+
+
+async def _emit_claude_tool_return(
+    part: dict[str, Any], state: StreamTextState
+) -> None:
+    tool_call_id = part.get("tool_use_id") or part.get("toolUseId")
+    if not isinstance(tool_call_id, str) or not tool_call_id:
+        return
+    if tool_call_id in state.emitted_tool_return_ids:
+        return
+    state.emitted_tool_return_ids.add(tool_call_id)
+    if state.event_sink is None:
+        return
+
+    tool_name = state.tool_names_by_call_id.get(tool_call_id, "unknown_tool")
+    state.streamed_messages = True
+    await emit_tool_return(
+        state.event_sink,
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+        tool_result=_claude_tool_result(part),
+        harness_kind=state.harness_kind,
+    )
+
+
+def _claude_tool_result(part: dict[str, Any]) -> Any:
+    content = part.get("content")
+    if isinstance(content, list):
+        text_parts = [
+            str(item.get("text"))
+            for item in content
+            if isinstance(item, dict) and isinstance(item.get("text"), str)
+        ]
+        value: Any = (
+            parse_jsonish("\n".join(text_parts))
+            if text_parts and len(text_parts) == len(content)
+            else content
+        )
+    elif isinstance(content, str):
+        value = parse_jsonish(content)
+    else:
+        value = content
+
+    if not bool(part.get("is_error") or part.get("isError")):
+        return value
+    if isinstance(value, dict):
+        return {**value, "success": False}
+    return {
+        "success": False,
+        "error": value if value is not None else "Claude tool returned an error.",
+    }
 
 
 def _claude_stream_session_id(event: dict[str, Any]) -> str | None:

--- a/lemma-cli/tests/test_claude_tool_results.py
+++ b/lemma-cli/tests/test_claude_tool_results.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from lemma_cli.daemon.harnesses.base import StreamTextState
+from lemma_cli.daemon.harnesses.claude_code import _handle_claude_stream_event
+
+
+async def _capture_tool_result(content: Any, *, is_error: bool = False) -> list[dict]:
+    events: list[tuple[str, dict]] = []
+
+    async def sink(event_type: str, data: dict) -> None:
+        events.append((event_type, data))
+
+    state = StreamTextState(harness_kind="CLAUDE_CODE", event_sink=sink)
+    call_event = {
+        "type": "assistant",
+        "message": {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "mcp__lemma_tools__lemma_display_resource",
+                    "input": {"request": {"type": "TABLE", "name": "orders"}},
+                }
+            ]
+        },
+    }
+    return_event = {
+        "type": "user",
+        "message": {
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_1",
+                    "content": content,
+                    "is_error": is_error,
+                }
+            ]
+        },
+    }
+
+    await _handle_claude_stream_event(call_event, state)
+    await _handle_claude_stream_event(return_event, state)
+    await _handle_claude_stream_event(return_event, state)
+    return [data for event_type, data in events if event_type == "message"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ('{"success":true,"url":"/widgets/1"}', {"success": True, "url": "/widgets/1"}),
+        ([{"type": "text", "text": '{"count":3}'}], {"count": 3}),
+        (
+            [
+                {"type": "text", "text": "caption"},
+                {"type": "image", "data": "abc"},
+            ],
+            [
+                {"type": "text", "text": "caption"},
+                {"type": "image", "data": "abc"},
+            ],
+        ),
+        ("plain output", "plain output"),
+    ],
+)
+async def test_claude_user_tool_result_emits_one_paired_return(
+    content: Any, expected: Any
+) -> None:
+    messages = await _capture_tool_result(content)
+
+    assert [message["kind"] for message in messages] == ["tool_call", "tool_return"]
+    assert messages[0]["tool_call_id"] == messages[1]["tool_call_id"] == "toolu_1"
+    assert messages[1]["tool_name"] == "mcp__lemma_tools__lemma_display_resource"
+    assert messages[1]["tool_result"] == expected
+
+
+@pytest.mark.asyncio
+async def test_claude_error_tool_result_is_a_failed_return() -> None:
+    messages = await _capture_tool_result("permission denied", is_error=True)
+
+    assert messages[-1]["tool_result"] == {
+        "success": False,
+        "error": "permission denied",
+    }

--- a/lemma-cli/tests/test_daemon_cli.py
+++ b/lemma-cli/tests/test_daemon_cli.py
@@ -931,6 +931,13 @@ async def test_claude_stream_persists_assistant_text_before_tool_call(monkeypatc
                     "input": {"cmd": "pwd"},
                 },
             ]}}))
+            print(json.dumps({"type": "user", "message": {"content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "toolu_1",
+                    "content": "{\\"success\\": true, \\"stdout\\": \\"/workspace\\"}",
+                }
+            ]}}))
             print(json.dumps({"type": "assistant", "message": {"content": [
                 {"type": "text", "text": "Done."}
             ]}}))
@@ -973,6 +980,9 @@ async def test_claude_stream_persists_assistant_text_before_tool_call(monkeypatc
     assert messages[0]["text"] == "Checking now."
     assert messages[0]["metadata"]["is_final_answer"] is False
     assert messages[1]["kind"] == "tool_call"
+    assert messages[2]["kind"] == "tool_return"
+    assert messages[2]["tool_call_id"] == "toolu_1"
+    assert messages[2]["tool_result"] == {"success": True, "stdout": "/workspace"}
     assert messages[-1]["kind"] == "text"
     assert messages[-1]["text"] == "Done."
     assert [event["type"] for event in events][-1] == "completed"

--- a/lemma-frontend/components/lemma/assistant/assistant-approval-cards.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-approval-cards.tsx
@@ -286,13 +286,13 @@ export function InlineUserApprovalCall({
     <button
       type="button"
       onClick={onClick}
-      className="lemma-assistant-inline-approval-button inline-flex max-w-full items-center gap-2 border-0 bg-transparent p-0 text-left text-sm leading-5 transition-colors hover:text-[var(--text-primary)]"
+      className="lemma-assistant-inline-approval-button inline-flex max-w-full items-center gap-2 border-0 bg-transparent p-0 text-left text-[13px] font-normal leading-5 tracking-normal text-[var(--text-secondary)] [font-family:var(--font-body-family)] transition-colors hover:text-[var(--text-primary)] data-[selected=true]:text-[var(--text-primary)]"
       data-selected={isSelected}
     >
-      <span className="flex size-3.5 flex-shrink-0 items-center justify-center text-[var(--text-tertiary)]" aria-hidden="true">
+      <span className="flex size-3.5 flex-shrink-0 items-center justify-center text-current opacity-80" aria-hidden="true">
         {isResolved ? (isDenied ? <XCircle className="size-3.5" /> : <CheckCircle2 className="size-3.5" />) : pendingIcon}
       </span>
-      <span className="min-w-0 truncate text-[var(--text-secondary)]">{title}</span>
+      <span className="min-w-0 truncate">{title}</span>
     </button>
   );
 }

--- a/lemma-frontend/components/lemma/assistant/assistant-approval-cards.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-approval-cards.tsx
@@ -286,7 +286,7 @@ export function InlineUserApprovalCall({
     <button
       type="button"
       onClick={onClick}
-      className="lemma-assistant-inline-approval-button inline-flex max-w-full items-center gap-2 border-0 bg-transparent p-0 text-left text-[13px] font-normal leading-5 tracking-normal text-[var(--text-secondary)] [font-family:var(--font-body-family)] transition-colors hover:text-[var(--text-primary)] data-[selected=true]:text-[var(--text-primary)]"
+      className="lemma-assistant-inline-approval-button inline-flex max-w-full items-center gap-2 border-0 bg-transparent p-0 text-left transition-colors"
       data-selected={isSelected}
     >
       <span className="flex size-3.5 flex-shrink-0 items-center justify-center text-current opacity-80" aria-hidden="true">

--- a/lemma-frontend/components/lemma/assistant/assistant-format.ts
+++ b/lemma-frontend/components/lemma/assistant/assistant-format.ts
@@ -13,6 +13,7 @@ import {
   messageHasToolActivity,
   messageTextContent,
   messageTimeMs,
+  normalizeAgentToolName,
   preferToolInvocation,
   prepareMessagesForDisplay,
   rowIsAfterIndex,
@@ -594,13 +595,12 @@ export function pickPreferredEntries(
 }
 
 export function normalizeToolNameForDisplay(toolName: string): string {
-  const normalized = toolName
+  return normalizeAgentToolName(toolName)
     .trim()
     .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
     .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
     .toLowerCase()
     .replace(/[.\-:\s]+/g, "_");
-  return normalized.startsWith("lemma_") ? normalized.slice("lemma_".length) : normalized;
 }
 
 function normalizedPayloadKey(key: string): string {

--- a/lemma-frontend/components/lemma/assistant/assistant-tool-details.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-tool-details.tsx
@@ -294,7 +294,7 @@ function InlineToolCall({
     <button
       type="button"
       onClick={onClick}
-      className="lemma-assistant-inline-tool-button inline-flex max-w-full items-center gap-2 border-0 bg-transparent p-0 text-left text-[13px] font-normal leading-5 tracking-normal text-[var(--text-secondary)] [font-family:var(--font-body-family)] transition-colors hover:text-[var(--text-primary)] data-[selected=true]:text-[var(--text-primary)]"
+      className="lemma-assistant-inline-tool-button inline-flex max-w-full items-center gap-2 border-0 bg-transparent p-0 text-left transition-colors"
       data-state={isExecuting ? "executing" : isFailed ? "failed" : "complete"}
       data-selected={isSelected}
     >
@@ -429,14 +429,14 @@ export function RunTraceHeader({
       {isInteractive ? (
         <button
           type="button"
-          className="flex w-fit max-w-full items-center gap-1.5 border-0 bg-transparent p-0 text-left text-sm font-normal leading-6 tracking-normal text-[var(--text-secondary)] [font-family:var(--font-body-family)] transition-colors hover:text-[var(--text-primary)]"
+          className="lemma-assistant-run-trace-header flex w-fit max-w-full items-center gap-1.5 border-0 bg-transparent p-0 text-left transition-colors"
           onClick={onToggle}
           aria-expanded={isExpanded}
         >
           {content}
         </button>
       ) : (
-        <div className="flex w-fit max-w-full items-center gap-1.5 text-sm font-normal leading-6 tracking-normal text-[var(--text-secondary)] [font-family:var(--font-body-family)]">
+        <div className="lemma-assistant-run-trace-header flex w-fit max-w-full items-center gap-1.5">
           {content}
         </div>
       )}

--- a/lemma-frontend/components/lemma/assistant/assistant-tool-details.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-tool-details.tsx
@@ -14,6 +14,7 @@ import {
   isToolInvocationActive,
   isUserApprovalToolName,
   isUserInteractionToolName,
+  isRenderableUserInteractionInvocation,
   userApprovalResolvedDecision,
 } from "lemma-sdk";
 import { Check, ChevronDown, Copy } from "lucide-react";
@@ -54,6 +55,7 @@ import type {
   ToolCardResult,
   UserApprovalDecision,
 } from "./assistant-experience";
+import { ToolCallIcon } from "./assistant-tool-icon";
 
 export function ToolDetailsPanel({
   toolCallId,
@@ -155,14 +157,14 @@ export function ToolDetailsPanel({
   const hiddenInputCount = Math.max(0, countSummarizablePayloadEntries(args, summaryOptions.input) - inputEntries.length);
   const hiddenOutputCount = Math.max(0, countSummarizablePayloadEntries(resultData, summaryOptions.output) - outputEntries.length);
 
-  if (isUserInteractionToolName(toolName)) {
-    const interactionInvocation = {
+  const interactionInvocation = {
       toolCallId,
       toolName,
       args,
       state: (state === "result" ? "result" : "call") as "result" | "call",
       ...(result ? { result } : {}),
     };
+  if (isRenderableUserInteractionInvocation(interactionInvocation)) {
     return (
       <div className="mt-1.5">
         {isAskUserToolName(toolName) ? (
@@ -292,13 +294,17 @@ function InlineToolCall({
     <button
       type="button"
       onClick={onClick}
-      className="lemma-assistant-inline-tool-button inline-flex max-w-full items-center gap-1.5 border-0 bg-transparent p-0 text-left text-sm leading-5 transition-colors hover:text-[var(--text-primary)]"
+      className="lemma-assistant-inline-tool-button inline-flex max-w-full items-center gap-2 border-0 bg-transparent p-0 text-left text-[13px] font-normal leading-5 tracking-normal text-[var(--text-secondary)] [font-family:var(--font-body-family)] transition-colors hover:text-[var(--text-primary)] data-[selected=true]:text-[var(--text-primary)]"
       data-state={isExecuting ? "executing" : isFailed ? "failed" : "complete"}
       data-selected={isSelected}
     >
+      <ToolCallIcon
+        toolName={invocation.toolName}
+        className="size-3.5 shrink-0 text-current opacity-80"
+      />
       <span
         className={cn(
-          "min-w-0 truncate text-[var(--text-secondary)]",
+          "min-w-0 truncate",
           isExecuting && "lemma-assistant-thinking-shimmer bg-clip-text text-transparent animate-[lemma-skeleton-breathe_1.5s_ease-in-out_infinite]",
         )}
       >
@@ -423,14 +429,14 @@ export function RunTraceHeader({
       {isInteractive ? (
         <button
           type="button"
-          className="flex w-fit max-w-full items-center gap-1.5 border-0 bg-transparent p-0 text-left text-sm font-normal leading-6 text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]"
+          className="flex w-fit max-w-full items-center gap-1.5 border-0 bg-transparent p-0 text-left text-sm font-normal leading-6 tracking-normal text-[var(--text-secondary)] [font-family:var(--font-body-family)] transition-colors hover:text-[var(--text-primary)]"
           onClick={onToggle}
           aria-expanded={isExpanded}
         >
           {content}
         </button>
       ) : (
-        <div className="flex w-fit max-w-full items-center gap-1.5 text-sm font-normal leading-6 text-[var(--text-secondary)]">
+        <div className="flex w-fit max-w-full items-center gap-1.5 text-sm font-normal leading-6 tracking-normal text-[var(--text-secondary)] [font-family:var(--font-body-family)]">
           {content}
         </div>
       )}
@@ -512,7 +518,7 @@ export function ToolActivityRollup({
   const renderToolActivityPart = (part: ToolActivityPart): ReactNode => {
     const invocation = part.toolInvocation;
     const isSelected = activeDetailId === invocation.toolCallId;
-    if (isUserInteractionToolName(invocation.toolName)) {
+    if (isRenderableUserInteractionInvocation(invocation)) {
       const resultData = (invocation.result || {}) as ToolCardResult;
       const isResolved = invocation.state === "result" || !!userApprovalResolvedDecision(resultData);
       if (isResolved) {

--- a/lemma-frontend/components/lemma/assistant/assistant-tool-icon.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-tool-icon.tsx
@@ -1,0 +1,139 @@
+import {
+  Bot,
+  BookOpen,
+  CheckCircle2,
+  CircleHelp,
+  Code2,
+  Database,
+  FilePenLine,
+  FileSearch,
+  FileText,
+  Folder,
+  Globe2,
+  Image as ImageIcon,
+  Link2,
+  ListChecks,
+  MessageSquare,
+  Mic,
+  PanelsTopLeft,
+  Settings2,
+  ShieldCheck,
+  SquareTerminal,
+  Table2,
+  Users,
+  Volume2,
+  Wrench,
+  type LucideIcon,
+  type LucideProps,
+} from "lucide-react";
+import { normalizeToolNameForDisplay } from "./assistant-format";
+
+export type ToolIconKind =
+  | "agent"
+  | "approval"
+  | "audio-input"
+  | "audio-output"
+  | "code"
+  | "complete"
+  | "data"
+  | "display"
+  | "file-edit"
+  | "file-read"
+  | "file-search"
+  | "files"
+  | "image"
+  | "link"
+  | "message"
+  | "plan"
+  | "process"
+  | "question"
+  | "skills"
+  | "table"
+  | "terminal"
+  | "users"
+  | "web"
+  | "tool";
+
+const TOOL_ICON_KINDS: Record<string, ToolIconKind> = {
+  apply_patch: "file-edit",
+  ask_user: "question",
+  command_execution: "terminal",
+  create_file: "file-edit",
+  display_resource: "display",
+  edit_file: "file-edit",
+  exec_command: "terminal",
+  execute_command: "terminal",
+  execute_python: "code",
+  file_processor: "file-read",
+  final_answer: "complete",
+  final_result: "complete",
+  grep: "file-search",
+  interact_subagent: "message",
+  listen: "audio-input",
+  list_processes: "process",
+  list_skill_resources: "skills",
+  list_skills: "skills",
+  load_skill: "skills",
+  load_skill_resource: "skills",
+  manage_process: "process",
+  pod_get_file_url: "link",
+  pod_get_records: "data",
+  pod_list_files: "files",
+  pod_query: "data",
+  pod_read_file: "file-read",
+  pod_search_files: "file-search",
+  pod_tables: "table",
+  pod_view_document_pages: "file-read",
+  pod_write_file: "file-edit",
+  pod_write_record: "data",
+  query_subagents: "users",
+  read_file: "file-read",
+  request_approval: "approval",
+  say: "audio-output",
+  search_query: "web",
+  search_tools: "tool",
+  spawn_subagent: "agent",
+  terminate_process: "process",
+  tool_search: "tool",
+  update_plan: "plan",
+  view_image: "image",
+  web_search: "web",
+  write_stdin: "terminal",
+  write_todos: "plan",
+};
+
+const ICONS: Record<ToolIconKind, LucideIcon> = {
+  agent: Bot,
+  approval: ShieldCheck,
+  "audio-input": Mic,
+  "audio-output": Volume2,
+  code: Code2,
+  complete: CheckCircle2,
+  data: Database,
+  display: PanelsTopLeft,
+  "file-edit": FilePenLine,
+  "file-read": FileText,
+  "file-search": FileSearch,
+  files: Folder,
+  image: ImageIcon,
+  link: Link2,
+  message: MessageSquare,
+  plan: ListChecks,
+  process: Settings2,
+  question: CircleHelp,
+  skills: BookOpen,
+  table: Table2,
+  terminal: SquareTerminal,
+  users: Users,
+  web: Globe2,
+  tool: Wrench,
+};
+
+export function toolIconKind(toolName: string): ToolIconKind {
+  return TOOL_ICON_KINDS[normalizeToolNameForDisplay(toolName)] || "tool";
+}
+
+export function ToolCallIcon({ toolName, ...props }: { toolName: string } & LucideProps) {
+  const Icon = ICONS[toolIconKind(toolName)];
+  return <Icon aria-hidden="true" strokeWidth={1.8} {...props} />;
+}

--- a/lemma-frontend/lib/assistant/__tests__/assistant-tool-names.test.ts
+++ b/lemma-frontend/lib/assistant/__tests__/assistant-tool-names.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeToolNameForDisplay } from '@/components/lemma/assistant/assistant-format';
+import { toolIconKind } from '@/components/lemma/assistant/assistant-tool-icon';
+
+describe('normalizeToolNameForDisplay', () => {
+    it('uses canonical Lemma MCP names for contextual tool rendering', () => {
+        expect(normalizeToolNameForDisplay('mcp__lemma_tools__lemma_exec_command')).toBe('exec_command');
+        expect(normalizeToolNameForDisplay('lemma_tools_lemma_display_resource')).toBe('display_resource');
+        expect(normalizeToolNameForDisplay('commandExecution')).toBe('command_execution');
+    });
+});
+
+describe('toolIconKind', () => {
+    it('assigns small semantic icons from canonical and wrapped tool names', () => {
+        expect(toolIconKind('mcp__lemma_tools__lemma_exec_command')).toBe('terminal');
+        expect(toolIconKind('display_resource')).toBe('display');
+        expect(toolIconKind('ask_user')).toBe('question');
+        expect(toolIconKind('pod_write_record')).toBe('data');
+        expect(toolIconKind('spawn_subagent')).toBe('agent');
+        expect(toolIconKind('unknown_custom_tool')).toBe('tool');
+    });
+});

--- a/lemma-frontend/lib/assistant/__tests__/display-resource.test.ts
+++ b/lemma-frontend/lib/assistant/__tests__/display-resource.test.ts
@@ -11,6 +11,8 @@ describe('isDisplayResourceToolName', () => {
         expect(isDisplayResourceToolName('display_resource')).toBe(true);
         expect(isDisplayResourceToolName('lemma_display_resource')).toBe(true);
         expect(isDisplayResourceToolName('mcp.display_resource')).toBe(true);
+        expect(isDisplayResourceToolName('mcp__lemma_tools__lemma_display_resource')).toBe(true);
+        expect(isDisplayResourceToolName('lemma_tools_lemma_display_resource')).toBe(true);
         expect(isDisplayResourceToolName('something_else')).toBe(false);
         expect(isDisplayResourceToolName(123)).toBe(false);
     });

--- a/lemma-frontend/lib/assistant/display-resource.ts
+++ b/lemma-frontend/lib/assistant/display-resource.ts
@@ -1,3 +1,5 @@
+import { normalizeAgentToolName } from 'lemma-sdk';
+
 export type DisplayResourceType =
     | 'FILE'
     | 'TABLE'
@@ -84,10 +86,8 @@ function normalizeResourceType(value: unknown): DisplayResourceType | null {
 
 export function isDisplayResourceToolName(toolName: unknown): boolean {
     if (typeof toolName !== 'string') return false;
-    const normalized = toolName.trim().toLowerCase().replace(/[.:]/g, '_');
-    return normalized === 'display_resource'
-        || normalized === 'lemma_display_resource'
-        || normalized.endsWith('_display_resource');
+    const normalized = normalizeAgentToolName(toolName).toLowerCase().replace(/[.:]/g, '_');
+    return normalized === 'display_resource' || normalized === 'mcp_display_resource';
 }
 
 export function extractDisplayResourceRequest(value: unknown): DisplayResourceRequest | null {

--- a/lemma-frontend/styles/features/assistant-overrides.css
+++ b/lemma-frontend/styles/features/assistant-overrides.css
@@ -216,6 +216,36 @@
   display: none;
 }
 
+.lemma-assistant-inline-tool-button,
+.lemma-assistant-inline-approval-button {
+  color: var(--text-secondary);
+  font-family: var(--font-body-family);
+  font-size: 0.8125rem;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.25rem;
+}
+
+.lemma-assistant-inline-tool-button:hover,
+.lemma-assistant-inline-tool-button[data-selected="true"],
+.lemma-assistant-inline-approval-button:hover,
+.lemma-assistant-inline-approval-button[data-selected="true"] {
+  color: var(--text-primary);
+}
+
+.lemma-assistant-run-trace-header {
+  color: var(--text-secondary);
+  font-family: var(--font-body-family);
+  font-size: 0.875rem;
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+}
+
+button.lemma-assistant-run-trace-header:hover {
+  color: var(--text-primary);
+}
+
 /* ============================================================
    LEMMA GLOBAL STYLES
    Design philosophy: warm clarity · operational calm · anti-corporate

--- a/lemma-typescript/public/lemma-ui.js
+++ b/lemma-typescript/public/lemma-ui.js
@@ -885,6 +885,28 @@ var LemmaUI = (() => {
     }
   };
 
+  // src/core/agent/tool-names.ts
+  var LEMMA_MCP_TOOL_PREFIXES = [
+    "mcp.lemma_tools.",
+    "mcp__lemma_tools__",
+    "lemma_tools_",
+    "lemma_tools.",
+    "mcp.lemma-tools.",
+    "mcp__lemma-tools__",
+    "lemma-tools_",
+    "lemma-tools."
+  ];
+  function normalizeAgentToolName(toolName) {
+    let normalized = toolName.trim();
+    const lower = normalized.toLowerCase();
+    const providerPrefix = LEMMA_MCP_TOOL_PREFIXES.find((prefix) => lower.startsWith(prefix));
+    if (providerPrefix) normalized = normalized.slice(providerPrefix.length);
+    if (normalized.toLowerCase().startsWith("lemma_")) {
+      normalized = normalized.slice("lemma_".length);
+    }
+    return normalized;
+  }
+
   // src/core/agent/output.ts
   function isRecord4(value) {
     return !!value && typeof value === "object" && !Array.isArray(value);
@@ -945,7 +967,7 @@ var LemmaUI = (() => {
     return candidates.filter((candidate) => candidate.trim().length > 0);
   }
   function isFinalResultToolName(toolName) {
-    const normalized = toolName.trim().toLowerCase().replace(/[.\-:]/g, "_");
+    const normalized = normalizeAgentToolName(toolName).toLowerCase().replace(/[.\-:]/g, "_");
     return normalized === "final_result" || normalized === "final_answer";
   }
   function unwrapFinalResultPayload(value) {

--- a/lemma-typescript/src/__tests__/agent-display.test.ts
+++ b/lemma-typescript/src/__tests__/agent-display.test.ts
@@ -4,12 +4,14 @@ import {
   collectCompletedRunTraceGroups,
   dedupToolInvocations,
   isAskUserToolName,
+  isRenderableUserInteractionInvocation,
   isUserApprovalToolName,
   isUserInteractionToolName,
   latestPlanSummary,
   messageTextContent,
   normalizeAssistantMarkdown,
 } from "../core/agent/display.js";
+import { normalizeAgentToolName } from "../core/agent/tool-names.js";
 import { parseAssistantStreamEvent } from "../assistant-events.js";
 import type { AssistantRenderableMessage } from "../core/agent/renderable.js";
 
@@ -22,7 +24,53 @@ describe("user-interaction tool predicates", () => {
     // The combined predicate matches either pausing tool.
     expect(isUserInteractionToolName("ask_user")).toBe(true);
     expect(isUserInteractionToolName("request_approval")).toBe(true);
+    expect(isAskUserToolName("mcp__lemma_tools__lemma_ask_user")).toBe(true);
+    expect(isUserApprovalToolName("lemma_tools_lemma_request_approval")).toBe(true);
     expect(isUserInteractionToolName("exec_command")).toBe(false);
+  });
+
+  it("does not render a completed daemon prose fallback as an interaction card", () => {
+    expect(isRenderableUserInteractionInvocation({
+      toolCallId: "ask-1",
+      toolName: "mcp__lemma_tools__lemma_ask_user",
+      args: {},
+      state: "result",
+      result: {
+        success: false,
+        interaction_fallback: true,
+        message: "Ask the user directly in your reply.",
+      },
+    })).toBe(false);
+    expect(isRenderableUserInteractionInvocation({
+      toolCallId: "ask-2",
+      toolName: "ask_user",
+      args: {},
+      state: "call",
+    })).toBe(true);
+    expect(isRenderableUserInteractionInvocation({
+      toolCallId: "ask-3",
+      toolName: "ask_user",
+      args: {},
+      state: "result",
+      result: { success: true, answers: { Runtime: "Claude" } },
+    })).toBe(true);
+    expect(isRenderableUserInteractionInvocation({
+      toolCallId: "ask-4",
+      toolName: "ask_user",
+      args: {},
+      state: "result",
+      result: { success: false, answers: {}, message: "User dismissed the questions." },
+    })).toBe(true);
+  });
+});
+
+describe("normalizeAgentToolName", () => {
+  it("strips only Lemma MCP wrappers", () => {
+    expect(normalizeAgentToolName("mcp__lemma_tools__lemma_display_resource")).toBe("display_resource");
+    expect(normalizeAgentToolName("mcp.lemma_tools.lemma_exec_command")).toBe("exec_command");
+    expect(normalizeAgentToolName("lemma_tools_lemma_ask_user")).toBe("ask_user");
+    expect(normalizeAgentToolName("mcp__github__create_issue")).toBe("mcp__github__create_issue");
+    expect(normalizeAgentToolName("commandExecution")).toBe("commandExecution");
   });
 });
 

--- a/lemma-typescript/src/core/agent/display.ts
+++ b/lemma-typescript/src/core/agent/display.ts
@@ -9,6 +9,7 @@
 // the hooks, web components, and the app. Formatting/labels and JSX stay in the
 // caller.
 import { isFinalResultToolName } from "./output.js";
+import { normalizeAgentToolName } from "./tool-names.js";
 import type {
   AssistantMessagePart,
   AssistantRenderableMessage,
@@ -768,19 +769,32 @@ function rowIsAfterIndex(row: DisplayMessageRow, index: number): boolean {
 /** Whether a tool is the higher-order approval gate (`request_approval`, or the
  * legacy `user_approval`). */
 export function isUserApprovalToolName(toolName: string): boolean {
-  const normalized = toolName.trim().toLowerCase();
+  const normalized = normalizeAgentToolName(toolName).toLowerCase();
   return normalized === "request_approval" || normalized === "user_approval";
 }
 
 /** Whether a tool is the multiple-choice question gate (`ask_user`). */
 export function isAskUserToolName(toolName: string): boolean {
-  return toolName.trim().toLowerCase() === "ask_user";
+  return normalizeAgentToolName(toolName).toLowerCase() === "ask_user";
 }
 
 /** Whether a tool pauses the run for the user (an approval OR a question). Both
  * end the run (conversation -> WAITING) and resume via the approvals endpoint. */
 export function isUserInteractionToolName(toolName: string): boolean {
   return isUserApprovalToolName(toolName) || isAskUserToolName(toolName);
+}
+
+/** Whether an interaction invocation should use the specialized question /
+ * approval UI. Failed daemon fallbacks have a terminal result but no user
+ * decision or answers, so they deliberately render as ordinary tool activity. */
+export function isRenderableUserInteractionInvocation(
+  invocation: AssistantToolInvocation,
+): boolean {
+  if (!isUserInteractionToolName(invocation.toolName)) return false;
+  if (invocation.state !== "result") return true;
+  const result = (invocation.result || {}) as Record<string, unknown>;
+  const output = asRecord(result.output);
+  return result.interaction_fallback !== true && output.interaction_fallback !== true;
 }
 
 export function userApprovalResolvedDecision(resultData: Record<string, unknown>): string | undefined {

--- a/lemma-typescript/src/core/agent/output.ts
+++ b/lemma-typescript/src/core/agent/output.ts
@@ -8,6 +8,8 @@
 // consumes it from the SDK — one implementation for hooks, web components, and
 // the app. No React, no DOM.
 
+import { normalizeAgentToolName } from "./tool-names.js";
+
 export type MessagePartLike = {
   type?: string;
   text?: string;
@@ -144,7 +146,7 @@ export function latestAssistantText(messages: MessageLike[]): string {
 }
 
 export function isFinalResultToolName(toolName: string): boolean {
-  const normalized = toolName.trim().toLowerCase().replace(/[.\-:]/g, "_");
+  const normalized = normalizeAgentToolName(toolName).toLowerCase().replace(/[.\-:]/g, "_");
   return normalized === "final_result" || normalized === "final_answer";
 }
 

--- a/lemma-typescript/src/core/agent/tool-names.ts
+++ b/lemma-typescript/src/core/agent/tool-names.ts
@@ -1,0 +1,23 @@
+const LEMMA_MCP_TOOL_PREFIXES = [
+  "mcp.lemma_tools.",
+  "mcp__lemma_tools__",
+  "lemma_tools_",
+  "lemma_tools.",
+  "mcp.lemma-tools.",
+  "mcp__lemma-tools__",
+  "lemma-tools_",
+  "lemma-tools.",
+] as const;
+
+/** Convert a provider-scoped Lemma MCP tool name to Lemma's canonical name.
+ * Provider-native and third-party MCP tool names are intentionally unchanged. */
+export function normalizeAgentToolName(toolName: string): string {
+  let normalized = toolName.trim();
+  const lower = normalized.toLowerCase();
+  const providerPrefix = LEMMA_MCP_TOOL_PREFIXES.find((prefix) => lower.startsWith(prefix));
+  if (providerPrefix) normalized = normalized.slice(providerPrefix.length);
+  if (normalized.toLowerCase().startsWith("lemma_")) {
+    normalized = normalized.slice("lemma_".length);
+  }
+  return normalized;
+}

--- a/lemma-typescript/src/index.ts
+++ b/lemma-typescript/src/index.ts
@@ -52,6 +52,7 @@ export {
 export type { AnyRunStatus } from "./run-utils.js";
 export { parseAssistantStreamEvent, upsertConversationMessage } from "./assistant-events.js";
 export type { ParsedAssistantStreamEvent } from "./assistant-events.js";
+export { normalizeAgentToolName } from "./core/agent/tool-names.js";
 // Framework-agnostic agent core (drives the React hooks and, next, web components).
 export {
   AgentController,
@@ -78,6 +79,7 @@ export {
   isUserApprovalToolName,
   isAskUserToolName,
   isUserInteractionToolName,
+  isRenderableUserInteractionInvocation,
   userApprovalResolvedDecision,
   latestPlanSummary,
   latestUserIndex,


### PR DESCRIPTION
## Summary

- parse Claude and Cursor tool-result events and close orphaned daemon calls
- canonicalize Lemma MCP tool names while preserving provider diagnostics
- keep daemon interaction tools on an explicit prose fallback
- use human-facing typography and monochrome semantic icons for tool calls

## Verification

- CLI: 597 passed, 1 skipped
- Backend agent unit tests: 354 passed
- TypeScript SDK: 117 passed
- Frontend: 42 passed
- TypeScript, ESLint, Ruff, Chromium computed-style and console checks passed