### PR TITLE
chore(release): prepare 0.6.2

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -1942,7 +1942,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lemma-desktop"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lemma-desktop"
-version = "0.6.1"
+version = "0.6.2"
 description = "Lemma desktop shell"
 edition = "2021"
 

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Lemma",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "identifier": "work.lemma.desktop",
   "build": {
     "frontendDist": "ui"

--- a/lemma-cli/lemma_cli/__init__.py
+++ b/lemma-cli/lemma_cli/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 __all__ = ["__version__"]
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 if sys.platform == "win32":
     for _stream in (sys.stdout, sys.stderr):

--- a/lemma-cli/pyproject.toml
+++ b/lemma-cli/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
   # >= the version that has the endpoints the current commands use, so a fresh
   # `uv tool install` upgrades an already-installed older lemma-sdk. The release
   # workflow rewrites this to the release version on every tagged build.
-  "lemma-sdk>=0.6.1",
+  "lemma-sdk>=0.6.2",
   # Shared pod bundle format vocabulary (layout/jsonc/diff/portability/
   # normalize/archive), extracted so the backend can consume the same format.
   "lemma-pod-bundle>=0.1.0",

--- a/lemma-cli/uv.lock
+++ b/lemma-cli/uv.lock
@@ -493,7 +493,7 @@ source = { directory = "../lemma-pod-bundle" }
 
 [[package]]
 name = "lemma-sdk"
-version = "0.6.1"
+version = "0.6.2"
 source = { directory = "../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/lemma-frontend/package-lock.json
+++ b/lemma-frontend/package-lock.json
@@ -72,7 +72,7 @@
     },
     "../lemma-typescript": {
       "name": "lemma-sdk",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "supertokens-web-js": "^0.16.0"

--- a/lemma-python/pyproject.toml
+++ b/lemma-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-sdk"
-version = "0.6.1"
+version = "0.6.2"
 description = "Python SDK for Lemma"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/lemma-python/uv.lock
+++ b/lemma-python/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "lemma-sdk"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },

--- a/lemma-typescript/package-lock.json
+++ b/lemma-typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemma-sdk",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lemma-sdk",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "Apache-2.0",
       "dependencies": {
         "supertokens-web-js": "^0.16.0"

--- a/lemma-typescript/package.json
+++ b/lemma-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemma-sdk",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Official TypeScript SDK for Lemma APIs, optimized around pod-scoped workflows",
   "license": "Apache-2.0",
   "author": "Lemma",

--- a/lemma-typescript/public/lemma-client.js
+++ b/lemma-typescript/public/lemma-client.js
@@ -9795,7 +9795,7 @@ var LemmaClient = (() => {
   }
 
   // src/version.ts
-  var SDK_VERSION = "0.6.1";
+  var SDK_VERSION = "0.6.2";
   var CLIENT_HEADER_NAME = "X-Lemma-Client";
   var CLIENT_HEADER_VALUE = `lemma-sdk-ts/${SDK_VERSION}`;
 

--- a/lemma-typescript/src/version.ts
+++ b/lemma-typescript/src/version.ts
@@ -1,6 +1,6 @@
 // Keep SDK_VERSION in sync with package.json "version". The CI codegen/drift
 // gate (workstream A) asserts they match so this can't silently drift.
-export const SDK_VERSION = "0.6.1";
+export const SDK_VERSION = "0.6.2";
 
 /** Sent as `X-Lemma-Client` on every request so the backend can log which client
  *  + version hit an endpoint (User-Agent is a forbidden header in browser fetch). */


### PR DESCRIPTION
## Summary

- align the TypeScript and Python SDKs, terminal CLI, and desktop app at 0.6.2
- update the CLI SDK floor and local lockfile versions
- regenerate the committed TypeScript browser bundle with the 0.6.2 client header

## Verification

- TypeScript SDK release pack: passed (`lemma-sdk-0.6.2.tgz`)
- TypeScript registry: 20 items passed
- TypeScript SDK: 117 tests passed
- Frontend checks and 43 tests passed
- Terminal CLI: 597 passed, 1 skipped
- Python SDK: 52 passed, 1 skipped; wheel/sdist build and Twine checks passed
- Lemma Stack: 53 passed, 3 skipped; mono-version and browser bundle checks passed
- Desktop: 9 Rust tests passed
- `git diff --check`: passed