### PR TITLE
Fix resumable Telegram managed-bot setup

### DIFF
--- a/lemma-backend/app/modules/agent_surfaces/services/managed_bot_persistence.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/managed_bot_persistence.py
@@ -94,9 +94,7 @@ async def persist_managed_bot(
             account.credentials = GenericCredentials.model_validate(
                 {"bot_token": bot_token}
             )
-            account.display_name = (
-                f"@{bot_username}" if bot_username else str(bot_id)
-            )
+            account.display_name = f"@{bot_username}" if bot_username else str(bot_id)
             account = await accounts.update(account)
         from app.modules.agent_surfaces.api.dependencies import get_surface_service
 

--- a/lemma-backend/app/modules/agent_surfaces/services/telegram_manager_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/telegram_manager_service.py
@@ -104,6 +104,20 @@ class TelegramManagerService:
         if not self.configured:
             raise TelegramManagerNotConfiguredError()
 
+        existing = await self._store.get_by_target(pod_id, surface_name)
+        if (
+            existing is not None
+            and existing.user_id == user_id
+            and existing.organization_id == organization_id
+            and existing.status
+            in {
+                TelegramManagedBotSetupStatus.PENDING,
+                TelegramManagedBotSetupStatus.WAITING_FOR_TELEGRAM,
+                TelegramManagedBotSetupStatus.PROVISIONING,
+            }
+        ):
+            return existing
+
         for _ in range(5):
             setup_id = secrets.token_urlsafe(18)
             request_id = secrets.randbelow(2_147_483_646) + 1
@@ -134,10 +148,7 @@ class TelegramManagerService:
     def launch_url(self, setup: TelegramManagedBotSetup) -> str:
         if not self.configured:
             raise TelegramManagerNotConfiguredError()
-        return (
-            f"https://t.me/{self._manager_username}"
-            f"?start=surface_{setup.setup_id}"
-        )
+        return f"https://t.me/{self._manager_username}?start=surface_{setup.setup_id}"
 
     async def get_setup(
         self,
@@ -199,9 +210,7 @@ class TelegramManagerService:
         owner: str,
     ) -> AsyncIterator[None]:
         owner_task = asyncio.current_task()
-        lease_lost_message = (
-            f"Telegram provisioning lease lost for {setup_id}:{owner}"
-        )
+        lease_lost_message = f"Telegram provisioning lease lost for {setup_id}:{owner}"
 
         async def _renew() -> None:
             while True:
@@ -262,11 +271,15 @@ def _suggested_bot_username(
     surface_name: str,
     setup_id: str,
 ) -> str:
-    base = re.sub(
-        r"[^A-Za-z0-9_]+",
-        "_",
-        f"lemma_{pod_name}_{surface_name}",
-    ).strip("_").lower()
+    base = (
+        re.sub(
+            r"[^A-Za-z0-9_]+",
+            "_",
+            f"lemma_{pod_name}_{surface_name}",
+        )
+        .strip("_")
+        .lower()
+    )
     suffix = setup_id[:4].lower()
     max_base = 32 - len(f"_{suffix}_bot")
     base = base[:max_base].rstrip("_") or "lemma"

--- a/lemma-backend/app/modules/agent_surfaces/services/telegram_manager_store.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/telegram_manager_store.py
@@ -247,9 +247,7 @@ class TelegramManagedBotSetupStore:
                     setup.setup_id,
                 )
             if not target_created:
-                raise TelegramManagedBotSetupAlreadyInProgressError(
-                    setup.surface_name
-                )
+                raise TelegramManagedBotSetupAlreadyInProgressError(setup.surface_name)
             return False
         finally:
             await redis.aclose()
@@ -259,6 +257,31 @@ class TelegramManagedBotSetupStore:
         try:
             raw = await redis.get(self._setup_key(setup_id))
             return TelegramManagedBotSetup.model_validate_json(raw) if raw else None
+        finally:
+            await redis.aclose()
+
+    async def get_by_target(
+        self,
+        pod_id: UUID,
+        surface_name: str,
+    ) -> TelegramManagedBotSetup | None:
+        redis = Redis.from_url(self._redis_url, decode_responses=True)
+        target_key = self._target_key(pod_id, surface_name)
+        try:
+            setup_id = await redis.get(target_key)
+            if not setup_id:
+                return None
+            raw = await redis.get(self._setup_key(setup_id))
+            if raw:
+                return TelegramManagedBotSetup.model_validate_json(raw)
+            await _eval(
+                redis,
+                _COMPARE_DELETE_SCRIPT,
+                1,
+                target_key,
+                setup_id,
+            )
+            return None
         finally:
             await redis.aclose()
 

--- a/lemma-backend/app/modules/agent_surfaces/services/telegram_manager_updates.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/telegram_manager_updates.py
@@ -5,6 +5,8 @@ import secrets
 from typing import Any
 from uuid import UUID
 
+from sqlalchemy.exc import IntegrityError
+
 from app.core.domain.errors import DomainError
 from app.core.log.log import get_logger
 from app.modules.agent_surfaces.platforms.delivery import DeliveryClassification
@@ -157,14 +159,17 @@ async def _save_waiting_setup(
     setup.telegram_username = (
         str(from_user.get("username") or "").strip().lstrip("@") or None
     )
-    setup.telegram_display_name = " ".join(
-        part
-        for part in (
-            str(from_user.get("first_name") or "").strip(),
-            str(from_user.get("last_name") or "").strip(),
+    setup.telegram_display_name = (
+        " ".join(
+            part
+            for part in (
+                str(from_user.get("first_name") or "").strip(),
+                str(from_user.get("last_name") or "").strip(),
+            )
+            if part
         )
-        if part
-    ) or setup.telegram_username
+        or setup.telegram_username
+    )
     setup.status = TelegramManagedBotSetupStatus.WAITING_FOR_TELEGRAM
     saved = await runtime._store.save_if_status(
         setup,
@@ -323,7 +328,7 @@ def _setup_accepts_created_bot(
 def _parse_created_bot(bot: dict[str, Any]) -> tuple[int, str | None] | None:
     try:
         bot_id = int(bot["id"])
-    except (KeyError, TypeError, ValueError):
+    except KeyError, TypeError, ValueError:
         return None
     username = str(bot.get("username") or "").strip().lstrip("@") or None
     return bot_id, username
@@ -380,10 +385,7 @@ async def _begin_provisioning(
     if saved:
         return True
     current = await runtime._store.get(setup.setup_id)
-    if (
-        current is not None
-        and current.status is TelegramManagedBotSetupStatus.COMPLETE
-    ):
+    if current is not None and current.status is TelegramManagedBotSetupStatus.COMPLETE:
         return False
     raise TelegramManagedBotProvisioningInProgressError(
         f"Telegram managed-bot setup '{setup.setup_id}' changed state"
@@ -426,6 +428,7 @@ async def _provision(
         return True
     except (
         DomainError,
+        IntegrityError,
         KeyError,
         _PermanentProvisioningError,
         TelegramApiError,
@@ -554,9 +557,7 @@ def _safe_setup_error(exc: Exception) -> str:
 
 def _is_transient_setup_error(exc: Exception) -> bool:
     if isinstance(exc, TelegramApiError):
-        return (
-            classify_telegram_error(exc) is DeliveryClassification.TRANSIENT
-        )
+        return classify_telegram_error(exc) is DeliveryClassification.TRANSIENT
     return isinstance(exc, DomainError) and (
         exc.status_code == 429 or exc.status_code >= 500
     )

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_telegram_manager_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_telegram_manager_service.py
@@ -7,6 +7,7 @@ from uuid import UUID, uuid4
 
 import pytest
 from redis.asyncio import Redis
+from sqlalchemy.exc import IntegrityError
 
 from app.core.config import settings
 from app.core.domain.errors import DomainError
@@ -59,6 +60,14 @@ class _Store:
         setup = self.by_id.get(setup_id)
         return setup.model_copy(deep=True) if setup else None
 
+    async def get_by_target(
+        self,
+        pod_id: UUID,
+        surface_name: str,
+    ) -> TelegramManagedBotSetup | None:
+        setup_id = self.by_target.get((pod_id, surface_name.casefold()))
+        return await self.get(setup_id) if setup_id else None
+
     async def get_by_request_id(
         self, request_id: int
     ) -> TelegramManagedBotSetup | None:
@@ -98,10 +107,7 @@ class _Store:
         if (
             current is None
             or current.status not in expected
-            or (
-                owner is not None
-                and self.lease_by_setup.get(setup.setup_id) != owner
-            )
+            or (owner is not None and self.lease_by_setup.get(setup.setup_id) != owner)
         ):
             return False
         await self.save(setup)
@@ -174,12 +180,13 @@ async def _start(
     service: TelegramManagerService,
     *,
     user_id: UUID | None = None,
+    organization_id: UUID | None = None,
     pod_id: UUID | None = None,
     surface_name: str = "telegram-support",
 ) -> TelegramManagedBotSetup:
     return await service.start_setup(
         user_id=user_id or uuid4(),
-        organization_id=uuid4(),
+        organization_id=organization_id or uuid4(),
         pod_id=pod_id or uuid4(),
         surface_name=surface_name,
         agent_id=None,
@@ -202,6 +209,31 @@ async def test_start_setup_builds_short_native_launch_and_suggestions():
     assert setup.suggested_bot_username.endswith("_bot")
     assert len(setup.suggested_bot_username) <= 32
     assert setup.status is TelegramManagedBotSetupStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_start_setup_resumes_same_users_active_target():
+    store = _Store()
+    service = _service(store)
+    user_id = uuid4()
+    organization_id = uuid4()
+    pod_id = uuid4()
+
+    first = await _start(
+        service,
+        user_id=user_id,
+        organization_id=organization_id,
+        pod_id=pod_id,
+    )
+    resumed = await _start(
+        service,
+        user_id=user_id,
+        organization_id=organization_id,
+        pod_id=pod_id,
+    )
+
+    assert resumed.setup_id == first.setup_id
+    assert len(store.by_id) == 1
 
 
 @pytest.mark.asyncio
@@ -248,9 +280,7 @@ async def test_created_managed_bot_persists_surface_and_finishes_setup():
     )
     account_id = uuid4()
     surface_id = uuid4()
-    service._persist_managed_bot = AsyncMock(
-        return_value=(account_id, surface_id)
-    )
+    service._persist_managed_bot = AsyncMock(return_value=(account_id, surface_id))
     service._configure_managed_bot = AsyncMock()
 
     async def _call(method, payload):
@@ -406,9 +436,7 @@ async def test_transient_failures_can_replay_same_bot():
     )
     account_id = uuid4()
     surface_id = uuid4()
-    service._persist_managed_bot = AsyncMock(
-        return_value=(account_id, surface_id)
-    )
+    service._persist_managed_bot = AsyncMock(return_value=(account_id, surface_id))
     service._configure_managed_bot = AsyncMock()
     service._client.call = AsyncMock(
         side_effect=TelegramApiError(
@@ -454,15 +482,62 @@ async def test_transient_failures_can_replay_same_bot():
     assert interrupted.status is TelegramManagedBotSetupStatus.PROVISIONING
     assert 21 not in store.processed_updates
 
-    service._persist_managed_bot = AsyncMock(
-        return_value=(account_id, surface_id)
-    )
+    service._persist_managed_bot = AsyncMock(return_value=(account_id, surface_id))
     await service.handle_update(update)
 
     completed = await store.get(setup.setup_id)
     assert completed is not None
     assert completed.status is TelegramManagedBotSetupStatus.COMPLETE
     service._persist_managed_bot.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_integrity_failure_marks_setup_failed_and_releases_target():
+    store = _Store()
+    service = _service(store)
+    setup = await _start(service)
+    setup.telegram_user_id = 77
+    setup.status = TelegramManagedBotSetupStatus.WAITING_FOR_TELEGRAM
+    await store.save(setup)
+    await store.bind_telegram_user(
+        setup_id=setup.setup_id,
+        telegram_user_id=77,
+    )
+    service._client.call = AsyncMock(
+        side_effect=lambda method, payload: (
+            {"ok": True, "result": "child-token"}
+            if method == "getManagedBotToken"
+            else {"ok": True, "result": True}
+        )
+    )
+    service._persist_managed_bot = AsyncMock(
+        side_effect=IntegrityError(
+            "INSERT INTO accounts ...",
+            {},
+            Exception("null connector_id"),
+        )
+    )
+
+    await service.handle_update(
+        {
+            "update_id": 22,
+            "message": {
+                "chat": {"id": 99},
+                "from": {"id": 77},
+                "managed_bot_created": {
+                    "bot": {"id": 1234, "username": "surface_bot"},
+                },
+            },
+        }
+    )
+
+    failed = await store.get(setup.setup_id)
+    assert failed is not None
+    assert failed.status is TelegramManagedBotSetupStatus.FAILED
+    assert failed.error == "Lemma could not finish connecting the managed bot."
+    assert (setup.pod_id, setup.surface_name.casefold()) not in store.by_target
+    assert 77 not in store.by_telegram_user
+    assert 22 in store.processed_updates
 
 
 @pytest.mark.asyncio
@@ -510,6 +585,9 @@ async def test_redis_store_enforces_atomic_state_and_claims():
         with pytest.raises(TelegramManagedBotSetupAlreadyInProgressError):
             await _start(service, pod_id=setup.pod_id)
         assert await store.get(setup.setup_id) is not None
+        reserved = await store.get_by_target(setup.pod_id, setup.surface_name)
+        assert reserved is not None
+        assert reserved.setup_id == setup.setup_id
         assert await store.bind_telegram_user(
             setup_id=setup.setup_id,
             telegram_user_id=telegram_user_id,
@@ -603,9 +681,7 @@ async def test_configure_managed_bot_sets_selected_app_as_web_app(monkeypatch):
         pod_id=uuid4(),
         surface_name="telegram-support",
         agent_id=None,
-        surface_config=SurfaceConfig(
-            telegram=SurfaceTelegramConfig(app_name=app_name)
-        ),
+        surface_config=SurfaceConfig(telegram=SurfaceTelegramConfig(app_name=app_name)),
         is_enabled=True,
         pod_name="Customer Success",
     )
@@ -678,8 +754,7 @@ async def test_configure_managed_bot_propagates_transient_telegram_failure(
         call_multipart=AsyncMock(),
     )
     monkeypatch.setattr(
-        "app.modules.agent_surfaces.services.managed_bot_configurator."
-        "TelegramClient",
+        "app.modules.agent_surfaces.services.managed_bot_configurator.TelegramClient",
         lambda **_: child,
     )
     monkeypatch.setattr(
@@ -769,8 +844,7 @@ async def test_persist_managed_bot_bootstraps_native_auth_config_and_commits(
         lambda **_: auth_configs,
     )
     monkeypatch.setattr(
-        "app.modules.agent_surfaces.services.managed_bot_persistence."
-        "AccountRepository",
+        "app.modules.agent_surfaces.services.managed_bot_persistence.AccountRepository",
         lambda **_: accounts,
     )
     monkeypatch.setattr(
@@ -783,13 +857,11 @@ async def test_persist_managed_bot_bootstraps_native_auth_config_and_commits(
         lambda _: external_users,
     )
 
-    persisted_account_id, persisted_surface_id = (
-        await service._persist_managed_bot(
-            setup=setup,
-            bot_id=1234,
-            bot_username="surface_bot",
-            bot_token="child-token",
-        )
+    persisted_account_id, persisted_surface_id = await service._persist_managed_bot(
+        setup=setup,
+        bot_id=1234,
+        bot_username="surface_bot",
+        bot_token="child-token",
     )
 
     assert persisted_account_id == account_id
@@ -841,9 +913,7 @@ async def test_persist_managed_bot_reuses_matching_account_and_surface(
         display_name="@old_bot",
     )
     accounts = SimpleNamespace(
-        get_by_user_auth_config_and_provider_account=AsyncMock(
-            return_value=account
-        ),
+        get_by_user_auth_config_and_provider_account=AsyncMock(return_value=account),
         update=AsyncMock(return_value=account),
     )
     surface = SimpleNamespace(
@@ -873,8 +943,7 @@ async def test_persist_managed_bot_reuses_matching_account_and_surface(
         ),
     )
     monkeypatch.setattr(
-        "app.modules.agent_surfaces.services.managed_bot_persistence."
-        "AccountRepository",
+        "app.modules.agent_surfaces.services.managed_bot_persistence.AccountRepository",
         lambda **_: accounts,
     )
     monkeypatch.setattr(

--- a/lemma-backend/app/modules/connectors/infrastructure/repositories/account_repository.py
+++ b/lemma-backend/app/modules/connectors/infrastructure/repositories/account_repository.py
@@ -13,7 +13,10 @@ from app.modules.connectors.domain.errors import (
     AccountAlreadyConnectedError,
     AccountNotFoundError,
 )
-from app.modules.connectors.domain.ports import AccountRepositoryPort, SecretEncryptionPort
+from app.modules.connectors.domain.ports import (
+    AccountRepositoryPort,
+    SecretEncryptionPort,
+)
 from app.modules.connectors.infrastructure.models import Account
 
 
@@ -46,7 +49,11 @@ class AccountRepository(
         return None
 
     async def _to_model(self, entity: AccountEntity) -> Account:
-        data = entity.model_dump(exclude_unset=True)
+        # ``connector`` is a read-side domain projection, not a relationship
+        # assignment for writes. Passing an explicit ``connector=None`` to the
+        # ORM model makes SQLAlchemy synchronize the relationship by clearing
+        # ``connector_id``, even when the entity contains a valid connector id.
+        data = entity.model_dump(exclude_unset=True, exclude={"connector"})
         data["credentials"] = await self.encryption.encrypt_json_async(
             self._serialize_credentials(entity.credentials)
         )
@@ -123,7 +130,11 @@ class AccountRepository(
         instance.provider_account_id = entity.provider_account_id
         instance.email = entity.email
         instance.display_name = entity.display_name
-        instance.status = entity.status.value if hasattr(entity.status, "value") else str(entity.status)
+        instance.status = (
+            entity.status.value
+            if hasattr(entity.status, "value")
+            else str(entity.status)
+        )
 
         try:
             await self.session.flush()
@@ -306,7 +317,9 @@ class AccountRepository(
     ) -> tuple[Sequence[AccountEntity], UUID | None]:
         stmt = (
             select(Account)
-            .where(Account.user_id == user_id, Account.organization_id == organization_id)
+            .where(
+                Account.user_id == user_id, Account.organization_id == organization_id
+            )
             .options(selectinload(Account.connector))
         )
         if connector_id:

--- a/lemma-backend/app/modules/connectors/tests/unit/test_account_repository.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_account_repository.py
@@ -91,7 +91,7 @@ def _duplicate_identity_error() -> IntegrityError:
         "INSERT INTO accounts ...",
         {},
         Exception(
-            'duplicate key value violates unique constraint '
+            "duplicate key value violates unique constraint "
             '"uq_accounts_provider_identity"'
         ),
     )
@@ -102,7 +102,7 @@ def _unrelated_error() -> IntegrityError:
         "INSERT INTO accounts ...",
         {},
         Exception(
-            'duplicate key value violates unique constraint '
+            "duplicate key value violates unique constraint "
             '"uq_accounts_default_per_auth_config"'
         ),
     )
@@ -114,6 +114,16 @@ async def test_create_translates_duplicate_identity_violation():
 
     with pytest.raises(AccountAlreadyConnectedError):
         await repo.create(_account_entity())
+
+
+async def test_write_model_ignores_read_side_connector_relationship():
+    session = _FakeSession()
+    repo = AccountRepository(uow=_FakeUow(session), encryption=_NoopEncryption())
+
+    model = await repo._to_model(_account_entity(connector=None))
+
+    assert model.connector_id == "asana"
+    assert "connector" not in model.__dict__
 
 
 async def test_create_reraises_unrelated_integrity_error():


### PR DESCRIPTION
## What broke

Managed-bot account creation explicitly populated both connector_id=telegram and the read-side connector relationship with None. SQLAlchemy relationship synchronization cleared connector_id, so PostgreSQL rejected every provisioning attempt with a NOT NULL violation. Because IntegrityError was outside the setup failure state machine, Telegram retried the webhook while the setup remained PROVISIONING until its 30-minute Redis TTL expired.

## Fix

- exclude the read-side connector projection from Account ORM write models so it cannot overwrite connector_id
- treat permanent database integrity failures as terminal setup failures and release target/user reservations immediately
- resolve active setups by pod + surface and return the same setup to its owner, making repeated setup submissions resumable instead of producing an already-in-progress error
- remove stale target pointers when their setup record has expired
- add regression coverage for connector relationship synchronization, idempotent setup starts, Redis target lookup, and integrity-failure cleanup

## Live dev verification

The existing mira2 bot was recovered without creating another bot. Its setup is COMPLETE; Telegram getWebhookInfo reports api.asur.work, zero pending updates, and no last error; help and retry commands are installed.

## Validation

- backend Ruff: passed
- all agent-surfaces unit tests plus account repository tests: 487 passed
- focused Telegram/account regression suite: 22 passed
- live dev setup recovery and Telegram webhook inspection: passed