### PR TITLE
Reconcile terminal E2B process output before completion

### DIFF
--- a/agentbox/agentbox/adapters/e2b.py
+++ b/agentbox/agentbox/adapters/e2b.py
@@ -182,25 +182,78 @@ class _ProcessBuffer:
         if not encoded:
             return
         async with self.condition:
-            chunk = ProcessOutputChunk(
-                sequence=self.next_sequence,
-                channel=channel,
-                data=encoded,
-            )
-            self.next_sequence += 1
-            self.chunks.append(chunk)
-            self.total_bytes += len(encoded)
-            while self.chunks and self.total_bytes > self.output_limit_bytes:
-                removed = self.chunks.popleft()
-                self.total_bytes -= len(removed.data)
-                self.truncated_before_sequence = removed.sequence + 1
+            if self.state != ProcessState.RUNNING:
+                return
+            self._append_locked(channel, encoded)
             self.condition.notify_all()
 
-    async def complete(self, state: ProcessState, exit_code: int | None) -> None:
+    async def complete(
+        self,
+        state: ProcessState,
+        exit_code: int | None,
+        *,
+        stdout: str | bytes | None = None,
+        stderr: str | bytes | None = None,
+    ) -> None:
         async with self.condition:
+            if self.state != ProcessState.RUNNING:
+                return
+            self._append_authoritative_suffix_locked(
+                ProcessOutputChannel.STDOUT,
+                stdout,
+            )
+            self._append_authoritative_suffix_locked(
+                ProcessOutputChannel.STDERR,
+                stderr,
+            )
             self.state = state
             self.exit_code = exit_code
             self.condition.notify_all()
+
+    def _append_authoritative_suffix_locked(
+        self,
+        channel: ProcessOutputChannel,
+        data: str | bytes | None,
+    ) -> None:
+        if data is None:
+            return
+        encoded = data.encode(errors="replace") if isinstance(data, str) else data
+        if not encoded:
+            return
+        buffered = b"".join(
+            chunk.data for chunk in self.chunks if chunk.channel == channel
+        )
+        if not buffered:
+            missing = encoded
+        elif encoded.startswith(buffered):
+            missing = encoded[len(buffered) :]
+        else:
+            buffered_offset = encoded.rfind(buffered)
+            missing = (
+                encoded[buffered_offset + len(buffered) :]
+                if buffered_offset >= 0
+                else b""
+            )
+        if missing:
+            self._append_locked(channel, missing)
+
+    def _append_locked(
+        self,
+        channel: ProcessOutputChannel,
+        data: bytes,
+    ) -> None:
+        chunk = ProcessOutputChunk(
+            sequence=self.next_sequence,
+            channel=channel,
+            data=data,
+        )
+        self.next_sequence += 1
+        self.chunks.append(chunk)
+        self.total_bytes += len(data)
+        while self.chunks and self.total_bytes > self.output_limit_bytes:
+            removed = self.chunks.popleft()
+            self.total_bytes -= len(removed.data)
+            self.truncated_before_sequence = removed.sequence + 1
 
 
 class E2BSandboxAdapter:
@@ -1187,7 +1240,12 @@ class E2BSandboxAdapter:
         try:
             result = await handle.wait()
         except CommandExitException as exc:
-            await buffer.complete(ProcessState.FAILED, exc.exit_code)
+            await buffer.complete(
+                ProcessState.FAILED,
+                exc.exit_code,
+                stdout=exc.stdout,
+                stderr=exc.stderr,
+            )
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -1200,6 +1258,8 @@ class E2BSandboxAdapter:
                 if result.exit_code == 0
                 else ProcessState.FAILED,
                 result.exit_code,
+                stdout=getattr(result, "stdout", None),
+                stderr=getattr(result, "stderr", None),
             )
 
     async def _enforce_process_deadline(

--- a/agentbox/tests/adapters/test_e2b_adapter.py
+++ b/agentbox/tests/adapters/test_e2b_adapter.py
@@ -11,7 +11,11 @@ from e2b.sandbox.filesystem.filesystem import EntryInfo, FileType
 import pytest
 import pytest_asyncio
 
-from agentbox.adapters.e2b import E2BAdapterConfig, E2BSandboxAdapter
+from agentbox.adapters.e2b import (
+    E2BAdapterConfig,
+    E2BSandboxAdapter,
+    _ProcessBuffer,
+)
 from agentbox.domain import (
     AdmissionClass,
     ByteRange,
@@ -19,6 +23,7 @@ from agentbox.domain import (
     EnvironmentVariable,
     ExecutePythonRequest,
     PortProtocol,
+    ProcessOutputChannel,
     ProcessState,
     PythonExecutionState,
     SandboxCapability,
@@ -38,6 +43,34 @@ from agentbox.python_sessions import PythonSessionService
 
 
 pytestmark = pytest.mark.asyncio
+
+
+async def test_terminal_result_reconciles_output_before_completion() -> None:
+    buffer = _ProcessBuffer(output_limit_bytes=65_536)
+    await buffer.append(ProcessOutputChannel.STDOUT, "first\n")
+
+    await buffer.complete(
+        ProcessState.SUCCEEDED,
+        0,
+        stdout="first\nlast\n",
+        stderr="warning\n",
+    )
+    # A callback delivered after handle.wait() must not duplicate the
+    # authoritative terminal result.
+    await buffer.append(ProcessOutputChannel.STDOUT, "last\n")
+
+    assert buffer.state == ProcessState.SUCCEEDED
+    assert buffer.exit_code == 0
+    assert b"".join(
+        chunk.data
+        for chunk in buffer.chunks
+        if chunk.channel == ProcessOutputChannel.STDOUT
+    ) == b"first\nlast\n"
+    assert b"".join(
+        chunk.data
+        for chunk in buffer.chunks
+        if chunk.channel == ProcessOutputChannel.STDERR
+    ) == b"warning\n"
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- treat `CommandHandle.wait()` stdout/stderr as the authoritative terminal output
- append only output suffixes not already delivered by streaming callbacks
- atomically mark the buffer terminal so late callbacks cannot duplicate terminal chunks

## Why
The dev AgentBox release smoke ran `lemma --version` successfully, but `handle.wait()` became terminal before the final stdout callback populated the AgentBox buffer. The API returned `state=succeeded` with only the first two lines, failing the release gate and potentially truncating real workspace command output.

E2B returns complete stdout/stderr on the terminal command result. This change reconciles that result with already-streamed chunks before exposing the terminal state.

## Validation
- AgentBox full suite: 125 passed, 6 skipped
- focused E2B adapter suite: 8 passed
- Ruff: passed
- regression test covers missing terminal suffix and ignores a late duplicate callback

No migration or configuration change is required.