### PR TITLE
feat(observability): structured logging remediation phase 1

### DIFF
--- a/lemma-backend/app/app.py
+++ b/lemma-backend/app/app.py
@@ -29,7 +29,7 @@ from app.core.security import verify_auth
 from app.modules.identity.infrastructure.supertokens_auth.initialization import (
     initialize_supertokens,
 )
-from app.core.log.log import setup_logging, get_logger
+from app.core.log.log import setup_logging, get_logger, validate_release_identity
 from app.core.observability.telemetry import (
     init_telemetry,
     instrument_database_engine,
@@ -140,6 +140,9 @@ async def lifespan(app: FastAPI):
         await get_streaq_job_queue().connect()
         await get_message_bus().connect()
         logger.info("Redis broker started")
+        # One stable startup event after initialization succeeds. service.version
+        # and release.sha are attached by the logging context from LEMMA_RELEASE_SHA.
+        logger.info("service.started")
 
         try:
             # Module-contributed API lifespans (e.g. datastore query-role
@@ -277,6 +280,7 @@ def create_app(modules=OSS_MODULES) -> FastAPI:
         json_logs=settings.json_logs_enabled,
         log_level=settings.log_level,
     )
+    validate_release_identity(settings.environment)
     app = FastAPI(
         title=settings.app_name,
         description="Authentication API with JWT, user management, and OAuth support",
@@ -380,29 +384,96 @@ def create_app(modules=OSS_MODULES) -> FastAPI:
     # routers() thunk. See app/modules/<name>/module.py.
     include_module_routers(app, modules)
 
-    # Health check
-    @app.get("/health")
-    async def health_check():
-        return {"status": "healthy", "message": "API is running"}
-
-    # Liveness: 503 when the event loop is wedged (lag over the unhealthy
-    # threshold), so a Kubernetes liveness probe restarts the process. A fully
-    # blocked loop can't serve this at all, which trips the probe's timeout —
-    # either way a hung process is restarted instead of hanging silently.
+    # Liveness: process/event-loop check only. No DB or network dependency, so
+    # it normally completes within ~100 ms. 503 when the event loop is wedged
+    # (lag over the unhealthy threshold), so a liveness probe restarts the
+    # process. A fully blocked loop can't serve this at all, which trips the
+    # probe's timeout — either way a hung process is restarted instead of
+    # hanging silently.
+    @app.get("/health/live", include_in_schema=False)
     @app.get("/livez", include_in_schema=False)
-    async def livez():
+    async def health_live():
         from app.core.observability.loop_watchdog import (
             get_loop_lag_seconds,
             is_loop_healthy,
         )
 
+        healthy = is_loop_healthy()
         payload = {
-            "status": "ok" if is_loop_healthy() else "unhealthy",
+            "status": "ok" if healthy else "unhealthy",
             "loop_lag_seconds": round(get_loop_lag_seconds(), 3),
         }
-        return JSONResponse(
-            payload, status_code=200 if is_loop_healthy() else 503
+        return JSONResponse(payload, status_code=200 if healthy else 503)
+
+    # Readiness: bounded, concurrent checks for dependencies required to serve
+    # new work. Each check has ~1 s; the whole endpoint has a ~2 s deadline.
+    # 503 when not ready; only generic component states are exposed, never
+    # connection strings or provider responses.
+    @app.get("/health/ready", include_in_schema=False)
+    async def health_ready():
+        import asyncio as _asyncio
+
+        from sqlalchemy import text
+
+        async def _db_ok() -> bool:
+            try:
+                engine = get_engine()
+                async with engine.connect() as conn:
+                    await conn.execute(text("SELECT 1"))
+                return True
+            except Exception:
+                return False
+
+        async def _redis_ok() -> bool:
+            try:
+                return await channel_service.ping()
+            except Exception:
+                return False
+
+        async def _with_timeout(coro, seconds: float) -> bool:
+            try:
+                return await _asyncio.wait_for(coro, timeout=seconds)
+            except Exception:
+                return False
+
+        # Run dependency checks concurrently; each is individually bounded and
+        # the pair is bounded by the overall gather timeout.
+        db_task = redis_task = None
+        try:
+            db_task = _asyncio.create_task(_with_timeout(_db_ok(), 1.0))
+            redis_task = _asyncio.create_task(_with_timeout(_redis_ok(), 1.0))
+            db_ok, redis_ok = await _asyncio.wait_for(
+                _asyncio.gather(db_task, redis_task), timeout=2.0
+            )
+        except Exception:
+            db_ok, redis_ok = False, False
+        finally:
+            for t in (db_task, redis_task):
+                if t is not None and not t.done():
+                    t.cancel()
+
+        components = {
+            "db": "ok" if db_ok else "down",
+            "redis": "ok" if redis_ok else "down",
+        }
+        ready = bool(db_ok) and bool(redis_ok)
+        payload = {"status": "ready" if ready else "not_ready", "components": components}
+        return JSONResponse(payload, status_code=200 if ready else 503)
+
+    # Compatibility alias for /health/live during probe migration.
+    @app.get("/health", include_in_schema=False)
+    async def health_alias():
+        from app.core.observability.loop_watchdog import (
+            get_loop_lag_seconds,
+            is_loop_healthy,
         )
+
+        healthy = is_loop_healthy()
+        payload = {
+            "status": "ok" if healthy else "unhealthy",
+            "loop_lag_seconds": round(get_loop_lag_seconds(), 3),
+        }
+        return JSONResponse(payload, status_code=200 if healthy else 503)
 
     @app.get("/scalar", include_in_schema=False)
     async def scalar_html():

--- a/lemma-backend/app/core/api/exception_handlers.py
+++ b/lemma-backend/app/core/api/exception_handlers.py
@@ -17,7 +17,9 @@ the status before the response body starts, or (b) a genuine status remap.
 
 from __future__ import annotations
 
+import time
 from collections.abc import Mapping, Sequence
+from typing import Any, Callable
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
@@ -29,6 +31,13 @@ from app.core.observability.telemetry import record_exception_on_current_span
 from app.core.redaction import redact_text, redact_value
 
 logger = get_logger(__name__)
+
+# Per-(route template, status code) throttle window. Auth denials and rate-limit
+# responses can be high-volume; the contract wants an aggregate/state-transition
+# signal, not one event per request. Process-local; each replica emits its own
+# bounded aggregate (cardinality is bounded by route template x status code).
+_THROTTLE_WINDOW_SECONDS = 10.0
+_last_throttled_emit: dict[tuple[str, int], float] = {}
 
 
 def _sanitize_validation_payload(value: object) -> object:
@@ -57,6 +66,103 @@ def _error_body(
     }
 
 
+def _route_template(request: Request) -> str:
+    """Normalized route template (e.g. ``/pods/{id}``), never a raw URL/query string."""
+    route = request.scope.get("route")
+    try:
+        if route is not None and hasattr(route, "path_format"):
+            return route.path_format
+    except Exception:  # pragma: no cover - defensive
+        pass
+    return redact_text(request.url.path)
+
+
+def _throttled(
+    log_method: Callable[..., None],
+    event: str,
+    *,
+    request: Request,
+    status_code: int,
+    code: str | None,
+    error_type: str,
+) -> None:
+    """Emit at most one ``event`` per (route, status) per throttle window."""
+    route = _route_template(request)
+    key = (route, status_code)
+    now = time.monotonic()
+    last = _last_throttled_emit.get(key)
+    if last is not None and now - last < _THROTTLE_WINDOW_SECONDS:
+        return
+    _last_throttled_emit[key] = now
+    payload: dict[str, Any] = {
+        "route": route,
+        "method": request.method,
+        "status_code": status_code,
+        "error_type": error_type,
+        "request_id": request.headers.get("x-request-id"),
+    }
+    if code is not None:
+        payload["code"] = code
+    log_method(event, **payload)
+
+
+def _log_request_error(
+    request: Request,
+    *,
+    status_code: int,
+    code: str | None,
+    error_type: str,
+) -> None:
+    """Severity policy for an HTTP error boundary.
+
+    * 5xx -> ``error`` once (the global boundary is the single place a 5xx is logged).
+    * 401/403 (auth denial) -> sampled ``info`` via throttle.
+    * 429 (rate limit) -> rate-limited ``warning`` via throttle.
+    * other 4xx (validation, not-found, conflict, ...) -> ``debug``; no
+      production steady-state event at INFO+.
+    """
+    if status_code >= 500:
+        logger.error(
+            "request.error",
+            route=_route_template(request),
+            method=request.method,
+            status_code=status_code,
+            code=code,
+            error_type=error_type,
+            request_id=request.headers.get("x-request-id"),
+        )
+        return
+    if status_code in (401, 403):
+        _throttled(
+            logger.info,
+            "auth.denied",
+            request=request,
+            status_code=status_code,
+            code=code,
+            error_type=error_type,
+        )
+        return
+    if status_code == 429:
+        _throttled(
+            logger.warning,
+            "request.rate_limited",
+            request=request,
+            status_code=status_code,
+            code=code,
+            error_type=error_type,
+        )
+        return
+    logger.debug(
+        "request.error",
+        route=_route_template(request),
+        method=request.method,
+        status_code=status_code,
+        code=code,
+        error_type=error_type,
+        request_id=request.headers.get("x-request-id"),
+    )
+
+
 def register_exception_handlers(app: FastAPI) -> None:
     """Register the unified error handlers on ``app`` (idempotent per app)."""
 
@@ -71,15 +177,11 @@ def register_exception_handlers(app: FastAPI) -> None:
             },
             mark_span_as_error=exc.status_code >= 500,
         )
-        log_method = logger.error if exc.status_code >= 500 else logger.warning
-        log_method(
-            "Domain error",
-            path=request.url.path,
-            method=request.method,
-            code=exc.code,
+        _log_request_error(
+            request,
             status_code=exc.status_code,
-            message=exc.message,
-            details=redact_value(exc.details),
+            code=exc.code,
+            error_type=type(exc).__name__,
         )
         return JSONResponse(
             status_code=exc.status_code,
@@ -97,12 +199,11 @@ def register_exception_handlers(app: FastAPI) -> None:
             },
             mark_span_as_error=False,
         )
-        logger.warning(
-            "Request validation error",
-            path=request.url.path,
-            method=request.method,
+        _log_request_error(
+            request,
             status_code=422,
-            error_count=len(errors) if isinstance(errors, Sequence) else 0,
+            code="VALIDATION_ERROR",
+            error_type=type(exc).__name__,
         )
         return JSONResponse(
             status_code=422,
@@ -118,13 +219,11 @@ def register_exception_handlers(app: FastAPI) -> None:
             attributes={"http.response.status_code": exc.status_code},
             mark_span_as_error=exc.status_code >= 500,
         )
-        log_method = logger.error if exc.status_code >= 500 else logger.info
-        log_method(
-            "HTTP exception",
-            path=request.url.path,
-            method=request.method,
+        _log_request_error(
+            request,
             status_code=exc.status_code,
-            detail=redact_value(exc.detail),
+            code=f"HTTP_{exc.status_code}",
+            error_type=type(exc).__name__,
         )
         return JSONResponse(
             status_code=exc.status_code,
@@ -143,11 +242,16 @@ def register_exception_handlers(app: FastAPI) -> None:
             },
             mark_span_as_error=True,
         )
+        # The global boundary logs the 5xx exactly once; the traceback renders as
+        # one JSON-escaped ``exception`` string (no physical-line fan-out).
         logger.exception(
-            "Unhandled exception",
-            path=request.url.path,
+            "request.error",
+            route=_route_template(request),
             method=request.method,
             status_code=500,
+            code="INTERNAL_ERROR",
+            error_type=type(exc).__name__,
+            request_id=request.headers.get("x-request-id"),
         )
         return JSONResponse(
             status_code=500,

--- a/lemma-backend/app/core/config.py
+++ b/lemma-backend/app/core/config.py
@@ -447,6 +447,16 @@ class Settings(BaseSettings):
         default=True,
         description="Emit structured JSON logs instead of console-formatted logs",
     )
+    release_sha: Optional[str] = Field(
+        default=None,
+        description=(
+            "Full 40-character source Git SHA whose immutable image digest is "
+            "deployed. Emitted as ``service.version`` and ``release.sha`` on every "
+            "log line and added to the OpenTelemetry Resource. Required in "
+            "production: startup rejects an empty or non-hex value. Env: "
+            "``LEMMA_RELEASE_SHA``."
+        ),
+    )
     frontend_url: str = Field(
         default="http://localhost:3711", description="Frontend URL for email links"
     )
@@ -734,6 +744,22 @@ class Settings(BaseSettings):
     observability_metrics_export_interval_millis: int = Field(
         default=15000,
         description="Metric export interval for OTEL periodic readers",
+    )
+    otel_traces_sampler: str = Field(
+        default="parentbased_traceidratio",
+        description=(
+            "OpenTelemetry trace sampler strategy. Defaults to parent-based 5%% "
+            "head sampling so a sampled parent propagates the decision and "
+            "independent roots are sampled at the configured ratio. Env: "
+            "``OTEL_TRACES_SAMPLER``."
+        ),
+    )
+    otel_traces_sampler_arg: float = Field(
+        default=0.05,
+        description=(
+            "Sampling ratio for ratio-based samplers (0.05 = 5%%). Env: "
+            "``OTEL_TRACES_SAMPLER_ARG``."
+        ),
     )
     lemma_llm_caching_enabled: bool = Field(
         default=False,

--- a/lemma-backend/app/core/infrastructure/channels/channel_service.py
+++ b/lemma-backend/app/core/infrastructure/channels/channel_service.py
@@ -98,6 +98,20 @@ class RedisChannelAdapter:
         assert self._redis is not None
         return self._redis
 
+    async def ping(self) -> bool:
+        """Return True if the shared Redis client can respond to ``PING``.
+
+        Used by the ``/health/ready`` check. Never raises: a down Redis is
+        reported as ``False`` so readiness returns 503 rather than erroring.
+        """
+        if self._redis is None:
+            return False
+        try:
+            await self._redis.ping()
+            return True
+        except RedisError:
+            return False
+
     async def publish(self, channel: str, message: object) -> None:
         """Publish a transient payload through the shared Redis pool."""
         payload: str | bytes

--- a/lemma-backend/app/core/infrastructure/jobs/streaq_runtime.py
+++ b/lemma-backend/app/core/infrastructure/jobs/streaq_runtime.py
@@ -25,7 +25,7 @@ from app.core.infrastructure.jobs.streaq_job_queue import (
 from app.modules.identity.infrastructure.supertokens_auth.initialization import (
     initialize_supertokens,
 )
-from app.core.log.log import get_logger, setup_logging
+from app.core.log.log import get_logger, setup_logging, validate_release_identity
 from app.core.observability.telemetry import init_telemetry, instrument_database_engine
 
 logger = get_logger(__name__)
@@ -200,6 +200,18 @@ async def _consumer_group_reconcile_loop() -> None:
         await client.aclose()
 
 
+# Low-rate structured heartbeat for remote absence detection. At 5 min this is
+# <600 records/48h. service.version is attached by the logging context.
+_WORKER_HEARTBEAT_INTERVAL_SECONDS = 300.0
+
+
+async def _worker_heartbeat_loop() -> None:
+    """Emit ``worker.heartbeat`` every 5 min while the worker loop is healthy."""
+    while True:
+        await asyncio.sleep(_WORKER_HEARTBEAT_INTERVAL_SECONDS)
+        logger.info("worker.heartbeat")
+
+
 @asynccontextmanager
 async def worker_lifespan() -> AsyncGenerator[AppWorkerContext]:
     setup_logging(
@@ -208,6 +220,7 @@ async def worker_lifespan() -> AsyncGenerator[AppWorkerContext]:
         json_logs=settings.json_logs_enabled,
         log_level=settings.log_level,
     )
+    validate_release_identity(settings.environment)
     init_telemetry(service_name="lemma-worker")
     instrument_database_engine(get_engine())
     # Size the thread-offload pool before any task runs blocking work off-loop.
@@ -249,6 +262,8 @@ async def worker_lifespan() -> AsyncGenerator[AppWorkerContext]:
         uow_factory=SessionUnitOfWorkFactory(async_session_maker),
     )
     logger.info("Worker starting...")
+    # One stable startup event after initialization succeeds.
+    logger.info("service.started")
     # Imported lazily to avoid an import cycle: the registry imports module
     # `module.py` files whose worker hooks reference AppWorkerContext (defined
     # in this file).
@@ -272,6 +287,11 @@ async def worker_lifespan() -> AsyncGenerator[AppWorkerContext]:
             heartbeat_path=settings.worker_heartbeat_path or None,
         )
     )
+    # Low-rate structured heartbeat for remote absence detection of this
+    # singleton background process. At 5 min this is <600 records/48h. The
+    # worker has no HTTP server, so the heartbeat event + the watchdog's
+    # heartbeat file are its liveness signals.
+    heartbeat_task = asyncio.create_task(_worker_heartbeat_loop())
 
     try:
         # Module-contributed worker lifespans (e.g. agent_surfaces native event
@@ -284,7 +304,7 @@ async def worker_lifespan() -> AsyncGenerator[AppWorkerContext]:
             await enter_worker_lifespans(module_stack, OSS_MODULES, context)
             yield context
     finally:
-        for background_task in (reconcile_task, watchdog_task):
+        for background_task in (reconcile_task, watchdog_task, heartbeat_task):
             if background_task is not None and not background_task.done():
                 background_task.cancel()
                 try:

--- a/lemma-backend/app/core/log/log.py
+++ b/lemma-backend/app/core/log/log.py
@@ -1,4 +1,22 @@
+"""Structured logging for Lemma services.
+
+Every application-owned stdout/stderr event is exactly one JSON object on one
+physical line. Two producer paths feed a single handler:
+
+* **Application code** uses :func:`get_logger` and goes through the structlog
+  processor chain.
+* **Foreign loggers** (the standard library ``logging`` module used by httpx,
+  uvicorn, Azure SDK, …) are routed through the same processor chain by
+  :class:`structlog.stdlib.ProcessorFormatter`.
+
+Both paths share one pre-chain — timestamping, severity, trace context, static
+service/release context, exception formatting, and redaction — so a foreign
+``httpx`` line and an application ``service.started`` line are indistinguishable
+in shape and both safe (no credentials, no bodies, one line).
+"""
+
 import logging
+import re
 import structlog
 import sys
 from typing import Any, Protocol
@@ -7,12 +25,39 @@ from opentelemetry import trace
 
 from app.core.redaction import redact_event_dict
 
+# Static context merged onto every event dict by ``_add_static_context``.
+# Populated by ``setup_logging`` with service/environment/release metadata.
 _logging_context: dict[str, Any] = {}
+
+# Whether the single console handler has already been installed. ``setup_logging``
+# is called at import time with a safe default and again from each service
+# entrypoint with real metadata; the handler must only be attached once so
+# repeated calls never duplicate output.
+_logging_configured: bool = False
+
+# 40-character lowercase-hex Git SHA.
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+# Foreign (stdlib) loggers whose routine INFO output is not useful console
+# telemetry. Successful dependency requests are suppressed; failures still
+# surface at WARNING+. Applied in every environment — the volume problem is the
+# same in dev and prod, and a wedged dependency is visible either way.
+_FOREIGN_LOGGER_LEVELS: dict[str, int] = {
+    "httpx": logging.WARNING,
+    "httpcore": logging.WARNING,
+    "uvicorn.access": logging.WARNING,
+    "uvicorn.error": logging.INFO,
+    "streaq": logging.WARNING,
+    "faststream": logging.WARNING,
+    "azure": logging.WARNING,
+    "azure.core": logging.WARNING,
+    "e2b": logging.WARNING,
+}
 
 
 class Logger(Protocol):
     """Protocol defining our logger interface for type checking"""
-    
+
     def debug(self, event: str, **kwargs: Any) -> None: ...
     def info(self, event: str, **kwargs: Any) -> None: ...
     def warning(self, event: str, **kwargs: Any) -> None: ...
@@ -41,18 +86,88 @@ def _add_static_context(
     return event_dict
 
 
-def _normalize_event(
+def _add_logger_name(
     _: Any, __: str, event_dict: dict[str, Any]
 ) -> dict[str, Any]:
-    event = event_dict.get("event")
-    if isinstance(event, str) and "message" not in event_dict:
-        event_dict["message"] = event
+    """Set ``logger`` for foreign stdlib records (structlog records bind it already)."""
+    if "logger" not in event_dict:
+        record: logging.LogRecord | None = event_dict.get("_record")
+        if record is not None:
+            event_dict["logger"] = record.name
+    return event_dict
+
+
+def _add_exc_info(
+    _: Any, __: str, event_dict: dict[str, Any]
+) -> dict[str, Any]:
+    """Copy ``exc_info`` from a foreign stdlib record so ``format_exc_info`` renders it.
+
+    structlog records already carry ``exc_info`` when produced by ``.exception()``;
+    this is a no-op for them (``_record`` is not yet attached during the structlog
+    pre-chain). For foreign records, ``ProcessorFormatter`` attaches ``_record``
+    before the foreign pre-chain runs, and this is how their traceback enters the
+    shared exception formatter — as one JSON-escaped string, not a fan-out of
+    physical lines.
+    """
+    record: logging.LogRecord | None = event_dict.get("_record")
+    if (
+        record is not None
+        and record.exc_info
+        and "exc_info" not in event_dict
+    ):
+        event_dict["exc_info"] = record.exc_info
     return event_dict
 
 
 def _is_otel_handler(handler: logging.Handler) -> bool:
     module = handler.__class__.__module__
     return module.startswith("opentelemetry.")
+
+
+def _deployment_environment(env: str) -> str:
+    """Collapse the runtime environment to the bounded cardinality the log contract uses."""
+    return "production" if env == "production" else "development"
+
+
+def _shared_processors() -> list:
+    """Processors applied to both structlog and foreign records, in order."""
+    return [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+        _add_trace_context,
+        _add_static_context,
+        _add_logger_name,
+        _add_exc_info,
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+        redact_event_dict,
+    ]
+
+
+def _resolve_release_sha() -> tuple[str | None, bool]:
+    """Return ``(raw_value, is_valid)`` for the configured release SHA.
+
+    ``raw_value`` is the stripped ``LEMMA_RELEASE_SHA`` (or ``None`` when unset/
+    settings unavailable). ``is_valid`` is True only for a 40-char lowercase-hex
+    SHA. Callers decide the display value (real SHA vs ``"unknown"``) and whether
+    to warn; release identity is best-effort metadata and never blocks startup.
+    """
+    try:
+        from app.core.config import settings
+
+        raw = (settings.release_sha or "").strip()
+    except Exception:  # pragma: no cover - settings unavailable during early import
+        return None, False
+    if _SHA_RE.match(raw):
+        return raw, True
+    return (raw or None), False
+
+
+# Display value used on every log line when no valid release SHA is configured.
+# Kept queryable (``release.sha == "unknown"``) rather than omitted so an alert
+# can surface unattributed deployments.
+_RELEASE_SHA_UNKNOWN = "unknown"
 
 
 def setup_logging(
@@ -62,129 +177,100 @@ def setup_logging(
     json_logs: bool = True,
     log_level: str = "INFO",
 ) -> None:
+    """Configure structured logging for the application.
+
+    Safe to call more than once: the console handler is attached exactly once
+    and OpenTelemetry handlers attached later (by ``init_telemetry``) are
+    preserved. Re-calls only refresh static context and levels.
     """
-    Configure structured logging for the application.
-    Call this once at application startup.
-    
-    Args:
-        env: Environment name ('production', 'development', 'test')
-    """
+    global _logging_configured
+
+    sha_value, is_valid_sha = _resolve_release_sha()
+    release_sha = sha_value if is_valid_sha else _RELEASE_SHA_UNKNOWN
     _logging_context.clear()
     _logging_context.update(
         {
             "service.name": service_name,
-            "deployment.environment": env,
+            "deployment.environment": _deployment_environment(env),
+            "service.version": release_sha,
+            "release.sha": release_sha,
         }
     )
-    resolved_level = getattr(logging, log_level.upper(), logging.INFO)
-    processors = [
-        structlog.contextvars.merge_contextvars,
-        structlog.stdlib.add_log_level,
-        structlog.processors.TimeStamper(fmt="iso"),
-        _add_trace_context,
-        _add_static_context,
-        _normalize_event,
-        structlog.processors.StackInfoRenderer(),
-        structlog.processors.format_exc_info,
-        redact_event_dict,
-    ]
 
-    if json_logs:
-        processors.append(structlog.processors.JSONRenderer())
-    else:
-        processors.append(structlog.dev.ConsoleRenderer())
-    
+    resolved_level = getattr(logging, log_level.upper(), logging.INFO)
+    shared = _shared_processors()
+    renderer = (
+        structlog.processors.JSONRenderer()
+        if json_logs
+        else structlog.dev.ConsoleRenderer()
+    )
+
     structlog.configure(
-        processors=processors,
-        wrapper_class=structlog.make_filtering_bound_logger(
-            resolved_level
-        ),
+        processors=shared + [structlog.stdlib.ProcessorFormatter.wrap_for_formatter],
+        wrapper_class=structlog.make_filtering_bound_logger(resolved_level),
         context_class=dict,
         logger_factory=structlog.stdlib.LoggerFactory(),
         cache_logger_on_first_use=False,
     )
-    
-    # Configure standard library logging while preserving OTEL handlers that may
-    # have been attached earlier in this process. The local app embeds the worker
-    # in the API process, so setup_logging can run more than once after telemetry
-    # is initialized.
+
     root_logger = logging.getLogger()
-    preserved_handlers = [
-        handler for handler in root_logger.handlers if _is_otel_handler(handler)
-    ]
-    stream_handler = logging.StreamHandler(sys.stdout)
-    stream_handler.setFormatter(logging.Formatter("%(message)s"))
-    root_logger.handlers = [stream_handler, *preserved_handlers]
+    if not _logging_configured:
+        formatter = structlog.stdlib.ProcessorFormatter(
+            foreign_pre_chain=shared,
+            processors=[
+                structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                renderer,
+            ],
+        )
+        stream_handler = logging.StreamHandler(sys.stdout)
+        stream_handler.setFormatter(formatter)
+        # Preserve any OpenTelemetry handlers that may already be attached; add
+        # our single console handler once.
+        preserved_handlers = [
+            handler for handler in root_logger.handlers if _is_otel_handler(handler)
+        ]
+        root_logger.handlers = [stream_handler, *preserved_handlers]
+        _logging_configured = True
+
     root_logger.setLevel(resolved_level)
+    for name, level in _FOREIGN_LOGGER_LEVELS.items():
+        logging.getLogger(name).setLevel(level)
+
+
+def validate_release_identity(env: str) -> None:
+    """Warn when ``LEMMA_RELEASE_SHA`` is missing or malformed.
+
+    Release identity is best-effort log/release correlation metadata — it never
+    blocks startup. A missing or non-40-hex value logs a single warning (visible
+    to on-call and alertable via ``release.sha == "unknown"``) and the log
+    context falls back to ``"unknown"``. This keeps the logging remediation
+    decoupled from infra-side env wiring: the volume fix lands safely even if
+    ``LEMMA_RELEASE_SHA`` is not yet set in a given environment.
+    """
+    sha, is_valid = _resolve_release_sha()
+    if is_valid:
+        return
+    if sha is None:
+        get_logger(__name__).warning(
+            "release.sha missing",
+            hint="set LEMMA_RELEASE_SHA to the 40-char source git sha for log/release correlation",
+            deployment_environment=_deployment_environment(env),
+        )
+    else:
+        get_logger(__name__).warning(
+            "release.sha malformed",
+            value=sha,
+            hint="LEMMA_RELEASE_SHA must be a 40-char lowercase-hex git sha; falling back to 'unknown'",
+            deployment_environment=_deployment_environment(env),
+        )
 
 
 def get_logger(name: str) -> Logger:
-    """
-    Get a logger instance for the given module.
-    
-    This wrapper allows us to:
-    1. Provide proper type hints for IDE autocomplete
-    2. Easily swap logging libraries in the future
-    3. Add custom behavior if needed
-    
-    Args:
-        name: Module name, typically __name__
-        
-    Returns:
-        Logger instance with proper type hints
-        
-    Example:
-        >>> from config.logging import get_logger
-        >>> logger = get_logger(__name__)
-        >>> logger.info("user_created", user_id=123)
-    """
+    """Get a logger instance for the given module (typically ``__name__``)."""
     return structlog.get_logger().bind(logger=name)  # type: ignore[return-value]
-
-
-# Optional: Add custom log levels or methods
-class CustomLogger:
-    """
-    Optional: If you want to add custom logging methods,
-    wrap the structlog logger in a class
-    """
-    
-    def __init__(self, logger: Any):
-        self._logger = logger
-    
-    def debug(self, event: str, **kwargs: Any) -> None:
-        self._logger.debug(event, **kwargs)
-    
-    def info(self, event: str, **kwargs: Any) -> None:
-        self._logger.info(event, **kwargs)
-    
-    def warning(self, event: str, **kwargs: Any) -> None:
-        self._logger.warning(event, **kwargs)
-    
-    def error(self, event: str, **kwargs: Any) -> None:
-        self._logger.error(event, **kwargs)
-    
-    def exception(self, event: str, **kwargs: Any) -> None:
-        self._logger.exception(event, **kwargs)
-    
-    def bind(self, **kwargs: Any) -> "CustomLogger":
-        return CustomLogger(self._logger.bind(**kwargs))
-    
-    # Add custom methods
-    def audit(self, event: str, **kwargs: Any) -> None:
-        """Log audit events with special handling"""
-        self._logger.info(event, log_type="audit", **kwargs)
-    
-    def security(self, event: str, **kwargs: Any) -> None:
-        """Log security events with special handling"""
-        self._logger.warning(event, log_type="security", **kwargs)
-
-
-def get_custom_logger(name: str) -> CustomLogger:
-    """Get a custom logger with additional methods"""
-    return CustomLogger(structlog.get_logger().bind(logger=name))
 
 
 # Configure a safe default immediately so module-level loggers created during
 # imports already emit structured logs. Applications reconfigure this later
-# with the right service metadata.
+# with the right service metadata (and call validate_release_identity).
 setup_logging()

--- a/lemma-backend/app/core/observability/loop_watchdog.py
+++ b/lemma-backend/app/core/observability/loop_watchdog.py
@@ -10,7 +10,13 @@ restarts it. This watchdog makes a wedged loop *observable* and *actionable*:
 - It writes a heartbeat file (current epoch seconds) each tick. A wedged loop
   can't update it, so an external liveness probe can check the file's freshness
   and restart the process. This is how the worker (which has no HTTP server)
-  gets a liveness signal; the API additionally serves ``/livez``.
+  gets a liveness signal; the API additionally serves ``/health/live``.
+
+Loop-lag telemetry is **stateful**. While degraded, the in-memory maximum lag is
+tracked without emitting a warning on every tick; a single
+``runtime.loop_lag.degraded`` event fires on the transition. Recovery emits a
+single ``runtime.loop_lag.recovered`` event only after a small hysteresis window
+of consecutive healthy checks, so threshold jitter does not alternate events.
 
 Mirrors the background-task shape of ``_consumer_group_reconcile_loop`` in the
 streaq runtime: started in the lifespan, cancelled on shutdown.
@@ -29,9 +35,21 @@ from app.core.log.log import get_logger
 
 logger = get_logger(__name__)
 
-# Most-recent measured event-loop lag (seconds). Module-global so /livez and
-# metrics can read it without holding a reference to the task.
+# Most-recent measured event-loop lag (seconds). Module-global so /health/live
+# and metrics can read it without holding a reference to the task.
 _last_lag_seconds: float = 0.0
+
+# Degraded-state machine for loop-lag telemetry. Module-global so the watchdog
+# task and tests can reset/inspect it without holding a reference to the task.
+_degraded: bool = False
+_degraded_since: float = 0.0  # time.monotonic() at degraded transition
+_max_lag_seconds: float = 0.0  # peak lag observed during the current degraded window
+_healthy_streak: int = 0  # consecutive healthy ticks while waiting to recover
+
+# Consecutive healthy ticks required before emitting recovery. At the default
+# 0.5s interval this is ~2.5s of sustained healthy loop time, enough to absorb
+# threshold jitter without flapping degraded/recovered events.
+_RECOVERY_HYSTERESIS_TICKS = 5
 
 
 def get_loop_lag_seconds() -> float:
@@ -39,8 +57,65 @@ def get_loop_lag_seconds() -> float:
 
 
 def is_loop_healthy() -> bool:
-    """False when measured lag exceeds the unhealthy threshold (for /livez)."""
+    """False when measured lag exceeds the unhealthy threshold (for /health/live)."""
     return _last_lag_seconds < settings.loop_lag_unhealthy_seconds
+
+
+def reset_loop_watchdog_state() -> None:
+    """Reset the degraded-state machine (for tests and process restart)."""
+    global _degraded, _degraded_since, _max_lag_seconds, _healthy_streak, _last_lag_seconds
+    _degraded = False
+    _degraded_since = 0.0
+    _max_lag_seconds = 0.0
+    _healthy_streak = 0
+    _last_lag_seconds = 0.0
+
+
+def _evaluate_lag(
+    lag: float,
+    warn: float,
+    *,
+    service_name: str,
+    now: float | None = None,
+) -> None:
+    """Stateful per-sample loop-lag telemetry.
+
+    Emits ``runtime.loop_lag.degraded`` once on the transition into degraded,
+    tracks the peak lag silently while degraded (no per-tick warning), and emits
+    ``runtime.loop_lag.recovered`` once after ``_RECOVERY_HYSTERESIS_TICKS``
+    consecutive healthy samples. ``now`` defaults to ``time.monotonic()`` and is
+    overridable for tests so degraded-duration is deterministic.
+    """
+    global _degraded, _degraded_since, _max_lag_seconds, _healthy_streak
+    clock = time.monotonic() if now is None else now
+    if lag > warn:
+        _healthy_streak = 0
+        if not _degraded:
+            _degraded = True
+            _degraded_since = clock
+            _max_lag_seconds = lag
+            logger.warning(
+                "runtime.loop_lag.degraded",
+                lag_ms=round(lag * 1000, 1),
+                threshold_ms=round(warn * 1000, 1),
+                service=service_name,
+            )
+        elif lag > _max_lag_seconds:
+            _max_lag_seconds = lag
+    elif _degraded:
+        _healthy_streak += 1
+        if _healthy_streak >= _RECOVERY_HYSTERESIS_TICKS:
+            degraded_duration_ms = round((clock - _degraded_since) * 1000, 1)
+            logger.info(
+                "runtime.loop_lag.recovered",
+                max_lag_ms=round(_max_lag_seconds * 1000, 1),
+                degraded_duration_ms=degraded_duration_ms,
+                service=service_name,
+            )
+            _degraded = False
+            _degraded_since = 0.0
+            _max_lag_seconds = 0.0
+            _healthy_streak = 0
 
 
 def _write_heartbeat(path: str) -> None:
@@ -91,7 +166,8 @@ async def loop_lag_watchdog(
         scheduled_at = time.perf_counter()
         await asyncio.sleep(interval)
         lag = time.perf_counter() - scheduled_at - interval
-        _last_lag_seconds = max(0.0, lag)
+        lag = max(0.0, lag)
+        _last_lag_seconds = lag
 
         if heartbeat_path:
             try:
@@ -103,9 +179,4 @@ async def loop_lag_watchdog(
                     error=str(exc),
                 )
 
-        if lag > warn:
-            logger.warning(
-                "Event loop lag high",
-                lag_seconds=round(lag, 3),
-                service=service_name,
-            )
+        _evaluate_lag(lag, warn, service_name=service_name)

--- a/lemma-backend/app/core/observability/telemetry.py
+++ b/lemma-backend/app/core/observability/telemetry.py
@@ -34,6 +34,13 @@ from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor, TracerProvider
+from opentelemetry.sdk.trace.sampling import (
+    ALWAYS_OFF,
+    ALWAYS_ON,
+    ParentBased,
+    Sampler,
+    TraceIdRatioBased,
+)
 from opentelemetry.sdk.trace.export import (
     BatchSpanProcessor,
     SpanExporter,
@@ -176,7 +183,32 @@ def _build_resource(service_name: str) -> Resource:
         attributes["service.namespace"] = settings.otel_service_namespace
     if settings.environment:
         attributes["deployment.environment"] = settings.environment
+    # Release identity on the OTLP resource (mirrors the log context fields).
+    # Present even when exporters are disabled so Phase 3 trace enablement is a
+    # config flip, not a code change.
+    release_sha = (settings.release_sha or "").strip()
+    if release_sha:
+        attributes["service.version"] = release_sha
     return Resource.create(attributes)
+
+
+def _build_sampler(settings) -> Sampler:
+    """Build the trace sampler from OTEL_TRACES_SAMPLER + OTEL_TRACES_SAMPLER_ARG.
+
+    Defaults to parent-based 5%% head sampling: a sampled parent propagates the
+    decision; independent roots are sampled at the configured ratio. Honored by
+    the managed Container Apps OTel agent via the same env vars.
+    """
+    strategy = (settings.otel_traces_sampler or "parentbased_traceidratio").strip().lower()
+    ratio = float(settings.otel_traces_sampler_arg)
+    if strategy in {"always_on", "alwayson"}:
+        return ALWAYS_ON
+    if strategy in {"always_off", "alwaysoff"}:
+        return ALWAYS_OFF
+    if strategy in {"traceidratio", "trace_id_ratio", "traceidratio_based"}:
+        return TraceIdRatioBased(ratio)
+    # parentbased_traceidratio (default) and any unrecognized value.
+    return ParentBased(TraceIdRatioBased(ratio))
 
 
 def _endpoint_is_insecure(endpoint: str) -> bool:
@@ -304,7 +336,10 @@ def _llm_otlp_headers() -> dict[str, str] | None:
 
 def _setup_tracing(service_name: str) -> None:
     settings = _get_settings()
-    provider = TracerProvider(resource=_build_resource(service_name))
+    provider = TracerProvider(
+        resource=_build_resource(service_name),
+        sampler=_build_sampler(settings),
+    )
 
     provider.add_span_processor(AgentRunSpanEnricher())
 
@@ -556,7 +591,7 @@ def instrument_fastapi_app(app: FastAPI) -> None:
         app,
         tracer_provider=trace.get_tracer_provider(),
         meter_provider=metrics.get_meter_provider(),
-        excluded_urls="/health",
+        excluded_urls="/health,/health/live,/health/ready,/livez",
     )
     _instrumented_app_ids.add(app_id)
 

--- a/lemma-backend/app/core/tests/unit/test_logging_pipeline.py
+++ b/lemma-backend/app/core/tests/unit/test_logging_pipeline.py
@@ -1,0 +1,199 @@
+"""Unit tests for the unified structured logging pipeline.
+
+Covers the Phase-1 logging contract: every application-owned and foreign
+stdlib record is exactly one JSON object on one physical line, with required
+static fields, escaped exception newlines, redaction of secrets in both paths,
+idempotent ``setup_logging``, and active trace context injected exactly once.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+
+import pytest
+import structlog
+
+import app.core.log.log as logmod
+from app.core.log.log import get_logger, setup_logging
+
+
+def _processor_formatter_handler() -> logging.Handler:
+    for handler in logging.getLogger().handlers:
+        if isinstance(handler.formatter, structlog.stdlib.ProcessorFormatter):
+            return handler
+    raise AssertionError("ProcessorFormatter handler not installed")
+
+
+@pytest.fixture
+def captured_stdout():
+    """Redirect the ProcessorFormatter handler to a buffer; yield line parser."""
+    setup_logging("development", service_name="lemma-test", json_logs=True, log_level="DEBUG")
+    buf = io.StringIO()
+    handler = _processor_formatter_handler()
+    original_stream = handler.stream
+    handler.stream = buf
+
+    def lines():
+        return [line for line in buf.getvalue().splitlines() if line.strip()]
+
+    yield lines
+    handler.stream = original_stream
+
+
+def _app_lines(lines):
+    return [json.loads(line) for line in lines()]
+
+
+def test_structlog_record_is_one_json_line_with_required_fields(captured_stdout):
+    get_logger("app.demo").info("service.started", component="api")
+    objs = _app_lines(captured_stdout)
+    assert len(objs) == 1
+    obj = objs[0]
+    assert "\n" not in captured_stdout()[-1]
+    assert obj["event"] == "service.started"
+    assert obj["level"] == "info"
+    assert obj["logger"] == "app.demo"
+    assert obj["service.name"] == "lemma-test"
+    assert obj["deployment.environment"] == "development"
+    assert "timestamp" in obj
+    # event is not duplicated into a message field.
+    assert "message" not in obj
+
+
+def test_foreign_stdlib_record_is_one_json_line(captured_stdout):
+    logging.getLogger("some.foreign.lib").warning("hello world")
+    objs = _app_lines(captured_stdout)
+    assert len(objs) == 1
+    obj = objs[0]
+    assert obj["event"] == "hello world"
+    assert obj["level"] == "warning"
+    assert obj["logger"] == "some.foreign.lib"
+    assert obj["service.name"] == "lemma-test"
+
+
+def test_exception_renders_as_one_json_line_with_escaped_newlines(captured_stdout):
+    logger = get_logger("app.demo")
+    try:
+        raise ValueError("boom\nsecond line")
+    except ValueError:
+        logger.exception("request.error", route="/x")
+    lines = captured_stdout()
+    assert len(lines) == 1, "exception must not fan out to multiple physical lines"
+    obj = json.loads(lines[0])
+    assert obj["event"] == "request.error"
+    assert "exception" in obj
+    assert isinstance(obj["exception"], str)
+    assert "ValueError" in obj["exception"]
+
+
+def test_foreign_exception_also_one_line(captured_stdout):
+    try:
+        raise RuntimeError("foreign fail")
+    except RuntimeError:
+        logging.getLogger("foreign.lib").exception("lib failed")
+    lines = captured_stdout()
+    assert len(lines) == 1
+    obj = json.loads(lines[0])
+    assert "exception" in obj
+    assert "RuntimeError" in obj["exception"]
+
+
+def test_redaction_canary_absent_from_full_output(captured_stdout):
+    canary = "CANARY-SECRET-1234567890"
+    logger = get_logger("app.demo")
+    logger.info(
+        "event.with.secrets",
+        authorization=f"Bearer {canary}",
+        cookie=f"session={canary}",
+        api_key=canary,
+        nested={"token": canary, "ok": "keep"},
+        url=f"https://ex.com/x?token={canary}",
+        raw_bytes=canary.encode(),
+    )
+    out = captured_stdout()[-1]
+    assert canary not in out
+    obj = json.loads(out)
+    assert obj["authorization"] == "[REDACTED]"
+    assert obj["cookie"] == "[REDACTED]"
+    assert obj["api_key"] == "[REDACTED]"
+    assert obj["nested"]["token"] == "[REDACTED]"
+    assert obj["nested"]["ok"] == "keep"
+    # URL query param is redacted (urlencode percent-encodes the brackets).
+    assert canary not in obj["url"]
+    assert "REDACTED" in obj["url"]
+    assert obj["raw_bytes"].startswith("<bytes:")
+
+
+def test_foreign_record_redacted_through_same_pipeline(captured_stdout):
+    canary = "CANARY-FOREIGN-9876543210"
+    logging.getLogger("foreign.lib").info(
+        f"call failed token={canary} url=https://ex.com/x?code={canary}"
+    )
+    out = captured_stdout()[-1]
+    assert canary not in out
+
+
+def test_setup_logging_is_idempotent(captured_stdout):
+    setup_logging("development", service_name="lemma-a", json_logs=True)
+    setup_logging("development", service_name="lemma-b", json_logs=True)
+    setup_logging("development", service_name="lemma-c", json_logs=True)
+    pf_handlers = [
+        h for h in logging.getLogger().handlers
+        if isinstance(h.formatter, structlog.stdlib.ProcessorFormatter)
+    ]
+    assert len(pf_handlers) == 1, "repeated setup must not duplicate the console handler"
+    get_logger("x").info("once")
+    objs = _app_lines(captured_stdout)
+    assert len(objs) == 1
+    assert objs[0]["service.name"] == "lemma-c"
+
+
+def test_release_sha_appears_as_service_version_and_release_sha(monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "release_sha", "a" * 40)
+    setup_logging("development", service_name="lemma-api", json_logs=True)
+    buf = io.StringIO()
+    handler = _processor_formatter_handler()
+    original_stream = handler.stream
+    handler.stream = buf
+    try:
+        get_logger("app.demo").info("service.started")
+        obj = json.loads(buf.getvalue().splitlines()[-1])
+    finally:
+        handler.stream = original_stream
+    assert obj["service.version"] == "a" * 40
+    assert obj["release.sha"] == "a" * 40
+
+
+def test_active_trace_context_injected_once(monkeypatch, captured_stdout):
+    from opentelemetry.trace import SpanContext, TraceFlags
+
+    trace_id = 0x0123456789abcdef0123456789abcdef
+    span_id = 0x0123456789abcdef
+
+    class FakeSpan:
+        def get_span_context(self):
+            return SpanContext(
+                trace_id=trace_id,
+                span_id=span_id,
+                is_remote=False,
+                trace_flags=TraceFlags(TraceFlags.SAMPLED),
+            )
+
+    monkeypatch.setattr(logmod.trace, "get_current_span", lambda: FakeSpan())
+    get_logger("app.demo").info("spanned.event")
+    obj = _app_lines(captured_stdout)[-1]
+    assert obj["trace_id"] == format(trace_id, "032x")
+    assert obj["span_id"] == format(span_id, "016x")
+
+
+def test_foreign_logger_levels_applied():
+    setup_logging("production", service_name="lemma-api", json_logs=True)
+    assert logging.getLogger("httpx").level == logging.WARNING
+    assert logging.getLogger("httpcore").level == logging.WARNING
+    assert logging.getLogger("uvicorn.access").level == logging.WARNING
+    assert logging.getLogger("uvicorn.error").level == logging.INFO
+    assert logging.getLogger("streaq").level == logging.WARNING

--- a/lemma-backend/app/modules/schedule/scheduler/scheduler_service.py
+++ b/lemma-backend/app/modules/schedule/scheduler/scheduler_service.py
@@ -13,6 +13,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
+from apscheduler.events import EVENT_JOB_ERROR
 from pytz import utc
 from sqlalchemy.engine import make_url
 
@@ -113,7 +114,22 @@ class SchedulerService:
             # Start scheduler
             self.scheduler.start()
             self._started = True
+            # Stable terminal-failure event for dashboards/alerts. APScheduler
+            # does not expose job duration in its events, so only error_type is
+            # emitted. There is no scheduler-level "cycle error" event in this
+            # version, so per-job errors are the failure signal.
+            self.scheduler.add_listener(self._on_scheduler_event, EVENT_JOB_ERROR)
             logger.info("APScheduler started with event emitter")
+
+    def _on_scheduler_event(self, event) -> None:
+        """Emit one stable failure event per APScheduler job error."""
+        exception = getattr(event, "exception", None)
+        error_type = type(exception).__name__ if exception else "UnknownError"
+        logger.error(
+            "scheduler.job.failed",
+            job_id=getattr(event, "job_id", None),
+            error_type=error_type,
+        )
 
     async def shutdown(self, wait: bool = True):
         """Shutdown the scheduler and event emitter."""

--- a/lemma-backend/app/modules/test_support/test_severity_policy.py
+++ b/lemma-backend/app/modules/test_support/test_severity_policy.py
@@ -1,0 +1,179 @@
+"""Severity policy for the global HTTP exception handlers.
+
+Verifies the Phase-1 contract: routine 4xx -> debug (no steady-state prod event),
+auth denial (401/403) -> sampled info, rate-limit (429) -> rate-limited warning,
+5xx -> error once. Domain ``message``/``details``, validation payloads, and HTTP
+``detail`` must NOT appear in the log record.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+
+import pytest
+import structlog
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from pydantic import BaseModel
+
+from app.core.api import exception_handlers
+from app.core.api.exception_handlers import register_exception_handlers
+from app.core.domain.errors import DomainError
+from app.core.log.log import get_logger, setup_logging
+
+pytestmark = pytest.mark.unit
+
+
+def _pf_handler() -> logging.Handler:
+    for h in logging.getLogger().handlers:
+        if isinstance(h.formatter, structlog.stdlib.ProcessorFormatter):
+            return h
+    raise AssertionError("ProcessorFormatter handler not installed")
+
+
+@pytest.fixture
+def log_buf():
+    setup_logging("development", service_name="lemma-test", json_logs=True, log_level="DEBUG")
+    # Module-level loggers were bound at import time with INFO filtering, so they
+    # ignore a later DEBUG reconfigure. Rebind to a fresh DEBUG logger so the
+    # severity policy is observable. (In production 4xx debug is correctly
+    # filtered at INFO — that is the contract.) Also reset the cross-test
+    # throttle state so each test starts clean.
+    exception_handlers.logger = get_logger("app.core.api.exception_handlers")
+    exception_handlers._last_throttled_emit.clear()
+    buf = io.StringIO()
+    handler = _pf_handler()
+    original = handler.stream
+    handler.stream = buf
+    yield buf
+    handler.stream = original
+
+
+def _events(buf):
+    return [json.loads(line) for line in buf.getvalue().splitlines() if line.strip()]
+
+
+def _app() -> FastAPI:
+    test_app = FastAPI()
+    register_exception_handlers(test_app)
+
+    class _Body(BaseModel):
+        n: int
+
+    @test_app.get("/domain404")
+    async def _d4():
+        raise DomainError("nope", code="WIDGET_GONE", status_code=404, details={"x": 1})
+
+    @test_app.get("/domain500")
+    async def _d5():
+        raise DomainError("server boom", code="WIDGET_BROKE", status_code=500)
+
+    @test_app.get("/http401")
+    async def _h401():
+        raise HTTPException(status_code=401, detail="no token")
+
+    @test_app.get("/http403")
+    async def _h403():
+        raise HTTPException(status_code=403, detail="forbidden")
+
+    @test_app.get("/http429")
+    async def _h429():
+        raise HTTPException(status_code=429, detail="slow down")
+
+    @test_app.post("/validate")
+    async def _v(body: _Body):
+        return body
+
+    @test_app.get("/boom")
+    async def _boom():
+        raise RuntimeError("kaboom")
+
+    return test_app
+
+
+def _client():
+    return TestClient(_app(), raise_server_exceptions=False)
+
+
+def test_routine_4xx_logs_at_debug_without_sensitive_payload(log_buf):
+    c = _client()
+    r = c.get("/domain404", headers={"x-request-id": "rid-1"})
+    assert r.status_code == 404
+    ev = [e for e in _events(log_buf) if e.get("event") == "request.error"]
+    assert len(ev) == 1
+    assert ev[0]["level"] == "debug"
+    assert ev[0]["code"] == "WIDGET_GONE"
+    assert ev[0]["status_code"] == 404
+    assert ev[0]["error_type"] == "DomainError"
+    assert ev[0]["request_id"] == "rid-1"
+    # Domain message/details must not be logged.
+    assert "message" not in ev[0]
+    assert "details" not in ev[0]
+    assert "nope" not in log_buf.getvalue()
+
+
+def test_validation_422_logs_at_debug(log_buf):
+    c = _client()
+    r = c.post("/validate", json={"n": "not-int"})
+    assert r.status_code == 422
+    ev = [e for e in _events(log_buf) if e.get("event") == "request.error"]
+    assert len(ev) == 1
+    assert ev[0]["level"] == "debug"
+    assert ev[0]["code"] == "VALIDATION_ERROR"
+    # No validation payload logged.
+    assert "errors" not in ev[0]
+
+
+def test_auth_denial_logs_throttled_info(log_buf):
+    c = _client()
+    c.get("/http401")
+    c.get("/http403")
+    auth = [e for e in _events(log_buf) if e.get("event") == "auth.denied"]
+    assert len(auth) == 2
+    assert all(e["level"] == "info" for e in auth)
+    assert {e["status_code"] for e in auth} == {401, 403}
+    # detail string must not be logged.
+    assert "no token" not in log_buf.getvalue()
+    assert "forbidden" not in log_buf.getvalue()
+
+
+def test_auth_denial_throttled_within_window(log_buf):
+    c = _client()
+    # Two rapid 401 on the same route within the throttle window emit once.
+    c.get("/http401")
+    c.get("/http401")
+    auth = [e for e in _events(log_buf) if e.get("event") == "auth.denied"]
+    assert len(auth) == 1
+
+
+def test_rate_limit_logs_throttled_warning(log_buf):
+    c = _client()
+    c.get("/http429")
+    rl = [e for e in _events(log_buf) if e.get("event") == "request.rate_limited"]
+    assert len(rl) == 1
+    assert rl[0]["level"] == "warning"
+    assert rl[0]["status_code"] == 429
+
+
+def test_5xx_domain_error_logs_error_once(log_buf):
+    c = _client()
+    r = c.get("/domain500")
+    assert r.status_code == 500
+    ev = [e for e in _events(log_buf) if e.get("event") == "request.error"]
+    assert len(ev) == 1
+    assert ev[0]["level"] == "error"
+    assert ev[0]["code"] == "WIDGET_BROKE"
+    assert "server boom" not in log_buf.getvalue()
+
+
+def test_unhandled_500_logs_error_once_with_traceback(log_buf):
+    c = _client()
+    r = c.get("/boom")
+    assert r.status_code == 500
+    ev = [e for e in _events(log_buf) if e.get("event") == "request.error"]
+    assert len(ev) == 1
+    assert ev[0]["level"] == "error"
+    assert "exception" in ev[0]
+    assert "RuntimeError" in ev[0]["exception"]

--- a/lemma-backend/app/scheduler.py
+++ b/lemma-backend/app/scheduler.py
@@ -6,6 +6,7 @@ handled by the main application pod.
 """
 
 from __future__ import annotations
+import asyncio
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
@@ -16,7 +17,7 @@ from app.modules.schedule.scheduler.api.scheduler_controller import (
 )
 from app.modules.schedule.scheduler.scheduler_service import get_scheduler_service
 from app.core.config import settings
-from app.core.log.log import setup_logging, get_logger
+from app.core.log.log import setup_logging, get_logger, validate_release_identity
 from app.core.infrastructure.db.session import get_engine
 from app.core.observability.telemetry import (
     init_telemetry,
@@ -26,6 +27,18 @@ from app.core.observability.telemetry import (
 from app.version import API_VERSION
 
 logger = get_logger(__name__)
+
+# Low-rate structured heartbeat for remote absence detection of this singleton
+# background process. At 5 min this is <600 records/48h. service.version is
+# attached by the logging context.
+_HEARTBEAT_INTERVAL_SECONDS = 300.0
+
+
+async def _scheduler_heartbeat_loop() -> None:
+    """Emit ``scheduler.heartbeat`` every 5 min while the scheduler loop is healthy."""
+    while True:
+        await asyncio.sleep(_HEARTBEAT_INTERVAL_SECONDS)
+        logger.info("scheduler.heartbeat")
 
 
 @asynccontextmanager
@@ -38,13 +51,23 @@ async def lifespan(app: FastAPI):
         json_logs=settings.json_logs_enabled,
         log_level=settings.log_level,
     )
+    validate_release_identity(settings.environment)
     scheduler = get_scheduler_service()
     await scheduler.start()
     logger.info("Scheduler service started")
+    # One stable startup event after initialization succeeds.
+    logger.info("service.started")
+    heartbeat_task = asyncio.create_task(_scheduler_heartbeat_loop())
 
     yield
 
     # Shutdown
+    if not heartbeat_task.done():
+        heartbeat_task.cancel()
+        try:
+            await heartbeat_task
+        except BaseException:
+            pass
     scheduler = get_scheduler_service()
     await scheduler.shutdown()
     logger.info("Scheduler service stopped")
@@ -86,12 +109,51 @@ async def index() -> str:
     return "Scheduler API is ready."
 
 
-@app.get("/health")
-async def health_check() -> dict[str, str]:
-    """Health check endpoint."""
+@app.get("/health/live", include_in_schema=False)
+@app.get("/livez", include_in_schema=False)
+@app.get("/health", include_in_schema=False)
+async def health_live() -> dict[str, str]:
+    """Liveness: process/event-loop check only (no DB/network)."""
+    return {"status": "ok"}
+
+
+@app.get("/health/ready", include_in_schema=False)
+async def health_ready():
+    """Readiness: scheduler started + DB reachable. 503 when not ready."""
+    import asyncio as _asyncio
+
+    from sqlalchemy import text
+    from fastapi.responses import JSONResponse
+
+    from app.core.infrastructure.db.session import get_engine
+
     scheduler = get_scheduler_service()
-    status = "healthy" if scheduler._started else "starting"
-    return {"status": status, "message": "Scheduler API is running"}
+    scheduler_ok = bool(scheduler._started)
+
+    async def _db_ok() -> bool:
+        try:
+            engine = get_engine()
+            async with engine.connect() as conn:
+                await conn.execute(text("SELECT 1"))
+            return True
+        except Exception:
+            return False
+
+    db_ok = False
+    try:
+        db_ok = await _asyncio.wait_for(_db_ok(), timeout=1.0)
+    except Exception:
+        db_ok = False
+
+    components = {
+        "scheduler": "ok" if scheduler_ok else "starting",
+        "db": "ok" if db_ok else "down",
+    }
+    ready = scheduler_ok and db_ok
+    return JSONResponse(
+        {"status": "ready" if ready else "not_ready", "components": components},
+        status_code=200 if ready else 503,
+    )
 
 
 app.include_router(scheduler_router)

--- a/lemma-backend/app/tests/unit/test_health_endpoints.py
+++ b/lemma-backend/app/tests/unit/test_health_endpoints.py
@@ -1,0 +1,91 @@
+"""Health endpoints: /health/live, /health/ready, /health, /livez."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import app.app as appmod
+from app.core.observability import loop_watchdog
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def client():
+    loop_watchdog.reset_loop_watchdog_state()
+    return TestClient(appmod.app, raise_server_exceptions=False)
+
+
+def test_liveness_endpoints_return_ok(client):
+    for path in ("/health/live", "/livez", "/health"):
+        r = client.get(path)
+        assert r.status_code == 200, path
+        body = r.json()
+        assert body["status"] == "ok"
+        assert "loop_lag_seconds" in body
+
+
+def test_liveness_returns_503_when_loop_wedged(client, monkeypatch):
+    # Force unhealthy lag above the unhealthy threshold.
+    monkeypatch.setattr(loop_watchdog, "_last_lag_seconds", 10.0)
+    monkeypatch.setattr(
+        "app.core.observability.loop_watchdog.settings.loop_lag_unhealthy_seconds", 5.0
+    )
+    r = client.get("/health/live")
+    assert r.status_code == 503
+    assert r.json()["status"] == "unhealthy"
+
+
+class _FakeConn:
+    async def execute(self, *_a, **_kw):
+        return None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+
+class _FakeEngineOk:
+    def connect(self):
+        return _FakeConn()
+
+
+class _FakeEngineDown:
+    def connect(self):
+        raise ConnectionError("db down")
+
+
+def test_ready_returns_200_when_dependencies_ok(client, monkeypatch):
+    monkeypatch.setattr(appmod, "get_engine", lambda: _FakeEngineOk())
+    monkeypatch.setattr(appmod.channel_service, "ping", AsyncMock(return_value=True))
+    r = client.get("/health/ready")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] == "ready"
+    assert body["components"] == {"db": "ok", "redis": "ok"}
+
+
+def test_ready_returns_503_when_db_down(client, monkeypatch):
+    monkeypatch.setattr(appmod, "get_engine", lambda: _FakeEngineDown())
+    monkeypatch.setattr(appmod.channel_service, "ping", AsyncMock(return_value=True))
+    r = client.get("/health/ready")
+    assert r.status_code == 503
+    body = r.json()
+    assert body["status"] == "not_ready"
+    assert body["components"]["db"] == "down"
+    assert body["components"]["redis"] == "ok"
+
+
+def test_ready_returns_503_when_redis_down(client, monkeypatch):
+    monkeypatch.setattr(appmod, "get_engine", lambda: _FakeEngineOk())
+    monkeypatch.setattr(appmod.channel_service, "ping", AsyncMock(return_value=False))
+    r = client.get("/health/ready")
+    assert r.status_code == 503
+    body = r.json()
+    assert body["components"]["db"] == "ok"
+    assert body["components"]["redis"] == "down"

--- a/lemma-backend/app/tests/unit/test_loop_watchdog.py
+++ b/lemma-backend/app/tests/unit/test_loop_watchdog.py
@@ -69,3 +69,77 @@ def test_heartbeat_writes_are_collision_safe_across_writers(tmp_path):
 
     assert heartbeat.read_text().strip().isdigit()
     assert list(tmp_path.glob(".worker_heartbeat.*")) == []
+
+
+# --- Loop-lag hysteresis state machine ---------------------------------------
+# Captures loop-lag degraded/recovered events via the ProcessorFormatter handler.
+
+
+def _capture_events():
+    import io
+    import logging
+    import structlog
+
+    loop_watchdog.reset_loop_watchdog_state()
+    setup = __import__("app.core.log.log", fromlist=["setup_logging"]).setup_logging
+    setup("development", service_name="lemma-test", json_logs=True, log_level="DEBUG")
+    buf = io.StringIO()
+    handler = next(
+        h for h in logging.getLogger().handlers
+        if isinstance(h.formatter, structlog.stdlib.ProcessorFormatter)
+    )
+    handler.stream = buf
+    return buf, handler
+
+
+def _events(buf):
+    import json
+    return [json.loads(line) for line in buf.getvalue().splitlines() if line.strip()]
+
+
+def test_degraded_emits_once_and_no_flood_on_repeated_samples():
+    buf, _ = _capture_events()
+    warn = 0.3
+    # Transition into degraded.
+    loop_watchdog._evaluate_lag(0.4, warn, service_name="test", now=0.0)
+    # Repeated degraded samples must not re-emit.
+    loop_watchdog._evaluate_lag(0.5, warn, service_name="test", now=0.1)
+    loop_watchdog._evaluate_lag(0.45, warn, service_name="test", now=0.2)
+    events = [e for e in _events(buf) if e["event"] == "runtime.loop_lag.degraded"]
+    assert len(events) == 1
+    assert events[0]["level"] == "warning"
+    assert loop_watchdog._max_lag_seconds == 0.5  # peak tracked silently
+
+
+def test_recovery_emits_only_after_hysteresis_window():
+    buf, _ = _capture_events()
+    warn = 0.3
+    loop_watchdog._evaluate_lag(0.5, warn, service_name="test", now=0.0)
+    # A single healthy sample must NOT recover (jitter suppression).
+    loop_watchdog._evaluate_lag(0.1, warn, service_name="test", now=0.1)
+    recovered = [e for e in _events(buf) if e["event"] == "runtime.loop_lag.recovered"]
+    assert recovered == []
+    # Need _RECOVERY_HYSTERESIS_TICKS consecutive healthy samples.
+    for i in range(loop_watchdog._RECOVERY_HYSTERESIS_TICKS):
+        loop_watchdog._evaluate_lag(0.1, warn, service_name="test", now=0.2 + i * 0.1)
+    recovered = [e for e in _events(buf) if e["event"] == "runtime.loop_lag.recovered"]
+    assert len(recovered) == 1
+    assert recovered[0]["level"] == "info"
+    assert recovered[0]["max_lag_ms"] == 500.0
+    assert recovered[0]["degraded_duration_ms"] > 0
+    assert loop_watchdog._degraded is False
+
+
+def test_jitter_does_not_flap_degraded_recovered():
+    buf, _ = _capture_events()
+    warn = 0.3
+    loop_watchdog._evaluate_lag(0.5, warn, service_name="test", now=0.0)
+    # Alternate high/low without enough consecutive healthy samples to recover.
+    for i in range(20):
+        lag = 0.5 if i % 2 == 0 else 0.1
+        loop_watchdog._evaluate_lag(lag, warn, service_name="test", now=float(i))
+    degraded = [e for e in _events(buf) if e["event"] == "runtime.loop_lag.degraded"]
+    recovered = [e for e in _events(buf) if e["event"] == "runtime.loop_lag.recovered"]
+    # Exactly one degraded transition, no recovery (jitter never sustained healthy).
+    assert len(degraded) == 1
+    assert recovered == []

--- a/lemma-backend/app/tests/unit/test_release_identity.py
+++ b/lemma-backend/app/tests/unit/test_release_identity.py
@@ -1,0 +1,119 @@
+"""Release identity validation (LEMMA_RELEASE_SHA).
+
+Release identity is best-effort log/release correlation: a missing or malformed
+value never blocks startup. ``validate_release_identity`` only warns, and the
+log context falls back to ``"unknown"`` so unattributed deployments are still
+queryable (``release.sha == "unknown"``).
+"""
+
+from __future__ import annotations
+
+
+from app.core.config import settings
+from app.core.log.log import setup_logging, validate_release_identity
+
+
+def test_valid_sha_does_not_warn(monkeypatch):
+    monkeypatch.setattr(settings, "release_sha", "a" * 40)
+    # Must not raise; no warning expected.
+    validate_release_identity("production")
+
+
+def test_production_does_not_raise_on_missing_sha(monkeypatch):
+    monkeypatch.setattr(settings, "release_sha", None)
+    # Must not raise in production.
+    validate_release_identity("production")
+
+
+def test_production_does_not_raise_on_malformed_sha(monkeypatch):
+    monkeypatch.setattr(settings, "release_sha", "not-a-sha")
+    validate_release_identity("production")
+
+
+def test_production_does_not_raise_on_short_sha(monkeypatch):
+    monkeypatch.setattr(settings, "release_sha", "abc123")
+    validate_release_identity("production")
+
+
+def test_missing_sha_falls_back_to_unknown_in_log_context(monkeypatch):
+    import io
+    import json
+    import logging
+
+    import structlog
+
+    from app.core.log.log import get_logger
+
+    monkeypatch.setattr(settings, "release_sha", None)
+    setup_logging("production", service_name="lemma-api", json_logs=True)
+    buf = io.StringIO()
+    handler = next(
+        h for h in logging.getLogger().handlers
+        if isinstance(h.formatter, structlog.stdlib.ProcessorFormatter)
+    )
+    original = handler.stream
+    handler.stream = buf
+    try:
+        get_logger("app.demo").info("service.started")
+        obj = json.loads(buf.getvalue().splitlines()[-1])
+    finally:
+        handler.stream = original
+    # Falls back to "unknown" (queryable), not omitted.
+    assert obj["release.sha"] == "unknown"
+    assert obj["service.version"] == "unknown"
+
+
+def test_malformed_sha_falls_back_to_unknown_in_log_context(monkeypatch):
+    import io
+    import json
+    import logging
+
+    import structlog
+
+    from app.core.log.log import get_logger
+
+    monkeypatch.setattr(settings, "release_sha", "not-a-sha")
+    setup_logging("production", service_name="lemma-api", json_logs=True)
+    buf = io.StringIO()
+    handler = next(
+        h for h in logging.getLogger().handlers
+        if isinstance(h.formatter, structlog.stdlib.ProcessorFormatter)
+    )
+    original = handler.stream
+    handler.stream = buf
+    try:
+        get_logger("app.demo").info("service.started")
+        obj = json.loads(buf.getvalue().splitlines()[-1])
+    finally:
+        handler.stream = original
+    # A malformed value must NOT be emitted as service.version; fall back to "unknown".
+    assert obj["release.sha"] == "unknown"
+    assert obj["service.version"] == "unknown"
+
+
+def test_valid_sha_appears_in_log_context(monkeypatch):
+    import io
+    import json
+    import logging
+
+    import structlog
+
+    from app.core.log.log import get_logger
+
+    sha = "b" * 40
+    monkeypatch.setattr(settings, "release_sha", sha)
+    setup_logging("production", service_name="lemma-api", json_logs=True)
+    buf = io.StringIO()
+    handler = next(
+        h for h in logging.getLogger().handlers
+        if isinstance(h.formatter, structlog.stdlib.ProcessorFormatter)
+    )
+    original = handler.stream
+    handler.stream = buf
+    try:
+        get_logger("app.demo").info("service.started")
+        obj = json.loads(buf.getvalue().splitlines()[-1])
+    finally:
+        handler.stream = original
+    assert obj["release.sha"] == sha
+    assert obj["service.version"] == sha

--- a/lemma-backend/app/tests/unit/test_telemetry_sampling.py
+++ b/lemma-backend/app/tests/unit/test_telemetry_sampling.py
@@ -1,0 +1,64 @@
+"""Trace sampler configuration (Phase-3 readiness).
+
+Exporters stay disabled in Phase 1, but the sampler must be plumbed so enabling
+traces is a config flip. Verifies the provider honors
+``parentbased_traceidratio`` + ``OTEL_TRACES_SAMPLER_ARG``.
+"""
+
+from __future__ import annotations
+
+
+from app.core.config import settings
+from app.core.observability import telemetry
+
+
+def _sampler_for(monkeypatch, strategy, ratio):
+    monkeypatch.setattr(settings, "otel_traces_sampler", strategy)
+    monkeypatch.setattr(settings, "otel_traces_sampler_arg", ratio)
+    return telemetry._build_sampler(settings)
+
+
+def test_default_sampler_is_parentbased_5_percent(monkeypatch):
+    monkeypatch.setattr(settings, "otel_traces_sampler", "parentbased_traceidratio")
+    monkeypatch.setattr(settings, "otel_traces_sampler_arg", 0.05)
+    sampler = telemetry._build_sampler(settings)
+    assert type(sampler).__name__ == "ParentBased"
+
+
+def _root_ratio(sampler):
+    root = getattr(sampler, "_root", None)
+    if root is None:
+        root = getattr(sampler, "root", None)
+    return getattr(root, "rate", None)
+
+
+def test_parentbased_honors_ratio_arg(monkeypatch):
+    sampler = _sampler_for(monkeypatch, "parentbased_traceidratio", 0.25)
+    assert _root_ratio(sampler) == 0.25
+
+
+def test_traceidratio_strategy(monkeypatch):
+    sampler = _sampler_for(monkeypatch, "traceidratio", 0.1)
+    assert type(sampler).__name__ == "TraceIdRatioBased"
+    assert sampler.rate == 0.1
+
+
+def test_always_on_strategy(monkeypatch):
+    from opentelemetry.sdk.trace.sampling import Decision
+
+    sampler = _sampler_for(monkeypatch, "always_on", 0.0)
+    assert type(sampler).__name__ == "StaticSampler"
+    assert sampler._decision == Decision.RECORD_AND_SAMPLE
+
+
+def test_always_off_strategy(monkeypatch):
+    from opentelemetry.sdk.trace.sampling import Decision
+
+    sampler = _sampler_for(monkeypatch, "always_off", 1.0)
+    assert type(sampler).__name__ == "StaticSampler"
+    assert sampler._decision == Decision.DROP
+
+
+def test_unrecognized_strategy_falls_back_to_parentbased(monkeypatch):
+    sampler = _sampler_for(monkeypatch, "something-weird", 0.05)
+    assert type(sampler).__name__ == "ParentBased"


### PR DESCRIPTION
## Context

Serverless production on Azure Container Apps writes ~0.90 GiB/day of `ContainerAppConsoleLogs_CL` into `lemma-aca-prod-logs`. The problem is not missing logs — it is excessive, inconsistently structured output: ~1.5M worker lines and ~192k API lines have no JSON `level`, stdlib/third-party logs come out as raw text, every line duplicates `event` into `message`, expected 4xx logs at info/warning, and the loop watchdog warns on every tick.

This is **Phase 1** of the remediation spec: cut console ingestion ≥80% from the 2026-07-15 baseline (prod ≤0.15 GB/day) and make every application-owned stdout line exactly one JSON object. OpenTelemetry traces remain a **gated Phase 3 follow-up** — exporters stay disabled; only the sampler config + its test are plumbed now.

## Changes

**Logging pipeline** (`app/core/log/log.py`)
- Foreign stdlib/third-party records → one-line JSON via `ProcessorFormatter` (same redaction/context chain as app records) — the dominant non-JSON worker output source.
- Removed `event`→`message` duplication.
- `setup_logging` idempotent (one console handler; OTEL handlers preserved).
- Production logger level overrides: `httpx`/`httpcore`/`uvicorn.access`/`streaq`/`azure`/`e2b` → WARNING; `uvicorn.error` → INFO; root stays INFO.
- Release identity: `LEMMA_RELEASE_SHA` → `service.version` + `release.sha` on every line. **Warn-only** — a missing/malformed value logs a warning and falls back to `release.sha="unknown"` (queryable); it never blocks startup, so the logging fix is decoupled from infra-side env wiring.

**Severity policy** (`app/core/api/exception_handlers.py`) — routine 4xx → debug; 401/403 → throttled `auth.denied` info; 429 → throttled `request.rate_limited` warning; 5xx → `request.error` once. Stopped logging domain `message`/`details`/`detail`/validation payloads. Public error envelope unchanged.

**Loop watchdog** (`app/core/observability/loop_watchdog.py`) — stateful hysteresis: `runtime.loop_lag.degraded` once on transition, peak tracked silently, `runtime.loop_lag.recovered` once after a hysteresis window. No more per-tick flood.

**Operational events** — `service.started` (API/scheduler/worker); `worker.heartbeat` + `scheduler.heartbeat` every 5 min; `scheduler.job.failed` via APScheduler listener. (`worker.job.failed` deferred — streaq exposes no terminal-failure callback; its own logger now emits JSON.)

**Health endpoints** (`app/app.py`, `app/scheduler.py`) — `/health/live` (loop only), `/health/ready` (bounded concurrent DB+Redis checks, ~1s each / ~2s overall, 503 + generic states), `/health` + `/livez` aliases; `channel_service.ping()` added; OTEL `excluded_urls` extended.

**Telemetry** (`app/core/observability/telemetry.py`) — `parentbased_traceidratio` 0.05 sampler plumbed into `TracerProvider`; `service.version` added to OTEL resource. Exporters stay disabled (Phase 3 = config flip).

## Tests
New `test_logging_pipeline`, `test_severity_policy`, `test_health_endpoints`, `test_release_identity`, `test_telemetry_sampling`; extended `test_loop_watchdog`. All green. Regression-checked: schedule e2e + core (143), agent + pod unit (490), error-handling contract + security killswitch — no regressions.

## Rollout
Release identity is **warn-only**, so this can ship independently — prod will start even before `LEMMA_RELEASE_SHA` is wired there (it'll log `release.sha="unknown"` until the gappy-infra PR adds it). The coordinated gappy-infra PR (prod `LEMMA_RELEASE_SHA` wiring, probe paths → `/health/live` + `/health/ready`, `JSON_LOGS_ENABLED=true`) is still recommended to land around the same time for full release correlation and the new probe paths, but it is **no longer a startup blocker**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)