### PR TITLE
fix(auth): improve WhatsApp verification feedback

### DIFF
--- a/lemma-backend/app/composition/identity_whatsapp.py
+++ b/lemma-backend/app/composition/identity_whatsapp.py
@@ -4,7 +4,17 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+import httpx
+
 from app.modules.agent_surfaces.config import surface_settings
+from app.modules.agent_surfaces.platforms.whatsapp.client import (
+    WhatsAppApiError,
+    WhatsAppClient,
+)
+
+
+class GlobalWhatsAppDeliveryError(RuntimeError):
+    """The shared global WhatsApp transport could not deliver a message."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -29,3 +39,29 @@ def global_whatsapp_configuration() -> GlobalWhatsAppConfiguration:
         verify_token=surface_settings.whatsapp_verify_token,
         webhook_security_enabled=surface_settings.surface_webhook_security_enabled,
     )
+
+
+async def send_global_whatsapp_text(
+    *,
+    to: str,
+    body: str,
+    reply_to_message_id: str | None = None,
+) -> bool:
+    """Send identity feedback through the existing global WhatsApp transport."""
+    whatsapp = global_whatsapp_configuration()
+    if not whatsapp.access_token or not whatsapp.phone_number_id:
+        return False
+    client = WhatsAppClient(
+        access_token=whatsapp.access_token,
+        phone_number_id=whatsapp.phone_number_id,
+    )
+    try:
+        await client.send_text(
+            phone_number_id=whatsapp.phone_number_id,
+            to=to,
+            body=body,
+            reply_to_message_id=reply_to_message_id,
+        )
+    except (httpx.HTTPError, WhatsAppApiError) as exc:
+        raise GlobalWhatsAppDeliveryError from exc
+    return True

--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -358,6 +358,7 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'identity.email_verification.local_user_missing': EventSpec('warning', frozenset()),
     'identity.middleware.auth_middleware.observed': EventSpec('debug', frozenset()),
     'identity.mobile_verification.whatsapp.ineligible_user': EventSpec('info', frozenset()),
+    'identity.mobile_verification.whatsapp.feedback_send_failed': EventSpec('warning', frozenset({'error_type', 'outcome'})),
     'identity.mobile_verification.whatsapp.invalid_sender': EventSpec('info', frozenset()),
     'identity.mobile_verification.whatsapp.number_lookup_failed': EventSpec('info', frozenset()),
     'identity.mobile_verification.whatsapp.owner_conflict': EventSpec('info', frozenset()),

--- a/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/client.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/client.py
@@ -111,6 +111,7 @@ class WhatsAppClient:
         to: str,
         body: str,
         preview_url: bool = False,
+        reply_to_message_id: str | None = None,
     ) -> str | None:
         """Send a plain-text message; return the outbound message id if any."""
         payload = {
@@ -120,6 +121,8 @@ class WhatsAppClient:
             "type": "text",
             "text": {"body": body, "preview_url": preview_url},
         }
+        if reply_to_message_id:
+            payload["context"] = {"message_id": reply_to_message_id}
         return await self.send_message_payload(
             phone_number_id=phone_number_id, payload=payload
         )

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_whatsapp_client.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_whatsapp_client.py
@@ -23,6 +23,7 @@ from app.modules.agent_surfaces.platforms.whatsapp.service import (
 
 # --- base resolution + envelope parsing -----------------------------------
 
+
 def test_resolve_api_base_prefers_credential_override():
     assert resolve_api_base({"api_base_url": "http://fake/v21.0"}) == "http://fake/v21.0"
     assert resolve_api_base({}) == "https://graph.facebook.com/v21.0"
@@ -62,7 +63,45 @@ def test_classify_whatsapp_error():
     assert classify_whatsapp_error(ValueError("x")) is DeliveryClassification.PERMANENT
 
 
+@pytest.mark.asyncio
+async def test_send_text_can_quote_the_inbound_message(monkeypatch):
+    client = WhatsAppClient(access_token="t", phone_number_id="phone-1")
+    calls: list[dict] = []
+
+    async def _capture(*, phone_number_id, payload):
+        calls.append({"phone_number_id": phone_number_id, "payload": payload})
+        return "wamid.out"
+
+    monkeypatch.setattr(client, "send_message_payload", _capture)
+
+    message_id = await client.send_text(
+        phone_number_id="phone-1",
+        to="14155552671",
+        body="Mobile number verified",
+        reply_to_message_id="wamid.in",
+    )
+
+    assert message_id == "wamid.out"
+    assert calls == [
+        {
+            "phone_number_id": "phone-1",
+            "payload": {
+                "messaging_product": "whatsapp",
+                "recipient_type": "individual",
+                "to": "14155552671",
+                "type": "text",
+                "text": {
+                    "body": "Mobile number verified",
+                    "preview_url": False,
+                },
+                "context": {"message_id": "wamid.in"},
+            },
+        }
+    ]
+
+
 # --- read receipt + typing indicator --------------------------------------
+
 
 def _inbound_event(*, message_id: str | None) -> ParsedInboundSurfaceEvent:
     return ParsedInboundSurfaceEvent(

--- a/lemma-backend/app/modules/identity/services/whatsapp_mobile_verification.py
+++ b/lemma-backend/app/modules/identity/services/whatsapp_mobile_verification.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import secrets
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Literal
@@ -20,7 +21,11 @@ import httpx
 from redis.asyncio import Redis
 from sqlalchemy.exc import IntegrityError
 
-from app.composition.identity_whatsapp import global_whatsapp_configuration
+from app.composition.identity_whatsapp import (
+    GlobalWhatsAppDeliveryError,
+    global_whatsapp_configuration,
+    send_global_whatsapp_text,
+)
 from app.core.config import settings
 from app.core.helpers.identifiers import normalize_mobile_e164
 from app.core.infrastructure.db.session import async_session_maker
@@ -44,6 +49,15 @@ _STATUS_TTL_SECONDS = 2 * 60
 _CODE_ALPHABET = "23456789ABCDEFGHJKMNPQRSTUVWXYZ"
 _MESSAGE_PREFIX = "LEMMA VERIFY "
 _META_GRAPH_API_BASE = "https://graph.facebook.com/v21.0"
+_SUCCESS_FEEDBACK = (
+    "Your mobile number is verified for Lemma. You can return to Lemma now."
+)
+_FAILURE_FEEDBACK = (
+    "We could not verify this mobile number. Return to Lemma, request a new code, "
+    "and send the full message from the mobile number on your profile."
+)
+
+WhatsAppFeedbackSender = Callable[..., Awaitable[bool]]
 
 _CLAIM_LUA = """
 local transaction_id = redis.call('GET', KEYS[1])
@@ -53,11 +67,14 @@ if redis.call('EXISTS', transaction_key) == 0 then return {'missing'} end
 local expected_phone = redis.call('HGET', transaction_key, 'phone')
 local user_id = redis.call('HGET', transaction_key, 'user_id')
 if expected_phone ~= ARGV[2] then return {'sender_mismatch'} end
-if redis.call('GET', ARGV[3] .. user_id) ~= transaction_id then return {'superseded'} end
-if redis.call('GET', ARGV[4] .. ARGV[5]) ~= transaction_id then return {'superseded'} end
 local status = redis.call('HGET', transaction_key, 'status')
 local processing_message = redis.call('HGET', transaction_key, 'message_id')
-if status == 'verified' then return {'replayed'} end
+if status == 'verified' then
+  if processing_message == ARGV[6] then return {'verified'} end
+  return {'replayed'}
+end
+if redis.call('GET', ARGV[3] .. user_id) ~= transaction_id then return {'superseded'} end
+if redis.call('GET', ARGV[4] .. ARGV[5]) ~= transaction_id then return {'superseded'} end
 if status == 'processing' and processing_message ~= ARGV[6] then return {'replayed'} end
 redis.call('HSET', transaction_key, 'status', 'processing', 'message_id', ARGV[6])
 return {'claimed', transaction_id, user_id, expected_phone}
@@ -109,6 +126,12 @@ class WhatsAppVerificationConfig:
     display_number: str | None = None
 
 
+@dataclass(frozen=True)
+class _ClaimedVerification:
+    transaction_id: str
+    user_id: UUID
+
+
 def is_whatsapp_verification_configured() -> bool:
     whatsapp = global_whatsapp_configuration()
     return bool(
@@ -135,12 +158,8 @@ def parse_reserved_verification_message(
         if not body.startswith(_MESSAGE_PREFIX):
             return None
         code = body.removeprefix(_MESSAGE_PREFIX)
-        if (
-            body != f"{_MESSAGE_PREFIX}{code}"
-            or len(code) != 10
-            or any(character not in _CODE_ALPHABET for character in code)
-        ):
-            return None
+        if len(code) > 64:
+            code = ""
         sender = str(message.get("from") or "")
         message_id = str(message.get("id") or "")
         if not sender or not destination or not message_id:
@@ -152,13 +171,45 @@ def parse_reserved_verification_message(
 
 class WhatsAppMobileVerificationService:
     def __init__(
-        self, redis_url: str | None = None, *, ttl_seconds: int = _TTL_SECONDS
+        self,
+        redis_url: str | None = None,
+        *,
+        ttl_seconds: int = _TTL_SECONDS,
+        feedback_sender: WhatsAppFeedbackSender | None = None,
     ):
         self._redis_url = redis_url or settings.redis_url
         self._ttl_seconds = ttl_seconds
         self._redis: Redis | None = None
         self._lock = asyncio.Lock()
         self._display_number: str | None = None
+        self._feedback_sender = feedback_sender or send_global_whatsapp_text
+
+    async def _send_feedback(
+        self,
+        *,
+        sender_wa_id: str,
+        whatsapp_message_id: str,
+        succeeded: bool,
+    ) -> None:
+        try:
+            sent = await self._feedback_sender(
+                to=sender_wa_id,
+                body=_SUCCESS_FEEDBACK if succeeded else _FAILURE_FEEDBACK,
+                reply_to_message_id=whatsapp_message_id,
+            )
+        except GlobalWhatsAppDeliveryError as exc:
+            logger.warning(
+                "identity.mobile_verification.whatsapp.feedback_send_failed",
+                outcome="success" if succeeded else "failure",
+                error_type=type(exc).__name__,
+            )
+            return
+        if not sent:
+            logger.warning(
+                "identity.mobile_verification.whatsapp.feedback_send_failed",
+                outcome="success" if succeeded else "failure",
+                error_type="Unavailable",
+            )
 
     async def _get_redis(self) -> Redis:
         if self._redis is not None:
@@ -302,6 +353,87 @@ class WhatsAppMobileVerificationService:
             return "EXPIRED"
         return "PENDING"
 
+    async def _claim_message(
+        self,
+        *,
+        redis: Redis,
+        code: str,
+        sender_phone: str,
+        whatsapp_message_id: str,
+    ) -> tuple[str, _ClaimedVerification | None]:
+        phone_hash = self._digest(sender_phone)
+        result = await redis.eval(
+            _CLAIM_LUA,
+            1,
+            self._code_key(code),
+            f"{_PREFIX}:transaction:",
+            sender_phone,
+            f"{_PREFIX}:user:",
+            f"{_PREFIX}:phone:",
+            phone_hash,
+            whatsapp_message_id,
+        )
+        state = str(result[0]) if result else "missing"
+        if state != "claimed":
+            return state, None
+        return state, _ClaimedVerification(
+            transaction_id=str(result[1]),
+            user_id=UUID(str(result[2])),
+        )
+
+    async def _persist_claim(
+        self, *, claim: _ClaimedVerification, sender_phone: str
+    ) -> bool:
+        async with async_session_maker() as session:
+            await acquire_mobile_number_claim_lock(
+                session, sender_phone.removeprefix("+")
+            )
+            user = await session.get(User, claim.user_id)
+            if (
+                user is None
+                or not user.is_active
+                or user.is_deleted
+                or not user.is_verified
+            ):
+                logger.info("identity.mobile_verification.whatsapp.ineligible_user")
+                return False
+            owner = await get_other_mobile_number_owner_id(
+                session,
+                digits=sender_phone.removeprefix("+"),
+                user_id=claim.user_id,
+            )
+            if owner is not None:
+                logger.info("identity.mobile_verification.whatsapp.owner_conflict")
+                return False
+            user.mobile_number = sender_phone
+            user.mobile_verified_at = datetime.now(timezone.utc)
+            try:
+                await session.commit()
+            except IntegrityError:
+                await session.rollback()
+                logger.info("identity.mobile_verification.whatsapp.owner_conflict")
+                return False
+        return True
+
+    async def _complete_claim(
+        self, *, redis: Redis, claim: _ClaimedVerification
+    ) -> None:
+        await get_user_cache().invalidate(claim.user_id)
+        phone_changed = UserMobileChangedEvent(user_id=claim.user_id)
+        await EventPublisher.publish(phone_changed.stream_name(), phone_changed)
+        await redis.eval(
+            _COMPLETE_LUA,
+            1,
+            self._transaction_key(claim.transaction_id),
+            f"{_PREFIX}:user:",
+            f"{_PREFIX}:phone:",
+            _STATUS_TTL_SECONDS,
+        )
+        logger.info(
+            "identity.mobile_verification.whatsapp.succeeded",
+            user_id=str(claim.user_id),
+        )
+
     async def consume_message(
         self,
         *,
@@ -322,72 +454,59 @@ class WhatsAppMobileVerificationService:
             logger.info("identity.mobile_verification.whatsapp.invalid_sender")
             return False
 
+        if len(code) != 10 or any(
+            character not in _CODE_ALPHABET for character in code
+        ):
+            logger.info(
+                "identity.mobile_verification.whatsapp.rejected",
+                reason="invalid_format",
+            )
+            await self._send_feedback(
+                sender_wa_id=sender_wa_id,
+                whatsapp_message_id=whatsapp_message_id,
+                succeeded=False,
+            )
+            return False
+
         redis = await self._get_redis()
-        phone_hash = self._digest(sender_phone)
-        result = await redis.eval(
-            _CLAIM_LUA,
-            1,
-            self._code_key(code),
-            f"{_PREFIX}:transaction:",
-            sender_phone,
-            f"{_PREFIX}:user:",
-            f"{_PREFIX}:phone:",
-            phone_hash,
-            whatsapp_message_id,
+        state, claim = await self._claim_message(
+            redis=redis,
+            code=code,
+            sender_phone=sender_phone,
+            whatsapp_message_id=whatsapp_message_id,
         )
-        state = str(result[0]) if result else "missing"
-        if state != "claimed":
+        if state == "verified":
+            await self._send_feedback(
+                sender_wa_id=sender_wa_id,
+                whatsapp_message_id=whatsapp_message_id,
+                succeeded=True,
+            )
+            return True
+        if claim is None:
             logger.info(
                 "identity.mobile_verification.whatsapp.rejected",
                 reason=state,
             )
+            await self._send_feedback(
+                sender_wa_id=sender_wa_id,
+                whatsapp_message_id=whatsapp_message_id,
+                succeeded=False,
+            )
             return False
 
-        transaction_id = str(result[1])
-        user_id = UUID(str(result[2]))
-        async with async_session_maker() as session:
-            await acquire_mobile_number_claim_lock(
-                session, sender_phone.removeprefix("+")
+        if not await self._persist_claim(claim=claim, sender_phone=sender_phone):
+            await self._send_feedback(
+                sender_wa_id=sender_wa_id,
+                whatsapp_message_id=whatsapp_message_id,
+                succeeded=False,
             )
-            user = await session.get(User, user_id)
-            if (
-                user is None
-                or not user.is_active
-                or user.is_deleted
-                or not user.is_verified
-            ):
-                logger.info("identity.mobile_verification.whatsapp.ineligible_user")
-                return False
-            owner = await get_other_mobile_number_owner_id(
-                session,
-                digits=sender_phone.removeprefix("+"),
-                user_id=user_id,
-            )
-            if owner is not None:
-                logger.info("identity.mobile_verification.whatsapp.owner_conflict")
-                return False
-            user.mobile_number = sender_phone
-            user.mobile_verified_at = datetime.now(timezone.utc)
-            try:
-                await session.commit()
-            except IntegrityError:
-                await session.rollback()
-                logger.info("identity.mobile_verification.whatsapp.owner_conflict")
-                return False
+            return False
 
-        await get_user_cache().invalidate(user_id)
-        phone_changed = UserMobileChangedEvent(user_id=user_id)
-        await EventPublisher.publish(phone_changed.stream_name(), phone_changed)
-        await redis.eval(
-            _COMPLETE_LUA,
-            1,
-            self._transaction_key(transaction_id),
-            f"{_PREFIX}:user:",
-            f"{_PREFIX}:phone:",
-            _STATUS_TTL_SECONDS,
-        )
-        logger.info(
-            "identity.mobile_verification.whatsapp.succeeded", user_id=str(user_id)
+        await self._complete_claim(redis=redis, claim=claim)
+        await self._send_feedback(
+            sender_wa_id=sender_wa_id,
+            whatsapp_message_id=whatsapp_message_id,
+            succeeded=True,
         )
         return True
 

--- a/lemma-backend/app/modules/identity/tests/e2e/test_whatsapp_mobile_verification_e2e.py
+++ b/lemma-backend/app/modules/identity/tests/e2e/test_whatsapp_mobile_verification_e2e.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from unittest.mock import AsyncMock
 from uuid import UUID, uuid4
 
 import pytest
@@ -46,7 +47,10 @@ async def test_whatsapp_transaction_sender_match_single_use_and_cache_invalidati
     _enable(monkeypatch)
     signed_up = await signup_user(email=f"wa-{uuid4().hex[:8]}@example.com")
     user_id = UUID(signed_up["id"])
-    service = WhatsAppMobileVerificationService(test_redis_url)
+    feedback_sender = AsyncMock(return_value=True)
+    service = WhatsAppMobileVerificationService(
+        test_redis_url, feedback_sender=feedback_sender
+    )
     try:
         transaction = await service.start(
             user_id=user_id,
@@ -62,10 +66,22 @@ async def test_whatsapp_transaction_sender_match_single_use_and_cache_invalidati
         )
 
         assert not await service.consume_message(
+            code="INVALID",
+            sender_wa_id="14155552671",
+            destination_phone_number_id="global-phone",
+            whatsapp_message_id="wamid.invalid-format",
+        )
+        assert not await service.consume_message(
             code=transaction.code,
             sender_wa_id="14155559999",
             destination_phone_number_id="global-phone",
             whatsapp_message_id="wamid.wrong-sender",
+        )
+        assert await service.consume_message(
+            code=transaction.code,
+            sender_wa_id="14155552671",
+            destination_phone_number_id="global-phone",
+            whatsapp_message_id="wamid.valid",
         )
         assert await service.consume_message(
             code=transaction.code,
@@ -92,6 +108,23 @@ async def test_whatsapp_transaction_sender_match_single_use_and_cache_invalidati
             destination_phone_number_id="global-phone",
             whatsapp_message_id="wamid.replay",
         )
+
+        assert feedback_sender.await_count == 5
+        invalid_feedback = feedback_sender.await_args_list[0].kwargs
+        assert invalid_feedback["to"] == "14155552671"
+        assert invalid_feedback["reply_to_message_id"] == "wamid.invalid-format"
+        assert "could not verify" in invalid_feedback["body"]
+        wrong_sender_feedback = feedback_sender.await_args_list[1].kwargs
+        assert wrong_sender_feedback["to"] == "14155559999"
+        assert wrong_sender_feedback["reply_to_message_id"] == "wamid.wrong-sender"
+        assert "could not verify" in wrong_sender_feedback["body"]
+        for index in (2, 3):
+            success_feedback = feedback_sender.await_args_list[index].kwargs
+            assert success_feedback["to"] == "14155552671"
+            assert "verified for Lemma" in success_feedback["body"]
+        replay_feedback = feedback_sender.await_args_list[4].kwargs
+        assert replay_feedback["reply_to_message_id"] == "wamid.replay"
+        assert "could not verify" in replay_feedback["body"]
     finally:
         await service.close()
 
@@ -208,6 +241,11 @@ async def test_authenticated_whatsapp_verification_api_journey(
 ):
     _enable(monkeypatch)
     monkeypatch.setattr(settings, "redis_url", e2e_settings.redis_url)
+    feedback_sender = AsyncMock(return_value=True)
+    monkeypatch.setattr(
+        "app.modules.identity.services.whatsapp_mobile_verification.send_global_whatsapp_text",
+        feedback_sender,
+    )
     await close_whatsapp_mobile_verification_service()
     try:
         config = await authenticated_client.get(
@@ -251,6 +289,10 @@ async def test_authenticated_whatsapp_verification_api_journey(
         assert user is not None
         assert user.mobile_number == "+14155552673"
         assert user.mobile_verified_at is not None
+        feedback_sender.assert_awaited_once()
+        assert feedback_sender.await_args.kwargs["reply_to_message_id"] == (
+            "wamid.api-journey"
+        )
     finally:
         await close_whatsapp_mobile_verification_service()
 

--- a/lemma-backend/app/modules/identity/tests/unit/test_identity_whatsapp_composition.py
+++ b/lemma-backend/app/modules/identity/tests/unit/test_identity_whatsapp_composition.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.composition.identity_whatsapp import (
+    GlobalWhatsAppDeliveryError,
+    send_global_whatsapp_text,
+)
+from app.modules.agent_surfaces.config import surface_settings
+from app.modules.agent_surfaces.platforms.whatsapp.client import WhatsAppClient
+
+
+@pytest.mark.asyncio
+async def test_global_whatsapp_feedback_reuses_surface_credentials(monkeypatch):
+    monkeypatch.setattr(surface_settings, "whatsapp_access_token", "surface-token")
+    monkeypatch.setattr(surface_settings, "whatsapp_phone_number_id", "global-phone")
+    calls: list[dict] = []
+
+    async def _capture(self, **kwargs):
+        calls.append(
+            {
+                "access_token": self._access_token,
+                "configured_phone": self._phone_number_id,
+                **kwargs,
+            }
+        )
+        return "wamid.out"
+
+    monkeypatch.setattr(WhatsAppClient, "send_text", _capture)
+
+    assert await send_global_whatsapp_text(
+        to="14155552671",
+        body="Mobile number verified",
+        reply_to_message_id="wamid.in",
+    )
+    assert calls == [
+        {
+            "access_token": "surface-token",
+            "configured_phone": "global-phone",
+            "phone_number_id": "global-phone",
+            "to": "14155552671",
+            "body": "Mobile number verified",
+            "reply_to_message_id": "wamid.in",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_global_whatsapp_feedback_wraps_transport_failures(monkeypatch):
+    monkeypatch.setattr(surface_settings, "whatsapp_access_token", "surface-token")
+    monkeypatch.setattr(surface_settings, "whatsapp_phone_number_id", "global-phone")
+
+    async def _fail(self, **kwargs):
+        del self, kwargs
+        raise httpx.ConnectError("offline")
+
+    monkeypatch.setattr(WhatsAppClient, "send_text", _fail)
+
+    with pytest.raises(GlobalWhatsAppDeliveryError):
+        await send_global_whatsapp_text(
+            to="14155552671",
+            body="Mobile number verified",
+            reply_to_message_id="wamid.in",
+        )

--- a/lemma-backend/app/modules/identity/tests/unit/test_whatsapp_mobile_verification.py
+++ b/lemma-backend/app/modules/identity/tests/unit/test_whatsapp_mobile_verification.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
+from app.composition.identity_whatsapp import GlobalWhatsAppDeliveryError
 from app.core.config import settings
 from app.core.helpers.identifiers import normalize_mobile_e164
 from app.modules.agent_surfaces.config import surface_settings
@@ -60,7 +63,7 @@ def test_normalize_mobile_e164_requires_explicit_country_code() -> None:
             raise AssertionError(f"expected {invalid!r} to be rejected")
 
 
-def test_parse_reserved_verification_message_requires_exact_format() -> None:
+def test_parse_reserved_verification_message_intercepts_reserved_attempts() -> None:
     assert parse_reserved_verification_message(_payload()) == (
         "23456789AB",
         "14155552671",
@@ -72,14 +75,25 @@ def test_parse_reserved_verification_message_requires_exact_format() -> None:
         parse_reserved_verification_message(_payload(body="lemma verify 23456789AB"))
         is None
     )
-    assert (
-        parse_reserved_verification_message(_payload(body="LEMMA VERIFY 23456789AB "))
-        is None
+    assert parse_reserved_verification_message(
+        _payload(body="LEMMA VERIFY 23456789AB ")
+    ) == (
+        "23456789AB ",
+        "14155552671",
+        "phone-id",
+        "wamid.123",
     )
-    assert (
-        parse_reserved_verification_message(_payload(body="LEMMA VERIFY 1111111111"))
-        is None
+    assert parse_reserved_verification_message(
+        _payload(body="LEMMA VERIFY 1111111111")
+    ) == (
+        "1111111111",
+        "14155552671",
+        "phone-id",
+        "wamid.123",
     )
+    assert parse_reserved_verification_message(
+        _payload(body=f"LEMMA VERIFY {'A' * 65}")
+    ) == ("", "14155552671", "phone-id", "wamid.123")
     assert parse_reserved_verification_message({}) is None
 
 
@@ -122,3 +136,28 @@ async def test_enable_flag_without_global_surface_config_stays_unavailable(
     config = await WhatsAppMobileVerificationService("redis://unused").config()
 
     assert config.available is False
+
+
+@pytest.mark.asyncio
+async def test_whatsapp_feedback_failure_never_reverts_verification() -> None:
+    feedback_sender = AsyncMock(
+        side_effect=GlobalWhatsAppDeliveryError("Meta is unavailable")
+    )
+    service = WhatsAppMobileVerificationService(
+        "redis://unused", feedback_sender=feedback_sender
+    )
+
+    with patch(
+        "app.modules.identity.services.whatsapp_mobile_verification.logger"
+    ) as logger:
+        await service._send_feedback(
+            sender_wa_id="14155552671",
+            whatsapp_message_id="wamid.in",
+            succeeded=True,
+        )
+
+    logger.warning.assert_called_once_with(
+        "identity.mobile_verification.whatsapp.feedback_send_failed",
+        outcome="success",
+        error_type="GlobalWhatsAppDeliveryError",
+    )

--- a/lemma-frontend/components/settings/whatsapp-mobile-verification.tsx
+++ b/lemma-frontend/components/settings/whatsapp-mobile-verification.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
+import QRCode from "react-qr-code";
 import { toast } from "sonner";
 
 import { buildApiUrl } from "@/components/auth/portal/auth/config";
 import { Button } from "@/components/ui/button";
 import { Clock, Copy, ExternalLink, MessageCircle } from "@/components/ui/icons";
+import {
+  buildWhatsAppVerificationMessage,
+  WHATSAPP_VERIFICATION_POLL_INTERVAL_MS,
+} from "@/lib/identity/whatsapp-mobile-verification";
 
 type VerificationConfig = {
   available: boolean;
@@ -117,7 +122,10 @@ export function WhatsAppMobileVerification({
       if (poll !== null) window.clearInterval(poll);
       if (document.visibilityState !== "visible") return;
       void check();
-      poll = window.setInterval(() => void check(), 2000);
+      poll = window.setInterval(
+        () => void check(),
+        WHATSAPP_VERIFICATION_POLL_INTERVAL_MS,
+      );
     };
     const visibilityChanged = () => beginPolling();
     beginPolling();
@@ -130,9 +138,18 @@ export function WhatsAppMobileVerification({
   }, [expireTransaction, onVerified, transaction]);
 
   const manualMessage = useMemo(
-    () => (transaction ? `LEMMA VERIFY ${transaction.code}` : ""),
+    () => (transaction ? buildWhatsAppVerificationMessage(transaction.code) : ""),
     [transaction],
   );
+
+  const copyVerificationMessage = async () => {
+    try {
+      await navigator.clipboard.writeText(manualMessage);
+      toast.success("Full verification message copied");
+    } catch {
+      toast.error("Could not copy the message. Select it and copy it manually.");
+    }
+  };
 
   const start = async () => {
     setStarting(true);
@@ -186,7 +203,7 @@ export function WhatsAppMobileVerification({
         <div>
           <p className="type-eyebrow text-[var(--text-tertiary)]">Verify in WhatsApp</p>
           <h3 className="mt-1 text-sm font-semibold text-[var(--text-primary)]">
-            Send this code from the number you’re verifying
+            Send this message from the number you’re verifying
           </h3>
         </div>
         <span className="chip chip-sm chip-pill chip-muted">
@@ -194,26 +211,60 @@ export function WhatsAppMobileVerification({
           {Math.floor(secondsRemaining / 60)}:{String(secondsRemaining % 60).padStart(2, "0")}
         </span>
       </div>
-      <div className="mt-4 flex items-center gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)] p-2.5">
-        <code className="min-w-0 flex-1 select-all text-center text-base font-semibold tracking-widest text-[var(--text-primary)]">
-          {transaction.code}
-        </code>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label="Copy verification message"
-          onClick={() => {
-            void navigator.clipboard.writeText(manualMessage);
-            toast.success("Verification message copied");
-          }}
-        >
-          <Copy className="h-4 w-4" />
-        </Button>
+      <div className="mt-4 grid gap-4 md:grid-cols-[minmax(0,1fr)_9.5rem]">
+        <div className="space-y-3">
+          <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)] p-3">
+            <p className="type-eyebrow text-[var(--text-tertiary)]">Send to</p>
+            <a
+              href={transaction.whatsapp_url}
+              target="_blank"
+              rel="noreferrer"
+              className="mt-1 block w-fit text-lg font-semibold tabular-nums text-[var(--text-primary)] underline decoration-[var(--border-strong)] underline-offset-4 hover:decoration-[var(--text-primary)]"
+            >
+              {transaction.display_number}
+            </a>
+            <p className="mt-1 text-xs text-[var(--text-tertiary)]">
+              Lemma&apos;s WhatsApp verification number
+            </p>
+          </div>
+
+          <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)] p-3">
+            <p className="type-eyebrow text-[var(--text-tertiary)]">Message to send</p>
+            <code className="mt-2 block select-all break-all text-sm font-semibold tracking-wide text-[var(--text-primary)]">
+              {manualMessage}
+            </code>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="mt-3"
+              onClick={() => void copyVerificationMessage()}
+            >
+              <Copy className="mr-1.5 h-3.5 w-3.5" />
+              Copy full message
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-col items-center justify-center rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)] p-3 text-center">
+          <div className="rounded-md bg-[var(--text-inverse)] p-2">
+            <QRCode
+              value={transaction.whatsapp_url}
+              size={112}
+              level="M"
+              bgColor="var(--text-inverse)"
+              fgColor="var(--text-primary)"
+              aria-label="Scan to open the verification message in WhatsApp"
+            />
+          </div>
+          <p className="mt-2 text-xs font-medium text-[var(--text-secondary)]">
+            Scan with your phone
+          </p>
+        </div>
       </div>
       <p className="mt-3 text-xs leading-5 text-[var(--text-secondary)]">
-        Open WhatsApp and send <strong>{manualMessage}</strong> to {transaction.display_number}.
-        The number you send it from must match your profile number.
+        Send the message from the mobile number on your Lemma profile. The QR code opens
+        WhatsApp on another device with the number and message already filled in.
       </p>
       <div className="mt-4 flex flex-wrap gap-2">
         <Button asChild type="button" size="sm">

--- a/lemma-frontend/lib/identity/whatsapp-mobile-verification.test.ts
+++ b/lemma-frontend/lib/identity/whatsapp-mobile-verification.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildWhatsAppVerificationMessage,
+  WHATSAPP_VERIFICATION_POLL_INTERVAL_MS,
+} from "./whatsapp-mobile-verification";
+
+describe("WhatsApp mobile verification presentation", () => {
+  it("copies the complete reserved verification message", () => {
+    expect(buildWhatsAppVerificationMessage("23456789AB")).toBe(
+      "LEMMA VERIFY 23456789AB",
+    );
+  });
+
+  it("polls no more frequently than every five seconds", () => {
+    expect(WHATSAPP_VERIFICATION_POLL_INTERVAL_MS).toBe(5_000);
+  });
+});

--- a/lemma-frontend/lib/identity/whatsapp-mobile-verification.ts
+++ b/lemma-frontend/lib/identity/whatsapp-mobile-verification.ts
@@ -1,0 +1,5 @@
+export const WHATSAPP_VERIFICATION_POLL_INTERVAL_MS = 5_000;
+
+export function buildWhatsAppVerificationMessage(code: string): string {
+  return `LEMMA VERIFY ${code.trim()}`;
+}

--- a/lemma-frontend/package-lock.json
+++ b/lemma-frontend/package-lock.json
@@ -45,6 +45,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
+        "react-qr-code": "^2.0.21",
         "react-router-dom": "^7.15.1",
         "remark-gemoji": "^8.0.0",
         "remark-gfm": "^4.0.1",

--- a/lemma-frontend/package.json
+++ b/lemma-frontend/package.json
@@ -71,6 +71,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
+    "react-qr-code": "^2.0.21",
     "react-router-dom": "^7.15.1",
     "remark-gemoji": "^8.0.0",
     "remark-gfm": "^4.0.1",


### PR DESCRIPTION
## Summary

- copy and display the complete `LEMMA VERIFY <code>` message, make the destination number prominent, and add a cross-device WhatsApp QR handoff
- reduce visible-page verification polling from two seconds to five seconds
- send best-effort quoted WhatsApp replies for successful and failed verification attempts through the existing global surface configuration and client
- keep reserved malformed verification attempts out of agent conversations, preserve idempotency for Meta retries, and reject genuine code replay

## Validation

- `env STORAGE_BACKEND=auto make coverage-backend-unit` — 2,554 passed, 1 skipped
- `uv run pytest app/modules/identity/tests/e2e/test_whatsapp_mobile_verification_e2e.py -q` — 6 passed
- `make test-frontend` — 118 passed
- `npm run check`
- `npm run build`
- `npm run design:audit:changed` — zero drift
- `make architecture`
- changed-file Ruff checks
- real local browser acceptance in dark/light and desktop/mobile: exact clipboard message, destination URL, rendered QR contrast, and five-second request cadence

## Notes

- no new WhatsApp credentials or duplicate configuration were introduced
- feedback delivery failures are logged without phone numbers or verification codes and never undo a completed verification
- `react-qr-code` is MIT licensed and was already present transitively; this makes it a direct frontend dependency