### PR TITLE
Fix AgentBox startup reconciliation conflict

### DIFF
--- a/agentbox/agentbox/api/app.py
+++ b/agentbox/agentbox/api/app.py
@@ -60,6 +60,28 @@ class _RateLimitedResponseError(RuntimeError):
     """Stable type used by the transition-based 429 incident log."""
 
 
+async def _reconcile_before_serving(
+    reconciler: AgentBoxReconciler,
+    *,
+    operation_timeout_seconds: float,
+) -> None:
+    try:
+        await reconciler.reconcile_once(
+            deadline_at=datetime.now(timezone.utc)
+            + timedelta(seconds=operation_timeout_seconds)
+        )
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        # Reconciliation is durable and retried by the bounded background loop.
+        # Provider/state repair must not make the request plane unavailable.
+        logger.warning(
+            "agentbox.reconcile.failed",
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )
+
+
 class RequestContextMiddleware:
     """Bind trusted request lineage and emit one redacted request outcome."""
 
@@ -464,9 +486,11 @@ async def lifespan(app: FastAPI):
         retry_seconds=max(0.1, settings.agentbox_reconcile_interval_seconds),
     )
     app.state.reconciler = reconciler
-    await reconciler.reconcile_once(
-        deadline_at=datetime.now(timezone.utc)
-        + timedelta(seconds=settings.agentbox_reconcile_operation_timeout_seconds)
+    await _reconcile_before_serving(
+        reconciler,
+        operation_timeout_seconds=(
+            settings.agentbox_reconcile_operation_timeout_seconds
+        ),
     )
     app.state.reconciliation_task = create_background_task(
         reconciliation_loop(

--- a/agentbox/agentbox/reconciliation.py
+++ b/agentbox/agentbox/reconciliation.py
@@ -4,6 +4,7 @@ import asyncio
 from datetime import datetime, timedelta, timezone
 
 from agentbox.domain import (
+    AgentBoxError,
     CreateReconcileCandidate,
     DispatchState,
     ErrorCode,
@@ -164,6 +165,7 @@ class AgentBoxReconciler:
                     deadline_at=deadline_at,
                 )
                 return
+            discard_conflicting_native_workspace = False
             async with self._database.uow() as uow:
                 allocation = await uow.repository.acknowledge_create(
                     allocation.allocation_token,
@@ -171,18 +173,41 @@ class AgentBoxReconciler:
                     provider_instance_id=match.provider_instance_id,
                 )
                 if match.workspace_storage is not None:
-                    await uow.repository.bind_workspace_storage(
-                        allocation.key,
-                        provider_storage_id=(
-                            match.workspace_storage.provider_storage_id
-                        ),
-                        allocation_id=(
-                            allocation.allocation_id
-                            if match.workspace_storage.bound_to_allocation
-                            else None
-                        ),
-                    )
-                await uow.commit()
+                    try:
+                        await uow.repository.bind_workspace_storage(
+                            allocation.key,
+                            provider_storage_id=(
+                                match.workspace_storage.provider_storage_id
+                            ),
+                            allocation_id=(
+                                allocation.allocation_id
+                                if match.workspace_storage.bound_to_allocation
+                                else None
+                            ),
+                        )
+                    except AgentBoxError as exc:
+                        if (
+                            exc.code == ErrorCode.OPERATION_CONFLICT
+                            and match.workspace_storage.bound_to_allocation
+                            and allocation.key.workload_kind == WorkloadKind.WORKSPACE
+                        ):
+                            # A newer sandbox-native workspace already owns the
+                            # logical workspace. Preserve it and discard only
+                            # this stale exact provider match.
+                            discard_conflicting_native_workspace = True
+                            await uow.rollback()
+                        else:
+                            raise
+                if not discard_conflicting_native_workspace:
+                    await uow.commit()
+            if discard_conflicting_native_workspace:
+                await self._destroy_failed_allocation(
+                    candidate.allocation,
+                    provider_id=match.provider_id,
+                    provider_instance_id=match.provider_instance_id,
+                    deadline_at=deadline_at,
+                )
+                return
 
         if allocation.provider_id is None:
             await self._defer(allocation)

--- a/agentbox/tests/state/test_reconciliation.py
+++ b/agentbox/tests/state/test_reconciliation.py
@@ -87,17 +87,26 @@ class LostCreateResponseProvider:
             assert expected["allocation-token"] == str(
                 self.create_calls[0].allocation_token
             )
-        return tuple(
-            ProviderInventoryAllocation(
-                provider_id=f"accepted-{index}",
-                provider_instance_id=f"accepted-{index}",
-                workspace_storage=ProviderStorageResult(
-                    provider_storage_id="workspace-volume",
-                    bound_to_allocation=False,
-                ),
+        matches: list[ProviderInventoryAllocation] = []
+        for index in range(self.inventory_matches):
+            provider_id = f"accepted-{index}"
+            matches.append(
+                ProviderInventoryAllocation(
+                    provider_id=provider_id,
+                    provider_instance_id=provider_id,
+                    workspace_storage=ProviderStorageResult(
+                        provider_storage_id=(
+                            provider_id
+                            if self.workspace_storage_kind == StorageKind.SANDBOX_NATIVE
+                            else "workspace-volume"
+                        ),
+                        bound_to_allocation=(
+                            self.workspace_storage_kind == StorageKind.SANDBOX_NATIVE
+                        ),
+                    ),
+                )
             )
-            for index in range(self.inventory_matches)
-        )
+        return tuple(matches)
 
     async def wait_ready(
         self,
@@ -122,6 +131,10 @@ class LostCreateResponseProvider:
 
     async def close(self) -> None:
         return None
+
+
+class SandboxNativeLostCreateResponseProvider(LostCreateResponseProvider):
+    workspace_storage_kind = StorageKind.SANDBOX_NATIVE
 
 
 async def make_ambiguous(
@@ -326,6 +339,92 @@ async def test_stale_dispatched_workspace_with_exact_match_is_adopted(
     assert handle is not None
     assert handle.ready is True
     assert handle.allocation_state == AllocationState.ACTIVE
+
+
+async def test_stale_native_workspace_match_never_rebinds_active_workspace(
+    database: StateDatabase,
+) -> None:
+    provider = SandboxNativeLostCreateResponseProvider(database)
+    lifecycle, key, deadline = await make_stale_dispatch(
+        database,
+        provider,
+        workload_kind=WorkloadKind.WORKSPACE,
+    )
+    current_profile = SandboxProfileRef(
+        "workspace-python-v2",
+        f"sha256:{'b' * 64}",
+    )
+    async with database.uow() as uow:
+        await uow.repository.ensure_logical(key, current_profile)
+        intent = await uow.repository.begin_allocation(
+            key,
+            current_profile,
+            provider_name=provider.name,
+            provider_scope=provider.scope,
+            admission_class=AdmissionClass.INTERACTIVE.value,
+            request_hash="c" * 64,
+        )
+        decision = await uow.repository.reserve_provider_capacity(
+            intent.allocation.allocation_id,
+            admission_class=AdmissionClass.INTERACTIVE,
+            policy=ProviderAdmissionPolicy.permissive_for_tests(),
+        )
+        assert decision.accepted is True
+        assert await uow.repository.mark_create_dispatched(
+            intent.allocation.allocation_token
+        )
+        current = await uow.repository.acknowledge_create(
+            intent.allocation.allocation_token,
+            provider_id="current-sandbox",
+            provider_instance_id="current-sandbox",
+        )
+        await uow.repository.bind_workspace_storage(
+            key,
+            provider_storage_id="current-sandbox",
+            allocation_id=current.allocation_id,
+        )
+        current = await uow.repository.publish_allocation(
+            intent.allocation.allocation_token
+        )
+        await uow.commit()
+
+    reconciled = await AgentBoxReconciler(
+        database,
+        provider,
+        dispatched_create_stale_seconds=30,
+    ).reconcile_once(deadline_at=deadline)
+    handle = await lifecycle.inspect(key)
+    async with database.uow() as uow:
+        storage = await uow.repository.get_workspace_storage(key)
+        allocations = await uow.repository.list_allocations(key)
+        await uow.commit()
+    async with database.engine.connect() as connection:
+        reserved_count = await connection.scalar(
+            select(ProviderAdmissionRow.reserved_count).where(
+                ProviderAdmissionRow.provider_scope == provider.scope
+            )
+        )
+        active_count = await connection.scalar(
+            select(ProviderAdmissionRow.active_count).where(
+                ProviderAdmissionRow.provider_scope == provider.scope
+            )
+        )
+
+    assert reconciled == 1
+    assert provider.destroyed == ["accepted-0"]
+    assert handle is not None
+    assert handle.ready is True
+    assert handle.allocation_id == current.allocation_id
+    assert handle.allocation_state == AllocationState.ACTIVE
+    assert storage is not None
+    assert storage.provider_storage_id == "current-sandbox"
+    assert storage.bound_allocation_id == current.allocation_id
+    assert [item.state for item in allocations] == [
+        AllocationState.ERROR,
+        AllocationState.ACTIVE,
+    ]
+    assert reserved_count == 0
+    assert active_count == 1
 
 
 async def test_reconciliation_repairs_terminal_allocation_reservation(

--- a/agentbox/tests/test_background_observability.py
+++ b/agentbox/tests/test_background_observability.py
@@ -6,6 +6,7 @@ import logging
 import pytest
 
 from agentbox import maintenance, reconciliation
+from agentbox.api.app import _reconcile_before_serving
 
 
 async def _stop_after_first_pass(_seconds: float) -> None:
@@ -53,6 +54,27 @@ async def test_reconcile_loop_reports_unexpected_failure(monkeypatch, caplog) ->
                 interval_seconds=1,
                 operation_timeout_seconds=1,
             )
+
+    record = next(
+        item for item in caplog.records if item.msg == "agentbox.reconcile.failed"
+    )
+    assert record.lemma_fields["error_type"] == "RuntimeError"
+    assert len(record.lemma_fields["error_stack_hash"]) == 64
+    assert "CANARY" not in repr(record.lemma_fields)
+
+
+@pytest.mark.asyncio
+async def test_initial_reconcile_failure_does_not_block_serving(caplog) -> None:
+    class FailingReconciler:
+        async def reconcile_once(self, *, deadline_at):
+            del deadline_at
+            raise RuntimeError("CANARY provider response")
+
+    with caplog.at_level(logging.WARNING):
+        await _reconcile_before_serving(
+            FailingReconciler(),
+            operation_timeout_seconds=1,
+        )
 
     record = next(
         item for item in caplog.records if item.msg == "agentbox.reconcile.failed"


### PR DESCRIPTION
## Why

The dev release of lemma-app c1a8571c exposed a durable-state edge case in AgentBox. Startup reconciliation found an exact stale E2B workspace sandbox, but that logical workspace was already bound to a newer active sandbox-native allocation. bind_workspace_storage correctly rejected the rebind with OPERATION_CONFLICT; the uncontained initial reconciliation exception then crash-looped the new Container App revision.

## What changes

- Preserve the active sandbox-native workspace when a stale exact provider match conflicts with its storage binding.
- Roll back adoption of only the stale allocation, destroy that exact stale provider resource, mark the stale create failed, and release its reserved capacity.
- Keep durable-volume conflicts strict; this exception applies only to allocation-bound workspace storage.
- Contain unexpected initial reconciliation errors at the serving boundary. The existing bounded background loop retries durable candidates and emits the existing redacted agentbox.reconcile.failed event.

## Safety invariants

- Never overwrite storage owned by the current active allocation.
- Never guess among provider resources; reconciliation still requires one exact metadata match.
- Cancellation still propagates.
- Unexpected exceptions log only safe type/stack metadata through the structured logger.

## Verification

- Full AgentBox test suite: 151 passed, 6 real-provider tests skipped.
- Ruff check and format check passed.
- New regression test recreates the stale E2B sandbox plus newer active workspace, verifies the stale sandbox alone is destroyed, current storage remains bound, and admission accounting becomes active=1/reserved=0.
- New startup-boundary test verifies an unexpected reconciliation failure is logged without blocking serving.