### PR TITLE
fix(schedule,surfaces): two bugs the 0.7 dev rollout exposed

### DIFF
--- a/lemma-backend/app/composition/schedule_filter.py
+++ b/lemma-backend/app/composition/schedule_filter.py
@@ -6,6 +6,7 @@ import json
 from typing import Any
 
 from pydantic_ai import Agent as PydanticAIAgent, UsageLimits
+from pydantic_ai.models import Model
 from pydantic_ai.output import StructuredDict
 
 from app.modules.agent.services.runtime_model_factory import (
@@ -45,6 +46,31 @@ FILTER_USAGE_LIMITS = UsageLimits(
     total_tokens_limit=36_000,
     count_tokens_before_request=True,
 )
+# Same caps, but without the pre-flight count. The limits are then enforced
+# against the usage the provider reports, so an oversized payload is refused
+# after the call rather than before it.
+FILTER_USAGE_LIMITS_WITHOUT_PRECOUNT = UsageLimits(
+    request_limit=1,
+    input_tokens_limit=32_000,
+    output_tokens_limit=4_000,
+    total_tokens_limit=36_000,
+    count_tokens_before_request=False,
+)
+
+
+def filter_usage_limits_for(model: Model) -> UsageLimits:
+    """Pick usage limits the model can actually honor.
+
+    ``count_tokens_before_request`` makes pydantic-ai call ``Model.count_tokens``
+    first, which only some providers implement — the base method raises
+    ``NotImplementedError``, and OpenAI-compatible models (the system runtime
+    used for the Fireworks profile) do not override it. Asking for the pre-count
+    there fails the whole filter, so it is requested only when the concrete
+    model actually implements it.
+    """
+    if type(model).count_tokens is Model.count_tokens:
+        return FILTER_USAGE_LIMITS_WITHOUT_PRECOUNT
+    return FILTER_USAGE_LIMITS
 
 
 class SystemModelScheduleFilter:
@@ -96,7 +122,7 @@ class SystemModelScheduleFilter:
         try:
             result = await agent.run(
                 self._user_message(event_payload),
-                usage_limits=FILTER_USAGE_LIMITS,
+                usage_limits=filter_usage_limits_for(model),
             )
         finally:
             await record_pydantic_ai_result_usage(

--- a/lemma-backend/app/modules/agent_surfaces/events/handlers.py
+++ b/lemma-backend/app/modules/agent_surfaces/events/handlers.py
@@ -149,18 +149,29 @@ async def _process_surface_webhook(
     consumer="surface-schedule-events-consumer",
 )
 async def handle_surface_schedule_event(
-    event: ScheduleFired,
+    event: dict,
     fs_logger: Logger,
     uow_factory: UnitOfWorkFactory = Depends(provide_uow_factory),
     job_queue: SharedStreaqJobQueue = Depends(provide_job_queue),
     inbox: EventInboxPort = Depends(provide_domain_event_inbox),
 ) -> None:
+    # ``schedule_events`` carries the lifecycle events too (created, updated,
+    # deleted, deactivated). Only fires reach a surface, so the parameter stays
+    # untyped and the fire is parsed after the tag check — declaring
+    # ``ScheduleFired`` here instead makes every lifecycle event a validation
+    # error that is redelivered forever, because a poison message is never
+    # acked and XAUTOCLAIM keeps reclaiming it.
+    if event.get("event_type") != ScheduleFired.get_event_type():
+        return
+
+    fired = ScheduleFired.model_validate(event)
+
     async def process() -> None:
         await _process_surface_schedule_event(
-            event, fs_logger, uow_factory=uow_factory, job_queue=job_queue
+            fired, fs_logger, uow_factory=uow_factory, job_queue=job_queue
         )
 
-    await inbox.process("agent-surfaces.schedule", event, process)
+    await inbox.process("agent-surfaces.schedule", fired, process)
 
 
 async def _process_surface_schedule_event(

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_pod_deleted_handler.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_pod_deleted_handler.py
@@ -20,7 +20,10 @@ from app.modules.agent_surfaces.domain.events import SurfaceWebhookReceivedEvent
 from app.modules.agent_surfaces.domain.ingress_context import SurfaceReplyContext
 from app.modules.agent_surfaces.events import handlers
 from app.modules.test_support.fakes import PassthroughEventInbox
-from app.modules.schedule.domain.events.schedule import ScheduleFired
+from app.modules.schedule.domain.events.schedule import (
+    ScheduleDeactivated,
+    ScheduleFired,
+)
 from app.modules.schedule.domain.schedule import ScheduleType
 
 
@@ -190,7 +193,7 @@ async def test_schedule_surface_event_is_inbox_backed_and_deterministically_queu
     )
 
     await handlers.handle_surface_schedule_event(
-        event,
+        event.model_dump(mode="json"),
         logging.getLogger("test"),
         uow_factory=partial(_mock_uow_factory, uow_mock),
         job_queue=job_queue,
@@ -206,6 +209,37 @@ async def test_schedule_surface_event_is_inbox_backed_and_deterministically_queu
         )
     else:
         job_queue.enqueue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_surface_schedule_subscriber_ignores_lifecycle_events(monkeypatch):
+    """A non-fire event on ``schedule_events`` is skipped, not a validation error.
+
+    The stream carries created/updated/deleted/deactivated too. Parsing one as a
+    fire raises, and a poison message is never acked, so XAUTOCLAIM redelivers it
+    forever.
+    """
+    handler = AsyncMock()
+    job_queue = AsyncMock()
+    uow_mock = AsyncMock()
+    monkeypatch.setattr(handlers, "build_surface_event_handler", lambda uow: handler)
+    deactivated = ScheduleDeactivated(
+        schedule_id=uuid4(),
+        user_id=uuid4(),
+        schedule_type=ScheduleType.TIME,
+        consecutive_failures=12,
+    )
+
+    await handlers.handle_surface_schedule_event(
+        deactivated.model_dump(mode="json"),
+        logging.getLogger("test"),
+        uow_factory=partial(_mock_uow_factory, uow_mock),
+        job_queue=job_queue,
+        inbox=PassthroughEventInbox(),
+    )
+
+    handler.prepare_ingress.assert_not_awaited()
+    job_queue.enqueue.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/lemma-backend/app/modules/schedule/tests/test_schedule_filter_usage_limits.py
+++ b/lemma-backend/app/modules/schedule/tests/test_schedule_filter_usage_limits.py
@@ -1,0 +1,83 @@
+"""The schedule filter must only ask for a pre-count the model can do.
+
+``UsageLimits.count_tokens_before_request`` makes pydantic-ai call
+``Model.count_tokens`` before the request. The base method raises
+``NotImplementedError`` and OpenAI-compatible models do not override it, so
+asking for it there fails every LLM-filtered datastore schedule.
+"""
+
+from __future__ import annotations
+
+from pydantic_ai.models import Model
+from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.models.openai import OpenAIChatModel
+
+from app.composition.schedule_filter import (
+    FILTER_USAGE_LIMITS,
+    FILTER_USAGE_LIMITS_WITHOUT_PRECOUNT,
+    filter_usage_limits_for,
+)
+
+
+class _CountingModel(Model):
+    """Stand-in for a provider that implements token counting."""
+
+    async def count_tokens(self, messages, model_settings, model_request_parameters):
+        raise AssertionError("not called in this test")
+
+    async def request(self, messages, model_settings, model_request_parameters):
+        raise AssertionError("not called in this test")
+
+    @property
+    def model_name(self) -> str:
+        return "counting"
+
+    @property
+    def system(self) -> str:
+        return "counting"
+
+
+class _NonCountingModel(Model):
+    """Stand-in for a provider that inherits the raising base method."""
+
+    async def request(self, messages, model_settings, model_request_parameters):
+        raise AssertionError("not called in this test")
+
+    @property
+    def model_name(self) -> str:
+        return "non-counting"
+
+    @property
+    def system(self) -> str:
+        return "non-counting"
+
+
+def test_model_without_token_counting_skips_the_precount() -> None:
+    limits = filter_usage_limits_for(_NonCountingModel())
+    assert limits is FILTER_USAGE_LIMITS_WITHOUT_PRECOUNT
+    assert limits.count_tokens_before_request is False
+
+
+def test_model_with_token_counting_keeps_the_precount() -> None:
+    limits = filter_usage_limits_for(_CountingModel())
+    assert limits is FILTER_USAGE_LIMITS
+    assert limits.count_tokens_before_request is True
+
+
+def test_both_limit_sets_enforce_the_same_caps() -> None:
+    """Dropping the pre-count must not quietly widen the budget."""
+    for field in (
+        "request_limit",
+        "input_tokens_limit",
+        "output_tokens_limit",
+        "total_tokens_limit",
+    ):
+        assert getattr(FILTER_USAGE_LIMITS, field) == getattr(
+            FILTER_USAGE_LIMITS_WITHOUT_PRECOUNT, field
+        ), field
+
+
+def test_real_provider_classes_are_classified_correctly() -> None:
+    """Guards the assumption against a pydantic-ai upgrade changing it."""
+    assert OpenAIChatModel.count_tokens is Model.count_tokens
+    assert AnthropicModel.count_tokens is not Model.count_tokens


### PR DESCRIPTION
Two independent bugs found while verifying the 0.7 dev release. Both break real functionality in dev right now; neither is a regression *from* 0.7 — the rollout just made them fire.

## 1. Surfaces schedule subscriber choked on lifecycle events

`handle_surface_schedule_event` declares its parameter as `ScheduleFired`, but subscribes to the whole `schedule_events` stream — which also carries `ScheduleCreated`/`Updated`/`Deleted`/`Deactivated`. Every lifecycle event fails pydantic validation before the handler body runs, and since a poison message is never acked, the reclaim subscriber's `XAUTOCLAIM` redelivers it **forever**.

Migration `0010_schedule_run_owner` backfilled real `consecutive_failures` values; the breaker then deactivated 8 schedules (counts 12–955), and those 8 events have been looping ever since — **7,532 errors in 9 hours** and still climbing. Deleting the schedules would not help: the events are already in the stream.

Fix: take the event as a `dict`, skip anything that isn't `schedule.fired`, parse after the tag check — the shape every other subscriber on a shared stream already uses (`on_schedule_deactivated`, `handle_datastore_event`, `on_pod_deleted`, `handle_identity_event`, `on_workflow_run_terminal`). I swept the rest: this was the only typed handler on a multi-event stream; `surface_events` carries a single class, so `handle_surface_webhook` is correct as-is.

## 2. Schedule LLM filter asked for a token pre-count the model can't do

`FILTER_USAGE_LIMITS` set `count_tokens_before_request=True` unconditionally. That makes pydantic-ai call `Model.count_tokens` first — the base method raises `NotImplementedError` and OpenAI-compatible models don't override it. The dev system runtime *is* the OpenAI-compatible Fireworks profile, so every LLM-filtered datastore schedule died with `NotImplementedError: Token counting ahead of the request is not supported by OpenAIChatModel` (40 in 9h).

Fix: choose the limits from the concrete model — identical caps either way, pre-count requested only when the model implements it. Without it the same ceilings are enforced against reported usage, so an oversized payload is refused after the call rather than before it (degraded, not unbounded). A test pins the real provider classifications so a pydantic-ai upgrade fails a test rather than dev.

## Tests

14 passed across the two touched suites (`test_pod_deleted_handler.py`, new `test_schedule_filter_usage_limits.py`). The existing fire test moved to the dict contract and still asserts ingress + enqueue + `_job_id`.

Note: 5 pre-existing failures in `test_schedule_e2e.py` are unrelated — they need seeded datastore tables (`Datastore table 'corrupt_records' was not found`) and fail identically on a clean checkout of this branch's base; verified by reverting my changes and re-running.

## Deliberately not fixed here

`recover_schedule_runs` reconciles the same 16 runs every cycle forever (warning each time). Their targets genuinely still exist in non-terminal states — 13 workflow runs `RUNNING` (2–21 days old), 1 `WAITING`, 2 agent conversations `WAITING` — and the `target_exists` branch re-marks `DISPATCHED` without incrementing `attempts`, so the dead-letter path is unreachable. Not bundled because deciding when a long-running target becomes "abandoned" is a policy call, not a bug fix, and the `WAITING` ones are legitimately in flight. Worth its own issue.

After this ships, dev's stuck `surface-schedule-events` PEL still needs draining — those messages redeliver until acked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)