### PR TITLE
Fix surface pod links and append runtime time notes

### DIFF
--- a/lemma-backend/app/modules/agent/capabilities/current_time.py
+++ b/lemma-backend/app/modules/agent/capabilities/current_time.py
@@ -12,12 +12,12 @@ not a user turn:
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-
 from pydantic_ai import RunContext
 from pydantic_ai._agent_graph import ModelRequestContext
 from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.messages import ModelRequest, SystemPromptPart
+
+from app.modules.agent.domain.runtime_notes import build_runtime_notes
 
 
 class CurrentTimeCapability(AbstractCapability[object]):
@@ -34,9 +34,8 @@ class CurrentTimeCapability(AbstractCapability[object]):
         ctx: RunContext[object],
         request_context: ModelRequestContext,
     ) -> ModelRequestContext:
-        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         marker = ModelRequest(
-            parts=[SystemPromptPart(content=f"Current date and time: {now} (UTC).")]
+            parts=[SystemPromptPart(content=build_runtime_notes())]
         )
         request_context.messages = [*request_context.messages, marker]
         return request_context

--- a/lemma-backend/app/modules/agent/domain/runtime_notes.py
+++ b/lemma-backend/app/modules/agent/domain/runtime_notes.py
@@ -1,0 +1,29 @@
+"""Ephemeral context appended at the end of each model request.
+
+Runtime notes are built only while dispatching a run. Callers must not write the
+rendered text back to a conversation message: keeping volatile context out of
+stored history both preserves the user's original prompt and leaves the stable
+prompt prefix eligible for provider caching.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def build_runtime_notes(*, now: datetime | None = None) -> str:
+    """Render the shared, extensible runtime-notes block for an agent request."""
+    current = now or datetime.now(timezone.utc)
+    current_utc = current.astimezone(timezone.utc)
+    timestamp = current_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+    return (
+        "<notes>\n"
+        f"Current date and time: {timestamp} (UTC).\n"
+        "</notes>"
+    )
+
+
+def append_runtime_notes(text: str, *, now: datetime | None = None) -> str:
+    """Return a transient prompt copy with runtime notes appended at the end."""
+    note = build_runtime_notes(now=now)
+    return f"{text}\n\n{note}" if text else note

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/daemon.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/daemon.py
@@ -11,6 +11,7 @@ from uuid import UUID
 from app.modules.agent.domain.context import AgentContext
 from app.modules.agent.domain.entities import Agent, Conversation, Message
 from app.modules.agent.domain.prompts import build_agent_instructions
+from app.modules.agent.domain.runtime_notes import append_runtime_notes
 from app.modules.agent.domain.value_objects import (
     AgentEvent,
     AgentEventType,
@@ -473,7 +474,10 @@ def _prompt_payload(
     session_id: str | None,
 ) -> JsonObject:
     instructions = build_agent_instructions(agent=agent, conversation=conversation, ctx=ctx)
-    user_prompt = _render_history(messages)
+    # Add volatile context only to this dispatch payload. The Message entities
+    # remain untouched, so runtime notes never enter persisted conversation
+    # history and the stable prompt prefix remains cacheable.
+    user_prompt = append_runtime_notes(_render_history(messages))
     session_sections: list[str] = []
     if instructions:
         session_sections.append("# Instructions\n" + instructions)

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_tools.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_tools.py
@@ -309,34 +309,17 @@ async def test_display_resource_returns_browser_access_url(
     user_id = uuid4()
     calls: list[tuple[str, object]] = []
 
-    class FakeAgentBoxClient:
-        def __init__(
+    class FakeWorkspaceSandboxService:
+        async def create_browser_access(
             self,
-            *,
-            base_url: str,
-            api_key: str,
-            timeout_seconds: float,
-            context_headers_provider=None,
-        ):
-            assert callable(context_headers_provider)
-            calls.append(("init", (base_url, api_key, timeout_seconds)))
-
-        async def ensure_sandbox(self, sandbox_id: str, *, env: dict[str, str]):
-            calls.append(("ensure_sandbox", (sandbox_id, env)))
-            return SimpleNamespace(id=sandbox_id)
-
-        async def get_app_access_url(
-            self,
-            sandbox_id: str,
-            app_name: str,
+            requested_user_id: UUID,
             *,
             ttl_seconds: int,
         ):
-            calls.append(("get_app_access_url", (sandbox_id, app_name, ttl_seconds)))
+            calls.append(("create_browser_access", (requested_user_id, ttl_seconds)))
             return SimpleNamespace(
-                app="browser",
                 url="https://browser.example/access-token",
-                expires_at=1893456000,
+                expires_at=datetime(2030, 1, 1, tzinfo=timezone.utc),
             )
 
         async def close(self):
@@ -344,27 +327,8 @@ async def test_display_resource_returns_browser_access_url(
 
     monkeypatch.setattr(
         user_interaction_adapter,
-        "AgentBoxClient",
-        FakeAgentBoxClient,
-    )
-    monkeypatch.setattr(
-        user_interaction_adapter.WorkspaceSandboxService,
-        "_resolve_runtime",
-        lambda: "docker",
-    )
-    monkeypatch.setattr(
-        user_interaction_adapter.settings,
-        "workspace_callback_api_url",
-        "http://host.lemma.internal:8711",
-    )
-    monkeypatch.setattr(
-        user_interaction_adapter.settings, "agentbox_api_url", "https://agentbox.test"
-    )
-    monkeypatch.setattr(
-        user_interaction_adapter.settings, "agentbox_api_key", "agentbox-key"
-    )
-    monkeypatch.setattr(
-        user_interaction_adapter.settings, "api_url", "https://api.test"
+        "WorkspaceSandboxService",
+        FakeWorkspaceSandboxService,
     )
 
     ctx = SimpleNamespace(deps=SimpleNamespace(user_id=user_id))
@@ -380,15 +344,7 @@ async def test_display_resource_returns_browser_access_url(
     assert response.url == "https://browser.example/access-token"
     assert response.expires_at == datetime(2030, 1, 1, tzinfo=timezone.utc)
     assert calls == [
-        ("init", ("https://agentbox.test", "agentbox-key", 300.0)),
-        (
-            "ensure_sandbox",
-            (
-                user_id,
-                {"LEMMA_BASE_URL": "http://host.lemma.internal:8711"},
-            ),
-        ),
-        ("get_app_access_url", (user_id, "browser", 1800)),
+        ("create_browser_access", (user_id, 1800)),
         ("close", None),
     ]
 

--- a/lemma-backend/app/modules/agent/tests/unit/test_capabilities.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_capabilities.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 import pytest
 from pydantic_ai import Agent
 from pydantic_ai.capabilities import ToolSearch
-from pydantic_ai.messages import ModelResponse, TextPart
+from pydantic_ai.messages import ModelResponse, SystemPromptPart, TextPart
 from pydantic_ai.models.function import AgentInfo, FunctionModel
 from pydantic_ai.toolsets import FunctionToolset
 
@@ -308,6 +308,7 @@ async def test_current_time_and_deferral_in_real_run():
         captured["settings"] = dict(info.model_settings or {})
         parts = messages[-1].parts
         captured["last_text"] = " ".join(getattr(part, "content", "") for part in parts)
+        captured["last_part"] = parts[-1]
         return ModelResponse(parts=[TextPart("done")])
 
     conversation_id = uuid4()
@@ -328,6 +329,10 @@ async def test_current_time_and_deferral_in_real_run():
     assert captured["defer"]["hidden_tool"] is True
     # Current time rides as the trailing (system) message, not the system prompt.
     assert "Current date and time:" in captured["last_text"]
+    last_part = captured["last_part"]
+    assert isinstance(last_part, SystemPromptPart)
+    assert last_part.content.startswith("<notes>")
+    assert last_part.content.endswith("</notes>")
     # Prompt-cache session affinity is applied to the request settings.
     assert captured["settings"].get("openai_user") == str(conversation_id)
 

--- a/lemma-backend/app/modules/agent/tests/unit/test_daemon_harness.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_daemon_harness.py
@@ -232,7 +232,14 @@ async def test_daemon_harness_forwards_run_start_and_yields_events(
         "provider process cwd is daemon scratch space"
         in start_payload["prompt"]["system_prompt"]
     )
-    assert "USER:\nhello" == start_payload["prompt"]["user_prompt"]
+    user_prompt = start_payload["prompt"]["user_prompt"]
+    assert user_prompt.startswith("USER:\nhello\n\n<notes>\n")
+    assert "Current date and time:" in user_prompt
+    assert user_prompt.endswith("</notes>")
+    # Runtime metadata is added only to the outbound copy, never the stored
+    # user-authored message.
+    assert message.text == "hello"
+    assert "<notes>" not in message.text
     assert "session_id" not in start_payload["prompt"]
     assert "text" not in start_payload["prompt"]
     assert "messages" not in start_payload
@@ -425,7 +432,12 @@ def test_daemon_harness_attaches_cached_session_and_recovery_prompt():
     recovery_prompt = payload["prompt"]["recovery_system_prompt"]
     assert "Stay concise." in recovery_prompt
     assert "You are running through a Lemma user daemon." in recovery_prompt
-    assert payload["prompt"]["user_prompt"] == "USER:\ncontinue"
+    user_prompt = payload["prompt"]["user_prompt"]
+    assert user_prompt.startswith("USER:\ncontinue\n\n<notes>\n")
+    assert "Current date and time:" in user_prompt
+    assert user_prompt.endswith("</notes>")
+    assert message.text == "continue"
+    assert "<notes>" not in message.text
 
 
 def test_daemon_harness_default_reconnect_grace_is_two_minutes():

--- a/lemma-backend/app/modules/agent/tests/unit/test_runtime_notes.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_runtime_notes.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timedelta, timezone
+
+from app.modules.agent.domain.runtime_notes import (
+    append_runtime_notes,
+    build_runtime_notes,
+)
+
+
+def test_runtime_notes_render_current_time_in_utc():
+    fixed = datetime(
+        2026,
+        7,
+        25,
+        18,
+        45,
+        12,
+        tzinfo=timezone(timedelta(hours=5, minutes=30)),
+    )
+
+    assert build_runtime_notes(now=fixed) == (
+        "<notes>\n"
+        "Current date and time: 2026-07-25T13:15:12Z (UTC).\n"
+        "</notes>"
+    )
+
+
+def test_runtime_notes_are_appended_without_mutating_source_text():
+    source = "USER:\nPlease summarize this."
+    fixed = datetime(2026, 7, 25, 13, 15, 12, tzinfo=timezone.utc)
+
+    rendered = append_runtime_notes(source, now=fixed)
+
+    assert source == "USER:\nPlease summarize this."
+    assert rendered.startswith(source + "\n\n<notes>\n")
+    assert rendered.endswith("</notes>")

--- a/lemma-backend/app/modules/agent/tools/user_interaction/pydantic_adapter.py
+++ b/lemma-backend/app/modules/agent/tools/user_interaction/pydantic_adapter.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
-from datetime import datetime, timezone
 
 from app.core.config import settings
-from app.core.request_context import correlation_headers
-from agentbox_client import AgentBoxClient
 from pydantic_ai.tools import RunContext
 from pydantic_ai.toolsets import FunctionToolset
 
@@ -21,10 +18,7 @@ from app.modules.agent.tools.user_interaction.models import (
     validate_display_payload,
 )
 from app.core.widget_html_validation import validate_widget_html
-from app.composition.agent_workspace import (
-    WorkspaceSandboxService,
-    agentbox_sandbox_id,
-)
+from app.composition.agent_workspace import WorkspaceSandboxService
 
 
 async def display_resource(
@@ -89,28 +83,10 @@ async def display_resource(
             )
 
     if request.type == DisplayResourceType.BROWSER:
-        runtime = WorkspaceSandboxService._resolve_runtime()
-        sandbox_id = agentbox_sandbox_id(ctx.deps.user_id)
-        client = AgentBoxClient(
-            base_url=settings.agentbox_api_url,
-            api_key=settings.agentbox_api_key,
-            timeout_seconds=300.0,
-            context_headers_provider=correlation_headers,
-        )
+        workspace_service = WorkspaceSandboxService()
         try:
-            await client.ensure_sandbox(
-                sandbox_id,
-                env={
-                    "LEMMA_BASE_URL": (
-                        WorkspaceSandboxService.resolve_workspace_api_url_for_runtime(
-                            runtime
-                        )
-                    )
-                },
-            )
-            access = await client.get_app_access_url(
-                sandbox_id,
-                "browser",
+            access = await workspace_service.create_browser_access(
+                ctx.deps.user_id,
                 ttl_seconds=1800,
             )
         except Exception as exc:
@@ -119,17 +95,14 @@ async def display_resource(
                 error=f"Failed to create browser display URL: {type(exc).__name__}: {exc}",
             )
         finally:
-            await client.close()
+            await workspace_service.close()
 
         response = DisplayResourceResponse(
             success=True,
             message="BROWSER resource ready for display.",
-            app=access.app,
+            app="browser",
             url=access.url,
-            expires_at=datetime.fromtimestamp(
-                access.expires_at,
-                tz=timezone.utc,
-            ),
+            expires_at=access.expires_at,
         )
         await _maybe_deliver_to_surface(ctx, request, response)
         return response

--- a/lemma-backend/app/modules/agent_surfaces/services/display_resource_renderer.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/display_resource_renderer.py
@@ -288,9 +288,7 @@ def build_display_resource_url(
         )
     if request.type is DisplayResourceType.SCHEDULE:
         return _append_conversation(
-            f"{pod_base}/schedules?{urlencode({'target': request.name})}"
-            if request.name
-            else f"{pod_base}/schedules",
+            f"{pod_base}/schedules",
             conversation_id,
         )
     return _conversation_url(pod_base, conversation_id, tool_call_id)

--- a/lemma-backend/app/modules/agent_surfaces/services/fallback_reply_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/fallback_reply_service.py
@@ -45,10 +45,10 @@ def surface_setup_message() -> str:
 
 
 def _pod_access_message(pod_id: UUID) -> str:
-    base = settings.auth_frontend_url.rstrip("/")
+    base = settings.frontend_url.rstrip("/")
     return (
         "You're signed up, but don't have access to this workspace yet. "
-        f"Request access here: {base}/pods/{pod_id}"
+        f"Request access here: {base}/pod/{pod_id}"
     )
 
 

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_display_resource_matrix_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_display_resource_matrix_e2e.py
@@ -31,12 +31,17 @@ N/A cells:
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
 import pytest
+from agentbox_client import PortAccessGrant, PortProtocol, WorkloadKind
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.modules.agent.tools.user_interaction import (
+    pydantic_adapter as user_interaction_adapter,
+)
 from app.modules.agent_surfaces.config import surface_settings
 from app.modules.agent_surfaces.domain.ingress_request import (
     SurfacePlatformWebhookIngress,
@@ -246,6 +251,35 @@ async def test_display_resource_slack_routes_pod_resource_catalog_to_deep_links(
     monkeypatch.setattr(app_settings, "api_url", "https://api.example.test")
     monkeypatch.setattr(app_settings, "frontend_url", "https://app.example.test")
     monkeypatch.setattr(surface_settings, "slack_signing_secret", "slack-secret")
+    browser_access_calls: list[tuple[UUID, int]] = []
+
+    class _FakeWorkspaceSandboxService:
+        """Keep this surface-delivery journey hermetic at the AgentBox boundary."""
+
+        async def create_browser_access(
+            self,
+            user_id: UUID,
+            *,
+            ttl_seconds: int,
+        ) -> PortAccessGrant:
+            browser_access_calls.append((user_id, ttl_seconds))
+            return PortAccessGrant(
+                workload_kind=WorkloadKind.WORKSPACE,
+                logical_id=user_id,
+                port=4848,
+                protocol=PortProtocol.HTTP,
+                url="https://agentbox.example.test/port-access/browser-token",
+                expires_at=datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds),
+            )
+
+        async def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        user_interaction_adapter,
+        "WorkspaceSandboxService",
+        _FakeWorkspaceSandboxService,
+    )
     pod_id = test_pod["id"]
     account = await _ensure_connector_account(
         db_session,
@@ -394,7 +428,16 @@ async def test_display_resource_slack_routes_pod_resource_catalog_to_deep_links(
     successful_returns = [
         message for message in tool_returns if message not in invalid_returns
     ]
-    assert all(message["tool_result"]["success"] for message in successful_returns)
+    unexpected_failures = [
+        {
+            "tool_call_id": message["tool_call_id"],
+            "tool_result": message["tool_result"],
+        }
+        for message in successful_returns
+        if not message["tool_result"]["success"]
+    ]
+    assert unexpected_failures == []
+    assert browser_access_calls == [(UUID(fixed_test_user["id"]), 1800)]
 
     slack_messages = await wait_for_messages(
         message_store, "SLACK", min_count=len(resource_calls) + 1

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_multi_pod_resolution_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_multi_pod_resolution_e2e.py
@@ -647,7 +647,7 @@ async def test_custom_bot_scope_and_system_bot_threads_do_not_cross(
         receiver_surface_ids=[custom_surface_id],
     )
     assert isinstance(non_member_ctx, SurfaceReplyContext)
-    assert f"/pods/{pod_id}" in (non_member_ctx.reply_message or "")
+    assert f"/pod/{pod_id}" in (non_member_ctx.reply_message or "")
 
     unknown_external = _external_id(platform, 703)
     unresolved_ctx = await _prepare_platform_dm(

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_onboarding_reply_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_onboarding_reply_e2e.py
@@ -78,7 +78,7 @@ async def test_system_bot_signed_up_non_member_does_not_get_pod_access_link(
     assert isinstance(context, SurfaceReplyContext)
     assert context.reply_kind == "surface_setup"
     message = context.reply_message or ""
-    assert f"/pods/{pod_id}" not in message
+    assert f"/pod/{pod_id}" not in message
     assert "set up or select a surface" in message.lower()
 
 
@@ -126,4 +126,4 @@ async def test_custom_bot_signed_up_non_member_gets_pod_access_link(
     assert context.reply_kind == "pod_access"
     message = context.reply_message or ""
     assert "access" in message.lower()
-    assert f"/pods/{pod_id}" in message
+    assert f"/pod/{pod_id}" in message

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_display_resource_renderer.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_display_resource_renderer.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
+import pytest
+
 from app.core.config import settings
 from app.modules.agent.tools.user_interaction.models import (
     DisplayResourceRequest,
@@ -122,3 +124,70 @@ def test_display_resource_renderer_links_inline_widget_to_lemma(monkeypatch):
         "toolCallId": ["tool-widget-inline"],
     }
     assert "External widget" not in plan.to_plain_text()
+
+
+@pytest.mark.parametrize(
+    ("request_payload", "path_suffix", "expected_query"),
+    [
+        (
+            {"type": "AGENT", "name": "incident triage"},
+            "/agents/incident%20triage",
+            {},
+        ),
+        ({"type": "AGENT"}, "/ai", {}),
+        (
+            {"type": "FUNCTION", "name": "summarize/incident"},
+            "/functions/summarize%2Fincident",
+            {},
+        ),
+        ({"type": "FUNCTION"}, "/functions", {}),
+        (
+            {"type": "WORKFLOW", "name": "incident response"},
+            "/flows/incident%20response",
+            {},
+        ),
+        ({"type": "WORKFLOW"}, "/flows", {}),
+        (
+            {"type": "APP", "name": "incident dashboard"},
+            "/app/view",
+            {"page": ["incident dashboard"]},
+        ),
+        ({"type": "APP"}, "/app/pages", {}),
+        (
+            {"type": "SCHEDULE", "name": "daily triage"},
+            "/schedules",
+            {},
+        ),
+        ({"type": "SCHEDULE"}, "/schedules", {}),
+        ({"type": "TABLE", "name": "incident log"}, "/data", {"tab": ["incident log"]}),
+        ({"type": "TABLE"}, "/data", {}),
+        (
+            {"type": "FILE", "path": "/me/reports/incident review.pdf"},
+            "/files",
+            {"file": ["/me/reports/incident review.pdf"]},
+        ),
+        ({"type": "FILE"}, "/files", {}),
+        ({"type": "WIDGET", "content": "<div>Ready</div>"}, "/widgets/view", {}),
+    ],
+)
+def test_display_resource_internal_urls_match_frontend_route_contract(
+    monkeypatch,
+    request_payload,
+    path_suffix,
+    expected_query,
+):
+    """Every internal link shared by all surface adapters targets a real UI route."""
+    monkeypatch.setattr(settings, "frontend_url", "https://app.example.test/")
+    pod_id = uuid4()
+
+    plan = build_display_resource_render_plan(
+        pod_id=pod_id,
+        request=DisplayResourceRequest.model_validate(request_payload),
+    )
+
+    assert plan.primary_action is not None
+    parsed = urlparse(plan.primary_action.url)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "app.example.test"
+    assert parsed.path == f"/pod/{pod_id}{path_suffix}"
+    assert parse_qs(parsed.query) == expected_query

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_fallback_reply_urls.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_fallback_reply_urls.py
@@ -1,0 +1,80 @@
+from uuid import uuid4
+
+import pytest
+
+from app.core.config import settings
+from app.modules.agent_surfaces.domain.entities import (
+    AgentSurfaceEntity,
+    ConversationType,
+    ParsedInboundSurfaceEvent,
+    SurfaceConfig,
+    SurfaceMode,
+    SurfacePlatform,
+)
+from app.modules.agent_surfaces.services.fallback_reply_service import (
+    _pod_access_message,
+    nonmember_context,
+    signup_message,
+    surface_setup_message,
+)
+
+
+def test_shared_surface_fallback_urls_use_their_matching_frontends(monkeypatch):
+    monkeypatch.setattr(settings, "frontend_url", "https://app.example.test/")
+    monkeypatch.setattr(
+        settings,
+        "auth_frontend_url",
+        "https://auth.example.test/auth/",
+    )
+    pod_id = uuid4()
+
+    assert signup_message().endswith("https://auth.example.test/auth")
+    assert surface_setup_message().endswith("https://app.example.test")
+    assert _pod_access_message(pod_id).endswith(
+        f"https://app.example.test/pod/{pod_id}"
+    )
+
+
+@pytest.mark.parametrize("platform", list(SurfacePlatform))
+def test_pod_access_url_is_shared_across_every_surface_platform(
+    monkeypatch,
+    platform,
+):
+    """All adapters receive the same frontend route from the shared fallback."""
+    monkeypatch.setattr(settings, "frontend_url", "https://app.example.test/")
+    pod_id = uuid4()
+    surface = AgentSurfaceEntity(
+        id=uuid4(),
+        pod_id=pod_id,
+        name=f"{platform.value.lower()}-access-link",
+        agent_id=uuid4(),
+        surface_type=platform,
+        mode=SurfaceMode.EMAIL if platform.is_email else SurfaceMode.DM,
+        account_id=uuid4(),
+        config=SurfaceConfig(),
+        is_active=True,
+    )
+    event = ParsedInboundSurfaceEvent(
+        platform=platform,
+        conversation_type=ConversationType.EXTERNAL_DM,
+        external_channel_id="channel-1",
+        external_thread_id="thread-1",
+        external_message_id="message-1",
+        sender_external_user_id="user-1",
+        message_text="hello",
+        is_dm=True,
+        reply_target={},
+    )
+
+    context = nonmember_context(
+        surface=surface,
+        parsed=event,
+        agent_display_name="Surface Agent",
+    )
+
+    assert context is not None
+    assert context.platform is platform
+    assert context.reply_kind == "pod_access"
+    assert context.reply_message.endswith(
+        f"https://app.example.test/pod/{pod_id}"
+    )

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_fallback_reply_urls.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_fallback_reply_urls.py
@@ -28,10 +28,17 @@ def test_shared_surface_fallback_urls_use_their_matching_frontends(monkeypatch):
     )
     pod_id = uuid4()
 
-    assert signup_message().endswith("https://auth.example.test/auth")
-    assert surface_setup_message().endswith("https://app.example.test")
-    assert _pod_access_message(pod_id).endswith(
-        f"https://app.example.test/pod/{pod_id}"
+    assert signup_message() == (
+        "Please sign up before chatting with this agent. "
+        "You can get started here: https://auth.example.test/auth"
+    )
+    assert surface_setup_message() == (
+        "You're signed in, but no agent surface is configured for you yet. "
+        "Open Lemma to set up or select a surface: https://app.example.test"
+    )
+    assert _pod_access_message(pod_id) == (
+        "You're signed up, but don't have access to this workspace yet. "
+        f"Request access here: https://app.example.test/pod/{pod_id}"
     )
 
 
@@ -75,6 +82,7 @@ def test_pod_access_url_is_shared_across_every_surface_platform(
     assert context is not None
     assert context.platform is platform
     assert context.reply_kind == "pod_access"
-    assert context.reply_message.endswith(
-        f"https://app.example.test/pod/{pod_id}"
+    assert context.reply_message == (
+        "You're signed up, but don't have access to this workspace yet. "
+        f"Request access here: https://app.example.test/pod/{pod_id}"
     )

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_ingress_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_ingress_service.py
@@ -374,9 +374,19 @@ async def test_prepare_webhook_avoids_pod_access_link_for_system_non_member():
     service.conversation_service.create_conversation.assert_not_called()
 
 
-async def test_prepare_webhook_returns_pod_access_link_for_custom_non_member():
+async def test_prepare_webhook_returns_pod_access_link_for_custom_non_member(
+    monkeypatch,
+):
     """A custom/bound bot maps to one configured surface, so the pod target is
     explicit and the access link is safe to show."""
+    from app.core.config import settings as app_settings
+
+    monkeypatch.setattr(app_settings, "frontend_url", "https://app.example.test/")
+    monkeypatch.setattr(
+        app_settings,
+        "auth_frontend_url",
+        "https://auth.example.test/auth/",
+    )
     surface = _telegram_surface()
     surface.credential_mode = SurfaceCredentialMode.CUSTOM
     event = ParsedInboundSurfaceEvent(
@@ -419,7 +429,10 @@ async def test_prepare_webhook_returns_pod_access_link_for_custom_non_member():
     assert isinstance(context, SurfaceReplyContext)
     assert context.reply_kind == "pod_access"
     assert "Request access" in (context.reply_message or "")
-    assert str(surface.pod_id) in (context.reply_message or "")
+    assert context.reply_message.endswith(
+        f"https://app.example.test/pod/{surface.pod_id}"
+    )
+    assert "auth.example.test" not in context.reply_message
     service.conversation_service.create_conversation.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- build every shared non-member onboarding link from the app frontend with the valid /pod/{id} route across Slack, Teams, WhatsApp, Telegram, Gmail, Outlook, and Resend
- align all shared display-resource links with actual frontend route contracts, including schedule collection links
- centralize a trailing <notes> block with the current UTC time for every in-process and daemon-backed agent harness
- keep runtime notes in outbound provider payloads only, never in persisted user messages
- route BROWSER display access through WorkspaceSandboxService so it uses the canonical AgentBox sandbox and port-access contracts
- keep the surface display E2E hermetic at its external AgentBox boundary and include failed tool payloads in assertion diagnostics

## Testing
- uv run pytest app/modules/agent/tests/unit app/modules/agent_surfaces/tests/unit plus affected workspace unit suites -q (835 passed)
- uv run pytest app/modules/agent_surfaces/tests/e2e/test_display_resource_matrix_e2e.py -q (10 passed)
- uv run pytest app/modules/agent_surfaces/tests/e2e/test_onboarding_reply_e2e.py app/modules/agent_surfaces/tests/e2e/test_multi_pod_resolution_e2e.py -q (8 passed)
- post-format focused unit and display E2E run (74 passed)
- focused Ruff lint and format checks (passed)
- git diff --check (passed)