### PR TITLE
Hold a port with a socket, not with a number

### DIFF
--- a/locald/Cargo.toml
+++ b/locald/Cargo.toml
@@ -18,11 +18,11 @@ reqwest = { version = "=0.13.4", default-features = false, features = ["blocking
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+socket2 = "0.6"
 tokio = { version = "1", features = ["io-util", "net", "rt-multi-thread", "sync"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
-socket2 = "0.6"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = [

--- a/locald/src/host_process.rs
+++ b/locald/src/host_process.rs
@@ -1946,6 +1946,7 @@ fn is_loopback(address: IpAddr) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::port_reservation::PortReservation;
     use std::net::{Ipv4Addr, TcpListener};
     use tempfile::tempdir;
 
@@ -2299,9 +2300,8 @@ mod tests {
     #[test]
     fn migration_setup_waits_for_its_exact_database_route() {
         let root = tempdir().unwrap();
-        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
-        let address = listener.local_addr().unwrap();
-        drop(listener);
+        let reservation = PortReservation::ephemeral().unwrap();
+        let address = reservation.address();
         let mut value = manifest(vec![
             service("frontend", &["backend"]),
             service("backend", &[]),
@@ -2321,7 +2321,12 @@ mod tests {
         // minutes of a CI runner before it was cancelled rather than failing.
         let route = thread::spawn(move || {
             thread::sleep(Duration::from_millis(150));
-            let listener = TcpListener::bind(address).unwrap();
+            // The port stays reserved for the whole wait, so no other test in
+            // this binary can be handed it. Until this line the reservation is
+            // bound but not listening, so `run_setups` is refused exactly as an
+            // absent route would refuse it; here the same socket starts
+            // listening, so the route opens without the port ever being free.
+            let listener = reservation.listen().unwrap();
             listener.set_nonblocking(true).unwrap();
             let deadline = Instant::now() + Duration::from_secs(10);
             while Instant::now() < deadline {

--- a/locald/src/lib.rs
+++ b/locald/src/lib.rs
@@ -6,6 +6,7 @@ pub mod native_host_pack;
 pub mod network;
 pub mod operator_config;
 pub mod paths;
+pub mod port_reservation;
 pub mod protocol;
 pub mod provider_probe;
 pub mod sharing;

--- a/locald/src/managed_runtime.rs
+++ b/locald/src/managed_runtime.rs
@@ -724,7 +724,28 @@ mod tests {
         server.join().unwrap();
         drop(client);
         drop(forwarder);
-        assert!(TcpListener::bind(local).is_ok());
+        // A forwarder that leaked its listener never gives the port back, so
+        // waiting distinguishes the regression from the coincidence. The
+        // coincidence is real: `local` is an ephemeral number the OS may hand
+        // to another test in this binary in the instant after the forwarder
+        // lets go, and that stranger is gone again in about a millisecond.
+        if let Err(error) = rebind_within(local, Duration::from_secs(5)) {
+            panic!("forwarder did not release {local} within 5s: {error}");
+        }
+    }
+
+    fn rebind_within(address: SocketAddr, patience: Duration) -> io::Result<TcpListener> {
+        let deadline = Instant::now() + patience;
+        loop {
+            let error = match TcpListener::bind(address) {
+                Ok(listener) => return Ok(listener),
+                Err(error) => error,
+            };
+            if Instant::now() >= deadline {
+                return Err(error);
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
     }
 
     #[test]

--- a/locald/src/network.rs
+++ b/locald/src/network.rs
@@ -1,13 +1,13 @@
 use std::env;
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
-use std::net::{Ipv4Addr, TcpListener};
 use std::path::Path;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
 use crate::paths::LocalPaths;
+use crate::port_reservation::PortReservation;
 
 const NETWORK_SCHEMA_VERSION: u64 = 1;
 const MIN_DYNAMIC_PORT: u16 = 49_152;
@@ -47,15 +47,57 @@ pub fn load_or_allocate(paths: &LocalPaths) -> io::Result<NetworkPorts> {
     let path = paths.root.join("network.json");
     if let Ok(raw) = fs::read(&path) {
         if let Ok(existing) = serde_json::from_slice::<NetworkPorts>(&raw) {
-            if existing.valid() && ports_available(existing) {
-                return Ok(existing);
+            if existing.valid() {
+                // Reserving is how the remembered pair is tested: claiming both
+                // at once answers a question a pair of separate probes cannot,
+                // and a reservation never listens, so a client still pointed at
+                // the old address is refused here rather than accepted by a
+                // socket that is about to disappear.
+                if let Some(reserved) = reserve_pair(existing) {
+                    reserved.release();
+                    return Ok(existing);
+                }
             }
         }
     }
 
-    let ports = allocate_ports()?;
+    let (ports, reserved) = allocate_ports()?;
+    // Hold both ports until the record naming them is durable. The services
+    // that finally bind them are child processes started later — sometimes in a
+    // later run entirely — so no reservation can reach all the way to their
+    // bind; what it can do is stop a second locald racing this one from being
+    // handed the very pair this call is about to write down and return.
     write_private_atomic(&path, &serde_json::to_vec_pretty(&ports)?)?;
+    reserved.release();
     Ok(ports)
+}
+
+struct ReservedPair {
+    frontend: PortReservation,
+    backend: PortReservation,
+}
+
+impl ReservedPair {
+    fn release(self) {
+        self.frontend.release();
+        self.backend.release();
+    }
+
+    /// Turn the frontend claim into a live listener and give the backend back.
+    #[cfg(test)]
+    fn occupy_frontend(self) -> io::Result<std::net::TcpListener> {
+        self.backend.release();
+        self.frontend.listen()
+    }
+}
+
+/// Take the remembered pair back, or report that someone else owns one of them.
+fn reserve_pair(ports: NetworkPorts) -> Option<ReservedPair> {
+    // Claim both before judging either: a port that is tested and let go says
+    // nothing about whether the pair is still ours by the time we answer.
+    let frontend = PortReservation::at_loopback_port(ports.frontend_port).ok()?;
+    let backend = PortReservation::at_loopback_port(ports.backend_port).ok()?;
+    Some(ReservedPair { frontend, backend })
 }
 
 fn override_ports() -> io::Result<Option<NetworkPorts>> {
@@ -104,36 +146,34 @@ fn parse_override(name: &str, value: &str) -> io::Result<u16> {
         })
 }
 
-fn allocate_ports() -> io::Result<NetworkPorts> {
+fn allocate_ports() -> io::Result<(NetworkPorts, ReservedPair)> {
     for _ in 0..64 {
         // Keep both reservations alive until the pair is complete so the OS
-        // cannot return the same ephemeral port twice.
-        let frontend = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))?;
-        let backend = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))?;
-        let frontend_port = frontend.local_addr()?.port();
-        let backend_port = backend.local_addr()?.port();
+        // cannot return the same ephemeral port twice, and hand them out with
+        // the numbers so the caller decides when the claim ends.
+        let frontend = PortReservation::ephemeral()?;
+        let backend = PortReservation::ephemeral()?;
+        let frontend_port = frontend.port();
+        let backend_port = backend.port();
         if frontend_port >= MIN_DYNAMIC_PORT
             && backend_port >= MIN_DYNAMIC_PORT
             && frontend_port != backend_port
         {
-            return Ok(NetworkPorts {
-                schema_version: NETWORK_SCHEMA_VERSION,
-                frontend_port,
-                backend_port,
-                allocated_at_ms: now_ms(),
-            });
+            return Ok((
+                NetworkPorts {
+                    schema_version: NETWORK_SCHEMA_VERSION,
+                    frontend_port,
+                    backend_port,
+                    allocated_at_ms: now_ms(),
+                },
+                ReservedPair { frontend, backend },
+            ));
         }
     }
     Err(io::Error::new(
         io::ErrorKind::AddrNotAvailable,
         "could not allocate high local ports for Lemma",
     ))
-}
-
-fn ports_available(ports: NetworkPorts) -> bool {
-    let frontend = TcpListener::bind((Ipv4Addr::LOCALHOST, ports.frontend_port));
-    let backend = TcpListener::bind((Ipv4Addr::LOCALHOST, ports.backend_port));
-    frontend.is_ok() && backend.is_ok()
 }
 
 fn write_private_atomic(path: &Path, contents: &[u8]) -> io::Result<()> {
@@ -205,32 +245,62 @@ fn now_ms() -> u128 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::{Ipv4Addr, TcpListener};
     use tempfile::tempdir;
 
     #[test]
+    fn a_fresh_allocation_still_owns_its_ports_while_it_is_being_recorded() {
+        let (ports, _reserved) = allocate_ports().unwrap();
+
+        // The gap between choosing the numbers and recording them is exactly
+        // where a bare pair of numbers can be stolen, so nothing may bind here.
+        // What happens after the release is deliberately not asserted: that
+        // instant belongs to whoever asks the OS for a port next.
+        assert!(TcpListener::bind((Ipv4Addr::LOCALHOST, ports.frontend_port)).is_err());
+        assert!(TcpListener::bind((Ipv4Addr::LOCALHOST, ports.backend_port)).is_err());
+    }
+
+    #[test]
     fn allocated_ports_are_high_distinct_and_persistent() {
-        let root = tempdir().unwrap();
-        let paths = LocalPaths::new(root.path().join("locald"));
-        paths.ensure().unwrap();
+        // Persistence is only observable while the recorded ports stay free,
+        // and the ports are unheld between the two calls by construction: the
+        // first call has to let go before it can return numbers. If something
+        // else on the machine takes one in that gap, rotating is the correct
+        // answer rather than the answer under test, so the scenario is retried.
+        // Code that genuinely failed to reuse its record would fail every
+        // attempt.
+        const ATTEMPTS: usize = 8;
+        for attempt in 1..=ATTEMPTS {
+            let root = tempdir().unwrap();
+            let paths = LocalPaths::new(root.path().join("locald"));
+            paths.ensure().unwrap();
 
-        let first = load_or_allocate(&paths).unwrap();
-        let second = load_or_allocate(&paths).unwrap();
+            let first = load_or_allocate(&paths).unwrap();
+            let second = load_or_allocate(&paths).unwrap();
 
-        assert!(first.frontend_port >= MIN_DYNAMIC_PORT);
-        assert!(first.backend_port >= MIN_DYNAMIC_PORT);
-        assert_ne!(first.frontend_port, first.backend_port);
-        assert_eq!(first, second);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            assert_eq!(
-                fs::metadata(paths.root.join("network.json"))
-                    .unwrap()
-                    .permissions()
-                    .mode()
-                    & 0o777,
-                0o600
-            );
+            assert!(first.frontend_port >= MIN_DYNAMIC_PORT);
+            assert!(first.backend_port >= MIN_DYNAMIC_PORT);
+            assert_ne!(first.frontend_port, first.backend_port);
+            if first != second {
+                assert!(
+                    attempt < ATTEMPTS,
+                    "load_or_allocate never reused its persisted record in {ATTEMPTS} attempts"
+                );
+                continue;
+            }
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                assert_eq!(
+                    fs::metadata(paths.root.join("network.json"))
+                        .unwrap()
+                        .permissions()
+                        .mode()
+                        & 0o777,
+                    0o600
+                );
+            }
+            return;
         }
     }
 
@@ -239,8 +309,17 @@ mod tests {
         let root = tempdir().unwrap();
         let paths = LocalPaths::new(root.path().join("locald"));
         paths.ensure().unwrap();
-        let first = load_or_allocate(&paths).unwrap();
-        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, first.frontend_port)).unwrap();
+        // Record a pair and let an unrelated owner take the frontend port, all
+        // without the port being free for an instant: allocating and then
+        // re-binding the number would leave this test racing the rest of the
+        // binary for the very port it is trying to prove is occupied.
+        let (first, reserved) = allocate_ports().unwrap();
+        write_private_atomic(
+            &paths.root.join("network.json"),
+            &serde_json::to_vec_pretty(&first).unwrap(),
+        )
+        .unwrap();
+        let listener = reserved.occupy_frontend().unwrap();
 
         let second = load_or_allocate(&paths).unwrap();
 

--- a/locald/src/port_reservation.rs
+++ b/locald/src/port_reservation.rs
@@ -1,0 +1,133 @@
+//! Loopback port reservations that live until the moment of use.
+//!
+//! Taking an ephemeral port from the OS, keeping only the number, and binding
+//! that number again later leaves a window in which anything else on the
+//! machine can claim it. A reservation instead holds the port with a real bound
+//! socket and is released explicitly at the handoff, so the window shrinks to
+//! the single step that genuinely needs the port free.
+//!
+//! A reservation is bound but never listening. A connection that arrives while
+//! one is held is refused exactly as it would be against an idle port, rather
+//! than accepted by a socket that is about to vanish; callers that gate on
+//! "can I connect yet?" therefore keep seeing the answer they would have seen
+//! if the reservation did not exist.
+
+use std::io;
+use std::net::{Ipv4Addr, SocketAddr, TcpListener};
+
+use socket2::{Domain, Protocol, Socket, Type};
+
+#[derive(Debug)]
+pub struct PortReservation {
+    socket: Socket,
+    address: SocketAddr,
+}
+
+impl PortReservation {
+    /// Reserve an OS-chosen loopback port.
+    pub fn ephemeral() -> io::Result<Self> {
+        Self::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)))
+    }
+
+    /// Reserve one exact loopback port, failing if anything else holds it.
+    pub fn at_loopback_port(port: u16) -> io::Result<Self> {
+        Self::bind(SocketAddr::from((Ipv4Addr::LOCALHOST, port)))
+    }
+
+    fn bind(address: SocketAddr) -> io::Result<Self> {
+        let socket = Socket::new(
+            Domain::for_address(address),
+            Type::STREAM,
+            Some(Protocol::TCP),
+        )?;
+        // Deliberately no SO_REUSEADDR: exclusivity is the whole point, and a
+        // reservation that a second binder can join reserves nothing. Nor
+        // `listen`, so the port stays indistinguishable from an idle one.
+        socket.bind(&address.into())?;
+        let address = socket
+            .local_addr()?
+            .as_socket()
+            .ok_or_else(|| io::Error::other("reserved socket has no IP address"))?;
+        Ok(Self { socket, address })
+    }
+
+    pub fn port(&self) -> u16 {
+        self.address.port()
+    }
+
+    pub fn address(&self) -> SocketAddr {
+        self.address
+    }
+
+    /// Hand the port back at the exact point its real owner takes it. Dropping
+    /// a reservation does the same thing; this names the handoff so the
+    /// released-too-early bug is visible at the call site rather than implied
+    /// by a scope ending.
+    pub fn release(self) {
+        drop(self.socket);
+    }
+
+    /// Become the listener that owns the port. There is no window at all here:
+    /// this is the reserving socket itself starting to listen, so the port goes
+    /// from reserved to served without passing through free. Use it whenever
+    /// the eventual owner lives in this process.
+    pub fn listen(self) -> io::Result<TcpListener> {
+        self.socket.listen(128)?;
+        Ok(self.socket.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpStream;
+    use std::time::Duration;
+
+    #[test]
+    fn a_held_reservation_cannot_be_bound_by_anyone_else() {
+        let reservation = PortReservation::ephemeral().unwrap();
+
+        assert!(TcpListener::bind(reservation.address()).is_err());
+        assert!(PortReservation::at_loopback_port(reservation.port()).is_err());
+
+        // Nothing is asserted after the release on purpose. "The port is free
+        // once I let go" is not this type's promise to keep — the instant after
+        // a release belongs to whoever asks next, and asserting otherwise would
+        // make this test the very race the module exists to remove.
+    }
+
+    #[test]
+    fn a_held_reservation_refuses_connections_like_an_idle_port() {
+        let reservation = PortReservation::ephemeral().unwrap();
+
+        let refused =
+            TcpStream::connect_timeout(&reservation.address(), Duration::from_millis(750));
+
+        // Callers gate on connectability to decide a service is up. A listening
+        // placeholder would answer for a service that does not exist yet.
+        assert!(
+            refused.is_err(),
+            "a reservation must not accept connections on behalf of the port's real owner"
+        );
+    }
+
+    #[test]
+    fn a_reservation_can_become_the_listener_without_ever_freeing_the_port() {
+        let reservation = PortReservation::ephemeral().unwrap();
+        let address = reservation.address();
+
+        let listener = reservation.listen().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream.write_all(b"served").unwrap();
+        });
+
+        let mut client = TcpStream::connect_timeout(&address, Duration::from_secs(5)).unwrap();
+        let mut answer = String::new();
+        client.read_to_string(&mut answer).unwrap();
+
+        assert_eq!(answer, "served");
+        server.join().unwrap();
+    }
+}

--- a/locald/src/sharing.rs
+++ b/locald/src/sharing.rs
@@ -22,6 +22,7 @@ use serde_json::{json, Value};
 use tokio::sync::oneshot;
 
 use crate::host_process::{installation_identity, process_identity, terminate_verified_process};
+use crate::port_reservation::PortReservation;
 
 const SHARING_SCHEMA_VERSION: u64 = 2;
 const PROCESS_MARKER_SCHEMA_VERSION: u64 = 1;
@@ -642,7 +643,8 @@ impl SharingController {
             ));
         }
         let user_config = ngrok_config_path(&executable)?;
-        let inspection_port = reserve_loopback_port()?;
+        let inspection = PortReservation::ephemeral()?;
+        let inspection_port = inspection.port();
         let supplemental = self.root.join("ngrok-lemma.yml");
         let contents = format!("version: 3\nagent:\n  web_addr: 127.0.0.1:{inspection_port}\n");
         write_private(&supplemental, contents.as_bytes())?;
@@ -669,6 +671,13 @@ impl SharingController {
             .stdout(Stdio::from(log))
             .stderr(Stdio::from(error_log));
         prepare_owned_command(&mut command);
+        // ngrok binds the inspection port in its own process, so the claim has
+        // to end here — but not one step earlier. Everything above is a synced
+        // config write and a log open, and a bare port number left unguarded
+        // across those is long enough for something else to take it; ngrok
+        // would then fail to serve its agent API, or worse, a stranger would
+        // answer the tunnel-URL poll below on the port we told ngrok to use.
+        inspection.release();
         let mut child = command.spawn().map_err(|error| {
             io::Error::other(format!(
                 "could not start ngrok at {}: {error}",
@@ -1661,12 +1670,6 @@ fn bounded_log(path: &Path) -> io::Result<File> {
         options.append(true);
     }
     options.open(path)
-}
-
-fn reserve_loopback_port() -> io::Result<u16> {
-    TcpListener::bind((Ipv4Addr::LOCALHOST, 0))?
-        .local_addr()
-        .map(|address| address.port())
 }
 
 fn render_qr(value: &str) -> Option<String> {


### PR DESCRIPTION
## The problem

locald takes ephemeral ports from the OS in several places, drops the socket, keeps only the **number**, and binds that number again later. Between the release and the re-bind the port belongs to whoever asks next — including another test in the same binary.

This was diagnosed while chasing a flake in `managed_runtime::tests::tcp_forwarder_relays_bytes_and_releases_its_port`: something else in the test binary was briefly listening on the forwarder's exact port microseconds after it let go, confirmed by a connect probe that succeeded with the stranger gone 1.3 ms later.

Three sites, and they are not equally serious:

**ngrok's inspection port is a genuine production hazard.** `reserve_loopback_port` handed back a bare number that then sat unguarded across a synced config write, a log open, and the spawn. Lose that race and ngrok cannot serve its agent API — or worse, **a stranger answers the tunnel-URL poll** on the port we just told ngrok to use.

**`network.json`'s port pair is a real but bounded hazard.** The ports are bound by child processes started later, sometimes in a later run entirely, so no reservation can reach their bind. What *was* fixable: two locald instances starting concurrently could each be handed the same pair, because the first released its ports before writing the record that claims them. Separately, `ports_available` bound *listening* sockets on the app's remembered ports — briefly accepting, then resetting, connections aimed at the real app.

**The migration-setup test is a test-only annoyance**, but a sharp one: it re-bound its number 150 ms later inside a spawned thread with `.unwrap()`, so losing the race panics the test.

## What this does

`PortReservation` holds a port with a bound socket and gives it up at the handoff. Two properties do the work:

**It never listens.** A connection arriving while a reservation is held is refused exactly as it would be against an idle port, rather than accepted by a socket about to vanish. Anything gating on *"can I connect yet?"* keeps seeing the answer it would have seen if the reservation didn't exist. This is what makes it safe to hold a port across code that probes it.

**It can become the listener in place.** Where the eventual owner lives in this process, `listen()` promotes the reserving socket itself — the port goes from reserved to served **without passing through free**. No window at all.

No `SO_REUSEADDR` on the reservation: exclusivity is the entire point, and a claim a second binder can join claims nothing.

### Per site

- **ngrok** — reserved up front, released on the line before `spawn()`. It can't be closed completely, since ngrok binds the port in its own process, but the window drops from a synced file write to one syscall.
- **`network.rs`** — both ports are held across the write that records them. `ports_available` is gone; `reserve_pair` replaces it, claiming both at once (a port tested and let go says nothing about the pair) and never accepting a connection.
- **migration-setup test** — keeps its reservation for the whole 150 ms wait and promotes it at the instant the route is meant to open. This only works *because* reservations don't listen: `run_setups` keeps getting refused, which is the behaviour under test.

`socket2` moves from the unix-only table to `[dependencies]`; the reservation is cross-platform and the lockfile is unchanged.

## The forwarder test, and one thing worth knowing

**The `tcp_forwarder` flake reproduces on untouched code** — I stashed this branch and confirmed it, so it is pre-existing rather than introduced here. It cannot be fixed by reservation: you cannot reserve a port whose release you are asserting. It now retries within a bounded deadline instead — a forwarder that genuinely leaked its listener never returns the port, while a stranger is gone in about a millisecond. **If a separate fix for this test is in flight, reconcile the two.**

Worth recording, because it cost a round: **asserting a port is free *after* release is the same antipattern.** A first pass at this branch failed 9 runs in 40 — my own new tests asserted rebind-after-release, and a 32-port reservation test starved everything else of ephemeral ports. Those assertions are gone, with a comment saying why. "The port is free once I let go" is not a promise this type keeps.

## Verification

- **60 consecutive full-suite runs: 1 failure**, and it was `services_boot_alongside_each_other_rather_than_one_after_another` — a wall-clock assertion (two 700 ms health delays inside a 1300 ms budget) with no port handling in it, tripping under back-to-back load. Pre-existing, unrelated, left alone.
- Targeted stress of the seven port-sensitive tests: **0 failures in 25 runs**.
- Baseline measured the same way for comparison, which is how the `tcp_forwarder` flake was confirmed as pre-existing.
- 87 unit tests pass; `cargo clippy --all-targets` and `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
