### PR TITLE
fix(onboarding): separate team workspaces from pods

### DIFF
--- a/lemma-frontend/components/onboarding/account-onboarding-helpers.ts
+++ b/lemma-frontend/components/onboarding/account-onboarding-helpers.ts
@@ -40,8 +40,8 @@ export const SETUP_STEPS: SetupStep[] = [
   "boot",
   "identity",
   "audience",
-  "team",
   "workspace",
+  "team",
   "connect",
   "start",
 ];
@@ -77,13 +77,38 @@ export function setupStepsForAudience(audience: Audience | null): SetupStep[] {
       "boot",
       "identity",
       "audience",
-      "team",
       "workspace",
+      "team",
       "connect",
       "start",
     ];
   }
   return SETUP_STEPS;
+}
+
+export function nextTeamSetupStep({
+  hasOrganization,
+  hasPod,
+}: {
+  hasOrganization: boolean;
+  hasPod: boolean;
+}): Extract<SetupStep, "workspace" | "team" | "connect"> {
+  if (hasPod) return "connect";
+  return hasOrganization ? "team" : "workspace";
+}
+
+export function normalizeOnboardingStep(
+  step: SetupStep,
+  audience: Audience | null,
+  hasOrganization: boolean,
+): SetupStep {
+  // Drafts created by the old team-first flow may resume on the team step
+  // before an organization exists. Send those users through workspace setup
+  // instead of letting the pod CTA lead to another unrelated step.
+  if (audience === "team" && step === "team" && !hasOrganization) {
+    return "workspace";
+  }
+  return step;
 }
 
 export type TeamKind =
@@ -385,7 +410,43 @@ export function splitName(value: string) {
   };
 }
 
-export function defaultWorkspaceName(name: string) {
+const COMMON_COUNTRY_CODE_SECOND_LEVEL_DOMAINS = new Set([
+  "ac",
+  "co",
+  "com",
+  "edu",
+  "gov",
+  "net",
+  "org",
+]);
+
+export function workspaceNameFromWorkDomain(domain: string) {
+  const labels = domain
+    .trim()
+    .toLowerCase()
+    .replace(/^@+/, "")
+    .split(".")
+    .filter(Boolean);
+  if (labels.length < 2) return null;
+
+  const topLevelDomain = labels.at(-1) || "";
+  const secondLevelDomain = labels.at(-2) || "";
+  const organizationLabel =
+    labels.length >= 3 &&
+    topLevelDomain.length === 2 &&
+    COMMON_COUNTRY_CODE_SECOND_LEVEL_DOMAINS.has(secondLevelDomain)
+      ? labels.at(-3) || ""
+      : secondLevelDomain;
+  const organizationName = toTitleCase(
+    organizationLabel.replace(/[-_]+/g, " "),
+  );
+  return organizationName ? `${organizationName} Workspace` : null;
+}
+
+export function defaultWorkspaceName(name: string, workDomain = "") {
+  const domainWorkspaceName = workspaceNameFromWorkDomain(workDomain);
+  if (domainWorkspaceName) return domainWorkspaceName;
+
   const firstName = splitName(name).firstName || "My";
   return `${firstName}'s Workspace`;
 }
@@ -395,11 +456,6 @@ export function defaultWorkspaceName(name: string) {
 export function personalWorkspaceName(name: string) {
   const firstName = splitName(name).firstName || "My";
   return `${firstName}'s Space`;
-}
-
-export function teamWorkspaceName(teamName: string) {
-  const label = toTitleCase(teamName.trim() || "Team");
-  return `${label} Workspace`;
 }
 
 export function podNameForAudience(audience: Audience, teamName = "") {

--- a/lemma-frontend/components/onboarding/account-onboarding-steps.tsx
+++ b/lemma-frontend/components/onboarding/account-onboarding-steps.tsx
@@ -431,7 +431,7 @@ export function TeamStep({
   return (
     <SetupSplitPanel
       title="What team do you work in?"
-      subtitle="We will create one clean starting pod for that team. Teammates, permissions, and workspace details can wait."
+      subtitle="This becomes the pod for that team's agents, apps, workflows, and operating data."
       preview={
         <StartPreviewBody
           podTitle={podTitle}

--- a/lemma-frontend/components/onboarding/account-onboarding.tsx
+++ b/lemma-frontend/components/onboarding/account-onboarding.tsx
@@ -69,13 +69,14 @@ import {
   buildPromptFromIntent,
   defaultWorkspaceName,
   inferFullName,
+  nextTeamSetupStep,
+  normalizeOnboardingStep,
   podNameForAudience,
   personalWorkspaceName,
   setupStepsForAudience,
   splitName,
   startRecipesForAudience,
   teamLabelForKind,
-  teamWorkspaceName,
   previousOnboardingStep,
   resolveOnboardingStartStep,
   type Audience,
@@ -268,7 +269,12 @@ function SetupAssistant({
   const workDomain = workDomainFromEmail(email);
   const normalizedWorkDomain = normalizeEmailDomain(workDomain);
   const inferredName = inferFullName(profile);
-  const [step, setStep] = useState<SetupStep>(initialStep);
+  const normalizedInitialStep = normalizeOnboardingStep(
+    initialStep,
+    initialAudience,
+    Boolean(initialOrganization),
+  );
+  const [step, setStep] = useState<SetupStep>(normalizedInitialStep);
   const [createdOrganization, setCreatedOrganization] =
     useState<Organization | null>(null);
   const [basePod, setBasePod] = useState<Pod | null>(() =>
@@ -282,7 +288,8 @@ function SetupAssistant({
   );
   const [identityName, setIdentityName] = useState(inferredName);
   const [workspaceName, setWorkspaceName] = useState(
-    initialDraft?.workspaceName || defaultWorkspaceName(inferredName),
+    initialDraft?.workspaceName ||
+      defaultWorkspaceName(inferredName, workDomain),
   );
   const [audience, setAudience] = useState<Audience | null>(
     initialDraft?.audience || initialAudience,
@@ -321,10 +328,10 @@ function SetupAssistant({
   const activeOrganization = createdOrganization || initialOrganization;
 
   useEffect(() => {
-    if (step === "boot" && initialStep !== "boot") {
-      setStep(initialStep);
+    if (step === "boot" && normalizedInitialStep !== "boot") {
+      setStep(normalizedInitialStep);
     }
-  }, [initialStep, step]);
+  }, [normalizedInitialStep, step]);
 
   useEffect(() => {
     if (!basePod && initialDraft?.basePodId) {
@@ -362,7 +369,7 @@ function SetupAssistant({
       {
         onSuccess: () => {
           toast.success("Operator profile saved");
-          const nextWorkspaceName = defaultWorkspaceName(identityName);
+          const nextWorkspaceName = defaultWorkspaceName(identityName, workDomain);
           setWorkspaceName(nextWorkspaceName);
           saveOnboardingDraft({ workspaceName: nextWorkspaceName });
           goTo("audience");
@@ -378,17 +385,17 @@ function SetupAssistant({
 
   const ensureOrganization = async (
     audienceForPod: Audience,
-    teamName = "",
     organizationOverride?: Organization | null,
   ): Promise<Organization | null> => {
     if (organizationOverride) return organizationOverride;
     if (activeOrganization) return activeOrganization;
 
+    // Team workspaces are user-owned identity and must be created or joined
+    // explicitly before a team pod can be created.
+    if (audienceForPod === "team") return null;
+
     const organization = await createOrganization.mutateAsync({
-      name:
-        audienceForPod === "personal"
-          ? personalWorkspaceName(identityName)
-          : teamWorkspaceName(teamName),
+      name: personalWorkspaceName(identityName),
       join_policy: OrganizationJoinPolicy.INVITE_ONLY,
       email_domain: null,
     });
@@ -430,7 +437,6 @@ function SetupAssistant({
       try {
         const organization = await ensureOrganization(
           audienceForPod,
-          teamName,
           organizationOverride,
         );
         if (!organization) {
@@ -478,7 +484,12 @@ function SetupAssistant({
     setSelectedRecipeId(startRecipesForAudience(value)[0]?.id ?? "");
 
     if (value === "team") {
-      goTo("team");
+      goTo(
+        nextTeamSetupStep({
+          hasOrganization: Boolean(activeOrganization),
+          hasPod: false,
+        }),
+      );
       return;
     }
 
@@ -493,13 +504,10 @@ function SetupAssistant({
       return;
     }
 
-    const nextWorkspaceName = teamWorkspaceName(teamName);
-    setWorkspaceName(nextWorkspaceName);
     saveOnboardingDraft({
       audience: "team",
       teamKind,
       customTeamName,
-      workspaceName: nextWorkspaceName,
     });
 
     if (!activeOrganization) {
@@ -508,7 +516,14 @@ function SetupAssistant({
     }
 
     const pod = await createBasePod("team", teamName, activeOrganization);
-    if (pod) goTo("connect");
+    if (pod) {
+      goTo(
+        nextTeamSetupStep({
+          hasOrganization: true,
+          hasPod: true,
+        }),
+      );
+    }
   };
 
   const handleJoinSuggested = async () => {
@@ -532,12 +547,12 @@ function SetupAssistant({
         return;
       }
 
-      const pod = await createBasePod(
-        "team",
-        resolveTeamName(),
-        organization,
+      goTo(
+        nextTeamSetupStep({
+          hasOrganization: true,
+          hasPod: false,
+        }),
       );
-      if (pod) goTo("connect");
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";
       toast.error(`Could not join workspace: ${message}`);
@@ -558,12 +573,12 @@ function SetupAssistant({
       setCreatedOrganization(organization);
       onOrganizationReady(organization);
       saveOnboardingDraft({ organizationId: organization.id });
-      const pod = await createBasePod(
-        "team",
-        resolveTeamName(),
-        organization,
+      goTo(
+        nextTeamSetupStep({
+          hasOrganization: true,
+          hasPod: false,
+        }),
       );
-      if (pod) goTo("connect");
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";
       toast.error(`Failed to create workspace: ${message}`);
@@ -578,10 +593,8 @@ function SetupAssistant({
 
     setIsConnectingAi(true);
     try {
-      const teamName = resolveTeamName();
       const organization = await ensureOrganization(
         audience ?? "personal",
-        teamName,
       );
       if (!organization) {
         toast.error("Could not prepare your workspace");

--- a/lemma-frontend/lib/pods/onboarding-steps.test.ts
+++ b/lemma-frontend/lib/pods/onboarding-steps.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  defaultWorkspaceName,
+  nextTeamSetupStep,
+  normalizeOnboardingStep,
+  podNameForAudience,
   previousOnboardingStep,
   resolveOnboardingStartStep,
   setupStepsForAudience,
 } from "@/components/onboarding/account-onboarding-helpers";
+import { workDomainFromEmail } from "@/lib/utils/organization-slugs";
 
 describe("onboarding step paths", () => {
   it("routes team onboarding through workspace selection", () => {
@@ -12,11 +17,56 @@ describe("onboarding step paths", () => {
       "boot",
       "identity",
       "audience",
-      "team",
       "workspace",
+      "team",
       "connect",
       "start",
     ]);
+  });
+
+  it("keeps workspace and team pod creation as separate transitions", () => {
+    expect(
+      nextTeamSetupStep({ hasOrganization: false, hasPod: false }),
+    ).toBe("workspace");
+    expect(
+      nextTeamSetupStep({ hasOrganization: true, hasPod: false }),
+    ).toBe("team");
+    expect(
+      nextTeamSetupStep({ hasOrganization: true, hasPod: true }),
+    ).toBe("connect");
+  });
+
+  it("uses the team label only for the pod name", () => {
+    expect(podNameForAudience("team", "Sales")).toBe("Sales Pod");
+  });
+
+  it("defaults team workspaces from non-public email domains", () => {
+    expect(
+      defaultWorkspaceName(
+        "Ada Lovelace",
+        workDomainFromEmail("ada@gappy.ai"),
+      ),
+    ).toBe("Gappy Workspace");
+    expect(
+      defaultWorkspaceName(
+        "Ada Lovelace",
+        workDomainFromEmail("ada@research.acme.co.uk"),
+      ),
+    ).toBe("Acme Workspace");
+  });
+
+  it("keeps the user-name fallback for public email providers", () => {
+    expect(
+      defaultWorkspaceName(
+        "Ada Lovelace",
+        workDomainFromEmail("ada@gmail.com"),
+      ),
+    ).toBe("Ada's Workspace");
+  });
+
+  it("moves old team-first drafts back to workspace setup", () => {
+    expect(normalizeOnboardingStep("team", "team", false)).toBe("workspace");
+    expect(normalizeOnboardingStep("team", "team", true)).toBe("team");
   });
 
   it("keeps personal onboarding workspace-free", () => {


### PR DESCRIPTION

## Summary

- Reorder team onboarding so users create or join their organization workspace before choosing a team pod.
- Separate workspace creation from pod creation: the workspace action now creates only the organization, while the team action creates the named pod.
- Use the team label only for the pod name, such as `Sales Pod`.
- Default workspace names from non-public email domains, such as `person@acme.com` → `Acme Workspace`.
- Retain the user-name fallback for public email providers such as Gmail and Outlook.
- Preserve the existing-organization shortcut and safely migrate saved drafts from the previous team-first ordering.
- Continue through the same Connect AI and starting-point journey used by personal onboarding after pod creation.

