### PR TITLE
fix(agentbox): suspend after one idle timeout

### DIFF
--- a/agentbox/agentbox/state.py
+++ b/agentbox/agentbox/state.py
@@ -371,7 +371,9 @@ class AgentBoxStateStore:
             self._conn.execute(
                 """
                 UPDATE sandboxes
-                SET idle_since_at = COALESCE(idle_since_at, ?), updated_at = ?
+                SET idle_since_at = COALESCE(
+                    idle_since_at, last_active_at, ?
+                ), updated_at = ?
                 WHERE sandbox_id = ?
                 """,
                 (now, now, sandbox_id),

--- a/agentbox/agentbox/state_store/postgres.py
+++ b/agentbox/agentbox/state_store/postgres.py
@@ -579,7 +579,10 @@ class PostgresStateStore:
             await conn.execute(
                 """
                 UPDATE agentbox_sandboxes s
-                SET idle_since_at = coalesce(idle_since_at, now()), updated_at = now()
+                SET idle_since_at = coalesce(
+                        idle_since_at, last_active_at, now()
+                    ),
+                    updated_at = now()
                 WHERE sandbox_id = %s AND desired_state = 'present'
                   AND NOT EXISTS (
                     SELECT 1 FROM agentbox_sessions x WHERE x.sandbox_id = s.sandbox_id
@@ -606,7 +609,9 @@ class PostgresStateStore:
                 await conn.execute(
                     """
                     UPDATE agentbox_sandboxes
-                    SET idle_since_at = coalesce(idle_since_at, now()),
+                    SET idle_since_at = coalesce(
+                            idle_since_at, last_active_at, now()
+                        ),
                         updated_at = now()
                     WHERE sandbox_id = %s AND desired_state = 'present'
                     """,
@@ -744,7 +749,10 @@ class PostgresStateStore:
             await conn.execute(
                 """
                 UPDATE agentbox_sandboxes s
-                SET idle_since_at = coalesce(idle_since_at, now()), updated_at = now()
+                SET idle_since_at = coalesce(
+                        idle_since_at, last_active_at, now()
+                    ),
+                    updated_at = now()
                 WHERE sandbox_id = %s AND NOT EXISTS (
                     SELECT 1 FROM agentbox_sessions x WHERE x.sandbox_id = s.sandbox_id
                 ) AND NOT EXISTS (

--- a/agentbox/agentbox/state_store/sqlite.py
+++ b/agentbox/agentbox/state_store/sqlite.py
@@ -704,7 +704,9 @@ class SQLiteStateStore:
         now = now if now is not None else time.time()
         self._store._conn.execute(
             """
-            UPDATE sandboxes SET idle_since_at = COALESCE(idle_since_at, ?),
+            UPDATE sandboxes SET idle_since_at = COALESCE(
+                    idle_since_at, last_active_at, ?
+                ),
                 updated_at = ?
             WHERE sandbox_id = ?
               AND desired_state = 'present'

--- a/agentbox/tests/test_async_state_store.py
+++ b/agentbox/tests/test_async_state_store.py
@@ -238,6 +238,39 @@ async def test_expiring_activity_lease_protects_idle_session(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_deleting_expired_session_preserves_sandbox_inactivity_clock(tmp_path):
+    store = await SQLiteStateStore.open(str(tmp_path / "state.db"))
+    try:
+        await store.upsert_sandbox("sandbox", SandboxEnsureRequest())
+        await store.upsert_session("sandbox", "session", cwd="/workspace", env_keys=[])
+        stale_at = time.time() - 120
+        with store._store._lock, store._store._conn:
+            store._store._conn.execute(
+                "UPDATE sessions SET last_active_at = ? WHERE sandbox_id = ?",
+                (stale_at, "sandbox"),
+            )
+            store._store._conn.execute(
+                """
+                UPDATE sandboxes SET last_active_at = ?, idle_since_at = NULL
+                WHERE sandbox_id = ?
+                """,
+                (stale_at, "sandbox"),
+            )
+
+        assert [row.session_id for row in await store.expired_sessions(60)] == [
+            "session"
+        ]
+        assert await store.delete_session("sandbox", "session") is True
+
+        record = await store.get_sandbox("sandbox")
+        assert record is not None
+        assert record.idle_since_at == pytest.approx(stale_at)
+        assert [row.sandbox_id for row in await store.idle_sandboxes(60)] == ["sandbox"]
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
 async def test_missing_heartbeat_returns_false_and_existing_returns_true(tmp_path):
     store = await SQLiteStateStore.open(str(tmp_path / "state.db"))
     try:
@@ -625,6 +658,30 @@ async def test_postgres_legacy_schema_migration_and_store_parity():
         assert await store.mark_sandbox_active("missing") is False
         assert await store.mark_sandbox_active("legacy") is True
         assert await store.touch_session("legacy", "session") is True
+
+        await store.ensure_sandbox_defaults("idle")
+        await store.upsert_session("idle", "session", cwd="/workspace", env_keys=[])
+        await admin.execute(
+            """
+            UPDATE agentbox_sessions
+            SET last_active_at = now() - interval '120 seconds'
+            WHERE sandbox_id = 'idle';
+            UPDATE agentbox_sandboxes
+            SET last_active_at = now() - interval '120 seconds',
+                idle_since_at = NULL
+            WHERE sandbox_id = 'idle';
+            """
+        )
+        assert [row.session_id for row in await store.expired_sessions(60)] == [
+            "session"
+        ]
+        assert await store.delete_session("idle", "session") is True
+        idle_record = await store.get_sandbox("idle")
+        assert idle_record is not None
+        assert idle_record.idle_since_at is not None
+        assert idle_record.idle_since_at < time.time() - 60
+        assert "idle" in {row.sandbox_id for row in await store.idle_sandboxes(60)}
+        assert await store.mark_pod_stopped("idle") is not None
 
         defaults = await asyncio.gather(
             *(store.ensure_sandbox_defaults("new") for _ in range(10))

--- a/agentbox/tests/test_lifecycle_manager.py
+++ b/agentbox/tests/test_lifecycle_manager.py
@@ -1221,6 +1221,41 @@ async def test_suspended_retention_is_measured_from_suspension(tmp_path, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_cleanup_suspends_sandbox_when_its_last_session_expires(
+    tmp_path, monkeypatch
+):
+    manager, provider, store = await _manager(tmp_path)
+    try:
+        monkeypatch.setattr(settings, "agentbox_session_idle_timeout_seconds", 60)
+        monkeypatch.setattr(settings, "agentbox_sandbox_idle_timeout_seconds", 60)
+        await manager.ensure("sandbox", SandboxEnsureRequest())
+        await store.upsert_session("sandbox", "session", cwd="/workspace", env_keys=[])
+        stale_at = time.time() - 120
+        with store._store._lock, store._store._conn:
+            store._store._conn.execute(
+                "UPDATE sessions SET last_active_at = ? WHERE sandbox_id = ?",
+                (stale_at, "sandbox"),
+            )
+            store._store._conn.execute(
+                """
+                UPDATE sandboxes SET last_active_at = ?, idle_since_at = NULL
+                WHERE sandbox_id = ?
+                """,
+                (stale_at, "sandbox"),
+            )
+
+        await lifecycle_module.cleanup_once(manager)
+
+        assert await store.get_session("sandbox", "session") is None
+        record = await store.get_sandbox("sandbox")
+        assert record is not None
+        assert record.desired_state == "suspended"
+        assert provider.release_count == 1
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
 async def test_lost_activity_lease_cancels_owner(monkeypatch):
     class LostStore:
         async def renew_activity_lease(self, *args, **kwargs):


### PR DESCRIPTION
## Summary
- preserve the sandbox's existing inactivity timestamp when its final session is removed
- allow session expiry and compute suspension in the same cleanup pass
- cover SQLite, PostgreSQL, and the legacy SQLite state path
- add state-store, lifecycle, and real PostgreSQL regression coverage
## Why
The dev release gate exposed that a 180-second idle session was deleted at the first timeout, but the sandbox idle clock restarted at deletion time. Compute therefore remained active for roughly 360 seconds instead of the configured 180 seconds
## Validation\n- targeted lifecycle regressions: 3 passed
- state-store + lifecycle suites: 57 passed, 1 skipped\n- real PostgreSQL 16 parity test: passed
- full AgentBox suite: 271 passed, 4 skipped; one unrelated Docker generation
- -conflict flake passed immediately in isolation
- Ruff and git diff checks passed