### PR TITLE
fix(agent): name the model the composer will actually run

### DIFF
--- a/lemma-frontend/components/agents/agent-runtime-helpers.test.ts
+++ b/lemma-frontend/components/agents/agent-runtime-helpers.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import {
+    HarnessKind,
+    RuntimeProfileKind,
+    RuntimeProfileProtocol,
+    RuntimeProfileScope,
+    RuntimeProfileStatus,
+} from 'lemma-sdk';
+import type {
+    AgentRuntimeProfileListResponse,
+    AgentRuntimeProfileResponse,
+} from 'lemma-sdk';
+
+import {
+    formatAgentRuntime,
+    hydrateRuntimeModel,
+    resolveDefaultAgentRuntime,
+    resolveRuntimeModelName,
+} from './agent-runtime-helpers';
+
+function profile(
+    overrides: Partial<AgentRuntimeProfileResponse> & { id: string },
+): AgentRuntimeProfileResponse {
+    return {
+        scope: RuntimeProfileScope.SYSTEM,
+        kind: RuntimeProfileKind.MODEL_PROVIDER,
+        protocol: RuntimeProfileProtocol.OPENAI_COMPATIBLE,
+        name: 'Lemma',
+        default_model_name: null,
+        model_catalog: [],
+        config: {},
+        status: RuntimeProfileStatus.ACTIVE,
+        metadata: {},
+        has_credentials: true,
+        derived_harness_kind: HarnessKind.LEMMA,
+        ...overrides,
+    };
+}
+
+function model(name: string) {
+    return {
+        name,
+        display_name: null,
+        provider_model_name: name,
+        capabilities: [],
+        default_model_settings: {},
+        metadata: {},
+    };
+}
+
+// The shape the backend actually returns: `default_runtime` names the system
+// profile and nothing else, because AgentRuntimeDefaultService.get_default()
+// builds it from a profile id alone.
+const catalog: AgentRuntimeProfileListResponse = {
+    items: [
+        profile({
+            id: 'system:lemma',
+            default_model_name: 'openai/gpt-5.1',
+            model_catalog: [model('openai/gpt-5.1'), model('openai/gpt-5.1-mini')],
+        }),
+        profile({
+            id: 'org:byo',
+            name: 'Acme',
+            scope: RuntimeProfileScope.ORGANIZATION,
+            // No pinned default — the backend falls to the first catalog entry.
+            model_catalog: [model('claude-sonnet-5'), model('claude-opus-5')],
+        }),
+    ],
+    default_runtime: { profile_id: 'system:lemma' },
+};
+
+describe('resolveRuntimeModelName', () => {
+    it('keeps an explicitly pinned model', () => {
+        expect(resolveRuntimeModelName(
+            { profile_id: 'system:lemma', model_name: 'openai/gpt-5.1-mini' },
+            catalog,
+        )).toBe('openai/gpt-5.1-mini');
+    });
+
+    it("names the profile's default model when the runtime pins only a profile", () => {
+        expect(resolveRuntimeModelName({ profile_id: 'system:lemma' }, catalog))
+            .toBe('openai/gpt-5.1');
+    });
+
+    it('falls back to the first catalog entry, as the backend does at dispatch', () => {
+        expect(resolveRuntimeModelName({ profile_id: 'org:byo' }, catalog))
+            .toBe('claude-sonnet-5');
+    });
+
+    it('names nothing when the catalog is absent or the profile has gone away', () => {
+        expect(resolveRuntimeModelName({ profile_id: 'system:lemma' }, undefined)).toBeNull();
+        expect(resolveRuntimeModelName({ profile_id: 'deleted' }, catalog)).toBeNull();
+        expect(resolveRuntimeModelName(null, catalog)).toBeNull();
+    });
+});
+
+describe('resolveDefaultAgentRuntime', () => {
+    // The composer's own case: a pod that never set a default falls through to
+    // the catalog's bare default_runtime, which used to reach the UI unnamed.
+    it('names a model for a pod with no default of its own', () => {
+        expect(resolveDefaultAgentRuntime(catalog, undefined)).toEqual({
+            profile_id: 'system:lemma',
+            model_name: 'openai/gpt-5.1',
+        });
+    });
+
+    it('resolves the legacy provider-only pod default through its profile', () => {
+        expect(resolveDefaultAgentRuntime(catalog, 'org:byo')).toEqual({
+            profile_id: 'org:byo',
+            model_name: 'claude-sonnet-5',
+        });
+    });
+
+    it('falls back to the catalog default when the pinned profile is gone', () => {
+        expect(resolveDefaultAgentRuntime(catalog, 'deleted')).toEqual({
+            profile_id: 'system:lemma',
+            model_name: 'openai/gpt-5.1',
+        });
+    });
+
+    it('resolves nothing while the catalog is still loading', () => {
+        expect(resolveDefaultAgentRuntime(undefined, 'system:lemma')).toBeNull();
+    });
+});
+
+describe('hydrateRuntimeModel', () => {
+    it('fills in the model an agent runtime leaves open', () => {
+        expect(hydrateRuntimeModel({ profile_id: 'org:byo' }, catalog))
+            .toEqual({ profile_id: 'org:byo', model_name: 'claude-sonnet-5' });
+    });
+
+    it('returns the runtime untouched when nothing can name its model', () => {
+        const runtime = { profile_id: 'deleted' };
+        expect(hydrateRuntimeModel(runtime, catalog)).toBe(runtime);
+        expect(hydrateRuntimeModel(null, catalog)).toBeNull();
+    });
+});
+
+describe('formatAgentRuntime', () => {
+    it("resolves through the runtime's own profile, not the catalog default", () => {
+        expect(formatAgentRuntime({ profile_id: 'org:byo' }, catalog))
+            .toBe('Acme · claude-sonnet-5');
+    });
+});

--- a/lemma-frontend/components/agents/agent-runtime-helpers.ts
+++ b/lemma-frontend/components/agents/agent-runtime-helpers.ts
@@ -101,6 +101,36 @@ export function defaultAgentRuntimeFromProfile(
     };
 }
 
+// The model a runtime will actually run on. A stored runtime routinely pins a
+// profile and leaves the model open: the catalog's own `default_runtime` is a
+// bare `{ profile_id: 'system:lemma' }`, a pod that never set a default has no
+// runtime at all, and an agent can inherit its profile's model. The backend
+// fills that gap at dispatch — the profile's default model, else the first
+// catalog entry (`_selected_model` in runtime_profile_service.py) — so resolve
+// it the same way here instead of calling a well-defined model "Default".
+export function resolveRuntimeModelName(
+    runtime?: AgentRuntimeConfig | null,
+    catalog?: AgentRuntimeProfileListResponse,
+): string | null {
+    if (!runtime) return null;
+    if (runtime.model_name) return runtime.model_name;
+    const profile = findProfileByRuntime(catalog, runtime);
+    return profile?.default_model_name ?? runtimeModels(profile)[0]?.name ?? null;
+}
+
+// The same runtime with its model spelled out, for pickers and labels that read
+// `model_name` directly. Returned unchanged when nothing can name the model —
+// while the catalog is still loading, or when its profile has gone away.
+export function hydrateRuntimeModel(
+    runtime?: AgentRuntimeConfig | null,
+    catalog?: AgentRuntimeProfileListResponse,
+): AgentRuntimeConfig | null {
+    if (!runtime) return null;
+    if (runtime.model_name) return runtime;
+    const modelName = resolveRuntimeModelName(runtime, catalog);
+    return modelName ? { ...runtime, model_name: modelName } : runtime;
+}
+
 export function resolveDefaultAgentRuntime(
     catalog?: AgentRuntimeProfileListResponse,
     profileId?: string | null,
@@ -108,7 +138,8 @@ export function resolveDefaultAgentRuntime(
     const profile = profileId
         ? catalog?.items.find((item) => item.id === profileId)
         : undefined;
-    return defaultAgentRuntimeFromProfile(profile) ?? catalog?.default_runtime ?? null;
+    return defaultAgentRuntimeFromProfile(profile)
+        ?? hydrateRuntimeModel(catalog?.default_runtime, catalog);
 }
 
 export function formatAgentRuntime(
@@ -118,7 +149,9 @@ export function formatAgentRuntime(
 ): string {
     if (!runtime) return includeModel ? 'Default model' : 'Default Agent Runtime';
     const profile = findProfileByRuntime(catalog, runtime);
-    const modelName = runtime.model_name ?? catalog?.default_runtime?.model_name ?? null;
+    // Resolve through this runtime's own profile — borrowing the catalog
+    // default's model would name a model this profile may not even serve.
+    const modelName = resolveRuntimeModelName(runtime, catalog);
     const prefix = profile?.name ?? (runtime.profile_id === catalog?.default_runtime?.profile_id ? 'Default Agent Runtime' : runtime.profile_id);
     return includeModel && modelName ? `${prefix} · ${shortModelName(modelName)}` : prefix;
 }

--- a/lemma-frontend/components/conversations/conversation-composer-context.tsx
+++ b/lemma-frontend/components/conversations/conversation-composer-context.tsx
@@ -5,7 +5,7 @@ import type {
     AgentRuntimeProfileListResponse,
 } from 'lemma-sdk';
 
-import { shortModelName } from '@/components/agents/agent-runtime-helpers';
+import { resolveRuntimeModelName, shortModelName } from '@/components/agents/agent-runtime-helpers';
 import { RuntimeModelPicker } from '@/components/lemma/assistant/model-picker';
 import {
     Select,
@@ -47,7 +47,13 @@ export function ConversationComposerContext({
     const agentLabel = agentDisplayLabel
         ?? (selectedAgentName ? formatAgentName(selectedAgentName) : 'Pod default');
     const agentValue = selectedAgentName || POD_DEFAULT_AGENT_VALUE;
-    const resolvedModelName = selectedRuntime?.model_name ?? defaultRuntime?.model_name ?? null;
+    // Neither runtime is required to carry a model — an inherited default names
+    // only its profile — so resolve both through the catalog the run will use.
+    // "Default" survives only until the catalog loads, or where nothing is set
+    // up to run at all; naming the model is the whole point of this row.
+    const defaultModelName = resolveRuntimeModelName(defaultRuntime, runtimeCatalog);
+    const resolvedModelName = resolveRuntimeModelName(selectedRuntime, runtimeCatalog)
+        ?? defaultModelName;
     const modelLabel = resolvedModelName ? shortModelName(resolvedModelName) : 'Default';
 
     if (!isNewConversation) {
@@ -99,7 +105,7 @@ export function ConversationComposerContext({
                 compact
                 scopeHint="Just for this chat"
                 manageHref={manageModelsHref}
-                autoTriggerLabel={defaultRuntime?.model_name ? shortModelName(defaultRuntime.model_name) : 'Default'}
+                autoTriggerLabel={defaultModelName ? shortModelName(defaultModelName) : 'Default'}
                 className="min-w-0 [&>button]:max-w-28 sm:[&>button]:max-w-52"
                 triggerClassName="text-xs font-normal"
                 triggerLabelClassName="text-xs font-normal"

--- a/lemma-frontend/components/lemma/assistant/model-picker.tsx
+++ b/lemma-frontend/components/lemma/assistant/model-picker.tsx
@@ -28,6 +28,7 @@ import {
   isLocalAgentKind,
   modelPathHint,
   profileHarnessKey,
+  resolveRuntimeModelName,
   runtimeCatalogToModelOptions,
   runtimeKey,
   shortModelName,
@@ -534,7 +535,10 @@ export function RuntimeModelPicker({
   allowAuto,
 }: RuntimeModelPickerProps) {
   const options = useMemo(() => runtimeCatalogToModelOptions(catalog), [catalog]);
-  const defaultModelLabel = defaultRuntime?.model_name ? shortModelName(defaultRuntime.model_name) : undefined;
+  // The default usually pins only a profile, so ask the catalog which model
+  // that profile will actually run rather than showing a nameless "Default".
+  const defaultModelName = resolveRuntimeModelName(defaultRuntime, catalog);
+  const defaultModelLabel = defaultModelName ? shortModelName(defaultModelName) : undefined;
   // "Currently <model>" signals this tracks the default — it'll move if the
   // default changes, unlike pinning a specific model below. Callers that *are*
   // the default (e.g. the pod-default setting) override this, since "use the

--- a/lemma-frontend/vitest.config.ts
+++ b/lemma-frontend/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     test: {
         environment: 'node',
         include: [
+            'components/agents/agent-runtime-helpers.{test,spec}.ts',
             'components/auth/portal/auth/**/*.{test,spec}.ts',
             'lib/**/*.{test,spec}.ts',
         ],


### PR DESCRIPTION
## What

The conversation composer showed the literal string `Default` where a model name belongs, so a new chat read **"Pod default · Default"** — nothing named on either side of the separator.

## Why it happened

The pod default wasn't failing to load. It resolved to a runtime that names a *profile* and no model, and the UI had no fallback for that.

For a pod that never set a default, both `pod.config.default_runtime` and `default_profile_id` are unset (`PodConfig` defaults them to `None`, and they're only written when someone explicitly picks a pod default). So `resolveDefaultAgentRuntime` fell through to the catalog's own `default_runtime` — which the backend builds from a profile id alone in `AgentRuntimeDefaultService.get_default()`, leaving `model_name` null. The catalog query being briefly unloaded is only an extra window on top of this; the steady state was already unnamed.

The model was never actually ambiguous. At dispatch the backend resolves that same bare runtime through `_selected_model` in `runtime_profile_service.py`: the profile's `default_model_name`, else the first `model_catalog` entry. The system profile ships in `catalog.items` with both fields populated — the frontend had the answer in hand and simply wasn't asking.

## What changed

`resolveRuntimeModelName(runtime, catalog)` mirrors that backend chain, with `hydrateRuntimeModel` for callers that need a filled-in `AgentRuntimeConfig`. Wired into the three places that render an inherited default:

- **`resolveDefaultAgentRuntime`** hydrates its `catalog.default_runtime` fallback — also fixes the pod home, agent-create page, and agent identity header.
- **`RuntimeModelPicker`** resolves the default through the catalog it already receives, so its "Currently ‹model›" subtitle fills in on every surface rather than only where a caller pre-resolved the runtime.
- **The composer** resolves both the selected and the default runtime. This also covers a selected agent whose `agent_runtime` pins a profile without a model, since `effectiveDefaultRuntime` passes that straight through.

The pill now reads "Pod default · gpt-5.1". `'Default'` survives only while the catalog is in flight, or when no provider is configured at all — cases where no model genuinely exists to name.

Also fixes an adjacent bug in `formatAgentRuntime`: it fell back to `catalog.default_runtime.model_name` for *any* runtime, labelling a BYO-profile runtime with the system profile's model. It resolves through the runtime's own profile now.

## Notes for reviewers

- **The agent half of the pill still reads "Pod default", deliberately.** Unlike the model, that isn't a failed lookup — a conversation with `agent_id: null` runs the pod's built-in assistant, which has no other name (`_default_agent_runtime_for_pod` in `conversation_service.py`). Renaming it is a copy decision, not a bug fix; happy to change it in a follow-up if you'd prefer different wording.
- **`vitest.config.ts` gains one narrow glob.** `components/agents/` wasn't in the include list, so a test there would have silently never run. The helper is pure logic with no React imports, matching the config's "no component surfaces" rule — hence a single-file glob rather than widening to `components/**`.
- No backend changes. This only teaches the frontend to resolve what the backend already does.

## Testing

11 new tests in `agent-runtime-helpers.test.ts` cover the bare-catalog-default case, the legacy `default_profile_id` path, the deleted-profile fallback, and the still-loading state. Full suite green at 251 passed / 42 files, plus `tsc --noEmit`, eslint on the changed files, and the design audit against its baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
