### PR TITLE
Fix auth abuse feedback and invalid-domain signup

### DIFF
--- a/docs/authentication-hardening.md
+++ b/docs/authentication-hardening.md
@@ -94,6 +94,17 @@ Hard bounces deactivate the unique matching active Lemma user and revoke its ses
 
 If the SMTP provider cannot produce authenticated hard-bounce events, leave `AUTH_BOUNCE_WEBHOOK_SECRET` unset. Invalid syntax, nonexistent domains, and explicit null MX records are still rejected before a user is created.
 
+Lemma additionally requires an explicit MX record before creating a new account
+or sending authentication mail. Domains that rely on the legacy SMTP A/AAAA
+fallback are rejected to avoid preventable bounces, but this policy is not
+treated as deterministic evidence for automatically deactivating an existing
+account. DNS timeouts and temporary resolver failures remain retryable.
+
+ALTCHA runs as a private, self-hosted proof-of-work check rather than a visual
+checkbox CAPTCHA. The authentication UI reports when the check is active,
+working, complete, or unavailable; no third-party tracker or paid service is
+loaded.
+
 ## Disposable-domain snapshot
 
 The bundled list at `lemma-backend/app/modules/identity/data/disposable_email_domains.txt` is a reviewed, pinned subset of the MIT-licensed [disposable/disposable-email-domains](https://github.com/disposable/disposable-email-domains) list. Updates must be reviewed and committed; production never fetches a remote list at request time. Add known false positives to `AUTH_DISPOSABLE_EMAIL_ALLOWLIST` before rollout.

--- a/lemma-backend/app/app.py
+++ b/lemma-backend/app/app.py
@@ -511,6 +511,7 @@ def create_app(modules=OSS_MODULES) -> FastAPI:
         # them here or the front-token gets clobbered and the SDK can't read it.
         expose_headers=[
             "X-Request-Id",
+            "Retry-After",
             "front-token",
             "anti-csrf",
             "st-access-token",

--- a/lemma-backend/app/auth_app.py
+++ b/lemma-backend/app/auth_app.py
@@ -29,6 +29,7 @@ def get_auth_app():
         # SuperTokens sets these as expose headers per-response; list them
         # explicitly so this stays correct regardless of middleware layering.
         expose_headers=[
+            "Retry-After",
             "front-token",
             "anti-csrf",
             "st-access-token",

--- a/lemma-backend/app/core/security.py
+++ b/lemma-backend/app/core/security.py
@@ -112,6 +112,7 @@ def _is_public_identity_auth_path(path: str, method: str) -> bool:
         normalized_method == "GET"
         and path
         in {
+            "/auth/altcha/config",
             "/auth/altcha/challenge",
             "/auth/telegram/config",
             "/auth/telegram/start",

--- a/lemma-backend/app/modules/identity/api/controllers/auth_controller.py
+++ b/lemma-backend/app/modules/identity/api/controllers/auth_controller.py
@@ -123,6 +123,10 @@ class AltchaChallengeResponse(BaseModel):
     signature: str | None = None
 
 
+class AltchaConfigResponse(BaseModel):
+    enabled: bool
+
+
 class TelegramConfigResponse(BaseModel):
     enabled: bool
 
@@ -149,6 +153,15 @@ def _telegram_error_redirect(return_to: str | None, code: str) -> RedirectRespon
         f"{destination}{separator}{urlencode({'telegram_error': code})}",
         status_code=303,
     )
+
+
+@router.get(
+    "/altcha/config",
+    include_in_schema=False,
+    response_model=AltchaConfigResponse,
+)
+async def altcha_config() -> AltchaConfigResponse:
+    return AltchaConfigResponse(enabled=settings.auth_altcha_enabled)
 
 
 @router.get(

--- a/lemma-backend/app/modules/identity/services/email_policy.py
+++ b/lemma-backend/app/modules/identity/services/email_policy.py
@@ -106,6 +106,15 @@ async def validate_auth_email(email: str) -> str:
         try:
             deliverable = await _validate_with_dns(normalized)
             normalized = normalize_identity_email(deliverable.normalized)
+            if deliverable.mx_fallback_type is not None:
+                # RFC 5321 still permits falling back to an A/AAAA record when a
+                # domain has no MX record. In practice this is a common source of
+                # avoidable verification-email bounces. Lemma requires an explicit
+                # MX record for new outbound auth mail, but treats this as a policy
+                # rejection rather than deterministic evidence for deactivation.
+                raise EmailPolicyError(
+                    EmailPolicyRejection("MISSING_MX", "dns", permanent=False)
+                )
         except EmailUndeliverableError as exc:
             rejection = _dns_rejection(exc)
             if rejection is not None:
@@ -114,6 +123,8 @@ async def validate_auth_email(email: str) -> str:
             raise EmailPolicyError(
                 EmailPolicyRejection("INVALID_SYNTAX", "email-validator")
             ) from exc
+        except EmailPolicyError:
+            raise
         except EmailNotValidError, TimeoutError, OSError:
             # The library treats resolver timeouts and temporary DNS failures as
             # unknown deliverability. Operational lookup failures are likewise

--- a/lemma-backend/app/modules/identity/tests/e2e/test_identity_e2e.py
+++ b/lemma-backend/app/modules/identity/tests/e2e/test_identity_e2e.py
@@ -9,6 +9,7 @@ import logging
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
 from uuid import UUID, uuid4
 
@@ -40,6 +41,7 @@ from app.modules.identity.services.telegram_oidc import (
     TelegramOIDCService,
 )
 from app.modules.identity.services import telegram_oidc
+from app.modules.identity.services import email_policy
 from app.modules.identity.services.auth_abuse import get_auth_abuse_store
 from app.core.config import settings
 from app.modules.test_support.e2e_base import verify_emailpassword_for_tests
@@ -358,6 +360,34 @@ async def test_disposable_email_is_rejected_before_account_creation(
     assert response.status_code == 200
     assert response.json()["status"] == "SIGN_UP_NOT_ALLOWED"
 
+    async with async_session_maker() as session:
+        local_user = await session.scalar(select(User).where(User.email == email))
+    assert local_user is None
+
+
+@pytest.mark.asyncio
+async def test_domain_without_explicit_mx_is_rejected_before_account_creation(
+    async_client: AsyncClient,
+    monkeypatch,
+):
+    email = f"blocked-{uuid4().hex[:10]}@legacy.example"
+    monkeypatch.setattr(settings, "auth_email_deliverability_checks_enabled", True)
+    monkeypatch.setattr(settings, "auth_disposable_email_domains_enabled", False)
+
+    async def a_record_fallback(_email):
+        return SimpleNamespace(normalized=email, mx_fallback_type="A")
+
+    monkeypatch.setattr(email_policy, "_validate_with_dns", a_record_fallback)
+    response = await async_client.post(
+        "/st/auth/signup",
+        json=_emailpassword_payload(email, "TestPassword@123"),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "SIGN_UP_NOT_ALLOWED",
+        "reason": "Please use a valid, non-disposable email address",
+    }
     async with async_session_maker() as session:
         local_user = await session.scalar(select(User).where(User.email == email))
     assert local_user is None

--- a/lemma-backend/app/modules/identity/tests/unit/test_auth_controller.py
+++ b/lemma-backend/app/modules/identity/tests/unit/test_auth_controller.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException
 from app.modules.identity.api.controllers.auth_controller import (
     DesktopAuthRequestCreate,
     DesktopAuthSessionRequest,
+    altcha_config,
     complete_desktop_auth_request,
     create_desktop_auth_request,
     create_desktop_auth_session,
@@ -46,6 +47,17 @@ class _FakePodMembership:
     async def get_pod_organization_id(self, pod_id):
         self.requested_pod_ids.append(pod_id)
         return self.organization_id
+
+
+@pytest.mark.asyncio
+async def test_altcha_config_reports_runtime_setting(monkeypatch):
+    from app.core.config import settings
+
+    monkeypatch.setattr(settings, "auth_altcha_enabled", True)
+    assert (await altcha_config()).enabled is True
+
+    monkeypatch.setattr(settings, "auth_altcha_enabled", False)
+    assert (await altcha_config()).enabled is False
 
 
 @pytest.mark.asyncio

--- a/lemma-backend/app/modules/identity/tests/unit/test_email_policy.py
+++ b/lemma-backend/app/modules/identity/tests/unit/test_email_policy.py
@@ -67,6 +67,28 @@ async def test_dns_invalid_is_permanent_but_unexpected_dns_failure_is_retryable(
 
 
 @pytest.mark.asyncio
+async def test_email_policy_requires_explicit_mx_without_deactivation_evidence(
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "auth_email_deliverability_checks_enabled", True)
+    monkeypatch.setattr(settings, "auth_disposable_email_domains_enabled", False)
+
+    async def a_record_fallback(_email):
+        return SimpleNamespace(
+            normalized="person@legacy.example",
+            mx_fallback_type="A",
+        )
+
+    monkeypatch.setattr(email_policy, "_validate_with_dns", a_record_fallback)
+    with pytest.raises(EmailPolicyError) as exc:
+        await email_policy.validate_auth_email("person@legacy.example")
+
+    assert exc.value.rejection.reason == "MISSING_MX"
+    assert exc.value.rejection.evidence_source == "dns"
+    assert exc.value.rejection.permanent is False
+
+
+@pytest.mark.asyncio
 async def test_only_explicit_null_mx_is_deactivation_safe(monkeypatch):
     monkeypatch.setattr(settings, "auth_email_deliverability_checks_enabled", True)
     monkeypatch.setattr(settings, "auth_disposable_email_domains_enabled", False)

--- a/lemma-backend/app/modules/identity/tests/unit/test_security_killswitch.py
+++ b/lemma-backend/app/modules/identity/tests/unit/test_security_killswitch.py
@@ -53,13 +53,17 @@ def test_only_desktop_request_creation_and_exchange_are_public():
 
 def test_signed_bounce_webhooks_are_public_but_other_auth_posts_are_not():
     assert security._is_public_identity_auth_path("/auth/email/bounces", "POST")
-    assert security._is_public_identity_auth_path(
-        "/auth/email/bounces/resend", "POST"
-    )
+    assert security._is_public_identity_auth_path("/auth/email/bounces/resend", "POST")
     assert not security._is_public_identity_auth_path(
         "/auth/email/bounces/resend", "GET"
     )
     assert not security._is_public_identity_auth_path("/auth/verify-token", "POST")
+
+
+def test_altcha_config_and_challenges_are_public():
+    assert security._is_public_identity_auth_path("/auth/altcha/config", "GET")
+    assert security._is_public_identity_auth_path("/auth/altcha/challenge", "GET")
+    assert not security._is_public_identity_auth_path("/auth/altcha/config", "POST")
 
 
 def _patch(monkeypatch, *, flag: bool, payload: dict):

--- a/lemma-frontend/app/auth/auth-portal.css
+++ b/lemma-frontend/app/auth/auth-portal.css
@@ -376,6 +376,38 @@
   animation-delay: 160ms;
 }
 
+.auth-protection-notice {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.7rem 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-soft);
+  color: var(--muted);
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+.auth-protection-notice svg {
+  flex: 0 0 auto;
+  color: var(--accent-strong);
+}
+
+.auth-protection-notice-error {
+  border-color: var(--auth-status-danger-border);
+  background: var(--attention-soft);
+  color: var(--attention);
+}
+
+.auth-protection-notice-error svg {
+  color: var(--attention);
+}
+
+.auth-protection-spinner {
+  animation: spin 1s linear infinite;
+}
+
 .status-panel,
 .session-panel {
   padding: 1.15rem 1.25rem;

--- a/lemma-frontend/components/auth/portal/auth-portal.tsx
+++ b/lemma-frontend/components/auth/portal/auth-portal.tsx
@@ -49,6 +49,7 @@ import {
   isTelegramMiniApp,
 } from "@/components/auth/portal/auth/supertokens";
 import { VerificationScreen } from "@/components/auth/portal/auth/verification-screen";
+import { AuthProtectionNotice } from "@/components/auth/portal/auth/auth-protection-notice";
 import {
   getDestinationLabel,
   getRedirectDestinationFallback,
@@ -467,6 +468,7 @@ function AuthLanding() {
     return (
       <AuthScreenLayout destination={destination} heroCopy={authHeroCopy}>
         <div className="auth-form-stack">
+          <AuthProtectionNotice />
           <VerificationScreen doesSessionExist={doesSessionExist} />
         </div>
       </AuthScreenLayout>
@@ -574,6 +576,7 @@ function AuthLanding() {
     <AuthScreenLayout destination={destination} heroCopy={authHeroCopy}>
       <div className="auth-form-stack">
         <TelegramLoginButton visible={authMode === "signin"} />
+        <AuthProtectionNotice />
         {getRoutingComponent([...preBuiltUiList])}
       </div>
     </AuthScreenLayout>

--- a/lemma-frontend/components/auth/portal/auth/altcha.test.ts
+++ b/lemma-frontend/components/auth/portal/auth/altcha.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  addAltchaProof,
+  fetchAltchaEnabled,
+  getAltchaProgress,
+} from "./altcha";
+
+describe("ALTCHA client state", () => {
+  it("reads whether proof-of-work protection is enabled", async () => {
+    const enabledFetch = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ enabled: true }), { status: 200 }),
+    );
+    await expect(fetchAltchaEnabled(enabledFetch)).resolves.toBe(true);
+
+    const unavailableFetch = vi
+      .fn<typeof fetch>()
+      .mockRejectedValue(new Error("offline"));
+    await expect(fetchAltchaEnabled(unavailableFetch)).resolves.toBeNull();
+  });
+
+  it("does not alter requests when protection is disabled", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ enabled: false }), { status: 200 }),
+    );
+    const request = { headers: { Accept: "application/json" } };
+
+    await expect(addAltchaProof(request, "signup", fetcher)).resolves.toBe(
+      request,
+    );
+    expect(getAltchaProgress()).toEqual({ phase: "idle", enabled: false });
+  });
+
+  it("fails closed and reports an unsolved challenge", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          enabled: true,
+          algorithm: "SHA-256",
+          challenge: "not-a-valid-digest",
+          maxnumber: 0,
+          salt: "test-salt",
+          signature: "test-signature",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await expect(addAltchaProof({}, "signup", fetcher)).rejects.toThrow(
+      "Unable to solve the proof-of-work challenge",
+    );
+    expect(getAltchaProgress()).toEqual({ phase: "error", enabled: true });
+  });
+});

--- a/lemma-frontend/components/auth/portal/auth/altcha.ts
+++ b/lemma-frontend/components/auth/portal/auth/altcha.ts
@@ -11,6 +11,45 @@ type AltchaChallenge = {
   signature?: string;
 };
 
+export type AltchaProgress = {
+  phase: "idle" | "checking" | "solving" | "complete" | "error";
+  enabled: boolean | null;
+};
+
+type Fetcher = typeof fetch;
+
+let progress: AltchaProgress = { phase: "idle", enabled: null };
+const progressListeners = new Set<() => void>();
+
+function updateProgress(next: AltchaProgress): void {
+  progress = next;
+  progressListeners.forEach((listener) => listener());
+}
+
+export function getAltchaProgress(): AltchaProgress {
+  return progress;
+}
+
+export function subscribeAltchaProgress(listener: () => void): () => void {
+  progressListeners.add(listener);
+  return () => progressListeners.delete(listener);
+}
+
+export async function fetchAltchaEnabled(
+  fetcher: Fetcher = fetch,
+): Promise<boolean | null> {
+  try {
+    const response = await fetcher(buildApiUrl("/auth/altcha/config"), {
+      credentials: "include",
+    });
+    if (!response.ok) return null;
+    const payload = (await response.json()) as { enabled?: boolean };
+    return typeof payload.enabled === "boolean" ? payload.enabled : null;
+  } catch {
+    return null;
+  }
+}
+
 function hex(bytes: ArrayBuffer): string {
   return Array.from(new Uint8Array(bytes), (value) => value.toString(16).padStart(2, "0")).join("");
 }
@@ -35,7 +74,7 @@ async function solve(challenge: AltchaChallenge): Promise<string | null> {
     );
     if (hex(digest) === challenge.challenge) break;
     if (number % 1000 === 0) {
-      await new Promise((resolve) => window.setTimeout(resolve, 0));
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 0));
     }
   }
   if (number > challenge.maxnumber) {
@@ -54,15 +93,32 @@ async function solve(challenge: AltchaChallenge): Promise<string | null> {
 export async function addAltchaProof(
   requestInit: RequestInit,
   purpose: AltchaPurpose,
+  fetcher: Fetcher = fetch,
 ): Promise<RequestInit> {
-  const response = await fetch(
-    buildApiUrl(`/auth/altcha/challenge?purpose=${encodeURIComponent(purpose)}`),
-    { credentials: "include" },
-  );
-  if (!response.ok) throw new Error("Authentication protection is temporarily unavailable");
-  const proof = await solve((await response.json()) as AltchaChallenge);
-  if (!proof) return requestInit;
-  const headers = new Headers(requestInit.headers);
-  headers.set("x-altcha-payload", proof);
-  return { ...requestInit, headers };
+  updateProgress({ phase: "checking", enabled: progress.enabled });
+  try {
+    const response = await fetcher(
+      buildApiUrl(`/auth/altcha/challenge?purpose=${encodeURIComponent(purpose)}`),
+      { credentials: "include" },
+    );
+    if (!response.ok) {
+      throw new Error("Authentication protection is temporarily unavailable");
+    }
+    const challenge = (await response.json()) as AltchaChallenge;
+    if (!challenge.enabled) {
+      updateProgress({ phase: "idle", enabled: false });
+      return requestInit;
+    }
+
+    updateProgress({ phase: "solving", enabled: true });
+    const proof = await solve(challenge);
+    if (!proof) return requestInit;
+    const headers = new Headers(requestInit.headers);
+    headers.set("x-altcha-payload", proof);
+    updateProgress({ phase: "complete", enabled: true });
+    return { ...requestInit, headers };
+  } catch (error) {
+    updateProgress({ phase: "error", enabled: progress.enabled });
+    throw error;
+  }
 }

--- a/lemma-frontend/components/auth/portal/auth/auth-errors.test.ts
+++ b/lemma-frontend/components/auth/portal/auth/auth-errors.test.ts
@@ -1,0 +1,75 @@
+import STGeneralError from "supertokens-web-js/utils/error";
+import { describe, expect, it } from "vitest";
+
+import {
+  authErrorMessageFromResponse,
+  formatRetryDelay,
+  runAuthRequest,
+} from "./auth-errors";
+
+describe("auth error presentation", () => {
+  it("turns a 429 into a specific retry message", async () => {
+    const response = new Response(
+      JSON.stringify({
+        status: "GENERAL_ERROR",
+        message: "Too many authentication attempts",
+      }),
+      { status: 429, headers: { "Retry-After": "125" } },
+    );
+
+    await expect(authErrorMessageFromResponse(response, "sign-in")).resolves.toBe(
+      "Too many sign-in attempts. Please try again in 3 minutes.",
+    );
+  });
+
+  it("uses request-specific rate-limit wording", async () => {
+    const response = new Response("{}", {
+      status: 429,
+      headers: { "Retry-After": "42" },
+    });
+
+    await expect(
+      authErrorMessageFromResponse(response, "password-reset"),
+    ).resolves.toBe(
+      "Too many password reset requests. Please try again in 42 seconds.",
+    );
+  });
+
+  it("humanizes retry durations", () => {
+    expect(formatRetryDelay(1)).toBe("1 second");
+    expect(formatRetryDelay(59)).toBe("59 seconds");
+    expect(formatRetryDelay(60)).toBe("1 minute");
+    expect(formatRetryDelay(61)).toBe("2 minutes");
+  });
+
+  it("maps proof and network failures without exposing internals", async () => {
+    const proofFailure = new Response(
+      JSON.stringify({
+        status: "GENERAL_ERROR",
+        message: "Proof-of-work expired or already used",
+      }),
+      { status: 400 },
+    );
+
+    await expect(
+      authErrorMessageFromResponse(proofFailure, "sign-up"),
+    ).resolves.toContain("private security check expired");
+
+    await expect(
+      runAuthRequest("sign-in", async () => {
+        throw new TypeError("fetch failed");
+      }),
+    ).rejects.toMatchObject({
+      message: "We couldn’t reach Lemma. Check your connection and try again.",
+    });
+  });
+
+  it("preserves SuperTokens general errors", async () => {
+    const original = new STGeneralError("Invalid credentials");
+    await expect(
+      runAuthRequest("sign-in", async () => {
+        throw original;
+      }),
+    ).rejects.toBe(original);
+  });
+});

--- a/lemma-frontend/components/auth/portal/auth/auth-errors.ts
+++ b/lemma-frontend/components/auth/portal/auth/auth-errors.ts
@@ -1,0 +1,114 @@
+import STGeneralError from "supertokens-web-js/utils/error";
+
+export type AuthRequestKind =
+  | "sign-in"
+  | "sign-up"
+  | "password-reset"
+  | "password-change"
+  | "email-check";
+
+type AuthErrorPayload = {
+  status?: string;
+  message?: string;
+};
+
+function retryDelaySeconds(response: Response): number | null {
+  const value = response.headers.get("retry-after");
+  if (!value) return null;
+
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds > 0) return Math.ceil(seconds);
+
+  const date = Date.parse(value);
+  if (!Number.isFinite(date)) return null;
+  return Math.max(1, Math.ceil((date - Date.now()) / 1000));
+}
+
+export function formatRetryDelay(seconds: number): string {
+  if (seconds < 60) {
+    return `${seconds} second${seconds === 1 ? "" : "s"}`;
+  }
+  const minutes = Math.ceil(seconds / 60);
+  return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+}
+
+function rateLimitLabel(kind: AuthRequestKind): string {
+  switch (kind) {
+    case "sign-in":
+      return "Too many sign-in attempts";
+    case "sign-up":
+      return "Too many account creation attempts";
+    case "password-reset":
+      return "Too many password reset requests";
+    case "password-change":
+      return "Too many password change attempts";
+    case "email-check":
+      return "Too many email checks";
+  }
+}
+
+async function responsePayload(response: Response): Promise<AuthErrorPayload> {
+  try {
+    return (await response.clone().json()) as AuthErrorPayload;
+  } catch {
+    return {};
+  }
+}
+
+export async function authErrorMessageFromResponse(
+  response: Response,
+  kind: AuthRequestKind,
+): Promise<string> {
+  const payload = await responsePayload(response);
+  const serverMessage = payload.message?.trim().toLowerCase() || "";
+
+  if (
+    response.status === 429 ||
+    serverMessage === "too many authentication attempts"
+  ) {
+    const delay = retryDelaySeconds(response);
+    const suffix = delay
+      ? ` Please try again in ${formatRetryDelay(delay)}.`
+      : " Please wait a little while and try again.";
+    return `${rateLimitLabel(kind)}.${suffix}`;
+  }
+
+  if (
+    serverMessage.includes("proof-of-work") ||
+    serverMessage.includes("security check")
+  ) {
+    return "The private security check expired or could not be completed. Please try again.";
+  }
+
+  if (response.status >= 500) {
+    return "Authentication is temporarily unavailable. Please try again shortly.";
+  }
+
+  return "We couldn’t complete that authentication request. Please try again.";
+}
+
+export async function runAuthRequest<T>(
+  kind: AuthRequestKind,
+  request: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await request();
+  } catch (error) {
+    if (STGeneralError.isThisError(error)) throw error;
+    if (error instanceof Response) {
+      throw new STGeneralError(await authErrorMessageFromResponse(error, kind));
+    }
+    if (
+      error instanceof Error &&
+      (error.message.includes("proof-of-work") ||
+        error.message.includes("Authentication protection"))
+    ) {
+      throw new STGeneralError(
+        "The private security check is temporarily unavailable. Please try again.",
+      );
+    }
+    throw new STGeneralError(
+      "We couldn’t reach Lemma. Check your connection and try again.",
+    );
+  }
+}

--- a/lemma-frontend/components/auth/portal/auth/auth-protection-notice.tsx
+++ b/lemma-frontend/components/auth/portal/auth/auth-protection-notice.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useState, useSyncExternalStore } from "react";
+
+import {
+  fetchAltchaEnabled,
+  getAltchaProgress,
+  subscribeAltchaProgress,
+} from "@/components/auth/portal/auth/altcha";
+import { AlertCircle, Loader2, ShieldCheck } from "@/components/ui/icons";
+
+export function AuthProtectionNotice() {
+  const [configured, setConfigured] = useState<boolean | null>(null);
+  const progress = useSyncExternalStore(
+    subscribeAltchaProgress,
+    getAltchaProgress,
+    getAltchaProgress,
+  );
+
+  useEffect(() => {
+    let active = true;
+    void fetchAltchaEnabled().then((enabled) => {
+      if (active) setConfigured(enabled);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const enabled = progress.enabled ?? configured;
+  if (enabled !== true) return null;
+
+  const isWorking = progress.phase === "checking" || progress.phase === "solving";
+  const isError = progress.phase === "error";
+  const message =
+    progress.phase === "checking"
+      ? "Preparing a private security check…"
+      : progress.phase === "solving"
+        ? "Completing a quick security check…"
+        : progress.phase === "complete"
+          ? "Private security check complete."
+          : isError
+            ? "Security check unavailable. Try submitting again."
+            : "Protected by private proof-of-work—no tracking CAPTCHA.";
+  const Icon = isWorking ? Loader2 : isError ? AlertCircle : ShieldCheck;
+
+  return (
+    <div
+      className={`auth-protection-notice${isError ? " auth-protection-notice-error" : ""}`}
+      role="status"
+      aria-live="polite"
+    >
+      <Icon
+        size={17}
+        weight="duotone"
+        className={isWorking ? "auth-protection-spinner" : undefined}
+        aria-hidden="true"
+      />
+      <span>{message}</span>
+    </div>
+  );
+}

--- a/lemma-frontend/components/auth/portal/auth/supertokens.ts
+++ b/lemma-frontend/components/auth/portal/auth/supertokens.ts
@@ -13,6 +13,7 @@ import {
   getStoredDesktopRequestId,
 } from "@/components/auth/portal/auth/desktop";
 import { addAltchaProof } from "@/components/auth/portal/auth/altcha";
+import { runAuthRequest } from "@/components/auth/portal/auth/auth-errors";
 
 export function isTelegramMiniApp(): boolean {
   if (typeof window === "undefined") return false;
@@ -183,6 +184,19 @@ const authSurfaceStyle = `
   color: var(--action-primary);
   font-weight: 500;
 }
+
+[data-supertokens~="generalError"] {
+  margin: 0 0 0.95rem;
+  padding: 0.8rem 0.9rem;
+  border: 1px solid var(--auth-status-danger-border);
+  border-radius: 8px;
+  background: var(--attention-soft);
+  color: var(--attention);
+  font-size: 0.875rem;
+  font-weight: 550;
+  line-height: 1.45;
+  text-align: left;
+}
 `;
 
 export function ensureSuperTokensInit(): void {
@@ -223,6 +237,31 @@ export function ensureSuperTokensInit(): void {
         tokenTransferMethod: "cookie",
       }),
       EmailPassword.init({
+        override: {
+          functions: (originalImplementation) => ({
+            ...originalImplementation,
+            signIn: (input) =>
+              runAuthRequest("sign-in", () =>
+                originalImplementation.signIn(input),
+              ),
+            signUp: (input) =>
+              runAuthRequest("sign-up", () =>
+                originalImplementation.signUp(input),
+              ),
+            sendPasswordResetEmail: (input) =>
+              runAuthRequest("password-reset", () =>
+                originalImplementation.sendPasswordResetEmail(input),
+              ),
+            submitNewPassword: (input) =>
+              runAuthRequest("password-change", () =>
+                originalImplementation.submitNewPassword(input),
+              ),
+            doesEmailExist: (input) =>
+              runAuthRequest("email-check", () =>
+                originalImplementation.doesEmailExist(input),
+              ),
+          }),
+        },
         preAPIHook: async (context) => {
           const purpose =
             context.action === "EMAIL_PASSWORD_SIGN_UP"


### PR DESCRIPTION
## Summary

- show specific, request-aware auth errors for throttling and security-check failures instead of SuperTokens' generic fallback
- expose `Retry-After` through CORS so the UI can show the actual remaining wait time
- make self-hosted ALTCHA proof-of-work visible with accessible checking, solving, success, and failure states
- require an explicit MX record for new auth/outbound email, preventing A/AAAA-fallback domains such as the reported case from creating users or triggering verification mail

## Why the reported address got through

`email-validator` follows RFC 5321 and treats a domain with no MX but an A/AAAA record as deliverable via legacy fallback. That verifies only the domain route, never whether a mailbox exists. Lemma now applies a stricter signup policy and requires explicit MX. Missing MX remains non-permanent evidence, so it does not automatically deactivate historical users.

## Validation

- Browser: invalid A-record-only domain is rejected on the signup form before account creation/email delivery
- Browser: throttled sign-in shows `Please try again in 15 minutes` from `Retry-After`
- Browser: ALTCHA notice and state checked at desktop and 390px mobile widths
- Backend: 2,529 unit tests passed, 1 skipped
- Backend: new identity E2E proves rejected signup creates no user row
- Backend: Ruff, async lint, critical typecheck, architecture and route inventory passed
- Frontend: 103 tests passed; new focused auth tests passed after final changes
- Frontend: lint, TypeScript, strict design audit and production build passed

## Notes

- No external validation service, paid CAPTCHA, mailbox probing, schema change, or suppression table
- ALTCHA remains the existing MIT-licensed, self-hosted proof-of-work control
