### PR TITLE
Normalize every component to 0.7.0 for the 0.7 release

### DIFF
--- a/agent-host/Cargo.lock
+++ b/agent-host/Cargo.lock
@@ -1218,7 +1218,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lemma-agent-host"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/agent-host/Cargo.toml
+++ b/agent-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lemma-agent-host"
-version = "0.1.0"
+version = "0.7.0"
 description = "Durable local bridge between Lemma and ACP-compatible coding agents"
 edition = "2024"
 rust-version = "1.88"

--- a/agentbox-client/pyproject.toml
+++ b/agentbox-client/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentbox-client"
-version = "0.1.0"
+version = "0.7.0"
 description = "Typed async Python client for the AgentBox sandbox fabric"
 requires-python = ">=3.14,<3.15"
 dependencies = [

--- a/agentbox-client/uv.lock
+++ b/agentbox-client/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "agentbox-client"
-version = "0.1.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/agentbox/pyproject.toml
+++ b/agentbox/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agentbox"
-version = "0.1.0"
+version = "0.7.0"
 description = "Provider-neutral sandbox fabric for Lemma workspaces and functions"
 requires-python = ">=3.14,<3.15"
 dependencies = [

--- a/agentbox/templates/function-python/uv.lock
+++ b/agentbox/templates/function-python/uv.lock
@@ -168,7 +168,7 @@ wheels = [
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.3"
+version = "0.7.0"
 source = { directory = "../../../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/agentbox/templates/workspace-python/uv.lock
+++ b/agentbox/templates/workspace-python/uv.lock
@@ -683,12 +683,12 @@ wheels = [
 
 [[package]]
 name = "lemma-pod-bundle"
-version = "0.1.0"
+version = "0.7.0"
 source = { directory = "../../../lemma-pod-bundle" }
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.3"
+version = "0.7.0"
 source = { directory = "../../../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/agentbox/uv.lock
+++ b/agentbox/uv.lock
@@ -4,7 +4,7 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "agentbox"
-version = "0.1.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -70,7 +70,7 @@ dev = [
 
 [[package]]
 name = "agentbox-client"
-version = "0.1.0"
+version = "0.7.0"
 source = { editable = "../agentbox-client" }
 dependencies = [
     { name = "httpx" },
@@ -594,7 +594,7 @@ wheels = [
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.3"
+version = "0.7.0"
 source = { editable = "../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2006,7 +2006,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lemma-desktop"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "interprocess",
  "libc",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lemma-desktop"
-version = "0.6.2"
+version = "0.7.0"
 description = "Lemma desktop shell"
 edition = "2021"
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -130,7 +130,7 @@ anything you intend to run.
 
 Run the **Release Local Images** workflow on the PR branch with:
 
-- `version`: the Desktop version, currently `0.6.2`;
+- `version`: the Desktop version, currently `0.7.0`;
 - `publish`: `false`.
 
 The workflow builds and verifies both runtimes, creates a resource-backed

--- a/desktop/runtime/lemma-local.json
+++ b/desktop/runtime/lemma-local.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "0.6.2",
+  "version": "0.7.0",
   "released_at": "2026-07-29T11:15:00Z",
   "min_admin_version": "0.1.0",
   "images": {
@@ -30,7 +30,7 @@
       "format": "zip",
       "platform": "macos",
       "architecture": "aarch64",
-      "runtime_version": "0.6.2",
+      "runtime_version": "0.7.0",
       "resource": "host-runtime.zip"
     }
   },
@@ -43,7 +43,7 @@
       "format": "zip",
       "platform": "linux",
       "architecture": "aarch64",
-      "runtime_version": "0.6.2",
+      "runtime_version": "0.7.0",
       "resource": "guest-runtime.zip"
     }
   }

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Lemma",
-  "version": "0.6.2",
+  "version": "0.7.0",
   "identifier": "work.lemma.desktop",
   "build": {
     "frontendDist": "ui"

--- a/lemma-backend/app/version.py
+++ b/lemma-backend/app/version.py
@@ -21,4 +21,4 @@ Use a normal MAJOR.MINOR.PATCH string.
 
 from __future__ import annotations
 
-API_VERSION = "0.7.3"
+API_VERSION = "0.7.0"

--- a/lemma-backend/lemma-connectors/pyproject.toml
+++ b/lemma-backend/lemma-connectors/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-connectors"
-version = "0.1.0"
+version = "0.7.0"
 description = "OpenAPI-native native connector packages for Lemma"
 readme = "README.md"
 requires-python = ">=3.14,<3.15"

--- a/lemma-backend/lemma-connectors/uv.lock
+++ b/lemma-backend/lemma-connectors/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "lemma-connectors"
-version = "0.1.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },

--- a/lemma-backend/pyproject.toml
+++ b/lemma-backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-backend"
-version = "0.1.0"
+version = "0.7.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.14,<3.15"

--- a/lemma-backend/uv.lock
+++ b/lemma-backend/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 
 [[package]]
 name = "agentbox"
-version = "0.1.0"
+version = "0.7.0"
 source = { editable = "../agentbox" }
 dependencies = [
     { name = "aiosqlite" },
@@ -61,7 +61,7 @@ dev = [
 
 [[package]]
 name = "agentbox-client"
-version = "0.1.0"
+version = "0.7.0"
 source = { editable = "../agentbox-client" }
 dependencies = [
     { name = "httpx" },
@@ -1739,7 +1739,7 @@ wheels = [
 
 [[package]]
 name = "lemma-backend"
-version = "0.1.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "agentbox-client" },
@@ -1903,7 +1903,7 @@ dev = [
 
 [[package]]
 name = "lemma-connectors"
-version = "0.1.0"
+version = "0.7.0"
 source = { editable = "lemma-connectors" }
 dependencies = [
     { name = "attrs" },
@@ -1930,7 +1930,7 @@ dev = [
 
 [[package]]
 name = "lemma-pod-bundle"
-version = "0.1.0"
+version = "0.7.0"
 source = { editable = "../lemma-pod-bundle" }
 
 [[package]]

--- a/lemma-cli/lemma_cli/__init__.py
+++ b/lemma-cli/lemma_cli/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 __all__ = ["__version__"]
 
-__version__ = "0.7.2"
+__version__ = "0.7.0"
 
 if sys.platform == "win32":
     for _stream in (sys.stdout, sys.stderr):

--- a/lemma-cli/pyproject.toml
+++ b/lemma-cli/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   # >= the version that has the endpoints the current commands use, so a fresh
   # `uv tool install` upgrades an already-installed older lemma-sdk. The release
   # workflow rewrites this to the release version on every tagged build.
-  "lemma-sdk>=0.7.2",
+  "lemma-sdk>=0.7.0",
   # Shared pod bundle format vocabulary (layout/jsonc/diff/portability/
   # normalize/archive), extracted so the backend can consume the same format.
   "lemma-pod-bundle>=0.1.0",

--- a/lemma-cli/uv.lock
+++ b/lemma-cli/uv.lock
@@ -314,12 +314,12 @@ wheels = [
 
 [[package]]
 name = "lemma-pod-bundle"
-version = "0.1.0"
+version = "0.7.0"
 source = { directory = "../lemma-pod-bundle" }
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.3"
+version = "0.7.0"
 source = { directory = "../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/lemma-frontend/package.json
+++ b/lemma-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemma-frontend",
-  "version": "0.1.0",
+  "version": "0.7.0",
   "private": true,
   "scripts": {
     "prepare:lemma-sdk": "npm --prefix ../lemma-typescript run build",

--- a/lemma-pod-bundle/pyproject.toml
+++ b/lemma-pod-bundle/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-pod-bundle"
-version = "0.1.0"
+version = "0.7.0"
 description = "Shared pod bundle format vocabulary for the Lemma CLI and backend"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/lemma-pod-bundle/uv.lock
+++ b/lemma-pod-bundle/uv.lock
@@ -4,5 +4,5 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "lemma-pod-bundle"
-version = "0.1.0"
+version = "0.7.0"
 source = { editable = "." }

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -12,5 +12,5 @@ SDK and the server it is talking to.
 
 from __future__ import annotations
 
-API_VERSION = "0.7.3"
-SPEC_SHA256 = "63b48832ad71b54c62ef3ff544213fb3822d61c67e6aac952a364be5eadc4422"
+API_VERSION = "0.7.0"
+SPEC_SHA256 = "ec00f4d7bdd0a1d1ef5bdea4ba2b6ed09476ce363490bc1bb0deb06504f3ac76"

--- a/lemma-python/lemma_sdk/openapi_spec.json
+++ b/lemma-python/lemma_sdk/openapi_spec.json
@@ -16372,7 +16372,7 @@
   "info": {
     "description": "Authentication API with JWT, user management, and OAuth support",
     "title": "Lemma Backend",
-    "version": "0.7.3"
+    "version": "0.7.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/lemma-python/pyproject.toml
+++ b/lemma-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-sdk"
-version = "0.7.3"
+version = "0.7.0"
 description = "Python SDK for Lemma"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/lemma-python/uv.lock
+++ b/lemma-python/uv.lock
@@ -130,7 +130,7 @@ wheels = [
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.3"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },

--- a/lemma-stack/pyproject.toml
+++ b/lemma-stack/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-stack"
-version = "0.1.0"
+version = "0.7.0"
 description = "Installer and management tool for a fully-local Lemma stack"
 readme = "README.md"
 requires-python = ">=3.14,<3.15"

--- a/lemma-stack/uv.lock
+++ b/lemma-stack/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "lemma-stack"
-version = "0.1.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },

--- a/lemma-typescript/package.json
+++ b/lemma-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemma-sdk",
-  "version": "0.7.3",
+  "version": "0.7.0",
   "description": "Official TypeScript SDK for Lemma APIs, optimized around pod-scoped workflows",
   "license": "Apache-2.0",
   "author": "Lemma",

--- a/lemma-typescript/public/lemma-client.js
+++ b/lemma-typescript/public/lemma-client.js
@@ -9835,7 +9835,7 @@ var LemmaClient = (() => {
   }
 
   // src/version.ts
-  var SDK_VERSION = "0.7.3";
+  var SDK_VERSION = "0.7.0";
   var CLIENT_HEADER_NAME = "X-Lemma-Client";
   var CLIENT_HEADER_VALUE = `lemma-sdk-ts/${SDK_VERSION}`;
   function shouldSendClientHeader(apiUrl, method) {
@@ -10243,7 +10243,7 @@ var LemmaClient = (() => {
   // src/openapi_client/core/OpenAPI.ts
   var OpenAPI = {
     BASE: "",
-    VERSION: "0.7.3",
+    VERSION: "0.7.0",
     WITH_CREDENTIALS: false,
     CREDENTIALS: "include",
     TOKEN: void 0,

--- a/lemma-typescript/src/openapi_client/core/OpenAPI.ts
+++ b/lemma-typescript/src/openapi_client/core/OpenAPI.ts
@@ -21,7 +21,7 @@ export type OpenAPIConfig = {
 
 export const OpenAPI: OpenAPIConfig = {
     BASE: '',
-    VERSION: '0.7.3',
+    VERSION: '0.7.0',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',
     TOKEN: undefined,

--- a/lemma-typescript/src/version.ts
+++ b/lemma-typescript/src/version.ts
@@ -1,6 +1,6 @@
 // Keep SDK_VERSION in sync with package.json "version". The CI codegen/drift
 // gate (workstream A) asserts they match so this can't silently drift.
-export const SDK_VERSION = "0.7.3";
+export const SDK_VERSION = "0.7.0";
 
 /** Sent as `X-Lemma-Client` when it will not add an otherwise avoidable browser
  *  preflight, so the backend can log which client + version hit an endpoint. */

--- a/local-runtime/guestd/Cargo.lock
+++ b/local-runtime/guestd/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lemma-guestd"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "libc",
  "serde",

--- a/local-runtime/guestd/Cargo.toml
+++ b/local-runtime/guestd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lemma-guestd"
-version = "0.1.0"
+version = "0.7.0"
 description = "Private guest control service for Lemma's managed local runtime"
 edition = "2021"
 license = "AGPL-3.0-or-later"

--- a/local-runtime/hostctl/Cargo.lock
+++ b/local-runtime/hostctl/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lemma-runtime"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "serde_json",
  "tempfile",

--- a/local-runtime/hostctl/Cargo.toml
+++ b/local-runtime/hostctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lemma-runtime"
-version = "0.1.0"
+version = "0.7.0"
 description = "Host bridge for Lemma's app-owned Linux runtime"
 edition = "2021"
 license = "AGPL-3.0-or-later"

--- a/local-runtime/manager/Cargo.lock
+++ b/local-runtime/manager/Cargo.lock
@@ -61,7 +61,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lemma-runtime-manager"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "getrandom 0.3.4",
  "libc",

--- a/local-runtime/manager/Cargo.toml
+++ b/local-runtime/manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lemma-runtime-manager"
-version = "0.1.0"
+version = "0.7.0"
 description = "Host lifecycle manager for Lemma's private macOS VZ and Windows WSL runtimes"
 edition = "2021"
 license = "AGPL-3.0-or-later"

--- a/locald/Cargo.lock
+++ b/locald/Cargo.lock
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-locald"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "getrandom 0.3.4",
@@ -974,7 +974,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-runtime-manager"
-version = "0.1.0"
+version = "0.7.0"
 dependencies = [
  "getrandom 0.3.4",
  "libc",

--- a/locald/Cargo.toml
+++ b/locald/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lemma-locald"
-version = "0.1.0"
+version = "0.7.0"
 description = "Durable local control plane for Lemma Desktop and lemma-stack"
 edition = "2021"
 license = "AGPL-3.0-or-later"

--- a/locald/src/host_process.rs
+++ b/locald/src/host_process.rs
@@ -1281,21 +1281,38 @@ fn reclaim_verified_processes(
     )
 }
 
+/// How long `process_identity` waits for a freshly forked process to finish
+/// `exec` before giving up on naming its executable.
 #[cfg(unix)]
-pub(crate) fn process_identity(pid: u32) -> io::Result<ProcessIdentity> {
-    let pid = pid.to_string();
+const IDENTITY_SETTLE_ATTEMPTS: u32 = 20;
+#[cfg(unix)]
+const IDENTITY_SETTLE_INTERVAL: Duration = Duration::from_millis(25);
+
+/// One `ps` query. `Ok(None)` means the process exists but has not yet reported
+/// a usable executable name, so the caller should look again.
+#[cfg(unix)]
+fn query_process_identity(pid: &str) -> io::Result<Option<ProcessIdentity>> {
     let executable = Command::new("/bin/ps")
-        .args(["-p", &pid, "-o", "comm="])
+        .args(["-p", pid, "-o", "comm="])
         .output()?;
     let started = Command::new("/bin/ps")
-        .args(["-p", &pid, "-o", "lstart="])
+        .args(["-p", pid, "-o", "lstart="])
         .output()?;
     if !executable.status.success() || !started.status.success() {
         return Err(io::Error::new(io::ErrorKind::NotFound, "process not found"));
     }
     let executable = String::from_utf8(executable.stdout)
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
-    let executable = Path::new(executable.trim())
+    let executable = executable.trim();
+    // `ps` brackets the name as `(sh)` while a process has forked but not yet
+    // finished `exec`, and while it is exiting. That placeholder is not a path,
+    // so canonicalizing it fails with ENOENT — which used to make a child that
+    // was merely still starting look unidentifiable, and cost it the ownership
+    // record it had just been spawned to receive.
+    if executable.starts_with('(') && executable.ends_with(')') {
+        return Ok(None);
+    }
+    let executable = Path::new(executable)
         .canonicalize()?
         .to_string_lossy()
         .into_owned();
@@ -1306,10 +1323,27 @@ pub(crate) fn process_identity(pid: u32) -> io::Result<ProcessIdentity> {
     if start_identity.is_empty() {
         return Err(io::Error::other("process start identity was empty"));
     }
-    Ok(ProcessIdentity {
+    Ok(Some(ProcessIdentity {
         executable,
         start_identity,
-    })
+    }))
+}
+
+#[cfg(unix)]
+pub(crate) fn process_identity(pid: u32) -> io::Result<ProcessIdentity> {
+    let pid = pid.to_string();
+    for attempt in 0..IDENTITY_SETTLE_ATTEMPTS {
+        if let Some(identity) = query_process_identity(&pid)? {
+            return Ok(identity);
+        }
+        if attempt + 1 < IDENTITY_SETTLE_ATTEMPTS {
+            thread::sleep(IDENTITY_SETTLE_INTERVAL);
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::NotFound,
+        "process never reported an executable path",
+    ))
 }
 
 #[cfg(unix)]
@@ -1913,8 +1947,25 @@ mod tests {
         let body = body.to_owned();
         let server = thread::spawn(move || {
             let (mut stream, _) = listener.accept().unwrap();
-            let mut request = [0_u8; 1024];
-            let _ = stream.read(&mut request);
+            // Consume the whole request head before answering. A single read can
+            // return before the client has finished writing, and a discarded read
+            // error hides that entirely. Responding and then dropping the socket
+            // while request bytes are still unread makes the kernel close with RST
+            // instead of FIN, so the client's in-flight write fails with EPIPE
+            // rather than reading the healthy response.
+            stream
+                .set_read_timeout(Some(Duration::from_secs(10)))
+                .unwrap();
+            let mut request = Vec::new();
+            let mut byte = [0_u8; 1];
+            while !request.ends_with(b"\r\n\r\n") {
+                match stream.read(&mut byte) {
+                    Ok(0) => break,
+                    Ok(_) => request.extend_from_slice(&byte),
+                    Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                    Err(_) => break,
+                }
+            }
             write!(
                 stream,
                 "HTTP/1.1 {status} Test\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
@@ -1923,6 +1974,11 @@ mod tests {
             .unwrap();
             stream.flush().unwrap();
             stream.shutdown(std::net::Shutdown::Write).unwrap();
+            // Hold the socket open until the client has read the response and
+            // closed its end, so the drop below is a graceful FIN rather than an
+            // RST that could discard buffered response bytes mid-read.
+            let mut drained = Vec::new();
+            let _ = stream.read_to_end(&mut drained);
         });
         (
             HttpHealthSpec {


### PR DESCRIPTION
Unify the platform on a single `0.7.0` version ahead of the 0.7 release. 42 files, 55 lines, all pure version changes — no dependency resolution drift.

## Versions

| Component | Before | After |
|---|---|---|
| API + both SDKs (backend `API_VERSION`, `lemma-python`, `lemma-typescript`) | `0.7.3` | `0.7.0` |
| CLI (`lemma-terminal`) | `0.7.2` | `0.7.0` |
| Desktop | `0.6.2` | `0.7.0` |
| `lemma-backend`, `lemma-connectors`, `lemma-pod-bundle`, `lemma-stack`, `agentbox`, `agentbox-client`, `lemma-frontend`, and crates `agent-host`, `locald`, `local-runtime/{guestd,hostctl,manager}` | `0.1.0` | `0.7.0` |

## API compatibility

No schema change. The regenerated spec is byte-identical to the committed one except `info.version`, verified by comparing the full document modulo `info`. `docs/versioning.md` requires the API and both SDK packages to share a major/minor line; all three are on `0.7`.

**Moving `0.7.3` down to `0.7.0` is safe because nothing on the 0.7 line was ever published** — PyPI and npm are both still at `0.6.2`, so `0.7.0` is unclaimed. Had `0.7.3` been released this would not have been possible.

## Generated artifacts were regenerated, not hand-edited

`lemma_sdk/_spec_info.py` carries a `SPEC_SHA256` fingerprint of `openapi_spec.json`, so hand-editing the spec would have silently invalidated it. The spec and both clients come from `dump_openapi_spec.py` + `generate_openapi_client.sh`. The committed browser bundle `lemma-typescript/public/lemma-client.js` had `0.7.3` baked in and is rebuilt via `npm run build:bundle` — CI gates on it being current.

## Operator note — Desktop release

`desktop/runtime/lemma-local.json` bumps `version` and both `runtime_version` fields together, because `artifact_install.rs:391` rejects a manifest where they disagree. **Its pinned image digests and runtime hashes still describe the `0.6.2`-era `test-` build.** The manifest is inert today (`url: null`, so it refuses to install and says so), but the **Release Local Images** workflow must regenerate it before an actual 0.7.0 Desktop release, or it will describe a runtime that does not exist.

## Dependency floors

`lemma-sdk>=0.7.2` in `lemma-cli` becomes `>=0.7.0` — left at `0.7.2` it would have excluded the very SDK it ships against. `lemma-pod-bundle>=0.1.0` is untouched; still satisfiable at `0.7.0`.

## Left alone deliberately

- `agentbox/templates/*` (`1.0.0`) and the CLI `app_vite_template` (`0.0.0`) version *user-generated* projects, not the platform.
- `min_admin_version: 0.1.0` in the desktop manifest is a compatibility floor, not an identity; raising it would change behavior.
- `.github/workflows/release-agent-host.yml:37` — the string "for example 0.6.2" is illustrative help text on a `workflow_dispatch` input.

## Tests run

```bash
cd lemma-backend && uv run pytest app/tests/unit/test_version_policy.py -q
cd lemma-backend && uv run python scripts/dump_openapi_spec.py --check
cd lemma-stack   && uv run pytest tests/test_install_experience.py -q -k version
cd lemma-typescript && npx tsc -p tsconfig.json --noEmit
```

All pass. Also verified: `cargo metadata --locked --offline` on all 6 crates, `uv lock --check` on all 10 lockfiles (every lock diff is version-only), and a codegen-drift simulation — re-running both generators against the committed spec produces zero further changes, so the CI gate is green.

## Security

None. Version strings only; no code paths, dependencies, or resolved dependency versions change.

## Rollback

Revert the commit. Nothing is published to PyPI, npm, or GHCR by this PR, so there is no external state to unwind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Second commit: two pre-existing `locald` flakes

The `locald crate` job went red on this branch. **Neither cause is related to the version bump — both reproduce on `main`** (2 failures in 8 full-suite runs), and the original failure passed on a plain rerun. Fixed in a separate commit so it can be split out of the release PR if preferred.

**1. EPIPE in `health_requires_two_xx_and_the_expected_runtime_identity`** (this is what failed CI). The fake test server took a single `read` and discarded its result, so a read returning before the client finished writing was invisible. It then answered and dropped the socket with request bytes still unread, which makes the kernel close with **RST instead of FIN**, so the client's in-flight write failed with `BrokenPipe`. Now it consumes the whole request head before answering and holds the socket open until the client closes. Test-only.

**2. ENOENT in `process_identity` — a production bug, not just a test issue.** It fed `ps -o comm=` straight into `canonicalize()`. macOS brackets that name as `(sh)` while a process has forked but not yet finished `exec`, so `canonicalize` failed with `ENOENT`. `record_child` and the sharing tunnel both call `process_identity` immediately after spawning, so on a loaded machine this made them **terminate the child they had just spawned** with `could not record ownership of backend`. The bracketed placeholder is now treated as "still starting" and polled for briefly (20 × 25 ms).

Verified: 2 failures in 8 full-suite runs before, **0 of these in 25 runs after**.

## Known remaining flake — not fixed here

`managed_runtime::tests::tcp_forwarder_relays_bytes_and_releases_its_port` fails ~2/25 on `main` and is untouched by this PR. `TcpForwarder::drop` joins its accept thread but detaches the per-connection relay threads, so an in-flight connection can still hold the port when `drop` returns and the immediate rebind hits `EADDRINUSE`. Note the port-reclaim guarantee is load-bearing in production — the `Drop` comment exists specifically so a restart can reclaim the exact callback port. Fixing it means tracking live connections and forcing them shut, which risks hanging shutdown if done naively, so it deserves its own change.
