### PR TITLE
Converge concurrent AgentBox readiness waiters

### DIFF
--- a/agentbox/agentbox/lifecycle.py
+++ b/agentbox/agentbox/lifecycle.py
@@ -223,6 +223,18 @@ class SandboxLifecycleService:
             return self._handle(intent.logical, intent.allocation)
         if pending_retry:
             return self._handle(intent.logical, intent.allocation)
+        if not intent.should_dispatch_create:
+            if (
+                intent.allocation.state == AllocationState.PROVISIONING
+                and intent.allocation.provider_id is not None
+            ):
+                return await self._wait_and_publish(
+                    intent.logical,
+                    intent.allocation,
+                    profile=profile,
+                    deadline_at=deadline_at,
+                )
+            return self._handle(intent.logical, intent.allocation)
 
         # Transaction 2: transition RESERVED -> DISPATCHED exactly once. The
         # provider has not been called yet and this transaction is closed before it is.

--- a/agentbox/agentbox/persistence/repository.py
+++ b/agentbox/agentbox/persistence/repository.py
@@ -1243,6 +1243,30 @@ class AgentBoxRepository:
             logical_id=allocation.logical_id,
         )
         logical = await self._select_logical(key, for_update=True)
+        current_active_allocation = (
+            logical is not None
+            and logical.desired_state == SandboxDesiredState.PRESENT.value
+            and logical.maintenance_action is None
+            and logical.resource_generation == expected_resource_generation
+            and allocation.resource_generation == expected_resource_generation
+            and logical.profile_digest == allocation.profile_digest
+            and logical.current_allocation_id == allocation.allocation_id
+            and allocation.state == AllocationState.ACTIVE.value
+        )
+        if current_active_allocation:
+            if allocation.provider_id != provider_id:
+                raise AgentBoxError(
+                    ErrorCode.OPERATION_CONFLICT,
+                    "allocation is already bound to another provider object",
+                    retry=RetryDisposition.DO_NOT_RETRY,
+                    status_code=409,
+                    context=AllocationErrorContext(
+                        kind="allocation",
+                        allocation_id=allocation.allocation_id,
+                        allocation_epoch=allocation.allocation_epoch,
+                    ),
+                )
+            return self._allocation(allocation)
         if (
             logical is None
             or logical.desired_state != SandboxDesiredState.PRESENT.value
@@ -1320,6 +1344,17 @@ class AgentBoxRepository:
         logical = await self._select_logical(key, for_update=True)
         if logical is None:  # pragma: no cover - state invariant
             raise RuntimeError("allocation owner does not exist")
+        current_active_allocation = (
+            logical.desired_state == SandboxDesiredState.PRESENT.value
+            and logical.maintenance_action is None
+            and logical.resource_generation == expected_resource_generation
+            and allocation.resource_generation == expected_resource_generation
+            and logical.profile_digest == allocation.profile_digest
+            and logical.current_allocation_id == allocation.allocation_id
+            and allocation.state == AllocationState.ACTIVE.value
+        )
+        if current_active_allocation:
+            return self._allocation(allocation)
         if (
             logical.desired_state != SandboxDesiredState.PRESENT.value
             or logical.maintenance_action is not None
@@ -1341,8 +1376,6 @@ class AgentBoxRepository:
             )
 
         previous_id = logical.current_allocation_id
-        if previous_id == allocation.allocation_id and allocation.state == "active":
-            return self._allocation(allocation)
         if previous_id is not None and previous_id != allocation.allocation_id:
             await self._session.execute(
                 update(AllocationRow)

--- a/agentbox/tests/state/test_repository.py
+++ b/agentbox/tests/state/test_repository.py
@@ -145,6 +145,33 @@ class InitiallyNotReadyProvider(FakeProvider):
         )
 
 
+class ConcurrentReadinessProvider(FakeProvider):
+    def __init__(self, database: StateDatabase) -> None:
+        super().__init__(database)
+        self.first_wait_started = asyncio.Event()
+        self.both_waiting = asyncio.Event()
+        self.release_waiters = asyncio.Event()
+
+    async def wait_ready(
+        self,
+        allocation: ProviderAllocationRef,
+        *,
+        profile: SandboxProfileRef,
+        deadline_at: datetime,
+    ) -> ProviderReadyResult:
+        del profile, deadline_at
+        assert self.database.active_units_of_work == 0
+        self.ready_calls += 1
+        self.first_wait_started.set()
+        if self.ready_calls == 2:
+            self.both_waiting.set()
+        await self.release_waiters.wait()
+        return ProviderReadyResult(
+            provider_id=allocation.provider_id,
+            provider_instance_id=allocation.provider_instance_id,
+        )
+
+
 class FailedReadinessProvider(FakeProvider):
     def __init__(self, database: StateDatabase, *, destroy_fails: bool = False) -> None:
         super().__init__(database)
@@ -373,6 +400,80 @@ async def test_verified_ensure_rechecks_active_without_changing_epoch(
     assert verified.allocation_epoch == created.allocation_epoch
     assert len(provider.create_calls) == 1
     assert provider.ready_calls == 2
+
+
+async def test_concurrent_ensure_waiters_publish_same_allocation_idempotently(
+    database: StateDatabase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider = ConcurrentReadinessProvider(database)
+    service = SandboxLifecycleService(database, provider)
+    key = SandboxKey(WorkloadKind.FUNCTION, uuid4())
+    selected_profile = profile("function-python-v1", "b")
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=30)
+    dispatch_claims = 0
+    original_mark_create_dispatched = AgentBoxRepository.mark_create_dispatched
+
+    async def count_dispatch_claims(
+        repository: AgentBoxRepository,
+        allocation_token,
+        *,
+        expected_resource_generation,
+        now=None,
+    ) -> bool:
+        nonlocal dispatch_claims
+        dispatch_claims += 1
+        return await original_mark_create_dispatched(
+            repository,
+            allocation_token,
+            expected_resource_generation=expected_resource_generation,
+            now=now,
+        )
+
+    monkeypatch.setattr(
+        AgentBoxRepository,
+        "mark_create_dispatched",
+        count_dispatch_claims,
+    )
+
+    first = asyncio.create_task(
+        service.ensure(
+            key,
+            selected_profile,
+            admission_class=AdmissionClass.LATENCY,
+            deadline_at=deadline,
+            verify_ready=True,
+        )
+    )
+    await asyncio.wait_for(provider.first_wait_started.wait(), timeout=5)
+    second = asyncio.create_task(
+        service.ensure(
+            key,
+            selected_profile,
+            admission_class=AdmissionClass.BATCH,
+            deadline_at=deadline,
+            verify_ready=True,
+        )
+    )
+    await asyncio.wait_for(provider.both_waiting.wait(), timeout=5)
+    provider.release_waiters.set()
+
+    first_handle, second_handle = await asyncio.gather(first, second)
+
+    assert first_handle.ready is True
+    assert second_handle.ready is True
+    assert first_handle.allocation_id == second_handle.allocation_id
+    assert first_handle.allocation_epoch == second_handle.allocation_epoch == 1
+    assert dispatch_claims == 1
+    assert len(provider.create_calls) == 1
+    assert provider.ready_calls == 2
+    async with database.uow() as uow:
+        allocations = await uow.repository.list_allocations(key)
+        active, reserved = await uow.repository._admission_counts(provider.scope)
+        await uow.commit()
+    assert [allocation.state for allocation in allocations] == [AllocationState.ACTIVE]
+    assert (active, reserved) == (1, 0)
+    assert database.active_units_of_work == 0
 
 
 async def test_lost_create_response_is_not_replayed(database: StateDatabase):


### PR DESCRIPTION
## Why

The newly deployed dev lifecycle release passed its formal gates, but an independent simultaneous API and job function probe exposed a remaining race. Both requests legitimately converged on the same in-flight AgentBox allocation. The provider create happened only once, but both readiness waiters tried to complete the durable acknowledgement/publication transition. The first made the allocation active; the second then received ALLOCATION_CHANGED even though it referred to the same current allocation, generation, profile, and provider object.

Production promotion is blocked on this fix.

## What changed

- Honor AllocationIntent.should_dispatch_create so only the owner attempts the RESERVED to DISPATCHED claim.
- Let non-owner callers join readiness only after the same allocation has a durable provider identity; otherwise they receive the existing non-ready handle and can poll safely.
- Make create acknowledgement idempotent when the allocation is already the current active allocation and every lifecycle fence still matches.
- Make publication idempotent under the same strict identity, desired-state, profile, and generation checks.
- Preserve ALLOCATION_CHANGED and OPERATION_CONFLICT behavior for real stale generations and mismatched provider objects.

## Regression coverage

A barrier-controlled concurrency test now forces two ensure calls, using latency and batch admission classes, to wait on the same provider allocation and complete simultaneously. It proves:

- one dispatch claim
- one provider create
- two successful ready handles
- the same allocation ID and epoch
- exactly one active admission and no reserved-capacity leak

## Verification

- AgentBox repository tests: 22 passed
- Full AgentBox suite with E2B extras: 179 passed, 8 real-provider tests skipped without explicit live-test opt-in
- AgentBox and client Ruff checks passed
- AgentBox OpenAPI drift check passed
- AgentBox client tests: 6 passed

## Rollout

After merge, lemma-app will pin this platform commit and build a new immutable release. We will deploy it to dev and repeat simultaneous real-E2B API and job probes before any production promotion.