### PR TITLE
fix(agentbox): type nullable lifecycle state parameters

### DIFF
--- a/agentbox/agentbox/state_store/postgres.py
+++ b/agentbox/agentbox/state_store/postgres.py
@@ -456,15 +456,15 @@ class PostgresStateStore:
                     UPDATE agentbox_sandboxes SET observed_state = %s,
                         last_failure = %s,
                         reconcile_after = CASE
-                            WHEN %s IS NULL THEN NULL
-                            ELSE to_timestamp(%s)
+                            WHEN %s::double precision IS NULL THEN NULL
+                            ELSE to_timestamp(%s::double precision)
                         END,
                         last_observed_at = now(), updated_at = now()
                     WHERE sandbox_id = %s
                       AND desired_state = 'present'
                       AND desired_generation = %s
                       AND observed_generation = %s
-                      AND (%s IS NULL OR observed_state = %s)
+                      AND (%s::text IS NULL OR observed_state = %s::text)
                     RETURNING {self._sandbox_columns()}
                     """,
                     (

--- a/agentbox/tests/test_async_state_store.py
+++ b/agentbox/tests/test_async_state_store.py
@@ -1035,6 +1035,30 @@ async def test_postgres_legacy_schema_migration_and_store_parity():
         assert session.active_operations == 9
         assert await store.mark_sandbox_active("missing") is False
         await _observe_running(store, "legacy")
+        current = await store.get_sandbox("legacy")
+        assert current is not None
+        degraded = await store.set_sandbox_observed_state(
+            "legacy",
+            observed_state="degraded",
+            expected_generation=current.desired_generation,
+            expected_observed_state=None,
+            last_failure="route unavailable",
+            reconcile_after=None,
+        )
+        assert degraded is not None
+        assert degraded.observed_state == "degraded"
+        assert degraded.last_failure == "route unavailable"
+        assert degraded.reconcile_after is None
+        restored = await store.set_sandbox_observed_state(
+            "legacy",
+            observed_state="running",
+            expected_generation=current.desired_generation,
+            expected_observed_state="degraded",
+            last_failure=None,
+            reconcile_after=None,
+        )
+        assert restored is not None
+        assert restored.observed_state == "running"
         assert await store.mark_sandbox_active("legacy") is True
         assert await store.touch_session("legacy", "session") is True
 


### PR DESCRIPTION
## Summary
- explicitly type nullable lifecycle-state SQL parameters for PostgreSQL
- prevent route-failure recording from masking E2B routing errors with IndeterminateDatatype
- add real PostgreSQL coverage for both nullable and guarded observed-state updates

## Production evidence
A transient E2B endpoint-routing failure reached set_sandbox_observed_state with expected_observed_state=None and reconcile_after=None. PostgreSQL could not infer parameter 8 and raised psycopg.errors.IndeterminateDatatype, turning the recoverable route failure into a manager 500.

## Validation
- 24 focused state-store tests passed (1 integration test skipped without DB)
- PostgreSQL 16 parity regression passed against a disposable real database
- Ruff check passed
- Ruff format --check passed