### PR TITLE
Recover missing E2B workspaces automatically

### DIFF
--- a/agentbox/agentbox/persistence/repository.py
+++ b/agentbox/agentbox/persistence/repository.py
@@ -560,12 +560,30 @@ class AgentBoxRepository:
                 status_code=404,
             )
         if row.provider_storage_id not in (None, provider_storage_id):
-            raise AgentBoxError(
-                ErrorCode.OPERATION_CONFLICT,
-                "workspace storage is already bound to another provider resource",
-                retry=RetryDisposition.DO_NOT_RETRY,
-                status_code=409,
-            )
+            stale_sandbox_native_binding = False
+            if (
+                row.storage_kind == StorageKind.SANDBOX_NATIVE.value
+                and row.bound_allocation_id is not None
+                and row.bound_allocation_id != allocation_id
+            ):
+                bound_allocation = await self._session.get(
+                    AllocationRow, row.bound_allocation_id
+                )
+                stale_sandbox_native_binding = (
+                    bound_allocation is None
+                    or bound_allocation.state
+                    in (
+                        AllocationState.ERROR.value,
+                        AllocationState.DESTROYED.value,
+                    )
+                )
+            if not stale_sandbox_native_binding:
+                raise AgentBoxError(
+                    ErrorCode.OPERATION_CONFLICT,
+                    "workspace storage is already bound to another provider resource",
+                    retry=RetryDisposition.DO_NOT_RETRY,
+                    status_code=409,
+                )
         row.provider_storage_id = provider_storage_id
         row.bound_allocation_id = allocation_id
         row.state = StorageState.READY.value

--- a/agentbox/tests/state/test_repository.py
+++ b/agentbox/tests/state/test_repository.py
@@ -159,6 +159,55 @@ class FailedReadinessProvider(FakeProvider):
             raise ProviderLifecycleError("provider unavailable during cleanup")
 
 
+class MissingNativeWorkspaceProvider(FakeProvider):
+    workspace_storage_kind = StorageKind.SANDBOX_NATIVE
+
+    def __init__(self, database: StateDatabase) -> None:
+        super().__init__(database)
+        self.destroy_calls: list[ProviderAllocationRef] = []
+
+    async def create(self, request: ProviderCreateRequest) -> ProviderCreateResult:
+        assert self.database.active_units_of_work == 0
+        self.create_calls.append(request)
+        provider_id = f"sandbox-{len(self.create_calls)}"
+        return ProviderCreateResult(
+            provider_id=provider_id,
+            provider_instance_id=provider_id,
+            provider_request_id=None,
+            workspace_storage=ProviderStorageResult(
+                provider_storage_id=provider_id,
+                bound_to_allocation=True,
+            ),
+        )
+
+    async def wait_ready(
+        self,
+        allocation: ProviderAllocationRef,
+        *,
+        profile: SandboxProfileRef,
+        deadline_at: datetime,
+    ) -> ProviderReadyResult:
+        del profile, deadline_at
+        assert self.database.active_units_of_work == 0
+        self.ready_calls += 1
+        if self.ready_calls == 1:
+            raise ProviderAllocationFailed("sandbox no longer exists")
+        return ProviderReadyResult(
+            provider_id=allocation.provider_id,
+            provider_instance_id=allocation.provider_instance_id,
+        )
+
+    async def destroy_allocation(
+        self,
+        allocation: ProviderAllocationRef,
+        *,
+        deadline_at: datetime,
+    ) -> None:
+        del deadline_at
+        assert self.database.active_units_of_work == 0
+        self.destroy_calls.append(allocation)
+
+
 async def test_logical_namespace_is_composite(database: StateDatabase):
     logical_id = uuid4()
     workspace = SandboxKey(WorkloadKind.WORKSPACE, logical_id)
@@ -337,6 +386,74 @@ async def test_failed_readiness_cleanup_failure_remains_reconcilable(
     assert reconciled == 1
     assert len(provider.destroy_calls) == 2
     assert allocations[0].state == AllocationState.ERROR
+
+
+async def test_missing_sandbox_native_workspace_rebinds_to_new_allocation(
+    database: StateDatabase,
+):
+    provider = MissingNativeWorkspaceProvider(database)
+    service = SandboxLifecycleService(database, provider)
+    key = SandboxKey(WorkloadKind.WORKSPACE, uuid4())
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=30)
+
+    with pytest.raises(AgentBoxError) as raised:
+        await service.ensure(
+            key,
+            profile(),
+            admission_class=AdmissionClass.INTERACTIVE,
+            deadline_at=deadline,
+        )
+
+    assert raised.value.retry == RetryDisposition.SAFE_SAME_OPERATION
+    recovered = await service.ensure(
+        key,
+        profile(),
+        admission_class=AdmissionClass.INTERACTIVE,
+        deadline_at=deadline,
+    )
+
+    assert recovered.ready is True
+    assert len(provider.create_calls) == 2
+    assert [item.provider_id for item in provider.destroy_calls] == ["sandbox-1"]
+    async with database.uow() as uow:
+        storage = await uow.repository.get_workspace_storage(key)
+        allocations = await uow.repository.list_allocations(key)
+        await uow.commit()
+    assert storage is not None
+    assert storage.provider_storage_id == "sandbox-2"
+    assert storage.bound_allocation_id == recovered.allocation_id
+    assert [item.state for item in allocations] == [
+        AllocationState.ERROR,
+        AllocationState.ACTIVE,
+    ]
+    assert allocations[1].provider_id == "sandbox-2"
+
+
+async def test_active_sandbox_native_workspace_cannot_be_rebound(
+    database: StateDatabase,
+):
+    provider = MissingNativeWorkspaceProvider(database)
+    provider.ready_calls = 1
+    service = SandboxLifecycleService(database, provider)
+    key = SandboxKey(WorkloadKind.WORKSPACE, uuid4())
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=30)
+
+    active = await service.ensure(
+        key,
+        profile(),
+        admission_class=AdmissionClass.INTERACTIVE,
+        deadline_at=deadline,
+    )
+
+    async with database.uow() as uow:
+        with pytest.raises(AgentBoxError) as raised:
+            await uow.repository.bind_workspace_storage(
+                key,
+                provider_storage_id="sandbox-other",
+                allocation_id=uuid4(),
+            )
+    assert raised.value.code == ErrorCode.OPERATION_CONFLICT
+    assert active.ready is True
 
 
 async def test_profile_change_replaces_and_fences_allocation(

--- a/lemma-backend/app/modules/workspace/services/agentbox_manager.py
+++ b/lemma-backend/app/modules/workspace/services/agentbox_manager.py
@@ -61,7 +61,10 @@ class AgentBoxSandbox(ISandbox):
                     deadline_at=deadline_at,
                 )
             except AgentBoxApiError as exc:
-                if exc.retry != RetryDisposition.WAIT:
+                if exc.retry not in (
+                    RetryDisposition.WAIT,
+                    RetryDisposition.SAFE_SAME_OPERATION,
+                ):
                     raise
                 await self._wait(exc.retry_after_ms, deadline_at)
                 continue

--- a/lemma-backend/app/modules/workspace/tests/unit/test_agentbox_manager.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_agentbox_manager.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from agentbox_client import (
+    AgentBoxApiError,
+    ProfileRef,
+    RetryDisposition,
+    SandboxHandle,
+    WorkloadKind,
+)
+from agentbox_client.models import AgentBoxErrorBody, AgentBoxErrorResponse
+from app.modules.workspace.services.agentbox_manager import AgentBoxSandbox
+
+
+def _api_error(retry: RetryDisposition) -> AgentBoxApiError:
+    response = httpx.Response(
+        503,
+        request=httpx.Request("PUT", "http://agentbox.test/sandboxes/workspace/id"),
+    )
+    return AgentBoxApiError(
+        response,
+        AgentBoxErrorResponse(
+            error=AgentBoxErrorBody(
+                code="PROVIDER_UNAVAILABLE",
+                message="provider allocation failed and was removed",
+                retry=retry,
+            )
+        ),
+    )
+
+
+def _ready_sandbox(logical_id):
+    return SandboxHandle(
+        workload_kind=WorkloadKind.WORKSPACE,
+        logical_id=logical_id,
+        desired_state="active",
+        profile=ProfileRef(
+            name="workspace-python-v1",
+            digest=f"sha256:{'a' * 64}",
+        ),
+        allocation_state="active",
+        allocation_id=uuid4(),
+        allocation_epoch=2,
+        ready=True,
+        operation_id=None,
+        retry_after_ms=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_workspace_retries_safe_same_operation(monkeypatch):
+    user_id = uuid4()
+
+    class _Client:
+        calls = 0
+
+        async def ensure_sandbox(self, *_args, **_kwargs):
+            self.calls += 1
+            if self.calls == 1:
+                raise _api_error(RetryDisposition.SAFE_SAME_OPERATION)
+            return _ready_sandbox(user_id)
+
+    sandbox = object.__new__(AgentBoxSandbox)
+    sandbox.client = _Client()
+
+    async def no_wait(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(AgentBoxSandbox, "_wait", no_wait)
+    result = await sandbox.ensure_sandbox(user_id)
+
+    assert result.status == "RUNNING"
+    assert sandbox.client.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_workspace_does_not_retry_unsafe_operation(monkeypatch):
+    user_id = uuid4()
+
+    class _Client:
+        calls = 0
+
+        async def ensure_sandbox(self, *_args, **_kwargs):
+            self.calls += 1
+            raise _api_error(RetryDisposition.DO_NOT_RETRY)
+
+    sandbox = object.__new__(AgentBoxSandbox)
+    sandbox.client = _Client()
+
+    async def no_wait(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(AgentBoxSandbox, "_wait", no_wait)
+    with pytest.raises(AgentBoxApiError):
+        await sandbox.ensure_sandbox(user_id)
+
+    assert sandbox.client.calls == 1


### PR DESCRIPTION
## Summary

- allow sandbox-native workspace storage to rebind only after its prior allocation is terminal (`error` or `destroyed`)
- keep active E2B bindings and durable storage providers strictly fenced
- retry AgentBox `SAFE_SAME_OPERATION` responses inside the backend workspace ensure loop
- add regression coverage for missing E2B sandbox recovery and unsafe rebind rejection

## Why

When an E2B workspace had been released and its provider sandbox no longer existed, AgentBox correctly marked the old allocation failed but kept the sandbox-native storage identity. The replacement allocation then returned a new E2B sandbox ID and hit the storage binding conflict, surfacing a 500 during function schema compilation.

## Validation

- `uv run --project agentbox pytest -q agentbox/tests` (123 passed, 6 skipped)
- `uv run --project lemma-backend pytest -q lemma-backend/app/modules/workspace/tests/unit/test_agentbox_manager.py lemma-backend/app/modules/workspace/tests/unit/test_workspace_container_service.py` (8 passed)
- focused Ruff check/format checks passed
