### PR TITLE
Fix AgentBox runtime home for cloud sandbox UIDs

### DIFF
--- a/agentbox/scripts/start-browser.sh
+++ b/agentbox/scripts/start-browser.sh
@@ -12,11 +12,18 @@ EXECUTABLE_PATH="${AGENT_BROWSER_EXECUTABLE_PATH:-/usr/local/bin/workspace-chrom
 DISPLAY_NUMBER="${DISPLAY_VALUE#:}"
 DISPLAY_NUMBER="${DISPLAY_NUMBER%%.*}"
 HOME_DIR="${HOME:-/home/appuser}"
-if [ ! -w "$HOME_DIR" ]; then
-  HOME_DIR="/home/appuser"
+if ! mkdir -p "$HOME_DIR" 2>/dev/null || [ ! -w "$HOME_DIR" ]; then
+  HOME_DIR="/tmp/agentbox-home-${UID:-10001}"
+  mkdir -p "$HOME_DIR"
+fi
+NPM_CACHE_DIR="${NPM_CONFIG_CACHE:-$HOME_DIR/.npm}"
+if ! mkdir -p "$NPM_CACHE_DIR" 2>/dev/null || [ ! -w "$NPM_CACHE_DIR" ]; then
+  NPM_CACHE_DIR="/tmp/agentbox-npm-${UID:-10001}"
+  mkdir -p "$NPM_CACHE_DIR"
 fi
 
 export HOME="$HOME_DIR"
+export NPM_CONFIG_CACHE="$NPM_CACHE_DIR"
 export DISPLAY="$DISPLAY_VALUE"
 export AGENT_BROWSER_HEADED="${AGENT_BROWSER_HEADED:-true}"
 export AGENT_BROWSER_PROFILE="$PROFILE_DIR"

--- a/agentbox/scripts/start-runtime.sh
+++ b/agentbox/scripts/start-runtime.sh
@@ -14,11 +14,21 @@ DISPLAY_NUMBER="${DISPLAY_VALUE#:}"
 DISPLAY_NUMBER="${DISPLAY_NUMBER%%.*}"
 HOME_DIR="${HOME:-/home/appuser}"
 
-if [ ! -w "$HOME_DIR" ]; then
-  HOME_DIR="/home/appuser"
+if ! mkdir -p "$HOME_DIR" 2>/dev/null || [ ! -w "$HOME_DIR" ]; then
+  # Cloud sandbox providers can preserve the image's numeric ownership while
+  # running commands as their own unprivileged UID. Keep caches and user-level
+  # installs compute-ephemeral when the image-owned home is not writable.
+  HOME_DIR="/tmp/agentbox-home-${UID:-10001}"
+  mkdir -p "$HOME_DIR"
+fi
+NPM_CACHE_DIR="${NPM_CONFIG_CACHE:-$HOME_DIR/.npm}"
+if ! mkdir -p "$NPM_CACHE_DIR" 2>/dev/null || [ ! -w "$NPM_CACHE_DIR" ]; then
+  NPM_CACHE_DIR="/tmp/agentbox-npm-${UID:-10001}"
+  mkdir -p "$NPM_CACHE_DIR"
 fi
 
 export HOME="$HOME_DIR"
+export NPM_CONFIG_CACHE="$NPM_CACHE_DIR"
 export DISPLAY="$DISPLAY_VALUE"
 export AGENT_BROWSER_HEADED="${AGENT_BROWSER_HEADED:-true}"
 export AGENT_BROWSER_PROFILE="$PROFILE_DIR"

--- a/agentbox/tests/test_workspace_contract.py
+++ b/agentbox/tests/test_workspace_contract.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 
 AGENTBOX_ROOT = Path(__file__).resolve().parents[1]
 
@@ -28,3 +30,13 @@ def test_runtime_start_clears_ephemeral_and_legacy_browser_state() -> None:
     assert "unset AGENT_BROWSER_SESSION_NAME" in script
     assert 'rm -rf -- "$HOME_DIR/.agent-browser" /workspace/.browser-profile' in script
     assert "rm -f -- /workspace/agent-browser.json" in script
+
+
+@pytest.mark.parametrize("name", ["start-runtime.sh", "start-browser.sh"])
+def test_runtime_scripts_fall_back_from_an_unwritable_home(name: str) -> None:
+    script = (AGENTBOX_ROOT / "scripts" / name).read_text()
+
+    assert 'HOME_DIR="/tmp/agentbox-home-${UID:-10001}"' in script
+    assert 'NPM_CACHE_DIR="/tmp/agentbox-npm-${UID:-10001}"' in script
+    assert 'export HOME="$HOME_DIR"' in script
+    assert 'export NPM_CONFIG_CACHE="$NPM_CACHE_DIR"' in script


### PR DESCRIPTION
## Summary
- fall back to a private writable `/tmp/agentbox-home-$UID` when a cloud provider runs the OCI image under a UID that cannot write `/home/appuser`
- give npm a writable compute-ephemeral cache with the same guarded fallback
- apply the contract consistently to runtime and standalone browser startup

`/workspace` and its conversation CWD contract are unchanged.

## Why
The real E2B OCI smoke reached healthy runtime/function services but ordinary `npm install react react-dom` failed because E2B’s effective command UID could not write `/home/appuser/.npm`. This then caused the React/Vite build to fail.

## Validation
- `uv run pytest -q tests/test_workspace_contract.py` (4 passed)
- `bash -n agentbox/scripts/start-runtime.sh agentbox/scripts/start-browser.sh`
- `git diff --check`