### PR TITLE
Fix pgvector bootstrap for datastore search

### DIFF
--- a/lemma-backend/app/modules/datastore/services/search/postgres_search_service.py
+++ b/lemma-backend/app/modules/datastore/services/search/postgres_search_service.py
@@ -64,7 +64,20 @@ class PostgresSearchService:
                 text("SELECT pg_advisory_xact_lock(:key)"),
                 {"key": self._ENSURE_SCHEMA_LOCK_KEY},
             )
-            await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+            # Azure Database for PostgreSQL checks CREATE EXTENSION privileges
+            # even when IF NOT EXISTS would otherwise be a no-op. The runtime
+            # datastore role is intentionally not an azure_pg_admin member, so
+            # first check the database-scoped catalog and only attempt creation
+            # for self-hosted installations where the extension is absent.
+            vector_installed = await conn.scalar(
+                text(
+                    "SELECT EXISTS ("
+                    "SELECT 1 FROM pg_extension WHERE extname = 'vector'"
+                    ")"
+                )
+            )
+            if not vector_installed:
+                await conn.execute(text("CREATE EXTENSION vector"))
             await conn.execute(
                 text(f'CREATE SCHEMA IF NOT EXISTS "{self.schema_name}"')
             )

--- a/lemma-backend/app/modules/datastore/tests/unit/test_postgres_search_service.py
+++ b/lemma-backend/app/modules/datastore/tests/unit/test_postgres_search_service.py
@@ -52,6 +52,44 @@ def _obj(file_id, chunk_index: int, score: float = 1.0) -> DatastoreFileSearchRe
     )
 
 
+class _Transaction:
+    def __init__(self, connection):
+        self.connection = connection
+
+    async def __aenter__(self):
+        return self.connection
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class _Engine:
+    def __init__(self, connection):
+        self.connection = connection
+
+    def begin(self):
+        return _Transaction(self.connection)
+
+
+@pytest.mark.asyncio
+async def test_ensure_schema_does_not_recreate_installed_vector_extension():
+    connection = AsyncMock()
+    connection.scalar.return_value = True
+    service = PostgresSearchService(
+        uuid4(),
+        engine=_Engine(connection),
+        session_factory=object(),
+        embedder=_FakeEmbedder(),
+        reranker=NoopReranker(),
+    )
+
+    await service.ensure_schema()
+
+    statements = [str(call.args[0]) for call in connection.execute.await_args_list]
+    assert not any(statement.startswith("CREATE EXTENSION") for statement in statements)
+    connection.scalar.assert_awaited_once()
+
+
 def test_merge_ranked_results_combines_text_and_vector_ranks():
     service = _search_service()
     file_id = uuid4()


### PR DESCRIPTION
Many postgres such as Azure PostgreSQL checks CREATE EXTENSION privileges even when IF NOT EXISTS would be a no-op. Query pg_extension first so the least-privilege datastore role skips CREATE when vector is already installed. Adds focused regression coverage; 9 datastore search tests pass locally.