### PR TITLE
perf(function): reuse warm runtime connections

### DIFF
--- a/agentbox/agentbox/function_runtime/runner.py
+++ b/agentbox/agentbox/function_runtime/runner.py
@@ -46,6 +46,11 @@ class GatewayClient:
             timeout=httpx.Timeout(20, read=60),
             follow_redirects=False,
             transport=transport,
+            limits=httpx.Limits(
+                max_connections=32,
+                max_keepalive_connections=16,
+                keepalive_expiry=300,
+            ),
         )
 
     async def claim(

--- a/agentbox/agentbox/function_runtime/server.py
+++ b/agentbox/agentbox/function_runtime/server.py
@@ -65,6 +65,7 @@ class FunctionRuntimeService:
             max_cached_revisions=max_cached_revisions,
         )
         self._runs: OrderedDict[UUID, _Run] = OrderedDict()
+        self._gateways: dict[str, GatewayClient] = {}
         self._lock = asyncio.Lock()
 
     async def invoke(
@@ -197,6 +198,21 @@ class FunctionRuntimeService:
             task.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)
         await self._workers.close()
+        async with self._lock:
+            gateways = tuple(self._gateways.values())
+            self._gateways.clear()
+        await asyncio.gather(
+            *(gateway.close() for gateway in gateways),
+            return_exceptions=True,
+        )
+
+    async def _gateway(self, gateway_url: str) -> GatewayClient:
+        async with self._lock:
+            gateway = self._gateways.get(gateway_url)
+            if gateway is None:
+                gateway = GatewayClient(gateway_url)
+                self._gateways[gateway_url] = gateway
+            return gateway
 
     async def _execute(
         self,
@@ -214,7 +230,7 @@ class FunctionRuntimeService:
         worker_ms = 0.0
         user_code_ms = 0.0
         artifact_cache_hit = False
-        gateway = GatewayClient(gateway_url)
+        gateway = await self._gateway(gateway_url)
         claim = None
         accepted = False
         try:
@@ -304,8 +320,6 @@ class FunctionRuntimeService:
             if not accepted:
                 await self._mark_rejected(run_id, exc)
             raise
-        finally:
-            await gateway.close()
 
     async def _mark_accepted(self, run_id: UUID, callback_token: str) -> None:
         async with self._lock:

--- a/agentbox/tests/runtime/test_function_server.py
+++ b/agentbox/tests/runtime/test_function_server.py
@@ -107,6 +107,40 @@ async def test_gateway_claim_receives_exact_invocation_identity(monkeypatch) -> 
     }
 
 
+async def test_gateway_client_is_reused_until_service_closes(monkeypatch) -> None:
+    from agentbox.function_runtime import server as server_module
+
+    created: list[str] = []
+    closed: list[str] = []
+
+    class _Gateway:
+        def __init__(self, base_url: str) -> None:
+            self.base_url = base_url
+            created.append(base_url)
+
+        async def close(self) -> None:
+            closed.append(self.base_url)
+
+    monkeypatch.setattr(server_module, "GatewayClient", _Gateway)
+    service = FunctionRuntimeService(max_workers=1, max_cached_revisions=1)
+
+    first = await service._gateway("https://gateway.lemma.test")
+    second = await service._gateway("https://gateway.lemma.test")
+    other = await service._gateway("https://other-gateway.lemma.test")
+
+    assert first is second
+    assert other is not first
+    assert created == [
+        "https://gateway.lemma.test",
+        "https://other-gateway.lemma.test",
+    ]
+    assert closed == []
+
+    await service.close()
+
+    assert closed == created
+
+
 async def test_async_accept_returns_after_claim_without_waiting_for_terminal(
     monkeypatch,
 ) -> None:

--- a/lemma-backend/app/modules/agent/config.py
+++ b/lemma-backend/app/modules/agent/config.py
@@ -41,7 +41,7 @@ class AgentSettings(BaseSettings):
         description="TTL for cached rendered agent runtime-context briefs; zero disables caching.",
     )
     function_run_poll_interval_seconds: float = Field(
-        default=5.0,
+        default=0.5,
         description="Interval an agent tool waits between function-run status polls.",
     )
     conversation_title_model: str | None = Field(

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_config.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_config.py
@@ -19,7 +19,7 @@ EXPECTED = [
         "AGENT_CONTEXT_BRIEF_CACHE_TTL_SECONDS",
         60,
     ),
-    ("function_run_poll_interval_seconds", "FUNCTION_RUN_POLL_INTERVAL_SECONDS", 5.0),
+    ("function_run_poll_interval_seconds", "FUNCTION_RUN_POLL_INTERVAL_SECONDS", 0.5),
     ("conversation_title_model", "CONVERSATION_TITLE_MODEL", None),
     ("daemon_ws_ping_stale_after_seconds", "DAEMON_WS_PING_STALE_AFTER_SECONDS", 90.0),
     ("daemon_reconnect_grace_seconds", "DAEMON_RECONNECT_GRACE_SECONDS", 120.0),

--- a/lemma-backend/app/modules/function/api/dependencies.py
+++ b/lemma-backend/app/modules/function/api/dependencies.py
@@ -51,6 +51,9 @@ from app.modules.function.application.function_session_token_cache import (
     FunctionSessionTokenCache,
 )
 from app.modules.function.application.function_dispatcher import FunctionDispatcher
+from app.modules.function.application.function_runtime_http_client import (
+    FunctionRuntimeHttpClientPool,
+)
 from app.modules.function.infrastructure.function_run_queue import (
     StreaqFunctionRunQueue,
 )
@@ -65,6 +68,11 @@ _function_runtime_endpoint_cache = FunctionRuntimeEndpointCache(
     ttl_seconds=settings.function_runtime_endpoint_cache_ttl_seconds,
     max_entries=settings.function_runtime_endpoint_cache_max_entries,
 )
+_function_runtime_http_clients = FunctionRuntimeHttpClientPool()
+
+
+async def close_function_runtime_http_clients() -> None:
+    await _function_runtime_http_clients.close()
 
 
 def get_function_storage_factory():
@@ -154,6 +162,7 @@ def build_function_dispatcher(uow_factory: UnitOfWorkFactory) -> FunctionDispatc
         token_minter=mint_workspace_token,
         token_cache=_function_session_token_cache,
         endpoint_cache=_function_runtime_endpoint_cache,
+        runtime_http_client_factory=_function_runtime_http_clients.get,
         delegated_tokens_enabled=settings.authz_delegated_tokens_enabled,
     )
 

--- a/lemma-backend/app/modules/function/application/function_dispatcher.py
+++ b/lemma-backend/app/modules/function/application/function_dispatcher.py
@@ -64,6 +64,7 @@ _FUNCTION_RUNTIME_PORT = 8090
 
 
 AgentBoxClientFactory = Callable[[], AgentBoxClient]
+RuntimeHttpClientFactory = Callable[[], httpx.AsyncClient]
 TokenMinter = Callable[..., Awaitable[str]]
 
 
@@ -90,6 +91,7 @@ class FunctionDispatcher:
         token_minter: TokenMinter,
         token_cache: FunctionSessionTokenCache,
         endpoint_cache: FunctionRuntimeEndpointCache,
+        runtime_http_client_factory: RuntimeHttpClientFactory,
         delegated_tokens_enabled: bool,
     ) -> None:
         self._uow_factory = uow_factory
@@ -98,6 +100,7 @@ class FunctionDispatcher:
         self._token_minter = token_minter
         self._token_cache = token_cache
         self._endpoint_cache = endpoint_cache
+        self._runtime_http_client_factory = runtime_http_client_factory
         self._delegated_tokens_enabled = delegated_tokens_enabled
         self._profile = ProfileRef(
             name=settings.agentbox_function_profile_name,
@@ -209,21 +212,19 @@ class FunctionDispatcher:
             dispatch,
             deadline_at=self._control_deadline(dispatch.deadline_at),
         )
-        async with httpx.AsyncClient(
+        runtime = self._runtime_http_client_factory()
+        await runtime.post(
+            urljoin(
+                endpoint.url,
+                f"runs/{dispatch.run_id}:cancel",
+            ),
+            headers={"Authorization": self._callback_authorization(run_id)},
             timeout=httpx.Timeout(5, read=5),
-            follow_redirects=False,
-        ) as runtime:
-            await runtime.post(
-                urljoin(
-                    endpoint.url,
-                    f"runs/{dispatch.run_id}:cancel",
-                ),
-                headers={"Authorization": self._callback_authorization(run_id)},
-            )
+        )
         async with self._uow_factory() as uow:
-            run = await FunctionExecutionRepository(
-                uow, self._signer
-            ).cancel_dispatch(dispatch)
+            run = await FunctionExecutionRepository(uow, self._signer).cancel_dispatch(
+                dispatch
+            )
         return run or await self._load_run(run_id)
 
     async def _resolve_dispatch(
@@ -259,9 +260,9 @@ class FunctionDispatcher:
         mode: FunctionDispatchMode,
     ) -> FunctionExecutionDispatch | None:
         async with self._uow_factory() as uow:
-            return await FunctionExecutionRepository(
-                uow, self._signer
-            ).active_dispatch(run_id, mode=mode)
+            return await FunctionExecutionRepository(uow, self._signer).active_dispatch(
+                run_id, mode=mode
+            )
 
     async def _ensure_sandbox(
         self,
@@ -327,18 +328,16 @@ class FunctionDispatcher:
         if dispatch.mode == FunctionDispatchMode.ASYNCHRONOUS:
             headers["Prefer"] = "respond-async"
         try:
-            async with httpx.AsyncClient(
+            runtime = self._runtime_http_client_factory()
+            response = await runtime.post(
+                url,
+                headers=headers,
+                json={"input": dispatch.input_data},
                 timeout=httpx.Timeout(
                     max(0.1, min(10.0, remaining)),
                     read=max(0.1, remaining),
                 ),
-                follow_redirects=False,
-            ) as runtime:
-                response = await runtime.post(
-                    url,
-                    headers=headers,
-                    json={"input": dispatch.input_data},
-                )
+            )
         except httpx.TransportError as exc:
             await self._endpoint_cache.invalidate(
                 self._endpoint_key(dispatch),
@@ -378,29 +377,23 @@ class FunctionDispatcher:
             )
         return RuntimeTerminalRequest.model_validate(response.json())
 
-    async def _best_effort_cancel(
-        self, dispatch: FunctionExecutionDispatch
-    ) -> None:
+    async def _best_effort_cancel(self, dispatch: FunctionExecutionDispatch) -> None:
         try:
             endpoint = await self._runtime_endpoint(
                 dispatch,
                 deadline_at=self._control_deadline(dispatch.deadline_at),
             )
-            async with httpx.AsyncClient(
+            runtime = self._runtime_http_client_factory()
+            await runtime.post(
+                urljoin(
+                    endpoint.url,
+                    f"runs/{dispatch.run_id}:cancel",
+                ),
+                headers={
+                    "Authorization": self._callback_authorization(dispatch.run_id)
+                },
                 timeout=httpx.Timeout(5),
-                follow_redirects=False,
-            ) as runtime:
-                await runtime.post(
-                    urljoin(
-                        endpoint.url,
-                        f"runs/{dispatch.run_id}:cancel",
-                    ),
-                    headers={
-                        "Authorization": self._callback_authorization(
-                            dispatch.run_id
-                        )
-                    },
-                )
+            )
         except Exception:
             logger.warning(
                 "function.dispatcher.runtime_cancellation.failed",
@@ -464,9 +457,7 @@ class FunctionDispatcher:
             raise LookupError(f"function run {run_id} does not exist")
         return run
 
-    async def _function_session_token(
-        self, dispatch: FunctionExecutionDispatch
-    ) -> str:
+    async def _function_session_token(self, dispatch: FunctionExecutionDispatch) -> str:
         return await self._token_cache.get(
             FunctionSessionTokenKey(
                 user_id=dispatch.user_id,

--- a/lemma-backend/app/modules/function/application/function_runtime_http_client.py
+++ b/lemma-backend/app/modules/function/application/function_runtime_http_client.py
@@ -1,0 +1,46 @@
+"""Process-local HTTP connection pool for resident function runtimes."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+
+import httpx
+
+
+HttpClientFactory = Callable[[], httpx.AsyncClient]
+
+
+def _build_client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        follow_redirects=False,
+        limits=httpx.Limits(
+            max_connections=100,
+            max_keepalive_connections=64,
+            keepalive_expiry=300,
+        ),
+    )
+
+
+class FunctionRuntimeHttpClientPool:
+    """Reuse runtime connections for the lifetime of each process event loop."""
+
+    def __init__(self, factory: HttpClientFactory = _build_client) -> None:
+        self._factory = factory
+        self._clients: dict[int, httpx.AsyncClient] = {}
+
+    def get(self) -> httpx.AsyncClient:
+        loop_id = id(asyncio.get_running_loop())
+        client = self._clients.get(loop_id)
+        if client is None:
+            client = self._factory()
+            self._clients[loop_id] = client
+        return client
+
+    async def close(self) -> None:
+        clients = tuple(self._clients.values())
+        self._clients.clear()
+        await asyncio.gather(
+            *(client.aclose() for client in clients),
+            return_exceptions=True,
+        )

--- a/lemma-backend/app/modules/function/module.py
+++ b/lemma-backend/app/modules/function/module.py
@@ -1,5 +1,7 @@
 """Function module registration."""
 
+from contextlib import asynccontextmanager
+
 from app.core.registry import LemmaModule
 
 
@@ -22,8 +24,23 @@ def _event_routers():
     return [router]
 
 
+@asynccontextmanager
+async def _close_runtime_http_clients(context):
+    del context
+    try:
+        yield
+    finally:
+        from app.modules.function.api.dependencies import (
+            close_function_runtime_http_clients,
+        )
+
+        await close_function_runtime_http_clients()
+
+
 module = LemmaModule(
     name="function",
     routers=_routers,
     event_routers=_event_routers,
+    api_lifespans=(_close_runtime_http_clients,),
+    worker_lifespans=(_close_runtime_http_clients,),
 )

--- a/lemma-backend/app/modules/function/tests/e2e/test_function_agentbox_execution_e2e.py
+++ b/lemma-backend/app/modules/function/tests/e2e/test_function_agentbox_execution_e2e.py
@@ -24,6 +24,9 @@ from app.modules.function.application.function_dispatcher import FunctionDispatc
 from app.modules.function.application.function_runtime_endpoint_cache import (
     FunctionRuntimeEndpointCache,
 )
+from app.modules.function.application.function_runtime_http_client import (
+    FunctionRuntimeHttpClientPool,
+)
 from app.modules.function.application.function_session_token_cache import (
     FunctionSessionTokenCache,
 )
@@ -89,9 +92,7 @@ async def _create_run(
     python_packages: tuple[str, ...] = (),
 ) -> UUID:
     function_id = uuid7()
-    artifact = await FunctionArtifactBuilder(
-        get_function_storage_factory()
-    ).build(
+    artifact = await FunctionArtifactBuilder(get_function_storage_factory()).build(
         function_id=function_id,
         code=code,
         python_packages=python_packages,
@@ -185,6 +186,7 @@ async def test_api_and_job_execute_through_one_per_pod_docker_sandbox(
                 timeout_seconds=60,
             )
 
+        runtime_http_clients = FunctionRuntimeHttpClientPool()
         dispatcher = FunctionDispatcher(
             uow_factory=SessionUnitOfWorkFactory(db_manager.session_factory),
             credential_signer=FunctionCallbackCredentialSigner(secret),
@@ -192,6 +194,7 @@ async def test_api_and_job_execute_through_one_per_pod_docker_sandbox(
             token_minter=mint_workspace_token,
             token_cache=FunctionSessionTokenCache(),
             endpoint_cache=FunctionRuntimeEndpointCache(),
+            runtime_http_client_factory=runtime_http_clients.get,
             delegated_tokens_enabled=settings.authz_delegated_tokens_enabled,
         )
 
@@ -244,4 +247,6 @@ async def test_api_and_job_execute_through_one_per_pod_docker_sandbox(
                 deadline_at=datetime.now(timezone.utc) + timedelta(seconds=15),
             )
     finally:
+        if "runtime_http_clients" in locals():
+            await runtime_http_clients.close()
         settings.function_runtime_gateway_url = original_gateway_url

--- a/lemma-backend/app/modules/function/tests/unit/test_function_dispatcher.py
+++ b/lemma-backend/app/modules/function/tests/unit/test_function_dispatcher.py
@@ -131,6 +131,7 @@ def _dispatcher(
         token_minter=_token_minter,
         token_cache=FunctionSessionTokenCache(),
         endpoint_cache=FunctionRuntimeEndpointCache(),
+        runtime_http_client_factory=lambda: httpx.AsyncClient(follow_redirects=False),
         delegated_tokens_enabled=True,
     )
 
@@ -187,7 +188,7 @@ async def test_dispatcher_invokes_run_once_and_holds_no_db_during_io(
         async def __aexit__(self, *_args):
             return None
 
-        async def post(self, url, *, headers, json=None):
+        async def post(self, url, *, headers, json=None, timeout=None):
             nonlocal terminal_persisted
             assert tracker.active == 0
             requests.append((url, {"headers": headers, "json": json}))
@@ -219,15 +220,11 @@ async def test_dispatcher_invokes_run_once_and_holds_no_db_during_io(
     assert result.status == FunctionRunStatus.COMPLETED
     assert len(requests) == 1
     url, request = requests[0]
-    assert url.endswith(
-        f"/functions/{dispatch.function_id}/runs/{dispatch.run_id}"
-    )
+    assert url.endswith(f"/functions/{dispatch.function_id}/runs/{dispatch.run_id}")
     assert request["json"] == {"input": dispatch.input_data}
     assert request["headers"]["Authorization"] == "Bearer delegated-function-token"
     assert request["headers"]["If-Match"] == f'"{dispatch.revision_hash}"'
-    assert request["headers"]["X-Lemma-Run-Token"] == signer.derive(
-        dispatch.run_id
-    )
+    assert request["headers"]["X-Lemma-Run-Token"] == signer.derive(dispatch.run_id)
     assert "Idempotency-Key" not in request["headers"]
     assert tracker.active == 0
 
@@ -278,7 +275,7 @@ async def test_job_returns_after_runtime_claim_without_polling_terminal(
         async def __aexit__(self, *_args):
             return None
 
-        async def post(self, url, *, headers, json=None):
+        async def post(self, url, *, headers, json=None, timeout=None):
             assert tracker.active == 0
             requests.append({"url": url, "headers": headers, "json": json})
             return httpx.Response(
@@ -303,9 +300,7 @@ async def test_job_returns_after_runtime_claim_without_polling_terminal(
     assert loads == 1
     assert len(requests) == 1
     assert requests[0]["headers"]["Prefer"] == "respond-async"
-    assert requests[0]["headers"]["X-Lemma-Run-Token"] == signer.derive(
-        dispatch.run_id
-    )
+    assert requests[0]["headers"]["X-Lemma-Run-Token"] == signer.derive(dispatch.run_id)
     assert requests[0]["json"] == {"input": dispatch.input_data}
     assert tracker.active == 0
 
@@ -353,9 +348,7 @@ async def test_lost_response_reconciles_terminal_callback_without_failing(
             return None
 
         async def post(self, url, **_kwargs):
-            raise httpx.ReadError(
-                "response lost", request=httpx.Request("POST", url)
-            )
+            raise httpx.ReadError("response lost", request=httpx.Request("POST", url))
 
     monkeypatch.setattr(
         "app.modules.function.application.function_dispatcher.httpx.AsyncClient",
@@ -422,16 +415,17 @@ async def test_lost_response_fails_once_and_cancels_exact_run(
             if url.endswith(":cancel"):
                 calls["cancel"] += 1
                 assert url.endswith(f"/runs/{dispatch.run_id}:cancel")
-                assert headers["Authorization"] == f"Bearer {signer.derive(dispatch.run_id)}"
+                assert (
+                    headers["Authorization"]
+                    == f"Bearer {signer.derive(dispatch.run_id)}"
+                )
                 return httpx.Response(
                     202,
                     request=httpx.Request("POST", url),
                     json={"accepted": True},
                 )
             calls["invoke"] += 1
-            raise httpx.ReadError(
-                "response lost", request=httpx.Request("POST", url)
-            )
+            raise httpx.ReadError("response lost", request=httpx.Request("POST", url))
 
     monkeypatch.setattr(
         "app.modules.function.application.function_dispatcher.httpx.AsyncClient",
@@ -485,7 +479,7 @@ async def test_cancel_targets_exact_run_then_persists_cancelled(monkeypatch) -> 
         async def __aexit__(self, *_args):
             return None
 
-        async def post(self, url, *, headers):
+        async def post(self, url, *, headers, **_kwargs):
             assert tracker.active == 0
             assert not persisted
             runtime_calls.append((url, headers["Authorization"]))
@@ -508,8 +502,7 @@ async def test_cancel_targets_exact_run_then_persists_cancelled(monkeypatch) -> 
     assert result.status == FunctionRunStatus.CANCELLED
     assert runtime_calls == [
         (
-            "https://agentbox.test/port-access/signed/"
-            f"runs/{dispatch.run_id}:cancel",
+            f"https://agentbox.test/port-access/signed/runs/{dispatch.run_id}:cancel",
             f"Bearer {signer.derive(dispatch.run_id)}",
         )
     ]

--- a/lemma-backend/app/modules/function/tests/unit/test_function_runtime_http_client.py
+++ b/lemma-backend/app/modules/function/tests/unit/test_function_runtime_http_client.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from app.modules.function.application.function_runtime_http_client import (
+    FunctionRuntimeHttpClientPool,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_pool_reuses_client_on_one_loop_and_closes_it() -> None:
+    closed = 0
+
+    class _Client:
+        async def aclose(self) -> None:
+            nonlocal closed
+            closed += 1
+
+    created: list[_Client] = []
+
+    def factory() -> _Client:
+        client = _Client()
+        created.append(client)
+        return client
+
+    pool = FunctionRuntimeHttpClientPool(factory=factory)
+
+    assert pool.get() is pool.get()
+    assert len(created) == 1
+
+    await pool.close()
+
+    assert closed == 1

--- a/lemma-cli/lemma_cli/cli_core/commands/functions.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/functions.py
@@ -210,7 +210,7 @@ def run_function(
         ),
     ),
     wait_timeout: float = typer.Option(180.0, "--wait-timeout", min=1.0),
-    poll_interval: float = typer.Option(2.0, "--poll-interval", min=0.5),
+    poll_interval: float = typer.Option(0.5, "--poll-interval", min=0.5),
 ) -> None:
     """Run a function with an optional JSON input payload."""
     payload = read_json(json_payload, file)

--- a/lemma-cli/tests/test_commands_functions.py
+++ b/lemma-cli/tests/test_commands_functions.py
@@ -179,3 +179,36 @@ def test_functions_runs_get_dispatches_api(monkeypatch):
     assert result.exit_code == 0, result.stdout
     assert captured.get("run_get_function") == "adder"
     assert captured.get("run_id") == "run-9"
+
+
+def test_functions_run_uses_low_latency_poll_default(monkeypatch):
+    client, captured = _make_client_and_captured()
+    _patch(monkeypatch, client)
+
+    def run_and_wait(
+        _functions,
+        *,
+        function,
+        inputs,
+        wait,
+        wait_timeout,
+        poll_interval,
+    ):
+        captured["run_function"] = function
+        captured["run_inputs"] = inputs
+        captured["wait"] = wait
+        captured["wait_timeout"] = wait_timeout
+        captured["poll_interval"] = poll_interval
+        return {"id": "run-1", "status": "COMPLETED"}
+
+    monkeypatch.setattr(functions, "_run_and_optionally_wait", run_and_wait)
+
+    result = runner.invoke(
+        app,
+        ["functions", "run", "adder", "--pod", "pod-1"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert captured["run_function"] == "adder"
+    assert captured["wait"] is True
+    assert captured["poll_interval"] == 0.5


### PR DESCRIPTION
## What changed

- reuse one backend HTTP connection pool for resident function runtime calls, with 5-minute keep-alive and lifecycle shutdown in API and worker processes
- reuse the AgentBox runtime gateway client instead of rebuilding TLS state for every claim and terminal callback
- reduce CLI and agent job observation polling defaults to 500 ms
- add lifecycle, reuse, and CLI-default regression coverage

## Why

Warm dev benchmarks still paid about 1.8 seconds of platform overhead for a no-op function even though the sandbox, artifact, and worker process were already warm. Both network legs were creating and closing a fresh HTTP client per invocation, forfeiting connection reuse.

## Verification

- 63 function-module unit tests passed
- 126 AgentBox non-e2e tests passed; 6 skipped
- AgentBox process-group test passed when rerun outside the local filesystem sandbox restriction
- 121 CLI compatibility tests and 9 function-command tests passed
- targeted basedpyright: 0 errors
- backend, AgentBox, and changed CLI lint passed
- backend architecture ratchet and route inventory passed

After merge, lemma-app should bump this commit and the same three dev benchmarks should be rerun before any production rollout.