### PR TITLE
Fix daemon and MCP token rotation

### DIFF
--- a/lemma-cli/lemma_cli/daemon/commands.py
+++ b/lemma-cli/lemma_cli/daemon/commands.py
@@ -46,6 +46,40 @@ def _refresh_auth_session(state) -> None:
     refresh_auth_session(state)
 
 
+def _daemon_token_provider(state, *, initial_token: str):
+    """Return the startup token once, then refresh before every reconnect.
+
+    A daemon connection can outlive the access token that authenticated it.
+    Keeping refresh here (where the mutable CLI state and refresh token live)
+    lets ``run_daemon`` ask for a current bearer token without coupling the
+    transport loop to CLI config persistence.
+    """
+    from lemma_sdk.config import resolve_token  # noqa: PLC0415
+
+    from .runner import DaemonTokenRefreshError  # noqa: PLC0415
+
+    first_token: str | None = initial_token
+
+    def provide_token() -> str:
+        nonlocal first_token
+        if first_token is not None:
+            token = first_token
+            first_token = None
+            return token
+
+        try:
+            _refresh_auth_session(state)
+            return resolve_token(
+                state.token,
+                state.config,
+                use_env=state.server_source == "env",
+            )
+        except ValueError as exc:
+            raise DaemonTokenRefreshError(str(exc)) from exc
+
+    return provide_token
+
+
 @app.command("discover")
 def discover_daemon() -> None:
     _console().print_json(data=discover_harness_catalog())
@@ -95,15 +129,20 @@ def start_daemon(
     resolved_base_url = resolve_base_url(
         state.base_url, state.config, use_env=state.server_source == "env",
     )
+    initial_token = resolve_token(
+        state.token,
+        state.config,
+        use_env=state.server_source == "env",
+    )
     write_daemon_status(os.getpid(), base_url=resolved_base_url, server=state.server)
     try:
         asyncio.run(
             run_daemon_with_graceful_shutdown(
                 base_url=resolved_base_url,
-                token=resolve_token(
-                    state.token,
-                    state.config,
-                    use_env=state.server_source == "env",
+                token=initial_token,
+                token_provider=_daemon_token_provider(
+                    state,
+                    initial_token=initial_token,
                 ),
                 verify_ssl=resolve_verify_ssl(state.no_verify_ssl),
                 debug=debug,

--- a/lemma-cli/lemma_cli/daemon/harnesses/codex.py
+++ b/lemma-cli/lemma_cli/daemon/harnesses/codex.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import hashlib
 import json
 import os
 import time
@@ -19,6 +20,7 @@ from .._utils import (
     strip_prompt_echo_from_text,
 )
 from ..mcp import (
+    mcp_authorization,
     mcp_conversation_id,
     provider_command,
     provider_cwd_for_run,
@@ -205,6 +207,7 @@ class CodexWorker:
         self.command: list[str] = []
         self.cwd: Path | None = None
         self.mcp_url: str | None = None
+        self.mcp_auth_fingerprint: str | None = None
         self.last_used_at = time.monotonic()
         self._lock = asyncio.Lock()
 
@@ -252,6 +255,7 @@ class CodexWorker:
             await self.client.close()
             self.client = None
         self.mcp_url = None
+        self.mcp_auth_fingerprint = None
 
     async def _ensure_started(
         self,
@@ -262,11 +266,13 @@ class CodexWorker:
     ) -> None:
         from ..mcp import mcp_url as get_mcp_url
         mcp_url_val = get_mcp_url(mcp)
+        mcp_auth_fingerprint = _mcp_auth_fingerprint(mcp)
         cwd = provider_cwd_for_run("CODEX", mcp)
         if (
             self.client is not None
             and self.client.is_alive()
             and self.mcp_url == mcp_url_val
+            and self.mcp_auth_fingerprint == mcp_auth_fingerprint
             and self.cwd == cwd
         ):
             return
@@ -299,6 +305,13 @@ class CodexWorker:
         self.command = command
         self.cwd = cwd
         self.mcp_url = mcp_url_val
+        self.mcp_auth_fingerprint = mcp_auth_fingerprint
+
+
+def _mcp_auth_fingerprint(mcp: dict[str, Any]) -> str:
+    """Compare rotating MCP credentials without retaining another raw copy."""
+    authorization = mcp_authorization(mcp)
+    return hashlib.sha256(authorization.encode("utf-8")).hexdigest()
 
 
 class CodexWorkerPool:

--- a/lemma-cli/lemma_cli/daemon/runner.py
+++ b/lemma-cli/lemma_cli/daemon/runner.py
@@ -28,6 +28,11 @@ from .process import create_subprocess
 # backoff, capped, to avoid hammering the server on a sustained outage.
 _RECONNECT_BASE_DELAY_SECONDS = 1.0
 _RECONNECT_MAX_DELAY_SECONDS = 30.0
+_MAX_CONSECUTIVE_AUTH_FAILURES = 2
+
+
+class DaemonTokenRefreshError(RuntimeError):
+    """A recoverable failure while obtaining the token for a reconnect."""
 
 # App-level heartbeat: sent on its own asyncio task, independent of run-handling
 # tasks, so a busy/slow run can never delay it. This is the primary liveness
@@ -281,12 +286,14 @@ async def run_daemon(
         # reconnect cycles used only to bound the loop in tests.
         backoff_attempt = 0
         reconnects = 0
+        consecutive_auth_failures = 0
         while True:
-            current_token = token_provider() if token_provider is not None else token
             daemon_log("connecting websocket", {"url": ws_url, "attempt": backoff_attempt})
             try:
+                current_token = token_provider() if token_provider is not None else token
                 async with connect_factory(current_token) as websocket:
                     backoff_attempt = 0  # reset backoff once we're connected
+                    consecutive_auth_failures = 0
                     await _serve_connection(
                         websocket,
                         config=config,
@@ -301,13 +308,29 @@ async def run_daemon(
             except InvalidStatus as exc:
                 status_code = getattr(getattr(exc, "response", None), "status_code", None)
                 if status_code in {401, 403}:
-                    import click
-                    raise click.ClickException(
-                        "Daemon websocket authentication failed. Run `lemma auth login` and try again."
-                    ) from exc
-                daemon_log("websocket rejected; will retry", {"status": status_code})
+                    consecutive_auth_failures += 1
+                    if consecutive_auth_failures >= _MAX_CONSECUTIVE_AUTH_FAILURES:
+                        import click
+                        raise click.ClickException(
+                            "Daemon websocket authentication failed after refreshing the session. "
+                            "Run `lemma auth login` and try again."
+                        ) from exc
+                    daemon_log(
+                        "websocket authentication rejected; refreshing and retrying",
+                        {"status": status_code},
+                    )
+                else:
+                    consecutive_auth_failures = 0
+                    daemon_log("websocket rejected; will retry", {"status": status_code})
             except (OSError, WebSocketException) as exc:
+                consecutive_auth_failures = 0
                 daemon_log("websocket connection error; will retry", {"error": str(exc)})
+            except DaemonTokenRefreshError as exc:
+                # Keep the daemon alive through a transient auth service
+                # outage; the next capped-backoff attempt refreshes from disk
+                # again (and observes rotation by another process).
+                consecutive_auth_failures = 0
+                daemon_log("daemon token refresh failed; will retry", {"error": str(exc)})
 
             reconnects += 1
             if max_reconnect_attempts is not None and reconnects > max_reconnect_attempts:

--- a/lemma-cli/tests/test_daemon_cli.py
+++ b/lemma-cli/tests/test_daemon_cli.py
@@ -505,6 +505,75 @@ async def test_codex_app_server_pool_reuses_worker_with_saved_thread(
 
 
 @pytest.mark.asyncio
+async def test_codex_app_server_restarts_worker_when_mcp_token_rotates(
+    monkeypatch,
+    tmp_path,
+):
+    websocket_one = _FakeWebSocket()
+    websocket_two = _FakeWebSocket()
+    monkeypatch.setattr(daemon, "provider_cwd", lambda _harness_kind: tmp_path)
+    monkeypatch.setattr(daemon, "_CODEX_APP_SERVER_POOL", daemon._CodexAppServerPool())
+    _FakeCodexJsonRpcProcess.instances = []
+    _FakeCodexJsonRpcProcess.next_thread_id = 0
+    monkeypatch.setattr(daemon, "_JsonRpcProcess", _FakeCodexJsonRpcProcess)
+
+    payload = {
+        "harness_kind": "CODEX",
+        "model_name": "default",
+        "prompt": {
+            "system_prompt": "# Instructions\nRemember user facts.",
+            "user_prompt": "USER:\nmy code word is alpha",
+        },
+        "mcp": {
+            "url": "http://localhost/conversation-rotation/mcp",
+            "server_name": "lemma_tools",
+            "conversation_id": "conversation-rotation",
+            "authorization": "Bearer token-one",
+            "token": "token-one",
+        },
+    }
+    try:
+        await _handle_run_start(
+            websocket_one,
+            {"type": "run.start", "agent_run_id": "run-one", "payload": payload},
+        )
+        payload = {
+            **payload,
+            "prompt": {
+                "session_id": "thread-1",
+                "user_prompt": "USER:\nwhat is my code word?",
+            },
+            "mcp": {
+                **payload["mcp"],
+                "authorization": "Bearer token-two",
+                "token": "token-two",
+            },
+        }
+        await _handle_run_start(
+            websocket_two,
+            {"type": "run.start", "agent_run_id": "run-two", "payload": payload},
+        )
+    finally:
+        await daemon._CODEX_APP_SERVER_POOL.close()
+
+    assert len(_FakeCodexJsonRpcProcess.instances) == 2
+    first, second = _FakeCodexJsonRpcProcess.instances
+    assert first.closed is True
+    assert first.env[daemon.LEMMA_MCP_AUTHORIZATION_ENV] == "Bearer token-one"
+    assert second.env[daemon.LEMMA_MCP_AUTHORIZATION_ENV] == "Bearer token-two"
+    assert [
+        params
+        for method, params in second.requests
+        if method == "thread/start"
+    ] == []
+    assert [
+        params["threadId"]
+        for method, params in second.requests
+        if method == "turn/start"
+    ] == ["thread-1"]
+
+
+@pytest.mark.asyncio
 async def test_codex_app_server_worker_closes_after_cancelled_turn(
     monkeypatch,
     tmp_path,

--- a/lemma-cli/tests/test_daemon_resiliency.py
+++ b/lemma-cli/tests/test_daemon_resiliency.py
@@ -109,6 +109,23 @@ class _FakeConn:
         return False
 
 
+class _RejectConn:
+    def __init__(self, status_code: int):
+        from websockets.datastructures import Headers
+        from websockets.exceptions import InvalidStatus
+        from websockets.http11 import Response
+
+        self._error = InvalidStatus(
+            Response(status_code, "Rejected", Headers())
+        )
+
+    async def __aenter__(self):
+        raise self._error
+
+    async def __aexit__(self, *_a):
+        return False
+
+
 @pytest.mark.asyncio
 async def test_send_json_swallows_send_failure():
     ws = _FakeWS()
@@ -204,6 +221,136 @@ async def test_run_daemon_uses_token_provider_on_each_connect(monkeypatch):
     )
 
     assert tokens_used == ["token-1", "token-2"]
+
+
+@pytest.mark.asyncio
+async def test_run_daemon_refreshes_token_after_auth_rejection(monkeypatch):
+    monkeypatch.setattr(
+        runner, "ensure_config", lambda: {"device_key": "k", "display_name": "t"}
+    )
+    monkeypatch.setattr(runner, "discover_harness_catalog", lambda: {})
+    monkeypatch.setattr(runner, "save_config", lambda _c: None)
+    monkeypatch.setattr(runner, "device_info", lambda: {})
+    monkeypatch.setattr(runner, "daemon_ws_url", lambda _b: "ws://example/daemon")
+    monkeypatch.setattr(runner, "reconnect_delay_seconds", lambda _a: 0.0)
+
+    tokens_provided = iter(["expired-token", "fresh-token"])
+    tokens_used: list[str] = []
+
+    def connect_factory(token: str):
+        tokens_used.append(token)
+        if token == "expired-token":
+            return _RejectConn(403)
+        return _FakeConn(_FakeWS(incoming=[]))
+
+    await runner.run_daemon(
+        base_url="http://example",
+        token="unused",
+        verify_ssl=True,
+        token_provider=lambda: next(tokens_provided),
+        connect_factory=connect_factory,
+        max_reconnect_attempts=1,
+    )
+
+    assert tokens_used == ["expired-token", "fresh-token"]
+
+
+@pytest.mark.asyncio
+async def test_run_daemon_fails_after_refreshed_token_is_rejected(monkeypatch):
+    import click
+
+    monkeypatch.setattr(
+        runner, "ensure_config", lambda: {"device_key": "k", "display_name": "t"}
+    )
+    monkeypatch.setattr(runner, "discover_harness_catalog", lambda: {})
+    monkeypatch.setattr(runner, "save_config", lambda _c: None)
+    monkeypatch.setattr(runner, "device_info", lambda: {})
+    monkeypatch.setattr(runner, "daemon_ws_url", lambda _b: "ws://example/daemon")
+    monkeypatch.setattr(runner, "reconnect_delay_seconds", lambda _a: 0.0)
+
+    tokens_used: list[str] = []
+
+    def connect_factory(token: str):
+        tokens_used.append(token)
+        return _RejectConn(403)
+
+    with pytest.raises(click.ClickException, match="after refreshing the session"):
+        await runner.run_daemon(
+            base_url="http://example",
+            token="unused",
+            verify_ssl=True,
+            token_provider=lambda: f"token-{len(tokens_used) + 1}",
+            connect_factory=connect_factory,
+        )
+
+    assert tokens_used == ["token-1", "token-2"]
+
+
+@pytest.mark.asyncio
+async def test_run_daemon_retries_transient_token_refresh_failure(monkeypatch):
+    monkeypatch.setattr(
+        runner, "ensure_config", lambda: {"device_key": "k", "display_name": "t"}
+    )
+    monkeypatch.setattr(runner, "discover_harness_catalog", lambda: {})
+    monkeypatch.setattr(runner, "save_config", lambda _c: None)
+    monkeypatch.setattr(runner, "device_info", lambda: {})
+    monkeypatch.setattr(runner, "daemon_ws_url", lambda _b: "ws://example/daemon")
+    monkeypatch.setattr(runner, "reconnect_delay_seconds", lambda _a: 0.0)
+
+    provider_calls = 0
+    tokens_used: list[str] = []
+
+    def token_provider() -> str:
+        nonlocal provider_calls
+        provider_calls += 1
+        if provider_calls == 1:
+            raise runner.DaemonTokenRefreshError("auth service unavailable")
+        return "fresh-token"
+
+    def connect_factory(token: str):
+        tokens_used.append(token)
+        return _FakeConn(_FakeWS(incoming=[]))
+
+    await runner.run_daemon(
+        base_url="http://example",
+        token="unused",
+        verify_ssl=True,
+        token_provider=token_provider,
+        connect_factory=connect_factory,
+        max_reconnect_attempts=1,
+    )
+
+    assert provider_calls == 2
+    assert tokens_used == ["fresh-token"]
+
+
+def test_daemon_token_provider_refreshes_after_initial_connection(monkeypatch):
+    from types import SimpleNamespace
+
+    from lemma_cli.daemon import commands
+
+    state = SimpleNamespace(
+        token=None,
+        config={"token": "stale-token"},
+        server_source="config",
+    )
+    refresh_calls = 0
+
+    def refresh(current_state) -> None:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        current_state.config["token"] = "fresh-token"
+
+    monkeypatch.setattr(commands, "_refresh_auth_session", refresh)
+    token_provider = commands._daemon_token_provider(
+        state,
+        initial_token="initial-token",
+    )
+
+    assert token_provider() == "initial-token"
+    assert refresh_calls == 0
+    assert token_provider() == "fresh-token"
+    assert refresh_calls == 1
 
 
 class _Resp:


### PR DESCRIPTION
## Summary
- refresh managed CLI authentication before daemon WebSocket reconnects
- retry one rejected daemon handshake with the renewed credential
- recycle warm Codex app-server workers when the per-run MCP authorization changes while preserving thread continuity

Fixes #170.

## Verification
- 602 CLI unit tests passed; 1 Windows-only test skipped
- Ruff passes on all changed files