### PR TITLE
fix(agent): tolerate legacy runtimes during orphan reconciliation

### DIFF
--- a/lemma-backend/app/modules/agent/infrastructure/repositories.py
+++ b/lemma-backend/app/modules/agent/infrastructure/repositories.py
@@ -69,6 +69,7 @@ from app.modules.agent.infrastructure.repository_status import (
     conversation_status_values_for_db as _conversation_status_values_for_db,
     run_status_values_for_db as _run_status_values_for_db,
 )
+from app.modules.agent.infrastructure.run_projections import StaleAgentRunRef
 from app.modules.connectors.contracts import SecretEncryptionPort
 
 
@@ -838,17 +839,15 @@ class ConversationRepository:
         *,
         cutoff_seconds: int,
         limit: int = 200,
-    ) -> list[AgentRunEntity]:
-        """List non-terminal agent runs whose ``started_at`` predates the cutoff.
+    ) -> list[StaleAgentRunRef]:
+        """List identities of active runs older than the post-timeout cutoff.
 
-        These are runs whose worker task died (crash/OOM/forced shutdown) without
-        finalizing them — they would otherwise sit in RUNNING forever. The cutoff
-        must exceed the streaq task timeout so legitimately long-running agents
-        are never swept up.
+        Only IDs are selected: reconciliation does not execute the run, and stale
+        legacy runtime JSON must not block a safe terminal status transition.
         """
         cutoff = datetime.now(timezone.utc) - timedelta(seconds=cutoff_seconds)
         result = await self.session.execute(
-            select(AgentRunModel)
+            select(AgentRunModel.id, AgentRunModel.conversation_id)
             .where(
                 AgentRunModel.status.in_(_ACTIVE_AGENT_RUN_STATUS_VALUES),
                 AgentRunModel.started_at < cutoff,
@@ -856,7 +855,7 @@ class ConversationRepository:
             .order_by(AgentRunModel.started_at.asc())
             .limit(limit)
         )
-        return [model.to_entity() for model in result.scalars().all()]
+        return [StaleAgentRunRef(*row) for row in result.all()]
 
     async def lock_conversation(self, conversation_id: UUID) -> None:
         await self.session.execute(

--- a/lemma-backend/app/modules/agent/infrastructure/run_projections.py
+++ b/lemma-backend/app/modules/agent/infrastructure/run_projections.py
@@ -1,0 +1,12 @@
+"""Minimal database projections used by agent-run maintenance operations."""
+
+from dataclasses import dataclass
+from uuid import UUID
+
+
+@dataclass(frozen=True, slots=True)
+class StaleAgentRunRef:
+    """Stable identity needed to reconcile an orphaned run."""
+
+    id: UUID
+    conversation_id: UUID

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_event_handlers.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_event_handlers.py
@@ -10,6 +10,7 @@ from app.modules.agent.domain.events import AgentRunCompletedEvent, AgentRunStop
 from app.modules.agent.events.handlers import conversation_title_job_id
 from app.modules.agent.domain.value_objects import AgentRunStatus
 from app.modules.agent.events import handlers
+from app.modules.agent.infrastructure.run_projections import StaleAgentRunRef
 from app.modules.test_support.fakes import PassthroughEventInbox
 
 
@@ -196,8 +197,8 @@ async def test_reconcile_orphaned_agent_runs_finalizes_and_publishes(
     conv1, run1 = uuid4(), uuid4()
     conv2, run2 = uuid4(), uuid4()
     stale = [
-        SimpleNamespace(id=run1, conversation_id=conv1),
-        SimpleNamespace(id=run2, conversation_id=conv2),
+        StaleAgentRunRef(id=run1, conversation_id=conv1),
+        StaleAgentRunRef(id=run2, conversation_id=conv2),
     ]
     finished: list[object] = []
     realtime: list[tuple[object, dict]] = []

--- a/lemma-backend/app/modules/agent/tests/unit/test_orphaned_agent_run_repository.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_orphaned_agent_run_repository.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from app.modules.agent.infrastructure.repositories import ConversationRepository
+from app.modules.agent.infrastructure.run_projections import StaleAgentRunRef
+
+
+class _Result:
+    def __init__(self, rows: list[tuple[object, object]]) -> None:
+        self.rows = rows
+
+    def all(self) -> list[tuple[object, object]]:
+        return self.rows
+
+    def scalars(self) -> None:
+        raise AssertionError("orphan reconciliation must not hydrate agent run models")
+
+
+class _Session:
+    def __init__(self, rows: list[tuple[object, object]]) -> None:
+        self.rows = rows
+        self.statement = None
+
+    async def execute(self, statement):
+        self.statement = statement
+        return _Result(self.rows)
+
+
+class _Uow:
+    def __init__(self, rows: list[tuple[object, object]]) -> None:
+        self.session = _Session(rows)
+
+    def collect_events(self, events: list[object]) -> None:
+        _ = events
+
+
+@pytest.mark.asyncio
+async def test_stale_run_lookup_uses_identity_projection_not_runtime_payload() -> None:
+    """Legacy agent_runtime JSON cannot prevent an orphan from being finalized."""
+    run_id = uuid4()
+    conversation_id = uuid4()
+    uow = _Uow([(run_id, conversation_id)])
+
+    stale = await ConversationRepository(uow).list_stale_active_runs(
+        cutoff_seconds=600,
+    )
+
+    assert stale == [
+        StaleAgentRunRef(id=run_id, conversation_id=conversation_id),
+    ]
+    assert uow.session.statement is not None
+    sql = str(
+        uow.session.statement.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+    selected_columns = sql.partition(" FROM ")[0]
+    assert "agent_runs.id" in selected_columns
+    assert "agent_runs.conversation_id" in selected_columns
+    assert "agent_runs.agent_runtime" not in selected_columns


### PR DESCRIPTION
## Summary

Prevent one stale agent run with legacy `agent_runtime` JSON from aborting the entire orphaned-run reconciliation sweep.

## Root cause

`ConversationRepository.list_stale_active_runs()` loaded full `AgentRunModel` objects and converted each one to `AgentRunEntity`. That conversion validates `agent_runtime` against the current schema.

The reconciler does not execute or inspect runtime configuration; it only needs the run ID and conversation ID to make a stale run terminal. Consequently, a historical row whose runtime JSON predates the current schema could raise during an unrelated conversion before any stale run was reconciled.

## Behavior

- query only `agent_runs.id` and `agent_runs.conversation_id`
- return a small immutable `StaleAgentRunRef` projection
- leave the existing stale cutoff, ordering, batch limit, transition rules, lifecycle events, and SSE publication unchanged
- leave persisted legacy runtime JSON untouched

This is deliberately not a fallback runtime parser. Reinterpreting or rewriting historical execution configuration during a maintenance sweep could corrupt audit data. The safe operation is to use stable identity fields and perform the existing terminal status transition.

Genuine query, transaction, or update errors are not swallowed. They still abort the unit of work and use the existing bounded exception pipeline, which emits exception type/fingerprint/application frames without exception messages, secret values, or user payloads.

## Tests

- focused orphan repository and handler tests: 7 passed
- complete agent unit suite: 389 passed
- full backend Ruff gate
- async-safety Ruff gate
- architecture ratchet
- route inventory check
- Python compile check

The regression test fails if the stale lookup hydrates ORM models again and verifies that `agent_runtime` is absent from the selected SQL columns.
