### PR TITLE
Fix email verification session refresh loops

### DIFF
--- a/lemma-backend/app/core/security.py
+++ b/lemma-backend/app/core/security.py
@@ -3,7 +3,10 @@ from fastapi import HTTPException
 from fastapi.security import HTTPBearer
 from starlette.requests import HTTPConnection
 from supertokens_python.recipe.session.asyncio import get_session
-from supertokens_python.recipe.session.exceptions import TryRefreshTokenError
+from supertokens_python.recipe.session.exceptions import (
+    InvalidClaimsError,
+    TryRefreshTokenError,
+)
 from app.core.authorization.current import set_current_context
 from app.core.config import settings
 from app.core.authorization.delegation import (
@@ -236,6 +239,12 @@ async def verify_auth(connection: HTTPConnection):
                     },
                 )
 
+    except InvalidClaimsError:
+        # Keep SuperTokens' invalid-claim contract intact. Its middleware turns
+        # this into a 403 response with ``claimValidationErrors``. Rewriting it
+        # to 401 makes the frontend treat an intentionally unverified session as
+        # expired and repeatedly refresh/retry the same protected request.
+        raise
     except TryRefreshTokenError:
         # This exception is raised when the access token has expired.
         # SuperTokens frontend SDKs handle the refresh flow, but for an API client,

--- a/lemma-backend/app/modules/identity/infrastructure/supertokens_auth/abuse_middleware.py
+++ b/lemma-backend/app/modules/identity/infrastructure/supertokens_auth/abuse_middleware.py
@@ -21,6 +21,16 @@ _EMAIL_ENDPOINTS = {
     "/auth/user/password/reset/token": "password-reset",
 }
 
+# These authenticated recovery endpoints must stay available even when an IP has
+# exhausted the broad auth ceiling. Blocking the verification-status refresh
+# leaves SuperTokens retrying the stale ``st-ev`` claim, while blocking sign-out
+# prevents the user from escaping that session. Neither endpoint creates an
+# account, checks credentials, nor sends email.
+_RATE_LIMIT_RECOVERY_ENDPOINTS = {
+    ("GET", "/auth/user/email/verify"),
+    ("POST", "/auth/signout"),
+}
+
 
 def _email_from_body(payload: dict[str, Any]) -> str | None:
     fields = payload.get("formFields")
@@ -243,6 +253,9 @@ class AuthAbuseMiddleware:
             return
         path = _normalised_path(scope)
         if self.auth_paths_only and not path.startswith("/auth/"):
+            await self.app(scope, receive, send)
+            return
+        if (scope.get("method"), path) in _RATE_LIMIT_RECOVERY_ENDPOINTS:
             await self.app(scope, receive, send)
             return
         store = get_auth_abuse_store()

--- a/lemma-backend/app/modules/identity/tests/e2e/test_identity_e2e.py
+++ b/lemma-backend/app/modules/identity/tests/e2e/test_identity_e2e.py
@@ -415,7 +415,8 @@ async def test_emailpassword_verification_welcome_and_password_reset_filesystem_
 
     # Signup alone must neither grant application access nor enqueue a welcome.
     blocked = await async_client.get("/users/me", headers=auth_headers)
-    assert blocked.status_code in {401, 403}
+    assert blocked.status_code == 403
+    assert blocked.json()["claimValidationErrors"][0]["id"] == "st-ev"
     assert _filesystem_emails(e2e_settings.email_output_dir, email) == []
 
     send_verification = await async_client.post(

--- a/lemma-backend/app/modules/identity/tests/unit/test_auth_abuse_middleware.py
+++ b/lemma-backend/app/modules/identity/tests/unit/test_auth_abuse_middleware.py
@@ -35,10 +35,10 @@ class _Store:
         return None
 
 
-def _scope(path="/auth/signup", *, root_path=""):
+def _scope(path="/auth/signup", *, root_path="", method="POST"):
     return {
         "type": "http",
-        "method": "POST",
+        "method": method,
         "path": path,
         "root_path": root_path,
         "client": ("203.0.113.7", 1234),
@@ -166,6 +166,42 @@ async def test_auth_paths_only_applies_global_limit_to_custom_auth_routes(monkey
     await middleware(_scope("/users/me"), _receive(b""), send)
     assert store.enforced == []
     assert called == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "method"),
+    [
+        ("/auth/user/email/verify", "GET"),
+        ("/auth/signout", "POST"),
+    ],
+)
+async def test_session_recovery_paths_bypass_exhausted_global_limit(
+    monkeypatch, path, method
+):
+    store = _Store(reject=True)
+    monkeypatch.setattr(abuse_middleware, "get_auth_abuse_store", lambda: store)
+    called = False
+    messages = []
+
+    async def inner(_scope, _receive, send):
+        nonlocal called
+        called = True
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"{}", "more_body": False})
+
+    async def send(message):
+        messages.append(message)
+
+    await AuthAbuseMiddleware(inner)(
+        _scope(path, method=method),
+        _receive(b""),
+        send,
+    )
+
+    assert called is True
+    assert store.enforced == []
+    assert messages[0]["status"] == 200
 
 
 @pytest.mark.asyncio

--- a/lemma-backend/app/modules/identity/tests/unit/test_security_killswitch.py
+++ b/lemma-backend/app/modules/identity/tests/unit/test_security_killswitch.py
@@ -9,6 +9,10 @@ from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
+from supertokens_python.recipe.session.exceptions import (
+    ClaimValidationError,
+    InvalidClaimsError,
+)
 
 from app.core import security
 from app.core.authorization.delegation import (
@@ -96,6 +100,24 @@ async def test_livez_bypasses_session_authentication(monkeypatch):
     await security.verify_auth(conn)
 
     get_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_invalid_session_claims_are_not_rewritten_as_unauthorised(monkeypatch):
+    invalid_claims = InvalidClaimsError(
+        "INVALID_CLAIMS",
+        [ClaimValidationError("st-ev", {"actualValue": False})],
+    )
+    monkeypatch.setattr(
+        security,
+        "get_session",
+        AsyncMock(side_effect=invalid_claims),
+    )
+
+    with pytest.raises(InvalidClaimsError) as exc:
+        await security.verify_auth(_connection())
+
+    assert exc.value is invalid_claims
 
 
 @pytest.mark.asyncio

--- a/lemma-frontend/components/auth/portal/auth-portal.tsx
+++ b/lemma-frontend/components/auth/portal/auth-portal.tsx
@@ -18,7 +18,9 @@ import Session, {
 import { EmailPasswordPreBuiltUI } from "supertokens-auth-react/recipe/emailpassword/prebuiltui";
 import { ThirdPartyPreBuiltUI } from "supertokens-auth-react/recipe/thirdparty/prebuiltui";
 import { EmailVerificationPreBuiltUI } from "supertokens-auth-react/recipe/emailverification/prebuiltui";
-import EmailVerification from "supertokens-auth-react/recipe/emailverification";
+import EmailVerification, {
+  EmailVerificationClaim,
+} from "supertokens-auth-react/recipe/emailverification";
 
 import { authConfig, buildApiUrl, refreshSessionPath } from "@/components/auth/portal/auth/config";
 import {
@@ -31,6 +33,10 @@ import {
   readRawRedirectUriFromSearch,
   readRedirectUriFromSearch,
 } from "@/components/auth/portal/auth/redirects";
+import {
+  canCompleteAuthenticatedNavigation,
+  shouldFetchCurrentUser,
+} from "@/components/auth/portal/auth/verification-controller";
 import {
   challengeForDesktopVerifier,
   clearPendingDesktopAuth,
@@ -270,8 +276,21 @@ function AuthLanding() {
   const isEmailVerificationRoute = effectivePathname
     .toLowerCase()
     .endsWith("/verify-email");
+  const invalidClaims = session.loading ? [] : session.invalidClaims;
+  const hasInvalidClaims = invalidClaims.length > 0;
+  const needsEmailVerification = invalidClaims.some(
+    (claim) => claim.id === EmailVerificationClaim.id,
+  );
+  const isVerificationExperience =
+    isEmailVerificationRoute || needsEmailVerification;
+  const canNavigateAsAuthenticated = canCompleteAuthenticatedNavigation({
+    sessionLoading: session.loading,
+    doesSessionExist,
+    hasInvalidClaims,
+    isVerificationExperience,
+  });
   const authHeroCopy: HeroCopy =
-    isEmailVerificationRoute
+    isVerificationExperience
       ? {
           eyebrow: "Account security",
           title: "One quick verification.",
@@ -321,7 +340,15 @@ function AuthLanding() {
   ]);
 
   useEffect(() => {
-    if (session.loading || !doesSessionExist || desktopRequestId) {
+    if (
+      !shouldFetchCurrentUser({
+        sessionLoading: session.loading,
+        doesSessionExist,
+        hasInvalidClaims,
+        desktopRequestId,
+        isVerificationExperience,
+      })
+    ) {
       return;
     }
 
@@ -356,7 +383,13 @@ function AuthLanding() {
     return () => {
       isActive = false;
     };
-  }, [desktopRequestId, doesSessionExist, session.loading]);
+  }, [
+    desktopRequestId,
+    doesSessionExist,
+    hasInvalidClaims,
+    isVerificationExperience,
+    session.loading,
+  ]);
 
   useEffect(() => {
     if (session.loading || !doesSessionExist || !isTelegramMiniApp()) {
@@ -396,7 +429,7 @@ function AuthLanding() {
   }, [doesSessionExist, session.loading]);
 
   useEffect(() => {
-    if (session.loading || !doesSessionExist || desktopRequestId) {
+    if (!canNavigateAsAuthenticated || desktopRequestId) {
       return;
     }
 
@@ -409,14 +442,13 @@ function AuthLanding() {
     window.location.replace(finalRedirectUri);
   }, [
     desktopRequestId,
-    doesSessionExist,
+    canNavigateAsAuthenticated,
     queryRedirectUri,
     redirectUri,
-    session.loading,
   ]);
 
   useEffect(() => {
-    if (session.loading || !doesSessionExist || !desktopRequestId) {
+    if (!canNavigateAsAuthenticated || !desktopRequestId) {
       return;
     }
 
@@ -453,7 +485,7 @@ function AuthLanding() {
     return () => {
       cancelled = true;
     };
-  }, [desktopRequestId, doesSessionExist, session.loading]);
+  }, [canNavigateAsAuthenticated, desktopRequestId]);
 
   if (session.loading) {
     return (
@@ -464,7 +496,7 @@ function AuthLanding() {
     );
   }
 
-  if (isEmailVerificationRoute) {
+  if (isVerificationExperience) {
     return (
       <AuthScreenLayout destination={destination} heroCopy={authHeroCopy}>
         <div className="auth-form-stack">

--- a/lemma-frontend/components/auth/portal/auth/verification-controller.test.ts
+++ b/lemma-frontend/components/auth/portal/auth/verification-controller.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  canCompleteAuthenticatedNavigation,
+  clearVerificationEmailSent,
+  getVerificationEmailSentAt,
+  isRateLimitError,
+  markVerificationEmailSent,
   runVerificationAttempt,
   runVerificationSend,
   refreshVerifiedSession,
   signOutForDifferentAccount,
+  shouldFetchCurrentUser,
   verificationCooldownSeconds,
   verificationDestination,
   verificationTokenFromSearch,
@@ -39,6 +45,36 @@ describe("verification controller", () => {
     expect(
       await runVerificationSend(vi.fn().mockRejectedValue(new Error("offline"))),
     ).toBe("error");
+    expect(
+      await runVerificationSend(
+        vi.fn().mockRejectedValue(new Response(null, { status: 429 })),
+      ),
+    ).toBe("rate-limited");
+  });
+
+  it("recognises only explicit rate-limit failures", () => {
+    expect(isRateLimitError(new Response(null, { status: 429 }))).toBe(true);
+    expect(isRateLimitError(new Error("Too many verification email requests"))).toBe(
+      true,
+    );
+    expect(isRateLimitError(new Error("offline"))).toBe(false);
+  });
+
+  it("remembers the first verification email across page reloads", () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+      removeItem: (key: string) => values.delete(key),
+    };
+
+    expect(getVerificationEmailSentAt(storage, "user-1")).toBeNull();
+    markVerificationEmailSent(storage, "user-1", 12_345);
+    expect(getVerificationEmailSentAt(storage, "user-1")).toBe(12_345);
+    expect(getVerificationEmailSentAt(storage, "user-2")).toBeNull();
+
+    clearVerificationEmailSent(storage);
+    expect(getVerificationEmailSentAt(storage, "user-1")).toBeNull();
   });
 
   it("reads tokens without losing tenant or redirect query parameters", () => {
@@ -76,6 +112,53 @@ describe("verification controller", () => {
     ).toBe(
       "https://lemma.work/auth?desktop_browser=1&desktop_request=request-123",
     );
+  });
+
+  it("does not load protected user data during required email verification", () => {
+    const base = {
+      sessionLoading: false,
+      doesSessionExist: true,
+      hasInvalidClaims: false,
+      desktopRequestId: null,
+      isVerificationExperience: false,
+    };
+
+    expect(shouldFetchCurrentUser(base)).toBe(true);
+    expect(
+      shouldFetchCurrentUser({ ...base, isVerificationExperience: true }),
+    ).toBe(false);
+    expect(shouldFetchCurrentUser({ ...base, hasInvalidClaims: true })).toBe(false);
+    expect(shouldFetchCurrentUser({ ...base, sessionLoading: true })).toBe(false);
+    expect(shouldFetchCurrentUser({ ...base, doesSessionExist: false })).toBe(false);
+    expect(
+      shouldFetchCurrentUser({ ...base, desktopRequestId: "desktop-request" }),
+    ).toBe(false);
+  });
+
+  it("does not redirect or complete handoffs until every session claim is valid", () => {
+    const base = {
+      sessionLoading: false,
+      doesSessionExist: true,
+      hasInvalidClaims: false,
+      isVerificationExperience: false,
+    };
+
+    expect(canCompleteAuthenticatedNavigation(base)).toBe(true);
+    expect(
+      canCompleteAuthenticatedNavigation({ ...base, hasInvalidClaims: true }),
+    ).toBe(false);
+    expect(
+      canCompleteAuthenticatedNavigation({
+        ...base,
+        isVerificationExperience: true,
+      }),
+    ).toBe(false);
+    expect(
+      canCompleteAuthenticatedNavigation({ ...base, sessionLoading: true }),
+    ).toBe(false);
+    expect(
+      canCompleteAuthenticatedNavigation({ ...base, doesSessionExist: false }),
+    ).toBe(false);
   });
 
   it("refreshes the verified session and clears redirects after sign-out", async () => {

--- a/lemma-frontend/components/auth/portal/auth/verification-controller.ts
+++ b/lemma-frontend/components/auth/portal/auth/verification-controller.ts
@@ -1,7 +1,19 @@
 export const VERIFICATION_RESEND_COOLDOWN_MS = 30_000;
+const VERIFICATION_EMAIL_SENT_STORAGE_KEY = "lemma.auth.verification-email-sent";
 
-export type VerificationAttempt = "verified" | "invalid" | "error";
-export type VerificationSendAttempt = "sent" | "already-verified" | "error";
+export type VerificationAttempt = "verified" | "invalid" | "rate-limited" | "error";
+export type VerificationSendAttempt =
+  | "sent"
+  | "already-verified"
+  | "rate-limited"
+  | "error";
+
+type VerificationEmailSentState = {
+  userId: string;
+  sentAt: number;
+};
+
+type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
 
 type VerifyResponse = {
   status: "OK" | "EMAIL_VERIFICATION_INVALID_TOKEN_ERROR";
@@ -17,8 +29,8 @@ export async function runVerificationAttempt(
   try {
     const result = await verify();
     return result.status === "OK" ? "verified" : "invalid";
-  } catch {
-    return "error";
+  } catch (error) {
+    return isRateLimitError(error) ? "rate-limited" : "error";
   }
 }
 
@@ -28,8 +40,57 @@ export async function runVerificationSend(
   try {
     const result = await send();
     return result.status === "OK" ? "sent" : "already-verified";
+  } catch (error) {
+    return isRateLimitError(error) ? "rate-limited" : "error";
+  }
+}
+
+export function isRateLimitError(error: unknown): boolean {
+  if (error instanceof Response) return error.status === 429;
+  if (!(error instanceof Error)) return false;
+  const message = error.message.toLowerCase();
+  return message.includes("too many") || message.includes("rate limit");
+}
+
+export function getVerificationEmailSentAt(
+  storage: StorageLike,
+  userId: string,
+): number | null {
+  try {
+    const raw = storage.getItem(VERIFICATION_EMAIL_SENT_STORAGE_KEY);
+    if (!raw) return null;
+    const state = JSON.parse(raw) as Partial<VerificationEmailSentState>;
+    return state.userId === userId &&
+      typeof state.sentAt === "number" &&
+      Number.isFinite(state.sentAt) &&
+      state.sentAt > 0
+      ? state.sentAt
+      : null;
   } catch {
-    return "error";
+    return null;
+  }
+}
+
+export function markVerificationEmailSent(
+  storage: StorageLike,
+  userId: string,
+  sentAt: number,
+): void {
+  try {
+    storage.setItem(
+      VERIFICATION_EMAIL_SENT_STORAGE_KEY,
+      JSON.stringify({ userId, sentAt } satisfies VerificationEmailSentState),
+    );
+  } catch {
+    // Storage can be unavailable in privacy-restricted browser contexts.
+  }
+}
+
+export function clearVerificationEmailSent(storage: StorageLike): void {
+  try {
+    storage.removeItem(VERIFICATION_EMAIL_SENT_STORAGE_KEY);
+  } catch {
+    // Storage cleanup is best effort; server-side limits remain authoritative.
   }
 }
 
@@ -64,6 +125,47 @@ export function verificationDestination({
     return destination.toString();
   }
   return redirectUri || defaultRedirect;
+}
+
+export function shouldFetchCurrentUser({
+  sessionLoading,
+  doesSessionExist,
+  hasInvalidClaims,
+  desktopRequestId,
+  isVerificationExperience,
+}: {
+  sessionLoading: boolean;
+  doesSessionExist: boolean;
+  hasInvalidClaims: boolean;
+  desktopRequestId: string | null;
+  isVerificationExperience: boolean;
+}): boolean {
+  return (
+    !sessionLoading &&
+    doesSessionExist &&
+    !hasInvalidClaims &&
+    !desktopRequestId &&
+    !isVerificationExperience
+  );
+}
+
+export function canCompleteAuthenticatedNavigation({
+  sessionLoading,
+  doesSessionExist,
+  hasInvalidClaims,
+  isVerificationExperience,
+}: {
+  sessionLoading: boolean;
+  doesSessionExist: boolean;
+  hasInvalidClaims: boolean;
+  isVerificationExperience: boolean;
+}): boolean {
+  return (
+    !sessionLoading &&
+    doesSessionExist &&
+    !hasInvalidClaims &&
+    !isVerificationExperience
+  );
 }
 
 export async function refreshVerifiedSession(

--- a/lemma-frontend/components/auth/portal/auth/verification-screen.tsx
+++ b/lemma-frontend/components/auth/portal/auth/verification-screen.tsx
@@ -16,6 +16,10 @@ import { authConfig } from "@/components/auth/portal/auth/config";
 import {
   runVerificationAttempt,
   runVerificationSend,
+  clearVerificationEmailSent,
+  getVerificationEmailSentAt,
+  isRateLimitError,
+  markVerificationEmailSent,
   refreshVerifiedSession,
   signOutForDifferentAccount,
   verificationCooldownSeconds,
@@ -32,6 +36,7 @@ type VerificationPhase =
   | "verifying"
   | "verified"
   | "invalid"
+  | "rate-limited"
   | "error"
   | "sign-in-required";
 
@@ -52,7 +57,7 @@ function VerificationIcon({ phase }: { phase: VerificationPhase }) {
   const Icon =
     phase === "verified"
       ? CheckCircle2
-      : phase === "invalid" || phase === "error"
+      : phase === "invalid" || phase === "rate-limited" || phase === "error"
         ? AlertCircle
         : phase === "verifying" || phase === "sending"
           ? RefreshCw
@@ -80,10 +85,22 @@ export function VerificationScreen({
   const [now, setNow] = useState(() => Date.now());
   const [resendMessage, setResendMessage] = useState<string | null>(null);
   const initialAttemptStarted = useRef(false);
+  const userIdRef = useRef<string | null>(null);
   const cooldownSeconds = verificationCooldownSeconds(lastSentAt, now);
+
+  const getUserId = useCallback(async () => {
+    if (userIdRef.current) return userIdRef.current;
+    try {
+      userIdRef.current = await Session.getUserId();
+      return userIdRef.current;
+    } catch {
+      return null;
+    }
+  }, []);
 
   const finishVerification = useCallback(async () => {
     await refreshVerifiedSession(() => Session.attemptRefreshingSession());
+    clearVerificationEmailSent(window.localStorage);
     setPhase("verified");
   }, []);
 
@@ -100,16 +117,24 @@ export function VerificationScreen({
       await finishVerification();
       return;
     }
+    if (result === "rate-limited") {
+      setPhase("rate-limited");
+      return;
+    }
     if (result === "error") {
       setPhase("error");
       return;
     }
     const sentAt = Date.now();
+    const userId = await getUserId();
+    if (userId) {
+      markVerificationEmailSent(window.localStorage, userId, sentAt);
+    }
     setLastSentAt(sentAt);
     setNow(sentAt);
     setResendMessage("A fresh verification email is on its way.");
     setPhase("inbox");
-  }, [doesSessionExist, finishVerification]);
+  }, [doesSessionExist, finishVerification, getUserId]);
 
   const verifyToken = useCallback(async () => {
     setPhase("verifying");
@@ -138,10 +163,23 @@ export function VerificationScreen({
           await finishVerification();
           return;
         }
+        const userId = await getUserId();
+        const sentAt = userId
+          ? getVerificationEmailSentAt(window.localStorage, userId)
+          : null;
+        if (sentAt) {
+          setLastSentAt(sentAt);
+          setNow(Date.now());
+          setResendMessage("A verification email has already been sent.");
+          setPhase("inbox");
+          return;
+        }
         await sendEmail();
       })
-      .catch(() => setPhase("error"));
-  }, [doesSessionExist, finishVerification, sendEmail, token, verifyToken]);
+      .catch((error) =>
+        setPhase(isRateLimitError(error) ? "rate-limited" : "error"),
+      );
+  }, [doesSessionExist, finishVerification, getUserId, sendEmail, token, verifyToken]);
 
   useEffect(() => {
     if (cooldownSeconds <= 0) return;
@@ -150,14 +188,52 @@ export function VerificationScreen({
   }, [cooldownSeconds]);
 
   const switchAccount = async () => {
+    setResendMessage(null);
     await signOutForDifferentAccount(
       () => Session.signOut(),
-      clearStoredRedirectUri,
+      () => {
+        clearStoredRedirectUri();
+        clearVerificationEmailSent(window.localStorage);
+      },
     );
     window.location.replace(
       new URL(authConfig.websiteBasePath, authConfig.websiteUrl).toString(),
     );
   };
+
+  if (phase === "rate-limited") {
+    return (
+      <StatusPanel
+        eyebrow="Please wait a moment"
+        title="Too many verification attempts."
+        description="Your account is safe. Wait a few minutes, then try again or use a different account."
+        tone="danger"
+      >
+        <div className="verification-state" role="alert">
+          <VerificationIcon phase={phase} />
+        </div>
+        <div className="button-row">
+          <button
+            type="button"
+            className="primary-button auth-portal-session-button"
+            onClick={() => void (token ? verifyToken() : sendEmail())}
+          >
+            Try again
+          </button>
+          {doesSessionExist ? (
+            <Button
+              type="button"
+              variant="link"
+              className="auth-text-button"
+              onClick={() => void switchAccount()}
+            >
+              Use a different account
+            </Button>
+          ) : null}
+        </div>
+      </StatusPanel>
+    );
+  }
 
   if (phase === "sending" || phase === "verifying") {
     const verifying = phase === "verifying";


### PR DESCRIPTION
## What changed

- preserve SuperTokens invalid-claim responses as 403 instead of rewriting them to 401
- treat invalid session claims as an explicit verification state in the auth portal
- block protected user fetches, stored redirects, and desktop handoff until claims are valid
- remember successful verification-email dispatches across reloads and show an honest rate-limit state
- keep verification-status refresh and sign-out available when the broad auth IP budget is exhausted
- strengthen E2E and unit coverage around the st-ev contract and recovery paths

## Root cause

The verification page fetched /users/me while the st-ev claim was intentionally invalid. The backend converted SuperTokens InvalidClaimsError into 401, which the frontend interpreted as an expired session and retried ten times. Those retries exhausted the global auth bucket, after which verification refresh and sign-out also received 429 responses and the UI looped.

## Verification

- 175 identity backend tests passed
- 108 frontend tests passed
- frontend lint, typecheck, design audit, and education-anchor checks passed
- Ruff lint and format checks passed
- real Chrome: five verification-page reloads produced no console errors and did not increase verification-email counters
- real Chrome: Use a different account still signed out successfully with the global auth bucket forced to 60/minute