### PR TITLE
fix(agentbox): harden E2B lifecycle readiness

### DIFF
--- a/agentbox/agentbox/providers/e2b.py
+++ b/agentbox/agentbox/providers/e2b.py
@@ -751,9 +751,49 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
         sandbox = await self._connect(sandbox_id, resume=True)
         if sandbox is None:
             raise SandboxNotFoundError(sandbox_id)
-        await self._bootstrap_sandbox(sandbox, request.env)
+        sandbox = await self._bootstrap_sandbox(sandbox_id, sandbox, request.env)
+        self._sandboxes[sandbox_id] = sandbox
 
-    async def _bootstrap_sandbox(self, sandbox, env: dict[str, str]) -> None:
+    async def _reconnect_bootstrap_generation(self, sandbox_id: str, sandbox):
+        """Refresh SDK data-plane credentials for one fenced generation."""
+
+        info = self._known_infos.get(sandbox_id)
+        provider_id = str(getattr(sandbox, "sandbox_id", ""))
+        if info is None or not provider_id or info.provider_id != provider_id:
+            raise ProviderError(
+                "E2B bootstrap lost its durable provider generation",
+                code="provider_identity_mismatch",
+                retryable=False,
+                status_code=409,
+            )
+        refreshed = await self._with_rate_limit_retry(
+            lambda: self._sdk.sandbox_cls.connect(
+                provider_id,
+                timeout=self.config.timeout_seconds,
+                **self._api_options(),
+            )
+        )
+        self._sandboxes[sandbox_id] = refreshed
+        self._known_infos[sandbox_id] = _E2BManagedInfo(
+            provider_id=provider_id,
+            metadata=info.metadata,
+            state="running",
+        )
+        self._lease_renewed_at[sandbox_id] = self._clock()
+        self.invalidate_endpoint_cache(sandbox_id)
+        logger.info(
+            "agentbox_e2b_bootstrap_reconnected sandbox_id=%s provider_id=%s",
+            sandbox_id,
+            provider_id,
+        )
+        return refreshed
+
+    async def _bootstrap_sandbox(
+        self,
+        sandbox_id: str,
+        sandbox,
+        env: dict[str, str],
+    ):
         """Start the runtime after create-time env exists in the sandbox.
 
         E2B template start commands run during the build snapshot and cannot
@@ -763,6 +803,7 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
         """
 
         deadline = self._clock() + self.config.runtime_bootstrap_timeout_seconds
+        next_route_refresh_at = self._clock() + 1.0
         runtime_started = False
         health_command = (
             'python -c "import urllib.request; '
@@ -800,7 +841,10 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
                                     "PYTHONPATH": self.config.runtime_pythonpath,
                                 },
                                 user=self.config.runtime_user,
-                                timeout=(self.config.runtime_bootstrap_timeout_seconds),
+                                # Keep the background command connection valid
+                                # for the sandbox lease. The shorter bootstrap
+                                # deadline below only bounds readiness checks.
+                                timeout=self.config.timeout_seconds,
                             )
                         )
                     runtime_started = True
@@ -823,13 +867,44 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
                     continue
 
                 if await self._public_runtime_ready(sandbox):
-                    return
+                    return sandbox
+                # Local health with a missing public route can mean the
+                # resumed SDK object still carries stale routing credentials.
+                # Refresh at most once per second and only by exact provider
+                # ID; do not inventory or create another generation.
+                if self._clock() >= next_route_refresh_at:
+                    try:
+                        sandbox = await self._reconnect_bootstrap_generation(
+                            sandbox_id, sandbox
+                        )
+                    except (
+                        self._sdk.not_found_error,
+                        self._sdk.sandbox_error,
+                    ) as reconnect_error:
+                        last_error = reconnect_error
+                    else:
+                        runtime_started = False
+                    next_route_refresh_at = self._clock() + 1.0
             except (self._sdk.not_found_error, self._sdk.sandbox_error) as exc:
                 # E2B currently reports the same early data-plane propagation
                 # race as either SandboxNotFoundException or TimeoutException
-                # (both provider sandbox errors). Retry only within the
-                # configured readiness budget and fail closed below.
+                # (both provider sandbox errors). A resumed SDK object can
+                # retain stale command/route tokens, so reconnect only the
+                # already fenced provider generation before retrying. Never
+                # inventory by logical ID and never create a replacement here.
                 last_error = exc
+                try:
+                    sandbox = await self._reconnect_bootstrap_generation(
+                        sandbox_id, sandbox
+                    )
+                except (
+                    self._sdk.not_found_error,
+                    self._sdk.sandbox_error,
+                ) as reconnect_error:
+                    last_error = reconnect_error
+                else:
+                    runtime_started = False
+                next_route_refresh_at = self._clock() + 1.0
             await self._sleep(0.25)
         raise ProviderError(
             "E2B runtime did not become ready inside the sandbox",
@@ -844,6 +919,7 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
         token = getattr(sandbox, "traffic_access_token", None)
         if not token:
             return False
+
         def check_public_endpoint() -> bool:
             for port in (8080, 8090):
                 public_request = urlrequest.Request(
@@ -1148,11 +1224,9 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
             while True:
                 try:
                     running = bool(await current.is_running())
-                    # A successful false response is STOPPED unless the
-                    # authenticated data plane proves this is another E2B
-                    # propagation race. The bounded retry budget remains only
-                    # for NotFound/Timeout exceptions.
-                    if not running and await self._public_runtime_ready(current):
+                    if running:
+                        break
+                    if await self._public_runtime_ready(current):
                         running = True
                         logger.warning(
                             "agentbox_e2b_status_false_data_plane_override "
@@ -1160,7 +1234,16 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
                             sandbox_id,
                             getattr(current, "sandbox_id", None),
                         )
-                    break
+                        break
+                    # E2B can transiently return a successful `false` for a
+                    # running generation while both public routes propagate.
+                    # Require the whole bounded observation window before
+                    # converting a cached known-running generation to paused.
+                    # Explicit release already removes the cache and records
+                    # the generation as paused, so status remains non-resuming.
+                    if self._clock() >= deadline:
+                        break
+                    await self._sleep(random.uniform(0.05, 0.2))
                 except (self._sdk.not_found_error, self._sdk.sandbox_error) as exc:
                     last_error = exc
                     if await self._public_runtime_ready(current):

--- a/agentbox/tests/test_cloud_provider_contract.py
+++ b/agentbox/tests/test_cloud_provider_contract.py
@@ -54,10 +54,7 @@ def _healthy_urlopen(req, **kwargs):
     del kwargs
     url = str(getattr(req, "full_url", req))
     if "e2b.test" in url and not any(
-        any(
-            f"{provider_id}-{port}.e2b.test" in url
-            for port in (8080, 8090)
-        )
+        any(f"{provider_id}-{port}.e2b.test" in url for port in (8080, 8090))
         and sandbox.running
         for provider_id, sandbox in _E2BSandbox.instances.items()
     ):
@@ -199,6 +196,9 @@ class _E2BSandbox:
             raise _NotFound from exc
         sandbox.running = True
         sandbox.commands = _FakeCommands()
+        sandbox.traffic_access_token = (
+            f"token-{provider_id}-connected-{cls.connect_count}"
+        )
         cls.infos[provider_id].state = "running"
         return sandbox
 
@@ -405,6 +405,7 @@ def test_e2b_contract_is_idempotent_and_refreshes_endpoint_token() -> None:
         "PYTHONPATH": "/app",
     }
     assert sandbox.commands.run_calls[0]["user"] == "appuser"
+    assert sandbox.commands.run_calls[0]["timeout"] == 3600
     assert all("urlopen" in call["cmd"] for call in sandbox.commands.run_calls[1:])
     assert (
         endpoint_one.headers["e2b-traffic-access-token"]
@@ -611,6 +612,52 @@ def test_e2b_bootstrap_retries_transient_commands_data_plane() -> None:
     assert status.ready is True
     sandbox = next(iter(_E2BSandbox.instances.values()))
     assert sandbox.commands.list_failures == 0
+    assert _E2BSandbox.connect_count == 1
+
+
+def test_e2b_bootstrap_reconnects_only_the_exact_provider_generation() -> None:
+    provider = _e2b_provider_with(runtime_bootstrap_timeout_seconds=1)
+    _E2BSandbox.bootstrap_list_failures = 1
+
+    request = SandboxEnsureRequest()
+    asyncio.run(provider.create("sandbox-1", request))
+    provider_id = provider._known_infos["sandbox-1"].provider_id
+    asyncio.run(provider.bootstrap("sandbox-1", request))
+
+    assert _E2BSandbox.connect_count == 1
+    assert _E2BSandbox.create_count == 1
+    assert set(_E2BSandbox.instances) == {provider_id}
+    assert provider._sandboxes["sandbox-1"].sandbox_id == provider_id
+
+
+def test_e2b_bootstrap_refreshes_stale_public_route_credentials() -> None:
+    def stale_until_reconnect(req, **kwargs):
+        del kwargs
+        token = dict(req.header_items()).get("E2b-traffic-access-token", "")
+        if "-connected-" not in token:
+            raise urlerror.HTTPError(
+                str(getattr(req, "full_url", req)),
+                502,
+                "sandbox not found",
+                {},
+                None,
+            )
+        return _HealthResponse()
+
+    provider = _e2b_provider_with(
+        urlopen=stale_until_reconnect,
+        runtime_bootstrap_timeout_seconds=3,
+    )
+    request = SandboxEnsureRequest()
+    asyncio.run(provider.create("sandbox-1", request))
+    provider_id = provider._known_infos["sandbox-1"].provider_id
+
+    asyncio.run(provider.bootstrap("sandbox-1", request))
+
+    assert _E2BSandbox.connect_count == 1
+    assert _E2BSandbox.create_count == 1
+    assert set(_E2BSandbox.instances) == {provider_id}
+    assert "-connected-" in provider._sandboxes["sandbox-1"].traffic_access_token
 
 
 def test_e2b_bootstrap_fails_closed_when_commands_data_plane_never_arrives() -> None:
@@ -707,6 +754,40 @@ def test_e2b_status_uses_data_plane_when_control_plane_temporarily_says_stopped(
 
     assert status.ready is True
     assert status.status == "RUNNING"
+
+
+def test_e2b_status_retries_transient_false_without_pausing_generation() -> None:
+    public_failures = 2
+
+    def delayed_gateway(req, **kwargs):
+        nonlocal public_failures
+        del kwargs
+        if public_failures:
+            public_failures -= 1
+            raise urlerror.HTTPError(
+                str(getattr(req, "full_url", req)),
+                502,
+                "sandbox not found",
+                {},
+                None,
+            )
+        return _healthy_urlopen(req)
+
+    provider = _e2b_provider_with(
+        status_retry_seconds=1,
+        urlopen=delayed_gateway,
+    )
+    asyncio.run(provider.create("sandbox-1", SandboxEnsureRequest()))
+    provider_id = provider._known_infos["sandbox-1"].provider_id
+    _E2BSandbox.status_false_failures = 2
+
+    status = asyncio.run(provider.get_status("sandbox-1"))
+
+    assert status.ready is True
+    assert provider._known_infos["sandbox-1"].state == "running"
+    assert provider._sandboxes["sandbox-1"].sandbox_id == provider_id
+    assert _E2BSandbox.connect_count == 0
+    assert _E2BSandbox.pause_count == 0
 
 
 def test_e2b_status_fails_when_control_and_data_planes_are_unavailable() -> None:
@@ -880,9 +961,7 @@ def test_e2b_exact_purge_converges_when_provider_id_is_already_absent() -> None:
     _E2BSandbox.instances.pop(provider_id)
     _E2BSandbox.infos.pop(provider_id)
 
-    deleted = asyncio.run(
-        provider.purge_managed(SandboxRef("sandbox-1", provider_id))
-    )
+    deleted = asyncio.run(provider.purge_managed(SandboxRef("sandbox-1", provider_id)))
 
     assert deleted is True
     assert "sandbox-1" not in provider._known_infos
@@ -1047,8 +1126,8 @@ def test_e2b_provider_rate_limit_without_header_uses_short_backoff(
 def test_e2b_bootstrap_failure_is_separate_from_compute_create() -> None:
     provider = _e2b_provider_with(max_active=1)
 
-    async def fail_bootstrap(sandbox, env):
-        del sandbox, env
+    async def fail_bootstrap(sandbox_id, sandbox, env):
+        del sandbox_id, sandbox, env
         raise RuntimeError("bootstrap failed")
 
     provider._bootstrap_sandbox = fail_bootstrap  # type: ignore[method-assign]
@@ -1278,9 +1357,7 @@ def test_daytona_exact_purge_converges_when_provider_id_is_already_absent() -> N
     client.sandboxes.pop(provider_id)
     provider.invalidate_sandbox_cache("sandbox-1")
 
-    deleted = asyncio.run(
-        provider.purge_managed(SandboxRef("sandbox-1", provider_id))
-    )
+    deleted = asyncio.run(provider.purge_managed(SandboxRef("sandbox-1", provider_id)))
 
     assert deleted is True
     assert "sandbox-1" not in provider._sandboxes


### PR DESCRIPTION
## Summary
- confirm transient false E2B status responses across the bounded retry window before marking a known-running sandbox paused
- reconnect only the already-fenced provider ID when resume/bootstrap command or public-route credentials are stale
- keep the runtime command connection aligned with the sandbox lease instead of the shorter bootstrap readiness budget
- preserve explicit pause/delete behavior and prevent replacement sandbox creation during recovery

## Validation
- `uv run pytest -q tests/test_cloud_provider_contract.py -k e2b` — 51 passed
- `uv run python -m pytest -q tests -m "not e2e"` — 240 passed, 1 skipped
- AgentBox client — 8 passed
- Ruff check/format clean for changed files

## Live failure addressed
The dev E2B release smoke reached runtime, function executor, React/Vite, browser, and callback health, but later saw transient `is_running() == false` and resume bootstrap `sandbox not found` while retaining the same durable E2B generation. This change treats those as bounded exact-generation recovery events; it never falls back to logical-ID inventory or replacement creation.