### PR TITLE
Wire up local HyperDX + Phoenix observability, ClickStack MCP, and quiet dev logs

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "clickstack": {
+      "type": "http",
+      "url": "http://localhost:8080/api/mcp",
+      "headers": {
+        "Authorization": "Bearer ${CLICKSTACK_ACCESS_KEY}"
+      }
+    }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ SHELL := /bin/bash
 #   make dev           start infra + backend + frontend (hot-reload)
 #   make dev-public    same, with an ephemeral public Cloudflare API URL
 #   make dev RELOAD=1  same, with uvicorn --reload on the backend
+#   make dev OTEL=1 LLM_OTEL=1  same, with local HyperDX + Phoenix dashboards
 #   make agent-host    build, pair, and run the local Agent Host against make dev
 #   make stop          stop backend/frontend processes
 #   make stop-all      also stop infra containers
@@ -15,6 +16,7 @@ SHELL := /bin/bash
 # ──────────────────────────────────────────────────────────────────────────────
 
 .PHONY: help init dev dev-public agent-host verify-agent-host stop-agent-host stop stop-all logs otel-up otel-down otel-tail otel-smoke \
+        observability-up observability-down observability-open \
         _prepare-dev _start-public-api-tunnel _ensure-databases _ensure-agentbox-images \
         _ensure-native-connectors \
         test-dev-workflow \
@@ -30,7 +32,7 @@ RELOAD        ?= 0
 E2E_WORKERS   ?= 2
 MODULE        ?=
 OTEL          ?= 0
-OTEL_LOGS     ?= 0
+OTEL_LOGS     ?= 1
 LLM_OTEL      ?= 0
 
 BACKEND_DIR   := lemma-backend
@@ -94,28 +96,58 @@ DEV_JSON_LOGS_ENABLED ?= true
 # first request — which buries exactly that. Hold the chatty dependencies at
 # WARNING; set DEV_QUIET_DEPENDENCY_LOGS=0 when debugging one of them.
 DEV_QUIET_DEPENDENCY_LOGS ?= 1
-OTEL_DEBUG_GRPC_PORT  ?= 14317
-OTEL_DEBUG_LLM_GRPC_PORT ?= 15317
-OTEL_DEBUG_HEALTH_PORT ?= 14333
+# Debug Collector (used only by `make otel-smoke`, a fast CI-safe check that
+# signals reach a collector and LLM spans stay isolated — not for human
+# review). Numbered away from the real observability stack below so both can
+# run at once without a port clash.
+OTEL_DEBUG_GRPC_PORT     ?= 29317
+OTEL_DEBUG_HTTP_PORT     ?= 29318
+OTEL_DEBUG_LLM_GRPC_PORT ?= 29417
+OTEL_DEBUG_LLM_HTTP_PORT ?= 29418
+OTEL_DEBUG_HEALTH_PORT   ?= 29333
 
 OTEL_DEBUG_COMPOSE_ENV := \
 	OTEL_DEBUG_GRPC_PORT=$(OTEL_DEBUG_GRPC_PORT) \
+	OTEL_DEBUG_HTTP_PORT=$(OTEL_DEBUG_HTTP_PORT) \
 	OTEL_DEBUG_LLM_GRPC_PORT=$(OTEL_DEBUG_LLM_GRPC_PORT) \
+	OTEL_DEBUG_LLM_HTTP_PORT=$(OTEL_DEBUG_LLM_HTTP_PORT) \
 	OTEL_DEBUG_HEALTH_PORT=$(OTEL_DEBUG_HEALTH_PORT)
 
-OTEL_DEV_ENV := \
+# Real observability stack (`make observability-up`): HyperDX/ClickStack for
+# general API traces/metrics, Phoenix for LLM/OpenInference prompt review.
+# Port defaults mirror lemma-backend/docker-compose.observability.yml.
+HYPERDX_UI_PORT        ?= 8080
+HYPERDX_OTLP_HTTP_PORT ?= 14318
+HYPERDX_OTLP_GRPC_PORT ?= 14317
+PHOENIX_UI_PORT         ?= 16006
+PHOENIX_OTLP_GRPC_PORT  ?= 16317
+
+OBSERVABILITY_COMPOSE_ENV := \
+	HYPERDX_UI_PORT=$(HYPERDX_UI_PORT) \
+	HYPERDX_OTLP_HTTP_PORT=$(HYPERDX_OTLP_HTTP_PORT) \
+	HYPERDX_OTLP_GRPC_PORT=$(HYPERDX_OTLP_GRPC_PORT) \
+	PHOENIX_UI_PORT=$(PHOENIX_UI_PORT) \
+	PHOENIX_OTLP_GRPC_PORT=$(PHOENIX_OTLP_GRPC_PORT)
+
+# Ingestion key `observability-up` bootstraps from HyperDX and writes here;
+# read back lazily (recursive `=`, not `:=`) so it reflects the file at the
+# time `_run-backend` actually starts, not at Makefile parse time.
+HYPERDX_API_KEY_FILE := $(abspath $(DEV_LOG_DIR)/hyperdx-api-key)
+
+OTEL_DEV_ENV = \
 	OBSERVABILITY_ENABLED=$(if $(filter 1,$(OTEL)),true,false) \
-	OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:$(OTEL_DEBUG_GRPC_PORT) \
+	OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:$(HYPERDX_OTLP_GRPC_PORT) \
 	OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
+	OTEL_EXPORTER_OTLP_HEADERS=authorization=$(shell cat $(HYPERDX_API_KEY_FILE) 2>/dev/null) \
 	OTEL_TRACES_EXPORTER=otlp \
 	OTEL_METRICS_EXPORTER=otlp \
 	OTEL_LOGS_EXPORTER=$(if $(filter 1,$(OTEL_LOGS)),otlp,none) \
 	OTEL_TRACES_SAMPLER=always_on \
 	OTEL_METRIC_EXPORT_INTERVAL=5000
 
-LLM_OTEL_DEV_ENV := \
+LLM_OTEL_DEV_ENV = \
 	LLM_OTEL_ENABLED=$(if $(filter 1,$(LLM_OTEL)),true,false) \
-	LLM_OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:$(OTEL_DEBUG_LLM_GRPC_PORT) \
+	LLM_OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:$(PHOENIX_OTLP_GRPC_PORT) \
 	LLM_OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
 	LLM_OTEL_TRACES_SAMPLER=always_on
 # Immutable-profile inputs used by the local Docker provider.
@@ -240,8 +272,12 @@ help:
 	@echo "    make stop               stop app and tunnel processes"
 	@echo "    make stop-all           also bring down infra containers"
 	@echo "    make logs               tail infrastructure container logs"
-	@echo "    make dev OTEL=1         enable local OTLP traces + metrics"
-	@echo "    make otel-smoke         verify traces, metrics, logs, and LLM isolation"
+	@echo "    make dev OTEL=1         send API traces + metrics + logs to a local HyperDX dashboard"
+	@echo "    make dev LLM_OTEL=1     send full LLM prompts/responses to a local Phoenix dashboard"
+	@echo "    make observability-up   start HyperDX + Phoenix without the rest of the dev stack"
+	@echo "    make observability-open open the HyperDX + Phoenix dashboards in a browser"
+	@echo "    make observability-down stop the observability stack"
+	@echo "    make otel-smoke         verify traces, metrics, logs, and LLM isolation (CI-safe, no dashboards)"
 	@echo ""
 	@echo "  Tests"
 	@echo "    make test-dev-workflow  test generated dev config and startup diagnostics"
@@ -598,7 +634,7 @@ _prepare-dev:
 	@$(MAKE) --no-print-directory _ensure-databases
 	@$(MAKE) --no-print-directory migrate
 	@$(MAKE) --no-print-directory _ensure-native-connectors
-	@if [ "$(OTEL)" = "1" ]; then $(MAKE) --no-print-directory otel-up; fi
+	@if [ "$(OTEL)" = "1" ] || [ "$(LLM_OTEL)" = "1" ]; then $(MAKE) --no-print-directory observability-up; fi
 
 _ensure-native-connectors:
 	@telegram_present=$$(cd $(BACKEND_DIR) && docker compose exec -T db \
@@ -779,6 +815,37 @@ stop-all: stop
 	@echo "→ Stopping infra containers…"
 	@cd $(BACKEND_DIR) && $(COMMON_DEV_ENV) docker compose down
 	@$(MAKE) --no-print-directory otel-down
+	@$(MAKE) --no-print-directory observability-down
+
+observability-up:
+	@echo "→ Starting HyperDX (ClickStack) + Phoenix observability stack…"
+	@cd $(BACKEND_DIR) && $(OBSERVABILITY_COMPOSE_ENV) docker compose -f docker-compose.observability.yml up -d --quiet-pull
+	@ready=0; for i in $$(seq 1 60); do \
+		if curl -fsS http://localhost:$(HYPERDX_UI_PORT)/api/health >/dev/null 2>&1; then \
+			ready=1; break; \
+		fi; \
+		sleep 1; \
+	done; [ "$$ready" = "1" ] || { echo "  ✗ HyperDX did not become ready"; exit 1; }
+	@mkdir -p $(DEV_LOG_DIR)
+	@cd $(BACKEND_DIR) && uv run python scripts/hyperdx_bootstrap.py \
+		--base-url http://localhost:$(HYPERDX_UI_PORT) > $(HYPERDX_API_KEY_FILE) || { \
+		echo "  ✗ HyperDX bootstrap failed"; rm -f $(HYPERDX_API_KEY_FILE); exit 1; \
+	}
+	@echo "  ✓ HyperDX  → http://localhost:$(HYPERDX_UI_PORT)  (general API traces/metrics)"
+	@echo "  ✓ Phoenix  → http://localhost:$(PHOENIX_UI_PORT)  (LLM prompts/responses)"
+
+observability-down:
+	@cd $(BACKEND_DIR) && docker compose -f docker-compose.observability.yml down >/dev/null 2>&1 || true
+	@rm -f $(HYPERDX_API_KEY_FILE)
+
+observability-open:
+	@case "$$(uname)" in \
+		Darwin) open http://localhost:$(HYPERDX_UI_PORT) http://localhost:$(PHOENIX_UI_PORT) ;; \
+		Linux) xdg-open http://localhost:$(HYPERDX_UI_PORT) >/dev/null 2>&1 & \
+			xdg-open http://localhost:$(PHOENIX_UI_PORT) >/dev/null 2>&1 & ;; \
+		*) echo "  HyperDX → http://localhost:$(HYPERDX_UI_PORT)"; \
+			echo "  Phoenix → http://localhost:$(PHOENIX_UI_PORT)" ;; \
+	esac
 
 otel-up:
 	@echo "→ Starting pinned OpenTelemetry debug Collector…"
@@ -805,8 +872,16 @@ otel-smoke: otel-down otel-up
 		echo "$$logs" | grep -q "lemma-otel-smoke"; \
 		echo "$$logs" | grep -q "lemma.observability.smoke"; \
 		echo "$$logs" | grep -q "smoke-model"; \
-		if echo "$$logs" | grep -q "CANARY"; then echo "  ✗ unsafe canary reached Collector"; exit 1; fi
-	@echo "  ✓ General traces/metrics/logs and isolated LLM traces reached Collector safely"
+		if echo "$$logs" | grep -qF "SELECT 'CANARY'"; then \
+			echo "  ✗ unsafe canary (db.statement) reached Collector via the general pipeline"; exit 1; \
+		fi; \
+		if echo "$$logs" | grep -qF "CANARY.invalid"; then \
+			echo "  ✗ unsafe canary (url.full) reached Collector via the general pipeline"; exit 1; \
+		fi; \
+		if ! echo "$$logs" | grep -qF "CANARY prompt"; then \
+			echo "  ✗ LLM pipeline did not carry prompt content (regression: content should ship when LLM_OTEL_ENABLED)"; exit 1; \
+		fi
+	@echo "  ✓ General pipeline stayed sanitized; isolated LLM pipeline carried full prompt content"
 
 logs:
 	@cd $(BACKEND_DIR) && docker compose logs -f

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,8 +1,41 @@
-# OpenTelemetry
+# Observability
 
 Lemma can export traces, metrics, and structured application logs to any OTLP
 collector. The implementation has no dependency on a particular cloud or
 observability vendor.
+
+For local dev there are two purpose-built backends, started together with one
+command:
+
+- **HyperDX (ClickStack)** — general API traces, metrics, and logs. Latency,
+  error rates, slow routes, log volume. No LLM/prompt awareness.
+- **Arize Phoenix** — LLM/OpenInference traces only: full prompts, responses,
+  tool calls, token usage. Independent, isolated pipeline.
+
+No single OSS tool does both well — ClickStack's UI has no prompt-aware trace
+viewer (it renders raw span attributes), and Phoenix isn't a general APM tool.
+Splitting them is deliberate, not a compromise.
+
+```shell
+make observability-up      # start HyperDX + Phoenix, print URLs + keys
+make dev OTEL=1 LLM_OTEL=1 # start the app, sending telemetry to both
+make observability-open    # open both dashboards in a browser
+make observability-down    # stop HyperDX + Phoenix
+```
+
+| Service | URL | Purpose |
+|---|---|---|
+| HyperDX UI | http://localhost:8080 | Traces, metrics, logs, dashboards |
+| Phoenix UI | http://localhost:16006 | LLM prompt/response inspection |
+
+`make observability-up` is idempotent — it registers (or logs into, on later
+runs) a fixed local-only HyperDX team, persisted in a Docker volume across
+restarts, and provisions a "Lemma API Overview" dashboard the first time it
+runs. It prints two secrets each time: the OTLP ingestion key (used
+automatically by `make dev OTEL=1`) and an `export CLICKSTACK_ACCESS_KEY=...`
+line for the MCP server below. Neither is written to a committed file.
+
+## Signal selection
 
 Telemetry is disabled unless `OBSERVABILITY_ENABLED=true`. The standard
 `OTEL_SDK_DISABLED=true` switch always disables it. Each signal is selected
@@ -21,6 +54,10 @@ signal-specific endpoint is used as supplied. Selected signals require an
 endpoint. `OTEL_SIGNALS` remains a deprecated compatibility selector; an empty
 value selects traces only, and explicit standard exporter variables win.
 
+`make dev OTEL=1` sets all three (traces, metrics, **and logs** — `OTEL_LOGS`
+defaults to `1`) pointed at HyperDX, with the bootstrapped ingestion key as
+the bearer token. Set `OTEL_LOGS=0` to opt back out.
+
 Root traces use `parentbased_traceidratio` sampling at 5% by default. Configure
 the standard `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG` variables to
 change it. Metrics export every 60 seconds by default via
@@ -28,11 +65,21 @@ change it. Metrics export every 60 seconds by default via
 other high-cardinality attributes are removed before export. Exemplars are
 disabled so filtered attributes cannot survive inside exemplar payloads.
 
+The general pipeline's export boundary (`app/core/observability/span_sanitizer.py`)
+is default-deny: only a fixed allowlist of attribute keys crosses it (route
+templates, status codes, token counts, bounded Lemma business-context fields),
+strings are truncated to 256 chars, and span names are collapsed to a small
+safe set (`http.server`, `db.operation`, ...) rather than the raw operation
+name. This is why the dashboard's "Endpoints" tile groups by the
+`http.route` *attribute* instead of span name, and why general logs never
+carry log message bodies beyond a bounded field allowlist
+(`SanitizingLoggingHandler`). None of this is configurable — it's a
+production-safety invariant, not a dev convenience.
+
 ## LLM observability
 
-Pydantic AI/OpenInference traces use a separate, disabled-by-default pipeline.
-They never go to the general OTLP endpoint and never emit LLM metrics or logs.
-Enable it with:
+Pydantic AI/OpenInference traces use a separate, disabled-by-default pipeline
+that never touches the general OTLP endpoint or the sanitizer above:
 
 ```dotenv
 LLM_OTEL_ENABLED=true
@@ -40,26 +87,114 @@ LLM_OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:16317
 LLM_OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 ```
 
+Unlike the general pipeline, this one ships **full prompt/response content**
+by design whenever it's enabled — that's the entire point of turning it on.
+There's no separate opt-in flag for content: `LLM_OTEL_ENABLED=true` means
+"send everything a developer needs to review what was sent to the model,"
+including system instructions, tool calls, and token usage. Never enable this
+against a shared or production Phoenix instance without understanding that
+implication.
+
 The LLM pipeline defaults to independent deterministic 1% sampling. Configure
-`LLM_OTEL_TRACES_SAMPLER` and `LLM_OTEL_TRACES_SAMPLER_ARG` as needed. Prompt,
-response, tool argument/result, system-instruction, and binary capture is
-disabled at instrumentation time and enforced again by the export allowlist.
+`LLM_OTEL_TRACES_SAMPLER` and `LLM_OTEL_TRACES_SAMPLER_ARG` as needed.
+`make dev LLM_OTEL=1` sets `always_on` sampling instead, so every local call
+shows up in Phoenix.
 
-## Local debug Collector
+## The dashboard
 
-The repository includes a pinned OpenTelemetry Collector with separate general
-and LLM receivers and the detailed CLI `debug` exporter:
+`make observability-up` provisions "Lemma API Overview" in HyperDX
+(`scripts/hyperdx_bootstrap.py`), organized into containers:
+
+- **Overview** — Requests, Errors, P95 Duration (the three RED-metric KPIs,
+  scoped to inbound `SpanKind:"Server"` spans — i.e. calls *to* this API, not
+  calls this API makes outward).
+- **Performance** — Latency percentiles (p50/p95/p99) and a duration
+  distribution heatmap.
+- **Endpoints** — Per-route request/error/P95 breakdown. This is a raw SQL
+  tile, not a builder table — HyperDX's builder table + map-attribute
+  `groupBy` combination silently ignores `where` filters (a known gap in the
+  tool itself), so raw SQL is the reliable path here.
+- **Errors** — Errors by span kind over time (inbound endpoint failures vs.
+  outbound dependency failures look very different — most local errors are
+  outbound `Client`-kind calls, e.g. AgentBox polling), errors by HTTP status
+  code, and a recent-error-spans search tile.
+- **Logs** — Volume by severity and a recent warnings/errors search tile
+  (now that `OTEL_LOGS=1` ships logs by default).
+
+The dashboard defaults to a **15-minute time window** — if a tile looks
+empty after `make dev`, widen it to 1h or 24h first before assuming
+something's broken.
+
+## The ClickStack MCP server
+
+HyperDX ships a first-party MCP server at `/api/mcp`
+(Streamable HTTP, Bearer auth using your **Personal API Access Key** — a
+different credential from the OTLP ingestion key, printed by
+`make observability-up` as `CLICKSTACK_ACCESS_KEY`). It lets a coding agent
+query traces/logs/metrics, build and validate dashboards, and inspect
+individual trace waterfalls directly — the same tools used to build the
+dashboard above.
+
+This repo's `.mcp.json` already registers it for Claude Code as `clickstack`,
+reading the key from the `CLICKSTACK_ACCESS_KEY` env var (never committed).
+One-time setup per shell session:
+
+```shell
+eval "$(make observability-up 2>&1 | grep CLICKSTACK_ACCESS_KEY)"
+```
+
+or just copy the `export CLICKSTACK_ACCESS_KEY=...` line `make observability-up`
+prints and paste it before starting Claude Code.
+
+For other clients:
+
+```shell
+# Codex CLI
+export CLICKSTACK_ACCESS_KEY="<key>"
+codex mcp add clickstack --url http://localhost:8080/api/mcp \
+  --bearer-token-env-var CLICKSTACK_ACCESS_KEY
+
+# Claude Code, manual registration (if not using the repo's .mcp.json)
+claude mcp add --transport http clickstack http://localhost:8080/api/mcp \
+  --header "Authorization: Bearer <key>"
+```
+
+```json
+// Cursor — .cursor/mcp.json
+{
+  "mcpServers": {
+    "clickstack": {
+      "url": "http://localhost:8080/api/mcp",
+      "headers": { "Authorization": "Bearer <key>" }
+    }
+  }
+}
+```
+
+Example prompts once connected:
+
+- "What are the slowest endpoints in the last hour?"
+- "Show me the last 5 errors and their status codes."
+- "Pull up the full prompt and response for the most recent LLM call."
+- "Is there anything unusual in the logs in the last 15 minutes?"
+
+## Local debug Collector (CI-safe correctness check, not for dashboards)
+
+Separate from the real stack above, the repository includes a pinned
+OpenTelemetry Collector with separate general and LLM receivers and the
+detailed CLI `debug` exporter — console-only, no ClickHouse/Mongo, fast to
+start. It exists purely to back `make otel-smoke`, a deterministic
+traces/metrics/logs/LLM canary test:
 
 ```shell
 make otel-up
-make dev OTEL=1
 make otel-tail
+make otel-smoke   # runs the canary end-to-end and asserts on collector output
+make otel-down
 ```
 
-`make dev OTEL=1` enables general traces and metrics. Add `OTEL_LOGS=1` to test
-OTLP logs and `LLM_OTEL=1` to test the separate LLM receiver. Neither is enabled
-by default.
-
-Run `make otel-smoke` for a deterministic traces/metrics/logs/LLM canary test.
-It fails if a prompt, SQL statement, URL, or filtered metric attribute reaches
-the Collector. `make otel-down` stops the debug Collector.
+`make otel-smoke` asserts the general pipeline never leaks the canary's
+adversarial `db.statement`/`url.full` content (proving the sanitizer works)
+and that the LLM pipeline *does* carry its canary prompt (proving content
+capture works) — the same two invariants described above, exercised without
+needing HyperDX or Phoenix running.

--- a/lemma-backend/app/core/log/log.py
+++ b/lemma-backend/app/core/log/log.py
@@ -74,6 +74,7 @@ _FOREIGN_LOGGER_PREFIXES = frozenset(
         "openai",
         "sqlalchemy",
         "streaq",
+        "urllib3",
         "uvicorn",
     }
 )
@@ -96,32 +97,55 @@ _INFO_NOISE_LOGGER_PREFIXES = (
     "streaq",
     "uvicorn.access",
 )
+_DEBUG_ONLY_NOISE_LOGGER_PREFIXES = (
+    # Unlike _INFO_NOISE_LOGGER_PREFIXES, these are never floored at INFO —
+    # their INFO-level output (login outcomes, scheduler faults) is
+    # legitimate in production. Only their sub-INFO chatter is pure protocol
+    # narration with no diagnostic value: SuperTokens logs internal
+    # getSession/middleware plumbing on every single request, the MCP SDK
+    # logs handler registration on every connection, filelock logs every
+    # acquire/release pair, and APScheduler logs every empty polling tick.
+    "apscheduler",
+    "com.supertokens",
+    "filelock",
+    "mcp",
+    "urllib3",
+)
+
+
+def _quiet_dependencies_enabled() -> bool:
+    return os.getenv("LOG_QUIET_DEPENDENCIES", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
 
 
 def _dependency_floor_applies(configured_level: int, name: str) -> bool:
     """Whether a chatty dependency is held at WARNING.
 
-    At INFO, always: these libraries narrate every successful operation and the
-    console is for the application's own story.
+    At INFO, always for ``_INFO_NOISE_LOGGER_PREFIXES``: these libraries
+    narrate every successful operation and the console is for the
+    application's own story.
 
-    At DEBUG, only when ``LOG_QUIET_DEPENDENCIES`` is set. Asking for DEBUG
-    deliberately means "show me everything", and a developer debugging
-    SQLAlchemy itself must still be able to get it - so the default stays as it
-    was. `make dev` opts in, because SQLAlchemy alone emits a record per mapped
-    column at import: thousands of lines before the first request, which buries
-    the application logs the flag was turned on to read.
+    At DEBUG, only when ``LOG_QUIET_DEPENDENCIES`` is set, for both
+    ``_INFO_NOISE_LOGGER_PREFIXES`` and ``_DEBUG_ONLY_NOISE_LOGGER_PREFIXES``.
+    Asking for DEBUG deliberately means "show me everything", and a developer
+    debugging SQLAlchemy (or SuperTokens, or the scheduler) itself must still
+    be able to get it - so the default stays as it was. `make dev` opts in,
+    because SQLAlchemy alone emits a record per mapped column at import:
+    thousands of lines before the first request, which buries the
+    application logs the flag was turned on to read.
     """
-    if not name.startswith(_INFO_NOISE_LOGGER_PREFIXES):
+    if name.startswith(_INFO_NOISE_LOGGER_PREFIXES):
+        if configured_level == logging.INFO:
+            return True
+        if configured_level < logging.INFO:
+            return _quiet_dependencies_enabled()
         return False
-    if configured_level == logging.INFO:
-        return True
-    if configured_level < logging.INFO:
-        return os.getenv("LOG_QUIET_DEPENDENCIES", "").strip().lower() in {
-            "1",
-            "true",
-            "yes",
-            "on",
-        }
+    if name.startswith(_DEBUG_ONLY_NOISE_LOGGER_PREFIXES):
+        return configured_level < logging.INFO and _quiet_dependencies_enabled()
     return False
 
 

--- a/lemma-backend/app/core/observability/telemetry.py
+++ b/lemma-backend/app/core/observability/telemetry.py
@@ -448,24 +448,25 @@ def _setup_llm_tracing(service_name: str) -> TracerProvider | None:
     provider.add_span_processor(
         BatchSpanProcessor(
             FilteringSpanExporter(
-                SanitizingSpanExporter(
-                    _build_span_exporter(
-                        endpoint,
-                        protocol=settings.llm_otel_exporter_otlp_protocol,
-                        headers=_llm_otlp_headers(),
-                    ),
-                    llm=True,
+                _build_span_exporter(
+                    endpoint,
+                    protocol=settings.llm_otel_exporter_otlp_protocol,
+                    headers=_llm_otlp_headers(),
                 ),
                 _is_llm_span,
             )
         )
     )
+    # Unlike the general pipeline, this one is opt-in, isolated, and exists
+    # specifically to let developers review what's sent to the LLM — so it
+    # carries full prompt/response content and skips SanitizingSpanExporter's
+    # attribute allowlist (which would truncate/strip it right back out).
     Agent.instrument_all(
         InstrumentationSettings(
             tracer_provider=provider,
             meter_provider=NoOpMeterProvider(),
             logger_provider=NoOpLoggerProvider(),
-            include_content=False,
+            include_content=True,
             include_binary_content=False,
             version=2,
             event_mode="attributes",

--- a/lemma-backend/app/core/tests/unit/test_logging_pipeline.py
+++ b/lemma-backend/app/core/tests/unit/test_logging_pipeline.py
@@ -493,3 +493,64 @@ def test_sqlalchemy_debug_remains_available_when_requested(
     logging.getLogger(logger_name).debug("SQLAlchemy debug detail")
 
     assert captured_stdout()[-1]["event"] == "SQLAlchemy debug detail"
+
+
+@pytest.mark.parametrize(
+    "logger_name",
+    (
+        "com.supertokens",
+        "mcp.server.lowlevel.server",
+        "filelock",
+        "apscheduler.scheduler",
+        "urllib3.connectionpool",
+    ),
+)
+def test_debug_only_noise_is_suppressed_when_quiet_dependencies_requested(
+    captured_stdout,
+    monkeypatch,
+    logger_name,
+) -> None:
+    monkeypatch.setenv("LOG_QUIET_DEPENDENCIES", "1")
+    setup_logging(
+        "development",
+        service_name="lemma-api",
+        json_logs=True,
+        log_level="DEBUG",
+    )
+    dependency_logger = logging.getLogger(logger_name)
+
+    dependency_logger.debug("routine protocol chatter")
+    dependency_logger.info("routine protocol chatter")
+    dependency_logger.warning("dependency warning")
+    get_logger("app.demo").info("service.started")
+
+    records = captured_stdout()
+    assert [record["event"] for record in records] == [
+        "dependency warning",
+        "service.started",
+    ]
+
+
+@pytest.mark.parametrize(
+    "logger_name",
+    (
+        "com.supertokens",
+        "mcp.server.lowlevel.server",
+        "filelock",
+        "apscheduler.scheduler",
+        "urllib3.connectionpool",
+    ),
+)
+def test_debug_only_noise_remains_available_by_default_at_debug(
+    captured_stdout,
+    logger_name,
+) -> None:
+    setup_logging(
+        "development",
+        service_name="lemma-api",
+        json_logs=True,
+        log_level="DEBUG",
+    )
+    logging.getLogger(logger_name).debug("routine protocol chatter")
+
+    assert captured_stdout()[-1]["event"] == "routine protocol chatter"

--- a/lemma-backend/app/core/tests/unit/test_otel_safety.py
+++ b/lemma-backend/app/core/tests/unit/test_otel_safety.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 import logging
 
+from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
 import pytest
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
@@ -277,7 +278,7 @@ def test_exporter_drops_only_fastapi_asgi_internal_spans() -> None:
     ]
 
 
-def test_llm_pipeline_disables_content_and_uses_dedicated_provider(
+def test_llm_pipeline_enables_content_and_uses_dedicated_provider(
     monkeypatch,
 ) -> None:
     configured = _settings(
@@ -301,13 +302,50 @@ def test_llm_pipeline_disables_content_and_uses_dedicated_provider(
         assert provider is not None
         assert len(captured) == 1
         instrumentation = captured[0]
-        assert instrumentation.include_content is False
+        assert instrumentation.include_content is True
         assert instrumentation.include_binary_content is False
         assert instrumentation.tracer.resource is provider.resource
         assert instrumentation.event_mode == "attributes"
     finally:
         if provider is not None:
             provider.shutdown()
+
+
+def test_llm_pipeline_exports_full_content_without_sanitization(monkeypatch) -> None:
+    """The LLM pipeline is opt-in and isolated specifically to let developers
+    review real prompts/responses, so — unlike the general pipeline — it must
+    not run spans through SanitizingSpanExporter's allowlist/truncation."""
+    configured = _settings(
+        llm_otel_enabled=True,
+        llm_otel_exporter_otlp_endpoint="http://phoenix:4317",
+        llm_otel_traces_sampler="always_on",
+    )
+    monkeypatch.setattr(telemetry, "_get_settings", lambda: configured)
+    capture = _CaptureExporter()
+    monkeypatch.setattr(
+        telemetry, "_build_span_exporter", lambda *args, **kwargs: capture
+    )
+    monkeypatch.setattr(
+        telemetry.Agent, "instrument_all", lambda instrumentation_settings: None
+    )
+    provider = telemetry._setup_llm_tracing("lemma-test")
+    assert provider is not None
+    try:
+        long_prompt = "You are a helpful assistant. " * 20
+        assert len(long_prompt) > 256
+        tracer = provider.get_tracer("test")
+        with tracer.start_as_current_span("llm.call") as span:
+            span.set_attribute(
+                SpanAttributes.OPENINFERENCE_SPAN_KIND,
+                OpenInferenceSpanKindValues.LLM.value,
+            )
+            span.set_attribute(SpanAttributes.INPUT_VALUE, long_prompt)
+        assert provider.force_flush()
+        assert len(capture.spans) == 1
+        exported_value = capture.spans[0].attributes[SpanAttributes.INPUT_VALUE]
+        assert exported_value == long_prompt
+    finally:
+        provider.shutdown()
 
 
 def test_otel_log_handler_constructs_only_bounded_records(monkeypatch) -> None:

--- a/lemma-backend/scripts/hyperdx_bootstrap.py
+++ b/lemma-backend/scripts/hyperdx_bootstrap.py
@@ -1,0 +1,399 @@
+"""Bootstrap a local HyperDX (ClickStack) team and print its ingestion API key.
+
+HyperDX's all-in-one image runs in REQUIRED_AUTH mode: nothing can send or
+view telemetry until a team exists. This registers a fixed local-dev team on
+first run and logs into that same team on every run after (the Mongo volume
+persists it across restarts), then reads the team's OTLP ingestion API key
+from `GET /api/team`. Prints only the key to stdout so a Makefile recipe can
+capture it directly; everything else goes to stderr.
+
+It also provisions (once, idempotently) a default "Lemma API Overview"
+dashboard covering the auto-created Traces and Logs sources, and prints the
+user's Personal API Access Key (`GET /api/me`) as a ready-to-export
+`CLICKSTACK_ACCESS_KEY` line — the credential the ClickStack MCP server
+(`/api/mcp`, see `.mcp.json` and `docs/observability.md`) authenticates with.
+"""
+
+from __future__ import annotations
+
+import argparse
+from http.cookies import SimpleCookie
+import sys
+
+import httpx
+
+_EMAIL = "dev@lemma.local"
+# HyperDX requires >=12 chars, upper+lower+digit+special. Local-only, never
+# used for anything but this throwaway dev team.
+_PASSWORD = "Lemma-Dev-Observability-1!"
+
+_DASHBOARD_NAME = "Lemma API Overview"
+_SERVER = 'SpanKind:"Server"'
+_ERROR = 'StatusCode:"Error"'
+_DURATION_FORMAT = {"output": "duration", "factor": 0.000000001}
+
+
+def _select(agg_fn, *, alias, value_expression="", level=None, condition=""):
+    item = {
+        "aggFn": agg_fn,
+        "aggCondition": condition,
+        "aggConditionLanguage": "lucene",
+        "valueExpression": value_expression,
+        "alias": alias,
+        "isDelta": False,
+    }
+    if level is not None:
+        item["level"] = level
+        item["numberFormat"] = _DURATION_FORMAT
+    return item
+
+
+def _quantile(level, alias, *, condition=_SERVER):
+    return _select(
+        "quantile", alias=alias, value_expression="Duration", level=level, condition=condition
+    )
+
+
+def _overview_dashboard(traces_source_id: str, logs_source_id: str, connection_id: str) -> dict:
+    """Tile shapes are the exact structures HyperDX persisted after being
+    authored and validated (via `clickstack_save_dashboard` +
+    `clickstack_query_tile`, one tile at a time) through the ClickStack MCP
+    server against a live instance — not hand-guessed against the schema.
+    Two things learned that aren't obvious from the schema alone:
+
+    - A select item's conditional filter must be `aggCondition` +
+      `aggConditionLanguage` (not `where`), or the condition silently fails
+      at render time despite passing save-time validation.
+    - Builder `table` tiles combining a top-level `where` with a
+      map-attribute `groupBy` (e.g. ``SpanAttributes['http.route']``) silently
+      ignore the `where` filter. Raw SQL tiles (`configType: "sql"`) don't
+      have this problem and also get a clean column alias instead of the
+      literal `arrayElement(SpanAttributes, 'http.route')` header a builder
+      groupBy on a map attribute would render.
+    """
+    return {
+        "name": _DASHBOARD_NAME,
+        "tags": [],
+        "containers": [
+            {"id": "overview", "title": "Overview", "collapsed": False},
+            {"id": "performance", "title": "Performance", "collapsed": False},
+            {"id": "endpoints", "title": "Endpoints", "collapsed": False},
+            {"id": "errors", "title": "Errors", "collapsed": False},
+            {"id": "logs", "title": "Logs", "collapsed": False},
+        ],
+        "tiles": [
+            {
+                "id": "requests",
+                "x": 0,
+                "y": 0,
+                "w": 8,
+                "h": 4,
+                "containerId": "overview",
+                "config": {
+                    "name": "Requests",
+                    "displayType": "number",
+                    "source": traces_source_id,
+                    "where": "",
+                    "select": [_select("count", alias="Requests", condition=_SERVER)],
+                },
+            },
+            {
+                "id": "errors",
+                "x": 8,
+                "y": 0,
+                "w": 8,
+                "h": 4,
+                "containerId": "overview",
+                "config": {
+                    "name": "Errors",
+                    "displayType": "number",
+                    "source": traces_source_id,
+                    "where": "",
+                    "select": [
+                        _select(
+                            "count",
+                            alias="Errors",
+                            condition=f"({_SERVER}) AND ({_ERROR})",
+                        )
+                    ],
+                },
+            },
+            {
+                "id": "p95-duration",
+                "x": 16,
+                "y": 0,
+                "w": 8,
+                "h": 4,
+                "containerId": "overview",
+                "config": {
+                    "name": "P95 Duration",
+                    "displayType": "number",
+                    "source": traces_source_id,
+                    "where": "",
+                    "select": [_quantile(0.95, "P95")],
+                },
+            },
+            {
+                "id": "latency-percentiles",
+                "x": 0,
+                "y": 4,
+                "w": 12,
+                "h": 6,
+                "containerId": "performance",
+                "config": {
+                    "name": "Latency Percentiles",
+                    "displayType": "line",
+                    "source": traces_source_id,
+                    "where": "",
+                    "select": [
+                        _quantile(0.5, "P50"),
+                        _quantile(0.95, "P95"),
+                        _quantile(0.99, "P99"),
+                    ],
+                },
+            },
+            {
+                "id": "duration-distribution",
+                "x": 12,
+                "y": 4,
+                "w": 12,
+                "h": 6,
+                "containerId": "performance",
+                "config": {
+                    "name": "Duration Distribution",
+                    "displayType": "heatmap",
+                    "source": traces_source_id,
+                    "where": _SERVER,
+                    "whereLanguage": "lucene",
+                    "numberFormat": _DURATION_FORMAT,
+                    "select": [
+                        _select("count", alias="", value_expression="Duration")
+                    ],
+                },
+            },
+            {
+                "id": "endpoints",
+                "x": 0,
+                "y": 10,
+                "w": 24,
+                "h": 8,
+                "containerId": "endpoints",
+                "config": {
+                    "name": "Endpoints",
+                    "configType": "sql",
+                    "displayType": "table",
+                    "connection": connection_id,
+                    "source": traces_source_id,
+                    "sqlTemplate": (
+                        "SELECT SpanAttributes['http.route'] AS Endpoint, "
+                        "count() AS Requests, "
+                        "countIf(StatusCode = 'Error') AS Errors, "
+                        "quantile(0.95)(Duration / 1e9) AS P95Duration "
+                        "FROM $__sourceTable "
+                        "WHERE SpanKind = 'Server' AND SpanAttributes['http.route'] != '' "
+                        "AND $__timeFilter(Timestamp) AND $__filters "
+                        "GROUP BY Endpoint ORDER BY Requests DESC"
+                    ),
+                },
+            },
+            {
+                "id": "errors-by-kind",
+                "x": 0,
+                "y": 18,
+                "w": 12,
+                "h": 6,
+                "containerId": "errors",
+                "config": {
+                    "name": "Errors over time (by kind)",
+                    "displayType": "stacked_bar",
+                    "source": traces_source_id,
+                    "where": "",
+                    "groupBy": "SpanKind",
+                    "select": [_select("count", alias="Errors", condition=_ERROR)],
+                },
+            },
+            {
+                "id": "errors-by-status",
+                "x": 12,
+                "y": 18,
+                "w": 12,
+                "h": 6,
+                "containerId": "errors",
+                "config": {
+                    "name": "Errors by HTTP status code",
+                    "configType": "sql",
+                    "displayType": "table",
+                    "connection": connection_id,
+                    "source": traces_source_id,
+                    "sqlTemplate": (
+                        "SELECT SpanAttributes['http.status_code'] AS StatusCode_, "
+                        "count() AS Count "
+                        "FROM $__sourceTable "
+                        "WHERE StatusCode = 'Error' AND $__timeFilter(Timestamp) AND $__filters "
+                        "GROUP BY StatusCode_ ORDER BY Count DESC"
+                    ),
+                },
+            },
+            {
+                "id": "recent-error-spans",
+                "x": 0,
+                "y": 24,
+                "w": 24,
+                "h": 6,
+                "containerId": "errors",
+                "config": {
+                    "name": "Recent error spans",
+                    "displayType": "search",
+                    "source": traces_source_id,
+                    "where": _ERROR,
+                    "whereLanguage": "lucene",
+                    "select": (
+                        "Timestamp, ServiceName, SpanKind, SpanName, "
+                        "SpanAttributes['http.status_code'], "
+                        "SpanAttributes['http.route'], round(Duration/1e6)"
+                    ),
+                },
+            },
+            {
+                "id": "logs-by-severity",
+                "x": 0,
+                "y": 30,
+                "w": 12,
+                "h": 6,
+                "containerId": "logs",
+                "config": {
+                    "name": "Volume by severity",
+                    "displayType": "stacked_bar",
+                    "source": logs_source_id,
+                    "where": "",
+                    "groupBy": "SeverityText",
+                    "select": [_select("count", alias="Events")],
+                },
+            },
+            {
+                "id": "recent-warnings-errors",
+                "x": 12,
+                "y": 30,
+                "w": 12,
+                "h": 6,
+                "containerId": "logs",
+                "config": {
+                    "name": "Recent warnings & errors",
+                    "displayType": "search",
+                    "source": logs_source_id,
+                    "where": "SeverityText:warn OR SeverityText:error",
+                    "whereLanguage": "lucene",
+                    "select": "Timestamp, ServiceName, SeverityText, Body",
+                },
+            },
+        ],
+    }
+
+
+def _session_cookie(response: httpx.Response) -> str | None:
+    # HyperDX's session cookie is scoped to `Domain=localhost` (no dot), which
+    # httpx's cookie jar (backed by stdlib http.cookiejar) silently refuses to
+    # attach to later requests. Parse and carry it manually instead.
+    raw = response.headers.get("set-cookie")
+    if not raw:
+        return None
+    parsed: SimpleCookie = SimpleCookie()
+    parsed.load(raw)
+    morsel = parsed.get("connect.sid")
+    return morsel.value if morsel else None
+
+
+def _register_or_login(client: httpx.Client) -> str:
+    register = client.post(
+        "/api/register/password",
+        json={"email": _EMAIL, "password": _PASSWORD, "confirmPassword": _PASSWORD},
+    )
+    if register.status_code == 200:
+        cookie = _session_cookie(register)
+        if cookie:
+            return cookie
+        raise RuntimeError("HyperDX registration succeeded but set no session cookie")
+    if register.status_code != 409:
+        raise RuntimeError(
+            f"HyperDX registration failed: {register.status_code} {register.text}"
+        )
+    # 409 means a team already exists from a previous run — log into it
+    # instead. HyperDX's local strategy authenticates on `email`, not
+    # `username`.
+    login = client.post(
+        "/api/login/password",
+        json={"email": _EMAIL, "password": _PASSWORD},
+    )
+    if login.status_code not in (200, 303):
+        raise RuntimeError(f"HyperDX login failed: {login.status_code} {login.text}")
+    cookie = _session_cookie(login)
+    if not cookie:
+        raise RuntimeError("HyperDX login succeeded but set no session cookie")
+    return cookie
+
+
+def _ensure_dashboard(client: httpx.Client) -> None:
+    dashboards = client.get("/api/dashboards")
+    dashboards.raise_for_status()
+    if any(d.get("name") == _DASHBOARD_NAME for d in dashboards.json()):
+        return  # already provisioned by a previous run
+
+    sources = client.get("/api/sources")
+    sources.raise_for_status()
+    by_kind = {s.get("kind"): s for s in sources.json()}
+    traces_source = by_kind.get("trace")
+    logs_source = by_kind.get("log")
+    if traces_source is None or logs_source is None:
+        raise RuntimeError("HyperDX is missing a default Traces or Logs source")
+
+    created = client.post(
+        "/api/dashboards",
+        json=_overview_dashboard(
+            traces_source["_id"], logs_source["_id"], traces_source["connection"]
+        ),
+    )
+    created.raise_for_status()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://localhost:8080")
+    parser.add_argument("--timeout", type=float, default=10.0)
+    args = parser.parse_args()
+
+    try:
+        with httpx.Client(
+            base_url=args.base_url, timeout=args.timeout, follow_redirects=False
+        ) as client:
+            cookie = _register_or_login(client)
+            client.headers["Cookie"] = f"connect.sid={cookie}"
+            team = client.get("/api/team")
+            team.raise_for_status()
+            api_key = team.json().get("apiKey")
+            me = client.get("/api/me")
+            me.raise_for_status()
+            personal_access_key = me.json().get("accessKey")
+            _ensure_dashboard(client)
+    except httpx.HTTPError as exc:
+        print(f"hyperdx_bootstrap: request to {args.base_url} failed: {exc}", file=sys.stderr)
+        return 1
+    except RuntimeError as exc:
+        print(f"hyperdx_bootstrap: {exc}", file=sys.stderr)
+        return 1
+
+    if not api_key:
+        print(f"hyperdx_bootstrap: team response had no apiKey: {team.text}", file=sys.stderr)
+        return 1
+    if personal_access_key:
+        print(
+            f"export CLICKSTACK_ACCESS_KEY={personal_access_key}  "
+            "# for the ClickStack MCP server (.mcp.json) — see docs/observability.md",
+            file=sys.stderr,
+        )
+
+    print(api_key)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **Real dashboards instead of a throwaway collector.** `make dev OTEL=1 LLM_OTEL=1` previously only pointed at a console-only debug collector. `docker-compose.observability.yml` (HyperDX/ClickStack + Phoenix) already existed but was never wired to anything. New `make observability-up` / `-down` / `-open` targets bootstrap it: register/log into a fixed local HyperDX team, capture its ingestion + personal-access keys, and provision a validated "Lemma API Overview" dashboard (Overview/Performance/Endpoints/Errors/Logs containers) — built and tile-by-tile validated live through the ClickStack MCP server itself.
- **Fixed LLM content capture.** `_setup_llm_tracing` hardcoded `include_content=False` and ran LLM spans through the same content-stripping sanitizer as the general pipeline, so even with Phoenix wired up you'd never see an actual prompt. Now `LLM_OTEL_ENABLED=true` ships full prompt/response content by design (that pipeline is isolated, opt-in, and exists specifically for this) — verified end-to-end against a real agent run.
- **ClickStack MCP server registered** for this repo via `.mcp.json` (env-var-based auth, no secret committed), so coding agents can query traces/logs/metrics and inspect trace waterfalls directly.
- **Logs on by default.** `OTEL_LOGS` now defaults to `1` instead of requiring a third flag.
- **Quieted noisy dependency debug logs.** SuperTokens, the MCP SDK, filelock, and APScheduler were narrating internal protocol/lock chatter on every request in local DEBUG mode, drowning first-party app logs. Added a `_DEBUG_ONLY_NOISE_LOGGER_PREFIXES` floor (distinct from the existing `_INFO_NOISE_LOGGER_PREFIXES`) so this only applies under `LOG_QUIET_DEPENDENCIES` at DEBUG — their INFO/production behavior is untouched.
- New `docs/observability.md` covering the architecture, dashboard layout, and MCP usage (with example prompts).
- Debug-collector ports renumbered to avoid colliding with the new real stack.

## Test plan

- [x] `uv run pytest app/core/tests/unit` — 231 passed (includes new/updated tests in `test_otel_safety.py` and `test_logging_pipeline.py`)
- [x] `make otel-smoke` — passes with updated assertions (general pipeline stays sanitized; LLM pipeline now must carry content)
- [x] `make observability-up` from a clean state (fresh volumes) — HyperDX + Phoenix start, team bootstraps, dashboard provisions, all 11 tiles validated via `clickstack_query_tile`
- [x] `make dev OTEL=1 LLM_OTEL=1` + real traffic (CLI calls, a 404) — confirmed real traces/metrics/logs land in ClickHouse and populate every dashboard tile with real data
- [x] Ran a real agent (`system:lemma` model provider) via `lemma chat` — confirmed Phoenix captured the full system prompt, user message, and model response in plain text
- [x] MCP server `tools/list`/`tools/call` round-tripped against the personal access key from a running instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)