### PR TITLE
Suppress SQLAlchemy ORM startup log noise

### DIFF
--- a/lemma-backend/app/core/log/log.py
+++ b/lemma-backend/app/core/log/log.py
@@ -85,7 +85,13 @@ _INFO_NOISE_LOGGER_PREFIXES = (
     "httpcore",
     "httpx",
     "sqlalchemy.engine",
-    "sqlalchemy.orm.mapper",
+    # SQLAlchemy's mapper configuration narrates every relationship, column
+    # property, and loader strategy through class-specific descendants such as
+    # ``sqlalchemy.orm.relationships.RelationshipProperty`` and
+    # ``sqlalchemy.orm.strategies.LazyLoader``. Keep the ORM at its documented
+    # WARNING default during normal INFO operation; warnings/errors still
+    # propagate through the redacted JSON pipeline.
+    "sqlalchemy.orm",
     "sqlalchemy.pool",
     "streaq",
     "uvicorn.access",

--- a/lemma-backend/app/core/tests/unit/test_logging_pipeline.py
+++ b/lemma-backend/app/core/tests/unit/test_logging_pipeline.py
@@ -438,7 +438,13 @@ def test_release_and_trace_identity_are_top_level(monkeypatch, captured_stdout) 
 
 @pytest.mark.parametrize(
     "logger_name",
-    ("sqlalchemy.engine.Engine", "sqlalchemy.orm.mapper.Mapper"),
+    (
+        "sqlalchemy.engine.Engine",
+        "sqlalchemy.orm.mapper.Mapper",
+        "sqlalchemy.orm.properties.ColumnProperty",
+        "sqlalchemy.orm.relationships.RelationshipProperty",
+        "sqlalchemy.orm.strategies.LazyLoader",
+    ),
 )
 def test_sqlalchemy_info_noise_is_suppressed_at_info(
     captured_stdout,
@@ -452,16 +458,27 @@ def test_sqlalchemy_info_noise_is_suppressed_at_info(
     )
     sqlalchemy_logger = logging.getLogger(logger_name)
 
-    sqlalchemy_logger.info("routine SQLAlchemy detail")
-    sqlalchemy_logger.warning("SQLAlchemy warning")
+    sqlalchemy_logger.info("routine SQLAlchemy detail token=CANARY")
+    sqlalchemy_logger.warning("SQLAlchemy warning token=CANARY")
+    get_logger("app.demo").info("service.started")
 
     records = captured_stdout()
-    assert [record["event"] for record in records] == ["SQLAlchemy warning"]
+    assert [record["event"] for record in records] == [
+        "SQLAlchemy warning token=[REDACTED]",
+        "service.started",
+    ]
+    assert "CANARY" not in json.dumps(records)
 
 
 @pytest.mark.parametrize(
     "logger_name",
-    ("sqlalchemy.engine.Engine", "sqlalchemy.orm.mapper.Mapper"),
+    (
+        "sqlalchemy.engine.Engine",
+        "sqlalchemy.orm.mapper.Mapper",
+        "sqlalchemy.orm.properties.ColumnProperty",
+        "sqlalchemy.orm.relationships.RelationshipProperty",
+        "sqlalchemy.orm.strategies.LazyLoader",
+    ),
 )
 def test_sqlalchemy_debug_remains_available_when_requested(
     captured_stdout,


### PR DESCRIPTION
## Summary

- suppress SQLAlchemy ORM mapper-configuration narration during normal `INFO` operation
- cover relationship, loader-strategy, column-property, and mapper logger descendants
- preserve application `INFO`, SQLAlchemy warnings/errors, redaction, and explicit `DEBUG` diagnostics

## Root cause

The existing logging policy raised `sqlalchemy.orm.mapper` to `WARNING`, but SQLAlchemy emits the high-volume startup records through sibling class loggers such as:

- `sqlalchemy.orm.relationships.RelationshipProperty`
- `sqlalchemy.orm.strategies.LazyLoader`
- `sqlalchemy.orm.properties.ColumnProperty`

Those loggers inherited the process-wide `INFO` level and narrated mapper initialization for every model on API and worker startup. In the observed dev release this was the dominant source behind roughly 742 MB/day of console logs.

SQLAlchemy documents `WARNING` as its default logging level. This PR applies that normal level to the `sqlalchemy.orm` namespace instead of one mapper submodule. It uses only Python logging configuration and has no cloud-provider coupling.

## Expected effect

Routine ORM startup records disappear at `INFO`, while actionable SQLAlchemy warnings/errors continue through the existing single-line redacted JSON pipeline. Setting the application log level to `DEBUG` still enables the ORM diagnostics for an intentional investigation.

## Validation

- `148 passed` — full `app/core/tests/unit` suite
- Ruff passes across `lemma-backend/app`
- tests verify application `INFO` remains visible and warning messages remain redacted
