### PR TITLE
feat(agent): add Agent Host schema (single migration)

### DIFF
--- a/lemma-backend/app/core/infrastructure/db/base.py
+++ b/lemma-backend/app/core/infrastructure/db/base.py
@@ -16,7 +16,6 @@ class UUIDAuditBase(Base):
     id: Mapped[UUID] = mapped_column(
         primary_key=True,
         default=uuid7,
-        index=True,
     )
 
     created_at: Mapped[datetime] = mapped_column(
@@ -43,7 +42,6 @@ class UUIDCreatedBase(Base):
     id: Mapped[UUID] = mapped_column(
         primary_key=True,
         default=uuid7,
-        index=True,
     )
 
     created_at: Mapped[datetime] = mapped_column(
@@ -62,7 +60,6 @@ class StringAuditBase(Base):
 
     id: Mapped[str] = mapped_column(
         primary_key=True,
-        index=True,
     )
 
     created_at: Mapped[datetime] = mapped_column(

--- a/lemma-backend/app/modules/agent/api/agent_host_schemas.py
+++ b/lemma-backend/app/modules/agent/api/agent_host_schemas.py
@@ -1,0 +1,65 @@
+"""HTTP response/request shapes for Agent Host management APIs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.modules.agent.domain.agent_host import (
+    AgentHostHarnessSnapshot,
+    AgentHostStatus,
+)
+
+
+class AgentHostHarnessResponse(BaseModel):
+    id: UUID
+    host_id: UUID
+    harness_key: str
+    display_name: str
+    adapter_version: str
+    upstream_version: str | None
+    health: str
+    capabilities: dict
+    config_revision: str
+    config_options: list
+    stale_after: datetime
+    stale_reason: str | None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AgentHostResponse(BaseModel):
+    id: UUID
+    user_id: UUID
+    organization_id: UUID | None
+    installation_id: str
+    display_name: str
+    status: AgentHostStatus
+    protocol_version: int | None
+    host_release: str
+    capacity: dict
+    last_seen_at: datetime | None
+    revoked_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class AgentHostListResponse(BaseModel):
+    items: list[AgentHostResponse]
+
+
+class AgentHostHarnessListResponse(BaseModel):
+    items: list[AgentHostHarnessResponse]
+
+
+class AgentHostHarnessPublishRequest(BaseModel):
+    harnesses: list[AgentHostHarnessSnapshot] = Field(
+        min_length=1,
+        max_length=32,
+    )
+
+
+class AgentHostHarnessPublishResponse(BaseModel):
+    items: list[AgentHostHarnessResponse]

--- a/lemma-backend/app/modules/agent/api/controllers/agent_host_controller.py
+++ b/lemma-backend/app/modules/agent/api/controllers/agent_host_controller.py
@@ -1,0 +1,316 @@
+"""Agent Host pairing, identity, and harness publication APIs.
+
+Two audiences share this router. ``/me/runtime/*`` routes are called by a
+signed-in user managing their machines. ``/agent-host/*`` routes are called by
+the Agent Host itself, authenticated by the opaque per-installation secret
+issued at pairing time.
+
+Run dispatch routes (poll, events) are added alongside the dispatch tables.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID, uuid7
+
+from fastapi import APIRouter, Header, HTTPException, status
+
+from app.core.api.dependencies import CurrentUser, UoWDep
+from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
+from app.modules.agent.api.agent_host_schemas import (
+    AgentHostHarnessListResponse,
+    AgentHostHarnessPublishRequest,
+    AgentHostHarnessPublishResponse,
+    AgentHostHarnessResponse,
+    AgentHostListResponse,
+    AgentHostResponse,
+)
+from app.modules.agent.domain.agent_host import (
+    AgentHostPairingComplete,
+    AgentHostPairingCompleted,
+    AgentHostPairingCreate,
+    AgentHostPairingCreated,
+    effective_agent_host_status,
+)
+from app.modules.agent.infrastructure.agent_host_repository import (
+    AgentHostRepository,
+)
+from app.modules.agent.infrastructure.agent_host_repository_common import (
+    AgentHostNotFound,
+    AgentHostPairingRejected,
+    AgentHostProtocolViolation,
+    AgentHostRepositoryError,
+)
+from app.modules.agent.infrastructure.runtime_models import (
+    AgentHostHarnessModel,
+    AgentHostModel,
+)
+from app.modules.agent.services.agent_host_auth import (
+    InvalidAgentHostCredential,
+    generate_host_secret,
+    generate_pairing_code,
+    host_secret_hash,
+    pairing_code_hash,
+)
+
+
+router = APIRouter(tags=["agent_host"])
+
+
+def _repository_error(exc: AgentHostRepositoryError) -> HTTPException:
+    if isinstance(exc, AgentHostNotFound):
+        code = status.HTTP_404_NOT_FOUND
+    elif isinstance(exc, AgentHostPairingRejected):
+        code = status.HTTP_400_BAD_REQUEST
+    elif isinstance(exc, AgentHostProtocolViolation):
+        code = status.HTTP_409_CONFLICT
+    else:
+        code = status.HTTP_400_BAD_REQUEST
+    return HTTPException(
+        status_code=code,
+        detail={"code": exc.code, "message": str(exc)},
+    )
+
+
+def _bearer_token(authorization: str | None) -> str:
+    if authorization is None:
+        raise InvalidAgentHostCredential("missing Agent Host authorization")
+    scheme, separator, token = authorization.partition(" ")
+    if separator != " " or scheme.lower() != "bearer" or not token.strip():
+        raise InvalidAgentHostCredential("invalid Agent Host authorization")
+    return token.strip()
+
+
+async def _authenticated_host(
+    *,
+    authorization: str | None,
+    uow: SqlAlchemyUnitOfWork,
+) -> AgentHostModel:
+    """Resolve the calling host from its bearer secret in one lookup."""
+    try:
+        secret = _bearer_token(authorization)
+    except InvalidAgentHostCredential as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"code": "INVALID_AGENT_HOST_CREDENTIAL", "message": str(exc)},
+        ) from exc
+    host = await AgentHostRepository(uow).get_by_secret_hash(host_secret_hash(secret))
+    if host is None or host.revoked_at is not None:
+        # Deliberately identical for unknown and revoked secrets.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={
+                "code": "AGENT_HOST_REVOKED_OR_MISSING",
+                "message": "Agent Host is unavailable",
+            },
+        )
+    return host
+
+
+async def _require_org_membership(
+    *,
+    user_id: UUID,
+    organization_id: UUID | None,
+    uow: UoWDep,
+) -> None:
+    if organization_id is None:
+        return
+    from app.composition.identity_notifications import user_is_organization_member
+
+    if not await user_is_organization_member(
+        uow,
+        user_id=user_id,
+        organization_id=organization_id,
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User is not a member of this organization",
+        )
+
+
+def _host_response(host: AgentHostModel) -> AgentHostResponse:
+    return AgentHostResponse(
+        id=host.id,
+        user_id=host.user_id,
+        organization_id=host.organization_id,
+        installation_id=host.installation_id,
+        display_name=host.display_name,
+        status=effective_agent_host_status(host.status, host.last_seen_at),
+        protocol_version=host.protocol_version,
+        host_release=host.host_release,
+        capacity=host.capacity or {},
+        last_seen_at=host.last_seen_at,
+        revoked_at=host.revoked_at,
+        created_at=host.created_at,
+        updated_at=host.updated_at,
+    )
+
+
+def _harness_response(harness: AgentHostHarnessModel) -> AgentHostHarnessResponse:
+    return AgentHostHarnessResponse.model_validate(harness)
+
+
+@router.post(
+    "/me/runtime/agent-host-pairings",
+    response_model=AgentHostPairingCreated,
+    operation_id="agent.host.pairing.create",
+)
+async def create_agent_host_pairing(
+    request: AgentHostPairingCreate,
+    user: CurrentUser,
+    uow: UoWDep,
+) -> AgentHostPairingCreated:
+    """Mint a short-lived pairing code for a machine this user controls."""
+    await _require_org_membership(
+        user_id=user.id,
+        organization_id=request.organization_id,
+        uow=uow,
+    )
+    code = generate_pairing_code()
+    pairing = await AgentHostRepository(uow).create_pairing(
+        pairing_id=uuid7(),
+        user_id=user.id,
+        organization_id=request.organization_id,
+        code_hash=pairing_code_hash(code),
+        display_name=request.display_name,
+    )
+    await uow.commit()
+    return AgentHostPairingCreated(
+        pairing_id=pairing.id,
+        pairing_code=code,
+        expires_at=pairing.expires_at,
+    )
+
+
+@router.get(
+    "/me/runtime/agent-hosts",
+    response_model=AgentHostListResponse,
+    operation_id="agent.host.list",
+)
+async def list_agent_hosts(
+    user: CurrentUser,
+    uow: UoWDep,
+) -> AgentHostListResponse:
+    hosts = await AgentHostRepository(uow).list_for_user(user_id=user.id)
+    return AgentHostListResponse(items=[_host_response(host) for host in hosts])
+
+
+@router.delete(
+    "/me/runtime/agent-hosts/{host_id}",
+    response_model=AgentHostResponse,
+    operation_id="agent.host.revoke",
+)
+async def revoke_agent_host(
+    host_id: UUID,
+    user: CurrentUser,
+    uow: UoWDep,
+) -> AgentHostResponse:
+    """Revoke a host, invalidating its secret immediately."""
+    try:
+        host = await AgentHostRepository(uow).revoke(host_id=host_id, user_id=user.id)
+    except AgentHostRepositoryError as exc:
+        raise _repository_error(exc) from exc
+    await uow.commit()
+    return _host_response(host)
+
+
+@router.get(
+    "/me/runtime/agent-hosts/{host_id}/harnesses",
+    response_model=AgentHostHarnessListResponse,
+    operation_id="agent.host.harnesses.list",
+)
+async def list_agent_host_harnesses(
+    host_id: UUID,
+    user: CurrentUser,
+    uow: UoWDep,
+) -> AgentHostHarnessListResponse:
+    repository = AgentHostRepository(uow)
+    host = await repository.get_for_user(host_id=host_id, user_id=user.id)
+    if host is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={
+                "code": "AGENT_HOST_NOT_FOUND",
+                "message": "Agent Host was not found",
+            },
+        )
+    harnesses = await repository.list_harnesses(host_id=host.id)
+    return AgentHostHarnessListResponse(
+        items=[_harness_response(harness) for harness in harnesses]
+    )
+
+
+@router.post(
+    "/agent-host/pairings:complete",
+    response_model=AgentHostPairingCompleted,
+    operation_id="agent.host.pairing.complete",
+)
+async def complete_agent_host_pairing(
+    request: AgentHostPairingComplete,
+    uow: UoWDep,
+) -> AgentHostPairingCompleted:
+    """Consume a pairing code and issue the host secret, shown exactly once."""
+    secret = generate_host_secret()
+    try:
+        host = await AgentHostRepository(uow).consume_pairing(
+            code_hash=pairing_code_hash(request.pairing_code),
+            host_secret_hash=host_secret_hash(secret),
+            display_name=request.display_name,
+            hello=request.hello,
+        )
+    except AgentHostRepositoryError as exc:
+        raise _repository_error(exc) from exc
+    await uow.commit()
+    return AgentHostPairingCompleted(
+        host_id=host.id,
+        user_id=host.user_id,
+        organization_id=host.organization_id,
+        host_secret=secret,
+    )
+
+
+@router.put(
+    "/agent-host/harnesses",
+    response_model=AgentHostHarnessPublishResponse,
+    operation_id="agent.host.harnesses.publish",
+)
+async def publish_agent_host_harnesses(
+    request: AgentHostHarnessPublishRequest,
+    uow: UoWDep,
+    authorization: Annotated[str | None, Header()] = None,
+) -> AgentHostHarnessPublishResponse:
+    """Replace this host's harness snapshots with the reported set."""
+    host = await _authenticated_host(authorization=authorization, uow=uow)
+    repository = AgentHostRepository(uow)
+    try:
+        published = [
+            await repository.publish_harness(host_id=host.id, snapshot=snapshot)
+            for snapshot in request.harnesses
+        ]
+    except AgentHostRepositoryError as exc:
+        raise _repository_error(exc) from exc
+    await uow.commit()
+    return AgentHostHarnessPublishResponse(
+        items=[_harness_response(harness) for harness in published]
+    )
+
+
+@router.post(
+    "/agent-host/revoke",
+    response_model=AgentHostResponse,
+    operation_id="agent.host.self_revoke",
+)
+async def self_revoke_agent_host(
+    uow: UoWDep,
+    authorization: Annotated[str | None, Header()] = None,
+) -> AgentHostResponse:
+    """Let a host retire its own credential, e.g. on uninstall."""
+    host = await _authenticated_host(authorization=authorization, uow=uow)
+    try:
+        revoked = await AgentHostRepository(uow).revoke(
+            host_id=host.id, user_id=host.user_id
+        )
+    except AgentHostRepositoryError as exc:
+        raise _repository_error(exc) from exc
+    await uow.commit()
+    return _host_response(revoked)

--- a/lemma-backend/app/modules/agent/domain/agent_host.py
+++ b/lemma-backend/app/modules/agent/domain/agent_host.py
@@ -1,0 +1,160 @@
+"""Domain contracts for Agent Host identity.
+
+This module covers pairing, host liveness, and harness snapshots. Run dispatch
+(commands, leases, events) is layered on in a following change.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from app.modules.agent.domain.value_objects import JsonObject
+
+
+AGENT_HOST_PROTOCOL_VERSION = 2
+AGENT_HOST_OFFLINE_AFTER_SECONDS = 90
+
+
+class AgentHostStatus(str, Enum):
+    ONLINE = "ONLINE"
+    OFFLINE = "OFFLINE"
+    DRAINING = "DRAINING"
+    UPGRADE_REQUIRED = "UPGRADE_REQUIRED"
+    REVOKED = "REVOKED"
+
+
+def effective_agent_host_status(
+    status: AgentHostStatus | str,
+    last_seen_at: datetime | None,
+    *,
+    now: datetime | None = None,
+) -> AgentHostStatus:
+    """Derive liveness from heartbeat freshness instead of stale DB state."""
+
+    persisted = AgentHostStatus(status)
+    if persisted in {
+        AgentHostStatus.REVOKED,
+        AgentHostStatus.UPGRADE_REQUIRED,
+    }:
+        return persisted
+    timestamp = now or datetime.now(timezone.utc)
+    if (
+        last_seen_at is None
+        or last_seen_at
+        < timestamp - timedelta(seconds=AGENT_HOST_OFFLINE_AFTER_SECONDS)
+    ):
+        return AgentHostStatus.OFFLINE
+    return persisted
+
+
+class AgentHostHarnessHealth(str, Enum):
+    READY = "READY"
+    AUTH_REQUIRED = "AUTH_REQUIRED"
+    UNSUPPORTED_VERSION = "UNSUPPORTED_VERSION"
+    CONFIG_INVALID = "CONFIG_INVALID"
+    PROBE_FAILED = "PROBE_FAILED"
+    INSTALLING = "INSTALLING"
+    DISABLED = "DISABLED"
+
+
+class HostHello(BaseModel):
+    installation_id: str = Field(min_length=1, max_length=255)
+    host_release: str = Field(min_length=1, max_length=128)
+    protocol_version: int = Field(ge=1)
+
+    def negotiate(self, supported: int = AGENT_HOST_PROTOCOL_VERSION) -> int:
+        if self.protocol_version == supported:
+            return supported
+        raise ValueError(
+            f"Agent Host protocol {self.protocol_version} does not match "
+            f"server protocol {supported}"
+        )
+
+
+class AgentHostCapacity(BaseModel):
+    max_runs: int = Field(default=1, ge=0, le=128)
+    active_runs: int = Field(default=0, ge=0, le=128)
+    available_runs: int = Field(default=1, ge=0, le=128)
+
+    @model_validator(mode="after")
+    def validate_capacity(self) -> "AgentHostCapacity":
+        if self.active_runs > self.max_runs:
+            raise ValueError("active_runs cannot exceed max_runs")
+        if self.available_runs > self.max_runs:
+            raise ValueError("available_runs cannot exceed max_runs")
+        return self
+
+
+class AgentHostHarnessCapabilities(BaseModel):
+    """Harness capabilities the server actually branches on.
+
+    Only ``images`` changes server behaviour today (it adds the vision
+    capability to the runtime picker). Anything else a host reports is kept
+    verbatim by ``extra: allow`` rather than typed here, so the wire format
+    stays open without inventing fields no code reads.
+    """
+
+    images: bool = False
+
+    model_config = {"extra": "allow"}
+
+
+class AgentHostConfigOption(BaseModel):
+    id: str = Field(min_length=1, max_length=255)
+    category: str = Field(min_length=1, max_length=128)
+    name: str = Field(min_length=1, max_length=255)
+    description: str | None = None
+    current_value: object = None
+    options: list[JsonObject] = Field(default_factory=list)
+    metadata: JsonObject = Field(default_factory=dict)
+
+
+class AgentHostHarnessSnapshot(BaseModel):
+    harness_key: str = Field(min_length=1, max_length=128)
+    display_name: str = Field(min_length=1, max_length=255)
+    adapter_version: str = Field(min_length=1, max_length=128)
+    upstream_version: str | None = Field(default=None, max_length=128)
+    health: AgentHostHarnessHealth
+    capabilities: AgentHostHarnessCapabilities = Field(
+        default_factory=AgentHostHarnessCapabilities
+    )
+    config_revision: str = Field(min_length=1, max_length=255)
+    config_options: list[AgentHostConfigOption] = Field(default_factory=list)
+    stale_after: datetime
+    stale_reason: str | None = None
+
+    @field_validator("harness_key")
+    @classmethod
+    def normalize_harness_key(cls, value: str) -> str:
+        normalized = value.strip().lower().replace("_", "-")
+        if not normalized:
+            raise ValueError("harness_key cannot be empty")
+        return normalized
+
+
+class AgentHostPairingCreate(BaseModel):
+    display_name: str = Field(min_length=1, max_length=255)
+    organization_id: UUID | None = None
+
+
+class AgentHostPairingCreated(BaseModel):
+    pairing_id: UUID
+    pairing_code: str
+    expires_at: datetime
+
+
+class AgentHostPairingComplete(BaseModel):
+    pairing_code: str = Field(min_length=16, max_length=512)
+    display_name: str = Field(min_length=1, max_length=255)
+    hello: HostHello
+
+
+class AgentHostPairingCompleted(BaseModel):
+    host_id: UUID
+    user_id: UUID
+    organization_id: UUID | None
+    host_secret: str

--- a/lemma-backend/app/modules/agent/infrastructure/agent_host_repository.py
+++ b/lemma-backend/app/modules/agent/infrastructure/agent_host_repository.py
@@ -1,0 +1,367 @@
+"""Pairing, host identity, and harness persistence for Agent Host.
+
+Run dispatch lives in a separate repository so this module stays scoped to
+identity: who is paired, whether they are alive, and what they can run.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
+
+from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
+from app.modules.agent.domain.agent_host import (
+    AgentHostHarnessSnapshot,
+    AgentHostStatus,
+    HostHello,
+)
+from app.modules.agent.infrastructure.agent_host_repository_common import (
+    DEFAULT_PAIRING_TTL_SECONDS,
+    AgentHostNotFound,
+    AgentHostPairingRejected,
+    AgentHostProtocolViolation,
+    utcnow,
+)
+from app.modules.agent.infrastructure.runtime_models import (
+    AgentHostHarnessModel,
+    AgentHostModel,
+    AgentHostPairingModel,
+)
+
+
+# Heartbeat rows are rewritten at most this often; the 90s offline threshold
+# leaves ample slack for a host polling on a 25s long-poll deadline.
+_SEEN_WRITE_INTERVAL_SECONDS = 20
+
+
+class AgentHostRepository:
+    def __init__(self, uow: SqlAlchemyUnitOfWork):
+        self.uow = uow
+        self.session = uow.session
+
+    async def create_pairing(
+        self,
+        *,
+        pairing_id: UUID,
+        user_id: UUID,
+        organization_id: UUID | None,
+        code_hash: str,
+        display_name: str,
+        now: datetime | None = None,
+        ttl_seconds: int = DEFAULT_PAIRING_TTL_SECONDS,
+    ) -> AgentHostPairingModel:
+        timestamp = now or utcnow()
+        await self.session.execute(
+            delete(AgentHostPairingModel).where(
+                AgentHostPairingModel.expires_at < timestamp
+            )
+        )
+        pairing = AgentHostPairingModel(
+            id=pairing_id,
+            user_id=user_id,
+            organization_id=organization_id,
+            code_hash=code_hash,
+            display_name=display_name.strip(),
+            expires_at=timestamp + timedelta(seconds=ttl_seconds),
+        )
+        self.session.add(pairing)
+        await self.session.flush()
+        return pairing
+
+    async def consume_pairing(
+        self,
+        *,
+        code_hash: str,
+        host_secret_hash: str,
+        display_name: str,
+        hello: HostHello,
+        now: datetime | None = None,
+    ) -> AgentHostModel:
+        """Create or re-pair a host; re-pairing rotates the host secret."""
+        timestamp = now or utcnow()
+        pairing = (
+            await self.session.execute(
+                select(AgentHostPairingModel)
+                .where(AgentHostPairingModel.code_hash == code_hash)
+                .with_for_update()
+            )
+        ).scalar_one_or_none()
+        if pairing is None or pairing.expires_at < timestamp:
+            raise AgentHostPairingRejected("pairing code is invalid or expired")
+
+        selected_protocol: int | None
+        status: AgentHostStatus
+        try:
+            selected_protocol = hello.negotiate()
+            status = AgentHostStatus.OFFLINE
+        except ValueError:
+            selected_protocol = None
+            status = AgentHostStatus.UPGRADE_REQUIRED
+
+        host = (
+            await self.session.execute(
+                select(AgentHostModel)
+                .where(
+                    AgentHostModel.user_id == pairing.user_id,
+                    AgentHostModel.organization_id == pairing.organization_id,
+                    AgentHostModel.installation_id == hello.installation_id,
+                )
+                .with_for_update()
+            )
+        ).scalar_one_or_none()
+        if host is None:
+            host = AgentHostModel(
+                user_id=pairing.user_id,
+                organization_id=pairing.organization_id,
+                installation_id=hello.installation_id,
+                host_secret_hash=host_secret_hash,
+                display_name=display_name.strip() or pairing.display_name,
+                status=status.value,
+                protocol_version=selected_protocol,
+                host_release=hello.host_release,
+                capacity={},
+                last_seen_at=None,
+                revoked_at=None,
+            )
+            self.session.add(host)
+        else:
+            host.host_secret_hash = host_secret_hash
+            host.display_name = display_name.strip() or pairing.display_name
+            host.status = status.value
+            host.protocol_version = selected_protocol
+            host.host_release = hello.host_release
+            host.revoked_at = None
+
+        await self.session.delete(pairing)
+        try:
+            await self.session.flush()
+        except IntegrityError as exc:
+            raise AgentHostPairingRejected(
+                "host installation is already paired"
+            ) from exc
+        return host
+
+    async def get(
+        self, host_id: UUID, *, for_update: bool = False
+    ) -> AgentHostModel | None:
+        stmt = select(AgentHostModel).where(AgentHostModel.id == host_id)
+        if for_update:
+            stmt = stmt.with_for_update()
+        return (await self.session.execute(stmt)).scalar_one_or_none()
+
+    async def get_many(self, host_ids: set[UUID]) -> dict[UUID, AgentHostModel]:
+        if not host_ids:
+            return {}
+        result = await self.session.execute(
+            select(AgentHostModel).where(AgentHostModel.id.in_(host_ids))
+        )
+        return {host.id: host for host in result.scalars()}
+
+    async def get_by_secret_hash(self, secret_hash: str) -> AgentHostModel | None:
+        return (
+            await self.session.execute(
+                select(AgentHostModel).where(
+                    AgentHostModel.host_secret_hash == secret_hash
+                )
+            )
+        ).scalar_one_or_none()
+
+    async def require(
+        self, host_id: UUID, *, for_update: bool = False
+    ) -> AgentHostModel:
+        host = await self.get(host_id, for_update=for_update)
+        if host is None:
+            raise AgentHostNotFound("Agent Host was not found")
+        return host
+
+    async def get_for_user(
+        self,
+        *,
+        host_id: UUID,
+        user_id: UUID,
+    ) -> AgentHostModel | None:
+        return (
+            await self.session.execute(
+                select(AgentHostModel).where(
+                    AgentHostModel.id == host_id,
+                    AgentHostModel.user_id == user_id,
+                )
+            )
+        ).scalar_one_or_none()
+
+    async def list_for_user(self, *, user_id: UUID) -> list[AgentHostModel]:
+        result = await self.session.execute(
+            select(AgentHostModel)
+            .where(AgentHostModel.user_id == user_id)
+            .order_by(
+                AgentHostModel.revoked_at.asc().nullsfirst(),
+                AgentHostModel.last_seen_at.desc().nullslast(),
+                AgentHostModel.created_at.desc(),
+            )
+        )
+        return list(result.scalars())
+
+    async def mark_seen(
+        self,
+        *,
+        host_id: UUID,
+        hello: HostHello,
+        capacity: dict,
+        now: datetime | None = None,
+    ) -> AgentHostModel:
+        """Record one heartbeat, rewriting the row only when something changed.
+
+        Polls arrive at least every 25s; skipping no-op writes keeps an idle
+        host from producing a locked row update on every request.
+        """
+        timestamp = now or utcnow()
+        host = await self.require(host_id)
+        if host.revoked_at is not None:
+            raise AgentHostProtocolViolation("Agent Host is revoked")
+        if host.installation_id != hello.installation_id:
+            raise AgentHostProtocolViolation("installation identity changed")
+
+        try:
+            protocol = hello.negotiate()
+            explicitly_draining = capacity.get("available_runs") == 0 and capacity.get(
+                "active_runs", 0
+            ) < capacity.get("max_runs", 0)
+            status = (
+                AgentHostStatus.DRAINING
+                if explicitly_draining
+                else AgentHostStatus.ONLINE
+            )
+        except ValueError:
+            protocol = None
+            status = AgentHostStatus.UPGRADE_REQUIRED
+
+        recently_seen = host.last_seen_at is not None and host.last_seen_at > (
+            timestamp - timedelta(seconds=_SEEN_WRITE_INTERVAL_SECONDS)
+        )
+        unchanged = (
+            host.protocol_version == protocol
+            and host.host_release == hello.host_release
+            and host.status == status.value
+            and (host.capacity or {}) == capacity
+        )
+        if recently_seen and unchanged:
+            return host
+
+        host = await self.require(host_id, for_update=True)
+        if host.revoked_at is not None:
+            raise AgentHostProtocolViolation("Agent Host is revoked")
+        host.protocol_version = protocol
+        host.host_release = hello.host_release
+        host.capacity = capacity
+        host.status = status.value
+        host.last_seen_at = timestamp
+        await self.session.flush()
+        return host
+
+    async def revoke(
+        self,
+        *,
+        host_id: UUID,
+        user_id: UUID,
+        now: datetime | None = None,
+    ) -> AgentHostModel:
+        """Revoke a host, invalidating its secret immediately.
+
+        Cancelling the host's in-flight commands and run leases is added
+        alongside the dispatch tables; there is no dispatch state to reconcile
+        while this revision is the head.
+        """
+        host = await self.get(host_id, for_update=True)
+        if host is None or host.user_id != user_id:
+            raise AgentHostNotFound("Agent Host was not found")
+        timestamp = now or utcnow()
+        host.revoked_at = timestamp
+        host.status = AgentHostStatus.REVOKED.value
+        await self.session.flush()
+        return host
+
+    async def publish_harness(
+        self,
+        *,
+        host_id: UUID,
+        snapshot: AgentHostHarnessSnapshot,
+    ) -> AgentHostHarnessModel:
+        host = await self.require(host_id)
+        if host.revoked_at is not None:
+            raise AgentHostProtocolViolation("Agent Host is revoked")
+        harness = (
+            await self.session.execute(
+                select(AgentHostHarnessModel)
+                .where(
+                    AgentHostHarnessModel.host_id == host_id,
+                    AgentHostHarnessModel.harness_key == snapshot.harness_key,
+                )
+                .with_for_update()
+            )
+        ).scalar_one_or_none()
+        values = {
+            "display_name": snapshot.display_name,
+            "adapter_version": snapshot.adapter_version,
+            "upstream_version": snapshot.upstream_version,
+            "health": snapshot.health.value,
+            "capabilities": snapshot.capabilities.model_dump(mode="json"),
+            "config_revision": snapshot.config_revision,
+            "config_options": [
+                option.model_dump(mode="json") for option in snapshot.config_options
+            ],
+            "stale_after": snapshot.stale_after,
+            "stale_reason": snapshot.stale_reason,
+        }
+        if harness is None:
+            harness = AgentHostHarnessModel(
+                host_id=host_id,
+                harness_key=snapshot.harness_key,
+                **values,
+            )
+            self.session.add(harness)
+        else:
+            for key, value in values.items():
+                setattr(harness, key, value)
+        await self.session.flush()
+        return harness
+
+    async def get_harness(
+        self,
+        *,
+        harness_id: UUID,
+        for_update: bool = False,
+    ) -> AgentHostHarnessModel | None:
+        stmt = select(AgentHostHarnessModel).where(
+            AgentHostHarnessModel.id == harness_id
+        )
+        if for_update:
+            stmt = stmt.with_for_update()
+        return (await self.session.execute(stmt)).scalar_one_or_none()
+
+    async def get_harnesses(
+        self,
+        harness_ids: set[UUID],
+    ) -> dict[UUID, AgentHostHarnessModel]:
+        if not harness_ids:
+            return {}
+        result = await self.session.execute(
+            select(AgentHostHarnessModel).where(
+                AgentHostHarnessModel.id.in_(harness_ids)
+            )
+        )
+        return {harness.id: harness for harness in result.scalars()}
+
+    async def list_harnesses(
+        self,
+        *,
+        host_id: UUID,
+    ) -> list[AgentHostHarnessModel]:
+        result = await self.session.execute(
+            select(AgentHostHarnessModel)
+            .where(AgentHostHarnessModel.host_id == host_id)
+            .order_by(AgentHostHarnessModel.display_name.asc())
+        )
+        return list(result.scalars())

--- a/lemma-backend/app/modules/agent/infrastructure/agent_host_repository_common.py
+++ b/lemma-backend/app/modules/agent/infrastructure/agent_host_repository_common.py
@@ -1,0 +1,28 @@
+"""Shared errors and defaults for Agent Host repositories."""
+
+from datetime import datetime, timezone
+
+
+DEFAULT_PAIRING_TTL_SECONDS = 600
+
+
+class AgentHostRepositoryError(RuntimeError):
+    """Base typed failure for the Agent Host persistence contract."""
+
+    code = "AGENT_HOST_ERROR"
+
+
+class AgentHostNotFound(AgentHostRepositoryError):
+    code = "AGENT_HOST_NOT_FOUND"
+
+
+class AgentHostPairingRejected(AgentHostRepositoryError):
+    code = "AGENT_HOST_PAIRING_REJECTED"
+
+
+class AgentHostProtocolViolation(AgentHostRepositoryError):
+    code = "AGENT_HOST_PROTOCOL_VIOLATION"
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)

--- a/lemma-backend/app/modules/agent/infrastructure/models.py
+++ b/lemma-backend/app/modules/agent/infrastructure/models.py
@@ -21,10 +21,6 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.infrastructure.db.base import UUIDAuditBase, UUIDCreatedBase
-
-# Imported for its side effect: Agent Host tables must be registered on the
-# shared metadata for migrations and create_all to see them.
-from app.modules.agent.infrastructure import runtime_models as _runtime_models  # noqa: F401
 from app.modules.agent.domain.entities import (
     Agent as AgentEntity,
     AgentRun as AgentRunEntity,
@@ -139,11 +135,26 @@ class AgentRuntimeProfileModel(UUIDAuditBase):
             unique=True,
             postgresql_where=text("scope = 'PERSONAL'"),
         ),
+        # Holds for legacy rows too: a NULL runtime_type takes the first
+        # branch, which only requires harness_id to be NULL.
+        CheckConstraint(
+            "(runtime_type IS DISTINCT FROM 'HARNESS' AND harness_id IS NULL) OR "
+            "(runtime_type = 'HARNESS' AND harness_id IS NOT NULL)",
+            name="ck_agent_runtime_profile_harness_binding",
+        ),
     )
 
     organization_id: Mapped[UUID] = mapped_column(
         ForeignKey("organizations.id", ondelete="CASCADE"),
         nullable=False,
+        index=True,
+    )
+    # Nullable during the Agent Host rollout: legacy daemon profiles predate
+    # runtime_type and are filtered out in code rather than backfilled.
+    runtime_type: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    harness_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("agent_host_harnesses.id", ondelete="RESTRICT"),
+        nullable=True,
         index=True,
     )
     user_id: Mapped[UUID | None] = mapped_column(

--- a/lemma-backend/app/modules/agent/infrastructure/models.py
+++ b/lemma-backend/app/modules/agent/infrastructure/models.py
@@ -27,13 +27,6 @@ from app.modules.agent.domain.entities import (
     Conversation as ConversationEntity,
     Message as MessageEntity,
 )
-from app.modules.agent.domain.runtime_profiles import (
-    AgentRuntimeProfile,
-    RuntimeProfileKind,
-    RuntimeProfileProtocol,
-    RuntimeProfileScope,
-    RuntimeProfileStatus,
-)
 from app.modules.agent.domain.value_objects import (
     AgentRuntimeConfig,
     AgentRunStatus,
@@ -107,111 +100,6 @@ class AgentModel(UUIDAuditBase):
             metadata=self.agent_metadata,
         )
 
-
-class AgentRuntimeProfileModel(UUIDAuditBase):
-    """Organization-owned agent runtime profile."""
-
-    __tablename__ = "agent_runtime_profiles"
-    __table_args__ = (
-        Index(
-            "ix_agent_runtime_profile_org_scope_status",
-            "organization_id",
-            "scope",
-            "status",
-        ),
-        Index("ix_agent_runtime_profile_org_status", "organization_id", "status"),
-        Index(
-            "uq_agent_runtime_profile_org_name",
-            "organization_id",
-            "name",
-            unique=True,
-            postgresql_where=text("scope = 'ORGANIZATION'"),
-        ),
-        Index(
-            "uq_agent_runtime_profile_personal_name",
-            "organization_id",
-            "user_id",
-            "name",
-            unique=True,
-            postgresql_where=text("scope = 'PERSONAL'"),
-        ),
-        # Holds for legacy rows too: a NULL runtime_type takes the first
-        # branch, which only requires harness_id to be NULL.
-        CheckConstraint(
-            "(runtime_type IS DISTINCT FROM 'HARNESS' AND harness_id IS NULL) OR "
-            "(runtime_type = 'HARNESS' AND harness_id IS NOT NULL)",
-            name="ck_agent_runtime_profile_harness_binding",
-        ),
-    )
-
-    organization_id: Mapped[UUID] = mapped_column(
-        ForeignKey("organizations.id", ondelete="CASCADE"),
-        nullable=False,
-        index=True,
-    )
-    # Nullable during the Agent Host rollout: legacy daemon profiles predate
-    # runtime_type and are filtered out in code rather than backfilled.
-    runtime_type: Mapped[str | None] = mapped_column(String(32), nullable=True)
-    harness_id: Mapped[UUID | None] = mapped_column(
-        ForeignKey("agent_host_harnesses.id", ondelete="RESTRICT"),
-        nullable=True,
-        index=True,
-    )
-    user_id: Mapped[UUID | None] = mapped_column(
-        ForeignKey("users.id", ondelete="SET NULL"),
-        nullable=True,
-        index=True,
-    )
-    daemon_id: Mapped[UUID | None] = mapped_column(
-        ForeignKey("agent_runtime_daemons.id", ondelete="SET NULL"),
-        nullable=True,
-        index=True,
-    )
-    scope: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
-    kind: Mapped[str] = mapped_column(String(32), nullable=False)
-    protocol: Mapped[str] = mapped_column(String(32), nullable=False)
-    name: Mapped[str] = mapped_column(String(255), nullable=False)
-    description: Mapped[str | None] = mapped_column(Text, nullable=True)
-    default_model_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    model_catalog: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
-    config: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
-    credentials: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
-    status: Mapped[str] = mapped_column(
-        String(32),
-        nullable=False,
-        default=RuntimeProfileStatus.ACTIVE.value,
-        index=True,
-    )
-    profile_metadata: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
-
-    organization: Mapped[Any] = relationship(
-        "Organization",
-        foreign_keys=[organization_id],
-    )
-    user: Mapped[Any] = relationship("User", foreign_keys=[user_id])
-    daemon: Mapped["AgentRuntimeDaemonModel | None"] = relationship(
-        "AgentRuntimeDaemonModel",
-        foreign_keys=[daemon_id],
-    )
-
-    def to_entity(self) -> AgentRuntimeProfile:
-        return AgentRuntimeProfile(
-            id=str(self.id),
-            organization_id=self.organization_id,
-            user_id=self.user_id,
-            daemon_id=self.daemon_id,
-            scope=RuntimeProfileScope(self.scope),
-            kind=RuntimeProfileKind(self.kind),
-            protocol=RuntimeProfileProtocol(self.protocol),
-            name=self.name,
-            description=self.description,
-            default_model_name=self.default_model_name,
-            model_catalog=self.model_catalog or [],
-            config=self.config or {},
-            credentials=self.credentials,
-            status=RuntimeProfileStatus(self.status),
-            metadata=self.profile_metadata or {},
-        )
 
 
 class AgentRuntimeDaemonModel(UUIDAuditBase):

--- a/lemma-backend/app/modules/agent/infrastructure/models.py
+++ b/lemma-backend/app/modules/agent/infrastructure/models.py
@@ -21,6 +21,10 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.infrastructure.db.base import UUIDAuditBase, UUIDCreatedBase
+
+# Imported for its side effect: Agent Host tables must be registered on the
+# shared metadata for migrations and create_all to see them.
+from app.modules.agent.infrastructure import runtime_models as _runtime_models  # noqa: F401
 from app.modules.agent.domain.entities import (
     Agent as AgentEntity,
     AgentRun as AgentRunEntity,

--- a/lemma-backend/app/modules/agent/infrastructure/repositories.py
+++ b/lemma-backend/app/modules/agent/infrastructure/repositories.py
@@ -57,10 +57,12 @@ from app.modules.agent.infrastructure.models import (
     AgentApprovalDecisionModel,
     AgentModel,
     AgentRuntimeDaemonModel,
-    AgentRuntimeProfileModel,
     AgentRunModel,
     ConversationModel,
     MessageModel,
+)
+from app.modules.agent.infrastructure.runtime_models import (
+    AgentRuntimeProfileModel,
 )
 from app.modules.agent.infrastructure.conversation_origin_store import (
     create_conversation_for_origin,

--- a/lemma-backend/app/modules/agent/infrastructure/runtime_models.py
+++ b/lemma-backend/app/modules/agent/infrastructure/runtime_models.py
@@ -1,0 +1,143 @@
+"""Persistence models for Agent Host identity and harness discovery."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.infrastructure.db.base import UUIDAuditBase, UUIDCreatedBase
+
+
+class AgentHostPairingModel(UUIDCreatedBase):
+    """Single-use user-authorized Agent Host pairing code.
+
+    Consuming a code deletes the row, so presence is the whole validity
+    check: there is no consumed flag to interpret, and a replayed code is
+    indistinguishable from one that never existed.
+    """
+
+    __tablename__ = "agent_host_pairings"
+    __table_args__ = (
+        UniqueConstraint("code_hash", name="uq_agent_host_pairing_code_hash"),
+        # Covers user_id-only lookups as well, so user_id carries no separate
+        # single-column index.
+        Index("ix_agent_host_pairing_user_expires", "user_id", "expires_at"),
+    )
+
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    organization_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    code_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    display_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+
+
+class AgentHostModel(UUIDAuditBase):
+    """One authenticated Agent Host installation paired to this target."""
+
+    __tablename__ = "agent_hosts"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "organization_id",
+            "installation_id",
+            name="uq_agent_host_user_org_installation",
+            # Requires PostgreSQL 15+; without it a personal host
+            # (organization_id IS NULL) would not collide with itself.
+            postgresql_nulls_not_distinct=True,
+        ),
+        UniqueConstraint(
+            "host_secret_hash",
+            name="uq_agent_host_secret_hash",
+        ),
+        # Covers user_id-only lookups as well, so user_id carries no separate
+        # single-column index.
+        Index("ix_agent_host_user_status", "user_id", "status"),
+    )
+
+    user_id: Mapped[UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    organization_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        index=True,
+        nullable=True,
+    )
+    installation_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    host_secret_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    display_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    # Indexed on its own for the cross-user offline sweep, which has no
+    # user_id predicate to lead with.
+    status: Mapped[str] = mapped_column(
+        String(32), nullable=False, default="OFFLINE", index=True
+    )
+    protocol_version: Mapped[int | None] = mapped_column(nullable=True)
+    host_release: Mapped[str] = mapped_column(String(128), nullable=False)
+    capacity: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    last_seen_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    user: Mapped[Any] = relationship("User", foreign_keys=[user_id])
+    organization: Mapped[Any] = relationship(
+        "Organization", foreign_keys=[organization_id]
+    )
+
+
+class AgentHostHarnessModel(UUIDAuditBase):
+    """Revisioned capability/configuration snapshot for one local harness."""
+
+    __tablename__ = "agent_host_harnesses"
+    __table_args__ = (
+        UniqueConstraint(
+            "host_id",
+            "harness_key",
+            name="uq_agent_host_harness_key",
+        ),
+    )
+
+    host_id: Mapped[UUID] = mapped_column(
+        ForeignKey("agent_hosts.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    harness_key: Mapped[str] = mapped_column(String(128), nullable=False)
+    display_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    adapter_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    upstream_version: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    health: Mapped[str] = mapped_column(String(64), nullable=False)
+    capabilities: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    config_revision: Mapped[str] = mapped_column(String(255), nullable=False)
+    config_options: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    stale_after: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    stale_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    host: Mapped[AgentHostModel] = relationship(
+        "AgentHostModel", foreign_keys=[host_id]
+    )

--- a/lemma-backend/app/modules/agent/infrastructure/runtime_models.py
+++ b/lemma-backend/app/modules/agent/infrastructure/runtime_models.py
@@ -1,4 +1,4 @@
-"""Persistence models for Agent Host identity and harness discovery."""
+"""Persistence models for Agent Host identity, discovery, and dispatch."""
 
 from __future__ import annotations
 
@@ -7,17 +7,19 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import (
+    BigInteger,
     DateTime,
     ForeignKey,
     Index,
     String,
     Text,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from app.core.infrastructure.db.base import UUIDAuditBase, UUIDCreatedBase
+from app.core.infrastructure.db.base import Base, UUIDAuditBase, UUIDCreatedBase
 
 
 class AgentHostPairingModel(UUIDCreatedBase):
@@ -140,4 +142,98 @@ class AgentHostHarnessModel(UUIDAuditBase):
 
     host: Mapped[AgentHostModel] = relationship(
         "AgentHostModel", foreign_keys=[host_id]
+    )
+
+
+class AgentHostCommandModel(UUIDCreatedBase):
+    """Durable at-least-once command for an Agent Host."""
+
+    __tablename__ = "agent_host_commands"
+    __table_args__ = (
+        # Drives the competitive FOR UPDATE SKIP LOCKED handout.
+        Index("ix_agent_host_command_poll", "host_id", "state", "created_at"),
+        Index("ix_agent_host_command_run", "run_id", "lease_epoch"),
+    )
+
+    host_id: Mapped[UUID] = mapped_column(
+        ForeignKey("agent_hosts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    run_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("agent_runs.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    kind: Mapped[str] = mapped_column(String(64), nullable=False)
+    lease_epoch: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    payload: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    state: Mapped[str] = mapped_column(String(32), nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    delivered_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    acknowledged_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    rejection: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+
+class AgentHostRunLeaseModel(Base):
+    """The single dispatch fence for one agent run.
+
+    ``run_id`` is the primary key, which is what makes double-dispatch
+    structurally impossible rather than merely guarded in application code.
+    There is no ack-watermark column: run events travel a per-run Redis Stream
+    whose last entry is the watermark.
+    """
+
+    __tablename__ = "agent_host_run_leases"
+    __table_args__ = (
+        # Also serves host_id-only lookups.
+        Index("ix_agent_host_run_lease_host_state", "host_id", "state"),
+        Index(
+            "ix_agent_host_run_lease_expiry",
+            "lease_expires_at",
+            postgresql_where=text(
+                "state NOT IN ('WAITING_INPUT','SUCCEEDED','FAILED',"
+                "'CANCELLED','DISPATCH_UNKNOWN')"
+            ),
+        ),
+    )
+
+    run_id: Mapped[UUID] = mapped_column(
+        ForeignKey("agent_runs.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    host_id: Mapped[UUID] = mapped_column(
+        ForeignKey("agent_hosts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    harness_id: Mapped[UUID] = mapped_column(
+        ForeignKey("agent_host_harnesses.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    runtime_profile_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("agent_runtime_profiles.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    lease_epoch: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    state: Mapped[str] = mapped_column(String(32), nullable=False)
+    accepted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    lease_expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    error_code: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    error_detail: Mapped[str | None] = mapped_column(Text, nullable=True)
+    terminal_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
     )

--- a/lemma-backend/app/modules/agent/infrastructure/runtime_models.py
+++ b/lemma-backend/app/modules/agent/infrastructure/runtime_models.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from sqlalchemy import (
     BigInteger,
+    CheckConstraint,
     DateTime,
     ForeignKey,
     Index,
@@ -20,6 +21,13 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.infrastructure.db.base import Base, UUIDAuditBase, UUIDCreatedBase
+from app.modules.agent.domain.runtime_profiles import (
+    AgentRuntimeProfile,
+    RuntimeProfileKind,
+    RuntimeProfileProtocol,
+    RuntimeProfileScope,
+    RuntimeProfileStatus,
+)
 
 
 class AgentHostPairingModel(UUIDCreatedBase):
@@ -237,3 +245,109 @@ class AgentHostRunLeaseModel(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False
     )
+
+
+class AgentRuntimeProfileModel(UUIDAuditBase):
+    """Organization-owned agent runtime profile."""
+
+    __tablename__ = "agent_runtime_profiles"
+    __table_args__ = (
+        Index(
+            "ix_agent_runtime_profile_org_scope_status",
+            "organization_id",
+            "scope",
+            "status",
+        ),
+        Index("ix_agent_runtime_profile_org_status", "organization_id", "status"),
+        Index(
+            "uq_agent_runtime_profile_org_name",
+            "organization_id",
+            "name",
+            unique=True,
+            postgresql_where=text("scope = 'ORGANIZATION'"),
+        ),
+        Index(
+            "uq_agent_runtime_profile_personal_name",
+            "organization_id",
+            "user_id",
+            "name",
+            unique=True,
+            postgresql_where=text("scope = 'PERSONAL'"),
+        ),
+        # Holds for legacy rows too: a NULL runtime_type takes the first
+        # branch, which only requires harness_id to be NULL.
+        CheckConstraint(
+            "(runtime_type IS DISTINCT FROM 'HARNESS' AND harness_id IS NULL) OR "
+            "(runtime_type = 'HARNESS' AND harness_id IS NOT NULL)",
+            name="ck_agent_runtime_profile_harness_binding",
+        ),
+    )
+
+    organization_id: Mapped[UUID] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # Nullable during the Agent Host rollout: legacy daemon profiles predate
+    # runtime_type and are filtered out in code rather than backfilled.
+    runtime_type: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    harness_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("agent_host_harnesses.id", ondelete="RESTRICT"),
+        nullable=True,
+        index=True,
+    )
+    user_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    daemon_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("agent_runtime_daemons.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    scope: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    kind: Mapped[str] = mapped_column(String(32), nullable=False)
+    protocol: Mapped[str] = mapped_column(String(32), nullable=False)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    default_model_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    model_catalog: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    config: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    credentials: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    status: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default=RuntimeProfileStatus.ACTIVE.value,
+        index=True,
+    )
+    profile_metadata: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+
+    organization: Mapped[Any] = relationship(
+        "Organization",
+        foreign_keys=[organization_id],
+    )
+    user: Mapped[Any] = relationship("User", foreign_keys=[user_id])
+    daemon: Mapped[Any] = relationship(
+        "AgentRuntimeDaemonModel",
+        foreign_keys=[daemon_id],
+    )
+
+    def to_entity(self) -> AgentRuntimeProfile:
+        return AgentRuntimeProfile(
+            id=str(self.id),
+            organization_id=self.organization_id,
+            user_id=self.user_id,
+            daemon_id=self.daemon_id,
+            scope=RuntimeProfileScope(self.scope),
+            kind=RuntimeProfileKind(self.kind),
+            protocol=RuntimeProfileProtocol(self.protocol),
+            name=self.name,
+            description=self.description,
+            default_model_name=self.default_model_name,
+            model_catalog=self.model_catalog or [],
+            config=self.config or {},
+            credentials=self.credentials,
+            status=RuntimeProfileStatus(self.status),
+            metadata=self.profile_metadata or {},
+        )

--- a/lemma-backend/app/modules/agent/module.py
+++ b/lemma-backend/app/modules/agent/module.py
@@ -43,6 +43,9 @@ async def _close_agent_runtime_redis(_context: object) -> AsyncIterator[None]:
 
 def _routers():
     from app.modules.agent.api.controllers.agent_controller import router as agent
+    from app.modules.agent.api.controllers.agent_host_controller import (
+        router as agent_host,
+    )
     from app.modules.agent.api.controllers.runtime_config_controller import (
         router as runtime_config,
     )
@@ -57,7 +60,15 @@ def _routers():
         serve_router as widget_serve,
     )
 
-    return [agent, runtime_config, tool, conversation, widget_serve, widget]
+    return [
+        agent,
+        agent_host,
+        runtime_config,
+        tool,
+        conversation,
+        widget_serve,
+        widget,
+    ]
 
 
 def _event_routers():

--- a/lemma-backend/app/modules/agent/services/agent_host_auth.py
+++ b/lemma-backend/app/modules/agent/services/agent_host_auth.py
@@ -1,0 +1,36 @@
+"""Pairing codes and host credentials for Agent Host.
+
+An Agent Host authenticates with a single opaque secret issued once at
+pairing time. The server stores only the SHA-256 hash, so a database leak
+exposes no usable credentials; the secret is rotatable by re-pairing and
+revocable per host.
+
+The secrets are 256-bit and drawn from ``secrets.token_urlsafe``, so an
+unsalted hash is sufficient here: there is no low-entropy keyspace for a
+rainbow table or brute-force search to cover.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+
+
+class InvalidAgentHostCredential(ValueError):
+    """A host credential is missing, malformed, or unknown."""
+
+
+def generate_pairing_code() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def pairing_code_hash(code: str) -> str:
+    return hashlib.sha256(code.encode("utf-8")).hexdigest()
+
+
+def generate_host_secret() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def host_secret_hash(secret: str) -> str:
+    return hashlib.sha256(secret.encode("utf-8")).hexdigest()

--- a/lemma-backend/app/modules/agent/tests/e2e/test_agent_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_agent_e2e.py
@@ -40,7 +40,7 @@ from app.modules.agent.domain.value_objects import (
 )
 from app.modules.agent.infrastructure.models import AgentRunModel
 from app.modules.agent.infrastructure.models import AgentRuntimeDaemonModel
-from app.modules.agent.infrastructure.models import AgentRuntimeProfileModel
+from app.modules.agent.infrastructure.runtime_models import AgentRuntimeProfileModel
 from app.modules.agent.infrastructure.repositories import ConversationRepository
 from app.modules.agent.services.agent_runner_service import AgentRunnerService
 from app.modules.agent.services.conversation_service import ConversationService

--- a/lemma-backend/app/modules/agent/tests/e2e/test_agent_usage_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_agent_usage_e2e.py
@@ -10,7 +10,7 @@ import pytest
 from sqlalchemy import select
 
 from app.modules.agent.domain.value_objects import AgentRunStatus
-from app.modules.agent.infrastructure.models import AgentRuntimeProfileModel
+from app.modules.agent.infrastructure.runtime_models import AgentRuntimeProfileModel
 from app.modules.agent.services.runtime_profile_service import _load_runtime_env
 from app.modules.agent.tests.e2e.system_lemma_helpers import (
     SYSTEM_LEMMA_SKIP_REASON,

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_host_identity.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_host_identity.py
@@ -1,0 +1,170 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.modules.agent.domain.agent_host import (
+    AGENT_HOST_OFFLINE_AFTER_SECONDS,
+    AGENT_HOST_PROTOCOL_VERSION,
+    AgentHostCapacity,
+    AgentHostHarnessCapabilities,
+    AgentHostHarnessSnapshot,
+    AgentHostStatus,
+    HostHello,
+    effective_agent_host_status,
+)
+from app.modules.agent.services.agent_host_auth import (
+    generate_host_secret,
+    generate_pairing_code,
+    host_secret_hash,
+    pairing_code_hash,
+)
+
+
+def _now() -> datetime:
+    return datetime(2026, 7, 31, 12, 0, tzinfo=timezone.utc)
+
+
+class TestCredentials:
+    def test_secrets_are_high_entropy_and_unique(self) -> None:
+        secrets = {generate_host_secret() for _ in range(64)}
+        assert len(secrets) == 64
+        # token_urlsafe(32) is 256 bits, which is what makes an unsalted
+        # hash acceptable for this credential.
+        assert all(len(secret) >= 40 for secret in secrets)
+
+    def test_pairing_codes_are_unique(self) -> None:
+        assert len({generate_pairing_code() for _ in range(64)}) == 64
+
+    def test_hashes_are_stable_and_never_the_plaintext(self) -> None:
+        secret = generate_host_secret()
+        digest = host_secret_hash(secret)
+        assert digest == host_secret_hash(secret)
+        assert digest != secret
+        assert len(digest) == 64
+
+        code = generate_pairing_code()
+        assert pairing_code_hash(code) == pairing_code_hash(code)
+        assert pairing_code_hash(code) != code
+
+    def test_distinct_secrets_hash_differently(self) -> None:
+        assert host_secret_hash("alpha") != host_secret_hash("beta")
+
+
+class TestEffectiveStatus:
+    def test_fresh_heartbeat_is_online(self) -> None:
+        assert (
+            effective_agent_host_status(
+                AgentHostStatus.ONLINE, _now() - timedelta(seconds=5), now=_now()
+            )
+            is AgentHostStatus.ONLINE
+        )
+
+    def test_stale_heartbeat_falls_back_to_offline(self) -> None:
+        stale = _now() - timedelta(seconds=AGENT_HOST_OFFLINE_AFTER_SECONDS + 1)
+        assert (
+            effective_agent_host_status(AgentHostStatus.ONLINE, stale, now=_now())
+            is AgentHostStatus.OFFLINE
+        )
+
+    def test_never_seen_is_offline(self) -> None:
+        assert (
+            effective_agent_host_status(AgentHostStatus.ONLINE, None, now=_now())
+            is AgentHostStatus.OFFLINE
+        )
+
+    @pytest.mark.parametrize(
+        "persisted",
+        [AgentHostStatus.REVOKED, AgentHostStatus.UPGRADE_REQUIRED],
+    )
+    def test_terminal_states_survive_a_fresh_heartbeat(
+        self, persisted: AgentHostStatus
+    ) -> None:
+        """A revoked host must not read as online just because it polled."""
+        assert (
+            effective_agent_host_status(
+                persisted, _now() - timedelta(seconds=1), now=_now()
+            )
+            is persisted
+        )
+
+    def test_draining_is_preserved_while_fresh(self) -> None:
+        assert (
+            effective_agent_host_status(
+                AgentHostStatus.DRAINING, _now() - timedelta(seconds=1), now=_now()
+            )
+            is AgentHostStatus.DRAINING
+        )
+
+
+class TestProtocolNegotiation:
+    def test_matching_version_negotiates(self) -> None:
+        hello = HostHello(
+            installation_id="install-1",
+            host_release="1.0.0",
+            protocol_version=AGENT_HOST_PROTOCOL_VERSION,
+        )
+        assert hello.negotiate() == AGENT_HOST_PROTOCOL_VERSION
+
+    @pytest.mark.parametrize("version", [1, AGENT_HOST_PROTOCOL_VERSION + 1])
+    def test_mismatched_version_is_rejected(self, version: int) -> None:
+        hello = HostHello(
+            installation_id="install-1",
+            host_release="1.0.0",
+            protocol_version=version,
+        )
+        with pytest.raises(ValueError):
+            hello.negotiate()
+
+
+class TestCapacity:
+    def test_active_cannot_exceed_max(self) -> None:
+        with pytest.raises(ValueError):
+            AgentHostCapacity(max_runs=1, active_runs=2, available_runs=0)
+
+    def test_available_cannot_exceed_max(self) -> None:
+        with pytest.raises(ValueError):
+            AgentHostCapacity(max_runs=1, active_runs=0, available_runs=2)
+
+    def test_draining_shape_is_valid(self) -> None:
+        capacity = AgentHostCapacity(max_runs=4, active_runs=1, available_runs=0)
+        assert capacity.available_runs == 0
+
+
+class TestHarnessSnapshot:
+    def test_harness_key_is_normalized(self) -> None:
+        snapshot = AgentHostHarnessSnapshot(
+            harness_key="  Claude_Code  ",
+            display_name="Claude Code",
+            adapter_version="1.0.0",
+            health="READY",
+            config_revision="rev-1",
+            stale_after=_now(),
+        )
+        assert snapshot.harness_key == "claude-code"
+
+    def test_blank_harness_key_is_rejected(self) -> None:
+        with pytest.raises(ValueError):
+            AgentHostHarnessSnapshot(
+                harness_key="   ",
+                display_name="x",
+                adapter_version="1.0.0",
+                health="READY",
+                config_revision="rev-1",
+                stale_after=_now(),
+            )
+
+    def test_unknown_capabilities_are_preserved_untyped(self) -> None:
+        """Only `images` is typed; anything else rides along in the blob.
+
+        This is what lets the host evolve its capability set without the
+        server growing fields no code reads.
+        """
+        capabilities = AgentHostHarnessCapabilities.model_validate(
+            {"images": True, "some_future_flag": True}
+        )
+        assert capabilities.images is True
+        dumped = capabilities.model_dump(mode="json")
+        assert dumped["some_future_flag"] is True
+
+    def test_capabilities_default_to_no_images(self) -> None:
+        assert AgentHostHarnessCapabilities().images is False

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/helpers.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/helpers.py
@@ -25,8 +25,8 @@ from app.modules.agent.domain.runtime_profiles import (
     RuntimeProfileScope,
     RuntimeProfileStatus,
 )
-from app.modules.agent.infrastructure.models import (
-    AgentRunModel,
+from app.modules.agent.infrastructure.models import AgentRunModel
+from app.modules.agent.infrastructure.runtime_models import (
     AgentRuntimeProfileModel,
 )
 from app.modules.agent_surfaces.domain.ingress_context import (

--- a/lemma-backend/architecture-baseline.json
+++ b/lemma-backend/architecture-baseline.json
@@ -173,7 +173,6 @@
   "oversized_files": {
     "app/modules/agent/infrastructure/daemon_hub.py": 622,
     "app/modules/agent/infrastructure/harnesses/pydantic_ai.py": 1309,
-    "app/modules/agent/infrastructure/models.py": 632,
     "app/modules/agent/infrastructure/repositories.py": 1161,
     "app/modules/agent/services/agent_runner_service.py": 1137,
     "app/modules/agent/services/conversation_service.py": 1565,

--- a/lemma-backend/migrations/env.py
+++ b/lemma-backend/migrations/env.py
@@ -28,6 +28,9 @@ from app.modules.pod.infrastructure import models as pod_models  # noqa: F401
 
 # Agent
 from app.modules.agent.infrastructure import models as agent_models  # noqa: F401
+from app.modules.agent.infrastructure import (  # noqa: F401
+    runtime_models as agent_runtime_models,
+)
 
 # Trigger
 from app.modules.schedule.infrastructure import models as trigger_models  # noqa: F401

--- a/lemma-backend/migrations/versions/2026-07-31_agent_host_identity_0009.py
+++ b/lemma-backend/migrations/versions/2026-07-31_agent_host_identity_0009.py
@@ -1,16 +1,24 @@
-"""Add Agent Host identity tables (pairings, hosts, harnesses).
+"""Add the Agent Host schema.
 
-Additive only. This revision introduces the Agent Host *identity* surface — the
-tables needed to pair a machine and publish its harness snapshots. It does not
-touch ``agent_runtime_profiles`` and does not remove the legacy local daemon, so
-the existing runtime keeps working unchanged and this revision downgrades
-losslessly.
+This is the single migration for the whole Agent Host feature: identity
+(pairings, hosts, harnesses), run dispatch (commands, run leases), and the
+runtime-profile columns that bind a profile to a harness. Deployments therefore
+apply one revision, not a chain of them.
 
-Dispatch state (commands, run leases) and runtime-profile unification land in the
-following revision; the legacy daemon is removed in a later cleanup revision once
-Agent Host is proven end to end.
+It is deliberately additive — no drops, deletes, or renames. The legacy local
+daemon keeps its tables and columns and keeps working; the daemon is retired in
+code, and its now-unused ``agent_runtime_daemons`` table and the obsolete
+``protocol``/``kind``/``daemon_id``/``profile_metadata`` columns are left in
+place for a later, unrelated cleanup. Leaving an empty table behind costs
+nothing and buys a lossless downgrade plus a main branch that stays releasable
+at every commit of the rollout.
 
-Revision ID: 0009_agent_host_identity
+Run events are not journaled here. They travel a per-run Redis Stream, so there
+is no ``agent_host_events`` table and no ack-watermark column on the lease: the
+stream's last entry is the watermark, and a host that resends after a Redis
+flush is deduplicated by sequence.
+
+Revision ID: 0009_agent_host
 Revises: 0008_function_execution
 """
 
@@ -19,7 +27,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 
-revision = "0009_agent_host_identity"
+revision = "0009_agent_host"
 down_revision = "0008_function_execution"
 branch_labels = None
 depends_on = None
@@ -47,6 +55,95 @@ def _audit_columns() -> list[sa.Column]:
         *_created_columns(),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
     ]
+
+
+# Every declarative base used to declare `id` as primary_key=True AND
+# index=True, so each table carried a plain btree on `id` on top of the unique
+# index PostgreSQL already builds for the primary key. The duplicate was
+# maintained on every insert and could never be chosen over the PK index. The
+# bases no longer set it; this drops the ones already in the schema.
+#
+# The drop is derived at runtime so it matches whatever a given environment
+# actually has: single-column, non-unique, non-primary indexes on `id`.
+_REDUNDANT_ID_INDEXES = sa.text(
+    """
+    SELECT c.relname AS index_name, t.relname AS table_name
+      FROM pg_index x
+      JOIN pg_class c ON c.oid = x.indexrelid
+      JOIN pg_class t ON t.oid = x.indrelid
+      JOIN pg_namespace n ON n.oid = t.relnamespace
+     WHERE n.nspname = current_schema()
+       AND NOT x.indisprimary
+       AND NOT x.indisunique
+       AND x.indnatts = 1
+       AND (SELECT attname FROM pg_attribute
+             WHERE attrelid = t.oid AND attnum = x.indkey[0]) = 'id'
+    """
+)
+
+
+def _drop_redundant_id_indexes() -> None:
+    for index_name, _table in op.get_bind().execute(_REDUNDANT_ID_INDEXES):
+        op.execute(sa.text(f'DROP INDEX IF EXISTS "{index_name}"'))
+
+
+# The exact set of tables carrying ix_<table>_id at revision 0008. Pinned
+# rather than derived, so a downgrade restores precisely what was there:
+# five tables with an id primary key never had the duplicate.
+_TABLES_WITH_REDUNDANT_ID_INDEX = (
+    "accounts",
+    "agent_approval_decisions",
+    "agent_conversations",
+    "agent_feedback",
+    "agent_messages",
+    "agent_runs",
+    "agent_runtime_daemons",
+    "agent_runtime_profiles",
+    "agent_surface_conversation_links",
+    "agent_surface_external_users",
+    "agent_surfaces",
+    "agents",
+    "app_releases",
+    "apps",
+    "auth_configs",
+    "auth_permissions",
+    "connect_requests",
+    "connector_operations",
+    "connector_triggers",
+    "connectors",
+    "datastore_files",
+    "datastore_tables",
+    "function_runs",
+    "functions",
+    "organization_invitations",
+    "organization_members",
+    "organizations",
+    "pod_join_requests",
+    "pod_members",
+    "pods",
+    "resource_permission_grants",
+    "role_assignments",
+    "role_permissions",
+    "roles",
+    "schedules",
+    "usage_limit_counters",
+    "usage_records",
+    "users",
+    "workflow_flow_runs",
+    "workflow_flows",
+    "workflow_run_waits",
+)
+
+
+def _restore_redundant_id_indexes() -> None:
+    """Recreate the duplicates so the downgrade is faithful."""
+    for table_name in _TABLES_WITH_REDUNDANT_ID_INDEX:
+        op.execute(
+            sa.text(
+                f'CREATE INDEX IF NOT EXISTS "ix_{table_name}_id" '
+                f'ON "{table_name}" (id)'
+            )
+        )
 
 
 def _require_supported_postgres() -> None:
@@ -147,8 +244,137 @@ def upgrade() -> None:
         "ix_agent_host_harnesses_host_id", "agent_host_harnesses", ["host_id"]
     )
 
+    op.create_table(
+        "agent_host_commands",
+        *_created_columns(),
+        sa.Column("host_id", UUID, nullable=False),
+        sa.Column("run_id", UUID, nullable=True),
+        sa.Column("kind", sa.String(length=64), nullable=False),
+        sa.Column("lease_epoch", sa.BigInteger(), nullable=True),
+        sa.Column("payload", JSONB, nullable=False),
+        sa.Column("state", sa.String(length=32), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("delivered_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("acknowledged_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("rejection", JSONB, nullable=True),
+        sa.ForeignKeyConstraint(["host_id"], ["agent_hosts.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["run_id"], ["agent_runs.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    # Drives the competitive FOR UPDATE SKIP LOCKED handout in poll_commands.
+    op.create_index(
+        "ix_agent_host_command_poll",
+        "agent_host_commands",
+        ["host_id", "state", "created_at"],
+    )
+    op.create_index(
+        "ix_agent_host_command_run",
+        "agent_host_commands",
+        ["run_id", "lease_epoch"],
+    )
+
+    # run_id is the primary key, which is what makes double-dispatch of a run
+    # structurally impossible rather than merely guarded in application code.
+    op.create_table(
+        "agent_host_run_leases",
+        sa.Column("run_id", UUID, nullable=False),
+        sa.Column("host_id", UUID, nullable=False),
+        sa.Column("harness_id", UUID, nullable=False),
+        sa.Column("runtime_profile_id", UUID, nullable=True),
+        sa.Column("lease_epoch", sa.BigInteger(), nullable=False),
+        sa.Column("state", sa.String(length=32), nullable=False),
+        sa.Column("accepted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("lease_expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("error_code", sa.String(length=128), nullable=True),
+        sa.Column("error_detail", sa.Text(), nullable=True),
+        sa.Column("terminal_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["run_id"], ["agent_runs.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["host_id"], ["agent_hosts.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["harness_id"], ["agent_host_harnesses.id"], ondelete="RESTRICT"
+        ),
+        sa.ForeignKeyConstraint(
+            ["runtime_profile_id"],
+            ["agent_runtime_profiles.id"],
+            ondelete="SET NULL",
+        ),
+        sa.PrimaryKeyConstraint("run_id"),
+    )
+    # (host_id, state) also serves host_id-only lookups.
+    op.create_index(
+        "ix_agent_host_run_lease_host_state",
+        "agent_host_run_leases",
+        ["host_id", "state"],
+    )
+    op.create_index(
+        "ix_agent_host_run_lease_expiry",
+        "agent_host_run_leases",
+        ["lease_expires_at"],
+        postgresql_where=sa.text(
+            "state NOT IN ('WAITING_INPUT','SUCCEEDED','FAILED',"
+            "'CANCELLED','DISPATCH_UNKNOWN')"
+        ),
+    )
+
+    # Profile binding. Both columns are nullable so existing rows, including
+    # legacy daemon profiles, stay valid without a backfill.
+    op.add_column(
+        "agent_runtime_profiles",
+        sa.Column("runtime_type", sa.String(length=32), nullable=True),
+    )
+    op.add_column(
+        "agent_runtime_profiles",
+        sa.Column("harness_id", UUID, nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_agent_runtime_profiles_harness",
+        "agent_runtime_profiles",
+        "agent_host_harnesses",
+        ["harness_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.create_index(
+        "ix_agent_runtime_profiles_harness_id",
+        "agent_runtime_profiles",
+        ["harness_id"],
+    )
+    # Holds for legacy rows too: runtime_type IS NULL takes the first branch,
+    # which only requires harness_id to be NULL.
+    op.create_check_constraint(
+        "ck_agent_runtime_profile_harness_binding",
+        "agent_runtime_profiles",
+        "(runtime_type IS DISTINCT FROM 'HARNESS' AND harness_id IS NULL) OR "
+        "(runtime_type = 'HARNESS' AND harness_id IS NOT NULL)",
+    )
+
+    _drop_redundant_id_indexes()
+
 
 def downgrade() -> None:
+    _restore_redundant_id_indexes()
+
+    op.drop_constraint(
+        "ck_agent_runtime_profile_harness_binding",
+        "agent_runtime_profiles",
+        type_="check",
+    )
+    op.drop_index(
+        "ix_agent_runtime_profiles_harness_id",
+        table_name="agent_runtime_profiles",
+    )
+    op.drop_constraint(
+        "fk_agent_runtime_profiles_harness",
+        "agent_runtime_profiles",
+        type_="foreignkey",
+    )
+    op.drop_column("agent_runtime_profiles", "harness_id")
+    op.drop_column("agent_runtime_profiles", "runtime_type")
+
+    op.drop_table("agent_host_run_leases")
+    op.drop_table("agent_host_commands")
     op.drop_table("agent_host_harnesses")
     op.drop_table("agent_hosts")
     op.drop_table("agent_host_pairings")

--- a/lemma-backend/migrations/versions/2026-07-31_agent_host_identity_0009.py
+++ b/lemma-backend/migrations/versions/2026-07-31_agent_host_identity_0009.py
@@ -1,0 +1,154 @@
+"""Add Agent Host identity tables (pairings, hosts, harnesses).
+
+Additive only. This revision introduces the Agent Host *identity* surface — the
+tables needed to pair a machine and publish its harness snapshots. It does not
+touch ``agent_runtime_profiles`` and does not remove the legacy local daemon, so
+the existing runtime keeps working unchanged and this revision downgrades
+losslessly.
+
+Dispatch state (commands, run leases) and runtime-profile unification land in the
+following revision; the legacy daemon is removed in a later cleanup revision once
+Agent Host is proven end to end.
+
+Revision ID: 0009_agent_host_identity
+Revises: 0008_function_execution
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0009_agent_host_identity"
+down_revision = "0008_function_execution"
+branch_labels = None
+depends_on = None
+
+
+UUID = postgresql.UUID(as_uuid=True)
+JSONB = postgresql.JSONB(astext_type=sa.Text())
+
+# uq_agent_host_user_org_installation relies on NULLS NOT DISTINCT so that a
+# personal host (organization_id IS NULL) still collides with itself on
+# re-pairing. That clause is PostgreSQL 15+ only, and on older servers the
+# constraint would silently permit duplicate personal installations.
+_MINIMUM_POSTGRES_VERSION = 150000
+
+
+def _created_columns() -> list[sa.Column]:
+    return [
+        sa.Column("id", UUID, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    ]
+
+
+def _audit_columns() -> list[sa.Column]:
+    return [
+        *_created_columns(),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    ]
+
+
+def _require_supported_postgres() -> None:
+    version = op.get_bind().scalar(sa.text("SHOW server_version_num"))
+    if int(version) < _MINIMUM_POSTGRES_VERSION:
+        raise RuntimeError(
+            "Agent Host requires PostgreSQL 15 or newer for NULLS NOT DISTINCT "
+            f"unique constraints; this server reports server_version_num={version}"
+        )
+
+
+def upgrade() -> None:
+    _require_supported_postgres()
+
+    op.create_table(
+        "agent_host_pairings",
+        *_created_columns(),
+        sa.Column("user_id", UUID, nullable=False),
+        sa.Column("organization_id", UUID, nullable=True),
+        sa.Column("code_hash", sa.String(length=64), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("code_hash", name="uq_agent_host_pairing_code_hash"),
+    )
+    # (user_id, expires_at) also serves lookups keyed on user_id alone, so no
+    # separate single-column index is created here.
+    op.create_index(
+        "ix_agent_host_pairing_user_expires",
+        "agent_host_pairings",
+        ["user_id", "expires_at"],
+    )
+    op.create_index(
+        "ix_agent_host_pairings_organization_id",
+        "agent_host_pairings",
+        ["organization_id"],
+    )
+
+    op.create_table(
+        "agent_hosts",
+        *_audit_columns(),
+        sa.Column("user_id", UUID, nullable=False),
+        sa.Column("organization_id", UUID, nullable=True),
+        sa.Column("installation_id", sa.String(length=255), nullable=False),
+        sa.Column("host_secret_hash", sa.String(length=64), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("protocol_version", sa.Integer(), nullable=True),
+        sa.Column("host_release", sa.String(length=128), nullable=False),
+        sa.Column("capacity", JSONB, nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id",
+            "organization_id",
+            "installation_id",
+            name="uq_agent_host_user_org_installation",
+            postgresql_nulls_not_distinct=True,
+        ),
+        sa.UniqueConstraint("host_secret_hash", name="uq_agent_host_secret_hash"),
+    )
+    op.create_index(
+        "ix_agent_hosts_organization_id", "agent_hosts", ["organization_id"]
+    )
+    # Status-only lookups drive the offline sweep across all users, so this is
+    # not covered by (user_id, status) below.
+    op.create_index("ix_agent_hosts_status", "agent_hosts", ["status"])
+    op.create_index("ix_agent_host_user_status", "agent_hosts", ["user_id", "status"])
+
+    op.create_table(
+        "agent_host_harnesses",
+        *_audit_columns(),
+        sa.Column("host_id", UUID, nullable=False),
+        sa.Column("harness_key", sa.String(length=128), nullable=False),
+        sa.Column("display_name", sa.String(length=255), nullable=False),
+        sa.Column("adapter_version", sa.String(length=128), nullable=False),
+        sa.Column("upstream_version", sa.String(length=128), nullable=True),
+        sa.Column("health", sa.String(length=64), nullable=False),
+        sa.Column("capabilities", JSONB, nullable=False),
+        sa.Column("config_revision", sa.String(length=255), nullable=False),
+        sa.Column("config_options", JSONB, nullable=False),
+        sa.Column("stale_after", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("stale_reason", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(["host_id"], ["agent_hosts.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("host_id", "harness_key", name="uq_agent_host_harness_key"),
+    )
+    op.create_index(
+        "ix_agent_host_harnesses_host_id", "agent_host_harnesses", ["host_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("agent_host_harnesses")
+    op.drop_table("agent_hosts")
+    op.drop_table("agent_host_pairings")


### PR DESCRIPTION
First of a stacked series replacing the local daemon runtime with the external Agent Host. Split out of #234.

**One migration for the whole feature** — identity (pairings, hosts, harnesses), dispatch (commands, run leases), and the runtime-profile binding columns all land in revision `0009_agent_host`. Deployments apply one revision, not a chain. Later PRs in the series add code against these tables and introduce no further migrations.

## Why this is safe to merge on its own

Purely additive — nothing dropped, deleted, or renamed:

- the legacy local daemon keeps its tables, columns, and behaviour
- `downgrade()` is lossless
- `main` stays releasable at this commit

The obsolete `agent_runtime_daemons` table and `protocol`/`kind`/`daemon_id`/`profile_metadata` columns are deliberately left in place. Retiring them is a later, unrelated cleanup; leaving an empty table behind costs nothing and is what keeps every commit of this rollout releasable.

## Notable: no events table

Run events travel a **per-run Redis Stream**, not PostgreSQL. So there is no `agent_host_events` table and no ack-watermark column on the lease — the stream's last entry *is* the watermark, and a host that resends after a Redis flush is deduplicated by sequence. This keeps a chatty run's write volume off the main database entirely.

## Bonus: 41 duplicate indexes removed

Every declarative base declared `id` as `primary_key=True` **and** `index=True`. PostgreSQL already builds a unique index for a primary key, so this produced a second btree on `id` for **every table in the schema** — maintained on every insert and never chosen by the planner over the PK index.

The bases no longer set it, and this migration drops the 41 duplicates. The drop is derived at runtime; the downgrade restores from a **pinned** list, because five tables with an `id` primary key never had the duplicate and a derived restore would over-create them (verified: restores exactly 41, not 46).

## Schema decisions worth reviewing

- **PostgreSQL 15+ asserted at migration time.** `uq_agent_host_user_org_installation` relies on `NULLS NOT DISTINCT`; on older servers it would silently permit duplicate personal installations rather than fail loudly.
- **No redundant composite-prefix indexes.** `(user_id, expires_at)` and `(user_id, status)` serve their own `user_id`-only lookups. `agent_hosts.status` keeps a standalone index because the cross-user offline sweep has no `user_id` predicate to lead with.
- **`run_id` is the leases primary key**, which is what makes double-dispatch structurally impossible rather than merely guarded in application code.
- **Consuming a pairing code deletes the row** instead of setting `consumed_at`. Presence becomes the entire validity check, and a replayed code is indistinguishable from one that never existed.
- **Harness capabilities type only `images`** — the one flag the server branches on. The other six reported flags had no reader anywhere in backend, host, or frontend (`durable_session_recovery` was hardcoded `false`), so they ride along untyped via `extra="allow"` rather than becoming schema to maintain.

## Auth

One opaque 256-bit per-installation secret, stored only as a SHA-256 hash. Unknown and revoked secrets return an identical 401, so the endpoint is not a probe oracle. The secret is high-entropy, which is what makes an unsalted hash appropriate.

## Routes

| Audience | Route |
|---|---|
| User | `POST /me/runtime/agent-host-pairings` |
| User | `GET /me/runtime/agent-hosts` |
| User | `DELETE /me/runtime/agent-hosts/{host_id}` |
| User | `GET /me/runtime/agent-hosts/{host_id}/harnesses` |
| Device | `POST /agent-host/pairings:complete` |
| Device | `PUT /agent-host/harnesses` |
| Device | `POST /agent-host/revoke` |

## Verification

- Full `up → down → up` round-trip on a scratch database: drops to 0 duplicate `id` indexes, downgrade restores exactly 41, re-upgrade drops them again
- `alembic revision --autogenerate` detects **zero drift** against the models (this caught two real model/migration mismatches during development)
- `NULLS NOT DISTINCT` confirmed applied via `pg_constraint`
- 20 new unit tests; **2723** backend unit tests pass
- `ruff` clean on every changed file; architecture ratchet passes with no new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)