### PR TITLE
Fix AgentBox capacity reservation leaks

### DIFF
--- a/agentbox/agentbox/api/app.py
+++ b/agentbox/agentbox/api/app.py
@@ -203,9 +203,7 @@ class RequestContextMiddleware:
                             exc_info=exc_info,
                         )
                     elif status_code == 429:
-                        incident_key = (
-                            f"{scope.get('method', 'UNKNOWN')}:{route}"
-                        )
+                        incident_key = f"{scope.get('method', 'UNKNOWN')}:{route}"
                         _rate_limit_incidents.setdefault(
                             incident_key,
                             DependencyIncident(
@@ -214,9 +212,7 @@ class RequestContextMiddleware:
                             ),
                         ).record_failure(_RateLimitedResponseError())
                     else:
-                        incident_key = (
-                            f"{scope.get('method', 'UNKNOWN')}:{route}"
-                        )
+                        incident_key = f"{scope.get('method', 'UNKNOWN')}:{route}"
                         incident = _rate_limit_incidents.get(incident_key)
                         if incident is not None:
                             incident.record_success()
@@ -460,6 +456,9 @@ async def lifespan(app: FastAPI):
         provider,
         create_absence_grace_seconds=(
             settings.agentbox_ambiguous_create_absence_grace_seconds
+        ),
+        dispatched_create_stale_seconds=(
+            settings.agentbox_dispatched_create_stale_seconds
         ),
         claim_seconds=settings.agentbox_reconcile_claim_seconds,
         retry_seconds=max(0.1, settings.agentbox_reconcile_interval_seconds),

--- a/agentbox/agentbox/config.py
+++ b/agentbox/agentbox/config.py
@@ -141,6 +141,15 @@ class Settings(BaseSettings):
     agentbox_ambiguous_create_absence_grace_seconds: float = Field(
         default=30, ge=1, le=600
     )
+    agentbox_dispatched_create_stale_seconds: float = Field(
+        default=15 * 60,
+        ge=30,
+        le=24 * 60 * 60,
+        description=(
+            "Age after which an unfinalized provider create dispatch is treated "
+            "as ambiguous and reconciled by exact allocation metadata."
+        ),
+    )
     agentbox_reconcile_claim_seconds: float = Field(default=30, ge=5, le=300)
     agentbox_workspace_retention_seconds: float = Field(default=604800, ge=1)
     agentbox_add_host_gateway: bool = False

--- a/agentbox/agentbox/event_catalog.py
+++ b/agentbox/agentbox/event_catalog.py
@@ -51,6 +51,10 @@ EVENT_CATALOG: dict[str, EventSpec] = {
         "warning",
         frozenset({"error_type"}),
     ),
+    "agentbox.admission.invariant_repaired": EventSpec(
+        "warning",
+        frozenset({"allocation_count", "provider_scope"}),
+    ),
     "port.proxy.upstream_failed": EventSpec(
         "error",
         frozenset({"method", "protocol", "provider"}),

--- a/agentbox/agentbox/lifecycle.py
+++ b/agentbox/agentbox/lifecycle.py
@@ -23,6 +23,7 @@ from agentbox.domain import (
     SandboxProfileRef,
     WorkloadKind,
 )
+from agentbox.observability import create_inherited_task
 from agentbox.ports import (
     ProviderAllocationFailed,
     ProviderAllocationRef,
@@ -699,7 +700,7 @@ class SandboxLifecycleService:
                 )
                 await uow.commit()
 
-        task = asyncio.create_task(
+        task = create_inherited_task(
             persist(),
             name=f"agentbox-create-cancel:{allocation_token}",
         )
@@ -723,7 +724,7 @@ class SandboxLifecycleService:
                 )
                 await uow.commit()
 
-        task = asyncio.create_task(
+        task = create_inherited_task(
             persist(),
             name=f"agentbox-create-failed:{allocation_token}",
         )

--- a/agentbox/agentbox/lifecycle.py
+++ b/agentbox/agentbox/lifecycle.py
@@ -704,11 +704,7 @@ class SandboxLifecycleService:
             persist(),
             name=f"agentbox-create-cancel:{allocation_token}",
         )
-        try:
-            await asyncio.shield(task)
-        except asyncio.CancelledError:
-            # A second cancellation must not cancel the durable repair write.
-            await task
+        return await self._await_durable_write(task)
 
     async def _mark_create_failed_durably(
         self,
@@ -728,10 +724,18 @@ class SandboxLifecycleService:
             persist(),
             name=f"agentbox-create-failed:{allocation_token}",
         )
-        try:
-            await asyncio.shield(task)
-        except asyncio.CancelledError:
-            await task
+        return await self._await_durable_write(task)
+
+    @staticmethod
+    async def _await_durable_write(task: asyncio.Task[None]) -> None:
+        while True:
+            try:
+                return await asyncio.shield(task)
+            except asyncio.CancelledError:
+                # Repeated caller cancellation must not interrupt the state
+                # transition that makes the provider outcome reconcilable.
+                if task.done():
+                    return task.result()
 
     @staticmethod
     def _create_request_hash(

--- a/agentbox/agentbox/lifecycle.py
+++ b/agentbox/agentbox/lifecycle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import hashlib
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
@@ -95,51 +96,60 @@ class SandboxLifecycleService:
         # Transaction 1: durable logical resource and one allocation intent.
         decision: ProviderAdmissionDecision
         pending_retry = False
-        async with self._database.uow() as uow:
-            logical = await uow.repository.ensure_logical(key, profile)
-            storage = None
-            if key.workload_kind == WorkloadKind.WORKSPACE:
-                storage = await uow.repository.ensure_workspace_storage(
-                    key,
-                    provider_name=self._provider.name,
-                    storage_kind=self._provider.workspace_storage_kind,
+        intent = None
+        resumed = None
+        storage = None
+        try:
+            async with self._database.uow() as uow:
+                logical = await uow.repository.ensure_logical(key, profile)
+                if key.workload_kind == WorkloadKind.WORKSPACE:
+                    storage = await uow.repository.ensure_workspace_storage(
+                        key,
+                        provider_name=self._provider.name,
+                        storage_kind=self._provider.workspace_storage_kind,
+                    )
+                resumed = await uow.repository.resume_released_allocation(key, profile)
+                if resumed is None:
+                    intent = await uow.repository.begin_allocation(
+                        key,
+                        profile,
+                        provider_name=self._provider.name,
+                        provider_scope=self._provider.scope,
+                        admission_class=admission_class.value,
+                        request_hash=request_hash,
+                    )
+                allocation_for_admission = resumed or (
+                    intent.allocation if intent is not None else None
                 )
-            resumed = await uow.repository.resume_released_allocation(key, profile)
-            intent = None
-            if resumed is None:
-                intent = await uow.repository.begin_allocation(
-                    key,
-                    profile,
-                    provider_name=self._provider.name,
-                    provider_scope=self._provider.scope,
-                    admission_class=admission_class.value,
-                    request_hash=request_hash,
+                if allocation_for_admission is None:  # pragma: no cover
+                    raise RuntimeError("ensure produced no allocation for admission")
+                pending_retry = (
+                    intent is not None
+                    and intent.allocation.state == AllocationState.RESERVED
+                    and intent.allocation.retry_after is not None
+                    and intent.allocation.retry_after > datetime.now(timezone.utc)
                 )
-            allocation_for_admission = resumed or (
-                intent.allocation if intent is not None else None
-            )
-            if allocation_for_admission is None:  # pragma: no cover
-                raise RuntimeError("ensure produced no allocation for admission")
-            pending_retry = (
-                intent is not None
-                and intent.allocation.state == AllocationState.RESERVED
-                and intent.allocation.retry_after is not None
-                and intent.allocation.retry_after > datetime.now(timezone.utc)
-            )
-            if pending_retry:
-                decision = ProviderAdmissionDecision(
-                    accepted=True,
-                    active=0,
-                    reserved=0,
-                    limit=self._admission_policy.max_active,
+                if pending_retry:
+                    decision = ProviderAdmissionDecision(
+                        accepted=True,
+                        active=0,
+                        reserved=0,
+                        limit=self._admission_policy.max_active,
+                    )
+                else:
+                    decision = await uow.repository.reserve_provider_capacity(
+                        allocation_for_admission.allocation_id,
+                        admission_class=admission_class,
+                        policy=self._admission_policy,
+                    )
+                await uow.commit()
+        except asyncio.CancelledError:
+            if intent is not None and intent.should_dispatch_create:
+                await self._mark_create_failed_durably(
+                    intent.allocation.allocation_token,
+                    error_code=ErrorCode.DEADLINE_EXCEEDED,
                 )
-            else:
-                decision = await uow.repository.reserve_provider_capacity(
-                    allocation_for_admission.allocation_id,
-                    admission_class=admission_class,
-                    policy=self._admission_policy,
-                )
-            await uow.commit()
+            raise
 
         if not decision.accepted:
             raise self._admission_error(decision)
@@ -161,11 +171,30 @@ class SandboxLifecycleService:
 
         # Transaction 2: transition RESERVED -> DISPATCHED exactly once. The
         # provider has not been called yet and this transaction is closed before it is.
-        async with self._database.uow() as uow:
-            dispatch = await uow.repository.mark_create_dispatched(
-                intent.allocation.allocation_token
+        try:
+            self._check_deadline(deadline_at)
+            async with self._database.uow() as uow:
+                dispatch = await uow.repository.mark_create_dispatched(
+                    intent.allocation.allocation_token
+                )
+                await uow.commit()
+        except AgentBoxError as exc:
+            if exc.code != ErrorCode.DEADLINE_EXCEEDED:
+                raise
+            await self._mark_create_failed_durably(
+                intent.allocation.allocation_token,
+                error_code=ErrorCode.DEADLINE_EXCEEDED,
             )
-            await uow.commit()
+            raise
+        except asyncio.CancelledError:
+            # The provider has not been called yet. Regardless of whether the
+            # dispatch transaction committed before cancellation arrived, this
+            # create is definitively unaccepted and can release its reservation.
+            await self._mark_create_failed_durably(
+                intent.allocation.allocation_token,
+                error_code=ErrorCode.DEADLINE_EXCEEDED,
+            )
+            raise
 
         if not dispatch:
             allocation = await self._get_allocation(intent.allocation.allocation_token)
@@ -181,7 +210,6 @@ class SandboxLifecycleService:
                 )
             return self._handle(intent.logical, allocation)
 
-        self._check_deadline(deadline_at)
         create_request = ProviderCreateRequest(
             allocation_id=intent.allocation.allocation_id,
             allocation_token=intent.allocation.allocation_token,
@@ -208,7 +236,26 @@ class SandboxLifecycleService:
 
         # External create I/O: no SQLAlchemy unit of work/session exists here.
         try:
+            self._check_deadline(deadline_at)
             created = await self._provider.create(create_request)
+        except AgentBoxError as exc:
+            if exc.code != ErrorCode.DEADLINE_EXCEEDED:
+                raise
+            async with self._database.uow() as uow:
+                await uow.repository.mark_create_failed(
+                    intent.allocation.allocation_token,
+                    error_code=ErrorCode.DEADLINE_EXCEEDED.value,
+                )
+                await uow.commit()
+            raise
+        except asyncio.CancelledError:
+            # Cancellation may race a provider accepting the create. Preserve
+            # that ambiguity durably so exact metadata reconciliation can
+            # adopt or remove the allocation without replaying the create.
+            await self._mark_create_unknown_durably(
+                intent.allocation.allocation_token
+            )
+            raise
         except ProviderCreateAmbiguous as exc:
             async with self._database.uow() as uow:
                 await uow.repository.mark_create_unknown(
@@ -638,6 +685,52 @@ class SandboxLifecycleService:
         if allocation is None:  # pragma: no cover - state corruption
             raise RuntimeError("allocation disappeared after dispatch claim")
         return allocation
+
+    async def _mark_create_unknown_durably(
+        self,
+        allocation_token: UUID,
+    ) -> None:
+        async def persist() -> None:
+            async with self._database.uow() as uow:
+                await uow.repository.mark_create_unknown(
+                    allocation_token,
+                    reconcile_after=datetime.now(timezone.utc) + timedelta(seconds=1),
+                    error_code=ErrorCode.AMBIGUOUS_CREATE.value,
+                )
+                await uow.commit()
+
+        task = asyncio.create_task(
+            persist(),
+            name=f"agentbox-create-cancel:{allocation_token}",
+        )
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            # A second cancellation must not cancel the durable repair write.
+            await task
+
+    async def _mark_create_failed_durably(
+        self,
+        allocation_token: UUID,
+        *,
+        error_code: ErrorCode,
+    ) -> None:
+        async def persist() -> None:
+            async with self._database.uow() as uow:
+                await uow.repository.mark_create_failed(
+                    allocation_token,
+                    error_code=error_code.value,
+                )
+                await uow.commit()
+
+        task = asyncio.create_task(
+            persist(),
+            name=f"agentbox-create-failed:{allocation_token}",
+        )
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            await task
 
     @staticmethod
     def _create_request_hash(

--- a/agentbox/agentbox/persistence/repository.py
+++ b/agentbox/agentbox/persistence/repository.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid4
 
-from sqlalchemy import Select, and_, exists, func, or_, select, update
+from sqlalchemy import Select, and_, case, exists, func, or_, select, update
 from sqlalchemy.dialects.postgresql import insert as postgresql_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -61,6 +61,12 @@ NONTERMINAL_ALLOCATION_STATES = (
     AllocationState.ACTIVE.value,
     AllocationState.QUIESCING.value,
     AllocationState.DRAINING.value,
+)
+
+TERMINAL_ALLOCATION_STATES = (
+    AllocationState.RELEASED.value,
+    AllocationState.DESTROYED.value,
+    AllocationState.ERROR.value,
 )
 
 NONTERMINAL_PROCESS_STATES = (
@@ -637,7 +643,7 @@ class AgentBoxRepository:
         now: datetime | None = None,
     ) -> None:
         timestamp = now or utc_now()
-        await self._session.execute(
+        result = await self._session.execute(
             update(CreateAttemptRow)
             .where(
                 CreateAttemptRow.allocation_token == allocation_token,
@@ -651,9 +657,19 @@ class AgentBoxRepository:
                 updated_at=timestamp,
             )
         )
+        if result.rowcount != 1:
+            return
         await self._session.execute(
             update(AllocationRow)
-            .where(AllocationRow.allocation_token == allocation_token)
+            .where(
+                AllocationRow.allocation_token == allocation_token,
+                AllocationRow.state.in_(
+                    (
+                        AllocationState.PROVISIONING.value,
+                        AllocationState.UNKNOWN.value,
+                    )
+                ),
+            )
             .values(
                 state=AllocationState.UNKNOWN.value,
                 last_error_code=error_code,
@@ -665,10 +681,32 @@ class AgentBoxRepository:
         self,
         provider_scope: str,
         *,
+        stale_dispatched_before: datetime,
         now: datetime | None = None,
         limit: int = 100,
     ) -> tuple[CreateReconcileCandidate, ...]:
         timestamp = now or utc_now()
+        due_reconciliation = or_(
+            and_(
+                CreateAttemptRow.dispatch_state.in_(
+                    (
+                        DispatchState.UNKNOWN.value,
+                        DispatchState.ACKNOWLEDGED.value,
+                    )
+                ),
+                CreateAttemptRow.reconcile_after.is_not(None),
+                CreateAttemptRow.reconcile_after <= timestamp,
+            ),
+            and_(
+                CreateAttemptRow.dispatch_state == DispatchState.DISPATCHED.value,
+                CreateAttemptRow.dispatch_started_at.is_not(None),
+                CreateAttemptRow.dispatch_started_at <= stale_dispatched_before,
+                or_(
+                    CreateAttemptRow.reconcile_after.is_(None),
+                    CreateAttemptRow.reconcile_after <= timestamp,
+                ),
+            ),
+        )
         rows = (
             await self._session.execute(
                 select(AllocationRow, CreateAttemptRow)
@@ -678,16 +716,15 @@ class AgentBoxRepository:
                 )
                 .where(
                     AllocationRow.provider_scope == provider_scope,
-                    CreateAttemptRow.dispatch_state.in_(
-                        (
-                            DispatchState.UNKNOWN.value,
-                            DispatchState.ACKNOWLEDGED.value,
-                        )
-                    ),
-                    CreateAttemptRow.reconcile_after.is_not(None),
-                    CreateAttemptRow.reconcile_after <= timestamp,
+                    due_reconciliation,
                 )
-                .order_by(CreateAttemptRow.reconcile_after)
+                .order_by(
+                    func.coalesce(
+                        CreateAttemptRow.reconcile_after,
+                        CreateAttemptRow.dispatch_started_at,
+                        CreateAttemptRow.created_at,
+                    )
+                )
                 .limit(limit)
             )
         ).all()
@@ -710,13 +747,12 @@ class AgentBoxRepository:
         allocation_token: UUID,
         *,
         claimed_until: datetime,
+        stale_dispatched_before: datetime,
         now: datetime | None = None,
     ) -> bool:
         timestamp = now or utc_now()
-        result = await self._session.execute(
-            update(CreateAttemptRow)
-            .where(
-                CreateAttemptRow.allocation_token == allocation_token,
+        due_reconciliation = or_(
+            and_(
                 CreateAttemptRow.dispatch_state.in_(
                     (
                         DispatchState.UNKNOWN.value,
@@ -725,14 +761,86 @@ class AgentBoxRepository:
                 ),
                 CreateAttemptRow.reconcile_after.is_not(None),
                 CreateAttemptRow.reconcile_after <= timestamp,
+            ),
+            and_(
+                CreateAttemptRow.dispatch_state == DispatchState.DISPATCHED.value,
+                CreateAttemptRow.dispatch_started_at.is_not(None),
+                CreateAttemptRow.dispatch_started_at <= stale_dispatched_before,
+                or_(
+                    CreateAttemptRow.reconcile_after.is_(None),
+                    CreateAttemptRow.reconcile_after <= timestamp,
+                ),
+            ),
+        )
+        result = await self._session.execute(
+            update(CreateAttemptRow)
+            .where(
+                CreateAttemptRow.allocation_token == allocation_token,
+                due_reconciliation,
             )
             .values(
+                dispatch_state=case(
+                    (
+                        CreateAttemptRow.dispatch_state
+                        == DispatchState.DISPATCHED.value,
+                        DispatchState.UNKNOWN.value,
+                    ),
+                    else_=CreateAttemptRow.dispatch_state,
+                ),
                 last_reconcile_at=timestamp,
                 reconcile_after=claimed_until,
                 updated_at=timestamp,
             )
         )
-        return result.rowcount == 1
+        if result.rowcount != 1:
+            return False
+        await self._session.execute(
+            update(AllocationRow)
+            .where(
+                AllocationRow.allocation_token == allocation_token,
+                AllocationRow.state == AllocationState.PROVISIONING.value,
+            )
+            .values(
+                state=AllocationState.UNKNOWN.value,
+                last_error_code=ErrorCode.AMBIGUOUS_CREATE.value,
+                updated_at=timestamp,
+            )
+        )
+        return True
+
+    async def repair_terminal_admission_invariants(
+        self,
+        provider_scope: str,
+        *,
+        now: datetime | None = None,
+    ) -> int:
+        """Release capacity retained by allocations already known to be terminal."""
+
+        timestamp = now or utc_now()
+        admission_query = select(ProviderAdmissionRow).where(
+            ProviderAdmissionRow.provider_scope == provider_scope
+        )
+        if self._dialect_name == "postgresql":
+            admission_query = admission_query.with_for_update()
+        admission = await self._session.scalar(admission_query)
+        result = await self._session.execute(
+            update(AllocationRow)
+            .where(
+                AllocationRow.provider_scope == provider_scope,
+                AllocationRow.state.in_(TERMINAL_ALLOCATION_STATES),
+                AllocationRow.admission_state != AdmissionState.RELEASED.value,
+            )
+            .values(
+                admission_state=AdmissionState.RELEASED.value,
+                updated_at=timestamp,
+            )
+        )
+        active, reserved = await self._admission_counts(provider_scope)
+        if admission is not None:
+            admission.active_count = active
+            admission.reserved_count = reserved
+            admission.updated_at = timestamp
+        return int(result.rowcount or 0)
 
     async def defer_create_reconciliation(
         self,
@@ -783,7 +891,7 @@ class AgentBoxRepository:
         """Return a definitively unaccepted create to the same durable token."""
 
         timestamp = now or utc_now()
-        await self._session.execute(
+        result = await self._session.execute(
             update(CreateAttemptRow)
             .where(
                 CreateAttemptRow.allocation_token == allocation_token,
@@ -796,6 +904,8 @@ class AgentBoxRepository:
                 updated_at=timestamp,
             )
         )
+        if result.rowcount != 1:
+            return
         await self._session.execute(
             update(AllocationRow)
             .where(AllocationRow.allocation_token == allocation_token)
@@ -824,7 +934,7 @@ class AgentBoxRepository:
         now: datetime | None = None,
     ) -> None:
         timestamp = now or utc_now()
-        await self._session.execute(
+        result = await self._session.execute(
             update(CreateAttemptRow)
             .where(
                 CreateAttemptRow.allocation_token == allocation_token,
@@ -832,7 +942,9 @@ class AgentBoxRepository:
                     (
                         DispatchState.RESERVED.value,
                         DispatchState.DISPATCHED.value,
+                        DispatchState.ACKNOWLEDGED.value,
                         DispatchState.UNKNOWN.value,
+                        DispatchState.RESOLVED.value,
                     )
                 ),
             )
@@ -842,6 +954,8 @@ class AgentBoxRepository:
                 updated_at=timestamp,
             )
         )
+        if result.rowcount != 1:
+            return
         allocation = await self._session.scalar(
             select(AllocationRow).where(
                 AllocationRow.allocation_token == allocation_token

--- a/agentbox/agentbox/reconciliation.py
+++ b/agentbox/agentbox/reconciliation.py
@@ -35,6 +35,7 @@ class AgentBoxReconciler:
         provider: SandboxProviderPort,
         *,
         create_absence_grace_seconds: float = 30,
+        dispatched_create_stale_seconds: float = 15 * 60,
         claim_seconds: float = 30,
         retry_seconds: float = 1,
         batch_size: int = 100,
@@ -42,6 +43,9 @@ class AgentBoxReconciler:
         self._database = database
         self._provider = provider
         self._absence_grace = timedelta(seconds=create_absence_grace_seconds)
+        self._dispatched_create_stale = timedelta(
+            seconds=dispatched_create_stale_seconds
+        )
         self._claim_seconds = claim_seconds
         self._retry_seconds = retry_seconds
         self._batch_size = batch_size
@@ -49,12 +53,23 @@ class AgentBoxReconciler:
     async def reconcile_once(self, *, deadline_at: datetime) -> int:
         now = datetime.now(timezone.utc)
         async with self._database.uow() as uow:
+            repaired = await uow.repository.repair_terminal_admission_invariants(
+                self._provider.scope,
+                now=now,
+            )
             candidates = await uow.repository.list_due_create_reconciliation(
                 self._provider.scope,
+                stale_dispatched_before=now - self._dispatched_create_stale,
                 now=now,
                 limit=self._batch_size,
             )
             await uow.commit()
+        if repaired:
+            logger.warning(
+                "agentbox.admission.invariant_repaired",
+                provider_scope=self._provider.scope,
+                allocation_count=repaired,
+            )
         reconciled = 0
         for candidate in candidates:
             if datetime.now(timezone.utc) >= deadline_at:
@@ -67,6 +82,9 @@ class AgentBoxReconciler:
                 claimed = await uow.repository.claim_create_reconciliation(
                     candidate.allocation.allocation_token,
                     claimed_until=claimed_until,
+                    stale_dispatched_before=(
+                        datetime.now(timezone.utc) - self._dispatched_create_stale
+                    ),
                 )
                 await uow.commit()
             if not claimed:
@@ -82,7 +100,10 @@ class AgentBoxReconciler:
         deadline_at: datetime,
     ) -> None:
         allocation = candidate.allocation
-        if candidate.dispatch_state == DispatchState.UNKNOWN:
+        if candidate.dispatch_state in {
+            DispatchState.DISPATCHED,
+            DispatchState.UNKNOWN,
+        }:
             try:
                 matches = await self._provider.find_allocations(
                     allocation_metadata(

--- a/agentbox/tests/state/test_reconciliation.py
+++ b/agentbox/tests/state/test_reconciliation.py
@@ -6,11 +6,15 @@ from uuid import uuid4
 
 import pytest
 import pytest_asyncio
+from sqlalchemy import select, update
 
 from agentbox.domain import (
     AdmissionClass,
+    AdmissionState,
     AgentBoxError,
     AllocationState,
+    DispatchState,
+    ProviderAdmissionPolicy,
     SandboxKey,
     SandboxProfileRef,
     StorageKind,
@@ -18,6 +22,11 @@ from agentbox.domain import (
 )
 from agentbox.lifecycle import SandboxLifecycleService
 from agentbox.persistence.uow import StateDatabase
+from agentbox.persistence.models import (
+    AllocationRow,
+    CreateAttemptRow,
+    ProviderAdmissionRow,
+)
 from agentbox.ports import (
     ProviderAllocationRef,
     ProviderCreateAmbiguous,
@@ -74,9 +83,10 @@ class LostCreateResponseProvider:
         assert self.database.active_units_of_work == 0
         self.inventory_calls += 1
         expected = {item.name: item.value for item in metadata}
-        assert expected["allocation-token"] == str(
-            self.create_calls[0].allocation_token
-        )
+        if self.create_calls:
+            assert expected["allocation-token"] == str(
+                self.create_calls[0].allocation_token
+            )
         return tuple(
             ProviderInventoryAllocation(
                 provider_id=f"accepted-{index}",
@@ -198,3 +208,170 @@ async def test_multiple_inventory_matches_remain_indeterminate(
     assert handle.allocation_state == AllocationState.UNKNOWN
     assert len(provider.create_calls) == 1
     assert provider.destroyed == []
+
+
+async def make_stale_dispatch(
+    database: StateDatabase,
+    provider: LostCreateResponseProvider,
+    *,
+    workload_kind: WorkloadKind,
+) -> tuple[SandboxLifecycleService, SandboxKey, datetime]:
+    key = SandboxKey(workload_kind, uuid4())
+    selected_profile = profile()
+    admission_class = AdmissionClass.INTERACTIVE
+    if workload_kind == WorkloadKind.FUNCTION:
+        selected_profile = SandboxProfileRef("function-python-v1", f"sha256:{'b' * 64}")
+        admission_class = AdmissionClass.BATCH
+    stale_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    async with database.uow() as uow:
+        await uow.repository.ensure_logical(key, selected_profile)
+        if workload_kind == WorkloadKind.WORKSPACE:
+            await uow.repository.ensure_workspace_storage(
+                key,
+                provider_name=provider.name,
+                storage_kind=provider.workspace_storage_kind,
+            )
+        intent = await uow.repository.begin_allocation(
+            key,
+            selected_profile,
+            provider_name=provider.name,
+            provider_scope=provider.scope,
+            admission_class=admission_class.value,
+            request_hash="f" * 64,
+        )
+        decision = await uow.repository.reserve_provider_capacity(
+            intent.allocation.allocation_id,
+            admission_class=admission_class,
+            policy=ProviderAdmissionPolicy.permissive_for_tests(),
+        )
+        assert decision.accepted is True
+        assert await uow.repository.mark_create_dispatched(
+            intent.allocation.allocation_token,
+            now=stale_at,
+        )
+        await uow.commit()
+    return (
+        SandboxLifecycleService(database, provider),
+        key,
+        datetime.now(timezone.utc) + timedelta(seconds=30),
+    )
+
+
+async def test_stale_dispatched_create_without_inventory_match_releases_capacity(
+    database: StateDatabase,
+) -> None:
+    provider = LostCreateResponseProvider(database)
+    provider.inventory_matches = 0
+    lifecycle, key, deadline = await make_stale_dispatch(
+        database,
+        provider,
+        workload_kind=WorkloadKind.FUNCTION,
+    )
+
+    reconciled = await AgentBoxReconciler(
+        database,
+        provider,
+        create_absence_grace_seconds=1,
+        dispatched_create_stale_seconds=30,
+    ).reconcile_once(deadline_at=deadline)
+    handle = await lifecycle.inspect(key)
+
+    assert reconciled == 1
+    assert handle is not None
+    assert handle.allocation_state == AllocationState.ERROR
+    async with database.engine.connect() as connection:
+        allocation_token = await connection.scalar(
+            select(AllocationRow.allocation_token).where(
+                AllocationRow.logical_id == key.logical_id
+            )
+        )
+        admission_state = await connection.scalar(
+            select(AllocationRow.admission_state).where(
+                AllocationRow.logical_id == key.logical_id
+            )
+        )
+        attempt_state = await connection.scalar(
+            select(CreateAttemptRow.dispatch_state).where(
+                CreateAttemptRow.allocation_token == allocation_token
+            )
+        )
+        reserved_count = await connection.scalar(
+            select(ProviderAdmissionRow.reserved_count).where(
+                ProviderAdmissionRow.provider_scope == provider.scope
+            )
+        )
+    assert admission_state == AdmissionState.RELEASED.value
+    assert attempt_state == DispatchState.RESOLVED.value
+    assert reserved_count == 0
+
+
+async def test_stale_dispatched_workspace_with_exact_match_is_adopted(
+    database: StateDatabase,
+) -> None:
+    provider = LostCreateResponseProvider(database)
+    lifecycle, key, deadline = await make_stale_dispatch(
+        database,
+        provider,
+        workload_kind=WorkloadKind.WORKSPACE,
+    )
+
+    reconciled = await AgentBoxReconciler(
+        database,
+        provider,
+        dispatched_create_stale_seconds=30,
+    ).reconcile_once(deadline_at=deadline)
+    handle = await lifecycle.inspect(key)
+
+    assert reconciled == 1
+    assert handle is not None
+    assert handle.ready is True
+    assert handle.allocation_state == AllocationState.ACTIVE
+
+
+async def test_reconciliation_repairs_terminal_allocation_reservation(
+    database: StateDatabase,
+) -> None:
+    provider = LostCreateResponseProvider(database)
+    provider.inventory_matches = 0
+    lifecycle, key, deadline = await make_stale_dispatch(
+        database,
+        provider,
+        workload_kind=WorkloadKind.FUNCTION,
+    )
+    reconciler = AgentBoxReconciler(
+        database,
+        provider,
+        create_absence_grace_seconds=1,
+        dispatched_create_stale_seconds=30,
+    )
+    await reconciler.reconcile_once(deadline_at=deadline)
+
+    async with database.engine.begin() as connection:
+        await connection.execute(
+            update(AllocationRow)
+            .where(AllocationRow.logical_id == key.logical_id)
+            .values(admission_state=AdmissionState.RESERVED.value)
+        )
+        await connection.execute(
+            update(ProviderAdmissionRow)
+            .where(ProviderAdmissionRow.provider_scope == provider.scope)
+            .values(reserved_count=1)
+        )
+
+    assert await reconciler.reconcile_once(deadline_at=deadline) == 0
+    handle = await lifecycle.inspect(key)
+    assert handle is not None
+    assert handle.allocation_state == AllocationState.ERROR
+    async with database.engine.connect() as connection:
+        admission_state = await connection.scalar(
+            select(AllocationRow.admission_state).where(
+                AllocationRow.logical_id == key.logical_id
+            )
+        )
+        reserved_count = await connection.scalar(
+            select(ProviderAdmissionRow.reserved_count).where(
+                ProviderAdmissionRow.provider_scope == provider.scope
+            )
+        )
+    assert admission_state == AdmissionState.RELEASED.value
+    assert reserved_count == 0

--- a/agentbox/tests/state/test_repository.py
+++ b/agentbox/tests/state/test_repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from uuid import uuid4
@@ -32,6 +33,7 @@ from agentbox.ports import (
     ProviderReadyResult,
     ProviderStorageResult,
 )
+from agentbox.persistence.repository import AgentBoxRepository
 from agentbox.persistence.uow import StateDatabase
 from agentbox.reconciliation import AgentBoxReconciler
 
@@ -108,6 +110,19 @@ class AmbiguousProvider(FakeProvider):
         assert self.database.active_units_of_work == 0
         self.create_calls.append(request)
         raise ProviderCreateAmbiguous("response lost after provider acceptance")
+
+
+class CancelledCreateProvider(FakeProvider):
+    def __init__(self, database: StateDatabase) -> None:
+        super().__init__(database)
+        self.started = asyncio.Event()
+
+    async def create(self, request: ProviderCreateRequest) -> ProviderCreateResult:
+        assert self.database.active_units_of_work == 0
+        self.create_calls.append(request)
+        self.started.set()
+        await asyncio.Future()
+        raise AssertionError("unreachable")
 
 
 class InitiallyNotReadyProvider(FakeProvider):
@@ -286,6 +301,129 @@ async def test_lost_create_response_is_not_replayed(database: StateDatabase):
     assert pending.ready is False
     assert pending.allocation_state == AllocationState.UNKNOWN
     assert len(provider.create_calls) == 1
+
+
+async def test_cancelled_create_becomes_durably_reconcilable(
+    database: StateDatabase,
+) -> None:
+    provider = CancelledCreateProvider(database)
+    service = SandboxLifecycleService(database, provider)
+    key = SandboxKey(WorkloadKind.FUNCTION, uuid4())
+    task = asyncio.create_task(
+        service.ensure(
+            key,
+            profile("function-python-v1", "b"),
+            admission_class=AdmissionClass.BATCH,
+            deadline_at=datetime.now(timezone.utc) + timedelta(seconds=30),
+        )
+    )
+
+    await provider.started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    pending = await service.inspect(key)
+    assert pending is not None
+    assert pending.allocation_state == AllocationState.UNKNOWN
+    assert len(provider.create_calls) == 1
+    assert database.active_units_of_work == 0
+
+
+async def test_cancelled_dispatch_transaction_releases_capacity(
+    database: StateDatabase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = FakeProvider(database)
+    service = SandboxLifecycleService(database, provider)
+    key = SandboxKey(WorkloadKind.FUNCTION, uuid4())
+    original = AgentBoxRepository.mark_create_dispatched
+
+    async def cancel_after_dispatch(
+        repository: AgentBoxRepository,
+        allocation_token,
+        *,
+        now=None,
+    ) -> bool:
+        dispatched = await original(repository, allocation_token, now=now)
+        current_task = asyncio.current_task()
+        assert current_task is not None
+        current_task.cancel()
+        return dispatched
+
+    monkeypatch.setattr(
+        AgentBoxRepository,
+        "mark_create_dispatched",
+        cancel_after_dispatch,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await service.ensure(
+            key,
+            profile("function-python-v1", "b"),
+            admission_class=AdmissionClass.BATCH,
+            deadline_at=datetime.now(timezone.utc) + timedelta(seconds=30),
+        )
+
+    failed = await service.inspect(key)
+    assert failed is not None
+    assert failed.allocation_state == AllocationState.ERROR
+    assert provider.create_calls == []
+    assert database.active_units_of_work == 0
+
+
+async def test_cancelled_admission_transaction_does_not_leak_capacity(
+    database: StateDatabase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = FakeProvider(database)
+    service = SandboxLifecycleService(database, provider)
+    key = SandboxKey(WorkloadKind.FUNCTION, uuid4())
+    original = AgentBoxRepository.reserve_provider_capacity
+
+    async def cancel_after_reservation(
+        repository: AgentBoxRepository,
+        allocation_id,
+        *,
+        admission_class,
+        policy,
+        now=None,
+    ):
+        decision = await original(
+            repository,
+            allocation_id,
+            admission_class=admission_class,
+            policy=policy,
+            now=now,
+        )
+        current_task = asyncio.current_task()
+        assert current_task is not None
+        current_task.cancel()
+        return decision
+
+    monkeypatch.setattr(
+        AgentBoxRepository,
+        "reserve_provider_capacity",
+        cancel_after_reservation,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await service.ensure(
+            key,
+            profile("function-python-v1", "b"),
+            admission_class=AdmissionClass.BATCH,
+            deadline_at=datetime.now(timezone.utc) + timedelta(seconds=30),
+        )
+
+    allocation = await service.inspect(key)
+    if allocation is not None:
+        assert allocation.allocation_state == AllocationState.ERROR
+    async with database.uow() as uow:
+        active, reserved = await uow.repository._admission_counts(provider.scope)
+        await uow.commit()
+    assert (active, reserved) == (0, 0)
+    assert provider.create_calls == []
+    assert database.active_units_of_work == 0
 
 
 async def test_acknowledged_create_resumes_readiness_without_recreate(

--- a/agentbox/tests/state/test_repository.py
+++ b/agentbox/tests/state/test_repository.py
@@ -303,12 +303,40 @@ async def test_lost_create_response_is_not_replayed(database: StateDatabase):
     assert len(provider.create_calls) == 1
 
 
-async def test_cancelled_create_becomes_durably_reconcilable(
+async def test_repeatedly_cancelled_create_becomes_durably_reconcilable(
     database: StateDatabase,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     provider = CancelledCreateProvider(database)
     service = SandboxLifecycleService(database, provider)
     key = SandboxKey(WorkloadKind.FUNCTION, uuid4())
+    durable_write_started = asyncio.Event()
+    allow_durable_write = asyncio.Event()
+    original = AgentBoxRepository.mark_create_unknown
+
+    async def delay_durable_write(
+        repository: AgentBoxRepository,
+        allocation_token,
+        *,
+        reconcile_after,
+        error_code,
+        now=None,
+    ) -> None:
+        durable_write_started.set()
+        await allow_durable_write.wait()
+        await original(
+            repository,
+            allocation_token,
+            reconcile_after=reconcile_after,
+            error_code=error_code,
+            now=now,
+        )
+
+    monkeypatch.setattr(
+        AgentBoxRepository,
+        "mark_create_unknown",
+        delay_durable_write,
+    )
     task = asyncio.create_task(
         service.ensure(
             key,
@@ -320,8 +348,14 @@ async def test_cancelled_create_becomes_durably_reconcilable(
 
     await provider.started.wait()
     task.cancel()
+    await durable_write_started.wait()
+    task.cancel()
+    await asyncio.sleep(0)
+    assert not task.done()
+    allow_durable_write.set()
     with pytest.raises(asyncio.CancelledError):
-        await task
+        unexpected = await task
+        pytest.fail(f"cancelled ensure unexpectedly returned {unexpected!r}")
 
     pending = await service.inspect(key)
     assert pending is not None

--- a/lemma-backend/app/modules/function/application/function_dispatcher.py
+++ b/lemma-backend/app/modules/function/application/function_dispatcher.py
@@ -469,6 +469,8 @@ class FunctionDispatcher:
             code = str(getattr(exc, "code", "PROVIDER_UNAVAILABLE"))
             if code.upper() == "DEADLINE_EXCEEDED":
                 return "Function execution timed out (deadline exceeded)"
+            if code.upper() == "CAPACITY_EXHAUSTED":
+                return "Function sandbox capacity exhausted before execution"
             return f"Function sandbox error ({redact_text(code)})"
         if isinstance(exc, ValueError) and "token expires" in str(exc):
             return "Function execution exceeds delegated token lifetime"

--- a/lemma-backend/app/modules/function/application/function_runtime_endpoint_cache.py
+++ b/lemma-backend/app/modules/function/application/function_runtime_endpoint_cache.py
@@ -90,22 +90,15 @@ class FunctionRuntimeEndpointCache:
                     )
                     self._inflight[key] = task
 
-            retry_joined_failure = False
-            try:
-                return await asyncio.shield(task)
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                retry_joined_failure = joined and attempt == 0
-                if not retry_joined_failure:
-                    raise
-            finally:
-                if task.done():
-                    async with self._lock:
-                        if self._inflight.get(key) is task:
-                            self._inflight.pop(key, None)
-            if retry_joined_failure:
+            await asyncio.wait((task,))
+            if task.cancelled():
+                raise asyncio.CancelledError
+            failure = task.exception()
+            if failure is None:
+                return task.result()
+            if joined and attempt == 0:
                 continue
+            raise failure
         raise AssertionError("unreachable runtime endpoint cache retry state")
 
     async def invalidate(
@@ -127,19 +120,27 @@ class FunctionRuntimeEndpointCache:
         *,
         loader: RuntimeEndpointLoader,
     ) -> FunctionRuntimeEndpoint:
-        endpoint = await loader()
-        grant_remaining = (endpoint.expires_at - self._wall_clock()).total_seconds()
-        # Never serve a grant at its expiry boundary. Very short grants still
-        # satisfy the caller but are deliberately not cached.
-        cache_seconds = min(self._ttl_seconds, max(0.0, grant_remaining - 2))
-        if cache_seconds <= 0:
+        task = asyncio.current_task()
+        try:
+            endpoint = await loader()
+            grant_remaining = (
+                endpoint.expires_at - self._wall_clock()
+            ).total_seconds()
+            # Never serve a grant at its expiry boundary. Very short grants still
+            # satisfy the caller but are deliberately not cached.
+            cache_seconds = min(self._ttl_seconds, max(0.0, grant_remaining - 2))
+            if cache_seconds <= 0:
+                return endpoint
+            async with self._lock:
+                self._entries[key] = _CachedEndpoint(
+                    endpoint=endpoint,
+                    valid_until=self._clock() + cache_seconds,
+                )
+                self._entries.move_to_end(key)
+                while len(self._entries) > self._max_entries:
+                    self._entries.popitem(last=False)
             return endpoint
-        async with self._lock:
-            self._entries[key] = _CachedEndpoint(
-                endpoint=endpoint,
-                valid_until=self._clock() + cache_seconds,
-            )
-            self._entries.move_to_end(key)
-            while len(self._entries) > self._max_entries:
-                self._entries.popitem(last=False)
-        return endpoint
+        finally:
+            async with self._lock:
+                if self._inflight.get(key) is task:
+                    self._inflight.pop(key, None)

--- a/lemma-backend/app/modules/function/application/function_runtime_endpoint_cache.py
+++ b/lemma-backend/app/modules/function/application/function_runtime_endpoint_cache.py
@@ -57,9 +57,9 @@ class FunctionRuntimeEndpointCache:
         self._max_entries = max_entries
         self._clock = clock
         self._wall_clock = wall_clock
-        self._entries: OrderedDict[
-            FunctionRuntimeEndpointKey, _CachedEndpoint
-        ] = OrderedDict()
+        self._entries: OrderedDict[FunctionRuntimeEndpointKey, _CachedEndpoint] = (
+            OrderedDict()
+        )
         self._inflight: dict[
             FunctionRuntimeEndpointKey,
             asyncio.Task[FunctionRuntimeEndpoint],
@@ -72,29 +72,41 @@ class FunctionRuntimeEndpointCache:
         *,
         loader: RuntimeEndpointLoader,
     ) -> FunctionRuntimeEndpoint:
-        now = self._clock()
-        async with self._lock:
-            cached = self._entries.get(key)
-            if cached is not None and cached.valid_until > now:
-                self._entries.move_to_end(key)
-                return cached.endpoint
-            if cached is not None:
-                self._entries.pop(key, None)
-            task = self._inflight.get(key)
-            if task is None:
-                task = create_inherited_task(
-                    self._load(key, loader=loader),
-                    name=f"function-runtime-endpoint:{key.pod_id}",
-                )
-                self._inflight[key] = task
+        for attempt in range(2):
+            now = self._clock()
+            async with self._lock:
+                cached = self._entries.get(key)
+                if cached is not None and cached.valid_until > now:
+                    self._entries.move_to_end(key)
+                    return cached.endpoint
+                if cached is not None:
+                    self._entries.pop(key, None)
+                task = self._inflight.get(key)
+                joined = task is not None
+                if task is None:
+                    task = create_inherited_task(
+                        self._load(key, loader=loader),
+                        name=f"function-runtime-endpoint:{key.pod_id}",
+                    )
+                    self._inflight[key] = task
 
-        try:
-            return await asyncio.shield(task)
-        finally:
-            if task.done():
-                async with self._lock:
-                    if self._inflight.get(key) is task:
-                        self._inflight.pop(key, None)
+            retry_joined_failure = False
+            try:
+                return await asyncio.shield(task)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                retry_joined_failure = joined and attempt == 0
+                if not retry_joined_failure:
+                    raise
+            finally:
+                if task.done():
+                    async with self._lock:
+                        if self._inflight.get(key) is task:
+                            self._inflight.pop(key, None)
+            if retry_joined_failure:
+                continue
+        raise AssertionError("unreachable runtime endpoint cache retry state")
 
     async def invalidate(
         self,
@@ -116,9 +128,7 @@ class FunctionRuntimeEndpointCache:
         loader: RuntimeEndpointLoader,
     ) -> FunctionRuntimeEndpoint:
         endpoint = await loader()
-        grant_remaining = (
-            endpoint.expires_at - self._wall_clock()
-        ).total_seconds()
+        grant_remaining = (endpoint.expires_at - self._wall_clock()).total_seconds()
         # Never serve a grant at its expiry boundary. Very short grants still
         # satisfy the caller but are deliberately not cached.
         cache_seconds = min(self._ttl_seconds, max(0.0, grant_remaining - 2))

--- a/lemma-backend/app/modules/function/application/function_runtime_route_resolver.py
+++ b/lemma-backend/app/modules/function/application/function_runtime_route_resolver.py
@@ -137,6 +137,7 @@ class FunctionRuntimeRouteResolver:
         deadline_at: datetime,
     ) -> None:
         attempt = 0
+        capacity_error: AgentBoxApiError | None = None
         while self._now() < deadline_at:
             try:
                 handle = await client.ensure_sandbox(
@@ -151,6 +152,10 @@ class FunctionRuntimeRouteResolver:
                     deadline_at=deadline_at,
                 )
             except AgentBoxApiError as exc:
+                if str(getattr(exc, "code", "")).upper() == "CAPACITY_EXHAUSTED":
+                    capacity_error = exc
+                else:
+                    capacity_error = None
                 if exc.retry not in {
                     RetryDisposition.WAIT,
                     RetryDisposition.SAFE_SAME_OPERATION,
@@ -175,6 +180,8 @@ class FunctionRuntimeRouteResolver:
                 attempt=attempt,
             )
             attempt += 1
+        if capacity_error is not None:
+            raise capacity_error
         raise TimeoutError("function sandbox was not ready before the deadline")
 
     def _key(

--- a/lemma-backend/app/modules/function/tests/unit/test_function_dispatcher.py
+++ b/lemma-backend/app/modules/function/tests/unit/test_function_dispatcher.py
@@ -8,6 +8,13 @@ from uuid import uuid4
 import httpx
 import pytest
 
+from agentbox_client import AgentBoxApiError
+from agentbox_client.models import (
+    AgentBoxErrorBody,
+    AgentBoxErrorResponse,
+    RetryDisposition,
+)
+
 from app.modules.function.application.function_dispatcher import FunctionDispatcher
 from app.modules.function.application.function_runtime_endpoint_cache import (
     FunctionRuntimeEndpoint,
@@ -296,4 +303,22 @@ async def test_runtime_cancel_uses_allocation_channel_without_bearer() -> None:
 def test_timeout_keeps_stable_user_facing_error() -> None:
     assert FunctionDispatcher._execution_error(TimeoutError()) == (
         "Function execution timed out (deadline exceeded)"
+    )
+
+
+def test_capacity_exhaustion_reports_pre_execution_failure() -> None:
+    error = AgentBoxApiError(
+        httpx.Response(429),
+        AgentBoxErrorResponse(
+            error=AgentBoxErrorBody(
+                code="CAPACITY_EXHAUSTED",
+                message="provider active sandbox capacity is exhausted",
+                retry=RetryDisposition.WAIT,
+                retry_after_ms=1_000,
+            )
+        ),
+    )
+
+    assert FunctionDispatcher._execution_error(error) == (
+        "Function sandbox capacity exhausted before execution"
     )

--- a/lemma-backend/app/modules/function/tests/unit/test_function_runtime_endpoint_cache.py
+++ b/lemma-backend/app/modules/function/tests/unit/test_function_runtime_endpoint_cache.py
@@ -14,7 +14,9 @@ from app.modules.function.application.function_runtime_endpoint_cache import (
 
 
 @pytest.mark.asyncio
-async def test_runtime_endpoint_cache_single_flights_and_invalidates_exact_value() -> None:
+async def test_runtime_endpoint_cache_single_flights_and_invalidates_exact_value() -> (
+    None
+):
     now = datetime.now(timezone.utc)
     monotonic = 10.0
     cache = FunctionRuntimeEndpointCache(
@@ -43,10 +45,7 @@ async def test_runtime_endpoint_cache_single_flights_and_invalidates_exact_value
         await release.wait()
         return first
 
-    tasks = [
-        asyncio.create_task(cache.get(key, loader=load_first))
-        for _ in range(10)
-    ]
+    tasks = [asyncio.create_task(cache.get(key, loader=load_first)) for _ in range(10)]
     await asyncio.sleep(0)
     release.set()
     assert await asyncio.gather(*tasks) == [first] * 10
@@ -98,3 +97,45 @@ async def test_runtime_endpoint_cache_expires_before_port_grant() -> None:
 
     assert refreshed != first
     assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_runtime_endpoint_cache_joiner_reloads_after_leader_deadline() -> None:
+    now = datetime.now(timezone.utc)
+    cache = FunctionRuntimeEndpointCache(wall_clock=lambda: now)
+    key = FunctionRuntimeEndpointKey(
+        pod_id=uuid4(),
+        profile_digest=f"sha256:{'c' * 64}",
+    )
+    first_started = asyncio.Event()
+    fail_first = asyncio.Event()
+    endpoint = FunctionRuntimeEndpoint(
+        url="https://runtime.example/recovered/",
+        expires_at=now + timedelta(minutes=5),
+    )
+    first_calls = 0
+    second_calls = 0
+
+    async def expired_loader() -> FunctionRuntimeEndpoint:
+        nonlocal first_calls
+        first_calls += 1
+        first_started.set()
+        await fail_first.wait()
+        raise TimeoutError("first caller deadline elapsed")
+
+    async def later_loader() -> FunctionRuntimeEndpoint:
+        nonlocal second_calls
+        second_calls += 1
+        return endpoint
+
+    leader = asyncio.create_task(cache.get(key, loader=expired_loader))
+    await first_started.wait()
+    joiner = asyncio.create_task(cache.get(key, loader=later_loader))
+    await asyncio.sleep(0)
+    fail_first.set()
+
+    with pytest.raises(TimeoutError, match="first caller deadline elapsed"):
+        await leader
+    assert await joiner == endpoint
+    assert first_calls == 1
+    assert second_calls == 1

--- a/lemma-backend/app/modules/function/tests/unit/test_function_runtime_endpoint_cache.py
+++ b/lemma-backend/app/modules/function/tests/unit/test_function_runtime_endpoint_cache.py
@@ -135,7 +135,8 @@ async def test_runtime_endpoint_cache_joiner_reloads_after_leader_deadline() -> 
     fail_first.set()
 
     with pytest.raises(TimeoutError, match="first caller deadline elapsed"):
-        await leader
+        unexpected = await leader
+        pytest.fail(f"leader unexpectedly returned {unexpected!r}")
     assert await joiner == endpoint
     assert first_calls == 1
     assert second_calls == 1

--- a/lemma-backend/app/modules/function/tests/unit/test_function_runtime_route_resolver.py
+++ b/lemma-backend/app/modules/function/tests/unit/test_function_runtime_route_resolver.py
@@ -7,7 +7,13 @@ from uuid import uuid4
 
 import pytest
 
-from agentbox_client import AdmissionClass, WorkloadKind
+import httpx
+from agentbox_client import AdmissionClass, AgentBoxApiError, WorkloadKind
+from agentbox_client.models import (
+    AgentBoxErrorBody,
+    AgentBoxErrorResponse,
+    RetryDisposition,
+)
 
 from app.modules.function.application.function_runtime_endpoint_cache import (
     FunctionRuntimeEndpointCache,
@@ -96,3 +102,36 @@ async def test_control_endpoint_never_creates_or_ensures_a_sandbox() -> None:
     client.ensure_sandbox.assert_not_awaited()
     client.create_port_access.assert_awaited_once()
     client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_capacity_exhaustion_survives_ensure_deadline() -> None:
+    dispatch = _dispatch(FunctionDispatchMode.ASYNCHRONOUS)
+    error = AgentBoxApiError(
+        httpx.Response(429),
+        AgentBoxErrorResponse(
+            error=AgentBoxErrorBody(
+                code="CAPACITY_EXHAUSTED",
+                message="provider active sandbox capacity is exhausted",
+                retry=RetryDisposition.WAIT,
+                retry_after_ms=1,
+            )
+        ),
+    )
+    client = SimpleNamespace(
+        ensure_sandbox=AsyncMock(side_effect=error),
+        close=AsyncMock(),
+    )
+    resolver = FunctionRuntimeRouteResolver(
+        agentbox_client_factory=lambda: client,
+        endpoint_cache=FunctionRuntimeEndpointCache(),
+    )
+
+    with pytest.raises(AgentBoxApiError) as raised:
+        await resolver._ensure_sandbox(
+            client,
+            dispatch,
+            deadline_at=datetime.now(timezone.utc) + timedelta(milliseconds=5),
+        )
+
+    assert raised.value.code == "CAPACITY_EXHAUSTED"


### PR DESCRIPTION
## What changed

- Reconcile stale `DISPATCHED` create attempts even when `reconcile_after` was never set.
- Promote ambiguous creates to `UNKNOWN`, query provider inventory by the exact allocation token, adopt exactly one match, and only release after a confirmed absence.
- Make cancellation durable at all create boundaries: pre-provider cancellation releases capacity; cancellation during provider I/O remains ambiguous for exact-token reconciliation.
- Periodically repair terminal allocations that still retain admission capacity and recompute admission counters while holding the provider admission lock.
- Let runtime endpoint-cache joiners start one fresh single-flight load after the original caller deadline fails.
- Preserve `CAPACITY_EXHAUSTED` through the ensure deadline and surface `Function sandbox capacity exhausted before execution` instead of a misleading execution timeout.

## Live investigation

Read-only inspection found the same reservation leak in both environments:

- Asur dev: 0 active sandboxes, 13 reserved slots against a BATCH/JOB limit of 12. This fully blocks cold JOB functions.
- Production: 3 active sandboxes and 22 reserved slots. Production was not saturated yet, but was accumulating the same leak.
- Dev leaked rows: 9 stale provisioning allocations and 4 terminal ERROR allocations that remained reserved.
- Production leaked rows: 16 stale provisioning allocations and 6 terminal ERROR allocations that remained reserved.
- Exact E2B inventory comparison matched only the stale workspace allocations (3 dev, 1 production). None of the stale function allocation tokens existed in E2B. This is why the repair reconciles by exact token instead of resetting counters blindly.

The LEDFlex production Outlook workflow is currently processing runs successfully. Its recent `prepare_thread_context` chunk-size failures are a separate application error and are intentionally not changed here.

No dev or production state was mutated during investigation. On deployment, the reconciler repairs terminal reservations immediately and safely processes stale dispatches against provider inventory.

## Validation

- AgentBox Ruff: passed
- AgentBox suite: `149 passed, 6 skipped`
- AgentBox client OpenAPI drift check: passed
- Backend function unit suite: `68 passed`
- Backend Ruff and BasedPyright: `0 errors, 0 warnings`
- Real AgentBox Docker conformance: `4 passed`
- Real backend to AgentBox to Docker execution: API + async JOB + compiled dependency all passed in one per-pod function sandbox
- Rebuilt `agentbox-manager:dev`, `agentbox-workspace:dev`, and `agentbox-function:dev` from this branch before real-container validation

## Rollout verification

After AgentBox deployment, verify:

1. The warning event `agentbox.admission.invariant_repaired` reports the terminal rows repaired.
2. Reserved admission counts fall as exact-token reconciliation processes the stale rows.
3. Exact-match stale workspaces remain active; absent stale function allocations become ERROR/RELEASED.
4. Cold JOB runs no longer receive `CAPACITY_EXHAUSTED` in Asur dev.

No infrastructure or schema migration is required.