### PR TITLE
fix(agentbox): include CLI skills in E2B build context

### DIFF
--- a/agentbox/templates/e2b/build_templates.py
+++ b/agentbox/templates/e2b/build_templates.py
@@ -115,6 +115,7 @@ def workspace_template():
         .copy("lemma-python", "/build/lemma-python")
         .copy("lemma-pod-bundle", "/build/lemma-pod-bundle")
         .copy("lemma-cli", "/build/lemma-cli")
+        .copy("lemma-skills", "/build/lemma-skills")
         .copy(
             "agentbox/templates/workspace-python",
             "/build/agentbox/templates/workspace-python",
@@ -145,7 +146,7 @@ def workspace_template():
             "> /root/.local/share/jupyter/kernels/python3/kernel.json && "
             "uv cache clean && "
             "rm -rf /build/lemma-python /build/lemma-pod-bundle "
-            "/build/lemma-cli /build/agentbox",
+            "/build/lemma-cli /build/lemma-skills /build/agentbox",
             user="root",
         )
         .copy(

--- a/agentbox/tests/test_e2b_templates.py
+++ b/agentbox/tests/test_e2b_templates.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "templates" / "e2b" / "build_templates.py"
+)
+_SPEC = spec_from_file_location("agentbox_e2b_build_templates", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+build_templates = module_from_spec(_SPEC)
+_SPEC.loader.exec_module(build_templates)
+
+
+class _RecordingTemplate:
+    copies: list[tuple[str, str]]
+
+    def __init__(self, **_: object) -> None:
+        self.copies = []
+
+    def __getattr__(self, name: str):
+        def record(*args: object, **_: object) -> _RecordingTemplate:
+            if name == "copy":
+                self.copies.append((str(args[0]), str(args[1])))
+            return self
+
+        return record
+
+
+def test_workspace_template_includes_cli_skill_sources(monkeypatch) -> None:
+    monkeypatch.setattr(build_templates, "Template", _RecordingTemplate)
+
+    template = build_templates.workspace_template()
+
+    assert ("lemma-cli", "/build/lemma-cli") in template.copies
+    assert ("lemma-skills", "/build/lemma-skills") in template.copies


### PR DESCRIPTION
## Summary
- copy lemma-skills beside lemma-cli in the workspace E2B image build context
- remove the copied skills after the locked workspace environment is installed
- add a regression test covering the CLI and skills source pairing

## Why
The first dev publication run failed while building lemma-terminal: its packaging guard correctly rejected a monorepo build context containing lemma-cli without sibling lemma-skills.

Failed publication: https://github.com/lemma-work/lemma-app/actions/runs/30071105562

## Validation
- AgentBox suite: 121 passed, 6 skipped
- Ruff: passed for the changed template and test

Dev publication will be retried from the merged commit; production remains untouched.