### PR TITLE
Externalize and right-size E2B profiles

### DIFF
--- a/.github/workflows/agentbox-function-benchmark.yml
+++ b/.github/workflows/agentbox-function-benchmark.yml
@@ -104,15 +104,24 @@ jobs:
       - name: Run E2B workspace and function provider conformance
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          AGENTBOX_E2B_WORKSPACE_TEMPLATE: ${{ vars.AGENTBOX_E2B_WORKSPACE_TEMPLATE }}
+          AGENTBOX_E2B_WORKSPACE_BUILD_ID: ${{ vars.AGENTBOX_E2B_WORKSPACE_BUILD_ID }}
+          AGENTBOX_E2B_FUNCTION_TEMPLATE: ${{ vars.AGENTBOX_E2B_FUNCTION_TEMPLATE }}
+          AGENTBOX_E2B_FUNCTION_BUILD_ID: ${{ vars.AGENTBOX_E2B_FUNCTION_BUILD_ID }}
         run: |
-          set -a
-          source ../agentbox/templates/e2b/promoted-builds.env
-          set +a
+          test -n "$AGENTBOX_E2B_WORKSPACE_TEMPLATE"
+          test -n "$AGENTBOX_E2B_WORKSPACE_BUILD_ID"
+          test -n "$AGENTBOX_E2B_FUNCTION_TEMPLATE"
+          test -n "$AGENTBOX_E2B_FUNCTION_BUILD_ID"
           cd ../agentbox
           AGENTBOX_RUN_E2B_TESTS=1 .venv/bin/pytest -q tests/adapters/test_e2b_real.py
       - name: Run E2B benchmark at concurrency 5
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          AGENTBOX_E2B_WORKSPACE_TEMPLATE: ${{ vars.AGENTBOX_E2B_WORKSPACE_TEMPLATE }}
+          AGENTBOX_E2B_WORKSPACE_BUILD_ID: ${{ vars.AGENTBOX_E2B_WORKSPACE_BUILD_ID }}
+          AGENTBOX_E2B_FUNCTION_TEMPLATE: ${{ vars.AGENTBOX_E2B_FUNCTION_TEMPLATE }}
+          AGENTBOX_E2B_FUNCTION_BUILD_ID: ${{ vars.AGENTBOX_E2B_FUNCTION_BUILD_ID }}
           FUNCTION_BENCH_CONCURRENCY: "5"
           # The protected lane has no ngrok account dependency. Local acceptance
           # may select ngrok to distinguish tunnel failures from executor failures.

--- a/agentbox/templates/e2b/README.md
+++ b/agentbox/templates/e2b/README.md
@@ -11,8 +11,15 @@ AgentBox uses two immutable E2B template builds:
   file.
 - `lemma-agentbox-function` contains only the function runner and Lemma SDK.
 
-Builds are created from the monorepo source, and the returned template and build
-IDs must both be configured. AgentBox combines them as
+Builds are created from the monorepo source. Both profiles default to 1 vCPU and
+2 GB RAM; deployments may override the build resources with
+`AGENTBOX_E2B_{WORKSPACE,FUNCTION}_{CPU_COUNT,MEMORY_MB}`. E2B's template build
+API does not expose a disk-size setting, and function filesystems are treated as
+ephemeral because the provider allocation is destroyed after the configured idle
+period.
+
+The returned template and build IDs must both be configured outside this source
+repository. AgentBox combines them as
 `<template_id>:<build_id>` so a mutable tag can never change a running profile.
 
 ```bash
@@ -23,13 +30,11 @@ set +a
 .venv/bin/python templates/e2b/build_templates.py --target all
 ```
 
-The script prints identifiers only. It does not write credentials or modify an
-environment file.
-
-After both real provider conformance suites and the backend API/JOB benchmark pass,
-the promoted immutable IDs are recorded in `promoted-builds.env`. That file is the
-single non-secret release manifest consumed by local benchmark commands and CI; a
-new build is not promoted merely because template publication succeeded.
+The script prints identifiers and effective resource values only. It does not
+write credentials or modify an environment file. After both real provider
+conformance suites and the backend API/JOB benchmark pass, promote the immutable
+IDs in deployment configuration. A new build is not promoted merely because
+template publication succeeded.
 
 Python environments are resolved with `uv --locked`; Node dependencies are resolved
 with `pnpm --frozen-lockfile`. Template publication must fail rather than update a
@@ -44,8 +49,8 @@ Do not configure a template name alone. Runtime profiles require both the templa
 ID and its exact build ID through:
 
 ```text
-E2B_WORKSPACE_TEMPLATE
-E2B_WORKSPACE_TEMPLATE_BUILD_ID
-E2B_FUNCTION_TEMPLATE
-E2B_FUNCTION_TEMPLATE_BUILD_ID
+AGENTBOX_E2B_WORKSPACE_TEMPLATE
+AGENTBOX_E2B_WORKSPACE_BUILD_ID
+AGENTBOX_E2B_FUNCTION_TEMPLATE
+AGENTBOX_E2B_FUNCTION_BUILD_ID
 ```

--- a/agentbox/templates/e2b/build_templates.py
+++ b/agentbox/templates/e2b/build_templates.py
@@ -16,6 +16,21 @@ NODE_LINUX_X64_SHA256 = (
     "55aa7153f9d88f28d765fcdad5ae6945b5c0f98a36881703817e4c450fa76742"
 )
 PNPM_VERSION = "11.15.1"
+DEFAULT_CPU_COUNT = 1
+DEFAULT_MEMORY_MB = 2048
+
+
+def _positive_int_environment(name: str, *, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if value < 1:
+        raise ValueError(f"{name} must be at least 1")
+    return value
 
 
 def _install_uv_command() -> str:
@@ -298,11 +313,33 @@ def build(
     if not os.environ.get("E2B_API_KEY"):
         raise RuntimeError("E2B_API_KEY is required")
     selected = {
-        "workspace": (workspace_template, "lemma-agentbox-workspace", 2, 2048),
+        "workspace": (
+            workspace_template,
+            "lemma-agentbox-workspace",
+            _positive_int_environment(
+                "AGENTBOX_E2B_WORKSPACE_CPU_COUNT",
+                default=DEFAULT_CPU_COUNT,
+            ),
+            _positive_int_environment(
+                "AGENTBOX_E2B_WORKSPACE_MEMORY_MB",
+                default=DEFAULT_MEMORY_MB,
+            ),
+        ),
         # The resident runtime imports each immutable revision once and adds
         # workers as concurrent invocations arrive. This is a safety envelope,
         # not an advertised four-request admission limit.
-        "function": (function_template, "lemma-agentbox-function", 4, 2048),
+        "function": (
+            function_template,
+            "lemma-agentbox-function",
+            _positive_int_environment(
+                "AGENTBOX_E2B_FUNCTION_CPU_COUNT",
+                default=DEFAULT_CPU_COUNT,
+            ),
+            _positive_int_environment(
+                "AGENTBOX_E2B_FUNCTION_MEMORY_MB",
+                default=DEFAULT_MEMORY_MB,
+            ),
+        ),
     }
     names = tuple(selected) if target == "all" else (target,)
     result: dict[str, dict[str, str]] = {}
@@ -320,6 +357,8 @@ def build(
             "template_id": built.template_id,
             "build_id": built.build_id,
             "name": built.name,
+            "cpu_count": str(cpu_count),
+            "memory_mb": str(memory_mb),
         }
     return result
 

--- a/agentbox/templates/e2b/promoted-builds.env
+++ b/agentbox/templates/e2b/promoted-builds.env
@@ -1,6 +1,0 @@
-# Immutable E2B profile release that passed real workspace/function conformance
-# and the full backend API/JOB benchmark. This file contains no credentials.
-AGENTBOX_E2B_WORKSPACE_TEMPLATE=m5g4h0znlqxdk6rcjd8d
-AGENTBOX_E2B_WORKSPACE_BUILD_ID=ef697d86-7bf3-456b-a61f-dad790ec4f77
-AGENTBOX_E2B_FUNCTION_TEMPLATE=cnn429nq2bo43gxfi9p4
-AGENTBOX_E2B_FUNCTION_BUILD_ID=4992db5b-0431-4d1d-beb5-f2667da06975

--- a/agentbox/tests/test_e2b_template_build_config.py
+++ b/agentbox/tests/test_e2b_template_build_config.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "templates" / "e2b" / "build_templates.py"
+)
+_SPEC = importlib.util.spec_from_file_location("e2b_build_templates", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+def test_template_resources_default_to_one_cpu_and_two_gib(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AGENTBOX_E2B_WORKSPACE_CPU_COUNT", raising=False)
+    monkeypatch.delenv("AGENTBOX_E2B_WORKSPACE_MEMORY_MB", raising=False)
+
+    assert (
+        _MODULE._positive_int_environment(
+            "AGENTBOX_E2B_WORKSPACE_CPU_COUNT",
+            default=_MODULE.DEFAULT_CPU_COUNT,
+        )
+        == 1
+    )
+    assert (
+        _MODULE._positive_int_environment(
+            "AGENTBOX_E2B_WORKSPACE_MEMORY_MB",
+            default=_MODULE.DEFAULT_MEMORY_MB,
+        )
+        == 2048
+    )
+
+
+def test_template_resources_accept_positive_environment_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENTBOX_E2B_FUNCTION_CPU_COUNT", "2")
+
+    assert (
+        _MODULE._positive_int_environment(
+            "AGENTBOX_E2B_FUNCTION_CPU_COUNT",
+            default=_MODULE.DEFAULT_CPU_COUNT,
+        )
+        == 2
+    )
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "not-an-integer"])
+def test_template_resources_reject_invalid_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    value: str,
+) -> None:
+    monkeypatch.setenv("AGENTBOX_E2B_FUNCTION_CPU_COUNT", value)
+
+    with pytest.raises(ValueError):
+        _MODULE._positive_int_environment(
+            "AGENTBOX_E2B_FUNCTION_CPU_COUNT",
+            default=_MODULE.DEFAULT_CPU_COUNT,
+        )

--- a/lemma-backend/Makefile
+++ b/lemma-backend/Makefile
@@ -36,7 +36,8 @@ BACKEND_COVERAGE_DATA_ENV = COVERAGE_FILE=$(BACKEND_COVERAGE_FILE)
 # Full-path function quality benchmark. E2B identifiers are exact immutable
 # test inputs; this target never changes templates, aliases, or account state
 # beyond creating and exactly deleting its own tracked sandboxes. The E2B API
-# key is read from lemma-backend/.env or the environment.
+# key and immutable profile IDs are read from lemma-backend/.env or the
+# environment.
 FUNCTION_BENCH_CONCURRENCY ?= 5
 FUNCTION_BENCH_INVOCATIONS ?= 5
 FUNCTION_BENCH_SOURCE_ROWS ?= 1000
@@ -44,7 +45,6 @@ FUNCTION_BENCH_WRITE_ROWS ?= 1000
 FUNCTION_BENCH_POLL_INTERVAL_SECONDS ?= 0.5
 FUNCTION_BENCH_TERMINAL_TIMEOUT_SECONDS ?= 300
 FUNCTION_BENCH_TUNNEL ?= ngrok
-include ../agentbox/templates/e2b/promoted-builds.env
 FUNCTION_BENCH_ENV = \
 	E2E_REAL=1 \
 	DEBUG=false \

--- a/lemma-backend/app/modules/test_support/e2e/runtime.py
+++ b/lemma-backend/app/modules/test_support/e2e/runtime.py
@@ -59,10 +59,7 @@ def _e2b_environment(key: str) -> str | None:
     backend_value = _read_env_file_value(repo_root / "lemma-backend" / ".env", key)
     if backend_value:
         return backend_value
-    return _read_env_file_value(
-        repo_root / "agentbox" / "templates" / "e2b" / "promoted-builds.env",
-        key,
-    )
+    return None
 
 
 _NGROK_URL = re.compile(r"https://[a-z0-9-]+\.(?:ngrok-free\.app|ngrok\.app)")


### PR DESCRIPTION
## Summary
- remove repository-pinned E2B template/build IDs; protected benchmarks now read deployment/repository variables
- make workspace and function CPU/RAM configurable at build time, defaulting both to 1 vCPU and 2 GB
- document ephemeral function storage and environment-owned immutable profile promotion
- add validation tests for resource configuration

## Validation
- `uv run --locked pytest -q tests/test_e2b_template_build_config.py tests/state/test_maintenance.py`
- AgentBox and backend Ruff checks

## Release note
Merge this first. Fresh immutable templates must then be published from this commit and their IDs placed in the dev infra contract before the lemma-app release PR is merged.