### PR TITLE
fix(agentbox): recover poisoned workspace allocations

### DIFF
--- a/agentbox-client/agentbox_client/client.py
+++ b/agentbox-client/agentbox_client/client.py
@@ -101,8 +101,8 @@ class AgentBoxClient:
                 "profile": profile.model_dump(mode="json"),
                 "admission_class": admission_class.value,
                 "deadline_at": deadline_at.isoformat(),
-                "verify_ready": verify_ready,
             },
+            params={"verify_ready": "true"} if verify_ready else None,
         )
 
     async def inspect_sandbox(

--- a/agentbox-client/agentbox_client/client.py
+++ b/agentbox-client/agentbox_client/client.py
@@ -91,6 +91,7 @@ class AgentBoxClient:
         profile: ProfileRef,
         admission_class: AdmissionClass,
         deadline_at: datetime,
+        verify_ready: bool = False,
     ) -> SandboxHandle:
         return await self._model_request(
             "PUT",
@@ -100,6 +101,7 @@ class AgentBoxClient:
                 "profile": profile.model_dump(mode="json"),
                 "admission_class": admission_class.value,
                 "deadline_at": deadline_at.isoformat(),
+                "verify_ready": verify_ready,
             },
         )
 

--- a/agentbox-client/openapi/agentbox-manager.openapi.json
+++ b/agentbox-client/openapi/agentbox-manager.openapi.json
@@ -1136,6 +1136,16 @@
             }
           },
           {
+            "in": "query",
+            "name": "verify_ready",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Verify Ready",
+              "type": "boolean"
+            }
+          },
+          {
             "in": "header",
             "name": "x-api-key",
             "required": false,

--- a/agentbox-client/tests/test_canonical_client.py
+++ b/agentbox-client/tests/test_canonical_client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-import json
 import struct
 from uuid import UUID, uuid4
 
@@ -67,9 +66,10 @@ async def test_client_uses_typed_workload_route_and_absolute_deadline() -> None:
 
     assert result.ready is True
     assert captured[0].url.path == f"/sandboxes/workspace/{logical_id}"
+    assert captured[0].url.params["verify_ready"] == "true"
     assert captured[0].headers["X-API-Key"] == "secret"
     assert b'"deadline_at"' in captured[0].content
-    assert json.loads(captured[0].content)["verify_ready"] is True
+    assert b'"verify_ready"' not in captured[0].content
     await http.aclose()
 
 

--- a/agentbox-client/tests/test_canonical_client.py
+++ b/agentbox-client/tests/test_canonical_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+import json
 import struct
 from uuid import UUID, uuid4
 
@@ -61,12 +62,14 @@ async def test_client_uses_typed_workload_route_and_absolute_deadline() -> None:
         profile=ProfileRef(name="workspace-python-v1", digest=f"sha256:{'a' * 64}"),
         admission_class=AdmissionClass.INTERACTIVE,
         deadline_at=deadline(),
+        verify_ready=True,
     )
 
     assert result.ready is True
     assert captured[0].url.path == f"/sandboxes/workspace/{logical_id}"
     assert captured[0].headers["X-API-Key"] == "secret"
     assert b'"deadline_at"' in captured[0].content
+    assert json.loads(captured[0].content)["verify_ready"] is True
     await http.aclose()
 
 

--- a/agentbox/agentbox/adapters/docker.py
+++ b/agentbox/agentbox/adapters/docker.py
@@ -314,6 +314,8 @@ class DockerSandboxAdapter:
                 raise ProviderAllocationFailed(
                     "Docker container image does not match profile artifact"
                 )
+            if workload_kind == WorkloadKind.WORKSPACE:
+                self._validate_workspace_mount(inspected)
             if artifact.runtime_port is not None:
                 if workload_kind == WorkloadKind.FUNCTION:
                     await self._wait_function_runtime_ready(
@@ -324,6 +326,12 @@ class DockerSandboxAdapter:
                 else:
                     await self._wait_runtime_ready(
                         inspected,
+                        runtime_port=artifact.runtime_port,
+                        deadline_at=deadline_at,
+                    )
+                    await self._verify_workspace_filesystem(
+                        inspected,
+                        allocation,
                         runtime_port=artifact.runtime_port,
                         deadline_at=deadline_at,
                     )
@@ -352,6 +360,79 @@ class DockerSandboxAdapter:
             provider_id=allocation.provider_id,
             provider_instance_id=allocation.provider_id,
         )
+
+    @staticmethod
+    def _validate_workspace_mount(inspected: DockerContainerInspect) -> None:
+        storage_id = inspected.config.labels.get("workspace-storage-id")
+        if not storage_id:
+            raise ProviderAllocationFailed(
+                "Docker workspace has no persisted storage identity"
+            )
+        mounted_storage_ids = {
+            source
+            for binding in inspected.host_config.binds
+            for source, separator, target_and_mode in (binding.partition(":"),)
+            if separator
+            and target_and_mode.split(":", 1)[0].rstrip("/") == "/workspace"
+        }
+        if mounted_storage_ids != {storage_id}:
+            raise ProviderAllocationFailed(
+                "Docker workspace mount does not match persisted storage identity"
+            )
+
+    async def _verify_workspace_filesystem(
+        self,
+        inspected: DockerContainerInspect,
+        allocation: ProviderAllocationRef,
+        *,
+        runtime_port: int,
+        deadline_at: datetime,
+    ) -> None:
+        if self._runtime_credentials is None:  # pragma: no cover - checked earlier
+            raise ProviderAllocationFailed(
+                "Docker workspace runtime credentials are not configured"
+            )
+        marker = f"/workspace/.agentbox-readiness-{allocation.allocation_token.hex}"
+        payload = allocation.allocation_token.bytes
+
+        async def chunks() -> AsyncIterator[bytes]:
+            yield payload
+
+        client = self._runtime_client_from_inspect(
+            inspected,
+            runtime_port=runtime_port,
+            token=self._runtime_credentials.token(inspected.container_id),
+            private_network=self._config.private_network,
+        )
+        try:
+            await client.write_file(
+                marker,
+                chunks(),
+                expected_sha256=None,
+                deadline_at=deadline_at,
+            )
+            stream = await client.open_file(
+                marker,
+                ByteRange(offset=0, length=None),
+                deadline_at=deadline_at,
+            )
+            observed = b"".join([chunk async for chunk in stream])
+            if observed != payload:
+                raise ProviderAllocationFailed(
+                    "Docker workspace filesystem readiness marker did not round-trip"
+                )
+        except WorkspaceRuntimeError as exc:
+            raise ProviderAllocationFailed(str(exc)) from exc
+        finally:
+            try:
+                await client.delete_file(
+                    marker,
+                    recursive=False,
+                    deadline_at=deadline_at,
+                )
+            except WorkspaceRuntimeError:
+                pass
+            await client.close()
 
     async def start_process(
         self, request: ProviderProcessStartRequest

--- a/agentbox/agentbox/adapters/docker.py
+++ b/agentbox/agentbox/adapters/docker.py
@@ -431,6 +431,8 @@ class DockerSandboxAdapter:
                     deadline_at=deadline_at,
                 )
             except WorkspaceRuntimeError:
+                # Cleanup is best-effort: it must not replace the readiness result
+                # with a secondary error after the shared deadline has expired.
                 pass
             await client.close()
 

--- a/agentbox/agentbox/adapters/docker_engine.py
+++ b/agentbox/agentbox/adapters/docker_engine.py
@@ -117,6 +117,10 @@ class DockerContainerInspect(DockerApiModel):
     container_id: str = Field(alias="Id")
     state: DockerContainerState = Field(alias="State")
     config: DockerContainerConfig = Field(alias="Config")
+    host_config: DockerHostConfig = Field(
+        default_factory=DockerHostConfig,
+        alias="HostConfig",
+    )
     network_settings: DockerNetworkSettings = Field(alias="NetworkSettings")
 
 

--- a/agentbox/agentbox/adapters/e2b.py
+++ b/agentbox/agentbox/adapters/e2b.py
@@ -454,6 +454,8 @@ class E2BSandboxAdapter:
                     if response.status_code == 200 and response.json().get("ready"):
                         return
                 except (httpx.TransportError, ValueError):
+                    # The gateway can race runtime startup; retry under the shared
+                    # deadline instead of treating a transient response as fatal.
                     pass
                 await asyncio.sleep(0.1)
         raise ProviderNotReady(

--- a/agentbox/agentbox/adapters/e2b.py
+++ b/agentbox/agentbox/adapters/e2b.py
@@ -90,6 +90,8 @@ from agentbox.profiles import ProfileRegistry
 
 _PROCESS_ROOT = "/tmp/.agentbox/processes"
 _OPERATION_ENV = "AGENTBOX_OPERATION_ID"
+_WORKSPACE_ROOT = "/workspace"
+_FUNCTION_RUNTIME_PORT = 8090
 
 
 class E2BSandboxType(Protocol):
@@ -268,10 +270,12 @@ class E2BSandboxAdapter:
         config: E2BAdapterConfig,
         *,
         sandbox_class: type[Any] = AsyncSandbox,
+        http_transport: httpx.AsyncBaseTransport | None = None,
     ) -> None:
         self._profiles = profiles
         self._config = config
         self._sandbox_class = sandbox_class
+        self._http_transport = http_transport
         self.scope = config.scope
         self._sandboxes: dict[str, E2BSandboxType] = {}
         self._processes: dict[tuple[str, str], _ProcessBuffer] = {}
@@ -369,6 +373,17 @@ class E2BSandboxAdapter:
                 request_timeout=self._request_timeout(deadline_at)
             ):
                 raise ProviderNotReady("E2B sandbox is not running", retry_after_ms=250)
+            if allocation.key.workload_kind == WorkloadKind.WORKSPACE:
+                await self._verify_workspace_filesystem(
+                    sandbox,
+                    allocation,
+                    deadline_at=deadline_at,
+                )
+            else:
+                await self._wait_function_runtime_ready(
+                    sandbox,
+                    deadline_at=deadline_at,
+                )
         except ProviderNotReady:
             raise
         except (TimeoutException, httpx.TimeoutException) as exc:
@@ -378,6 +393,72 @@ class E2BSandboxAdapter:
         return ProviderReadyResult(
             provider_id=allocation.provider_id,
             provider_instance_id=allocation.provider_id,
+        )
+
+    async def _verify_workspace_filesystem(
+        self,
+        sandbox: E2BSandboxType,
+        allocation: ProviderAllocationRef,
+        *,
+        deadline_at: datetime,
+    ) -> None:
+        marker = (
+            f"{_WORKSPACE_ROOT}/.agentbox-readiness-"
+            f"{allocation.allocation_token.hex}"
+        )
+        payload = allocation.allocation_token.bytes
+        try:
+            await sandbox.files.write(
+                marker,
+                payload,
+                request_timeout=self._request_timeout(deadline_at),
+                use_octet_stream=True,
+            )
+            observed = await sandbox.files.read(
+                marker,
+                format="bytes",
+                request_timeout=self._request_timeout(deadline_at),
+            )
+            if bytes(observed) != payload:
+                raise ProviderAllocationFailed(
+                    "E2B workspace filesystem readiness marker did not round-trip"
+                )
+        finally:
+            await sandbox.files.remove(
+                marker,
+                request_timeout=self._request_timeout(deadline_at),
+            )
+
+    async def _wait_function_runtime_ready(
+        self,
+        sandbox: E2BSandboxType,
+        *,
+        deadline_at: datetime,
+    ) -> None:
+        headers = (
+            {"E2B-Traffic-Access-Token": sandbox.traffic_access_token}
+            if sandbox.traffic_access_token
+            else {}
+        )
+        async with httpx.AsyncClient(
+            transport=self._http_transport,
+            timeout=httpx.Timeout(2),
+            follow_redirects=False,
+        ) as client:
+            while datetime.now(timezone.utc) < deadline_at:
+                try:
+                    response = await client.get(
+                        f"https://{sandbox.get_host(_FUNCTION_RUNTIME_PORT)}/healthz",
+                        headers=headers,
+                    )
+                    if response.status_code == 200 and response.json().get("ready"):
+                        return
+                except (httpx.TransportError, ValueError):
+                    pass
+                await asyncio.sleep(0.1)
+        raise ProviderNotReady(
+            "E2B function runtime is still starting",
+            retry_after_ms=250,
         )
 
     async def release_allocation(
@@ -390,7 +471,7 @@ class E2BSandboxAdapter:
             sandbox = await self._connect(allocation, deadline_at=deadline_at)
             await self._quiesce(sandbox, allocation.provider_id, deadline_at)
             await sandbox.pause(
-                keep_memory=True,
+                keep_memory=False,
                 request_timeout=self._request_timeout(deadline_at),
             )
             self._sandboxes.pop(allocation.provider_id, None)

--- a/agentbox/agentbox/api/contracts.py
+++ b/agentbox/agentbox/api/contracts.py
@@ -60,6 +60,7 @@ class EnsureSandboxRequest(StrictApiModel):
     profile: ProfileRefModel
     admission_class: AdmissionClass
     deadline_at: datetime
+    verify_ready: bool = False
 
     @field_validator("deadline_at")
     @classmethod

--- a/agentbox/agentbox/api/contracts.py
+++ b/agentbox/agentbox/api/contracts.py
@@ -60,7 +60,6 @@ class EnsureSandboxRequest(StrictApiModel):
     profile: ProfileRefModel
     admission_class: AdmissionClass
     deadline_at: datetime
-    verify_ready: bool = False
 
     @field_validator("deadline_at")
     @classmethod

--- a/agentbox/agentbox/api/fabric.py
+++ b/agentbox/agentbox/api/fabric.py
@@ -64,6 +64,7 @@ async def ensure_sandbox(
     workload_kind: WorkloadKind,
     logical_id: UUID,
     request: EnsureSandboxRequest,
+    verify_ready: bool = Query(default=False),
     service: SandboxLifecycleService = Depends(sandbox_lifecycle),
 ) -> Response | SandboxHandleResponse:
     handle = await service.ensure(
@@ -71,7 +72,7 @@ async def ensure_sandbox(
         request.profile.to_domain(),
         admission_class=request.admission_class,
         deadline_at=request.deadline_at,
-        verify_ready=request.verify_ready,
+        verify_ready=verify_ready,
     )
     response = SandboxHandleResponse.from_domain(handle)
     if handle.ready:

--- a/agentbox/agentbox/api/fabric.py
+++ b/agentbox/agentbox/api/fabric.py
@@ -71,6 +71,7 @@ async def ensure_sandbox(
         request.profile.to_domain(),
         admission_class=request.admission_class,
         deadline_at=request.deadline_at,
+        verify_ready=request.verify_ready,
     )
     response = SandboxHandleResponse.from_domain(handle)
     if handle.ready:

--- a/agentbox/agentbox/config.py
+++ b/agentbox/agentbox/config.py
@@ -152,7 +152,7 @@ class Settings(BaseSettings):
     )
     agentbox_reconcile_claim_seconds: float = Field(default=30, ge=5, le=300)
     agentbox_workspace_retention_seconds: float = Field(
-        default=48 * 60 * 60,
+        default=7 * 24 * 60 * 60,
         ge=1,
         description=(
             "Total workspace inactivity before physical sandbox and storage "

--- a/agentbox/agentbox/config.py
+++ b/agentbox/agentbox/config.py
@@ -1,4 +1,4 @@
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -151,7 +151,14 @@ class Settings(BaseSettings):
         ),
     )
     agentbox_reconcile_claim_seconds: float = Field(default=30, ge=5, le=300)
-    agentbox_workspace_retention_seconds: float = Field(default=604800, ge=1)
+    agentbox_workspace_retention_seconds: float = Field(
+        default=48 * 60 * 60,
+        ge=1,
+        description=(
+            "Total workspace inactivity before physical sandbox and storage "
+            "are destroyed. The logical workspace remains recreatable."
+        ),
+    )
     agentbox_add_host_gateway: bool = False
     agentbox_host_alias: str | None = None
     agentbox_local_runtime_cli: str = ""
@@ -165,6 +172,18 @@ class Settings(BaseSettings):
     agentbox_local_callback_url: str | None = None
     agentbox_local_callback_health_path: str = "/health"
     agentbox_local_callback_timeout_seconds: float = Field(default=30, ge=1, le=300)
+
+    @model_validator(mode="after")
+    def validate_workspace_lifecycle(self) -> Settings:
+        if (
+            self.agentbox_workspace_retention_seconds
+            <= self.agentbox_workspace_idle_seconds
+        ):
+            raise ValueError(
+                "AGENTBOX_WORKSPACE_RETENTION_SECONDS must exceed "
+                "AGENTBOX_WORKSPACE_IDLE_SECONDS"
+            )
+        return self
 
     @property
     def agentbox_e2b_function_allow_out_hosts(self) -> tuple[str, ...]:

--- a/agentbox/agentbox/lifecycle.py
+++ b/agentbox/agentbox/lifecycle.py
@@ -21,6 +21,7 @@ from agentbox.domain import (
     SandboxKey,
     SandboxMaintenanceClaim,
     SandboxProfileRef,
+    StorageKind,
     WorkloadKind,
 )
 from agentbox.observability import create_inherited_task
@@ -68,7 +69,7 @@ class SandboxLifecycleService:
         provider: SandboxProviderPort,
         admission_policy: ProviderAdmissionPolicy | None = None,
         *,
-        workspace_retention_seconds: float = 7 * 24 * 60 * 60,
+        workspace_retention_seconds: float = 48 * 60 * 60,
     ) -> None:
         self._database = database
         self._provider = provider
@@ -84,6 +85,7 @@ class SandboxLifecycleService:
         *,
         admission_class: AdmissionClass,
         deadline_at: datetime,
+        verify_ready: bool = False,
     ) -> SandboxHandle:
         self._check_deadline(deadline_at)
         request_hash = self._create_request_hash(
@@ -100,6 +102,7 @@ class SandboxLifecycleService:
         intent = None
         resumed = None
         storage = None
+        superseded_native_allocation = None
         try:
             async with self._database.uow() as uow:
                 logical = await uow.repository.ensure_logical(key, profile)
@@ -124,6 +127,30 @@ class SandboxLifecycleService:
                 )
                 if allocation_for_admission is None:  # pragma: no cover
                     raise RuntimeError("ensure produced no allocation for admission")
+                if (
+                    storage is not None
+                    and storage.storage_kind == StorageKind.SANDBOX_NATIVE
+                    and storage.bound_allocation_id is not None
+                    and storage.bound_allocation_id
+                    != allocation_for_admission.allocation_id
+                ):
+                    bound_allocation = await uow.repository.get_allocation_by_id(
+                        storage.bound_allocation_id
+                    )
+                    if (
+                        bound_allocation is not None
+                        and bound_allocation.state
+                        in {
+                            AllocationState.ACTIVE,
+                            AllocationState.DRAINING,
+                            AllocationState.RELEASED,
+                        }
+                    ):
+                        superseded_native_allocation = bound_allocation
+                        if bound_allocation.state == AllocationState.ACTIVE:
+                            await uow.repository.mark_allocation_draining(
+                                bound_allocation.allocation_id
+                            )
                 pending_retry = (
                     intent is not None
                     and intent.allocation.state == AllocationState.RESERVED
@@ -155,6 +182,12 @@ class SandboxLifecycleService:
         if not decision.accepted:
             raise self._admission_error(decision)
 
+        if superseded_native_allocation is not None:
+            await self._retire_superseded_native_workspace(
+                superseded_native_allocation,
+                deadline_at=deadline_at,
+            )
+
         if resumed is not None:
             return await self._wait_and_publish(
                 logical,
@@ -166,6 +199,13 @@ class SandboxLifecycleService:
             raise RuntimeError("allocation intent was not created")
 
         if intent.allocation.state == AllocationState.ACTIVE:
+            if verify_ready:
+                return await self._wait_and_publish(
+                    intent.logical,
+                    intent.allocation,
+                    profile=profile,
+                    deadline_at=deadline_at,
+                )
             return self._handle(intent.logical, intent.allocation)
         if pending_retry:
             return self._handle(intent.logical, intent.allocation)
@@ -337,29 +377,78 @@ class SandboxLifecycleService:
                 status_code=500,
             )
         # Transaction 3: persist provider acceptance before any readiness I/O.
-        async with self._database.uow() as uow:
-            allocation = await uow.repository.acknowledge_create(
-                intent.allocation.allocation_token,
-                provider_id=created.provider_id,
-                provider_instance_id=created.provider_instance_id,
-                provider_request_id=created.provider_request_id,
-            )
-            if created.workspace_storage is not None:
-                await uow.repository.bind_workspace_storage(
-                    key,
-                    provider_storage_id=created.workspace_storage.provider_storage_id,
-                    allocation_id=(
-                        intent.allocation.allocation_id
-                        if created.workspace_storage.bound_to_allocation
-                        else None
-                    ),
-                )
-            if contract_error is not None:
-                await uow.repository.mark_create_failed(
+        try:
+            async with self._database.uow() as uow:
+                allocation = await uow.repository.acknowledge_create(
                     intent.allocation.allocation_token,
-                    error_code=contract_error.code.value,
+                    provider_id=created.provider_id,
+                    provider_instance_id=created.provider_instance_id,
+                    provider_request_id=created.provider_request_id,
                 )
-            await uow.commit()
+                if created.workspace_storage is not None:
+                    await uow.repository.bind_workspace_storage(
+                        key,
+                        provider_storage_id=(
+                            created.workspace_storage.provider_storage_id
+                        ),
+                        allocation_id=(
+                            intent.allocation.allocation_id
+                            if created.workspace_storage.bound_to_allocation
+                            else None
+                        ),
+                    )
+                if contract_error is not None:
+                    await uow.repository.mark_create_failed(
+                        intent.allocation.allocation_token,
+                        error_code=contract_error.code.value,
+                    )
+                await uow.commit()
+        except AgentBoxError as exc:
+            if (
+                exc.code != ErrorCode.OPERATION_CONFLICT
+                or created.workspace_storage is None
+            ):
+                raise
+            cleanup_pending = False
+            try:
+                await self._provider.destroy_allocation(
+                    ProviderAllocationRef(
+                        provider_id=created.provider_id,
+                        provider_instance_id=created.provider_instance_id,
+                        allocation_id=intent.allocation.allocation_id,
+                        allocation_token=intent.allocation.allocation_token,
+                        key=key,
+                    ),
+                    deadline_at=deadline_at,
+                )
+            except ProviderLifecycleError:
+                cleanup_pending = True
+                await self._mark_create_unknown_durably(
+                    intent.allocation.allocation_token
+                )
+            else:
+                await self._mark_create_failed_durably(
+                    intent.allocation.allocation_token,
+                    error_code=ErrorCode.PROVIDER_UNAVAILABLE,
+                )
+            raise AgentBoxError(
+                ErrorCode.PROVIDER_UNAVAILABLE,
+                (
+                    "workspace storage reconciliation is pending"
+                    if cleanup_pending
+                    else "stale workspace storage binding was fenced"
+                ),
+                retry=(
+                    RetryDisposition.WAIT
+                    if cleanup_pending
+                    else RetryDisposition.SAFE_SAME_OPERATION
+                ),
+                status_code=503,
+                retry_after_ms=1000 if cleanup_pending else None,
+                context=ProviderErrorContext(
+                    kind="provider", provider_name=self._provider.name
+                ),
+            ) from exc
         if contract_error is not None:
             raise contract_error
 
@@ -473,6 +562,9 @@ class SandboxLifecycleService:
                 ),
             )
 
+        if allocation.state == AllocationState.ACTIVE:
+            return self._handle(logical, allocation)
+
         # Transaction 4: publish only the exact allocation proven ready.
         async with self._database.uow() as uow:
             allocation = await uow.repository.acknowledge_create(
@@ -488,6 +580,55 @@ class SandboxLifecycleService:
         if logical is None:  # pragma: no cover - state corruption
             raise RuntimeError("logical sandbox disappeared after publication")
         return self._handle(logical, allocation)
+
+    async def _retire_superseded_native_workspace(
+        self,
+        allocation: PhysicalAllocation,
+        *,
+        deadline_at: datetime,
+    ) -> None:
+        """Fence and discard sandbox-native storage before rebinding its workspace."""
+
+        if allocation.provider_id is not None:
+            try:
+                if allocation.state != AllocationState.RELEASED:
+                    await self._provider.release_allocation(
+                        ProviderAllocationRef(
+                            provider_id=allocation.provider_id,
+                            provider_instance_id=allocation.provider_instance_id,
+                            allocation_id=allocation.allocation_id,
+                            allocation_token=allocation.allocation_token,
+                            key=allocation.key,
+                        ),
+                        deadline_at=deadline_at,
+                    )
+                await self._provider.destroy_allocation(
+                    ProviderAllocationRef(
+                        provider_id=allocation.provider_id,
+                        provider_instance_id=allocation.provider_instance_id,
+                        allocation_id=allocation.allocation_id,
+                        allocation_token=allocation.allocation_token,
+                        key=allocation.key,
+                    ),
+                    deadline_at=deadline_at,
+                )
+            except ProviderLifecycleError as exc:
+                raise AgentBoxError(
+                    ErrorCode.PROVIDER_UNAVAILABLE,
+                    "superseded sandbox-native workspace cleanup is pending",
+                    retry=RetryDisposition.WAIT,
+                    status_code=503,
+                    retry_after_ms=1000,
+                    context=ProviderErrorContext(
+                        kind="provider", provider_name=self._provider.name
+                    ),
+                ) from exc
+        async with self._database.uow() as uow:
+            await uow.repository.mark_create_failed(
+                allocation.allocation_token,
+                error_code=ErrorCode.PROVIDER_UNAVAILABLE.value,
+            )
+            await uow.commit()
 
     async def inspect(self, key: SandboxKey) -> SandboxHandle | None:
         """Read durable state only; provider inventory is never on this path."""
@@ -569,11 +710,15 @@ class SandboxLifecycleService:
         _claim: SandboxMaintenanceClaim | None = None,
     ) -> bool:
         self._check_deadline(deadline_at)
+        recreate_on_ensure = (
+            _claim is not None and key.workload_kind == WorkloadKind.WORKSPACE
+        )
         async with self._database.uow() as uow:
             claim, _logical, allocation, storage = await uow.repository.begin_destroy(
                 key,
                 claimed_until=deadline_at,
                 claim=_claim,
+                recreate_on_ensure=recreate_on_ensure,
             )
             await uow.commit()
         try:
@@ -620,6 +765,7 @@ class SandboxLifecycleService:
                     allocation.allocation_id if allocation is not None else None
                 ),
                 claim_token=claim.token,
+                recreate_on_ensure=recreate_on_ensure,
             )
             await uow.commit()
         return True

--- a/agentbox/agentbox/lifecycle.py
+++ b/agentbox/agentbox/lifecycle.py
@@ -69,7 +69,7 @@ class SandboxLifecycleService:
         provider: SandboxProviderPort,
         admission_policy: ProviderAdmissionPolicy | None = None,
         *,
-        workspace_retention_seconds: float = 48 * 60 * 60,
+        workspace_retention_seconds: float = 7 * 24 * 60 * 60,
     ) -> None:
         self._database = database
         self._provider = provider

--- a/agentbox/agentbox/persistence/repository.py
+++ b/agentbox/agentbox/persistence/repository.py
@@ -539,6 +539,14 @@ class AgentBoxRepository:
                 retry=RetryDisposition.DO_NOT_RETRY,
                 status_code=409,
             )
+        if row.state == StorageState.DELETED.value:
+            row.state = StorageState.PROVISIONING.value
+            row.provider_storage_id = None
+            row.bound_allocation_id = None
+            row.delete_token = uuid4()
+            row.deleted_at = None
+            row.content_generation += 1
+            row.updated_at = timestamp
         return self._storage(row)
 
     async def bind_workspace_storage(
@@ -590,8 +598,15 @@ class AgentBoxRepository:
                     retry=RetryDisposition.DO_NOT_RETRY,
                     status_code=409,
                 )
+        provider_storage_changed = (
+            row.storage_kind == StorageKind.SANDBOX_NATIVE.value
+            and row.provider_storage_id is not None
+            and row.provider_storage_id != provider_storage_id
+        )
         row.provider_storage_id = provider_storage_id
         row.bound_allocation_id = allocation_id
+        if provider_storage_changed:
+            row.content_generation += 1
         row.state = StorageState.READY.value
         row.updated_at = timestamp
         await self._session.flush()
@@ -998,6 +1013,27 @@ class AgentBoxRepository:
         await self._session.flush()
         return self._allocation(row)
 
+    async def mark_allocation_draining(
+        self,
+        allocation_id: UUID,
+        *,
+        now: datetime | None = None,
+    ) -> PhysicalAllocation:
+        timestamp = now or utc_now()
+        row = await self._session.get(AllocationRow, allocation_id)
+        if row is None:
+            raise AgentBoxError(
+                ErrorCode.SANDBOX_NOT_FOUND,
+                "allocation does not exist",
+                retry=RetryDisposition.DO_NOT_RETRY,
+                status_code=404,
+            )
+        if row.state == AllocationState.ACTIVE.value:
+            row.state = AllocationState.DRAINING.value
+            row.updated_at = timestamp
+            await self._session.flush()
+        return self._allocation(row)
+
     async def acknowledge_create(
         self,
         allocation_token: UUID,
@@ -1322,8 +1358,9 @@ class AgentBoxRepository:
         )
         logical.desired_state = SandboxDesiredState.RELEASED.value
         logical.released_at = timestamp
+        idle_since = _aware(logical.last_used_at) or timestamp
         logical.delete_after = (
-            timestamp + timedelta(seconds=retention_seconds)
+            idle_since + timedelta(seconds=retention_seconds)
             if key.workload_kind == WorkloadKind.WORKSPACE
             else None
         )
@@ -1434,6 +1471,7 @@ class AgentBoxRepository:
         *,
         claimed_until: datetime,
         claim: SandboxMaintenanceClaim | None = None,
+        recreate_on_ensure: bool = False,
         now: datetime | None = None,
     ) -> tuple[
         SandboxMaintenanceClaim,
@@ -1457,7 +1495,11 @@ class AgentBoxRepository:
             claim=claim,
             now=timestamp,
         )
-        logical.desired_state = SandboxDesiredState.DELETED.value
+        logical.desired_state = (
+            SandboxDesiredState.RELEASED.value
+            if recreate_on_ensure
+            else SandboxDesiredState.DELETED.value
+        )
         logical.delete_after = None
         logical.updated_at = timestamp
         allocation: AllocationRow | None = None
@@ -1502,6 +1544,7 @@ class AgentBoxRepository:
         *,
         allocation_id: UUID | None,
         claim_token: UUID,
+        recreate_on_ensure: bool = False,
         now: datetime | None = None,
     ) -> None:
         timestamp = now or utc_now()
@@ -1537,8 +1580,17 @@ class AgentBoxRepository:
             storage_row.state = StorageState.DELETED.value
             storage_row.deleted_at = timestamp
             storage_row.provider_storage_id = None
+            storage_row.bound_allocation_id = None
             storage_row.updated_at = timestamp
         logical.current_allocation_id = None
+        logical.desired_state = (
+            SandboxDesiredState.RELEASED.value
+            if recreate_on_ensure
+            else SandboxDesiredState.DELETED.value
+        )
+        if recreate_on_ensure:
+            logical.released_at = timestamp
+            logical.delete_after = None
         logical.maintenance_action = None
         logical.maintenance_token = None
         logical.maintenance_claimed_until = None

--- a/agentbox/tests/adapters/test_docker_engine.py
+++ b/agentbox/tests/adapters/test_docker_engine.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 import httpx
 import pytest
 
+from agentbox.adapters.docker import DockerSandboxAdapter
 from agentbox.adapters.docker_engine import (
     DockerContainerCreateRequest,
     DockerContainerInspect,
@@ -14,6 +15,7 @@ from agentbox.adapters.docker_engine import (
     DockerNetworkCreateRequest,
     DockerRequestAmbiguous,
 )
+from agentbox.ports import ProviderAllocationFailed
 
 
 pytestmark = pytest.mark.asyncio
@@ -67,7 +69,11 @@ async def test_container_inspect_parses_private_network_attachment():
         {
             "Id": "container-123",
             "State": {"Status": "running", "Running": True, "ExitCode": 0},
-            "Config": {"Image": "workspace:dev", "Labels": {}},
+            "Config": {
+                "Image": "workspace:dev",
+                "Labels": {"workspace-storage-id": "volume-123"},
+            },
+            "HostConfig": {"Binds": ["volume-123:/workspace"]},
             "NetworkSettings": {
                 "Ports": {},
                 "Networks": {
@@ -80,6 +86,14 @@ async def test_container_inspect_parses_private_network_attachment():
     assert (
         inspected.network_settings.networks["lemma-private"].ip_address == "172.28.0.7"
     )
+    assert inspected.host_config.binds == ("volume-123:/workspace",)
+    DockerSandboxAdapter._validate_workspace_mount(inspected)
+
+    mismatched = inspected.model_copy(
+        update={"host_config": DockerHostConfig(binds=("volume-other:/workspace",))}
+    )
+    with pytest.raises(ProviderAllocationFailed):
+        DockerSandboxAdapter._validate_workspace_mount(mismatched)
 
 
 async def test_network_create_and_delete_use_typed_engine_requests():

--- a/agentbox/tests/adapters/test_e2b_adapter.py
+++ b/agentbox/tests/adapters/test_e2b_adapter.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 from e2b import RateLimitException
 from e2b.sandbox.filesystem.filesystem import EntryInfo, FileType
+import httpx
 import pytest
 import pytest_asyncio
 
@@ -18,6 +19,7 @@ from agentbox.adapters.e2b import (
 )
 from agentbox.domain import (
     AdmissionClass,
+    AgentBoxError,
     ByteRange,
     CreatePythonSessionRequest,
     EnvironmentVariable,
@@ -31,6 +33,7 @@ from agentbox.domain import (
     SandboxProfileRef,
     StartProcessRequest,
     StorageKind,
+    RetryDisposition,
     WorkloadKind,
 )
 from agentbox.filesystem import FilesystemService
@@ -184,6 +187,7 @@ class FakeFiles:
         self.data: dict[str, bytes] = {}
         self.directories: set[str] = set()
         self.stream_read_calls = 0
+        self.fail_writes = False
 
     async def make_dir(self, path: str, **_kwargs) -> bool:
         self.directories.add(path)
@@ -201,6 +205,8 @@ class FakeFiles:
         return bytearray(value) if format == "bytes" else value.decode()
 
     async def write(self, path: str, data, **_kwargs):
+        if self.fail_writes:
+            raise RuntimeError("injected filesystem failure")
         payload = data.read() if hasattr(data, "read") else data
         self.data[path] = bytes(payload)
         return self._info(path)
@@ -272,6 +278,7 @@ class FakeSandbox:
     connect_calls = 0
     kill_calls: list[str] = []
     fail_rate_limit = False
+    fail_workspace_filesystem = False
     last_create_kwargs: dict[str, object] = {}
 
     def __init__(self, sandbox_id: str) -> None:
@@ -284,6 +291,7 @@ class FakeSandbox:
         self.next_pid = 100
         self.contexts: dict[str, FakeContext] = {}
         self.paused = False
+        self.pause_keep_memory: bool | None = None
         self.timeout = 300
         self.timeout_calls = 0
         self.last_python_env: dict[str, str] = {}
@@ -296,6 +304,7 @@ class FakeSandbox:
         cls.connect_calls = 0
         cls.kill_calls = []
         cls.fail_rate_limit = False
+        cls.fail_workspace_filesystem = False
         cls.last_create_kwargs = {}
 
     @classmethod
@@ -306,6 +315,7 @@ class FakeSandbox:
             raise RateLimitException("429")
         sandbox_id = f"e2b-{cls.create_calls}"
         sandbox = cls(sandbox_id)
+        sandbox.files.fail_writes = cls.fail_workspace_filesystem
         cls.instances[sandbox_id] = sandbox
         cls.infos[sandbox_id] = FakeInfo(
             sandbox_id, template.split(":", 1)[0], dict(metadata)
@@ -346,7 +356,8 @@ class FakeSandbox:
         self.timeout = timeout
         self.timeout_calls += 1
 
-    async def pause(self, **_kwargs):
+    async def pause(self, keep_memory: bool = True, **_kwargs):
+        self.pause_keep_memory = keep_memory
         self.paused = True
         return True
 
@@ -417,6 +428,16 @@ def function_profile() -> SandboxProfile:
     )
 
 
+def function_health_transport() -> httpx.MockTransport:
+    return httpx.MockTransport(
+        lambda request: httpx.Response(
+            200,
+            json={"ready": True},
+            request=request,
+        )
+    )
+
+
 async def test_function_egress_is_restricted_to_configured_gateway(
     database: StateDatabase,
 ) -> None:
@@ -429,6 +450,7 @@ async def test_function_egress_is_restricted_to_configured_gateway(
             function_allow_out=("benchmark.trycloudflare.com",),
         ),
         sandbox_class=FakeSandbox,
+        http_transport=function_health_transport(),
     )
     lifecycle = SandboxLifecycleService(database, provider)
     key = SandboxKey(WorkloadKind.FUNCTION, uuid4())
@@ -488,6 +510,7 @@ async def test_function_port_access_extends_timeout_once_across_a_burst(
             scope="e2b:function-timeout-test",
         ),
         sandbox_class=FakeSandbox,
+        http_transport=function_health_transport(),
     )
     lifecycle = SandboxLifecycleService(database, provider)
     key = SandboxKey(WorkloadKind.FUNCTION, uuid4())
@@ -596,12 +619,34 @@ async def test_workspace_uses_exact_pause_resume_identity_and_native_storage(
     assert FakeSandbox.connect_calls == 1
     assert provider_id in FakeSandbox.instances
     assert data == b"persistent"
+    assert sandbox.pause_keep_memory is False
 
     await lifecycle.destroy(key, deadline_at=deadline)
     assert provider_id not in FakeSandbox.instances
     assert FakeSandbox.kill_calls == [provider_id]
     assert stat.sha256 is None
     assert sandbox.files.stream_read_calls == 1
+
+
+async def test_workspace_readiness_fences_failed_filesystem(
+    database: StateDatabase,
+) -> None:
+    FakeSandbox.fail_workspace_filesystem = True
+    provider = adapter()
+    lifecycle = SandboxLifecycleService(database, provider)
+    key = SandboxKey(WorkloadKind.WORKSPACE, uuid4())
+
+    with pytest.raises(AgentBoxError) as raised:
+        await lifecycle.ensure(
+            key,
+            profile().ref,
+            admission_class=AdmissionClass.INTERACTIVE,
+            deadline_at=datetime.now(timezone.utc) + timedelta(seconds=30),
+        )
+
+    assert raised.value.retry == RetryDisposition.SAFE_SAME_OPERATION
+    assert FakeSandbox.create_calls == 1
+    assert FakeSandbox.kill_calls == ["e2b-1"]
 
 
 async def test_rate_limit_reuses_same_allocation_token_without_hot_loop(

--- a/agentbox/tests/adapters/test_e2b_real.py
+++ b/agentbox/tests/adapters/test_e2b_real.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 import os
 from pathlib import Path
@@ -15,6 +16,7 @@ from agentbox.adapters.e2b import E2BAdapterConfig, E2BSandboxAdapter
 from agentbox.api.port_proxy import access_router, create_port_proxy_http_client
 from agentbox.domain import (
     AdmissionClass,
+    AgentBoxError,
     ByteRange,
     CreatePythonSessionRequest,
     EnvironmentVariable,
@@ -23,6 +25,7 @@ from agentbox.domain import (
     ProcessState,
     PythonExecutionState,
     PythonSessionState,
+    RetryDisposition,
     SandboxCapability,
     SandboxKey,
     SandboxProfileRef,
@@ -32,6 +35,7 @@ from agentbox.domain import (
 )
 from agentbox.filesystem import FilesystemService
 from agentbox.lifecycle import SandboxLifecycleService
+from agentbox.maintenance import SandboxMaintenanceWorker
 from agentbox.persistence.uow import StateDatabase
 from agentbox.port_access import PortAccessService, PortAccessSigner
 from agentbox.ports import ProviderAllocationRef
@@ -429,6 +433,168 @@ async def test_real_e2b_workspace_full_conformance(tmp_path: Path) -> None:
     finally:
         provider_id = provider_id or await _provider_id(database, key)
         await _kill_exact(provider_id)
+        await adapter.close()
+        await database.dispose()
+
+
+async def test_real_e2b_missing_workspace_is_fenced_and_recreated(
+    tmp_path: Path,
+) -> None:
+    profile = _workspace_profile()
+    adapter = _adapter(
+        ProfileRegistry((profile,)),
+        scope=f"e2b:workspace-recovery-test:{uuid4()}",
+    )
+    database = StateDatabase(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}")
+    await database.create_schema_for_test()
+    lifecycle = SandboxLifecycleService(database, adapter)
+    filesystem = FilesystemService(database, adapter)
+    key = SandboxKey(WorkloadKind.WORKSPACE, uuid4())
+    deadline = datetime.now(timezone.utc) + timedelta(minutes=6)
+    original_provider_id: str | None = None
+    recovered_provider_id: str | None = None
+
+    try:
+        created = await lifecycle.ensure(
+            key,
+            profile.ref,
+            admission_class=AdmissionClass.INTERACTIVE,
+            deadline_at=deadline,
+        )
+        original_provider_id = await _provider_id(database, key)
+        assert created.ready is True
+        assert original_provider_id is not None
+        await filesystem.write(
+            key,
+            "/workspace/will-be-discarded",
+            b"old-generation",
+            expected_sha256=None,
+            deadline_at=deadline,
+        )
+
+        await _kill_exact(original_provider_id)
+        with pytest.raises(AgentBoxError) as raised:
+            await lifecycle.ensure(
+                key,
+                profile.ref,
+                admission_class=AdmissionClass.INTERACTIVE,
+                deadline_at=deadline,
+                verify_ready=True,
+            )
+        assert raised.value.retry == RetryDisposition.SAFE_SAME_OPERATION
+
+        recovered = await lifecycle.ensure(
+            key,
+            profile.ref,
+            admission_class=AdmissionClass.INTERACTIVE,
+            deadline_at=deadline,
+            verify_ready=True,
+        )
+        recovered_provider_id = await _provider_id(database, key)
+        assert recovered.ready is True
+        assert recovered.allocation_id != created.allocation_id
+        assert recovered_provider_id is not None
+        assert recovered_provider_id != original_provider_id
+        await filesystem.write(
+            key,
+            "/workspace/new-generation",
+            b"fresh",
+            expected_sha256=None,
+            deadline_at=deadline,
+        )
+        assert (
+            await filesystem.read(
+                key,
+                "/workspace/new-generation",
+                ByteRange(offset=0, length=None),
+                deadline_at=deadline,
+            )
+            == b"fresh"
+        )
+        assert await lifecycle.destroy(key, deadline_at=deadline)
+    finally:
+        await _kill_exact(original_provider_id)
+        await _kill_exact(recovered_provider_id)
+        await adapter.close()
+        await database.dispose()
+
+
+async def test_real_e2b_hard_expiry_allows_fresh_workspace(
+    tmp_path: Path,
+) -> None:
+    profile = _workspace_profile()
+    replacement_profile = replace(
+        profile,
+        ref=SandboxProfileRef(
+            name="workspace-python-v2",
+            digest=f"sha256:{'d' * 64}",
+        ),
+    )
+    adapter = _adapter(
+        ProfileRegistry((profile, replacement_profile)),
+        scope=f"e2b:workspace-expiry-test:{uuid4()}",
+    )
+    database = StateDatabase(f"sqlite+aiosqlite:///{tmp_path / 'state.db'}")
+    await database.create_schema_for_test()
+    lifecycle = SandboxLifecycleService(
+        database,
+        adapter,
+        workspace_retention_seconds=0,
+    )
+    maintenance = SandboxMaintenanceWorker(
+        database,
+        lifecycle,
+        workspace_idle_seconds=0,
+        function_idle_seconds=0,
+        batch_size=1,
+    )
+    key = SandboxKey(WorkloadKind.WORKSPACE, uuid4())
+    deadline = datetime.now(timezone.utc) + timedelta(minutes=6)
+    original_provider_id: str | None = None
+    fresh_provider_id: str | None = None
+    replacement_provider_id: str | None = None
+
+    try:
+        await lifecycle.ensure(
+            key,
+            profile.ref,
+            admission_class=AdmissionClass.INTERACTIVE,
+            deadline_at=deadline,
+        )
+        original_provider_id = await _provider_id(database, key)
+        assert original_provider_id is not None
+
+        assert await maintenance.run_once(deadline_at=deadline) == 1
+        assert await maintenance.run_once(deadline_at=deadline) == 1
+
+        fresh = await lifecycle.ensure(
+            key,
+            profile.ref,
+            admission_class=AdmissionClass.INTERACTIVE,
+            deadline_at=deadline,
+            verify_ready=True,
+        )
+        fresh_provider_id = await _provider_id(database, key)
+        assert fresh.ready is True
+        assert fresh_provider_id is not None
+        assert fresh_provider_id != original_provider_id
+
+        replacement = await lifecycle.ensure(
+            key,
+            replacement_profile.ref,
+            admission_class=AdmissionClass.INTERACTIVE,
+            deadline_at=deadline,
+            verify_ready=True,
+        )
+        replacement_provider_id = await _provider_id(database, key)
+        assert replacement.ready is True
+        assert replacement_provider_id is not None
+        assert replacement_provider_id != fresh_provider_id
+        assert await lifecycle.destroy(key, deadline_at=deadline)
+    finally:
+        await _kill_exact(original_provider_id)
+        await _kill_exact(fresh_provider_id)
+        await _kill_exact(replacement_provider_id)
         await adapter.close()
         await database.dispose()
 

--- a/agentbox/tests/api/test_lifecycle_api.py
+++ b/agentbox/tests/api/test_lifecycle_api.py
@@ -167,6 +167,33 @@ async def test_ensure_and_inspect_use_typed_canonical_routes(api):
     assert database.active_units_of_work == 0
 
 
+async def test_ensure_can_revalidate_an_active_provider_allocation(api):
+    client, provider, database = api
+    logical_id = "d5f4ba6c-27c2-4b07-9eac-b4c8c4b95f83"
+    headers = {"X-API-Key": API_KEY}
+
+    created = await client.put(
+        f"/sandboxes/workspace/{logical_id}",
+        headers=headers,
+        json=ensure_body(),
+    )
+    verify_body = ensure_body()
+    verify_body["verify_ready"] = True
+    verified = await client.put(
+        f"/sandboxes/workspace/{logical_id}",
+        headers=headers,
+        json=verify_body,
+    )
+
+    assert created.status_code == 200
+    assert verified.status_code == 200
+    assert verified.json()["allocation_id"] == created.json()["allocation_id"]
+    assert verified.json()["allocation_epoch"] == created.json()["allocation_epoch"]
+    assert provider.create_calls == 1
+    assert provider.ready_calls == 2
+    assert database.active_units_of_work == 0
+
+
 async def test_unknown_fields_and_naive_deadlines_are_rejected(api):
     client, provider, _database = api
     logical_id = "693006b8-712e-44e3-9e90-6fa7e9eb0154"
@@ -229,6 +256,34 @@ async def test_ambiguous_create_returns_typed_error_and_is_not_replayed(
     assert provider.create_calls == 1
     assert database.active_units_of_work == 0
     await database.dispose()
+
+
+async def test_explicit_destroy_remains_permanent(api):
+    client, _provider, _database = api
+    logical_id = "fd727488-07e2-46fe-a58d-9684c46bb002"
+    headers = {"X-API-Key": API_KEY}
+    deadline = (datetime.now(timezone.utc) + timedelta(seconds=30)).isoformat()
+
+    created = await client.put(
+        f"/sandboxes/workspace/{logical_id}",
+        headers=headers,
+        json=ensure_body(),
+    )
+    destroyed = await client.delete(
+        f"/sandboxes/workspace/{logical_id}",
+        headers=headers,
+        params={"deadline_at": deadline},
+    )
+    recreated = await client.put(
+        f"/sandboxes/workspace/{logical_id}",
+        headers=headers,
+        json=ensure_body(),
+    )
+
+    assert created.status_code == 200
+    assert destroyed.status_code == 204
+    assert recreated.status_code == 404
+    assert recreated.json()["error"]["code"] == "SANDBOX_NOT_FOUND"
 
 
 async def test_release_resume_reuses_exact_workspace_and_destroy_removes_storage(api):

--- a/agentbox/tests/api/test_lifecycle_api.py
+++ b/agentbox/tests/api/test_lifecycle_api.py
@@ -177,12 +177,11 @@ async def test_ensure_can_revalidate_an_active_provider_allocation(api):
         headers=headers,
         json=ensure_body(),
     )
-    verify_body = ensure_body()
-    verify_body["verify_ready"] = True
     verified = await client.put(
         f"/sandboxes/workspace/{logical_id}",
         headers=headers,
-        json=verify_body,
+        params={"verify_ready": "true"},
+        json=ensure_body(),
     )
 
     assert created.status_code == 200

--- a/agentbox/tests/state/test_maintenance.py
+++ b/agentbox/tests/state/test_maintenance.py
@@ -133,7 +133,7 @@ async def _ensure(
     )
 
 
-async def test_workspace_release_then_retention_delete_is_provider_exact(
+async def test_workspace_release_then_hard_expiry_recreates_fresh(
     database: StateDatabase,
 ) -> None:
     provider = Provider(database)
@@ -177,10 +177,57 @@ async def test_workspace_release_then_retention_delete_is_provider_exact(
 
     assert second == 1
     assert deleted is not None
-    assert deleted.desired_state == SandboxDesiredState.DELETED
+    assert deleted.desired_state == SandboxDesiredState.RELEASED
+    assert deleted.current_allocation_id is None
     assert storage is not None and storage.provider_storage_id is None
     assert len(provider.destroy_calls) == 1
     assert len(provider.destroyed_storage) == 1
+
+    await _ensure(lifecycle, key)
+    async with database.uow() as uow:
+        recreated = await uow.repository.get_logical(key)
+        fresh_storage = await uow.repository.get_workspace_storage(key)
+        allocations = await uow.repository.list_allocations(key)
+        await uow.commit()
+
+    assert recreated is not None
+    assert recreated.desired_state == SandboxDesiredState.PRESENT
+    assert recreated.current_allocation_id is not None
+    assert fresh_storage is not None
+    assert fresh_storage.provider_storage_id is not None
+    assert fresh_storage.content_generation == 1
+    assert len(allocations) == 2
+    assert allocations[0].state == AllocationState.DESTROYED
+    assert allocations[1].state == AllocationState.ACTIVE
+
+
+async def test_workspace_hard_expiry_is_measured_from_last_activity(
+    database: StateDatabase,
+) -> None:
+    provider = Provider(database)
+    lifecycle = SandboxLifecycleService(
+        database,
+        provider,
+        workspace_retention_seconds=48 * 60 * 60,
+    )
+    key = SandboxKey(WorkloadKind.WORKSPACE, uuid4())
+    await _ensure(lifecycle, key)
+    async with database.uow() as uow:
+        before_release = await uow.repository.get_logical(key)
+        await uow.commit()
+    assert before_release is not None
+    paused_at = before_release.last_used_at + timedelta(minutes=5)
+
+    async with database.uow() as uow:
+        _claim, released, _allocation = await uow.repository.begin_release(
+            key,
+            claimed_until=paused_at + timedelta(seconds=30),
+            retention_seconds=48 * 60 * 60,
+            now=paused_at,
+        )
+        await uow.commit()
+
+    assert released.delete_after == before_release.last_used_at + timedelta(hours=48)
 
 
 async def test_idle_function_compute_is_destroyed_and_can_be_recreated(

--- a/agentbox/tests/state/test_repository.py
+++ b/agentbox/tests/state/test_repository.py
@@ -180,6 +180,7 @@ class MissingNativeWorkspaceProvider(FakeProvider):
     def __init__(self, database: StateDatabase) -> None:
         super().__init__(database)
         self.destroy_calls: list[ProviderAllocationRef] = []
+        self.release_calls: list[ProviderAllocationRef] = []
 
     async def create(self, request: ProviderCreateRequest) -> ProviderCreateResult:
         assert self.database.active_units_of_work == 0
@@ -221,6 +222,16 @@ class MissingNativeWorkspaceProvider(FakeProvider):
         del deadline_at
         assert self.database.active_units_of_work == 0
         self.destroy_calls.append(allocation)
+
+    async def release_allocation(
+        self,
+        allocation: ProviderAllocationRef,
+        *,
+        deadline_at: datetime,
+    ) -> None:
+        del deadline_at
+        assert self.database.active_units_of_work == 0
+        self.release_calls.append(allocation)
 
 
 async def test_logical_namespace_is_composite(database: StateDatabase):
@@ -275,6 +286,35 @@ async def test_ensure_commits_before_provider_io_and_creates_once(
     assert storage is not None
     assert storage.state == StorageState.READY
     assert storage.provider_storage_id is not None
+
+
+async def test_verified_ensure_rechecks_active_without_changing_epoch(
+    database: StateDatabase,
+):
+    provider = FakeProvider(database)
+    service = SandboxLifecycleService(database, provider)
+    key = SandboxKey(WorkloadKind.WORKSPACE, uuid4())
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=30)
+
+    created = await service.ensure(
+        key,
+        profile(),
+        admission_class=AdmissionClass.INTERACTIVE,
+        deadline_at=deadline,
+    )
+    verified = await service.ensure(
+        key,
+        profile(),
+        admission_class=AdmissionClass.INTERACTIVE,
+        deadline_at=deadline,
+        verify_ready=True,
+    )
+
+    assert verified.ready is True
+    assert verified.allocation_id == created.allocation_id
+    assert verified.allocation_epoch == created.allocation_epoch
+    assert len(provider.create_calls) == 1
+    assert provider.ready_calls == 2
 
 
 async def test_lost_create_response_is_not_replayed(database: StateDatabase):
@@ -599,6 +639,120 @@ async def test_missing_sandbox_native_workspace_rebinds_to_new_allocation(
         AllocationState.ACTIVE,
     ]
     assert allocations[1].provider_id == "sandbox-2"
+
+
+async def test_storage_bind_conflict_fences_new_provider_and_returns_retryable_error(
+    database: StateDatabase,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    provider = MissingNativeWorkspaceProvider(database)
+    provider.ready_calls = 1
+    service = SandboxLifecycleService(database, provider)
+    key = SandboxKey(WorkloadKind.WORKSPACE, uuid4())
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=30)
+
+    async def conflict(*_args, **_kwargs):
+        raise AgentBoxError(
+            ErrorCode.OPERATION_CONFLICT,
+            "workspace storage is already bound to another provider resource",
+            retry=RetryDisposition.DO_NOT_RETRY,
+            status_code=409,
+        )
+
+    monkeypatch.setattr(AgentBoxRepository, "bind_workspace_storage", conflict)
+
+    with pytest.raises(AgentBoxError) as raised:
+        await service.ensure(
+            key,
+            profile(),
+            admission_class=AdmissionClass.INTERACTIVE,
+            deadline_at=deadline,
+        )
+
+    assert raised.value.code == ErrorCode.PROVIDER_UNAVAILABLE
+    assert raised.value.retry == RetryDisposition.SAFE_SAME_OPERATION
+    assert "already bound" not in str(raised.value)
+    assert [item.provider_id for item in provider.destroy_calls] == ["sandbox-1"]
+
+
+async def test_released_native_workspace_with_new_profile_is_retired_and_rebound(
+    database: StateDatabase,
+):
+    provider = MissingNativeWorkspaceProvider(database)
+    provider.ready_calls = 1
+    service = SandboxLifecycleService(database, provider)
+    key = SandboxKey(WorkloadKind.WORKSPACE, uuid4())
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=30)
+
+    first = await service.ensure(
+        key,
+        profile(),
+        admission_class=AdmissionClass.INTERACTIVE,
+        deadline_at=deadline,
+    )
+    await service.release(key, deadline_at=deadline)
+    second = await service.ensure(
+        key,
+        profile(name="workspace-python-v2", fill="b"),
+        admission_class=AdmissionClass.INTERACTIVE,
+        deadline_at=deadline,
+    )
+
+    assert second.ready is True
+    assert second.allocation_id != first.allocation_id
+    assert [item.provider_id for item in provider.release_calls] == ["sandbox-1"]
+    assert [item.provider_id for item in provider.destroy_calls] == ["sandbox-1"]
+    async with database.uow() as uow:
+        storage = await uow.repository.get_workspace_storage(key)
+        allocations = await uow.repository.list_allocations(key)
+        await uow.commit()
+    assert storage is not None
+    assert storage.provider_storage_id == "sandbox-2"
+    assert storage.bound_allocation_id == second.allocation_id
+    assert storage.content_generation == 1
+    assert [item.state for item in allocations] == [
+        AllocationState.ERROR,
+        AllocationState.ACTIVE,
+    ]
+
+
+async def test_active_native_workspace_with_new_profile_is_fenced_and_rebound(
+    database: StateDatabase,
+):
+    provider = MissingNativeWorkspaceProvider(database)
+    provider.ready_calls = 1
+    service = SandboxLifecycleService(database, provider)
+    key = SandboxKey(WorkloadKind.WORKSPACE, uuid4())
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=30)
+
+    first = await service.ensure(
+        key,
+        profile(),
+        admission_class=AdmissionClass.INTERACTIVE,
+        deadline_at=deadline,
+    )
+    second = await service.ensure(
+        key,
+        profile(name="workspace-python-v2", fill="b"),
+        admission_class=AdmissionClass.INTERACTIVE,
+        deadline_at=deadline,
+    )
+
+    assert second.ready is True
+    assert second.allocation_id != first.allocation_id
+    assert [item.provider_id for item in provider.release_calls] == ["sandbox-1"]
+    assert [item.provider_id for item in provider.destroy_calls] == ["sandbox-1"]
+    async with database.uow() as uow:
+        storage = await uow.repository.get_workspace_storage(key)
+        allocations = await uow.repository.list_allocations(key)
+        await uow.commit()
+    assert storage is not None
+    assert storage.provider_storage_id == "sandbox-2"
+    assert storage.content_generation == 1
+    assert [item.state for item in allocations] == [
+        AllocationState.ERROR,
+        AllocationState.ACTIVE,
+    ]
 
 
 async def test_active_sandbox_native_workspace_cannot_be_rebound(

--- a/docs/design/agentbox/README.md
+++ b/docs/design/agentbox/README.md
@@ -283,7 +283,7 @@ stateDiagram-v2
     Active --> Draining: profile replacement
     Draining --> Provisioning: old allocation destroyed
     Active --> Destroying: permanent delete
-    Suspended --> Destroying: 48h inactivity or permanent delete
+    Suspended --> Destroying: retention expiry or permanent delete
     Destroying --> Expired: retention cleanup
     Expired --> Provisioning: next operation, fresh disk
     Destroying --> Absent: permanent delete
@@ -295,8 +295,9 @@ stateDiagram-v2
   the provider release primitive.
 - `/workspace` files survive release.
 - Session and process continuity is not portable across release.
-- Suspended retention ends 48 hours after the last accepted activity; activity
-  before that deadline resumes the exact physical sandbox and disk.
+- Suspended retention is configurable (currently seven days by default) and is
+  measured from the last accepted activity; activity before that deadline resumes
+  the exact physical sandbox and disk.
 - Retention expiry removes compute and storage but keeps the logical workspace
   recreatable. Its next operation receives a fresh storage generation.
 - Permanent delete removes every exact physical allocation and the durable storage.

--- a/docs/design/agentbox/README.md
+++ b/docs/design/agentbox/README.md
@@ -283,8 +283,10 @@ stateDiagram-v2
     Active --> Draining: profile replacement
     Draining --> Provisioning: old allocation destroyed
     Active --> Destroying: permanent delete
-    Suspended --> Destroying: retention or permanent delete
-    Destroying --> Absent: compute and storage absent
+    Suspended --> Destroying: 48h inactivity or permanent delete
+    Destroying --> Expired: retention cleanup
+    Expired --> Provisioning: next operation, fresh disk
+    Destroying --> Absent: permanent delete
 ```
 
 - Running idle timeout: five minutes.
@@ -293,8 +295,10 @@ stateDiagram-v2
   the provider release primitive.
 - `/workspace` files survive release.
 - Session and process continuity is not portable across release.
-- Suspended retention is seven days; activity during that period resumes the
-  logical workspace.
+- Suspended retention ends 48 hours after the last accepted activity; activity
+  before that deadline resumes the exact physical sandbox and disk.
+- Retention expiry removes compute and storage but keeps the logical workspace
+  recreatable. Its next operation receives a fresh storage generation.
 - Permanent delete removes every exact physical allocation and the durable storage.
 
 ### 7.2 Function lifecycle

--- a/docs/design/agentbox/provider-adapters.md
+++ b/docs/design/agentbox/provider-adapters.md
@@ -433,7 +433,7 @@ the filesystem data plane with a temporary write/read/delete marker before
 publication. See [persistence](https://e2b.dev/docs/sandbox/persistence).
 
 Paused E2B sandboxes are retained indefinitely by the provider, so AgentBox's
-48-hour inactivity worker must explicitly kill them.
+configured retention worker must explicitly kill them.
 
 ### 7.3 Workspace profile replacement
 

--- a/docs/design/agentbox/provider-adapters.md
+++ b/docs/design/agentbox/provider-adapters.md
@@ -420,42 +420,30 @@ and pauses it again before normal ensure may return it. This keeps provider time
 from bypassing the portable release contract.
 
 Thus the E2B snapshot contains the static clean template/runtime state plus workspace
-files, not live delegated credentials. Although E2B can preserve process memory,
-portable callers are promised files only.
+files, not live delegated credentials. AgentBox pauses with `keep_memory=False`:
+E2B drops the memory snapshot and cold-boots the same sandbox from its persisted
+filesystem on reconnect.
 
 With auto-resume enabled, native commands, file operations, and authenticated tunnel
 traffic can resume a paused sandbox. An adapter operation may use its cached handle;
 otherwise it connects by exact provider ID. It does not call list/status first.
-E2B documents that normal pause preserves filesystem and memory, connection resumes
-the same sandbox, and auto-resume is valid only for full-memory pause. See
-[persistence](https://e2b.dev/docs/sandbox/persistence) and
-[auto-resume](https://e2b.dev/docs/sandbox/auto-resume).
+E2B documents that filesystem-only pause preserves disk while dropping running
+processes and open connections. AgentBox reconnects by exact sandbox ID and proves
+the filesystem data plane with a temporary write/read/delete marker before
+publication. See [persistence](https://e2b.dev/docs/sandbox/persistence).
 
 Paused E2B sandboxes are retained indefinitely by the provider, so AgentBox's
-seven-day logical retention worker must explicitly kill them.
+48-hour inactivity worker must explicitly kill them.
 
 ### 7.3 Workspace profile replacement
 
 An E2B sandbox filesystem is native to that physical sandbox, unlike a Docker
-volume or Kubernetes PVC. Replacing a workspace profile therefore uses an explicit
-two-allocation migration:
-
-1. quiesce the old allocation and keep it as the current fenced allocation;
-2. reserve temporary replacement capacity and create the new template allocation
-   with a new allocation token;
-3. enumerate `/workspace` through native file APIs and build a manifest containing
-   path, type, mode, size, and content digest;
-4. stream allowed regular files and directories into the new allocation without
-   passing whole files through shell/base64 commands;
-5. reject path or symlink escapes and verify the destination manifest and digests;
-6. run the new profile readiness checks;
-7. transactionally bind the storage row and logical sandbox to the new allocation,
-   increment the allocation epoch, and only then destroy the old sandbox.
-
-If copy or verification fails, the old allocation remains current and recoverable;
-the incomplete replacement is destroyed. New operations cannot observe the new
-allocation before the atomic bind. This is the only E2B path that migrates files
-between sandbox IDs; ordinary pause/auto-resume reconnects the same exact sandbox.
+volume or Kubernetes PVC. A profile replacement therefore fences and quiesces the
+old allocation, destroys its exact sandbox ID, increments the storage generation,
+and creates a fresh sandbox from the new immutable template. Availability and
+profile correctness take precedence over attempting an implicit cross-sandbox
+file migration. Ordinary pause/resume still reconnects the same exact sandbox and
+preserves its filesystem.
 
 ### 7.4 Workspace execution
 

--- a/docs/design/agentbox/sandbox-protocol.md
+++ b/docs/design/agentbox/sandbox-protocol.md
@@ -716,8 +716,8 @@ scheduler.
 4. Terminate remaining managed processes and Python contexts.
 5. Clear dynamic session data and provider port grants.
 6. Invoke provider release.
-7. Mark `RELEASED`, record a hard-expiry deadline 48 hours after the last accepted
-   activity, and release active provider capacity.
+7. Mark `RELEASED`, record the configured hard-expiry deadline relative to the last
+   accepted activity, and release active provider capacity.
 
 If the deadline expires before safe quiescence, release fails and leaves the
 allocation active or explicitly degraded; it never pauses behind an active process.

--- a/docs/design/agentbox/sandbox-protocol.md
+++ b/docs/design/agentbox/sandbox-protocol.md
@@ -716,10 +716,16 @@ scheduler.
 4. Terminate remaining managed processes and Python contexts.
 5. Clear dynamic session data and provider port grants.
 6. Invoke provider release.
-7. Mark `RELEASED`, record retention deadline, and release active provider capacity.
+7. Mark `RELEASED`, record a hard-expiry deadline 48 hours after the last accepted
+   activity, and release active provider capacity.
 
 If the deadline expires before safe quiescence, release fails and leaves the
 allocation active or explicitly degraded; it never pauses behind an active process.
+
+At hard expiry, AgentBox destroys the exact allocation and workspace storage but
+retains a recreatable logical workspace. The next ensure creates a new allocation
+and storage generation. An explicit delete is different: it permanently tombstones
+the logical workspace and future ensure returns `SANDBOX_NOT_FOUND`.
 
 ### 7.3 Function idle destruction
 

--- a/docs/design/agentbox/verification-and-rollout.md
+++ b/docs/design/agentbox/verification-and-rollout.md
@@ -190,7 +190,8 @@ case IDs become mandatory for Kubernetes before that adapter is enabled.
 - Docker-volume profile replacement preserves files while changing allocation epoch.
 - E2B-native profile replacement fences and removes the old exact sandbox, then
   publishes a fresh storage generation.
-- Activity before 48 hours of total inactivity resumes the exact paused workspace.
+- Activity before the configured total-inactivity deadline resumes the exact paused
+  workspace.
 - Retention expiry removes compute and storage but the next operation recreates
   the logical workspace with a fresh disk.
 - Explicit delete prevents a late event/inventory item from resurrecting state.

--- a/docs/design/agentbox/verification-and-rollout.md
+++ b/docs/design/agentbox/verification-and-rollout.md
@@ -187,11 +187,12 @@ case IDs become mandatory for Kubernetes before that adapter is enabled.
 - Release terminates sessions/processes and revokes port grants.
 - Resume preserves `/workspace` but callers recreate nonportable session state.
 - Repeated release/resume does not create duplicate resources.
-- Profile replacement preserves files while changing allocation epoch.
-- E2B profile replacement verifies a streamed file manifest before the atomic bind;
-  an injected copy failure leaves the old sandbox current.
-- Seven-day retention activity resumes the workspace.
-- Retention expiry permanently removes compute and storage.
+- Docker-volume profile replacement preserves files while changing allocation epoch.
+- E2B-native profile replacement fences and removes the old exact sandbox, then
+  publishes a fresh storage generation.
+- Activity before 48 hours of total inactivity resumes the exact paused workspace.
+- Retention expiry removes compute and storage but the next operation recreates
+  the logical workspace with a fresh disk.
 - Explicit delete prevents a late event/inventory item from resurrecting state.
 
 ### 4.5 Port access

--- a/lemma-backend/app/modules/function/application/function_runtime_route_resolver.py
+++ b/lemma-backend/app/modules/function/application/function_runtime_route_resolver.py
@@ -150,6 +150,7 @@ class FunctionRuntimeRouteResolver:
                         else AdmissionClass.BATCH
                     ),
                     deadline_at=deadline_at,
+                    verify_ready=True,
                 )
             except AgentBoxApiError as exc:
                 if str(getattr(exc, "code", "")).upper() == "CAPACITY_EXHAUSTED":

--- a/lemma-backend/app/modules/function/tests/unit/test_function_runtime_route_resolver.py
+++ b/lemma-backend/app/modules/function/tests/unit/test_function_runtime_route_resolver.py
@@ -72,6 +72,7 @@ async def test_execution_endpoint_ensures_once_and_caches_exact_grant() -> None:
     ensure = client.ensure_sandbox.await_args
     assert ensure.args[:2] == (WorkloadKind.FUNCTION, dispatch.pod_id)
     assert ensure.kwargs["admission_class"] == AdmissionClass.LATENCY
+    assert ensure.kwargs["verify_ready"] is True
     client.create_port_access.assert_awaited_once()
     client.close.assert_awaited_once()
 

--- a/lemma-backend/app/modules/workspace/services/agentbox_manager.py
+++ b/lemma-backend/app/modules/workspace/services/agentbox_manager.py
@@ -61,6 +61,7 @@ class AgentBoxSandbox(ISandbox):
                     profile=profile,
                     admission_class=AdmissionClass.INTERACTIVE,
                     deadline_at=deadline_at,
+                    verify_ready=True,
                 )
             except AgentBoxApiError as exc:
                 if exc.retry not in (

--- a/lemma-backend/app/modules/workspace/tests/unit/test_agentbox_manager.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_agentbox_manager.py
@@ -59,9 +59,11 @@ async def test_workspace_retries_safe_same_operation(monkeypatch):
 
     class _Client:
         calls = 0
+        verify_ready_values = []
 
         async def ensure_sandbox(self, *_args, **_kwargs):
             self.calls += 1
+            self.verify_ready_values.append(_kwargs.get("verify_ready"))
             if self.calls == 1:
                 raise _api_error(RetryDisposition.SAFE_SAME_OPERATION)
             return _ready_sandbox(user_id)
@@ -77,6 +79,7 @@ async def test_workspace_retries_safe_same_operation(monkeypatch):
 
     assert result.status == "RUNNING"
     assert sandbox.client.calls == 2
+    assert sandbox.client.verify_ready_values == [True, True]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- revalidate active AgentBox allocations against the provider and sandbox data plane before workspace commands and function port grants
- fence poisoned or profile-mismatched E2B allocations, destroy the exact stale sandbox binding, and provision a fresh usable sandbox instead of retrying the same bad binding
- preserve disk across ordinary pause/resume with disk-only E2B pause, while making retention expiry recreatable and keeping explicit deletion permanent
- validate real `/workspace` filesystem access and function `/healthz` readiness for E2B, plus exact Docker workspace mounts
- send the opt-in readiness probe as a rollout-compatible query parameter so older strict AgentBox request bodies keep working during staggered deployment

## Incident evidence

- production logs showed the same workspace polling `202` until timeout on three separate requests on 2026-07-27
- a live personal-pod agent probe reproduced five failures, including the exact `workspace storage is already bound to another provider resource` conflict
- the conflict was routed back into the same persisted allocation/storage binding instead of being fenced and replaced

## Lifecycle semantics

- idle pause keeps the E2B sandbox disk and removes compute; resume targets the same sandbox
- retention expiry destroys the provider sandbox but leaves the logical workspace recreatable with a fresh storage generation
- explicit delete remains permanent
- provider loss, stale bindings, profile mismatch, and readiness failures favor availability by fencing the bad allocation and starting fresh
- idle and retention durations remain configurable; this PR does not change the current production values

## Verification

- real E2B lifecycle/conformance suite: `4 passed`
  - pause/resume filesystem persistence
  - out-of-band sandbox loss and fenced recreation
  - hard-expiry recreation and active profile replacement
  - function runtime port and `/healthz` readiness with exact destruction
- AgentBox suite: `159 passed, 8 skipped`
- backend workspace/function tests: `109 passed`
- AgentBox client tests: `6 passed`
- Ruff and `git diff --check`: passed

## Deployment note

The readiness opt-in is a query parameter. Old AgentBox deployments ignore it while accepting the unchanged strict JSON body, so backend and AgentBox can be deployed normally without a request-wide `422` window. After deployment, the saved personal-pod agent probe can be rerun against the same poisoned workspace scenario.
