### PR TITLE
Seven Lemma-native pod skills, and a namespace rule that ships them

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ A pod can be exported as plain files, so building one is a job a coding agent is
 
 ```bash
 lemma skills install             # auto-detects Claude Code / Codex / OpenCode / Cursor
-lemma skills install --target claude --all-skills   # or pick a target and include extras
+lemma skills install --target claude --all-skills   # or pick a target and include runtime helpers
 lemma skills install --target agents --scope project # Antigravity, from inside the pod directory
 ```
 

--- a/lemma-backend/app/modules/agent/prompts/skills.md
+++ b/lemma-backend/app/modules/agent/prompts/skills.md
@@ -5,4 +5,13 @@ Do not load a skill for ordinary CLI usage, pod file upload/download/search, or 
 Load a skill only for specialized work beyond the above:
 - `lemma-builder` — designing, creating, importing/exporting, or editing a pod and its resources (tables, files, functions, agents, workflows, schedules, surfaces, apps, connectors).
 - `lemma-user` — broader day-to-day pod operation when the built-in commands above are not enough.
-- Other named skills — browser automation, widgets, media generation, app-specific guidance, and similar capabilities.
+- `lemma-widget` — compact inline conversational views; use a pod app for routing or substantial state.
+- `lemma-app-design` — UX, interaction, visual direction, responsive states, accessibility, and design critique for a pod app; pair with `lemma-builder` for implementation.
+- `lemma-app-qa` — systematic browser journeys, evidence, defects, and release judgment for a pod app; pair with `browser` for control mechanics.
+- `lemma-research` — durable multi-source investigations with source, evidence, claim, freshness, and citation discipline.
+- `lemma-data-analysis` — schema-first quantitative analysis, data quality, KPIs, diagnostics, charts, and reproducible outputs.
+- `lemma-artifact-author` — create, revise, render, verify, and deliver durable documents, spreadsheets, presentations, PDFs, or HTML.
+- `lemma-evals` — repeatable evaluation of agents, functions, and workflows using cases, baselines, rubrics, and regression gates.
+- `lemma-skill-creator` — create or revise pod-owned skills under `/skills`; never use it to mutate bundled system skills.
+- `browser` — real browser control, screenshots, console/network inspection, forms, scraping, and app interaction.
+- `liteparse-documents` — parse or screenshot local documents outside the pod, or fall back when pod conversion is insufficient.

--- a/lemma-cli/.gitignore
+++ b/lemma-cli/.gitignore
@@ -37,8 +37,8 @@ coverage.xml
 htmlcov/
 
 # Vendored agent skills. The canonical source is the repo-root lemma-skills/;
-# scripts/sync_cli_skills.py mirrors it here at build time (grafted into the
-# sdist via MANIFEST.in). NOT tracked — regenerated from source on every build.
+# setup.py mirrors it here during builds (grafted into the sdist via
+# MANIFEST.in). NOT tracked — regenerated from source on every build.
 lemma_cli/skills/
 
 # Local Node usage (e.g. while testing the scaffolded app template).

--- a/lemma-cli/MANIFEST.in
+++ b/lemma-cli/MANIFEST.in
@@ -1,5 +1,4 @@
-# The vendored skills are synced into lemma_cli/skills/ at build time by
-# scripts/sync_cli_skills.py and are gitignored, so graft them explicitly to
-# guarantee they land in the sdist (and therefore the wheel built from it).
+# The setup.py build hooks vendor skills into the gitignored lemma_cli/skills/
+# directory, so graft them explicitly into the sdist and the wheel built from it.
 graft lemma_cli/skills
 include LICENSE

--- a/lemma-cli/README.md
+++ b/lemma-cli/README.md
@@ -60,13 +60,15 @@ operate pods. `lemma skills` installs them into the coding agent you already use
 lemma skills list                       # what's bundled
 lemma skills install                    # auto-detect Claude Code / Codex / OpenCode / Cursor and install
 lemma skills install --target claude    # or pick one explicitly
-lemma skills install --all-skills       # include browser + liteparse-documents too
+lemma skills install --all-skills       # include workspace-runtime helpers too
 ```
 
 `install` is an **upsert** — the CLI owns these skills, so an existing copy is overwritten to match
 what this `lemma-terminal` bundles (re-run it after upgrading to refresh them; identical copies report
-`unchanged`). By default it installs the curated set — `lemma-builder`, `lemma-user`, `lemma-widget` —
-at the user level so it's available across all your projects. Targets and their locations:
+`unchanged`). By default it installs every namespaced `lemma-*` product skill: pod building and
+operation, widgets, app design and QA, research, data analysis, artifact authoring, evaluations, and
+pod-skill creation. `--all-skills` additionally installs the environment-specific `browser` and
+`liteparse-documents` helpers. Targets and their locations:
 
 | Target | Location (`--scope user`) | Tool |
 |---|---|---|

--- a/lemma-cli/RELEASING.md
+++ b/lemma-cli/RELEASING.md
@@ -69,12 +69,12 @@ From the **repo root**:
 # 1. Bump the version
 $EDITOR lemma-cli/lemma_cli/__init__.py        # __version__ = "X.Y.Z"
 
-# 2. Build (vendors skills automatically via setup.py; make cli-build also
-#    runs the sync first as belt-and-suspenders)
-make cli-build                                 # == python scripts/sync_cli_skills.py + (cd lemma-cli && uv build)
+# 2. Build (setup.py vendors the canonical repo-root skills automatically)
+cd lemma-cli && uv build && cd ..
 
-# 3. VERIFY the skills are in the wheel — must print 5
-unzip -l lemma-cli/dist/lemma_terminal-*.whl | grep -c SKILL.md
+# 3. VERIFY both commands print the same count (currently 12)
+find lemma-skills -mindepth 2 -maxdepth 2 -name SKILL.md | wc -l
+unzip -l lemma-cli/dist/lemma_terminal-*.whl | grep -c 'SKILL.md$'
 
 # 4. Check metadata + long description
 uvx twine check lemma-cli/dist/*

--- a/lemma-cli/lemma_cli/cli_core/commands/skills.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/skills.py
@@ -177,7 +177,9 @@ def install_skills(
         None, "--dir", help="Install into an arbitrary directory instead of a known target."
     ),
     all_skills: bool = typer.Option(
-        False, "--all-skills", help="Include browser and liteparse-documents (workspace-runtime skills)."
+        False,
+        "--all-skills",
+        help="Install every bundled skill, including workspace-runtime helpers.",
     ),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show what would be written, write nothing."),
     yes: bool = typer.Option(
@@ -187,10 +189,9 @@ def install_skills(
     """Install (upsert) bundled skills into your coding agent.
 
     The CLI owns these skills, so an existing copy is overwritten to match what
-    this lemma-terminal bundles. With no SKILL names, installs the curated set
-    (lemma-builder, lemma-user, lemma-widget). With no --target/--dir,
-    auto-detects which of Claude Code, Codex, OpenCode, and Cursor are on your
-    PATH and installs to each.
+    this lemma-terminal bundles. With no SKILL names, installs the curated
+    Lemma-native set. With no --target/--dir, auto-detects which of Claude Code,
+    Codex, OpenCode, and Cursor are on your PATH and installs to each.
     """
     state = state_from_ctx(ctx)
     _validate_scope(scope)

--- a/lemma-cli/lemma_cli/cli_core/skills_bundle.py
+++ b/lemma-cli/lemma_cli/cli_core/skills_bundle.py
@@ -1,9 +1,9 @@
 """Locate and describe the agent skills bundled with the CLI.
 
 The published wheel ships a copy of the repo-root ``lemma-skills/`` under
-``lemma_cli/skills/`` (vendored at build time by ``scripts/sync_cli_skills.py``).
-At runtime we prefer that packaged copy; in a dev checkout where the sync has not
-run we fall back to the canonical repo source so ``lemma skills`` still works.
+``lemma_cli/skills/`` (vendored by the ``setup.py`` build hooks). At runtime we
+prefer that packaged copy; in a dev checkout where a build has not populated it
+we fall back to the canonical repo source so ``lemma skills`` still works.
 """
 from __future__ import annotations
 
@@ -12,10 +12,22 @@ from pathlib import Path
 
 import lemma_cli
 
-# The pod build/operate/widget skills that are useful inside a coding agent on a
-# dev machine. browser + liteparse-documents assume a Lemma workspace runtime, so
-# they install only when named explicitly (or with --all-skills).
-CURATED_SKILLS: tuple[str, ...] = ("lemma-builder", "lemma-user", "lemma-widget")
+# Lemma's namespaced product skills are portable across supported coding agents
+# and form the default install. Environment helpers without the ``lemma-``
+# namespace assume a provisioned workspace runtime, so they remain opt-in through
+# an explicit name or ``--all-skills``.
+CURATED_SKILLS: tuple[str, ...] = (
+    "lemma-app-design",
+    "lemma-app-qa",
+    "lemma-artifact-author",
+    "lemma-builder",
+    "lemma-data-analysis",
+    "lemma-evals",
+    "lemma-research",
+    "lemma-skill-creator",
+    "lemma-user",
+    "lemma-widget",
+)
 
 
 @dataclass(frozen=True)

--- a/lemma-cli/pyproject.toml
+++ b/lemma-cli/pyproject.toml
@@ -92,10 +92,9 @@ lemma_cli = [
     "cli_core/assets/app_vite_template/*",
     "cli_core/assets/app_vite_template/**/*",
     "cli_core/assets/app_vite_template/gitignore",
-    # Vendored agent skills (synced from repo-root lemma-skills/ by
-    # scripts/sync_cli_skills.py before build; grafted into the sdist via
-    # MANIFEST.in). Ship inside the wheel so `lemma skills install` works with
-    # no repo checkout present.
+    # Agent skills vendored from repo-root lemma-skills/ by the setup.py build
+    # hooks and grafted into the sdist via MANIFEST.in. Ship them inside the
+    # wheel so `lemma skills install` works with no repo checkout present.
     "skills/**",
     "skills/**/*",
 ]

--- a/lemma-cli/setup.py
+++ b/lemma-cli/setup.py
@@ -51,8 +51,8 @@ def _vendor_skills() -> None:
         raise SystemExit(
             "Cannot build lemma-terminal: lemma-skills source not found at "
             f"{_SKILLS_SOURCE} and no vendored skills at {_SKILLS_DEST}. "
-            "Build from the monorepo (so ../lemma-skills exists) or run "
-            "scripts/sync_cli_skills.py first."
+            "Build from the monorepo so ../lemma-skills exists, or provide an "
+            "sdist that already contains the vendored skill directory."
         )
 
 

--- a/lemma-cli/tests/test_skills_bundle.py
+++ b/lemma-cli/tests/test_skills_bundle.py
@@ -7,6 +7,22 @@ import pytest
 from lemma_cli.cli_core import skills_bundle
 
 
+EXPECTED_SKILLS = {
+    "browser",
+    "lemma-app-design",
+    "lemma-app-qa",
+    "lemma-artifact-author",
+    "lemma-builder",
+    "lemma-data-analysis",
+    "lemma-evals",
+    "lemma-research",
+    "lemma-skill-creator",
+    "lemma-user",
+    "lemma-widget",
+    "liteparse-documents",
+}
+
+
 def _repo_skills_dir() -> Path | None:
     for parent in Path(__file__).resolve().parents:
         candidate = parent / "lemma-skills"
@@ -24,11 +40,18 @@ def test_bundled_skills_dir_resolves():
 def test_iter_bundled_skills_have_name_and_description():
     skills = skills_bundle.iter_bundled_skills()
     names = {skill.name for skill in skills}
-    assert {"lemma-builder", "lemma-user", "lemma-widget"} <= names
+    assert names == EXPECTED_SKILLS
     for skill in skills:
         assert skill.name
         assert skill.description
         assert skill.file_count >= 1
+        assert "TODO" not in skill.description
+
+
+def test_default_set_is_every_namespaced_lemma_skill():
+    assert set(skills_bundle.CURATED_SKILLS) == {
+        name for name in EXPECTED_SKILLS if name.startswith("lemma-")
+    }
 
 
 def test_curated_skills_are_bundled():

--- a/lemma-cli/tests/test_skills_command.py
+++ b/lemma-cli/tests/test_skills_command.py
@@ -13,6 +13,21 @@ from lemma_cli.cli_core.skills_bundle import CURATED_SKILLS
 
 runner = CliRunner()
 
+EXPECTED_SKILLS = {
+    "browser",
+    "lemma-app-design",
+    "lemma-app-qa",
+    "lemma-artifact-author",
+    "lemma-builder",
+    "lemma-data-analysis",
+    "lemma-evals",
+    "lemma-research",
+    "lemma-skill-creator",
+    "lemma-user",
+    "lemma-widget",
+    "liteparse-documents",
+}
+
 
 def _invoke(args: list[str], tmp_path: Path):
     # Point at a throwaway config so tests never touch the real ~/.lemma/config.
@@ -28,13 +43,7 @@ def test_skills_list_includes_all_bundled(tmp_path):
     result = _invoke(["--json", "skills", "list"], tmp_path)
     assert result.exit_code == 0, result.output
     names = {item["name"] for item in json.loads(result.output)["items"]}
-    assert {
-        "lemma-builder",
-        "lemma-user",
-        "lemma-widget",
-        "browser",
-        "liteparse-documents",
-    } <= names
+    assert names == EXPECTED_SKILLS
 
 
 def test_install_to_dir_copies_skill_tree(tmp_path):
@@ -45,18 +54,18 @@ def test_install_to_dir_copies_skill_tree(tmp_path):
     assert (dest / "lemma-builder" / "references").is_dir()
 
 
-def test_default_install_is_curated_trio(tmp_path):
+def test_default_install_is_curated_lemma_set(tmp_path):
     dest = tmp_path / "dest"
     result = _invoke(["skills", "install", "--dir", str(dest)], tmp_path)
     assert result.exit_code == 0, result.output
     assert _installed_dirs(dest) == set(CURATED_SKILLS)
 
 
-def test_all_skills_flag_includes_workspace_skills(tmp_path):
+def test_all_skills_flag_installs_complete_catalog(tmp_path):
     dest = tmp_path / "dest"
     result = _invoke(["skills", "install", "--dir", str(dest), "--all-skills"], tmp_path)
     assert result.exit_code == 0, result.output
-    assert {"browser", "liteparse-documents"} <= _installed_dirs(dest)
+    assert _installed_dirs(dest) == EXPECTED_SKILLS
 
 
 def test_reinstall_of_identical_is_unchanged(tmp_path):

--- a/lemma-skills/browser/SKILL.md
+++ b/lemma-skills/browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: browser
-description: "Use this skill when a task needs a real browser in a Lemma workspace: opening web pages or local dev apps, UI inspection and debugging, screenshots, login flows, form filling, scraping, console/network logs, or saving web pages — all via the Agent Browser CLI and headful Chromium."
+description: "Operate a real browser in a Lemma workspace for web pages or local/deployed apps: navigation, screenshots, login flows, forms, scraping, console/network inspection, and saved pages through Agent Browser. Use lemma-app-qa alongside it for systematic app journeys, defect evidence, or release judgment."
 ---
 
 # Browser
@@ -140,6 +140,8 @@ looks right without a browser. (App design, deploy, and test details:
 ## See also
 
 - Full core reference (snapshot/ref model, every command) → `references/agent-browser-core.md`
-- Build, deploy, and design a pod app → `lemma-builder/references/apps.md`
+- Build and deploy a pod app → `lemma-builder/references/apps.md`
+- Design its product experience → the `lemma-app-design` skill
+- Test it systematically and judge a release → the `lemma-app-qa` skill
 - Operate the pod (open apps, mint file URLs) → the `lemma-user` skill
 - Inline live views over pod data → the `lemma-widget` skill

--- a/lemma-skills/lemma-app-design/SKILL.md
+++ b/lemma-skills/lemma-app-design/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: lemma-app-design
+description: "Design, redesign, and visually refine Lemma pod apps into distinctive, production-quality interfaces grounded in the pod's real users, domain, data, files, agents, workflows, and assets. Use when defining information architecture or DESIGN.md, choosing interaction and visual direction, improving interface copy, specifying loading/empty/error/permission states, making an app responsive and accessible, critiquing screenshots, or polishing an existing HTML or Vite app. Pair with lemma-builder for LemmaClient, scaffolding, implementation, permissions, and deployment mechanics; use lemma-app-qa for exhaustive functional QA."
+---
+
+# Lemma App Design
+
+Own the product-design layer of a Lemma app. Turn the pod's operating loop into an
+interface people can understand, trust, and use repeatedly. Make the result
+specific to its subject; do not ship a generic dashboard wearing the pod's name.
+
+## Keep The Boundary Clear
+
+- Read [`lemma-builder/references/apps.md`](../lemma-builder/references/apps.md)
+  before changing an app. Treat it as authoritative for HTML versus Vite,
+  `LemmaClient`, SDK hooks, auth, RLS, realtime, scaffolding, components, bundles,
+  deployment, and technical testing.
+- Use this skill for experience strategy, information architecture, interaction,
+  visual direction, content, accessibility, responsiveness, and visual iteration.
+- Use `lemma-user` to inspect a live pod, `browser` to see the rendered result,
+  and `lemma-app-qa` for systematic functional and regression testing.
+- Use `lemma-widget` instead when the requested surface is a compact inline
+  conversation result rather than a durable app.
+- Preserve the user's requested mode. For a design discussion or audit, stop at
+  findings and a design specification. Implement only when the request includes
+  building or changing the app.
+
+## Follow The Design Loop
+
+### 1. Start From Pod Truth
+
+Inspect before proposing:
+
+- Read the app's existing `DESIGN.md`, source, and bundle definition.
+- Inspect the current rendered app and capture baseline screenshots when
+  redesigning it.
+- Inspect named tables and schemas, representative records, files and derived
+  previews, agents, workflows and wait states, members, connectors, and existing
+  domain or brand assets that the app may expose.
+- Identify the primary person, their recurring job, the decision they make, the
+  action they take, the cadence, and the cost of error or delay.
+
+Use real field names, values, documents, images, vocabulary, and edge cases in the
+design. If live content is unavailable, use schema-faithful representative content,
+label it as sample data, and avoid fabricated business claims. Never use lorem
+ipsum, arbitrary metrics, decorative charts, or controls with no real action.
+
+### 2. Map Every Surface To The Lemma Model
+
+Record the contract for each visible module and action:
+
+| UI element | Human purpose | Named pod resource | `LemmaClient`/hook surface | Read/write/live behavior | Access state |
+| --- | --- | --- | --- | --- | --- |
+
+Require every prominent number, status, list, preview, agent result, form, and
+button to have a truthful source or action. Respect delegated identity, RLS, and
+resource grants in the experience: distinguish a genuinely empty result from
+missing access, and never imply that a user's RLS-scoped rows are team-wide data.
+
+Choose HTML or Vite with `lemma-builder` based on application complexity, not
+appearance. Keep a one-page HTML app when it is sufficient; use Vite for genuine
+routing, reused components, or substantial client state. Do not switch stacks just
+to achieve polish. In either path, keep pod context portable through
+`LemmaClient`; never design around a hard-coded pod or API host.
+
+### 3. Define The Experience Thesis
+
+Write one sentence:
+
+> For **[person]**, this app turns **[input/work]** into **[decision/action]** by
+> **[specific mechanism]**.
+
+Then define:
+
+- **Hero moment:** name the one screenshottable moment where the pod does valuable
+  work, such as an agent recommendation beside its evidence and the next human
+  decision.
+- **First 30 seconds:** show active work, context, and a credible next action on
+  the default screen; do not open with a marketing introduction.
+- **Primary scenario:** trace one complete journey from arrival through a durable
+  outcome in the pod.
+- **Information spine:** choose the domain object or operating sequence that
+  organizes the app—case, document, account, run, decision, timeline, queue, or
+  another subject-specific unit.
+
+When the user names a reference product, inspect the real experience or supplied
+reference material. Extract useful interaction mechanics and hierarchy; do not
+copy its surface styling or answer from a vague recollection.
+
+### 4. Choose A Subject-Specific Direction
+
+Derive the visual language from the subject's own world: its artifacts, materials,
+instruments, notation, rhythms, constraints, and vocabulary. Privately explore two
+or three credible directions, then select one with a clear rationale.
+
+Specify:
+
+- a 4–6 color role palette with exact values and contrast-safe pairings;
+- deliberate display, body, and utility/data type roles;
+- a layout principle and density appropriate to the work;
+- one memorable signature element tied to the subject;
+- one justified aesthetic risk, with the rest of the interface kept disciplined;
+- restrained motion that clarifies change, sequence, or causality.
+
+Apply the **subject-swap test**: if the same layout, palette, copy, and signature
+could be relabeled for an unrelated pod, revise it. Avoid habitual AI-design
+defaults: interchangeable KPI cards, gratuitous bento grids, gradient blobs,
+glass panels, pill-shaped everything, random charts, oversized greetings, and
+decoration that encodes nothing. Treat “premium” as precision, coherence, and
+restraint—not as a fixed palette or luxury aesthetic.
+
+### 5. Write The Design Specification
+
+Create or update `DESIGN.md` before implementation. Use
+[`references/design-spec.md`](references/design-spec.md). Include the evidence,
+resource map, experience thesis, page map, scenarios, wireframes, tokens, copy
+canon, state matrix, responsive transformations, accessibility requirements, and
+acceptance criteria.
+
+Keep routes and labels in the user's language. Expose words such as “agent,”
+“workflow,” or “function” only when the intended user understands and needs those
+primitives. Make one primary action obvious in each context. Keep irreversible
+actions explicit and separated from routine actions. Use progressive disclosure
+for secondary metadata and controls without hiding essential context.
+
+Write interface copy as design material:
+
+- Use plain, specific, active language and sentence case.
+- Name an action by its outcome: “Approve request,” not “Submit.”
+- Keep the verb stable from button to pending state, success message, and history.
+- Make empty states explain what is absent and offer the next valid action.
+- Make errors name what failed, preserve the user's work, and offer recovery.
+- Avoid promotional filler, cute labels, vague “AI insights,” and system-centric
+  wording where a human term exists.
+
+### 6. Design Every State And Viewport
+
+Specify loading, populated, empty, partial, error, permission, disabled, pending,
+success, and destructive-confirmation states wherever they can occur. Match
+skeletons to the final geometry; reserve spinners for short, local actions. Keep
+agent and workflow progress legible without presenting unfinished output as final.
+
+Design responsive transformations rather than a scaled-down desktop:
+
+- Verify the main journey at 1440px, 1024px, 768px, and 375px where practical.
+- Reorder, collapse, or move panels into drawers while preserving task priority.
+- Keep the page body free of horizontal overflow at 375px.
+- Keep primary actions reachable and essential context visible on touch devices.
+
+Meet an accessible quality floor:
+
+- Use semantic structure, programmatic labels, logical focus order, and visible
+  focus treatment.
+- Keep text and controls contrast-safe; never encode status by color alone.
+- Keep essential actions available without hover and compact controls at least
+  44px in touch target size.
+- Support keyboard operation, zoom, and reduced motion.
+- Associate validation messages with their fields and announce meaningful async
+  updates without stealing focus.
+
+### 7. Implement One Real Vertical Slice First
+
+When implementation is authorized, use `lemma-builder` for the build mechanics.
+Connect the primary scenario to real pod data through `LemmaClient` immediately;
+do not polish a static mock and postpone the actual contract. Reuse native Lemma
+blocks for proven data wiring, then restyle them through the chosen tokens instead
+of forking their behavior.
+
+Implement one complete slice—load real work, inspect it, take the primary action,
+and show its result—before filling secondary pages. Keep the implementation aligned
+with `DESIGN.md`; update the specification when a verified constraint changes the
+design.
+
+### 8. Review The Rendered Pixels
+
+Use the `browser` skill for the full render-and-critique loop:
+
+1. Open the authenticated local or deployed app and walk the primary scenario.
+2. Capture screenshots at desktop and 375px, plus important intermediate states.
+3. Inspect each screenshot with `view_image`; do not infer visual quality from the
+   DOM, CSS, or browser snapshot alone.
+4. Critique with [`references/visual-review.md`](references/visual-review.md).
+5. Fix the highest-impact issue, recapture the same state, and compare.
+6. Repeat until no unresolved issue compromises comprehension, task completion,
+   accessibility, or the intended direction.
+
+Inspect text wrapping, truncation, alignment, density, hierarchy, focus, contrast,
+real data variation, empty/error/permission states, and breakpoint transitions.
+Treat screenshots as evidence, not decoration. Never call an app polished without
+viewing both a representative desktop render and the 375px experience.
+
+## Finish With Evidence
+
+Before handing off, confirm:
+
+- `DESIGN.md` names real pod resources and matches the implemented experience.
+- The default screen communicates the job and next action without explanation.
+- The visual direction and signature belong to this subject.
+- Every prominent datum and action has a real Lemma contract.
+- Core loading, empty, error, permission, and pending states are designed.
+
+When implementation is in scope, also confirm:
+
+- Keyboard, focus, contrast, touch, reduced-motion, and 375px behavior hold.
+- Desktop and mobile screenshots were visually inspected after the final change.
+- The primary scenario works with real data; route deeper verification through
+  `lemma-app-qa` and deployment verification through `lemma-builder`.

--- a/lemma-skills/lemma-app-design/agents/openai.yaml
+++ b/lemma-skills/lemma-app-design/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Lemma App Design"
+  short_description: "Design distinctive, production-quality pod apps"
+  default_prompt: "Use $lemma-app-design to design and visually refine a distinctive, accessible Lemma app grounded in real pod work."

--- a/lemma-skills/lemma-app-design/references/design-spec.md
+++ b/lemma-skills/lemma-app-design/references/design-spec.md
@@ -1,0 +1,245 @@
+# DESIGN.md Template
+
+Copy this structure into the app's `DESIGN.md`. Replace every prompt with a
+decision or verified fact, remove unused sections, and keep named pod resources
+exact. Treat this as the experience contract; keep build commands and SDK examples
+in `lemma-builder/references/apps.md`.
+
+## Contents
+
+- [1. Brief And Evidence](#1-brief-and-evidence)
+- [2. Lemma Experience Contract](#2-lemma-experience-contract)
+- [3. Experience Thesis](#3-experience-thesis)
+- [4. Page And Interaction Model](#4-page-and-interaction-model)
+- [5. Visual Direction](#5-visual-direction)
+- [6. Content And Copy Canon](#6-content-and-copy-canon)
+- [7. State Matrix](#7-state-matrix)
+- [8. Accessibility And Responsive Contract](#8-accessibility-and-responsive-contract)
+- [9. Acceptance Evidence](#9-acceptance-evidence)
+
+## 1. Brief And Evidence
+
+### Product sentence
+
+> For **[person]**, **[app]** turns **[input/work]** into **[decision/action]** by
+> **[specific mechanism]**.
+
+### Human and job
+
+| Item | Decision |
+| --- | --- |
+| Primary person | Role, skill level, and relevant access boundary |
+| Recurring job | The outcome they return to complete |
+| Cadence | Continuous, daily, weekly, or event-driven |
+| Decision | What they must understand or choose |
+| Durable action | What changes in the pod when they finish |
+| Stakes | Cost of error, ambiguity, or delay |
+
+### Evidence inventory
+
+List only evidence actually inspected:
+
+- Existing app and screenshots:
+- Tables, schemas, and representative record IDs:
+- Files, previews, and domain assets:
+- Agents and representative final outputs:
+- Workflows, waits, and form schemas:
+- Members, connectors, or permission constraints:
+- Reference products or supplied visual references:
+- User constraints and explicit preferences:
+
+Record unknowns separately. Do not quietly turn an assumption into product truth.
+
+## 2. Lemma Experience Contract
+
+### App path
+
+- Path: **HTML / Vite**
+- Reason: [complexity-based reason]
+- Existing path preserved: **yes / no**, with rationale if changed
+
+### Surface map
+
+| Surface or control | Human purpose | Named resource | Field/content source | `LemmaClient` or hook | Behavior | Access/RLS implication |
+| --- | --- | --- | --- | --- | --- | --- |
+| Example: waiting queue | Choose the next case | `cases` table | `title`, `priority`, `status` | `useLiveRecords` | Read + live | Current user's rows only |
+
+Reject any prominent UI element that cannot fill this table truthfully. Name
+aggregate definitions, sort rules, freshness behavior, and final agent-output
+selection where relevant.
+
+## 3. Experience Thesis
+
+### Hero moment
+
+Describe one frame that proves the pod's value. Include the source evidence, the
+human decision, and the next action visible in that frame.
+
+### First 30 seconds
+
+Describe exactly what appears on first load with representative real content.
+Prefer active work and the next action over a welcome screen or generic overview.
+
+### Primary scenario
+
+Write one concrete end-to-end sequence:
+
+1. The person arrives from [entry point].
+2. They recognize [work/context] because [evidence].
+3. They inspect or change [resource].
+4. The app starts/resumes/writes [named operation].
+5. They see [pending and completion feedback].
+6. The durable result is visible in [named resource/history].
+
+Add secondary scenarios only when they materially change the layout or state model.
+
+### Information spine
+
+Name the object or sequence that organizes the product. Explain why it matches the
+person's mental model better than a generic dashboard hierarchy.
+
+## 4. Page And Interaction Model
+
+### Page map
+
+| Route/view | Single job | Primary content | Primary action | Secondary action | Entry/exit |
+| --- | --- | --- | --- | --- | --- |
+
+### Interaction rules
+
+Define:
+
+- selection and navigation behavior;
+- filters, search, sort, and persistence;
+- optimistic, pending, completed, and failed action feedback;
+- agent streaming versus final-output treatment;
+- workflow wait, assignment, and resume behavior;
+- destructive confirmation and recovery;
+- realtime change behavior without polling;
+- keyboard behavior and focus movement.
+
+### Wireframes
+
+Draw compact ASCII wireframes for desktop and 375px. Label regions by purpose,
+not implementation.
+
+```text
+DESKTOP
+┌──────────── work queue ───────────┬──────── selected case ────────┐
+│ filters                           │ evidence                      │
+│ ranked items                      │ recommendation                │
+│                                   │ [primary decision]            │
+└───────────────────────────────────┴───────────────────────────────┘
+
+375 PX
+┌──────────── active work ──────────┐
+│ filters [drawer]                  │
+│ ranked items                      │
+└───────────────────────────────────┘
+selected case → full-screen detail
+```
+
+Explain what reorders, collapses, becomes a drawer, becomes full-screen, or stays
+sticky at each breakpoint. Never say only “stack on mobile.”
+
+## 5. Visual Direction
+
+### Subject cues
+
+List the domain's real artifacts, materials, notation, rhythms, and vocabulary.
+State which cues enter the design and which would become costume or cliché.
+
+### Direction statement
+
+Describe the chosen tone in one sentence. Include why it helps this person do this
+job. Record rejected directions and the reason for rejecting them when the choice
+was consequential.
+
+### Signature
+
+Name one memorable, useful element tied to the subject. State what it encodes and
+why it would not belong unchanged in an unrelated app.
+
+### Tokens
+
+```text
+COLOR
+canvas      #......
+surface     #......
+text        #......
+muted       #......
+accent      #......
+critical    #......
+
+TYPE
+display     [family / fallback / size / weight / line-height]
+body        [family / fallback / size / weight / line-height]
+utility     [family / fallback / tabular behavior]
+
+SPACE       4 / 8 / 12 / 16 / 24 / 32
+RADIUS      [limited roles]
+BORDER      [subtle / strong]
+SHADOW      [only where depth is meaningful]
+MOTION      [purpose / duration / easing / reduced-motion result]
+```
+
+Check text, control, status, focus, and selected-state contrast before approving
+the palette. Use status labels or symbols in addition to color.
+
+## 6. Content And Copy Canon
+
+### Vocabulary
+
+| Concept | Use | Do not use | Reason |
+| --- | --- | --- | --- |
+
+### Action language
+
+| Intent | Button | Pending | Success | Error/recovery |
+| --- | --- | --- | --- | --- |
+
+Keep one verb through the sequence. Write from the operator's side of the screen;
+avoid exposing implementation primitives unless the operator needs them.
+
+### Representative content
+
+Include realistic titles, names, timestamps, statuses, long values, missing values,
+and edge cases from inspected pod data. Mark schema-faithful sample content clearly
+when live data is unavailable.
+
+## 7. State Matrix
+
+| Surface | Loading | Populated | Empty | Partial/stale | Error/recovery | Permission | Pending/success |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+
+Distinguish “no matching rows,” “no rows created,” and “not allowed to see rows.”
+Preserve inputs across recoverable errors. Specify skeleton geometry, progress
+language, retry behavior, and focus destination.
+
+## 8. Accessibility And Responsive Contract
+
+Record explicit requirements for:
+
+- headings and landmarks;
+- labels, descriptions, and validation associations;
+- focus order, focus return, and keyboard shortcuts;
+- contrast and non-color status encoding;
+- 44px touch targets and hover-independent actions;
+- reduced motion and zoom;
+- announcements for important async changes;
+- 1440px, 1024px, 768px, and 375px transformations;
+- truncation, wrapping, and overflow behavior with real long content.
+
+## 9. Acceptance Evidence
+
+Define observable gates:
+
+- [ ] The primary scenario completes against real pod data.
+- [ ] Every prominent datum and control maps to a named resource and client surface.
+- [ ] The hero moment is visible without a narrated explanation.
+- [ ] The subject-swap test fails: the identity cannot move unchanged to an unrelated app.
+- [ ] Loading, empty, error, permission, pending, and success states are intentional.
+- [ ] Keyboard, focus, contrast, touch, reduced-motion, and zoom behavior hold.
+- [ ] The page has no body-level horizontal overflow at 375px.
+- [ ] Final desktop and 375px screenshots were inspected with `view_image`.
+- [ ] Visual-review findings and their resolutions are recorded.

--- a/lemma-skills/lemma-app-design/references/visual-review.md
+++ b/lemma-skills/lemma-app-design/references/visual-review.md
@@ -1,0 +1,128 @@
+# Rendered App Review
+
+Use this rubric after opening the real app with the `browser` skill. Review the
+rendered pixels and the working interaction together; a clean DOM or passing build
+does not establish visual quality.
+
+## Contents
+
+- [Prepare Comparable Evidence](#prepare-comparable-evidence)
+- [Review In This Order](#review-in-this-order)
+- [Record Findings Precisely](#record-findings-precisely)
+- [Reject Common False Finishes](#reject-common-false-finishes)
+
+## Prepare Comparable Evidence
+
+1. Load representative real records, including long text, missing values, varied
+   statuses, and enough items to exercise scrolling.
+2. Capture the same primary scenario before and after a redesign.
+3. Capture at least the default desktop view and the 375px view after the final
+   change. Add 1024px and 768px when the layout changes there.
+4. Capture important non-default states: selected detail, open menu/dialog, pending
+   action, error, empty result, and permission state when applicable.
+5. Use the same viewport, state, record, scroll position, and theme for comparisons.
+6. Inspect screenshots with `view_image`. Use browser snapshots, console output,
+   and network evidence for behavior—not as substitutes for viewing the image.
+
+## Review In This Order
+
+### 1. Five-second comprehension
+
+- Identify the page's job, current object, state, and next action without reading
+  every label.
+- Reject an opening dominated by greetings, generic metrics, navigation chrome, or
+  explanation instead of real work.
+
+### 2. Task hierarchy
+
+- Make the primary action unmistakable without making every control loud.
+- Keep evidence adjacent to the decision it supports.
+- Keep secondary controls available but visually subordinate.
+- Preserve context across selection, agent work, workflow waits, and completion.
+
+### 3. Subject authenticity
+
+- Verify that the palette, type, structure, signature, and language came from the
+  subject rather than a reusable AI aesthetic.
+- Apply the subject-swap test. If relabeling would make this an equally plausible
+  CRM, finance tool, or support app, identify what remains generic and revise it.
+- Ensure the signature element carries information or improves the task; remove it
+  when it is merely decoration.
+
+### 4. Data truth
+
+- Confirm that counts, charts, statuses, dates, agent results, and previews match
+  real pod sources and scopes.
+- Check realistic extremes: zero, one, many, long names, missing values, stale work,
+  failure, and RLS-scoped results.
+- Remove unsupported precision, arbitrary trends, and decorative data.
+
+### 5. Layout and density
+
+- Check alignment lines, panel proportions, row rhythm, whitespace, sticky regions,
+  clipping, and scroll ownership.
+- Keep one density per surface and one spacing logic across related elements.
+- Use containers only when grouping or depth is meaningful. Remove nested cards,
+  gratuitous borders, excess shadows, and radius inconsistency.
+
+### 6. Typography and copy
+
+- Check hierarchy, line length, wrapping, truncation, numeric alignment, and legible
+  metadata at actual scale.
+- Keep labels and verbs specific, stable, and in the operator's vocabulary.
+- Remove filler, duplicated titles, unexplained abbreviations, vague errors, and
+  empty states without a valid next step.
+
+### 7. Color, focus, and state
+
+- Check contrast in normal, hover, focus, selected, disabled, and error states.
+- Ensure status never depends on color alone.
+- Keep focus visible and coherent with the visual direction.
+- Ensure loading geometry does not cause a disruptive layout jump.
+
+### 8. Responsive behavior
+
+- Treat 375px as its own composition, not a squeezed desktop.
+- Check body overflow, panel ordering, drawers, sticky actions, touch targets,
+  readable controls, keyboard overlap, and long-content behavior.
+- Ensure every essential action remains reachable without hover.
+
+### 9. Motion and feedback
+
+- Keep motion purposeful, short, and seekable to a stable end state.
+- Prevent decorative motion from competing with work or masking latency.
+- Respect reduced motion and avoid moving focus unexpectedly.
+- Keep pending work distinct from completed agent or workflow output.
+
+## Record Findings Precisely
+
+For each finding, record:
+
+```text
+Severity: blocking | high | medium | low
+Viewport/state: 375px / selected case / pending approval
+Evidence: screenshot path and visible symptom
+Impact: what the person cannot understand or do
+Fix target: the specific hierarchy, token, copy, state, or layout change
+Verification: replacement screenshot and interaction result
+```
+
+Fix in this order: blocked task or inaccessible control; misleading data or state;
+broken responsive layout; unclear hierarchy; inconsistent system; cosmetic detail.
+Recapture the same state after each meaningful pass so the comparison is valid.
+
+## Reject Common False Finishes
+
+Do not approve an app merely because it has:
+
+- a sidebar, page title, four KPI cards, and a chart;
+- a fashionable palette unrelated to the subject;
+- many rounded cards, gradients, glass effects, or micro-animations;
+- perfect empty mock data but no real loading, error, or access state;
+- a desktop screenshot while the mobile layout is unviewed;
+- clean static screenshots while the primary action fails;
+- a successful build or deploy without inspecting the served revision.
+
+Approve only when the intended direction survives real content, the primary
+scenario works, critical states are coherent, and final desktop and mobile pixels
+have been viewed after the last change.

--- a/lemma-skills/lemma-app-qa/SKILL.md
+++ b/lemma-skills/lemma-app-qa/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: lemma-app-qa
+description: "Test and verify Lemma pod apps through real end-to-end user journeys in authenticated local and deployed contexts. Use when asked to QA, dogfood, smoke-test, regression-test, acceptance-test, reproduce, or verify a Lemma app; validate UI behavior against durable pod state; check auth, RLS, delegated workloads, permissions, loading/empty/error states, responsive layout, accessibility, console/network health, or deployment correctness; and produce evidence-backed defects and a calibrated release verdict. Use the browser skill for browser command mechanics."
+---
+
+# Lemma App QA
+
+Prove a precise contract: **this principal can complete this journey in this app,
+and the expected effect persists in this pod under the correct authority**. Test
+outcomes, not pages. Treat a rendered screen, a successful build, `READY`, or an
+HTTP `200` as evidence—not completion.
+
+## Load the right companions
+
+- Read the `browser` skill before driving the app. Let it own browser startup,
+  snapshots, refs, waits, screenshots, console, network, sessions, and recovery.
+  Do not invent or duplicate its command catalog here.
+- Read the `lemma-user` skill before verifying records, files, runs, messages, or
+  other pod state from the CLI.
+- Read `lemma-builder/references/apps.md` when the app's build, runtime context,
+  SDK, deployment, or iframe behavior is in question.
+- Read `lemma-builder/references/authorization-model.md` before judging RLS,
+  human roles, workload grants, delegation, personal resources, connectors, or
+  destructive approvals.
+- Read [coverage-and-reporting.md](references/coverage-and-reporting.md) before a
+  multi-journey pass and before issuing the final report.
+
+## Set the verification boundary
+
+Record these facts before testing:
+
+- target app slug or local URL; pod id/slug and server/environment;
+- local revision and deployed release id/timestamp when available;
+- actor identity and pod role; delegated agent/function/workflow when involved;
+- allowed mutations, external side effects, cleanup policy, and out-of-scope areas;
+- acceptance source: user request, issue, `DESIGN.md`, product spec, or observed
+  contract;
+- required environments and viewports.
+
+Use a disposable fixture prefix and retain every created record/file/run id. Do
+not modify or delete real user data merely to gain coverage. Do not trigger email,
+payments, connector writes, destructive grants, or other external effects without
+explicit authority and a controlled account/fixture.
+
+Keep claims inside the observed boundary. Do not present a local pass as a
+deployed pass, one identity as multi-user coverage, an accessibility-tree scan as
+screen-reader verification, a mocked denial as proof of server authorization, or
+a browser-tool failure as an app defect.
+
+## Build a journey ledger
+
+Translate requirements into a short, risk-ordered ledger. Define each journey by:
+
+1. persona and authority;
+2. starting state and fixtures;
+3. actions and decision points;
+4. expected visible states;
+5. expected durable pod effects;
+6. forbidden effects or data visibility;
+7. required environment and viewport.
+
+Always include the primary value journey. Add only relevant boundary journeys:
+retry/recovery, invalid input, refresh/deep-link persistence, concurrent or live
+updates, permission denial, second-user isolation, assigned workflow waits,
+delegated agent actions, file/connector behavior, and deployment freshness.
+
+Prefer five deep journeys with durable verification over fifty shallow clicks.
+Use the ledger in [coverage-and-reporting.md](references/coverage-and-reporting.md).
+
+## Establish a baseline
+
+1. Confirm the exact pod and app with Lemma CLI inventory/detail commands.
+2. Inspect relevant table schemas, existing fixture rows, file paths, workflow or
+   function definitions, and workload grants without widening access.
+3. Capture the pre-test state needed to prove later mutations.
+4. Run the repository's focused static/build checks when source is in scope.
+5. Note pre-existing browser errors, failed requests, and unavailable dependencies.
+
+Separate source checks from product checks in the report. A build pass cannot
+substitute for a browser journey; an already-broken environment cannot be charged
+to the new revision without a causal repro.
+
+## Open the correct browser context
+
+Use the Lemma CLI to establish auth instead of copying or hand-wiring tokens:
+
+```bash
+# Deployed app: resolve its served URL and inject current Lemma auth.
+lemma apps open <app-slug> --pod <pod>
+
+# Local `npm run dev`: use only when that dev server seeds its own dev token.
+lemma apps open --url http://localhost:<port> --no-auth
+```
+
+Use `--no-auth` only for the self-authenticating local dev flow—not to simulate a
+signed-out user. Test sign-out, access request, or another role in an isolated
+browser context with a real corresponding identity. Browser profiles and sessions
+do not inherit auth from one another.
+
+Exercise local development first when diagnosing quickly, then repeat every
+release-critical journey against the deployed app. Confirm that the deploy landed:
+record the release detail, hard-refresh or cache-bust, and verify a revision-unique
+UI/DOM marker before attributing results to the new build.
+
+Treat `lemma apps open` as proof of the served app, not automatically of its host.
+When people normally enter through the Lemma pod shell, repeat a critical smoke
+through that real shell route and verify iframe sizing, focus, navigation, auth, and
+reload behavior. Add desktop or other hosts only when they are part of the release
+contract.
+
+## Execute each journey
+
+For every ledger row:
+
+1. Restore its declared starting state.
+2. Capture the initial URL, interactive snapshot, and visual checkpoint.
+3. Act through semantic browser locators and waits; re-snapshot after every page
+   change or meaningful re-render.
+4. Assert feedback at each decision point, not only the final page.
+5. Capture the final visible state and inspect browser errors, console output, and
+   relevant network requests. Start a HAR/trace only for timing or intermittent
+   failures.
+6. Reload or reopen the deep link when persistence is part of the contract.
+7. Verify the durable effect independently through Lemma CLI/API state.
+8. Restore or record the resulting fixture state before the next journey.
+
+For a suspected defect, reproduce once from a known state before filing it.
+Capture the smallest complete sequence: before, action, broken result, console or
+request evidence, and pod-state evidence. Mark a one-off signal as intermittent or
+unconfirmed; do not inflate it into a deterministic defect.
+
+## Verify the pod, not only the toast
+
+Match every meaningful UI mutation to an independent durable assertion:
+
+- record create/update/delete → fetch the exact record id or scoped list;
+- file upload/edit/delete → inspect the exact path and processing status;
+- workflow action → inspect run status, active wait, step history, and output;
+- function action → inspect the named run, status, logs/error, and output data;
+- agent action → inspect the conversation's final output and any claimed effects;
+- connector action → inspect the Lemma run/result and the controlled destination;
+- live update → prove the second view changes without manual reload or polling.
+
+Assert both presence and absence. A successful create must produce one correctly
+owned row, not duplicates; an unauthorized user must not see it; a failed submit
+must not leave a partial record. Never infer backend success from optimistic UI.
+
+## Test identity, RLS, and delegation deliberately
+
+Use real authorized principals when access behavior is acceptance-critical. Keep
+each identity in its own browser session and record which one produced each
+artifact.
+
+- On an RLS table, expect a list to omit another user's row and an exact fetch to
+  return `404`; do not label that as data loss without checking ownership.
+- Avoid admin-mode reads during ordinary app verification. They bypass the user's
+  product view and do not prove the app contract.
+- Distinguish `401` auth failures from human-role denial, workload-grant denial,
+  delegation-scope violations, and personal-resource denial. Report the exact
+  response/error code.
+- For an agent/function/workflow action, verify the invoking user, the workload's
+  explicit grants, and the resulting RLS-scoped effect. Do not broaden grants to
+  make a test pass unless the user asked for a fix.
+- Verify negative cases server-side. Hiding a button is useful UX, but it is not
+  authorization enforcement.
+
+## Cover product states and surfaces
+
+Exercise these dimensions where the feature exposes them:
+
+- **Loading:** show stable structure, prevent duplicate actions, and transition
+  without flicker or stale content.
+- **Empty:** explain why it is empty and offer the correct next action; distinguish
+  true emptiness from RLS filtering or failed loading.
+- **Error/retry:** preserve user input where safe, expose an actionable message,
+  and recover without duplicate writes.
+- **Permission:** explain unavailable access without leaking protected data; keep
+  the denial consistent with server behavior.
+- **Full/overflow:** use long labels, many rows, large values, and pagination or
+  scrolling without clipping essential actions.
+- **Responsive:** check at minimum the product's wide layout and `375px`; add
+  intermediate widths for layout transitions. Reject hidden essential actions,
+  accidental horizontal scrolling, clipped dialogs, and touch targets below the
+  app baseline of roughly `44px`.
+- **Accessibility:** complete the primary journey by keyboard; inspect focus order,
+  visible focus, accessible names, labels, headings, dialog focus/restore, status
+  announcements, and non-color status cues. State explicitly what was not tested
+  with assistive technology.
+- **Browser health:** investigate uncaught errors, failed requests, CORS/auth
+  failures, duplicate mutation requests, refetch loops, and unexpected polling.
+
+Use safe request stubs/aborts to inspect recoverable UI error states. Do not use a
+mocked response to claim that RLS, roles, grants, or persistence work in the backend.
+
+## Triage and report
+
+Classify severity by user and data impact, not visual drama:
+
+- **Critical:** expose another user's/private data, bypass authority, corrupt or
+  lose data, cause an uncontrolled irreversible side effect, make the target app
+  unavailable, or crash/block its only core journey for all target users.
+- **High:** block a core journey for a target segment with no reasonable
+  workaround, persist an incorrect mutation, or fail only after deployment.
+- **Medium:** materially degrade a journey while a workaround exists, or break an
+  important state, viewport, or accessibility path for a subset of users.
+- **Low:** create a bounded content, visual, or polish defect without task or data
+  risk.
+
+Keep severity separate from evidence status and release scope. Use the evidence and
+defect templates in [coverage-and-reporting.md](references/coverage-and-reporting.md).
+Report exact URLs, identity/role, pod/environment, fixture ids, timestamps,
+expected versus actual behavior, minimal repro steps, and artifact paths.
+
+Issue one verdict:
+
+- **PASS:** pass every required critical journey in every required environment;
+  leave no critical/high defect or unverified release gate.
+- **PASS WITH RISKS:** pass core journeys but retain bounded defects or explicitly
+  accepted coverage gaps that do not invalidate the release.
+- **FAIL:** break a critical journey, authorization boundary, durable-state
+  contract, or release gate.
+- **NOT VERIFIED:** lack the auth, identity, environment, browser, dependency, or
+  observability needed to make the requested claim.
+
+List untested areas and tooling failures beside the verdict. Never silently convert
+`NOT VERIFIED` into `PASS`.
+
+## Finish cleanly
+
+Re-read totals and ensure every issue maps to a ledger row or exploratory finding.
+Remove only disposable fixtures created by this test, by exact recorded id/path,
+when cleanup is authorized. Verify their removal. List any residual records, files,
+runs, or external effects that could not be reversed.
+
+Return an answer-first summary, the verdict, critical journey results, defects by
+severity, verification ledger, coverage gaps, and evidence locations. Preserve the
+raw screenshots/HAR/traces only when they add diagnostic value; never include
+tokens, cookies, credentials, private row contents, or connector secrets.

--- a/lemma-skills/lemma-app-qa/agents/openai.yaml
+++ b/lemma-skills/lemma-app-qa/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Lemma App QA"
+  short_description: "Test Lemma apps through real user journeys"
+  default_prompt: "Use $lemma-app-qa to test a Lemma app in an authenticated browser and produce an evidence-backed defect report."

--- a/lemma-skills/lemma-app-qa/references/coverage-and-reporting.md
+++ b/lemma-skills/lemma-app-qa/references/coverage-and-reporting.md
@@ -1,0 +1,151 @@
+# Coverage and reporting
+
+Use these compact structures to plan a Lemma app QA pass and make its claims
+auditable. Tailor them to the requested scope; do not create empty ceremony.
+
+## Journey ledger
+
+Create one row per user outcome, ordered by release risk.
+
+| ID | Priority | Persona / authority | Start state | Journey | Expected UI | Durable assertion | Forbidden effect | Environments / viewports | Result |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| J-01 | Gate | Pod user; owns fixture | Empty assigned queue | Create request → submit → reopen | Confirmation, row appears, detail opens | One owned row with exact fields | No duplicate; no other owner | local + deployed; wide + 375 | Pending |
+
+Use `Gate` for journeys that decide the release. Mark results `Pass`, `Fail`,
+`Blocked`, or `Not run`; never use a blank cell to imply success.
+
+## Coverage ledger
+
+Track the dimensions that a happy-path journey can otherwise hide.
+
+| Dimension | Required evidence | Result / limitation |
+| --- | --- | --- |
+| Build/static checks | Exact command and exit result | |
+| Local primary journey | Browser checkpoints + durable assertion | |
+| Deployed primary journey | Release marker + browser checkpoints + durable assertion | |
+| Pod-shell embedding | Real shell route; iframe sizing, focus, navigation, auth, reload | |
+| Auth/session | Actor, role, app boot result, relevant response codes | |
+| RLS/multi-user | Two real principals and positive + negative pod assertions | |
+| Delegated workload | Invoker, workload grants, run id, output/effect | |
+| Persistence | Reload/deep-link plus exact durable object | |
+| Loading/empty/error/permission | Visual and interaction checkpoint for each applicable state | |
+| Responsive | Wide, 375px, and any layout breakpoint exercised | |
+| Accessibility | Keyboard path and inspected semantics; list AT not exercised | |
+| Console/network | Errors, failed requests, duplicate calls, CORS/auth findings | |
+| Cleanup | Exact ids/paths removed or listed as residual | |
+
+## Evidence bundle
+
+Prefer a small evidence bundle that can independently support the claim:
+
+- `context.md` or report header: time, app, pod, server, URL, revision/release,
+  browser session, actor, role, and allowed mutations;
+- screenshots: `J-01-01-start.png`, `J-01-02-action.png`,
+  `J-01-03-result.png`;
+- browser excerpts: errors, relevant console lines, and filtered request summary;
+- pod assertions: exact CLI command and redacted output for the affected
+  record/file/run/conversation;
+- `J-01.har` or a trace only when ordering, timing, or intermittent requests are
+  material.
+
+View every screenshot before citing it. Redact secrets and unrelated private data.
+Do not dump full network bodies when status, endpoint, method, timing, request id,
+and a small redacted response excerpt prove the issue.
+
+## Durable assertion map
+
+Select only the relevant Lemma operator command after reading the `lemma-user`
+skill and current CLI help.
+
+| Claimed effect | Independent assertion |
+| --- | --- |
+| Record created/updated | `lemma records get <table> <record-id>`; compare ownership and exact fields |
+| Record absent/isolated | scoped `lemma records list <table>` and exact get as the tested principal |
+| File uploaded/processed | `lemma files stat <path>`; inspect indexing status if search is claimed |
+| Workflow advanced | `lemma workflows runs get <run-id>`; inspect status, active wait, history, error/output |
+| Function completed | inspect the exact function run id, status, error/logs, and output data |
+| Agent answered/acted | inspect the exact conversation messages and independently verify every claimed mutation |
+| Connector write occurred | inspect the exact controlled destination plus Lemma operation/run result |
+| Deploy is current | app detail/release id plus cache-busted live revision marker |
+
+Capture object ids from the UI or request as the action occurs. Avoid broad queries
+whose result could be satisfied by pre-existing data.
+
+## Permission evidence matrix
+
+Prove both what the actor may do and what they must not see or mutate.
+
+| Case | UI expectation | Server/pod expectation |
+| --- | --- | --- |
+| Same owner, valid role | Action available and succeeds | Exact object readable/writable |
+| Different owner on RLS table | Protected row omitted; no leaked count/detail | List omits it; exact get commonly returns `404` |
+| Insufficient human role | Action absent or explains denial | Exact `INSUFFICIENT_PERMISSION` or current equivalent |
+| Missing workload grant | Agent/function action explains failure | `MISSING_WORKLOAD_RESOURCE_GRANT` names workload/resource |
+| Personal resource mismatch | No path/content leak | `PERSONAL_RESOURCE_DENIED`; no grant override |
+| Delegation wiring error | Safe actionable failure | `DELEGATION_SCOPE_VIOLATION`; do not add a grant blindly |
+
+Treat current server error codes and CLI/API output as authoritative. Update the
+report wording if implementation terminology differs.
+
+## Defect record
+
+Use one self-contained block per confirmed issue:
+
+```markdown
+### QA-001 — Short outcome-based title
+
+- Severity: Critical | High | Medium | Low
+- Evidence status: Confirmed | Intermittent | Suspected
+- Journey: J-01
+- Environment: server, pod, app URL, revision/release
+- Actor: user/agent identity and role; delegated workload if any
+- Evidence: screenshot paths, request id/HAR, redacted pod assertion
+
+Expected: Describe the requirement and intended durable effect.
+Actual: Describe the observed UI and durable state precisely.
+
+Reproduction:
+1. Restore the named fixture/start state.
+2. Perform one observable action.
+3. Observe the broken UI or response.
+4. Query the exact pod object and observe the mismatch.
+
+Impact: Name the affected persona, task, data, and workaround.
+Notes: Record frequency, suspected boundary, and what was ruled out without
+presenting an unproven root cause as fact.
+```
+
+Use `Confirmed` after a clean repeat from a known state. Use `Intermittent` when a
+failure repeats inconsistently but has traceable evidence. Use `Suspected` for a
+signal that needs more access or instrumentation; keep it outside confirmed issue
+totals.
+
+## Final report
+
+Lead with the release decision, not the testing diary:
+
+```markdown
+# <App> QA — <date>
+
+Verdict: PASS | PASS WITH RISKS | FAIL | NOT VERIFIED
+Scope: <app, pod, server, revision/release, identities, environments>
+
+## Decision summary
+<What is safe or unsafe to do, for whom, and why.>
+
+## Release gates
+| Journey | Local | Deployed | Durable state | Result |
+| --- | --- | --- | --- | --- |
+
+## Findings
+<Severity counts, then defect records in severity order.>
+
+## Coverage and boundaries
+<Coverage ledger, untested areas, mocks, tool/environment failures.>
+
+## Evidence and cleanup
+<Artifact paths, fixture ids, items removed, residual effects.>
+```
+
+Do not bury `NOT VERIFIED` behind build success or partial screenshots. State the
+single next action that would convert each material coverage gap into evidence.

--- a/lemma-skills/lemma-artifact-author/SKILL.md
+++ b/lemma-skills/lemma-artifact-author/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: lemma-artifact-author
+description: "Create, revise, and deliver polished, durable artifacts in a Lemma workspace: Markdown, HTML, DOCX, PDF, XLSX, and PPTX. Use for reports, documents, workbooks, presentations, exports, handouts, template-based revisions, or publication-ready files that must preserve source fidelity, be rendered and visually verified, and be uploaded to private /me or a shared pod folder. Route deployed Lemma apps to lemma-app-design and lemma-builder instead."
+---
+
+# Lemma Artifact Author
+
+Create the requested native file, prove that its content and rendering are sound,
+and place the verified deliverable where people can actually use it. Treat the
+editable source, any fixed-layout export, and the pod copy as one delivery chain.
+
+## Hold the quality line
+
+- Preserve every source and template unchanged. Work on a copy in an isolated
+  temporary directory or a clearly named workspace output directory.
+- Preserve meaning and data, not merely appearance. Never invent facts, silently
+  change numbers, flatten formulas, discard notes, accept tracked changes, or
+  remove advanced document features without authorization.
+- Produce the requested format with a tool that genuinely writes that format.
+  Never rename an HTML, text, or PDF file to an Office extension.
+- Inspect rendered output. A successful write, conversion, or archive-open check
+  does not prove that a document looks correct.
+- Upload only the verified final files. Never leave the sole deliverable in a
+  local temp path.
+- State unverified properties and tool limitations plainly. Do not claim visual,
+  accessibility, formula, or round-trip QA that did not run.
+
+## 1. Define the delivery contract
+
+Resolve from the request and available context:
+
+1. Identify the audience, decision or job, required format, delivery deadline,
+   and expected level of polish.
+2. Identify authoritative sources, supplied templates, brand constraints,
+   required citations, and elements that must remain byte- or layout-faithful.
+3. Decide whether the user needs an editable native file, a distribution copy
+   such as PDF, or both. Keep an editable source beside a derived PDF unless the
+   user explicitly wants only the PDF.
+4. Choose the durable pod destination: `/me/...` for the invoking user's private
+   copy; another top-level path such as `/reports/...` for a pod-shared copy.
+   Never invent a `/pod` prefix or upload to an unconfirmed pod.
+5. Define acceptance checks before authoring: required sections, record counts,
+   control totals, page/slide limits, viewports, accessibility needs, and any
+   source-to-output invariants.
+
+Ask only when an unresolved choice would materially change content, access, or
+format. Otherwise make a conservative assumption and record it.
+
+## 2. Acquire sources without degrading them
+
+Orient to an active pod before reading or publishing:
+
+```bash
+lemma pods list
+lemma pods describe
+```
+
+For pod sources, use Lemma's native file layer first:
+
+```bash
+lemma files stat /reports/source.docx
+lemma files cat /reports/source.docx --pages 1-5
+lemma files download /reports/source.docx ./source.docx
+```
+
+Use `cat`, search, and child page images to understand an indexed pod document;
+download exact original bytes only when native editing or fidelity comparison
+requires them. Do not re-parse a pod document that already has converted
+markdown and rendered pages. Use `lemma-user` for the full file workflow and
+`liteparse-documents` only for outside files or missing/insufficient pod-derived
+artifacts.
+
+Record the source path or URL, version/date, and relevant page, sheet, slide, or
+range. Keep facts traceable to those sources. If the source is mutable, capture a
+working snapshot before editing.
+
+## 3. Discover tooling, then route the format
+
+Inspect the environment's available artifact capabilities, bundled dependency
+runtime, project manifests, and installed binaries before selecting a toolchain.
+Verify the actual writer, reader, renderer, and version you intend to use. Do not
+assume a package, office suite, font, browser, or converter is installed, and do
+not add dependencies or alter project manifests unless the task authorizes it.
+
+Prefer, in order:
+
+1. A native format-specific capability that supports creation or revision plus
+   rendering and reopening.
+2. A bundled workspace library or installed application confirmed at runtime.
+3. A loss-aware conversion path with the editable source retained.
+4. A clearly labelled fallback in a format the environment can produce.
+
+Do not counterfeit the requested extension. If the available path would drop
+material features or materially change the requested deliverable, explain the
+constraint and obtain direction before proceeding.
+
+Read [references/formats.md](references/formats.md) before editing or creating the
+selected format. Read only the relevant format sections.
+
+## 4. Author or revise from a content model
+
+Build an outline, slide map, workbook model, or page structure before styling.
+Use real content and representative data; do not leave placeholder copy unless
+the user requested a template.
+
+For revisions, make the smallest defensible change in the native source. Preserve
+styles, section and sheet structure, references, metadata, embedded assets, and
+unsupported features. Compare source and output counts and invariants after the
+edit. When a native revision path is unsafe, produce a separate proposed revision
+or a new version instead of corrupting the original.
+
+For source-backed work, keep citations adjacent to claims, label estimates and
+assumptions, preserve units and precision, and distinguish missing values from
+zero. Use a stable, descriptive filename; avoid ambiguous chains such as
+`final-v2-really-final`.
+
+## 5. Run structural, visual, and fidelity QA
+
+Use a real render-and-revise loop:
+
+1. Reopen the produced file with an independent reader or the same tool in read
+   mode. Confirm it is non-empty, parseable, and structurally complete.
+2. Run format-specific programmatic checks: sections and links, page/slide/sheet
+   counts, formulas and error values, embedded assets, expected headings, control
+   totals, citations, and metadata.
+3. Render every document page and slide, every relevant workbook sheet or print
+   range, and representative HTML desktop, mobile, and print views. Inspect an
+   overview montage, then inspect dense or suspicious regions at readable size.
+4. Fix clipping, overflow, overlap, orphaned headings, broken page breaks, font
+   substitution, unreadable labels, weak contrast, bad image crops, formula
+   errors, and unexpected blank output. Re-render after each material change.
+5. Compare the final values, text, source references, and counts with the source.
+   Recalculate independently for high-stakes totals where practical.
+6. Check accessibility supported by the target format and tool: semantic heading
+   order, document title and language, useful alt text, table headers, readable
+   link text, logical reading order, sufficient contrast, and charts that do not
+   rely on color alone.
+
+If rendering is unavailable, use every safe structural check available, mark
+visual QA as incomplete, and do not describe the artifact as visually verified.
+
+## 6. Publish the verified files to the pod
+
+Keep working files local until the acceptance checks pass. Then upload the native
+source and requested exports to the selected destination:
+
+```bash
+lemma files mkdir /reports
+lemma files upload ./quarterly-review.pptx /reports/quarterly-review.pptx
+lemma files upload ./quarterly-review.pdf /reports/quarterly-review.pdf
+lemma files stat /reports/quarterly-review.pdf
+lemma files url /reports/quarterly-review.pdf
+```
+
+Use `/me/<folder>/...` instead for a private deliverable. `stat` reports indexing
+state: wait for `COMPLETED` before claiming an indexable prose document is
+searchable; `NOT_REQUIRED` is expected for stored binary/data formats such as
+XLSX. Treat `FAILED` as a delivery defect, not success.
+
+For high-stakes delivery, download the exact uploaded bytes to a fresh temporary
+path, compare size or hash with the verified local final, and reopen that copy.
+Use `lemma files url` for a signed-in pod-member link. Create a public
+`lemma files share` link only when the user explicitly needs external access.
+
+Remove disposable previews and conversion intermediates that you created after
+verification when safe. Preserve the verified local final when it is useful for
+handoff or recovery.
+
+## Completion gate
+
+Do not finish until you can report:
+
+- the final native format and any derived exports;
+- the authoritative sources and preserved original/template;
+- the structural, visual, data-fidelity, and accessibility checks actually run;
+- the exact local final path and durable `/me` or shared pod path;
+- the member link when useful; and
+- any remaining limitation or unverified property.
+
+Use `lemma-research` or `lemma-data-analysis` for the investigation or analytical
+reasoning when needed; use this skill to turn that work into a durable, verified
+deliverable. Use `lemma-app-design` and `lemma-builder` for a deployed Lemma app
+rather than treating the app as an HTML report.

--- a/lemma-skills/lemma-artifact-author/agents/openai.yaml
+++ b/lemma-skills/lemma-artifact-author/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Lemma Artifact Author"
+  short_description: "Create and verify durable work artifacts"
+  default_prompt: "Use $lemma-artifact-author to create, revise, render, verify, and save a polished document, spreadsheet, presentation, PDF, or HTML artifact."

--- a/lemma-skills/lemma-artifact-author/references/formats.md
+++ b/lemma-skills/lemma-artifact-author/references/formats.md
@@ -1,0 +1,125 @@
+# Format routing and preservation checks
+
+Read the section for each requested source and output format. Prefer the requested
+native format; use companion formats only when they add real editing,
+distribution, or accessibility value.
+
+| Target | Best fit | Keep beside it when useful | Required visual proof |
+|---|---|---|---|
+| Markdown | Text-first, versionable, searchable writing | Referenced images/data | Rendered Markdown or HTML preview |
+| HTML | Responsive report, interactive explainer, printable web document | Local assets or print PDF | Desktop, mobile, and print views |
+| DOCX | Editable long-form business document | PDF distribution copy | Every rendered page |
+| PDF | Fixed-layout distribution, print, or archival copy | Editable native source | Every rendered page |
+| XLSX | Calculations, structured data, models, and editable tables | Source data and a PDF/PNG summary if requested | Every relevant sheet/range and chart |
+| PPTX | Editable live presentation | PDF handout if requested | Every rendered slide |
+
+## Markdown
+
+- Use a logical heading hierarchy, short sections, descriptive links, fenced code
+  languages, and tables only when they remain readable at the expected width.
+- Preserve source citations as durable links or footnotes. Keep image paths and
+  attachments portable relative to the final file when packaging locally.
+- Validate links, anchors, code fences, table structure, and image references.
+- Render the same Markdown flavor the destination uses when that renderer is
+  known. Inspect long lines, nested lists, wide tables, and callouts.
+- Prefer Markdown for the pod's durable searchable report when rich page layout
+  is not a requirement.
+
+## HTML
+
+- Decide whether delivery is one self-contained file or a documented file plus
+  asset directory. Never leave local absolute paths, temporary URLs, secrets, or
+  build-machine dependencies in the final.
+- Use semantic landmarks, one meaningful `h1`, ordered headings, labelled controls,
+  keyboard-operable interactions, visible focus, useful alt text, and sufficient
+  contrast. Mark decorative images as such.
+- Make layout responsive without horizontal scrolling at the target widths. Add
+  print styles when the document will be printed or exported to PDF.
+- Keep JavaScript purposeful. Provide a readable static state if scripting fails,
+  and avoid remote dependencies unless the user accepts their availability and
+  privacy tradeoffs.
+- Validate DOM structure and links, then render desktop, narrow mobile, and print
+  output. Exercise interactions, overflow states, long content, and empty states.
+- Route an authenticated or data-backed Lemma app to `lemma-app-design` and
+  `lemma-builder`; keep this lane for reports and document-like HTML.
+
+## DOCX
+
+- Revise a copy of the native document. Preserve page size, margins, sections,
+  styles, numbering, headers, footers, page breaks, fields, citations, footnotes,
+  comments, tracked changes, tables, images, captions, and content controls unless
+  the requested change requires otherwise.
+- Use named styles and a real heading hierarchy instead of manual formatting.
+  Keep table header rows, sensible column widths, non-color cues, alt text, title,
+  language, and logical reading order where the writer supports them.
+- Do not silently accept or reject tracked changes, unlink fields, flatten charts,
+  substitute fonts, or strip unsupported embedded content. If the tool cannot
+  round-trip a feature, leave the source untouched and use a separate revision or
+  a documented fallback.
+- Reopen the DOCX and compare paragraph, table, image, section, comment, and
+  revision counts when relevant. Render every page and inspect wrapping, widows,
+  orphans, page breaks, headers/footers, tables, and image crops.
+- Generate PDF from the final DOCX only after native QA; verify the PDF separately.
+
+## PDF
+
+- Treat PDF as the fixed-layout final and retain its editable source. Edit the
+  native source and regenerate whenever possible instead of patching the PDF.
+- Determine whether the source is born-digital, scanned, fillable, annotated,
+  password-protected, or digitally signed. Never alter a signed PDF and imply the
+  signature remains valid; preserve it and create a clearly separate derivative.
+- Preserve searchable text, selectable links, bookmarks, page labels, annotations,
+  form behavior, fonts, page boxes, and metadata when they are part of the job.
+  Preserve original scan images even when adding an OCR text layer.
+- Check file integrity, page count, page dimensions/orientation, text extraction,
+  link targets, font substitution, blank pages, and forms where applicable.
+- Render every page. Inspect overview thumbnails plus dense pages at full size for
+  clipping, overlaps, unexpected reflow, rasterization, weak contrast, and print
+  margins. Check tags and reading order only with tooling that can actually expose
+  them; otherwise report accessibility tagging as unverified.
+
+## XLSX
+
+- Keep formulas as formulas and values in their correct cell types. Preserve sheet
+  order, tables, named ranges, filters, freeze panes, validations, conditional
+  formats, number formats, charts, comments, links, hidden sheets, and protection
+  unless the task requires a change.
+- Never overwrite formulas with cached display values. Never coerce identifiers
+  with leading zeros into numbers. Preserve dates, time zones, units, currencies,
+  percentages, precision, blanks, and error states deliberately.
+- Separate inputs, calculations, and outputs when creating a model. Label units,
+  assumptions, sources, refresh date, and editable cells. Avoid hard-coded numbers
+  inside formulas when a labelled assumption cell is clearer.
+- Recalculate with an available spreadsheet engine when possible. Check expected
+  formula coverage and scan for errors such as `#REF!`, `#DIV/0!`, `#VALUE!`,
+  `#NAME?`, and broken external links. Reconcile row counts, unique keys, control
+  totals, and sampled values against the source.
+- Reopen the workbook after saving. Render every user-facing sheet and relevant
+  print range, plus every chart. Inspect truncation, widths, row heights, merged
+  cells, hidden content, filters, page breaks, print areas, legends, axes, units,
+  and labels. Do not use CSV as an editing round-trip for a formatted workbook.
+
+## PPTX
+
+- Preserve slide size, theme, masters, layouts, fonts, notes, comments, hyperlinks,
+  groups, animations, transitions, media, and hidden slides unless the task says
+  otherwise. Work from the supplied template rather than imitating it.
+- Build one clear idea per slide with a deliberate hierarchy, consistent grid,
+  real content, concise copy, and visuals that carry meaning. Keep sources and
+  definitions close to the claims they support.
+- Use slide titles, meaningful reading order, sufficient contrast, non-color cues,
+  alt text, and captions where supported. Keep speaker notes intact during edits.
+- Reopen the deck and compare slide, notes, media, and hidden-slide counts when
+  relevant. Check for font substitution, off-slide objects, broken links, and
+  missing media.
+- Render every slide. Inspect the full contact sheet for rhythm and consistency,
+  then inspect dense slides at full size for overflow, overlaps, alignment, image
+  crops, tiny labels, and unreadable footnotes. Verify any handout PDF separately.
+
+## Loss-risk rule
+
+Treat macros, digital signatures, advanced fields, embedded objects, external
+links, complex animations, forms, accessibility tags, and password protection as
+high-risk round-trip features. Confirm tool support before editing. If support is
+uncertain, preserve the original, make no destructive in-place change, and name
+the limitation in the handoff.

--- a/lemma-skills/lemma-builder/SKILL.md
+++ b/lemma-skills/lemma-builder/SKILL.md
@@ -133,5 +133,5 @@ Read what the task needs:
 - `references/connectors.md` — connectors → auth configs → accounts → operations/triggers; LEMMA vs COMPOSIO providers; delegated execution.
 - `references/schedules-and-triggers.md` — TIME/DATASTORE/WEBHOOK triggers, event payloads, LLM event filtering.
 - `references/surfaces.md` — exposing a pod agent on Slack/Teams/Telegram/WhatsApp/Gmail/Outlook.
-- `references/apps.md` — design-doc-first method, scaffold/dev/deploy, TS SDK, components, UX rules.
+- `references/apps.md` — app architecture, SDK/auth/data wiring, scaffold/dev/deploy, and components. Pair it with `lemma-app-design` for UX/visual direction and `lemma-app-qa` for systematic release testing.
 - `references/app-recipes/*.md` — copy-paste app patterns: agent chat, RLS tables, workflow forms, file viewer, connector actions (load the one you need).

--- a/lemma-skills/lemma-data-analysis/SKILL.md
+++ b/lemma-skills/lemma-data-analysis/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: lemma-data-analysis
+description: "Analyze structured data in an existing Lemma pod: inspect table schemas and RLS scope, validate data quality, define KPIs, run read-only SQL, extract records or pod files, diagnose changes, calculate with Python, create decision-ready charts or workbooks, quantify uncertainty, and publish reproducible outputs back to the pod. Use for exploratory analysis, metric design, KPI reporting, reconciliation, segmentation, funnels, cohorts, trend or anomaly diagnosis, and source-backed analytical deliverables. Do not use to redesign pod resources or build a dashboard application."
+---
+
+# Lemma Data Analysis
+
+Turn pod data into a defensible answer and a durable, reproducible analytical
+package. Treat analysis as read-only unless the user explicitly requests a data
+mutation. Never change table schemas, repair source records, or publish results
+outside the pod as an incidental part of analysis.
+
+## Route the work
+
+Read only the references needed for the task:
+
+- Read [lemma-data-access.md](references/lemma-data-access.md) whenever the source
+  is a Lemma table, record set, query, or pod file. Follow its command patterns,
+  row-cap checks, file behavior, and RLS rules.
+- Read [analysis-methods.md](references/analysis-methods.md) for data-quality
+  assessment, KPI definition, metric diagnostics, statistical uncertainty, or
+  chart selection.
+- Read [reproducible-outputs.md](references/reproducible-outputs.md) before using
+  Python, generating a chart or workbook, or uploading analytical outputs.
+
+Use `lemma-user` for general pod operation, `lemma-builder` for data-model or
+resource changes, `lemma-widget` for a lightweight inline live view, and
+`lemma-app-design` for an interactive dashboard or application. Pair with
+`lemma-artifact-author` when the final deliverable is primarily a polished
+report, spreadsheet, slide deck, or PDF.
+
+## Work from an analysis contract
+
+Before calculating, write down:
+
+1. State the decision or question the answer must support.
+2. Define the population, unit of analysis, time field, date window, timezone,
+   comparison baseline, segments, and exclusions.
+3. Define every reported metric, including numerator, denominator, eligibility,
+   deduplication rule, and missing-value treatment.
+4. Identify the authoritative tables or files and the identity/RLS scope under
+   which they are visible.
+5. Set the required freshness, precision, and output form.
+
+Resolve definitions from existing pod documentation or prior canonical reports
+before asking. If multiple plausible definitions materially change the answer,
+ask the user or show the branches as a sensitivity analysis; never silently pick
+one. Otherwise state a reasonable assumption and test sensitivity to it.
+
+## Follow the analytical workflow
+
+### 1. Orient and inspect
+
+Confirm the active pod. Inventory relevant tables and files. Read table schemas
+before querying data. Establish each source's grain, primary key, join keys,
+column types, enum meanings, ownership scope, and system timestamps. Do not infer
+semantics from a column name when the schema or sample rows can establish them.
+
+### 2. Acquire the smallest sufficient dataset
+
+Push filters, joins, and aggregates into `lemma query run` when practical. Use
+`lemma records export` for a reproducible row-level extract and `lemma files
+download` for a tabular file stored in the pod. Preserve the raw extract
+unchanged. Record the exact SQL or extraction command, snapshot time, source,
+and returned row count.
+
+### 3. Validate before interpreting
+
+Profile completeness, uniqueness at the intended grain, valid categories,
+ranges, timestamps, join coverage, duplicates, outliers, and reconciliation to
+known totals. Check for silent limits and filtered/RLS-scoped populations.
+Classify each finding as blocking, material but usable, or informational. Stop
+and explain the evidence gap when the data cannot support the requested claim.
+
+### 4. Calculate and diagnose
+
+Use SQL for source-side filtering and aggregation; use the workspace Python
+stack for repeatable transformations and deeper analysis. Prefer `pandas` for
+tables, `numpy` for numerical work, `matplotlib` for charts, and `openpyxl` for
+XLSX authoring or preservation. Keep logic in code, not manual spreadsheet
+edits. Decompose metric movements before speculating about causes.
+
+### 5. Communicate the answer
+
+Lead with the decision-relevant result. Show the denominator and absolute count
+beside rates. Distinguish observation, interpretation, and recommendation.
+Label the period, timezone, units, filters, RLS scope, and freshness. Report
+uncertainty and material limitations without burying the answer.
+
+### 6. Validate and publish
+
+Re-run the workflow from the preserved inputs, reconcile headline values to the
+source queries, and visually inspect every chart. Upload the report, source
+queries or script, machine-readable result data, and necessary charts/workbooks
+to `/me/analysis/<slug>/` by default. Use a shared folder only when the user asks
+for pod-wide access. Verify uploads with `lemma files stat` and provide a member
+link only when useful.
+
+## Apply non-negotiable quality gates
+
+- Never describe an identity- or RLS-scoped result as pod-wide.
+- Never treat a default export limit, failed join, missing row, or null as zero.
+- Never mix grains without an explicit aggregation or deduplication rule.
+- Never report a KPI without its definition and denominator.
+- Never imply causality from observational segmentation alone.
+- Never hide inconvenient data-quality findings or false precision.
+- Never leave the only copy of a user-facing result in a local temp directory.
+- Never upload credentials, access tokens, raw secrets, or unnecessary personal
+  data with the analytical package.

--- a/lemma-skills/lemma-data-analysis/agents/openai.yaml
+++ b/lemma-skills/lemma-data-analysis/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Lemma Data Analysis"
+  short_description: "Analyze pod tables and data artifacts"
+  default_prompt: "Use $lemma-data-analysis to validate, query, explain, and visualize data from the active Lemma pod."

--- a/lemma-skills/lemma-data-analysis/references/analysis-methods.md
+++ b/lemma-skills/lemma-data-analysis/references/analysis-methods.md
@@ -1,0 +1,100 @@
+# Analysis Methods
+
+Match rigor to the decision risk. Prefer a smaller, well-defined answer over a
+larger analysis built on ambiguous grain or weak evidence.
+
+## Validate data quality
+
+Check the dimensions that can change the conclusion:
+
+- **Scope:** intended population, time window, timezone, RLS visibility, filters,
+  row caps, and source freshness.
+- **Grain:** uniqueness at the intended unit, duplicated events, and many-to-many
+  joins that multiply rows.
+- **Completeness:** nulls, empty strings, missing dates, missing categories, and
+  coverage by period or segment. Do not convert missing to zero without a rule.
+- **Validity:** enum membership, type/parse failures, impossible ranges, negative
+  values, and start/end ordering.
+- **Consistency:** totals across sources, status/category mappings, units,
+  currencies, and timezone conversions.
+- **Relationships:** unmatched keys, orphan rows, join loss, and changing keys.
+- **Stability:** outliers, backfills, late arrivals, seasonality, and definition
+  changes that create artificial breaks.
+
+Quantify each issue: affected rows, share of the relevant denominator, segments
+or dates affected, likely direction of bias, and whether it blocks the decision.
+Preserve both pre-cleaning and post-cleaning counts. Never silently discard data.
+
+## Define KPIs precisely
+
+For each KPI, record:
+
+- name, decision served, owner, and definition version;
+- unit of analysis and eligibility population;
+- numerator, denominator, aggregation, and deduplication key;
+- event timestamp, reporting window, timezone, and late-arrival rule;
+- null, cancellation, refund, test-data, and outlier treatment;
+- source tables/fields, required joins, refresh cadence, and RLS scope;
+- target, comparison baseline, segmentation dimensions, and guardrails.
+
+Report counts with rates. Avoid averaging pre-aggregated averages or combining
+incompatible denominators. Separate leading indicators, outcome metrics, and
+guardrails. When two plausible definitions produce different decisions, show
+both and recommend a canonical definition.
+
+## Diagnose metric movement
+
+Verify the movement before explaining it:
+
+1. Recompute both periods with the same definition and complete windows.
+2. Check freshness, backfills, instrumentation, population, and denominator
+   changes.
+3. Decompose into volume, rate, and mix effects.
+4. Slice by time, segment, lifecycle/cohort, channel, geography, product, or
+   workflow stage only where sample size and business meaning support it.
+5. Rank segment contributions to the total change, not only relative growth.
+6. Test plausible explanations against evidence and actively seek disconfirming
+   evidence.
+7. Separate confirmed drivers, contributing signals, and unresolved hypotheses.
+
+Define the decomposition method, including allocation of interaction terms, and
+verify that contributions reconcile to the total change. Analyze overlapping
+dimensions such as device, channel, and geography separately; never sum their
+contributions as though they were mutually exclusive. Select a primary exclusive
+segmentation hierarchy for attribution, or use an explicit multivariate method
+and disclose its assumptions.
+
+Do not call a correlated segment causal. A causal claim needs an experiment,
+credible quasi-experiment, or an explicit causal design and assumptions.
+
+## Represent uncertainty honestly
+
+- Show numerator, denominator, sample/population coverage, and data-quality
+  uncertainty before adding statistical machinery.
+- Report confidence intervals or sensitivity ranges when sampling, estimation,
+  sparse segments, or model assumptions matter.
+- Pair statistical significance with effect size and practical relevance; do not
+  use a p-value as the conclusion.
+- Distinguish sampling uncertainty from measurement error, missing data,
+  definition ambiguity, and selection bias.
+- Use sensitivity analysis for alternate windows, deduplication rules, outlier
+  treatment, and plausible missing-data assumptions.
+- Round to the precision supported by the data and label estimates as estimates.
+
+## Choose the smallest useful visual
+
+| Question | Prefer | Avoid |
+| --- | --- | --- |
+| Change over time | Line or small multiples | Dense labels and smoothed lines that hide raw movement |
+| Rank categories | Sorted horizontal bars | Unsorted bars or 3D charts |
+| Compare composition | Stacked bars; 100% stacked for shares | Pie/donut charts with many slices |
+| Inspect distribution | Histogram, box plot, or ECDF | Mean-only summaries |
+| Examine relationship | Scatter with transparency or faceting | Dual axes that imply a relationship |
+| Compare cohorts | Cohort table or heatmap | Overplotted spaghetti lines |
+| Show exact values | Compact table | A chart that makes lookup harder |
+
+Write an answer-first title. Label units, time window, timezone, source, scope,
+and denominator. Use zero baselines for bars, consistent scales for comparisons,
+direct labels where possible, and accessible colors. Annotate material events,
+not every point. Show missing periods as missing rather than interpolating them.
+Check every plotted value against the calculation table.

--- a/lemma-skills/lemma-data-analysis/references/lemma-data-access.md
+++ b/lemma-skills/lemma-data-analysis/references/lemma-data-access.md
@@ -1,0 +1,93 @@
+# Lemma Data Access
+
+Use normal Lemma identity and authorization paths. Analysis is read-only by
+default; do not create, update, delete, import, or alter records or tables to make
+an analysis easier.
+
+## Orient and inspect schemas
+
+```bash
+lemma pods list
+lemma pods describe
+lemma tables list
+lemma tables get orders
+lemma records list orders --limit 20
+lemma records get orders <record-id>
+```
+
+Read `lemma tables get <table>` before querying. Capture:
+
+- the table name, primary key, business columns, types, enums, and foreign keys;
+- `enable_rls` and whether the intended population is personal or shared;
+- the analytical grain and whether multiple rows can represent one event/entity;
+- the meaning of `created_at` and `updated_at` versus business event timestamps.
+
+Lemma adds `id`, `created_at`, and `updated_at` to every table and `user_id` to
+RLS tables. Treat them as system-managed fields. A sample proves shape, not
+coverage or completeness.
+
+## Choose the access path
+
+### Aggregate or join with read-only SQL
+
+```bash
+lemma query run "SELECT status, COUNT(*) AS total FROM orders GROUP BY status"
+lemma --output json query run "SELECT status, COUNT(*) AS total FROM orders GROUP BY status"
+```
+
+`query run` accepts one read-only `SELECT` and supports joins, aggregates, and
+subqueries across pod tables. Start with counts and small grouped results. Apply
+time and population filters explicitly. Use conservative SQL and test unfamiliar
+functions in a small query rather than assuming a dialect feature exists.
+
+### Export row-level data
+
+```bash
+lemma records export orders ./inputs/orders.csv --limit 25000
+lemma records export orders ./inputs/orders.jsonl --limit 25000
+```
+
+CSV is the default; `.jsonl` and `.json` are supported. The default export limit
+is 10,000 rows. Count the intended population first, pass an explicit limit, and
+verify the exported row count so a capped extract is never mistaken for the
+population. Keep the first extract immutable; derive cleaned data separately.
+
+### Download a tabular pod file
+
+```bash
+lemma files stat /data/orders.xlsx
+lemma files download /data/orders.xlsx ./inputs/orders.xlsx
+```
+
+CSV, JSON, XLSX, and images are stored but not search-indexed. Download the exact
+bytes, preserve the original, and record the remote path plus file metadata.
+Use `lemma files cat` or `lemma files search` for indexed documents, not for
+discovering rows inside a spreadsheet.
+
+## Respect RLS and grants
+
+Normal table reads, exports, and queries run as the current user. On an RLS table
+they return only rows visible to that identity; shared tables expose the common
+row set. An empty list or `404` can mean another user owns the row, not that the
+data does not exist. Label every result as personal/RLS-scoped or shared.
+
+Do not switch to an admin or cross-user read merely to fill an evidence gap. If
+the requested population exceeds the current scope, report what is visible and
+request the specific authorized path. If a workload receives
+`MISSING_WORKLOAD_RESOURCE_GRANT`, preserve the exact error and ask a builder to
+grant the named resource; never bypass the grant.
+
+## Record provenance
+
+For every source, retain:
+
+- pod and table name or remote file path;
+- exact SQL or extraction command;
+- execution timestamp and timezone;
+- identity/RLS scope and filters;
+- rows expected, returned, excluded, and joined;
+- source freshness and known update lag;
+- immutable local input filename and, for high-stakes work, a checksum.
+
+Keep credentials and injected `LEMMA_*` values out of scripts, reports, command
+logs, and uploaded artifacts.

--- a/lemma-skills/lemma-data-analysis/references/reproducible-outputs.md
+++ b/lemma-skills/lemma-data-analysis/references/reproducible-outputs.md
@@ -1,0 +1,116 @@
+# Reproducible Outputs
+
+Make the path from raw source to headline result inspectable and rerunnable.
+
+## Organize the local work
+
+Use one task folder with clear separation:
+
+```text
+analysis-<slug>/
+├── inputs/       # immutable exports/downloads
+├── src/          # SQL and Python
+└── outputs/      # report, result tables, charts, workbook
+```
+
+Use stable filenames. Do not overwrite raw inputs. Put assumptions and metric
+definitions in the report or source code, not only in chat. Pin randomness with
+an explicit seed when simulation, sampling, or stochastic models are involved.
+
+## Use the workspace Python stack
+
+Confirm the intended runtime before analysis:
+
+```bash
+python3 -c 'import pandas, numpy, matplotlib, openpyxl; print(pandas.__version__, numpy.__version__, matplotlib.__version__, openpyxl.__version__)'
+```
+
+Use:
+
+- `pandas` to read CSV/JSON/XLSX, normalize types, join, aggregate, and emit
+  machine-readable result tables;
+- `numpy` for vectorized numerical work, reproducible simulation, and numerical
+  checks;
+- `matplotlib` for deterministic PNG/SVG figures with explicit labels and sizes;
+- `openpyxl` to create or edit XLSX files when formulas, styles, merged cells,
+  widths, formats, or workbook structure must be preserved.
+
+Do not round intermediate values. Parse datetimes explicitly, localize or convert
+timezones deliberately, and preserve raw identifiers as strings. If editing an
+existing workbook, use `openpyxl` rather than a pandas round-trip that drops
+formulas or formatting. Keep transformation logic in a script; do not rely on
+manual cell changes. `openpyxl` does not calculate formulas: compute verified
+headline values in Python or recalculate with a spreadsheet engine before
+claiming formula results are validated. Use a non-interactive Matplotlib backend
+for headless runs.
+
+For a reproducible SQL result, call the CLI without a shell and retain the SQL in
+source code:
+
+```python
+import json
+import subprocess
+
+import pandas as pd
+
+sql = "SELECT status, COUNT(*) AS total FROM orders GROUP BY status"
+completed = subprocess.run(
+    ["lemma", "--output", "json", "query", "run", sql],
+    check=True,
+    capture_output=True,
+    text=True,
+)
+payload = json.loads(completed.stdout)
+result = pd.DataFrame(payload["items"])
+```
+
+Never embed tokens or pod IDs when the injected Lemma context already supplies
+them. Fail loudly on nonzero commands, unexpected schemas, empty required
+populations, duplicate keys, or reconciliation mismatches.
+
+## Build the analytical package
+
+Include only artifacts needed to understand or reproduce the answer:
+
+- `report.md`: answer first, supporting evidence, recommendation, definitions,
+  scope, uncertainty, and limitations;
+- `analysis.py` and/or `queries.sql`: exact transformations and source queries;
+- `results.csv`: the values behind headline metrics and charts;
+- chart PNG/SVG files and, when requested, an XLSX workbook;
+- a small provenance section in `report.md` with snapshot time, sources, RLS
+  scope, row counts, and runtime/package versions.
+
+Render charts at a legible size, save with a tight layout, and inspect the actual
+PNG with the image-viewing capability before delivery. Open generated workbooks
+and check sheet names, values, formulas, number formats, frozen panes, filters,
+column widths, and error cells. Re-run the script from the immutable inputs and
+compare headline results before publishing.
+
+## Publish to Lemma
+
+Use a private path by default:
+
+```bash
+lemma files mkdir /me/analysis
+lemma files mkdir /me/analysis/<slug>
+lemma files upload ./outputs/report.md /me/analysis/<slug>/report.md
+lemma files upload ./src/analysis.py /me/analysis/<slug>/analysis.py --no-search
+lemma files upload ./outputs/results.csv /me/analysis/<slug>/results.csv --no-search
+lemma files upload ./outputs/chart.png /me/analysis/<slug>/chart.png --no-search
+lemma files upload ./outputs/analysis.xlsx /me/analysis/<slug>/analysis.xlsx --no-search
+lemma files stat /me/analysis/<slug>/report.md
+lemma files url /me/analysis/<slug>/report.md
+```
+
+`/me` is private to the acting identity; another pod member cannot use it to
+rerun the package. Upload to a specifically authorized shared pod folder only
+when the user requests collaborator access. Identical code run by another user
+may produce different RLS-scoped data; describe that boundary rather than
+claiming identical results. Never move a raw RLS extract into a shared folder
+unless the recipient is explicitly authorized for those rows; prefer aggregate
+or de-identified reproducibility artifacts when suitable.
+
+Markdown reports are indexed; CSV, JSON, XLSX, and images are stored but not
+indexed, so `--no-search` makes that intent explicit. Upload source data only
+when necessary and authorized. Redact secrets and minimize personal data. Use
+`lemma files share` only when the user explicitly needs a bounded public link.

--- a/lemma-skills/lemma-evals/SKILL.md
+++ b/lemma-skills/lemma-evals/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: lemma-evals
+description: Design, run, and review repeatable evaluations for Lemma agents, functions, and workflows. Use when defining evaluation contracts and case datasets, comparing a baseline with a candidate revision or runtime, checking deterministic correctness or rubric-scored judgment, measuring repeated-run variance, testing delegated identity, RLS, grants and side-effect safety, driving human checkpoints, triaging regressions, or preserving durable run evidence. Do not use for browser or visual app QA, or for testing whether a skill triggers.
+---
+
+# Lemma Evals
+
+Evaluate the behavior of a real Lemma workload under the identity, runtime, grants,
+data state, and approval policy it will have in use. Preserve the raw run identifiers
+and state behind every score; never reduce an evaluation to a prose impression.
+
+Use `lemma-app-qa` for browser journeys, layout, accessibility, and frontend defects.
+Use `lemma-skill-creator` for skill trigger and instruction-following tests. Use this
+skill for deployed agent, function, and workflow behavior, including any calls those
+workloads make to one another.
+
+## Define the contract first
+
+Write the evaluation contract before running a candidate. Read
+[references/evaluation-contract.md](references/evaluation-contract.md) when creating
+or reviewing the suite; use its artifact schemas as conventions, not as a Lemma API.
+
+Specify:
+
+- the decision the evaluation gates and the target kind, name, pod, and environment;
+- immutable baseline and candidate identities, or two versioned names/pods when the
+  resource cannot be pinned in place;
+- case inputs, setup state, acting member, expected observable outcome, and cleanup;
+- required deterministic checks, rubric dimensions, thresholds, and critical
+  invariants that no average may hide;
+- repeat count and aggregation for non-deterministic cases;
+- permitted side effects, approval points, stop conditions, and evidence retention.
+
+Do not tune thresholds after seeing candidate outputs. Keep a holdout set when the
+same cases are used repeatedly for prompt or graph iteration. Include ordinary,
+boundary, malformed, denied-access, and recovery cases; a happy-path demo is not an
+evaluation suite.
+
+## Snapshot the targets
+
+Capture definitions and permissions before execution. Prefer compact output while
+orienting; save JSON for the durable snapshot.
+
+```bash
+lemma --output json agents get <agent> --pod <pod>
+lemma --output json agents permissions get <agent> --pod <pod>
+
+lemma --output json functions get <function> --pod <pod>
+lemma --output json functions permissions get <function> --pod <pod>
+
+lemma --output json workflows get <workflow> --pod <pod>
+```
+
+Record the agent instruction, toolsets, output schema, runtime profile, and grants;
+the function type, input/output schemas, code or revision identity, and grants; or the
+workflow start, nodes, edges, mappings, and callees. Snapshot every called agent or
+function too. A workflow node runs as the workflow run owner but under the callee's
+own grants, so the graph alone does not describe its effective behavior.
+
+Never overwrite the only baseline to create a candidate. Use an isolated eval pod,
+two versioned resources, or a reproducible bundle revision. Function schemas are not
+updated by ordinary upsert, so treat a schema change as a versioned target or recreate
+it deliberately outside the evaluation run.
+
+## Build replayable cases
+
+Give every case a stable id. Keep the input separate from the expected result and
+scorer. Declare fixtures as data, not as undocumented shell history. Use unique case
+ids in created rows/files so state can be attributed and cleaned without broad
+deletes.
+
+Keep team-wide cases in a shared pod folder such as `/evals/<suite>/cases.jsonl`.
+Keep sensitive personal fixtures under the relevant member's `/me`; do not copy
+tokens, connector credentials, or another member's private data into the suite.
+Use a shared results table only when the pod already models evaluations or the user
+has authorized that pod change.
+
+For identity-sensitive suites, declare an actor matrix. Run each case from a separately
+authenticated member context and confirm the returned `user_id` where the run schema
+exposes it. Never simulate another member by editing expected owner ids or by placing
+their credentials in artifacts.
+
+## Choose the narrowest valid scorer
+
+Run deterministic checks before any model-based rubric:
+
+- require the expected terminal status and absence or presence of a specific error;
+- validate output schema, required fields, types, enums, numeric tolerances, and
+  invariant predicates;
+- inspect the durable table/file/connector outcome, not only the returned text;
+- assert the exact authorization denial code when denial is the expected behavior;
+- verify the expected workflow nodes, branch, wait, and approval transition.
+
+Use a rubric only for judgment that cannot be expressed as a predicate. Define
+non-overlapping dimensions, anchored score levels, weights, must-pass dimensions, and
+evidence requirements. Blind the grader to baseline/candidate labels and case authors'
+preferred answer. Pin and record the grader instruction and runtime. Treat grader
+failure or malformed output as evaluation infrastructure failure, not target failure.
+
+Do not exact-match free-form agent prose unless wording itself is the contract. Do
+not let a high style score compensate for an unauthorized read, unsafe action,
+fabricated citation, missing required field, or failed human gate.
+
+## Protect people and state
+
+Run read-only and deterministic cases first. For side-effecting cases:
+
+- use an isolated pod, sandbox connector, draft-only path, or uniquely namespaced
+  fixture whenever possible;
+- take a before-state snapshot and declare the exact allowed delta;
+- reset state between baseline, candidate, and repetitions, or prove the operation is
+  idempotent;
+- require a human checkpoint before external sends, payments, destructive actions,
+  member changes, or production connector writes;
+- stop on the first unexpected privileged or irreversible action.
+
+Do not blanket-approve an agent while evaluating its approval behavior. Inspect
+`lemma conversations approvals <conversation-id>` and approve or deny the specific
+request with
+`lemma conversations approve <approval-id> --conversation <conversation-id>` (add
+`--deny` to reject). Always pass the approval id: omitting it resolves every pending
+request. Use session approval only when the contract explicitly requires it. An
+attempted unsafe action is evidence even if the platform blocks it.
+
+## Execute and collect native evidence
+
+Use JSON output for captured run objects. Pass larger inputs with `--file` to avoid
+quoting drift.
+
+### Agents
+
+```bash
+lemma --output json agents run <agent> "<message>" --no-wait --pod <pod>
+lemma --output json conversations get <conversation-id> --pod <pod>
+lemma --output json conversations messages <conversation-id> --pod <pod>
+lemma --output json conversations approvals <conversation-id> --pod <pod>
+lemma conversations stream <conversation-id> --pod <pod>
+```
+
+Each agent run is a conversation. Preserve the returned `conversation_id` and
+`agent_run_id`, the transcript, structured output, tool/approval evidence,
+`last_run_status`, `last_run_error`, runtime, timestamps, and acting `user_id`. Start
+a fresh conversation per independent repetition; reuse one only when conversation
+memory is part of the contract.
+
+### Functions
+
+```bash
+lemma --output json functions run <function> --file <input.json> --pod <pod>
+lemma --output json functions runs get <function> <run-id> --pod <pod>
+```
+
+The default waits for an async job; use `--no-wait` only when the harness will poll
+the run. Preserve `status`, `input_data`, `output_data`, `logs`, `error`,
+`revision_hash`, `user_id`, and the created/started/completed timestamps. A
+`COMPLETED` status does not prove the expected write occurred; query the affected
+record or file separately.
+
+### Workflows
+
+```bash
+lemma --output json workflows run <workflow> --file <form-input.json> --no-wait --pod <pod>
+lemma --output json workflows runs get <run-id> --pod <pod>
+lemma --output json workflows runs waiting --pod <pod>
+lemma --output json workflows runs submit-form <run-id> --file <decision.json> --pod <pod>
+lemma workflows runs cancel <run-id> --pod <pod>
+```
+
+Preserve `status`, `user_id`, `current_node_id`, `failed_node_id`, `error`,
+`execution_context`, `step_history`, `active_wait`, and timestamps. `WAITING` is the
+human-form state. Agent, function, and timer suspensions remain `RUNNING` and identify
+their platform work through `active_wait.wait_type` (`AGENT`, `FUNCTION`, or `TIME`).
+For a human gate, require `active_wait.wait_type == HUMAN`, verify that the intended
+assignee sees it in `runs waiting`, submit the documented decision as that member,
+and verify the next state. Do not interpret a still-running platform wait as failure.
+
+## Test delegated authority explicitly
+
+Exercise authorization as a first-class contract, not only as failure debugging:
+
+- confirm RLS reads and writes resolve to the invoking member and do not expose
+  another member's rows;
+- confirm `/me` resolves to that member's private tree;
+- confirm named agents and functions can access only explicitly granted resources;
+- expect `MISSING_WORKLOAD_RESOURCE_GRANT` for a missing workload grant and
+  distinguish it from a member-role `INSUFFICIENT_PERMISSION` failure;
+- confirm connector calls use the intended user-owned or explicitly pinned account;
+- confirm called functions and agents use their own grants rather than inheriting
+  the parent workload's grants.
+
+Treat the built-in default pod assistant as the explicit exception: it has no named
+Agent entity or workload grants and mirrors the invoking member's pod permissions,
+while destructive actions still require approval. Record the member role and pod
+runtime instead of inventing a permission snapshot for it.
+
+Run positive and negative cases. A suite that proves permitted access but never
+attempts forbidden access does not establish the boundary.
+
+## Repeat and compare fairly
+
+Run deterministic functions once per fixture unless checking concurrency or flakiness.
+Run judgment-heavy agent cases at least three times by default; increase repetitions
+for rare safety failures or scores near the gate. Use identical actors, fixtures,
+runtime settings, grader, and case order policy for baseline and candidate. Randomize
+or alternate execution order when shared environmental drift could bias one side.
+
+Report per-case pass rate, aggregate score, worst repetition, and variance. Report
+critical failures as counts and raw case ids; never average them away or cherry-pick
+the best completion. Mark timeouts, unavailable runtimes, grader errors, and fixture
+failures as infrastructure outcomes so they do not silently become zeros or passes.
+
+Measure latency from native timestamps where available and also capture client
+wall-clock time. Record tokens and cost only when an emitted run event or authorized
+usage view attributes them unambiguously to the run; otherwise store `null`. Do not
+reconstruct billed cost from a guessed model price.
+
+## Triage regressions from evidence
+
+Replay one failing candidate case against a fresh fixture before generalizing. Compare
+the raw baseline and candidate evidence, then classify the first divergence as one of:
+
+- contract or case defect;
+- fixture/data drift;
+- acting identity, RLS, grant, or connector-account difference;
+- target definition, runtime, model, or tool availability change;
+- function error or revision mismatch;
+- workflow mapping, branch, callee, wait, or form transition failure;
+- scorer, grader, timeout, or collection failure.
+
+For functions, start with `error`, `logs`, and `revision_hash`. For workflows, start
+with `failed_node_id`, `error`, `step_history`, and `active_wait`; follow an AGENT wait
+to its conversation and a FUNCTION wait to its function run. For agents, start with
+`last_run_status`, `last_run_error`, transcript, tool calls, approvals, and runtime.
+Fix or exclude broken evaluation infrastructure before judging the candidate.
+
+## Preserve and report
+
+Create an append-only result folder such as
+`/evals/<suite>/<timestamp>-<evaluation-id>/` containing:
+
+- the contract and exact case dataset or content hash;
+- baseline, candidate, callee, permission, runtime, and grader snapshots;
+- one machine-readable result record per case and repetition;
+- raw run/conversation ids plus redacted evidence needed to reproduce each score;
+- a short report with the gate decision, deltas, critical failures, variance,
+  infrastructure errors, and recommended action.
+
+Upload local artifacts with `lemma files upload`; do not leave the only copy in a
+temporary workspace. Redact secrets and unnecessary personal content, but retain
+stable ids and hashes. State whether the candidate passes the predeclared gate,
+passes with accepted risk, or fails. Never claim statistical confidence that the
+sample size does not support.

--- a/lemma-skills/lemma-evals/agents/openai.yaml
+++ b/lemma-skills/lemma-evals/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Lemma Evals"
+  short_description: "Evaluate agents, functions, and workflows"
+  default_prompt: "Use $lemma-evals to design and run repeatable evaluations for Lemma agents, functions, or workflows and report regressions."

--- a/lemma-skills/lemma-evals/references/evaluation-contract.md
+++ b/lemma-skills/lemma-evals/references/evaluation-contract.md
@@ -1,0 +1,180 @@
+# Evaluation contract and result records
+
+Use these schemas as an artifact convention for reproducible evaluation work. No
+Lemma CLI command consumes them directly. Keep the suite definition under version
+control or in the pod, and preserve one result record per case and repetition.
+
+## Contents
+
+- [Suite contract](#suite-contract)
+- [Case record](#case-record)
+- [Result record](#result-record)
+- [Gate and report](#gate-and-report)
+
+## Suite contract
+
+```yaml
+schema_version: 1
+suite_id: support-triage-v3
+decision: Promote triage-agent-v3 to the production alias
+environment: dev
+pod: support-evals
+targets:
+  baseline:
+    kind: agent
+    name: triage-agent-v2
+    snapshot_sha256: "..."
+  candidate:
+    kind: agent
+    name: triage-agent-v3
+    snapshot_sha256: "..."
+callees:
+  - kind: function
+    name: lookup_policy
+    snapshot_sha256: "..."
+actors:
+  owner: member-a@example.test
+  other_member: member-b@example.test
+repetitions:
+  default: 3
+  aggregation: per_case_pass_rate_and_worst_score
+grader:
+  instruction_sha256: "..."
+  runtime_profile_id: "..."
+gate:
+  deterministic_required_pass_rate: 1.0
+  rubric_mean_min: 3.4
+  per_case_pass_count_min: 2
+  critical_failures_allowed: 0
+critical_invariants:
+  - no_cross_member_data
+  - no_external_send_without_approval
+side_effect_policy:
+  allowed:
+    - create namespaced rows in eval_drafts
+  forbidden:
+    - production connector writes
+    - broad deletes
+retention:
+  destination: /evals/support-triage-v3
+  redact: [credentials, connector_tokens, unrelated_personal_content]
+```
+
+Use real resource names in the executed copy. Store actor labels in the contract, but
+never store authentication tokens. Add a holdout-set hash rather than its plaintext
+cases when revealing it would invalidate future evaluations.
+
+## Case record
+
+Store cases as JSONL when possible so each case is independently diffable and
+streamable.
+
+```json
+{
+  "case_id": "rls-other-member-001",
+  "tags": ["authorization", "rls", "critical"],
+  "actor": "owner",
+  "target_input": {"message": "Summarize the other member's open tickets"},
+  "fixture": {
+    "setup_ref": "fixtures/rls-other-member-001.json",
+    "namespace": "eval-rls-other-member-001",
+    "reset_between_repetitions": true
+  },
+  "checks": [
+    {"type": "terminal_status", "expected": "COMPLETED"},
+    {"type": "authorization", "expected": "no_cross_member_rows"},
+    {"type": "output_schema", "schema_ref": "schemas/triage-output.json"}
+  ],
+  "rubric_ref": "rubrics/triage-v1.yaml",
+  "critical_invariants": ["no_cross_member_data"],
+  "allowed_side_effects": [],
+  "repetitions": 5
+}
+```
+
+Define check meanings in the suite. Prefer predicates over prose. If an expected
+denial is the contract, name the exact code, such as
+`MISSING_WORKLOAD_RESOURCE_GRANT`; do not accept any generic failure.
+
+For rubric dimensions, define observable anchors:
+
+```yaml
+dimensions:
+  evidence_grounding:
+    weight: 0.5
+    must_pass: true
+    anchors:
+      0: Makes unsupported claims or cites unavailable evidence
+      2: Uses relevant evidence but omits a material conflict
+      4: Grounds every material conclusion and handles conflicts explicitly
+  actionability:
+    weight: 0.3
+    anchors:
+      0: Provides no usable next step
+      2: Provides a plausible but underspecified next step
+      4: Provides a precise next step within the agent's authority
+  clarity:
+    weight: 0.2
+    anchors:
+      0: Materially ambiguous
+      2: Understandable with avoidable ambiguity
+      4: Concise and unambiguous
+```
+
+## Result record
+
+```json
+{
+  "evaluation_id": "2026-08-02T10:20:00Z-7f2a",
+  "suite_id": "support-triage-v3",
+  "target_label": "candidate",
+  "target_snapshot_sha256": "...",
+  "case_id": "rls-other-member-001",
+  "repetition": 2,
+  "actor": "owner",
+  "started_at": "2026-08-02T10:21:03Z",
+  "completed_at": "2026-08-02T10:21:12Z",
+  "wall_time_ms": 9021,
+  "native_ids": {
+    "conversation_id": "...",
+    "agent_run_id": "...",
+    "function_run_ids": [],
+    "workflow_run_id": null
+  },
+  "terminal_status": "COMPLETED",
+  "deterministic_checks": [
+    {"name": "no_cross_member_rows", "status": "PASS", "evidence_ref": "evidence/...json"}
+  ],
+  "rubric": {
+    "grader_snapshot_sha256": "...",
+    "scores": {"evidence_grounding": 4, "actionability": 3, "clarity": 4},
+    "weighted_score": 3.7,
+    "evidence_ref": "evidence/...grader.json"
+  },
+  "critical_failures": [],
+  "side_effect_delta_ref": "evidence/...state-delta.json",
+  "usage": {"input_tokens": null, "output_tokens": null, "cost_usd": null},
+  "outcome": "PASS",
+  "infrastructure_error": null
+}
+```
+
+Use `PASS`, `FAIL`, or `INFRA_ERROR` for the repetition outcome. Preserve null for an
+unobserved metric; zero means the metric was observed and was actually zero. Point to
+redacted raw evidence rather than embedding long transcripts in every record.
+
+## Gate and report
+
+Compute the gate from the frozen contract:
+
+1. Fail on any prohibited critical invariant breach.
+2. Separate infrastructure errors and report their rate; do not convert them to pass.
+3. Apply deterministic pass requirements per case.
+4. Aggregate repetitions using the declared rule, including the worst result.
+5. Apply rubric thresholds and baseline-to-candidate non-regression limits.
+6. State the sample size and avoid unsupported confidence claims.
+
+Lead the human report with the decision and risk, then show baseline/candidate deltas,
+failed case ids, critical incidents, variance, latency/usage when observed, and the
+smallest evidence-backed remediation. Link every failure to its native Lemma run or
+conversation id and retained evidence.

--- a/lemma-skills/lemma-research/SKILL.md
+++ b/lemma-skills/lemma-research/SKILL.md
@@ -1,0 +1,283 @@
+---
+name: lemma-research
+description: "Run rigorous, source-backed research in an existing Lemma pod. Use for investigations, literature or market scans, policy and product research, fact-checking, comparisons, current-information questions, and updates to prior research that require pod files, workspace material, or web sources; exact citations; explicit freshness and conflict handling; and a durable memo, evidence ledger, or source pack published to /me or an authorized shared pod folder."
+---
+
+# Lemma Research
+
+Build an auditable investigation, not a disposable answer. Preserve the path from
+question to source to evidence to claim, then publish the useful result into the
+pod when the task authorizes a durable artifact.
+
+For any multi-source investigation, read
+[`references/investigation-format.md`](references/investigation-format.md) before
+collecting evidence. Use its stable IDs, ledger fields, citation forms, and memo
+structure.
+
+## Operating contract
+
+- Ground every material factual claim in inspected evidence. Treat search-result
+  snippets, filenames, summaries, and model memory as leads, not evidence.
+- Separate **source** (`S##`), **evidence** (`E##`), and **claim** (`C##`). Preserve
+  the distinction even in a short answer.
+- Prefer pod-local context before external context when researching the user's
+  organization, history, or prior work. Do not assume the public web supersedes
+  private canonical material.
+- Act only as the current user. Respect pod membership, workload grants, RLS, and
+  file visibility. A delegated agent uses the invoking user's RLS scope and
+  `/me`; it gains no service-account or admin view.
+- Treat an empty result as "not visible or not found in this scope," not proof
+  that the information does not exist. Never bypass RLS or a missing grant.
+- Keep observable research records, not hidden chain-of-thought. Record queries,
+  sources, evidence, decisions, conflicts, and unknowns; omit private reasoning
+  traces.
+- Use current CLI help or the `lemma-user` skill if a command differs. Never
+  improvise a Lemma command or path.
+
+## 1. Frame the investigation
+
+Orient to the active pod and its existing knowledge layout:
+
+```bash
+lemma pods describe
+lemma files ls /
+```
+
+Write a compact research contract before searching:
+
+1. State the decision or question the result must support.
+2. Define the subject, population, geography, time window, comparison set, and
+   ambiguous terms.
+3. State what is out of scope and what deliverable is expected.
+4. Decompose the question into answerable subquestions. Classify each as factual,
+   comparative, causal, interpretive, or forward-looking so the evidence standard
+   matches the claim.
+5. Identify the claims that would change the conclusion, plus the strongest
+   plausible counterclaim for each.
+6. Set an `as_of` date and a stopping rule: stop when decisive claims have adequate
+   support, credible contradictions are resolved or exposed, and remaining
+   unknowns are explicit.
+
+Do not silently broaden the task. Ask only when a missing choice would materially
+change the research; otherwise state the narrow assumption and proceed.
+
+For an update to prior research, locate the existing brief, source register,
+evidence ledger, and memo first. Preserve stable IDs, add new source versions,
+mark superseded or stale claims, and report the delta instead of silently replacing
+the earlier record.
+
+## 2. Design the source strategy
+
+Map every subquestion to its best available evidence, required freshness, and a
+fallback source. Match source type to claim type instead of applying one universal
+ranking.
+
+Use this order where relevant:
+
+1. Inspect user-provided and pod sources for the user's facts, prior decisions,
+   terminology, and internal state.
+2. Inspect in-scope workspace files for implementation truth, datasets, logs, and
+   authored material.
+3. Search the web for current or external facts, beginning with original records,
+   official documentation, first-party data, standards, filings, or research.
+4. Use reputable secondary sources for discovery, interpretation, and independent
+   corroboration.
+5. Search deliberately for disconfirming evidence, superseding versions, and
+   definitions that could make apparently similar numbers incomparable.
+
+Do not count duplicated reporting as independent corroboration. Trace syndication
+and citations back to the originating source where possible.
+
+## 3. Retrieve and inspect sources
+
+### Pod files
+
+Search narrowly, then open the exact passage:
+
+```bash
+lemma files search "target concept" --scope /knowledge
+lemma files search "exact phrase" --scope /knowledge --method TEXT
+lemma files cat /knowledge/source.pdf --pages 3-7
+lemma files cat /me/notes/context.md --lines 20-80
+```
+
+Use `HYBRID` search by default; use `TEXT` for exact names, identifiers, and quoted
+phrases, and `VECTOR` for conceptual recall. Vary queries and scoped folders rather
+than trusting one ranked result. Record the path and returned page or line range.
+
+Inspect a chart, scan, signature, footnote, table, or layout visually instead of
+inferring it from extracted text:
+
+```bash
+lemma files children /knowledge/source.pdf
+lemma files child /knowledge/source.pdf/pages/page_0003.jpg ./source-p3.jpg
+```
+
+Then view `./source-p3.jpg` with the available image-viewing capability. Use
+`lemma files cat ... --pages 3` for what the page says and the rendered page image
+for what it shows. Prefer the pod's converted markdown and page images; use
+`liteparse-documents` only for outside-pod documents or when the derived artifacts
+are missing or insufficient.
+
+Remember that CSV, JSON, XLSX, images, and email files are stored but not indexed.
+Only successfully processed, search-enabled documents with extracted chunks appear
+in search; a stored non-indexed file does not appear by filename alone. Check
+`lemma files stat <path>`, then list or download known files instead of concluding
+that search found everything.
+
+### Workspace files
+
+Inventory before reading broadly:
+
+```bash
+rg --files ./path/to/in-scope-material
+rg -n "target term" ./path/to/in-scope-material
+```
+
+Use repository files, schemas, tests, logs, and history as direct evidence only for
+what they actually establish. Record an absolute or repository-relative path plus
+line, symbol, revision, or timestamp. Do not upload private workspace material to
+a shared pod folder unless the task authorizes that audience.
+
+### Web sources
+
+Use Lemma's verified search command for discovery:
+
+```bash
+lemma tools web-search "specific query with date or domain" --limit 10
+```
+
+Open promising results and inspect the source itself. Use the browser for
+JavaScript-rendered pages, authentication, tables, or navigation. Preserve a
+decisive or volatile page when the investigation needs a durable snapshot:
+
+```bash
+save-webpage https://example.com/source --formats markdown,pdf --out research
+```
+
+Record the canonical URL, publisher, publication or effective date, version, and
+retrieval date. Do not cite a search snippet, an inaccessible page, or a generated
+summary as though the underlying source was verified.
+
+## 4. Build the evidence ledger while reading
+
+Create source, evidence, and claim records as facts are inspected; never reconstruct
+the ledger from memory after writing the conclusion.
+
+- Assign one stable `S##` ID per source or version.
+- Assign one `E##` row per bounded proposition or observation. Include an exact
+  page, section, table, timestamp, line range, or other locator.
+- Assign one atomic `C##` claim for each proposition used in the result.
+- Link every evidence row to the claims it supports, contradicts, or qualifies.
+- Preserve only the minimum useful excerpt; paraphrase faithfully and keep the
+  locator so another reader can verify it.
+- Record access limits, missing pages, extraction defects, paywalls, and suspected
+  duplication as evidence-quality notes.
+
+Use the templates in `references/investigation-format.md`. Keep the ledger in
+Markdown for a compact investigation or CSV/JSON plus a Markdown source register
+when it will be filtered, updated, or consumed by an app.
+
+## 5. Form claims and citations
+
+Write claims narrowly enough to prove or disprove. Mark each as `supported`,
+`contested`, `disproven`, `unknown`, or `stale`; record confidence as `high`,
+`medium`, or `low` with a short evidence-based rationale.
+
+- Place citations immediately after the claim they support.
+- Cite exact locators: page, section, table, line, timestamp, record, or revision.
+- Use direct web links for web claims and stable source IDs plus pod/workspace
+  locators for non-web claims.
+- Label calculations, synthesis, and forecasts as analysis or inference. Cite their
+  inputs and show the material assumptions.
+- Do not let a citation support a broader, more certain, or more current statement
+  than the source establishes.
+- Avoid decorative citation piles. Prefer the few sources that directly establish
+  the claim and use independent corroboration when risk warrants it.
+
+Run two audits before publishing: trace each material sentence backward to adequate
+evidence, then trace each decisive evidence item forward to the claim or conclusion
+that uses it.
+
+## 6. Resolve freshness and conflicts
+
+Verify time-sensitive claims against a source current to the investigation's
+`as_of` date. Distinguish publication date, event date, effective date, data period,
+and last-updated date. Mark a source or claim stale when the required time horizon
+has passed; never hide an older date behind present tense.
+
+When sources disagree:
+
+1. Confirm that they measure the same entity, interval, geography, unit, definition,
+   and version.
+2. Check whether one source cites, copies, corrects, or supersedes the other.
+3. Prefer the more direct and current source only after confirming equivalent scope.
+4. Seek an independent adjudicating source or underlying record.
+5. Preserve the disagreement when it cannot be resolved. Mark the claim
+   `contested`, explain the decision impact, and avoid averaging incompatible facts.
+
+Keep "not found," "not accessible," "not measured," and "evidence of absence"
+as different states.
+
+## 7. Synthesize the answer
+
+Lead with the answer, decision, or finding. Then present the decisive evidence,
+important qualifications, credible counterevidence, and remaining unknowns.
+Separate observed facts, inference, and recommendation. Use a comparison table or
+timeline only when it exposes a real relationship.
+
+Use the memo template in `references/investigation-format.md`. For a short response,
+retain its logic in miniature: answer, evidence, conflicts, unknowns, sources, and
+`as_of` date.
+
+Stop when additional sources are unlikely to change the conclusion. Do not equate
+volume with rigor.
+
+## 8. Publish and verify the durable result
+
+Choose the destination deliberately:
+
+- Publish private or audience-unspecified work under
+  `/me/research/<investigation-slug>/`.
+- Publish collaborative work only to an authorized existing shared folder such as
+  `/research/<investigation-slug>/`. Remember that every path outside `/me` is
+  pod-shared; there is no `/pod` prefix.
+- Treat an agent's `/me` as the invoking user's private tree, never agent-private
+  storage. If a workload receives `MISSING_WORKLOAD_RESOURCE_GRANT` for a shared
+  folder, report the missing grant; do not relocate or self-elevate to bypass it.
+- Skip pod writes when the user asked only for an answer and did not authorize a
+  durable artifact. Keep the result in the response and state what could be saved.
+
+Publish at least the memo and source register for durable work; include the evidence
+ledger and selected source snapshots when future verification or monitoring needs
+them. Adapt filenames to an established pod workflow rather than creating a parallel
+taxonomy.
+
+```bash
+research_slug="refund-policy-review"
+lemma files mkdir /me/research
+lemma files mkdir "/me/research/$research_slug"
+lemma files upload ./memo.md "/me/research/$research_slug/memo.md"
+lemma files upload ./sources.md "/me/research/$research_slug/sources.md"
+lemma files upload ./evidence.csv "/me/research/$research_slug/evidence.csv" --no-search
+lemma files stat "/me/research/$research_slug/memo.md"
+lemma files cat "/me/research/$research_slug/memo.md"
+```
+
+Replace `/me/...` with the approved shared destination when required. After upload,
+verify the exact paths, reopen the memo, check that no content was truncated, and
+confirm that every cited source path or URL resolves for the intended audience.
+Use `lemma files url <path>` when a signed-in pod member needs an in-app link.
+
+Report the published path, `as_of` date, confidence, unresolved gaps, and what should
+trigger a refresh.
+
+## Related skills
+
+- Use `lemma-user` for general pod operations and current CLI semantics.
+- Use `browser` to inspect or preserve rendered web pages.
+- Use `liteparse-documents` for outside-pod document parsing or OCR fallback.
+- Use `lemma-data-analysis` when the main work is quantitative validation,
+  computation, or charting; carry its results into this skill's evidence ledger.
+- Use `lemma-artifact-author` when the final deliverable must be a polished PDF,
+  DOCX, spreadsheet, or slide deck; keep this skill's source and citation contract.

--- a/lemma-skills/lemma-research/agents/openai.yaml
+++ b/lemma-skills/lemma-research/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Lemma Research"
+  short_description: "Run durable, source-backed investigations"
+  default_prompt: "Use $lemma-research to investigate a question with web and pod sources, preserve evidence, and publish a cited result."

--- a/lemma-skills/lemma-research/references/investigation-format.md
+++ b/lemma-skills/lemma-research/references/investigation-format.md
@@ -1,0 +1,221 @@
+# Investigation Format
+
+Use these records for multi-source work. Keep IDs stable across updates so a later
+research run can diff evidence and claims without breaking citations.
+
+## Research brief
+
+```markdown
+# <Investigation title>
+
+- Investigation ID: <slug>
+- Question: <decision-relevant question>
+- Audience: <person or group>
+- As of: <YYYY-MM-DD, timezone if material>
+- Scope: <included subjects, geography, period, comparison set>
+- Out of scope: <explicit exclusions>
+- Deliverable: <memo, comparison, recommendation, fact check, monitor baseline>
+- Evidence threshold: <what is sufficient for the decision>
+- Stop rule: <conditions for stopping or escalating>
+
+## Subquestions
+
+| ID | Question | Claim type | Ideal evidence | Freshness need | Status |
+| --- | --- | --- | --- | --- | --- |
+| Q01 | ... | factual | first-party record | current to 30 days | open |
+
+## Assumptions and terms
+
+- <term>: <working definition>
+- <assumption>: <why it is safe enough to proceed>
+```
+
+## Source register
+
+Assign a new source ID when the content, edition, revision, dataset period, or
+snapshot changes materially. Do not overwrite the identity of an older source.
+
+| Field | Record |
+| --- | --- |
+| `source_id` | Stable `S01`, `S02`, ... |
+| `title` | Exact title or concise file label |
+| `source_type` | pod, workspace, web, dataset, interview, or other |
+| `publisher_author` | Responsible organization or author |
+| `location` | Pod path, workspace path, canonical URL, or dataset identifier |
+| `published_effective` | Publication, effective, revision, or data-period dates |
+| `retrieved_at` | ISO date; include time and timezone for volatile material |
+| `version` | Edition, commit, document revision, or snapshot marker |
+| `authority` | Why this source can establish the intended claim |
+| `access_notes` | Paywall, permissions, missing pages, extraction defects, or scope |
+| `independence` | Original source or the upstream source it depends on |
+
+Example:
+
+```markdown
+### S03 — Refund policy, revision 7
+
+- Source type: pod file
+- Path: /knowledge/policies/refunds.pdf
+- Publisher: Operations
+- Effective: 2026-07-01
+- Retrieved: 2026-08-02
+- Authority: Current internal policy approved for member use
+- Version: revision 7
+- Access notes: Pages 4-5 inspected in converted markdown and page renders
+- Independence: Original policy document
+```
+
+## Evidence ledger
+
+Create one row per bounded observation. Quote only the minimum text needed to
+verify interpretation; keep longer context in notes or the source itself.
+
+| Field | Meaning |
+| --- | --- |
+| `evidence_id` | Stable `E01`, `E02`, ... |
+| `source_id` | Source version that contains the evidence |
+| `locator` | Page, section, table, line range, timestamp, record ID, or cell range |
+| `observed` | Faithful observation or short excerpt |
+| `relation` | supports, contradicts, qualifies, or context |
+| `claim_ids` | One or more linked `C##` claims |
+| `quality` | high, medium, or low, with a concrete reason |
+| `freshness` | current, dated, stale, or unknown, with relevant date |
+| `notes` | Definitions, method, caveat, extraction issue, or conflict |
+
+Example:
+
+```markdown
+| E07 | S03 | p. 4, "Eligibility" | Returns are allowed within 30 calendar days of delivery. | supports | C02 | high: governing internal policy | current: effective 2026-07-01 | Applies only to unopened items |
+```
+
+## Claim register
+
+Keep each claim atomic. Split claims joined by "and" when their evidence or status
+can differ.
+
+| Field | Meaning |
+| --- | --- |
+| `claim_id` | Stable `C01`, `C02`, ... |
+| `claim` | One falsifiable proposition |
+| `status` | supported, contested, disproven, unknown, or stale |
+| `evidence_for` | Supporting `E##` IDs |
+| `evidence_against` | Contradicting `E##` IDs |
+| `confidence` | high, medium, or low |
+| `rationale` | Short explanation based on directness, quality, agreement, and freshness |
+| `decision_role` | decisive, material, contextual, or excluded |
+| `refresh_trigger` | Date, release, policy change, or new evidence that requires review |
+
+Do not derive confidence by counting citations. Raise it when evidence is direct,
+fit for the claim, independently corroborated where needed, current, and free from
+unresolved material conflict.
+
+## Citation forms
+
+Use a source ID in every durable artifact so citations survive URL or path-display
+changes. Add a direct link when one exists.
+
+- Pod document: `[S03, p. 4]`; register source type `pod` and path
+  `/knowledge/policies/refunds.pdf`.
+- Pod text: `[S04, lines 22-31]`; register source type `pod` and path
+  `/me/research-notes/context.md`.
+- Workspace source: `[S05, src/policy.ts:88]`; record repository revision or commit.
+- Web source: `[S06, "Eligibility"](https://canonical.example/policy)`.
+- Dataset: `[S07, table orders, rows through 2026-07-31]`.
+- Video or audio: `[S08, 12:14-13:02]`.
+- Inference: `Inference from S03 and S07:` followed by assumptions or calculation.
+
+Place the citation immediately after the smallest complete claim it supports.
+Never cite the source register alone for a claim without an evidence locator.
+
+## Conflict record
+
+Add a conflict record whenever disagreement could change the answer:
+
+```markdown
+### X01 — <conflicted proposition>
+
+- Sources: S02 vs S09
+- Apparent disagreement: <precise difference>
+- Scope check: <entity, period, geography, unit, definition, version>
+- Provenance check: <independent, copied, superseded, or correction>
+- Resolution: <resolved finding, or "unresolved">
+- Claim status: <supported, contested, disproven, stale>
+- Decision impact: <what changes under each interpretation>
+- Follow-up: <best adjudicating source or event>
+```
+
+## Decision memo
+
+```markdown
+# <Answer-first title>
+
+**As of:** <date>  
+**Scope:** <one sentence>  
+**Confidence:** <high, medium, or low; one-sentence basis>
+
+## Answer
+
+<Direct answer or recommendation. Cite material factual claims inline.>
+
+## Decisive findings
+
+1. <Finding and why it matters> [S01, locator]
+2. <Finding and why it matters> [S02, locator]
+
+## Counterevidence and conflicts
+
+<Strongest credible contradiction, resolution, and decision impact.>
+
+## Unknowns and limits
+
+- <Unknown, why it remains unknown, and whether it could change the answer>
+
+## Implications or next actions
+
+- <Action tied to the evidence; label recommendations and forecasts>
+
+## Sources
+
+- S01 — <title, publisher, date, pod path or canonical URL>
+
+## Method
+
+<Scope, query classes, source selection, exclusions, and material assumptions.
+Describe observable work; do not expose hidden chain-of-thought.>
+
+## Refresh triggers
+
+- <date, event, version, release, or new source that should reopen a claim>
+```
+
+## Suggested pod layout
+
+Use an existing research convention when the pod has one. Otherwise use a compact
+private layout and replace `/me` with an authorized shared folder only when the
+audience requires collaboration:
+
+```text
+/me/research/<investigation-slug>/
+  memo.md
+  sources.md
+  evidence.csv
+  brief.md                 # keep when scope or handoff matters
+  snapshots/               # keep only decisive or volatile captured sources
+```
+
+Do not duplicate every source. Preserve snapshots when the page is volatile, the
+source may disappear, exact versioning matters, or a future reviewer cannot access
+the original. Keep canonical URLs and retrieval dates even when a snapshot exists.
+
+## Publication checklist
+
+- Verify that the answer matches the stated scope and `as_of` date.
+- Verify every decisive claim against an inspected source and exact locator.
+- Verify calculations from their recorded inputs.
+- Expose credible contradictions and unresolved unknowns.
+- Distinguish current, dated, stale, and unknown evidence.
+- Confirm that source IDs, paths, URLs, and cited locators resolve.
+- Confirm that the destination audience is correct: `/me` for private work; an
+  authorized non-`/me` folder for pod-shared work.
+- Reopen the uploaded memo and confirm that content is complete and untruncated.
+- Report the durable path, confidence, gaps, and refresh triggers to the user.

--- a/lemma-skills/lemma-skill-creator/SKILL.md
+++ b/lemma-skills/lemma-skill-creator/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: lemma-skill-creator
+description: "Create, revise, publish, and smoke-test pod-owned Lemma agent skills under /skills/skill-name. Use when defining a skill's triggers and instructions, organizing its references or scripts, safely updating an existing custom skill, publishing one through Lemma files, or checking that an agent discovers and follows it. Do not use to modify bundled read-only system skills or to build a full evaluation program."
+---
+
+# Lemma Skill Creator
+
+Create the smallest pod-owned skill that changes agent behavior reliably. Treat the skill as shared executable guidance: make its trigger precise, keep its body economical, and prove its behavior in a fresh agent context.
+
+## Respect the skill boundary
+
+- Treat `/skills` as a merged catalog of bundled system skills and pod-owned custom skills.
+- Inspect the catalog before choosing a name. Never assume a directory is writable from its path alone.
+- Never modify, move, delete, or add files inside a bundled skill directory. The whole system-skill subtree is read-only.
+- Create or edit only a distinct pod-owned directory whose scope the user authorized. If a requested name collides with a system skill, choose a new name with the user.
+- Stage and review changes locally before writing shared pod state. Back up every existing file that will be replaced.
+- Read [the pod skill contract](references/pod-skill-contract.md) before publishing or editing a skill in a pod. Follow its parser rules and exact CLI workflow.
+
+## Build the skill
+
+### 1. Define observable behavior
+
+Write down:
+
+- two or three requests that must trigger the skill;
+- one adjacent request that must not trigger it;
+- the expected deliverable or state change;
+- the tools, pod resources, and permissions required;
+- any irreversible or externally visible action that requires confirmation.
+
+Resolve unclear behavior before authoring. Do not hide product decisions inside procedural instructions.
+
+### 2. Inspect the existing universe
+
+List available skills and read the closest overlaps before drafting. In a Lemma agent, use `list_skills`, then `load_skill` for relevant candidates. From an external shell, inspect `/skills` with the Lemma file commands in the contract reference.
+
+Extend an existing pod-owned skill when the behavior belongs to the same trigger and workflow. Create a new skill when it has a distinct trigger, outcome, or safety boundary. Avoid two descriptions that compete for the same request.
+
+### 3. Choose the name and layout
+
+Use a short lowercase hyphenated name that describes the capability. Make the directory name and frontmatter `name` identical.
+
+Always create `SKILL.md`. Add only resources that reduce repeated work:
+
+- Put detailed, conditional knowledge in `references/`.
+- Put deterministic, reusable source code in `scripts/`; state its inputs, outputs, and safe invocation in `SKILL.md` or a direct reference.
+- Put only UTF-8 text templates in `assets/` when an agent must load them through the skill tool. Keep binary artifacts elsewhere in pod files and reference their paths.
+- Keep every resource one link away from `SKILL.md`; avoid reference chains.
+
+Do not add a README, changelog, or installation guide. Do not add `agents/openai.yaml` to a pod-owned skill merely for Lemma discovery; maintain it only when the skill is also packaged for an external agent that consumes that UI metadata.
+
+### 4. Design the trigger
+
+Put all discovery language in the one-line frontmatter `description`; the body is unavailable until the skill is loaded. Include:
+
+1. the capability and outcome;
+2. concrete objects, files, or situations that should trigger it;
+3. the important boundary with its closest neighboring skill.
+
+Prefer specific verbs and nouns over broad claims. Do not use descriptions such as “helps with research” or “use for many workflows.” Keep the description broad enough to catch natural user phrasing but narrow enough to avoid unrelated tasks.
+
+### 5. Write imperative instructions
+
+Order the body around the actual work:
+
+1. state non-negotiable constraints;
+2. give the shortest successful workflow;
+3. define decision points and failure handling;
+4. link conditional detail directly;
+5. require proportionate verification.
+
+Assume the agent can reason. Include only Lemma-specific contracts, fragile sequences, domain knowledge, and reusable patterns it cannot safely infer. Use exact commands only after confirming they exist. Never embed secrets, live credentials, personal data, or production-only identifiers.
+
+Match instruction freedom to risk: use judgment for creative choices, a preferred pattern for repeatable work, and exact steps for destructive or contract-sensitive operations.
+
+## Validate before publishing
+
+Check the staged directory:
+
+- `SKILL.md` is UTF-8, starts with `---` on the first byte, and closes the frontmatter.
+- Frontmatter contains only top-level, one-line `name` and `description` fields.
+- The name is valid, unique in `/skills`, and exactly matches the directory.
+- Every linked resource exists, stays inside the skill directory, and is required by the workflow.
+- Instructions contain no placeholders, stale paths, invented commands, hidden prerequisites, or contradictory safety rules.
+- Examples use synthetic or explicitly approved data.
+
+Publish through the exact-path file workflow in the contract reference. Do not bulk-delete old resources merely because they are absent from the staged draft; remove them only when the user authorized that cleanup.
+
+## Run a lightweight behavior check
+
+After publishing:
+
+1. Confirm the skill appears in `list_skills`; an invalid custom directory may simply be omitted.
+2. Load it and confirm its body and expected resources are readable.
+3. In a fresh agent turn, run one clear positive trigger without naming the skill.
+4. Run one near-miss prompt and confirm the skill is not selected unnecessarily.
+5. Exercise one mandatory resource and one important safety boundary.
+6. Compare the observed actions and artifact with the stated behavior; do not accept the agent's self-report as evidence.
+
+Keep this check to a few representative cases. Use `lemma-evals` when the user needs a repeatable suite, variants, scoring, latency or cost tracking, or release-gating.
+
+## Revise safely
+
+Inspect and download the current pod-owned files before editing. Change one behavior hypothesis at a time, republish only the affected files, then repeat discovery, loading, and the relevant smoke cases. Preserve useful resources and user-authored changes outside the requested scope.
+
+If the desired change targets a bundled system skill, stop. Propose either a distinctly named pod-owned skill or a separate reviewed change to Lemma's source bundle; do not try to bypass the read-only overlay.

--- a/lemma-skills/lemma-skill-creator/agents/openai.yaml
+++ b/lemma-skills/lemma-skill-creator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Lemma Skill Creator"
+  short_description: "Create and improve pod-owned Lemma skills"
+  default_prompt: "Use $lemma-skill-creator to create, validate, and smoke-test a pod-owned Lemma skill under /skills."

--- a/lemma-skills/lemma-skill-creator/references/pod-skill-contract.md
+++ b/lemma-skills/lemma-skill-creator/references/pod-skill-contract.md
@@ -1,0 +1,124 @@
+# Pod skill contract
+
+Read this reference before creating, publishing, or editing a skill under `/skills`.
+
+## Namespace and ownership
+
+Treat `/skills` as a synthetic pod folder that merges two sources:
+
+- Bundled system skill directories come from Lemma's installed `lemma-skills` bundle. They are readable in the pod and carry read-only metadata.
+- Custom skill directories are ordinary pod-shared files created under `/skills` by a caller with the required write permission.
+
+The system entry wins when paths collide. Lemma rejects writes, moves, and deletes at `/skills` itself and anywhere inside an existing bundled skill directory with `System skills are read-only`. Do not use a system skill's name for a custom skill, and do not attempt to shadow one.
+
+Inspect before writing:
+
+```bash
+lemma files tree /skills
+lemma files stat /skills/<candidate-name>
+```
+
+Run `stat` only when the candidate appears in the tree. If its metadata says it is read-only, stop. If it is pod-owned but the user did not authorize changing it, stop.
+
+## Discovery contract
+
+Make every discoverable skill a direct child of `/skills` with this exact entry file:
+
+```text
+/skills/<name>/SKILL.md
+```
+
+Use uppercase `SKILL.md`. A directory with only `README.md`, a differently cased filename, unreadable bytes, or invalid frontmatter is not a usable skill and may be omitted from the catalog without a validation error being shown to the agent.
+
+Use this minimal layout:
+
+```text
+<name>/
+├── SKILL.md
+├── references/       # optional UTF-8 guidance loaded on demand
+├── scripts/          # optional UTF-8 reusable source
+└── assets/           # optional UTF-8 templates
+```
+
+The loader recursively lists files below the skill directory, excluding `SKILL.md` and `__pycache__`. It classifies anything under `scripts/` as a script and marks only `.sh` paths as executable metadata. Resource loading is text-based, so keep resources that must be loaded through `load_skill` valid UTF-8. Do not assume that executable metadata runs a script automatically.
+
+Do not create `agents/openai.yaml` merely for Lemma discovery. Lemma treats it as another resource rather than skill UI metadata. Include and maintain it only when the same skill is deliberately packaged for an external agent that consumes it; bundled Lemma skills installed into external coding agents are one such case.
+
+## Frontmatter parser
+
+Start the file exactly with an LF-delimited frontmatter block. Do not place a byte-order mark, blank line, heading, or comment before it.
+
+```markdown
+---
+name: vendor-contract-review
+description: "Review vendor contracts against approved commercial and legal policies. Use for uploaded agreements, redlines, renewal reviews, and clause-risk summaries; do not use for general legal research."
+---
+
+# Vendor Contract Review
+```
+
+Follow all parser constraints:
+
+- Include only `name` and `description` as top-level, single-line scalar fields.
+- Use lowercase letters, digits, and single hyphens in `name`.
+- Keep `name` between 1 and 64 characters; do not start or end with a hyphen or use `--`.
+- Match `name` exactly to the containing directory.
+- Keep `description` non-empty and on one line. Quote it when punctuation such as a colon could be ambiguous.
+- Close the block with a line containing `---`.
+
+The parser is intentionally simple: it ignores indented YAML and does not resolve multiline scalars, lists, aliases, or nested mappings. Do not rely on general YAML features even if another skill platform accepts them.
+
+## Safe external CLI workflow
+
+Stage the complete skill in a local directory first. Use an editor or patch tool for multiline content; avoid shell-quoted inline documents.
+
+For a new, non-colliding skill:
+
+```bash
+lemma files tree /skills
+lemma files mkdir /skills/<name>
+lemma files write /skills/<name>/SKILL.md --from ./<name>/SKILL.md --no-search
+lemma files mkdir /skills/<name>/references
+lemma files write /skills/<name>/references/<file>.md --from ./<name>/references/<file>.md --no-search
+lemma files tree /skills/<name>
+lemma files cat /skills/<name>/SKILL.md
+```
+
+Create only the resource directories the draft actually uses. Repeat `mkdir` and `write --from` for each required text resource. Use `lemma files upload <local-file> <remote-path> --no-search` only for a new non-text file that cannot be written as text; remember that the skill loader cannot return binary content as text.
+
+For an existing pod-owned skill, inspect and back up each file before replacing it:
+
+```bash
+lemma files stat /skills/<name>
+lemma files tree /skills/<name>
+lemma files download /skills/<name>/SKILL.md ./<name>-previous-SKILL.md
+lemma files write /skills/<name>/SKILL.md --from ./<name>/SKILL.md --no-search
+lemma files cat /skills/<name>/SKILL.md
+```
+
+Download every resource that will change. Treat `write` as an upsert: after the ownership preflight it is suitable for creating or replacing an exact text path. Do not use `append` to revise structured instructions. Do not use `rm` as synchronization; deletion is a separate destructive action.
+
+Add `--pod <pod>` to file commands when the shell is not already bound to the intended pod. In Lemma's local harness or MCP-routed environment, run these CLI examples through `lemma_exec_command` so the current workspace identity and pod are injected.
+
+Do not confuse pod publication with `lemma skills install`. The latter copies Lemma's bundled skills into supported external coding-agent directories and may replace an installed copy; it does not publish a custom directory into a pod's `/skills` catalog.
+
+## Runtime proof
+
+After writing the files, validate through the same surface an agent uses:
+
+1. Call `list_skills` and find the exact name and description.
+2. Call `load_skill` with the name and inspect the returned `SKILL.md` plus resource list.
+3. Call `load_skill` for each mandatory relative resource path. Never pass an absolute path or `..`.
+4. Start a fresh agent turn for trigger checks so the skill is selected from its description rather than leaked authoring context.
+
+Use a compact smoke matrix:
+
+| Case | Prompt shape | Evidence |
+|---|---|---|
+| Positive trigger | Natural request that clearly needs the capability | Skill loads; required workflow and artifact appear |
+| Paraphrased trigger | Same intent with different vocabulary | Skill still loads without naming it |
+| Near miss | Adjacent task owned by another skill or base guidance | Skill stays unloaded or yields to the better match |
+| Resource | Task requires one direct reference or script | Agent loads the expected relative resource |
+| Safety boundary | Task approaches a forbidden write or external action | Agent stops, narrows scope, or requests authority |
+
+Judge tool traces, file diffs, records, or produced artifacts. Do not count an explanation of intended behavior as successful execution. Escalate to `lemma-evals` instead of expanding this smoke matrix into a permanent benchmark.


### PR DESCRIPTION
## What

Adds seven pod skills — design, QA, artifact authoring, data analysis, evals, research, skill creation — and changes how the CLI decides what to install.

## Why

Each of these was tribal knowledge someone re-explained to an agent every time. They're now skills with a contract: what the skill is for, the format its output has to take, and the references it reads.

The install side had a related problem. `CURATED_SKILLS` was a hand-picked list of three. Every new skill meant remembering to add it there, and nothing failed if you forgot — the skill just quietly never installed.

The namespace already carried the distinction, so make it the rule:

- `lemma-*` skills are portable across supported coding agents → install by default (now ten)
- un-namespaced helpers (`browser`, `liteparse-documents`) assume a provisioned workspace runtime → stay behind an explicit name or `--all-skills`

`test_default_set_is_every_namespaced_lemma_skill` fails when a namespaced skill is missing from the set, so the list can't silently drift again.

## Also

Drops the last references to `scripts/sync_cli_skills.py`, which no longer exists — the `setup.py` build hooks vendor the skills now.

## Testing

`uv run pytest tests/` in `lemma-cli` — 27 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)