### PR TITLE
Refresh landing experience and README framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 <img src="docs/Assets/Banner/lemma-brand-loop.gif" alt="Apps, agents, and data connected through Lemma to WhatsApp, Telegram, Slack, and Microsoft Teams" width="100%">
 
-**Give every recurring job its own agentic app.**
+**Build AI around the way your team works.**
+
+Create a custom harness with its own state, agents, workflows, permissions, and screens. Add your teammates and use it wherever the work already happens.
 
 ![License](https://img.shields.io/github/license/lemma-work/lemma-platform)
 ![Release](https://img.shields.io/github/v/release/lemma-work/lemma-platform)
@@ -10,7 +12,7 @@
 
 <a href="https://github.com/lemma-work/lemma-platform/releases/latest"><img src="https://img.shields.io/badge/Download_for_macOS-141414?style=for-the-badge&logo=apple&logoColor=white" alt="Download Lemma for macOS"></a>
 
-[Quickstart](#quickstart) · [Why an app](#why-an-app-not-another-chat) · [Inside a pod](#inside-a-pod) · [Surfaces](#one-app-many-surfaces) · [Coding agents](#build-and-operate-with-the-coding-agent-you-already-have) · [Docs](https://lemma.work/docs)
+[Quickstart](#quickstart) · [Why a harness](#one-harness-built-around-the-job) · [Inside a pod](#inside-a-pod) · [Surfaces](#one-app-many-surfaces) · [Coding agents](#build-with-the-coding-agent-you-already-use) · [Docs](https://lemma.work/docs)
 
 Website → **[lemma.work](https://lemma.work)**
 
@@ -18,35 +20,20 @@ Website → **[lemma.work](https://lemma.work)**
 
 ---
 
-A **Telegram bot** that tracks your expenses. A **research room** where agents gather sources, compare findings, and challenge each other's claims. A **support desk** where agents triage requests in the background and people step in for decisions.
+A Lemma harness is a working system built around one job—not a prompt wrapped in a chatbox. Your team works through purpose-built screens and the tools they already use. Agents work against the same state, follow the same workflows and permissions, and keep the job moving in the background.
 
-Each job carries its own state, actions, and ways for people to see the work. Lemma gives each job its own app: a place for people to see and direct the work, and for agents to remember, act, and keep it moving.
-
-**Open source. Runs locally. Use Claude Code or Codex through your existing subscription, Lemma-managed models, or any OpenAI-compatible or Anthropic-compatible provider. Run it on your laptop, your server, or Lemma Cloud.**
-
-<div align="center">
-
-**Build and operate Lemma apps with the coding agent you already use.**
-
-<table>
-  <tr>
-    <td align="center" width="112"><img src="docs/Assets/Logos/claude.svg" height="36" alt="Claude Code"><br><sub>Claude Code</sub></td>
-    <td align="center" width="112"><img src="docs/Assets/Logos/codex.svg" height="36" alt="Codex"><br><sub>Codex</sub></td>
-    <td align="center" width="112"><img src="docs/Assets/Logos/opencode-logo-light.svg" height="36" alt="OpenCode"><br><sub>OpenCode</sub></td>
-    <td align="center" width="112"><img src="docs/Assets/Logos/cursor.svg" height="36" alt="Cursor"><br><sub>Cursor</sub></td>
-    <td align="center" width="112"><img src="lemma-frontend/public/harnesslogos/antigravity.png" height="36" alt="Antigravity"><br><sub>Antigravity</sub></td>
-  </tr>
-</table>
-
-<em>The same agent authors the app, data, agents, workflows, and permissions — then verifies the result.</em>
-
-</div>
+**Open source. Run it on your laptop, your server, or Lemma Cloud. Use Claude Code or Codex through your existing subscription, Lemma-managed models, or any OpenAI- or Anthropic-compatible provider.**
 
 ## Quickstart
 
 ### Install Lemma Desktop
 
 <a href="https://github.com/lemma-work/lemma-platform/releases/latest"><img src="https://img.shields.io/badge/Download_for_macOS-141414?style=for-the-badge&logo=apple&logoColor=white" alt="Download Lemma for macOS"></a>
+
+Download Lemma Desktop, choose **Local**, and select **Install local services**. Lemma owns the local runtime, and the CLI discovers it automatically.
+
+<details>
+<summary>Desktop installation and local runtime details</summary>
 
 Download the signed **online** package from the latest release for macOS 14+
 on Apple silicon or Windows 11 23H2+ on x86-64. On macOS, drag Lemma to
@@ -66,7 +53,9 @@ workspace, API, built-app, and OAuth callback URLs. The CLI discovers the same
 endpoints from Desktop automatically. See the complete [local installation and
 operations guide](docs/installation.md).
 
-Install the CLI, point it at the local stack, and give your coding agent Lemma's skills:
+</details>
+
+Install the CLI, connect it to the local stack, and give your coding agent Lemma's skills:
 
 ```bash
 uv tool install lemma-terminal
@@ -118,9 +107,9 @@ lemma pod create my-team --with-starter   # scaffolds a working starter (table +
 lemma chat "what can you do in this pod?"
 ```
 
-## Why an app, not another chat
+## One harness, built around the job
 
-The shape of an agentic app follows the job. Picture three of them:
+The shape of a Lemma harness follows the job. The app is how people use it:
 
 **Personal expenses.** Send a receipt or voice note through Telegram. An agent extracts the purchase, asks when something is unclear, and keeps the ledger current. The app is where you review transactions, correct categories, and see where the money went.
 
@@ -128,7 +117,7 @@ The shape of an agentic app follows the job. Picture three of them:
 
 **Customer support.** Agents read new requests, gather the relevant context, draft replies, and flag decisions. The app brings together the conversation, proposed response, customer history, and the controls to edit, approve, or direct what happens next.
 
-Each app gives its job a purpose-built interface, shared state, and agents that keep working between visits. People work with what the agents produce and direct what happens next; the agents carry that direction back into the work.
+Each harness gives its job a purpose-built interface, shared state, and agents that keep working between visits. People work with what the agents produce and direct what happens next; the agents carry that direction back into the work.
 
 ## Work compounds inside the app
 
@@ -183,11 +172,27 @@ Supported today: **Slack, Microsoft Teams, Gmail, Outlook, Telegram, WhatsApp** 
 
 A pod also works for one person. One human and a few agents — with WhatsApp as the front door and tables as the memory — make a personal assistant that keeps state, asks before it acts, and picks up tomorrow where it left off today.
 
-## Build and operate with the coding agent you already have
+## Build with the coding agent you already use
 
 A pod can be exported as plain files, so building one is a job a coding agent is already good at: describe the system, let the agent author the bundle, and import it. The agent that builds it also tests it by creating records, running workflows, and chatting with the agents it defined. Building and operating use the same CLI.
 
-**Install Lemma's skills into the agent you already use** — Claude Code, Codex, OpenCode, or Cursor:
+<div align="center">
+
+<table>
+  <tr>
+    <td align="center" width="112"><img src="docs/Assets/Logos/claude.svg" height="36" alt="Claude Code"><br><sub>Claude Code</sub></td>
+    <td align="center" width="112"><img src="docs/Assets/Logos/codex.svg" height="36" alt="Codex"><br><sub>Codex</sub></td>
+    <td align="center" width="112"><img src="docs/Assets/Logos/opencode-logo-light.svg" height="36" alt="OpenCode"><br><sub>OpenCode</sub></td>
+    <td align="center" width="112"><img src="docs/Assets/Logos/cursor.svg" height="36" alt="Cursor"><br><sub>Cursor</sub></td>
+    <td align="center" width="112"><img src="lemma-frontend/public/harnesslogos/antigravity.png" height="36" alt="Antigravity"><br><sub>Antigravity</sub></td>
+  </tr>
+</table>
+
+<em>The same agent authors the app, data, agents, workflows, and permissions—then verifies the result.</em>
+
+</div>
+
+**Install Lemma's skills into the agent you already use** — Claude Code, Codex, OpenCode, Cursor, or Antigravity:
 
 ```bash
 lemma skills install             # auto-detects Claude Code / Codex / OpenCode / Cursor

--- a/lemma-frontend/components/auth/portal/auth/auth-protection-notice.tsx
+++ b/lemma-frontend/components/auth/portal/auth/auth-protection-notice.tsx
@@ -29,6 +29,7 @@ export function AuthProtectionNotice() {
 
   const enabled = progress.enabled ?? configured;
   if (enabled !== true) return null;
+  if (progress.phase === "idle") return null;
 
   const isWorking = progress.phase === "checking" || progress.phase === "solving";
   const isError = progress.phase === "error";
@@ -41,7 +42,7 @@ export function AuthProtectionNotice() {
           ? "Private security check complete."
           : isError
             ? "Security check unavailable. Try submitting again."
-            : "Protected by private proof-of-work—no tracking CAPTCHA.";
+            : null;
   const Icon = isWorking ? Loader2 : isError ? AlertCircle : ShieldCheck;
 
   return (

--- a/lemma-frontend/components/auth/portal/auth/supertokens.ts
+++ b/lemma-frontend/components/auth/portal/auth/supertokens.ts
@@ -68,7 +68,8 @@ const authSurfaceStyle = `
   text-align: left;
 }
 
-[data-supertokens~="headerSubtitle"] [data-supertokens~="secondaryText"] {
+[data-supertokens~="headerSubtitle"][data-supertokens~="secondaryText"] {
+  color: var(--text-secondary);
   text-align: left;
 }
 

--- a/lemma-frontend/components/landing/hero-pod-demo.tsx
+++ b/lemma-frontend/components/landing/hero-pod-demo.tsx
@@ -1,0 +1,1920 @@
+"use client";
+
+import {
+  useEffect,
+  useState,
+  type ComponentType,
+  type ReactNode,
+} from "react";
+import {
+  ArrowRight,
+  ArrowUpRight,
+  BarChart3,
+  Briefcase,
+  Calendar,
+  Check,
+  ChevronDown,
+  Clock,
+  Database,
+  Eye,
+  FileText,
+  Filter,
+  GithubLogo,
+  GitMerge,
+  Home,
+  ListChecks,
+  Mail,
+  MessageCircle,
+  MoreHorizontal,
+  Pause,
+  Play,
+  Plug,
+  Plus,
+  Search,
+  Send,
+  Sparkles,
+  SquaresFour,
+  Table,
+  Terminal,
+  User,
+  Users,
+  Zap,
+} from "@/components/ui/icons";
+
+type DemoView =
+  | "home"
+  | "apps"
+  | "crm"
+  | "campaign"
+  | "agents"
+  | "workflows"
+  | "data"
+  | "docs"
+  | "connectors";
+
+type AppSection =
+  | "campaign-command"
+  | "campaign-work"
+  | "campaign-calendar"
+  | "campaign-assets"
+  | "campaign-performance"
+  | "crm-overview"
+  | "crm-pipeline"
+  | "crm-accounts"
+  | "crm-inbox"
+  | "crm-tasks";
+
+const autoViews: DemoView[] = [
+  "campaign",
+  "crm",
+  "workflows",
+  "docs",
+  "connectors",
+];
+
+const activityEvents = [
+  {
+    actor: "Claude · Campaign Manager",
+    action: "revised the Q3 launch brief",
+    target: "2 claims need review",
+    tone: "violet",
+    icon: Sparkles,
+  },
+  {
+    actor: "Codex · CRM",
+    action: "enriched 8 account records",
+    target: "Pipeline updated",
+    tone: "blue",
+    icon: Terminal,
+  },
+  {
+    actor: "Weekly campaign review",
+    action: "paused at approval",
+    target: "Waiting for Maya",
+    tone: "amber",
+    icon: GitMerge,
+  },
+  {
+    actor: "campaign_metrics",
+    action: "received 18 new rows",
+    target: "Google Ads · just now",
+    tone: "green",
+    icon: Database,
+  },
+] as const;
+
+const decisions = [
+  {
+    eyebrow: "SPEND EXCEPTION",
+    title: "Meta prospecting is 18% over pace",
+    detail: "Claude traced the change to two high-frequency ad sets.",
+    state: "Needs review",
+    tone: "amber",
+  },
+  {
+    eyebrow: "BUDGET PLAN",
+    title: "Move $4,200 to high-intent search",
+    detail: "A proposed allocation with projected impact and rollback rules.",
+    state: "Approval",
+    tone: "violet",
+  },
+  {
+    eyebrow: "WEEKLY BRIEF",
+    title: "Monday performance brief is ready",
+    detail: "Every claim links back to campaign data and source notes.",
+    state: "Ready",
+    tone: "green",
+  },
+] as const;
+
+const crmColumns = [
+  {
+    label: "Qualified",
+    value: "$184k",
+    accounts: [
+      ["Northwind AI", "$72k", "Codex enriched"],
+      ["Meridian Labs", "$64k", "Reply drafted"],
+      ["Aster Systems", "$48k", "New signal"],
+    ],
+  },
+  {
+    label: "Meeting booked",
+    value: "$126k",
+    accounts: [
+      ["Copper Grid", "$82k", "Tomorrow · 10:30"],
+      ["Orbit Health", "$44k", "Friday · 14:00"],
+    ],
+  },
+  {
+    label: "Proposal",
+    value: "$98k",
+    accounts: [
+      ["Vesper Cloud", "$98k", "Legal review"],
+      ["Luma Works", "$36k", "Follow-up due"],
+    ],
+  },
+] as const;
+
+const agentRows = [
+  {
+    name: "Campaign Analyst",
+    description: "Runs on Claude. Reads briefs, performance data, and notes.",
+    state: "Working",
+    meta: "Reviewing Q3 launch",
+    tone: "violet",
+  },
+  {
+    name: "CRM Operator",
+    description: "Runs on Codex. Enriches accounts and prepares follow-ups.",
+    state: "Working",
+    meta: "8 records updated",
+    tone: "blue",
+  },
+  {
+    name: "Report Writer",
+    description: "Turns approved evidence into the Monday operating brief.",
+    state: "Ready",
+    meta: "Brief updated 2 min ago",
+    tone: "green",
+  },
+  {
+    name: "Budget Advisor",
+    description: "Prepares changes but cannot publish without a person.",
+    state: "Waiting",
+    meta: "1 decision with Maya",
+    tone: "amber",
+  },
+] as const;
+
+const tableRows = [
+  ["Meta · Prospecting", "$18,420", "$72.10", "+18%", "Review"],
+  ["Google · Brand", "$6,280", "$24.80", "−6%", "Healthy"],
+  ["LinkedIn · Enterprise", "$9,640", "$118.40", "+3%", "Watching"],
+  ["Google · Non-brand", "$14,310", "$42.60", "−11%", "Healthy"],
+] as const;
+
+const docFiles = [
+  {
+    id: "launch-brief",
+    label: "Q3 launch brief.md",
+    folder: "Campaigns",
+    icon: FileText,
+  },
+  {
+    id: "positioning",
+    label: "Positioning notes.md",
+    folder: "Campaigns",
+    icon: FileText,
+  },
+  {
+    id: "review-playbook",
+    label: "Weekly review.md",
+    folder: "Operations",
+    icon: FileText,
+  },
+] as const;
+
+const connectors = [
+  {
+    id: "google-ads",
+    name: "Google Ads",
+    account: "growth@northstar.co",
+    status: "Connected",
+    usedBy: ["Campaign Manager", "Campaign Analyst", "Weekly review"],
+    access: "Read campaigns, performance, and conversion data",
+    icon: SquaresFour,
+    tone: "amber",
+  },
+  {
+    id: "gmail",
+    name: "Gmail",
+    account: "maya@northstar.co",
+    status: "Connected",
+    usedBy: ["CRM Operator", "Follow-up queue"],
+    access: "Read approved threads and create drafts",
+    icon: Mail,
+    tone: "red",
+  },
+  {
+    id: "github",
+    name: "GitHub",
+    account: "northstar-growth",
+    status: "Connected",
+    usedBy: ["Codex CRM", "CRM Operator"],
+    access: "Read issues and open pull requests with approval",
+    icon: GithubLogo,
+    tone: "ink",
+  },
+  {
+    id: "slack",
+    name: "Slack",
+    account: "Northstar workspace",
+    status: "Connected",
+    usedBy: ["Campaign Manager", "Weekly review"],
+    access: "Post approvals and reviewed briefs",
+    icon: MessageCircle,
+    tone: "violet",
+  },
+] as const;
+
+const workflowSteps = [
+  {
+    id: "trigger",
+    kind: "SCHEDULE",
+    title: "Every Monday · 08:00",
+    detail: "Starts in the pod timezone.",
+    output: "Run 184 started at 08:00:00",
+    tone: "neutral",
+  },
+  {
+    id: "query",
+    kind: "DATA",
+    title: "Load campaign_metrics",
+    detail: "Last 7 days compared with plan.",
+    output: "128 rows · 6 channels · freshness 41s",
+    tone: "green",
+  },
+  {
+    id: "claude",
+    kind: "AGENT · CLAUDE",
+    title: "Explain movement",
+    detail: "Campaign Analyst checks the brief and source data.",
+    output: "3 findings · 7 citations · confidence 0.91",
+    tone: "violet",
+  },
+  {
+    id: "decision",
+    kind: "DECISION",
+    title: "Material change?",
+    detail: "Routes only meaningful exceptions to a person.",
+    output: "Yes · spend variance exceeded 15%",
+    tone: "blue",
+  },
+  {
+    id: "approval",
+    kind: "HUMAN APPROVAL",
+    title: "Maya reviews budget move",
+    detail: "The workflow cannot publish the change itself.",
+    output: "Waiting · sent to Slack #growth-approvals",
+    tone: "amber",
+  },
+  {
+    id: "publish",
+    kind: "APP + SLACK",
+    title: "Publish Monday brief",
+    detail: "Updates Campaign Manager and shares the result.",
+    output: "Blocked until approval completes",
+    tone: "neutral",
+  },
+] as const;
+
+function StatusDot({ tone }: { tone: string }) {
+  return <i className={`lp-demo-status-dot is-${tone}`} aria-hidden="true" />;
+}
+
+function DemoHome() {
+  return (
+    <div className="lp-demo-home">
+      <span className="lp-demo-assist-mark" aria-hidden="true">
+        <Sparkles />
+      </span>
+      <p className="lp-demo-overline">LEMMA ASSIST</p>
+      <h3>What should this pod take care of?</h3>
+      <p className="lp-demo-home-copy">
+        Give it work now, or build an app, agent, or workflow that keeps doing
+        it.
+      </p>
+      <div className="lp-demo-composer">
+        <span>Ask Growth Ops to…</span>
+        <span className="lp-demo-composer-send" aria-hidden="true">
+          <ArrowRight />
+        </span>
+      </div>
+      <div className="lp-demo-quick-actions" aria-label="Example pod actions">
+        <span>Build an app</span>
+        <span>Automate work</span>
+        <span>Create an agent</span>
+      </div>
+    </div>
+  );
+}
+
+function DemoApps({
+  onOpen,
+}: {
+  onOpen: (view: "crm" | "campaign") => void;
+}) {
+  return (
+    <div className="lp-demo-page">
+      <div className="lp-demo-page-head">
+        <div>
+          <p className="lp-demo-overline">APPS</p>
+          <h3>Software this pod runs</h3>
+          <p>
+            Interfaces for people, backed by the same agents, data, documents,
+            connectors, and approvals.
+          </p>
+        </div>
+        <span className="lp-demo-page-meta">2 deployed</span>
+      </div>
+
+      <div className="lp-demo-app-library">
+        <button
+          className="lp-demo-app-card is-campaign"
+          type="button"
+          onClick={() => onOpen("campaign")}
+        >
+          <span className="lp-demo-app-card-head">
+            <span className="lp-demo-app-icon">CM</span>
+            <span>
+              <strong>Campaign Manager</strong>
+              <small>Claude · Google Ads · Slack</small>
+            </span>
+            <em>Live</em>
+          </span>
+          <span className="lp-demo-app-preview lp-demo-campaign-preview">
+            <span>
+              <small>Q3 PRODUCT LAUNCH</small>
+              <strong>2 decisions need review</strong>
+            </span>
+            <i />
+            <i />
+            <i />
+          </span>
+          <span className="lp-demo-app-card-foot">
+            Briefs, approvals, calendar, and live performance
+            <ArrowRight />
+          </span>
+        </button>
+
+        <button
+          className="lp-demo-app-card is-crm"
+          type="button"
+          onClick={() => onOpen("crm")}
+        >
+          <span className="lp-demo-app-card-head">
+            <span className="lp-demo-app-icon">CX</span>
+            <span>
+              <strong>Codex CRM</strong>
+              <small>Codex · Gmail · GitHub</small>
+            </span>
+            <em>Live</em>
+          </span>
+          <span className="lp-demo-app-preview lp-demo-crm-preview">
+            {["Qualified", "Meeting", "Proposal"].map((column, index) => (
+              <span key={column}>
+                <small>{column}</small>
+                <i />
+                <i />
+                {index === 0 ? <i /> : null}
+              </span>
+            ))}
+          </span>
+          <span className="lp-demo-app-card-foot">
+            Accounts, pipeline, meeting prep, and follow-ups
+            <ArrowRight />
+          </span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const campaignWork = [
+  {
+    title: "Launch film cutdown",
+    channel: "LinkedIn · Video",
+    owner: "Claude + Maya",
+    state: "Approval",
+    due: "Today · 14:00",
+    note: "Claude created three variants from the approved launch-film transcript.",
+  },
+  {
+    title: "Enterprise proof carousel",
+    channel: "LinkedIn · Organic",
+    owner: "Claude",
+    state: "In review",
+    due: "Today · 17:30",
+    note: "Six customer claims are linked to source interviews and proof notes.",
+  },
+  {
+    title: "Founder launch note",
+    channel: "Newsletter",
+    owner: "Maya",
+    state: "Draft",
+    due: "Tomorrow · 09:00",
+    note: "The working draft uses positioning.md and the approved message hierarchy.",
+  },
+  {
+    title: "Search launch groups",
+    channel: "Google Ads",
+    owner: "Claude",
+    state: "Scheduled",
+    due: "Wed · 08:00",
+    note: "Budget, keywords, and rollback limits are ready for the launch window.",
+  },
+] as const;
+
+const crmAccounts = [
+  {
+    name: "Northwind AI",
+    initials: "NA",
+    segment: "Enterprise",
+    value: "$72k",
+    state: "High intent",
+    owner: "Maya",
+    touch: "Today",
+    domain: "northwind.ai",
+    signal: "Pricing page visited 4× after the security review.",
+  },
+  {
+    name: "Copper Grid",
+    initials: "CG",
+    segment: "Enterprise",
+    value: "$82k",
+    state: "Meeting booked",
+    owner: "Dana",
+    touch: "12 min",
+    domain: "coppergrid.com",
+    signal: "Three stakeholders accepted Thursday’s technical review.",
+  },
+  {
+    name: "Meridian Labs",
+    initials: "ML",
+    segment: "Mid-market",
+    value: "$64k",
+    state: "Reply drafted",
+    owner: "Maya",
+    touch: "1 hr",
+    domain: "meridianlabs.io",
+    signal: "New VP Operations matched the target persona.",
+  },
+  {
+    name: "Vesper Cloud",
+    initials: "VC",
+    segment: "Enterprise",
+    value: "$98k",
+    state: "Legal review",
+    owner: "Dana",
+    touch: "Yesterday",
+    domain: "vesper.cloud",
+    signal: "MSA question requires a human answer before follow-up.",
+  },
+] as const;
+
+function ProductAppShell({
+  title,
+  mark,
+  runtime,
+  tone,
+  sections,
+  activeSection,
+  onSection,
+  children,
+}: {
+  title: string;
+  mark: string;
+  runtime: string;
+  tone: "violet" | "blue";
+  sections: Array<{
+    id: AppSection;
+    label: string;
+    icon: ComponentType;
+    badge?: string;
+  }>;
+  activeSection: AppSection;
+  onSection: (section: AppSection) => void;
+  children: ReactNode;
+}) {
+  return (
+    <div className={`lp-product-app is-${tone}`}>
+      <header className="lp-product-topbar">
+        <span className="lp-product-mark">{mark}</span>
+        <strong>{title}</strong>
+        <span className="lp-product-search">
+          <Search />
+          Search anything
+          <kbd>⌘ K</kbd>
+        </span>
+        <span className={`lp-demo-runtime is-${tone}`}>
+          <i aria-hidden="true" />
+          {runtime}
+        </span>
+        <button type="button" aria-label="More options">
+          <MoreHorizontal />
+        </button>
+        <span className="lp-product-avatar">MK</span>
+      </header>
+      <aside className="lp-product-sidebar">
+        <span className="lp-product-workspace">
+          <small>WORKSPACE</small>
+          <strong>Q3 Operating Plan</strong>
+        </span>
+        <nav aria-label={`${title} sections`}>
+          {sections.map(({ id, label, icon: Icon, badge }) => (
+            <button
+              type="button"
+              className={activeSection === id ? "is-active" : ""}
+              onClick={() => onSection(id)}
+              key={id}
+            >
+              <Icon />
+              <span>{label}</span>
+              {badge ? <small>{badge}</small> : null}
+            </button>
+          ))}
+        </nav>
+        <div className="lp-product-agent">
+          <span>
+            <Sparkles />
+          </span>
+          <strong>{tone === "violet" ? "Claude" : "Codex"}</strong>
+          <small>{tone === "violet" ? "Monitoring 12 items" : "Working 3 tasks"}</small>
+        </div>
+      </aside>
+      <main className="lp-product-main">{children}</main>
+    </div>
+  );
+}
+
+function ProductPageHeader({
+  eyebrow,
+  title,
+  description,
+  action,
+}: {
+  eyebrow: string;
+  title: string;
+  description: string;
+  action: string;
+}) {
+  return (
+    <div className="lp-product-page-head">
+      <div>
+        <p>{eyebrow}</p>
+        <h3>{title}</h3>
+        <span>{description}</span>
+      </div>
+      <div className="lp-product-page-actions">
+        <button type="button">
+          <Filter />
+          Filter
+        </button>
+        <button type="button" className="is-primary">
+          <Plus />
+          {action}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function MiniTrend({ variant = "violet" }: { variant?: "violet" | "blue" }) {
+  return (
+    <span
+      className={`lp-product-mini-trend is-${variant}`}
+      aria-hidden="true"
+    >
+      <i /><i /><i /><i /><i /><i /><i /><i />
+    </span>
+  );
+}
+
+function CampaignCommand({
+  selectedDecision,
+  onDecision,
+}: {
+  selectedDecision: number;
+  onDecision: (index: number) => void;
+}) {
+  const decision = decisions[selectedDecision];
+  return (
+    <div className="lp-product-page">
+      <ProductPageHeader
+        eyebrow="COMMAND CENTER · WEEK 4"
+        title="Q3 product launch"
+        description="One operating view across creative, distribution, spend, and approvals."
+        action="New work"
+      />
+      <div className="lp-product-kpis">
+        {[
+          ["Qualified pipeline", "$486k", "+21%", "violet"],
+          ["Spend vs plan", "$48.6k", "94%", "blue"],
+          ["Content ready", "18 / 24", "3 in review", "green"],
+          ["Needs attention", "2", "Human decision", "amber"],
+        ].map(([label, value, delta, tone], index) => (
+          <article key={label}>
+            <span>
+              <small>{label}</small>
+              <em className={`is-${tone}`}>{delta}</em>
+            </span>
+            <strong>{value}</strong>
+            {index < 2 ? <MiniTrend variant={index === 0 ? "violet" : "blue"} /> : (
+              <span className={`lp-product-progress is-${tone}`}>
+                <i className={index === 2 ? "is-w75" : "is-w42"} />
+              </span>
+            )}
+          </article>
+        ))}
+      </div>
+      <div className="lp-campaign-command-grid">
+        <section className="lp-product-panel lp-campaign-trajectory">
+          <header>
+            <span>
+              <strong>Demand trajectory</strong>
+              <small>Qualified pipeline by week</small>
+            </span>
+            <em>Actual</em>
+            <em className="is-muted">Plan</em>
+          </header>
+          <div className="lp-trajectory-chart">
+            <span className="is-grid g1" />
+            <span className="is-grid g2" />
+            <span className="is-grid g3" />
+            <div className="lp-css-chart lp-css-chart-trajectory" aria-hidden="true">
+              <i /><i /><i /><i /><i /><i /><i /><i />
+            </div>
+            <div className="lp-trajectory-axis">
+              <span>W1</span><span>W2</span><span>W3</span><span>W4</span>
+            </div>
+          </div>
+        </section>
+        <aside className="lp-product-panel lp-claude-brief">
+          <header>
+            <span className="lp-product-ai-icon"><Sparkles /></span>
+            <span><strong>Claude&apos;s brief</strong><small>Updated 6 minutes ago</small></span>
+          </header>
+          <h4>Enterprise demand is ahead, but paid social efficiency is slipping.</h4>
+          <ul>
+            <li><i /> Search produced 41% of new qualified demand.</li>
+            <li><i /> Meta frequency crossed the campaign guardrail.</li>
+            <li><i /> Launch film accounts for 3 of the top 5 journeys.</li>
+          </ul>
+          <span className="lp-product-source-row">7 sources <ArrowRight /></span>
+        </aside>
+        <section className="lp-product-panel lp-attention-panel">
+          <header>
+            <span><strong>Needs attention</strong><small>Decisions only you can make</small></span>
+            <button type="button">View all</button>
+          </header>
+          <div className="lp-attention-list">
+            {decisions.slice(0, 2).map((item, index) => (
+              <button
+                type="button"
+                className={selectedDecision === index ? "is-active" : ""}
+                onClick={() => onDecision(index)}
+                key={item.title}
+              >
+                <StatusDot tone={item.tone} />
+                <span><strong>{item.title}</strong><small>{item.state} · 7 sources</small></span>
+                <ArrowRight />
+              </button>
+            ))}
+          </div>
+          <div className="lp-attention-detail" key={decision.title}>
+            <span><small>{decision.eyebrow}</small><strong>{decision.title}</strong></span>
+            <p>{decision.detail}</p>
+            <div>
+              <button type="button">Open evidence</button>
+              <button type="button" className="is-approve"><Check /> Approve</button>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function CampaignWork({
+  selected,
+  onSelect,
+}: {
+  selected: number;
+  onSelect: (index: number) => void;
+}) {
+  const work = campaignWork[selected];
+  return (
+    <div className="lp-product-page">
+      <ProductPageHeader
+        eyebrow="CONTENT OPERATIONS"
+        title="Campaign work"
+        description="Briefs, generation, review, and publishing—tracked as one production system."
+        action="Create item"
+      />
+      <div className="lp-product-split-view">
+        <section className="lp-product-table-card">
+          <header>
+            <span>24 items</span>
+            <nav><button type="button" className="is-active">All</button><button type="button">Mine</button><button type="button">Waiting</button></nav>
+            <button type="button"><Search /></button>
+          </header>
+          <div className="lp-product-table-row is-head">
+            <span>Work</span><span>Owner</span><span>Status</span><span>Due</span>
+          </div>
+          {campaignWork.map((item, index) => (
+            <button
+              type="button"
+              className={`lp-product-table-row${selected === index ? " is-selected" : ""}`}
+              onClick={() => onSelect(index)}
+              key={item.title}
+            >
+              <span><i>{index % 2 ? <FileText /> : <Eye />}</i><strong>{item.title}</strong><small>{item.channel}</small></span>
+              <span>{item.owner}</span>
+              <span><em className={`is-state s${index}`}>{item.state}</em></span>
+              <span>{item.due}</span>
+            </button>
+          ))}
+        </section>
+        <aside className="lp-product-record">
+          <header>
+            <span className="lp-product-record-icon"><FileText /></span>
+            <button type="button"><MoreHorizontal /></button>
+          </header>
+          <small>{work.channel}</small>
+          <h4>{work.title}</h4>
+          <p>{work.note}</p>
+          <dl>
+            <div><dt>Owner</dt><dd>{work.owner}</dd></div>
+            <div><dt>Due</dt><dd>{work.due}</dd></div>
+            <div><dt>Brief</dt><dd>Q3 launch brief ↗</dd></div>
+          </dl>
+          <div className="lp-product-record-preview">
+            <span>V03 · 00:28</span>
+            <i className="is-frame one" /><i className="is-frame two" /><i className="is-frame three" />
+          </div>
+          <div className="lp-product-record-actions">
+            <button type="button">Comment</button>
+            <button type="button" className="is-primary">Review item</button>
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function CampaignCalendar() {
+  const days = [
+    ["MON 18", "Product story", "LinkedIn · Draft", "violet"],
+    ["TUE 19", "Founder note", "Newsletter · Review", "amber"],
+    ["WED 20", "Launch film", "All channels · Ready", "green"],
+    ["THU 21", "Customer proof", "LinkedIn · Planned", "blue"],
+    ["FRI 22", "Performance recap", "Slack · Automated", "neutral"],
+  ] as const;
+  return (
+    <div className="lp-product-page">
+      <ProductPageHeader
+        eyebrow="CALENDAR · JUNE 18–22"
+        title="Launch week"
+        description="Every item keeps its brief, owner, dependencies, source material, and publish state."
+        action="Schedule"
+      />
+      <div className="lp-product-calendar">
+        <div className="lp-product-calendar-times"><span>09:00</span><span>12:00</span><span>15:00</span><span>18:00</span></div>
+        {days.map(([day, title, meta, tone], index) => (
+          <section className={index === 2 ? "is-today" : ""} key={day}>
+            <header><small>{day}</small>{index === 2 ? <em>Today</em> : null}</header>
+            <article className={`is-${tone}`}>
+              <StatusDot tone={tone} />
+              <strong>{title}</strong>
+              <small>{meta}</small>
+              <span>{index < 2 ? "Maya" : index === 2 ? "Claude + Maya" : "Claude"}</span>
+            </article>
+            {index === 1 ? <article className="is-light"><strong>Ad QA</strong><small>Google Ads</small></article> : null}
+            {index === 3 ? <article className="is-light"><strong>Review window</strong><small>2 approvers</small></article> : null}
+          </section>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CampaignAssets() {
+  return (
+    <div className="lp-product-page">
+      <ProductPageHeader
+        eyebrow="ASSET LIBRARY"
+        title="Approved campaign system"
+        description="Current messaging, proof, media, and channel-ready variants."
+        action="Upload"
+      />
+      <div className="lp-asset-layout">
+        <aside className="lp-asset-folders">
+          <button type="button" className="is-active"><Briefcase /> Launch system <small>38</small></button>
+          <button type="button"><FileText /> Messaging <small>8</small></button>
+          <button type="button"><Eye /> Creative <small>16</small></button>
+          <button type="button"><Users /> Customer proof <small>9</small></button>
+          <button type="button"><Table /> Channel kits <small>5</small></button>
+        </aside>
+        <section className="lp-asset-grid">
+          {[
+            ["Launch film · master", "VIDEO · 4K", "is-film"],
+            ["Enterprise narrative", "DECK · 12 SLIDES", "is-deck"],
+            ["Northwind proof", "CUSTOMER STORY", "is-proof"],
+            ["Product UI selects", "18 IMAGES", "is-ui"],
+            ["Search launch kit", "32 VARIANTS", "is-copy"],
+            ["Founder announcement", "APPROVED COPY", "is-note"],
+          ].map(([title, meta, className]) => (
+            <article key={title}>
+              <span className={className}><i /><i /><i /></span>
+              <strong>{title}</strong>
+              <small>{meta}</small>
+              <em><Check /> Approved</em>
+            </article>
+          ))}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function CampaignPerformance({
+  range,
+  onRange,
+}: {
+  range: "7d" | "30d";
+  onRange: (range: "7d" | "30d") => void;
+}) {
+  const channels = [
+    ["Google Search", "$18.4k", "428", "$43", "+18%"],
+    ["LinkedIn", "$12.8k", "196", "$65", "+8%"],
+    ["Meta", "$11.2k", "122", "$92", "−14%"],
+    ["Newsletter", "$3.6k", "88", "$41", "+25%"],
+  ];
+  return (
+    <div className="lp-product-page">
+      <div className="lp-product-page-head">
+        <div><p>PERFORMANCE</p><h3>Qualified demand</h3><span>Live channel data reconciled against the operating plan.</span></div>
+        <div className="lp-product-segmented">
+          {(["7d", "30d"] as const).map((value) => (
+            <button type="button" className={range === value ? "is-active" : ""} onClick={() => onRange(value)} key={value}>{value}</button>
+          ))}
+        </div>
+      </div>
+      <div className="lp-performance-kpis">
+        <article><small>Qualified leads</small><strong>{range === "7d" ? "834" : "2,946"}</strong><em>↑ 21.4%</em></article>
+        <article><small>Pipeline created</small><strong>{range === "7d" ? "$486k" : "$1.82m"}</strong><em>↑ 18.2%</em></article>
+        <article><small>Cost / qualified</small><strong>{range === "7d" ? "$58" : "$61"}</strong><em className="is-good">↓ 9.6%</em></article>
+      </div>
+      <div className="lp-performance-layout">
+        <section className="lp-product-panel lp-performance-chart">
+          <header><span><strong>Qualified demand</strong><small>Actual vs plan</small></span><em>● Actual</em><em className="is-muted">┈ Plan</em></header>
+          <div className="lp-performance-plot">
+            <span className="is-grid g1" /><span className="is-grid g2" /><span className="is-grid g3" />
+            <div className="lp-css-chart lp-css-chart-performance" aria-hidden="true">
+              <i /><i /><i /><i /><i /><i /><i /><i /><i /><i />
+            </div>
+          </div>
+        </section>
+        <aside className="lp-product-panel lp-performance-insight">
+          <span className="lp-product-ai-icon"><Sparkles /></span>
+          <small>CLAUDE ANALYSIS</small>
+          <h4>Enterprise demand accelerated after the launch film.</h4>
+          <p>The effect is concentrated in search and direct visits from target accounts.</p>
+          <div><span>Confidence</span><strong>89%</strong></div>
+          <button type="button">Open analysis <ArrowRight /></button>
+        </aside>
+      </div>
+      <div className="lp-channel-table">
+        <header><span>Channel</span><span>Spend</span><span>Qualified</span><span>CPQ</span><span>vs plan</span></header>
+        {channels.map((row, index) => <div key={row[0]}>{row.map((cell, cellIndex) => <span className={cellIndex === 4 ? (index === 2 ? "is-down" : "is-up") : ""} key={cell}>{cell}</span>)}</div>)}
+      </div>
+    </div>
+  );
+}
+
+function DemoCampaignManager({
+  section,
+  onSection,
+  selectedDecision,
+  onDecision,
+}: {
+  section: AppSection;
+  onSection: (section: AppSection) => void;
+  selectedDecision: number;
+  onDecision: (index: number) => void;
+}) {
+  const [selectedWork, setSelectedWork] = useState(0);
+  const [range, setRange] = useState<"7d" | "30d">("7d");
+  const sections = [
+    { id: "campaign-command", label: "Command center", icon: SquaresFour },
+    { id: "campaign-work", label: "Campaign work", icon: ListChecks, badge: "4" },
+    { id: "campaign-calendar", label: "Calendar", icon: Calendar },
+    { id: "campaign-assets", label: "Assets", icon: Briefcase },
+    { id: "campaign-performance", label: "Performance", icon: BarChart3 },
+  ] satisfies Array<{ id: AppSection; label: string; icon: ComponentType; badge?: string }>;
+  return (
+    <ProductAppShell title="Campaign Manager" mark="CM" runtime="Claude monitoring" tone="violet" sections={sections} activeSection={section} onSection={onSection}>
+      {section === "campaign-command" ? <CampaignCommand selectedDecision={selectedDecision} onDecision={onDecision} /> : null}
+      {section === "campaign-work" ? <CampaignWork selected={selectedWork} onSelect={setSelectedWork} /> : null}
+      {section === "campaign-calendar" ? <CampaignCalendar /> : null}
+      {section === "campaign-assets" ? <CampaignAssets /> : null}
+      {section === "campaign-performance" ? <CampaignPerformance range={range} onRange={setRange} /> : null}
+    </ProductAppShell>
+  );
+}
+
+function CrmOverview() {
+  return (
+    <div className="lp-product-page">
+      <ProductPageHeader
+        eyebrow="REVENUE COMMAND CENTER"
+        title="Good morning, Maya"
+        description="Your pipeline is healthy. Three accounts need a human move today."
+        action="Add account"
+      />
+      <div className="lp-product-kpis lp-crm-kpis">
+        {[
+          ["Open pipeline", "$1.84m", "+14.2%"],
+          ["Forecast", "$624k", "82% confidence"],
+          ["Meetings", "12", "5 this week"],
+          ["Agent hours saved", "38.4h", "+6.2h"],
+        ].map(([label, value, delta], index) => (
+          <article key={label}><span><small>{label}</small><ArrowUpRight /></span><strong>{value}</strong><em className={index === 1 ? "is-neutral" : ""}>{delta}</em><MiniTrend variant="blue" /></article>
+        ))}
+      </div>
+      <div className="lp-crm-overview-grid">
+        <section className="lp-product-panel lp-crm-funnel">
+          <header><span><strong>Pipeline movement</strong><small>Last 30 days</small></span><button type="button">All teams <ChevronDown /></button></header>
+          {[
+            ["Qualified", "$412k", 92],
+            ["Meeting booked", "$318k", 73],
+            ["Evaluation", "$246k", 58],
+            ["Proposal", "$184k", 42],
+            ["Commit", "$96k", 24],
+          ].map(([label, value, width]) => (
+            <div key={label}><span><strong>{label}</strong><small>{value}</small></span><i><em className={`is-w${width}`} /></i></div>
+          ))}
+        </section>
+        <aside className="lp-product-panel lp-crm-today">
+          <header><span><strong>Today</strong><small>3 actions · 41 min</small></span><em>Focus</em></header>
+          {[
+            ["09:30", "Northwind AI", "Review meeting brief", "blue"],
+            ["11:00", "Copper Grid", "Approve follow-up", "amber"],
+            ["14:30", "Vesper Cloud", "Answer legal question", "violet"],
+          ].map(([time, account, action, tone]) => (
+            <article key={account}><time>{time}</time><StatusDot tone={tone} /><span><strong>{account}</strong><small>{action}</small></span></article>
+          ))}
+        </aside>
+        <section className="lp-product-panel lp-crm-agent-feed">
+          <header><span><strong>Codex activity</strong><small>Work completed from live signals</small></span><span className="lp-demo-runtime is-blue"><i /> working</span></header>
+          {[
+            ["Enriched 8 buying-committee records", "Gmail + LinkedIn notes · 4 min"],
+            ["Prepared Northwind meeting brief", "6 sources · 12 min"],
+            ["Drafted follow-up for Copper Grid", "Call transcript + CRM · 18 min"],
+          ].map(([title, meta], index) => <article key={title}><span><Zap /></span><div><strong>{title}</strong><small>{meta}</small></div><em>{index === 0 ? "New" : "Ready"}</em></article>)}
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function CrmPipeline({
+  selected,
+  onSelect,
+}: {
+  selected: number;
+  onSelect: (index: number) => void;
+}) {
+  const account = crmAccounts[selected];
+  return (
+    <div className="lp-product-page">
+      <ProductPageHeader eyebrow="PIPELINE · NORTH AMERICA" title="Accounts in motion" description="Live deal state, next actions, and agent-prepared context." action="New opportunity" />
+      <div className="lp-crm-pipeline-layout">
+        <div className="lp-demo-kanban lp-crm-kanban">
+          {crmColumns.map((column) => (
+            <section key={column.label}>
+              <header><span><strong>{column.label}</strong><small>{column.accounts.length}</small></span><em>{column.value}</em></header>
+              {column.accounts.map(([name, value, meta], itemIndex) => {
+                const knownIndex = crmAccounts.findIndex((item) => item.name === name);
+                const index = knownIndex >= 0
+                  ? knownIndex
+                  : (itemIndex + column.label.length) % crmAccounts.length;
+                return (
+                  <button type="button" className={selected === index ? "is-selected" : ""} onClick={() => onSelect(index)} key={name}>
+                    <span className="lp-demo-account-mark">{name.split(" ").map((part) => part[0]).join("")}</span>
+                    <strong>{name}</strong><span>{value}</span><small>{meta}</small>
+                    <i><User /> {index % 2 ? "Dana" : "Maya"}</i>
+                  </button>
+                );
+              })}
+            </section>
+          ))}
+        </div>
+        <aside className="lp-crm-deal-drawer">
+          <header><span className="lp-demo-account-mark">{account.initials}</span><button type="button"><MoreHorizontal /></button></header>
+          <small>OPPORTUNITY</small><h4>{account.name}</h4><a>{account.domain}</a>
+          <div className="lp-crm-deal-value"><span><small>Value</small><strong>{account.value}</strong></span><em>{account.state}</em></div>
+          <h5>Latest signal</h5><p>{account.signal}</p>
+          <h5>Next best action</h5>
+          <div className="lp-crm-next-action"><Sparkles /><span><strong>Send the security follow-up</strong><small>Codex prepared a draft from 6 sources.</small></span></div>
+          <button type="button" className="lp-crm-open-record">Open account <ArrowRight /></button>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function CrmAccounts({
+  selected,
+  onSelect,
+}: {
+  selected: number;
+  onSelect: (index: number) => void;
+}) {
+  const account = crmAccounts[selected];
+  return (
+    <div className="lp-product-page">
+      <ProductPageHeader eyebrow="ACCOUNTS" title="One record, every signal" description="Firmographics, people, correspondence, research, and agent work together." action="Add account" />
+      <div className="lp-product-split-view lp-crm-accounts-view">
+        <section className="lp-product-table-card">
+          <header><span>124 accounts</span><nav><button type="button" className="is-active">All</button><button type="button">Tier 1</button><button type="button">My accounts</button></nav><button type="button"><Search /></button></header>
+          <div className="lp-product-table-row is-head"><span>Account</span><span>Owner</span><span>Value</span><span>State</span></div>
+          {crmAccounts.map((item, index) => (
+            <button type="button" className={`lp-product-table-row${selected === index ? " is-selected" : ""}`} onClick={() => onSelect(index)} key={item.name}>
+              <span><i>{item.initials}</i><strong>{item.name}</strong><small>{item.segment}</small></span>
+              <span>{item.owner}</span><span>{item.value}</span><span><em className={`is-state s${index}`}>{item.state}</em></span>
+            </button>
+          ))}
+        </section>
+        <aside className="lp-account-record">
+          <header><span className="lp-demo-account-mark">{account.initials}</span><span><h4>{account.name}</h4><a>{account.domain}</a></span><button type="button"><MoreHorizontal /></button></header>
+          <div className="lp-account-chips"><em>{account.segment}</em><em>{account.state}</em><em>{account.value} ARR</em></div>
+          <nav><button type="button" className="is-active">Overview</button><button type="button">People</button><button type="button">Activity</button></nav>
+          <section><small>LATEST SIGNAL</small><p>{account.signal}</p><em>Detected by Codex · 12 min ago</em></section>
+          <dl><div><dt>Owner</dt><dd>{account.owner}</dd></div><div><dt>Last touch</dt><dd>{account.touch}</dd></div><div><dt>Open opportunity</dt><dd>{account.value}</dd></div><div><dt>Buying committee</dt><dd>6 people</dd></div></dl>
+          <div className="lp-account-contact"><span>ER</span><span><strong>Elena Rios</strong><small>VP Operations · Champion</small></span><button type="button"><Mail /></button></div>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function CrmInbox() {
+  const messages = [
+    ["Elena · Northwind AI", "Re: Security review and rollout plan", "Thanks — looping in our IT lead. Thursday works…", "8m", true],
+    ["Jordan · Copper Grid", "Technical review follow-up", "The architecture diagram answered the main question…", "42m", true],
+    ["Priya · Meridian Labs", "Intro to our new VP Operations", "Maya, meet Tom. He is taking over the evaluation…", "2h", false],
+    ["Alex · Vesper Cloud", "MSA question", "Legal needs clarification on the data retention clause…", "1d", false],
+  ] as const;
+  return (
+    <div className="lp-product-page lp-crm-inbox-page">
+      <ProductPageHeader eyebrow="SHARED INBOX" title="Revenue conversations" description="Email and CRM context with drafts prepared—but never sent—by Codex." action="Compose" />
+      <div className="lp-crm-inbox">
+        <aside>
+          <header><button type="button" className="is-active">All <small>12</small></button><button type="button">Needs reply <small>4</small></button></header>
+          {messages.map(([sender, subject, preview, time, unread], index) => (
+            <button type="button" className={`${index === 0 ? "is-active" : ""}${unread ? " is-unread" : ""}`} key={sender}>
+              <span>{sender.split(" ")[0].slice(0, 2).toUpperCase()}</span>
+              <div><strong>{sender}</strong><em>{time}</em><b>{subject}</b><small>{preview}</small></div>
+            </button>
+          ))}
+        </aside>
+        <section>
+          <header><span><small>NORTHWIND AI</small><strong>Re: Security review and rollout plan</strong></span><button type="button"><MoreHorizontal /></button></header>
+          <article className="lp-crm-message"><span>ER</span><div><strong>Elena Rios <small>elena@northwind.ai</small></strong><p>Thanks — looping in our IT lead. Thursday works for the rollout discussion. Could you also send the data-retention summary before then?</p></div></article>
+          <div className="lp-codex-draft"><header><span><Sparkles /></span><strong>Codex prepared a reply</strong><em>6 sources</em></header><p>Hi Elena — absolutely. I&apos;ve attached the data-retention summary and highlighted the controls your IT lead asked about during the review…</p><footer><button type="button">Edit draft</button><button type="button" className="is-primary"><Send /> Review & send</button></footer></div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function CrmTasks() {
+  const tasks = [
+    ["Review Northwind meeting brief", "Codex prepared from 6 sources", "Maya", "09:30", "Meeting"],
+    ["Approve Copper Grid follow-up", "Draft references the call transcript", "Dana", "11:00", "Approval"],
+    ["Resolve Vesper legal question", "Human answer required before Codex continues", "Maya", "14:30", "Blocked"],
+    ["Confirm Meridian buying committee", "Two contacts need role verification", "Dana", "Tomorrow", "Research"],
+  ];
+  return (
+    <div className="lp-product-page">
+      <ProductPageHeader eyebrow="WORK QUEUE" title="What needs a person" description="Decisions, relationships, and actions that agents should not take alone." action="Add task" />
+      <div className="lp-crm-task-board">
+        <section className="lp-product-panel">
+          <header><span><strong>Today</strong><small>3 tasks · 41 min</small></span><button type="button"><Filter /> Priority</button></header>
+          {tasks.map(([title, description, owner, time, kind], index) => (
+            <article key={title}><button type="button" aria-label={`Complete ${title}`}><Check /></button><span><em>{kind}</em><strong>{title}</strong><small>{description}</small></span><i>{owner}</i><time>{time}</time>{index === 0 ? <b>Open brief <ArrowRight /></b> : null}</article>
+          ))}
+        </section>
+        <aside className="lp-product-panel lp-task-capacity">
+          <header><span><strong>Team capacity</strong><small>This week</small></span><em>74%</em></header>
+          {[
+            ["Maya", "8 / 11 tasks", 72],
+            ["Dana", "6 / 8 tasks", 75],
+            ["Codex", "24 / 26 tasks", 92],
+          ].map(([name, label, width], index) => <div key={name}><span>{index === 2 ? <Terminal /> : <User />}</span><div><strong>{name}</strong><small>{label}</small><i><em className={`is-w${width}`} /></i></div></div>)}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function DemoCodexCrm({
+  section,
+  onSection,
+}: {
+  section: AppSection;
+  onSection: (section: AppSection) => void;
+}) {
+  const [selectedAccount, setSelectedAccount] = useState(0);
+  const sections = [
+    { id: "crm-overview", label: "Overview", icon: SquaresFour },
+    { id: "crm-pipeline", label: "Pipeline", icon: Briefcase },
+    { id: "crm-accounts", label: "Accounts", icon: Users },
+    { id: "crm-inbox", label: "Inbox", icon: Mail, badge: "4" },
+    { id: "crm-tasks", label: "Tasks", icon: Check, badge: "3" },
+  ] satisfies Array<{ id: AppSection; label: string; icon: ComponentType; badge?: string }>;
+  return (
+    <ProductAppShell title="Codex CRM" mark="CX" runtime="Codex working" tone="blue" sections={sections} activeSection={section} onSection={onSection}>
+      {section === "crm-overview" ? <CrmOverview /> : null}
+      {section === "crm-pipeline" ? <CrmPipeline selected={selectedAccount} onSelect={setSelectedAccount} /> : null}
+      {section === "crm-accounts" ? <CrmAccounts selected={selectedAccount} onSelect={setSelectedAccount} /> : null}
+      {section === "crm-inbox" ? <CrmInbox /> : null}
+      {section === "crm-tasks" ? <CrmTasks /> : null}
+    </ProductAppShell>
+  );
+}
+
+function DemoAgents() {
+  return (
+    <div className="lp-demo-page">
+      <div className="lp-demo-page-head">
+        <div>
+          <p className="lp-demo-overline">AGENTS</p>
+          <h3>Workers with a real boundary</h3>
+          <p>
+            Each one has a runtime, instructions, tools, accessible resources,
+            and clear stopping points.
+          </p>
+        </div>
+        <span className="lp-demo-page-meta">2 working · 1 waiting</span>
+      </div>
+      <div className="lp-demo-agent-list">
+        {agentRows.map((agent, index) => (
+          <article className="lp-demo-agent" key={agent.name}>
+            <span
+              className={`lp-demo-agent-mark is-${agent.tone}`}
+              aria-hidden="true"
+            >
+              {index === 1 ? <Terminal /> : <Sparkles />}
+            </span>
+            <span className="lp-demo-agent-copy">
+              <strong>{agent.name}</strong>
+              <span>{agent.description}</span>
+            </span>
+            <span className="lp-demo-agent-meta">
+              <em className={index < 2 ? "is-running" : ""}>
+                <i aria-hidden="true" />
+                {agent.state}
+              </em>
+              <small>{agent.meta}</small>
+            </span>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DemoWorkflow({
+  selectedStep,
+  onStep,
+}: {
+  selectedStep: number;
+  onStep: (index: number) => void;
+}) {
+  const step = workflowSteps[selectedStep];
+  return (
+    <div className="lp-demo-page lp-demo-workflow-page">
+      <div className="lp-demo-page-head">
+        <div>
+          <p className="lp-demo-overline">WORKFLOW RUN · 184</p>
+          <h3>Weekly campaign review</h3>
+          <p>Inspect the actual handoffs, output, and reason this run stopped.</p>
+        </div>
+        <span className="lp-demo-run-badge">
+          <i aria-hidden="true" />
+          Waiting for approval
+        </span>
+      </div>
+      <div className="lp-demo-workflow-layout">
+        <aside className="lp-demo-workflow-list">
+          <small>WORKFLOWS</small>
+          <button type="button" className="is-active">
+            <GitMerge />
+            <span>
+              <strong>Weekly campaign review</strong>
+              <em>Run 184 · waiting</em>
+            </span>
+          </button>
+          <button type="button">
+            <GitMerge />
+            <span>
+              <strong>Follow-up queue</strong>
+              <em>Run 583 · complete</em>
+            </span>
+          </button>
+          <button type="button">
+            <GitMerge />
+            <span>
+              <strong>Account enrichment</strong>
+              <em>Run 922 · working</em>
+            </span>
+          </button>
+        </aside>
+
+        <div className="lp-demo-workflow-canvas">
+          <span className="lp-demo-wire is-top" />
+          <span className="lp-demo-wire is-right" />
+          <span className="lp-demo-wire is-middle" />
+          <span className="lp-demo-wire is-left" />
+          <span className="lp-demo-flow-packet" aria-hidden="true" />
+          {workflowSteps.map((item, index) => (
+            <button
+              type="button"
+              className={`lp-demo-canvas-node is-node-${index}${selectedStep === index ? " is-selected" : ""}${index < 4 ? " is-complete" : ""}${index === 4 ? " is-waiting" : ""}`}
+              onClick={() => onStep(index)}
+              key={item.id}
+            >
+              <small>{item.kind}</small>
+              <strong>{item.title}</strong>
+              <span>{index < 4 ? "Complete" : index === 4 ? "Waiting" : "Blocked"}</span>
+            </button>
+          ))}
+        </div>
+
+        <aside className="lp-demo-step-inspector" key={step.id}>
+          <span className={`lp-demo-agent-mark is-${step.tone}`}>
+            {step.id === "claude" ? <Sparkles /> : null}
+            {step.id === "query" ? <Database /> : null}
+            {step.id === "trigger" ? <Clock /> : null}
+            {step.id === "decision" ? <GitMerge /> : null}
+            {step.id === "approval" ? <Users /> : null}
+            {step.id === "publish" ? <MessageCircle /> : null}
+          </span>
+          <small>{step.kind}</small>
+          <h4>{step.title}</h4>
+          <p>{step.detail}</p>
+          <div>
+            <small>LAST OUTPUT</small>
+            <strong>{step.output}</strong>
+          </div>
+          <dl>
+            <dt>Duration</dt>
+            <dd>{selectedStep === 4 ? "Waiting 12m" : selectedStep === 2 ? "48s" : "0.8s"}</dd>
+            <dt>Attempt</dt>
+            <dd>1 of 3</dd>
+          </dl>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function DemoData() {
+  return (
+    <div className="lp-demo-page">
+      <div className="lp-demo-page-head">
+        <div>
+          <p className="lp-demo-overline">DATA · CAMPAIGN_METRICS</p>
+          <h3>Campaign performance</h3>
+          <p>Shared state for the app, agents, workflows, and people.</p>
+        </div>
+        <span className="lp-demo-sync">
+          <i aria-hidden="true" />
+          Google Ads · synced 41s ago
+        </span>
+      </div>
+      <div className="lp-demo-table-shell">
+        <div className="lp-demo-table-tools">
+          <span>All campaigns</span>
+          <span>128 records · 5 columns</span>
+        </div>
+        <table>
+          <thead>
+            <tr>
+              <th>Campaign</th>
+              <th>Spend</th>
+              <th>CPA</th>
+              <th>vs plan</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tableRows.map((row, index) => (
+              <tr key={row[0]} className={index === 0 ? "is-alert" : ""}>
+                {row.map((cell, cellIndex) => (
+                  <td key={`${row[0]}-${cellIndex}`}>
+                    {cellIndex === 0 ? <i aria-hidden="true" /> : null}
+                    {cell}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function DocumentBody({ docId }: { docId: string }) {
+  if (docId === "positioning") {
+    return (
+      <>
+        <p className="lp-demo-doc-kicker">CAMPAIGN / POSITIONING</p>
+        <h3>Positioning notes</h3>
+        <p className="lp-demo-doc-lede">
+          The launch should make the operating model visible: people use the
+          app; agents work through it.
+        </p>
+        <h4>What the campaign must establish</h4>
+        <ul>
+          <li>The app is the working surface, not a generated mockup.</li>
+          <li>Every result stays attached to source data and decisions.</li>
+          <li>Agents stop at the boundary of human judgment.</li>
+        </ul>
+        <blockquote>
+          Avoid “AI workspace.” Show the specific software the team now has.
+        </blockquote>
+      </>
+    );
+  }
+
+  if (docId === "review-playbook") {
+    return (
+      <>
+        <p className="lp-demo-doc-kicker">OPERATIONS / PLAYBOOK</p>
+        <h3>Weekly campaign review</h3>
+        <p className="lp-demo-doc-lede">
+          A repeatable review for signal, spend, message quality, and decisions.
+        </p>
+        <h4>Before the meeting</h4>
+        <ol>
+          <li>Refresh channel data and compare against plan.</li>
+          <li>Ask Campaign Analyst to explain material movement.</li>
+          <li>Queue only decisions that require an owner.</li>
+        </ol>
+        <h4>Approval policy</h4>
+        <p>
+          Budget moves above $2,000 or changes to launch claims require Maya.
+          Everything else may continue automatically.
+        </p>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <p className="lp-demo-doc-kicker">CAMPAIGN / ACTIVE BRIEF</p>
+      <h3>Q3 product launch</h3>
+      <p className="lp-demo-doc-lede">
+        Introduce the product through the software teams create for work that
+        never had the right interface.
+      </p>
+      <div className="lp-demo-doc-callout">
+        <Sparkles />
+        <span>
+          <strong>Claude is using this brief</strong>
+          Campaign Manager · last read 2 min ago
+        </span>
+      </div>
+      <h4>Operating thesis</h4>
+      <p>
+        Show a campaign moving through a purpose-built app, a scoped agent, live
+        data, and one meaningful human approval.
+      </p>
+      <h4>Launch sequence</h4>
+      <ul>
+        <li>Lead with the missing software, not the agent.</li>
+        <li>Prove that the app and agent share durable state.</li>
+        <li>End on the decision a person still owns.</li>
+      </ul>
+    </>
+  );
+}
+
+function DemoDocs({
+  selectedDoc,
+  onDoc,
+}: {
+  selectedDoc: string;
+  onDoc: (docId: string) => void;
+}) {
+  const selected = docFiles.find((file) => file.id === selectedDoc) ?? docFiles[0];
+  return (
+    <div className="lp-demo-page lp-demo-doc-page">
+      <div className="lp-demo-page-head">
+        <div>
+          <p className="lp-demo-overline">DOCS</p>
+          <h3>{selected.label}</h3>
+          <p>Pod knowledge people edit and agents can use with permission.</p>
+        </div>
+        <span className="lp-demo-page-meta">Saved · shared with pod</span>
+      </div>
+      <div className="lp-demo-doc-layout">
+        <aside className="lp-demo-doc-tree">
+          <div className="lp-demo-doc-search">
+            <Search />
+            Search docs
+          </div>
+          <small>CAMPAIGNS</small>
+          {docFiles
+            .filter((file) => file.folder === "Campaigns")
+            .map(({ id, label, icon: Icon }) => (
+              <button
+                type="button"
+                className={selectedDoc === id ? "is-active" : ""}
+                onClick={() => onDoc(id)}
+                key={id}
+              >
+                <Icon />
+                {label}
+              </button>
+            ))}
+          <small>OPERATIONS</small>
+          {docFiles
+            .filter((file) => file.folder === "Operations")
+            .map(({ id, label, icon: Icon }) => (
+              <button
+                type="button"
+                className={selectedDoc === id ? "is-active" : ""}
+                onClick={() => onDoc(id)}
+                key={id}
+              >
+                <Icon />
+                {label}
+              </button>
+            ))}
+        </aside>
+        <article className="lp-demo-document" key={selectedDoc}>
+          <DocumentBody docId={selectedDoc} />
+        </article>
+        <aside className="lp-demo-doc-context">
+          <small>USED BY</small>
+          <div>
+            <span className="lp-demo-agent-mark is-violet">
+              <Sparkles />
+            </span>
+            <span>
+              <strong>Campaign Analyst</strong>
+              <em>read access</em>
+            </span>
+          </div>
+          <div>
+            <span className="lp-demo-agent-mark is-amber">
+              <SquaresFour />
+            </span>
+            <span>
+              <strong>Campaign Manager</strong>
+              <em>linked brief</em>
+            </span>
+          </div>
+          <div>
+            <span className="lp-demo-agent-mark is-blue">
+              <GitMerge />
+            </span>
+            <span>
+              <strong>Weekly review</strong>
+              <em>workflow input</em>
+            </span>
+          </div>
+          <small>ACTIVITY</small>
+          <p>Claude cited this doc in 3 findings.</p>
+          <p>Maya edited the launch sequence.</p>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function DemoConnectors({
+  selectedConnector,
+  onConnector,
+}: {
+  selectedConnector: string;
+  onConnector: (connectorId: string) => void;
+}) {
+  const selected =
+    connectors.find((connector) => connector.id === selectedConnector) ??
+    connectors[0];
+  const SelectedIcon = selected.icon;
+
+  return (
+    <div className="lp-demo-page">
+      <div className="lp-demo-page-head">
+        <div>
+          <p className="lp-demo-overline">CONNECTORS</p>
+          <h3>Accounts this pod can use</h3>
+          <p>
+            Every connector shows the account, granted capability, and resources
+            using it.
+          </p>
+        </div>
+        <span className="lp-demo-page-meta">4 connected</span>
+      </div>
+      <div className="lp-demo-connectors-layout">
+        <div className="lp-demo-connector-list">
+          {connectors.map(({ id, name, account, status, icon: Icon, tone }) => (
+            <button
+              type="button"
+              className={selectedConnector === id ? "is-selected" : ""}
+              onClick={() => onConnector(id)}
+              key={id}
+            >
+              <span className={`lp-demo-connector-icon is-${tone}`}>
+                <Icon />
+              </span>
+              <span>
+                <strong>{name}</strong>
+                <small>{account}</small>
+              </span>
+              <em>
+                <i aria-hidden="true" />
+                {status}
+              </em>
+              <ArrowRight />
+            </button>
+          ))}
+        </div>
+        <aside className="lp-demo-connector-detail" key={selected.id}>
+          <span className={`lp-demo-connector-icon is-${selected.tone}`}>
+            <SelectedIcon />
+          </span>
+          <small>CONNECTED ACCOUNT</small>
+          <h4>{selected.name}</h4>
+          <p>{selected.account}</p>
+          <dl>
+            <div>
+              <dt>Granted access</dt>
+              <dd>{selected.access}</dd>
+            </div>
+            <div>
+              <dt>Credential owner</dt>
+              <dd>Maya Chen · Growth Ops</dd>
+            </div>
+          </dl>
+          <small>USED BY</small>
+          <div className="lp-demo-used-by">
+            {selected.usedBy.map((resource) => (
+              <span key={resource}>{resource}</span>
+            ))}
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function DemoScreen({
+  activeView,
+  appSection,
+  selectedDecision,
+  selectedWorkflowStep,
+  selectedDoc,
+  selectedConnector,
+  onView,
+  onAppSection,
+  onDecision,
+  onWorkflowStep,
+  onDoc,
+  onConnector,
+}: {
+  activeView: DemoView;
+  appSection: AppSection;
+  selectedDecision: number;
+  selectedWorkflowStep: number;
+  selectedDoc: string;
+  selectedConnector: string;
+  onView: (view: DemoView) => void;
+  onAppSection: (section: AppSection) => void;
+  onDecision: (index: number) => void;
+  onWorkflowStep: (index: number) => void;
+  onDoc: (docId: string) => void;
+  onConnector: (connectorId: string) => void;
+}) {
+  if (activeView === "home") return <DemoHome />;
+  if (activeView === "apps") {
+    return <DemoApps onOpen={onView} />;
+  }
+  if (activeView === "campaign") {
+    return (
+      <DemoCampaignManager
+        section={appSection}
+        onSection={onAppSection}
+        selectedDecision={selectedDecision}
+        onDecision={onDecision}
+      />
+    );
+  }
+  if (activeView === "crm") {
+    return <DemoCodexCrm section={appSection} onSection={onAppSection} />;
+  }
+  if (activeView === "agents") return <DemoAgents />;
+  if (activeView === "workflows") {
+    return (
+      <DemoWorkflow
+        selectedStep={selectedWorkflowStep}
+        onStep={onWorkflowStep}
+      />
+    );
+  }
+  if (activeView === "data") return <DemoData />;
+  if (activeView === "docs") {
+    return <DemoDocs selectedDoc={selectedDoc} onDoc={onDoc} />;
+  }
+  return (
+    <DemoConnectors
+      selectedConnector={selectedConnector}
+      onConnector={onConnector}
+    />
+  );
+}
+
+function isAppsView(view: DemoView) {
+  return view === "apps" || view === "crm" || view === "campaign";
+}
+
+export function HeroPodDemo() {
+  const [activeView, setActiveView] = useState<DemoView>("campaign");
+  const [appSection, setAppSection] =
+    useState<AppSection>("campaign-command");
+  const [activityIndex, setActivityIndex] = useState(0);
+  const [selectedDecision, setSelectedDecision] = useState(0);
+  const [selectedWorkflowStep, setSelectedWorkflowStep] = useState(4);
+  const [selectedDoc, setSelectedDoc] = useState("launch-brief");
+  const [selectedConnector, setSelectedConnector] = useState("google-ads");
+  const [isLive, setIsLive] = useState(true);
+
+  useEffect(() => {
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    if (!reducedMotion.matches) return;
+    const timer = window.setTimeout(() => setIsLive(false), 0);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    if (!isLive) return;
+    const activityTimer = window.setInterval(() => {
+      setActivityIndex((current) => (current + 1) % activityEvents.length);
+    }, 3400);
+    const viewTimer = window.setInterval(() => {
+      setActiveView((current) => {
+        const currentIndex = autoViews.indexOf(current);
+        const next = autoViews[(currentIndex + 1) % autoViews.length];
+        if (next === "campaign") setAppSection("campaign-command");
+        if (next === "crm") setAppSection("crm-overview");
+        return next;
+      });
+    }, 9000);
+    return () => {
+      window.clearInterval(activityTimer);
+      window.clearInterval(viewTimer);
+    };
+  }, [isLive]);
+
+  const chooseView = (view: DemoView) => {
+    if (view === "campaign") setAppSection("campaign-command");
+    if (view === "crm") setAppSection("crm-overview");
+    setActiveView(view);
+    setIsLive(false);
+  };
+
+  const interact = (action: () => void) => {
+    action();
+    setIsLive(false);
+  };
+
+  const activity = activityEvents[activityIndex];
+  const ActivityIcon = activity.icon;
+  const activeLabel =
+    activeView === "campaign"
+      ? "Campaign Manager"
+      : activeView === "crm"
+        ? "Codex CRM"
+        : activeView.charAt(0).toUpperCase() + activeView.slice(1);
+
+  const mainNav = [
+    { key: "apps", label: "Apps", count: 2, icon: SquaresFour },
+    { key: "agents", label: "Agents", count: 4, icon: Sparkles },
+    { key: "workflows", label: "Workflows", count: 3, icon: GitMerge },
+    { key: "data", label: "Data", count: 4, icon: Database },
+    { key: "docs", label: "Docs", count: 3, icon: FileText },
+    { key: "connectors", label: "Connectors", count: 4, icon: Plug },
+  ] satisfies Array<{
+    key: DemoView;
+    label: string;
+    count: number;
+    icon: ComponentType;
+  }>;
+
+  return (
+    <div className={`lp-demo-shell${isLive ? " is-live" : ""}`}>
+      <aside className="lp-demo-sidebar" aria-label="Demo pod navigation">
+        <button
+          className="lp-demo-pod-switcher"
+          type="button"
+          onClick={() => chooseView("home")}
+        >
+          <span>GO</span>
+          <strong>
+            Growth Ops
+            <small>Team pod</small>
+          </strong>
+          <ChevronDown aria-hidden="true" />
+        </button>
+
+        <div className="lp-demo-sidebar-actions">
+          <button type="button" onClick={() => chooseView("home")}>
+            <Plus />
+            New
+          </button>
+          <button
+            type="button"
+            className={activeView === "home" ? "is-active" : ""}
+            onClick={() => chooseView("home")}
+          >
+            <Home />
+            Home
+          </button>
+        </div>
+
+        <p className="lp-demo-nav-label">Pod</p>
+        <nav className="lp-demo-nav">
+          {mainNav.map(({ key, label, count, icon: Icon }) => {
+            const isActive =
+              key === "apps" ? isAppsView(activeView) : activeView === key;
+            return (
+              <div className="lp-demo-nav-group" key={key}>
+                <button
+                  type="button"
+                  className={isActive ? "is-active" : ""}
+                  aria-pressed={isActive}
+                  onClick={() => chooseView(key)}
+                >
+                  <Icon />
+                  <span>{label}</span>
+                  <small>{count}</small>
+                </button>
+                {key === "apps" && isAppsView(activeView) ? (
+                  <div className="lp-demo-app-worktree">
+                    <button
+                      type="button"
+                      className={activeView === "campaign" ? "is-active" : ""}
+                      onClick={() => chooseView("campaign")}
+                    >
+                      <i>CM</i>
+                      <span>Campaign Manager</span>
+                    </button>
+                    <button
+                      type="button"
+                      className={activeView === "crm" ? "is-active" : ""}
+                      onClick={() => chooseView("crm")}
+                    >
+                      <i>CX</i>
+                      <span>Codex CRM</span>
+                    </button>
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </nav>
+
+        <div className="lp-demo-sidebar-foot">
+          <span className="lp-demo-person">M</span>
+          <span>
+            <strong>Maya Chen</strong>
+            <small>Growth Ops</small>
+          </span>
+        </div>
+      </aside>
+
+      <div className="lp-demo-workspace">
+        <header className="lp-demo-tabbar">
+          <div className="lp-demo-tabs">
+            <button
+              type="button"
+              className={activeView === "home" ? "is-active" : ""}
+              onClick={() => chooseView("home")}
+            >
+              <Home />
+              Home
+            </button>
+            {activeView !== "home" ? (
+              <span className="is-active">
+                {isAppsView(activeView) ? <SquaresFour /> : null}
+                {activeView === "agents" ? <Sparkles /> : null}
+                {activeView === "workflows" ? <GitMerge /> : null}
+                {activeView === "data" ? <Database /> : null}
+                {activeView === "docs" ? <FileText /> : null}
+                {activeView === "connectors" ? <Plug /> : null}
+                {activeLabel}
+              </span>
+            ) : null}
+          </div>
+          <span className="lp-demo-running">
+            <i aria-hidden="true" />
+            3 active
+          </span>
+        </header>
+
+        <main className="lp-demo-main" key={activeView}>
+          <DemoScreen
+            activeView={activeView}
+            appSection={appSection}
+            selectedDecision={selectedDecision}
+            selectedWorkflowStep={selectedWorkflowStep}
+            selectedDoc={selectedDoc}
+            selectedConnector={selectedConnector}
+            onView={chooseView}
+            onAppSection={(section) =>
+              interact(() => setAppSection(section))
+            }
+            onDecision={(index) =>
+              interact(() => setSelectedDecision(index))
+            }
+            onWorkflowStep={(index) =>
+              interact(() => setSelectedWorkflowStep(index))
+            }
+            onDoc={(docId) => interact(() => setSelectedDoc(docId))}
+            onConnector={(connectorId) =>
+              interact(() => setSelectedConnector(connectorId))
+            }
+          />
+        </main>
+
+        <footer className="lp-demo-livebar">
+          <span
+            className={`lp-demo-activity-icon is-${activity.tone}`}
+            aria-hidden="true"
+          >
+            <ActivityIcon />
+          </span>
+          <p key={activity.actor}>
+            <strong>{activity.actor}</strong>
+            <span>{activity.action}</span>
+          </p>
+          <em>{activity.target}</em>
+          <span className="lp-demo-live-label">
+            <i aria-hidden="true" />
+            {isLive ? "Live" : "Paused"}
+          </span>
+          <button
+            type="button"
+            aria-label={isLive ? "Pause live demo" : "Play live demo"}
+            onClick={() => setIsLive((current) => !current)}
+          >
+            {isLive ? <Pause /> : <Play />}
+          </button>
+          <span
+            className="lp-demo-live-progress"
+            key={`${activityIndex}-${activeView}`}
+          >
+            <i />
+          </span>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/lemma-frontend/components/landing/landing-animations.tsx
+++ b/lemma-frontend/components/landing/landing-animations.tsx
@@ -1,286 +1,47 @@
+import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 import type { TerminalLine } from "./landing-data";
-import {
-  fullTerminalLines,
-  heroTickerEvents,
-  machineStations,
-  podBlocks,
-  terminalScript,
-} from "./landing-data";
+import { fullTerminalLines, terminalScript } from "./landing-data";
 
-export function PodBlockGlyph({ kind }: { kind: (typeof podBlocks)[number]["key"] }) {
-  switch (kind) {
-    case "data":
-      return (
-        <svg viewBox="0 0 28 28" className="lp-glyph lp-glyph-data">
-          <rect className="lp-g-row" x="4" y="6" width="20" height="3.4" rx="1.4" />
-          <rect className="lp-g-row" x="4" y="12.3" width="15" height="3.4" rx="1.4" />
-          <rect className="lp-g-row" x="4" y="18.6" width="18" height="3.4" rx="1.4" />
-        </svg>
-      );
-    case "agents":
-      return (
-        <svg viewBox="0 0 28 28" className="lp-glyph lp-glyph-agents">
-          <line className="lp-g-edge" x1="6.5" y1="20" x2="14" y2="8" />
-          <line className="lp-g-edge" x1="14" y1="8" x2="21.5" y2="18" />
-          <line className="lp-g-edge" x1="6.5" y1="20" x2="21.5" y2="18" />
-          <circle className="lp-g-node" cx="6.5" cy="20" r="2.8" />
-          <circle className="lp-g-node is-gold" cx="14" cy="8" r="3.2" />
-          <circle className="lp-g-node" cx="21.5" cy="18" r="2.8" />
-        </svg>
-      );
-    case "workflows":
-      return (
-        <svg viewBox="0 0 28 28" className="lp-glyph lp-glyph-workflows">
-          <line className="lp-g-edge" x1="5" y1="14" x2="23" y2="14" />
-          <circle className="lp-g-node" cx="5" cy="14" r="2.5" />
-          <rect
-            className="lp-g-gate"
-            x="11.2"
-            y="11.2"
-            width="5.6"
-            height="5.6"
-          />
-          <circle className="lp-g-node" cx="23" cy="14" r="2.5" />
-          <circle className="lp-g-packet" cx="0" cy="14" r="1.9" />
-        </svg>
-      );
-    case "apps":
-      return (
-        <svg viewBox="0 0 28 28" className="lp-glyph lp-glyph-apps">
-          <rect className="lp-g-frame" x="4" y="5" width="20" height="18" rx="2.4" />
-          <line className="lp-g-edge" x1="4" y1="10" x2="24" y2="10" />
-          <rect className="lp-g-bar" x="8" y="13.5" width="2.8" height="6" rx="1" />
-          <rect className="lp-g-bar" x="12.6" y="13.5" width="2.8" height="6" rx="1" />
-          <rect className="lp-g-bar" x="17.2" y="13.5" width="2.8" height="6" rx="1" />
-        </svg>
-      );
-    case "access":
-      return (
-        <svg viewBox="0 0 28 28" className="lp-glyph lp-glyph-access">
-          <path
-            className="lp-g-frame"
-            d="M14 4.2l7.6 2.9v5.7c0 4.8-3.2 8.2-7.6 9.8-4.4-1.6-7.6-5-7.6-9.8V7.1z"
-          />
-          <circle className="lp-g-dot" cx="14" cy="13.4" r="2.2" />
-        </svg>
-      );
-    case "connectors":
-      return (
-        <svg viewBox="0 0 28 28" className="lp-glyph lp-glyph-connectors">
-          <line className="lp-g-edge" x1="14" y1="14" x2="14" y2="5.5" />
-          <line className="lp-g-edge" x1="14" y1="14" x2="22.5" y2="14" />
-          <line className="lp-g-edge" x1="14" y1="14" x2="14" y2="22.5" />
-          <line className="lp-g-edge" x1="14" y1="14" x2="5.5" y2="14" />
-          <circle className="lp-g-frame" cx="14" cy="14" r="3.1" />
-          <circle className="lp-g-sat" cx="14" cy="5.5" r="1.9" />
-          <circle className="lp-g-sat" cx="22.5" cy="14" r="1.9" />
-          <circle className="lp-g-sat" cx="14" cy="22.5" r="1.9" />
-          <circle className="lp-g-sat" cx="5.5" cy="14" r="1.9" />
-        </svg>
-      );
-  }
-}
+const workSurfaces = [
+  {
+    label: "WhatsApp",
+    src: "/landing-page/app-logos/whatsapp.svg",
+  },
+  {
+    label: "Telegram",
+    src: "/landing-page/app-logos/telegram.svg",
+  },
+  {
+    label: "Claude Code",
+    src: "/harnesslogos/claudecode.png",
+  },
+  {
+    label: "Codex",
+    src: "/harnesslogos/codex.png",
+  },
+] as const;
 
-export function MachineStationIcon({
-  kind,
-}: {
-  kind: (typeof machineStations)[number]["key"];
-}) {
-  switch (kind) {
-    case "inbound":
-      return (
-        <svg viewBox="0 0 24 24">
-          <rect x="3.5" y="5.5" width="17" height="13" rx="2" />
-          <path d="M4.5 7l7.5 6 7.5-6" />
-        </svg>
-      );
-    case "agent":
-      return (
-        <svg viewBox="0 0 24 24">
-          <path d="M12 3l7.5 4.4v8.2L12 20l-7.5-4.4V7.4z" />
-          <circle cx="12" cy="11.5" r="2.4" />
-        </svg>
-      );
-    case "table":
-      return (
-        <svg viewBox="0 0 24 24">
-          <rect x="3.5" y="4.5" width="17" height="15" rx="2" />
-          <line x1="3.5" y1="10" x2="20.5" y2="10" />
-          <line x1="3.5" y1="14.5" x2="20.5" y2="14.5" />
-          <line x1="10" y1="10" x2="10" y2="19.5" />
-        </svg>
-      );
-    case "approval":
-      return (
-        <svg viewBox="0 0 24 24">
-          <circle cx="12" cy="8.5" r="3.4" />
-          <path d="M5 20c.8-3.6 3.6-5.5 7-5.5s6.2 1.9 7 5.5" />
-        </svg>
-      );
-    case "routed":
-      return (
-        <svg viewBox="0 0 24 24">
-          <circle cx="6" cy="12" r="2.4" />
-          <circle cx="18" cy="6.5" r="2.4" />
-          <circle cx="18" cy="17.5" r="2.4" />
-          <line x1="8" y1="11" x2="15.8" y2="7.4" />
-          <line x1="8" y1="13" x2="15.8" y2="16.6" />
-        </svg>
-      );
-  }
-}
-
-export function MachineAtWork() {
-  const wrapRef = useRef<HTMLDivElement>(null);
-  const fillRef = useRef<HTMLDivElement>(null);
-  const packetRef = useRef<HTMLDivElement>(null);
-  const readoutRef = useRef<HTMLSpanElement>(null);
-  const stationRefs = useRef<(HTMLDivElement | null)[]>([]);
-  const [isStatic, setIsStatic] = useState(false);
-
-  useEffect(() => {
-    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const narrow = window.matchMedia("(max-width: 860px)");
-    const sync = () => setIsStatic(reduced.matches || narrow.matches);
-    sync();
-    reduced.addEventListener("change", sync);
-    narrow.addEventListener("change", sync);
-    return () => {
-      reduced.removeEventListener("change", sync);
-      narrow.removeEventListener("change", sync);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (isStatic) return;
-    let ticking = false;
-    const update = () => {
-      ticking = false;
-      const wrap = wrapRef.current;
-      if (!wrap) return;
-      const total = wrap.offsetHeight - window.innerHeight;
-      if (total <= 0) return;
-      const progress = Math.min(
-        1,
-        Math.max(0, -wrap.getBoundingClientRect().top / total),
-      );
-      if (fillRef.current)
-        fillRef.current.style.width = `${progress * 100}%`;
-      if (packetRef.current)
-        packetRef.current.style.left = `${progress * 100}%`;
-      let lit = 0;
-      stationRefs.current.forEach((station, index) => {
-        if (!station) return;
-        const threshold = index / (machineStations.length - 1);
-        const isLit = progress >= threshold - 0.02;
-        station.classList.toggle("is-lit", isLit);
-        if (isLit) lit = index + 1;
-      });
-      if (readoutRef.current)
-        readoutRef.current.textContent = `WORK://NORTHWIND :: 0${lit}/05 COMPLETE`;
-    };
-    const onScroll = () => {
-      if (!ticking) {
-        ticking = true;
-        requestAnimationFrame(update);
-      }
-    };
-    window.addEventListener("scroll", onScroll, { passive: true });
-    window.addEventListener("resize", onScroll, { passive: true });
-    update();
-    return () => {
-      window.removeEventListener("scroll", onScroll);
-      window.removeEventListener("resize", onScroll);
-    };
-  }, [isStatic]);
-
+export function WorkSurfaceStrip() {
   return (
-    <section
-      className={`lp-mw-section${isStatic ? " is-static" : ""}`}
-      id="runtime"
-      aria-labelledby="mw-title"
+    <div
+      className="lp-work-surfaces"
+      aria-label="Use Lemma from WhatsApp, Telegram, Claude Code, Codex, or anywhere you work"
     >
-      <div className="lp-mw-wrap" ref={wrapRef}>
-        <div className="lp-mw-sticky">
-          <div className="lp-section-inner">
-            <div className="lp-mw-head lp-reveal">
-              <div>
-                <p className="lp-section-kicker">Runtime</p>
-                <h2 className="lp-section-title" id="mw-title">
-                  Watch one unit of work <span>move.</span>
-                </h2>
-                <p className="lp-section-subhead">
-                  Not a chat transcript. A piece of work with an owner and
-                  state, moving through agents, tables, and people.
-                </p>
-              </div>
-              <span className="lp-mw-readout" ref={readoutRef}>
-                WORK://NORTHWIND :: 00/05 COMPLETE
-              </span>
-            </div>
-
-            <div className="lp-mw-stage">
-              <div className="lp-mw-track" aria-hidden="true">
-                <div className="lp-mw-fill" ref={fillRef} />
-                <div className="lp-mw-packet" ref={packetRef} />
-              </div>
-              <div className="lp-mw-stations">
-                {machineStations.map((station, index) => (
-                  <div
-                    className="lp-mw-station"
-                    key={station.key}
-                    ref={(el) => {
-                      stationRefs.current[index] = el;
-                    }}
-                  >
-                    <span className="lp-mw-chip" aria-hidden="true">
-                      <MachineStationIcon kind={station.key} />
-                    </span>
-                    <span className="lp-mw-label">{station.label}</span>
-                    <span className="lp-mw-sub">{station.sub}</span>
-                    <p className="lp-mw-caption">{station.caption}</p>
-                    {station.key === "approval" ? (
-                      <span className="lp-mw-approval">
-                        <strong>Route Northwind to enterprise?</strong>
-                        <em>Approved by Dana</em>
-                      </span>
-                    ) : null}
-                  </div>
-                ))}
-              </div>
-            </div>
-
-            <p className="lp-mw-coda">
-              The pause at ST/04 was Dana clicking Approve in Slack. Every
-              other step ran itself.
-            </p>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-export function HeroTicker() {
-  const [eventIndex, setEventIndex] = useState(0);
-
-  useEffect(() => {
-    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
-    const id = setInterval(
-      () => setEventIndex((current) => (current + 1) % heroTickerEvents.length),
-      2600,
-    );
-    return () => clearInterval(id);
-  }, []);
-
-  return (
-    <p className="lp-hero-ticker" aria-hidden="true">
-      <i className="lp-ticker-dot" />
-      <span className="lp-ticker-text" key={eventIndex}>
-        {heroTickerEvents[eventIndex]}
+      <span className="lp-work-surfaces-lead">Use it from</span>
+      <span className="lp-work-surface-list" aria-hidden="true">
+        {workSurfaces.map((surface) => (
+          <span className="lp-work-surface" key={surface.label}>
+            <Image src={surface.src} alt="" width={18} height={18} />
+            <span>{surface.label}</span>
+          </span>
+        ))}
       </span>
-    </p>
+      <span className="lp-work-surfaces-anywhere">
+        <i aria-hidden="true">+</i>
+        anywhere you work
+      </span>
+    </div>
   );
 }
 

--- a/lemma-frontend/components/landing/landing-data.ts
+++ b/lemma-frontend/components/landing/landing-data.ts
@@ -1,59 +1,159 @@
 export const podBlocks = [
   {
-    key: "data",
-    title: "Data Stores",
-    icon: "/landing-page/pod-icons/data.svg",
-    stat: "5 typed tables",
-    summary:
-      "Structured business data created by the pod and ingested from external sources.",
+    key: "apps",
+    title: "Apps",
+    iconKind: "apps",
+    count: "2",
+    summary: "The software your team opens and uses.",
     detail:
-      "Pull from SQL databases, REST APIs, or SaaS apps. Lemma stores it in typed tables. Your leads, tickets, events, and pipeline records are readable by agents, queryable by your app, and owned by the pod.",
+      "Full interfaces for the job, built on everything else in the pod.",
+    items: [
+      {
+        name: "Campaign Manager",
+        meta: "Briefs, approvals, calendar, performance",
+        state: "Live",
+      },
+      {
+        name: "Codex CRM",
+        meta: "Accounts, pipeline, inbox, follow-ups",
+        state: "Live",
+      },
+      {
+        name: "Monday Brief",
+        meta: "A focused review surface for leadership",
+        state: "Internal",
+      },
+    ],
   },
   {
     key: "agents",
     title: "Agents",
-    icon: "/landing-page/pod-icons/agents.svg",
-    stat: "4 active agents",
-    summary: "LLM workers that execute judgment tasks inside the pod.",
+    iconKind: "agents",
+    count: "4",
+    summary: "AI workers with a specific job and access.",
     detail:
-      "Each agent receives a role, input schema, tool grants, accessible tables, folders, and connected apps - never vague access to everything. Results come back as structured data before a workflow or human reviewer decides what happens next.",
+      "Each agent knows what it can read, what it can change, and when to stop.",
+    items: [
+      {
+        name: "Campaign Analyst",
+        meta: "Claude · reads campaign data and briefs",
+        state: "Working",
+      },
+      {
+        name: "CRM Operator",
+        meta: "Codex · researches accounts and drafts replies",
+        state: "Working",
+      },
+      {
+        name: "Budget Advisor",
+        meta: "Prepares changes · cannot publish them",
+        state: "Waiting",
+      },
+    ],
   },
   {
     key: "workflows",
     title: "Workflows",
-    icon: "/landing-page/pod-icons/workflows.svg",
-    stat: "8 workflow graphs",
-    summary:
-      "Real business processes with agents, humans, approvals, and handoffs.",
+    iconKind: "workflows",
+    count: "3",
+    summary: "The repeatable steps that keep work moving.",
     detail:
-      "Workflows mix forms, agents, functions, decisions, waits, loops, and approval steps. The same graph can start from a schedule, a Slack action, a new record, a webhook, or a button in the app.",
+      "They connect triggers, agent work, decisions, people, and outside actions.",
+    items: [
+      {
+        name: "Weekly campaign review",
+        meta: "Schedule → analysis → approval → publish",
+        state: "Waiting",
+      },
+      {
+        name: "Account enrichment",
+        meta: "New account → research → update record",
+        state: "Running",
+      },
+      {
+        name: "Follow-up queue",
+        meta: "Reply signal → draft → human review",
+        state: "Ready",
+      },
+    ],
   },
   {
-    key: "apps",
-    title: "App Interface",
-    icon: "/landing-page/pod-icons/apps.svg",
-    stat: "2 operator apps",
-    summary: "The operator UI your team runs on, deployed at a URL.",
+    key: "data",
+    title: "Data",
+    iconKind: "data",
+    count: "4",
+    summary: "The shared records every part of the pod uses.",
     detail:
-      "Real multi-screen apps, not screenshots - record tables, detail pages, workflow launch forms, review queues, and embedded assistants, all built on the same pod APIs.",
+      "Apps, agents, and workflows read and update the same typed tables.",
+    items: [
+      {
+        name: "campaign_metrics",
+        meta: "128 rows · synced 41 seconds ago",
+        state: "Healthy",
+      },
+      {
+        name: "accounts",
+        meta: "124 records · 8 updated today",
+        state: "Healthy",
+      },
+      {
+        name: "decisions",
+        meta: "31 records · 2 need review",
+        state: "Attention",
+      },
+    ],
   },
   {
-    key: "access",
-    title: "RBAC + Auth",
-    icon: "/landing-page/pod-icons/auth-rbac.svg",
-    stat: "People + agent grants",
-    summary: "Roles decide what people and agents can access or change.",
+    key: "docs",
+    title: "Docs",
+    iconKind: "docs",
+    count: "3",
+    summary: "The context and working files behind the job.",
     detail:
-      "Pod roles, table grants, resource visibility, and approval policies decide who can view data, change records, run workflows, or let an agent take an external action.",
+      "People and agents work from the same briefs, policies, and notes.",
+    items: [
+      {
+        name: "Q3 launch brief.md",
+        meta: "Used by Campaign Manager + 2 agents",
+        state: "Updated",
+      },
+      {
+        name: "Positioning notes.md",
+        meta: "Used by Campaign Analyst",
+        state: "Current",
+      },
+      {
+        name: "Weekly review.md",
+        meta: "Used by Monday review workflow",
+        state: "Current",
+      },
+    ],
   },
   {
     key: "connectors",
     title: "Connectors",
-    icon: "/landing-page/pod-icons/connectors.svg",
-    stat: "4 connected",
-    summary: "Connect the pod to tools your team already uses.",
+    iconKind: "connectors",
+    count: "4",
+    summary: "The accounts the pod can use to get work done.",
     detail:
-      "Gmail, Slack, GitHub, Salesforce, Teams, and custom APIs can be called by functions, workflows, and agents - using the current user's account or a fixed service account, per the pod's rules.",
+      "Every connection shows the account, its access, and what uses it.",
+    items: [
+      {
+        name: "Google Ads",
+        meta: "growth@northstar.co · read campaign data",
+        state: "Connected",
+      },
+      {
+        name: "Gmail",
+        meta: "maya@northstar.co · read threads, create drafts",
+        state: "Connected",
+      },
+      {
+        name: "Slack",
+        meta: "Northstar · send approvals and reviewed briefs",
+        state: "Connected",
+      },
+    ],
   },
 ] as const;
 
@@ -163,47 +263,6 @@ export const showcaseCards = [
 ] as const;
 
 export const githubUrl = "https://github.com/lemma-work/lemma-platform";
-
-export const machineStations = [
-  {
-    key: "inbound",
-    label: "INBOUND",
-    sub: "ST/01",
-    caption: "Email from Northwind hits the pod inbox.",
-  },
-  {
-    key: "agent",
-    label: "AGENT:QUILL",
-    sub: "ST/02",
-    caption: "Quill parses intent and drafts the lead record.",
-  },
-  {
-    key: "table",
-    label: "TABLE:LEADS",
-    sub: "ST/03",
-    caption: "Row written, row-level security applied.",
-  },
-  {
-    key: "approval",
-    label: "HUMAN:APPROVAL",
-    sub: "ST/04",
-    caption: "The gate pauses the work for a person.",
-  },
-  {
-    key: "routed",
-    label: "ROUTED",
-    sub: "ST/05",
-    caption: "Owner assigned. State updated for everyone.",
-  },
-] as const;
-
-export const heroTickerEvents = [
-  "lead northwind.com hit the inbox",
-  "quill scored it 87 · qualified",
-  "row written to leads · rls applied",
-  "approval sent to #sales on slack",
-  "dana approved · routed to enterprise",
-] as const;
 
 export const terminalScript = [
   { command: "uv tool install lemma-terminal", output: [] },

--- a/lemma-frontend/components/landing/landing-page.tsx
+++ b/lemma-frontend/components/landing/landing-page.tsx
@@ -2,9 +2,10 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { GithubLogo, Minus, Plus } from "@/components/ui/icons";
+import { ArrowRight, GithubLogo } from "@/components/ui/icons";
 import { useEffect, useRef, useState } from "react";
 import { Logo } from "@/components/brand/logo";
+import { ProductIcon } from "@/components/pod/product-icon";
 import type { SurfaceMode } from "./landing-data";
 import {
   githubUrl,
@@ -13,11 +14,10 @@ import {
   surfaceModes,
 } from "./landing-data";
 import {
-  HeroTicker,
-  MachineAtWork,
-  PodBlockGlyph,
   TypingTerminal,
+  WorkSurfaceStrip,
 } from "./landing-animations";
+import { HeroPodDemo } from "./hero-pod-demo";
 import { StackComparison, SurfacePreview } from "./landing-surfaces";
 
 export default function LandingPage() {
@@ -27,7 +27,7 @@ export default function LandingPage() {
     () => new Set(),
   );
   const [stackCompare, setStackCompare] = useState(50);
-  const [openPodBlock, setOpenPodBlock] = useState<string>("data");
+  const [openPodBlock, setOpenPodBlock] = useState<string>("apps");
   const podIframeRef = useRef<HTMLIFrameElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
 
@@ -53,8 +53,9 @@ export default function LandingPage() {
 
   const openPodSection = (key: string) => {
     setOpenPodBlock(key);
+    const visualKey = key === "connectors" ? "integrations" : key;
     podIframeRef.current?.contentWindow?.postMessage(
-      { type: "pod-drill", section: key },
+      { type: "pod-drill", section: visualKey },
       "*",
     );
   };
@@ -66,7 +67,7 @@ export default function LandingPage() {
   return (
     <div className="lp-react" ref={rootRef}>
       <header className="lp-header" aria-label="Site header">
-        <Link className="lp-brand" href="/">
+        <Link className="lp-brand" href="/" aria-label="Lemma home">
           <Logo
             className="lp-brand-logo"
             size="sm"
@@ -74,11 +75,11 @@ export default function LandingPage() {
           />
         </Link>
         <nav className="lp-nav" aria-label="Primary navigation">
-          <a href="#inside">Product</a>
+          <a href="#inside">How it works</a>
+          <a href="#showcase">Examples</a>
           <a href="/docs" target="_blank" rel="noreferrer">
             Docs
           </a>
-          <a href="#showcase">Showcase</a>
           <a
             className="lp-gh-link"
             href={githubUrl}
@@ -90,16 +91,9 @@ export default function LandingPage() {
           </a>
         </nav>
         <div className="lp-header-actions">
-          <Link href="/auth">Log in</Link>
-          <a
-            className="lp-button primary"
-            href={githubUrl}
-            target="_blank"
-            rel="noreferrer"
-          >
-            <GithubLogo aria-hidden className="lp-gh-icon" />
-            Star on GitHub
-          </a>
+          <Link className="lp-button primary" href="/auth">
+            Get started
+          </Link>
         </div>
       </header>
 
@@ -111,18 +105,17 @@ export default function LandingPage() {
                 <GithubLogo aria-hidden className="lp-gh-icon" />
                 Open source
               </span>
-              AI-native workspace
+              Purpose-built AI apps
             </p>
             <h1 className="lp-hero-headline" id="hero-title">
-              <span className="lp-hl-line">How humans and AI do</span>
+              The software you need
               <span className="lp-hl-line">
-                <span className="lp-hl-accent">real work</span>, together.
+                <span className="lp-hl-accent">doesn&apos;t exist yet.</span>
               </span>
             </h1>
             <p className="lp-subhead">
-              Teammates work from apps, Slack, WhatsApp, and email. Agents work
-              from the CLI. Lemma holds the shared state that keeps it all
-              moving.
+              Lemma gives any job its own AI app. Add your teammates, and let
+              agents keep the work moving in the background.
             </p>
 
             <div className="lp-actions">
@@ -140,16 +133,13 @@ export default function LandingPage() {
               </a>
             </div>
 
-            <HeroTicker />
+            <WorkSurfaceStrip />
           </div>
 
           <section className="lp-hero-theater" aria-label="Inside a Lemma pod">
             <div className="lp-theater-stage">
               <div className="lp-product-frame">
-                <iframe
-                  title="Inside a Lemma pod"
-                  src="/landing-page/pod-workspace.html?embed=1&section=agents"
-                />
+                <HeroPodDemo />
               </div>
             </div>
           </section>
@@ -159,50 +149,45 @@ export default function LandingPage() {
           <div className="lp-section-inner lp-reveal">
             <p className="lp-section-kicker">Inside a pod</p>
             <h2 className="lp-section-title">
-              A pod is where AI and humans <span>work together.</span>
+              Everything the work needs, <span>in one place.</span>
             </h2>
             <p className="lp-section-subhead">
-              Tables, agents, workflows, and approval gates - six building
-              blocks, one coherent system.
+              A pod holds the app people use and the agents, workflows, data,
+              docs, and connections behind it.
             </p>
 
             <div className="lp-pod-explorer">
-              <div className="lp-pod-acc" aria-label="Pod building blocks">
+              <nav className="lp-pod-resource-nav" aria-label="Pod resources">
                 {podBlocks.map((block) => {
                   const isOpen = openPodBlock === block.key;
                   return (
-                    <div
-                      className={`lp-pod-acc-item${isOpen ? " is-open" : ""}`}
+                    <button
+                      type="button"
+                      className={isOpen ? "is-active" : ""}
+                      aria-pressed={isOpen}
+                      onClick={() => openPodSection(block.key)}
                       key={block.key}
                     >
-                      <button
-                        type="button"
-                        className="lp-pod-acc-head"
-                        aria-expanded={isOpen}
-                        onClick={() => openPodSection(block.key)}
-                      >
-                        <span className="lp-pod-acc-glyph" aria-hidden="true">
-                          <PodBlockGlyph kind={block.key} />
-                        </span>
-                        <span className="lp-pod-acc-titles">
-                          <strong>{block.title}</strong>
-                          <span>{block.summary}</span>
-                        </span>
-                        <span className="lp-pod-acc-toggle" aria-hidden="true">
-                          {isOpen ? <Minus aria-hidden="true" /> : <Plus aria-hidden="true" />}
-                        </span>
-                      </button>
-                      <div className="lp-pod-acc-detail">
-                        <div>
-                          <p>{block.detail}</p>
-                        </div>
-                      </div>
-                    </div>
+                      <ProductIcon
+                        kind={block.iconKind}
+                        size="md"
+                        state={isOpen ? "selected" : "default"}
+                      />
+                      <span>
+                        <strong>{block.title}</strong>
+                        <small>{block.summary}</small>
+                      </span>
+                      <em>{block.count}</em>
+                      <ArrowRight aria-hidden="true" />
+                    </button>
                   );
                 })}
-              </div>
+              </nav>
 
-              <aside className="lp-pod-visual" aria-label="Inside a pod interactive component">
+              <aside
+                className="lp-pod-visual"
+                aria-label="Inside a pod interactive component"
+              >
                 <iframe
                   ref={podIframeRef}
                   title="Inside a pod"
@@ -336,8 +321,6 @@ export default function LandingPage() {
             <StackComparison value={stackCompare} onChange={setStackCompare} />
           </div>
         </section>
-
-        <MachineAtWork />
 
         <section className="lp-section lp-quickstart-section" id="quickstart">
           <div className="lp-section-inner lp-quickstart-grid lp-reveal">

--- a/lemma-frontend/styles/features/landing-page.css
+++ b/lemma-frontend/styles/features/landing-page.css
@@ -7,8 +7,8 @@
     min-height: 100vh;
     min-height: 100dvh;
     background: #ffffff;
-    color: #0d0f12;
-    font-family: var(--font-display-family);
+    color: #17181a;
+    font-family: var(--font-landing-sans), "Inter", system-ui, sans-serif;
   }
 
   .lp-react * {
@@ -16,14 +16,28 @@
   }
 
   .lp-header {
+    position: fixed;
+    z-index: 20;
+    top: 18px;
+    left: 50%;
     display: grid;
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
     align-items: center;
-    gap: 24px;
-    max-width: 1440px;
-    margin: 0 auto;
-    padding: 22px clamp(24px, 4vw, 56px);
-    background: #ffffff;
+    width: min(calc(100% - 36px), 1180px);
+    gap: 10px;
+    margin: 0;
+    padding: 8px 9px 8px 12px;
+    border: 1px solid rgba(13, 15, 18, 0.1);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.82);
+    box-shadow: 0 12px 40px rgba(13, 15, 18, 0.07);
+    backdrop-filter: blur(18px);
+    transform: translateX(-50%);
+    animation: lpHeaderEnter 0.6s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+  }
+
+  .lp-header::after {
+    display: none;
   }
 
   .lp-brand,
@@ -36,35 +50,62 @@
   }
 
   .lp-brand {
-    gap: 10px;
+    justify-self: start;
+    justify-content: center;
+    width: auto;
+    height: 38px;
+    padding: 0 8px;
+    border-radius: 9px;
     color: #0d0f12;
     text-decoration: none;
+    transition: background 0.16s ease;
   }
 
-  .lp-brand-logo .lemma-logo-wordmark {
-    color: #0d0f12 !important;
-    font-size: 1.05rem;
-    font-weight: 650 !important;
+  .lp-brand:hover {
+    background: rgba(13, 15, 18, 0.05);
+  }
+
+  .lp-brand-logo {
+    --text-primary: #17181a;
   }
 
   .lp-brand-logo .lemma-mark-bar {
     background: #0d0f12 !important;
   }
 
-  .lp-nav,
+  .lp-nav {
+    gap: 2px;
+    padding: 0;
+  }
+
   .lp-header-actions {
-    gap: 24px;
+    gap: 7px;
   }
 
   .lp-nav a,
   .lp-header-actions a {
-    color: #1f2227;
-    font-size: 0.92rem;
+    color: #35383d;
+    font-size: 0.8rem;
+    font-weight: 400;
     text-decoration: none;
-    transition: color 0.16s ease, opacity 0.16s ease;
+    transition:
+      color 0.16s ease,
+      background 0.16s ease,
+      opacity 0.16s ease;
+  }
+
+  .lp-nav a {
+    padding: 7px 10px;
+    border-radius: 7px;
   }
 
   .lp-nav a:hover,
+  .lp-nav a:focus-visible {
+    background: rgba(255, 255, 255, 0.9);
+    color: #0d0f12;
+    outline: none;
+  }
+
   .lp-header-actions a:not(.lp-button):hover {
     color: #0d0f12;
     opacity: 0.72;
@@ -72,6 +113,17 @@
 
   .lp-header-actions {
     justify-content: end;
+  }
+
+  .lp-header-actions > a:not(.lp-button) {
+    padding: 8px 7px;
+  }
+
+  .lp-header .lp-button {
+    min-height: 34px;
+    padding: 0 14px;
+    border-radius: 8px;
+    font-size: 0.8rem;
   }
 
   .lp-gh-icon {
@@ -92,13 +144,13 @@
 
   .lp-button {
     justify-content: center;
-    min-height: 42px;
-    padding: 0 20px;
+    min-height: 38px;
+    padding: 0 17px;
     border: 1px solid rgba(13, 15, 18, 0.2);
-    border-radius: 10px;
+    border-radius: 8px;
     color: #0d0f12;
-    font-size: 0.94rem;
-    font-weight: 650;
+    font-size: 0.875rem;
+    font-weight: 500;
     text-decoration: none;
     transition:
       background 0.18s ease,
@@ -137,12 +189,84 @@
     box-shadow: 0 8px 22px rgba(13, 15, 18, 0.08);
   }
 
+  .lp-header .lp-button.primary {
+    border-color: transparent;
+    background: transparent;
+    color: #202226;
+    box-shadow: none;
+  }
+
+  .lp-header .lp-button.primary:hover,
+  .lp-header .lp-button.primary:focus,
+  .lp-header .lp-button.primary:focus-visible {
+    border-color: #0d0f12;
+    background: #0d0f12;
+    color: #ffffff;
+    box-shadow: none;
+    outline: none;
+  }
+
   .lp-hero {
     position: relative;
-    padding: clamp(52px, 7vw, 102px) clamp(18px, 4vw, 56px) 64px;
+    padding: clamp(146px, 12vw, 170px) clamp(18px, 4vw, 56px) 48px;
     background:
-      radial-gradient(940px 480px at 18% -4%, rgba(217, 154, 50, 0.16), transparent 62%),
-      radial-gradient(760px 420px at 86% -8%, rgba(111, 169, 187, 0.1), transparent 64%);
+      linear-gradient(rgba(83, 70, 49, 0.025) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(83, 70, 49, 0.025) 1px, transparent 1px),
+      radial-gradient(940px 480px at 18% -4%, rgba(217, 154, 50, 0.11), transparent 62%),
+      radial-gradient(760px 420px at 86% -8%, rgba(111, 169, 187, 0.06), transparent 64%),
+      #fbfaf7;
+    background-size:
+      40px 40px,
+      40px 40px,
+      auto,
+      auto,
+      auto;
+  }
+
+  .lp-hero::before {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+      radial-gradient(480px 220px at 44% 14%, rgba(255, 255, 255, 0.78), transparent 70%),
+      radial-gradient(360px 220px at 67% 32%, rgba(217, 154, 50, 0.08), transparent 72%);
+    background-position:
+      38% 0,
+      64% 0;
+    background-repeat: no-repeat;
+    content: "";
+    animation: lpHeroAmbient 16s ease-in-out infinite alternate;
+  }
+
+  .lp-hero > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  @keyframes lpHeaderEnter {
+    from {
+      opacity: 0;
+      transform: translate(-50%, -10px);
+    }
+
+    to {
+      opacity: 1;
+      transform: translate(-50%, 0);
+    }
+  }
+
+  @keyframes lpHeroAmbient {
+    from {
+      background-position:
+        38% 0,
+        64% 0;
+    }
+
+    to {
+      background-position:
+        48% 6%,
+        58% 8%;
+    }
   }
 
   .lp-corner {
@@ -167,34 +291,34 @@
     width: 100%;
     flex-direction: column;
     align-items: center;
-    max-width: 1320px;
-    margin: 0 auto clamp(22px, 3vw, 38px);
+    max-width: 980px;
+    margin: 0 auto clamp(22px, 2.5vw, 30px);
     text-align: center;
   }
 
   .lp-eyebrow {
     display: flex;
     align-items: center;
-    gap: 12px;
-    margin: 0 0 18px;
-    color: #565a60;
-    font-size: 0.9rem;
-    font-weight: 750;
-    letter-spacing: 0.02em;
+    gap: 10px;
+    margin: 0 0 20px;
+    color: #62666c;
+    font-size: 0.78rem;
+    font-weight: 500;
+    letter-spacing: 0.01em;
   }
 
   .lp-eyebrow-badge {
     display: inline-flex;
     align-items: center;
     gap: 7px;
-    padding: 5px 12px;
+    padding: 4px 10px;
     border: 1px solid rgba(47, 105, 61, 0.26);
     border-radius: 999px;
     background: rgba(47, 105, 61, 0.07);
     color: #2f693d;
-    font-size: 0.8rem;
-    font-weight: 750;
-    letter-spacing: 0.04em;
+    font-size: 0.7rem;
+    font-weight: 500;
+    letter-spacing: 0.06em;
     text-transform: uppercase;
   }
 
@@ -219,14 +343,14 @@
   .lp-footer-box h2 {
     margin: 0;
     color: #151619;
-    font-weight: 520;
-    letter-spacing: 0;
   }
 
   .lp-hero h1 {
-    font-size: clamp(2.7rem, 5vw, 4.7rem);
-    line-height: 1.02;
-    letter-spacing: -0.015em;
+    font-family: var(--font-landing-serif), Georgia, serif;
+    font-size: clamp(2.85rem, 4.5vw, 4.35rem);
+    font-weight: 300;
+    line-height: 0.99;
+    letter-spacing: -0.035em;
   }
 
   .lp-hero h1 span {
@@ -243,7 +367,8 @@
 
   .lp-hero h1.lp-hero-headline .lp-hl-accent {
     display: inline;
-    color: #c0801f;
+    color: #ae671f;
+    font-style: italic;
   }
 
   .lp-compiled-headline {
@@ -346,11 +471,12 @@
   }
 
   .lp-subhead {
-    max-width: 660px;
-    margin: 24px auto 0;
-    color: #3f4248;
-    font-size: clamp(1.02rem, 1.28vw, 1.18rem);
-    line-height: 1.45;
+    max-width: 560px;
+    margin: 20px auto 0;
+    color: #51555a;
+    font-size: 1rem;
+    font-weight: 400;
+    line-height: 1.52;
   }
 
 
@@ -393,8 +519,8 @@
   .lp-actions {
     flex-wrap: wrap;
     justify-content: center;
-    gap: 10px;
-    margin-top: 28px;
+    gap: 8px;
+    margin-top: 24px;
   }
 
   .lp-hero-theater {
@@ -475,6 +601,16 @@
     border: 1px solid rgba(13, 15, 18, 0.12);
     background: #ffffff;
     box-shadow: 0 30px 80px rgba(13, 15, 18, 0.18);
+    transition:
+      border-color 0.3s ease,
+      box-shadow 0.3s ease,
+      transform 0.3s ease;
+  }
+
+  .lp-product-frame:hover {
+    border-color: rgba(13, 15, 18, 0.18);
+    box-shadow: 0 38px 96px rgba(13, 15, 18, 0.2);
+    transform: translateY(-3px);
   }
 
   .lp-product-frame iframe,
@@ -486,8 +622,2838 @@
     border: 0;
   }
 
+  /* ===== Current pod shell hero demo ===== */
+
+  .lp-demo-shell {
+    display: grid;
+    grid-template-columns: 208px minmax(0, 1fr);
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    background: #f1f0ed;
+    color: #1d1e20;
+    font-size: 13px;
+    text-align: left;
+  }
+
+  .lp-demo-shell button {
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+  }
+
+  .lp-demo-shell svg {
+    flex: none;
+    width: 15px;
+    height: 15px;
+  }
+
+  .lp-demo-sidebar {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    overflow: hidden;
+    padding: 12px 10px 10px;
+    border-right: 1px solid rgba(22, 24, 27, 0.07);
+    background: #efeeeb;
+  }
+
+  .lp-demo-pod-switcher {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    gap: 8px;
+    margin: 0 0 12px;
+    padding: 5px 6px;
+    border: 0;
+    border-radius: 7px;
+    background: transparent;
+    text-align: left;
+    transition: background 0.16s ease;
+  }
+
+  .lp-demo-pod-switcher:hover {
+    background: rgba(255, 255, 255, 0.66);
+  }
+
+  .lp-demo-pod-switcher > span {
+    display: grid;
+    width: 29px;
+    height: 29px;
+    flex: none;
+    place-items: center;
+    border-radius: 7px;
+    background:
+      linear-gradient(145deg, rgba(255, 255, 255, 0.48), transparent),
+      #dda54c;
+    color: #4d350c;
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+  }
+
+  .lp-demo-pod-switcher strong {
+    min-width: 0;
+    flex: 1;
+    color: #222326;
+    font-size: 0.78rem;
+    font-weight: 570;
+    line-height: 1.2;
+  }
+
+  .lp-demo-pod-switcher strong small {
+    display: block;
+    margin-top: 2px;
+    color: #8b8c8e;
+    font-size: 0.63rem;
+    font-weight: 420;
+  }
+
+  .lp-demo-pod-switcher > svg {
+    width: 12px;
+    height: 12px;
+    color: #929395;
+  }
+
+  .lp-demo-sidebar-actions {
+    display: grid;
+    gap: 2px;
+  }
+
+  .lp-demo-sidebar-actions button,
+  .lp-demo-nav button,
+  .lp-demo-sidebar-foot button {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    min-width: 0;
+    min-height: 31px;
+    gap: 9px;
+    padding: 0 8px;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: #616368;
+    text-align: left;
+    transition:
+      background 0.16s ease,
+      color 0.16s ease;
+  }
+
+  .lp-demo-sidebar-actions button:hover,
+  .lp-demo-nav button:hover,
+  .lp-demo-sidebar-foot button:hover {
+    background: rgba(255, 255, 255, 0.7);
+    color: #202225;
+  }
+
+  .lp-demo-sidebar-actions button.is-active,
+  .lp-demo-nav button.is-active {
+    background: rgba(255, 255, 255, 0.9);
+    color: #202225;
+    box-shadow: inset 0 0 0 1px rgba(22, 24, 27, 0.05);
+  }
+
+  .lp-demo-sidebar-actions svg,
+  .lp-demo-nav svg,
+  .lp-demo-sidebar-foot svg {
+    color: #818388;
+  }
+
+  .lp-demo-nav-label {
+    margin: 18px 8px 6px;
+    color: #9a9b9e;
+    font-size: 0.6rem;
+    font-weight: 590;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .lp-demo-nav {
+    display: grid;
+    gap: 2px;
+  }
+
+  .lp-demo-nav button span,
+  .lp-demo-sidebar-foot button span {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .lp-demo-nav button small {
+    color: #a0a1a4;
+    font-size: 0.64rem;
+  }
+
+  .lp-demo-sidebar-foot {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: auto;
+    padding-top: 10px;
+    border-top: 1px solid rgba(22, 24, 27, 0.06);
+  }
+
+  .lp-demo-sidebar-foot button {
+    flex: 1;
+  }
+
+  .lp-demo-person {
+    display: grid;
+    width: 27px;
+    height: 27px;
+    flex: none;
+    place-items: center;
+    border-radius: 50%;
+    background: #d9d4ca;
+    color: #57544f;
+    font-size: 0.66rem;
+    font-weight: 650;
+  }
+
+  .lp-demo-workspace {
+    display: flex;
+    min-width: 0;
+    min-height: 0;
+    flex-direction: column;
+    background: #ffffff;
+  }
+
+  .lp-demo-tabbar {
+    display: flex;
+    height: 46px;
+    flex: none;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 0 12px 0 8px;
+    border-bottom: 1px solid #ececea;
+    background: rgba(255, 255, 255, 0.96);
+  }
+
+  .lp-demo-tabs {
+    display: flex;
+    min-width: 0;
+    align-items: stretch;
+    align-self: stretch;
+  }
+
+  .lp-demo-tabs button {
+    position: relative;
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 7px;
+    padding: 0 12px;
+    border: 0;
+    background: transparent;
+    color: #7d7f83;
+    font-size: 0.72rem;
+    white-space: nowrap;
+  }
+
+  .lp-demo-tabs button:hover {
+    color: #222326;
+  }
+
+  .lp-demo-tabs button.is-active {
+    color: #202124;
+  }
+
+  .lp-demo-tabs button.is-active::after {
+    position: absolute;
+    right: 9px;
+    bottom: 0;
+    left: 9px;
+    height: 2px;
+    border-radius: 2px 2px 0 0;
+    background: #27282a;
+    content: "";
+  }
+
+  .lp-demo-tabs .lp-demo-new-tab {
+    width: 33px;
+    padding: 0;
+    justify-content: center;
+  }
+
+  .lp-demo-tabs .lp-demo-new-tab svg {
+    width: 13px;
+    height: 13px;
+  }
+
+  .lp-demo-running,
+  .lp-demo-run-badge,
+  .lp-demo-sync {
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+    gap: 6px;
+    color: #5d6d62;
+    font-size: 0.65rem;
+    white-space: nowrap;
+  }
+
+  .lp-demo-running i,
+  .lp-demo-run-badge i,
+  .lp-demo-sync i,
+  .lp-demo-live-label i {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #58a36a;
+    box-shadow: 0 0 0 3px rgba(88, 163, 106, 0.1);
+  }
+
+  .lp-demo-main {
+    min-width: 0;
+    min-height: 0;
+    flex: 1;
+    overflow: hidden;
+    background:
+      radial-gradient(560px 260px at 92% 0%, rgba(217, 154, 50, 0.035), transparent 68%),
+      #ffffff;
+    animation: lpDemoViewIn 0.32s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+  }
+
+  .lp-demo-page {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    flex-direction: column;
+    padding: clamp(23px, 3vw, 38px);
+  }
+
+  .lp-demo-page-head {
+    display: flex;
+    flex: none;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+    padding-bottom: clamp(20px, 2.5vw, 30px);
+  }
+
+  .lp-demo-overline {
+    margin: 0 0 8px;
+    color: #8e8f92;
+    font-family: var(--font-mono-family);
+    font-size: 0.6rem;
+    font-weight: 560;
+    letter-spacing: 0.09em;
+  }
+
+  .lp-demo-page-head h3,
+  .lp-demo-home h3 {
+    margin: 0;
+    color: #242529;
+    font-size: clamp(1.18rem, 2vw, 1.65rem);
+    font-weight: 530;
+    letter-spacing: -0.025em;
+    line-height: 1.12;
+  }
+
+  .lp-demo-page-head p {
+    max-width: 510px;
+    margin: 7px 0 0;
+    color: #77797e;
+    font-size: 0.74rem;
+    line-height: 1.45;
+  }
+
+  .lp-demo-primary-action {
+    display: inline-flex;
+    min-height: 32px;
+    flex: none;
+    align-items: center;
+    justify-content: center;
+    gap: 7px;
+    padding: 0 11px;
+    border: 1px solid #252629;
+    border-radius: 6px;
+    background: #252629;
+    color: #ffffff !important;
+    font-size: 0.68rem !important;
+    font-weight: 520 !important;
+    transition:
+      background 0.16s ease,
+      transform 0.16s ease;
+  }
+
+  .lp-demo-primary-action:hover {
+    background: #3d3f43;
+    transform: translateY(-1px);
+  }
+
+  .lp-demo-primary-action svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  .lp-demo-app-grid {
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template-columns: minmax(0, 1.4fr) minmax(220px, 0.8fr);
+    gap: clamp(14px, 2vw, 24px);
+  }
+
+  .lp-demo-decision-list {
+    display: grid;
+    align-content: start;
+    gap: 7px;
+  }
+
+  .lp-demo-decision {
+    display: grid;
+    grid-template-columns: 8px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 11px;
+    width: 100%;
+    padding: 13px 14px;
+    border: 1px solid #ebeae7;
+    border-radius: 9px;
+    background: rgba(255, 255, 255, 0.78);
+    text-align: left;
+    transition:
+      border-color 0.18s ease,
+      background 0.18s ease,
+      box-shadow 0.18s ease,
+      transform 0.18s ease;
+  }
+
+  .lp-demo-decision:hover {
+    border-color: #d8d5cf;
+    transform: translateX(2px);
+  }
+
+  .lp-demo-decision.is-selected {
+    border-color: #d3cec5;
+    background: #fbfaf7;
+    box-shadow: 0 7px 22px rgba(24, 26, 29, 0.055);
+  }
+
+  .lp-demo-status-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #a1a3a6;
+  }
+
+  .lp-demo-status-dot.is-amber {
+    background: #d69a3d;
+    box-shadow: 0 0 0 4px rgba(214, 154, 61, 0.11);
+  }
+
+  .lp-demo-status-dot.is-violet {
+    background: #8978b7;
+    box-shadow: 0 0 0 4px rgba(137, 120, 183, 0.1);
+  }
+
+  .lp-demo-status-dot.is-green {
+    background: #62a172;
+    box-shadow: 0 0 0 4px rgba(98, 161, 114, 0.1);
+  }
+
+  .lp-demo-decision-copy {
+    min-width: 0;
+  }
+
+  .lp-demo-decision-copy small,
+  .lp-demo-decision-copy strong,
+  .lp-demo-decision-copy > span {
+    display: block;
+  }
+
+  .lp-demo-decision-copy small,
+  .lp-demo-decision-detail > small,
+  .lp-demo-approval small {
+    color: #999a9d;
+    font-size: 0.54rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+  }
+
+  .lp-demo-decision-copy strong {
+    overflow: hidden;
+    margin-top: 4px;
+    color: #343539;
+    font-size: 0.73rem;
+    font-weight: 550;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-demo-decision-copy > span {
+    overflow: hidden;
+    margin-top: 3px;
+    color: #85868a;
+    font-size: 0.62rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-demo-decision > em {
+    padding: 4px 6px;
+    border-radius: 999px;
+    background: #f2f1ee;
+    color: #75767a;
+    font-size: 0.56rem;
+    font-style: normal;
+    white-space: nowrap;
+  }
+
+  .lp-demo-decision-detail {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: clamp(18px, 2.4vw, 28px);
+    border: 1px solid #e7e4de;
+    border-radius: 12px;
+    background:
+      radial-gradient(200px 160px at 100% 0%, rgba(218, 171, 94, 0.1), transparent 70%),
+      #f8f7f4;
+    animation: lpDemoDetailIn 0.28s ease both;
+  }
+
+  .lp-demo-detail-orb,
+  .lp-demo-agent-mark,
+  .lp-demo-activity-icon {
+    display: grid;
+    place-items: center;
+    border-radius: 8px;
+  }
+
+  .lp-demo-detail-orb {
+    width: 34px;
+    height: 34px;
+    margin-bottom: 22px;
+    color: #7c5a23;
+  }
+
+  .lp-demo-detail-orb.is-amber,
+  .lp-demo-agent-mark.is-amber,
+  .lp-demo-activity-icon.is-amber {
+    background: #f6ead5;
+    color: #a06b19;
+  }
+
+  .lp-demo-detail-orb.is-violet,
+  .lp-demo-agent-mark.is-violet,
+  .lp-demo-activity-icon.is-violet {
+    background: #ece8f6;
+    color: #7767a5;
+  }
+
+  .lp-demo-detail-orb.is-green,
+  .lp-demo-agent-mark.is-green,
+  .lp-demo-activity-icon.is-green {
+    background: #e7f1e9;
+    color: #4c8159;
+  }
+
+  .lp-demo-agent-mark.is-blue,
+  .lp-demo-activity-icon.is-blue {
+    background: #e4f0f3;
+    color: #477a86;
+  }
+
+  .lp-demo-decision-detail h4 {
+    margin: 7px 0 0;
+    color: #2c2d30;
+    font-size: 0.96rem;
+    font-weight: 540;
+    line-height: 1.28;
+  }
+
+  .lp-demo-decision-detail p {
+    margin: 8px 0 0;
+    color: #77797d;
+    font-size: 0.66rem;
+    line-height: 1.5;
+  }
+
+  .lp-demo-decision-detail dl {
+    display: grid;
+    width: 100%;
+    grid-template-columns: 1fr 1fr;
+    gap: 10px;
+    margin: auto 0 16px;
+    padding-top: 18px;
+  }
+
+  .lp-demo-decision-detail dl div {
+    padding-top: 9px;
+    border-top: 1px solid #dfdcd6;
+  }
+
+  .lp-demo-decision-detail dt {
+    color: #96979a;
+    font-size: 0.55rem;
+  }
+
+  .lp-demo-decision-detail dd {
+    margin: 4px 0 0;
+    color: #505155;
+    font-size: 0.62rem;
+    font-weight: 520;
+  }
+
+  .lp-demo-decision-detail > button {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: #303235;
+    font-size: 0.64rem;
+    font-weight: 560;
+  }
+
+  .lp-demo-decision-detail > button svg {
+    width: 12px;
+    height: 12px;
+    transition: transform 0.16s ease;
+  }
+
+  .lp-demo-decision-detail > button:hover svg {
+    transform: translateX(2px);
+  }
+
+  .lp-demo-agent-list {
+    display: grid;
+    min-height: 0;
+    align-content: start;
+    overflow: hidden;
+    border: 1px solid #e9e8e5;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.76);
+  }
+
+  .lp-demo-agent {
+    display: grid;
+    grid-template-columns: 34px minmax(0, 1fr) minmax(130px, auto) 16px;
+    align-items: center;
+    gap: 13px;
+    min-width: 0;
+    padding: 13px 15px;
+    border: 0;
+    border-bottom: 1px solid #efeeec;
+    background: transparent;
+    text-align: left;
+    transition: background 0.16s ease;
+  }
+
+  .lp-demo-agent:last-child {
+    border-bottom: 0;
+  }
+
+  .lp-demo-agent:hover {
+    background: #faf9f6;
+  }
+
+  .lp-demo-agent-mark {
+    width: 31px;
+    height: 31px;
+  }
+
+  .lp-demo-agent-mark svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  .lp-demo-agent-copy,
+  .lp-demo-agent-meta {
+    min-width: 0;
+  }
+
+  .lp-demo-agent-copy strong,
+  .lp-demo-agent-copy span,
+  .lp-demo-agent-meta em,
+  .lp-demo-agent-meta small {
+    display: block;
+  }
+
+  .lp-demo-agent-copy strong {
+    color: #35363a;
+    font-size: 0.73rem;
+    font-weight: 560;
+  }
+
+  .lp-demo-agent-copy span,
+  .lp-demo-agent-meta small {
+    overflow: hidden;
+    margin-top: 3px;
+    color: #898a8e;
+    font-size: 0.61rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-demo-agent-meta {
+    text-align: right;
+  }
+
+  .lp-demo-agent-meta em {
+    color: #626469;
+    font-size: 0.61rem;
+    font-style: normal;
+    font-weight: 520;
+  }
+
+  .lp-demo-agent-meta em i {
+    display: inline-block;
+    width: 5px;
+    height: 5px;
+    margin-right: 6px;
+    border-radius: 50%;
+    background: #9c9da0;
+    vertical-align: 1px;
+  }
+
+  .lp-demo-agent-meta em.is-running i {
+    background: #d59a3e;
+    box-shadow: 0 0 0 3px rgba(213, 154, 62, 0.1);
+  }
+
+  .lp-demo-row-arrow {
+    color: #b3b4b6;
+    opacity: 0;
+    transform: translateX(-3px);
+    transition:
+      opacity 0.16s ease,
+      transform 0.16s ease;
+  }
+
+  .lp-demo-agent:hover .lp-demo-row-arrow {
+    opacity: 1;
+    transform: none;
+  }
+
+  .lp-demo-run-badge {
+    padding: 6px 9px;
+    border: 1px solid rgba(88, 163, 106, 0.18);
+    border-radius: 999px;
+    background: rgba(88, 163, 106, 0.06);
+  }
+
+  .lp-demo-flow {
+    position: relative;
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    align-items: start;
+    gap: 8px;
+    padding: clamp(30px, 5vw, 62px) 2px 0;
+  }
+
+  .lp-demo-flow-line {
+    position: absolute;
+    top: clamp(42px, calc(5vw + 12px), 74px);
+    right: 8%;
+    left: 8%;
+    height: 2px;
+    overflow: hidden;
+    background: #e7e5e0;
+  }
+
+  .lp-demo-flow-line i {
+    display: block;
+    width: 60%;
+    height: 100%;
+    background: #738f78;
+    transform-origin: left;
+  }
+
+  .lp-demo-flow-step {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .lp-demo-flow-node {
+    display: grid;
+    width: 27px;
+    height: 27px;
+    place-items: center;
+    border: 2px solid #e5e3de;
+    border-radius: 50%;
+    background: #ffffff;
+    color: #aaa9a6;
+  }
+
+  .lp-demo-flow-node svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  .lp-demo-flow-step.is-complete .lp-demo-flow-node {
+    border-color: #75937c;
+    background: #75937c;
+    color: #ffffff;
+  }
+
+  .lp-demo-flow-step.is-current .lp-demo-flow-node {
+    border-color: #8b7bb7;
+    color: #7464a0;
+    box-shadow: 0 0 0 6px rgba(139, 123, 183, 0.1);
+  }
+
+  .lp-demo-flow-step > small {
+    margin-top: 12px;
+    color: #aaa9a7;
+    font-family: var(--font-mono-family);
+    font-size: 0.52rem;
+  }
+
+  .lp-demo-flow-step > strong {
+    max-width: 110px;
+    margin-top: 5px;
+    color: #3c3d40;
+    font-size: 0.67rem;
+    font-weight: 550;
+    line-height: 1.3;
+  }
+
+  .lp-demo-flow-step > em {
+    max-width: 110px;
+    margin-top: 4px;
+    color: #96979a;
+    font-size: 0.56rem;
+    font-style: normal;
+    line-height: 1.3;
+  }
+
+  .lp-demo-approval {
+    display: flex;
+    flex: none;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 14px;
+    border: 1px solid #ded9e9;
+    border-radius: 9px;
+    background: #faf8fd;
+  }
+
+  .lp-demo-approval > span:nth-child(2) {
+    min-width: 0;
+    flex: 1;
+  }
+
+  .lp-demo-approval strong {
+    display: block;
+    margin-top: 3px;
+    color: #3a3741;
+    font-size: 0.7rem;
+    font-weight: 550;
+  }
+
+  .lp-demo-approval > button {
+    min-height: 28px;
+    padding: 0 10px;
+    border: 1px solid #c8c0d8;
+    border-radius: 6px;
+    background: #ffffff;
+    color: #5e527b;
+    font-size: 0.62rem;
+    font-weight: 540;
+  }
+
+  .lp-demo-sync {
+    color: #54705c;
+  }
+
+  .lp-demo-table-shell {
+    min-height: 0;
+    overflow: hidden;
+    border: 1px solid #e7e6e3;
+    border-radius: 10px;
+    background: #ffffff;
+  }
+
+  .lp-demo-table-tools {
+    display: flex;
+    min-height: 37px;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 13px;
+    border-bottom: 1px solid #ecebe8;
+    color: #797b80;
+    font-size: 0.61rem;
+  }
+
+  .lp-demo-table-tools span:first-child {
+    color: #424347;
+    font-weight: 540;
+  }
+
+  .lp-demo-table-shell table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.63rem;
+  }
+
+  .lp-demo-table-shell th,
+  .lp-demo-table-shell td {
+    height: 39px;
+    padding: 0 13px;
+    border-bottom: 1px solid #efeeec;
+    color: #65676b;
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  .lp-demo-table-shell th {
+    height: 32px;
+    background: #faf9f7;
+    color: #9a9b9e;
+    font-size: 0.55rem;
+    font-weight: 520;
+    letter-spacing: 0.03em;
+  }
+
+  .lp-demo-table-shell tbody tr:last-child td {
+    border-bottom: 0;
+  }
+
+  .lp-demo-table-shell tbody tr {
+    transition: background 0.16s ease;
+  }
+
+  .lp-demo-table-shell tbody tr:hover,
+  .lp-demo-table-shell tbody tr.is-alert {
+    background: #fcfaf5;
+  }
+
+  .lp-demo-table-shell td:first-child {
+    color: #3d3e42;
+    font-weight: 520;
+  }
+
+  .lp-demo-table-shell td:first-child i {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    margin-right: 7px;
+    border-radius: 2px;
+    background: #aeb0b2;
+  }
+
+  .lp-demo-table-shell tr.is-alert td:first-child i {
+    background: #d49a40;
+  }
+
+  .lp-demo-home {
+    display: flex;
+    width: min(620px, calc(100% - 48px));
+    height: 100%;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto;
+    padding-bottom: 5%;
+    text-align: center;
+  }
+
+  .lp-demo-assist-mark {
+    display: grid;
+    width: 38px;
+    height: 38px;
+    margin-bottom: 16px;
+    place-items: center;
+    border: 1px solid #e1ded8;
+    border-radius: 11px;
+    background: #faf8f3;
+    color: #9e6c20;
+    box-shadow: 0 8px 24px rgba(40, 36, 27, 0.06);
+  }
+
+  .lp-demo-assist-mark svg {
+    width: 17px;
+    height: 17px;
+  }
+
+  .lp-demo-home-copy {
+    max-width: 430px;
+    margin: 9px 0 0;
+    color: #7e8084;
+    font-size: 0.7rem;
+    line-height: 1.5;
+  }
+
+  .lp-demo-composer {
+    display: flex;
+    width: min(520px, 100%);
+    min-height: 58px;
+    align-items: center;
+    gap: 12px;
+    margin-top: 25px;
+    padding: 0 10px 0 16px;
+    border: 1px solid #dcdad5;
+    border-radius: 12px;
+    background: #ffffff;
+    color: #a0a1a4;
+    text-align: left;
+    box-shadow: 0 12px 36px rgba(31, 33, 36, 0.07);
+  }
+
+  .lp-demo-composer > span {
+    flex: 1;
+    font-size: 0.7rem;
+  }
+
+  .lp-demo-composer button {
+    display: grid;
+    width: 30px;
+    height: 30px;
+    place-items: center;
+    border: 0;
+    border-radius: 7px;
+    background: #252629;
+    color: #ffffff;
+  }
+
+  .lp-demo-quick-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 6px;
+    margin-top: 12px;
+  }
+
+  .lp-demo-quick-actions button {
+    min-height: 27px;
+    padding: 0 9px;
+    border: 1px solid #e4e2dd;
+    border-radius: 6px;
+    background: #faf9f6;
+    color: #73757a;
+    font-size: 0.59rem;
+  }
+
+  .lp-demo-livebar {
+    position: relative;
+    display: grid;
+    height: 47px;
+    flex: none;
+    grid-template-columns: 28px minmax(0, 1fr) auto auto 28px;
+    align-items: center;
+    gap: 9px;
+    overflow: hidden;
+    padding: 0 10px 0 12px;
+    border-top: 1px solid #eae9e6;
+    background: #fcfbf8;
+  }
+
+  .lp-demo-activity-icon {
+    width: 27px;
+    height: 27px;
+  }
+
+  .lp-demo-activity-icon svg {
+    width: 13px;
+    height: 13px;
+  }
+
+  .lp-demo-livebar p {
+    display: flex;
+    min-width: 0;
+    align-items: baseline;
+    gap: 7px;
+    margin: 0;
+    animation: lpDemoActivityIn 0.28s ease both;
+  }
+
+  .lp-demo-livebar p strong,
+  .lp-demo-livebar p span,
+  .lp-demo-livebar > em {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-demo-livebar p strong {
+    color: #45464a;
+    font-size: 0.63rem;
+    font-weight: 560;
+  }
+
+  .lp-demo-livebar p span,
+  .lp-demo-livebar > em {
+    color: #8b8c90;
+    font-size: 0.59rem;
+  }
+
+  .lp-demo-livebar > em {
+    font-style: normal;
+  }
+
+  .lp-demo-live-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    color: #657369;
+    font-family: var(--font-mono-family);
+    font-size: 0.55rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .lp-demo-livebar > button {
+    display: grid;
+    width: 26px;
+    height: 26px;
+    place-items: center;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: #8d8e91;
+  }
+
+  .lp-demo-livebar > button:hover {
+    background: #f0efec;
+    color: #44464a;
+  }
+
+  .lp-demo-livebar > button svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  .lp-demo-live-progress {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    height: 2px;
+    background: rgba(76, 129, 89, 0.06);
+  }
+
+  .lp-demo-live-progress i {
+    display: block;
+    width: 100%;
+    height: 100%;
+    background: rgba(76, 129, 89, 0.42);
+    transform: scaleX(0);
+    transform-origin: left;
+  }
+
+  /* ===== Deep pod demo surfaces ===== */
+
+  .lp-demo-nav-group {
+    display: grid;
+    gap: 2px;
+  }
+
+  .lp-demo-app-worktree {
+    display: grid;
+    gap: 2px;
+    margin: 2px 0 4px 19px;
+    padding-left: 8px;
+    border-left: 1px solid rgba(33, 35, 38, 0.09);
+  }
+
+  .lp-demo-app-worktree button {
+    min-height: 27px;
+    gap: 7px;
+    padding: 0 6px;
+    color: #77797e;
+    font-size: 0.65rem;
+  }
+
+  .lp-demo-app-worktree button i {
+    display: grid;
+    width: 19px;
+    height: 19px;
+    flex: none;
+    place-items: center;
+    border-radius: 5px;
+    background: #e8e3d9;
+    color: #745823;
+    font-size: 0.45rem;
+    font-style: normal;
+    font-weight: 700;
+  }
+
+  .lp-demo-app-worktree button:last-child i {
+    background: #e1eaed;
+    color: #426978;
+  }
+
+  .lp-demo-app-worktree button.is-active {
+    background: rgba(255, 255, 255, 0.7);
+    color: #333539;
+  }
+
+  .lp-demo-sidebar-foot {
+    justify-content: flex-start;
+  }
+
+  .lp-demo-sidebar-foot > span:last-child {
+    min-width: 0;
+  }
+
+  .lp-demo-sidebar-foot > span:last-child strong,
+  .lp-demo-sidebar-foot > span:last-child small {
+    display: block;
+  }
+
+  .lp-demo-sidebar-foot > span:last-child strong {
+    overflow: hidden;
+    color: #54565a;
+    font-size: 0.64rem;
+    font-weight: 540;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-demo-sidebar-foot > span:last-child small {
+    margin-top: 2px;
+    color: #999a9d;
+    font-size: 0.54rem;
+  }
+
+  .lp-demo-tabs > span {
+    position: relative;
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 7px;
+    padding: 0 12px;
+    color: #202124;
+    font-size: 0.72rem;
+    white-space: nowrap;
+  }
+
+  .lp-demo-tabs > span::after {
+    position: absolute;
+    right: 9px;
+    bottom: 0;
+    left: 9px;
+    height: 2px;
+    border-radius: 2px 2px 0 0;
+    background: #27282a;
+    content: "";
+  }
+
+  .lp-demo-page-meta {
+    display: inline-flex;
+    flex: none;
+    align-items: center;
+    min-height: 27px;
+    padding: 0 9px;
+    border: 1px solid #e5e3df;
+    border-radius: 999px;
+    background: #faf9f6;
+    color: #77797d;
+    font-size: 0.59rem;
+    white-space: nowrap;
+  }
+
+  .lp-demo-app-library {
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: clamp(14px, 2vw, 22px);
+  }
+
+  .lp-demo-app-card {
+    display: flex;
+    min-width: 0;
+    min-height: 0;
+    flex-direction: column;
+    overflow: hidden;
+    padding: 0;
+    border: 1px solid #e2e0db;
+    border-radius: 12px;
+    background: #faf9f6;
+    text-align: left;
+    transition:
+      border-color 0.2s ease,
+      box-shadow 0.2s ease,
+      transform 0.2s ease;
+  }
+
+  .lp-demo-app-card:hover {
+    border-color: #cbc7bf;
+    box-shadow: 0 16px 38px rgba(31, 33, 36, 0.08);
+    transform: translateY(-2px);
+  }
+
+  .lp-demo-app-card-head {
+    display: grid;
+    grid-template-columns: 33px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 10px;
+    padding: 13px 14px;
+  }
+
+  .lp-demo-app-icon {
+    display: grid;
+    width: 32px;
+    height: 32px;
+    place-items: center;
+    border-radius: 8px;
+    background: #e8e2d6;
+    color: #6d5220;
+    font-size: 0.58rem;
+    font-weight: 700;
+  }
+
+  .lp-demo-app-card.is-crm .lp-demo-app-icon {
+    background: #e2ecef;
+    color: #416d7b;
+  }
+
+  .lp-demo-app-card-head > span:nth-child(2) {
+    min-width: 0;
+  }
+
+  .lp-demo-app-card-head strong,
+  .lp-demo-app-card-head small {
+    display: block;
+  }
+
+  .lp-demo-app-card-head strong {
+    color: #36373a;
+    font-size: 0.75rem;
+    font-weight: 570;
+  }
+
+  .lp-demo-app-card-head small {
+    overflow: hidden;
+    margin-top: 3px;
+    color: #8b8c90;
+    font-size: 0.57rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-demo-app-card-head em {
+    color: #598164;
+    font-size: 0.55rem;
+    font-style: normal;
+  }
+
+  .lp-demo-app-card-head em::before {
+    display: inline-block;
+    width: 5px;
+    height: 5px;
+    margin-right: 5px;
+    border-radius: 50%;
+    background: #63a071;
+    content: "";
+    vertical-align: 1px;
+  }
+
+  .lp-demo-app-preview {
+    display: block;
+    min-height: 0;
+    flex: 1;
+    margin: 0 12px;
+    overflow: hidden;
+    border: 1px solid #e6e3dc;
+    border-radius: 8px 8px 0 0;
+    background: #ffffff;
+  }
+
+  .lp-demo-campaign-preview {
+    padding: 20px;
+    background:
+      radial-gradient(180px 100px at 100% 0%, rgba(139, 123, 183, 0.09), transparent 70%),
+      #ffffff;
+  }
+
+  .lp-demo-campaign-preview > span {
+    display: block;
+    margin-bottom: 20px;
+  }
+
+  .lp-demo-campaign-preview small,
+  .lp-demo-campaign-preview strong {
+    display: block;
+  }
+
+  .lp-demo-campaign-preview small {
+    color: #96979a;
+    font-size: 0.5rem;
+    letter-spacing: 0.08em;
+  }
+
+  .lp-demo-campaign-preview strong {
+    margin-top: 6px;
+    color: #3c3d41;
+    font-size: 0.73rem;
+    font-weight: 540;
+  }
+
+  .lp-demo-campaign-preview > i {
+    display: block;
+    height: 20px;
+    margin-top: 7px;
+    border: 1px solid #eeeae4;
+    border-radius: 5px;
+    background: linear-gradient(90deg, #f6efe3 18%, #faf9f7 18%);
+  }
+
+  .lp-demo-campaign-preview > i:nth-of-type(1) {
+    width: 78%;
+  }
+
+  .lp-demo-campaign-preview > i:nth-of-type(2) {
+    width: 56%;
+  }
+
+  .lp-demo-campaign-preview > i:nth-of-type(3) {
+    width: 68%;
+  }
+
+  .lp-demo-crm-preview {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 6px;
+    padding: 12px;
+    background: #f6f7f7;
+  }
+
+  .lp-demo-crm-preview > span {
+    min-width: 0;
+  }
+
+  .lp-demo-crm-preview small {
+    display: block;
+    overflow: hidden;
+    margin: 0 0 7px;
+    color: #8c8e91;
+    font-size: 0.48rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-demo-crm-preview i {
+    display: block;
+    height: 34px;
+    margin-top: 5px;
+    border: 1px solid #e1e5e6;
+    border-radius: 5px;
+    background: #ffffff;
+    box-shadow: 0 3px 9px rgba(31, 42, 46, 0.03);
+  }
+
+  .lp-demo-app-card-foot {
+    display: flex;
+    min-height: 42px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 0 14px;
+    border-top: 1px solid #e7e4de;
+    background: #ffffff;
+    color: #77797d;
+    font-size: 0.59rem;
+  }
+
+  .lp-demo-app-card-foot svg {
+    width: 12px;
+    height: 12px;
+    color: #888a8d;
+    transition: transform 0.16s ease;
+  }
+
+  .lp-demo-app-card:hover .lp-demo-app-card-foot svg {
+    transform: translateX(2px);
+  }
+
+  .lp-demo-purpose-app {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .lp-demo-app-toolbar {
+    display: grid;
+    min-height: 46px;
+    flex: none;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 14px;
+    padding: 0 15px;
+    border-bottom: 1px solid #e9e8e5;
+    background: #faf9f6;
+  }
+
+  .lp-demo-app-identity {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding-right: 14px;
+    border-right: 1px solid #e5e3de;
+  }
+
+  .lp-demo-app-identity > span {
+    display: grid;
+    width: 25px;
+    height: 25px;
+    place-items: center;
+    border-radius: 6px;
+    background: #e8e2d6;
+    color: #6f5321;
+    font-size: 0.49rem;
+    font-weight: 700;
+  }
+
+  .lp-demo-app-identity strong {
+    color: #3c3d40;
+    font-size: 0.69rem;
+    font-weight: 570;
+    white-space: nowrap;
+  }
+
+  .lp-demo-app-toolbar nav {
+    display: flex;
+    align-self: stretch;
+    gap: 2px;
+  }
+
+  .lp-demo-app-toolbar nav button {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 0 9px;
+    border: 0;
+    background: transparent;
+    color: #86878b;
+    font-size: 0.61rem;
+  }
+
+  .lp-demo-app-toolbar nav button:hover,
+  .lp-demo-app-toolbar nav button.is-active {
+    color: #36373a;
+  }
+
+  .lp-demo-app-toolbar nav button.is-active::after {
+    position: absolute;
+    right: 8px;
+    bottom: 0;
+    left: 8px;
+    height: 2px;
+    background: #333438;
+    content: "";
+  }
+
+  .lp-demo-app-toolbar nav svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  .lp-demo-runtime {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: #72757a;
+    font-size: 0.56rem;
+    white-space: nowrap;
+  }
+
+  .lp-demo-runtime i {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #7f8a83;
+  }
+
+  .lp-demo-runtime.is-violet i {
+    background: #8b7bb7;
+    box-shadow: 0 0 0 3px rgba(139, 123, 183, 0.11);
+  }
+
+  .lp-demo-runtime.is-blue i {
+    background: #5b8793;
+    box-shadow: 0 0 0 3px rgba(91, 135, 147, 0.11);
+  }
+
+  .lp-demo-app-content {
+    display: flex;
+    min-width: 0;
+    min-height: 0;
+    flex: 1;
+    flex-direction: column;
+    padding: clamp(20px, 2.8vw, 32px);
+    animation: lpDemoViewIn 0.28s ease both;
+  }
+
+  .lp-demo-app-title-row {
+    display: flex;
+    flex: none;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 18px;
+    padding-bottom: clamp(18px, 2.4vw, 26px);
+  }
+
+  .lp-demo-app-title-row h3 {
+    margin: 0;
+    color: #292a2d;
+    font-size: clamp(1.08rem, 1.8vw, 1.45rem);
+    font-weight: 540;
+    letter-spacing: -0.026em;
+  }
+
+  .lp-demo-app-title-row > div > p:last-child {
+    margin: 6px 0 0;
+    color: #7e8084;
+    font-size: 0.64rem;
+  }
+
+  .lp-demo-human-gate {
+    display: inline-flex;
+    min-height: 28px;
+    flex: none;
+    align-items: center;
+    gap: 6px;
+    padding: 0 9px;
+    border: 1px solid #dfd6c6;
+    border-radius: 999px;
+    background: #fcf8f0;
+    color: #8a6529;
+    font-size: 0.58rem;
+  }
+
+  .lp-demo-human-gate svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  .lp-demo-text-action {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    color: #303235;
+    font-size: 0.64rem;
+    font-weight: 560;
+  }
+
+  .lp-demo-text-action svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  .lp-demo-calendar {
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 6px;
+    padding: 8px;
+    border: 1px solid #e7e6e2;
+    border-radius: 10px;
+    background: #f8f7f4;
+  }
+
+  .lp-demo-calendar > div {
+    min-width: 0;
+    padding: 9px 7px;
+    border-radius: 7px;
+  }
+
+  .lp-demo-calendar > div.is-today {
+    background: #ffffff;
+    box-shadow: 0 4px 16px rgba(35, 37, 40, 0.07);
+  }
+
+  .lp-demo-calendar > div > small {
+    display: block;
+    margin-bottom: 12px;
+    color: #a0a1a4;
+    font-size: 0.5rem;
+    letter-spacing: 0.05em;
+  }
+
+  .lp-demo-calendar-card {
+    display: flex;
+    min-height: 110px;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 10px;
+    border: 1px solid #e6e3dd;
+    border-radius: 7px;
+    background: #ffffff;
+  }
+
+  .lp-demo-calendar-card strong {
+    margin-top: 12px;
+    color: #46474b;
+    font-size: 0.63rem;
+    font-weight: 550;
+    line-height: 1.3;
+  }
+
+  .lp-demo-calendar-card em {
+    margin-top: auto;
+    color: #98999c;
+    font-size: 0.52rem;
+    font-style: normal;
+    line-height: 1.3;
+  }
+
+  .lp-demo-performance-grid {
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template-columns: minmax(0, 1.3fr) minmax(190px, 0.7fr);
+    gap: 14px;
+  }
+
+  .lp-demo-chart {
+    display: grid;
+    min-height: 0;
+    grid-template-columns: 1fr 1fr;
+    padding: 20px 18px 12px;
+    border: 1px solid #e6e5e2;
+    border-radius: 10px;
+    background:
+      linear-gradient(rgba(42, 44, 48, 0.035) 1px, transparent 1px),
+      #ffffff;
+    background-size: 100% 25%;
+  }
+
+  .lp-demo-chart-bars {
+    display: flex;
+    grid-column: 1 / -1;
+    align-items: flex-end;
+    gap: 7px;
+  }
+
+  .lp-demo-chart-bars i {
+    flex: 1;
+    border-radius: 4px 4px 1px 1px;
+    background: #aabdb1;
+  }
+
+  .lp-demo-chart-bars i.is-h42 { height: 42%; }
+  .lp-demo-chart-bars i.is-h54 { height: 54%; }
+  .lp-demo-chart-bars i.is-h58 { height: 58%; }
+  .lp-demo-chart-bars i.is-h66 { height: 66%; }
+  .lp-demo-chart-bars i.is-h72 { height: 72%; }
+  .lp-demo-chart-bars i.is-h74 { height: 74%; }
+  .lp-demo-chart-bars i.is-h79 { height: 79%; }
+  .lp-demo-chart-bars i.is-h81 { height: 81%; }
+  .lp-demo-chart-bars i.is-h88 { height: 88%; }
+  .lp-demo-chart-bars i.is-h92 { height: 92%; }
+
+  .lp-demo-chart-bars i.is-marked {
+    background: #8675b4;
+    box-shadow: 0 0 0 3px rgba(134, 117, 180, 0.09);
+  }
+
+  .lp-demo-chart > span {
+    align-self: end;
+    padding-top: 8px;
+    color: #a1a2a5;
+    font-size: 0.48rem;
+  }
+
+  .lp-demo-chart > span:last-child {
+    text-align: right;
+  }
+
+  .lp-demo-insight {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 20px;
+    border: 1px solid #ddd7e8;
+    border-radius: 10px;
+    background: #faf8fd;
+  }
+
+  .lp-demo-insight > small {
+    color: #8d82aa;
+    font-size: 0.52rem;
+    letter-spacing: 0.07em;
+  }
+
+  .lp-demo-insight h4 {
+    margin: 8px 0 0;
+    color: #3e3a47;
+    font-size: 0.82rem;
+    font-weight: 550;
+    line-height: 1.35;
+  }
+
+  .lp-demo-insight p {
+    margin: 9px 0 0;
+    color: #77727f;
+    font-size: 0.61rem;
+    line-height: 1.48;
+  }
+
+  .lp-demo-insight em {
+    margin-top: auto;
+    color: #99949f;
+    font-size: 0.53rem;
+    font-style: normal;
+  }
+
+  .lp-demo-kanban {
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+    overflow: hidden;
+  }
+
+  .lp-demo-kanban > section {
+    min-width: 0;
+    overflow: hidden;
+    padding: 8px;
+    border: 1px solid #e6e7e7;
+    border-radius: 9px;
+    background: #f6f7f7;
+  }
+
+  .lp-demo-kanban section > header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 2px 2px 9px;
+    color: #77797d;
+    font-size: 0.56rem;
+  }
+
+  .lp-demo-kanban section > header strong {
+    font-weight: 560;
+  }
+
+  .lp-demo-kanban article {
+    display: grid;
+    grid-template-columns: 25px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 7px;
+    margin-top: 6px;
+    padding: 9px;
+    border: 1px solid #e3e5e5;
+    border-radius: 7px;
+    background: #ffffff;
+    box-shadow: 0 3px 9px rgba(34, 41, 44, 0.025);
+  }
+
+  .lp-demo-account-mark {
+    display: grid;
+    width: 24px;
+    height: 24px;
+    grid-row: 1 / span 2;
+    place-items: center;
+    border-radius: 6px;
+    background: #e6edef;
+    color: #5f7c84;
+    font-size: 0.45rem;
+    font-weight: 700;
+  }
+
+  .lp-demo-kanban article > strong {
+    overflow: hidden;
+    color: #47494d;
+    font-size: 0.61rem;
+    font-weight: 550;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-demo-kanban article > span:not(.lp-demo-account-mark) {
+    color: #777a7e;
+    font-size: 0.55rem;
+  }
+
+  .lp-demo-kanban article small {
+    display: flex;
+    grid-column: 2 / -1;
+    align-items: center;
+    gap: 5px;
+    overflow: hidden;
+    color: #96989b;
+    font-size: 0.5rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-demo-crm-table {
+    min-height: 0;
+    overflow: hidden;
+    border: 1px solid #e6e7e7;
+    border-radius: 9px;
+    background: #ffffff;
+  }
+
+  .lp-demo-crm-table > div {
+    display: grid;
+    grid-template-columns: 1.5fr 0.8fr 0.65fr 0.9fr 0.6fr;
+    align-items: center;
+    min-height: 44px;
+    border-bottom: 1px solid #eeefef;
+  }
+
+  .lp-demo-crm-table > div:last-child {
+    border-bottom: 0;
+  }
+
+  .lp-demo-crm-table > div.is-selected {
+    background: #f4f8f9;
+  }
+
+  .lp-demo-crm-table span {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 7px;
+    overflow: hidden;
+    padding: 0 10px;
+    color: #696b6f;
+    font-size: 0.59rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-demo-crm-table-head {
+    min-height: 30px !important;
+    background: #fafafa;
+  }
+
+  .lp-demo-crm-table-head span {
+    color: #96989b;
+    font-size: 0.51rem;
+  }
+
+  .lp-demo-crm-table span i {
+    display: grid;
+    width: 23px;
+    height: 23px;
+    flex: none;
+    place-items: center;
+    border-radius: 6px;
+    background: #e6edef;
+    color: #577782;
+    font-size: 0.43rem;
+    font-style: normal;
+    font-weight: 700;
+  }
+
+  .lp-demo-task-list {
+    display: grid;
+    align-content: start;
+    overflow: hidden;
+    border: 1px solid #e5e6e6;
+    border-radius: 10px;
+  }
+
+  .lp-demo-task-list article {
+    display: grid;
+    grid-template-columns: 30px minmax(0, 1fr) 70px 54px;
+    align-items: center;
+    gap: 11px;
+    min-height: 60px;
+    padding: 0 14px;
+    border-bottom: 1px solid #eceeed;
+  }
+
+  .lp-demo-task-list article:last-child {
+    border-bottom: 0;
+  }
+
+  .lp-demo-task-check {
+    display: grid;
+    width: 28px;
+    height: 28px;
+    place-items: center;
+    border-radius: 7px;
+    background: #e8f0f2;
+    color: #547985;
+  }
+
+  .lp-demo-task-check.is-urgent {
+    background: #f6eddd;
+    color: #9b7029;
+  }
+
+  .lp-demo-task-list article > span:nth-child(2) {
+    min-width: 0;
+  }
+
+  .lp-demo-task-list strong,
+  .lp-demo-task-list small {
+    display: block;
+  }
+
+  .lp-demo-task-list strong {
+    color: #46484c;
+    font-size: 0.65rem;
+    font-weight: 550;
+  }
+
+  .lp-demo-task-list small {
+    overflow: hidden;
+    margin-top: 4px;
+    color: #919397;
+    font-size: 0.54rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-demo-task-list em,
+  .lp-demo-task-list time {
+    color: #85878b;
+    font-size: 0.55rem;
+    font-style: normal;
+    text-align: right;
+  }
+
+  .lp-demo-workflow-page {
+    padding-bottom: 18px;
+  }
+
+  .lp-demo-workflow-page .lp-demo-page-head {
+    padding-bottom: 16px;
+  }
+
+  .lp-demo-workflow-layout {
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template-columns: 160px minmax(300px, 1fr) 186px;
+    overflow: hidden;
+    border: 1px solid #e5e4e1;
+    border-radius: 10px;
+    background: #ffffff;
+  }
+
+  .lp-demo-workflow-list {
+    min-width: 0;
+    padding: 12px 8px;
+    border-right: 1px solid #e7e6e3;
+    background: #f7f6f3;
+  }
+
+  .lp-demo-workflow-list > small {
+    display: block;
+    margin: 0 7px 8px;
+    color: #9a9b9e;
+    font-size: 0.48rem;
+    letter-spacing: 0.08em;
+  }
+
+  .lp-demo-workflow-list button {
+    display: grid;
+    width: 100%;
+    min-width: 0;
+    grid-template-columns: 16px minmax(0, 1fr);
+    align-items: start;
+    gap: 7px;
+    padding: 8px 7px;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: #77797d;
+    text-align: left;
+  }
+
+  .lp-demo-workflow-list button.is-active {
+    background: #ffffff;
+    color: #35373a;
+    box-shadow: inset 0 0 0 1px #e4e2dd;
+  }
+
+  .lp-demo-workflow-list button svg {
+    width: 13px;
+    height: 13px;
+    margin-top: 2px;
+  }
+
+  .lp-demo-workflow-list button span {
+    min-width: 0;
+  }
+
+  .lp-demo-workflow-list button strong,
+  .lp-demo-workflow-list button em {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-demo-workflow-list button strong {
+    font-size: 0.57rem;
+    font-weight: 540;
+  }
+
+  .lp-demo-workflow-list button em {
+    margin-top: 3px;
+    color: #9a9b9e;
+    font-size: 0.48rem;
+    font-style: normal;
+  }
+
+  .lp-demo-workflow-canvas {
+    position: relative;
+    min-width: 0;
+    overflow: hidden;
+    background:
+      radial-gradient(circle at 1px 1px, rgba(53, 56, 60, 0.08) 1px, transparent 0);
+    background-size: 16px 16px;
+  }
+
+  .lp-demo-canvas-node {
+    position: absolute;
+    z-index: 2;
+    display: flex;
+    width: 116px;
+    min-height: 62px;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 9px;
+    border: 1px solid #deddd9;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.96);
+    text-align: left;
+    box-shadow: 0 4px 14px rgba(28, 31, 34, 0.05);
+    transition:
+      border-color 0.16s ease,
+      box-shadow 0.16s ease,
+      transform 0.16s ease;
+  }
+
+  .lp-demo-canvas-node:hover {
+    transform: translateY(-1px);
+  }
+
+  .lp-demo-canvas-node.is-selected {
+    border-color: #9082b5;
+    box-shadow:
+      0 0 0 3px rgba(144, 130, 181, 0.1),
+      0 7px 18px rgba(28, 31, 34, 0.07);
+  }
+
+  .lp-demo-canvas-node.is-complete::before,
+  .lp-demo-canvas-node.is-waiting::before {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #6d9a78;
+    content: "";
+  }
+
+  .lp-demo-canvas-node.is-waiting::before {
+    background: #d29a42;
+    box-shadow: 0 0 0 3px rgba(210, 154, 66, 0.1);
+  }
+
+  .lp-demo-canvas-node small,
+  .lp-demo-canvas-node strong,
+  .lp-demo-canvas-node span {
+    display: block;
+  }
+
+  .lp-demo-canvas-node small {
+    padding-right: 10px;
+    color: #929397;
+    font-size: 0.43rem;
+    letter-spacing: 0.06em;
+  }
+
+  .lp-demo-canvas-node strong {
+    margin-top: 6px;
+    color: #3f4144;
+    font-size: 0.56rem;
+    font-weight: 550;
+    line-height: 1.25;
+  }
+
+  .lp-demo-canvas-node span {
+    margin-top: auto;
+    padding-top: 5px;
+    color: #9a9b9e;
+    font-size: 0.46rem;
+  }
+
+  .lp-demo-canvas-node.is-node-0 {
+    top: 24px;
+    left: 18px;
+  }
+
+  .lp-demo-canvas-node.is-node-1 {
+    top: 24px;
+    left: calc(50% - 58px);
+  }
+
+  .lp-demo-canvas-node.is-node-2 {
+    top: 24px;
+    right: 18px;
+  }
+
+  .lp-demo-canvas-node.is-node-3 {
+    top: calc(50% - 30px);
+    right: 18px;
+  }
+
+  .lp-demo-canvas-node.is-node-4 {
+    right: calc(50% - 58px);
+    bottom: 22px;
+  }
+
+  .lp-demo-canvas-node.is-node-5 {
+    bottom: 22px;
+    left: 18px;
+  }
+
+  .lp-demo-wire {
+    position: absolute;
+    z-index: 1;
+    background: #cdd1ce;
+  }
+
+  .lp-demo-wire.is-top {
+    top: 55px;
+    right: 74px;
+    left: 74px;
+    height: 2px;
+  }
+
+  .lp-demo-wire.is-right {
+    top: 55px;
+    right: 74px;
+    bottom: 51%;
+    width: 2px;
+  }
+
+  .lp-demo-wire.is-middle {
+    right: 74px;
+    bottom: 53px;
+    left: 50%;
+    height: 2px;
+  }
+
+  .lp-demo-wire.is-left {
+    bottom: 53px;
+    left: 74px;
+    width: calc(50% - 74px);
+    height: 2px;
+  }
+
+  .lp-demo-flow-packet {
+    position: absolute;
+    z-index: 3;
+    top: 51px;
+    left: 48%;
+    width: 8px;
+    height: 8px;
+    border: 2px solid #ffffff;
+    border-radius: 50%;
+    background: #897ab2;
+    box-shadow: 0 0 0 3px rgba(137, 122, 178, 0.16);
+  }
+
+  .lp-demo-step-inspector {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 15px;
+    border-left: 1px solid #e7e6e3;
+    background: #fbfaf8;
+    animation: lpDemoDetailIn 0.24s ease both;
+  }
+
+  .lp-demo-step-inspector > small {
+    margin-top: 14px;
+    color: #999a9d;
+    font-size: 0.47rem;
+    letter-spacing: 0.07em;
+  }
+
+  .lp-demo-step-inspector h4 {
+    margin: 6px 0 0;
+    color: #3f4044;
+    font-size: 0.72rem;
+    font-weight: 550;
+    line-height: 1.3;
+  }
+
+  .lp-demo-step-inspector p {
+    margin: 7px 0 0;
+    color: #7d7f83;
+    font-size: 0.55rem;
+    line-height: 1.45;
+  }
+
+  .lp-demo-step-inspector > div {
+    width: 100%;
+    margin-top: 16px;
+    padding: 10px;
+    border: 1px solid #e3e1dc;
+    border-radius: 7px;
+    background: #ffffff;
+  }
+
+  .lp-demo-step-inspector > div small,
+  .lp-demo-step-inspector > div strong {
+    display: block;
+  }
+
+  .lp-demo-step-inspector > div small {
+    color: #a0a1a4;
+    font-size: 0.44rem;
+    letter-spacing: 0.06em;
+  }
+
+  .lp-demo-step-inspector > div strong {
+    margin-top: 6px;
+    color: #55575b;
+    font-size: 0.52rem;
+    font-weight: 520;
+    line-height: 1.4;
+  }
+
+  .lp-demo-step-inspector dl {
+    display: grid;
+    width: 100%;
+    grid-template-columns: 1fr auto;
+    gap: 7px;
+    margin: auto 0 0;
+    padding-top: 12px;
+    border-top: 1px solid #e7e5e0;
+    font-size: 0.5rem;
+  }
+
+  .lp-demo-step-inspector dt {
+    color: #9a9b9e;
+  }
+
+  .lp-demo-step-inspector dd {
+    margin: 0;
+    color: #5c5e62;
+  }
+
+  .lp-demo-doc-page {
+    padding-bottom: 18px;
+  }
+
+  .lp-demo-doc-page .lp-demo-page-head {
+    padding-bottom: 16px;
+  }
+
+  .lp-demo-doc-layout {
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template-columns: 170px minmax(300px, 1fr) 172px;
+    overflow: hidden;
+    border: 1px solid #e5e4e0;
+    border-radius: 10px;
+  }
+
+  .lp-demo-doc-tree {
+    padding: 10px 8px;
+    border-right: 1px solid #e7e5e1;
+    background: #f7f6f3;
+  }
+
+  .lp-demo-doc-search {
+    display: flex;
+    min-height: 29px;
+    align-items: center;
+    gap: 7px;
+    margin-bottom: 12px;
+    padding: 0 8px;
+    border: 1px solid #e2e0db;
+    border-radius: 6px;
+    background: #ffffff;
+    color: #a0a1a4;
+    font-size: 0.53rem;
+  }
+
+  .lp-demo-doc-search svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  .lp-demo-doc-tree > small,
+  .lp-demo-doc-context > small {
+    display: block;
+    margin: 10px 7px 5px;
+    color: #a0a1a4;
+    font-size: 0.45rem;
+    letter-spacing: 0.08em;
+  }
+
+  .lp-demo-doc-tree button {
+    display: flex;
+    width: 100%;
+    min-width: 0;
+    min-height: 29px;
+    align-items: center;
+    gap: 7px;
+    padding: 0 7px;
+    border: 0;
+    border-radius: 5px;
+    background: transparent;
+    color: #74767a;
+    font-size: 0.55rem;
+    text-align: left;
+  }
+
+  .lp-demo-doc-tree button:hover,
+  .lp-demo-doc-tree button.is-active {
+    background: #ffffff;
+    color: #35373a;
+    box-shadow: inset 0 0 0 1px #e6e3dd;
+  }
+
+  .lp-demo-doc-tree button svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  .lp-demo-document {
+    min-width: 0;
+    overflow: hidden;
+    padding: 24px clamp(24px, 4vw, 48px);
+    background: #ffffff;
+    animation: lpDemoViewIn 0.24s ease both;
+  }
+
+  .lp-demo-doc-kicker {
+    margin: 0;
+    color: #939497;
+    font-size: 0.48rem;
+    font-weight: 560;
+    letter-spacing: 0.08em;
+  }
+
+  .lp-demo-document h3 {
+    margin: 7px 0 0;
+    color: #303134;
+    font-family: var(--font-landing-serif), Georgia, serif;
+    font-size: clamp(1.25rem, 2.2vw, 1.8rem);
+    font-weight: 400;
+    letter-spacing: -0.025em;
+  }
+
+  .lp-demo-doc-lede {
+    margin: 9px 0 0;
+    color: #6d6f73;
+    font-size: 0.66rem;
+    line-height: 1.5;
+  }
+
+  .lp-demo-document h4 {
+    margin: 18px 0 0;
+    color: #44464a;
+    font-size: 0.65rem;
+    font-weight: 600;
+  }
+
+  .lp-demo-document > p:not(.lp-demo-doc-kicker):not(.lp-demo-doc-lede),
+  .lp-demo-document li {
+    color: #707276;
+    font-size: 0.59rem;
+    line-height: 1.48;
+  }
+
+  .lp-demo-document > p:not(.lp-demo-doc-kicker):not(.lp-demo-doc-lede) {
+    margin: 6px 0 0;
+  }
+
+  .lp-demo-document ul,
+  .lp-demo-document ol {
+    margin: 7px 0 0;
+    padding-left: 16px;
+  }
+
+  .lp-demo-document li + li {
+    margin-top: 3px;
+  }
+
+  .lp-demo-document blockquote {
+    margin: 16px 0 0;
+    padding: 10px 12px;
+    border-left: 2px solid #a79676;
+    background: #faf7f1;
+    color: #6b6253;
+    font-size: 0.58rem;
+    line-height: 1.45;
+  }
+
+  .lp-demo-doc-callout {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    margin-top: 15px;
+    padding: 9px 10px;
+    border: 1px solid #ddd7e8;
+    border-radius: 7px;
+    background: #faf8fd;
+    color: #776b94;
+  }
+
+  .lp-demo-doc-callout svg {
+    width: 14px;
+    height: 14px;
+  }
+
+  .lp-demo-doc-callout strong {
+    display: block;
+    margin-bottom: 2px;
+    color: #5b516f;
+    font-size: 0.56rem;
+    font-weight: 560;
+  }
+
+  .lp-demo-doc-callout span {
+    font-size: 0.49rem;
+  }
+
+  .lp-demo-doc-context {
+    min-width: 0;
+    padding: 10px 9px;
+    border-left: 1px solid #e7e5e1;
+    background: #faf9f6;
+  }
+
+  .lp-demo-doc-context > div {
+    display: grid;
+    grid-template-columns: 27px minmax(0, 1fr);
+    align-items: center;
+    gap: 7px;
+    margin-top: 5px;
+    padding: 7px;
+    border-radius: 6px;
+    background: #ffffff;
+  }
+
+  .lp-demo-doc-context .lp-demo-agent-mark {
+    width: 26px;
+    height: 26px;
+  }
+
+  .lp-demo-doc-context strong,
+  .lp-demo-doc-context em {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-demo-doc-context strong {
+    color: #5b5d61;
+    font-size: 0.52rem;
+    font-weight: 540;
+  }
+
+  .lp-demo-doc-context em {
+    margin-top: 2px;
+    color: #9a9b9e;
+    font-size: 0.45rem;
+    font-style: normal;
+  }
+
+  .lp-demo-doc-context p {
+    margin: 7px;
+    color: #85878b;
+    font-size: 0.5rem;
+    line-height: 1.42;
+  }
+
+  .lp-demo-connectors-layout {
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template-columns: minmax(0, 1.2fr) minmax(220px, 0.8fr);
+    gap: 14px;
+  }
+
+  .lp-demo-connector-list {
+    display: grid;
+    align-content: start;
+    overflow: hidden;
+    border: 1px solid #e5e4e1;
+    border-radius: 10px;
+    background: #ffffff;
+  }
+
+  .lp-demo-connector-list button {
+    display: grid;
+    min-width: 0;
+    min-height: 62px;
+    grid-template-columns: 34px minmax(0, 1fr) auto 14px;
+    align-items: center;
+    gap: 11px;
+    padding: 0 13px;
+    border: 0;
+    border-bottom: 1px solid #eeedeb;
+    background: transparent;
+    text-align: left;
+  }
+
+  .lp-demo-connector-list button:last-child {
+    border-bottom: 0;
+  }
+
+  .lp-demo-connector-list button:hover,
+  .lp-demo-connector-list button.is-selected {
+    background: #faf9f6;
+  }
+
+  .lp-demo-connector-icon {
+    display: grid;
+    width: 33px;
+    height: 33px;
+    place-items: center;
+    border-radius: 8px;
+    background: #ecebea;
+    color: #636569;
+  }
+
+  .lp-demo-connector-icon.is-amber {
+    background: #f5ead6;
+    color: #a17022;
+  }
+
+  .lp-demo-connector-icon.is-red {
+    background: #f5e6e2;
+    color: #a0584a;
+  }
+
+  .lp-demo-connector-icon.is-violet {
+    background: #ece8f5;
+    color: #7768a0;
+  }
+
+  .lp-demo-connector-icon.is-ink {
+    background: #e8e9ea;
+    color: #3d3f43;
+  }
+
+  .lp-demo-connector-list button > span:nth-child(2) {
+    min-width: 0;
+  }
+
+  .lp-demo-connector-list strong,
+  .lp-demo-connector-list small {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-demo-connector-list strong {
+    color: #45464a;
+    font-size: 0.66rem;
+    font-weight: 550;
+  }
+
+  .lp-demo-connector-list small {
+    margin-top: 4px;
+    color: #939498;
+    font-size: 0.54rem;
+  }
+
+  .lp-demo-connector-list em {
+    color: #5f8067;
+    font-size: 0.53rem;
+    font-style: normal;
+    white-space: nowrap;
+  }
+
+  .lp-demo-connector-list em i {
+    display: inline-block;
+    width: 5px;
+    height: 5px;
+    margin-right: 5px;
+    border-radius: 50%;
+    background: #65a174;
+    vertical-align: 1px;
+  }
+
+  .lp-demo-connector-list button > svg {
+    width: 12px;
+    height: 12px;
+    color: #aaa;
+  }
+
+  .lp-demo-connector-detail {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 20px;
+    border: 1px solid #e5e3de;
+    border-radius: 10px;
+    background: #faf9f6;
+    animation: lpDemoDetailIn 0.24s ease both;
+  }
+
+  .lp-demo-connector-detail > small {
+    margin-top: 17px;
+    color: #9b9c9f;
+    font-size: 0.48rem;
+    letter-spacing: 0.08em;
+  }
+
+  .lp-demo-connector-detail h4 {
+    margin: 6px 0 0;
+    color: #3f4144;
+    font-size: 0.88rem;
+    font-weight: 550;
+  }
+
+  .lp-demo-connector-detail > p {
+    margin: 4px 0 0;
+    color: #85868a;
+    font-size: 0.58rem;
+  }
+
+  .lp-demo-connector-detail dl {
+    width: 100%;
+    margin: 17px 0 0;
+  }
+
+  .lp-demo-connector-detail dl div {
+    padding: 9px 0;
+    border-top: 1px solid #e2e0db;
+  }
+
+  .lp-demo-connector-detail dt {
+    color: #97989b;
+    font-size: 0.5rem;
+  }
+
+  .lp-demo-connector-detail dd {
+    margin: 4px 0 0;
+    color: #55575b;
+    font-size: 0.56rem;
+    line-height: 1.4;
+  }
+
+  .lp-demo-used-by {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    margin-top: 8px;
+  }
+
+  .lp-demo-used-by span {
+    padding: 4px 6px;
+    border: 1px solid #e0ded8;
+    border-radius: 5px;
+    background: #ffffff;
+    color: #66686c;
+    font-size: 0.49rem;
+  }
+
+  .lp-demo-shell.is-live .lp-demo-live-progress i {
+    animation: lpDemoLiveProgress 3.2s linear both;
+  }
+
+  .lp-demo-shell.is-live .lp-demo-running i,
+  .lp-demo-shell.is-live .lp-demo-run-badge i,
+  .lp-demo-shell.is-live .lp-demo-sync i,
+  .lp-demo-shell.is-live .lp-demo-live-label i,
+  .lp-demo-shell.is-live .lp-demo-agent-meta em.is-running i {
+    animation: lpDemoSignal 1.8s ease-in-out infinite;
+  }
+
+  .lp-demo-shell.is-live .lp-demo-flow-step.is-current .lp-demo-flow-node {
+    animation: lpDemoCurrentStep 2.2s ease-in-out infinite;
+  }
+
+  @keyframes lpDemoViewIn {
+    from {
+      opacity: 0;
+      transform: translateY(6px);
+    }
+
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  @keyframes lpDemoDetailIn {
+    from {
+      opacity: 0;
+      transform: translateX(5px);
+    }
+
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  @keyframes lpDemoActivityIn {
+    from {
+      opacity: 0;
+      transform: translateY(5px);
+    }
+
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  @keyframes lpDemoLiveProgress {
+    from {
+      transform: scaleX(0);
+    }
+
+    to {
+      transform: scaleX(1);
+    }
+  }
+
+  @keyframes lpDemoSignal {
+    0%,
+    100% {
+      opacity: 0.64;
+      transform: scale(0.9);
+    }
+
+    50% {
+      opacity: 1;
+      transform: scale(1.14);
+    }
+  }
+
+  @keyframes lpDemoCurrentStep {
+    0%,
+    100% {
+      box-shadow: 0 0 0 5px rgba(139, 123, 183, 0.08);
+    }
+
+    50% {
+      box-shadow: 0 0 0 9px rgba(139, 123, 183, 0.13);
+    }
+  }
+
   .lp-section {
-    padding: clamp(70px, 8vw, 112px) clamp(18px, 4vw, 56px);
+    scroll-margin-top: 88px;
+    padding: clamp(62px, 7vw, 92px) clamp(18px, 4vw, 56px);
   }
 
   .lp-section-inner {
@@ -496,27 +3462,29 @@
   }
 
   .lp-section-kicker {
-    margin: 0 0 14px;
+    margin: 0 0 12px;
     color: #2f693d;
-    font-size: 0.8rem;
-    font-weight: 780;
+    font-size: 0.72rem;
+    font-weight: 500;
     letter-spacing: 0.14em;
     text-transform: uppercase;
   }
 
   .lp-section-title {
-    max-width: 880px;
-    font-size: clamp(2.3rem, 3.6vw, 3.6rem);
-    line-height: 1.05;
-    letter-spacing: -0.012em;
+    max-width: 780px;
+    font-family: var(--font-display-family);
+    font-size: clamp(2rem, 2.7vw, 2.75rem);
+    font-weight: 500;
+    line-height: 1.08;
+    letter-spacing: -0.035em;
   }
 
   .lp-section-subhead {
-    max-width: 760px;
-    margin: 18px 0 0;
+    max-width: 680px;
+    margin: 16px 0 0;
     color: #5d625d;
-    font-size: clamp(1rem, 1.4vw, 1.2rem);
-    line-height: 1.45;
+    font-size: 1rem;
+    line-height: 1.52;
   }
 
   .lp-js .lp-reveal {
@@ -549,9 +3517,9 @@
   .lp-pod-explorer {
     display: grid;
     grid-template-columns: minmax(0, 1fr) clamp(360px, 46%, 560px);
-    gap: clamp(20px, 3vw, 46px);
+    gap: clamp(20px, 2.5vw, 36px);
     align-items: start;
-    margin-top: clamp(34px, 4vw, 54px);
+    margin-top: clamp(28px, 3.2vw, 40px);
   }
 
   .lp-pod-visual {
@@ -570,12 +3538,12 @@
   .lp-pod-acc {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 8px;
   }
 
   .lp-pod-acc-item {
     border: 1px solid rgba(13, 15, 18, 0.1);
-    border-radius: 16px;
+    border-radius: 12px;
     background: #fbfaf7;
     transition:
       border-color 0.2s ease,
@@ -586,15 +3554,15 @@
   .lp-pod-acc-item.is-open {
     background: #ffffff;
     border-color: rgba(13, 15, 18, 0.16);
-    box-shadow: 0 12px 34px rgba(13, 15, 18, 0.05);
+    box-shadow: 0 8px 24px rgba(13, 15, 18, 0.04);
   }
 
   .lp-pod-acc-head {
     display: flex;
     align-items: flex-start;
-    gap: 18px;
+    gap: 14px;
     width: 100%;
-    padding: clamp(16px, 1.8vw, 22px) clamp(18px, 2vw, 24px);
+    padding: clamp(14px, 1.5vw, 18px) clamp(16px, 1.8vw, 20px);
     border: 0;
     background: transparent;
     cursor: pointer;
@@ -612,14 +3580,14 @@
     display: block;
     margin-bottom: 5px;
     color: #1a1c1f;
-    font-size: 1.12rem;
-    font-weight: 600;
+    font-size: 1rem;
+    font-weight: 550;
   }
 
   .lp-pod-acc-titles > span {
     color: #5b5f66;
-    font-size: 0.96rem;
-    line-height: 1.5;
+    font-size: 0.9rem;
+    line-height: 1.45;
   }
 
   .lp-pod-acc-toggle {
@@ -659,10 +3627,117 @@
 
   .lp-pod-acc-detail p {
     margin: 0;
-    padding: 0 clamp(18px, 2vw, 24px) clamp(18px, 2vw, 22px);
+    padding: 0 clamp(16px, 1.8vw, 20px) clamp(16px, 1.8vw, 19px);
     color: #45484d;
+    font-size: 0.92rem;
+    line-height: 1.58;
+  }
+
+  .lp-pod-resource-nav {
+    display: grid;
+    gap: 8px;
+  }
+
+  .lp-pod-resource-nav > button {
+    display: grid;
+    width: 100%;
+    min-height: 72px;
+    grid-template-columns: 38px minmax(0, 1fr) 24px 16px;
+    align-items: center;
+    gap: 12px;
+    padding: 12px 14px;
+    border: 1px solid rgba(13, 15, 18, 0.09);
+    border-radius: 12px;
+    background: #fbfaf7;
+    color: #6f7278;
+    cursor: pointer;
+    font: inherit;
+    text-align: left;
+    transition:
+      border-color 0.18s ease,
+      background 0.18s ease,
+      box-shadow 0.18s ease,
+      transform 0.18s ease;
+  }
+
+  .lp-pod-resource-nav > button:hover {
+    border-color: rgba(13, 15, 18, 0.15);
+    background: #ffffff;
+    transform: translateX(2px);
+  }
+
+  .lp-pod-resource-nav > button.is-active {
+    border-color: rgba(13, 15, 18, 0.18);
+    background: #ffffff;
+    box-shadow: 0 12px 30px rgba(13, 15, 18, 0.055);
+    color: #25272a;
+  }
+
+  .lp-pod-resource-nav .lemma-product-icon {
+    display: grid;
+    width: 38px;
+    height: 38px;
+    place-items: center;
+    padding: 9px;
+    border: 1px solid rgba(13, 15, 18, 0.08);
+    border-radius: 10px;
+    background: #ffffff;
+    color: #74777d;
+  }
+
+  .lp-pod-resource-nav > button.is-active .lemma-product-icon {
+    border-color: rgba(192, 128, 31, 0.25);
+    background: #fbf5e9;
+    color: #9d6d23;
+  }
+
+  .lp-pod-resource-nav > button > span:nth-child(2) {
+    min-width: 0;
+  }
+
+  .lp-pod-resource-nav strong,
+  .lp-pod-resource-nav small {
+    display: block;
+  }
+
+  .lp-pod-resource-nav strong {
+    color: #26282c;
     font-size: 0.98rem;
-    line-height: 1.62;
+    font-weight: 570;
+  }
+
+  .lp-pod-resource-nav small {
+    overflow: hidden;
+    margin-top: 4px;
+    color: #73767b;
+    font-size: 0.78rem;
+    line-height: 1.35;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-pod-resource-nav > button > em {
+    display: grid;
+    width: 24px;
+    height: 24px;
+    place-items: center;
+    border-radius: 12px;
+    background: rgba(13, 15, 18, 0.045);
+    color: #777a80;
+    font-size: 0.7rem;
+    font-style: normal;
+  }
+
+  .lp-pod-resource-nav > button > svg {
+    width: 15px;
+    height: 15px;
+    color: #a3a5a9;
+    transition: transform 0.18s ease;
+  }
+
+  .lp-pod-resource-nav > button.is-active > svg {
+    color: #4a4d52;
+    transform: translateX(2px);
   }
 
   .lp-pod-map {
@@ -820,6 +3895,10 @@
 
     .lp-pod-visual iframe {
       height: clamp(560px, 120vw, 720px);
+    }
+
+    .lp-pod-resource-nav {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
 
@@ -3549,8 +6628,11 @@
 
   .lp-footer-box h2 {
     color: #ffffff;
+    font-family: var(--font-display-family);
     font-size: clamp(2.2rem, 3.4vw, 3.4rem);
+    font-weight: 500;
     line-height: 1.02;
+    letter-spacing: -0.035em;
   }
 
   .lp-footer-box p {
@@ -3579,12 +6661,13 @@
 
   @media (max-width: 980px) {
     .lp-header {
+      top: 14px;
       grid-template-columns: auto auto;
       justify-content: space-between;
+      width: calc(100% - 28px);
     }
 
-    .lp-nav,
-    .lp-header-actions a:first-child {
+    .lp-nav {
       display: none;
     }
 
@@ -3671,11 +6754,61 @@
     .lp-showcase-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
+
+    .lp-demo-shell {
+      grid-template-columns: 178px minmax(0, 1fr);
+    }
+
+    .lp-demo-sidebar {
+      padding-right: 8px;
+      padding-left: 8px;
+    }
+
+    .lp-demo-page {
+      padding: 24px;
+    }
+
+    .lp-demo-app-grid {
+      grid-template-columns: minmax(0, 1.35fr) minmax(190px, 0.75fr);
+    }
+
+    .lp-demo-agent {
+      grid-template-columns: 32px minmax(0, 1fr) minmax(110px, auto);
+    }
+
+    .lp-demo-agent .lp-demo-row-arrow {
+      display: none;
+    }
+
+    .lp-demo-workflow-layout {
+      grid-template-columns: 138px minmax(270px, 1fr) 164px;
+    }
+
+    .lp-demo-canvas-node {
+      width: 102px;
+    }
+
+    .lp-demo-canvas-node.is-node-1,
+    .lp-demo-canvas-node.is-node-4 {
+      left: calc(50% - 51px);
+      right: auto;
+    }
+
+    .lp-demo-doc-layout {
+      grid-template-columns: 150px minmax(280px, 1fr) 150px;
+    }
+
+    .lp-demo-document {
+      padding-right: 24px;
+      padding-left: 24px;
+    }
   }
 
   @media (max-width: 640px) {
     .lp-header {
-      padding: 16px;
+      top: 10px;
+      width: calc(100% - 20px);
+      padding: 7px 8px;
     }
 
     .lp-hero,
@@ -3740,6 +6873,679 @@
 
     .lp-pod-screen-head {
       padding: 22px 20px 16px;
+    }
+
+    .lp-theater-stage {
+      min-height: 520px;
+      padding-right: 0;
+      padding-left: 0;
+    }
+
+    .lp-product-frame {
+      height: 520px;
+      border-radius: 12px;
+    }
+
+    .lp-demo-shell {
+      grid-template-columns: 48px minmax(0, 1fr);
+    }
+
+    .lp-demo-sidebar {
+      align-items: center;
+      padding: 9px 5px 8px;
+    }
+
+    .lp-demo-pod-switcher {
+      justify-content: center;
+      margin-bottom: 10px;
+      padding: 4px 0;
+    }
+
+    .lp-demo-pod-switcher > span {
+      width: 28px;
+      height: 28px;
+    }
+
+    .lp-demo-pod-switcher strong,
+    .lp-demo-pod-switcher > svg,
+    .lp-demo-nav-label,
+    .lp-demo-sidebar-actions button span,
+    .lp-demo-nav button span,
+    .lp-demo-nav button small,
+    .lp-demo-sidebar-foot button span,
+    .lp-demo-person {
+      display: none;
+    }
+
+    .lp-demo-sidebar-actions,
+    .lp-demo-nav,
+    .lp-demo-sidebar-foot {
+      width: 100%;
+    }
+
+    .lp-demo-sidebar-actions button,
+    .lp-demo-nav button,
+    .lp-demo-sidebar-foot button {
+      justify-content: center;
+      min-height: 32px;
+      padding: 0;
+    }
+
+    .lp-demo-sidebar-foot {
+      justify-content: center;
+    }
+
+    .lp-demo-sidebar-foot > span:last-child,
+    .lp-demo-app-worktree {
+      display: none;
+    }
+
+    .lp-demo-tabbar {
+      height: 42px;
+      padding-right: 8px;
+      padding-left: 3px;
+    }
+
+    .lp-demo-tabs button {
+      padding: 0 8px;
+      font-size: 0.64rem;
+    }
+
+    .lp-demo-tabs button:first-child {
+      width: 31px;
+      padding: 0;
+      justify-content: center;
+      font-size: 0;
+    }
+
+    .lp-demo-tabs .lp-demo-new-tab {
+      display: none;
+    }
+
+    .lp-demo-tabs > span {
+      padding: 0 8px;
+      font-size: 0.64rem;
+    }
+
+    .lp-demo-tabs > span::after {
+      right: 6px;
+      left: 6px;
+    }
+
+    .lp-demo-running {
+      font-size: 0;
+    }
+
+    .lp-demo-running::after {
+      content: "3";
+      font-size: 0.6rem;
+    }
+
+    .lp-demo-page {
+      padding: 18px 16px;
+    }
+
+    .lp-demo-page-head {
+      gap: 10px;
+      padding-bottom: 16px;
+    }
+
+    .lp-demo-page-head h3,
+    .lp-demo-home h3 {
+      font-size: 1.08rem;
+    }
+
+    .lp-demo-page-head p {
+      max-width: 300px;
+      font-size: 0.63rem;
+    }
+
+    .lp-demo-primary-action {
+      min-height: 29px;
+      padding: 0 8px;
+      font-size: 0 !important;
+    }
+
+    .lp-demo-primary-action svg {
+      width: 13px;
+      height: 13px;
+    }
+
+    .lp-demo-app-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .lp-demo-decision {
+      grid-template-columns: 7px minmax(0, 1fr);
+      padding: 11px 12px;
+    }
+
+    .lp-demo-decision > em {
+      display: none;
+    }
+
+    .lp-demo-decision-detail {
+      display: none;
+    }
+
+    .lp-demo-agent {
+      grid-template-columns: 29px minmax(0, 1fr);
+      gap: 10px;
+      padding: 11px 12px;
+    }
+
+    .lp-demo-agent-mark {
+      width: 28px;
+      height: 28px;
+    }
+
+    .lp-demo-agent-meta {
+      display: none;
+    }
+
+    .lp-demo-flow {
+      grid-template-columns: 1fr;
+      gap: 0;
+      padding: 0 0 4px 4px;
+    }
+
+    .lp-demo-flow-line {
+      top: 13px;
+      bottom: 16px;
+      left: 17px;
+      width: 2px;
+      height: auto;
+    }
+
+    .lp-demo-flow-line i {
+      width: 100%;
+      height: 60%;
+    }
+
+    .lp-demo-flow-step {
+      display: grid;
+      grid-template-columns: 27px 26px minmax(0, 1fr) auto;
+      align-items: center;
+      gap: 7px;
+      min-height: 43px;
+      text-align: left;
+    }
+
+    .lp-demo-flow-step > small,
+    .lp-demo-flow-step > strong,
+    .lp-demo-flow-step > em {
+      max-width: none;
+      margin: 0;
+    }
+
+    .lp-demo-flow-step > em {
+      padding-right: 3px;
+      text-align: right;
+    }
+
+    .lp-demo-approval {
+      padding: 10px;
+    }
+
+    .lp-demo-approval > button {
+      padding: 0 8px;
+    }
+
+    .lp-demo-table-shell {
+      overflow-x: auto;
+    }
+
+    .lp-demo-table-shell table {
+      min-width: 520px;
+    }
+
+    .lp-demo-home {
+      width: calc(100% - 24px);
+    }
+
+    .lp-demo-composer {
+      min-height: 52px;
+      margin-top: 20px;
+    }
+
+    .lp-demo-livebar {
+      height: 44px;
+      grid-template-columns: 25px minmax(0, 1fr) auto 26px;
+      gap: 7px;
+      padding-left: 9px;
+    }
+
+    .lp-demo-livebar > em,
+    .lp-demo-livebar p span {
+      display: none;
+    }
+
+    .lp-demo-livebar p strong {
+      font-size: 0.59rem;
+    }
+
+    .lp-demo-activity-icon {
+      width: 25px;
+      height: 25px;
+    }
+
+    .lp-demo-app-library {
+      grid-template-columns: 1fr;
+      gap: 9px;
+      overflow: hidden;
+    }
+
+    .lp-demo-app-card-head {
+      padding: 9px 10px;
+    }
+
+    .lp-demo-app-card-head > .lp-demo-app-icon {
+      width: 28px;
+      height: 28px;
+    }
+
+    .lp-demo-app-preview {
+      min-height: 78px;
+      margin-right: 8px;
+      margin-left: 8px;
+    }
+
+    .lp-demo-campaign-preview {
+      padding: 10px 12px;
+    }
+
+    .lp-demo-campaign-preview > span {
+      margin-bottom: 8px;
+    }
+
+    .lp-demo-campaign-preview > i {
+      height: 12px;
+      margin-top: 4px;
+    }
+
+    .lp-demo-crm-preview {
+      padding: 8px;
+    }
+
+    .lp-demo-crm-preview i {
+      height: 21px;
+    }
+
+    .lp-demo-app-card-foot {
+      min-height: 31px;
+      padding: 0 10px;
+      font-size: 0.52rem;
+    }
+
+    .lp-demo-app-toolbar {
+      min-height: 42px;
+      grid-template-columns: 27px minmax(0, 1fr) auto;
+      gap: 5px;
+      padding: 0 8px;
+    }
+
+    .lp-demo-app-identity {
+      padding-right: 0;
+      border-right: 0;
+    }
+
+    .lp-demo-app-identity strong {
+      display: none;
+    }
+
+    .lp-demo-app-toolbar nav {
+      justify-content: center;
+    }
+
+    .lp-demo-app-toolbar nav button {
+      justify-content: center;
+      width: 32px;
+      padding: 0;
+      font-size: 0;
+    }
+
+    .lp-demo-runtime {
+      width: 18px;
+      justify-content: center;
+      font-size: 0;
+    }
+
+    .lp-demo-app-content {
+      padding: 16px 13px;
+    }
+
+    .lp-demo-app-title-row {
+      gap: 8px;
+      padding-bottom: 13px;
+    }
+
+    .lp-demo-app-title-row h3 {
+      font-size: 1.02rem;
+    }
+
+    .lp-demo-app-title-row > div > p:last-child {
+      max-width: 220px;
+      font-size: 0.56rem;
+    }
+
+    .lp-demo-human-gate {
+      width: 27px;
+      min-height: 27px;
+      justify-content: center;
+      padding: 0;
+      font-size: 0;
+    }
+
+    .lp-demo-calendar {
+      gap: 3px;
+      padding: 4px;
+    }
+
+    .lp-demo-calendar > div {
+      padding: 6px 3px;
+    }
+
+    .lp-demo-calendar > div > small {
+      margin-bottom: 7px;
+      font-size: 0.42rem;
+    }
+
+    .lp-demo-calendar-card {
+      min-height: 105px;
+      padding: 6px;
+    }
+
+    .lp-demo-calendar-card strong {
+      margin-top: 8px;
+      font-size: 0.52rem;
+    }
+
+    .lp-demo-calendar-card em {
+      font-size: 0.43rem;
+    }
+
+    .lp-demo-performance-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .lp-demo-insight {
+      display: none;
+    }
+
+    .lp-demo-kanban {
+      overflow-x: auto;
+    }
+
+    .lp-demo-kanban > section {
+      min-width: 150px;
+    }
+
+    .lp-demo-crm-table {
+      overflow-x: auto;
+    }
+
+    .lp-demo-crm-table > div {
+      min-width: 520px;
+    }
+
+    .lp-demo-task-list article {
+      grid-template-columns: 28px minmax(0, 1fr) 40px;
+      gap: 8px;
+      min-height: 56px;
+      padding: 0 9px;
+    }
+
+    .lp-demo-task-list article time {
+      display: none;
+    }
+
+    .lp-demo-workflow-page {
+      padding-bottom: 12px;
+    }
+
+    .lp-demo-workflow-page .lp-demo-page-head {
+      padding-bottom: 10px;
+    }
+
+    .lp-demo-workflow-layout {
+      grid-template-columns: 1fr;
+      grid-template-rows: minmax(230px, 1fr) 138px;
+    }
+
+    .lp-demo-workflow-list {
+      display: none;
+    }
+
+    .lp-demo-step-inspector {
+      display: grid;
+      grid-template-columns: 30px minmax(0, 1fr);
+      align-content: start;
+      gap: 2px 9px;
+      padding: 9px 11px;
+      border-top: 1px solid #e7e6e3;
+      border-left: 0;
+    }
+
+    .lp-demo-step-inspector > .lp-demo-agent-mark {
+      grid-row: 1 / span 3;
+      width: 29px;
+      height: 29px;
+    }
+
+    .lp-demo-step-inspector > small {
+      margin-top: 0;
+    }
+
+    .lp-demo-step-inspector h4 {
+      margin-top: 2px;
+      font-size: 0.62rem;
+    }
+
+    .lp-demo-step-inspector p {
+      margin-top: 2px;
+      font-size: 0.5rem;
+    }
+
+    .lp-demo-step-inspector > div {
+      grid-column: 1 / -1;
+      margin-top: 5px;
+      padding: 6px 8px;
+    }
+
+    .lp-demo-step-inspector dl {
+      display: none;
+    }
+
+    .lp-demo-canvas-node {
+      width: 86px;
+      min-height: 52px;
+      padding: 7px;
+    }
+
+    .lp-demo-canvas-node strong {
+      margin-top: 4px;
+      font-size: 0.48rem;
+    }
+
+    .lp-demo-canvas-node span {
+      font-size: 0.4rem;
+    }
+
+    .lp-demo-canvas-node.is-node-0 {
+      top: 15px;
+      left: 10px;
+    }
+
+    .lp-demo-canvas-node.is-node-1 {
+      top: 15px;
+      left: calc(50% - 43px);
+    }
+
+    .lp-demo-canvas-node.is-node-2 {
+      top: 15px;
+      right: 10px;
+    }
+
+    .lp-demo-canvas-node.is-node-3 {
+      top: calc(50% - 25px);
+      right: 10px;
+    }
+
+    .lp-demo-canvas-node.is-node-4 {
+      right: auto;
+      bottom: 14px;
+      left: calc(50% - 43px);
+    }
+
+    .lp-demo-canvas-node.is-node-5 {
+      bottom: 14px;
+      left: 10px;
+    }
+
+    .lp-demo-wire.is-top {
+      top: 42px;
+      right: 53px;
+      left: 53px;
+    }
+
+    .lp-demo-wire.is-right {
+      top: 42px;
+      right: 53px;
+      bottom: 51%;
+    }
+
+    .lp-demo-wire.is-middle {
+      right: 53px;
+      bottom: 41px;
+    }
+
+    .lp-demo-wire.is-left {
+      bottom: 41px;
+      left: 53px;
+      width: calc(50% - 53px);
+    }
+
+    .lp-demo-flow-packet {
+      top: 38px;
+    }
+
+    .lp-demo-doc-page {
+      padding-bottom: 12px;
+    }
+
+    .lp-demo-doc-page .lp-demo-page-head {
+      padding-bottom: 10px;
+    }
+
+    .lp-demo-doc-layout {
+      grid-template-columns: 1fr;
+      grid-template-rows: 84px minmax(0, 1fr);
+    }
+
+    .lp-demo-doc-tree {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      overflow-x: auto;
+      padding: 7px;
+      border-right: 0;
+      border-bottom: 1px solid #e7e5e1;
+    }
+
+    .lp-demo-doc-search,
+    .lp-demo-doc-tree > small {
+      display: none;
+    }
+
+    .lp-demo-doc-tree button {
+      width: auto;
+      flex: none;
+      padding: 0 8px;
+    }
+
+    .lp-demo-document {
+      padding: 17px 18px;
+    }
+
+    .lp-demo-document h3 {
+      font-size: 1.18rem;
+    }
+
+    .lp-demo-doc-context {
+      display: none;
+    }
+
+    .lp-demo-connectors-layout {
+      grid-template-columns: 1fr;
+      grid-template-rows: auto minmax(0, 1fr);
+      gap: 8px;
+      overflow: hidden;
+    }
+
+    .lp-demo-connector-list {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .lp-demo-connector-list button {
+      min-height: 50px;
+      grid-template-columns: 28px minmax(0, 1fr);
+      gap: 7px;
+      padding: 0 8px;
+      border-right: 1px solid #eeedeb;
+    }
+
+    .lp-demo-connector-list button > em,
+    .lp-demo-connector-list button > svg {
+      display: none;
+    }
+
+    .lp-demo-connector-icon {
+      width: 28px;
+      height: 28px;
+    }
+
+    .lp-demo-connector-detail {
+      display: grid;
+      grid-template-columns: 35px minmax(0, 1fr);
+      align-content: start;
+      gap: 3px 9px;
+      overflow: hidden;
+      padding: 11px;
+    }
+
+    .lp-demo-connector-detail > .lp-demo-connector-icon {
+      grid-row: 1 / span 3;
+    }
+
+    .lp-demo-connector-detail > small {
+      margin-top: 0;
+    }
+
+    .lp-demo-connector-detail h4 {
+      margin-top: 2px;
+      font-size: 0.7rem;
+    }
+
+    .lp-demo-connector-detail > p {
+      margin-top: 0;
+    }
+
+    .lp-demo-connector-detail dl {
+      display: grid;
+      grid-column: 1 / -1;
+      grid-template-columns: 1fr 1fr;
+      gap: 8px;
+      margin-top: 7px;
+    }
+
+    .lp-demo-connector-detail dl div {
+      padding: 6px 0 0;
+    }
+
+    .lp-demo-connector-detail > small:last-of-type,
+    .lp-demo-used-by {
+      display: none;
     }
 
     .lp-pod-panel-body {
@@ -3861,10 +7667,10 @@
     flex: none;
     display: grid;
     place-items: center;
-    width: 46px;
-    height: 46px;
+    width: 40px;
+    height: 40px;
     border: 1px solid rgba(13, 15, 18, 0.12);
-    border-radius: 12px;
+    border-radius: 10px;
     background: #ffffff;
     transition:
       border-color 0.2s ease,
@@ -3877,7 +7683,7 @@
   }
 
   .lp-glyph {
-    width: 28px;
+    width: 24px;
     height: 28px;
     overflow: visible;
   }
@@ -4072,255 +7878,6 @@
     }
   }
 
-  /* ===== Watch one unit of work move ===== */
-
-  .lp-mw-section {
-    padding: 0 clamp(18px, 4vw, 56px);
-  }
-
-  .lp-mw-wrap {
-    height: 260vh;
-  }
-
-  .lp-mw-sticky {
-    position: sticky;
-    top: 0;
-    display: flex;
-    align-items: center;
-    min-height: 100vh;
-    min-height: 100dvh;
-  }
-
-  .lp-mw-sticky > .lp-section-inner {
-    width: 100%;
-  }
-
-  .lp-mw-head {
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    gap: 24px;
-  }
-
-  .lp-mw-readout {
-    flex: none;
-    padding: 8px 12px;
-    border: 1px solid rgba(13, 15, 18, 0.12);
-    border-radius: 8px;
-    background: #fbfaf7;
-    color: #9a8f78;
-    font-family: var(--font-mono-family);
-    font-size: 0.76rem;
-    letter-spacing: 0.08em;
-    white-space: nowrap;
-  }
-
-  .lp-mw-stage {
-    position: relative;
-    margin-top: clamp(44px, 5vw, 76px);
-  }
-
-  .lp-mw-track {
-    position: absolute;
-    top: 28px;
-    left: 10%;
-    right: 10%;
-    height: 2px;
-    border-radius: 2px;
-    background: rgba(13, 15, 18, 0.12);
-  }
-
-  .lp-mw-fill {
-    position: absolute;
-    inset: 0 auto 0 0;
-    width: 0%;
-    background: linear-gradient(90deg, #d99a32, #c0801f);
-    box-shadow: 0 0 12px rgba(192, 128, 31, 0.5);
-  }
-
-  .lp-mw-packet {
-    position: absolute;
-    left: 0%;
-    top: 50%;
-    width: 12px;
-    height: 12px;
-    margin: -6px 0 0 -6px;
-    border-radius: 50%;
-    background: #c0801f;
-    box-shadow:
-      0 0 0 4px rgba(192, 128, 31, 0.16),
-      0 0 18px rgba(192, 128, 31, 0.7);
-  }
-
-  .lp-mw-stations {
-    position: relative;
-    display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-  }
-
-  .lp-mw-station {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 4px;
-    padding: 0 8px;
-    text-align: center;
-  }
-
-  .lp-mw-chip {
-    position: relative;
-    z-index: 1;
-    display: grid;
-    place-items: center;
-    width: 56px;
-    height: 56px;
-    border: 1px solid rgba(13, 15, 18, 0.14);
-    border-radius: 16px;
-    background: #ffffff;
-    transition:
-      border-color 0.3s ease,
-      box-shadow 0.3s ease,
-      transform 0.3s ease;
-  }
-
-  .lp-mw-chip svg {
-    width: 26px;
-    height: 26px;
-    fill: none;
-    stroke: rgba(13, 15, 18, 0.42);
-    stroke-width: 1.6;
-    stroke-linecap: round;
-    stroke-linejoin: round;
-    transition: stroke 0.3s ease;
-  }
-
-  .lp-mw-station.is-lit .lp-mw-chip {
-    border-color: rgba(192, 128, 31, 0.55);
-    box-shadow: 0 10px 26px rgba(192, 128, 31, 0.18);
-    transform: translateY(-3px);
-  }
-
-  .lp-mw-station.is-lit .lp-mw-chip svg {
-    stroke: #c0801f;
-  }
-
-  .lp-mw-label {
-    margin-top: 12px;
-    color: #8b8f96;
-    font-family: var(--font-mono-family);
-    font-size: 0.74rem;
-    font-weight: 600;
-    letter-spacing: 0.1em;
-    transition: color 0.3s ease;
-  }
-
-  .lp-mw-station.is-lit .lp-mw-label {
-    color: #1a1c1f;
-  }
-
-  .lp-mw-sub {
-    color: #b3b6bb;
-    font-family: var(--font-mono-family);
-    font-size: 0.66rem;
-    letter-spacing: 0.16em;
-  }
-
-  .lp-mw-caption {
-    margin: 6px 0 0;
-    max-width: 190px;
-    color: #5b5f66;
-    font-size: 0.85rem;
-    line-height: 1.45;
-    opacity: 0.3;
-    transform: translateY(6px);
-    transition:
-      opacity 0.4s ease,
-      transform 0.4s ease;
-  }
-
-  .lp-mw-station.is-lit .lp-mw-caption {
-    opacity: 1;
-    transform: none;
-  }
-
-  .lp-mw-approval {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    margin-top: 10px;
-    padding: 10px 12px;
-    border: 1px solid rgba(13, 15, 18, 0.12);
-    border-left: 3px solid #c0801f;
-    border-radius: 10px;
-    background: #ffffff;
-    box-shadow: 0 10px 24px rgba(13, 15, 18, 0.07);
-    font-size: 0.78rem;
-    opacity: 0;
-    transform: translateY(8px);
-    transition:
-      opacity 0.45s ease 0.15s,
-      transform 0.45s ease 0.15s;
-  }
-
-  .lp-mw-station.is-lit .lp-mw-approval {
-    opacity: 1;
-    transform: none;
-  }
-
-  .lp-mw-approval strong {
-    color: #1a1c1f;
-    font-weight: 600;
-  }
-
-  .lp-mw-approval em {
-    color: #2f693d;
-    font-style: normal;
-    font-weight: 600;
-  }
-
-  .lp-mw-approval em::before {
-    content: "✓ ";
-  }
-
-  .lp-mw-section.is-static {
-    padding: clamp(70px, 8vw, 112px) clamp(18px, 4vw, 56px);
-  }
-
-  .lp-mw-section.is-static .lp-mw-wrap {
-    height: auto;
-  }
-
-  .lp-mw-section.is-static .lp-mw-sticky {
-    position: static;
-    min-height: 0;
-  }
-
-  .lp-mw-section.is-static .lp-mw-fill {
-    width: 100%;
-  }
-
-  .lp-mw-section.is-static .lp-mw-packet {
-    display: none;
-  }
-
-  .lp-mw-section.is-static .lp-mw-chip {
-    border-color: rgba(192, 128, 31, 0.45);
-  }
-
-  .lp-mw-section.is-static .lp-mw-chip svg {
-    stroke: #c0801f;
-  }
-
-  .lp-mw-section.is-static .lp-mw-label {
-    color: #1a1c1f;
-  }
-
-  .lp-mw-section.is-static .lp-mw-caption,
-  .lp-mw-section.is-static .lp-mw-approval {
-    opacity: 1;
-    transform: none;
-  }
-
   /* ===== Typing terminal ===== */
 
   .lp-terminal pre {
@@ -4395,133 +7952,2884 @@
     }
   }
 
-  .lp-hero-ticker {
+  .lp-work-surfaces {
     display: inline-flex;
     align-items: center;
-    gap: 10px;
-    overflow: hidden;
-    margin: 22px 0 0;
-    padding: 9px 16px;
-    border: 1px solid rgba(13, 15, 18, 0.1);
-    border-radius: 999px;
-    background: #fbfaf7;
+    gap: 12px;
+    margin: 18px 0 0;
+    padding: 0;
     color: #5b5f66;
-    font-family: var(--font-mono-family);
-    font-size: 0.78rem;
-    letter-spacing: 0.04em;
+    font-size: 0.72rem;
+    font-weight: 400;
     white-space: nowrap;
   }
 
-  .lp-ticker-dot {
+  .lp-work-surfaces-lead {
+    color: #6c7077;
+    font-family: var(--font-mono-family);
+    font-size: 0.68rem;
+    font-weight: 400;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .lp-work-surface-list {
+    display: inline-flex;
+    align-items: center;
+    gap: 14px;
+  }
+
+  .lp-work-surface {
+    display: inline-flex;
+    align-items: center;
+    min-height: 22px;
+    gap: 5px;
+    padding: 0;
+    color: #4b4f54;
+  }
+
+  .lp-work-surface img {
     flex: none;
-    width: 7px;
-    height: 7px;
+    width: 16px;
+    height: 16px;
     border-radius: 50%;
-    background: #c0801f;
-    box-shadow: 0 0 0 3px rgba(192, 128, 31, 0.16);
-    animation: lpTickerPulse 2.6s ease-in-out infinite;
+    object-fit: contain;
+    animation: lpSurfaceSignal 10s ease-in-out infinite;
+    transform-origin: center;
   }
 
-  .lp-ticker-text {
-    display: inline-block;
-    animation: lpTickerIn 0.45s cubic-bezier(0.2, 0.7, 0.2, 1) both;
+  .lp-work-surface:nth-child(2) img {
+    animation-delay: 1.1s;
   }
 
-  @keyframes lpTickerIn {
-    from {
-      opacity: 0;
-      transform: translateY(9px);
-    }
-
-    to {
-      opacity: 1;
-      transform: none;
-    }
+  .lp-work-surface:nth-child(3) img {
+    animation-delay: 2.2s;
   }
 
-  @keyframes lpTickerPulse {
+  .lp-work-surface:nth-child(4) img {
+    animation-delay: 3.3s;
+  }
+
+  @keyframes lpSurfaceSignal {
     0%,
+    8%,
     100% {
-      box-shadow: 0 0 0 3px rgba(192, 128, 31, 0.16);
+      filter: saturate(0.82);
+      opacity: 0.78;
+      transform: translateY(0) scale(1);
     }
 
-    50% {
-      box-shadow: 0 0 0 6px rgba(192, 128, 31, 0.06);
+    4% {
+      filter: saturate(1.08);
+      opacity: 1;
+      transform: translateY(-1px) scale(1.08);
     }
   }
 
-  /* ===== Runtime coda ===== */
-
-  .lp-mw-coda {
-    margin: clamp(28px, 3.4vw, 44px) 0 0;
-    color: #8b8f96;
-    font-size: 0.95rem;
-    text-align: center;
+  .lp-work-surfaces-anywhere {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding-left: 2px;
+    color: #4b4f54;
   }
 
-  .lp-mw-coda::before {
-    content: "";
+  .lp-work-surfaces-anywhere i {
+    color: #c0801f;
+    font-style: normal;
+    font-size: 1rem;
+    line-height: 1;
+  }
+
+  @media (max-width: 640px) {
+    .lp-work-surfaces {
+      gap: 9px;
+    }
+
+    .lp-work-surface {
+      width: 24px;
+      min-height: 24px;
+      justify-content: center;
+    }
+
+    .lp-work-surface-list {
+      gap: 8px;
+    }
+
+    .lp-work-surface > span {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      white-space: nowrap;
+      clip-path: inset(50%);
+    }
+
+    .lp-work-surfaces-anywhere {
+      padding-left: 0;
+      font-size: 0;
+    }
+
+    .lp-work-surfaces-anywhere::after {
+      content: "anywhere";
+      font-size: 0.76rem;
+    }
+  }
+
+  /* ===== Full product apps inside the pod ===== */
+
+  .lp-product-app {
+    display: grid;
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    grid-template: 42px minmax(0, 1fr) / 134px minmax(0, 1fr);
+    overflow: hidden;
+    background: #f7f7f5;
+    color: #34363a;
+  }
+
+  .lp-product-topbar {
+    display: grid;
+    z-index: 2;
+    grid-column: 1 / -1;
+    grid-template-columns: 25px auto minmax(100px, 280px) 1fr auto auto;
+    align-items: center;
+    gap: 8px;
+    padding: 0 11px;
+    border-bottom: 1px solid #e5e4e1;
+    background: rgba(255, 255, 255, 0.94);
+  }
+
+  .lp-product-mark {
+    display: grid;
+    width: 24px;
+    height: 24px;
+    place-items: center;
+    border-radius: 6px;
+    background: #e9e3f1;
+    color: #66557d;
+    font-size: 0.47rem;
+    font-weight: 750;
+  }
+
+  .lp-product-app.is-blue .lp-product-mark {
+    background: #e0ebee;
+    color: #3e6b75;
+  }
+
+  .lp-product-topbar > strong {
+    padding-right: 10px;
+    border-right: 1px solid #e9e8e5;
+    font-size: 0.64rem;
+    font-weight: 650;
+    white-space: nowrap;
+  }
+
+  .lp-product-search {
+    display: flex;
+    min-width: 0;
+    height: 25px;
+    align-items: center;
+    gap: 6px;
+    margin-left: 2px;
+    padding: 0 7px;
+    border: 1px solid #e7e6e3;
+    border-radius: 6px;
+    background: #f8f8f6;
+    color: #a0a1a4;
+    font-size: 0.51rem;
+  }
+
+  .lp-product-search svg,
+  .lp-product-topbar > button svg {
+    width: 11px;
+    height: 11px;
+  }
+
+  .lp-product-search kbd {
+    margin-left: auto;
+    padding: 1px 4px;
+    border: 1px solid #e3e2df;
+    border-radius: 3px;
+    background: #ffffff;
+    color: #a0a1a3;
+    font: inherit;
+  }
+
+  .lp-product-topbar > .lp-demo-runtime {
+    justify-self: end;
+  }
+
+  .lp-product-topbar > button {
+    display: grid;
+    width: 24px;
+    height: 24px;
+    place-items: center;
+    border: 0;
+    border-radius: 5px;
+    background: transparent;
+    color: #77797c;
+  }
+
+  .lp-product-avatar {
+    display: grid;
+    width: 23px;
+    height: 23px;
+    place-items: center;
+    border-radius: 50%;
+    background: #2f3337;
+    color: #ffffff;
+    font-size: 0.44rem;
+    font-weight: 650;
+  }
+
+  .lp-product-sidebar {
+    display: flex;
+    min-height: 0;
+    flex-direction: column;
+    padding: 13px 8px 9px;
+    border-right: 1px solid #e5e4e1;
+    background: #f2f2ef;
+  }
+
+  .lp-product-workspace {
     display: block;
-    width: 54px;
-    height: 1px;
-    margin: 0 auto 16px;
-    background: rgba(192, 128, 31, 0.5);
+    margin: 0 4px 12px;
   }
 
-  @media (max-width: 860px) {
-    .lp-mw-track {
+  .lp-product-workspace small,
+  .lp-product-workspace strong {
+    display: block;
+  }
+
+  .lp-product-workspace small {
+    color: #a0a19f;
+    font-size: 0.43rem;
+    font-weight: 650;
+    letter-spacing: 0.08em;
+  }
+
+  .lp-product-workspace strong {
+    overflow: hidden;
+    margin-top: 4px;
+    color: #5c5e61;
+    font-size: 0.55rem;
+    font-weight: 580;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-product-sidebar nav {
+    display: grid;
+    gap: 2px;
+  }
+
+  .lp-product-sidebar nav button {
+    display: grid;
+    width: 100%;
+    min-height: 28px;
+    grid-template-columns: 14px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 6px;
+    padding: 0 7px;
+    border: 0;
+    border-radius: 5px;
+    background: transparent;
+    color: #77797c;
+    font-size: 0.54rem;
+    text-align: left;
+  }
+
+  .lp-product-sidebar nav button:hover,
+  .lp-product-sidebar nav button.is-active {
+    background: #ffffff;
+    color: #313337;
+    box-shadow: 0 1px 2px rgba(32, 34, 37, 0.04);
+  }
+
+  .lp-product-sidebar nav button.is-active {
+    font-weight: 620;
+  }
+
+  .lp-product-app.is-violet .lp-product-sidebar nav button.is-active svg {
+    color: #7c69a3;
+  }
+
+  .lp-product-app.is-blue .lp-product-sidebar nav button.is-active svg {
+    color: #4a7f8b;
+  }
+
+  .lp-product-sidebar nav svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  .lp-product-sidebar nav button small {
+    display: grid;
+    min-width: 16px;
+    height: 16px;
+    place-items: center;
+    border-radius: 8px;
+    background: #e8e6e2;
+    color: #818286;
+    font-size: 0.44rem;
+  }
+
+  .lp-product-agent {
+    display: grid;
+    grid-template-columns: 25px minmax(0, 1fr);
+    gap: 0 7px;
+    margin-top: auto;
+    padding: 8px 6px;
+    border: 1px solid #e1e0dc;
+    border-radius: 7px;
+    background: rgba(255, 255, 255, 0.72);
+  }
+
+  .lp-product-agent > span {
+    display: grid;
+    width: 24px;
+    height: 24px;
+    grid-row: 1 / span 2;
+    place-items: center;
+    border-radius: 6px;
+    background: #ebe6f1;
+    color: #75658e;
+  }
+
+  .lp-product-app.is-blue .lp-product-agent > span {
+    background: #e1eaed;
+    color: #4b7580;
+  }
+
+  .lp-product-agent svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  .lp-product-agent strong {
+    align-self: end;
+    font-size: 0.52rem;
+    font-weight: 620;
+  }
+
+  .lp-product-agent small {
+    overflow: hidden;
+    align-self: start;
+    color: #96979a;
+    font-size: 0.42rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-product-main {
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+    background: #fbfbfa;
+  }
+
+  .lp-product-page {
+    display: flex;
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+    flex-direction: column;
+    gap: 10px;
+    overflow: hidden;
+    padding: clamp(13px, 1.8vw, 20px);
+    animation: lpDemoViewIn 0.24s ease both;
+  }
+
+  .lp-product-page-head {
+    display: flex;
+    min-width: 0;
+    flex: none;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 14px;
+  }
+
+  .lp-product-page-head > div:first-child {
+    min-width: 0;
+  }
+
+  .lp-product-page-head p {
+    margin: 0 0 4px;
+    color: #9a959e;
+    font-size: 0.43rem;
+    font-weight: 650;
+    letter-spacing: 0.085em;
+  }
+
+  .lp-product-page-head h3 {
+    margin: 0;
+    color: #24262a;
+    font-size: clamp(0.9rem, 1.5vw, 1.2rem);
+    font-weight: 590;
+    letter-spacing: -0.025em;
+  }
+
+  .lp-product-page-head > div:first-child > span {
+    display: block;
+    overflow: hidden;
+    margin-top: 4px;
+    color: #8b8d90;
+    font-size: 0.53rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-product-page-actions {
+    display: flex;
+    flex: none;
+    gap: 5px;
+  }
+
+  .lp-product-page-actions button,
+  .lp-product-segmented button {
+    display: flex;
+    height: 26px;
+    align-items: center;
+    gap: 5px;
+    padding: 0 8px;
+    border: 1px solid #e0dfdc;
+    border-radius: 5px;
+    background: #ffffff;
+    color: #686a6d;
+    font-size: 0.5rem;
+  }
+
+  .lp-product-page-actions button svg {
+    width: 10px;
+    height: 10px;
+  }
+
+  .lp-product-page-actions button.is-primary,
+  .lp-product-record-actions button.is-primary,
+  .lp-codex-draft footer button.is-primary {
+    border-color: #3e3c42;
+    background: #38363c;
+    color: #ffffff;
+  }
+
+  .lp-product-app.is-blue .lp-product-page-actions button.is-primary,
+  .lp-product-app.is-blue .lp-product-record-actions button.is-primary,
+  .lp-product-app.is-blue .lp-codex-draft footer button.is-primary {
+    border-color: #3d6872;
+    background: #416f79;
+  }
+
+  .lp-product-kpis {
+    display: grid;
+    flex: none;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 7px;
+  }
+
+  .lp-product-kpis article {
+    position: relative;
+    min-width: 0;
+    min-height: 76px;
+    overflow: hidden;
+    padding: 9px 10px;
+    border: 1px solid #e6e5e2;
+    border-radius: 7px;
+    background: #ffffff;
+  }
+
+  .lp-product-kpis article > span:first-child {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 4px;
+  }
+
+  .lp-product-kpis article small {
+    color: #85878a;
+    font-size: 0.47rem;
+  }
+
+  .lp-product-kpis article em {
+    color: #6c9b75;
+    font-size: 0.43rem;
+    font-style: normal;
+  }
+
+  .lp-product-kpis article em.is-amber {
+    color: #a27735;
+  }
+
+  .lp-product-kpis article em.is-blue {
+    color: #5b8491;
+  }
+
+  .lp-product-kpis article > strong {
+    display: block;
+    margin-top: 5px;
+    color: #303236;
+    font-size: 0.9rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+  }
+
+  .lp-product-mini-trend {
+    position: absolute;
+    right: 8px;
+    bottom: 6px;
+    left: 8px;
+    display: flex;
+    align-items: flex-end;
+    width: calc(100% - 16px);
+    height: 24px;
+    gap: 2px;
+  }
+
+  .lp-product-mini-trend i {
+    flex: 1;
+    border-radius: 2px 2px 0 0;
+    background: rgba(138, 121, 175, 0.34);
+  }
+
+  .lp-product-mini-trend i:nth-child(1) { height: 30%; }
+  .lp-product-mini-trend i:nth-child(2) { height: 42%; }
+  .lp-product-mini-trend i:nth-child(3) { height: 38%; }
+  .lp-product-mini-trend i:nth-child(4) { height: 55%; }
+  .lp-product-mini-trend i:nth-child(5) { height: 62%; }
+  .lp-product-mini-trend i:nth-child(6) { height: 76%; }
+  .lp-product-mini-trend i:nth-child(7) { height: 70%; }
+  .lp-product-mini-trend i:nth-child(8) { height: 90%; }
+
+  .lp-product-mini-trend.is-blue i {
+    background: rgba(92, 135, 146, 0.34);
+  }
+
+  .lp-product-progress {
+    display: block;
+    height: 4px;
+    margin-top: 10px;
+    overflow: hidden;
+    border-radius: 4px;
+    background: #efefed;
+  }
+
+  .lp-product-progress i {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: #849f8b;
+  }
+
+  .lp-product-progress i.is-w42,
+  .lp-crm-funnel em.is-w42 { width: 42%; }
+  .lp-crm-funnel em.is-w24 { width: 24%; }
+  .lp-crm-funnel em.is-w58 { width: 58%; }
+  .lp-crm-funnel em.is-w73 { width: 73%; }
+  .lp-product-progress i.is-w75,
+  .lp-task-capacity em.is-w75 { width: 75%; }
+  .lp-task-capacity em.is-w72 { width: 72%; }
+  .lp-crm-funnel em.is-w92,
+  .lp-task-capacity em.is-w92 { width: 92%; }
+
+  .lp-product-progress.is-amber i {
+    background: #b89459;
+  }
+
+  .lp-product-panel {
+    min-width: 0;
+    min-height: 0;
+    border: 1px solid #e5e4e1;
+    border-radius: 8px;
+    background: #ffffff;
+  }
+
+  .lp-product-panel > header {
+    display: flex;
+    min-height: 40px;
+    align-items: center;
+    gap: 8px;
+    padding: 0 11px;
+    border-bottom: 1px solid #ecebe8;
+  }
+
+  .lp-product-panel > header > span:first-child {
+    min-width: 0;
+    margin-right: auto;
+  }
+
+  .lp-product-panel > header strong,
+  .lp-product-panel > header small {
+    display: block;
+  }
+
+  .lp-product-panel > header strong {
+    color: #44464a;
+    font-size: 0.57rem;
+    font-weight: 620;
+  }
+
+  .lp-product-panel > header small {
+    margin-top: 2px;
+    color: #999a9d;
+    font-size: 0.43rem;
+  }
+
+  .lp-product-panel > header em {
+    color: #817393;
+    font-size: 0.43rem;
+    font-style: normal;
+  }
+
+  .lp-product-panel > header em.is-muted {
+    color: #aaa8ad;
+  }
+
+  .lp-campaign-command-grid {
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template: minmax(116px, 1fr) minmax(135px, 1.05fr) / minmax(0, 1.3fr) minmax(170px, 0.7fr);
+    gap: 8px;
+  }
+
+  .lp-campaign-trajectory {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .lp-trajectory-chart {
+    position: relative;
+    min-height: 0;
+    flex: 1;
+    overflow: hidden;
+    padding: 9px 10px 5px;
+  }
+
+  .lp-trajectory-chart .is-grid,
+  .lp-performance-plot .is-grid {
+    position: absolute;
+    right: 10px;
+    left: 10px;
+    border-top: 1px dashed #efeeec;
+  }
+
+  .lp-trajectory-chart .g1,
+  .lp-performance-plot .g1 { top: 25%; }
+  .lp-trajectory-chart .g2,
+  .lp-performance-plot .g2 { top: 50%; }
+  .lp-trajectory-chart .g3,
+  .lp-performance-plot .g3 { top: 75%; }
+
+  .lp-css-chart {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: stretch;
+    width: 100%;
+    gap: 5px;
+  }
+
+  .lp-css-chart i {
+    position: relative;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .lp-css-chart i::before {
+    position: absolute;
+    right: 18%;
+    bottom: 0;
+    left: 18%;
+    height: var(--actual);
+    border-radius: 3px 3px 0 0;
+    background: linear-gradient(180deg, #927db2, #715d92);
+    content: "";
+  }
+
+  .lp-css-chart i::after {
+    position: absolute;
+    right: 3%;
+    bottom: var(--plan);
+    left: 3%;
+    border-top: 1px dashed #bdb8c3;
+    content: "";
+  }
+
+  .lp-css-chart-trajectory {
+    height: calc(100% - 15px);
+  }
+
+  .lp-css-chart-trajectory i:nth-child(1) { --actual: 18%; --plan: 22%; }
+  .lp-css-chart-trajectory i:nth-child(2) { --actual: 28%; --plan: 29%; }
+  .lp-css-chart-trajectory i:nth-child(3) { --actual: 34%; --plan: 36%; }
+  .lp-css-chart-trajectory i:nth-child(4) { --actual: 48%; --plan: 44%; }
+  .lp-css-chart-trajectory i:nth-child(5) { --actual: 53%; --plan: 52%; }
+  .lp-css-chart-trajectory i:nth-child(6) { --actual: 68%; --plan: 61%; }
+  .lp-css-chart-trajectory i:nth-child(7) { --actual: 74%; --plan: 70%; }
+  .lp-css-chart-trajectory i:nth-child(8) { --actual: 91%; --plan: 80%; }
+
+  .lp-trajectory-axis {
+    display: flex;
+    justify-content: space-between;
+    color: #aaa9ac;
+    font-size: 0.4rem;
+  }
+
+  .lp-claude-brief {
+    display: flex;
+    flex-direction: column;
+    padding: 11px;
+    border-color: #ded7e8;
+    background: #faf8fc;
+  }
+
+  .lp-claude-brief > header {
+    min-height: auto;
+    padding: 0;
+    border: 0;
+  }
+
+  .lp-product-ai-icon {
+    display: grid;
+    width: 25px;
+    height: 25px;
+    flex: none;
+    place-items: center;
+    border-radius: 6px;
+    background: #eae4f0;
+    color: #74618d;
+  }
+
+  .lp-product-ai-icon svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  .lp-claude-brief h4 {
+    margin: 10px 0 6px;
+    color: #48424f;
+    font-size: 0.66rem;
+    font-weight: 600;
+    line-height: 1.35;
+  }
+
+  .lp-claude-brief ul {
+    display: grid;
+    gap: 5px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .lp-claude-brief li {
+    display: grid;
+    grid-template-columns: 5px 1fr;
+    gap: 5px;
+    color: #77727d;
+    font-size: 0.48rem;
+    line-height: 1.35;
+  }
+
+  .lp-claude-brief li i {
+    width: 3px;
+    height: 3px;
+    margin-top: 4px;
+    border-radius: 50%;
+    background: #8a79a6;
+  }
+
+  .lp-product-source-row {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    margin-top: auto;
+    padding-top: 7px;
+    color: #766887;
+    font-size: 0.46rem;
+    font-weight: 600;
+  }
+
+  .lp-product-source-row svg {
+    width: 9px;
+    height: 9px;
+  }
+
+  .lp-attention-panel {
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template: 40px minmax(0, 1fr) / minmax(0, 1fr) minmax(230px, 0.9fr);
+    overflow: hidden;
+  }
+
+  .lp-attention-panel > header {
+    grid-column: 1 / -1;
+  }
+
+  .lp-attention-panel > header button,
+  .lp-product-panel > header > button {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    border: 0;
+    background: transparent;
+    color: #76787c;
+    font-size: 0.45rem;
+  }
+
+  .lp-attention-list {
+    display: grid;
+    align-content: start;
+    border-right: 1px solid #ecebe8;
+  }
+
+  .lp-attention-list button {
+    display: grid;
+    min-height: 47px;
+    grid-template-columns: 7px minmax(0, 1fr) 11px;
+    align-items: center;
+    gap: 7px;
+    padding: 6px 10px;
+    border: 0;
+    border-bottom: 1px solid #f0efed;
+    background: #ffffff;
+    text-align: left;
+  }
+
+  .lp-attention-list button.is-active {
+    background: #faf8fc;
+  }
+
+  .lp-attention-list strong,
+  .lp-attention-list small {
+    display: block;
+  }
+
+  .lp-attention-list strong {
+    overflow: hidden;
+    font-size: 0.5rem;
+    font-weight: 590;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-attention-list small {
+    margin-top: 3px;
+    color: #999a9d;
+    font-size: 0.41rem;
+  }
+
+  .lp-attention-list svg {
+    width: 9px;
+    height: 9px;
+    color: #9a9b9e;
+  }
+
+  .lp-attention-detail {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    padding: 9px 11px;
+    background: #fcfcfb;
+  }
+
+  .lp-attention-detail small,
+  .lp-attention-detail strong {
+    display: block;
+  }
+
+  .lp-attention-detail small {
+    color: #9d8a6a;
+    font-size: 0.39rem;
+    font-weight: 650;
+    letter-spacing: 0.07em;
+  }
+
+  .lp-attention-detail strong {
+    overflow: hidden;
+    margin-top: 3px;
+    font-size: 0.54rem;
+    font-weight: 620;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-attention-detail p {
+    display: -webkit-box;
+    overflow: hidden;
+    margin: 6px 0;
+    color: #7f8084;
+    font-size: 0.46rem;
+    line-height: 1.4;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  .lp-attention-detail > div {
+    display: flex;
+    gap: 5px;
+    margin-top: auto;
+  }
+
+  .lp-attention-detail button {
+    height: 23px;
+    padding: 0 7px;
+    border: 1px solid #e2e0dc;
+    border-radius: 4px;
+    background: #ffffff;
+    color: #707276;
+    font-size: 0.43rem;
+  }
+
+  .lp-attention-detail button.is-approve {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    border-color: #758c79;
+    background: #748c79;
+    color: #ffffff;
+  }
+
+  .lp-attention-detail button svg {
+    width: 8px;
+    height: 8px;
+  }
+
+  .lp-product-split-view {
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template-columns: minmax(0, 1.45fr) minmax(190px, 0.55fr);
+    overflow: hidden;
+    border: 1px solid #e4e3e0;
+    border-radius: 8px;
+    background: #ffffff;
+  }
+
+  .lp-product-table-card {
+    min-width: 0;
+    overflow: hidden;
+    border-right: 1px solid #e8e7e4;
+  }
+
+  .lp-product-table-card > header {
+    display: flex;
+    min-height: 38px;
+    align-items: center;
+    gap: 10px;
+    padding: 0 10px;
+    border-bottom: 1px solid #e9e8e5;
+  }
+
+  .lp-product-table-card > header > span {
+    margin-right: auto;
+    color: #737579;
+    font-size: 0.49rem;
+    font-weight: 600;
+  }
+
+  .lp-product-table-card > header nav {
+    display: flex;
+    gap: 2px;
+  }
+
+  .lp-product-table-card > header button {
+    display: grid;
+    min-width: 22px;
+    height: 23px;
+    place-items: center;
+    padding: 0 6px;
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: #898a8d;
+    font-size: 0.44rem;
+  }
+
+  .lp-product-table-card > header button.is-active {
+    background: #f0efec;
+    color: #3c3e41;
+  }
+
+  .lp-product-table-card > header svg {
+    width: 10px;
+    height: 10px;
+  }
+
+  .lp-product-table-row {
+    display: grid;
+    width: 100%;
+    min-height: 46px;
+    grid-template-columns: minmax(150px, 1.5fr) minmax(75px, 0.7fr) minmax(70px, 0.7fr) minmax(75px, 0.7fr);
+    align-items: center;
+    padding: 0 9px;
+    border: 0;
+    border-bottom: 1px solid #efeeec;
+    background: #ffffff;
+    color: #727478;
+    font-size: 0.46rem;
+    text-align: left;
+  }
+
+  .lp-product-table-row.is-head {
+    min-height: 26px;
+    background: #f8f8f6;
+    color: #9a9b9e;
+    font-size: 0.41rem;
+    font-weight: 620;
+  }
+
+  button.lp-product-table-row:hover,
+  button.lp-product-table-row.is-selected {
+    background: #f9f7fb;
+  }
+
+  .lp-product-app.is-blue button.lp-product-table-row.is-selected {
+    background: #f3f7f8;
+  }
+
+  .lp-product-table-row > span {
+    min-width: 0;
+  }
+
+  .lp-product-table-row > span:first-child {
+    display: grid;
+    grid-template-columns: 25px minmax(0, 1fr);
+    align-items: center;
+    gap: 0 7px;
+  }
+
+  .lp-product-table-row > span:first-child > i {
+    display: grid;
+    width: 24px;
+    height: 24px;
+    grid-row: 1 / span 2;
+    place-items: center;
+    border-radius: 5px;
+    background: #efebf3;
+    color: #786b8b;
+    font-size: 0.43rem;
+    font-style: normal;
+    font-weight: 700;
+  }
+
+  .lp-product-app.is-blue .lp-product-table-row > span:first-child > i {
+    background: #e7eef0;
+    color: #4e747d;
+  }
+
+  .lp-product-table-row > span:first-child svg {
+    width: 11px;
+    height: 11px;
+  }
+
+  .lp-product-table-row strong,
+  .lp-product-table-row small {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-product-table-row strong {
+    color: #4b4d51;
+    font-size: 0.49rem;
+    font-weight: 590;
+  }
+
+  .lp-product-table-row small {
+    margin-top: 2px;
+    color: #9a9b9e;
+    font-size: 0.4rem;
+  }
+
+  .lp-product-table-row .is-state {
+    display: inline-flex;
+    min-height: 18px;
+    align-items: center;
+    padding: 0 6px;
+    border-radius: 8px;
+    background: #f0edf4;
+    color: #756688;
+    font-style: normal;
+    white-space: nowrap;
+  }
+
+  .lp-product-table-row .is-state.s1,
+  .lp-product-table-row .is-state.s3 {
+    background: #edf3ee;
+    color: #61806a;
+  }
+
+  .lp-product-table-row .is-state.s2 {
+    background: #f4efe6;
+    color: #8e713e;
+  }
+
+  .lp-product-record,
+  .lp-account-record {
+    display: flex;
+    min-width: 0;
+    min-height: 0;
+    flex-direction: column;
+    overflow: hidden;
+    padding: 12px;
+    background: #fcfcfb;
+  }
+
+  .lp-product-record > header,
+  .lp-account-record > header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .lp-product-record > header button,
+  .lp-account-record > header button {
+    display: grid;
+    width: 23px;
+    height: 23px;
+    place-items: center;
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: #8b8c90;
+  }
+
+  .lp-product-record > header button svg,
+  .lp-account-record > header button svg {
+    width: 11px;
+    height: 11px;
+  }
+
+  .lp-product-record-icon {
+    display: grid;
+    width: 27px;
+    height: 27px;
+    place-items: center;
+    border-radius: 6px;
+    background: #eee9f2;
+    color: #746584;
+  }
+
+  .lp-product-record-icon svg {
+    width: 12px;
+    height: 12px;
+  }
+
+  .lp-product-record > small {
+    margin-top: 12px;
+    color: #9a8ba3;
+    font-size: 0.4rem;
+    font-weight: 650;
+    letter-spacing: 0.06em;
+  }
+
+  .lp-product-record h4 {
+    margin: 4px 0 0;
+    font-size: 0.7rem;
+    font-weight: 620;
+  }
+
+  .lp-product-record > p {
+    margin: 7px 0;
+    color: #7f8084;
+    font-size: 0.47rem;
+    line-height: 1.45;
+  }
+
+  .lp-product-record dl {
+    display: grid;
+    gap: 5px;
+    margin: 3px 0 8px;
+  }
+
+  .lp-product-record dl div {
+    display: flex;
+    justify-content: space-between;
+    gap: 10px;
+    font-size: 0.43rem;
+  }
+
+  .lp-product-record dt {
+    color: #a0a1a4;
+  }
+
+  .lp-product-record dd {
+    overflow: hidden;
+    margin: 0;
+    color: #66686b;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-product-record-preview {
+    position: relative;
+    display: grid;
+    min-height: 60px;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 3px;
+    margin-top: auto;
+    overflow: hidden;
+    border-radius: 6px;
+    background: #302f33;
+  }
+
+  .lp-product-record-preview > span {
+    position: absolute;
+    z-index: 2;
+    right: 5px;
+    bottom: 4px;
+    color: rgba(255, 255, 255, 0.72);
+    font-size: 0.38rem;
+  }
+
+  .lp-product-record-preview .is-frame {
+    background: linear-gradient(145deg, #847497, #343139);
+  }
+
+  .lp-product-record-preview .two {
+    background: linear-gradient(145deg, #5b6f78, #282e31);
+  }
+
+  .lp-product-record-preview .three {
+    background: linear-gradient(145deg, #b38b65, #3b332c);
+  }
+
+  .lp-product-record-actions {
+    display: flex;
+    gap: 5px;
+    margin-top: 8px;
+  }
+
+  .lp-product-record-actions button,
+  .lp-codex-draft footer button {
+    flex: 1;
+    height: 24px;
+    border: 1px solid #dfdedb;
+    border-radius: 4px;
+    background: #ffffff;
+    color: #696b6f;
+    font-size: 0.43rem;
+  }
+
+  .lp-product-calendar {
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template-columns: 34px repeat(5, minmax(0, 1fr));
+    overflow: hidden;
+    border: 1px solid #e4e3e0;
+    border-radius: 8px;
+    background:
+      repeating-linear-gradient(to bottom, #ffffff 0, #ffffff 24%, #efeeec 25%);
+  }
+
+  .lp-product-calendar-times {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    padding: 28px 4px 6px;
+    color: #a2a3a6;
+    font-size: 0.38rem;
+    text-align: right;
+  }
+
+  .lp-product-calendar > section {
+    min-width: 0;
+    padding: 0 5px;
+    border-left: 1px solid #ecebe8;
+  }
+
+  .lp-product-calendar > section.is-today {
+    background: rgba(241, 236, 246, 0.34);
+  }
+
+  .lp-product-calendar section > header {
+    display: flex;
+    height: 28px;
+    align-items: center;
+    justify-content: space-between;
+    color: #929397;
+    font-size: 0.42rem;
+  }
+
+  .lp-product-calendar section > header em {
+    padding: 2px 4px;
+    border-radius: 5px;
+    background: #8875a1;
+    color: #ffffff;
+    font-size: 0.36rem;
+    font-style: normal;
+  }
+
+  .lp-product-calendar article {
+    display: flex;
+    min-height: 80px;
+    flex-direction: column;
+    align-items: flex-start;
+    margin-top: 8px;
+    padding: 8px;
+    border: 1px solid #dfd6e6;
+    border-left: 3px solid #8b77a3;
+    border-radius: 5px;
+    background: #faf8fc;
+  }
+
+  .lp-product-calendar article.is-green {
+    border-color: #d9e4db;
+    border-left-color: #6f9579;
+    background: #f7faf7;
+  }
+
+  .lp-product-calendar article.is-blue {
+    border-color: #d8e3e6;
+    border-left-color: #5f8791;
+    background: #f6f9fa;
+  }
+
+  .lp-product-calendar article.is-amber {
+    border-color: #e7dece;
+    border-left-color: #aa8144;
+    background: #fcfaf5;
+  }
+
+  .lp-product-calendar article.is-light {
+    min-height: 46px;
+    border-color: #e4e3e0;
+    border-left-color: #b8b8b6;
+    background: #ffffff;
+  }
+
+  .lp-product-calendar article strong {
+    overflow: hidden;
+    width: 100%;
+    margin-top: 8px;
+    font-size: 0.5rem;
+    font-weight: 620;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-product-calendar article small {
+    overflow: hidden;
+    width: 100%;
+    margin-top: 3px;
+    color: #8e8f92;
+    font-size: 0.4rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-product-calendar article > span:last-child {
+    margin-top: auto;
+    color: #a0a1a4;
+    font-size: 0.39rem;
+  }
+
+  .lp-asset-layout {
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template-columns: 120px minmax(0, 1fr);
+    gap: 8px;
+  }
+
+  .lp-asset-folders {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 7px;
+    border: 1px solid #e5e4e1;
+    border-radius: 8px;
+    background: #f6f6f4;
+  }
+
+  .lp-asset-folders button {
+    display: grid;
+    min-height: 28px;
+    grid-template-columns: 13px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 5px;
+    padding: 0 6px;
+    border: 0;
+    border-radius: 5px;
+    background: transparent;
+    color: #7e8083;
+    font-size: 0.46rem;
+    text-align: left;
+  }
+
+  .lp-asset-folders button.is-active {
+    background: #ffffff;
+    color: #44464a;
+    box-shadow: 0 1px 4px rgba(30, 32, 35, 0.05);
+  }
+
+  .lp-asset-folders svg {
+    width: 10px;
+    height: 10px;
+  }
+
+  .lp-asset-folders small {
+    color: #aaa;
+    font-size: 0.4rem;
+  }
+
+  .lp-asset-grid {
+    display: grid;
+    min-height: 0;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 7px;
+    overflow: auto;
+  }
+
+  .lp-asset-grid article {
+    display: flex;
+    min-width: 0;
+    min-height: 0;
+    flex-direction: column;
+    padding: 6px;
+    border: 1px solid #e6e5e2;
+    border-radius: 7px;
+    background: #ffffff;
+  }
+
+  .lp-asset-grid article > span {
+    display: flex;
+    min-height: 58px;
+    flex: 1;
+    align-items: flex-end;
+    justify-content: center;
+    gap: 4px;
+    overflow: hidden;
+    padding: 10px;
+    border-radius: 5px;
+    background: linear-gradient(145deg, #302e34, #696172);
+  }
+
+  .lp-asset-grid article > span.is-deck { background: linear-gradient(145deg, #e7dfd1, #a58d69); }
+  .lp-asset-grid article > span.is-proof { background: linear-gradient(145deg, #384247, #79939c); }
+  .lp-asset-grid article > span.is-ui { background: linear-gradient(145deg, #edf0ef, #9aa7a6); }
+  .lp-asset-grid article > span.is-copy { background: linear-gradient(145deg, #ede7df, #bca890); }
+  .lp-asset-grid article > span.is-note { background: linear-gradient(145deg, #e9e4ec, #9c8fa5); }
+
+  .lp-asset-grid article > span i {
+    width: 22%;
+    height: 55%;
+    border-radius: 2px;
+    background: rgba(255, 255, 255, 0.55);
+  }
+
+  .lp-asset-grid article > span i:nth-child(2) { height: 82%; }
+  .lp-asset-grid article > span i:nth-child(3) { height: 68%; }
+
+  .lp-asset-grid article > strong {
+    overflow: hidden;
+    margin-top: 6px;
+    font-size: 0.48rem;
+    font-weight: 600;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-asset-grid article > small {
+    margin-top: 2px;
+    color: #9b9c9f;
+    font-size: 0.38rem;
+  }
+
+  .lp-asset-grid article > em {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    margin-top: 5px;
+    color: #698172;
+    font-size: 0.39rem;
+    font-style: normal;
+  }
+
+  .lp-asset-grid article > em svg {
+    width: 8px;
+    height: 8px;
+  }
+
+  .lp-product-segmented {
+    display: flex;
+    padding: 2px;
+    border: 1px solid #e1e0dd;
+    border-radius: 6px;
+    background: #f3f3f1;
+  }
+
+  .lp-product-segmented button {
+    height: 21px;
+    border: 0;
+    background: transparent;
+  }
+
+  .lp-product-segmented button.is-active {
+    background: #ffffff;
+    color: #3f4145;
+    box-shadow: 0 1px 3px rgba(30, 32, 35, 0.08);
+  }
+
+  .lp-performance-kpis {
+    display: grid;
+    flex: none;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 7px;
+  }
+
+  .lp-performance-kpis article {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: end;
+    padding: 8px 10px;
+    border: 1px solid #e5e4e1;
+    border-radius: 7px;
+    background: #ffffff;
+  }
+
+  .lp-performance-kpis small {
+    grid-column: 1 / -1;
+    margin-bottom: 3px;
+    color: #929397;
+    font-size: 0.43rem;
+  }
+
+  .lp-performance-kpis strong {
+    font-size: 0.83rem;
+    font-weight: 610;
+  }
+
+  .lp-performance-kpis em {
+    color: #6f9978;
+    font-size: 0.43rem;
+    font-style: normal;
+  }
+
+  .lp-performance-layout {
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template-columns: minmax(0, 1.5fr) minmax(180px, 0.5fr);
+    gap: 7px;
+  }
+
+  .lp-performance-chart {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .lp-performance-plot {
+    position: relative;
+    min-height: 0;
+    flex: 1;
+    padding: 9px 12px;
+  }
+
+  .lp-css-chart-performance {
+    height: 100%;
+  }
+
+  .lp-css-chart-performance i:nth-child(1) { --actual: 14%; --plan: 18%; }
+  .lp-css-chart-performance i:nth-child(2) { --actual: 22%; --plan: 25%; }
+  .lp-css-chart-performance i:nth-child(3) { --actual: 30%; --plan: 32%; }
+  .lp-css-chart-performance i:nth-child(4) { --actual: 42%; --plan: 39%; }
+  .lp-css-chart-performance i:nth-child(5) { --actual: 48%; --plan: 46%; }
+  .lp-css-chart-performance i:nth-child(6) { --actual: 60%; --plan: 54%; }
+  .lp-css-chart-performance i:nth-child(7) { --actual: 67%; --plan: 62%; }
+  .lp-css-chart-performance i:nth-child(8) { --actual: 73%; --plan: 70%; }
+  .lp-css-chart-performance i:nth-child(9) { --actual: 84%; --plan: 78%; }
+  .lp-css-chart-performance i:nth-child(10) { --actual: 92%; --plan: 86%; }
+
+  .lp-performance-insight {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 11px;
+    border-color: #dfd8e8;
+    background: #faf8fc;
+  }
+
+  .lp-performance-insight > small {
+    margin-top: 7px;
+    color: #8d7b9f;
+    font-size: 0.39rem;
+    font-weight: 650;
+    letter-spacing: 0.08em;
+  }
+
+  .lp-performance-insight h4 {
+    margin: 5px 0;
+    font-size: 0.59rem;
+    font-weight: 610;
+    line-height: 1.35;
+  }
+
+  .lp-performance-insight p {
+    margin: 0;
+    color: #7e7982;
+    font-size: 0.45rem;
+    line-height: 1.4;
+  }
+
+  .lp-performance-insight > div {
+    display: flex;
+    width: 100%;
+    justify-content: space-between;
+    margin-top: auto;
+    padding: 7px 0;
+    border-top: 1px solid #e5deea;
+    color: #8a838f;
+    font-size: 0.43rem;
+  }
+
+  .lp-performance-insight > button {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: #756388;
+    font-size: 0.44rem;
+    font-weight: 600;
+  }
+
+  .lp-performance-insight > button svg {
+    width: 9px;
+    height: 9px;
+  }
+
+  .lp-channel-table {
+    flex: none;
+    overflow: hidden;
+    border: 1px solid #e6e5e2;
+    border-radius: 7px;
+    background: #ffffff;
+  }
+
+  .lp-channel-table header,
+  .lp-channel-table > div {
+    display: grid;
+    min-height: 24px;
+    grid-template-columns: 1.4fr repeat(4, 0.7fr);
+    align-items: center;
+    padding: 0 9px;
+    border-bottom: 1px solid #efeeec;
+    color: #66686c;
+    font-size: 0.41rem;
+  }
+
+  .lp-channel-table header {
+    background: #f7f7f5;
+    color: #999a9d;
+    font-weight: 620;
+  }
+
+  .lp-channel-table > div:last-child {
+    border-bottom: 0;
+  }
+
+  .lp-channel-table .is-up { color: #6f9277; }
+  .lp-channel-table .is-down { color: #a3645f; }
+
+  .lp-crm-kpis article > span:first-child svg {
+    width: 9px;
+    height: 9px;
+    color: #9b9da0;
+  }
+
+  .lp-crm-kpis article > em {
+    display: block;
+    margin-top: 2px;
+  }
+
+  .lp-crm-kpis article > em.is-neutral {
+    color: #7a8b90;
+  }
+
+  .lp-crm-overview-grid {
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template: minmax(160px, 1.2fr) minmax(100px, 0.8fr) / minmax(0, 1.35fr) minmax(180px, 0.65fr);
+    gap: 7px;
+  }
+
+  .lp-crm-funnel {
+    padding-bottom: 8px;
+  }
+
+  .lp-crm-funnel > header button svg {
+    width: 9px;
+    height: 9px;
+  }
+
+  .lp-crm-funnel > div {
+    display: grid;
+    grid-template-columns: 90px minmax(0, 1fr);
+    align-items: center;
+    gap: 9px;
+    padding: 6px 10px 0;
+  }
+
+  .lp-crm-funnel > div > span {
+    display: flex;
+    justify-content: space-between;
+    gap: 5px;
+    font-size: 0.45rem;
+  }
+
+  .lp-crm-funnel > div > span strong {
+    font-weight: 540;
+  }
+
+  .lp-crm-funnel > div > span small {
+    color: #9b9c9f;
+  }
+
+  .lp-crm-funnel > div > i,
+  .lp-task-capacity > div > div > i {
+    display: block;
+    height: 6px;
+    overflow: hidden;
+    border-radius: 4px;
+    background: #edf0f0;
+  }
+
+  .lp-crm-funnel > div > i em,
+  .lp-task-capacity > div > div > i em {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, #78959c, #507b85);
+  }
+
+  .lp-crm-today {
+    overflow: hidden;
+  }
+
+  .lp-crm-today > header > em {
+    padding: 2px 5px;
+    border-radius: 5px;
+    background: #e8eff0;
+    color: #4d737c;
+  }
+
+  .lp-crm-today article {
+    display: grid;
+    grid-template-columns: 28px 6px minmax(0, 1fr);
+    align-items: center;
+    gap: 6px;
+    padding: 8px 9px;
+    border-bottom: 1px solid #eeefed;
+  }
+
+  .lp-crm-today time {
+    color: #8c8e91;
+    font-size: 0.42rem;
+  }
+
+  .lp-crm-today article strong,
+  .lp-crm-today article small {
+    display: block;
+  }
+
+  .lp-crm-today article strong {
+    font-size: 0.48rem;
+    font-weight: 590;
+  }
+
+  .lp-crm-today article small {
+    margin-top: 2px;
+    color: #989a9d;
+    font-size: 0.39rem;
+  }
+
+  .lp-crm-agent-feed {
+    grid-column: 1 / -1;
+    overflow: hidden;
+  }
+
+  .lp-crm-agent-feed article {
+    display: grid;
+    min-height: 32px;
+    grid-template-columns: 22px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 7px;
+    padding: 4px 10px;
+    border-bottom: 1px solid #efefed;
+  }
+
+  .lp-crm-agent-feed article > span {
+    display: grid;
+    width: 21px;
+    height: 21px;
+    place-items: center;
+    border-radius: 5px;
+    background: #e5edef;
+    color: #4d747d;
+  }
+
+  .lp-crm-agent-feed article svg {
+    width: 10px;
+    height: 10px;
+  }
+
+  .lp-crm-agent-feed article strong,
+  .lp-crm-agent-feed article small {
+    display: block;
+  }
+
+  .lp-crm-agent-feed article strong {
+    font-size: 0.46rem;
+    font-weight: 580;
+  }
+
+  .lp-crm-agent-feed article small {
+    margin-top: 1px;
+    color: #999b9e;
+    font-size: 0.38rem;
+  }
+
+  .lp-crm-agent-feed article em {
+    color: #66856e;
+    font-size: 0.39rem;
+    font-style: normal;
+  }
+
+  .lp-crm-pipeline-layout {
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template-columns: minmax(0, 1fr) 180px;
+    gap: 7px;
+  }
+
+  .lp-crm-kanban {
+    gap: 6px;
+    overflow: auto;
+  }
+
+  .lp-crm-kanban > section {
+    padding: 6px;
+  }
+
+  .lp-crm-kanban section > header span {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .lp-crm-kanban section > header small {
+    display: grid;
+    width: 14px;
+    height: 14px;
+    place-items: center;
+    border-radius: 7px;
+    background: #e8eaea;
+    font-size: 0.38rem;
+  }
+
+  .lp-crm-kanban section > header em {
+    color: #838588;
+    font-size: 0.43rem;
+    font-style: normal;
+  }
+
+  .lp-crm-kanban section > button {
+    display: grid;
+    width: 100%;
+    grid-template-columns: 24px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 5px;
+    margin-top: 5px;
+    padding: 7px;
+    border: 1px solid #e1e4e4;
+    border-radius: 6px;
+    background: #ffffff;
+    color: #5f6265;
+    font-size: 0.44rem;
+    text-align: left;
+  }
+
+  .lp-crm-kanban section > button.is-selected {
+    border-color: #a9c0c5;
+    box-shadow: 0 0 0 2px rgba(86, 126, 135, 0.08);
+  }
+
+  .lp-crm-kanban section > button > strong {
+    overflow: hidden;
+    color: #46494c;
+    font-size: 0.47rem;
+    font-weight: 600;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-crm-kanban section > button > small {
+    grid-column: 2 / -1;
+    overflow: hidden;
+    color: #939598;
+    font-size: 0.39rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-crm-kanban section > button > i {
+    display: flex;
+    grid-column: 2 / -1;
+    align-items: center;
+    gap: 3px;
+    color: #a0a1a4;
+    font-size: 0.37rem;
+    font-style: normal;
+  }
+
+  .lp-crm-kanban section > button > i svg {
+    width: 8px;
+    height: 8px;
+  }
+
+  .lp-crm-deal-drawer {
+    display: flex;
+    min-height: 0;
+    flex-direction: column;
+    padding: 11px;
+    border: 1px solid #e2e5e5;
+    border-radius: 8px;
+    background: #ffffff;
+  }
+
+  .lp-crm-deal-drawer > header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .lp-crm-deal-drawer > header button {
+    display: grid;
+    width: 22px;
+    height: 22px;
+    place-items: center;
+    border: 0;
+    background: transparent;
+    color: #929497;
+  }
+
+  .lp-crm-deal-drawer > header button svg {
+    width: 11px;
+    height: 11px;
+  }
+
+  .lp-crm-deal-drawer > small {
+    margin-top: 10px;
+    color: #91a0a3;
+    font-size: 0.38rem;
+    font-weight: 650;
+    letter-spacing: 0.07em;
+  }
+
+  .lp-crm-deal-drawer h4 {
+    margin: 3px 0 0;
+    font-size: 0.69rem;
+    font-weight: 620;
+  }
+
+  .lp-crm-deal-drawer > a,
+  .lp-account-record a {
+    color: #718e95;
+    font-size: 0.42rem;
+  }
+
+  .lp-crm-deal-value {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: 10px 0;
+    padding: 8px;
+    border-radius: 6px;
+    background: #f2f6f6;
+  }
+
+  .lp-crm-deal-value small,
+  .lp-crm-deal-value strong {
+    display: block;
+  }
+
+  .lp-crm-deal-value small {
+    color: #919396;
+    font-size: 0.38rem;
+  }
+
+  .lp-crm-deal-value strong {
+    margin-top: 2px;
+    font-size: 0.65rem;
+  }
+
+  .lp-crm-deal-value em {
+    padding: 3px 5px;
+    border-radius: 6px;
+    background: #dfeaec;
+    color: #4f747d;
+    font-size: 0.39rem;
+    font-style: normal;
+  }
+
+  .lp-crm-deal-drawer h5 {
+    margin: 7px 0 3px;
+    color: #97999b;
+    font-size: 0.38rem;
+    font-weight: 650;
+    letter-spacing: 0.06em;
+  }
+
+  .lp-crm-deal-drawer > p {
+    margin: 0;
+    color: #696c6f;
+    font-size: 0.44rem;
+    line-height: 1.4;
+  }
+
+  .lp-crm-next-action {
+    display: grid;
+    grid-template-columns: 20px minmax(0, 1fr);
+    gap: 6px;
+    padding: 7px;
+    border: 1px solid #dce7e9;
+    border-radius: 6px;
+    background: #f5f9f9;
+  }
+
+  .lp-crm-next-action > svg {
+    width: 11px;
+    height: 11px;
+    color: #567f88;
+  }
+
+  .lp-crm-next-action strong,
+  .lp-crm-next-action small {
+    display: block;
+  }
+
+  .lp-crm-next-action strong {
+    font-size: 0.44rem;
+    font-weight: 600;
+  }
+
+  .lp-crm-next-action small {
+    margin-top: 2px;
+    color: #8a9193;
+    font-size: 0.37rem;
+    line-height: 1.35;
+  }
+
+  .lp-crm-open-record {
+    display: flex;
+    width: 100%;
+    min-height: 25px;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    margin-top: auto;
+    border: 0;
+    border-radius: 5px;
+    background: #416f79;
+    color: #ffffff;
+    font-size: 0.43rem;
+  }
+
+  .lp-crm-open-record svg {
+    width: 9px;
+    height: 9px;
+  }
+
+  .lp-crm-accounts-view .lp-product-table-row {
+    grid-template-columns: minmax(145px, 1.5fr) 0.65fr 0.6fr 0.8fr;
+  }
+
+  .lp-account-record {
+    padding: 11px;
+  }
+
+  .lp-account-record > header {
+    display: grid;
+    grid-template-columns: 29px minmax(0, 1fr) 22px;
+    justify-content: initial;
+    gap: 7px;
+  }
+
+  .lp-account-record header h4 {
+    margin: 0;
+    font-size: 0.61rem;
+    font-weight: 620;
+  }
+
+  .lp-account-record header a {
+    display: block;
+    margin-top: 2px;
+  }
+
+  .lp-account-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin: 10px 0;
+  }
+
+  .lp-account-chips em {
+    padding: 3px 5px;
+    border-radius: 5px;
+    background: #eaf1f2;
+    color: #56747b;
+    font-size: 0.38rem;
+    font-style: normal;
+  }
+
+  .lp-account-record > nav {
+    display: flex;
+    border-bottom: 1px solid #e8e8e5;
+  }
+
+  .lp-account-record > nav button {
+    padding: 6px 7px;
+    border: 0;
+    border-bottom: 2px solid transparent;
+    background: transparent;
+    color: #8e9093;
+    font-size: 0.41rem;
+  }
+
+  .lp-account-record > nav button.is-active {
+    border-bottom-color: #527b84;
+    color: #3f555a;
+  }
+
+  .lp-account-record > section {
+    margin-top: 9px;
+    padding: 8px;
+    border-radius: 6px;
+    background: #f3f7f7;
+  }
+
+  .lp-account-record > section small {
+    color: #7e979c;
+    font-size: 0.37rem;
+    font-weight: 650;
+  }
+
+  .lp-account-record > section p {
+    margin: 5px 0;
+    color: #5f696b;
+    font-size: 0.44rem;
+    line-height: 1.38;
+  }
+
+  .lp-account-record > section em {
+    color: #9a9c9e;
+    font-size: 0.36rem;
+    font-style: normal;
+  }
+
+  .lp-account-record dl {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+    margin: 10px 0;
+  }
+
+  .lp-account-record dt {
+    color: #9a9b9e;
+    font-size: 0.37rem;
+  }
+
+  .lp-account-record dd {
+    margin: 2px 0 0;
+    font-size: 0.44rem;
+    font-weight: 570;
+  }
+
+  .lp-account-contact {
+    display: grid;
+    grid-template-columns: 24px minmax(0, 1fr) 22px;
+    align-items: center;
+    gap: 6px;
+    margin-top: auto;
+    padding: 7px;
+    border: 1px solid #e4e6e5;
+    border-radius: 6px;
+  }
+
+  .lp-account-contact > span:first-child {
+    display: grid;
+    width: 23px;
+    height: 23px;
+    place-items: center;
+    border-radius: 50%;
+    background: #e8e2dc;
+    color: #786858;
+    font-size: 0.4rem;
+    font-weight: 700;
+  }
+
+  .lp-account-contact strong,
+  .lp-account-contact small {
+    display: block;
+  }
+
+  .lp-account-contact strong {
+    font-size: 0.43rem;
+  }
+
+  .lp-account-contact small {
+    color: #989a9d;
+    font-size: 0.36rem;
+  }
+
+  .lp-account-contact button {
+    display: grid;
+    width: 22px;
+    height: 22px;
+    place-items: center;
+    border: 1px solid #e1e3e2;
+    border-radius: 4px;
+    background: #ffffff;
+    color: #647a7e;
+  }
+
+  .lp-account-contact button svg {
+    width: 9px;
+    height: 9px;
+  }
+
+  .lp-crm-inbox {
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template-columns: minmax(200px, 0.8fr) minmax(0, 1.2fr);
+    overflow: hidden;
+    border: 1px solid #e3e5e4;
+    border-radius: 8px;
+    background: #ffffff;
+  }
+
+  .lp-crm-inbox > aside {
+    min-width: 0;
+    overflow: hidden;
+    border-right: 1px solid #e7e8e6;
+  }
+
+  .lp-crm-inbox > aside > header {
+    display: flex;
+    min-height: 35px;
+    gap: 4px;
+    align-items: center;
+    padding: 0 8px;
+    border-bottom: 1px solid #e9eae8;
+  }
+
+  .lp-crm-inbox > aside > header button {
+    height: 22px;
+    padding: 0 6px;
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: #8b8d90;
+    font-size: 0.42rem;
+  }
+
+  .lp-crm-inbox > aside > header button.is-active {
+    background: #eef3f4;
+    color: #45656c;
+  }
+
+  .lp-crm-inbox > aside > button {
+    display: grid;
+    width: 100%;
+    min-height: 62px;
+    grid-template-columns: 25px minmax(0, 1fr);
+    gap: 7px;
+    padding: 8px;
+    border: 0;
+    border-bottom: 1px solid #eceeec;
+    background: #ffffff;
+    text-align: left;
+  }
+
+  .lp-crm-inbox > aside > button.is-active {
+    background: #f1f6f7;
+  }
+
+  .lp-crm-inbox > aside > button > span {
+    display: grid;
+    width: 24px;
+    height: 24px;
+    place-items: center;
+    border-radius: 50%;
+    background: #e4ebec;
+    color: #55737a;
+    font-size: 0.39rem;
+    font-weight: 700;
+  }
+
+  .lp-crm-inbox > aside > button div {
+    display: grid;
+    min-width: 0;
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .lp-crm-inbox > aside strong,
+  .lp-crm-inbox > aside b,
+  .lp-crm-inbox > aside small {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .lp-crm-inbox > aside strong {
+    font-size: 0.43rem;
+    font-weight: 560;
+  }
+
+  .lp-crm-inbox > aside > button.is-unread strong,
+  .lp-crm-inbox > aside > button.is-unread b {
+    font-weight: 670;
+  }
+
+  .lp-crm-inbox > aside em {
+    color: #a0a1a4;
+    font-size: 0.37rem;
+    font-style: normal;
+  }
+
+  .lp-crm-inbox > aside b {
+    grid-column: 1 / -1;
+    margin-top: 3px;
+    color: #5f6265;
+    font-size: 0.42rem;
+    font-weight: 540;
+  }
+
+  .lp-crm-inbox > aside small {
+    grid-column: 1 / -1;
+    margin-top: 2px;
+    color: #9a9c9f;
+    font-size: 0.38rem;
+  }
+
+  .lp-crm-inbox > section {
+    display: flex;
+    min-width: 0;
+    min-height: 0;
+    flex-direction: column;
+    padding: 12px;
+    overflow: hidden;
+  }
+
+  .lp-crm-inbox > section > header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-bottom: 9px;
+    border-bottom: 1px solid #e9eae8;
+  }
+
+  .lp-crm-inbox > section > header small,
+  .lp-crm-inbox > section > header strong {
+    display: block;
+  }
+
+  .lp-crm-inbox > section > header small {
+    color: #7d979d;
+    font-size: 0.37rem;
+    font-weight: 650;
+  }
+
+  .lp-crm-inbox > section > header strong {
+    margin-top: 3px;
+    font-size: 0.56rem;
+  }
+
+  .lp-crm-inbox > section > header button {
+    display: grid;
+    width: 22px;
+    height: 22px;
+    place-items: center;
+    border: 0;
+    background: transparent;
+    color: #8d8f92;
+  }
+
+  .lp-crm-inbox > section > header svg {
+    width: 11px;
+    height: 11px;
+  }
+
+  .lp-crm-message {
+    display: grid;
+    grid-template-columns: 27px minmax(0, 1fr);
+    gap: 8px;
+    padding: 12px 2px;
+  }
+
+  .lp-crm-message > span {
+    display: grid;
+    width: 26px;
+    height: 26px;
+    place-items: center;
+    border-radius: 50%;
+    background: #e7e1dc;
+    color: #735f53;
+    font-size: 0.42rem;
+    font-weight: 700;
+  }
+
+  .lp-crm-message strong {
+    font-size: 0.45rem;
+  }
+
+  .lp-crm-message strong small {
+    color: #9b9c9f;
+    font-size: 0.37rem;
+    font-weight: 400;
+  }
+
+  .lp-crm-message p {
+    margin: 6px 0 0;
+    color: #686b6e;
+    font-size: 0.46rem;
+    line-height: 1.48;
+  }
+
+  .lp-codex-draft {
+    margin-top: auto;
+    padding: 10px;
+    border: 1px solid #cfdfe2;
+    border-radius: 7px;
+    background: #f4f9f9;
+  }
+
+  .lp-codex-draft header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .lp-codex-draft header > span {
+    display: grid;
+    width: 21px;
+    height: 21px;
+    place-items: center;
+    border-radius: 5px;
+    background: #dcebed;
+    color: #4d737b;
+  }
+
+  .lp-codex-draft header svg {
+    width: 10px;
+    height: 10px;
+  }
+
+  .lp-codex-draft header strong {
+    font-size: 0.44rem;
+  }
+
+  .lp-codex-draft header em {
+    margin-left: auto;
+    color: #82999e;
+    font-size: 0.38rem;
+    font-style: normal;
+  }
+
+  .lp-codex-draft p {
+    margin: 8px 0;
+    color: #627175;
+    font-size: 0.44rem;
+    line-height: 1.5;
+  }
+
+  .lp-codex-draft footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 5px;
+  }
+
+  .lp-codex-draft footer button {
+    flex: none;
+    padding: 0 8px;
+  }
+
+  .lp-codex-draft footer button.is-primary {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .lp-codex-draft footer svg {
+    width: 8px;
+    height: 8px;
+  }
+
+  .lp-crm-task-board {
+    display: grid;
+    min-height: 0;
+    flex: 1;
+    grid-template-columns: minmax(0, 1.45fr) minmax(170px, 0.55fr);
+    gap: 7px;
+  }
+
+  .lp-crm-task-board > section {
+    overflow: hidden;
+  }
+
+  .lp-crm-task-board > section > header button svg {
+    width: 9px;
+    height: 9px;
+  }
+
+  .lp-crm-task-board > section > article {
+    display: grid;
+    grid-template-columns: 23px minmax(0, 1fr) 34px 40px;
+    align-items: center;
+    gap: 7px;
+    min-height: 57px;
+    padding: 7px 10px;
+    border-bottom: 1px solid #ececea;
+  }
+
+  .lp-crm-task-board > section > article > button {
+    display: grid;
+    width: 20px;
+    height: 20px;
+    place-items: center;
+    border: 1px solid #d9dddc;
+    border-radius: 50%;
+    background: #ffffff;
+    color: transparent;
+  }
+
+  .lp-crm-task-board > section > article > button:hover {
+    border-color: #63858c;
+    color: #63858c;
+  }
+
+  .lp-crm-task-board > section > article > button svg {
+    width: 9px;
+    height: 9px;
+  }
+
+  .lp-crm-task-board article strong,
+  .lp-crm-task-board article small {
+    display: block;
+  }
+
+  .lp-crm-task-board article > span > em {
+    color: #6d8b91;
+    font-size: 0.36rem;
+    font-style: normal;
+  }
+
+  .lp-crm-task-board article strong {
+    margin-top: 2px;
+    font-size: 0.47rem;
+    font-weight: 590;
+  }
+
+  .lp-crm-task-board article small {
+    margin-top: 2px;
+    color: #999a9d;
+    font-size: 0.38rem;
+  }
+
+  .lp-crm-task-board article > i {
+    color: #7c7e81;
+    font-size: 0.4rem;
+    font-style: normal;
+  }
+
+  .lp-crm-task-board article time {
+    color: #8e9093;
+    font-size: 0.4rem;
+  }
+
+  .lp-crm-task-board article > b {
+    grid-column: 2 / -1;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: -4px;
+    color: #4f747d;
+    font-size: 0.39rem;
+    font-weight: 580;
+  }
+
+  .lp-crm-task-board article > b svg {
+    width: 8px;
+    height: 8px;
+  }
+
+  .lp-task-capacity {
+    padding-bottom: 7px;
+  }
+
+  .lp-task-capacity > header > em {
+    color: #577b83;
+    font-size: 0.48rem;
+  }
+
+  .lp-task-capacity > div {
+    display: grid;
+    grid-template-columns: 24px minmax(0, 1fr);
+    gap: 7px;
+    padding: 9px 10px 2px;
+  }
+
+  .lp-task-capacity > div > span {
+    display: grid;
+    width: 23px;
+    height: 23px;
+    place-items: center;
+    border-radius: 50%;
+    background: #e5ecee;
+    color: #52747c;
+  }
+
+  .lp-task-capacity > div > span svg {
+    width: 10px;
+    height: 10px;
+  }
+
+  .lp-task-capacity > div strong,
+  .lp-task-capacity > div small {
+    display: block;
+  }
+
+  .lp-task-capacity > div strong {
+    font-size: 0.45rem;
+  }
+
+  .lp-task-capacity > div small {
+    margin-top: 1px;
+    color: #999b9d;
+    font-size: 0.37rem;
+  }
+
+  .lp-task-capacity > div > div > i {
+    height: 4px;
+    margin-top: 5px;
+  }
+
+  @media (max-width: 780px) {
+    .lp-product-app {
+      grid-template: 38px 40px minmax(0, 1fr) / minmax(0, 1fr);
+    }
+
+    .lp-product-topbar {
+      grid-column: 1;
+      grid-row: 1;
+      grid-template-columns: 23px auto minmax(80px, 1fr) auto;
+      padding: 0 8px;
+    }
+
+    .lp-product-search,
+    .lp-product-topbar > .lp-demo-runtime {
       display: none;
     }
 
-    .lp-mw-head {
-      flex-direction: column;
+    .lp-product-topbar > button {
+      margin-left: auto;
+    }
+
+    .lp-product-sidebar {
+      display: block;
+      grid-row: 2;
+      padding: 5px 7px;
+      overflow-x: auto;
+      border-right: 0;
+      border-bottom: 1px solid #e5e4e1;
+      white-space: nowrap;
+    }
+
+    .lp-product-workspace,
+    .lp-product-agent {
+      display: none;
+    }
+
+    .lp-product-sidebar nav {
+      display: flex;
+      width: max-content;
+      gap: 3px;
+    }
+
+    .lp-product-sidebar nav button {
+      width: auto;
+      min-height: 28px;
+      grid-template-columns: 13px auto auto;
+    }
+
+    .lp-product-main {
+      grid-row: 3;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .lp-product-page {
+      gap: 8px;
+      padding: 10px;
+      overflow-y: auto;
+    }
+
+    .lp-product-page-head {
       align-items: flex-start;
     }
 
-    .lp-mw-stations {
-      grid-template-columns: 1fr;
-      gap: 18px;
+    .lp-product-page-head > div:first-child > span {
+      white-space: normal;
     }
 
-    .lp-mw-station {
+    .lp-product-page-actions button:first-child {
+      display: none;
+    }
+
+    .lp-product-kpis {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .lp-campaign-command-grid,
+    .lp-crm-overview-grid {
+      display: flex;
+      min-height: auto;
+      flex-direction: column;
+    }
+
+    .lp-campaign-command-grid > *,
+    .lp-crm-overview-grid > * {
+      min-height: 150px;
+    }
+
+    .lp-attention-panel {
       display: grid;
-      grid-template-columns: 56px minmax(0, 1fr);
-      column-gap: 14px;
-      justify-items: start;
-      text-align: left;
+      min-height: 250px;
+      grid-template: 40px auto minmax(110px, 1fr) / minmax(0, 1fr);
     }
 
-    .lp-mw-chip {
-      grid-row: 1 / -1;
+    .lp-attention-panel > header,
+    .lp-crm-agent-feed {
+      grid-column: 1;
     }
 
-    .lp-mw-station > :not(.lp-mw-chip) {
-      grid-column: 2;
+    .lp-attention-list {
+      border-right: 0;
+      border-bottom: 1px solid #ecebe8;
     }
 
-    .lp-mw-label {
-      margin-top: 0;
+    .lp-product-split-view,
+    .lp-crm-pipeline-layout,
+    .lp-crm-inbox,
+    .lp-crm-task-board {
+      min-height: 520px;
+      grid-template-columns: minmax(0, 1fr);
+      overflow: visible;
     }
 
-    .lp-mw-caption {
-      max-width: none;
+    .lp-product-table-card,
+    .lp-crm-inbox > aside {
+      min-height: 280px;
+      overflow-x: auto;
+      border-right: 0;
+      border-bottom: 1px solid #e7e8e6;
+    }
+
+    .lp-product-table-card > * {
+      min-width: 520px;
+    }
+
+    .lp-product-record,
+    .lp-account-record,
+    .lp-crm-deal-drawer,
+    .lp-crm-inbox > section {
+      min-height: 300px;
+    }
+
+    .lp-product-calendar {
+      min-width: 670px;
+      min-height: 380px;
+    }
+
+    .lp-product-page:has(.lp-product-calendar) {
+      overflow-x: auto;
+    }
+
+    .lp-asset-layout {
+      min-height: 460px;
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .lp-asset-folders {
+      display: flex;
+      flex-direction: row;
+      overflow-x: auto;
+    }
+
+    .lp-asset-folders button {
+      min-width: 110px;
+    }
+
+    .lp-asset-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .lp-performance-layout {
+      min-height: 380px;
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .lp-performance-chart,
+    .lp-performance-insight {
+      min-height: 180px;
+    }
+
+    .lp-channel-table {
+      min-width: 520px;
+    }
+
+    .lp-product-page:has(.lp-channel-table) {
+      overflow-x: auto;
+    }
+
+    .lp-crm-kanban {
+      min-height: 360px;
+    }
+
+    .lp-crm-inbox {
+      min-height: 620px;
     }
   }
 
   @media (prefers-reduced-motion: reduce) {
+    .lp-header,
     .lp-glyph *,
     .lp-term-cursor,
+    .lp-hero::before,
     .lp-hero-copy > *,
     .lp-hero-theater,
-    .lp-ticker-dot,
-    .lp-ticker-text {
+    .lp-work-surface img,
+    .lp-demo-main,
+    .lp-demo-decision-detail,
+    .lp-demo-livebar p,
+    .lp-demo-live-progress i,
+    .lp-demo-running i,
+    .lp-demo-run-badge i,
+    .lp-demo-sync i,
+    .lp-demo-live-label i,
+    .lp-demo-agent-meta em.is-running i,
+    .lp-demo-flow-step.is-current .lp-demo-flow-node {
       animation: none !important;
-    }
-
-    .lp-mw-chip,
-    .lp-mw-caption,
-    .lp-mw-approval {
-      transition: none;
     }
   }
 }


### PR DESCRIPTION
## Summary

- refresh the public landing page with the purpose-built AI apps story, a compact sticky header, work-surface cues, and a richer interactive pod demo
- tighten the supporting landing sections and responsive behavior while preserving the existing product graphics and examples
- reframe the README around custom AI harnesses, team collaboration, and a shorter path into setup
- hide the idle proof-of-work notice and correct the auth subtitle selector

## Validation

- `npm --prefix lemma-frontend run check`
- desktop browser QA at 1440x900
- mobile browser QA at 390x844 with zero horizontal overflow
- README anchors, local assets, and whitespace verified