### PR TITLE
Fix silent direct-message surface fallbacks

### DIFF
--- a/lemma-backend/app/modules/agent_surfaces/domain/ingress_context.py
+++ b/lemma-backend/app/modules/agent_surfaces/domain/ingress_context.py
@@ -13,6 +13,14 @@ from app.modules.agent_surfaces.domain.entities import (
 from app.modules.agent_surfaces.domain.models import SurfaceMessageMetadata
 
 
+SurfaceReplyKind = Literal[
+    "signup",
+    "identity_link",
+    "surface_setup",
+    "pod_access",
+]
+
+
 class SurfaceContextBase(BaseModel):
     platform: SurfacePlatform
     surface_id: UUID | None = None
@@ -27,6 +35,7 @@ class SurfaceReplyContext(SurfaceContextBase):
     (signup prompts, contact-link requests/confirmations)."""
 
     mode: Literal["reply"] = "reply"
+    reply_kind: SurfaceReplyKind = "signup"
     reply_message: str
     reply_metadata: dict = Field(default_factory=dict)
 

--- a/lemma-backend/app/modules/agent_surfaces/domain/ports.py
+++ b/lemma-backend/app/modules/agent_surfaces/domain/ports.py
@@ -312,7 +312,7 @@ class SurfaceEventDedupStorePort(Protocol):
     async def claim_message(
         self,
         *,
-        surface_installation_id: UUID,
+        surface_installation_id: UUID | None,
         platform: str,
         external_channel_id: str | None,
         external_thread_id: str | None,

--- a/lemma-backend/app/modules/agent_surfaces/infrastructure/adapters/redis_event_dedup_store.py
+++ b/lemma-backend/app/modules/agent_surfaces/infrastructure/adapters/redis_event_dedup_store.py
@@ -38,21 +38,24 @@ class RedisSurfaceEventDedupStore:
     def _key(
         self,
         *,
-        surface_installation_id: UUID,
+        surface_installation_id: UUID | None,
         platform: str,
         external_channel_id: str | None,
         external_message_id: str,
     ) -> str:
         channel_key = external_channel_id or "none"
+        surface_key = (
+            str(surface_installation_id) if surface_installation_id else "unrouted"
+        )
         return (
             "agent_surfaces:event_dedup:"
-            f"{platform.lower()}:{surface_installation_id}:{channel_key}:{external_message_id}"
+            f"{platform.lower()}:{surface_key}:{channel_key}:{external_message_id}"
         )
 
     async def claim_message(
         self,
         *,
-        surface_installation_id: UUID,
+        surface_installation_id: UUID | None,
         platform: str,
         external_channel_id: str | None,
         external_thread_id: str | None,

--- a/lemma-backend/app/modules/agent_surfaces/services/fallback_reply_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/fallback_reply_service.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from app.core.config import settings
+from app.core.log.log import get_logger
+from app.modules.agent_surfaces.config import surface_settings
+from app.modules.agent_surfaces.domain.entities import (
+    AgentSurfaceEntity,
+    ParsedInboundSurfaceEvent,
+    ResolvedSurfaceUser,
+    SurfaceCredentialMode,
+    SurfacePlatform,
+)
+from app.modules.agent_surfaces.domain.ingress_context import (
+    SurfaceReplyContext,
+    SurfaceReplyKind,
+)
+from app.modules.agent_surfaces.domain.ports import (
+    SurfaceEventDedupStorePort,
+    SurfacePlatformAdapterPort,
+)
+
+logger = get_logger(__name__)
+
+
+def signup_message() -> str:
+    signup_url = settings.auth_frontend_url.rstrip("/")
+    return (
+        "Please sign up before chatting with this agent. "
+        f"You can get started here: {signup_url}"
+    )
+
+
+def surface_setup_message() -> str:
+    frontend_url = settings.frontend_url.rstrip("/")
+    return (
+        "You're signed in, but no agent surface is configured for you yet. "
+        "Open Lemma to set up or select a surface: "
+        f"{frontend_url}"
+    )
+
+
+def _pod_access_message(pod_id: UUID) -> str:
+    base = settings.auth_frontend_url.rstrip("/")
+    return (
+        "You're signed up, but don't have access to this workspace yet. "
+        f"Request access here: {base}/pods/{pod_id}"
+    )
+
+
+def _can_disclose_pod_access_link(surface: AgentSurfaceEntity) -> bool:
+    if surface.credential_mode is not SurfaceCredentialMode.SYSTEM:
+        return True
+    if surface.account_id is not None:
+        return True
+    return surface.surface_type not in {
+        SurfacePlatform.TELEGRAM,
+        SurfacePlatform.WHATSAPP,
+    }
+
+
+def _reply_context(
+    *,
+    platform: str | SurfacePlatform,
+    surface: AgentSurfaceEntity | None,
+    parsed: ParsedInboundSurfaceEvent,
+    agent_display_name: str,
+    reply: tuple[str, dict[str, Any]],
+    reply_kind: SurfaceReplyKind,
+    include_surface_id: bool = True,
+) -> SurfaceReplyContext:
+    message, reply_metadata = reply
+    return SurfaceReplyContext(
+        platform=SurfacePlatform(platform),
+        surface_id=surface.id if surface and include_surface_id else None,
+        surface_account_id=surface.account_id if surface else None,
+        surface_config=surface.config if surface else None,
+        agent_display_name=agent_display_name,
+        reply_kind=reply_kind,
+        reply_message=message,
+        reply_metadata=reply_metadata,
+        event=parsed,
+    )
+
+
+def unresolved_sender_context(
+    *,
+    surface: AgentSurfaceEntity,
+    parsed: ParsedInboundSurfaceEvent,
+    adapter: SurfacePlatformAdapterPort,
+    agent_display_name: str,
+) -> SurfaceReplyContext | None:
+    if not parsed.is_dm:
+        return None
+    identity_reply = adapter.unresolved_sender_reply(parsed)
+    reply = identity_reply or (signup_message(), {})
+    reply_kind: SurfaceReplyKind = (
+        "identity_link" if identity_reply is not None else "signup"
+    )
+    return _reply_context(
+        platform=surface.surface_type,
+        surface=surface,
+        parsed=parsed,
+        agent_display_name=agent_display_name,
+        reply=reply,
+        reply_kind=reply_kind,
+    )
+
+
+def identity_confirmation_context(
+    *,
+    surface: AgentSurfaceEntity,
+    parsed: ParsedInboundSurfaceEvent,
+    agent_display_name: str,
+    confirmation: tuple[str, dict[str, Any]],
+) -> SurfaceReplyContext:
+    return _reply_context(
+        platform=surface.surface_type,
+        surface=surface,
+        parsed=parsed,
+        agent_display_name=agent_display_name,
+        reply=confirmation,
+        reply_kind="identity_link",
+    )
+
+
+def nonmember_context(
+    *,
+    surface: AgentSurfaceEntity,
+    parsed: ParsedInboundSurfaceEvent,
+    agent_display_name: str,
+) -> SurfaceReplyContext | None:
+    if not parsed.is_dm:
+        return None
+    disclose_pod = _can_disclose_pod_access_link(surface)
+    message = (
+        _pod_access_message(surface.pod_id)
+        if disclose_pod
+        else surface_setup_message()
+    )
+    reply_kind: SurfaceReplyKind = "pod_access" if disclose_pod else "surface_setup"
+    return _reply_context(
+        platform=surface.surface_type,
+        surface=surface,
+        parsed=parsed,
+        agent_display_name=agent_display_name,
+        reply=(message, {}),
+        reply_kind=reply_kind,
+    )
+
+
+def surface_setup_context(
+    *,
+    surface: AgentSurfaceEntity,
+    parsed: ParsedInboundSurfaceEvent,
+    agent_display_name: str,
+) -> SurfaceReplyContext | None:
+    if not parsed.is_dm:
+        return None
+    return _reply_context(
+        platform=surface.surface_type,
+        surface=surface,
+        parsed=parsed,
+        agent_display_name=agent_display_name,
+        reply=(surface_setup_message(), {}),
+        reply_kind="surface_setup",
+    )
+
+
+async def prepare_unrouted_context(
+    *,
+    platform: str,
+    surface: AgentSurfaceEntity | None,
+    parsed: ParsedInboundSurfaceEvent,
+    adapter: SurfacePlatformAdapterPort,
+    resolved_user: ResolvedSurfaceUser,
+    agent_display_name: str,
+    event_dedup_store: SurfaceEventDedupStorePort,
+) -> SurfaceReplyContext | None:
+    claimed = await event_dedup_store.claim_message(
+        surface_installation_id=None,
+        platform=platform,
+        external_channel_id=parsed.external_channel_id,
+        external_thread_id=parsed.external_thread_id,
+        external_message_id=parsed.external_message_id,
+    )
+    if not claimed:
+        logger.info(
+            "Agent surface ignored duplicate unrouted message platform=%s channel=%s message_id=%s",
+            platform,
+            parsed.external_channel_id,
+            parsed.external_message_id,
+        )
+        return None
+
+    identity_reply = adapter.unresolved_sender_reply(parsed)
+    confirmation = adapter.linked_sender_confirmation(parsed)
+    reply, reply_kind = _unrouted_reply(
+        resolved_user=resolved_user,
+        identity_reply=identity_reply,
+        confirmation=confirmation,
+    )
+    logger.info(
+        "Agent surface prepared unrouted fallback",
+        platform=platform,
+        reply_kind=reply_kind,
+        message_id=parsed.external_message_id,
+    )
+    return _reply_context(
+        platform=platform,
+        surface=surface,
+        parsed=parsed,
+        agent_display_name=agent_display_name,
+        reply=reply,
+        reply_kind=reply_kind,
+        include_surface_id=False,
+    )
+
+
+def _unrouted_reply(
+    *,
+    resolved_user: ResolvedSurfaceUser,
+    identity_reply: tuple[str, dict[str, Any]] | None,
+    confirmation: tuple[str, dict[str, Any]] | None,
+) -> tuple[tuple[str, dict[str, Any]], SurfaceReplyKind]:
+    if resolved_user.internal_user_id is None:
+        return (
+            identity_reply or (signup_message(), {}),
+            "identity_link" if identity_reply is not None else "signup",
+        )
+    if confirmation is not None:
+        return confirmation, "identity_link"
+    return (surface_setup_message(), {}), "surface_setup"
+
+
+def has_delivery_credentials(
+    platform: SurfacePlatform,
+    credentials: dict[str, Any],
+) -> bool:
+    normalized = str(platform).upper()
+    if normalized == SurfacePlatform.WHATSAPP:
+        return bool(credentials.get("access_token"))
+    if normalized == SurfacePlatform.TELEGRAM:
+        return bool(credentials.get("bot_token"))
+    if normalized == SurfacePlatform.SLACK:
+        raw_response = credentials.get("raw_response") or {}
+        return bool(
+            credentials.get("access_token")
+            or credentials.get("bot_token")
+            or raw_response.get("access_token")
+        )
+    if normalized == SurfacePlatform.TEAMS:
+        return bool(
+            surface_settings.microsoft_bot_app_id
+            and surface_settings.microsoft_bot_app_password
+        )
+    if normalized == SurfacePlatform.RESEND:
+        return bool(credentials.get("api_key"))
+    return any(value for value in credentials.values())
+
+
+async def deliver_fallback_reply(
+    *,
+    adapter: SurfacePlatformAdapterPort,
+    context: SurfaceReplyContext,
+    credentials: dict[str, Any],
+) -> None:
+    if not has_delivery_credentials(context.platform, credentials):
+        logger.error(
+            "Surface fallback delivery unavailable",
+            platform=str(context.platform),
+            reply_kind=context.reply_kind,
+            message_id=context.event.external_message_id,
+            failure_reason="missing_credentials",
+        )
+        return
+    try:
+        await adapter.send_message(
+            credentials=credentials,
+            event=context.event,
+            message=context.reply_message or signup_message(),
+            metadata={
+                "agent_display_name": context.agent_display_name,
+                **dict(context.reply_metadata or {}),
+            },
+        )
+    except Exception as exc:
+        logger.error(
+            "Surface fallback delivery failed",
+            platform=str(context.platform),
+            reply_kind=context.reply_kind,
+            message_id=context.event.external_message_id,
+            failure_reason=type(exc).__name__,
+        )

--- a/lemma-backend/app/modules/agent_surfaces/services/ingress_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/ingress_service.py
@@ -11,7 +11,6 @@ from pydantic import TypeAdapter
 
 from app.core.authorization.current import reset_current_context, set_current_context
 from app.core.authorization.factory import create_authorization_data_service
-from app.core.config import settings
 from app.core.infrastructure.db.uow_factory import UnitOfWorkFactory
 from app.modules.agent.contracts import AgentRunApprovalDecision
 from app.composition.surface_agent import ConversationService
@@ -22,7 +21,6 @@ from app.modules.agent.contracts import (
 )
 from app.modules.agent_surfaces.platforms.attachment_limits import fits_inline
 from app.modules.agent_surfaces.platforms.rendering import sanitize_user_visible_text
-from app.modules.agent_surfaces.config import surface_settings
 from app.composition.surface_datastore import build_file_service
 from app.modules.agent_surfaces.domain.entities import (
     AgentSurfaceConversationLink,
@@ -45,7 +43,6 @@ from app.modules.agent_surfaces.domain.ingress_context import (
     AgentSurfaceContext,
     SurfaceChatContext,
     SurfaceReplyContext,
-    SurfaceReplyKind,
 )
 from app.modules.agent_surfaces.domain.models import (
     SurfaceMessageMetadata,
@@ -73,6 +70,14 @@ from app.modules.agent_surfaces.infrastructure.repositories.surface_repository i
 )
 from app.modules.agent_surfaces.services.credential_resolver import (
     SurfaceCredentialResolver,
+)
+from app.modules.agent_surfaces.services.fallback_reply_service import (
+    deliver_fallback_reply,
+    identity_confirmation_context,
+    nonmember_context,
+    prepare_unrouted_context,
+    surface_setup_context,
+    unresolved_sender_context,
 )
 from app.modules.agent_surfaces.services.identity_resolution_service import (
     SurfaceIdentityResolutionService,
@@ -278,32 +283,11 @@ class AgentSurfaceIngressService:
                 bool((parsed.metadata or {}).get("is_thread_reply")),
                 parsed.external_channel_id,
             )
-            if not parsed.is_dm:
-                return None
-
-            # A parsed DM should still receive onboarding guidance even when no
-            # configured surface is eligible. Native managed webhooks can reply
-            # without a surface row; receiver-scoped webhooks may safely use the
-            # first surface served by that receiver.
-            identity_surface = (
-                surfaces[0] if request.receiver_surface_ids and surfaces else None
-            )
-            credentials = (
-                await self._resolve_credentials(identity_surface)
-                if identity_surface is not None
-                else await self.credential_resolver.for_platform(platform, None)
-            )
-            resolved_user = await self._resolve_sender_identity(
-                adapter=adapter,
-                parsed=parsed,
-                credentials=credentials,
-            )
-            return await self._prepare_unrouted_reply_context(
+            return await self._prepare_unrouted_platform_context(
                 platform=platform,
-                surface=identity_surface,
+                surface=self._scoped_fallback_surface(request, surfaces),
                 parsed=parsed,
                 adapter=adapter,
-                resolved_user=resolved_user,
             )
 
         # Resolve the sender once (using the first candidate's credentials) and
@@ -334,9 +318,7 @@ class AgentSurfaceIngressService:
                 platform,
                 parsed.tenant_id,
             )
-            if not parsed.is_dm:
-                return None
-            return await self._prepare_unrouted_reply_context(
+            return await self._prepare_unrouted_platform_context(
                 platform=platform,
                 surface=identity_surface,
                 parsed=parsed,
@@ -435,52 +417,12 @@ class AgentSurfaceIngressService:
 
         if isinstance(parsed_context, SurfaceReplyContext):
             # Credentials are needed only to send the automated fallback.
-            try:
-                credentials = await self._resolve_credentials_from_context(
-                    parsed_context
-                )
-            except Exception as exc:
-                logger.error(
-                    "Surface fallback delivery unavailable",
-                    platform=str(platform),
-                    reply_kind=parsed_context.reply_kind,
-                    message_id=parsed_context.event.external_message_id,
-                    failure_reason=f"credential_resolution_{type(exc).__name__}",
-                )
-                return
-            if not self._has_fallback_delivery_credentials(
-                platform=platform,
+            credentials = await self._resolve_credentials_from_context(parsed_context)
+            await deliver_fallback_reply(
+                adapter=adapter,
+                context=parsed_context,
                 credentials=credentials,
-            ):
-                logger.error(
-                    "Surface fallback delivery unavailable",
-                    platform=str(platform),
-                    reply_kind=parsed_context.reply_kind,
-                    message_id=parsed_context.event.external_message_id,
-                    failure_reason="missing_credentials",
-                )
-                return
-            try:
-                reply_metadata = dict(
-                    getattr(parsed_context, "reply_metadata", {}) or {}
-                )
-                await adapter.send_message(
-                    credentials=credentials,
-                    event=parsed_context.event,
-                    message=parsed_context.reply_message or self._signup_message(),
-                    metadata={
-                        "agent_display_name": parsed_context.agent_display_name,
-                        **reply_metadata,
-                    },
-                )
-            except Exception as exc:
-                logger.error(
-                    "Surface fallback delivery failed",
-                    platform=str(platform),
-                    reply_kind=parsed_context.reply_kind,
-                    message_id=parsed_context.event.external_message_id,
-                    failure_reason=type(exc).__name__,
-                )
+            )
             return
 
         await self.start_agent_chat(parsed_context)
@@ -1771,106 +1713,24 @@ class AgentSurfaceIngressService:
         platform = SurfacePlatform.from_source(source)
         return platform.value if platform else None
 
-    def _signup_message(self) -> str:
-        signup_url = settings.auth_frontend_url.rstrip("/")
-        return (
-            "Please sign up before chatting with this agent. "
-            f"You can get started here: {signup_url}"
-        )
+    @staticmethod
+    def _scoped_fallback_surface(
+        request: SurfacePlatformWebhookIngress,
+        surfaces: list[AgentSurfaceEntity],
+    ) -> AgentSurfaceEntity | None:
+        if request.receiver_surface_ids and surfaces:
+            return surfaces[0]
+        return None
 
-    def _pod_access_message(self, pod_id: UUID) -> str:
-        base = settings.auth_frontend_url.rstrip("/")
-        return (
-            "You're signed up, but don't have access to this workspace yet. "
-            f"Request access here: {base}/pods/{pod_id}"
-        )
-
-    def _surface_setup_message(self) -> str:
-        frontend_url = settings.frontend_url.rstrip("/")
-        return (
-            "You're signed in, but no agent surface is configured for you yet. "
-            "Open Lemma to set up or select a surface: "
-            f"{frontend_url}"
-        )
-
-    def _has_fallback_delivery_credentials(
-        self,
-        *,
-        platform: SurfacePlatform,
-        credentials: dict[str, Any],
-    ) -> bool:
-        normalized = str(platform).upper()
-        if normalized == SurfacePlatform.WHATSAPP:
-            return bool(credentials.get("access_token"))
-        if normalized == SurfacePlatform.TELEGRAM:
-            return bool(credentials.get("bot_token"))
-        if normalized == SurfacePlatform.SLACK:
-            raw_response = credentials.get("raw_response") or {}
-            return bool(
-                credentials.get("access_token")
-                or credentials.get("bot_token")
-                or raw_response.get("access_token")
-            )
-        if normalized == SurfacePlatform.TEAMS:
-            return bool(
-                surface_settings.microsoft_bot_app_id
-                and surface_settings.microsoft_bot_app_password
-            )
-        if normalized == SurfacePlatform.RESEND:
-            return bool(credentials.get("api_key"))
-        return any(value for value in credentials.values())
-
-    def _can_disclose_pod_access_link(self, surface: AgentSurfaceEntity) -> bool:
-        """Whether a non-member DM can safely receive a pod-specific link.
-
-        Shared system chat identities (Telegram/WhatsApp) can fan into many pod
-        surfaces. Sending a pod-specific URL to a signed-up non-member on those
-        shared identities can disclose an unrelated pod id. A custom/bound
-        account has a surface-specific credential, so its pod target is clear.
-        """
-        if surface.credential_mode is not SurfaceCredentialMode.SYSTEM:
-            return True
-        if surface.account_id is not None:
-            return True
-        return surface.surface_type not in {
-            SurfacePlatform.TELEGRAM,
-            SurfacePlatform.WHATSAPP,
-        }
-
-    def _reply_context(
-        self,
-        *,
-        platform: str | SurfacePlatform,
-        surface: AgentSurfaceEntity | None,
-        parsed: ParsedInboundSurfaceEvent,
-        agent_display_name: str | None,
-        reply: tuple[str, dict[str, Any]],
-        reply_kind: SurfaceReplyKind,
-        include_surface_id: bool = True,
-    ) -> SurfaceReplyContext:
-        message, reply_metadata = reply
-        return SurfaceReplyContext(
-            platform=SurfacePlatform(platform),
-            surface_id=surface.id if surface and include_surface_id else None,
-            surface_account_id=surface.account_id if surface else None,
-            surface_config=surface.config if surface else None,
-            agent_display_name=agent_display_name,
-            reply_kind=reply_kind,
-            reply_message=message,
-            reply_metadata=reply_metadata,
-            event=parsed,
-        )
-
-    async def _prepare_unrouted_reply_context(
+    async def _prepare_unrouted_platform_context(
         self,
         *,
         platform: str,
         surface: AgentSurfaceEntity | None,
         parsed: ParsedInboundSurfaceEvent,
         adapter: SurfacePlatformAdapterPort,
-        resolved_user: ResolvedSurfaceUser,
+        resolved_user: ResolvedSurfaceUser | None = None,
     ) -> SurfaceReplyContext | None:
-        """Build a DM-only fallback when normal surface routing cannot proceed."""
         if not parsed.is_dm:
             return None
         if surface is not None:
@@ -1878,55 +1738,28 @@ class AgentSurfaceIngressService:
                 return None
             if surface.should_ignore_sender(parsed.sender_external_user_id):
                 return None
-
-        claimed = await self.event_dedup_store.claim_message(
-            surface_installation_id=None,
-            platform=platform,
-            external_channel_id=parsed.external_channel_id,
-            external_thread_id=parsed.external_thread_id,
-            external_message_id=parsed.external_message_id,
-        )
-        if not claimed:
-            logger.info(
-                "Agent surface ignored duplicate unrouted message platform=%s channel=%s message_id=%s",
-                platform,
-                parsed.external_channel_id,
-                parsed.external_message_id,
+        if resolved_user is None:
+            credentials = (
+                await self._resolve_credentials(surface)
+                if surface is not None
+                else await self.credential_resolver.for_platform(platform, None)
             )
-            return None
-
+            resolved_user = await self._resolve_sender_identity(
+                adapter=adapter,
+                parsed=parsed,
+                credentials=credentials,
+            )
         agent_display_name = (
             (await self._agent_name_for_surface(surface)) if surface else None
         ) or "Lemma"
-        if resolved_user.internal_user_id is None:
-            identity_reply = adapter.unresolved_sender_reply(parsed)
-            reply = identity_reply or (self._signup_message(), {})
-            reply_kind: SurfaceReplyKind = (
-                "identity_link" if identity_reply is not None else "signup"
-            )
-        else:
-            confirmation = adapter.linked_sender_confirmation(parsed)
-            if confirmation is not None:
-                reply = confirmation
-                reply_kind = "identity_link"
-            else:
-                reply = (self._surface_setup_message(), {})
-                reply_kind = "surface_setup"
-
-        logger.info(
-            "Agent surface prepared unrouted fallback",
-            platform=platform,
-            reply_kind=reply_kind,
-            message_id=parsed.external_message_id,
-        )
-        return self._reply_context(
+        return await prepare_unrouted_context(
             platform=platform,
             surface=surface,
             parsed=parsed,
+            adapter=adapter,
+            resolved_user=resolved_user,
             agent_display_name=agent_display_name,
-            reply=reply,
-            reply_kind=reply_kind,
-            include_surface_id=False,
+            event_dedup_store=self.event_dedup_store,
         )
 
     async def _prepare_surface_context(
@@ -2026,35 +1859,19 @@ class AgentSurfaceIngressService:
                 surface.surface_type,
                 parsed.sender_external_user_id,
             )
-            # In a group/channel, never post a contact-share / signup prompt — it
-            # would spam the group. Silently ignore senders we can't resolve; they
-            # can DM the bot or link their profile (telegram_username / number).
-            if not parsed.is_dm:
-                return None
-            identity_reply = adapter.unresolved_sender_reply(parsed)
-            reply = identity_reply or (
-                self._signup_message(),
-                {},
-            )
-            return self._reply_context(
-                platform=surface.surface_type,
+            return unresolved_sender_context(
                 surface=surface,
                 parsed=parsed,
+                adapter=adapter,
                 agent_display_name=fallback_agent_display_name,
-                reply=reply,
-                reply_kind=(
-                    "identity_link" if identity_reply is not None else "signup"
-                ),
             )
         confirmation = adapter.linked_sender_confirmation(parsed)
         if confirmation is not None:
-            return self._reply_context(
-                platform=surface.surface_type,
+            return identity_confirmation_context(
                 surface=surface,
                 parsed=parsed,
                 agent_display_name=fallback_agent_display_name,
-                reply=confirmation,
-                reply_kind="identity_link",
+                confirmation=confirmation,
             )
         if (
             await self._match_surface_for_user(
@@ -2070,29 +1887,11 @@ class AgentSurfaceIngressService:
                 resolved_user.internal_user_id,
                 surface.pod_id,
             )
-            # Signed up but not a pod member: on a pod-specific DM surface,
-            # point them to the pod home page to request access. Shared system
-            # Telegram/WhatsApp identities can front many pods, so they receive
-            # a generic message that does not disclose this pod id.
-            if parsed.is_dm:
-                reply_message = (
-                    self._pod_access_message(surface.pod_id)
-                    if self._can_disclose_pod_access_link(surface)
-                    else self._surface_setup_message()
-                )
-                return self._reply_context(
-                    platform=surface.surface_type,
-                    surface=surface,
-                    parsed=parsed,
-                    agent_display_name=fallback_agent_display_name,
-                    reply=(reply_message, {}),
-                    reply_kind=(
-                        "pod_access"
-                        if self._can_disclose_pod_access_link(surface)
-                        else "surface_setup"
-                    ),
-                )
-            return None
+            return nonmember_context(
+                surface=surface,
+                parsed=parsed,
+                agent_display_name=fallback_agent_display_name,
+            )
         if not surface.config.identity.allows_email(resolved_user.email):
             logger.info(
                 "Agent surface identity policy rejected sender platform=%s surface=%s user=%s email=%s",
@@ -2101,16 +1900,11 @@ class AgentSurfaceIngressService:
                 resolved_user.internal_user_id,
                 resolved_user.email,
             )
-            if parsed.is_dm:
-                return self._reply_context(
-                    platform=surface.surface_type,
-                    surface=surface,
-                    parsed=parsed,
-                    agent_display_name=fallback_agent_display_name,
-                    reply=(self._surface_setup_message(), {}),
-                    reply_kind="surface_setup",
-                )
-            return None
+            return surface_setup_context(
+                surface=surface,
+                parsed=parsed,
+                agent_display_name=fallback_agent_display_name,
+            )
 
         route = await self._resolve_route(surface=surface, parsed=parsed)
         if route is None:
@@ -2120,16 +1914,11 @@ class AgentSurfaceIngressService:
                 surface.id,
                 parsed.external_channel_id,
             )
-            if parsed.is_dm:
-                return self._reply_context(
-                    platform=surface.surface_type,
-                    surface=surface,
-                    parsed=parsed,
-                    agent_display_name=fallback_agent_display_name,
-                    reply=(self._surface_setup_message(), {}),
-                    reply_kind="surface_setup",
-                )
-            return None
+            return surface_setup_context(
+                surface=surface,
+                parsed=parsed,
+                agent_display_name=fallback_agent_display_name,
+            )
 
         link = await self._get_or_create_conversation_link(
             surface=surface,

--- a/lemma-backend/app/modules/agent_surfaces/services/ingress_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/ingress_service.py
@@ -22,6 +22,7 @@ from app.modules.agent.contracts import (
 )
 from app.modules.agent_surfaces.platforms.attachment_limits import fits_inline
 from app.modules.agent_surfaces.platforms.rendering import sanitize_user_visible_text
+from app.modules.agent_surfaces.config import surface_settings
 from app.composition.surface_datastore import build_file_service
 from app.modules.agent_surfaces.domain.entities import (
     AgentSurfaceConversationLink,
@@ -44,6 +45,7 @@ from app.modules.agent_surfaces.domain.ingress_context import (
     AgentSurfaceContext,
     SurfaceChatContext,
     SurfaceReplyContext,
+    SurfaceReplyKind,
 )
 from app.modules.agent_surfaces.domain.models import (
     SurfaceMessageMetadata,
@@ -276,7 +278,33 @@ class AgentSurfaceIngressService:
                 bool((parsed.metadata or {}).get("is_thread_reply")),
                 parsed.external_channel_id,
             )
-            return None
+            if not parsed.is_dm:
+                return None
+
+            # A parsed DM should still receive onboarding guidance even when no
+            # configured surface is eligible. Native managed webhooks can reply
+            # without a surface row; receiver-scoped webhooks may safely use the
+            # first surface served by that receiver.
+            identity_surface = (
+                surfaces[0] if request.receiver_surface_ids and surfaces else None
+            )
+            credentials = (
+                await self._resolve_credentials(identity_surface)
+                if identity_surface is not None
+                else await self.credential_resolver.for_platform(platform, None)
+            )
+            resolved_user = await self._resolve_sender_identity(
+                adapter=adapter,
+                parsed=parsed,
+                credentials=credentials,
+            )
+            return await self._prepare_unrouted_reply_context(
+                platform=platform,
+                surface=identity_surface,
+                parsed=parsed,
+                adapter=adapter,
+                resolved_user=resolved_user,
+            )
 
         # Resolve the sender once (using the first candidate's credentials) and
         # pick the surface this event belongs to (continuity → pod membership →
@@ -306,7 +334,15 @@ class AgentSurfaceIngressService:
                 platform,
                 parsed.tenant_id,
             )
-            return None
+            if not parsed.is_dm:
+                return None
+            return await self._prepare_unrouted_reply_context(
+                platform=platform,
+                surface=identity_surface,
+                parsed=parsed,
+                adapter=adapter,
+                resolved_user=resolved_user,
+            )
 
         return await self._prepare_surface_context(
             surface=matched_surface,
@@ -398,8 +434,32 @@ class AgentSurfaceIngressService:
         )
 
         if isinstance(parsed_context, SurfaceReplyContext):
-            # Credentials are needed only to send the signup/reply message.
-            credentials = await self._resolve_credentials_from_context(parsed_context)
+            # Credentials are needed only to send the automated fallback.
+            try:
+                credentials = await self._resolve_credentials_from_context(
+                    parsed_context
+                )
+            except Exception as exc:
+                logger.error(
+                    "Surface fallback delivery unavailable",
+                    platform=str(platform),
+                    reply_kind=parsed_context.reply_kind,
+                    message_id=parsed_context.event.external_message_id,
+                    failure_reason=f"credential_resolution_{type(exc).__name__}",
+                )
+                return
+            if not self._has_fallback_delivery_credentials(
+                platform=platform,
+                credentials=credentials,
+            ):
+                logger.error(
+                    "Surface fallback delivery unavailable",
+                    platform=str(platform),
+                    reply_kind=parsed_context.reply_kind,
+                    message_id=parsed_context.event.external_message_id,
+                    failure_reason="missing_credentials",
+                )
+                return
             try:
                 reply_metadata = dict(
                     getattr(parsed_context, "reply_metadata", {}) or {}
@@ -415,7 +475,11 @@ class AgentSurfaceIngressService:
                 )
             except Exception as exc:
                 logger.error(
-                    "Failed sending signup surface reply: %s", exc, exc_info=True
+                    "Surface fallback delivery failed",
+                    platform=str(platform),
+                    reply_kind=parsed_context.reply_kind,
+                    message_id=parsed_context.event.external_message_id,
+                    failure_reason=type(exc).__name__,
                 )
             return
 
@@ -1721,12 +1785,40 @@ class AgentSurfaceIngressService:
             f"Request access here: {base}/pods/{pod_id}"
         )
 
-    def _ambiguous_system_surface_access_message(self) -> str:
+    def _surface_setup_message(self) -> str:
+        frontend_url = settings.frontend_url.rstrip("/")
         return (
-            "You're signed up, but this shared bot can't determine which "
-            "workspace to connect you to. Ask a workspace admin to add you, or "
-            "open Lemma and choose the workspace there."
+            "You're signed in, but no agent surface is configured for you yet. "
+            "Open Lemma to set up or select a surface: "
+            f"{frontend_url}"
         )
+
+    def _has_fallback_delivery_credentials(
+        self,
+        *,
+        platform: SurfacePlatform,
+        credentials: dict[str, Any],
+    ) -> bool:
+        normalized = str(platform).upper()
+        if normalized == SurfacePlatform.WHATSAPP:
+            return bool(credentials.get("access_token"))
+        if normalized == SurfacePlatform.TELEGRAM:
+            return bool(credentials.get("bot_token"))
+        if normalized == SurfacePlatform.SLACK:
+            raw_response = credentials.get("raw_response") or {}
+            return bool(
+                credentials.get("access_token")
+                or credentials.get("bot_token")
+                or raw_response.get("access_token")
+            )
+        if normalized == SurfacePlatform.TEAMS:
+            return bool(
+                surface_settings.microsoft_bot_app_id
+                and surface_settings.microsoft_bot_app_password
+            )
+        if normalized == SurfacePlatform.RESEND:
+            return bool(credentials.get("api_key"))
+        return any(value for value in credentials.values())
 
     def _can_disclose_pod_access_link(self, surface: AgentSurfaceEntity) -> bool:
         """Whether a non-member DM can safely receive a pod-specific link.
@@ -1748,21 +1840,93 @@ class AgentSurfaceIngressService:
     def _reply_context(
         self,
         *,
-        surface: AgentSurfaceEntity,
+        platform: str | SurfacePlatform,
+        surface: AgentSurfaceEntity | None,
         parsed: ParsedInboundSurfaceEvent,
         agent_display_name: str | None,
         reply: tuple[str, dict[str, Any]],
+        reply_kind: SurfaceReplyKind,
+        include_surface_id: bool = True,
     ) -> SurfaceReplyContext:
         message, reply_metadata = reply
         return SurfaceReplyContext(
-            platform=surface.surface_type,
-            surface_id=surface.id,
-            surface_account_id=surface.account_id,
-            surface_config=surface.config,
+            platform=SurfacePlatform(platform),
+            surface_id=surface.id if surface and include_surface_id else None,
+            surface_account_id=surface.account_id if surface else None,
+            surface_config=surface.config if surface else None,
             agent_display_name=agent_display_name,
+            reply_kind=reply_kind,
             reply_message=message,
             reply_metadata=reply_metadata,
             event=parsed,
+        )
+
+    async def _prepare_unrouted_reply_context(
+        self,
+        *,
+        platform: str,
+        surface: AgentSurfaceEntity | None,
+        parsed: ParsedInboundSurfaceEvent,
+        adapter: SurfacePlatformAdapterPort,
+        resolved_user: ResolvedSurfaceUser,
+    ) -> SurfaceReplyContext | None:
+        """Build a DM-only fallback when normal surface routing cannot proceed."""
+        if not parsed.is_dm:
+            return None
+        if surface is not None:
+            if self._is_self_email_event(surface=surface, parsed=parsed):
+                return None
+            if surface.should_ignore_sender(parsed.sender_external_user_id):
+                return None
+
+        claimed = await self.event_dedup_store.claim_message(
+            surface_installation_id=None,
+            platform=platform,
+            external_channel_id=parsed.external_channel_id,
+            external_thread_id=parsed.external_thread_id,
+            external_message_id=parsed.external_message_id,
+        )
+        if not claimed:
+            logger.info(
+                "Agent surface ignored duplicate unrouted message platform=%s channel=%s message_id=%s",
+                platform,
+                parsed.external_channel_id,
+                parsed.external_message_id,
+            )
+            return None
+
+        agent_display_name = (
+            (await self._agent_name_for_surface(surface)) if surface else None
+        ) or "Lemma"
+        if resolved_user.internal_user_id is None:
+            identity_reply = adapter.unresolved_sender_reply(parsed)
+            reply = identity_reply or (self._signup_message(), {})
+            reply_kind: SurfaceReplyKind = (
+                "identity_link" if identity_reply is not None else "signup"
+            )
+        else:
+            confirmation = adapter.linked_sender_confirmation(parsed)
+            if confirmation is not None:
+                reply = confirmation
+                reply_kind = "identity_link"
+            else:
+                reply = (self._surface_setup_message(), {})
+                reply_kind = "surface_setup"
+
+        logger.info(
+            "Agent surface prepared unrouted fallback",
+            platform=platform,
+            reply_kind=reply_kind,
+            message_id=parsed.external_message_id,
+        )
+        return self._reply_context(
+            platform=platform,
+            surface=surface,
+            parsed=parsed,
+            agent_display_name=agent_display_name,
+            reply=reply,
+            reply_kind=reply_kind,
+            include_surface_id=False,
         )
 
     async def _prepare_surface_context(
@@ -1867,23 +2031,30 @@ class AgentSurfaceIngressService:
             # can DM the bot or link their profile (telegram_username / number).
             if not parsed.is_dm:
                 return None
-            reply = adapter.unresolved_sender_reply(parsed) or (
+            identity_reply = adapter.unresolved_sender_reply(parsed)
+            reply = identity_reply or (
                 self._signup_message(),
                 {},
             )
             return self._reply_context(
+                platform=surface.surface_type,
                 surface=surface,
                 parsed=parsed,
                 agent_display_name=fallback_agent_display_name,
                 reply=reply,
+                reply_kind=(
+                    "identity_link" if identity_reply is not None else "signup"
+                ),
             )
         confirmation = adapter.linked_sender_confirmation(parsed)
         if confirmation is not None:
             return self._reply_context(
+                platform=surface.surface_type,
                 surface=surface,
                 parsed=parsed,
                 agent_display_name=fallback_agent_display_name,
                 reply=confirmation,
+                reply_kind="identity_link",
             )
         if (
             await self._match_surface_for_user(
@@ -1907,13 +2078,19 @@ class AgentSurfaceIngressService:
                 reply_message = (
                     self._pod_access_message(surface.pod_id)
                     if self._can_disclose_pod_access_link(surface)
-                    else self._ambiguous_system_surface_access_message()
+                    else self._surface_setup_message()
                 )
                 return self._reply_context(
+                    platform=surface.surface_type,
                     surface=surface,
                     parsed=parsed,
                     agent_display_name=fallback_agent_display_name,
                     reply=(reply_message, {}),
+                    reply_kind=(
+                        "pod_access"
+                        if self._can_disclose_pod_access_link(surface)
+                        else "surface_setup"
+                    ),
                 )
             return None
         if not surface.config.identity.allows_email(resolved_user.email):
@@ -1924,6 +2101,15 @@ class AgentSurfaceIngressService:
                 resolved_user.internal_user_id,
                 resolved_user.email,
             )
+            if parsed.is_dm:
+                return self._reply_context(
+                    platform=surface.surface_type,
+                    surface=surface,
+                    parsed=parsed,
+                    agent_display_name=fallback_agent_display_name,
+                    reply=(self._surface_setup_message(), {}),
+                    reply_kind="surface_setup",
+                )
             return None
 
         route = await self._resolve_route(surface=surface, parsed=parsed)
@@ -1934,6 +2120,15 @@ class AgentSurfaceIngressService:
                 surface.id,
                 parsed.external_channel_id,
             )
+            if parsed.is_dm:
+                return self._reply_context(
+                    platform=surface.surface_type,
+                    surface=surface,
+                    parsed=parsed,
+                    agent_display_name=fallback_agent_display_name,
+                    reply=(self._surface_setup_message(), {}),
+                    reply_kind="surface_setup",
+                )
             return None
 
         link = await self._get_or_create_conversation_link(

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_multi_pod_resolution_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_multi_pod_resolution_e2e.py
@@ -518,11 +518,12 @@ async def test_shared_system_bot_multi_user_routing_matrix(
             message_id=107,
         ),
     )
-    if non_member_ctx is not None:
-        assert isinstance(non_member_ctx, SurfaceReplyContext)
-        message = non_member_ctx.reply_message or ""
-        assert f"/pods/{org_a.pod_id}" not in message
-        assert f"/pods/{org_b.pod_id}" not in message
+    assert isinstance(non_member_ctx, SurfaceReplyContext)
+    assert non_member_ctx.reply_kind == "surface_setup"
+    message = non_member_ctx.reply_message or ""
+    assert "set up or select a surface" in message
+    assert f"/pods/{org_a.pod_id}" not in message
+    assert f"/pods/{org_b.pod_id}" not in message
 
 
 @pytest.mark.parametrize("platform", ["TELEGRAM", "WHATSAPP"])

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_onboarding_reply_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_onboarding_reply_e2e.py
@@ -76,9 +76,10 @@ async def test_system_bot_signed_up_non_member_does_not_get_pod_access_link(
     )
 
     assert isinstance(context, SurfaceReplyContext)
+    assert context.reply_kind == "surface_setup"
     message = context.reply_message or ""
     assert f"/pods/{pod_id}" not in message
-    assert "shared bot" in message.lower()
+    assert "set up or select a surface" in message.lower()
 
 
 async def test_custom_bot_signed_up_non_member_gets_pod_access_link(
@@ -122,6 +123,7 @@ async def test_custom_bot_signed_up_non_member_gets_pod_access_link(
 
     # Instead of being dropped, they get a pod-access / join-request link.
     assert isinstance(context, SurfaceReplyContext)
+    assert context.reply_kind == "pod_access"
     message = context.reply_message or ""
     assert "access" in message.lower()
     assert f"/pods/{pod_id}" in message

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_ingress_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_ingress_service.py
@@ -984,7 +984,7 @@ async def test_execute_chat_logs_missing_fallback_credentials(monkeypatch):
     )
     log = Mock()
     monkeypatch.setattr(
-        "app.modules.agent_surfaces.services.ingress_service.logger", log
+        "app.modules.agent_surfaces.services.fallback_reply_service.logger", log
     )
     context = SurfaceReplyContext(
         platform="TELEGRAM",
@@ -1015,7 +1015,7 @@ async def test_execute_chat_logs_delivery_failure_without_secret(monkeypatch):
     )
     log = Mock()
     monkeypatch.setattr(
-        "app.modules.agent_surfaces.services.ingress_service.logger", log
+        "app.modules.agent_surfaces.services.fallback_reply_service.logger", log
     )
     context = SurfaceReplyContext(
         platform="TELEGRAM",

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_ingress_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_ingress_service.py
@@ -323,6 +323,7 @@ async def test_prepare_webhook_returns_signup_context_for_unresolved_user():
 
     assert isinstance(context, SurfaceReplyContext)
     assert context.surface_id == surface.id
+    assert context.reply_kind == "signup"
     assert context.agent_display_name == "Surface Agent"
     service.conversation_service.create_conversation.assert_not_called()
 
@@ -368,7 +369,8 @@ async def test_prepare_webhook_avoids_pod_access_link_for_system_non_member():
     assert isinstance(context, SurfaceReplyContext)
     assert "Request access" not in (context.reply_message or "")
     assert str(surface.pod_id) not in (context.reply_message or "")
-    assert "shared bot" in (context.reply_message or "")
+    assert context.reply_kind == "surface_setup"
+    assert "set up or select a surface" in (context.reply_message or "")
     service.conversation_service.create_conversation.assert_not_called()
 
 
@@ -415,9 +417,164 @@ async def test_prepare_webhook_returns_pod_access_link_for_custom_non_member():
     )
 
     assert isinstance(context, SurfaceReplyContext)
+    assert context.reply_kind == "pod_access"
     assert "Request access" in (context.reply_message or "")
     assert str(surface.pod_id) in (context.reply_message or "")
     service.conversation_service.create_conversation.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "platform", [SurfacePlatform.TELEGRAM, SurfacePlatform.WHATSAPP]
+)
+async def test_unresolved_managed_dm_with_multiple_surfaces_gets_one_fallback(
+    platform: SurfacePlatform,
+):
+    surfaces = [
+        AgentSurfaceEntity(
+            id=uuid4(),
+            pod_id=uuid4(),
+            name=f"{platform.value.lower()}-{index}",
+            agent_id=uuid4(),
+            surface_type=platform,
+            mode=SurfaceMode.DM,
+            account_id=None,
+            credential_mode=SurfaceCredentialMode.SYSTEM,
+            config=SurfaceConfig(),
+            is_active=True,
+        )
+        for index in range(2)
+    ]
+    event = ParsedInboundSurfaceEvent(
+        platform=platform,
+        conversation_type=ConversationType.EXTERNAL_DM,
+        external_channel_id="dm-123",
+        external_thread_id="dm-123",
+        external_message_id="message-123",
+        sender_external_user_id="external-123",
+        message_text="hello",
+        is_dm=True,
+        reply_target={"chat_id": "dm-123", "sender_wa_id": "external-123"},
+    )
+    adapter = AsyncMock()
+    adapter.parse_inbound_event.return_value = event
+    adapter.unresolved_sender_reply.return_value = None
+    service = _build_service(
+        adapter=adapter,
+        surfaces=surfaces,
+        resolved_user=ResolvedSurfaceUser(
+            internal_user_id=None,
+            external_user_id="external-123",
+        ),
+    )
+    service.event_dedup_store.claim_message.side_effect = [True, False]
+
+    first = await service.prepare_ingress(
+        SurfacePlatformWebhookIngress(
+            source=platform.value.lower(), payload={}, headers={}
+        )
+    )
+    second = await service.prepare_ingress(
+        SurfacePlatformWebhookIngress(
+            source=platform.value.lower(), payload={}, headers={}
+        )
+    )
+
+    assert isinstance(first, SurfaceReplyContext)
+    assert first.reply_kind == "signup"
+    assert first.surface_id is None
+    assert second is None
+    assert (
+        service.event_dedup_store.claim_message.await_args.kwargs[
+            "surface_installation_id"
+        ]
+        is None
+    )
+
+
+async def test_resolved_dm_without_matching_surface_gets_setup_link(monkeypatch):
+    from app.core.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "frontend_url", "https://app.example.test/")
+    surfaces = [_telegram_surface(), _telegram_surface()]
+    event = _telegram_event(chat_id="dm-setup", message_id="message-setup")
+    adapter = AsyncMock()
+    adapter.parse_inbound_event.return_value = event
+    service = _build_service(
+        adapter=adapter,
+        surfaces=surfaces,
+        resolved_user=ResolvedSurfaceUser(
+            internal_user_id=uuid4(),
+            external_user_id="777",
+            email="signed-in@example.com",
+        ),
+    )
+    service.pod_membership_port = SimpleNamespace(
+        get_user_pod_ids=AsyncMock(return_value=[]),
+        get_user_email=AsyncMock(return_value="signed-in@example.com"),
+    )
+
+    context = await service.prepare_ingress(
+        SurfacePlatformWebhookIngress(source="telegram", payload={}, headers={})
+    )
+
+    assert isinstance(context, SurfaceReplyContext)
+    assert context.reply_kind == "surface_setup"
+    assert context.surface_id is None
+    assert context.reply_message.endswith("https://app.example.test")
+
+
+async def test_unroutable_group_remains_silent():
+    surfaces = [_slack_surface(), _slack_surface()]
+    event = _slack_channel_event()
+    adapter = AsyncMock()
+    adapter.parse_inbound_event.return_value = event
+    service = _build_service(
+        adapter=adapter,
+        surfaces=surfaces,
+        resolved_user=ResolvedSurfaceUser(
+            internal_user_id=None,
+            external_user_id="U123",
+        ),
+    )
+
+    context = await service.prepare_ingress(
+        SurfacePlatformWebhookIngress(source="slack", payload={}, headers={})
+    )
+
+    assert context is None
+    service.event_dedup_store.claim_message.assert_not_awaited()
+
+
+async def test_resolved_dm_with_no_route_gets_setup_reply():
+    surface = _slack_surface()
+    user_id = uuid4()
+    event = _slack_event()
+    adapter = AsyncMock()
+    service = _build_service(
+        adapter=adapter,
+        surfaces=[surface],
+        resolved_user=ResolvedSurfaceUser(
+            internal_user_id=user_id,
+            external_user_id="U123",
+            email="sender@example.com",
+        ),
+    )
+    service._resolve_route = AsyncMock(return_value=None)
+
+    context = await service._prepare_surface_context(
+        surface=surface,
+        parsed=event,
+        adapter=adapter,
+        resolved_user=ResolvedSurfaceUser(
+            internal_user_id=user_id,
+            external_user_id="U123",
+            email="sender@example.com",
+        ),
+    )
+
+    assert isinstance(context, SurfaceReplyContext)
+    assert context.reply_kind == "surface_setup"
+    assert "set up or select a surface" in context.reply_message
 
 
 async def test_prepare_webhook_creates_conversation_link_for_resolved_user():
@@ -792,6 +949,9 @@ async def test_execute_chat_sends_direct_replies():
     parsed_event = _slack_event()
     adapter = AsyncMock()
     service = _build_service(adapter=adapter)
+    service._resolve_credentials_from_context = AsyncMock(
+        return_value={"bot_token": "test-token", "access_token": "test-token"}
+    )
     signup_context = SurfaceReplyContext(
         platform="SLACK",
         agent_display_name="Lemma",
@@ -813,6 +973,67 @@ async def test_execute_chat_sends_direct_replies():
     assert adapter.send_message.await_args.kwargs["metadata"]["reply_markup"] == {
         "remove_keyboard": True
     }
+
+
+async def test_execute_chat_logs_missing_fallback_credentials(monkeypatch):
+    parsed_event = _telegram_event(chat_id="123", message_id="missing-creds")
+    adapter = AsyncMock()
+    service = _build_service(adapter=adapter)
+    service._resolve_credentials_from_context = AsyncMock(
+        return_value={"bot_token": ""}
+    )
+    log = Mock()
+    monkeypatch.setattr(
+        "app.modules.agent_surfaces.services.ingress_service.logger", log
+    )
+    context = SurfaceReplyContext(
+        platform="TELEGRAM",
+        reply_kind="signup",
+        reply_message="Please sign up",
+        event=parsed_event,
+    )
+
+    await service.execute_chat(context)
+
+    adapter.send_message.assert_not_awaited()
+    log.error.assert_called_once_with(
+        "Surface fallback delivery unavailable",
+        platform="TELEGRAM",
+        reply_kind="signup",
+        message_id="missing-creds",
+        failure_reason="missing_credentials",
+    )
+
+
+async def test_execute_chat_logs_delivery_failure_without_secret(monkeypatch):
+    parsed_event = _telegram_event(chat_id="123", message_id="failed-delivery")
+    adapter = AsyncMock()
+    adapter.send_message.side_effect = RuntimeError("provider exposed secret-token")
+    service = _build_service(adapter=adapter)
+    service._resolve_credentials_from_context = AsyncMock(
+        return_value={"bot_token": "secret-token"}
+    )
+    log = Mock()
+    monkeypatch.setattr(
+        "app.modules.agent_surfaces.services.ingress_service.logger", log
+    )
+    context = SurfaceReplyContext(
+        platform="TELEGRAM",
+        reply_kind="surface_setup",
+        reply_message="Set up a surface",
+        event=parsed_event,
+    )
+
+    await service.execute_chat(context)
+
+    log.error.assert_called_once_with(
+        "Surface fallback delivery failed",
+        platform="TELEGRAM",
+        reply_kind="surface_setup",
+        message_id="failed-delivery",
+        failure_reason="RuntimeError",
+    )
+    assert "secret-token" not in repr(log.error.call_args)
 
 
 async def test_execute_chat_starts_agent_run_with_surface_metadata():


### PR DESCRIPTION
## Summary

- reply to unresolved direct-message senders with platform identity linking or the signup URL
- reply to resolved but unroutable users with the environment-aware surface setup URL
- preserve custom-bot pod access links, routed conversations, and silent group/channel handling
- deduplicate unrouted fallbacks and emit credential-safe structured delivery errors

## Production symptom

Production WhatsApp webhooks were parsed successfully, but shared managed surfaces could not select a pod surface for the sender. Ingress returned None before onboarding logic ran, so neither signup nor setup guidance was delivered.

## Validation

- 402 agent-surface unit tests passed
- 8 onboarding and multi-pod E2E tests passed for Telegram and WhatsApp
- backend Ruff lint passed
- required critical basedpyright gate passed

No production configuration, stored surface records, public API, or database schema is changed.