### PR TITLE
fix(logging): suppress routine SQLAlchemy engine output

### DIFF
--- a/lemma-backend/app/core/log/log.py
+++ b/lemma-backend/app/core/log/log.py
@@ -77,7 +77,10 @@ _FOREIGN_LOGGER_PREFIXES = frozenset(
         "uvicorn",
     }
 )
-_INFO_NOISE_LOGGER_PREFIXES = ("sqlalchemy.orm.mapper",)
+_INFO_NOISE_LOGGER_PREFIXES = (
+    "sqlalchemy.engine",
+    "sqlalchemy.orm.mapper",
+)
 _PROHIBITED_FIELDS = {
     "authorization",
     "body",
@@ -412,6 +415,7 @@ def _reconcile_named_loggers(configured_level: int) -> None:
     manager = logging.root.manager.loggerDict
     prefixes = tuple(_FOREIGN_LOGGER_PREFIXES)
     names = set(prefixes)
+    names.update(_INFO_NOISE_LOGGER_PREFIXES)
     names.update(
         name
         for name in manager

--- a/lemma-backend/app/core/tests/unit/test_logging_pipeline.py
+++ b/lemma-backend/app/core/tests/unit/test_logging_pipeline.py
@@ -435,8 +435,13 @@ def test_release_and_trace_identity_are_top_level(monkeypatch, captured_stdout) 
     assert record["span_id"] == format(2, "016x")
 
 
-def test_sqlalchemy_mapper_info_noise_is_suppressed_at_info(
+@pytest.mark.parametrize(
+    "logger_name",
+    ("sqlalchemy.engine.Engine", "sqlalchemy.orm.mapper.Mapper"),
+)
+def test_sqlalchemy_info_noise_is_suppressed_at_info(
     captured_stdout,
+    logger_name,
 ) -> None:
     setup_logging(
         "development",
@@ -444,17 +449,22 @@ def test_sqlalchemy_mapper_info_noise_is_suppressed_at_info(
         json_logs=True,
         log_level="INFO",
     )
-    mapper_logger = logging.getLogger("sqlalchemy.orm.mapper.Mapper")
+    sqlalchemy_logger = logging.getLogger(logger_name)
 
-    mapper_logger.info("mapper construction detail")
-    mapper_logger.warning("mapper warning")
+    sqlalchemy_logger.info("routine SQLAlchemy detail")
+    sqlalchemy_logger.warning("SQLAlchemy warning")
 
     records = captured_stdout()
-    assert [record["event"] for record in records] == ["mapper warning"]
+    assert [record["event"] for record in records] == ["SQLAlchemy warning"]
 
 
-def test_sqlalchemy_mapper_debug_remains_available_when_requested(
+@pytest.mark.parametrize(
+    "logger_name",
+    ("sqlalchemy.engine.Engine", "sqlalchemy.orm.mapper.Mapper"),
+)
+def test_sqlalchemy_debug_remains_available_when_requested(
     captured_stdout,
+    logger_name,
 ) -> None:
     setup_logging(
         "development",
@@ -462,6 +472,6 @@ def test_sqlalchemy_mapper_debug_remains_available_when_requested(
         json_logs=True,
         log_level="DEBUG",
     )
-    logging.getLogger("sqlalchemy.orm.mapper.Mapper").debug("mapper debug detail")
+    logging.getLogger(logger_name).debug("SQLAlchemy debug detail")
 
-    assert captured_stdout()[-1]["event"] == "mapper debug detail"
+    assert captured_stdout()[-1]["event"] == "SQLAlchemy debug detail"


### PR DESCRIPTION
## Problem

The post-release Grafana review showed about 403k development log lines in six
hours. The near-real-time view was dominated by:

- `sqlalchemy.engine.Engine` query text
- `BEGIN (implicit)`
- `COMMIT`
- SQL compilation cache details

The deployment already sets `LOG_LEVEL=INFO`. The existing INFO-noise policy
covered ORM mapper setup but did not cover SQLAlchemy's engine logger, so normal
transaction chatter still reached stdout and Log Analytics.

## Change

- Treat `sqlalchemy.engine` the same as `sqlalchemy.orm.mapper` when the
  configured application level is `INFO`.
- Materialize both noise-policy parent loggers during logging setup so child
  loggers created later inherit the correct level.
- Keep SQLAlchemy warnings and errors.
- Keep full SQLAlchemy debug/info output when the operator explicitly selects
  `LOG_LEVEL=DEBUG`.

This does not hide application logs, rewrite messages, add custom telemetry, or
change OpenTelemetry instrumentation. It only makes the existing logger-level
contract behave as configured.

## Validation

- `uv run pytest app/core/tests/unit/test_logging_pipeline.py -q`
  - 28 passed
- `uv run ruff check ...`
- `uv run ruff format --check ...`

The tests cover both `sqlalchemy.engine.Engine` and
`sqlalchemy.orm.mapper.Mapper` at INFO and DEBUG.

## Rollout

After merge, `lemma-app` should pin this exact platform commit and let the normal
release-build → dev-manifest flow deploy it. We can then verify the log-rate drop
in the dev live-logs dashboard before any production promotion.
