### PR TITLE
fix(observability): bound route labels and drop ASGI internals

### DIFF
--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -263,6 +263,8 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'connectors.schema_compiler.rejected_connector_schema_snippet.diagnostic': EventSpec('debug', frozenset({'error_type'})),
     'crypto.keys.ignoring_unparsable_secret_encryption_keyset.diagnostic': EventSpec('debug', frozenset()),
     'crypto.rotation.reencrypt_s_scanned_d_migrated.observed': EventSpec('debug', frozenset()),
+    'datastore.access.files_withheld': EventSpec('warning', frozenset({'actor_type', 'total_candidates', 'withheld_count'})),
+    'datastore.access.files_withheld.expected': EventSpec('info', frozenset({'actor_type', 'total_candidates', 'withheld_count'})),
     'datastore.authorization.authorization_check_document_admin_user.diagnostic': EventSpec('debug', frozenset({'pod_id', 'user_id'})),
     'datastore.changes_controller.rejected_datastore_changes_websocket.diagnostic': EventSpec('debug', frozenset({'pod_id', 'user_id'})),
     'datastore.changes_controller.session_resolution_datastore_changes_websocket.diagnostic': EventSpec('debug', frozenset()),

--- a/lemma-backend/app/core/observability/span_sanitizer.py
+++ b/lemma-backend/app/core/observability/span_sanitizer.py
@@ -18,12 +18,37 @@ from opentelemetry.sdk.trace.export import (
     SpanExportResult,
 )
 from opentelemetry.sdk.util.instrumentation import InstrumentationScope
-from opentelemetry.trace import Link, SpanContext, Status, StatusCode, TraceState
+from opentelemetry.trace import (
+    Link,
+    SpanContext,
+    SpanKind,
+    Status,
+    StatusCode,
+    TraceState,
+)
 
 
 _SAFE_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)+$")
+_SAFE_ROUTE_SEGMENT_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.-]{0,63}$")
+_SAFE_ROUTE_PARAMETER_RE = re.compile(
+    r"^\{[A-Za-z_][A-Za-z0-9_]*(?::[A-Za-z_][A-Za-z0-9_]*)?\}$"
+)
+_UUID_ROUTE_SEGMENT_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-"
+    r"[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$"
+)
+_ULID_ROUTE_SEGMENT_RE = re.compile(r"^[0-9A-HJKMNP-TV-Z]{26}$")
+_HEX_ROUTE_SEGMENT_RE = re.compile(r"^[0-9a-fA-F]{8,}$")
+_TOKEN_ROUTE_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_-]{16,}$")
 _MAX_STRING = 256
 _MAX_SEQUENCE = 16
+_MAX_ROUTE_SEGMENTS = 32
+_REDUNDANT_INTERNAL_SCOPE_NAMES = frozenset(
+    {
+        "opentelemetry.instrumentation.asgi",
+        "opentelemetry.instrumentation.fastapi",
+    }
+)
 
 RESOURCE_ATTRIBUTE_KEYS = frozenset(
     {
@@ -167,6 +192,44 @@ def _safe_value(value: Any) -> Any | None:
     return None
 
 
+def sanitize_http_route(value: Any) -> str | None:
+    """Keep bounded routes while rejecting common concrete identifier forms.
+
+    Instrumentation normally supplies the declared framework route (for example
+    ``/pods/{pod_id}``), but compatibility fallbacks have returned request paths
+    containing UUIDs and other high-cardinality identifiers. Route attributes
+    are labels, so UUID, ULID, numeric, digest, token-like, URL, and malformed
+    segments are omitted at the final export boundary.
+    """
+    if not isinstance(value, str) or not value.startswith("/"):
+        return None
+    if len(value) > _MAX_STRING or any(
+        marker in value for marker in ("?", "#", "%", "\\", "@", "://")
+    ):
+        return None
+    segments = [segment for segment in value.split("/") if segment]
+    if len(segments) > _MAX_ROUTE_SEGMENTS:
+        return None
+    for segment in segments:
+        if _SAFE_ROUTE_PARAMETER_RE.fullmatch(segment):
+            continue
+        if (
+            segment.isdecimal()
+            or _UUID_ROUTE_SEGMENT_RE.fullmatch(segment)
+            or _ULID_ROUTE_SEGMENT_RE.fullmatch(segment)
+            or _HEX_ROUTE_SEGMENT_RE.fullmatch(segment)
+            or (
+                _TOKEN_ROUTE_SEGMENT_RE.fullmatch(segment)
+                and any(character.isalpha() for character in segment)
+                and any(character.isdigit() for character in segment)
+            )
+        ):
+            return None
+        if not _SAFE_ROUTE_SEGMENT_RE.fullmatch(segment):
+            return None
+    return value
+
+
 def sanitize_attributes(
     attributes: Mapping[str, Any] | None,
     *,
@@ -177,7 +240,9 @@ def sanitize_attributes(
     for key, value in (attributes or {}).items():
         if key not in allowed:
             continue
-        sanitized = _safe_value(value)
+        sanitized = (
+            sanitize_http_route(value) if key == "http.route" else _safe_value(value)
+        )
         if sanitized is not None:
             safe[key] = sanitized
     return safe
@@ -284,6 +349,14 @@ class SanitizingSpanExporter(SpanExporter):
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         safe_spans: list[ReadableSpan] = []
         for span in spans:
+            scope_name = (
+                getattr(span.instrumentation_scope, "name", None) or ""
+            ).lower()
+            if (
+                span.kind is SpanKind.INTERNAL
+                and scope_name in _REDUNDANT_INTERNAL_SCOPE_NAMES
+            ):
+                continue
             try:
                 safe_spans.append(sanitize_span(span, llm=self._llm))
             except Exception:

--- a/lemma-backend/app/core/observability/telemetry.py
+++ b/lemma-backend/app/core/observability/telemetry.py
@@ -66,6 +66,7 @@ from app.core.redaction import redact_text
 from app.core.observability.span_sanitizer import (
     METRIC_ATTRIBUTE_KEYS,
     SanitizingSpanExporter,
+    sanitize_http_route,
 )
 
 logger = get_logger(__name__)
@@ -780,7 +781,7 @@ def _patch_fastapi_route_details() -> None:
 
     def _safe_get_route_details(scope: Any):
         try:
-            return original(scope)
+            return sanitize_http_route(original(scope))
         except AttributeError:
             return None
 

--- a/lemma-backend/app/core/tests/unit/test_otel_safety.py
+++ b/lemma-backend/app/core/tests/unit/test_otel_safety.py
@@ -19,7 +19,10 @@ from opentelemetry.trace import (
 )
 
 from app.core.observability import telemetry
-from app.core.observability.span_sanitizer import SanitizingSpanExporter
+from app.core.observability.span_sanitizer import (
+    SanitizingSpanExporter,
+    sanitize_http_route,
+)
 
 
 class _CaptureExporter(SpanExporter):
@@ -101,7 +104,12 @@ def test_signal_endpoint_resolution_obeys_otlp_protocol_rules(monkeypatch) -> No
     assert telemetry._otlp_signal_endpoint("traces") == ("https://traces.test/custom")
 
 
-def _adversarial_span() -> ReadableSpan:
+def _adversarial_span(
+    *,
+    http_route: str = "/pods/{pod_id}",
+    kind: SpanKind = SpanKind.SERVER,
+    scope_name: str = "opentelemetry.instrumentation.fastapi",
+) -> ReadableSpan:
     context = SpanContext(
         trace_id=1,
         span_id=2,
@@ -121,7 +129,7 @@ def _adversarial_span() -> ReadableSpan:
         ),
         attributes={
             "http.request.method": "GET",
-            "http.route": "/pods/{pod_id}",
+            "http.route": http_route,
             "url.full": "https://example.test/private?token=CANARY",
             "db.statement": "SELECT 'CANARY'",
             "db.system": "postgresql",
@@ -142,10 +150,8 @@ def _adversarial_span() -> ReadableSpan:
             ),
         ),
         links=(Link(context, {"url.full": "https://CANARY", "error.type": "Error"}),),
-        kind=SpanKind.SERVER,
-        instrumentation_scope=InstrumentationScope(
-            "opentelemetry.instrumentation.fastapi"
-        ),
+        kind=kind,
+        instrumentation_scope=InstrumentationScope(scope_name),
         status=Status(StatusCode.ERROR, "CANARY status"),
         start_time=1,
         end_time=2,
@@ -170,6 +176,105 @@ def test_export_boundary_span_sanitizer_drops_adversarial_content() -> None:
     assert safe.events[0].attributes == {"exception.type": "RuntimeError"}
     assert safe.links[0].attributes == {"error.type": "Error"}
     assert "CANARY" not in str(safe.to_json())
+
+
+@pytest.mark.parametrize(
+    ("route", "expected"),
+    [
+        ("/pods/{pod_id}/datastore/tables/{table_id}/records", True),
+        ("/port-access/{token}/{path:path}", True),
+        ("/health/ready", True),
+        ("/openapi.json", True),
+        ("/pods/019f99c1-5a45-739e-ba96-717bc9fccad7/functions", False),
+        ("/users/12345", False),
+        ("/runs/01K0YZH3VX8FB2M7G5WC6NQ9TR", False),
+        ("/files/5383eddca8db622d42865ea7a9e672e15d058018", False),
+        ("/reset/AbCdEf0123456789", False),
+        ("/users/alice@example.test", False),
+        ("https://example.test/health", False),
+    ],
+)
+def test_http_route_export_boundary_rejects_concrete_identifiers(
+    route: str,
+    expected: bool,
+) -> None:
+    assert (sanitize_http_route(route) is not None) is expected
+    capture = _CaptureExporter()
+    exporter = SanitizingSpanExporter(capture)
+    assert (
+        exporter.export([_adversarial_span(http_route=route)])
+        is SpanExportResult.SUCCESS
+    )
+    assert len(capture.spans) == 1
+    assert ("http.route" in capture.spans[0].attributes) is expected
+
+
+def test_fastapi_route_patch_filters_labels_before_span_and_metric_collection(
+    monkeypatch,
+) -> None:
+    from opentelemetry.instrumentation import fastapi as otel_fastapi
+
+    monkeypatch.setattr(telemetry, "_fastapi_route_details_patched", False)
+    monkeypatch.setattr(
+        otel_fastapi,
+        "_get_route_details",
+        lambda scope: scope["route"],
+    )
+    telemetry._patch_fastapi_route_details()
+
+    assert otel_fastapi._get_route_details({"route": "/pods/{pod_id}"}) == (
+        "/pods/{pod_id}"
+    )
+    assert (
+        otel_fastapi._get_route_details(
+            {"route": "/pods/019f99c1-5a45-739e-ba96-717bc9fccad7"}
+        )
+        is None
+    )
+
+
+def test_exporter_drops_only_fastapi_asgi_internal_spans() -> None:
+    capture = _CaptureExporter()
+    exporter = SanitizingSpanExporter(capture)
+    assert (
+        exporter.export(
+            [
+                _adversarial_span(
+                    kind=SpanKind.INTERNAL,
+                    scope_name="opentelemetry.instrumentation.fastapi",
+                ),
+                _adversarial_span(
+                    kind=SpanKind.INTERNAL,
+                    scope_name="opentelemetry.instrumentation.asgi",
+                ),
+                _adversarial_span(kind=SpanKind.SERVER),
+                _adversarial_span(
+                    kind=SpanKind.CLIENT,
+                    scope_name="opentelemetry.instrumentation.httpx",
+                ),
+                _adversarial_span(
+                    kind=SpanKind.INTERNAL,
+                    scope_name="app.core.background_jobs",
+                ),
+                _adversarial_span(
+                    kind=SpanKind.INTERNAL,
+                    scope_name="app.fastapi_adapter",
+                ),
+                _adversarial_span(
+                    kind=SpanKind.INTERNAL,
+                    scope_name="custom.asgi.pipeline",
+                ),
+            ]
+        )
+        is SpanExportResult.SUCCESS
+    )
+    assert [span.kind for span in capture.spans] == [
+        SpanKind.SERVER,
+        SpanKind.CLIENT,
+        SpanKind.INTERNAL,
+        SpanKind.INTERNAL,
+        SpanKind.INTERNAL,
+    ]
 
 
 def test_llm_pipeline_disables_content_and_uses_dedicated_provider(

--- a/lemma-backend/app/modules/datastore/services/files/authorizer.py
+++ b/lemma-backend/app/modules/datastore/services/files/authorizer.py
@@ -254,14 +254,19 @@ class FileAuthorizer:
                 ActorType.FUNCTION,
                 ActorType.DELEGATED_USER_WORKLOAD,
             )
-            log = logger.warning if is_workload else logger.info
-            log(
-                "datastore.access.files_withheld",
-                pod_id=str(pod_id),
-                actor_type=getattr(actor_type, "value", actor_type),
-                actor_user_id=str(getattr(ctx, "user_id", None) or ""),
-                withheld_count=withheld_count,
-                total_candidates=len(items),
-            )
+            if is_workload:
+                logger.warning(
+                    "datastore.access.files_withheld",
+                    actor_type=getattr(actor_type, "value", actor_type),
+                    withheld_count=withheld_count,
+                    total_candidates=len(items),
+                )
+            else:
+                logger.info(
+                    "datastore.access.files_withheld.expected",
+                    actor_type=getattr(actor_type, "value", actor_type),
+                    withheld_count=withheld_count,
+                    total_candidates=len(items),
+                )
 
         return visible_ids


### PR DESCRIPTION
## Summary

Tightens the existing generic OpenTelemetry boundary without adding Azure-specific configuration or custom business spans.

- keeps declared FastAPI route templates and bounded static routes, but omits UUID, ULID, numeric, digest, token-like, URL, and malformed `http.route` values
- applies the same route guard to FastAPI's route-details hook before span and metric labels are created
- drops only FastAPI/ASGI spans whose kind is `INTERNAL`; SERVER request spans, HTTP client spans, database spans, Lemma job spans, and other internal spans remain
- registers the file-withholding operational events with bounded counts/principal type only; pod and user IDs are no longer logged

## Why

FastAPI compatibility fallbacks can produce concrete request paths instead of
declared route templates, creating privacy and cardinality risk. Its ASGI
instrumentation also emits redundant INTERNAL send/receive child spans around
the useful SERVER request span. Separately, the file-withholding operational
event was missing from the exact logging catalog.

## Safety and expected effect

- No request, dependency, or application behavior changes.
- Recognizable UUID, ULID, numeric, digest, token-like, URL, and malformed route labels are omitted rather than rewritten to a misleading value.
- Valid templates such as `/pods/{pod_id}` and `/port-access/{token}/{path:path}`, plus bounded static routes such as `/health/ready`, remain available.
- The standard FastAPI SERVER request span remains the request latency/error signal.
- Useful external dependencies and Lemma background-job spans remain unchanged.
- The internal-span filter removes the redundant framework child spans while retaining the request trace and useful dependencies.
- The file-withholding logs retain only `actor_type`, `withheld_count`, and `total_candidates`; no user or pod identifiers cross the log boundary.

## Verification

- `uv run pytest app/core/tests/unit/test_otel_safety.py app/core/tests/unit/test_logging_contract_static.py app/modules/datastore/tests/unit/test_file_authorizer_workload.py -q` — 27 passed
- Ruff checks passed for every changed Python file
- Regression coverage verifies safe templates/static routes, unsafe concrete route rejection, pre-collection FastAPI route filtering, INTERNAL-only ASGI filtering, SERVER/client/non-framework span preservation, and exact logging contracts

## Scope

This intentionally does not add Azure-specific settings, middleware, or per-function custom instrumentation. `redis.stream.snapshot` was already correctly registered on current `main`, so this PR does not touch that contract.
