### PR TITLE
fix(agentbox): defer unresolved state during reconciliation

### DIFF
--- a/agentbox/agentbox/lifecycle_manager.py
+++ b/agentbox/agentbox/lifecycle_manager.py
@@ -1299,12 +1299,26 @@ class SandboxLifecycleManager:
                             record.to_ensure_request(),
                         )
                 except ProviderError as exc:
-                    if exc.code != "lifecycle_busy":
-                        raise
-                    logger.debug(
-                        "AgentBox reconciliation skipped busy lifecycle; sandbox_id=%s",
-                        record.sandbox_id,
-                    )
+                    if exc.code == "lifecycle_busy":
+                        logger.debug(
+                            "AgentBox reconciliation skipped busy lifecycle; "
+                            "sandbox_id=%s",
+                            record.sandbox_id,
+                        )
+                        continue
+                    if exc.code in _OUTCOME_UNKNOWN_CODES:
+                        # One unresolved cloud create/delete must remain fenced,
+                        # but it must not keep the manager from serving every
+                        # other sandbox. The periodic reconciler will retry this
+                        # record after a later provider inventory pass.
+                        logger.warning(
+                            "AgentBox reconciliation deferred unresolved provider "
+                            "outcome; sandbox_id=%s code=%s",
+                            record.sandbox_id,
+                            exc.code,
+                        )
+                        continue
+                    raise
 
             expired = await self.store.expired_orphans(
                 settings.agentbox_orphan_grace_seconds,

--- a/agentbox/tests/test_lifecycle_manager.py
+++ b/agentbox/tests/test_lifecycle_manager.py
@@ -507,6 +507,53 @@ async def test_ambiguous_create_blocks_environment_replacement(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_reconcile_defers_legacy_env_upgrade_with_unresolved_allocation(
+    tmp_path,
+    caplog,
+):
+    provider = AmbiguousLifecycleProvider()
+    manager, _, store = await _manager(tmp_path, provider)
+    try:
+        # Simulate a record written before function concurrency became part of
+        # the durable sandbox environment, plus a create whose provider outcome
+        # is still unknown. Startup must preserve that fence without crashing.
+        await store.upsert_sandbox(
+            "legacy-sandbox",
+            SandboxEnsureRequest(env={"LEMMA_BASE_URL": "https://lemma.test"}),
+        )
+        allocation = await store.reserve_provider_allocation(
+            "fake:test",
+            "legacy-sandbox",
+            owner="manager-that-exited",
+            max_active=10,
+            ttl_seconds=600,
+        )
+        assert allocation is not None
+        held = await store.hold_provider_allocation(
+            "fake:test",
+            allocation.allocation_id,
+            owner="agentbox:outcome-unknown",
+        )
+        assert held is not None
+
+        with caplog.at_level("WARNING"):
+            await manager.reconcile()
+
+        record = await store.get_sandbox("legacy-sandbox")
+        assert record is not None
+        assert record.env == {"LEMMA_BASE_URL": "https://lemma.test"}
+        allocations = await store.list_provider_allocations("fake:test")
+        assert [(row.state, row.provider_id) for row in allocations] == [
+            ("reserved", None)
+        ]
+        assert provider.create_count == 0
+        assert "sandbox_id=legacy-sandbox" in caplog.text
+        assert "code=provider_create_outcome_unknown" in caplog.text
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
 async def test_create_intent_without_observed_compute_never_retries_create(tmp_path):
     provider = AmbiguousLifecycleProvider()
     manager, _, store = await _manager(tmp_path, provider)


### PR DESCRIPTION
## Summary
- keep unresolved cloud create/delete outcomes durably fenced during reconciliation
- defer only known outcome-unknown records instead of aborting manager startup
- let the periodic reconciliation loop retry after later provider inventory
- continue failing startup for unexpected provider errors

## Live dev failure reproduced
The first native-provider manager revision reached startup reconciliation with a legacy sandbox record whose durable env predates the new function concurrency keys and whose provider allocation is still outcome-unknown. `ensure()` correctly rejected changing that environment, but `reconcile()` propagated the retryable error and crashed the entire manager revision.

The old revision remains healthy; the failed revision never received traffic.

## Safety
- no second sandbox generation is created
- the ambiguous allocation remains reserved and fenced
- the legacy environment remains unchanged
- the manager starts and serves other sandboxes

## Validation
- new legacy-env/unresolved-allocation regression test passes
- existing ambiguous-create restart and environment-replacement tests pass
- focused result: 3 passed
- Ruff and diff checks pass
