### PR TITLE
Retry fenced pre-dispatch allocation races

### DIFF
--- a/agentbox/agentbox/adapters/e2b.py
+++ b/agentbox/agentbox/adapters/e2b.py
@@ -1332,31 +1332,60 @@ class E2BSandboxAdapter:
         provider_id: str,
         deadline_at: datetime,
     ) -> None:
-        processes = await sandbox.commands.list(
-            request_timeout=self._request_timeout(deadline_at)
-        )
-        await asyncio.gather(
-            *(
-                sandbox.commands.kill(
-                    process.pid,
-                    request_timeout=self._request_timeout(deadline_at),
+        # These are hygiene steps, not the lifecycle boundary. In particular,
+        # E2B can keep the sandbox command and filesystem APIs healthy while
+        # its optional code-interpreter port is unavailable. Failing release in
+        # that state leaves the durable allocation permanently quiescing even
+        # though pause(keep_memory=False) can still stop it safely.
+        async def best_effort(awaitable: Any) -> Any | None:
+            # Reserve at least half of the remaining lifecycle deadline for the
+            # authoritative provider pause. Some optional E2B APIs do not
+            # expose request_timeout, so an outer bound is required too.
+            timeout = min(5.0, self._remaining(deadline_at) / 2)
+            try:
+                return await asyncio.wait_for(awaitable, timeout=timeout)
+            except Exception:
+                return None
+
+        processes = (
+            await best_effort(
+                sandbox.commands.list(
+                    request_timeout=self._request_timeout(deadline_at)
                 )
-                for process in processes
-            ),
-            return_exceptions=True,
+            )
+            or ()
         )
-        contexts = await sandbox.list_code_contexts()
-        await asyncio.gather(
-            *(sandbox.remove_code_context(context.id) for context in contexts),
-            return_exceptions=True,
+        await best_effort(
+            asyncio.gather(
+                *(
+                    sandbox.commands.kill(
+                        process.pid,
+                        request_timeout=self._request_timeout(deadline_at),
+                    )
+                    for process in processes
+                ),
+                return_exceptions=True,
+            )
+        )
+        contexts = await best_effort(sandbox.list_code_contexts()) or ()
+        await best_effort(
+            asyncio.gather(
+                *(sandbox.remove_code_context(context.id) for context in contexts),
+                return_exceptions=True,
+            )
         )
         self._python_contexts.pop(provider_id, None)
         self._python_context_locks.pop(provider_id, None)
-        if await sandbox.files.exists(
-            _PROCESS_ROOT, request_timeout=self._request_timeout(deadline_at)
-        ):
-            await sandbox.files.remove(
+        process_root_exists = await best_effort(
+            sandbox.files.exists(
                 _PROCESS_ROOT, request_timeout=self._request_timeout(deadline_at)
+            )
+        )
+        if process_root_exists:
+            await best_effort(
+                sandbox.files.remove(
+                    _PROCESS_ROOT, request_timeout=self._request_timeout(deadline_at)
+                )
             )
         await self._drop_process_buffers(provider_id)
 

--- a/agentbox/agentbox/lifecycle.py
+++ b/agentbox/agentbox/lifecycle.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from agentbox.domain import (
     AdmissionClass,
     AgentBoxError,
+    AllocationErrorContext,
     AllocationState,
     CapacityErrorContext,
     ErrorCode,
@@ -228,12 +229,34 @@ class SandboxLifecycleService:
         try:
             self._check_deadline(deadline_at)
             async with self._database.uow() as uow:
-                dispatch = await uow.repository.mark_create_dispatched(
-                    intent.allocation.allocation_token,
-                    expected_resource_generation=(
-                        intent.allocation.resource_generation
-                    ),
-                )
+                try:
+                    dispatch = await uow.repository.mark_create_dispatched(
+                        intent.allocation.allocation_token,
+                        expected_resource_generation=(
+                            intent.allocation.resource_generation
+                        ),
+                    )
+                except AgentBoxError as exc:
+                    if exc.code != ErrorCode.ALLOCATION_CHANGED:
+                        raise
+                    # A release, destroy, or profile transition won after the
+                    # reservation transaction but before provider create I/O.
+                    # The repository fenced and resolved the undispatched
+                    # attempt; commit that cleanup and tell the caller that
+                    # retrying ensure is safe.
+                    await uow.commit()
+                    raise AgentBoxError(
+                        ErrorCode.ALLOCATION_CHANGED,
+                        "allocation changed before provider creation; retry ensure",
+                        retry=RetryDisposition.SAFE_SAME_OPERATION,
+                        status_code=409,
+                        retry_after_ms=250,
+                        context=AllocationErrorContext(
+                            kind="allocation",
+                            allocation_id=intent.allocation.allocation_id,
+                            allocation_epoch=intent.allocation.allocation_epoch,
+                        ),
+                    ) from exc
                 await uow.commit()
         except AgentBoxError as exc:
             if exc.code != ErrorCode.DEADLINE_EXCEEDED:

--- a/agentbox/tests/adapters/test_e2b_adapter.py
+++ b/agentbox/tests/adapters/test_e2b_adapter.py
@@ -290,6 +290,7 @@ class FakeSandbox:
         self.processes: dict[int, FakeProcessInfo] = {}
         self.next_pid = 100
         self.contexts: dict[str, FakeContext] = {}
+        self.fail_context_list = False
         self.paused = False
         self.pause_keep_memory: bool | None = None
         self.timeout = 300
@@ -367,6 +368,8 @@ class FakeSandbox:
         return context
 
     async def list_code_contexts(self):
+        if self.fail_context_list:
+            raise RuntimeError("optional interpreter service is unavailable")
         return list(self.contexts.values())
 
     async def restart_code_context(self, _context):
@@ -630,6 +633,23 @@ async def test_workspace_uses_exact_pause_resume_identity_and_native_storage(
     assert FakeSandbox.kill_calls == [provider_id]
     assert stat.sha256 is None
     assert sandbox.files.stream_read_calls == 1
+
+
+async def test_workspace_release_pauses_when_optional_interpreter_is_unavailable(
+    database: StateDatabase,
+) -> None:
+    _provider, lifecycle, key, deadline, _created = await provision(database)
+    provider_id = next(iter(FakeSandbox.instances))
+    sandbox = FakeSandbox.instances[provider_id]
+    sandbox.fail_context_list = True
+    sandbox.files.data["/tmp/.agentbox/processes/stale/exit"] = b"0"
+
+    released = await lifecycle.release(key, deadline_at=deadline)
+
+    assert released.ready is False
+    assert sandbox.paused is True
+    assert sandbox.pause_keep_memory is False
+    assert not await sandbox.files.exists("/tmp/.agentbox/processes")
 
 
 async def test_workspace_readiness_fences_failed_filesystem(

--- a/agentbox/tests/state/test_repository.py
+++ b/agentbox/tests/state/test_repository.py
@@ -520,6 +520,63 @@ async def test_cancelled_dispatch_transaction_releases_capacity(
     assert database.active_units_of_work == 0
 
 
+async def test_predispatch_generation_race_is_safe_to_retry(
+    database: StateDatabase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = FakeProvider(database)
+    service = SandboxLifecycleService(database, provider)
+    key = SandboxKey(WorkloadKind.FUNCTION, uuid4())
+    original = AgentBoxRepository.mark_create_dispatched
+
+    async def release_before_dispatch(
+        repository: AgentBoxRepository,
+        allocation_token,
+        *,
+        expected_resource_generation,
+        now=None,
+    ) -> bool:
+        timestamp = now or datetime.now(timezone.utc)
+        await repository.begin_release(
+            key,
+            claimed_until=timestamp + timedelta(seconds=30),
+            retention_seconds=0,
+            now=timestamp,
+        )
+        return await original(
+            repository,
+            allocation_token,
+            expected_resource_generation=expected_resource_generation,
+            now=timestamp,
+        )
+
+    monkeypatch.setattr(
+        AgentBoxRepository,
+        "mark_create_dispatched",
+        release_before_dispatch,
+    )
+
+    with pytest.raises(AgentBoxError) as raised:
+        await service.ensure(
+            key,
+            profile("function-python-v1", "b"),
+            admission_class=AdmissionClass.BATCH,
+            deadline_at=datetime.now(timezone.utc) + timedelta(seconds=30),
+        )
+
+    assert raised.value.code == ErrorCode.ALLOCATION_CHANGED
+    assert raised.value.retry == RetryDisposition.SAFE_SAME_OPERATION
+    assert raised.value.retry_after_ms == 250
+    assert provider.create_calls == []
+    async with database.uow() as uow:
+        attempts = await uow.repository.list_allocations(key)
+        active, reserved = await uow.repository._admission_counts(provider.scope)
+        await uow.commit()
+    assert [item.state for item in attempts] == [AllocationState.ERROR]
+    assert (active, reserved) == (0, 0)
+    assert database.active_units_of_work == 0
+
+
 async def test_cancelled_admission_transaction_does_not_leak_capacity(
     database: StateDatabase,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Problems found in live dev

The dev rollout exposed two independent lifecycle edge cases:

1. A function ensure raced idle cleanup after reservation but before provider
   creation. The repository generation fence correctly prevented stale work from
   reaching E2B, but leaked its internal
   `ALLOCATION_CHANGED / DO_NOT_RETRY` result to the caller. A manual retry then
   succeeded.
2. Workspace release could remain permanently in `quiescing` when E2B's optional
   code-interpreter service was unavailable. Process/context cleanup failed
   before the authoritative provider pause, leaving a running sandbox and a
   durable maintenance claim.

## Fix

- Keep the repository's strict generation fence unchanged.
- Commit fenced reserved-attempt cleanup so it cannot leak admission capacity.
- Translate only the pre-provider-I/O race to
  `ALLOCATION_CHANGED / SAFE_SAME_OPERATION` with a short retry interval.
- Treat command, code-context, and process-root cleanup as bounded,
  best-effort hygiene during workspace quiesce.
- Preserve lifecycle deadline for the authoritative
  `pause(keep_memory=False)` operation; pause failures still propagate.
- Clear local Python context/process buffers even if the optional remote
  interpreter service is unavailable.
- Add regressions for both race and release paths.

No provider create is retried after provider I/O begins, and no release is
reported successful unless the authoritative pause succeeds.

## Validation

- Full AgentBox suite: **178 passed, 8 skipped**.
- Adapter/repository lifecycle suites: **32 passed**.
- Exact immutable dev E2B templates, using the real E2B control plane:
  **4 passed in 74.02s**.
  - workspace shell, PTY, files, Python, ports, release, and resume;
  - missing-workspace fencing and recreation;
  - hard-expiry fresh workspace;
  - function runtime port and exact destroy.
- Live dev baseline after exact stale-state recovery:
  - fresh API and JOB runtime creation;
  - API and JOB happy, intentional-failure, and immediate-recovery runs;
  - two API plus two JOB invocations dispatched concurrently with correct
    request/result correlation;
  - fresh workspace agent shell/Python default-cwd and relative-file parity.
  Exactly one ready function sandbox and one ready workspace sandbox exist for
  the personal probe after the run.
- Ruff and `git diff --check`: passed.

The live Lemma API, JOB, workspace-agent, and release/recreate gates will be
repeated against the released build before production promotion.
