### PR TITLE
fix(agentbox): remove function execution latency stalls

### DIFF
--- a/agentbox/agentbox/providers/e2b.py
+++ b/agentbox/agentbox/providers/e2b.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
 import logging
@@ -845,12 +846,21 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
             status_code=504,
         ) from last_error
 
-    async def _public_runtime_ready(self, sandbox) -> bool:  # type: ignore[no-untyped-def]
+    async def _public_runtime_ready(
+        self,
+        sandbox,  # type: ignore[no-untyped-def]
+        *,
+        request_timeout: float | None = None,
+    ) -> bool:
         """Use E2B's authenticated runtime gateway as data-plane evidence."""
 
         token = getattr(sandbox, "traffic_access_token", None)
         if not token:
             return False
+
+        endpoint_timeout = 5.0
+        if request_timeout is not None:
+            endpoint_timeout = max(min(endpoint_timeout, request_timeout), 0.001)
 
         def check_public_endpoint() -> bool:
             for port in (8080, 8090):
@@ -860,7 +870,9 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
                     method="GET",
                 )
                 try:
-                    with self._sdk.urlopen(public_request, timeout=5) as response:
+                    with self._sdk.urlopen(
+                        public_request, timeout=endpoint_timeout
+                    ) as response:
                         if not 200 <= response.status < 300:
                             return False
                 except (urlerror.URLError, OSError, TimeoutError):
@@ -868,6 +880,22 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
             return True
 
         return await asyncio.to_thread(check_public_endpoint)
+
+    async def _bounded_status_probe(
+        self,
+        operation: Callable[[float], Awaitable[Any]],
+        *,
+        deadline: float,
+    ) -> Any:
+        """Run one status probe without exceeding the shared status deadline."""
+
+        remaining = min(
+            self.config.request_timeout_seconds,
+            max(deadline - self._clock(), 0.0),
+        )
+        if remaining <= 0:
+            raise TimeoutError("E2B sandbox status probe deadline expired")
+        return await asyncio.wait_for(operation(remaining), timeout=remaining)
 
     async def _renew_timeout(self, sandbox, sandbox_id: str) -> bool:  # type: ignore[no-untyped-def]
         """Best-effort lease renewal without rejecting healthy data-plane work."""
@@ -1152,77 +1180,112 @@ class E2BSandboxProvider(LegacyRuntimeProviderMixin):
         )
 
     async def _status(self, sandbox_id: str, sandbox) -> SandboxInternalStatus:
-        deadline = self._clock() + self.config.status_retry_seconds
+        started_at = self._clock()
+        # Status is a hot read on every session/function handout. Never let the
+        # provider's general 15-20 second retry budgets leak into this path.
+        # Data-plane health, control-plane status, and an optional exact-ID
+        # reconnect share one strict two-second observation budget.
+        probe_deadline = started_at + min(
+            self.config.request_timeout_seconds,
+            2.0,
+        )
         current = sandbox
         last_error: Exception | None = None
-        try:
-            while True:
+
+        async def observe(candidate) -> tuple[bool | None, Exception | None]:  # type: ignore[no-untyped-def]
+            try:
+                public_ready = bool(
+                    await self._bounded_status_probe(
+                        lambda remaining: self._public_runtime_ready(
+                            candidate,
+                            # Two public ports are checked serially. Give each
+                            # at most 500ms so a slow gateway still leaves time
+                            # for the authoritative control-plane check.
+                            request_timeout=min(remaining / 2, 0.5),
+                        ),
+                        deadline=probe_deadline,
+                    )
+                )
+            except TimeoutError:
+                public_ready = False
+            if public_ready:
+                return True, None
+
+            try:
+                return (
+                    bool(
+                        await self._bounded_status_probe(
+                            lambda _remaining: candidate.is_running(),
+                            deadline=probe_deadline,
+                        )
+                    ),
+                    None,
+                )
+            except (
+                self._sdk.not_found_error,
+                self._sdk.sandbox_error,
+                TimeoutError,
+            ) as exc:
+                return None, exc
+
+        running, last_error = await observe(current)
+        if running is not True:
+            info = self._known_infos.get(sandbox_id)
+            if info is not None and info.state == "running":
                 try:
-                    running = bool(await current.is_running())
-                    if running:
-                        break
-                    if await self._public_runtime_ready(current):
-                        running = True
-                        logger.warning(
-                            "agentbox_e2b_status_false_data_plane_override "
-                            "sandbox_id=%s provider_id=%s",
-                            sandbox_id,
-                            getattr(current, "sandbox_id", None),
-                        )
-                        break
-                    # E2B can transiently return a successful `false` for a
-                    # running generation while both public routes propagate.
-                    # Require the whole bounded observation window before
-                    # converting a cached known-running generation to paused.
-                    # Explicit release already removes the cache and records
-                    # the generation as paused, so status remains non-resuming.
-                    if self._clock() >= deadline:
-                        break
-                    await self._sleep(random.uniform(0.05, 0.2))
-                except (self._sdk.not_found_error, self._sdk.sandbox_error) as exc:
-                    last_error = exc
-                    if await self._public_runtime_ready(current):
-                        running = True
-                        logger.warning(
-                            "agentbox_e2b_status_data_plane_fallback "
-                            "sandbox_id=%s provider_id=%s",
-                            sandbox_id,
-                            getattr(current, "sandbox_id", None),
-                        )
-                        break
-                    if self._clock() >= deadline:
-                        self.invalidate_endpoint_cache(sandbox_id)
-                        raise ProviderError(
-                            "E2B exact sandbox status is temporarily unavailable",
-                            code="provider_adoption_unavailable",
-                            retryable=True,
-                            status_code=503,
-                            headers={"Retry-After": "1"},
-                        ) from exc
-                    info = self._known_infos.get(sandbox_id)
-                    await self._sleep(random.uniform(0.05, 0.2))
-                    if info is None or info.state != "running":
-                        continue
-                    try:
-                        current = await self._with_rate_limit_retry(
+                    reconnected = await self._bounded_status_probe(
+                        lambda _remaining: self._with_rate_limit_retry(
                             lambda: self._sdk.sandbox_cls.connect(
                                 info.provider_id,
                                 timeout=self.config.timeout_seconds,
                                 **self._api_options(),
                             )
-                        )
-                    except (self._sdk.not_found_error, self._sdk.sandbox_error):
-                        continue
-                    self._sandboxes[sandbox_id] = current
-                    logger.info(
-                        "agentbox_e2b_status_reconnected sandbox_id=%s provider_id=%s",
-                        sandbox_id,
-                        info.provider_id,
+                        ),
+                        deadline=probe_deadline,
                     )
-        except self._sdk.sandbox_error as exc:
-            raise ProviderError(
-                f"E2B sandbox status failed: {exc}", retryable=True
-            ) from (last_error or exc)
+                except (
+                    self._sdk.not_found_error,
+                    self._sdk.sandbox_error,
+                    TimeoutError,
+                ) as exc:
+                    # A successful control-plane `false` is authoritative
+                    # enough to report STOPPED. An unavailable first check is
+                    # not: preserve the durable identity and fail closed.
+                    if running is None:
+                        last_error = exc
+                    else:
+                        running = False
+                else:
+                    if str(getattr(reconnected, "sandbox_id", "")) != info.provider_id:
+                        last_error = ProviderError(
+                            "E2B reconnect returned a different provider generation",
+                            code="endpoint_generation_changed",
+                            retryable=True,
+                            status_code=409,
+                        )
+                        running = None
+                    else:
+                        current = reconnected
+                        self._sandboxes[sandbox_id] = current
+                        logger.info(
+                            "agentbox_e2b_status_reconnected "
+                            "sandbox_id=%s provider_id=%s",
+                            sandbox_id,
+                            info.provider_id,
+                        )
+                        running, last_error = await observe(current)
+
+            if running is None:
+                self.invalidate_endpoint_cache(sandbox_id)
+                raise ProviderError(
+                    "E2B exact sandbox status is temporarily unavailable",
+                    code="provider_adoption_unavailable",
+                    retryable=True,
+                    status_code=503,
+                    headers={"Retry-After": "1"},
+                ) from last_error
+
+        assert running is not None
         sandbox = current
         apps = {
             app.name: SandboxInternalAppStatus(

--- a/agentbox/tests/test_cloud_provider_contract.py
+++ b/agentbox/tests/test_cloud_provider_contract.py
@@ -116,6 +116,7 @@ class _E2BSandbox:
     bootstrap_list_failures = 0
     timeout_not_found_failures = 0
     status_false_failures = 0
+    status_check_count = 0
     timeout_set_count = 0
     connect_not_found_failures = 0
     last_create_kwargs: dict[str, object] = {}
@@ -143,6 +144,7 @@ class _E2BSandbox:
         cls.bootstrap_list_failures = 0
         cls.timeout_not_found_failures = 0
         cls.status_false_failures = 0
+        cls.status_check_count = 0
         cls.timeout_set_count = 0
         cls.connect_not_found_failures = 0
         cls.last_create_kwargs = {}
@@ -230,6 +232,7 @@ class _E2BSandbox:
         return True
 
     async def is_running(self):
+        type(self).status_check_count += 1
         if type(self).status_false_failures:
             type(self).status_false_failures -= 1
             return False
@@ -689,6 +692,7 @@ def test_e2b_public_readiness_uses_gateway_safe_timeout() -> None:
     provider = _e2b_provider_with(urlopen=capture_timeout)
     request = SandboxEnsureRequest()
     asyncio.run(provider.create("sandbox-1", request))
+    timeouts.clear()
 
     asyncio.run(provider.bootstrap("sandbox-1", request))
 
@@ -779,6 +783,46 @@ def test_e2b_status_uses_authenticated_data_plane_when_control_plane_flaps() -> 
     assert provider._sandboxes["sandbox-1"].sandbox_id == provider_id
 
 
+def test_e2b_status_checks_healthy_data_plane_before_control_plane() -> None:
+    provider = _e2b_provider_with(status_retry_seconds=1)
+    asyncio.run(provider.create("sandbox-1", SandboxEnsureRequest()))
+    _E2BSandbox.status_check_count = 0
+
+    status = asyncio.run(provider.get_status("sandbox-1"))
+
+    assert status.ready is True
+    assert _E2BSandbox.status_check_count == 0
+
+
+def test_e2b_status_bounds_hung_data_and_control_plane_probes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = _e2b_provider_with(
+        status_retry_seconds=0.01,
+        request_timeout_seconds=0.02,
+    )
+    asyncio.run(provider.create("sandbox-1", SandboxEnsureRequest()))
+    sandbox = provider._sandboxes["sandbox-1"]
+
+    async def hung_public_runtime_ready(*args, **kwargs):
+        del args, kwargs
+        await asyncio.sleep(1)
+        return False
+
+    async def hung_is_running():
+        await asyncio.sleep(1)
+        return True
+
+    monkeypatch.setattr(provider, "_public_runtime_ready", hung_public_runtime_ready)
+    monkeypatch.setattr(sandbox, "is_running", hung_is_running)
+
+    with pytest.raises(ProviderError) as error:
+        asyncio.run(asyncio.wait_for(provider.get_status("sandbox-1"), timeout=0.2))
+
+    assert error.value.code == "provider_adoption_unavailable"
+    assert error.value.status_code == 503
+
+
 def test_e2b_status_uses_data_plane_when_control_plane_temporarily_says_stopped() -> (
     None
 ):
@@ -792,38 +836,71 @@ def test_e2b_status_uses_data_plane_when_control_plane_temporarily_says_stopped(
     assert status.status == "RUNNING"
 
 
-def test_e2b_status_retries_transient_false_without_pausing_generation() -> None:
-    public_failures = 2
+def test_e2b_status_reconnects_once_after_transient_false() -> None:
+    data_plane_available = True
 
-    def delayed_gateway(req, **kwargs):
-        nonlocal public_failures
+    def conditional_gateway(req, **kwargs):
         del kwargs
-        if public_failures:
-            public_failures -= 1
-            raise urlerror.HTTPError(
-                str(getattr(req, "full_url", req)),
-                502,
-                "sandbox not found",
-                {},
-                None,
-            )
-        return _healthy_urlopen(req)
+        if data_plane_available:
+            return _healthy_urlopen(req)
+        raise urlerror.HTTPError(
+            str(getattr(req, "full_url", req)),
+            502,
+            "sandbox not found",
+            {},
+            None,
+        )
 
     provider = _e2b_provider_with(
         status_retry_seconds=1,
-        urlopen=delayed_gateway,
+        urlopen=conditional_gateway,
     )
     asyncio.run(provider.create("sandbox-1", SandboxEnsureRequest()))
     provider_id = provider._known_infos["sandbox-1"].provider_id
-    _E2BSandbox.status_false_failures = 2
+    data_plane_available = False
+    _E2BSandbox.status_false_failures = 1
+    _E2BSandbox.status_check_count = 0
 
     status = asyncio.run(provider.get_status("sandbox-1"))
 
     assert status.ready is True
     assert provider._known_infos["sandbox-1"].state == "running"
     assert provider._sandboxes["sandbox-1"].sandbox_id == provider_id
-    assert _E2BSandbox.connect_count == 0
+    assert _E2BSandbox.status_check_count == 2
+    assert _E2BSandbox.connect_count == 1
     assert _E2BSandbox.pause_count == 0
+
+
+def test_e2b_status_does_not_poll_successful_false_until_retry_deadline() -> None:
+    data_plane_available = True
+
+    def conditional_gateway(req, **kwargs):
+        del kwargs
+        if data_plane_available:
+            return _healthy_urlopen(req)
+        raise urlerror.HTTPError(
+            str(getattr(req, "full_url", req)),
+            502,
+            "sandbox not found",
+            {},
+            None,
+        )
+
+    provider = _e2b_provider_with(
+        status_retry_seconds=15,
+        urlopen=conditional_gateway,
+    )
+    asyncio.run(provider.create("sandbox-1", SandboxEnsureRequest()))
+    data_plane_available = False
+    _E2BSandbox.status_false_failures = 2
+    _E2BSandbox.status_check_count = 0
+
+    status = asyncio.run(provider.get_status("sandbox-1"))
+
+    assert status.ready is False
+    assert status.status == "STOPPED"
+    assert _E2BSandbox.status_check_count == 2
+    assert _E2BSandbox.connect_count == 1
 
 
 def test_e2b_status_fails_when_control_and_data_planes_are_unavailable() -> None:

--- a/lemma-backend/app/core/infrastructure/channels/channel_service.py
+++ b/lemma-backend/app/core/infrastructure/channels/channel_service.py
@@ -135,14 +135,46 @@ class RedisChannelAdapter:
         async with self._subscription_lock:
             pubsub = await self._ensure_pubsub()
             new_channels = [
-                channel for channel in client.channels if channel not in self._clients_by_channel
+                channel
+                for channel in client.channels
+                if channel not in self._clients_by_channel
             ]
             if new_channels:
-                await pubsub.subscribe(*new_channels)
+                try:
+                    await pubsub.subscribe(*new_channels)
+                except (RedisConnectionError, RedisTimeoutError, OSError) as exc:
+                    reconnect_counter.add(1)
+                    logger.warning(
+                        "Realtime Pub/Sub subscribe failed; replacing stale lease",
+                        error_type=type(exc).__name__,
+                    )
+                    await self._replace_pubsub()
+                    pubsub = await self._ensure_pubsub()
+                    recovery_channels = tuple(
+                        dict.fromkeys((*self._clients_by_channel, *new_channels))
+                    )
+                    try:
+                        await pubsub.subscribe(*recovery_channels)
+                    except RedisConnectionError, RedisTimeoutError, OSError:
+                        # Existing logical subscribers must retain the reconnecting
+                        # listener even when the one inline retry also fails.
+                        if self._clients_by_channel:
+                            self._ensure_listener()
+                        raise
             for channel in client.channels:
                 self._clients_by_channel.setdefault(channel, set()).add(client)
             subscriber_delta.add(1)
             self._ensure_listener()
+
+    async def _replace_pubsub(self) -> None:
+        """Stop the listener and discard a stale Pub/Sub connection lease."""
+        task = self._listener_task
+        self._listener_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        await self._close_pubsub()
 
     async def _unregister(self, client: _ClientSubscription) -> None:
         if client.closed:
@@ -165,9 +197,7 @@ class RedisChannelAdapter:
 
     async def _ensure_pubsub(self) -> PubSub:
         if self._pubsub is None:
-            self._pubsub = (await self._client()).pubsub(
-                ignore_subscribe_messages=True
-            )
+            self._pubsub = (await self._client()).pubsub(ignore_subscribe_messages=True)
         return self._pubsub
 
     def _ensure_listener(self) -> None:
@@ -266,7 +296,7 @@ class RedisChannelAdapter:
             return
         try:
             await pubsub.aclose()
-        except (RedisError, OSError):
+        except RedisError, OSError:
             logger.warning("Failed to close realtime Pub/Sub connection")
 
 

--- a/lemma-backend/app/core/tests/unit/test_realtime_channels.py
+++ b/lemma-backend/app/core/tests/unit/test_realtime_channels.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 
 import pytest
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from app.core.infrastructure.channels import channel_service as channel_module
 from app.core.infrastructure.channels.channel_service import RedisChannelAdapter
@@ -29,14 +31,18 @@ class _FakePubSub:
 
 
 class _FakeRedis:
-    def __init__(self) -> None:
-        self.pubsub_instance = _FakePubSub()
+    def __init__(self, pubsub_instances: list[_FakePubSub] | None = None) -> None:
+        self.pubsub_instances = pubsub_instances or [_FakePubSub()]
+        self.pubsub_instance = self.pubsub_instances[0]
+        self.pubsub_calls = 0
         self.published: list[tuple[str, str | bytes]] = []
         self.closed = False
 
     def pubsub(self, *, ignore_subscribe_messages: bool):
         assert ignore_subscribe_messages is True
-        return self.pubsub_instance
+        instance = self.pubsub_instances[self.pubsub_calls]
+        self.pubsub_calls += 1
+        return instance
 
     async def publish(self, channel: str, payload: str | bytes) -> None:
         self.published.append((channel, payload))
@@ -63,6 +69,73 @@ async def test_realtime_adapter_publishes_json_and_releases_subscription() -> No
     assert redis.pubsub_instance.closed is False
     await adapter.disconnect()
     assert redis.pubsub_instance.closed is True
+
+
+class _FailsOnSubscribePubSub(_FakePubSub):
+    def __init__(self, error: BaseException, *, after: int = 0) -> None:
+        super().__init__()
+        self.error = error
+        self.after = after
+        self.subscribe_calls: list[tuple[str, ...]] = []
+
+    async def subscribe(self, *channels: str) -> None:
+        self.subscribe_calls.append(channels)
+        if len(self.subscribe_calls) > self.after:
+            raise self.error
+        await super().subscribe(*channels)
+
+
+@pytest.mark.asyncio
+async def test_realtime_adapter_replaces_stale_pubsub_on_subscribe() -> None:
+    stale = _FailsOnSubscribePubSub(RedisConnectionError("stale"))
+    replacement = _FakePubSub()
+    redis = _FakeRedis([stale, replacement])
+    adapter = RedisChannelAdapter(client=redis)  # type: ignore[arg-type]
+
+    async with adapter.subscribe(["conversation:1"]):
+        assert stale.closed is True
+        assert replacement.subscribed == ("conversation:1",)
+
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_realtime_adapter_resubscribes_existing_channels_after_stale_subscribe() -> (
+    None
+):
+    stale = _FailsOnSubscribePubSub(
+        RedisConnectionError("stale"),
+        after=1,
+    )
+    replacement = _FakePubSub()
+    redis = _FakeRedis([stale, replacement])
+    adapter = RedisChannelAdapter(client=redis)  # type: ignore[arg-type]
+
+    async with adapter.subscribe(["conversation:1"]):
+        async with adapter.subscribe(["conversation:2"]):
+            assert stale.closed is True
+            assert replacement.subscribed == (
+                "conversation:1",
+                "conversation:2",
+            )
+
+    await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+async def test_realtime_adapter_propagates_second_subscribe_failure() -> None:
+    stale = _FailsOnSubscribePubSub(RedisConnectionError("stale"))
+    unavailable = _FailsOnSubscribePubSub(RedisTimeoutError("still unavailable"))
+    redis = _FakeRedis([stale, unavailable])
+    adapter = RedisChannelAdapter(client=redis)  # type: ignore[arg-type]
+
+    with pytest.raises(RedisTimeoutError, match="still unavailable"):
+        async with adapter.subscribe(["conversation:1"]):
+            pass
+
+    assert stale.closed is True
+    assert unavailable.closed is False
+    await adapter.disconnect()
 
 
 @pytest.mark.asyncio

--- a/lemma-backend/app/modules/function/application/function_executor_polling.py
+++ b/lemma-backend/app/modules/function/application/function_executor_polling.py
@@ -27,7 +27,7 @@ async def poll_executor_job(
     run_id: UUID,
     timeout_seconds: int,
     retry_max_attempts: int,
-    poll_interval_seconds: int,
+    poll_interval_seconds: float,
 ) -> FunctionInvokeResponse:
     """Poll one idempotent run without holding an E2B request open."""
 
@@ -62,7 +62,7 @@ async def poll_session_executor_job(
     run_id: UUID,
     timeout_seconds: int,
     retry_max_attempts: int,
-    poll_interval_seconds: int,
+    poll_interval_seconds: float,
     client_factory: Callable[[str], FunctionExecutorClient],
 ) -> FunctionInvokeResponse:
     """Build the authenticated client and poll one session's accepted run."""

--- a/lemma-backend/app/modules/function/application/function_executor_polling.py
+++ b/lemma-backend/app/modules/function/application/function_executor_polling.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from collections.abc import Callable
 from uuid import UUID
@@ -17,6 +18,13 @@ from app.modules.function.domain.errors import FunctionValidationError
 from app.modules.function.services.function_executor_cancellation import (
     cancel_executor_run,
     managed_executor_client,
+)
+
+API_FUNCTION_POLL_INTERVAL_SECONDS = float(
+    os.getenv("LEMMA_API_FUNCTION_POLL_INTERVAL_SECONDS", "0.5")
+)
+JOB_FUNCTION_POLL_INTERVAL_SECONDS = float(
+    os.getenv("LEMMA_FUNCTION_POLL_INTERVAL_SECONDS", "5")
 )
 
 

--- a/lemma-backend/app/modules/function/application/function_run_executor.py
+++ b/lemma-backend/app/modules/function/application/function_run_executor.py
@@ -85,9 +85,16 @@ _FUNCTION_EXECUTOR_READY_TIMEOUT_SECONDS = 30.0
 # small budget because the outer poll deadline provides the macro retry budget.
 _FUNCTION_EXECUTE_RETRY_MAX_ATTEMPTS = 12
 _FUNCTION_POLL_RETRY_MAX_ATTEMPTS = 4
-# How often to poll a JOB function's status while it runs. Kept coarse (the run
-# is async/background) so we don't hammer the manager proxy + in-sandbox app.
-_FUNCTION_POLL_INTERVAL_SECONDS = int(
+# API functions remain synchronous to their caller, so poll accepted executor
+# runs quickly enough that a short function does not pay the coarse JOB polling
+# interval. The executor run is idempotent by run ID, making these status reads
+# safe and cheap.
+_API_FUNCTION_POLL_INTERVAL_SECONDS = float(
+    os.getenv("LEMMA_API_FUNCTION_POLL_INTERVAL_SECONDS", "0.5")
+)
+# JOB functions are asynchronous/background and can keep the coarser interval
+# to avoid unnecessary manager and in-sandbox status traffic.
+_JOB_FUNCTION_POLL_INTERVAL_SECONDS = float(
     os.getenv("LEMMA_FUNCTION_POLL_INTERVAL_SECONDS", "5")
 )
 # How often to heartbeat the sandbox while a JOB runs. A JOB occupies the
@@ -434,6 +441,7 @@ class FunctionRunExecutor:
                             session=session,
                             run_id=run.id,
                             timeout_seconds=timeout_seconds,
+                            poll_interval_seconds=(_API_FUNCTION_POLL_INTERVAL_SECONDS),
                         )
                 return executor_response
             finally:
@@ -747,13 +755,14 @@ class FunctionRunExecutor:
         session,
         run_id: UUID,
         timeout_seconds: int,
+        poll_interval_seconds: float = _JOB_FUNCTION_POLL_INTERVAL_SECONDS,
     ) -> FunctionInvokeResponse:
         return await poll_session_executor_job(
             session=session,
             run_id=run_id,
             timeout_seconds=timeout_seconds,
             retry_max_attempts=_FUNCTION_POLL_RETRY_MAX_ATTEMPTS,
-            poll_interval_seconds=_FUNCTION_POLL_INTERVAL_SECONDS,
+            poll_interval_seconds=poll_interval_seconds,
             client_factory=self._build_function_executor_client,
         )
 

--- a/lemma-backend/app/modules/function/application/function_run_executor.py
+++ b/lemma-backend/app/modules/function/application/function_run_executor.py
@@ -51,6 +51,8 @@ from app.modules.function.domain.events import (
     FunctionRunFailedEvent,
 )
 from app.modules.function.application.function_executor_polling import (
+    API_FUNCTION_POLL_INTERVAL_SECONDS as _API_FUNCTION_POLL_INTERVAL_SECONDS,
+    JOB_FUNCTION_POLL_INTERVAL_SECONDS as _JOB_FUNCTION_POLL_INTERVAL_SECONDS,
     poll_session_executor_job,
 )
 from app.modules.function.services.function_runtime_command import (
@@ -85,18 +87,6 @@ _FUNCTION_EXECUTOR_READY_TIMEOUT_SECONDS = 30.0
 # small budget because the outer poll deadline provides the macro retry budget.
 _FUNCTION_EXECUTE_RETRY_MAX_ATTEMPTS = 12
 _FUNCTION_POLL_RETRY_MAX_ATTEMPTS = 4
-# API functions remain synchronous to their caller, so poll accepted executor
-# runs quickly enough that a short function does not pay the coarse JOB polling
-# interval. The executor run is idempotent by run ID, making these status reads
-# safe and cheap.
-_API_FUNCTION_POLL_INTERVAL_SECONDS = float(
-    os.getenv("LEMMA_API_FUNCTION_POLL_INTERVAL_SECONDS", "0.5")
-)
-# JOB functions are asynchronous/background and can keep the coarser interval
-# to avoid unnecessary manager and in-sandbox status traffic.
-_JOB_FUNCTION_POLL_INTERVAL_SECONDS = float(
-    os.getenv("LEMMA_FUNCTION_POLL_INTERVAL_SECONDS", "5")
-)
 # How often to heartbeat the sandbox while a JOB runs. A JOB occupies the
 # sandbox through the function_executor app and holds no runtime session, so
 # without this the idle reaper deletes the pod mid-run once it exceeds the

--- a/lemma-backend/app/modules/function/tests/unit/test_function_run_executor_resilience.py
+++ b/lemma-backend/app/modules/function/tests/unit/test_function_run_executor_resilience.py
@@ -373,6 +373,42 @@ async def test_poll_timeout_cancels_remote_executor_run():
     assert calls == [("sandbox-1", run_id)]
 
 
+async def test_api_and_job_poll_intervals_are_independent(monkeypatch):
+    observed: list[float] = []
+
+    async def _poll(**kwargs):
+        observed.append(kwargs["poll_interval_seconds"])
+        return FunctionInvokeResponse(
+            status="completed",
+            output_data={"ok": True},
+            code_hash="hash",
+            duration_ms=1,
+        )
+
+    monkeypatch.setattr(fre, "poll_session_executor_job", _poll)
+    executor = _executor()
+    session = SimpleNamespace(
+        env_vars={"LEMMA_TOKEN": "test-token"}, sandbox_id="sandbox-1"
+    )
+
+    await executor._poll_executor_job(
+        session=session,
+        run_id=uuid4(),
+        timeout_seconds=30,
+        poll_interval_seconds=fre._API_FUNCTION_POLL_INTERVAL_SECONDS,
+    )
+    await executor._poll_executor_job(
+        session=session,
+        run_id=uuid4(),
+        timeout_seconds=30,
+    )
+
+    assert observed == [
+        fre._API_FUNCTION_POLL_INTERVAL_SECONDS,
+        fre._JOB_FUNCTION_POLL_INTERVAL_SECONDS,
+    ]
+
+
 async def test_cancelled_execute_cancels_remote_executor_run():
     started = asyncio.Event()
     cancelled: list[tuple[str, object]] = []


### PR DESCRIPTION
## Summary

- remove the E2B cached-status 15–20 second hot-path stall by using one strict two-second observation budget and at most one exact-ID reconnect
- poll accepted API function runs every 500ms while retaining the 5-second JOB interval
- recover a stale Redis Pub/Sub lease during first subscription by replacing it and retrying exactly once

## Why

Live dev tracing showed one-second functions taking about 31 seconds. A cached E2B status read could consume 15–21 seconds, API functions then paid the coarse 5-second JOB polling interval, and stale idle Redis Pub/Sub sockets caused intermittent first-chat 500s.

## Safety

- successful E2B false status no longer loops; it reconnects the exact durable provider ID at most once
- ambiguous/unavailable provider status remains a retryable 503
- duplicate executor execution semantics are unchanged; API and JOB runs still use run-ID idempotency
- a second Redis subscribe failure is propagated

## Validation

- E2B provider tests: 57 passed
- backend function/Redis tests: 27 passed
- Ruff check and format pass on all touched files
- live dev mitigation reduced manager status reads to about 0.4 seconds and one-second API probes from about 31 seconds to about 12 seconds before the permanent 500ms API polling change
