### PR TITLE
Recover missing E2B workspaces discovered during I/O

### DIFF
--- a/agentbox/agentbox/adapters/e2b.py
+++ b/agentbox/agentbox/adapters/e2b.py
@@ -61,6 +61,7 @@ from agentbox.ports import (
     ProviderCreateRejected,
     ProviderCreateRequest,
     ProviderCreateResult,
+    ProviderAllocationMissing,
     ProviderFilesystemConflict,
     ProviderFilesystemNotFound,
     ProviderFilesystemRejected,
@@ -1410,10 +1411,11 @@ class E2BSandboxAdapter:
                 str(exc),
                 retry_after_ms=self._config.rate_limit_retry_after_ms,
             ) from exc
+        except SandboxNotFoundException as exc:
+            raise ProviderAllocationMissing(str(exc)) from exc
         except (
             AuthenticationException,
             FileUploadException,
-            SandboxNotFoundException,
             TemplateException,
             TimeoutException,
             SandboxException,

--- a/agentbox/agentbox/filesystem.py
+++ b/agentbox/agentbox/filesystem.py
@@ -15,6 +15,7 @@ from agentbox.domain import (
 )
 from agentbox.persistence.uow import StateDatabase
 from agentbox.ports import (
+    ProviderAllocationMissing,
     ProviderAllocationRef,
     ProviderFilesystemConflict,
     ProviderFilesystemNotFound,
@@ -54,7 +55,8 @@ class FilesystemService:
     ) -> FileStat:
         allocation = await self._current_allocation(key, deadline_at)
         return await self._provider_call(
-            self._provider.stat_file(allocation, path=path, deadline_at=deadline_at)
+            self._provider.stat_file(allocation, path=path, deadline_at=deadline_at),
+            allocation=allocation,
         )
 
     async def create_directory(
@@ -66,7 +68,8 @@ class FilesystemService:
                 allocation,
                 path=path,
                 deadline_at=deadline_at,
-            )
+            ),
+            allocation=allocation,
         )
 
     async def list(
@@ -74,7 +77,8 @@ class FilesystemService:
     ) -> tuple[FileStat, ...]:
         allocation = await self._current_allocation(key, deadline_at)
         return await self._provider_call(
-            self._provider.list_files(allocation, path=path, deadline_at=deadline_at)
+            self._provider.list_files(allocation, path=path, deadline_at=deadline_at),
+            allocation=allocation,
         )
 
     async def open_read(
@@ -92,9 +96,14 @@ class FilesystemService:
                 path=path,
                 byte_range=byte_range,
                 deadline_at=deadline_at,
-            )
+            ),
+            allocation=allocation,
         )
-        return self._guard_download(stream, deadline_at=deadline_at)
+        return self._guard_download(
+            stream,
+            allocation=allocation,
+            deadline_at=deadline_at,
+        )
 
     async def read(
         self,
@@ -149,7 +158,8 @@ class FilesystemService:
                 data=self._guard_upload(data, deadline_at=deadline_at),
                 expected_sha256=expected_sha256,
                 deadline_at=deadline_at,
-            )
+            ),
+            allocation=allocation,
         )
 
     async def move(
@@ -167,7 +177,8 @@ class FilesystemService:
                 source=source,
                 destination=destination,
                 deadline_at=deadline_at,
-            )
+            ),
+            allocation=allocation,
         )
 
     async def delete(
@@ -185,15 +196,23 @@ class FilesystemService:
                 path=path,
                 recursive=recursive,
                 deadline_at=deadline_at,
-            )
+            ),
+            allocation=allocation,
         )
 
-    @staticmethod
-    async def _provider_call(operation: Awaitable[ResultT]) -> ResultT:
+    async def _provider_call(
+        self,
+        operation: Awaitable[ResultT],
+        *,
+        allocation: ProviderAllocationRef,
+    ) -> ResultT:
         try:
             return await operation
+        except ProviderAllocationMissing as exc:
+            await self._mark_allocation_missing(allocation)
+            raise self._public_error(exc) from exc
         except _PROVIDER_FILESYSTEM_ERRORS as exc:
-            raise FilesystemService._public_error(exc) from exc
+            raise self._public_error(exc) from exc
 
     async def _guard_upload(
         self, stream: AsyncIterable[bytes], *, deadline_at: datetime
@@ -214,7 +233,11 @@ class FilesystemService:
             yield bytes(chunk)
 
     async def _guard_download(
-        self, stream: AsyncIterator[bytes], *, deadline_at: datetime
+        self,
+        stream: AsyncIterator[bytes],
+        *,
+        allocation: ProviderAllocationRef,
+        deadline_at: datetime,
     ) -> AsyncIterator[bytes]:
         transferred = 0
         try:
@@ -231,6 +254,9 @@ class FilesystemService:
                         status_code=413,
                     )
                 yield bytes(chunk)
+        except ProviderAllocationMissing as exc:
+            await self._mark_allocation_missing(allocation)
+            raise self._public_error(exc) from exc
         except _PROVIDER_FILESYSTEM_ERRORS as exc:
             raise self._public_error(exc) from exc
         finally:
@@ -266,6 +292,13 @@ class FilesystemService:
                 retry=RetryDisposition.DO_NOT_RETRY,
                 status_code=error.status_code,
             )
+        if isinstance(error, ProviderAllocationMissing):
+            return AgentBoxError(
+                ErrorCode.PROVIDER_UNAVAILABLE,
+                "sandbox provider allocation no longer exists",
+                retry=RetryDisposition.SAFE_SAME_OPERATION,
+                status_code=503,
+            )
         return AgentBoxError(
             ErrorCode.PROVIDER_UNAVAILABLE,
             "filesystem provider is unavailable",
@@ -273,6 +306,17 @@ class FilesystemService:
             status_code=503,
             retry_after_ms=error.retry_after_ms,
         )
+
+    async def _mark_allocation_missing(
+        self,
+        allocation: ProviderAllocationRef,
+    ) -> None:
+        async with self._database.uow() as uow:
+            await uow.repository.mark_create_failed(
+                allocation.allocation_token,
+                error_code=ErrorCode.PROVIDER_UNAVAILABLE.value,
+            )
+            await uow.commit()
 
     async def _current_allocation(
         self, key: SandboxKey, deadline_at: datetime

--- a/agentbox/agentbox/ports.py
+++ b/agentbox/agentbox/ports.py
@@ -207,6 +207,10 @@ class ProviderFilesystemUnavailable(RuntimeError):
         self.retry_after_ms = retry_after_ms
 
 
+class ProviderAllocationMissing(ProviderFilesystemUnavailable):
+    """The allocation backing an operation definitively no longer exists."""
+
+
 class ProviderProcessPort(Protocol):
     async def start_process(
         self, request: ProviderProcessStartRequest

--- a/agentbox/tests/filesystem/test_filesystem_service.py
+++ b/agentbox/tests/filesystem/test_filesystem_service.py
@@ -11,6 +11,7 @@ import pytest_asyncio
 from agentbox.domain import (
     AdmissionClass,
     AgentBoxError,
+    AllocationState,
     ByteRange,
     ErrorCode,
     FileKind,
@@ -25,6 +26,7 @@ from agentbox.filesystem import FilesystemService
 from agentbox.lifecycle import SandboxLifecycleService
 from agentbox.persistence.uow import StateDatabase
 from agentbox.ports import (
+    ProviderAllocationMissing,
     ProviderAllocationRef,
     ProviderCreateRequest,
     ProviderCreateResult,
@@ -33,6 +35,7 @@ from agentbox.ports import (
     ProviderFilesystemRejected,
     ProviderFilesystemUnavailable,
     ProviderReadyResult,
+    ProviderStorageResult,
 )
 
 
@@ -302,6 +305,74 @@ async def test_filesystem_provider_failures_have_typed_public_semantics(
     assert raised.value.status_code == status_code
     assert raised.value.retry == retry
     assert raised.value.retry_after_ms == retry_after_ms
+    assert database.active_units_of_work == 0
+
+
+async def test_missing_provider_allocation_is_fenced_for_safe_recreate(
+    database: StateDatabase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class SandboxNativeProvider(Provider):
+        workspace_storage_kind = StorageKind.SANDBOX_NATIVE
+
+        async def create(self, request: ProviderCreateRequest) -> ProviderCreateResult:
+            self._outside_transaction("create")
+            provider_id = f"sandbox-{request.allocation_id}"
+            return ProviderCreateResult(
+                provider_id=provider_id,
+                provider_instance_id=provider_id,
+                provider_request_id=None,
+                workspace_storage=ProviderStorageResult(
+                    provider_storage_id=provider_id,
+                    bound_to_allocation=True,
+                ),
+            )
+
+    provider = SandboxNativeProvider(database)
+    key = SandboxKey(WorkloadKind.WORKSPACE, uuid4())
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=30)
+    lifecycle = SandboxLifecycleService(database, provider)
+    await lifecycle.ensure(
+        key,
+        SandboxProfileRef("workspace-python-v1", f"sha256:{'a' * 64}"),
+        admission_class=AdmissionClass.INTERACTIVE,
+        deadline_at=deadline,
+    )
+
+    async def missing_stat(*_args, **_kwargs):
+        raise ProviderAllocationMissing("sandbox no longer exists")
+
+    monkeypatch.setattr(provider, "stat_file", missing_stat)
+
+    with pytest.raises(AgentBoxError) as raised:
+        await FilesystemService(database, provider).stat(
+            key, "/tmp/payload", deadline_at=deadline
+        )
+
+    assert raised.value.code == ErrorCode.PROVIDER_UNAVAILABLE
+    assert raised.value.status_code == 503
+    assert raised.value.retry == RetryDisposition.SAFE_SAME_OPERATION
+
+    recovered = await lifecycle.ensure(
+        key,
+        SandboxProfileRef("workspace-python-v1", f"sha256:{'a' * 64}"),
+        admission_class=AdmissionClass.INTERACTIVE,
+        deadline_at=deadline,
+    )
+    assert recovered.ready is True
+
+    async with database.uow() as uow:
+        allocations = await uow.repository.list_allocations(key)
+        storage = await uow.repository.get_workspace_storage(key)
+        await uow.commit()
+    assert [item.state for item in allocations] == [
+        AllocationState.ERROR,
+        AllocationState.ACTIVE,
+    ]
+    assert allocations[0].provider_id != allocations[1].provider_id
+    assert storage is not None
+    assert storage.provider_storage_id == allocations[1].provider_id
+    assert storage.bound_allocation_id == allocations[1].allocation_id
     assert database.active_units_of_work == 0
 
 

--- a/lemma-backend/app/modules/workspace/services/workspace_sandbox_service.py
+++ b/lemma-backend/app/modules/workspace/services/workspace_sandbox_service.py
@@ -11,9 +11,11 @@ from uuid import UUID, uuid4
 from app.core.config import settings
 from app.core.request_context import correlation_headers
 from agentbox_client import (
+    AgentBoxApiError,
     AgentBoxClient,
     PortAccessGrant,
     PortProtocol,
+    RetryDisposition,
     WorkloadKind,
 )
 from app.modules.workspace.contracts import SandboxInfo
@@ -307,12 +309,10 @@ class WorkspaceSandboxService:
         scope: list[str] | None = None,
         env_vars: dict[str, str] | None = None,
     ) -> IWorkspaceSession:
-        sandbox_info = await self.get_or_create_sandbox(user_id)
         resolved_cwd = canonical_workspace_cwd(initial_cwd)
-        await self._get_manager_client().create_directory(
-            agentbox_sandbox_id(user_id),
+        sandbox_info = await self._ensure_workspace_directory(
+            user_id,
             resolved_cwd,
-            deadline_at=datetime.now(timezone.utc) + timedelta(seconds=30),
         )
 
         if env_vars is None:
@@ -345,6 +345,41 @@ class WorkspaceSandboxService:
             auto_close=close_on_exit,
             activity_callback=_activity_callback,
             owns_client=False,
+        )
+
+    async def _ensure_workspace_directory(
+        self,
+        user_id: UUID,
+        path: str,
+    ) -> SandboxInfo:
+        deadline_at = datetime.now(timezone.utc) + timedelta(
+            seconds=_SANDBOX_MANAGER_HTTP_TIMEOUT_SECONDS
+        )
+        while datetime.now(timezone.utc) < deadline_at:
+            sandbox_info = await self.get_or_create_sandbox(user_id)
+            try:
+                await self._get_manager_client().create_directory(
+                    agentbox_sandbox_id(user_id),
+                    path,
+                    deadline_at=deadline_at,
+                )
+            except AgentBoxApiError as exc:
+                if exc.retry not in (
+                    RetryDisposition.WAIT,
+                    RetryDisposition.SAFE_SAME_OPERATION,
+                ):
+                    raise
+                remaining = (
+                    deadline_at - datetime.now(timezone.utc)
+                ).total_seconds()
+                if remaining <= 0:
+                    break
+                delay = max(0.05, (exc.retry_after_ms or 250) / 1000)
+                await asyncio.sleep(min(delay, remaining))
+                continue
+            return sandbox_info
+        raise TimeoutError(
+            f"workspace sandbox {agentbox_sandbox_id(user_id)} did not become usable"
         )
 
     def _get_manager_client(self) -> AgentBoxClient:

--- a/lemma-backend/app/modules/workspace/tests/unit/test_workspace_container_service.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_workspace_container_service.py
@@ -4,8 +4,11 @@ import asyncio
 from typing import Any
 from uuid import UUID, uuid4
 
+import httpx
 import pytest
 
+from agentbox_client import AgentBoxApiError, RetryDisposition
+from agentbox_client.models import AgentBoxErrorBody, AgentBoxErrorResponse
 from app.core.config import settings
 from app.modules.workspace.contracts import SandboxInfo
 from app.modules.workspace.services.workspace_sandbox_service import (
@@ -92,6 +95,25 @@ class _FakeManagerClient:
     ) -> None:
         del deadline_at
         self.directories.append((logical_id, path))
+
+
+def _api_error(retry: RetryDisposition) -> AgentBoxApiError:
+    response = httpx.Response(
+        503,
+        request=httpx.Request(
+            "PUT", "http://agentbox.test/sandboxes/workspace/id/directories"
+        ),
+    )
+    return AgentBoxApiError(
+        response,
+        AgentBoxErrorResponse(
+            error=AgentBoxErrorBody(
+                code="PROVIDER_UNAVAILABLE",
+                message="sandbox provider allocation no longer exists",
+                retry=retry,
+            )
+        ),
+    )
 
 
 def _service(
@@ -211,3 +233,53 @@ async def test_get_session_uses_canonical_logical_workspace_id(
     assert session.client is manager_client
     assert session.env_vars == {"LEMMA_TOKEN": "dynamic"}
     assert manager_client.directories == [(user_id, "/workspace")]
+
+
+@pytest.mark.asyncio
+async def test_get_session_reensures_after_missing_provider_allocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_id = uuid4()
+    sandbox = _FakeSandbox()
+    service = _service(sandbox)
+
+    class _RecoveringManagerClient(_FakeManagerClient):
+        async def create_directory(
+            self,
+            logical_id: UUID,
+            path: str,
+            *,
+            deadline_at,
+        ) -> None:
+            await super().create_directory(
+                logical_id,
+                path,
+                deadline_at=deadline_at,
+            )
+            if len(self.directories) == 1:
+                raise _api_error(RetryDisposition.SAFE_SAME_OPERATION)
+
+    manager_client = _RecoveringManagerClient()
+
+    async def environment(*_args: Any, **_kwargs: Any) -> dict[str, str]:
+        return {"LEMMA_TOKEN": "dynamic"}
+
+    async def no_wait(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(service, "get_env_vars", environment)
+    monkeypatch.setattr(service, "_get_manager_client", lambda: manager_client)
+    monkeypatch.setattr(asyncio, "sleep", no_wait)
+
+    session = await service.get_session(
+        user_id=user_id,
+        pod_id=None,
+        session_id="conversation",
+    )
+
+    assert session.sandbox_id == str(user_id)
+    assert len(sandbox.ensure_calls) == 2
+    assert manager_client.directories == [
+        (user_id, "/workspace"),
+        (user_id, "/workspace"),
+    ]


### PR DESCRIPTION
## Summary
- distinguish a definitively missing E2B allocation from transient filesystem provider failures
- fence the vanished allocation and return `SAFE_SAME_OPERATION`, allowing sandbox-native workspace storage to rebind safely
- retry workspace session acquisition through ensure + directory creation until the replacement sandbox is usable

## Why
The live dev fault injection after #220 proved a remaining race: `ensure` returned the durable ACTIVE allocation without provider I/O, then the first compiler filesystem call failed with `filesystem provider is unavailable`. The allocation stayed ACTIVE, so the replacement path never ran.

This change handles the provider-disappearance signal at the point where it is actually observed and retries the whole safe session-acquisition operation. Transient provider failures remain `WAIT`; unsafe failures are not retried.

## Validation
- AgentBox full suite: 124 passed, 6 skipped
- focused workspace backend tests: 9 passed
- Ruff on all changed Python files: passed
- integrated test proves ACTIVE -> missing filesystem provider -> ERROR fence -> new ACTIVE allocation -> sandbox-native storage rebound to the new provider id

No migration or configuration change is required.