### PR TITLE
Fix agent-scoped conversation loading

### DIFF
--- a/lemma-frontend/app/pod/[id]/conversations/[conversationId]/page.tsx
+++ b/lemma-frontend/app/pod/[id]/conversations/[conversationId]/page.tsx
@@ -17,7 +17,12 @@ import { usePod } from '@/lib/hooks/use-pods';
 import { usePodAccess } from '@/lib/hooks/use-pod-access';
 import type { AgentRuntimeConfig } from '@/lib/types';
 import { cn } from '@/lib/utils';
-import { getConversationStatusView, type ConversationStatusView } from '@/lib/utils/conversations';
+import {
+    buildPodConversationHref,
+    buildPodConversationsHref,
+    getConversationStatusView,
+    type ConversationStatusView,
+} from '@/lib/utils/conversations';
 
 function ConversationStatusPill({ statusView }: { statusView: ConversationStatusView }) {
     if (statusView.state === 'unknown' || statusView.state === 'completed') return null;
@@ -92,6 +97,7 @@ export default function PodConversationPage({
         sendMessage,
     } = assistant;
     const assistantMessage = searchParams.get('assistantMessage');
+    const scopedAgentName = searchParams.get('agent');
     const conversationInstructions = searchParams.get('conversationInstructions');
     const conversationMetadata = useMemo(
         () => parseConversationMetadata(searchParams.get('conversationMetadata')),
@@ -159,8 +165,8 @@ export default function PodConversationPage({
         if (assistantMessage) return;
         if (!isNewConversation || !activeConversationId) return;
         if (activeConversationId === ignoredConversationIdAfterNewRef.current) return;
-        router.replace(`/pod/${podId}/conversations/${encodeURIComponent(activeConversationId)}`);
-    }, [activeConversationId, assistantMessage, isNewConversation, podId, router]);
+        router.replace(buildPodConversationHref(podId, activeConversationId, scopedAgentName));
+    }, [activeConversationId, assistantMessage, isNewConversation, podId, router, scopedAgentName]);
 
     useEffect(() => {
         if (!isNewConversation || !assistantMessage || !isReady) return;
@@ -198,7 +204,7 @@ export default function PodConversationPage({
     }, [assistantMessage, clearMessages, closeAssistant, conversationInstructions, conversationMetadata, isNewConversation, isReady, podId, router, searchParams, sendMessage]);
 
     const startNewConversation = () => {
-        router.push(`/pod/${podId}/conversations/new`);
+        router.push(buildPodConversationHref(podId, 'new', scopedAgentName));
     };
 
     return (
@@ -218,7 +224,7 @@ export default function PodConversationPage({
                             </button>
                         ) : null}
                         <Link
-                            href={`/pod/${podId}/conversations`}
+                            href={buildPodConversationsHref(podId, scopedAgentName)}
                             className="custom-focus-ring inline-flex h-8 shrink-0 items-center gap-1 rounded-md px-1.5 leading-none text-[var(--text-tertiary)] transition-colors hover:bg-[var(--surface-2)] hover:text-[var(--text-primary)]"
                         >
                             <ArrowLeft className="h-3.5 w-3.5" strokeWidth={1.8} />

--- a/lemma-frontend/app/pod/[id]/layout.tsx
+++ b/lemma-frontend/app/pod/[id]/layout.tsx
@@ -23,9 +23,12 @@ import { getLemmaClient } from "@/lib/sdk/lemma-client";
 import { usePod } from "@/lib/hooks/use-pods";
 import { usePodContext } from "@/lib/hooks/use-pod-context";
 import { usePodAccess } from "@/lib/hooks/use-pod-access";
+import { useAgents } from "@/lib/hooks/use-agents";
+import { useConversation } from "@/lib/hooks/use-assistants";
 import { clearLastOpenedPodId, writeLastOpenedPodId } from "@/lib/pods/last-opened-pod";
 import type { PodRoutePolicyKey } from "@/lib/authz/pod-permissions";
 import { cn } from "@/lib/utils";
+import { findConversationAgentName, getConversationRouteId } from "@/lib/utils/conversations";
 import type { Pod } from "@/lib/types";
 import type { PodContext } from "@/lib/types/ai";
 
@@ -783,14 +786,33 @@ function PodAssistantScope({
     const [shouldLoadPodContext, setShouldLoadPodContext] = useState(false);
     const { context: loadedPodContext } = usePodContext(pod.id, { enabled: shouldLoadPodContext });
     const pathname = usePathname();
+    const router = useRouter();
     const searchParams = useSearchParams();
-    // A conversation route may name the agent it targets via `?agent=`, so the
-    // "message this agent" composer starts a chat scoped to that agent rather than
-    // the pod default. Only applies on conversation routes; absent elsewhere.
-    const scopedAgentName = useMemo(() => {
+    // Agent-scoped links carry `?agent=` for a fast handoff. Direct/bookmarked
+    // conversation URLs recover the scope from the conversation's agent id and
+    // canonicalize the URL before mounting the assistant controller.
+    const explicitAgentName = useMemo(() => {
         if (!/\/conversations(?:\/|$)/.test(pathname)) return null;
         return searchParams.get("agent");
     }, [pathname, searchParams]);
+    const routeConversationId = useMemo(() => getConversationRouteId(pathname), [pathname]);
+    const shouldResolveConversationAgent = Boolean(routeConversationId && !explicitAgentName);
+    const routeConversationQuery = useConversation(
+        shouldResolveConversationAgent ? pod.id : "",
+        shouldResolveConversationAgent ? routeConversationId || "" : "",
+    );
+    const routeConversationAgentId = routeConversationQuery.data?.agent_id;
+    const shouldLoadConversationAgents = shouldResolveConversationAgent && Boolean(routeConversationAgentId);
+    const routeAgentsQuery = useAgents(shouldLoadConversationAgents ? pod.id : undefined);
+    const inferredAgentName = useMemo(
+        () => findConversationAgentName(routeConversationAgentId, routeAgentsQuery.data?.items),
+        [routeAgentsQuery.data?.items, routeConversationAgentId],
+    );
+    const scopedAgentName = explicitAgentName || inferredAgentName;
+    const isResolvingConversationAgent = shouldResolveConversationAgent && (
+        routeConversationQuery.isLoading
+        || (Boolean(routeConversationAgentId) && routeAgentsQuery.isLoading)
+    );
     const conversationScopeOverride = useMemo(
         () => (scopedAgentName ? { agentName: scopedAgentName } : undefined),
         [scopedAgentName],
@@ -804,6 +826,18 @@ function PodAssistantScope({
         appPages: [],
         connectedAccounts: [],
     }), [pod]);
+
+    useEffect(() => {
+        if (explicitAgentName || !inferredAgentName || !routeConversationId) return;
+
+        const nextSearchParams = new URLSearchParams(searchParams.toString());
+        nextSearchParams.set("agent", inferredAgentName);
+        router.replace(`${pathname}?${nextSearchParams.toString()}`, { scroll: false });
+    }, [explicitAgentName, inferredAgentName, pathname, routeConversationId, router, searchParams]);
+
+    if (isResolvingConversationAgent) {
+        return <PageLoader />;
+    }
 
     return (
         <AIAssistantProvider

--- a/lemma-frontend/components/pod/resource-automation.tsx
+++ b/lemma-frontend/components/pod/resource-automation.tsx
@@ -30,6 +30,7 @@ import { formatAgentName } from '@/lib/utils/agents';
 import { ScheduleType, type Schedule } from '@/lib/types';
 import type { AssistantSurface } from '@/lib/types';
 import { cn } from '@/lib/utils';
+import { buildPodConversationHref } from '@/lib/utils/conversations';
 
 // ---------------------------------------------------------------------------
 // Layout wrapper — a scrollable, centered pane for detail-page automation tabs.
@@ -431,7 +432,7 @@ export function RecentConversations({
                     return (
                         <Link
                             key={conversation.id}
-                            href={`/pod/${podId}/conversations/${conversation.id}`}
+                            href={buildPodConversationHref(podId, conversation.id, agentName)}
                             className="lemma-index-row group flex items-center gap-2.5"
                         >
                             <MessageCircle className="h-3.5 w-3.5 shrink-0 text-[var(--text-tertiary)]" aria-hidden />

--- a/lemma-frontend/components/pod/start-conversation-button.tsx
+++ b/lemma-frontend/components/pod/start-conversation-button.tsx
@@ -5,6 +5,7 @@ import { MessageSquarePlus } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { buildPodConversationHref } from '@/lib/utils/conversations';
 
 // Opens the pod's new-conversation composer, optionally scoped to a specific
 // agent via `?agent=` (the pod layout reads it and scopes the assistant). No
@@ -29,8 +30,7 @@ export function StartConversationButton({
     const router = useRouter();
 
     const start = () => {
-        const query = agentName ? `?agent=${encodeURIComponent(agentName)}` : '';
-        router.push(`/pod/${podId}/conversations/new${query}`);
+        router.push(buildPodConversationHref(podId, 'new', agentName));
     };
 
     return (

--- a/lemma-frontend/lib/utils/__tests__/conversations.test.ts
+++ b/lemma-frontend/lib/utils/__tests__/conversations.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    buildPodConversationHref,
+    buildPodConversationsHref,
+    findConversationAgentName,
+    getConversationRouteId,
+} from '../conversations';
+
+describe('conversation route helpers', () => {
+    it('preserves an agent scope on list, existing, and new conversation routes', () => {
+        expect(buildPodConversationsHref('pod-1', 'research agent')).toBe(
+            '/pod/pod-1/conversations?agent=research+agent',
+        );
+        expect(buildPodConversationHref('pod-1', 'conversation-1', 'research agent')).toBe(
+            '/pod/pod-1/conversations/conversation-1?agent=research+agent',
+        );
+        expect(buildPodConversationHref('pod-1', 'new', 'research agent')).toBe(
+            '/pod/pod-1/conversations/new?agent=research+agent',
+        );
+    });
+
+    it('keeps pod-default conversation routes free of agent query parameters', () => {
+        expect(buildPodConversationsHref('pod-1')).toBe('/pod/pod-1/conversations');
+        expect(buildPodConversationHref('pod-1', 'conversation-1')).toBe(
+            '/pod/pod-1/conversations/conversation-1',
+        );
+    });
+
+    it('extracts only existing conversation ids from pod conversation routes', () => {
+        expect(getConversationRouteId('/pod/pod-1/conversations/conversation%201')).toBe('conversation 1');
+        expect(getConversationRouteId('/pod/pod-1/conversations/new')).toBeNull();
+        expect(getConversationRouteId('/pod/pod-1/conversations')).toBeNull();
+        expect(getConversationRouteId('/pod/pod-1/agents/king')).toBeNull();
+    });
+
+    it('maps a conversation agent id back to the agent name used for controller scope', () => {
+        const agents = [
+            { id: 'agent-1', name: 'writer' },
+            { id: 'agent-2', name: 'king' },
+        ];
+
+        expect(findConversationAgentName('agent-2', agents)).toBe('king');
+        expect(findConversationAgentName('deleted-agent', agents)).toBeNull();
+        expect(findConversationAgentName(null, agents)).toBeNull();
+    });
+});

--- a/lemma-frontend/lib/utils/conversations.ts
+++ b/lemma-frontend/lib/utils/conversations.ts
@@ -4,6 +4,47 @@ export function normalizeConversationStatus(status: unknown): string {
         : '';
 }
 
+function appendAgentScope(href: string, agentName?: string | null): string {
+    const normalizedAgentName = agentName?.trim();
+    if (!normalizedAgentName) return href;
+
+    const params = new URLSearchParams({ agent: normalizedAgentName });
+    return `${href}?${params.toString()}`;
+}
+
+export function buildPodConversationsHref(podId: string, agentName?: string | null): string {
+    return appendAgentScope(`/pod/${encodeURIComponent(podId)}/conversations`, agentName);
+}
+
+export function buildPodConversationHref(
+    podId: string,
+    conversationId: string,
+    agentName?: string | null,
+): string {
+    const href = `/pod/${encodeURIComponent(podId)}/conversations/${encodeURIComponent(conversationId)}`;
+    return appendAgentScope(href, agentName);
+}
+
+export function getConversationRouteId(pathname: string): string | null {
+    const match = /^\/pod\/[^/]+\/conversations\/([^/]+)\/?$/.exec(pathname);
+    if (!match?.[1]) return null;
+
+    try {
+        const conversationId = decodeURIComponent(match[1]);
+        return conversationId === 'new' ? null : conversationId;
+    } catch {
+        return match[1] === 'new' ? null : match[1];
+    }
+}
+
+export function findConversationAgentName(
+    agentId: string | null | undefined,
+    agents: Array<{ id?: string | null; name?: string | null }> | null | undefined,
+): string | null {
+    if (!agentId || !agents) return null;
+    return agents.find((agent) => agent.id === agentId)?.name?.trim() || null;
+}
+
 export type ConversationStatusState = 'running' | 'stopping' | 'waiting' | 'completed' | 'failed' | 'stopped' | 'unknown';
 export type ConversationStatusTone = 'live' | 'warning' | 'neutral' | 'danger' | 'muted';
 


### PR DESCRIPTION
## Summary

- preserve agent scope when navigating from an agent page into recent or new conversations
- recover the owning agent for direct or bookmarked conversation URLs that omit the agent query parameter
- canonicalize recovered conversation URLs and keep new/back navigation inside the same agent scope
- add focused tests for route construction, route parsing, and agent lookup

## Verification

- npm --prefix lemma-frontend test -- lib/utils/__tests__/conversations.test.ts
- npm --prefix lemma-frontend test (54 tests)
- npm --prefix lemma-frontend run typecheck
- npm --prefix lemma-frontend run check
- git diff --check

## Reproduction

Opening an agent conversation from its Recent conversations list previously omitted the agent scope. The assistant provider then mounted with the pod default agent while the page waited for the requested conversation, leaving the route on Loading conversation. Scoped links now preserve the agent, while direct links infer it from the conversation record.