### PR TITLE
fix(daemon): refresh auth token on reconnect to survive 24h expiry

### DIFF
--- a/lemma-cli/lemma_cli/daemon/commands.py
+++ b/lemma-cli/lemma_cli/daemon/commands.py
@@ -97,14 +97,19 @@ def start_daemon(
     )
     write_daemon_status(os.getpid(), base_url=resolved_base_url, server=state.server)
     try:
+        use_env = state.server_source == "env"
+
+        def _token_provider() -> str:
+            # Called before each (re)connect. Refreshes the stored session so the
+            # daemon survives token expiry (typically ~24h) without user intervention.
+            _refresh_auth_session(state)
+            return resolve_token(state.token, state.config, use_env=use_env)
+
         asyncio.run(
             run_daemon_with_graceful_shutdown(
                 base_url=resolved_base_url,
-                token=resolve_token(
-                    state.token,
-                    state.config,
-                    use_env=state.server_source == "env",
-                ),
+                token=resolve_token(state.token, state.config, use_env=use_env),
+                token_provider=_token_provider if not state.token else None,
                 verify_ssl=resolve_verify_ssl(state.no_verify_ssl),
                 debug=debug,
             )

--- a/lemma-cli/lemma_cli/daemon/runner.py
+++ b/lemma-cli/lemma_cli/daemon/runner.py
@@ -301,11 +301,20 @@ async def run_daemon(
             except InvalidStatus as exc:
                 status_code = getattr(getattr(exc, "response", None), "status_code", None)
                 if status_code in {401, 403}:
-                    import click
-                    raise click.ClickException(
-                        "Daemon websocket authentication failed. Run `lemma auth login` and try again."
-                    ) from exc
-                daemon_log("websocket rejected; will retry", {"status": status_code})
+                    if token_provider is not None:
+                        # Token expired — the next loop iteration will call
+                        # token_provider() to get a fresh credential. Don't crash.
+                        daemon_log(
+                            "websocket auth failed; will refresh token and retry",
+                            {"status": status_code},
+                        )
+                    else:
+                        import click
+                        raise click.ClickException(
+                            "Daemon websocket authentication failed. Run `lemma auth login` and try again."
+                        ) from exc
+                else:
+                    daemon_log("websocket rejected; will retry", {"status": status_code})
             except (OSError, WebSocketException) as exc:
                 daemon_log("websocket connection error; will retry", {"error": str(exc)})
 


### PR DESCRIPTION
Fixes #170.

The daemon was dying every ~24 hours because its login token expired. When it tried to reconnect after a dropped connection, the server returned 401, and the daemon immediately crashed instead of refreshing the token.

Two-part fix:

1. runner.py: When a token_provider is present, treat a 401/403 as a transient failure and continue the reconnect loop instead of crashing. The next iteration calls token_provider() for a fresh credential. Without a provider (e.g. bare --token flag) the old hard-fail is kept.

2. commands.py: Pass a _token_provider closure to run_daemon that calls refresh_auth_session() + resolve_token() before every (re)connect. This wires up the refresh path that already existed in the CLI state layer but was never connected to the daemon reconnect loop.

The token_provider hook and its test coverage already existed in test_daemon_resiliency.py; this commit activates it in production.