### PR TITLE
feat(frontend): redesign Pod Home and starter discovery

### DIFF
--- a/lemma-frontend/app/pod/[id]/app/pages/page.tsx
+++ b/lemma-frontend/app/pod/[id]/app/pages/page.tsx
@@ -11,6 +11,7 @@ import { StepLoader } from '@/components/brand/loader';
 import { ConceptHint } from '@/components/education/concept-hint';
 import { SectionPrimer } from '@/components/education/section-primer';
 import { ResourceIndexHeader, ResourceIndexShell } from '@/components/pod/resource-layout';
+import { RecipeCard } from '@/components/recipes/recipe-card';
 import { DestructiveConfirmationDialog } from '@/components/shared/destructive-confirmation-dialog';
 import { EmptyState } from '@/components/shared/empty-state';
 import { DestructiveResourceActionItem, ResourceActionsMenu } from '@/components/shared/resource-actions-menu';
@@ -21,8 +22,7 @@ import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import { resourceAllows } from '@/lib/authz/resource-actions';
 import { useDeleteApp, useAppPages, useUpdateAppVisibility } from '@/lib/hooks/use-app';
 import { usePodAccess } from '@/lib/hooks/use-pod-access';
-import { appRecipes, getRecipeAccent, type Recipe } from '@/lib/recipes/recipes';
-import { renderRecipeIcon } from '@/components/recipes/recipe-icon';
+import { appRecipes } from '@/lib/recipes/recipes';
 import { useLaunchRecipe } from '@/lib/recipes/use-launch-recipe';
 import type { AppPageRef } from '@/lib/types/app';
 
@@ -39,28 +39,6 @@ function formatAppHost(value: string | null | undefined) {
     } catch {
         return 'Live app';
     }
-}
-
-function RecipeStarterCard({ recipe, onLaunch }: { recipe: Recipe; onLaunch: () => void }) {
-    return (
-        <button
-            type="button"
-            onClick={onLaunch}
-            className="resource-index-card custom-focus-ring group flex min-h-[7.5rem] flex-col items-start gap-2 rounded-lg p-4 text-left transition-colors hover:border-[var(--border-strong)]"
-        >
-            <div className="flex w-full items-start justify-between gap-2">
-                <span className="recipe-icon-tile h-9 w-9 rounded-lg" data-accent={getRecipeAccent(recipe)}>
-                    {renderRecipeIcon(recipe, { className: 'h-[18px] w-[18px]', strokeWidth: 1.8 })}
-                </span>
-                <span className="inline-flex items-center gap-1 text-xs text-[var(--text-tertiary)] opacity-0 transition-opacity group-hover:opacity-100">
-                    Build
-                    <ArrowUpRight className="h-3.5 w-3.5" />
-                </span>
-            </div>
-            <span className="text-sm font-medium text-[var(--text-primary)]">{recipe.name}</span>
-            <span className="line-clamp-2 text-xs leading-5 text-[var(--text-tertiary)]">{recipe.blurb}</span>
-        </button>
-    );
 }
 
 function buildAppViewHref(podId: string, page: string, searchParams: { toString(): string }) {
@@ -171,15 +149,16 @@ export default function AppPagesRoute({ params }: { params: Promise<{ id: string
                 canCreateApp ? (
                     <div className="grid gap-5">
                         <div className="max-w-2xl">
-                            <h2 className="text-lg font-medium text-[var(--text-primary)]">Start from a recipe</h2>
+                            <h2 className="text-lg font-medium text-[var(--text-primary)]">Choose an app shape</h2>
                             <p className="mt-1 text-sm leading-6 text-[var(--text-secondary)]">
-                                Pick a starting point and the assistant builds it into a working app — a screen where your team works with this pod’s agents. Or describe your own.
+                                Start from a recognizable product shape. Lemma builds the app, its data, and the agents or workflows that make it useful.
                             </p>
                         </div>
                         <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
                             {appRecipes.slice(0, 5).map((recipe) => (
-                                <RecipeStarterCard
+                                <RecipeCard
                                     key={recipe.id}
+                                    podId={podId}
                                     recipe={recipe}
                                     onLaunch={() => launchRecipe(recipe)}
                                 />
@@ -200,7 +179,7 @@ export default function AppPagesRoute({ params }: { params: Promise<{ id: string
                             href={`/pod/${podId}/recipes`}
                             className="custom-focus-ring inline-flex w-fit items-center gap-1.5 text-sm font-medium text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]"
                         >
-                            Browse all recipes — bots, creator tools, and more
+                            Add a channel agent or automate a loop
                             <ArrowUpRight className="h-4 w-4" />
                         </Link>
                     </div>

--- a/lemma-frontend/app/pod/[id]/layout.tsx
+++ b/lemma-frontend/app/pod/[id]/layout.tsx
@@ -121,7 +121,7 @@ function getPodSectionLabel(podId: string, pathname: string) {
             return "Apps";
         case "recipes":
         case "kits":
-            return "Recipes";
+            return "Add capability";
         default:
             return formatDisplayName(section);
     }

--- a/lemma-frontend/app/pod/[id]/page.tsx
+++ b/lemma-frontend/app/pod/[id]/page.tsx
@@ -1,21 +1,21 @@
 'use client';
 
 import { use, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
-import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { ArrowRight, ArrowUp, Loader2, MessageCircle, Plus, UserPlus, X } from '@/components/ui/icons';
+import { ArrowRight, ArrowUp, ChevronDown, ChevronUp, Loader2, Plus, UserPlus, X } from '@/components/ui/icons';
 
 import { useAIAssistant } from '@/components/ai/ai-assistant-context';
 import { StepLoader } from '@/components/brand/loader';
 import { ProtectedRoute } from '@/components/auth/protected-route';
-import { FirstWinChecklist } from '@/components/education/first-win-checklist';
 import { resolveDefaultAgentRuntime } from '@/components/agents/agent-runtime-helpers';
 import { RuntimeModelPicker } from '@/components/lemma/assistant/model-picker';
-import { RecipeFeatureCard } from '@/components/recipes/recipe-card';
-import { featuredRecipes } from '@/lib/recipes/recipes';
+import { StarterThemePicker } from '@/components/recipes/starter-theme-card';
+import { Button } from '@/components/ui/button';
+import { FEATURED_STARTER_THEMES } from '@/lib/recipes/recipes';
 import { useLaunchRecipe } from '@/lib/recipes/use-launch-recipe';
 import { useAgents } from '@/lib/hooks/use-agents';
+import { useAppPages } from '@/lib/hooks/use-app';
 import { useScopedConversations } from '@/lib/hooks/use-assistants';
 import { useAgentRuntimes, useAvailableAgentRuntimeHarnesses } from '@/lib/hooks/use-agent-runtime';
 import {
@@ -32,7 +32,11 @@ import { cn } from '@/lib/utils';
 import { formatAgentName } from '@/lib/utils/agents';
 import { isConversationRunningStatus, normalizeConversationStatus } from '@/lib/utils/conversations';
 import { describeScheduleConfig, getScheduleTargetKind, getScheduleTargetName } from '@/lib/utils/schedules';
-import type { AgentRuntimeConfig, AssistantSurface, Conversation } from '@/lib/types';
+import {
+    resolvePodHomeStarterMode,
+    type PodHomeResourceSignals,
+} from '@/lib/pods/pod-home-starters';
+import type { AgentRuntimeConfig, Conversation } from '@/lib/types';
 
 const RUNNING_RUN_STATUSES = new Set(['PENDING', 'RUNNING', 'EXECUTING', 'IN_PROGRESS', 'PROCESSING']);
 const FAILED_RUN_STATUSES = new Set(['FAILED', 'ERROR', 'CANCELLED', 'CANCELED']);
@@ -40,6 +44,7 @@ const COMPLETED_RUN_STATUSES = new Set(['COMPLETED', 'SUCCESS', 'SUCCEEDED']);
 const RECENT_CONVERSATION_STATUSES = new Set(['completed', 'complete', 'success', 'succeeded', 'failed', 'error']);
 const COMPOSER_LAUNCH_DURATION_MS = 560;
 const HOME_PANELS_DEFER_MS = 600;
+const POD_HOME_STARTER_DISMISS_KEY = 'lemma:pod-home:starter-nudge';
 
 interface ComposerLaunchAnimation {
     id: number;
@@ -60,9 +65,22 @@ function PodBlankChatHome({ podId }: { podId: string }) {
     const assistant = useAIAssistant();
     const podAccess = usePodAccess(podId);
     const { data: pod } = usePod(podId);
+    const { launchRecipe } = useLaunchRecipe(podId, { podName: pod?.name });
     const { data: runtimeCatalog } = useAgentRuntimes(pod?.organization_id);
     const { data: availableHarnesses } = useAvailableAgentRuntimeHarnesses();
     const canWriteConversations = podAccess.can('conversation.write');
+    const canReadAgents = podAccess.can('agent.read');
+    const canReadWorkflows = podAccess.can('workflow.read');
+    const canReadSurfaces = podAccess.canAccessRoute('surfaces');
+    const canReadConversations = podAccess.can('conversation.read');
+    const { data: homeAgentsData, isLoading: isLoadingHomeAgents } = useAgents(canReadAgents ? podId : undefined);
+    const { data: homeFlows = [], isLoading: isLoadingHomeFlows } = useFlows(canReadWorkflows ? podId : undefined);
+    const { pages: homeAppPages, isLoading: isLoadingHomeApps } = useAppPages(podId);
+    const { data: homeSurfaces = [], isLoading: isLoadingHomeSurfaces } = usePodSurfaces(canReadSurfaces ? podId : undefined);
+    const { data: homeConversationsData, isLoading: isLoadingHomeConversations } = useScopedConversations(
+        { podId },
+        { limit: 1, enabled: canReadConversations },
+    );
     const [draft, setDraft] = useState('');
     const [isSending, setIsSending] = useState(false);
     const [launchAnimation, setLaunchAnimation] = useState<ComposerLaunchAnimation | null>(null);
@@ -84,6 +102,24 @@ function PodBlankChatHome({ podId }: { podId: string }) {
     const podDefaultRuntime = pod?.config?.default_runtime
         ?? resolveDefaultAgentRuntime(runtimeCatalog, pod?.config?.default_profile_id, availableHarnesses);
     const selectedCommandRuntime = assistant.conversationRuntime ?? null;
+    const isLoadingHomeState =
+        isLoadingHomeAgents ||
+        isLoadingHomeFlows ||
+        isLoadingHomeApps ||
+        isLoadingHomeSurfaces ||
+        isLoadingHomeConversations;
+    const podHomeResourceSignals = useMemo<PodHomeResourceSignals>(() => ({
+        appCount: homeAppPages.length,
+        agentCount: homeAgentsData?.items?.length || 0,
+        workflowCount: homeFlows.length,
+        surfaceCount: homeSurfaces.length,
+        activeSurfaceCount: homeSurfaces.filter((surface) => String(surface.status || '').toUpperCase() === 'ACTIVE').length,
+        scheduleCount: 0,
+        conversationCount: homeConversationsData?.items?.length || 0,
+        hasUsedWorkflow: false,
+    }), [homeAgentsData?.items?.length, homeAppPages.length, homeConversationsData?.items?.length, homeFlows.length, homeSurfaces]);
+    const starterMode = resolvePodHomeStarterMode(podHomeResourceSignals);
+    const showStarterHome = podAccess.isBuilder && !isLoadingHomeState && starterMode === 'fresh';
 
     const handleCommandRuntimeChange = (runtime: AgentRuntimeConfig | null) => {
         void assistant.setConversationModel(
@@ -217,10 +253,44 @@ function PodBlankChatHome({ podId }: { podId: string }) {
             <main
                 aria-hidden={isBlankingHome}
                 className={cn(
-                    "mx-auto flex min-h-full w-full max-w-6xl flex-1 flex-col items-center px-5 pb-10 pt-10 sm:px-6 md:pt-14",
+                    "mx-auto flex min-h-full w-full max-w-6xl flex-1 flex-col items-center px-5 pb-10 pt-8 sm:px-6 md:pt-12",
                     isBlankingHome && "pointer-events-none opacity-0",
                 )}
             >
+                {showStarterHome ? (
+                    <section className="w-full">
+                        <div className="max-w-3xl">
+                            <p className="type-eyebrow-mono text-[var(--text-tertiary)]">Start inside this pod</p>
+                            <h1 className="mt-3 text-3xl font-semibold leading-tight tracking-tight text-[var(--text-primary)] sm:text-4xl">
+                                What should {pod?.name || 'this pod'} become?
+                            </h1>
+                            <p className="mt-3 max-w-2xl text-base leading-7 text-[var(--text-secondary)]">
+                                Choose a direction, then pick a concrete starting point inside it. Lemma builds the app, agent, data, and connections together — all inside this pod.
+                            </p>
+                        </div>
+                        <div className="mt-7">
+                            <StarterThemePicker
+                                themes={FEATURED_STARTER_THEMES}
+                                onLaunch={(recipe, message) => launchRecipe(recipe, { message })}
+                            />
+                        </div>
+                        <div className="mt-5 flex items-center justify-between gap-4">
+                            <p className="text-sm text-[var(--text-tertiary)]">Explore a family first. Choose the concrete build inside.</p>
+                            <Link
+                                href={`/pod/${podId}/recipes`}
+                                className="custom-focus-ring inline-flex shrink-0 items-center gap-1.5 text-sm font-medium text-[var(--text-primary)]"
+                            >
+                                See every starting point
+                                <ArrowRight className="h-4 w-4" />
+                            </Link>
+                        </div>
+                        <div className="my-8 flex items-center gap-3 text-xs text-[var(--text-tertiary)]">
+                            <span className="h-px flex-1 bg-[var(--border-subtle)]" />
+                            or describe your own
+                            <span className="h-px flex-1 bg-[var(--border-subtle)]" />
+                        </div>
+                    </section>
+                ) : null}
                 <div className="w-full max-w-4xl">
                     {assistant.pendingFiles.length > 0 ? (
                         <div className="mb-3 flex flex-wrap justify-center gap-2">
@@ -284,7 +354,11 @@ function PodBlankChatHome({ podId }: { podId: string }) {
                                 }
                             }}
                             rows={1}
-                            placeholder={canWriteConversations ? "What should happen next?" : "You can read this pod, but not start new conversations."}
+                            placeholder={canWriteConversations
+                                ? showStarterHome
+                                    ? "Describe the app, agent, or workflow you want..."
+                                    : "What should happen next?"
+                                : "You can read this pod, but not start new conversations."}
                             disabled={!canWriteConversations}
                             className="inline-edit-field min-h-10 flex-1 resize-none bg-transparent py-3 text-base leading-6 text-[var(--text-primary)] outline-none placeholder:text-[var(--text-tertiary)]"
                         />
@@ -310,7 +384,11 @@ function PodBlankChatHome({ podId }: { podId: string }) {
                         </button>
                     </form>
                 </div>
-                {showHomePanels ? <PodAgentWorkflowKanban podId={podId} /> : <PodHomePanelsSkeleton />}
+                {!showStarterHome
+                    ? showHomePanels
+                        ? <PodAgentWorkflowKanban podId={podId} baseResourceSignals={podHomeResourceSignals} />
+                        : <PodHomePanelsSkeleton />
+                    : null}
             </main>
             {launchAnimation && launchAnimationStyle ? (
                 <div
@@ -427,7 +505,13 @@ type KanbanItem = {
     iconUrl?: string | null;
 };
 
-function PodAgentWorkflowKanban({ podId }: { podId: string }) {
+function PodAgentWorkflowKanban({
+    podId,
+    baseResourceSignals,
+}: {
+    podId: string;
+    baseResourceSignals: PodHomeResourceSignals;
+}) {
     const podAccess = usePodAccess(podId);
     const canReadAgents = podAccess.can('agent.read');
     const canReadWorkflows = podAccess.can('workflow.read');
@@ -546,277 +630,161 @@ function PodAgentWorkflowKanban({ podId }: { podId: string }) {
 
     const isLoading = loadingAgents || loadingWorkflows || loadingSchedules || loadingRuns || loadingConversations;
     const hasKanbanItems = upcomingItems.length + movingItems.length + recentOutcomeItems.length > 0;
+    const hasUsedWorkflow = runSnapshots.some((snapshot) => snapshot.runs.some((run) => {
+        const status = normalizeWorkflowRunStatus(run.status);
+        return RUNNING_RUN_STATUSES.has(status) || COMPLETED_RUN_STATUSES.has(status);
+    }));
+    const starterMode = resolvePodHomeStarterMode({
+        ...baseResourceSignals,
+        agentCount: agents.length,
+        workflowCount: workflows.length,
+        scheduleCount: schedules.length,
+        conversationCount: conversations.length,
+        hasUsedWorkflow,
+    });
+    const showFormingNudge = podAccess.isBuilder && !isLoading && starterMode === 'forming';
 
     return (
         <>
-            {!isLoading ? (
-                <FirstWinChecklist
-                    podId={podId}
-                    agentCount={agents.length}
-                    workflowCount={workflows.length}
-                    conversationCount={conversations.length}
-                />
-            ) : null}
             <div className="mt-8 w-full space-y-6">
                 <PodJoinRequestsHomePanel podId={podId} />
-                <PodSurfacesHomePanel podId={podId} />
-            {isLoading || hasKanbanItems ? (
-                <section className="pod-home-work-section">
-                    <div className="pod-home-work-heading flex items-center justify-between gap-4">
-                        <h2 className="pod-home-work-title">Activity</h2>
-                        <div className="pod-home-work-live-pill">
-                            {isLoading ? (
-                                <Loader2 className="h-3 w-3 animate-spin" />
-                            ) : movingItems.length > 0 ? (
-                                <span className="pod-home-work-live-dot" />
-                            ) : null}
-                            <span>
-                                {movingItems.length > 0 ? `${movingItems.length} running · ` : ''}
-                                {schedules.length} scheduled
-                            </span>
+                {isLoading || hasKanbanItems ? (
+                    <section className="pod-home-work-section">
+                        <div className="pod-home-work-heading flex items-center justify-between gap-4">
+                            <h2 className="pod-home-work-title">Activity</h2>
+                            <div className="pod-home-work-live-pill">
+                                {isLoading ? (
+                                    <Loader2 className="h-3 w-3 animate-spin" />
+                                ) : movingItems.length > 0 ? (
+                                    <span className="pod-home-work-live-dot" />
+                                ) : null}
+                                <span>
+                                    {movingItems.length > 0 ? `${movingItems.length} running · ` : ''}
+                                    {schedules.length} scheduled
+                                </span>
+                            </div>
                         </div>
-                    </div>
 
-                    <div className="pod-home-work-panel">
-                        {upcomingItems.length > 0 ? (
-                            <div className="pod-home-work-section-row">
-                                <p className="pod-home-work-section-label">Upcoming</p>
-                                <div className="pod-home-work-list">
-                                    {upcomingItems.map((item) => (
-                                        <KanbanCard key={item.id} item={item} />
-                                    ))}
+                        <div className="pod-home-work-panel">
+                            {upcomingItems.length > 0 ? (
+                                <div className="pod-home-work-section-row">
+                                    <p className="pod-home-work-section-label">Upcoming</p>
+                                    <div className="pod-home-work-list">
+                                        {upcomingItems.map((item) => (
+                                            <KanbanCard key={item.id} item={item} />
+                                        ))}
+                                    </div>
                                 </div>
-                            </div>
-                        ) : null}
+                            ) : null}
 
-                        {movingItems.length > 0 ? (
-                            <div className="pod-home-work-section-row">
-                                <p className="pod-home-work-section-label">Working now</p>
-                                <div className="pod-home-work-list">
-                                    {movingItems.map((item) => (
-                                        <KanbanCard key={item.id} item={item} />
-                                    ))}
+                            {movingItems.length > 0 ? (
+                                <div className="pod-home-work-section-row">
+                                    <p className="pod-home-work-section-label">Working now</p>
+                                    <div className="pod-home-work-list">
+                                        {movingItems.map((item) => (
+                                            <KanbanCard key={item.id} item={item} />
+                                        ))}
+                                    </div>
                                 </div>
-                            </div>
-                        ) : null}
+                            ) : null}
 
-                        {recentOutcomeItems.length > 0 ? (
-                            <div className="pod-home-work-section-row">
-                                <p className="pod-home-work-section-label">Recent outcomes</p>
-                                <div className="pod-home-work-list">
-                                    {recentOutcomeItems.map((item) => (
-                                        <KanbanCard key={item.id} item={item} />
-                                    ))}
+                            {recentOutcomeItems.length > 0 ? (
+                                <div className="pod-home-work-section-row">
+                                    <p className="pod-home-work-section-label">Recent outcomes</p>
+                                    <div className="pod-home-work-list">
+                                        {recentOutcomeItems.map((item) => (
+                                            <KanbanCard key={item.id} item={item} />
+                                        ))}
+                                    </div>
                                 </div>
-                            </div>
-                        ) : null}
-                    </div>
-                </section>
-            ) : null}
-
-                {!isLoading || hasKanbanItems ? <PodRecipesHomePanel podId={podId} /> : null}
+                            ) : null}
+                        </div>
+                    </section>
+                ) : null}
+                {showFormingNudge ? <PodRecipesHomeNudge podId={podId} /> : null}
             </div>
         </>
     );
 }
 
-const SURFACE_META: Record<string, { label: string; logo: string }> = {
-    SLACK: { label: 'Slack', logo: '/surfaces/slack.png' },
-    TEAMS: { label: 'Teams', logo: '/surfaces/teams.png' },
-    GMAIL: { label: 'Gmail', logo: '/surfaces/gmail.png' },
-    OUTLOOK: { label: 'Outlook', logo: '/surfaces/outlook.png' },
-    TELEGRAM: { label: 'Telegram', logo: '/surfaces/telegram.png' },
-    WHATSAPP: { label: 'WhatsApp', logo: '/surfaces/whatsapp.png' },
-};
-
-const SURFACE_STATUS_TONE: Record<'success' | 'warning' | 'danger' | 'muted', { text: string; dot: string }> = {
-    success: { text: 'text-[var(--state-success)]', dot: 'bg-[var(--state-success)]' },
-    warning: { text: 'text-[var(--state-warning)]', dot: 'bg-[var(--state-warning)]' },
-    danger: { text: 'text-[var(--state-error)]', dot: 'bg-[var(--state-error)]' },
-    muted: { text: 'text-[var(--text-tertiary)]', dot: 'bg-[var(--text-tertiary)]' },
-};
-
-function surfaceStatusView(status?: string | null): { label: string; tone: 'success' | 'warning' | 'danger' | 'muted' } {
-    const raw = String(status || '').toUpperCase();
-    if (raw === 'ACTIVE') return { label: 'Live', tone: 'success' };
-    if (raw === 'PENDING_ADMIN_CONSENT') return { label: 'Needs consent', tone: 'warning' };
-    if (raw === 'ERROR') return { label: 'Error', tone: 'danger' };
-    return { label: 'Paused', tone: 'muted' };
-}
-
-function surfaceAddress(surface: AssistantSurface): string {
-    const channel = surface.config?.channels?.[0];
-    return (channel?.channel_name || channel?.channel_id || surface.surface_identity_username || '').trim();
-}
-
-// "Reachable at" — the inbound twin of "Your apps". Surfaces shown as relationships
-// (channel → who answers → live), not as a platform config grid. A real callout
-// invites the first connection when nothing is wired up yet.
-function PodSurfacesHomePanel({ podId }: { podId: string }) {
-    const podAccess = usePodAccess(podId);
-    const canUse = podAccess.canAccessRoute('surfaces');
-    const { data: surfaces = [], isLoading } = usePodSurfaces(canUse ? podId : undefined);
-    const surfacesHref = `/pod/${podId}/surfaces`;
-
-    if (!canUse) return null;
-
-    if (isLoading) {
-        return (
-            <section className="pod-home-surfaces-panel w-full" data-state="loading" role="status" aria-label="Loading surfaces">
-                <div className="flex items-center justify-between gap-3">
-                    <h2 className="text-base font-normal text-[var(--text-secondary)]">Surfaces</h2>
-                    <div className="lemma-skeleton h-3 w-12 rounded-md" />
-                </div>
-                <ul className="mt-2 flex flex-col gap-0.5" aria-hidden="true">
-                    {[0, 1, 2].map((item) => (
-                        <li key={item} className="flex items-center gap-3 px-2 py-2">
-                            <div className="lemma-skeleton h-8 w-8 shrink-0 rounded-lg" />
-                            <div className="min-w-0 flex-1 space-y-2">
-                                <div className="lemma-skeleton h-3 w-40 max-w-full rounded-md" />
-                                <div className="lemma-skeleton h-2.5 w-24 rounded-md" />
-                            </div>
-                            <div className="lemma-skeleton h-3 w-10 rounded-md" />
-                        </li>
-                    ))}
-                </ul>
-            </section>
-        );
-    }
-
-    if (surfaces.length === 0) {
-        return (
-            <section className="pod-home-surfaces-panel w-full" data-state="ready">
-                <h2 className="text-base font-normal text-[var(--text-secondary)]">Surfaces</h2>
-                <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-2">
-                    <span className="flex items-center gap-1.5">
-                        {(['SLACK', 'GMAIL', 'TELEGRAM'] as const).map((key) => (
-                            <span
-                                key={key}
-                                className="surface-logo-chip flex h-7 w-7 items-center justify-center rounded-md"
-                            >
-                                <Image src={SURFACE_META[key].logo} alt={SURFACE_META[key].label} width={16} height={16} className="object-contain" />
-                            </span>
-                        ))}
-                    </span>
-                    <p className="text-sm leading-6 text-[var(--text-secondary)]">
-                        No surfaces yet —{' '}
-                        <Link
-                            href={surfacesHref}
-                            className="custom-focus-ring font-medium text-[var(--text-primary)] underline-offset-2 hover:underline"
-                        >
-                            connect a surface
-                        </Link>{' '}
-                        so this pod can answer messages where your team already works.
-                    </p>
-                </div>
-            </section>
-        );
-    }
-
-    const sorted = [...surfaces].sort(
-        (a, b) => (b.status === 'ACTIVE' ? 1 : 0) - (a.status === 'ACTIVE' ? 1 : 0),
-    );
-
-    return (
-        <section className="pod-home-surfaces-panel w-full" data-state="ready">
-            <div className="flex items-center justify-between gap-3">
-                <h2 className="text-base font-normal text-[var(--text-secondary)]">Surfaces</h2>
-                <Link
-                    href={surfacesHref}
-                    className="custom-focus-ring shrink-0 text-sm font-medium text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-primary)]"
-                >
-                    Manage
-                </Link>
-            </div>
-            <ul className="pod-home-surfaces-list mt-2 flex flex-col gap-0.5">
-                {sorted.map((surface) => {
-                    const platform = String(surface.platform || '').toUpperCase();
-                    const meta = SURFACE_META[platform];
-                    const label = meta?.label || formatDisplayName(platform);
-                    const status = surfaceStatusView(surface.status);
-                    const tone = SURFACE_STATUS_TONE[status.tone];
-                    const address = surfaceAddress(surface);
-                    const responder = surface.agent_name?.trim() || 'Pod default';
-
-                    return (
-                        <li key={surface.id}>
-                            <Link
-                                href={surfacesHref}
-                                className="group flex items-center gap-3 rounded-lg px-2 py-2 transition-colors hover:bg-[color:color-mix(in_srgb,var(--surface-2)_55%,transparent)]"
-                            >
-                                <span className={cn(
-                                    'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg',
-                                    meta?.logo
-                                        ? 'surface-logo-chip'
-                                        : 'border border-[color:color-mix(in_srgb,var(--border-subtle)_50%,transparent)] bg-[var(--surface-2)]'
-                                )}>
-                                    {meta?.logo ? (
-                                        <Image src={meta.logo} alt="" width={16} height={16} className="object-contain" />
-                                    ) : (
-                                        <MessageCircle className="h-4 w-4 text-[var(--text-secondary)]" />
-                                    )}
-                                </span>
-                                <div className="min-w-0 flex-1">
-                                    <p className="truncate text-sm text-[var(--text-primary)]">
-                                        <span className="font-normal">{label}</span>
-                                        {address ? <span className="text-[var(--text-tertiary)]"> · {address}</span> : null}
-                                    </p>
-                                    <p className="truncate text-xs text-[var(--text-secondary)]">
-                                        {responder} answers
-                                    </p>
-                                </div>
-                                <span className={cn('inline-flex shrink-0 items-center gap-1.5 text-xs', tone.text)}>
-                                    <span className={cn('h-1.5 w-1.5 rounded-full', tone.dot)} />
-                                    {status.label}
-                                </span>
-                            </Link>
-                        </li>
-                    );
-                })}
-            </ul>
-        </section>
-    );
-}
-
-function PodRecipesHomePanel({ podId }: { podId: string }) {
+function PodRecipesHomeNudge({ podId }: { podId: string }) {
+    const themes = FEATURED_STARTER_THEMES;
     const { launchRecipe } = useLaunchRecipe(podId);
-    const featured = featuredRecipes.slice(0, 3);
+    const [expanded, setExpanded] = useState(false);
+    const [dismissed, setDismissed] = useState<boolean | null>(null);
+    const storageKey = `${POD_HOME_STARTER_DISMISS_KEY}:${podId}`;
 
-    if (featured.length === 0) return null;
+    useEffect(() => {
+        let nextDismissed = false;
+        try {
+            nextDismissed = window.localStorage.getItem(storageKey) === '1';
+        } catch {}
+        const frame = window.requestAnimationFrame(() => setDismissed(nextDismissed));
+        return () => window.cancelAnimationFrame(frame);
+    }, [storageKey]);
+
+    const dismiss = () => {
+        try {
+            window.localStorage.setItem(storageKey, '1');
+        } catch {
+            // The in-memory dismissal still works when browser storage is unavailable.
+        }
+        setDismissed(true);
+    };
+
+    if (themes.length === 0 || dismissed !== false) return null;
 
     return (
-        <section className="w-full">
-            <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-                <div className="max-w-2xl">
-                    <p className="type-eyebrow-mono">
-                        Recipes
-                    </p>
-                    <h2 className="mt-2 text-lg font-medium text-[var(--text-primary)]">
-                        Fastest way to feel this pod work
-                    </h2>
-                    <p className="mt-1 text-sm leading-6 text-[var(--text-secondary)]">
-                        A recipe adds capability in minutes — from a one-line prompt the assistant builds, to a bot you message, to a full kit.
-                    </p>
+        <section className="pod-home-starter-nudge w-full" data-expanded={expanded ? 'true' : 'false'}>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                <span className="pod-home-starter-nudge-icon">
+                    <Plus className="h-4 w-4" />
+                </span>
+                <div className="min-w-0 flex-1">
+                    <h2 className="text-sm font-medium text-[var(--text-primary)]">Add another capability</h2>
+                    <p className="mt-0.5 truncate text-xs text-[var(--text-tertiary)]">Dashboards, channel agents, knowledge, intake, and automations.</p>
                 </div>
-                <Link
-                    href={`/pod/${podId}/recipes`}
-                    className="custom-focus-ring inline-flex h-9 items-center justify-center gap-2 rounded-md border border-[color:var(--button-secondary-border)] bg-[var(--button-secondary-bg)] px-3 text-sm font-medium text-[var(--button-secondary-fg)] transition-colors hover:border-[var(--field-border-hover)] hover:bg-[var(--button-secondary-bg-hover)]"
-                >
-                    All recipes
-                    <ArrowRight className="h-4 w-4" />
-                </Link>
+                <div className="flex shrink-0 items-center gap-1">
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => setExpanded((value) => !value)}
+                        aria-expanded={expanded}
+                        className="h-8 gap-1.5 px-2.5 text-xs"
+                    >
+                        {expanded ? 'Hide ideas' : 'Show ideas'}
+                        {expanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
+                    </Button>
+                    <Link
+                        href={`/pod/${podId}/recipes`}
+                        className="custom-focus-ring inline-flex h-8 items-center gap-1 rounded-md px-2.5 text-xs text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-primary)]"
+                    >
+                        Browse all
+                        <ArrowRight className="h-3.5 w-3.5" />
+                    </Link>
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        onClick={dismiss}
+                        aria-label="Dismiss starter suggestions for this pod"
+                        title="Dismiss"
+                        className="h-8 w-8 text-[var(--text-tertiary)]"
+                    >
+                        <X className="h-3.5 w-3.5" />
+                    </Button>
+                </div>
             </div>
 
-            <div className="mt-4 grid gap-3 lg:grid-cols-3">
-                {featured.map((recipe) => (
-                    <RecipeFeatureCard
-                        key={recipe.id}
-                        podId={podId}
-                        recipe={recipe}
-                        onLaunch={() => launchRecipe(recipe)}
+            {expanded ? (
+                <div className="mt-3 border-t border-[var(--border-subtle)] pt-3">
+                    <StarterThemePicker
+                        themes={themes}
+                        onLaunch={(recipe, message) => launchRecipe(recipe, { message })}
                     />
-                ))}
-            </div>
+                </div>
+            ) : null}
         </section>
     );
 }

--- a/lemma-frontend/app/pod/[id]/recipes/[recipeId]/page.tsx
+++ b/lemma-frontend/app/pod/[id]/recipes/[recipeId]/page.tsx
@@ -7,13 +7,15 @@ import { ArrowLeft, Check, ChevronDown, ExternalLink, PlayCircle, Sparkles } fro
 import { ProtectedRoute } from '@/components/auth/protected-route';
 import { RecipeReadme } from '@/components/recipes/recipe-readme';
 import { renderRecipeIcon } from '@/components/recipes/recipe-icon';
+import { StarterPreview } from '@/components/recipes/starter-preview';
 import { ResourceIndexHeader, ResourceIndexShell } from '@/components/pod/resource-layout';
 import { Button } from '@/components/ui/button';
 import { usePod } from '@/lib/hooks/use-pods';
 import { usePodAccess } from '@/lib/hooks/use-pod-access';
 import {
-    RECIPE_BUILDS_LABEL,
     RECIPE_CATEGORIES,
+    RECIPE_OUTPUT_LABEL,
+    getPrimaryThemeForRecipe,
     getRecipeAccent,
     getRecipeById,
     getRecipeHighlights,
@@ -39,16 +41,16 @@ export default function RecipeDetailPage({ params }: { params: Promise<{ id: str
             ) : (
                 <ResourceIndexShell>
                     <ResourceIndexHeader
-                        title="Recipe not found"
+                        title="Starter not found"
                         productIconKind="apps"
                         backHref={`/pod/${podId}/recipes`}
-                        backLabel="Recipes"
+                        backLabel="Starters"
                     />
                     <div className="surface-panel p-6">
                         <Button asChild variant="outline">
                             <Link href={`/pod/${podId}/recipes`}>
                                 <ArrowLeft className="mr-2 h-4 w-4" />
-                                Back to recipes
+                                Back to starters
                             </Link>
                         </Button>
                     </div>
@@ -70,6 +72,10 @@ function RecipeDetail({ podId, recipe }: { podId: string; recipe: Recipe }) {
     const accent = getRecipeAccent(recipe);
     const highlights = getRecipeHighlights(recipe);
     const categoryLabel = RECIPE_CATEGORIES.find((category) => category.id === recipe.category)?.label;
+    const theme = getPrimaryThemeForRecipe(recipe);
+    const backHref = theme
+        ? `/pod/${podId}/recipes?theme=${encodeURIComponent(theme.id)}`
+        : `/pod/${podId}/recipes`;
 
     const helper = isPrompt
         ? 'Opens a conversation where the assistant builds this with you. You stay in control of every step.'
@@ -80,8 +86,8 @@ function RecipeDetail({ podId, recipe }: { podId: string; recipe: Recipe }) {
             <ResourceIndexHeader
                 title={recipe.name}
                 productIconKind="apps"
-                backHref={`/pod/${podId}/recipes`}
-                backLabel="Recipes"
+                backHref={backHref}
+                backLabel={theme?.name || 'Starters'}
                 actions={recipe.source.kind === 'repo' ? (
                     <a
                         href={recipe.source.github}
@@ -97,7 +103,7 @@ function RecipeDetail({ podId, recipe }: { podId: string; recipe: Recipe }) {
 
             <div className="space-y-5">
                 <section className="recipe-hero rounded-xl p-5 sm:p-6" data-accent={accent}>
-                    <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+                    <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_20rem] lg:items-start">
                         <div className="min-w-0 flex-1">
                             <div className="flex items-start gap-3.5">
                                 <span className="recipe-icon-tile h-12 w-12 shrink-0 rounded-xl" data-accent={accent}>
@@ -105,25 +111,25 @@ function RecipeDetail({ podId, recipe }: { podId: string; recipe: Recipe }) {
                                 </span>
                                 <div className="min-w-0">
                                     <p className="type-eyebrow-mono text-[var(--text-tertiary)]">
-                                        {isPrompt ? 'Prompt recipe' : 'Kit recipe'} · {RECIPE_BUILDS_LABEL[recipe.builds]}
+                                        {categoryLabel || (isPrompt ? 'Starter' : 'Published kit')}
                                     </p>
                                     <h1 className="mt-1 text-2xl font-semibold tracking-normal text-[var(--text-primary)]">{recipe.name}</h1>
                                 </div>
                             </div>
-                            <p className="mt-3.5 max-w-2xl text-sm leading-6 text-[var(--text-secondary)]">{recipe.blurb}</p>
+                            <p className="mt-3.5 max-w-2xl text-base font-medium leading-6 text-[var(--text-primary)]">{recipe.kicker}</p>
+                            <p className="mt-1.5 max-w-2xl text-sm leading-6 text-[var(--text-secondary)]">{recipe.blurb}</p>
                             <div className="mt-4 flex flex-wrap gap-2">
-                                {categoryLabel ? <MetaChip>{categoryLabel}</MetaChip> : null}
-                                <MetaChip>{RECIPE_BUILDS_LABEL[recipe.builds]}</MetaChip>
-                                {recipe.featured ? <MetaChip>Fast to value</MetaChip> : null}
+                                {recipe.outputs.map((output) => <MetaChip key={output}>{RECIPE_OUTPUT_LABEL[output]}</MetaChip>)}
                             </div>
                         </div>
 
-                        <div className="flex shrink-0 flex-col items-start gap-2 lg:items-end">
+                        <div className="flex shrink-0 flex-col gap-3">
+                            <StarterPreview recipe={recipe} compact />
                             <Button onClick={() => launchRecipe(recipe)} disabled={!canBuild} size="lg">
                                 {isPrompt ? <Sparkles className="mr-2 h-4 w-4" /> : <PlayCircle className="mr-2 h-4 w-4" />}
                                 Add to {podName}
                             </Button>
-                            <p className="max-w-[15rem] text-xs leading-5 text-[var(--text-tertiary)] lg:text-right">
+                            <p className="text-xs leading-5 text-[var(--text-tertiary)]">
                                 {canBuild ? helper : 'You don’t have permission to build in this pod.'}
                             </p>
                         </div>
@@ -133,7 +139,7 @@ function RecipeDetail({ podId, recipe }: { podId: string; recipe: Recipe }) {
                 <section className="surface-panel p-5">
                     <p className="type-eyebrow-mono text-[var(--text-tertiary)]">What you’ll get</p>
                     <h2 className="mt-1 text-lg font-semibold text-[var(--text-primary)]">
-                        {isPrompt ? 'A working first version, built with you' : 'A full setup, installed with you'}
+                        {isPrompt ? 'A coherent first version, built inside this pod' : 'A full setup, installed with you'}
                     </h2>
                     <ul className="mt-4 grid gap-2.5 sm:grid-cols-3">
                         {highlights.map((point) => (

--- a/lemma-frontend/app/pod/[id]/recipes/page.tsx
+++ b/lemma-frontend/app/pod/[id]/recipes/page.tsx
@@ -6,12 +6,12 @@ import { PackageOpen, Search } from '@/components/ui/icons';
 import { ProtectedRoute } from '@/components/auth/protected-route';
 import { EmptyState } from '@/components/shared/empty-state';
 import { ResourceIndexHeader, ResourceIndexShell } from '@/components/pod/resource-layout';
-import { RecipeCard, RecipeFeatureCard } from '@/components/recipes/recipe-card';
+import { RecipeCard } from '@/components/recipes/recipe-card';
+import { StarterThemePicker } from '@/components/recipes/starter-theme-card';
 import { Input } from '@/components/ui/input';
 import { usePod } from '@/lib/hooks/use-pods';
 import {
-    RECIPE_CATEGORIES,
-    featuredRecipes,
+    STARTER_THEMES,
     recipeCatalog,
     recipesByCategory,
 } from '@/lib/recipes/recipes';
@@ -36,18 +36,27 @@ export default function PodRecipesPage({ params }: { params: Promise<{ id: strin
     const matches = useMemo(() => {
         if (!normalized) return [];
         return recipeCatalog.filter((recipe) => {
-            const haystack = [recipe.name, recipe.blurb, recipe.builds, recipe.category].join(' ').toLowerCase();
+            const haystack = [
+                recipe.name,
+                recipe.kicker,
+                recipe.blurb,
+                recipe.builds,
+                recipe.category,
+                ...recipe.outputs,
+                ...(recipe.platforms || []),
+                ...(recipe.examples || []),
+            ].join(' ').toLowerCase();
             return haystack.includes(normalized);
         });
     }, [normalized]);
 
-    const featured = featuredRecipes.slice(0, 3);
+    const publishedKits = recipesByCategory('published');
 
     return (
         <ProtectedRoute>
             <ResourceIndexShell>
                 <ResourceIndexHeader
-                    title="Recipes"
+                    title="Add capability"
                     productIconKind="apps"
                     actions={(
                         <div className="relative w-full sm:w-72">
@@ -55,7 +64,7 @@ export default function PodRecipesPage({ params }: { params: Promise<{ id: strin
                             <Input
                                 value={query}
                                 onChange={(event) => setQuery(event.target.value)}
-                                placeholder="Search recipes..."
+                                placeholder="Search starters..."
                                 className="pl-9"
                             />
                         </div>
@@ -63,8 +72,7 @@ export default function PodRecipesPage({ params }: { params: Promise<{ id: strin
                 />
 
                 <p className="mb-5 max-w-2xl text-sm leading-6 text-[var(--text-secondary)]">
-                    Recipes add capability to this pod — a prompt the assistant builds into a working app, a bot people
-                    message, or a full kit. Pick one and the assistant builds it with you in a conversation.
+                    Choose a direction, then start from an example prompt. Published kits stay available below when you want a complete source-backed setup.
                 </p>
 
                 {searching ? (
@@ -78,40 +86,33 @@ export default function PodRecipesPage({ params }: { params: Promise<{ id: strin
                         <EmptyState
                             variant="compact"
                             icon={<PackageOpen className="h-4 w-4" />}
-                            title="No recipes match this search"
-                            description="Try a different outcome, workflow, or domain."
+                            title="No starters match this search"
+                            description="Try a product shape, channel, or operating loop."
                         />
                     )
                 ) : (
                     <div className="space-y-9">
-                        {featured.length > 0 ? (
+                        <section>
+                            <h2 className="text-base font-medium text-[var(--text-primary)]">Choose a direction</h2>
+                            <p className="mt-0.5 text-sm leading-6 text-[var(--text-tertiary)]">Hover or click a category to see prompts you can start immediately.</p>
+                            <div className="mt-3">
+                                <StarterThemePicker
+                                    themes={STARTER_THEMES}
+                                    onLaunch={(recipe, message) => launchRecipe(recipe, { message })}
+                                />
+                            </div>
+                        </section>
+                        {publishedKits.length > 0 ? (
                             <section>
-                                <h2 className="text-base font-medium text-[var(--text-primary)]">Fastest to value</h2>
-                                <p className="mt-0.5 text-sm leading-6 text-[var(--text-tertiary)]">Set up in a couple of minutes, useful immediately.</p>
+                                <h2 className="text-base font-medium text-[var(--text-primary)]">Published kits</h2>
+                                <p className="mt-0.5 text-sm leading-6 text-[var(--text-tertiary)]">Complete source-backed setups ready to install into this pod.</p>
                                 <div className="mt-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-                                    {featured.map((recipe) => (
-                                        <RecipeFeatureCard key={recipe.id} podId={podId} recipe={recipe} onLaunch={() => launchRecipe(recipe)} />
+                                    {publishedKits.map((recipe) => (
+                                        <RecipeCard key={recipe.id} podId={podId} recipe={recipe} onLaunch={() => launchRecipe(recipe)} />
                                     ))}
                                 </div>
                             </section>
                         ) : null}
-
-                        {RECIPE_CATEGORIES.map((category) => {
-                            const items = recipesByCategory(category.id);
-                            if (items.length === 0) return null;
-
-                            return (
-                                <section key={category.id}>
-                                    <h2 className="text-base font-medium text-[var(--text-primary)]">{category.label}</h2>
-                                    <p className="mt-0.5 text-sm leading-6 text-[var(--text-tertiary)]">{category.blurb}</p>
-                                    <div className="mt-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
-                                        {items.map((recipe) => (
-                                            <RecipeCard key={recipe.id} podId={podId} recipe={recipe} onLaunch={() => launchRecipe(recipe)} />
-                                        ))}
-                                    </div>
-                                </section>
-                            );
-                        })}
                     </div>
                 )}
             </ResourceIndexShell>

--- a/lemma-frontend/components/onboarding/account-onboarding-helpers.ts
+++ b/lemma-frontend/components/onboarding/account-onboarding-helpers.ts
@@ -240,21 +240,19 @@ export const AUDIENCE_OPTIONS: Array<{
 // are concrete outcomes ("Personal CRM") rather than build strategies, so a
 // first-timer picks a result instead of a method.
 const PERSONAL_START_RECIPE_IDS = [
-  "meal-log-bot",
-  "expense-logger-bot",
-  "ask-my-data-bot",
-  "personal-crm",
-  "reading-digest",
-  "habit-tracker",
+  "telegram-personal-logger",
+  "dashboard-internal-tool",
+  "knowledge-workspace",
+  "monitor-alert",
 ];
 
 const TEAM_START_RECIPE_IDS = [
-  "support-triage",
-  "approvals-queue",
-  "slack-standup-bot",
-  "email-intake-bot",
-  "lightweight-crm",
-  "renewal-review",
+  "crm-pipeline-app",
+  "whatsapp-support-desk",
+  "slack-knowledge-teammate",
+  "email-agent",
+  "inbox-review-queue",
+  "approval-review",
 ];
 
 export function startRecipesForAudience(audience: Audience): Recipe[] {

--- a/lemma-frontend/components/onboarding/account-onboarding-steps.tsx
+++ b/lemma-frontend/components/onboarding/account-onboarding-steps.tsx
@@ -38,7 +38,8 @@ import {
   kitCatalog,
   type KitDefinition,
 } from "@/lib/kits/catalog";
-import { RECIPE_BUILDS_LABEL, type Recipe } from "@/lib/recipes/recipes";
+import { renderRecipeIcon } from "@/components/recipes/recipe-icon";
+import { RECIPE_OUTPUT_LABEL, type Recipe } from "@/lib/recipes/recipes";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { useAvailableAgentRuntimeHarnesses } from "@/lib/hooks/use-agent-runtime";
@@ -1017,15 +1018,15 @@ export function StartStep({
     ? "Build this"
     : selectedRecipe?.source.kind === "repo"
       ? "Install recipe"
-      : "Build recipe";
+      : "Start building";
 
   return (
     <SetupSplitPanel
-      title="What should we add first?"
+      title="What should this pod become?"
       subtitle={
         personal
-          ? `${podName} is ready. Add a recipe, let Lemma build with you, or describe something specific.`
-          : `${podName} is ready. Add a team recipe, let Lemma build with you, or describe the workflow you want.`
+          ? `${podName} is ready. Choose a strong starting shape or describe exactly what you want.`
+          : `${podName} is ready. Start with an app, a channel agent, or an operating loop for your team.`
       }
       preview={
         <StartPreviewBody
@@ -1083,7 +1084,7 @@ export function StartStep({
 
         <div className="mt-5 flex items-center gap-3 text-xs text-[var(--text-tertiary)]">
           <span className="h-px flex-1 bg-[var(--border-subtle)]" />
-          or install a recipe
+          or choose a starting point
           <span className="h-px flex-1 bg-[var(--border-subtle)]" />
         </div>
 
@@ -1106,20 +1107,29 @@ export function StartStep({
                 ].join(" ")}
               >
                 <span className="flex items-center justify-between gap-2">
-                  <span className="text-sm font-semibold text-[var(--text-primary)]">
-                    {recipe.name}
+                  <span className="flex min-w-0 items-center gap-2.5">
+                    <span className="recipe-icon-tile flex h-8 w-8 shrink-0 items-center justify-center rounded-lg">
+                      {renderRecipeIcon(recipe, { className: "h-4 w-4", strokeWidth: 1.8 })}
+                    </span>
+                    <span className="min-w-0 truncate text-sm font-semibold text-[var(--text-primary)]">
+                      {recipe.name}
+                    </span>
                   </span>
                   {selected ? (
                     <Check className="h-4 w-4 shrink-0 text-[var(--text-primary)]" />
                   ) : null}
                 </span>
                 <span className="mt-1 block text-xs leading-5 text-[var(--text-secondary)]">
-                  {recipe.blurb}
+                  {recipe.kicker}
                 </span>
-                <span className="chip chip-sm mt-3 self-start font-mono text-[var(--text-tertiary)]">
-                  {recipe.source.kind === "repo"
-                    ? "GitHub kit"
-                    : RECIPE_BUILDS_LABEL[recipe.builds]}
+                <span className="mt-3 flex flex-wrap gap-1.5">
+                  {recipe.source.kind === "repo" ? (
+                    <span className="chip chip-sm chip-muted">Published kit</span>
+                  ) : recipe.outputs.slice(0, 3).map((output) => (
+                    <span key={output} className="chip chip-sm chip-muted">
+                      {RECIPE_OUTPUT_LABEL[output]}
+                    </span>
+                  ))}
                 </span>
               </button>
             );

--- a/lemma-frontend/components/onboarding/account-onboarding.tsx
+++ b/lemma-frontend/components/onboarding/account-onboarding.tsx
@@ -454,8 +454,8 @@ function SetupAssistant({
           name: podName,
           description:
             audienceForPod === "personal"
-              ? "Personal pod created during onboarding. Add recipes, agents, apps, and automations here."
-              : `${teamName || "Team"} pod created during onboarding. Add recipes, agents, apps, and automations here.`,
+              ? "A private workspace for apps, channel agents, knowledge, and operating loops."
+              : `${teamName || "Team"}'s shared workspace for apps, channel agents, knowledge, and operating loops.`,
           organization_id: organization.id,
         });
         setBasePod(pod);

--- a/lemma-frontend/components/pod/pod-new-workspace.tsx
+++ b/lemma-frontend/components/pod/pod-new-workspace.tsx
@@ -181,7 +181,7 @@ export function PodNewWorkspace({
                     {recipes.length > 0 ? (
                         <div className="flex flex-wrap items-center gap-x-1 gap-y-1">
                             <div className="w-24 shrink-0 px-2 text-xs text-[var(--text-tertiary)]">
-                                From a recipe
+                                Starting points
                             </div>
                             {recipes.map((recipe) => (
                                 <RecipeLaunchRow
@@ -195,7 +195,7 @@ export function PodNewWorkspace({
                                 href={`/pod/${podId}/recipes`}
                                 className="custom-focus-ring inline-flex h-8 items-center gap-1 rounded-md px-2 text-xs text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-primary)]"
                             >
-                                All recipes
+                                All starters
                                 <ArrowRight className="h-3.5 w-3.5" />
                             </Link>
                         </div>

--- a/lemma-frontend/components/pod/workspace-sidebar.tsx
+++ b/lemma-frontend/components/pod/workspace-sidebar.tsx
@@ -610,7 +610,7 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
         if (isKitsRoute) {
             return (
                 <RouteWorktree>
-                    <WorktreeEmpty label="Preview a kit, then install or customize it." />
+                    <WorktreeEmpty label="Choose a starting point, then add it to this pod." />
                 </RouteWorktree>
             );
         }
@@ -787,7 +787,7 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
                                             className="lemma-menu-row px-2"
                                         >
                                             <ProductIcon kind="apps" size="xs" />
-                                            Browse recipes
+                                            Add from a starter
                                         </DropdownMenu.Item>
                                     ) : null}
                                     <DropdownMenu.Separator className="my-1 h-px bg-[var(--border-subtle)]" />

--- a/lemma-frontend/components/recipes/recipe-card.tsx
+++ b/lemma-frontend/components/recipes/recipe-card.tsx
@@ -4,15 +4,11 @@ import Link from 'next/link';
 import { ArrowRight, PlayCircle, Sparkles } from '@/components/ui/icons';
 
 import { Button } from '@/components/ui/button';
-import { RECIPE_BUILDS_LABEL, getRecipeAccent, type Recipe } from '@/lib/recipes/recipes';
+import { RECIPE_OUTPUT_LABEL, getRecipeAccent, type Recipe } from '@/lib/recipes/recipes';
 import { renderRecipeIcon } from './recipe-icon';
 
-function kindLabel(recipe: Recipe) {
-    return recipe.source.kind === 'prompt' ? 'Prompt' : 'Kit';
-}
-
 function actionLabel(recipe: Recipe) {
-    return recipe.source.kind === 'prompt' ? 'Build' : 'Install';
+    return recipe.source.kind === 'prompt' ? 'Start' : 'Install';
 }
 
 function ActionIcon({ recipe }: { recipe: Recipe }) {
@@ -21,80 +17,77 @@ function ActionIcon({ recipe }: { recipe: Recipe }) {
         : <PlayCircle className="h-3.5 w-3.5" />;
 }
 
-// Style B — colored icon tile, clean card. The workhorse for grids.
 export function RecipeCard({ podId, recipe, onLaunch }: { podId: string; recipe: Recipe; onLaunch: () => void }) {
     const detailHref = `/pod/${podId}/recipes/${encodeURIComponent(recipe.id)}`;
     const accent = getRecipeAccent(recipe);
+    const isPrompt = recipe.source.kind === 'prompt';
 
     return (
-        <article className="resource-index-card group overflow-hidden p-0">
-            <Link href={detailHref} className="custom-focus-ring block p-4">
-                <div className="flex items-start gap-3">
-                    <span className="recipe-icon-tile h-9 w-9 shrink-0 rounded-lg" data-accent={accent}>
-                        {renderRecipeIcon(recipe, { className: 'h-[18px] w-[18px]', strokeWidth: 1.8 })}
-                    </span>
-                    <div className="min-w-0 flex-1">
-                        <p className="type-eyebrow-mono text-[var(--text-tertiary)]">
-                            {kindLabel(recipe)} · {RECIPE_BUILDS_LABEL[recipe.builds]}
-                        </p>
-                        <h3 className="mt-1 truncate text-base font-medium text-[var(--text-primary)]">{recipe.name}</h3>
-                    </div>
-                </div>
-                <p className="mt-3 line-clamp-2 min-h-10 text-sm leading-6 text-[var(--text-secondary)]">{recipe.blurb}</p>
-            </Link>
+        <article className="resource-index-card group flex min-h-52 flex-col overflow-hidden p-0">
+            {isPrompt ? (
+                <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={onLaunch}
+                    className="h-auto flex-1 items-stretch justify-start whitespace-normal rounded-none p-4 text-left"
+                >
+                    <RecipeCardBody recipe={recipe} accent={accent} />
+                </Button>
+            ) : (
+                <Link href={detailHref} className="custom-focus-ring block flex-1 p-4">
+                    <RecipeCardBody recipe={recipe} accent={accent} />
+                </Link>
+            )}
             <div className="flex items-center gap-2 border-t border-[color:color-mix(in_srgb,var(--border-subtle)_60%,transparent)] px-4 py-3">
                 <Button size="sm" onClick={onLaunch} className="h-8 gap-1.5 rounded-md px-3 text-xs">
                     <ActionIcon recipe={recipe} />
                     {actionLabel(recipe)}
                 </Button>
-                <Link
-                    href={detailHref}
-                    className="custom-focus-ring ml-auto inline-flex h-8 items-center gap-1 rounded-md px-2.5 text-xs text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-primary)]"
-                >
-                    Details
-                    <ArrowRight className="h-3.5 w-3.5" />
-                </Link>
+                {!isPrompt ? (
+                    <Link
+                        href={detailHref}
+                        className="custom-focus-ring ml-auto inline-flex h-8 items-center gap-1 rounded-md px-2.5 text-xs text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-primary)]"
+                    >
+                        Details
+                        <ArrowRight className="h-3.5 w-3.5" />
+                    </Link>
+                ) : null}
             </div>
         </article>
     );
 }
 
-// Style C — preview-forward. A glimpse of what gets built, for featured rows.
-export function RecipeFeatureCard({ podId, recipe, onLaunch }: { podId: string; recipe: Recipe; onLaunch: () => void }) {
-    const detailHref = `/pod/${podId}/recipes/${encodeURIComponent(recipe.id)}`;
-    const accent = getRecipeAccent(recipe);
-
+function RecipeCardBody({ recipe, accent }: { recipe: Recipe; accent: ReturnType<typeof getRecipeAccent> }) {
     return (
-        <article className="resource-index-card group overflow-hidden p-0">
-            <Link href={detailHref} className="custom-focus-ring block">
-                <div className="recipe-preview flex flex-col gap-2 px-4 py-3.5" data-accent={accent}>
-                    <span className="recipe-preview-bar h-1.5 w-[46%] rounded-full" />
-                    <span className="recipe-preview-line h-1.5 w-[88%] rounded-full" />
-                    <span className="recipe-preview-line h-1.5 w-[72%] rounded-full" />
+        <div>
+            <div className="flex items-start gap-3">
+                <span className="recipe-icon-tile h-9 w-9 shrink-0 rounded-lg" data-accent={accent}>
+                    {renderRecipeIcon(recipe, { className: 'h-[18px] w-[18px]', strokeWidth: 1.8 })}
+                </span>
+                <div className="min-w-0 flex-1">
+                    <h3 className="truncate text-base font-medium text-[var(--text-primary)]">{recipe.name}</h3>
+                    <p className="mt-0.5 line-clamp-1 text-xs text-[var(--text-tertiary)]">{recipe.kicker}</p>
                 </div>
-                <div className="p-4">
-                    <div className="flex items-center gap-2.5">
-                        <span className="recipe-icon-tile h-8 w-8 shrink-0 rounded-lg" data-accent={accent}>
-                            {renderRecipeIcon(recipe, { className: 'h-4 w-4', strokeWidth: 1.8 })}
-                        </span>
-                        <h3 className="min-w-0 truncate text-base font-medium text-[var(--text-primary)]">{recipe.name}</h3>
-                    </div>
-                    <p className="mt-2.5 line-clamp-2 min-h-10 text-sm leading-6 text-[var(--text-secondary)]">{recipe.blurb}</p>
-                </div>
-            </Link>
-            <div className="flex items-center gap-2 px-4 pb-4">
-                <Button size="sm" onClick={onLaunch} className="h-8 gap-1.5 rounded-md px-3 text-xs">
-                    <ActionIcon recipe={recipe} />
-                    {actionLabel(recipe)}
-                </Button>
-                <Link
-                    href={detailHref}
-                    className="custom-focus-ring ml-auto inline-flex h-8 items-center gap-1 rounded-md px-2.5 text-xs text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-primary)]"
-                >
-                    Details
-                    <ArrowRight className="h-3.5 w-3.5" />
-                </Link>
             </div>
-        </article>
+            <p className="mt-3 line-clamp-2 min-h-10 text-sm leading-6 text-[var(--text-secondary)]">{recipe.blurb}</p>
+            {recipe.examples?.length ? (
+                <p className="mt-3 line-clamp-2 text-xs leading-5 text-[var(--text-tertiary)]">
+                    Good for {recipe.examples.join(' · ')}
+                </p>
+            ) : null}
+            <RecipeOutputs recipe={recipe} />
+        </div>
+    );
+}
+
+function RecipeOutputs({ recipe }: { recipe: Recipe }) {
+    return (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+            {recipe.outputs.slice(0, 4).map((output) => (
+                <span key={output} className="chip chip-sm chip-muted">
+                    {RECIPE_OUTPUT_LABEL[output]}
+                </span>
+            ))}
+        </div>
     );
 }

--- a/lemma-frontend/components/recipes/recipe-icon.ts
+++ b/lemma-frontend/components/recipes/recipe-icon.ts
@@ -1,22 +1,16 @@
 import { createElement, type ReactElement } from 'react';
 import {
     BookOpen,
-    Briefcase,
-    CalendarDays,
     Contact2,
     Eye,
-    Flame,
     Inbox,
-    Lightbulb,
     ListChecks,
     type LemmaIcon,
     MessageSquare,
     MessagesSquare,
     Newspaper,
-    NotebookPen,
     PackageOpen,
     PanelsTopLeft,
-    Receipt,
     RefreshCw,
     Send,
     Sparkles,
@@ -26,34 +20,20 @@ import {
 import type { Recipe, RecipeBuilds } from '@/lib/recipes/recipes';
 
 const BY_ID: Record<string, LemmaIcon> = {
-    // quick wins
-    'personal-crm': Contact2,
-    'reading-digest': BookOpen,
-    'meeting-notes': ListChecks,
-    'job-tracker': Briefcase,
-    'habit-tracker': Flame,
-    'daily-log': NotebookPen,
-    // bots & surfaces
-    'slack-standup-bot': MessageSquare,
-    'expense-logger-bot': Receipt,
-    'ask-my-data-bot': MessagesSquare,
-    'email-intake-bot': Inbox,
-    'site-support-bot': MessagesSquare,
-    // creators & indies
-    'content-idea-engine': Lightbulb,
-    'newsletter-curator': Newspaper,
-    'competitor-watch': Eye,
-    'lead-finder': Send,
-    // consultants
-    'client-invoice-tracker': Receipt,
-    'proposal-drafter': NotebookPen,
-    // team ops
-    'renewal-review': RefreshCw,
-    'support-triage': MessagesSquare,
-    'approvals-queue': ListChecks,
-    'standup-digest': CalendarDays,
-    'content-pipeline': NotebookPen,
-    'lightweight-crm': Contact2,
+    'dashboard-internal-tool': PanelsTopLeft,
+    'inbox-review-queue': Inbox,
+    'knowledge-workspace': BookOpen,
+    'portal-intake': Send,
+    'whatsapp-agent': MessageSquare,
+    'telegram-agent-app': Send,
+    'slack-agent': MessagesSquare,
+    'email-agent': Inbox,
+    'teams-agent': MessagesSquare,
+    'monitor-alert': Eye,
+    'intake-triage': RefreshCw,
+    'approval-review': ListChecks,
+    'scheduled-briefing': Newspaper,
+    'follow-up-chaser': Contact2,
 };
 
 const BY_BUILDS: Record<RecipeBuilds, LemmaIcon> = {

--- a/lemma-frontend/components/recipes/recipe-readme.tsx
+++ b/lemma-frontend/components/recipes/recipe-readme.tsx
@@ -89,7 +89,7 @@ export function RecipeReadme({ kit }: { kit: KitDefinition }) {
             <div className="mb-5 flex flex-col gap-2 border-b border-[var(--border-subtle)] pb-4 sm:flex-row sm:items-center sm:justify-between">
                 <div>
                     <p className="type-eyebrow-mono">README</p>
-                    <h2 className="mt-1 text-lg font-semibold text-[var(--text-primary)]">What this recipe sets up</h2>
+                    <h2 className="mt-1 text-lg font-semibold text-[var(--text-primary)]">What this kit sets up</h2>
                 </div>
                 <span className="rounded-md border border-[color:var(--chip-border)] bg-[var(--chip-bg)] px-2 py-1 font-mono text-xs text-[var(--chip-fg)]">
                     branch: {readmeState.branch}

--- a/lemma-frontend/components/recipes/starter-preview.tsx
+++ b/lemma-frontend/components/recipes/starter-preview.tsx
@@ -1,0 +1,171 @@
+import Image from 'next/image';
+
+import type { Recipe, RecipePreviewKind } from '@/lib/recipes/recipes';
+import { cn } from '@/lib/utils';
+
+const PLATFORM_PREVIEWS = new Set<RecipePreviewKind>(['whatsapp', 'telegram', 'slack', 'email', 'teams']);
+
+const PLATFORM_META: Partial<Record<RecipePreviewKind, { label: string; logo: string }>> = {
+    whatsapp: { label: 'WhatsApp', logo: '/surfaces/whatsapp.png' },
+    telegram: { label: 'Telegram', logo: '/surfaces/telegram.png' },
+    slack: { label: 'Slack', logo: '/surfaces/slack.png' },
+    email: { label: 'Gmail + Outlook', logo: '/surfaces/gmail.png' },
+    teams: { label: 'Microsoft Teams', logo: '/surfaces/teams.png' },
+};
+
+export function StarterPreview({ recipe, compact = false }: { recipe: Recipe; compact?: boolean }) {
+    if (PLATFORM_PREVIEWS.has(recipe.preview)) {
+        return <PlatformPreview preview={recipe.preview} compact={compact} />;
+    }
+
+    return (
+        <div
+            aria-hidden="true"
+            className={cn('starter-preview', compact && 'starter-preview-compact')}
+            data-preview={recipe.preview}
+        >
+            <div className="starter-preview-window-bar">
+                <span />
+                <span />
+                <span />
+                <span className="starter-preview-window-title">{recipe.kicker}</span>
+            </div>
+            <div className="starter-preview-canvas">
+                <ShapePreview preview={recipe.preview} />
+            </div>
+        </div>
+    );
+}
+
+function PlatformPreview({ preview, compact }: { preview: RecipePreviewKind; compact: boolean }) {
+    const meta = PLATFORM_META[preview];
+
+    return (
+        <div
+            aria-hidden="true"
+            className={cn('starter-preview starter-platform-preview', compact && 'starter-preview-compact')}
+            data-preview={preview}
+        >
+            <div className="starter-platform-header">
+                <span className="starter-platform-logo">
+                    {meta ? <Image src={meta.logo} alt="" width={18} height={18} /> : null}
+                </span>
+                <span className="starter-platform-label">{meta?.label}</span>
+                <span className="starter-platform-live"><i /> Live</span>
+            </div>
+            <div className="starter-platform-body">
+                <div className="starter-platform-thread">
+                    <span className="starter-chat-bubble starter-chat-bubble-user" />
+                    <span className="starter-chat-bubble starter-chat-bubble-agent" />
+                    <span className="starter-chat-bubble starter-chat-bubble-agent starter-chat-bubble-short" />
+                </div>
+                <div className="starter-platform-companion">
+                    <span className="starter-companion-kicker">Needs you</span>
+                    <span className="starter-companion-title" />
+                    <span className="starter-companion-line" />
+                    <span className="starter-companion-actions">
+                        <i />
+                        <i />
+                    </span>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function ShapePreview({ preview }: { preview: RecipePreviewKind }) {
+    if (preview === 'dashboard') {
+        return (
+            <div className="starter-dashboard-preview">
+                <div className="starter-mini-sidebar"><i /><i /><i /><i /></div>
+                <div className="starter-dashboard-main">
+                    <div className="starter-dashboard-heading"><span /><i /></div>
+                    <div className="starter-dashboard-metrics"><span /><span /><span /></div>
+                    <div className="starter-dashboard-table"><i /><i /><i /></div>
+                </div>
+            </div>
+        );
+    }
+
+    if (preview === 'inbox' || preview === 'triage') {
+        return (
+            <div className="starter-inbox-preview">
+                <div className="starter-inbox-list"><i /><i /><i /></div>
+                <div className="starter-inbox-detail">
+                    <span className="starter-inbox-status">Prepared by agent</span>
+                    <strong />
+                    <i /><i />
+                    <div><b /><b /></div>
+                </div>
+            </div>
+        );
+    }
+
+    if (preview === 'knowledge') {
+        return (
+            <div className="starter-knowledge-preview">
+                <div className="starter-knowledge-tree"><i /><i /><i /><i /></div>
+                <div className="starter-knowledge-doc"><strong /><span /><span /><span /><div /></div>
+            </div>
+        );
+    }
+
+    if (preview === 'portal') {
+        return (
+            <div className="starter-portal-preview">
+                <strong>Tell us what you need</strong>
+                <span />
+                <span />
+                <span className="starter-portal-field-wide" />
+                <i>Send request</i>
+            </div>
+        );
+    }
+
+    if (preview === 'monitor') {
+        return (
+            <div className="starter-monitor-preview">
+                <div className="starter-monitor-heading"><strong>Watching 12 signals</strong><i /></div>
+                <div className="starter-monitor-chart"><i /><i /><i /><i /><i /><i /></div>
+                <div className="starter-monitor-alert"><b /><span><strong>Meaningful change</strong><i /></span></div>
+            </div>
+        );
+    }
+
+    if (preview === 'approval') {
+        return (
+            <div className="starter-approval-preview">
+                <span className="starter-approval-kicker">Decision waiting</span>
+                <strong />
+                <i /><i />
+                <div><b /><b /></div>
+            </div>
+        );
+    }
+
+    if (preview === 'briefing') {
+        return (
+            <div className="starter-briefing-preview">
+                <div><span>MON</span><strong>9:00</strong></div>
+                <section><b /><i /><i /><i /><i /></section>
+            </div>
+        );
+    }
+
+    if (preview === 'follow-up') {
+        return (
+            <div className="starter-follow-up-preview">
+                <div><b /><span><strong /><i /></span><em>Today</em></div>
+                <div><b /><span><strong /><i /></span><em>2d</em></div>
+                <div><b /><span><strong /><i /></span><em>5d</em></div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="starter-kit-preview">
+            <span /><span /><span /><span />
+            <i /><i /><i />
+        </div>
+    );
+}

--- a/lemma-frontend/components/recipes/starter-theme-card.tsx
+++ b/lemma-frontend/components/recipes/starter-theme-card.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Image from 'next/image';
+import { ArrowUpRight, Sparkles } from '@/components/ui/icons';
+
+import { Button } from '@/components/ui/button';
+import {
+    recipesForTheme,
+    type Recipe,
+    type StarterTheme,
+    type StarterThemeId,
+} from '@/lib/recipes/recipes';
+import { cn } from '@/lib/utils';
+import { renderRecipeIcon } from './recipe-icon';
+
+const THEME_LOGOS: Partial<Record<StarterThemeId, { src: string; alt: string }>> = {
+    whatsapp: { src: '/surfaces/whatsapp.png', alt: 'WhatsApp' },
+    telegram: { src: '/surfaces/telegram.png', alt: 'Telegram' },
+    slack: { src: '/surfaces/slack.png', alt: 'Slack' },
+    email: { src: '/surfaces/gmail.png', alt: 'Email' },
+    teams: { src: '/surfaces/teams.png', alt: 'Microsoft Teams' },
+};
+
+export function StarterThemePicker({
+    themes,
+    onLaunch,
+}: {
+    themes: StarterTheme[];
+    onLaunch: (recipe: Recipe, message: string) => void;
+}) {
+    const [activeThemeId, setActiveThemeId] = useState<StarterThemeId | undefined>(themes[0]?.id);
+    const activeTheme = themes.find((theme) => theme.id === activeThemeId) ?? themes[0];
+    const recipes = useMemo(() => activeTheme ? recipesForTheme(activeTheme) : [], [activeTheme]);
+    const recipeById = new Map(recipes.map((recipe) => [recipe.id, recipe]));
+    const prompts = activeTheme?.promptExamples.flatMap((example) => {
+        const recipe = recipeById.get(example.recipeId);
+        return recipe ? [{ ...example, recipe }] : [];
+    }) ?? [];
+
+    if (!activeTheme) return null;
+
+    return (
+        <div className="starter-theme-picker">
+            <div className="starter-theme-rail" role="tablist" aria-label="Starter categories">
+                {themes.map((theme) => {
+                    const themeRecipes = recipesForTheme(theme);
+                    const leadRecipe = themeRecipes[0];
+                    const logo = THEME_LOGOS[theme.id];
+                    const active = theme.id === activeTheme.id;
+
+                    return (
+                        <Button
+                            key={theme.id}
+                            type="button"
+                            variant="ghost"
+                            role="tab"
+                            aria-selected={active}
+                            aria-controls="starter-theme-prompts"
+                            onMouseEnter={() => setActiveThemeId(theme.id)}
+                            onFocus={() => setActiveThemeId(theme.id)}
+                            onClick={() => setActiveThemeId(theme.id)}
+                            className={cn('starter-theme-tab', active && 'starter-theme-tab-active')}
+                            data-theme={theme.id}
+                        >
+                            <span className={cn('starter-theme-tab-icon', logo && 'starter-theme-tab-icon-logo')}>
+                                {logo ? (
+                                    <Image src={logo.src} alt={logo.alt} width={20} height={20} className="object-contain" />
+                                ) : leadRecipe ? (
+                                    renderRecipeIcon(leadRecipe, { className: 'h-4 w-4', strokeWidth: 1.8 })
+                                ) : (
+                                    <Sparkles className="h-4 w-4" />
+                                )}
+                            </span>
+                            <span>{theme.name}</span>
+                        </Button>
+                    );
+                })}
+            </div>
+
+            <div
+                id="starter-theme-prompts"
+                className="starter-theme-inline-prompts"
+                role="tabpanel"
+                aria-label={`${activeTheme.name} example prompts`}
+                data-theme={activeTheme.id}
+            >
+                <div>
+                    {prompts.map(({ recipe, title, prompt }, index) => (
+                        <Button
+                            key={`${recipe.id}-${index}`}
+                            type="button"
+                            variant="ghost"
+                            title={title}
+                            onClick={() => onLaunch(recipe, prompt)}
+                            className="starter-theme-inline-prompt"
+                        >
+                            <Sparkles className="h-3.5 w-3.5 shrink-0" />
+                            <span>{title}</span>
+                            <span className="starter-theme-inline-prompt-action">
+                                Use prompt
+                                <ArrowUpRight className="h-4 w-4" />
+                            </span>
+                        </Button>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/lemma-frontend/lib/pods/pod-home-starters.test.ts
+++ b/lemma-frontend/lib/pods/pod-home-starters.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolvePodHomeStarterMode, type PodHomeResourceSignals } from './pod-home-starters';
+
+const EMPTY: PodHomeResourceSignals = {
+    appCount: 0,
+    agentCount: 0,
+    workflowCount: 0,
+    surfaceCount: 0,
+    activeSurfaceCount: 0,
+    scheduleCount: 0,
+    conversationCount: 0,
+    hasUsedWorkflow: false,
+};
+
+describe('resolvePodHomeStarterMode', () => {
+    it('shows the full starter experience for a truly fresh pod', () => {
+        expect(resolvePodHomeStarterMode(EMPTY)).toBe('fresh');
+    });
+
+    it('keeps a conversation-only or single-resource pod in the forming state', () => {
+        expect(resolvePodHomeStarterMode({ ...EMPTY, conversationCount: 1 })).toBe('forming');
+        expect(resolvePodHomeStarterMode({ ...EMPTY, agentCount: 1 })).toBe('forming');
+        expect(resolvePodHomeStarterMode({ ...EMPTY, appCount: 1 })).toBe('forming');
+    });
+
+    it('treats a working app or live channel pairing as operating', () => {
+        expect(resolvePodHomeStarterMode({ ...EMPTY, appCount: 1, agentCount: 1 })).toBe('operating');
+        expect(resolvePodHomeStarterMode({ ...EMPTY, agentCount: 1, surfaceCount: 1, activeSurfaceCount: 1 })).toBe('operating');
+    });
+
+    it('treats scheduled or already-used workflows as operating', () => {
+        expect(resolvePodHomeStarterMode({ ...EMPTY, workflowCount: 1, scheduleCount: 1 })).toBe('operating');
+        expect(resolvePodHomeStarterMode({ ...EMPTY, workflowCount: 1, hasUsedWorkflow: true })).toBe('operating');
+    });
+
+    it('uses three durable resources as the fallback operating threshold', () => {
+        expect(resolvePodHomeStarterMode({ ...EMPTY, agentCount: 2, workflowCount: 1 })).toBe('operating');
+        expect(resolvePodHomeStarterMode({ ...EMPTY, surfaceCount: 1, conversationCount: 8 })).toBe('forming');
+    });
+});

--- a/lemma-frontend/lib/pods/pod-home-starters.ts
+++ b/lemma-frontend/lib/pods/pod-home-starters.ts
@@ -1,0 +1,37 @@
+export interface PodHomeResourceSignals {
+    appCount: number;
+    agentCount: number;
+    workflowCount: number;
+    surfaceCount: number;
+    activeSurfaceCount: number;
+    scheduleCount: number;
+    conversationCount: number;
+    hasUsedWorkflow: boolean;
+}
+
+export type PodHomeStarterMode = 'fresh' | 'forming' | 'operating';
+
+// This is deliberately derived from resources Home already loads. It must stay
+// pure: deciding whether to show starters should never create another pod-home
+// request or polling loop.
+export function resolvePodHomeStarterMode(signals: PodHomeResourceSignals): PodHomeStarterMode {
+    const durableResourceCount =
+        signals.appCount
+        + signals.agentCount
+        + signals.workflowCount
+        + signals.surfaceCount
+        + signals.scheduleCount;
+    const hasAnyPodWork = durableResourceCount > 0 || signals.conversationCount > 0;
+
+    if (!hasAnyPodWork) return 'fresh';
+
+    const hasWorkingApp = signals.appCount > 0 && (signals.agentCount > 0 || signals.workflowCount > 0);
+    const hasWorkingSurface = signals.activeSurfaceCount > 0 && signals.agentCount > 0;
+    const hasOperatingLoop = signals.scheduleCount > 0 || signals.hasUsedWorkflow;
+
+    if (hasWorkingApp || hasWorkingSurface || hasOperatingLoop || durableResourceCount >= 3) {
+        return 'operating';
+    }
+
+    return 'forming';
+}

--- a/lemma-frontend/lib/recipes/recipes.ts
+++ b/lemma-frontend/lib/recipes/recipes.ts
@@ -14,7 +14,35 @@ import {
 
 export type RecipeKind = 'prompt' | 'repo';
 export type RecipeBuilds = 'app' | 'agent' | 'workflow' | 'surface' | 'pod';
-export type RecipeCategory = 'quick-win' | 'creators' | 'consultants' | 'team-ops';
+export type RecipeOutput = RecipeBuilds | 'table' | 'files' | 'schedule';
+export type RecipeCategory = 'app-shapes' | 'agent-channels' | 'operating-loops' | 'published';
+export type RecipePreviewKind =
+    | 'dashboard'
+    | 'inbox'
+    | 'knowledge'
+    | 'portal'
+    | 'whatsapp'
+    | 'telegram'
+    | 'slack'
+    | 'email'
+    | 'teams'
+    | 'monitor'
+    | 'triage'
+    | 'approval'
+    | 'briefing'
+    | 'follow-up'
+    | 'kit';
+export type RecipePlatform = 'WHATSAPP' | 'TELEGRAM' | 'SLACK' | 'GMAIL' | 'OUTLOOK' | 'TEAMS';
+export type StarterThemeId =
+    | 'dashboards'
+    | 'whatsapp'
+    | 'telegram'
+    | 'slack'
+    | 'email'
+    | 'teams'
+    | 'knowledge'
+    | 'intake'
+    | 'automations';
 
 export type RecipeSource =
     | { kind: 'prompt'; prompt: string }
@@ -23,9 +51,14 @@ export type RecipeSource =
 export interface Recipe {
     id: string;
     name: string;
+    kicker: string;
     blurb: string;
     builds: RecipeBuilds;
+    outputs: RecipeOutput[];
     category: RecipeCategory;
+    preview: RecipePreviewKind;
+    platforms?: RecipePlatform[];
+    examples?: string[];
     featured?: boolean;
     highlights?: string[];
     source: RecipeSource;
@@ -43,12 +76,180 @@ export interface RecipeCategoryMeta {
     order: number;
 }
 
+export interface StarterTheme {
+    id: StarterThemeId;
+    name: string;
+    kicker: string;
+    description: string;
+    preview: RecipePreviewKind;
+    examples: string[];
+    recipeIds: string[];
+    promptExamples: Array<{
+        recipeId: string;
+        title: string;
+        prompt: string;
+    }>;
+}
+
 export const RECIPE_CATEGORIES: RecipeCategoryMeta[] = [
-    { id: 'quick-win', label: 'Quick wins', blurb: 'Solo, set up in a couple of minutes, useful immediately.', accent: 'success', order: 1 },
-    { id: 'creators', label: 'For creators & indies', blurb: 'Ship content, watch competitors, find leads.', accent: 'delight', order: 2 },
-    { id: 'consultants', label: 'For consultants', blurb: 'Track clients, invoices, and proposals.', accent: 'brand', order: 3 },
-    { id: 'team-ops', label: 'Team operations', blurb: 'Reviews, approvals, queues, and bots your team works in.', accent: 'intelligence', order: 4 },
+    { id: 'app-shapes', label: 'Build an app', blurb: 'Start from a recognizable product shape, then make it yours.', accent: 'brand', order: 1 },
+    { id: 'agent-channels', label: 'Put an agent where work happens', blurb: 'Give this pod a useful presence in the channels people already use.', accent: 'collaboration', order: 2 },
+    { id: 'operating-loops', label: 'Automate a loop', blurb: 'Set up work that keeps watching, routing, reviewing, or following up.', accent: 'intelligence', order: 3 },
+    { id: 'published', label: 'Published kits', blurb: 'Install a complete, source-backed setup into this pod.', accent: 'success', order: 4 },
 ];
+
+function starterPrompt(
+    recipeId: string,
+    title: string,
+    build: string,
+    askAbout: string,
+    finishedVersion: string,
+): StarterTheme['promptExamples'][number] {
+    return {
+        recipeId,
+        title,
+        prompt: [
+            `Build ${build} inside this pod.`,
+            'Before making changes, inspect the pod\'s existing apps, data, files, agents, workflows, connectors, and surfaces so you reuse what is already here.',
+            `Ask the user for the missing details needed to shape it, especially ${askAbout}. Ask only one or two concise questions at a time, do not repeat anything already clear from the pod, and do not turn discovery into a long questionnaire.`,
+            `Once you have enough context, build the smallest useful working version. ${finishedVersion}`,
+            'Use believable sample data where it helps the user understand the result, show one realistic flow working end to end, and keep consequential external actions behind explicit approval.',
+        ].join('\n\n'),
+    };
+}
+
+// Themes are the front doors of the starter experience. A theme describes a
+// product surface or family; the recipes inside it are the concrete builds.
+export const STARTER_THEMES: StarterTheme[] = [
+    {
+        id: 'dashboards',
+        name: 'Dashboards & internal tools',
+        kicker: 'Build the place where the work gets run',
+        description: 'Shape a focused operating screen around your data, decisions, and next actions.',
+        preview: 'dashboard',
+        examples: ['Operations', 'Pipeline', 'Project delivery'],
+        recipeIds: ['dashboard-internal-tool', 'crm-pipeline-app', 'project-delivery-console'],
+        promptExamples: [
+            starterPrompt('dashboard-internal-tool', 'An operations dashboard shaped around your team\'s decisions', 'an operations dashboard and internal tool', 'the people using it, the decisions they make, source data, workflow states, permissions, and the actions the screen must support', 'Create the focused app, underlying data model, and useful agent behavior around those decisions rather than a generic KPI wall.'),
+            starterPrompt('crm-pipeline-app', 'A CRM pipeline with owners, stages, and next actions', 'a CRM pipeline workspace', 'the relationship or revenue motion, pipeline stages, ownership, required account and contact data, next actions, and follow-up rules', 'Create the pipeline app, durable records, movement history, and agent-prepared research and follow-ups.'),
+            starterPrompt('project-delivery-console', 'A project delivery tracker for blockers, risks, and decisions', 'a project delivery tracker', 'how work is planned and reviewed, project types, milestones, owners, blockers, risks, decisions, and the reporting cadence', 'Create a calm delivery view that foregrounds movement, blockers, and decisions, plus concise agent-written status summaries.'),
+        ],
+    },
+    {
+        id: 'whatsapp',
+        name: 'WhatsApp agents',
+        kicker: 'Serve, qualify, and coordinate in WhatsApp',
+        description: 'Give this pod a WhatsApp presence with structured memory and a human handoff.',
+        preview: 'whatsapp',
+        examples: ['Customer support', 'Lead qualification', 'Field operations'],
+        recipeIds: ['whatsapp-agent', 'whatsapp-support-desk', 'whatsapp-lead-qualifier', 'whatsapp-field-ops'],
+        promptExamples: [
+            starterPrompt('whatsapp-support-desk', 'A WhatsApp support agent with clean human handoff', 'a WhatsApp customer support agent with clean human handoff', 'the customers it serves, common requests, approved knowledge sources, tone, business hours, data to capture, escalation rules, and who takes over', 'Create the agent, support records, WhatsApp surface, and a human review and handoff path.'),
+            starterPrompt('whatsapp-lead-qualifier', 'A WhatsApp agent that qualifies and routes inbound leads', 'a WhatsApp lead qualification agent', 'the ideal customer, qualification questions, disqualifiers, routing rules, ownership, CRM fields, response expectations, and when a salesperson should take over', 'Create the agent, lead records, WhatsApp surface, and a prepared handoff with the next sales action.'),
+            starterPrompt('whatsapp-field-ops', 'A WhatsApp field-ops agent for updates, photos, and escalation', 'a WhatsApp field operations agent', 'who reports from the field, the jobs or locations involved, required updates and photos, validation rules, escalation conditions, and how coordinators review progress', 'Create the agent, structured field records, WhatsApp surface, and a clear operations review view.'),
+        ],
+    },
+    {
+        id: 'telegram',
+        name: 'Telegram agents + mini apps',
+        kicker: 'Combine a fast bot with a visual companion',
+        description: 'Use Telegram for the conversation and a mini app for records, decisions, and review.',
+        preview: 'telegram',
+        examples: ['Community', 'Personal logging', 'Approvals'],
+        recipeIds: ['telegram-agent-app', 'telegram-community-concierge', 'telegram-personal-logger', 'telegram-approval-bot'],
+        promptExamples: [
+            starterPrompt('telegram-community-concierge', 'A Telegram concierge for community questions and routing', 'a Telegram community concierge', 'the community, membership rules, common questions, trusted sources, moderation boundaries, escalation path, and what context should be retained', 'Create the Telegram agent, usable community memory, and a small companion view for reviewing activity and unresolved questions.'),
+            starterPrompt('telegram-personal-logger', 'A Telegram capture bot with an organized personal logbook', 'a Telegram capture bot and personal logbook', 'what the user wants to capture, useful fields and tags, how entries should be organized, search and review habits, reminders, and privacy expectations', 'Create the Telegram bot, structured logbook, and a mini app for browsing, editing, and revisiting entries.'),
+            starterPrompt('telegram-approval-bot', 'A Telegram approval agent with a focused mini app', 'a Telegram approval agent with a mini app', 'the requests being approved, submitters, required context, approvers, decision states, deadlines, delegation, notifications, and audit requirements', 'Create the Telegram agent, approval records and workflow, and a mini app that makes each decision quick and well informed.'),
+        ],
+    },
+    {
+        id: 'slack',
+        name: 'Slack agents',
+        kicker: 'Put a useful teammate in channels and DMs',
+        description: 'Answer questions, coordinate incidents, and run recurring team rituals in Slack.',
+        preview: 'slack',
+        examples: ['Team knowledge', 'Incident response', 'Standup digest'],
+        recipeIds: ['slack-agent', 'slack-knowledge-teammate', 'slack-incident-coordinator', 'slack-standup-digest'],
+        promptExamples: [
+            starterPrompt('slack-knowledge-teammate', 'A Slack teammate that answers from your team\'s knowledge', 'a Slack knowledge teammate grounded in this pod', 'which teams and channels it serves, trusted sources, answer boundaries, citation expectations, unanswered-question handling, permissions, and escalation ownership', 'Create the Slack agent and a source-grounded answer flow that links back to evidence and records knowledge gaps.'),
+            starterPrompt('slack-incident-coordinator', 'A Slack incident coordinator with a live decision log', 'a Slack incident coordinator', 'incident types, severity rules, responders, channel conventions, required updates, decision capture, escalation paths, customer communication boundaries, and review expectations', 'Create the Slack agent, incident records and workflow, timeline and decision log, and a concise live status view.'),
+            starterPrompt('slack-standup-digest', 'A Slack standup collector that publishes a useful digest', 'a Slack standup collector and digest', 'participating teams, collection cadence, prompts, time zones, blockers and risks to highlight, distribution channels, and what makes the digest useful', 'Create the Slack agent, scheduled collection loop, update records, and a compact digest with clear follow-ups.'),
+        ],
+    },
+    {
+        id: 'email',
+        name: 'Email agents',
+        kicker: 'Turn a mailbox into an operating queue',
+        description: 'Triage incoming mail, prepare replies, and keep outbound work behind human review.',
+        preview: 'email',
+        examples: ['Support', 'Vendor requests', 'Executive inbox'],
+        recipeIds: ['email-agent'],
+        promptExamples: [
+            starterPrompt('email-agent', 'An email agent that triages support and drafts replies', 'a support inbox agent with human-reviewed drafts', 'the mailbox, support categories, urgency rules, customer context, approved knowledge, ownership, service expectations, escalation rules, and reply approval policy', 'Create the email agent, triage and review queue, support records, and safe draft-reply workflow.'),
+            starterPrompt('email-agent', 'An owned email queue for reviewing vendor requests', 'a vendor request email queue', 'the request types, required vendor information, reviewers, ownership, risk and urgency rules, decision states, response templates, and approval boundaries', 'Create the email agent, structured vendor requests, an owned review queue, and prepared responses that remain behind approval.'),
+            starterPrompt('email-agent', 'A daily executive inbox briefing with decisions and follow-ups', 'an executive inbox briefing agent', 'the mailbox, priority people and topics, what can be summarized or ignored, sensitive-message handling, preferred briefing format, cadence, and follow-up boundaries', 'Create the email agent and a concise briefing that separates decisions, replies, follow-ups, and information while keeping all outbound actions under human control.'),
+        ],
+    },
+    {
+        id: 'teams',
+        name: 'Microsoft Teams agents',
+        kicker: 'Bring the pod into Teams chats and channels',
+        description: 'Answer, capture, route, and escalate work without asking the team to leave Microsoft Teams.',
+        preview: 'teams',
+        examples: ['Policy Q&A', 'IT intake', 'Project updates'],
+        recipeIds: ['teams-agent'],
+        promptExamples: [
+            starterPrompt('teams-agent', 'A Teams agent that answers policy questions with sources', 'a policy Q&A agent in Microsoft Teams', 'the audiences and Teams locations, authoritative policy sources, permission boundaries, citation requirements, uncertain-answer handling, and the policy owner escalation path', 'Create the Teams agent and a grounded answer experience that cites evidence and captures unanswered questions.'),
+            starterPrompt('teams-agent', 'A Teams agent that captures and routes IT requests', 'an IT request intake agent in Microsoft Teams', 'request categories, required diagnostics, urgency and impact rules, routing and ownership, service expectations, escalation conditions, and status updates', 'Create the Teams agent, structured request records, triage workflow, and a clear queue for the IT team.'),
+            starterPrompt('teams-agent', 'A Teams agent that publishes a useful project digest', 'a project update collector and digest in Microsoft Teams', 'the projects and participants, update cadence, required signals, blocker and risk rules, decision owners, summary audience, and delivery channel', 'Create the Teams agent, scheduled collection loop, durable updates, and an action-oriented digest.'),
+        ],
+    },
+    {
+        id: 'knowledge',
+        name: 'Knowledge & research',
+        kicker: 'Make the pod useful with what your team knows',
+        description: 'Collect sources, find grounded answers, and turn knowledge into working material.',
+        preview: 'knowledge',
+        examples: ['Team handbook', 'Research library', 'Customer knowledge'],
+        recipeIds: ['knowledge-workspace'],
+        promptExamples: [
+            starterPrompt('knowledge-workspace', 'A source-grounded team handbook people can actually use', 'a source-grounded team handbook', 'the audience, existing documents, key sections, ownership, permissions, update process, search needs, and which questions it must answer reliably', 'Create the knowledge structure, import or organize the sources, and provide grounded answers with links back to evidence.'),
+            starterPrompt('knowledge-workspace', 'A research library that answers with links to evidence', 'a research library with evidence-backed answers', 'the research domain, source types, collection process, metadata, credibility rules, synthesis formats, permissions, and recurring research questions', 'Create the library, source organization, search and Q&A experience, and a workflow for turning evidence into useful briefs.'),
+            starterPrompt('knowledge-workspace', 'A customer knowledge base that stays useful and searchable', 'a customer knowledge base', 'who uses it, customer and product scope, existing sources, permission boundaries, common questions, freshness requirements, ownership, and how gaps should be handled', 'Create the knowledge structure and a grounded answer experience that keeps customer context usable and points back to sources.'),
+        ],
+    },
+    {
+        id: 'intake',
+        name: 'Intake & review',
+        kicker: 'Give incoming work a clean front door',
+        description: 'Capture requests, prepare context, route ownership, and make the next decision clear.',
+        preview: 'triage',
+        examples: ['Requests', 'Approvals', 'Human handoff'],
+        recipeIds: ['portal-intake', 'inbox-review-queue', 'intake-triage', 'approval-review'],
+        promptExamples: [
+            starterPrompt('portal-intake', 'A client request portal with routing and clear status', 'a client request portal', 'the clients and request types, required information and files, authentication, routing, service expectations, status visibility, notifications, and ownership', 'Create the portal, request records, routing workflow, and a clear operator view with the right next actions.'),
+            starterPrompt('inbox-review-queue', 'A review queue with prepared context and next actions', 'a queue where incoming work is prepared for human review', 'the incoming sources and item types, enrichment needed, urgency and ordering, reviewers, legal states, allowed actions, escalation rules, and approval boundaries', 'Create the queue, underlying records and workflow, and agent-prepared context and next actions for every item.'),
+            starterPrompt('approval-review', 'An approval workflow with owners, evidence, and audit history', 'an approval workflow with clear context and audit history', 'the request types, submitters, required evidence, approvers and delegation, decision rules, deadlines, reminders, notifications, and audit requirements', 'Create the approval records, workflow, review experience, and durable decision history.'),
+        ],
+    },
+    {
+        id: 'automations',
+        name: 'Monitors & operating loops',
+        kicker: 'Keep useful work running in the background',
+        description: 'Watch for change, prepare briefings, and follow up without losing human control.',
+        preview: 'monitor',
+        examples: ['Monitoring', 'Briefings', 'Follow-up'],
+        recipeIds: ['monitor-alert', 'scheduled-briefing', 'follow-up-chaser'],
+        promptExamples: [
+            starterPrompt('monitor-alert', 'A monitor that detects changes and alerts the right person', 'a monitor that detects important changes and alerts the right person', 'the sources to watch, meaningful events, thresholds, exclusions, check frequency, recipients, severity, escalation, and duplicate-alert handling', 'Create the monitor, durable event log, alert workflow, and a clear review path for what changed and why it matters.'),
+            starterPrompt('scheduled-briefing', 'A scheduled morning briefing built from the right sources', 'a useful scheduled morning briefing', 'the audience, decisions it supports, source systems, metrics and exceptions, preferred structure and tone, delivery time and surface, ownership, and follow-up expectations', 'Create the source collection, scheduled workflow, and concise agent-written briefing with links to the underlying evidence.'),
+            starterPrompt('follow-up-chaser', 'A follow-up loop for stalled commitments and next messages', 'a follow-up chaser for stalled commitments', 'the commitments or relationships to track, owners, promises, due dates, stale rules, priority, follow-up tone, approval boundaries, escalation, and delivery channel', 'Create the tracking records, scheduled checks, and agent-prepared follow-ups while keeping external messages behind explicit approval.'),
+        ],
+    },
+];
+
+export const FEATURED_STARTER_THEMES = STARTER_THEMES.slice(0, 5);
 
 const CATEGORY_ACCENT: Record<RecipeCategory, RecipeAccent> = RECIPE_CATEGORIES.reduce(
     (acc, meta) => ({ ...acc, [meta.id]: meta.accent }),
@@ -67,135 +268,224 @@ export const RECIPE_BUILDS_LABEL: Record<RecipeBuilds, string> = {
     pod: 'Sets up the pod',
 };
 
+export const RECIPE_OUTPUT_LABEL: Record<RecipeOutput, string> = {
+    app: 'App',
+    agent: 'Agent',
+    workflow: 'Workflow',
+    surface: 'Surface',
+    pod: 'Pod setup',
+    table: 'Data',
+    files: 'Knowledge',
+    schedule: 'Schedule',
+};
+
 const SEED = 'Seed a few believable sample rows so it feels alive and is testable the moment it opens.';
 
 const PROMPT_RECIPES: Recipe[] = [
-    // ── Quick wins ────────────────────────────────────────────────
+    // ── Recognizable app shapes ───────────────────────────────────
     {
-        id: 'meal-log-bot', name: 'Meal log from Telegram', category: 'quick-win', builds: 'surface', featured: true,
-        blurb: 'Text what you ate to a Telegram bot; ask “how did I eat this week?” anytime, or open a simple log.',
-        source: { kind: 'prompt', prompt: `Set up a meal logging bot for this pod.\nI message a Telegram bot what I ate — a line of text or a photo — and an agent logs it with the rough nutrition and the time. I can ask "how did I eat this week?" right in chat, or open a small app to browse the log and see trends.\n${SEED}\nConnect the Telegram surface as part of setup and confirm before anything external. Keep it calm and personal.` },
+        id: 'dashboard-internal-tool', name: 'Custom operations dashboard', kicker: 'Shape it around the decisions your team makes.',
+        category: 'app-shapes', builds: 'app', outputs: ['app', 'table', 'agent'], preview: 'dashboard', featured: true,
+        blurb: 'A purpose-built operating screen with live data, clear actions, and an agent keeping it current.',
+        examples: ['Sales pipeline', 'Project operations', 'Renewal review'],
+        highlights: ['A working app shaped around the decisions you make', 'Structured data behind every view and action', 'An agent that updates, drafts, and flags what needs attention'],
+        source: { kind: 'prompt', prompt: `Build a dashboard and internal tool for this pod.\nStart by asking what work the user needs to see and operate, then build a focused app, the tables behind it, and an agent that keeps the view useful. Avoid a generic KPI wall: design around the decisions, transitions, and next actions in this specific workflow.\n${SEED}\nOpen the finished app and show one realistic action working end to end.` },
     },
     {
-        id: 'personal-crm', name: 'Personal CRM', category: 'quick-win', builds: 'app', featured: true,
-        blurb: 'Keep track of people you meet, with a nudge when it’s time to follow up.',
-        source: { kind: 'prompt', prompt: `Build a personal CRM app for this pod.\nTrack people I meet with how we met, the last touch, and the next follow-up, and have an agent nudge me when someone is going cold.\n${SEED}\nKeep it minimal, calm, and personal — not enterprise CRM chrome.` },
+        id: 'crm-pipeline-app', name: 'Customer pipeline console', kicker: 'Accounts, opportunities, and next actions in one operating view.',
+        category: 'app-shapes', builds: 'app', outputs: ['app', 'table', 'agent', 'workflow'], preview: 'dashboard',
+        blurb: 'A working relationship and pipeline system with clear ownership, movement, and agent-prepared follow-up.',
+        examples: ['Sales pipeline', 'Partnerships', 'Customer success'],
+        highlights: ['A customer and opportunity data model', 'Pipeline views built around movement and ownership', 'Agent-prepared research and next actions'],
+        source: { kind: 'prompt', prompt: `Build a customer pipeline console for this pod.\nAsk what relationship or revenue motion the team runs, then create the account, contact, opportunity, and activity data it actually needs. Build a focused app for moving work through the pipeline and an agent that prepares research and next actions without sending anything externally.\n${SEED}\nDemonstrate one opportunity moving forward with its history intact.` },
     },
     {
-        id: 'reading-digest', name: 'Reading list digest', category: 'quick-win', builds: 'app',
-        blurb: 'Drop in links; an agent summarizes them and assembles a weekly digest.',
-        source: { kind: 'prompt', prompt: `Build a reading list app for this pod.\nI drop in links or articles; an agent saves each with a short summary and tags, and assembles a weekly digest of what I saved.\n${SEED}\nKeep it minimal and calm.` },
+        id: 'project-delivery-console', name: 'Project delivery console', kicker: 'Plans, owners, risks, and decisions without the project-management sprawl.',
+        category: 'app-shapes', builds: 'app', outputs: ['app', 'table', 'agent', 'workflow'], preview: 'dashboard',
+        blurb: 'A calm delivery workspace that shows what is moving, what is blocked, and what needs a decision.',
+        examples: ['Client delivery', 'Product launches', 'Operations projects'],
+        highlights: ['Projects, milestones, owners, and risks', 'A decision-oriented delivery view', 'Agent-written status and blocker summaries'],
+        source: { kind: 'prompt', prompt: `Build a project delivery console for this pod.\nAsk how the team plans and reviews delivery, then create the smallest useful model for projects, milestones, owners, risks, and decisions. Build a calm app that foregrounds movement and blockers, plus an agent that prepares status summaries from the underlying work.\n${SEED}\nShow one project review from signal to decision.` },
     },
     {
-        id: 'meeting-notes', name: 'Meeting notes → actions', category: 'quick-win', builds: 'app',
-        blurb: 'Paste a transcript; get clean notes, decisions, and action items with owners.',
-        source: { kind: 'prompt', prompt: `Build a meeting notes app for this pod.\nI paste a transcript or rough notes; an agent extracts a clean summary, the decisions, and action items with owners and due dates.\n${SEED}\nKeep it minimal and operational.` },
+        id: 'inbox-review-queue', name: 'Inbox & review queue', kicker: 'Everything that needs a human, already prepared.',
+        category: 'app-shapes', builds: 'app', outputs: ['app', 'table', 'agent', 'workflow'], preview: 'inbox',
+        blurb: 'Incoming work arrives sorted, enriched, and ready to approve, reply, assign, or escalate.',
+        examples: ['Support inbox', 'Lead review', 'Content approvals'],
+        highlights: ['A calm queue ordered by urgency and status', 'Agent-drafted context and next actions on every item', 'Clear approve, reply, assign, and escalate controls'],
+        source: { kind: 'prompt', prompt: `Build an inbox and review queue app for this pod.\nCreate a focused operator experience where incoming items arrive with urgency, context, an owner, and an agent-prepared next action. Include the workflow and data needed to move items through clear legal states. Keep consequential actions behind human approval.\n${SEED}\nShow the user the first prepared item and how it moves through the queue.` },
     },
     {
-        id: 'job-tracker', name: 'Job connector tracker', category: 'quick-win', builds: 'app',
-        blurb: 'Roles, stage, and the next action for each — with a nudge on what’s stalled.',
-        source: { kind: 'prompt', prompt: `Build a job connector tracker app for this pod.\nTrack each role with company, stage (applied → screen → onsite → offer), and the next action, and have an agent flag connectors that have gone quiet.\n${SEED}\nKeep it minimal and calm.` },
+        id: 'knowledge-workspace', name: 'Knowledge workspace', kicker: 'Docs, files, and an agent that can actually use them.',
+        category: 'app-shapes', builds: 'app', outputs: ['app', 'files', 'agent'], preview: 'knowledge',
+        blurb: 'A shared place to collect knowledge, find answers, and turn what the team knows into useful work.',
+        examples: ['Team handbook', 'Research library', 'Customer knowledge'],
+        highlights: ['A browsable home for the pod’s docs and files', 'Source-grounded answers with links back to evidence', 'A structure that stays editable as the knowledge grows'],
+        source: { kind: 'prompt', prompt: `Build a knowledge workspace for this pod.\nCreate a calm app for browsing the pod's important files and documents, plus an agent that answers from those sources and links back to evidence. Establish a small, believable information structure and seed example knowledge so search and Q&A work immediately.\nKeep the experience closer to a focused knowledge product than a dashboard.` },
     },
     {
-        id: 'habit-tracker', name: 'Habit tracker', category: 'quick-win', builds: 'app',
-        blurb: 'Log habits, see streaks, and get a gentle weekly recap.',
-        source: { kind: 'prompt', prompt: `Build a habit tracker app for this pod.\nLet me define a few habits, log them daily, and see streaks at a glance, with an agent that writes a short, encouraging weekly recap.\n${SEED}\nKeep it minimal, calm, and personal.` },
-    },
-    {
-        id: 'daily-log', name: 'Daily log', category: 'quick-win', builds: 'app',
-        blurb: 'A standup-for-one: jot what you did; an agent writes your weekly recap.',
-        source: { kind: 'prompt', prompt: `Build a daily log app for this pod — a standup for one person.\nI jot what I did and what's next each day; an agent compiles a weekly recap of progress and open threads.\n${SEED}\nKeep it minimal and calm.` },
-    },
-    {
-        id: 'expense-logger-bot', name: 'Expense logger bot', category: 'quick-win', builds: 'surface',
-        blurb: 'Text a receipt or amount; it stores and categorizes the expense.',
-        source: { kind: 'prompt', prompt: `Set up an expense logger bot for this pod.\nI message the bot a receipt photo or a quick "$42 lunch with Sam"; an agent stores it, categorizes it, and keeps a running total I can review.\n${SEED}` },
-    },
-    {
-        id: 'ask-my-data-bot', name: 'Ask-my-data bot', category: 'quick-win', builds: 'surface',
-        blurb: 'Ask questions in chat; the bot answers from this pod’s data.',
-        source: { kind: 'prompt', prompt: `Set up an ask-my-data bot for this pod.\nPeople ask questions in chat and an agent answers from this pod's tables, files, and records, with a link back to the source.\nSeed a small amount of sample data so questions return real answers immediately.` },
-    },
-
-    // ── For creators & indies ─────────────────────────────────────
-    {
-        id: 'content-idea-engine', name: 'Content idea engine', category: 'creators', builds: 'app', featured: true,
-        blurb: 'Rough notes in, post and thread drafts out — you pick what ships.',
-        source: { kind: 'prompt', prompt: `Build a content idea engine app for this pod.\nI drop in rough notes or a link; an agent turns each into a few post or thread drafts in my voice, and I mark which ones to keep.\n${SEED}\nKeep it minimal and creative, not a generic dashboard.` },
-    },
-    {
-        id: 'newsletter-curator', name: 'Newsletter curator', category: 'creators', builds: 'app',
-        blurb: 'Collect links all week; an agent drafts the issue for you to edit.',
-        source: { kind: 'prompt', prompt: `Build a newsletter curator app for this pod.\nI collect links and notes through the week; an agent groups them into themes and drafts the next issue with short blurbs for me to edit.\n${SEED}\nKeep it minimal and calm.` },
-    },
-    {
-        id: 'competitor-watch', name: 'Competitor / price watch', category: 'creators', builds: 'workflow',
-        blurb: 'Monitors pages on a schedule and flags meaningful changes.',
-        source: { kind: 'prompt', prompt: `Build a competitor watch for this pod.\nGiven a few pages or competitors, a scheduled workflow checks them regularly and flags meaningful changes (pricing, messaging, launches) with a short note on what changed.\n${SEED}` },
-    },
-    {
-        id: 'lead-finder', name: 'Lead finder + outreach', category: 'creators', builds: 'app',
-        blurb: 'A list of leads with a drafted, personalized first message each.',
-        source: { kind: 'prompt', prompt: `Build a lead finder app for this pod.\nKeep a list of leads with the context that matters, and have an agent draft a personalized first outreach message for each that I approve before sending.\n${SEED}\nKeep human approval before any outbound message.` },
+        id: 'portal-intake', name: 'Portal & intake', kicker: 'A clean front door for requests, submissions, and status.',
+        category: 'app-shapes', builds: 'app', outputs: ['app', 'table', 'workflow', 'agent'], preview: 'portal',
+        blurb: 'Collect structured requests, route them to the right people, and give submitters a clear next step.',
+        examples: ['Client requests', 'Hiring intake', 'Service desk'],
+        highlights: ['A focused submission experience with the right fields', 'Automatic validation, enrichment, and routing', 'A review view for the people handling each request'],
+        source: { kind: 'prompt', prompt: `Build a portal and intake app for this pod.\nCreate a polished submission experience, the table that stores requests, and a workflow that validates, enriches, and routes each one. Add an internal review view and use an agent only where drafting or classification genuinely helps.\n${SEED}\nDemonstrate one submission arriving and being routed.` },
     },
 
-    // ── For consultants & freelancers ─────────────────────────────
+    // ── Agents in the channels people already use ─────────────────
     {
-        id: 'client-invoice-tracker', name: 'Client & invoice tracker', category: 'consultants', builds: 'app',
-        blurb: 'Who owes what, what’s overdue, and a drafted reminder ready to send.',
-        source: { kind: 'prompt', prompt: `Build a client and invoice tracker app for this pod.\nTrack clients, their invoices, amounts, and status (draft → sent → paid → overdue), and have an agent draft a polite reminder for anything overdue that I approve before sending.\n${SEED}\nKeep it minimal and operational.` },
+        id: 'whatsapp-agent', name: 'Custom WhatsApp agent', kicker: 'Define the job; keep the conversation and handoff in one pod.',
+        category: 'agent-channels', builds: 'surface', outputs: ['agent', 'surface', 'app', 'table'], preview: 'whatsapp', platforms: ['WHATSAPP'], featured: true,
+        blurb: 'A useful WhatsApp agent for customers, plus an inbox where your team reviews context and takes over.',
+        examples: ['Customer support', 'Lead capture', 'Field updates'],
+        highlights: ['A WhatsApp identity connected to a focused agent', 'A companion inbox for history, escalation, and handoff', 'Structured records created from every useful conversation'],
+        source: { kind: 'prompt', prompt: `Set up a WhatsApp agent and companion operator inbox for this pod.\nAsk what the agent should handle, then create the agent, the WhatsApp surface, a table for the important records, and a small app where a human can review conversations, see context, and take over. Use Lemma's managed identity or help connect the user's account, and confirm before external actions.\n${SEED}\nFinish with one safe test conversation and show it in the inbox.` },
     },
     {
-        id: 'proposal-drafter', name: 'Proposal drafter', category: 'consultants', builds: 'app',
-        blurb: 'Capture the brief; an agent drafts a tailored proposal you refine.',
-        source: { kind: 'prompt', prompt: `Build a proposal drafter app for this pod.\nI capture a client brief and scope; an agent drafts a tailored proposal with scope, timeline, and price that I refine before it goes out.\n${SEED}\nKeep it minimal and calm.` },
+        id: 'whatsapp-support-desk', name: 'WhatsApp support & handoff', kicker: 'Resolve the routine; prepare the rest for a person.',
+        category: 'agent-channels', builds: 'surface', outputs: ['agent', 'surface', 'app', 'table'], preview: 'whatsapp', platforms: ['WHATSAPP'],
+        blurb: 'A customer support agent with grounded answers, case history, urgency, and a clean human takeover path.',
+        examples: ['Order questions', 'Service requests', 'Customer care'],
+        highlights: ['Grounded answers from approved knowledge', 'A durable customer and case history', 'Urgent and uncertain conversations routed to people'],
+        source: { kind: 'prompt', prompt: `Build a WhatsApp customer support desk for this pod.\nCreate a support agent grounded in the pod's approved knowledge, a WhatsApp surface, customer and case records, and an operator inbox for context, urgency, and human takeover. The agent may answer routine questions but must escalate uncertainty and confirm before any consequential action.\n${SEED}\nRun a safe test that demonstrates both resolution and handoff.` },
+    },
+    {
+        id: 'whatsapp-lead-qualifier', name: 'WhatsApp lead qualifier', kicker: 'Respond quickly, learn what matters, and hand over a prepared lead.',
+        category: 'agent-channels', builds: 'surface', outputs: ['agent', 'surface', 'table', 'workflow'], preview: 'whatsapp', platforms: ['WHATSAPP'],
+        blurb: 'A conversational front door that captures intent, qualifies fit, and prepares the next sales action.',
+        examples: ['Inbound enquiries', 'Property leads', 'Service sales'],
+        highlights: ['Natural qualification around the team’s real criteria', 'Structured lead and conversation records', 'A clear handoff with context and suggested next step'],
+        source: { kind: 'prompt', prompt: `Build a WhatsApp lead qualification agent for this pod.\nAsk how the team defines fit and what a useful handoff contains, then create the agent, WhatsApp surface, lead data, and routing workflow. Keep the conversation natural, capture only useful information, and never invent pricing or commitments.\n${SEED}\nDemonstrate one lead moving from first message to a prepared handoff.` },
+    },
+    {
+        id: 'whatsapp-field-ops', name: 'WhatsApp field operations', kicker: 'Let people report work from the field without learning another system.',
+        category: 'agent-channels', builds: 'surface', outputs: ['agent', 'surface', 'app', 'table'], preview: 'whatsapp', platforms: ['WHATSAPP'],
+        blurb: 'Capture updates, photos, issues, and confirmations in WhatsApp while operations sees a structured live view.',
+        examples: ['Site updates', 'Service visits', 'Delivery checks'],
+        highlights: ['Guided field updates through chat', 'Structured jobs, evidence, and exceptions', 'An operations view for review and escalation'],
+        source: { kind: 'prompt', prompt: `Build a WhatsApp field operations system for this pod.\nAsk what field event or job people need to report, then create the WhatsApp agent, structured records, evidence handling, and an operations app for progress, exceptions, and review. Keep the chat flow short and usable on the move.\n${SEED}\nDemonstrate one field update appearing in the operations view.` },
+    },
+    {
+        id: 'telegram-agent-app', name: 'Custom Telegram bot + mini app', kicker: 'Define the bot and the visual companion it should open.',
+        category: 'agent-channels', builds: 'surface', outputs: ['agent', 'surface', 'app', 'table'], preview: 'telegram', platforms: ['TELEGRAM'], featured: true,
+        blurb: 'A Telegram bot for fast input and answers, paired with an app for records, trends, and human review.',
+        examples: ['Personal logging', 'Team intake', 'Ask my data'],
+        highlights: ['A Telegram bot people can use immediately', 'A companion app for records, trends, and review', 'One shared data model across chat and the app'],
+        source: { kind: 'prompt', prompt: `Set up a Telegram agent with a companion app for this pod.\nAsk what people should message the bot, then create the agent, Telegram surface, structured data, and a small app for browsing records, seeing useful summaries, and reviewing anything the agent could not resolve. Use Lemma's bot or help connect the user's own bot, and confirm before external actions.\n${SEED}\nFinish by showing a test Telegram interaction reflected inside the app.` },
+    },
+    {
+        id: 'telegram-community-concierge', name: 'Telegram community concierge', kicker: 'Welcome, answer, route, and keep the community context usable.',
+        category: 'agent-channels', builds: 'surface', outputs: ['agent', 'surface', 'app', 'table'], preview: 'telegram', platforms: ['TELEGRAM'],
+        blurb: 'A community bot for grounded answers and intake, with a companion app for topics, people, and unresolved needs.',
+        examples: ['Member community', 'Cohort support', 'Customer group'],
+        highlights: ['A helpful bot for DMs and selected groups', 'Source-grounded answers and topic capture', 'A companion view for unresolved questions and member needs'],
+        source: { kind: 'prompt', prompt: `Build a Telegram community concierge for this pod.\nCreate a bot grounded in approved community knowledge, route the right groups and DMs, capture useful topics and unresolved needs, and build a companion app for human review. Avoid noisy proactive posting and confirm before inviting or messaging people.\n${SEED}\nShow one answered question and one escalated need.` },
+    },
+    {
+        id: 'telegram-personal-logger', name: 'Telegram capture & logbook', kicker: 'Message the bot in seconds; organize and revisit it in the mini app.',
+        category: 'agent-channels', builds: 'surface', outputs: ['agent', 'surface', 'app', 'table'], preview: 'telegram', platforms: ['TELEGRAM'],
+        blurb: 'A fast personal or team capture bot that turns messages into structured, searchable records.',
+        examples: ['Research notes', 'Expenses', 'Work log'],
+        highlights: ['Low-friction capture through Telegram', 'Agent-assisted extraction into useful fields', 'A mini app for search, trends, and correction'],
+        source: { kind: 'prompt', prompt: `Build a Telegram capture and logbook system for this pod.\nAsk what people need to log, then create the bot, structured data, extraction agent, and a mini app for browsing, searching, correcting, and summarizing entries. Accept text and useful attachments without making the chat flow heavy.\n${SEED}\nDemonstrate one message becoming an editable record.` },
+    },
+    {
+        id: 'telegram-approval-bot', name: 'Telegram approval bot', kicker: 'Bring a prepared decision to the right person, wherever they are.',
+        category: 'agent-channels', builds: 'surface', outputs: ['agent', 'surface', 'workflow', 'app'], preview: 'telegram', platforms: ['TELEGRAM'],
+        blurb: 'A decision bot with evidence, thresholds, and a mini app for queues, audit history, and deeper review.',
+        examples: ['Spend approval', 'Exceptions', 'Content review'],
+        highlights: ['Concise decision requests in Telegram', 'Explicit approve, reject, revise, and escalate paths', 'A durable queue and audit history in the companion app'],
+        source: { kind: 'prompt', prompt: `Build a Telegram approval bot with a companion app for this pod.\nAsk what decisions need approval and which evidence and thresholds matter, then create the workflow, Telegram surface, approval agent, and mini app for queues and audit history. Every consequential action must wait for an explicit human decision.\n${SEED}\nDemonstrate one safe approval from request through recorded decision.` },
+    },
+    {
+        id: 'slack-agent', name: 'Custom Slack agent', kicker: 'Give a focused job to a teammate in channels and DMs.',
+        category: 'agent-channels', builds: 'surface', outputs: ['agent', 'surface', 'workflow', 'schedule'], preview: 'slack', platforms: ['SLACK'], featured: true,
+        blurb: 'Give the pod a focused Slack presence that answers, routes work, and posts useful updates.',
+        examples: ['Team Q&A', 'Standup digest', 'Operations assistant'],
+        highlights: ['A Slack agent for DMs and selected channels', 'Channel-aware routing and mention behaviour', 'Optional scheduled digests and proactive updates'],
+        source: { kind: 'prompt', prompt: `Set up a Slack agent for this pod.\nAsk what job it should own, then create the agent, connect the Slack surface, route the relevant channels, and add a scheduled digest or proactive update only when it helps the use case. Seed believable context so the first DM or mention produces a useful answer.\nConfirm before connecting accounts, posting messages, or inviting people.` },
+    },
+    {
+        id: 'slack-knowledge-teammate', name: 'Slack knowledge teammate', kicker: 'Answer in the flow of work and point back to the source.',
+        category: 'agent-channels', builds: 'surface', outputs: ['agent', 'surface', 'files'], preview: 'slack', platforms: ['SLACK'],
+        blurb: 'A channel-aware teammate that answers from pod knowledge and escalates when the evidence is thin.',
+        examples: ['Policy Q&A', 'Product knowledge', 'Team handbook'],
+        highlights: ['Grounded answers in DMs and selected channels', 'Links back to source evidence', 'A clear uncertainty and escalation policy'],
+        source: { kind: 'prompt', prompt: `Build a Slack knowledge teammate for this pod.\nGround the agent in the pod's approved files and docs, connect it to the relevant Slack DMs and channels, and require answers to point back to source evidence. Define when it should stay quiet, express uncertainty, or route a question to a person.\nSeed enough believable knowledge to run a safe first test.` },
+    },
+    {
+        id: 'slack-incident-coordinator', name: 'Slack incident coordinator', kicker: 'Capture the signal, organize the response, and keep the channel current.',
+        category: 'agent-channels', builds: 'surface', outputs: ['agent', 'surface', 'workflow', 'table'], preview: 'slack', platforms: ['SLACK'],
+        blurb: 'An incident-room agent that structures reports, tracks owners and decisions, and prepares status updates.',
+        examples: ['Service incidents', 'Customer escalations', 'Operations exceptions'],
+        highlights: ['Structured incident intake from Slack', 'Owners, decisions, and timeline captured durably', 'Prepared status updates held for human review'],
+        source: { kind: 'prompt', prompt: `Build a Slack incident coordinator for this pod.\nAsk what counts as an incident and how response is run, then create the agent, Slack routing, incident records, and workflow for severity, owners, decisions, and status. It may prepare updates but must confirm before posting broadly or closing an incident.\n${SEED}\nDemonstrate one test incident from report to prepared update.` },
+    },
+    {
+        id: 'slack-standup-digest', name: 'Slack standup & digest', kicker: 'Collect updates with less ceremony and publish a useful team picture.',
+        category: 'agent-channels', builds: 'surface', outputs: ['agent', 'surface', 'workflow', 'schedule'], preview: 'slack', platforms: ['SLACK'],
+        blurb: 'A scheduled team ritual that gathers focused updates, spots blockers, and prepares a concise digest.',
+        examples: ['Daily standup', 'Weekly operations', 'Project pulse'],
+        highlights: ['Scheduled prompts in the right place', 'A concise digest organized around movement and blockers', 'Human review before broad or external posting'],
+        source: { kind: 'prompt', prompt: `Build a Slack standup and digest loop for this pod.\nAsk who the ritual serves, what questions matter, and the right cadence, then create the schedule, Slack surface, response workflow, and agent-written digest. Optimize for a useful team picture rather than repetitive status prose. Confirm before sending prompts or publishing the digest.\n${SEED}` },
+    },
+    {
+        id: 'email-agent', name: 'Gmail or Outlook agent', kicker: 'Turn a mailbox into a calm, reviewable work queue.',
+        category: 'agent-channels', builds: 'surface', outputs: ['agent', 'surface', 'app', 'workflow'], preview: 'email', platforms: ['GMAIL', 'OUTLOOK'],
+        blurb: 'Classify incoming mail, prepare replies, and bring only the decisions that need a person into one queue.',
+        examples: ['Support triage', 'Vendor requests', 'Executive inbox'],
+        highlights: ['A connected Gmail or Outlook mailbox with safe filters', 'Agent-drafted replies held for review', 'A queue for urgency, ownership, and escalation'],
+        source: { kind: 'prompt', prompt: `Set up an email agent for this pod using Gmail or Outlook.\nAsk which mailbox and messages matter, then create the agent, connect the email surface with safe sender filters, store the useful work, and build a small review queue for drafted replies, urgency, ownership, and escalation. Keep every outbound reply behind explicit approval.\n${SEED}` },
+    },
+    {
+        id: 'teams-agent', name: 'Microsoft Teams agent', kicker: 'Bring the pod into Teams chats and channels.',
+        category: 'agent-channels', builds: 'surface', outputs: ['agent', 'surface', 'workflow'], preview: 'teams', platforms: ['TEAMS'],
+        blurb: 'A Teams-native agent for answers, routed requests, and useful operational updates.',
+        examples: ['Policy Q&A', 'IT intake', 'Project updates'],
+        highlights: ['An agent available in Teams DMs and selected channels', 'Channel routing to the right pod capability', 'Clear escalation when a person needs to step in'],
+        source: { kind: 'prompt', prompt: `Set up a Microsoft Teams agent for this pod.\nAsk what job it should own, then create the agent, connect the Teams surface, route relevant channels, and add only the workflow needed to answer, capture, or escalate that work. Seed believable context and confirm before connecting accounts or sending external messages.` },
     },
 
-    // ── Team operations ───────────────────────────────────────────
+    // ── Durable operating loops ───────────────────────────────────
     {
-        id: 'slack-standup-bot', name: 'Slack standup bot', category: 'team-ops', builds: 'surface', featured: true,
-        blurb: 'People message the bot their update; it posts a compiled team digest.',
-        source: { kind: 'prompt', prompt: `Set up a Slack standup bot for this pod.\nPeople message the bot their daily update; an agent collects them and posts a compiled digest with blockers and next actions to a channel.\nSeed a couple of believable sample updates so it's testable immediately.` },
+        id: 'monitor-alert', name: 'Monitor & alert', kicker: 'Keep watching. Speak up only when something matters.',
+        category: 'operating-loops', builds: 'workflow', outputs: ['workflow', 'schedule', 'table', 'agent'], preview: 'monitor',
+        blurb: 'Watch pages, records, prices, or signals on a schedule and surface only meaningful changes.',
+        examples: ['Competitor changes', 'Pricing watch', 'Account risk'],
+        highlights: ['A scheduled watcher with a durable change history', 'Rules that separate meaningful movement from noise', 'A concise alert delivered where the team works'],
+        source: { kind: 'prompt', prompt: `Build a monitor-and-alert loop for this pod.\nAsk what should be watched and what counts as meaningful, then create the data history, checking workflow, schedule, and concise agent-written alert. Deliver alerts through the most appropriate existing surface and confirm before adding any external connection.\n${SEED}` },
     },
     {
-        id: 'email-intake-bot', name: 'Email intake & triage', category: 'team-ops', builds: 'surface',
-        blurb: 'Forward email to an address; it files, tags, and drafts a reply.',
-        source: { kind: 'prompt', prompt: `Set up an email intake bot for this pod.\nI forward email to a pod address; an agent files it, tags urgency, and drafts a reply for me to approve before anything is sent.\nKeep human approval before any outbound reply.\n${SEED}` },
+        id: 'intake-triage', name: 'Intake & triage', kicker: 'Turn messy incoming work into a clean, owned queue.',
+        category: 'operating-loops', builds: 'workflow', outputs: ['workflow', 'table', 'agent', 'app'], preview: 'triage',
+        blurb: 'Capture requests from the right source, classify them, assign ownership, and prepare the next action.',
+        examples: ['Support requests', 'Sales leads', 'Internal requests'],
+        highlights: ['One structured queue across the chosen intake source', 'Automatic urgency, classification, and ownership suggestions', 'A human-ready next action on every item'],
+        source: { kind: 'prompt', prompt: `Build an intake-and-triage loop for this pod.\nAsk where requests arrive and how they should be owned, then create the structured queue, agent classification, routing workflow, and a focused app for the people handling the work. Preserve human control over irreversible or outbound actions.\n${SEED}` },
     },
     {
-        id: 'site-support-bot', name: 'Website support bot', category: 'team-ops', builds: 'surface',
-        blurb: 'Answers visitor questions from your docs, escalates the rest to a human.',
-        source: { kind: 'prompt', prompt: `Set up a website support bot for this pod.\nVisitors ask questions and an agent answers from this pod's docs, escalating anything uncertain to a human with the context attached.\n${SEED}` },
+        id: 'approval-review', name: 'Approvals & reviews', kicker: 'Bring the context. Let a person make the call.',
+        category: 'operating-loops', builds: 'app', outputs: ['app', 'workflow', 'table', 'agent'], preview: 'approval',
+        blurb: 'A review queue with thresholds, evidence, and one clear decision for every item.',
+        examples: ['Spend approval', 'Content review', 'Customer exceptions'],
+        highlights: ['A focused queue of decisions waiting on people', 'Evidence, thresholds, and an agent-prepared recommendation', 'Explicit approve, reject, revise, and escalate paths'],
+        source: { kind: 'prompt', prompt: `Build an approvals-and-reviews system for this pod.\nAsk what requires approval and which thresholds matter, then create the queue app, underlying data, workflow states, and agent-prepared context for each decision. Every consequential action must wait for an explicit human choice.\n${SEED}` },
     },
     {
-        id: 'renewal-review', name: 'Renewal review app', category: 'team-ops', builds: 'app',
-        blurb: 'Upcoming renewals with account health, risk flags, and one-click approve or escalate.',
-        source: { kind: 'prompt', prompt: `Build a renewal review app for this pod.\nList upcoming renewals with account health, a risk flag, and the latest context for each account, and let a teammate approve the renewal or escalate it with a reason in one click.\n${SEED}\nKeep it minimal, calm, and operational — show the work, not generic dashboard chrome.` },
+        id: 'scheduled-briefing', name: 'Scheduled briefing', kicker: 'A useful update, assembled and delivered on time.',
+        category: 'operating-loops', builds: 'workflow', outputs: ['workflow', 'schedule', 'agent', 'surface'], preview: 'briefing',
+        blurb: 'Collect the right signals, write a concise briefing, and deliver it on a reliable cadence.',
+        examples: ['Daily operations', 'Weekly leadership', 'Customer health'],
+        highlights: ['A scheduled workflow gathering the right source material', 'A concise briefing written for its actual audience', 'Delivery through Slack, Teams, email, or another active surface'],
+        source: { kind: 'prompt', prompt: `Build a scheduled briefing loop for this pod.\nAsk what the audience needs to know and on what cadence, then create the source collection, scheduled workflow, and agent-written briefing. Deliver it through an existing surface when available, or offer to connect the best one with approval. Seed a believable first briefing so the format is immediately visible.` },
     },
     {
-        id: 'support-triage', name: 'Support triage app', category: 'team-ops', builds: 'app',
-        blurb: 'Each incoming ticket opens with a drafted reply, urgency, and a suggested owner.',
-        source: { kind: 'prompt', prompt: `Build a support triage app for this pod.\nEach incoming ticket opens with a drafted reply already written, a detected urgency, and a suggested owner, so a teammate can send, refine, or reassign in one place.\n${SEED}\nLet an agent draft and a human decide.` },
-    },
-    {
-        id: 'approvals-queue', name: 'Approvals queue', category: 'team-ops', builds: 'app',
-        blurb: 'Pending items with context and thresholds — approve or reject with a reason.',
-        source: { kind: 'prompt', prompt: `Build an approvals queue app for this pod.\nShow pending items that need a human decision, each with the context and the threshold that triggered it, and let a teammate approve or reject with a reason. Gate anything irreversible behind explicit approval.\n${SEED}\nKeep it minimal, calm, and operational.` },
-    },
-    {
-        id: 'standup-digest', name: 'Standup digest', category: 'team-ops', builds: 'app',
-        blurb: 'Gathers each person’s update and surfaces blockers and next actions.',
-        source: { kind: 'prompt', prompt: `Build a daily standup app for this pod.\nGather each person’s update, then surface the blockers and the next actions across the team in one view. Let an agent compile the digest and a human edit it before it goes out.\n${SEED}\nKeep it minimal and operational.` },
-    },
-    {
-        id: 'content-pipeline', name: 'Content pipeline', category: 'team-ops', builds: 'app',
-        blurb: 'Ideas → drafts → review → scheduled, with an agent that drafts and a human who approves.',
-        source: { kind: 'prompt', prompt: `Build a content pipeline app for this pod.\nMove pieces through ideas → drafts → review → scheduled, with clear statuses and legal transitions. An agent drafts and suggests; a human reviews and approves before anything is scheduled.\n${SEED}\nKeep it minimal, calm, and operational.` },
-    },
-    {
-        id: 'lightweight-crm', name: 'Lightweight CRM', category: 'team-ops', builds: 'app',
-        blurb: 'Accounts and follow-ups with next actions, owners, and an agent that flags what’s slipping.',
-        source: { kind: 'prompt', prompt: `Build a lightweight CRM app for this pod.\nTrack accounts and their follow-ups with an owner, a next action, and the latest update for each, and have an agent flag the relationships that are slipping so a human can act.\n${SEED}\nKeep it minimal and operational; show the work, not generic CRM chrome.` },
+        id: 'follow-up-chaser', name: 'Follow-up & chase', kicker: 'Keep promises, deadlines, and relationships from going quiet.',
+        category: 'operating-loops', builds: 'workflow', outputs: ['workflow', 'schedule', 'table', 'agent'], preview: 'follow-up',
+        blurb: 'Track what is waiting, notice what has stalled, and prepare the next follow-up for approval.',
+        examples: ['Sales follow-ups', 'Invoice reminders', 'Project commitments'],
+        highlights: ['A durable record of owners, promises, and next actions', 'Scheduled checks for anything becoming stale', 'A prepared follow-up that stays behind human approval'],
+        source: { kind: 'prompt', prompt: `Build a follow-up-and-chase loop for this pod.\nAsk what commitments or relationships must not go quiet, then create the tracking data, scheduled stale-item check, and agent-prepared follow-up. Keep external messages behind explicit approval and show the user which item needs attention first.\n${SEED}` },
     },
 ];
 
@@ -203,9 +493,12 @@ function kitToRecipe(kit: KitDefinition): Recipe {
     return {
         id: kit.id,
         name: kit.name,
+        kicker: 'A complete setup from a published source.',
         blurb: kit.description,
         builds: 'pod',
-        category: 'creators',
+        outputs: ['pod'],
+        category: 'published',
+        preview: 'kit',
         source: { kind: 'repo', github: kit.github },
     };
 }
@@ -217,6 +510,23 @@ export const recipeCatalog: Recipe[] = [
 
 export const appRecipes: Recipe[] = recipeCatalog.filter((recipe) => recipe.builds === 'app');
 export const featuredRecipes: Recipe[] = recipeCatalog.filter((recipe) => recipe.featured);
+
+export function getStarterTheme(id: string | null | undefined): StarterTheme | null {
+    if (!id) return null;
+    return STARTER_THEMES.find((theme) => theme.id === id) ?? null;
+}
+
+export function recipesForTheme(theme: StarterTheme): Recipe[] {
+    const recipeById = new Map(recipeCatalog.map((recipe) => [recipe.id, recipe]));
+    return theme.recipeIds.flatMap((recipeId) => {
+        const recipe = recipeById.get(recipeId);
+        return recipe ? [recipe] : [];
+    });
+}
+
+export function getPrimaryThemeForRecipe(recipe: Recipe): StarterTheme | null {
+    return STARTER_THEMES.find((theme) => theme.recipeIds.includes(recipe.id)) ?? null;
+}
 
 export function getRecipeById(id: string | null | undefined): Recipe | null {
     if (!id) return null;
@@ -286,7 +596,7 @@ export interface RecipeLaunch {
 
 function buildRecipePromptInstructions(recipe: Recipe): string {
     const resource = recipe.builds === 'app'
-        ? 'app app'
+        ? 'app'
         : recipe.builds === 'agent'
             ? 'agent'
             : recipe.builds === 'workflow'
@@ -297,6 +607,8 @@ function buildRecipePromptInstructions(recipe: Recipe): string {
 
     const lines = [
         `You are helping build the "${recipe.name}" recipe as a Lemma ${resource} in the current pod.`,
+        `The coherent first version is expected to include: ${recipe.outputs.map((output) => RECIPE_OUTPUT_LABEL[output]).join(', ')}.`,
+        ...(recipe.platforms?.length ? [`The intended external surface is: ${recipe.platforms.join(' or ')}.`] : []),
         'Use the user-visible message as the product intent. Do not repeat these hidden instructions back to the user.',
         'Inspect relevant pod context and existing resources before creating anything; reuse what already fits.',
         'Build the smallest useful first version. Keep it minimal, calm, and operational; avoid generic dashboard chrome.',
@@ -329,7 +641,14 @@ export const FIRST_RUN_DELIGHT = [
 
 // The message + hidden instructions + metadata used to open a full conversation
 // for a recipe (prompt recipes seed an intent; repo recipes seed the kit install).
-export function getRecipeLaunch(recipe: Recipe, opts?: { podName?: string | null; mode?: RecipeMode; firstRun?: boolean }): RecipeLaunch {
+export interface RecipeLaunchOptions {
+    podName?: string | null;
+    mode?: RecipeMode;
+    firstRun?: boolean;
+    message?: string | null;
+}
+
+export function getRecipeLaunch(recipe: Recipe, opts?: RecipeLaunchOptions): RecipeLaunch {
     const launch: RecipeLaunch = recipe.source.kind === 'repo'
         ? (() => {
             const kit = recipeToKit(recipe) as KitDefinition;
@@ -337,13 +656,31 @@ export function getRecipeLaunch(recipe: Recipe, opts?: { podName?: string | null
             return {
                 message: buildKitAssistantOpeningMessage(kit, mode),
                 instructions: buildKitAssistantInstructions(kit, mode, opts?.podName),
-                metadata: { source: 'recipe', recipe_id: recipe.id, recipe_kind: 'repo', github: (recipe.source as { github: string }).github, install_mode: mode, builds: recipe.builds },
+                metadata: {
+                    source: 'recipe',
+                    recipe_id: recipe.id,
+                    recipe_kind: 'repo',
+                    github: (recipe.source as { github: string }).github,
+                    install_mode: mode,
+                    builds: recipe.builds,
+                    outputs: recipe.outputs,
+                    category: recipe.category,
+                },
             };
         })()
         : {
-            message: recipe.source.prompt,
+            message: opts?.message?.trim() || recipe.source.prompt,
             instructions: buildRecipePromptInstructions(recipe),
-            metadata: { source: 'recipe', recipe_id: recipe.id, recipe_kind: 'prompt', intent: 'create_resource', resource_type: recipe.builds },
+            metadata: {
+                source: 'recipe',
+                recipe_id: recipe.id,
+                recipe_kind: 'prompt',
+                intent: 'create_resource',
+                resource_type: recipe.builds,
+                outputs: recipe.outputs,
+                category: recipe.category,
+                platforms: recipe.platforms || [],
+            },
         };
 
     if (opts?.firstRun) {
@@ -357,7 +694,7 @@ export function getRecipeLaunch(recipe: Recipe, opts?: { podName?: string | null
 }
 
 // Opening a recipe always lands in the full conversation view, not a background chat.
-export function buildRecipeConversationHref(podId: string, recipe: Recipe, opts?: { podName?: string | null; mode?: RecipeMode; firstRun?: boolean }): string {
+export function buildRecipeConversationHref(podId: string, recipe: Recipe, opts?: RecipeLaunchOptions): string {
     const launch = getRecipeLaunch(recipe, opts);
     const params = new URLSearchParams();
     params.set('assistantMessage', launch.message);

--- a/lemma-frontend/lib/recipes/use-launch-recipe.ts
+++ b/lemma-frontend/lib/recipes/use-launch-recipe.ts
@@ -3,7 +3,7 @@
 import { useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 
-import { buildRecipeConversationHref, type Recipe } from './recipes';
+import { buildRecipeConversationHref, type Recipe, type RecipeLaunchOptions } from './recipes';
 
 // One gesture for "add this recipe to the pod": open a full conversation primed
 // to build it. Prompt recipes seed an intent; repo recipes seed the kit install.
@@ -13,8 +13,8 @@ export function useLaunchRecipe(podId: string, opts?: { podName?: string | null 
     const podName = opts?.podName ?? null;
 
     const launchRecipe = useCallback(
-        (recipe: Recipe) => {
-            router.push(buildRecipeConversationHref(podId, recipe, { podName }));
+        (recipe: Recipe, launchOpts?: Pick<RecipeLaunchOptions, 'message' | 'mode' | 'firstRun'>) => {
+            router.push(buildRecipeConversationHref(podId, recipe, { podName, ...launchOpts }));
         },
         [podId, podName, router],
     );

--- a/lemma-frontend/scripts/design-audit-baseline.json
+++ b/lemma-frontend/scripts/design-audit-baseline.json
@@ -1,6 +1,6 @@
 {
   "informational": {
-    "rawButtonElements": 29,
+    "rawButtonElements": 28,
     "rawSwitchButtonElements": 0,
     "rawFieldElements": 2,
     "inlineEditableFieldElements": 1,

--- a/lemma-frontend/styles/features/resource-ledgers.css
+++ b/lemma-frontend/styles/features/resource-ledgers.css
@@ -118,7 +118,7 @@
   padding-inline: 0.5rem;
   color: var(--text-tertiary);
   font-size: var(--text-xs);
-  font-weight: 500;
+  font-weight: 400;
 }
 
 .pod-header-step[data-state="active"] {
@@ -339,3 +339,837 @@
 .recipe-hero[data-accent="brand"] { --recipe-accent: var(--action-primary); }
 .recipe-hero[data-accent="intelligence"] { --recipe-accent: var(--intelligence); }
 .recipe-hero[data-accent="collaboration"] { --recipe-accent: var(--collaboration); }
+
+/* Starter previews are small product scenes, not generic placeholder stripes. */
+.starter-preview {
+  --starter-accent: var(--intelligence);
+  position: relative;
+  height: 10rem;
+  overflow: hidden;
+  border-bottom: 1px solid color-mix(in srgb, var(--starter-accent) 18%, var(--border-subtle));
+  background:
+    radial-gradient(circle at 82% 12%, color-mix(in srgb, var(--starter-accent) 18%, transparent), transparent 38%),
+    color-mix(in srgb, var(--starter-accent) 5%, var(--surface-2));
+}
+
+.starter-preview-compact {
+  height: 7.5rem;
+  border: 1px solid color-mix(in srgb, var(--starter-accent) 16%, var(--border-subtle));
+  border-radius: var(--radius-lg);
+}
+
+.starter-preview[data-preview="dashboard"],
+.starter-preview[data-preview="portal"] { --starter-accent: var(--action-primary); }
+.starter-preview[data-preview="whatsapp"],
+.starter-preview[data-preview="teams"] { --starter-accent: var(--collaboration); }
+.starter-preview[data-preview="telegram"],
+.starter-preview[data-preview="slack"],
+.starter-preview[data-preview="knowledge"] { --starter-accent: var(--intelligence); }
+.starter-preview[data-preview="email"],
+.starter-preview[data-preview="approval"] { --starter-accent: var(--attention); }
+.starter-preview[data-preview="monitor"],
+.starter-preview[data-preview="briefing"] { --starter-accent: var(--state-info); }
+.starter-preview[data-preview="follow-up"],
+.starter-preview[data-preview="inbox"],
+.starter-preview[data-preview="triage"] { --starter-accent: var(--delight); }
+.starter-preview[data-preview="kit"] { --starter-accent: var(--state-success); }
+
+.starter-preview-window-bar,
+.starter-platform-header {
+  display: flex;
+  height: 2rem;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0 0.75rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--starter-accent) 13%, var(--border-subtle));
+  background: color-mix(in srgb, var(--surface-1) 86%, transparent);
+}
+
+.starter-preview-window-bar > span:not(.starter-preview-window-title) {
+  width: 0.3rem;
+  height: 0.3rem;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--starter-accent) 34%, var(--surface-2));
+}
+
+.starter-preview-window-title {
+  min-width: 0;
+  margin-left: 0.35rem;
+  overflow: hidden;
+  color: var(--text-tertiary);
+  font-size: 0.58rem;
+  font-weight: 500;
+  letter-spacing: 0.015em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.starter-preview-canvas {
+  height: calc(100% - 2rem);
+  padding: 0.65rem;
+}
+
+.starter-dashboard-preview,
+.starter-inbox-preview,
+.starter-knowledge-preview {
+  display: grid;
+  height: 100%;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--starter-accent) 18%, var(--border-subtle));
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--surface-1) 92%, transparent);
+  box-shadow: 0 8px 22px -20px rgba(15, 23, 42, 0.48);
+}
+
+.starter-dashboard-preview { grid-template-columns: 2.15rem 1fr; }
+.starter-mini-sidebar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.42rem;
+  padding-top: 0.65rem;
+  border-right: 1px solid var(--border-subtle);
+  background: color-mix(in srgb, var(--starter-accent) 7%, var(--surface-2));
+}
+.starter-mini-sidebar i {
+  width: 0.72rem;
+  height: 0.72rem;
+  border-radius: var(--radius-xs);
+  background: color-mix(in srgb, var(--starter-accent) 16%, var(--surface-1));
+}
+.starter-mini-sidebar i:first-child { background: color-mix(in srgb, var(--starter-accent) 56%, var(--surface-1)); }
+.starter-dashboard-main { padding: 0.6rem; }
+.starter-dashboard-heading { display: flex; align-items: center; justify-content: space-between; }
+.starter-dashboard-heading span { width: 35%; height: 0.42rem; border-radius: var(--radius-full); background: color-mix(in srgb, var(--text-primary) 58%, transparent); }
+.starter-dashboard-heading i { width: 1.9rem; height: 0.72rem; border-radius: var(--radius-sm); background: color-mix(in srgb, var(--starter-accent) 56%, var(--surface-1)); }
+.starter-dashboard-metrics { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.35rem; margin-top: 0.55rem; }
+.starter-dashboard-metrics span { height: 1.8rem; border: 1px solid color-mix(in srgb, var(--starter-accent) 12%, var(--border-subtle)); border-radius: var(--radius-sm); background: color-mix(in srgb, var(--starter-accent) 5%, var(--surface-1)); }
+.starter-dashboard-table { margin-top: 0.45rem; border-top: 1px solid var(--border-subtle); }
+.starter-dashboard-table i { display: block; height: 0.7rem; border-bottom: 1px solid color-mix(in srgb, var(--border-subtle) 72%, transparent); }
+
+.starter-platform-header { height: 2.35rem; gap: 0.5rem; }
+.starter-platform-logo { display: flex; width: 1.45rem; height: 1.45rem; align-items: center; justify-content: center; border: 1px solid var(--border-subtle); border-radius: var(--radius-sm); background: var(--surface-1); }
+.starter-platform-logo img { width: 0.95rem; height: 0.95rem; object-fit: contain; }
+.starter-platform-label { color: var(--text-primary); font-size: 0.68rem; font-weight: 600; }
+.starter-platform-live { display: inline-flex; align-items: center; gap: 0.3rem; margin-left: auto; color: var(--text-tertiary); font-family: var(--font-mono-family); font-size: 0.55rem; text-transform: uppercase; }
+.starter-platform-live i { width: 0.34rem; height: 0.34rem; border-radius: var(--radius-full); background: var(--state-success); box-shadow: 0 0 0 3px color-mix(in srgb, var(--state-success) 11%, transparent); }
+.starter-platform-body { display: grid; height: calc(100% - 2.35rem); grid-template-columns: 1fr 0.9fr; gap: 0.55rem; padding: 0.65rem; }
+.starter-platform-thread,
+.starter-platform-companion { border: 1px solid color-mix(in srgb, var(--starter-accent) 15%, var(--border-subtle)); border-radius: var(--radius-md); background: color-mix(in srgb, var(--surface-1) 88%, transparent); }
+.starter-platform-thread { display: flex; flex-direction: column; justify-content: flex-end; gap: 0.35rem; padding: 0.55rem; }
+.starter-chat-bubble { display: block; height: 0.85rem; border-radius: 0.5rem 0.5rem 0.18rem; }
+.starter-chat-bubble-user { width: 68%; align-self: flex-end; background: color-mix(in srgb, var(--starter-accent) 32%, var(--surface-2)); }
+.starter-chat-bubble-agent { width: 82%; background: color-mix(in srgb, var(--starter-accent) 10%, var(--surface-2)); }
+.starter-chat-bubble-short { width: 54%; }
+.starter-platform-companion { padding: 0.55rem; }
+.starter-companion-kicker { display: block; color: color-mix(in srgb, var(--starter-accent) 68%, var(--text-secondary)); font-family: var(--font-mono-family); font-size: 0.5rem; letter-spacing: 0.06em; text-transform: uppercase; }
+.starter-companion-title { display: block; width: 76%; height: 0.4rem; margin-top: 0.48rem; border-radius: var(--radius-full); background: color-mix(in srgb, var(--text-primary) 54%, transparent); }
+.starter-companion-line { display: block; width: 92%; height: 0.32rem; margin-top: 0.42rem; border-radius: var(--radius-full); background: color-mix(in srgb, var(--text-tertiary) 25%, transparent); }
+.starter-companion-actions { display: flex; gap: 0.3rem; margin-top: 0.7rem; }
+.starter-companion-actions i { width: 2.1rem; height: 0.75rem; border-radius: var(--radius-sm); background: color-mix(in srgb, var(--starter-accent) 42%, var(--surface-1)); }
+.starter-companion-actions i + i { background: color-mix(in srgb, var(--starter-accent) 8%, var(--surface-2)); }
+
+.starter-inbox-preview { grid-template-columns: 0.85fr 1.4fr; }
+.starter-inbox-list { padding: 0.35rem; border-right: 1px solid var(--border-subtle); }
+.starter-inbox-list i { display: block; height: 1.35rem; margin-bottom: 0.25rem; border-radius: var(--radius-sm); background: color-mix(in srgb, var(--starter-accent) 6%, var(--surface-2)); }
+.starter-inbox-list i:first-child { border-left: 2px solid var(--starter-accent); background: color-mix(in srgb, var(--starter-accent) 13%, var(--surface-1)); }
+.starter-inbox-detail { padding: 0.55rem; }
+.starter-inbox-status,
+.starter-approval-kicker { color: color-mix(in srgb, var(--starter-accent) 70%, var(--text-secondary)); font-family: var(--font-mono-family); font-size: 0.48rem; letter-spacing: 0.05em; text-transform: uppercase; }
+.starter-inbox-detail strong,
+.starter-approval-preview > strong { display: block; width: 72%; height: 0.42rem; margin: 0.45rem 0; border-radius: var(--radius-full); background: color-mix(in srgb, var(--text-primary) 58%, transparent); }
+.starter-inbox-detail > i,
+.starter-approval-preview > i { display: block; width: 94%; height: 0.27rem; margin-top: 0.3rem; border-radius: var(--radius-full); background: color-mix(in srgb, var(--text-tertiary) 24%, transparent); }
+.starter-inbox-detail div,
+.starter-approval-preview div { display: flex; gap: 0.3rem; margin-top: 0.65rem; }
+.starter-inbox-detail b,
+.starter-approval-preview b { width: 2.25rem; height: 0.72rem; border-radius: var(--radius-sm); background: color-mix(in srgb, var(--starter-accent) 46%, var(--surface-1)); }
+.starter-inbox-detail b + b,
+.starter-approval-preview b + b { background: color-mix(in srgb, var(--starter-accent) 8%, var(--surface-2)); }
+
+.starter-knowledge-preview { grid-template-columns: 0.8fr 1.55fr; }
+.starter-knowledge-tree { padding: 0.55rem; border-right: 1px solid var(--border-subtle); }
+.starter-knowledge-tree i { display: block; width: 80%; height: 0.35rem; margin-bottom: 0.48rem; border-radius: var(--radius-full); background: color-mix(in srgb, var(--text-tertiary) 22%, transparent); }
+.starter-knowledge-tree i:nth-child(2) { width: 95%; background: color-mix(in srgb, var(--starter-accent) 34%, transparent); }
+.starter-knowledge-doc { padding: 0.65rem; }
+.starter-knowledge-doc strong { display: block; width: 58%; height: 0.48rem; border-radius: var(--radius-full); background: color-mix(in srgb, var(--text-primary) 58%, transparent); }
+.starter-knowledge-doc span { display: block; width: 92%; height: 0.28rem; margin-top: 0.42rem; border-radius: var(--radius-full); background: color-mix(in srgb, var(--text-tertiary) 21%, transparent); }
+.starter-knowledge-doc span:nth-child(3) { width: 78%; }
+.starter-knowledge-doc div { width: 64%; height: 1.1rem; margin-top: 0.62rem; border-left: 2px solid color-mix(in srgb, var(--starter-accent) 58%, transparent); background: color-mix(in srgb, var(--starter-accent) 7%, transparent); }
+
+.starter-portal-preview { width: min(13rem, 82%); height: 100%; margin: 0 auto; padding: 0.65rem 0.8rem; border: 1px solid color-mix(in srgb, var(--starter-accent) 16%, var(--border-subtle)); border-radius: var(--radius-md); background: color-mix(in srgb, var(--surface-1) 92%, transparent); }
+.starter-portal-preview strong { display: block; color: var(--text-primary); font-size: 0.62rem; }
+.starter-portal-preview span { display: inline-block; width: calc(50% - 0.18rem); height: 0.8rem; margin: 0.55rem 0.18rem 0 0; border: 1px solid var(--border-subtle); border-radius: var(--radius-sm); background: var(--surface-1); }
+.starter-portal-preview .starter-portal-field-wide { width: 100%; height: 1.15rem; }
+.starter-portal-preview i { display: block; width: 4rem; margin-top: 0.55rem; padding: 0.23rem; border-radius: var(--radius-sm); background: color-mix(in srgb, var(--starter-accent) 58%, var(--surface-1)); color: var(--text-on-brand); font-size: 0.48rem; font-style: normal; text-align: center; }
+
+.starter-monitor-preview,
+.starter-approval-preview,
+.starter-briefing-preview,
+.starter-follow-up-preview,
+.starter-kit-preview { height: 100%; padding: 0.55rem; border: 1px solid color-mix(in srgb, var(--starter-accent) 16%, var(--border-subtle)); border-radius: var(--radius-md); background: color-mix(in srgb, var(--surface-1) 92%, transparent); }
+.starter-monitor-heading { display: flex; align-items: center; justify-content: space-between; }
+.starter-monitor-heading strong { color: var(--text-primary); font-size: 0.56rem; }
+.starter-monitor-heading i { width: 0.38rem; height: 0.38rem; border-radius: var(--radius-full); background: var(--state-success); }
+.starter-monitor-chart { display: flex; height: 2.5rem; align-items: flex-end; gap: 0.34rem; margin-top: 0.45rem; padding: 0 0.3rem; border-bottom: 1px solid var(--border-subtle); }
+.starter-monitor-chart i { width: 0.6rem; height: 28%; border-radius: var(--radius-xs) var(--radius-xs) 0 0; background: color-mix(in srgb, var(--starter-accent) 22%, var(--surface-2)); }
+.starter-monitor-chart i:nth-child(2) { height: 44%; }
+.starter-monitor-chart i:nth-child(3) { height: 36%; }
+.starter-monitor-chart i:nth-child(4) { height: 58%; }
+.starter-monitor-chart i:nth-child(5) { height: 52%; }
+.starter-monitor-chart i:nth-child(6) { height: 88%; background: color-mix(in srgb, var(--starter-accent) 68%, var(--surface-1)); }
+.starter-monitor-alert { display: flex; align-items: center; gap: 0.45rem; margin-top: 0.45rem; }
+.starter-monitor-alert > b { width: 0.38rem; height: 0.38rem; border-radius: var(--radius-full); background: var(--starter-accent); }
+.starter-monitor-alert span { display: flex; flex-direction: column; gap: 0.2rem; }
+.starter-monitor-alert strong { color: var(--text-primary); font-size: 0.48rem; }
+.starter-monitor-alert i { width: 4.5rem; height: 0.24rem; border-radius: var(--radius-full); background: color-mix(in srgb, var(--text-tertiary) 20%, transparent); }
+
+.starter-approval-preview { width: min(11.5rem, 78%); margin: 0 auto; padding: 0.75rem; }
+.starter-briefing-preview { display: grid; grid-template-columns: 2.2rem 1fr; gap: 0.6rem; }
+.starter-briefing-preview > div { display: flex; flex-direction: column; align-items: center; justify-content: center; border-radius: var(--radius-sm); background: color-mix(in srgb, var(--starter-accent) 11%, var(--surface-2)); color: var(--text-secondary); font-family: var(--font-mono-family); }
+.starter-briefing-preview > div span { font-size: 0.48rem; }
+.starter-briefing-preview > div strong { margin-top: 0.1rem; font-size: 0.68rem; }
+.starter-briefing-preview section { padding-top: 0.2rem; }
+.starter-briefing-preview section b { display: block; width: 58%; height: 0.42rem; margin-bottom: 0.5rem; border-radius: var(--radius-full); background: color-mix(in srgb, var(--text-primary) 54%, transparent); }
+.starter-briefing-preview section i { display: block; width: 92%; height: 0.27rem; margin-top: 0.35rem; border-radius: var(--radius-full); background: color-mix(in srgb, var(--text-tertiary) 21%, transparent); }
+.starter-briefing-preview section i:nth-child(3) { width: 72%; }
+
+.starter-follow-up-preview { display: flex; flex-direction: column; justify-content: center; gap: 0.35rem; }
+.starter-follow-up-preview > div { display: grid; grid-template-columns: 1.2rem 1fr auto; align-items: center; gap: 0.45rem; padding: 0.32rem 0.42rem; border: 1px solid color-mix(in srgb, var(--starter-accent) 9%, var(--border-subtle)); border-radius: var(--radius-sm); }
+.starter-follow-up-preview b { width: 1.15rem; height: 1.15rem; border-radius: var(--radius-full); background: color-mix(in srgb, var(--starter-accent) 18%, var(--surface-2)); }
+.starter-follow-up-preview span { display: flex; flex-direction: column; gap: 0.25rem; }
+.starter-follow-up-preview strong { width: 3.5rem; height: 0.3rem; border-radius: var(--radius-full); background: color-mix(in srgb, var(--text-primary) 48%, transparent); }
+.starter-follow-up-preview i { width: 5rem; height: 0.23rem; border-radius: var(--radius-full); background: color-mix(in srgb, var(--text-tertiary) 19%, transparent); }
+.starter-follow-up-preview em { color: color-mix(in srgb, var(--starter-accent) 68%, var(--text-secondary)); font-family: var(--font-mono-family); font-size: 0.46rem; font-style: normal; }
+
+.starter-kit-preview { position: relative; display: grid; grid-template-columns: repeat(4, 1fr); align-items: center; gap: 0.6rem; padding: 1rem; }
+.starter-kit-preview span { position: relative; z-index: 1; height: 1.4rem; border: 1px solid color-mix(in srgb, var(--starter-accent) 34%, var(--border-subtle)); border-radius: var(--radius-sm); background: color-mix(in srgb, var(--starter-accent) 12%, var(--surface-1)); }
+.starter-kit-preview i { position: absolute; top: 50%; left: 18%; width: 21%; height: 1px; background: color-mix(in srgb, var(--starter-accent) 38%, transparent); }
+.starter-kit-preview i:nth-of-type(2) { left: 39%; }
+.starter-kit-preview i:nth-of-type(3) { left: 60%; }
+
+/* Starter themes are category front doors. Their previews show the real
+   surface or a range of product shapes; concrete recipe cards live inside. */
+.starter-theme-card {
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  background: var(--surface-1);
+  box-shadow: 0 18px 46px -42px rgba(15, 23, 42, 0.54);
+  transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+.starter-theme-card:hover {
+  border-color: var(--border-strong);
+  box-shadow: 0 24px 52px -40px rgba(15, 23, 42, 0.6);
+  transform: translateY(-1px);
+}
+
+.starter-theme-preview {
+  --theme-brand: var(--intelligence);
+  position: relative;
+  height: 13rem;
+  overflow: hidden;
+  border-bottom: 1px solid color-mix(in srgb, var(--theme-brand) 22%, var(--border-subtle));
+  background:
+    radial-gradient(circle at 84% 12%, color-mix(in srgb, var(--theme-brand) 24%, transparent), transparent 38%),
+    color-mix(in srgb, var(--theme-brand) 7%, var(--surface-2));
+}
+
+.starter-theme-preview[data-theme="dashboards"] { --theme-brand: var(--action-primary); }
+.starter-theme-preview[data-theme="whatsapp"] { --theme-brand: rgb(37 211 102); }
+.starter-theme-preview[data-theme="telegram"] { --theme-brand: rgb(42 171 238); }
+.starter-theme-preview[data-theme="slack"] { --theme-brand: rgb(97 31 105); }
+.starter-theme-preview[data-theme="email"] { --theme-brand: var(--attention); }
+.starter-theme-preview[data-theme="teams"] { --theme-brand: rgb(98 100 167); }
+.starter-theme-preview[data-theme="knowledge"] { --theme-brand: var(--intelligence); }
+.starter-theme-preview[data-theme="intake"] { --theme-brand: var(--delight); }
+.starter-theme-preview[data-theme="automations"] { --theme-brand: var(--state-info); }
+
+.starter-theme-card-copy { padding: 1.15rem 1.25rem 1.2rem; }
+.starter-theme-card-copy > p:first-child {
+  color: color-mix(in srgb, var(--text-secondary) 76%, var(--text-tertiary));
+  font-family: var(--font-mono-family);
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.055em;
+  text-transform: uppercase;
+}
+.starter-theme-card-copy h3 { margin-top: 0.42rem; color: var(--text-primary); font-size: 1.08rem; font-weight: 600; letter-spacing: -0.012em; }
+.starter-theme-card-copy h3 + p { margin-top: 0.42rem; color: var(--text-secondary); font-size: 0.82rem; line-height: 1.38rem; }
+.starter-theme-card-examples { display: flex; flex-wrap: wrap; gap: 0.38rem; margin-top: 0.85rem; }
+.starter-theme-card-examples span { padding: 0.2rem 0.45rem; border: 1px solid var(--border-subtle); border-radius: var(--radius-full); background: var(--surface-2); color: var(--text-tertiary); font-size: 0.65rem; }
+.starter-theme-card-action { display: flex; align-items: center; gap: 0.4rem; margin-top: 1rem; color: var(--text-primary); font-size: 0.76rem; font-weight: 600; }
+.starter-theme-card-action svg { transition: transform 160ms ease; }
+.starter-theme-card:hover .starter-theme-card-action svg { transform: translateX(2px); }
+
+.starter-theme-platform-frame {
+  position: absolute;
+  top: 1rem;
+  right: 1.15rem;
+  bottom: 0;
+  left: 1.15rem;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--theme-brand) 25%, var(--border-subtle));
+  border-bottom: 0;
+  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  background: var(--surface-1);
+  box-shadow: 0 18px 38px -26px rgba(15, 23, 42, 0.66);
+}
+
+.starter-theme-platform-frame > header,
+.starter-theme-email-frame > header {
+  display: flex;
+  height: 2.65rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 0.8rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--theme-brand) 20%, var(--border-subtle));
+  background: color-mix(in srgb, var(--theme-brand) 7%, var(--surface-1));
+}
+.starter-theme-platform-frame > header > span:last-child,
+.starter-theme-email-frame > header > span:last-child { color: var(--text-tertiary); font-family: var(--font-mono-family); font-size: 0.55rem; text-transform: uppercase; }
+.starter-theme-platform-identity { display: inline-flex; align-items: center; gap: 0.5rem; }
+.starter-theme-platform-identity img { width: 1.25rem; height: 1.25rem; object-fit: contain; }
+.starter-theme-platform-identity strong { color: var(--text-primary); font-size: 0.72rem; font-weight: 650; }
+
+.starter-theme-whatsapp-frame > header { background: color-mix(in srgb, var(--theme-brand) 11%, var(--surface-1)); }
+.starter-theme-whatsapp-frame > main { position: relative; height: calc(100% - 2.65rem); padding: 0.7rem 0.85rem 0.5rem; background: color-mix(in srgb, rgb(239 231 219) 36%, var(--surface-1)); }
+.starter-theme-chat-contact { display: flex; align-items: center; gap: 0.5rem; }
+.starter-theme-chat-contact > b { display: grid; width: 1.5rem; height: 1.5rem; place-items: center; border-radius: var(--radius-full); background: color-mix(in srgb, var(--theme-brand) 24%, var(--surface-2)); color: color-mix(in srgb, var(--theme-brand) 76%, var(--text-primary)); font-size: 0.52rem; }
+.starter-theme-chat-contact > span { display: flex; flex-direction: column; gap: 0.04rem; }
+.starter-theme-chat-contact strong { color: var(--text-primary); font-size: 0.61rem; }
+.starter-theme-chat-contact i { color: var(--text-tertiary); font-size: 0.48rem; font-style: normal; }
+.starter-theme-chat-thread { display: flex; flex-direction: column; gap: 0.33rem; margin-top: 0.55rem; }
+.starter-theme-chat-thread p { width: fit-content; max-width: 78%; padding: 0.32rem 0.45rem; border-radius: 0.5rem 0.5rem 0.5rem 0.14rem; background: var(--surface-1); color: var(--text-secondary); font-size: 0.5rem; line-height: 0.72rem; box-shadow: 0 5px 14px -13px rgba(15, 23, 42, 0.7); }
+.starter-theme-chat-thread p:nth-child(2) { align-self: flex-end; border-radius: 0.5rem 0.5rem 0.14rem; background: color-mix(in srgb, var(--theme-brand) 17%, var(--surface-1)); color: var(--text-primary); }
+.starter-theme-chat-input { position: absolute; right: 0.75rem; bottom: 0.45rem; left: 0.75rem; display: flex; height: 1.55rem; align-items: center; justify-content: space-between; padding: 0 0.3rem 0 0.55rem; border: 1px solid color-mix(in srgb, var(--theme-brand) 12%, var(--border-subtle)); border-radius: var(--radius-full); background: var(--surface-1); color: var(--text-tertiary); font-size: 0.5rem; }
+.starter-theme-chat-input i { display: grid; width: 1.05rem; height: 1.05rem; place-items: center; border-radius: var(--radius-full); background: var(--theme-brand); color: rgb(255 255 255); font-size: 0.8rem; font-style: normal; }
+
+.starter-theme-telegram-frame > main { display: grid; height: calc(100% - 2.65rem); grid-template-columns: 0.9fr 1.1fr; background: color-mix(in srgb, var(--theme-brand) 5%, var(--surface-1)); }
+.starter-theme-telegram-thread { padding: 0.75rem; border-right: 1px solid color-mix(in srgb, var(--theme-brand) 16%, var(--border-subtle)); background: color-mix(in srgb, var(--theme-brand) 7%, var(--surface-2)); }
+.starter-theme-telegram-thread > p { width: fit-content; max-width: 90%; margin-top: 0.55rem; padding: 0.32rem 0.45rem; border-radius: 0.5rem; background: var(--surface-1); color: var(--text-secondary); font-size: 0.48rem; line-height: 0.7rem; }
+.starter-theme-telegram-thread > p + p { margin-top: 0.32rem; background: color-mix(in srgb, var(--theme-brand) 15%, var(--surface-1)); }
+.starter-theme-mini-app { padding: 0.7rem; }
+.starter-theme-mini-app > span { color: color-mix(in srgb, var(--theme-brand) 78%, var(--text-secondary)); font-family: var(--font-mono-family); font-size: 0.48rem; letter-spacing: 0.06em; }
+.starter-theme-mini-app > strong { display: block; margin-top: 0.32rem; color: var(--text-primary); font-size: 0.66rem; }
+.starter-theme-mini-app > div { display: flex; align-items: center; justify-content: space-between; margin-top: 0.38rem; padding: 0.36rem 0.42rem; border: 1px solid var(--border-subtle); border-radius: var(--radius-sm); }
+.starter-theme-mini-app b { color: var(--text-secondary); font-size: 0.5rem; }
+.starter-theme-mini-app i { color: var(--text-tertiary); font-size: 0.48rem; font-style: normal; }
+.starter-theme-mini-app > em { display: block; width: fit-content; margin-top: 0.45rem; padding: 0.28rem 0.55rem; border-radius: var(--radius-sm); background: var(--theme-brand); color: rgb(255 255 255); font-size: 0.5rem; font-style: normal; }
+
+.starter-theme-slack-frame > header { background: color-mix(in srgb, var(--theme-brand) 10%, var(--surface-1)); }
+.starter-theme-slack-frame > main { display: grid; height: calc(100% - 2.65rem); grid-template-columns: 5.8rem 1fr; }
+.starter-theme-slack-frame aside { display: flex; flex-direction: column; gap: 0.35rem; padding: 0.6rem; background: var(--theme-brand); color: color-mix(in srgb, rgb(255 255 255) 78%, transparent); font-size: 0.49rem; }
+.starter-theme-slack-frame aside strong { margin-bottom: 0.15rem; color: rgb(255 255 255); font-size: 0.57rem; }
+.starter-theme-slack-frame aside span:nth-child(2) { padding: 0.22rem 0.3rem; border-radius: var(--radius-xs); background: color-mix(in srgb, rgb(255 255 255) 17%, transparent); color: rgb(255 255 255); }
+.starter-theme-slack-frame section { position: relative; padding: 0.55rem 0.65rem; }
+.starter-theme-slack-frame section > div:first-child { display: flex; align-items: baseline; gap: 0.4rem; padding-bottom: 0.45rem; border-bottom: 1px solid var(--border-subtle); }
+.starter-theme-slack-frame section > div strong { color: var(--text-primary); font-size: 0.62rem; }
+.starter-theme-slack-frame section > div span { color: var(--text-tertiary); font-size: 0.46rem; }
+.starter-theme-slack-frame article { display: grid; grid-template-columns: 1.5rem 1fr; gap: 0.4rem; margin-top: 0.55rem; }
+.starter-theme-slack-frame article > b { display: grid; width: 1.45rem; height: 1.45rem; place-items: center; border-radius: var(--radius-sm); background: color-mix(in srgb, var(--theme-brand) 16%, var(--surface-2)); color: var(--theme-brand); font-size: 0.5rem; }
+.starter-theme-slack-frame article p { display: flex; flex-direction: column; gap: 0.12rem; }
+.starter-theme-slack-frame article p strong { color: var(--text-primary); font-size: 0.54rem; }
+.starter-theme-slack-frame article p span { color: var(--text-secondary); font-size: 0.48rem; line-height: 0.7rem; }
+.starter-theme-slack-frame article p em { margin-top: 0.14rem; color: color-mix(in srgb, var(--theme-brand) 76%, var(--text-primary)); font-size: 0.47rem; font-style: normal; font-weight: 600; }
+.starter-theme-slack-composer { position: absolute; right: 0.65rem; bottom: 0.48rem; left: 0.65rem; padding: 0.35rem 0.45rem; border: 1px solid var(--border-strong); border-radius: var(--radius-sm); color: var(--text-tertiary); font-size: 0.47rem; }
+
+.starter-theme-teams-frame > main { display: grid; height: calc(100% - 2.65rem); grid-template-columns: 6.2rem 1fr; }
+.starter-theme-teams-frame aside { display: flex; flex-direction: column; gap: 0.42rem; padding: 0.65rem; border-right: 1px solid var(--border-subtle); background: color-mix(in srgb, var(--theme-brand) 9%, var(--surface-2)); color: var(--text-tertiary); font-size: 0.49rem; }
+.starter-theme-teams-frame aside strong { margin-bottom: 0.12rem; color: var(--text-primary); font-size: 0.6rem; }
+.starter-theme-teams-frame aside span:first-of-type { padding: 0.24rem 0.3rem; border-radius: var(--radius-sm); background: color-mix(in srgb, var(--theme-brand) 14%, var(--surface-1)); color: var(--text-primary); }
+.starter-theme-teams-frame section { padding: 0.65rem; }
+.starter-theme-teams-frame section > div { display: flex; align-items: baseline; justify-content: space-between; padding-bottom: 0.48rem; border-bottom: 1px solid var(--border-subtle); }
+.starter-theme-teams-frame section > div strong { color: var(--text-primary); font-size: 0.6rem; }
+.starter-theme-teams-frame section > div span { color: var(--text-tertiary); font-size: 0.45rem; }
+.starter-theme-teams-frame article { display: grid; grid-template-columns: 1.55rem 1fr; gap: 0.42rem; margin-top: 0.65rem; }
+.starter-theme-teams-frame article > b { display: grid; width: 1.5rem; height: 1.5rem; place-items: center; border-radius: var(--radius-sm); background: color-mix(in srgb, var(--theme-brand) 18%, var(--surface-2)); color: var(--theme-brand); font-size: 0.48rem; }
+.starter-theme-teams-frame article p { display: flex; flex-direction: column; gap: 0.14rem; }
+.starter-theme-teams-frame article p strong { color: var(--text-primary); font-size: 0.54rem; }
+.starter-theme-teams-frame article p span { color: var(--text-secondary); font-size: 0.48rem; line-height: 0.72rem; }
+.starter-theme-teams-frame article p em { color: color-mix(in srgb, var(--theme-brand) 76%, var(--text-primary)); font-size: 0.46rem; font-style: normal; font-weight: 600; }
+
+.starter-theme-dashboard-stage { position: absolute; inset: 0; }
+.starter-theme-dashboard-stage::before { position: absolute; inset: 0; background-image: linear-gradient(color-mix(in srgb, var(--border-subtle) 48%, transparent) 1px, transparent 1px), linear-gradient(90deg, color-mix(in srgb, var(--border-subtle) 48%, transparent) 1px, transparent 1px); background-size: 1.5rem 1.5rem; content: ''; mask-image: linear-gradient(to bottom, black, transparent); }
+.starter-theme-dashboard-card { position: absolute; overflow: hidden; width: 62%; height: 72%; border: 1px solid color-mix(in srgb, var(--theme-brand) 25%, var(--border-subtle)); border-radius: var(--radius-lg); background: var(--surface-1); box-shadow: 0 18px 38px -26px rgba(15, 23, 42, 0.7); }
+.starter-theme-dashboard-card[data-view="ops"] { z-index: 3; top: 1.35rem; left: 18%; }
+.starter-theme-dashboard-card[data-view="pipeline"] { z-index: 2; top: 2.6rem; left: 3%; transform: rotate(-3deg); }
+.starter-theme-dashboard-card[data-view="delivery"] { z-index: 1; top: 2.35rem; right: 2.5%; transform: rotate(3deg); }
+.starter-theme-dashboard-card > div { display: flex; height: 2rem; align-items: center; justify-content: space-between; padding: 0 0.6rem; border-bottom: 1px solid var(--border-subtle); }
+.starter-theme-dashboard-card > div strong { color: var(--text-primary); font-size: 0.56rem; }
+.starter-theme-dashboard-card > div span { color: color-mix(in srgb, var(--theme-brand) 72%, var(--text-secondary)); font-family: var(--font-mono-family); font-size: 0.44rem; text-transform: uppercase; }
+.starter-theme-dashboard-card section { display: flex; height: 3.2rem; align-items: flex-end; gap: 0.38rem; padding: 0.55rem 0.65rem 0; }
+.starter-theme-dashboard-card section i { flex: 1; height: 46%; border-radius: var(--radius-xs) var(--radius-xs) 0 0; background: color-mix(in srgb, var(--theme-brand) 22%, var(--surface-2)); }
+.starter-theme-dashboard-card section i:nth-child(2) { height: 76%; }
+.starter-theme-dashboard-card section i:nth-child(3) { height: 58%; }
+.starter-theme-dashboard-card section i:nth-child(4) { height: 88%; background: color-mix(in srgb, var(--theme-brand) 62%, var(--surface-1)); }
+.starter-theme-dashboard-card footer { display: flex; flex-direction: column; gap: 0.28rem; padding: 0.5rem 0.65rem; border-top: 1px solid var(--border-subtle); }
+.starter-theme-dashboard-card footer b { height: 0.28rem; border-radius: var(--radius-full); background: color-mix(in srgb, var(--text-tertiary) 20%, transparent); }
+.starter-theme-dashboard-card footer b:nth-child(2) { width: 82%; }
+.starter-theme-dashboard-card footer b:nth-child(3) { width: 68%; }
+
+.starter-theme-email-frame,
+.starter-theme-knowledge-frame,
+.starter-theme-intake-frame,
+.starter-theme-monitor-frame { position: absolute; inset: 1rem 1.15rem 0; overflow: hidden; border: 1px solid color-mix(in srgb, var(--theme-brand) 22%, var(--border-subtle)); border-bottom: 0; border-radius: var(--radius-xl) var(--radius-xl) 0 0; background: var(--surface-1); box-shadow: 0 18px 38px -28px rgba(15, 23, 42, 0.65); }
+.starter-theme-email-frame main { display: grid; height: calc(100% - 2.65rem); grid-template-columns: 6.4rem 1fr; }
+.starter-theme-email-frame aside { display: flex; flex-direction: column; gap: 0.45rem; padding: 0.65rem; border-right: 1px solid var(--border-subtle); background: var(--surface-2); color: var(--text-tertiary); font-size: 0.49rem; }
+.starter-theme-email-frame aside strong { color: var(--text-primary); font-size: 0.62rem; }
+.starter-theme-email-frame section { padding: 0.75rem; }
+.starter-theme-email-frame section > span,
+.starter-theme-knowledge-frame main > span { color: color-mix(in srgb, var(--theme-brand) 72%, var(--text-secondary)); font-family: var(--font-mono-family); font-size: 0.46rem; letter-spacing: 0.06em; }
+.starter-theme-email-frame section > strong { display: block; margin-top: 0.35rem; color: var(--text-primary); font-size: 0.66rem; }
+.starter-theme-email-frame section > p { margin-top: 0.32rem; color: var(--text-secondary); font-size: 0.5rem; line-height: 0.74rem; }
+.starter-theme-email-frame section > div { display: flex; gap: 0.35rem; margin-top: 0.55rem; }
+.starter-theme-email-frame section b,
+.starter-theme-email-frame section i { padding: 0.28rem 0.45rem; border-radius: var(--radius-sm); background: color-mix(in srgb, var(--theme-brand) 55%, var(--surface-1)); color: var(--text-on-brand); font-size: 0.47rem; font-style: normal; }
+.starter-theme-email-frame section i { background: var(--surface-2); color: var(--text-secondary); }
+
+.starter-theme-knowledge-frame { display: grid; grid-template-columns: 7rem 1fr; }
+.starter-theme-knowledge-frame aside { display: flex; flex-direction: column; gap: 0.5rem; padding: 0.75rem; border-right: 1px solid var(--border-subtle); background: color-mix(in srgb, var(--theme-brand) 6%, var(--surface-2)); color: var(--text-tertiary); font-size: 0.5rem; }
+.starter-theme-knowledge-frame aside strong { margin-bottom: 0.18rem; color: var(--text-primary); font-size: 0.62rem; }
+.starter-theme-knowledge-frame main { padding: 0.8rem; }
+.starter-theme-knowledge-frame main > strong { display: block; margin-top: 0.38rem; color: var(--text-primary); font-size: 0.64rem; }
+.starter-theme-knowledge-frame main > p { margin-top: 0.48rem; color: var(--text-secondary); font-size: 0.5rem; line-height: 0.76rem; }
+.starter-theme-knowledge-frame main > div { width: fit-content; margin-top: 0.55rem; padding: 0.2rem 0.4rem; border-radius: var(--radius-full); background: color-mix(in srgb, var(--theme-brand) 10%, var(--surface-2)); color: color-mix(in srgb, var(--theme-brand) 72%, var(--text-secondary)); font-size: 0.45rem; }
+
+.starter-theme-intake-frame { padding: 0.75rem; }
+.starter-theme-intake-frame header,
+.starter-theme-monitor-frame header { display: flex; align-items: center; justify-content: space-between; }
+.starter-theme-intake-frame header strong,
+.starter-theme-monitor-frame header strong { color: var(--text-primary); font-size: 0.64rem; }
+.starter-theme-intake-frame header span { color: color-mix(in srgb, var(--theme-brand) 74%, var(--text-secondary)); font-family: var(--font-mono-family); font-size: 0.45rem; text-transform: uppercase; }
+.starter-theme-intake-frame main { display: grid; grid-template-columns: 1fr auto; gap: 0.7rem; margin-top: 0.65rem; padding: 0.65rem; border: 1px solid color-mix(in srgb, var(--theme-brand) 18%, var(--border-subtle)); border-radius: var(--radius-md); background: color-mix(in srgb, var(--theme-brand) 5%, var(--surface-1)); }
+.starter-theme-intake-frame main section { display: flex; flex-direction: column; gap: 0.22rem; }
+.starter-theme-intake-frame main section i { color: color-mix(in srgb, var(--theme-brand) 78%, var(--text-secondary)); font-size: 0.46rem; font-style: normal; }
+.starter-theme-intake-frame main section strong { color: var(--text-primary); font-size: 0.58rem; }
+.starter-theme-intake-frame main section span { color: var(--text-tertiary); font-size: 0.46rem; }
+.starter-theme-intake-frame main > div { display: flex; align-items: center; gap: 0.3rem; }
+.starter-theme-intake-frame main > div span,
+.starter-theme-intake-frame main > div b { padding: 0.28rem 0.4rem; border: 1px solid var(--border-subtle); border-radius: var(--radius-sm); color: var(--text-secondary); font-size: 0.45rem; font-weight: 500; }
+.starter-theme-intake-frame main > div b { border-color: transparent; background: color-mix(in srgb, var(--theme-brand) 58%, var(--surface-1)); color: var(--text-on-brand); }
+.starter-theme-intake-frame footer { display: flex; align-items: center; gap: 0.35rem; margin-top: 0.72rem; color: var(--text-tertiary); font-family: var(--font-mono-family); font-size: 0.43rem; text-transform: uppercase; }
+.starter-theme-intake-frame footer i { flex: 1; height: 1px; background: color-mix(in srgb, var(--theme-brand) 28%, var(--border-subtle)); }
+
+.starter-theme-monitor-frame { padding: 0.75rem; }
+.starter-theme-monitor-frame header span { display: inline-flex; align-items: center; gap: 0.3rem; color: var(--text-tertiary); font-size: 0.48rem; }
+.starter-theme-monitor-frame header span i { width: 0.35rem; height: 0.35rem; border-radius: var(--radius-full); background: var(--state-success); }
+.starter-theme-monitor-frame main { display: flex; height: 4.8rem; align-items: flex-end; gap: 0.45rem; margin-top: 0.45rem; padding: 0 0.5rem; border-bottom: 1px solid var(--border-subtle); }
+.starter-theme-monitor-frame main b { flex: 1; height: 26%; border-radius: var(--radius-xs) var(--radius-xs) 0 0; background: color-mix(in srgb, var(--theme-brand) 19%, var(--surface-2)); }
+.starter-theme-monitor-frame main b:nth-child(2) { height: 46%; }
+.starter-theme-monitor-frame main b:nth-child(3) { height: 38%; }
+.starter-theme-monitor-frame main b:nth-child(4) { height: 62%; }
+.starter-theme-monitor-frame main b:nth-child(5) { height: 49%; }
+.starter-theme-monitor-frame main b:nth-child(6) { height: 72%; }
+.starter-theme-monitor-frame main b:nth-child(7) { height: 92%; background: color-mix(in srgb, var(--theme-brand) 70%, var(--surface-1)); }
+.starter-theme-monitor-frame footer { display: grid; grid-template-columns: 0.45rem 1fr auto; align-items: center; gap: 0.45rem; margin-top: 0.55rem; }
+.starter-theme-monitor-frame footer > i { width: 0.42rem; height: 0.42rem; border-radius: var(--radius-full); background: var(--theme-brand); }
+.starter-theme-monitor-frame footer > span { display: flex; flex-direction: column; gap: 0.05rem; }
+.starter-theme-monitor-frame footer strong { color: var(--text-primary); font-size: 0.48rem; }
+.starter-theme-monitor-frame footer em { color: var(--text-tertiary); font-size: 0.43rem; font-style: normal; }
+.starter-theme-monitor-frame footer > b { padding: 0.25rem 0.38rem; border-radius: var(--radius-sm); background: color-mix(in srgb, var(--theme-brand) 11%, var(--surface-2)); color: color-mix(in srgb, var(--theme-brand) 74%, var(--text-secondary)); font-size: 0.45rem; }
+
+.starter-theme-collection {
+  display: grid;
+  grid-template-columns: minmax(0, 0.85fr) minmax(20rem, 1.15fr);
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  background: var(--surface-1);
+}
+.starter-theme-collection > div:first-child { display: flex; flex-direction: column; justify-content: center; padding: 1.75rem; }
+.starter-theme-collection > div:first-child > p:first-child { color: var(--text-tertiary); font-family: var(--font-mono-family); font-size: 0.66rem; font-weight: 600; letter-spacing: 0.055em; text-transform: uppercase; }
+.starter-theme-collection > div:first-child > h2 { margin-top: 0.55rem; color: var(--text-primary); font-size: 1.45rem; font-weight: 650; letter-spacing: -0.018em; }
+.starter-theme-collection > div:first-child > h2 + p { margin-top: 0.62rem; color: var(--text-secondary); font-size: 0.88rem; line-height: 1.5rem; }
+.starter-theme-collection > div:first-child > div { display: flex; flex-wrap: wrap; gap: 0.4rem; margin-top: 1rem; }
+.starter-theme-collection > div:first-child > div span { padding: 0.22rem 0.46rem; border: 1px solid var(--border-subtle); border-radius: var(--radius-full); background: var(--surface-2); color: var(--text-tertiary); font-size: 0.68rem; }
+.starter-theme-collection > .starter-theme-preview { height: 17rem; border-bottom: 0; border-left: 1px solid var(--border-subtle); }
+
+@media (max-width: 900px) {
+  .starter-theme-collection { grid-template-columns: 1fr; }
+  .starter-theme-collection > .starter-theme-preview { height: 14rem; border-top: 1px solid var(--border-subtle); border-left: 0; }
+}
+
+@media (max-width: 640px) {
+  .starter-platform-body { grid-template-columns: 1fr; }
+  .starter-platform-companion { display: none; }
+  .starter-theme-preview { height: 11.5rem; }
+  .starter-theme-platform-frame,
+  .starter-theme-email-frame,
+  .starter-theme-knowledge-frame,
+  .starter-theme-intake-frame,
+  .starter-theme-monitor-frame { right: 0.7rem; left: 0.7rem; }
+  .starter-theme-slack-frame > main { grid-template-columns: 4.8rem 1fr; }
+  .starter-theme-card-copy { padding-right: 1rem; padding-left: 1rem; }
+  .starter-theme-collection { grid-template-columns: 1fr; }
+  .starter-theme-collection > div:first-child { padding: 1.25rem; }
+  .starter-theme-collection > .starter-theme-preview { height: 12rem; border-top: 1px solid var(--border-subtle); border-left: 0; }
+}
+
+/* Compact starter categories: the tile names the family; the floating list
+   exposes concrete one-line prompts without turning a category into a product. */
+.starter-theme-compact {
+  --theme-brand: var(--intelligence);
+  position: relative;
+  min-width: 0;
+}
+
+.starter-theme-compact[data-theme="dashboards"] { --theme-brand: var(--action-primary); }
+.starter-theme-compact[data-theme="whatsapp"] { --theme-brand: rgb(37 211 102); }
+.starter-theme-compact[data-theme="telegram"] { --theme-brand: rgb(42 171 238); }
+.starter-theme-compact[data-theme="slack"] { --theme-brand: rgb(97 31 105); }
+.starter-theme-compact[data-theme="email"] { --theme-brand: var(--attention); }
+.starter-theme-compact[data-theme="teams"] { --theme-brand: rgb(98 100 167); }
+.starter-theme-compact[data-theme="knowledge"] { --theme-brand: var(--intelligence); }
+.starter-theme-compact[data-theme="intake"] { --theme-brand: var(--delight); }
+.starter-theme-compact[data-theme="automations"] { --theme-brand: var(--state-info); }
+
+.starter-theme-compact:hover,
+.starter-theme-compact:focus-within,
+.starter-theme-compact[data-open="true"] { z-index: 30; }
+
+.starter-theme-compact-trigger {
+  display: flex;
+  width: 100%;
+  min-height: 8.25rem;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-1);
+  padding: 0.75rem;
+  color: var(--text-primary);
+  text-align: left;
+  white-space: normal;
+  box-shadow: var(--shadow-xs);
+  transition: border-color 150ms ease, background-color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+}
+
+.starter-theme-compact-trigger:hover,
+.starter-theme-compact:focus-within .starter-theme-compact-trigger,
+.starter-theme-compact[data-open="true"] .starter-theme-compact-trigger {
+  border-color: color-mix(in srgb, var(--theme-brand) 38%, var(--border-strong));
+  background: color-mix(in srgb, var(--theme-brand) 3%, var(--surface-1));
+  box-shadow: var(--shadow-sm);
+  transform: translateY(-1px);
+}
+
+.starter-theme-compact-topline {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.starter-theme-compact-icon {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--theme-brand) 22%, var(--border-subtle));
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--theme-brand) 9%, var(--surface-2));
+  color: color-mix(in srgb, var(--theme-brand) 82%, var(--text-primary));
+}
+
+.starter-theme-compact-icon-logo { background: var(--surface-1); }
+.starter-theme-compact-chevron { color: var(--text-tertiary); transition: transform 150ms ease; }
+.starter-theme-compact:hover .starter-theme-compact-chevron,
+.starter-theme-compact:focus-within .starter-theme-compact-chevron,
+.starter-theme-compact[data-open="true"] .starter-theme-compact-chevron { transform: rotate(180deg); }
+
+.starter-theme-compact-title {
+  overflow: hidden;
+  max-width: 100%;
+  margin-top: 0.65rem;
+  color: var(--text-primary);
+  font-size: 0.82rem;
+  font-weight: 600;
+  line-height: 1.15rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.starter-theme-compact-description {
+  display: -webkit-box;
+  overflow: hidden;
+  margin-top: 0.25rem;
+  color: var(--text-secondary);
+  font-size: 0.7rem;
+  line-height: 1rem;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.starter-theme-compact-meta {
+  margin-top: auto;
+  padding-top: 0.55rem;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono-family);
+  font-size: 0.58rem;
+  font-weight: 550;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+}
+
+.starter-theme-prompt-menu {
+  position: absolute;
+  top: calc(100% + 0.38rem);
+  left: 50%;
+  width: min(20rem, calc(100vw - 2rem));
+  overflow: hidden;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  background: var(--surface-1);
+  box-shadow: var(--shadow-lg);
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -0.3rem);
+  transition: opacity 130ms ease, transform 130ms ease;
+}
+
+.starter-theme-compact:hover .starter-theme-prompt-menu,
+.starter-theme-compact:focus-within .starter-theme-prompt-menu,
+.starter-theme-compact[data-open="true"] .starter-theme-prompt-menu {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, 0);
+}
+
+.starter-theme-prompt-menu > p {
+  padding: 0.65rem 0.75rem 0.45rem;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono-family);
+  font-size: 0.6rem;
+  font-weight: 600;
+  letter-spacing: 0.045em;
+  text-transform: uppercase;
+}
+
+.starter-theme-prompt-menu > div { padding: 0 0.35rem 0.35rem; }
+
+.starter-theme-prompt-row {
+  display: flex;
+  width: 100%;
+  height: auto;
+  min-height: 2.25rem;
+  justify-content: flex-start;
+  gap: 0.5rem;
+  overflow: hidden;
+  border-radius: var(--radius-md);
+  padding: 0.48rem 0.5rem;
+  color: var(--text-secondary);
+  font-size: 0.72rem;
+  font-weight: 450;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.starter-theme-prompt-row svg { color: color-mix(in srgb, var(--theme-brand) 76%, var(--text-secondary)); }
+.starter-theme-prompt-row span { overflow: hidden; text-overflow: ellipsis; }
+.starter-theme-prompt-row:hover { background: color-mix(in srgb, var(--theme-brand) 7%, var(--surface-2)); color: var(--text-primary); }
+
+@media (max-width: 640px) {
+  .starter-theme-compact-trigger { min-height: 7.5rem; }
+  .starter-theme-prompt-menu { left: 0; transform: translate(0, -0.3rem); }
+  .starter-theme-compact:hover .starter-theme-prompt-menu,
+  .starter-theme-compact:focus-within .starter-theme-prompt-menu,
+  .starter-theme-compact[data-open="true"] .starter-theme-prompt-menu { transform: translate(0, 0); }
+}
+
+/* The current starter picker is deliberately flatter than the earlier card
+   treatment: categories switch one stable, non-overlapping prompt list. */
+.starter-theme-picker { min-width: 0; }
+
+.starter-theme-rail {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 0.4rem;
+}
+
+.starter-theme-tab,
+.starter-theme-inline-prompts {
+  --theme-brand: var(--intelligence);
+}
+
+.starter-theme-tab[data-theme="dashboards"],
+.starter-theme-inline-prompts[data-theme="dashboards"] { --theme-brand: var(--action-primary); }
+.starter-theme-tab[data-theme="whatsapp"],
+.starter-theme-inline-prompts[data-theme="whatsapp"] { --theme-brand: rgb(37 211 102); }
+.starter-theme-tab[data-theme="telegram"],
+.starter-theme-inline-prompts[data-theme="telegram"] { --theme-brand: rgb(42 171 238); }
+.starter-theme-tab[data-theme="slack"],
+.starter-theme-inline-prompts[data-theme="slack"] { --theme-brand: rgb(97 31 105); }
+.starter-theme-tab[data-theme="email"],
+.starter-theme-inline-prompts[data-theme="email"] { --theme-brand: var(--attention); }
+.starter-theme-tab[data-theme="teams"],
+.starter-theme-inline-prompts[data-theme="teams"] { --theme-brand: rgb(98 100 167); }
+.starter-theme-tab[data-theme="knowledge"],
+.starter-theme-inline-prompts[data-theme="knowledge"] { --theme-brand: var(--intelligence); }
+.starter-theme-tab[data-theme="intake"],
+.starter-theme-inline-prompts[data-theme="intake"] { --theme-brand: var(--delight); }
+.starter-theme-tab[data-theme="automations"],
+.starter-theme-inline-prompts[data-theme="automations"] { --theme-brand: var(--state-info); }
+
+.starter-theme-tab {
+  position: relative;
+  display: flex;
+  width: 100%;
+  height: 4rem;
+  min-width: 0;
+  justify-content: flex-start;
+  gap: 0.7rem;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface-1);
+  padding: 0.65rem 0.75rem;
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+  font-weight: 600;
+  line-height: 1.05rem;
+  box-shadow: none;
+  transition: border-color 150ms ease, background-color 150ms ease, color 150ms ease, transform 150ms ease;
+}
+
+.starter-theme-tab:hover {
+  border-color: var(--border-strong);
+  background: color-mix(in srgb, var(--theme-brand) 3%, var(--surface-1));
+  color: var(--text-primary);
+  transform: translateY(-1px);
+}
+
+.starter-theme-tab-active,
+.starter-theme-tab-active:hover {
+  border-color: color-mix(in srgb, var(--theme-brand) 52%, var(--border-strong));
+  background: linear-gradient(135deg, color-mix(in srgb, var(--theme-brand) 10%, var(--surface-1)), color-mix(in srgb, var(--theme-brand) 3%, var(--surface-1)) 72%);
+  color: var(--text-primary);
+}
+
+.starter-theme-tab::after {
+  position: absolute;
+  right: 0.75rem;
+  bottom: 0;
+  left: 0.75rem;
+  height: 2px;
+  border-radius: var(--radius-full) var(--radius-full) 0 0;
+  background: var(--theme-brand);
+  content: '';
+  opacity: 0;
+  transform: scaleX(0.55);
+  transition: opacity 150ms ease, transform 150ms ease;
+}
+
+.starter-theme-tab-active::after { opacity: 0.8; transform: scaleX(1); }
+
+.starter-theme-tab-icon {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--theme-brand) 20%, var(--border-subtle));
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--theme-brand) 8%, var(--surface-2));
+  color: color-mix(in srgb, var(--theme-brand) 78%, var(--text-primary));
+}
+
+.starter-theme-tab-icon-logo { background: var(--surface-1); }
+.starter-theme-tab > span:last-child {
+  display: -webkit-box;
+  overflow: hidden;
+  text-align: left;
+  white-space: normal;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.starter-theme-inline-prompts {
+  margin-top: 0.6rem;
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+  background: linear-gradient(90deg, color-mix(in srgb, var(--theme-brand) 3%, transparent), transparent 58%);
+  padding: 0.25rem 0;
+}
+
+.starter-theme-inline-prompts > div { min-width: 0; }
+
+.starter-theme-inline-prompt {
+  display: flex;
+  width: 100%;
+  height: 3rem;
+  min-width: 0;
+  justify-content: flex-start;
+  gap: 0.7rem;
+  overflow: hidden;
+  border-radius: 0;
+  padding: 0.55rem 0.75rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  font-weight: 500;
+  text-align: left;
+  white-space: nowrap;
+  transition: background-color 140ms ease, color 140ms ease;
+}
+
+.starter-theme-inline-prompt + .starter-theme-inline-prompt { border-top: 1px solid color-mix(in srgb, var(--border-subtle) 66%, transparent); }
+.starter-theme-inline-prompt > svg { color: color-mix(in srgb, var(--theme-brand) 80%, var(--text-secondary)); }
+.starter-theme-inline-prompt > span:not(.starter-theme-inline-prompt-action) { overflow: hidden; text-overflow: ellipsis; }
+.starter-theme-inline-prompt:hover { background: color-mix(in srgb, var(--theme-brand) 6%, var(--surface-2)); color: var(--text-primary); }
+.starter-theme-inline-prompt:hover > span:not(.starter-theme-inline-prompt-action) {
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--theme-brand) 58%, currentColor);
+  text-decoration-thickness: 1.5px;
+  text-underline-offset: 0.22em;
+}
+
+.starter-theme-inline-prompt-action {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.35rem;
+  margin-left: auto;
+  color: color-mix(in srgb, var(--theme-brand) 82%, var(--text-primary));
+  font-size: 0.72rem;
+  font-weight: 650;
+  opacity: 0;
+  transform: translateX(-0.35rem);
+  transition: opacity 140ms ease, transform 140ms ease;
+}
+
+.starter-theme-inline-prompt:hover .starter-theme-inline-prompt-action,
+.starter-theme-inline-prompt:focus-visible .starter-theme-inline-prompt-action { opacity: 1; transform: translateX(0); }
+
+@media (max-width: 900px) {
+  .starter-theme-rail { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+
+@media (max-width: 640px) {
+  .starter-theme-rail { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .starter-theme-inline-prompt { height: auto; min-height: 2.1rem; white-space: normal; }
+  .starter-theme-inline-prompt-action { display: none; }
+}
+
+.pod-home-starter-nudge {
+  border-top: 1px solid var(--border-subtle);
+  padding: 0.8rem 0;
+}
+
+.pod-home-starter-nudge[data-expanded="true"] {
+  border-bottom: 1px solid var(--border-subtle);
+  padding-bottom: 1rem;
+}
+
+.pod-home-starter-nudge-icon {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+  color: var(--text-secondary);
+}


### PR DESCRIPTION
## Summary

- replace the generic recipe catalog with concrete starter themes for dashboards, WhatsApp, Telegram, Slack, email, Teams, knowledge, intake, and automations
- make Pod Home maturity-aware: fresh pods lead with starter directions, forming pods get a dismissible capability nudge, and operating pods remain activity-first
- carry the same starter language, previews, output metadata, and prompt-specific launches through onboarding, app creation, and recipe detail surfaces
- keep the change frontend-scoped; no landing-page or marketing-page changes are included

## Verification

- `npm --prefix lemma-frontend run check`
- `npm --prefix lemma-frontend test -- lib/pods/pod-home-starters.test.ts` (5 tests)
- `npm --prefix lemma-frontend run build`
- `git diff --check`
