### PR TITLE
fix(agentbox): use E2B native authenticated routing

### DIFF
--- a/agentbox/agentbox/providers/e2b.py
+++ b/agentbox/agentbox/providers/e2b.py
@@ -10,6 +10,8 @@ from typing import Any
 from urllib import error as urlerror
 from urllib import request as urlrequest
 
+import httpx
+
 from agentbox.apps import SANDBOX_APPS, SandboxAppSpec
 from agentbox.schemas import (
     SandboxEnsureRequest,
@@ -230,23 +232,6 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
                 await self._sleep(delay)
                 fallback_delay = min(fallback_delay * 2, 8)
         raise RuntimeError("unreachable")
-
-    @staticmethod
-    def _network_policy() -> dict[str, object]:
-        return {
-            "allow_public_traffic": False,
-            "deny_out": [
-                "127.0.0.0/8",
-                "10.0.0.0/8",
-                "100.64.0.0/10",
-                "169.254.0.0/16",
-                "172.16.0.0/12",
-                "192.168.0.0/16",
-                "::1/128",
-                "fc00::/7",
-                "fe80::/10",
-            ],
-        }
 
     async def _list(self, metadata: dict[str, str]):
         async with self._list_lock:
@@ -754,40 +739,6 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
         sandbox = await self._bootstrap_sandbox(sandbox_id, sandbox, request.env)
         self._sandboxes[sandbox_id] = sandbox
 
-    async def _reconnect_bootstrap_generation(self, sandbox_id: str, sandbox):
-        """Refresh SDK data-plane credentials for one fenced generation."""
-
-        info = self._known_infos.get(sandbox_id)
-        provider_id = str(getattr(sandbox, "sandbox_id", ""))
-        if info is None or not provider_id or info.provider_id != provider_id:
-            raise ProviderError(
-                "E2B bootstrap lost its durable provider generation",
-                code="provider_identity_mismatch",
-                retryable=False,
-                status_code=409,
-            )
-        refreshed = await self._with_rate_limit_retry(
-            lambda: self._sdk.sandbox_cls.connect(
-                provider_id,
-                timeout=self.config.timeout_seconds,
-                **self._api_options(),
-            )
-        )
-        self._sandboxes[sandbox_id] = refreshed
-        self._known_infos[sandbox_id] = _E2BManagedInfo(
-            provider_id=provider_id,
-            metadata=info.metadata,
-            state="running",
-        )
-        self._lease_renewed_at[sandbox_id] = self._clock()
-        self.invalidate_endpoint_cache(sandbox_id)
-        logger.info(
-            "agentbox_e2b_bootstrap_reconnected sandbox_id=%s provider_id=%s",
-            sandbox_id,
-            provider_id,
-        )
-        return refreshed
-
     async def _bootstrap_sandbox(
         self,
         sandbox_id: str,
@@ -803,7 +754,7 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
         """
 
         deadline = self._clock() + self.config.runtime_bootstrap_timeout_seconds
-        next_route_refresh_at = self._clock() + 1.0
+        del sandbox_id
         runtime_started = False
         health_command = (
             'python -c "import urllib.request; '
@@ -868,43 +819,16 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
 
                 if await self._public_runtime_ready(sandbox):
                     return sandbox
-                # Local health with a missing public route can mean the
-                # resumed SDK object still carries stale routing credentials.
-                # Refresh at most once per second and only by exact provider
-                # ID; do not inventory or create another generation.
-                if self._clock() >= next_route_refresh_at:
-                    try:
-                        sandbox = await self._reconnect_bootstrap_generation(
-                            sandbox_id, sandbox
-                        )
-                    except (
-                        self._sdk.not_found_error,
-                        self._sdk.sandbox_error,
-                    ) as reconnect_error:
-                        last_error = reconnect_error
-                    else:
-                        runtime_started = False
-                    next_route_refresh_at = self._clock() + 1.0
-            except (self._sdk.not_found_error, self._sdk.sandbox_error) as exc:
-                # E2B currently reports the same early data-plane propagation
-                # race as either SandboxNotFoundException or TimeoutException
-                # (both provider sandbox errors). A resumed SDK object can
-                # retain stale command/route tokens, so reconnect only the
-                # already fenced provider generation before retrying. Never
-                # inventory by logical ID and never create a replacement here.
+            except (
+                self._sdk.not_found_error,
+                self._sdk.sandbox_error,
+                httpx.TransportError,
+            ) as exc:
+                # E2B can accept create before its command transport is ready.
+                # Retry only operations on this already-fenced SDK object.
+                # Bootstrap never reconnects, inventories, or creates another
+                # sandbox generation.
                 last_error = exc
-                try:
-                    sandbox = await self._reconnect_bootstrap_generation(
-                        sandbox_id, sandbox
-                    )
-                except (
-                    self._sdk.not_found_error,
-                    self._sdk.sandbox_error,
-                ) as reconnect_error:
-                    last_error = reconnect_error
-                else:
-                    runtime_started = False
-                next_route_refresh_at = self._clock() + 1.0
             await self._sleep(0.25)
         raise ProviderError(
             "E2B runtime did not become ready inside the sandbox",
@@ -928,7 +852,7 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
                     method="GET",
                 )
                 try:
-                    with self._sdk.urlopen(public_request, timeout=2) as response:
+                    with self._sdk.urlopen(public_request, timeout=5) as response:
                         if not 200 <= response.status < 300:
                             return False
                 except (urlerror.URLError, OSError, TimeoutError):
@@ -1080,7 +1004,10 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
                             envs=request.env,
                             secure=True,
                             allow_internet_access=self.config.allow_internet_access,
-                            network=self._network_policy(),
+                            # Use E2B's native authenticated public gateway.
+                            # Egress remains provider-default; no CIDR policy is
+                            # imposed on E2B sandboxes.
+                            network={"allow_public_traffic": False},
                             lifecycle={
                                 "on_timeout": {
                                     "action": "pause",

--- a/agentbox/docs/architecture.md
+++ b/agentbox/docs/architecture.md
@@ -226,14 +226,15 @@ E2B_SANDBOX_STATUS_RETRY_SECONDS=15
 E2B_RUNTIME_BOOTSTRAP_TIMEOUT_SECONDS=120
 ```
 
-E2B networking denies loopback, link-local, metadata, and private IPv4/IPv6
-ranges at the template boundary. `E2B_ALLOW_INTERNET_ACCESS` controls public
-internet access. Provider rate limits honor `Retry-After` before returning a
-structured retryable error. Control-plane requests are independently bounded
-so the one-hour sandbox lifetime cannot be mistaken for an HTTP request
-timeout. Active AgentBox heartbeats renew that lifetime through a throttled
-provider lease; idle suspension preserves the E2B filesystem until retention
-purges it.
+E2B uses provider-default egress and its native restricted-public-traffic mode,
+so runtime and function ports require the E2B traffic token. AgentBox does not
+apply the Docker/Kubernetes private-range policy to E2B-managed infrastructure;
+`E2B_ALLOW_INTERNET_ACCESS` controls public internet access. Provider rate
+limits honor `Retry-After` before returning a structured retryable error.
+Control-plane requests are independently bounded so the one-hour sandbox
+lifetime cannot be mistaken for an HTTP request timeout. Active AgentBox
+heartbeats renew that lifetime through a throttled provider lease; idle
+suspension preserves the E2B filesystem until retention purges it.
 
 ### Daytona
 

--- a/agentbox/pyproject.toml
+++ b/agentbox/pyproject.toml
@@ -5,6 +5,7 @@ description = "AgentBox sandbox manager and Python client"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi[standard]>=0.128.0",
+    "httpx>=0.28.1",
     "kubernetes>=34.1.0",
     "pydantic>=2.11.0",
     "pydantic-settings>=2.14.2",

--- a/agentbox/tests/test_cloud_provider_contract.py
+++ b/agentbox/tests/test_cloud_provider_contract.py
@@ -118,6 +118,7 @@ class _E2BSandbox:
     status_false_failures = 0
     timeout_set_count = 0
     connect_not_found_failures = 0
+    last_create_kwargs: dict[str, object] = {}
 
     def __init__(self, sandbox_id: str) -> None:
         self.sandbox_id = sandbox_id
@@ -144,6 +145,7 @@ class _E2BSandbox:
         cls.status_false_failures = 0
         cls.timeout_set_count = 0
         cls.connect_not_found_failures = 0
+        cls.last_create_kwargs = {}
 
     @classmethod
     def list(cls, *, query, limit, **kwargs):
@@ -165,7 +167,8 @@ class _E2BSandbox:
 
     @classmethod
     async def create(cls, template, *, metadata, envs, **kwargs):
-        del template, envs, kwargs
+        del template, envs
+        cls.last_create_kwargs = dict(kwargs)
         cls.create_count += 1
         provider_id = f"e2b-{cls.create_count}"
         sandbox = cls(provider_id)
@@ -419,6 +422,17 @@ def test_e2b_contract_is_idempotent_and_refreshes_endpoint_token() -> None:
     assert asyncio.run(provider.delete("sandbox-1")) is False
 
 
+def test_e2b_uses_native_authenticated_ingress_and_default_egress() -> None:
+    provider = _e2b_provider()
+
+    asyncio.run(provider.create("sandbox-1", SandboxEnsureRequest()))
+
+    assert _E2BSandbox.last_create_kwargs["network"] == {
+        "allow_public_traffic": False
+    }
+    assert _E2BSandbox.last_create_kwargs["allow_internet_access"] is True
+
+
 def test_e2b_endpoint_refresh_retries_direct_connect_without_inventory() -> None:
     provider = _e2b_provider_with(status_retry_seconds=1)
     request = SandboxEnsureRequest(env={"LEMMA_BASE_URL": "https://lemma.test"})
@@ -612,10 +626,10 @@ def test_e2b_bootstrap_retries_transient_commands_data_plane() -> None:
     assert status.ready is True
     sandbox = next(iter(_E2BSandbox.instances.values()))
     assert sandbox.commands.list_failures == 0
-    assert _E2BSandbox.connect_count == 1
+    assert _E2BSandbox.connect_count == 0
 
 
-def test_e2b_bootstrap_reconnects_only_the_exact_provider_generation() -> None:
+def test_e2b_bootstrap_never_reconnects_or_creates_a_replacement() -> None:
     provider = _e2b_provider_with(runtime_bootstrap_timeout_seconds=1)
     _E2BSandbox.bootstrap_list_failures = 1
 
@@ -624,40 +638,28 @@ def test_e2b_bootstrap_reconnects_only_the_exact_provider_generation() -> None:
     provider_id = provider._known_infos["sandbox-1"].provider_id
     asyncio.run(provider.bootstrap("sandbox-1", request))
 
-    assert _E2BSandbox.connect_count == 1
+    assert _E2BSandbox.connect_count == 0
     assert _E2BSandbox.create_count == 1
     assert set(_E2BSandbox.instances) == {provider_id}
     assert provider._sandboxes["sandbox-1"].sandbox_id == provider_id
 
 
-def test_e2b_bootstrap_refreshes_stale_public_route_credentials() -> None:
-    def stale_until_reconnect(req, **kwargs):
-        del kwargs
-        token = dict(req.header_items()).get("E2b-traffic-access-token", "")
-        if "-connected-" not in token:
-            raise urlerror.HTTPError(
-                str(getattr(req, "full_url", req)),
-                502,
-                "sandbox not found",
-                {},
-                None,
-            )
+def test_e2b_public_readiness_uses_gateway_safe_timeout() -> None:
+    timeouts: list[float] = []
+
+    def capture_timeout(req, **kwargs):
+        del req
+        timeouts.append(kwargs["timeout"])
         return _HealthResponse()
 
-    provider = _e2b_provider_with(
-        urlopen=stale_until_reconnect,
-        runtime_bootstrap_timeout_seconds=3,
-    )
+    provider = _e2b_provider_with(urlopen=capture_timeout)
     request = SandboxEnsureRequest()
     asyncio.run(provider.create("sandbox-1", request))
-    provider_id = provider._known_infos["sandbox-1"].provider_id
 
     asyncio.run(provider.bootstrap("sandbox-1", request))
 
-    assert _E2BSandbox.connect_count == 1
-    assert _E2BSandbox.create_count == 1
-    assert set(_E2BSandbox.instances) == {provider_id}
-    assert "-connected-" in provider._sandboxes["sandbox-1"].traffic_access_token
+    assert timeouts == [5, 5]
+    assert _E2BSandbox.connect_count == 0
 
 
 def test_e2b_bootstrap_fails_closed_when_commands_data_plane_never_arrives() -> None:

--- a/agentbox/uv.lock
+++ b/agentbox/uv.lock
@@ -13,6 +13,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "fastapi", extra = ["standard"] },
+    { name = "httpx" },
     { name = "kubernetes" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -44,6 +45,7 @@ requires-dist = [
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.196.0,<0.198.0" },
     { name = "e2b", marker = "extra == 'e2b'", specifier = "==2.32.1" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.128.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "kubernetes", specifier = ">=34.1.0" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.2.0" },
     { name = "psycopg-pool", marker = "extra == 'postgres'", specifier = ">=3.2.0" },


### PR DESCRIPTION
## Summary
- remove the Docker/Kubernetes private-CIDR egress policy from E2B sandboxes
- keep provider-default E2B egress and enable E2B's native restricted-public-traffic mode
- remove speculative bootstrap reconnect and route-token refresh loops
- retry only bounded operations on the single fenced E2B sandbox generation
- require the E2B traffic token for runtime and function-executor endpoints

## Root cause
The readiness probe assumed every E2B sandbox object had a traffic token, but the previous network configuration produced an unrestricted public route with no token. The probe therefore returned `False` before making a request even while ports 8080 and 8090 returned HTTP 200. Reconnects could not fix that configuration mismatch.

## Validation
- 52 focused E2B provider tests passed
- Ruff passed on the AgentBox provider and tests
- real E2B check: unauthenticated ports 8080/8090 return 403; authenticated requests return 200
- full OCI-backed E2B smoke passed: runtime HTTP, Python sessions, stdin, function callback, React/Vite, browser, service lifetime, and pause/resume persistence
- template stayed at 1 vCPU / 2 GiB

The release-smoke ownership isolation remains a separate change in lemma-work/lemma-app#199.
