### PR TITLE
Stop asserting a released forwarder port is instantly re-bindable

### DIFF
--- a/locald/src/managed_runtime.rs
+++ b/locald/src/managed_runtime.rs
@@ -674,6 +674,7 @@ fn bundled_executable(variable: &str, sibling_name: &str) -> io::Result<PathBuf>
 mod tests {
     use super::*;
     use std::io::Read;
+    use std::sync::mpsc;
     use tempfile::tempdir;
 
     #[test]
@@ -697,13 +698,47 @@ mod tests {
     fn tcp_forwarder_relays_bytes_and_releases_its_port() {
         let target = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
         let target_address = target.local_addr().unwrap();
+        // The test keeps `target` so it can still watch for relayed connections
+        // after the forwarder is gone; the upstream half of the exchange runs on
+        // a clone.
+        let upstream = target.try_clone().unwrap();
+        let (reached_target, relay_is_waiting) = mpsc::channel();
         let server = thread::spawn(move || {
-            let (mut stream, _) = target.accept().unwrap();
-            let mut input = [0_u8; 4];
-            stream.read_exact(&mut input).unwrap();
-            assert_eq!(&input, b"ping");
+            let (mut stream, _) = upstream.accept().unwrap();
+            // macOS inherits O_NONBLOCK from the listener onto accepted sockets.
+            // A relay that mistook the resulting EAGAIN for EOF would already
+            // have hung up on this connection before the client said anything,
+            // so require a read that runs out of time rather than one that
+            // reports EOF. The duration only bounds how long a healthy relay is
+            // watched; a broken one reports EOF immediately.
+            stream
+                .set_read_timeout(Some(Duration::from_millis(100)))
+                .unwrap();
+            let mut discard = [0_u8; 1];
+            let idle = stream.read(&mut discard).map_err(|error| error.kind());
+            assert!(
+                matches!(
+                    idle,
+                    Err(io::ErrorKind::WouldBlock) | Err(io::ErrorKind::TimedOut)
+                ),
+                "relay stopped waiting for a client that had not spoken yet: {idle:?}"
+            );
+            stream.set_read_timeout(None).unwrap();
+            reached_target.send(()).unwrap();
+
+            let mut request = [0_u8; 4];
+            stream.read_exact(&mut request).unwrap();
+            assert_eq!(&request, b"ping");
             stream.write_all(b"pong").unwrap();
+
+            // Hang up only after the client has, so the relay is the passive
+            // closer on both of its sockets and leaves no TCP state of its own
+            // behind on the port the release check below is about.
+            let mut trailing = Vec::new();
+            stream.read_to_end(&mut trailing).unwrap();
+            assert!(trailing.is_empty());
         });
+
         let forwarder = TcpForwarder::start(
             "test",
             SocketAddr::from((Ipv4Addr::LOCALHOST, 0)),
@@ -712,19 +747,64 @@ mod tests {
         .unwrap();
         let local = forwarder.local_address;
         let mut client = TcpStream::connect(local).unwrap();
-        // macOS inherits O_NONBLOCK from the listener onto accepted sockets.
-        // Prove the relay waits for a real client instead of treating the
-        // initial EAGAIN before request bytes arrive as EOF/failure.
-        thread::sleep(Duration::from_millis(50));
+        // Bounded only so a relay that never dials out fails this test instead
+        // of parking the whole test binary on a blocking accept forever.
+        relay_is_waiting
+            .recv_timeout(Duration::from_secs(10))
+            .expect("relay never opened its upstream connection");
         client.write_all(b"ping").unwrap();
-        let mut output = [0_u8; 4];
-        client.read_exact(&mut output).unwrap();
+        let mut response = [0_u8; 4];
+        client.read_exact(&mut response).unwrap();
+        assert_eq!(&response, b"pong");
 
-        assert_eq!(&output, b"pong");
+        // Half-close, then read to EOF: the relay passing the upstream hang-up
+        // back down is the observable proof that it finished both directions,
+        // which is what makes the release check below race-free.
+        client.shutdown(Shutdown::Write).unwrap();
+        let mut trailing = Vec::new();
+        client.read_to_end(&mut trailing).unwrap();
+        assert!(trailing.is_empty());
         server.join().unwrap();
         drop(client);
+
         drop(forwarder);
-        assert!(TcpListener::bind(local).is_ok());
+
+        // `local` is an ephemeral port, so its number is back in the machine's
+        // pool the instant Drop returns, and this binary hands ephemeral port
+        // numbers around and re-binds them later (`reserve_loopback_port`,
+        // `ports_available`) - one of those can and does take `local` in the
+        // microseconds that follow. "Nothing can bind `local`" is therefore a
+        // claim about the whole test binary rather than about this forwarder,
+        // and asserting it is what made this test flake. Assert instead what is
+        // only ever true of the forwarder: it stopped serving that port.
+        target.set_nonblocking(true).unwrap();
+        match TcpStream::connect_timeout(&local, Duration::from_secs(5)) {
+            Err(error) => assert_eq!(
+                error.kind(),
+                io::ErrorKind::ConnectionRefused,
+                "a released forwarder port must refuse connections, got {error}"
+            ),
+            Ok(_held_open) => {
+                // Something else already owns the number. That is only a failure
+                // if the something else is this forwarder, and the forwarder is
+                // identifiable by behaviour: it dials `target_address`, which
+                // nothing but this test knows. Hold the connection open while
+                // watching, so a relay that is still running has something to
+                // relay rather than a reset socket.
+                let deadline = Instant::now() + Duration::from_secs(1);
+                while Instant::now() < deadline {
+                    match target.accept() {
+                        Ok(_) => panic!(
+                            "forwarder kept relaying {local} to {target_address} after it was dropped"
+                        ),
+                        Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(10));
+                        }
+                        Err(error) => panic!("target listener stopped working: {error}"),
+                    }
+                }
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## The flake

`managed_runtime::tests::tcp_forwarder_relays_bytes_and_releases_its_port` failed roughly once in twenty full runs of `cargo test --manifest-path locald/Cargo.toml`, always on `assert!(TcpListener::bind(local).is_ok())`, and never when run alone with a filter.

## What was actually racing

Not the forwarder's shutdown timing. Instrumenting the assertion to ask *who owns the port* at the moment it fails gave:

```
bind(127.0.0.1:56417) failed: AddrInUse
connect probe: CONNECTED (someone is listening)
recovered after: 1.302167ms
```

Another listener **in the same test binary** claimed the number microseconds after `Drop` released it, and was gone 1.3 ms later. That is a standing property of this binary rather than a fixable timing bug — [`reserve_loopback_port`](locald/src/sharing.rs#L1666), [`ports_available`](locald/src/network.rs#L133) and [`migration_setup_waits_for_its_exact_database_route`](locald/src/host_process.rs#L2302) all take an ephemeral port, drop the socket, keep only the *number*, and re-bind it later. So `local` returns to a contended pool the instant `Drop` returns, and "nothing can bind this number" is a claim about the whole test binary, not about the forwarder.

Alternatives were ruled out with standalone probes rather than assumed:

- A lingering TIME_WAIT on the port does **not** block a rebind here — `SO_REUSEADDR` handles it, 0/3000 failures across every close-ordering and fd-lifetime combination.
- The detached proxy thread's socket close does not block it either (0/3000 with the close raced against the bind from another thread).
- The OS ephemeral counter is monotonic and advances only ~60 per suite run, so it never wraps back onto the port.

## The fix

Test-only; production code is untouched.

- **The release assertion now tests the forwarder, not the port number.** After `Drop`, a connect to `local` must be refused. If something has already claimed the number that is not by itself a verdict, so the test settles it by identity: the relay dials `target_address`, which nothing else on the machine knows, so it watches `target` and fails only when a connection actually arrives there.
- **The 50 ms sleep becomes the assertion it was standing in for.** It existed to give a relay that mistook the accepted socket's EAGAIN for EOF a window to misbehave in. The target side now sets a read timeout and requires the read to *time out* rather than report EOF, so a broken relay fails immediately.
- **Teardown is sequenced on observable events.** The client half-closes and reads to EOF, so the relay is the passive closer and the test waits for the relay's own hang-up instead of guessing when it finished.

## Verification

Fault injection, to confirm the assertions still bite:

| Injected fault | Result |
| --- | --- |
| `Drop` leaks the accept loop | **fails** — `forwarder kept relaying 127.0.0.1:54097 to 127.0.0.1:54096 after it was dropped` |
| accepted socket left non-blocking | **fails** — `relay stopped waiting for a client that had not spoken yet: Ok(0)` |

**140 full suite runs, zero failures of this test** (baseline ~1 in 20). `cargo clippy --all-targets` and `cargo fmt --check` are clean.

## Reviewer notes

- **Known limitation, stated plainly.** If a future change made `Drop` signal the accept loop but return without joining it, the port would stay bound for up to one 25 ms poll interval and this test would not catch it — the only way to observe that is the rebind assertion that cannot be trusted. `Drop` joining is what makes the property hold, and a leak that *outlives* `Drop` is caught.
- The test now runs ~125 ms instead of ~50 ms, because the EAGAIN guard is a real 100 ms observation window rather than dead sleep time. The duration only bounds how long a healthy relay is watched; a broken one fails instantly.
- **Unrelated flakes found while running the suite** (3 failures across the 140 runs), worth separate fixes: `host_process::tests::services_boot_alongside_each_other_rather_than_one_after_another` fails both on reading a spawned process's executable path before the OS publishes it (`host_process.rs:2502`) and on its wall-clock `elapsed < 1300ms` budget under parallel load (`host_process.rs:2508`); `host_process::tests::opens_restart_circuit_after_crash_budget_is_exhausted` paces crash reconciliation with fixed sleeps (`host_process.rs:2575`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
