### PR TITLE
fix(agentbox): isolate E2B inventory namespaces

### DIFF
--- a/agentbox/agentbox/providers/cloud_config.py
+++ b/agentbox/agentbox/providers/cloud_config.py
@@ -17,6 +17,7 @@ class E2BProviderConfig:
     template: str
     owner: str
     environment: str
+    managed_by: str = "agentbox"
     max_active: int = 10
     timeout_seconds: int = 3600
     api_url: str | None = None
@@ -65,6 +66,9 @@ class E2BProviderConfig:
         runtime_bootstrap_timeout_seconds = float(
             os.environ.get("E2B_RUNTIME_BOOTSTRAP_TIMEOUT_SECONDS", "120")
         )
+        managed_by = os.environ.get("E2B_SANDBOX_MANAGED_BY", "agentbox").strip()
+        if not managed_by:
+            raise RuntimeError("E2B_SANDBOX_MANAGED_BY cannot be empty")
         if not 0 < admission_wait <= 600:
             raise RuntimeError(
                 "E2B_SANDBOX_ADMISSION_WAIT_SECONDS must be greater than 0 "
@@ -97,6 +101,7 @@ class E2BProviderConfig:
             template=_required("E2B_SANDBOX_TEMPLATE", "E2B"),
             owner=_required("AGENTBOX_PROVIDER_OWNER", "E2B"),
             environment=_required("AGENTBOX_ENVIRONMENT", "E2B"),
+            managed_by=managed_by,
             max_active=max_active,
             timeout_seconds=timeout,
             api_url=os.environ.get("E2B_API_URL", "").strip() or None,

--- a/agentbox/agentbox/providers/e2b.py
+++ b/agentbox/agentbox/providers/e2b.py
@@ -149,7 +149,13 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
         generation_token: str | None = None,
     ) -> dict[str, str]:
         metadata = {
-            "managed-by": "agentbox",
+            # ``managed-by`` is the outermost inventory fence. Owner and
+            # environment remain mandatory inner scopes, but older AgentBox
+            # managers queried only this key. A versioned value lets a new
+            # deployment share an E2B team/API key with that legacy manager
+            # without either reconciler seeing or purging the other's
+            # sandboxes during a rolling migration.
+            "managed-by": self.config.managed_by,
             "agentbox-owner": self.config.owner,
             "agentbox-environment": self.config.environment,
         }

--- a/agentbox/agentbox/providers/e2b.py
+++ b/agentbox/agentbox/providers/e2b.py
@@ -154,7 +154,9 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
             # managers queried only this key. A versioned value lets a new
             # deployment share an E2B team/API key with that legacy manager
             # without either reconciler seeing or purging the other's
-            # sandboxes during a rolling migration.
+            # sandboxes during a rolling migration. Environment-specific
+            # values such as ``agentbox-dev`` and ``agentbox-prod`` are
+            # recommended when environments share an E2B team.
             "managed-by": self.config.managed_by,
             "agentbox-owner": self.config.owner,
             "agentbox-environment": self.config.environment,

--- a/agentbox/tests/test_cloud_provider_contract.py
+++ b/agentbox/tests/test_cloud_provider_contract.py
@@ -327,6 +327,42 @@ def test_e2b_sandbox_timeout_config_is_applied(
     assert E2BProviderConfig.from_env().timeout_seconds == 900
 
 
+def test_e2b_managed_by_scope_default_and_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_required_e2b_env(monkeypatch)
+    monkeypatch.delenv("E2B_SANDBOX_MANAGED_BY", raising=False)
+
+    assert E2BProviderConfig.from_env().managed_by == "agentbox"
+
+    monkeypatch.setenv("E2B_SANDBOX_MANAGED_BY", "agentbox-v2")
+    config = E2BProviderConfig.from_env()
+    assert config.managed_by == "agentbox-v2"
+
+    provider = E2BSandboxProvider(
+        config,
+        sdk=_E2BSdk(
+            sandbox_cls=_E2BSandbox,
+            query_cls=_Query,
+            rate_limit_error=_RateLimit,
+            not_found_error=_NotFound,
+            sandbox_error=_ProviderFailure,
+            urlopen=_healthy_urlopen,
+        ),
+    )
+    assert provider._metadata()["managed-by"] == "agentbox-v2"
+
+
+def test_e2b_managed_by_scope_rejects_empty_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _set_required_e2b_env(monkeypatch)
+    monkeypatch.setenv("E2B_SANDBOX_MANAGED_BY", "   ")
+
+    with pytest.raises(RuntimeError, match="E2B_SANDBOX_MANAGED_BY cannot be empty"):
+        E2BProviderConfig.from_env()
+
+
 def test_e2b_runtime_bootstrap_timeout_config_default_and_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -427,9 +463,7 @@ def test_e2b_uses_native_authenticated_ingress_and_default_egress() -> None:
 
     asyncio.run(provider.create("sandbox-1", SandboxEnsureRequest()))
 
-    assert _E2BSandbox.last_create_kwargs["network"] == {
-        "allow_public_traffic": False
-    }
+    assert _E2BSandbox.last_create_kwargs["network"] == {"allow_public_traffic": False}
     assert _E2BSandbox.last_create_kwargs["allow_internet_access"] is True
 
 

--- a/agentbox/tests/test_cloud_provider_contract.py
+++ b/agentbox/tests/test_cloud_provider_contract.py
@@ -335,9 +335,9 @@ def test_e2b_managed_by_scope_default_and_env(
 
     assert E2BProviderConfig.from_env().managed_by == "agentbox"
 
-    monkeypatch.setenv("E2B_SANDBOX_MANAGED_BY", "agentbox-v2")
+    monkeypatch.setenv("E2B_SANDBOX_MANAGED_BY", "agentbox-dev")
     config = E2BProviderConfig.from_env()
-    assert config.managed_by == "agentbox-v2"
+    assert config.managed_by == "agentbox-dev"
 
     provider = E2BSandboxProvider(
         config,
@@ -350,7 +350,7 @@ def test_e2b_managed_by_scope_default_and_env(
             urlopen=_healthy_urlopen,
         ),
     )
-    assert provider._metadata()["managed-by"] == "agentbox-v2"
+    assert provider._metadata()["managed-by"] == "agentbox-dev"
 
 
 def test_e2b_managed_by_scope_rejects_empty_env(


### PR DESCRIPTION
## Summary

- make the E2B `managed-by` inventory fence configurable via `E2B_SANDBOX_MANAGED_BY`
- preserve `agentbox` as the OSS/default value
- allow versioned rollout namespaces so a legacy manager sharing the same E2B team key cannot discover or reap new-manager sandboxes

## Incident evidence

Dev sandboxes tagged with owner/environment were being request-killed by another manager sharing the E2B key. The legacy production manager has no owner/environment config and queries the broad `managed-by=agentbox` namespace. New deployments will use the permanent environment scopes `agentbox-dev` and `agentbox-prod`.

## Validation

- `uv run --project agentbox pytest agentbox/tests/test_cloud_provider_contract.py -q`
- Ruff check and format check on changed files
- Real E2B lifecycle events confirmed request-kills had no corresponding dev DELETE request
