### PR TITLE
Fix legacy function revision migration on first execution

### DIFF
--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -342,6 +342,7 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'function.handlers.function_run_job.propagated': EventSpec('debug', frozenset({'run_id'})),
     'function.handlers.reconcile_function_runs.failed': EventSpec('error', frozenset()),
     'function.handlers.run_reconcile_enqueue_failed.degraded': EventSpec('warning', frozenset({'error_type', 'run_id'})),
+    'function.use_cases.legacy_revision_backfilled': EventSpec('info', frozenset({'function_id', 'pod_id', 'revision_hash'})),
     'function.use_cases.run_enqueue_deferred.degraded': EventSpec('warning', frozenset({'error_type', 'run_id'})),
     'http.request.completed': EventSpec('debug', frozenset({'duration_ms', 'method', 'route', 'status_code'})),
     'http.request.failed': EventSpec('error', frozenset({'duration_ms', 'error_code', 'error_type', 'method', 'route', 'status_code'})),

--- a/lemma-backend/app/modules/function/application/function_definition_compiler.py
+++ b/lemma-backend/app/modules/function/application/function_definition_compiler.py
@@ -42,6 +42,10 @@ class FunctionDefinitionCompiler:
         self._storage_factory = storage_factory
         self._artifact_builder = FunctionArtifactBuilder(storage_factory)
 
+    async def read_code(self, function_id: UUID, path: str) -> str:
+        code = await self._storage_factory(function_id).read_file(path)
+        return code.decode("utf-8") if isinstance(code, bytes) else code
+
     async def write_code(self, function_id: UUID, path: str, code: str) -> None:
         await self._storage_factory(function_id).write_file(path, code)
 

--- a/lemma-backend/app/modules/function/application/function_use_cases.py
+++ b/lemma-backend/app/modules/function/application/function_use_cases.py
@@ -142,7 +142,7 @@ class FunctionUseCases:
                 "Function revision migration did not activate an executable revision"
             )
         logger.info(
-            "function.legacy_revision_backfilled",
+            "function.use_cases.legacy_revision_backfilled",
             function_id=str(function.id),
             pod_id=str(function.pod_id),
             revision_hash=activated.revision_hash,

--- a/lemma-backend/app/modules/function/application/function_use_cases.py
+++ b/lemma-backend/app/modules/function/application/function_use_cases.py
@@ -14,7 +14,7 @@ ctx).
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from uuid import UUID
 
 from fastapi import Request
@@ -36,12 +36,17 @@ from app.modules.function.domain.entities import (
     FunctionUpdateEntity,
     RunAsWorkload,
 )
-from app.modules.function.domain.errors import FunctionRunQueueUnavailable
+from app.modules.function.domain.errors import (
+    FunctionRunQueueUnavailable,
+    FunctionValidationError,
+)
 from app.modules.function.domain.ports import FunctionExecutionPort
 from app.modules.function.domain.ports import FunctionRunQueuePort
 from app.modules.function.domain.types import JsonObject
 from app.modules.function.services.function_service import (
     FunctionService,
+    LegacyFunctionRevisionRequired,
+    ResolvedExecution,
     parse_python_packages,
 )
 from app.core.log.log import get_logger
@@ -106,6 +111,57 @@ class FunctionUseCases:
         # to the still-active database revision.
         await self._compiler.write_code(function.id, function.code_path, code)
         function.status = FunctionStatus.READY
+
+    async def _backfill_legacy_revision(self, function: FunctionEntity) -> None:
+        """Compile and atomically activate a pre-artifact function definition."""
+        if function.id is None or function.code_path is None:
+            raise FunctionValidationError(
+                "Function has no source available for revision migration"
+            )
+        legacy_code_path = function.code_path
+        code = await self._compiler.read_code(function.id, legacy_code_path)
+        artifact = await self._compiler.build_artifact(
+            function,
+            code,
+            python_packages=tuple(parse_python_packages(code)),
+        )
+        revision_code_path = (
+            f"revisions/{artifact.revision_hash.removeprefix('sha256:')}/function.py"
+        )
+        await self._compiler.write_code(function.id, revision_code_path, code)
+
+        async with uow_scope(self._uow_factory) as uow:
+            activated = await self._build(uow).activate_revision_if_missing(
+                function.id,
+                expected_code_path=legacy_code_path,
+                revision_hash=artifact.revision_hash,
+                code_path=revision_code_path,
+            )
+        if activated is None or activated.revision_hash is None:
+            raise FunctionValidationError(
+                "Function revision migration did not activate an executable revision"
+            )
+        logger.info(
+            "function.legacy_revision_backfilled",
+            function_id=str(function.id),
+            pod_id=str(function.pod_id),
+            revision_hash=activated.revision_hash,
+        )
+
+    async def _resolve_with_revision_backfill(
+        self,
+        resolve_once: Callable[[], Awaitable[ResolvedExecution]],
+    ) -> ResolvedExecution:
+        try:
+            return await resolve_once()
+        except LegacyFunctionRevisionRequired as required:
+            await self._backfill_legacy_revision(required.function)
+        try:
+            return await resolve_once()
+        except LegacyFunctionRevisionRequired as exc:
+            raise FunctionValidationError(
+                "Function revision migration did not activate an executable revision"
+            ) from exc
 
     # -- API-path operations (request ctx) ------------------------------------
 
@@ -309,12 +365,15 @@ class FunctionUseCases:
         request: Request,
         run_as_workload: RunAsWorkload | None = None,
     ) -> FunctionRunEntity:
-        async with pod_context_scope(
-            self._uow_factory, request=request, user_id=user_id, pod_id=pod_id
-        ) as scope:
-            resolved = await self._build(scope.uow).resolve_execute(
-                pod_id, name, input_data, user_id, user_email, ctx=scope.ctx
-            )
+        async def resolve_once() -> ResolvedExecution:
+            async with pod_context_scope(
+                self._uow_factory, request=request, user_id=user_id, pod_id=pod_id
+            ) as scope:
+                return await self._build(scope.uow).resolve_execute(
+                    pod_id, name, input_data, user_id, user_email, ctx=scope.ctx
+                )
+
+        resolved = await self._resolve_with_revision_backfill(resolve_once)
         return await self._run_resolved(
             resolved, user_email=user_email, run_as_workload=run_as_workload
         )
@@ -342,23 +401,26 @@ class FunctionUseCases:
         delegation_actor_name: str | None,
         run_as_workload: RunAsWorkload | None = None,
     ) -> FunctionRunEntity:
-        # Build the delegated ctx AND run resolve_execute inside one live UoW, so
-        # ctx.require's resource hydration never touches a closed session.
-        async with uow_scope(self._uow_factory) as uow:
-            auth_ctx = await AuthorizationDataService(
-                uow.session
-            ).build_delegated_workload_context(
-                user_id=user_id,
-                principal_type=principal_type,
-                principal_id=principal_id,
-                pod_id=pod_id,
-                delegation_scope=delegation_scope,
-                delegation_actor_name=delegation_actor_name,
-            )
-            async with context_scope(auth_ctx):
-                resolved = await self._build(uow).resolve_execute(
-                    pod_id, name, input_data, user_id, None, ctx=auth_ctx
+        async def resolve_once() -> ResolvedExecution:
+            # Build the delegated ctx AND resolve inside one live UoW, so
+            # ctx.require's resource hydration never touches a closed session.
+            async with uow_scope(self._uow_factory) as uow:
+                auth_ctx = await AuthorizationDataService(
+                    uow.session
+                ).build_delegated_workload_context(
+                    user_id=user_id,
+                    principal_type=principal_type,
+                    principal_id=principal_id,
+                    pod_id=pod_id,
+                    delegation_scope=delegation_scope,
+                    delegation_actor_name=delegation_actor_name,
                 )
+                async with context_scope(auth_ctx):
+                    return await self._build(uow).resolve_execute(
+                        pod_id, name, input_data, user_id, None, ctx=auth_ctx
+                    )
+
+        resolved = await self._resolve_with_revision_backfill(resolve_once)
         return await self._run_resolved(
             resolved, user_email=None, run_as_workload=run_as_workload
         )
@@ -373,15 +435,20 @@ class FunctionUseCases:
         input_data: JsonObject,
         user_id: UUID,
     ) -> FunctionRunEntity:
-        async with uow_scope(self._uow_factory) as uow:
-            auth_ctx = await AuthorizationDataService(uow.session).build_user_context(
-                user_id=user_id,
-                pod_id=pod_id,
-            )
-            async with context_scope(auth_ctx):
-                resolved = await self._build(uow).resolve_execute(
-                    pod_id, name, input_data, user_id, None, ctx=auth_ctx
+        async def resolve_once() -> ResolvedExecution:
+            async with uow_scope(self._uow_factory) as uow:
+                auth_ctx = await AuthorizationDataService(
+                    uow.session
+                ).build_user_context(
+                    user_id=user_id,
+                    pod_id=pod_id,
                 )
+                async with context_scope(auth_ctx):
+                    return await self._build(uow).resolve_execute(
+                        pod_id, name, input_data, user_id, None, ctx=auth_ctx
+                    )
+
+        resolved = await self._resolve_with_revision_backfill(resolve_once)
         return await self._run_resolved(resolved, user_email=None)
 
     async def dispatch_function_for_workflow(
@@ -399,21 +466,26 @@ class FunctionUseCases:
         suspends on the run id and releases its run-row lock instead of pinning it
         across the sandbox round-trip. The FunctionRunCompleted event resumes the
         workflow."""
-        async with uow_scope(self._uow_factory) as uow:
-            auth_ctx = await AuthorizationDataService(uow.session).build_user_context(
-                user_id=user_id,
-                pod_id=pod_id,
-            )
-            async with context_scope(auth_ctx):
-                resolved = await self._build(uow).resolve_execute(
-                    pod_id,
-                    name,
-                    input_data,
-                    user_id,
-                    None,
-                    ctx=auth_ctx,
-                    dispatch_mode=FunctionDispatchMode.ASYNCHRONOUS,
+        async def resolve_once() -> ResolvedExecution:
+            async with uow_scope(self._uow_factory) as uow:
+                auth_ctx = await AuthorizationDataService(
+                    uow.session
+                ).build_user_context(
+                    user_id=user_id,
+                    pod_id=pod_id,
                 )
+                async with context_scope(auth_ctx):
+                    return await self._build(uow).resolve_execute(
+                        pod_id,
+                        name,
+                        input_data,
+                        user_id,
+                        None,
+                        ctx=auth_ctx,
+                        dispatch_mode=FunctionDispatchMode.ASYNCHRONOUS,
+                    )
+
+        resolved = await self._resolve_with_revision_backfill(resolve_once)
         return await self._enqueue_run(resolved.run)
 
     # -- Shared dispatch ------------------------------------------------------

--- a/lemma-backend/app/modules/function/domain/ports.py
+++ b/lemma-backend/app/modules/function/domain/ports.py
@@ -25,6 +25,15 @@ class FunctionRepositoryPort(Protocol):
 
     async def update(self, function: FunctionEntity) -> FunctionEntity: ...
 
+    async def activate_revision_if_missing(
+        self,
+        function_id: UUID,
+        *,
+        expected_code_path: str,
+        revision_hash: str,
+        code_path: str,
+    ) -> FunctionEntity | None: ...
+
     async def delete(self, id: UUID) -> bool: ...
 
     async def list_by_pod(

--- a/lemma-backend/app/modules/function/infrastructure/repositories.py
+++ b/lemma-backend/app/modules/function/infrastructure/repositories.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 from sqlalchemy.orm import load_only
 
 from app.core.authorization.context import Context, ResourceType, ResourceVisibility
@@ -25,6 +25,7 @@ from app.modules.function.domain.entities import (
     FunctionEntity,
     FunctionRunEntity,
     FunctionRunStatus,
+    FunctionStatus,
 )
 from app.modules.function.domain.events import FunctionRunFailedEvent
 from app.modules.function.domain.errors import (
@@ -201,6 +202,41 @@ class FunctionRepository(FunctionRepositoryPort):
 
         await self.session.flush()
         return model.to_entity()
+
+    async def activate_revision_if_missing(
+        self,
+        function_id: UUID,
+        *,
+        expected_code_path: str,
+        revision_hash: str,
+        code_path: str,
+    ) -> FunctionEntity | None:
+        """Atomically activate one legacy source revision.
+
+        A first-run backfill may race with another invocation or a user update.
+        The compare-and-set protects the newer definition: only the row that
+        still points at the exact legacy source and has no active revision can
+        be changed.
+        """
+
+        statement = (
+            update(FunctionModel)
+            .where(
+                FunctionModel.id == function_id,
+                FunctionModel.revision_hash.is_(None),
+                FunctionModel.code_path == expected_code_path,
+            )
+            .values(
+                revision_hash=revision_hash,
+                code_path=code_path,
+                status=FunctionStatus.READY,
+            )
+            .returning(FunctionModel)
+        )
+        model = (await self.session.execute(statement)).scalar_one_or_none()
+        if model is not None:
+            return model.to_entity()
+        return await self.get(function_id)
 
     async def delete(self, id: UUID) -> bool:
         pod_id = (

--- a/lemma-backend/app/modules/function/services/function_service.py
+++ b/lemma-backend/app/modules/function/services/function_service.py
@@ -124,6 +124,14 @@ class ResolvedExecution:
     run: FunctionRunEntity
 
 
+class LegacyFunctionRevisionRequired(Exception):
+    """Internal control flow for a pre-artifact function definition."""
+
+    def __init__(self, function: FunctionEntity):
+        super().__init__(function.name)
+        self.function = function
+
+
 @dataclass(slots=True)
 class FunctionUpdatePlan:
     """In-memory-mutated function plus what the sandbox/persist phases need: the
@@ -226,6 +234,21 @@ class FunctionService:
     async def _delete_function_row(self, function_id: UUID) -> bool:
         async with self._repos() as (function_repository, _run_repository):
             return await function_repository.delete(function_id)
+
+    async def activate_revision_if_missing(
+        self,
+        function_id: UUID,
+        *,
+        expected_code_path: str,
+        revision_hash: str,
+        code_path: str,
+    ) -> FunctionEntity | None:
+        return await self.repository.activate_revision_if_missing(
+            function_id,
+            expected_code_path=expected_code_path,
+            revision_hash=revision_hash,
+            code_path=code_path,
+        )
 
     async def get_function_by_name(
         self,
@@ -480,7 +503,11 @@ class FunctionService:
             ),
         )
 
-        if function.status != FunctionStatus.READY or function.revision_hash is None:
+        if function.status != FunctionStatus.READY:
+            raise FunctionValidationError("Function has no ready executable revision")
+        if function.revision_hash is None:
+            if function.code_path is not None:
+                raise LegacyFunctionRevisionRequired(function)
             raise FunctionValidationError("Function has no ready executable revision")
 
         run_entity = FunctionRunEntity(

--- a/lemma-backend/app/modules/function/tests/unit/test_function_service.py
+++ b/lemma-backend/app/modules/function/tests/unit/test_function_service.py
@@ -24,6 +24,7 @@ from app.modules.function.domain.errors import (
 )
 from app.modules.function.services.function_service import (
     FunctionService,
+    LegacyFunctionRevisionRequired,
     parse_python_packages,
 )
 from app.modules.test_support.authz import allow_all_context, deny_all_context
@@ -256,3 +257,30 @@ async def test_resolve_execute_requires_ready_revision(
             None,
             ctx=context,
         )
+
+
+async def test_resolve_execute_requests_backfill_for_ready_legacy_source(
+    service: FunctionService,
+    function_repository: AsyncMock,
+    run_repository: AsyncMock,
+    context: Context,
+) -> None:
+    function = _function(
+        status=FunctionStatus.READY,
+        code_path="test-function.py",
+        revision_hash=None,
+    )
+    function_repository.get_by_name.return_value = function
+
+    with pytest.raises(LegacyFunctionRevisionRequired) as raised:
+        await service.resolve_execute(
+            function.pod_id,
+            function.name,
+            {},
+            function.user_id,
+            None,
+            ctx=context,
+        )
+
+    assert raised.value.function is function
+    run_repository.create_run.assert_not_awaited()

--- a/lemma-backend/app/modules/function/tests/unit/test_function_use_cases.py
+++ b/lemma-backend/app/modules/function/tests/unit/test_function_use_cases.py
@@ -27,6 +27,9 @@ from app.modules.function.domain.entities import (
 )
 from app.modules.function.domain.errors import FunctionRunQueueUnavailable
 from app.modules.function.services.function_service import ResolvedExecution
+from app.modules.function.services.function_service import (
+    LegacyFunctionRevisionRequired,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -190,6 +193,95 @@ async def test_execute_api_touches_sandbox_with_no_connection_held(monkeypatch):
     assert captured["mode"] == FunctionDispatchMode.SYNCHRONOUS
     assert result.status == FunctionRunStatus.FAILED
     assert factory.state["open"] is False
+
+
+@pytest.mark.asyncio
+async def test_execute_backfills_legacy_revision_before_creating_run():
+    factory = _TrackingUowFactory()
+    function = _function(
+        name="legacy-fn",
+        type=FunctionType.API,
+        status=FunctionStatus.READY,
+        code_path="legacy-fn.py",
+        revision_hash=None,
+    )
+    revision_hash = f"sha256:{'c' * 64}"
+    activated = function.model_copy(
+        update={
+            "revision_hash": revision_hash,
+            "code_path": f"revisions/{'c' * 64}/function.py",
+        }
+    )
+    run = FunctionRunEntity(
+        id=uuid4(),
+        function_id=function.id,
+        user_id=function.user_id,
+        status=FunctionRunStatus.PENDING,
+    )
+    resolved = ResolvedExecution(function=activated, run=run)
+    service = SimpleNamespace(
+        resolve_execute=AsyncMock(
+            side_effect=[
+                LegacyFunctionRevisionRequired(function),
+                resolved,
+            ]
+        ),
+        activate_revision_if_missing=AsyncMock(return_value=activated),
+    )
+    code = (
+        "# input_type_name: Input\n"
+        "# output_type_name: Output\n"
+        "# function_name: run\n"
+    )
+    compiler = SimpleNamespace(
+        read_code=AsyncMock(return_value=code),
+        build_artifact=AsyncMock(
+            return_value=FunctionArtifact(revision_hash=revision_hash)
+        ),
+        write_code=AsyncMock(),
+    )
+    completed = run.model_copy(update={"status": FunctionRunStatus.COMPLETED})
+    dispatcher = SimpleNamespace(
+        execute=AsyncMock(return_value=completed),
+        cancel=AsyncMock(),
+    )
+    use_cases = FunctionUseCases(
+        factory,
+        lambda uow: service,
+        compiler,
+        dispatcher,
+        AsyncMock(),
+    )
+
+    result = await use_cases.execute_function(
+        pod_id=function.pod_id,
+        name=function.name,
+        input_data={},
+        user_id=function.user_id,
+        user_email=None,
+        request=SimpleNamespace(),
+    )
+
+    assert result.status == FunctionRunStatus.COMPLETED
+    compiler.read_code.assert_awaited_once_with(function.id, "legacy-fn.py")
+    compiler.build_artifact.assert_awaited_once_with(
+        function,
+        code,
+        python_packages=(),
+    )
+    compiler.write_code.assert_awaited_once_with(
+        function.id,
+        f"revisions/{'c' * 64}/function.py",
+        code,
+    )
+    service.activate_revision_if_missing.assert_awaited_once_with(
+        function.id,
+        expected_code_path="legacy-fn.py",
+        revision_hash=revision_hash,
+        code_path=f"revisions/{'c' * 64}/function.py",
+    )
+    assert service.resolve_execute.await_count == 2
+    assert factory.state["opens"] == 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- detect READY functions that predate immutable revision artifacts
- build an immutable artifact from the existing source on first authorized execution
- atomically activate the revision without overwriting concurrent user updates
- retry API, JOB, workflow, and agent-tool execution through the normal path

## Why
The 0008 function migration added `revision_hash` but could not backfill blob-backed function source in SQL. Existing functions remained READY with a null revision and failed with `FUNCTION_VALIDATION_ERROR`.

## Validation
- 62 function unit tests passed
- function module Ruff passed
- git diff --check passed