### PR TITLE
fix: stop the agent page stretching sideways, and stop breaking spaced markdown tables

### DIFF
--- a/lemma-frontend/styles/features/agent-page.css
+++ b/lemma-frontend/styles/features/agent-page.css
@@ -17,8 +17,14 @@
   background: var(--bg-canvas);
 }
 
+/* `minmax(0, 1fr)`, not the default `auto`: an auto track is floored by its
+   items' min-content, so one unbreakable path in the instructions used to widen
+   the track past this max-width and stretch *every* card on the page with it,
+   leaving the whole column scrolling sideways. The column sets the width; a
+   card that cannot fit its content wraps or scrolls inside itself. */
 .resource-page-column {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   gap: var(--space-2-5);
   margin: 0 auto;
   max-width: 52rem;
@@ -27,6 +33,7 @@
 
 /* Three boxes on the canvas: what this thing is, what it says, and the dock. */
 .resource-card {
+  min-width: 0;
   border: 1px solid var(--card-border-subtle);
   border-radius: var(--radius-xl);
   background: var(--card-bg);

--- a/lemma-frontend/styles/primitives.css
+++ b/lemma-frontend/styles/primitives.css
@@ -421,6 +421,10 @@
 .tiptap-editor {
   min-height: inherit;
   line-height: 1.7;
+  /* Prose is written by agents and pasted from terminals: a path, a URL, or a
+     token with no spaces in it has to break rather than set the width of
+     whatever card the editor sits in. */
+  overflow-wrap: anywhere;
 }
 
 .tiptap-editor>*+* {
@@ -473,6 +477,14 @@
 .tiptap-editor pre code {
   background: transparent;
   padding: 0;
+}
+
+/* ProseMirror's own wrapper around a table. A table is the one block here that
+   cannot wrap, so it scrolls on its own — otherwise a wide one pushes past the
+   page it is written on. */
+.tiptap-editor .tableWrapper {
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 /* Pod badge — a compact, solid fallback when a pod has no uploaded identity. */

--- a/lemma-typescript/registry/default/lemma-assistant-experience/components/assistant-experience.tsx
+++ b/lemma-typescript/registry/default/lemma-assistant-experience/components/assistant-experience.tsx
@@ -573,16 +573,35 @@ function defaultMessageContent({ message }: AssistantMessageRenderArgs): ReactNo
   );
 }
 
+/** A GFM delimiter row on a line of its own — `| --- | :---: |`, `|---|---|`. */
+const TABLE_DELIMITER_ROW_PATTERN = /^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)*\|?\s*$/;
+
+/**
+ * Unpack one squashed line: a ` --- ` separator into a paragraph break, and
+ * cells that were run together back onto their own rows.
+ *
+ * A delimiter row that already has its own line is finished markdown, and every
+ * one of these rules would take it apart — so it is left alone.
+ */
+function repairCompactLine(line: string): string {
+  if (TABLE_DELIMITER_ROW_PATTERN.test(line)) return line;
+
+  return line
+    .replace(/[ \t]+---[ \t]+/g, "\n\n")
+    .replace(/\|\s+\|/g, "|\n|")
+    .replace(/\|\s+(?=\|?\s*:?-{3,})/g, "|\n")
+    .replace(/(\|\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|)\s+/g, "$1\n");
+}
+
 function normalizeAssistantMarkdown(content: string): string {
   const trimmed = content.trim();
   const isCompactMarkdown = trimmed.split(/\r?\n/).length <= 2 && /(?:[ \t]---[ \t]|[ \t]#{1,6}\s|\|\s+\|)/.test(trimmed);
   const normalized = trimmed
-    .replace(/[ \t]+---[ \t]+/g, "\n\n")
+    .split(/(\r?\n)/)
+    .map(repairCompactLine)
+    .join("")
     .replace(/([.!?)\]])[ \t]+(?=#{1,6}\s)/g, "$1\n\n")
-    .replace(/[ \t]+(?=#{1,6}\s)/g, "\n\n")
-    .replace(/\|\s+\|/g, "|\n|")
-    .replace(/\|\s+(?=\|?\s*:?-{3,})/g, "|\n")
-    .replace(/(\|\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|)\s+/g, "$1\n");
+    .replace(/[ \t]+(?=#{1,6}\s)/g, "\n\n");
 
   if (!isCompactMarkdown) return normalized;
 

--- a/lemma-typescript/src/__tests__/agent-display.test.ts
+++ b/lemma-typescript/src/__tests__/agent-display.test.ts
@@ -429,4 +429,23 @@ describe("normalizeAssistantMarkdown", () => {
   it("breaks a compact inline heading onto its own block", () => {
     expect(normalizeAssistantMarkdown("Done. ## Next steps")).toContain("\n\n");
   });
+
+  it("still turns a compact --- separator into a paragraph break", () => {
+    expect(normalizeAssistantMarkdown("Imported the pod. --- Then it ran.")).toBe("Imported the pod.\n\nThen it ran.");
+  });
+
+  it("leaves a spaced table delimiter row intact", () => {
+    const table = "## Next steps\n\n| Field | Type |\n| --- | --- |\n| id | int |";
+    expect(normalizeAssistantMarkdown(table)).toBe(table);
+  });
+
+  it("leaves an unspaced table delimiter row intact", () => {
+    const table = "## Next steps\n\n| Field | Type |\n|---|---|\n| id | int |";
+    expect(normalizeAssistantMarkdown(table)).toBe(table);
+  });
+
+  it("keeps aligned delimiter rows intact", () => {
+    const table = "| Field | Type |\n| :--- | ---: |\n| id | int |";
+    expect(normalizeAssistantMarkdown(table)).toBe(table);
+  });
 });

--- a/lemma-typescript/src/core/agent/display.ts
+++ b/lemma-typescript/src/core/agent/display.ts
@@ -1133,17 +1133,39 @@ export {
 
 // --- markdown ---------------------------------------------------------------
 
+/** A GFM delimiter row on a line of its own — `| --- | :---: |`, `|---|---|`. */
+const TABLE_DELIMITER_ROW_PATTERN = /^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)*\|?\s*$/;
+
+/**
+ * Unpack one squashed line: a ` --- ` separator into a paragraph break, and
+ * cells that were run together back onto their own rows.
+ *
+ * Line by line, because a delimiter row that already has its own line is
+ * finished markdown and every one of these rules would take it apart — the
+ * separator rule reads its ` --- ` cells as separators, and the two `|`-and-
+ * whitespace rules break it at each cell. Only the compact form, where a whole
+ * table arrives on one line, still needs them.
+ */
+function repairCompactLine(line: string): string {
+  if (TABLE_DELIMITER_ROW_PATTERN.test(line)) return line;
+
+  return line
+    .replace(/[ \t]+---[ \t]+/g, "\n\n")
+    .replace(/\|\s+\|/g, "|\n|")
+    .replace(/\|\s+(?=\|?\s*:?-{3,})/g, "|\n")
+    .replace(/(\|\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|)\s+/g, "$1\n");
+}
+
 /** Normalize compact/streamed assistant markdown for display (fixes table
  * alignment, heading spacing). Pure string transform. */
 export function normalizeAssistantMarkdown(content: string): string {
   const trimmed = content.trim();
   const isCompactMarkdown = trimmed.split(/\r?\n/).length <= 2 && /(?:[ \t]---[ \t]|[ \t]#{1,6}\s|\|\s+\|)/.test(trimmed);
   const normalized = trimmed
-    .replace(/[ \t]+---[ \t]+/g, "\n\n")
-    .replace(/([.!?)\]])[ \t]+(?=#{1,6}\s)/g, "$1\n\n")
-    .replace(/\|\s+\|/g, "|\n|")
-    .replace(/\|\s+(?=\|?\s*:?-{3,})/g, "|\n")
-    .replace(/(\|\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|)\s+/g, "$1\n");
+    .split(/(\r?\n)/)
+    .map(repairCompactLine)
+    .join("")
+    .replace(/([.!?)\]])[ \t]+(?=#{1,6}\s)/g, "$1\n\n");
 
   if (!isCompactMarkdown) return normalized;
 


### PR DESCRIPTION
Two display fixes that both come down to content the layout was never told how to handle.

## The agent page stretched past its column

`.resource-page-column` is a grid whose implicit track was `auto`, and an auto track is floored by its items' min-content. One unbreakable string in the instructions — a path, a URL, a wide table — pushed the track past the column's `max-width: 52rem`. Both cards share that one track, so the identity and wiring card was stretched too, which is why **Manage**, **Edit**, **+ Add trigger** and the header chips ended up off the right edge even though nothing in those rows is wide. The whole pane scrolled sideways.

- `lemma-frontend/styles/features/agent-page.css` — the column is now the width authority: `grid-template-columns: minmax(0, 1fr)` plus `min-width: 0` on `.resource-card`. This also covers the flows, assistant, function-editor and agent-builder pages, which use the same column.
- `lemma-frontend/styles/primitives.css` — `overflow-wrap: anywhere` on `.tiptap-editor`, so agent-written paths and URLs break instead of sizing the card; and `.tableWrapper` (ProseMirror renders it but ships no CSS for it) scrolls its own table.

Measured in a browser against a harness route using the real components at a 900px pane, with one 220-character token in the instructions:

| | column | card | pane scrollWidth |
|---|---|---|---|
| before | 832 | **1562** | 1607 (pane is 898) |
| after | 832 | 808 | 898 |

A wide table now scrolls inside its wrapper (774px visible, 1400px scrollWidth) rather than pushing the card out.

## Spaced markdown tables came out as raw pipe text

`normalizeAssistantMarkdown` repairs assistant markdown that arrived squashed onto one line. Three of those rules take apart a delimiter row that is already finished markdown: ` --- ` cells read as a compact separator, and the two `|`-and-whitespace rules break the row at every cell. So an ordinary table lost its delimiter row and react-markdown rendered the whole thing as pipes. The unspaced `|---|---|` form happened to survive, which is why only some tables broke.

The repairs now run line by line and leave a delimiter row alone; a table squashed onto a single line is still unpacked as before. The registry component carries its own duplicate of this function and had the same bug, so it got the same fix.

## Reviewer notes

- `overflow-wrap: anywhere` on `.tiptap-editor` is global to every TipTap surface, not just the agent page — deliberate, since the same class of content shows up in documents and surfaces.
- The registry change is outside the reported scope; it is the same function with the same defect, and it ships to anyone installing that component.
- Tests: 4 added to the `normalizeAssistantMarkdown` block (spaced, unspaced, aligned `:---`/`---:`, and the existing compact-separator behaviour). Full SDK suite passes (154 tests), `tsc --noEmit` clean, and the frontend design audit passes unchanged against its baseline (`productStrict=0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)