### PR TITLE
Desktop: quit cleanly, stop re-asking for secrets, and make the cloud path to a paired computer visible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -727,6 +727,11 @@ jobs:
           codesign --verify --strict --verbose=2 "${vz}"
           codesign -d --entitlements :- "${vz}" 2>/dev/null \
             | grep -F "com.apple.security.virtualization"
+          # The daemon's keychain access is keyed to this identifier, and Tauri
+          # re-signs sidecars without one of its own -- so this asserts the
+          # embedded Info.plist survived bundling. Ad-hoc builds re-prompt either
+          # way, but a drop here would reach release signing unnoticed.
+          codesign -dvvv "${locald}" 2>&1 | grep -Fx "Identifier=work.lemma.locald"
 
           signature_info="$(codesign -dvvv "${app}" 2>&1)"
           printf '%s\n' "${signature_info}"

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -218,6 +218,12 @@ jobs:
           codesign --verify --strict --verbose=2 "${runtime_bridge}"
           codesign --verify --strict --verbose=2 "${vz}"
           codesign -dvvv "${app}" 2>&1 | grep -F "Authority=Developer ID Application:"
+          # The daemon's keychain access is keyed to this identifier, and Tauri
+          # re-signs sidecars without one of its own -- so this asserts the
+          # embedded Info.plist survived bundling. If it ever does not, the app
+          # still ships and still works, and every user is asked to re-authorise
+          # access to their own secrets on the first launch of each release.
+          codesign -dvvv "${locald}" 2>&1 | grep -Fx "Identifier=work.lemma.locald"
           codesign -d --entitlements :- "${vz}" 2>/dev/null | grep -F "com.apple.security.virtualization"
           xcrun stapler validate "${app}"
           xcrun stapler validate \

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2020,6 +2020,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-autostart",
  "tauri-plugin-deep-link",
+ "tauri-plugin-dialog",
  "tauri-plugin-single-instance",
  "tempfile",
  "window-vibrancy",
@@ -2425,6 +2426,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3019,6 +3021,30 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3810,6 +3836,48 @@ dependencies = [
  "url",
  "windows-registry",
  "windows-result 0.3.4",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2d3c1dbe38037e7f590cdf2492594d5ceebe031e7bc7e827509b22a999d2940"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
 ]
 
 [[package]]

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -16,6 +16,11 @@ tauri = { version = "2", features = ["tray-icon", "image-png", "devtools", "unst
 tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 tauri-plugin-autostart = "2"
 tauri-plugin-deep-link = "2"
+# Quit has to be able to ask before it stops the stack, and it has to be able to
+# ask when there is no webview to ask in: ⌘Q from the tray with every window
+# hidden is the ordinary case. An OS-drawn alert is the only surface that
+# survives that, so this is used from Rust only and needs no capability entry.
+tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 interprocess = "2.4"

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -86,6 +86,39 @@ Build Desktop sidecars:
 desktop/scripts/build-sidecar.sh
 ```
 
+### Signing a local build you intend to actually use
+
+The sidecar script signs with a Developer ID when the machine has one and falls
+back to ad-hoc otherwise, saying which it chose. Set `APPLE_SIGNING_IDENTITY` to
+override it — including to `-` to force ad-hoc, which is what CI does for builds
+that are deliberately untrusted.
+
+Export the same identity when bundling, because the bundler re-signs the
+sidecars it copies in:
+
+```bash
+export APPLE_SIGNING_IDENTITY="Developer ID Application: NAME (TEAMID)"
+```
+
+Without it an otherwise Developer ID build ends up with an ad-hoc daemon, and
+that has a user-visible cost rather than just a Gatekeeper one. locald keeps the
+operator's secrets in the OS credential vault, which ties each stored item to
+the code identity of whoever created it. An ad-hoc designated requirement is a
+bare `cdhash`, so every rebuild is a new program as far as the vault is
+concerned and the user is asked to re-authorise access on the next launch. A
+Developer ID requirement names `work.lemma.locald` and the team instead — the
+identifier being fixed by the `Info.plist` that `locald/build.rs` links into the
+binary — and survives rebuilds.
+
+Verify with:
+
+```bash
+codesign -d -r- desktop/binaries/lemma-locald-aarch64-apple-darwin
+```
+
+A `designated => cdhash H"..."` line means the vault will re-prompt. A line
+naming `identifier "work.lemma.locald"` means it will not.
+
 To run Desktop local mode against the code you are editing:
 
 ```bash

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -23,8 +23,14 @@ sandboxes. There is no user-facing Docker/Podman dependency and no Kreuzberg
 container. PDF/document conversion runs in the backend.
 
 Closing every window hides Desktop to the tray. The daemon and desired services
-survive shell exit so schedules continue. **Quit and stop Lemma** performs a
-full stop before exit.
+survive shell exit so schedules continue. **Quit Lemma** (⌘Q) performs a full
+stop before exit, after naming what is running — closing the window is the way
+to leave without stopping anything, so quitting does not need to be the other
+one too.
+
+Every exit route funnels through `RunEvent::ExitRequested`, including Dock →
+Quit and the app's own `exit` after a confirmed stop. `Shell::quit_confirmed` is
+what keeps that from re-arming the prompt against the exit it just authorised.
 
 Because the stack outlives the shell, a relaunch is usually a reconcile rather
 than a start. Desktop records the serving workspace and its runtime generation,
@@ -197,9 +203,9 @@ and AgentBox images.
 ## Clean macOS acceptance test
 
 Use a disposable test machine where possible. For an intentionally destructive
-local reset, first select **Quit and stop Lemma**, remove the test app, then
-remove `~/Library/Application Support/Lemma`. Never make a release repair
-delete that directory.
+local reset, first **Quit Lemma**, remove the test app, then remove
+`~/Library/Application Support/Lemma`. Never make a release repair delete that
+directory.
 
 Acceptance flow:
 
@@ -251,15 +257,20 @@ Acceptance flow:
     item names a service. The tray's first line must report the stack's real
     state, and everything operational must sit under **Troubleshoot**.
 15. Close the window; verify schedules, the Agent Host, and active sharing
-    remain available from the tray. Full Quit must stop sharing and the Agent
-    Host before exiting, and must take its window off screen immediately rather
-    than leaving a black one while it does.
+    remain available from the tray. Then press ⌘Q with sharing on, the Agent
+    Host paired, and the stack up: the prompt must name all three, offer closing
+    the window as the alternative, and say data stays on this Mac. Cancel, and
+    confirm nothing stopped. Quit again and confirm it stops everything, takes
+    its window off screen immediately rather than leaving a black one, and that
+    Dock → Quit is asked in the same way. With the stack stopped, no Agent Host
+    and no shared link, ⌘Q must exit without asking anything.
 16. Restart and confirm ports and data persist, but LAN/Public mode does not
     resume automatically. The restart must reopen the pod you were last on with
     no installer splash; check **Diagnostics → Launch timing** and confirm the
     trace says `resume: hit` and reaches the window in well under a second.
 17. Inspect every Diagnostics source and exercise runtime repair.
-18. Use **Quit and stop Lemma** and confirm the VM also releases its memory.
+18. Quit and confirm the VM also releases its memory — `ps` must show no
+    `lemma-vz`, and Activity Monitor no multi-GB helper, once the app is gone.
 
 Also test with blocked Hugging Face access, a failed OCI registry/DNS request,
 and unrelated listeners occupying persisted ports.

--- a/desktop/runtime/lemma-local.json
+++ b/desktop/runtime/lemma-local.json
@@ -24,9 +24,9 @@
   "host_packs": {
     "aarch64-apple-darwin": {
       "url": null,
-      "sha256": "899ab6e39dcdb81f4121fb62d806be169637502ad612c7349759f24efe666aa0",
-      "size": 378275709,
-      "expanded_size": 1197488229,
+      "sha256": "56938b7dc50e7e2b59d9fc3ed04ac07e663f4debd2dd8c04093e6b74b2ff4e64",
+      "size": 293115395,
+      "expanded_size": 900287229,
       "format": "zip",
       "platform": "macos",
       "architecture": "aarch64",
@@ -37,9 +37,9 @@
   "guest_runtimes": {
     "macos-aarch64": {
       "url": null,
-      "sha256": "3ce18b0c02825b3836875a9b1e7e59d2b3d60d35eb51fb4bf83c4b2a4ea49a70",
-      "size": 222661052,
-      "expanded_size": 989226999,
+      "sha256": "d29934c88981b0008a609c701f76c865a9141700fec46a774988f274f2367007",
+      "size": 222621097,
+      "expanded_size": 989186093,
       "format": "zip",
       "platform": "linux",
       "architecture": "aarch64",

--- a/desktop/scripts/build-sidecar.sh
+++ b/desktop/scripts/build-sidecar.sh
@@ -24,26 +24,72 @@ cp "local-runtime/hostctl/target/$TRIPLE/release/lemma-runtime" \
 swift build --package-path local-runtime/macos-vz -c release --arch arm64
 cp "local-runtime/macos-vz/.build/arm64-apple-macosx/release/lemma-vz" \
   "$OUT_DIR/lemma-vz-$TRIPLE"
+# Prefer a real Developer ID over an ad-hoc signature when the machine has one.
+#
+# This is about locald's access to the OS credential vault, not about Gatekeeper.
+# macOS ties each stored secret to the code identity of the program that created
+# it, and an ad-hoc signature has no stable identity to tie to: its designated
+# requirement pins the exact code hash, so every rebuild reads as a different
+# program and the user is asked to authorise access again on the next launch.
+# A Developer ID requirement names the identifier and the team instead, which is
+# why locald carries an embedded Info.plist to keep that identifier fixed.
+#
+# Explicit beats discovered: CI sets APPLE_SIGNING_IDENTITY, including to "-" for
+# builds that are deliberately untrusted, and that choice is honoured as given.
+SIGNING_IDENTITY="${APPLE_SIGNING_IDENTITY:-}"
+if [[ -z "${SIGNING_IDENTITY}" ]]; then
+  SIGNING_IDENTITY="$(security find-identity -v -p codesigning 2>/dev/null \
+    | sed -n 's/.*"\(Developer ID Application: .*\)".*/\1/p' | head -1)"
+fi
+SIGNING_IDENTITY="${SIGNING_IDENTITY:--}"
+if [[ "${SIGNING_IDENTITY}" == "-" ]]; then
+  echo "signing: ad-hoc (no Developer ID identity available)"
+  echo "signing: expect a keychain prompt on each rebuild of locald"
+else
+  echo "signing: ${SIGNING_IDENTITY}"
+fi
+
+sign() {
+  local target="$1"
+  shift
+  local args=(--force --options runtime --sign "${SIGNING_IDENTITY}" "$@")
+  # A timestamp needs the network and means nothing ad-hoc, so it is only worth
+  # paying for on the signatures that can actually be notarised.
+  if [[ "${SIGNING_IDENTITY}" != "-" ]]; then
+    args+=(--timestamp)
+  fi
+  codesign "${args[@]}" "${target}"
+}
+
 # Re-seal copied Mach-O sidecars before executing smoke tests. Cargo's linker
 # signature is valid for the build output inode, but overwriting an existing
 # destination can leave macOS's executable-signature cache rejecting that
 # copied vnode with SIGKILL until it is explicitly signed again.
-codesign --force --sign - --options runtime "$OUT_DIR/lemma-locald-$TRIPLE"
-codesign --force --sign - --options runtime "$OUT_DIR/lemma-agent-host-$TRIPLE"
-codesign --force --sign - --options runtime "$OUT_DIR/lemma-runtime-$TRIPLE"
+sign "$OUT_DIR/lemma-locald-$TRIPLE"
+sign "$OUT_DIR/lemma-agent-host-$TRIPLE"
+sign "$OUT_DIR/lemma-runtime-$TRIPLE"
 # Virtualization.framework checks the code signature of the executable that
 # creates the VM. Keep the helper as a pre-signed app resource: Tauri applies
 # the app entitlement only to its main executable and re-signs externalBin
-# sidecars without helper-specific entitlements. Release CI replaces this
-# local ad-hoc signature with Developer ID before bundling.
-codesign --force --sign - --options runtime \
-  --entitlements desktop/entitlements.plist \
-  "$OUT_DIR/lemma-vz-$TRIPLE"
+# sidecars without helper-specific entitlements. Release CI re-signs this helper
+# with Developer ID and its entitlement before bundling.
+sign "$OUT_DIR/lemma-vz-$TRIPLE" --entitlements desktop/entitlements.plist
 echo "locald: $OUT_DIR/lemma-locald-$TRIPLE"
 echo "agent host: $OUT_DIR/lemma-agent-host-$TRIPLE"
 echo "runtime bridge: $OUT_DIR/lemma-runtime-$TRIPLE"
 echo "VZ helper: $OUT_DIR/lemma-vz-$TRIPLE"
 "$OUT_DIR/lemma-locald-$TRIPLE" --version >/dev/null && echo "locald: smoke ok"
+# Prove the embedded Info.plist survived the link. Without it codesign invents an
+# identifier from the binary's contents, the credential vault treats the next
+# build as a different program, and the app re-prompts for access on launch --
+# all of which looks like working software until someone opens it.
+locald_identifier="$(codesign -dv "$OUT_DIR/lemma-locald-$TRIPLE" 2>&1 \
+  | sed -n 's/^Identifier=//p')"
+if [[ "${locald_identifier}" != "work.lemma.locald" ]]; then
+  echo "locald signed as '${locald_identifier}', expected work.lemma.locald" >&2
+  exit 1
+fi
+echo "locald: identifier ${locald_identifier}"
 "$OUT_DIR/lemma-agent-host-$TRIPLE" --version >/dev/null \
   && echo "agent host: smoke ok"
 "$OUT_DIR/lemma-runtime-$TRIPLE" --version >/dev/null && echo "runtime bridge: smoke ok"

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -25,6 +25,7 @@ use tauri::{
     AppHandle, Emitter, Manager, PhysicalPosition, State, Webview, WebviewUrl, WebviewWindowBuilder,
 };
 use tauri_plugin_autostart::ManagerExt as _;
+use tauri_plugin_dialog::{DialogExt as _, MessageDialogButtons, MessageDialogKind};
 
 mod artifact_install;
 
@@ -138,6 +139,16 @@ struct Shell {
     // calls a command and expects a value back. The latest status is kept here
     // so a caller gets an answer immediately and the next poll sees the update.
     agent_host_status: Mutex<Option<Value>>,
+    /// The sharing mode locald last reported, so Quit can name what it is about
+    /// to take away. Read on the quit path, which must not wait on the daemon:
+    /// asking for a fresh snapshot there would mean a round trip in front of a
+    /// keystroke, and a stack too sick to answer is exactly when someone quits.
+    sharing_mode: Mutex<Option<String>>,
+    /// Set once the user has answered the quit prompt, so the exit that follows
+    /// is not asked about again. Every route out funnels through
+    /// `ExitRequested`, including the `app.exit` the confirmed path issues
+    /// itself; without this the prompt would re-arm and the app could not leave.
+    quit_confirmed: AtomicBool,
 }
 
 struct LocaldConnection {
@@ -164,6 +175,8 @@ impl Shell {
             tray_agent_host: Mutex::new(None),
             tray_status: Mutex::new(None),
             agent_host_status: Mutex::new(None),
+            sharing_mode: Mutex::new(None),
+            quit_confirmed: AtomicBool::new(false),
         }
     }
 }
@@ -1658,6 +1671,15 @@ fn handle_locald_event(app: &AppHandle, event: &Value) {
     if let Some(status) = event.get("agent_host").filter(|value| value.is_object()) {
         *shell.agent_host_status.lock().unwrap() = Some(status.clone());
         refresh_agent_host_tray(app, status);
+    }
+    // Same reason, for sharing: several events carry it, and Quit needs the last
+    // known answer without asking.
+    if let Some(mode) = event
+        .get("sharing")
+        .and_then(|sharing| sharing.get("mode"))
+        .and_then(Value::as_str)
+    {
+        *shell.sharing_mode.lock().unwrap() = Some(mode.to_owned());
     }
 
     let mut start_after_prepare = false;
@@ -3640,19 +3662,7 @@ fn handle_menu_action(app: &AppHandle, id: &str) {
             }
         }
         "quit" => {
-            app.exit(0);
-        }
-        "quit-and-stop" => {
-            if current_mode(&app) == "local" {
-                let shell: State<Shell> = app.state();
-                shell.quit_after_stop.store(true, Ordering::Release);
-                if stop_impl(app.clone(), Some(true)).is_err() {
-                    shell.quit_after_stop.store(false, Ordering::Release);
-                }
-            } else {
-                disconnect_locald(&app);
-                app.exit(0);
-            }
+            request_quit(&app);
         }
         _ => {}
     }
@@ -3701,7 +3711,10 @@ fn build_app_menu(app: &AppHandle) -> tauri::Result<Menu<tauri::Wry>> {
 
     let mut lemma_items: Vec<&dyn tauri::menu::IsMenuItem<tauri::Wry>> = Vec::new();
     let lemma_separator = PredefinedMenuItem::separator(app)?;
-    let quit = PredefinedMenuItem::quit(app, Some("Quit Lemma"))?;
+    // Deliberately app-owned rather than AppKit's predefined quit, which is
+    // `terminate:` and cannot be intercepted. Quit stops the local server, and
+    // that is worth one sentence first, so the app has to own ⌘Q.
+    let quit = MenuItem::with_id(app, "quit", "Quit Lemma", true, Some("CmdOrCtrl+Q"))?;
     lemma_items.push(&about);
     lemma_items.push(&lemma_separator);
     lemma_items.push(&settings);
@@ -3849,14 +3862,6 @@ fn build_tray(app: &AppHandle) -> tauri::Result<()> {
             &MenuItem::with_id(app, "logs", "Open Logs", local, None::<&str>)?,
             &MenuItem::with_id(app, "agent-host-log", "Open Agent Host Log", true, None::<&str>)?,
             &PredefinedMenuItem::separator(app)?,
-            &MenuItem::with_id(
-                app,
-                "quit-and-stop",
-                "Stop the local server and quit",
-                local,
-                None::<&str>,
-            )?,
-            &PredefinedMenuItem::separator(app)?,
             &MenuItem::with_id(app, "reload", "Reload", true, None::<&str>)?,
             &MenuItem::with_id(app, "devtools", "Developer Tools", true, None::<&str>)?,
             &PredefinedMenuItem::separator(app)?,
@@ -3908,8 +3913,147 @@ fn disconnect_locald(app: &AppHandle) {
     *shell.locald_writer.lock().unwrap() = None;
 }
 
-// Full quit must close any LAN or public exposure. The daemon deliberately
-// outlives the app, so it cannot infer this from its own shutdown.
+/// What quitting takes away, in the user's terms, or nothing.
+///
+/// Quit stops the local server, and the local server is the only thing that
+/// runs this installation's schedules, answers for the agents on this computer,
+/// and serves any link the user has shared. None of that is on screen, so a
+/// silent quit is a silent loss. An empty list means there is genuinely nothing
+/// to lose and quitting needs no ceremony.
+///
+/// Everything here is read from state the shell already holds. The quit path is
+/// a keystroke, and a stack too sick to answer a snapshot is exactly the state
+/// someone quits from — so it must not depend on the daemon replying.
+fn quit_impact(app: &AppHandle) -> Vec<String> {
+    if current_mode(app) != "local" {
+        return Vec::new();
+    }
+    let shell: State<Shell> = app.state();
+    let stack_up = {
+        let ui = shell.ui.lock().unwrap();
+        ui.ready || ui.running
+    };
+    let agent_host = shell.agent_host_status.lock().unwrap().clone();
+    let sharing = shell.sharing_mode.lock().unwrap().clone();
+    quit_impact_lines(stack_up, agent_host.as_ref(), sharing.as_deref())
+}
+
+fn quit_impact_lines(
+    stack_up: bool,
+    agent_host: Option<&Value>,
+    sharing: Option<&str>,
+) -> Vec<String> {
+    let mut impact = Vec::new();
+    if stack_up {
+        impact.push("Schedules and background work stop running.".into());
+    }
+    if let Some(status) = agent_host {
+        if status["running"].as_bool() == Some(true) {
+            let paired = status["targets"]
+                .as_array()
+                .map(|targets| targets.len())
+                .unwrap_or(0);
+            impact.push(match paired {
+                0 => "The agents on this computer stop answering.".into(),
+                1 => "The agents on this computer stop answering (1 paired workspace).".into(),
+                many => format!(
+                    "The agents on this computer stop answering ({many} paired workspaces)."
+                ),
+            });
+        }
+    }
+    match sharing {
+        Some("local_network") => impact.push("Your local network link closes.".into()),
+        Some("public") => impact.push("Your public link closes.".into()),
+        _ => {}
+    }
+    impact
+}
+
+fn quit_prompt_body(impact: &[String]) -> String {
+    let mut body = String::from("Quitting stops Lemma's local server on this Mac.\n\n");
+    for line in impact {
+        body.push_str("•  ");
+        body.push_str(line);
+        body.push('\n');
+    }
+    // Both halves matter. The first is why this is safe to say yes to; the
+    // second is the answer for someone who pressed ⌘Q meaning "get out of my
+    // way", which closing the window already does without stopping anything.
+    body.push_str(
+        "\nPods, files, and data stay on this Mac and come back when you reopen Lemma.\n\
+         To leave Lemma running, close the window instead.",
+    );
+    body
+}
+
+/// Quit, having said what that costs.
+///
+/// One Quit. It used to mean "close the shell and leave the server running",
+/// which was both a third state — closing the window already does exactly that,
+/// and keeps the tray as a way back — and a quiet inversion: it stopped sharing
+/// and the Agent Host, the cheap visible things, while leaving the VM, Postgres
+/// and the backend running with no owner on screen at all.
+fn request_quit(app: &AppHandle) {
+    {
+        // A second ⌘Q while a confirmed stop is still running is someone saying
+        // "go away now". Honour it instead of asking again: the daemon is
+        // durable, so whatever has not finished stopping outlives the shell
+        // either way, and this is the escape hatch if a stop ever wedges.
+        let shell: State<Shell> = app.state();
+        if shell.quit_confirmed.load(Ordering::Acquire) {
+            finish_quit(app);
+            return;
+        }
+    }
+    let impact = quit_impact(app);
+    if impact.is_empty() {
+        finish_quit(app);
+        return;
+    }
+    let handle = app.clone();
+    app.dialog()
+        .message(quit_prompt_body(&impact))
+        .title("Stop Lemma and quit?")
+        .kind(MessageDialogKind::Warning)
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            "Stop and Quit".into(),
+            "Cancel".into(),
+        ))
+        .show(move |confirmed| {
+            if confirmed {
+                stop_then_quit(&handle);
+            }
+        });
+}
+
+/// Stop everything this installation is running, then exit when it is down.
+///
+/// `stop_impl` shows the stop on the splash, so a stop that fails fails in
+/// front of the user rather than as an app that declines to quit. The exit
+/// itself is issued by the `stop`/`done` handler once the daemon confirms.
+fn stop_then_quit(app: &AppHandle) {
+    let shell: State<Shell> = app.state();
+    shell.quit_confirmed.store(true, Ordering::Release);
+    shell.quit_after_stop.store(true, Ordering::Release);
+    if stop_impl(app.clone(), Some(true)).is_err() {
+        shell.quit_after_stop.store(false, Ordering::Release);
+        shell.quit_confirmed.store(false, Ordering::Release);
+    }
+}
+
+/// Exit without stopping anything, for the cases where there is nothing to stop.
+fn finish_quit(app: &AppHandle) {
+    let shell: State<Shell> = app.state();
+    shell.quit_confirmed.store(true, Ordering::Release);
+    disconnect_locald(app);
+    app.exit(0);
+}
+
+// An exit that did not stop the stack must still close any LAN or public
+// exposure — `finish_quit`, and the second ⌘Q that leaves a wedged stop behind,
+// both reach here. The daemon deliberately outlives the app, so it cannot infer
+// this from its own shutdown.
 fn release_before_exit() -> Result<(), String> {
     let (sender, receiver) = std::sync::mpsc::sync_channel(1);
     std::thread::spawn(move || {
@@ -4059,6 +4203,7 @@ fn main() {
             None,
         ))
         .plugin(tauri_plugin_deep_link::init())
+        .plugin(tauri_plugin_dialog::init())
         .manage(Shell::new(mode.clone()))
         .invoke_handler(tauri::generate_handler![
             start,
@@ -4390,6 +4535,23 @@ fn main() {
                     let _ = window.set_focus();
                 }
             }
+            // Dock → Quit and any other OS-issued terminate arrive here without
+            // passing a menu, so the prompt is armed here rather than only on
+            // the items the app draws itself. Fail-safe by construction: an exit
+            // is only ever held once, and only when there is something running
+            // to say so about.
+            tauri::RunEvent::ExitRequested { api, .. } => {
+                let shell: State<Shell> = app.state();
+                if shell.quit_confirmed.load(Ordering::Acquire) {
+                    return;
+                }
+                if quit_impact(app).is_empty() {
+                    shell.quit_confirmed.store(true, Ordering::Release);
+                    return;
+                }
+                api.prevent_exit();
+                request_quit(app);
+            }
             tauri::RunEvent::Exit => {
                 // Read the route before anything is torn down or hidden.
                 remember_workspace_route(app);
@@ -4696,17 +4858,32 @@ mod tests {
         assert!(menus.contains("\"Settings…\", local, Some(\"CmdOrCtrl+,\")"));
         assert!(menus.contains("\"Connection…\""));
 
-        // Quit is one command. Stopping the local server is a different thing —
-        // it releases the VM's memory and ends schedules — so it lives in
-        // Troubleshoot rather than sitting next to Quit as a second way to
-        // leave, where it read as the obvious "quit properly" choice.
-        let lemma_menu = &menus[..menus.find("let edit_menu").expect("app menu order")];
+        // Quit is one command, and it is the one that stops the local server.
+        // There used to be two ways to leave — Quit, which left the VM and the
+        // whole stack running with no owner on screen, and a "Stop the local
+        // server and quit" buried in Troubleshoot that did what people mean by
+        // quitting. Closing the window already covers "go away and keep
+        // serving", and keeps the tray as a way back, so the middle state was
+        // strictly worse than both neighbours.
         assert!(
-            !lemma_menu.contains("quit-and-stop"),
-            "the application menu offers exactly one Quit",
+            !menus.contains("quit-and-stop") && !menus.contains("Stop the local server and quit"),
+            "there is exactly one Quit, and it stops the local server",
         );
         assert!(menus.contains("\"Stop the local server\""));
-        assert!(menus.contains("\"Stop the local server and quit\""));
+
+        // ⌘Q has to reach `request_quit`, which means owning the item. AppKit's
+        // predefined quit is `terminate:` and cannot be intercepted, so it would
+        // silently skip the prompt and take the stack down — or leave it up —
+        // without asking. Matched as a call, because this test reads its own
+        // source and the comment above the item names the thing it rules out.
+        assert!(
+            menus.contains("\"quit\", \"Quit Lemma\", true, Some(\"CmdOrCtrl+Q\")"),
+            "Quit is an app-owned item bound to CmdOrCtrl+Q",
+        );
+        assert!(
+            !menus.contains("PredefinedMenuItem::quit("),
+            "a predefined quit cannot be asked about first",
+        );
 
         // The operator vocabulary this replaced must not come back.
         for retired in ["Stop Services and Infra", "Switch Connection Mode", "Start Services"] {
@@ -4727,6 +4904,64 @@ mod tests {
             RELEASE_ON_EXIT_TIMEOUT <= Duration::from_secs(5),
             "a quit may not block the main thread for {RELEASE_ON_EXIT_TIMEOUT:?}"
         );
+    }
+
+    #[test]
+    fn quitting_names_the_work_it_is_about_to_stop() {
+        // The whole point of the prompt is that none of this is on screen. A
+        // warning that says "are you sure?" and nothing else would be worse than
+        // no warning, because it teaches people to dismiss it.
+        let running_host = json!({"running": true, "targets": [{"name": "work"}, {"name": "home"}]});
+        let lines = quit_impact_lines(true, Some(&running_host), Some("public"));
+        assert_eq!(
+            lines,
+            vec![
+                "Schedules and background work stop running.",
+                "The agents on this computer stop answering (2 paired workspaces).",
+                "Your public link closes.",
+            ]
+        );
+
+        // Singular reads as English, and an enabled-but-unpaired host still
+        // stops answering, so it is still worth one line.
+        let unpaired = json!({"running": true, "targets": []});
+        assert_eq!(
+            quit_impact_lines(false, Some(&unpaired), None),
+            vec!["The agents on this computer stop answering."]
+        );
+        let one = json!({"running": true, "targets": [{"name": "work"}]});
+        assert!(quit_impact_lines(false, Some(&one), None)[0].ends_with("(1 paired workspace)."));
+
+        assert_eq!(
+            quit_impact_lines(true, None, Some("local_network")),
+            vec![
+                "Schedules and background work stop running.",
+                "Your local network link closes.",
+            ]
+        );
+    }
+
+    #[test]
+    fn a_quit_with_nothing_running_asks_nothing() {
+        // Every dialog on the way out has to earn itself. A stopped stack with
+        // no Agent Host and no shared link costs the user nothing to quit, and
+        // being asked anyway is how a prompt becomes noise.
+        let idle_host = json!({"running": false, "targets": []});
+        assert!(quit_impact_lines(false, Some(&idle_host), Some("this_computer")).is_empty());
+        assert!(quit_impact_lines(false, None, None).is_empty());
+    }
+
+    #[test]
+    fn the_quit_prompt_offers_the_alternative_it_is_replacing() {
+        // Someone pressing ⌘Q may mean "get out of my way", which is what
+        // closing the window does — and unlike this, it keeps everything
+        // serving. The prompt has to say so, or the only discoverable way to
+        // keep schedules running is to already know about it.
+        let body = quit_prompt_body(&["Schedules and background work stop running.".into()]);
+        assert!(body.contains("Schedules and background work stop running."));
+        assert!(body.contains("close the window"));
+        // And it has to say what is not lost, or "stop" reads as "delete".
+        assert!(body.contains("stay on this Mac"));
     }
 
     #[test]

--- a/docs/design/local-desktop-app-experience.md
+++ b/docs/design/local-desktop-app-experience.md
@@ -113,8 +113,8 @@ And if connecting invalidates the window before `ready` arrives, the resume
 worker hands it the splash, which is the surface that reports the restart it is
 waiting for.
 
-**Services boot alongside each other.** The cold path — what you pay after
-**Quit and stop Lemma** — spawned a service, waited for it to pass its *full*
+**Services boot alongside each other.** The cold path — what you pay after a
+quit — spawned a service, waited for it to pass its *full*
 health gate, and only then spawned the next. Measured on a real install:
 
 ```text

--- a/docs/design/local-desktop-product-spec.md
+++ b/docs/design/local-desktop-product-spec.md
@@ -111,8 +111,10 @@ container sockets, PostgreSQL, Redis, SuperTokens, or fixed ports.
 - During install/start no misleading Start/Open/Create Account control appears.
 - Stop application preserves warm infrastructure.
 - Stop all releases the VM/WSL resources.
-- Quit leaves the durable desired state running.
-- Quit and stop Lemma stops everything before exit.
+- Closing the window leaves the durable desired state running, with the tray as
+  the way back.
+- Quit stops everything before exit, and says what that stops when anything is
+  running to stop.
 - A stable workspace is not navigated back to the installer for transient
   component recovery.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -151,27 +151,36 @@ calls, and webhook callbacks. Published pod apps stay local-only because their
 current routes require wildcard subdomains. PostgreSQL, Redis, SuperTokens, the
 private runtime and model endpoints are never exposed.
 
-Closing to the tray keeps sharing active. Full Quit, a Desktop disconnect,
+Closing to the tray keeps sharing active. Quitting, a Desktop disconnect,
 network-interface loss, or tunnel exit stops sharing. LAN/Public mode never
 resumes automatically.
 
 ## Lifecycle and tray behavior
 
-Closing the window hides Lemma to the tray so workers and schedules keep
-running.
+There are two ways to leave, and they mean different things.
+
+**Close the window** hides Lemma to the tray. Everything keeps running:
+schedules fire, the Agent Host answers, and any shared link stays up. The tray
+icon remains as the way back.
+
+**Quit Lemma** (⌘Q) stops the local server and then exits. Because that ends
+schedules, stops the agents on this computer, and closes any shared link, Lemma
+says so first and names what is running; a quit with nothing running asks
+nothing. Pods, files, and data stay on this Mac.
+
+Everything else is repair, and lives in the tray under **Troubleshoot**:
 
 | Action | Result |
 | --- | --- |
 | **Open Lemma** | Shows the workspace. |
-| **Start Services** | Starts or reconciles the current desired state. |
-| **Restart Services** | Restarts the backend and frontend without deleting data. |
-| **Stop Services** | Stops the backend and frontend but leaves infrastructure warm. |
-| **Stop Services and Infra** | Stops application processes and the private runtime. |
-| **Quit Lemma** | Closes Desktop while the durable daemon and desired services continue. |
-| **Quit and stop Lemma** | Stops all application/private-runtime resources, then exits. |
+| **Start Lemma** | Starts or reconciles the current desired state. |
+| **Restart Lemma** | Restarts the backend and frontend without deleting data. |
+| **Stop Lemma** | Stops the backend and frontend but leaves the private runtime warm. |
+| **Stop the local server** | Stops application processes and the private runtime. |
 
-Only explicit full stop releases all guest memory. A transient component
-restart after Ready does not bounce the workspace back to the installer.
+Only a full stop releases all guest memory, which is why quitting performs one.
+A transient component restart after Ready does not bounce the workspace back to
+the installer.
 
 ## URLs and ports
 
@@ -287,9 +296,9 @@ read-only. Volatile OS state uses tmpfs; PostgreSQL, Redis, SuperTokens,
 containerd, and AgentBox workspaces use the separate data disk. Updates replace
 the immutable release and preserve data.
 
-Removing the app does not silently remove user data. Quit and stop Lemma,
-back up anything important, remove the application, and only then remove the
-platform state directory if a destructive reset is intended.
+Removing the app does not silently remove user data. Quit Lemma, back up
+anything important, remove the application, and only then remove the platform
+state directory if a destructive reset is intended.
 
 ## Test an unreleased pull request
 

--- a/lemma-frontend/app/download/page.tsx
+++ b/lemma-frontend/app/download/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+
+import { DownloadPage } from '@/components/download/download-page';
+import { fetchLatestDesktopRelease } from '@/lib/desktop/desktop-release';
+
+export const metadata: Metadata = {
+    title: 'Download Lemma',
+    description:
+        'Install the Lemma desktop app to connect your computer, so agents that live on it can pick up work from your workspace.',
+};
+
+// The release read is cached for an hour inside the fetch; this keeps the page
+// itself static between those reads instead of rendering per visitor.
+export const revalidate = 3600;
+
+export default async function Download() {
+    const release = await fetchLatestDesktopRelease();
+    return <DownloadPage release={release} />;
+}

--- a/lemma-frontend/app/sitemap.ts
+++ b/lemma-frontend/app/sitemap.ts
@@ -12,6 +12,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     const fixed: MetadataRoute.Sitemap = [
         { url: base, changeFrequency: 'weekly', priority: 1 },
         { url: `${base}/templates`, changeFrequency: 'weekly', priority: 0.9 },
+        { url: `${base}/download`, changeFrequency: 'weekly', priority: 0.9 },
         { url: `${base}/docs`, changeFrequency: 'weekly', priority: 0.8 },
     ];
     const docs: MetadataRoute.Sitemap = docsPages

--- a/lemma-frontend/components/agents/harness-profile-dialog.tsx
+++ b/lemma-frontend/components/agents/harness-profile-dialog.tsx
@@ -310,7 +310,7 @@ export function HarnessProfileDialog({
                         loading={pending}
                         loadingLabel={isEdit ? 'Saving' : 'Adding'}
                     >
-                        {isEdit ? 'Save changes' : 'Add to chat models'}
+                        {isEdit ? 'Save changes' : 'Add to models'}
                     </Button>
                 </DialogFooter>
             </DialogContent>

--- a/lemma-frontend/components/agents/models-settings.tsx
+++ b/lemma-frontend/components/agents/models-settings.tsx
@@ -1,14 +1,29 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import { useCallback, useState } from 'react';
 import { RuntimeProfileKind, RuntimeProfileScope } from 'lemma-sdk';
 import type { AgentRuntimeProfileResponse } from 'lemma-sdk';
-import { Copy, KeyRound, Pencil, Plus, RefreshCw, RotateCcw, Sparkles, TerminalSquare, Trash2 } from '@/components/ui/icons';
+import { Copy, Cpu, Download, KeyRound, Pencil, Plus, RefreshCw, RotateCcw, Sparkles, TerminalSquare, Trash2 } from '@/components/ui/icons';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
-import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch, SwitchThumb, SwitchTrack } from '@/components/ui/switch';
@@ -16,8 +31,10 @@ import { DestructiveConfirmationDialog } from '@/components/shared/destructive-c
 import { DestructiveResourceActionItem, ResourceActionsMenu } from '@/components/shared/resource-actions-menu';
 import { SettingsList, SettingsPanel, SettingsRow, SettingsStack } from '@/components/settings/settings-kit';
 import { declineAutoConnect } from '@/lib/desktop/auto-connect';
+import { useIsDesktopShell } from '@/lib/desktop/agent-host-bridge';
 import {
     useAgentHostHarnesses,
+    useAgentHostHarnessOwners,
     useAgentHosts,
     useArchiveAgentRuntime,
     useCreateAgentHostPairing,
@@ -46,10 +63,16 @@ import {
     type CustomProviderKind,
 } from './agent-runtime-helpers';
 
+/**
+ * Ownership, but only when it is the exception.
+ *
+ * Workspace scope is the default every profile lands in, so labelling it put a
+ * "Workspace" chip on every row — a column of identical badges that said
+ * nothing and crowded out the one badge that does say something. Only a profile
+ * that is *not* shared earns a mark.
+ */
 function scopeBadge(scope: RuntimeProfileScope): { label: string; tone: 'ok' | 'muted' } | null {
-    if (scope === RuntimeProfileScope.SYSTEM) return null;
-    if (scope === RuntimeProfileScope.PERSONAL) return { label: 'Personal', tone: 'muted' };
-    return { label: 'Workspace', tone: 'muted' };
+    return scope === RuntimeProfileScope.PERSONAL ? { label: 'Personal', tone: 'muted' } : null;
 }
 
 // Quick-start presets for popular providers and routers. Clicking one prefills
@@ -81,15 +104,19 @@ export function ModelsSettings({
     // which must never reach the composer's model picker.
     const managed = useManagedAgentRuntimes(organizationId, { includeArchived: showArchived });
     const profiles = managed.data?.items ?? [];
-    const isRefreshing = managed.isFetching;
+    const hosts = useAgentHosts();
+    // A revoked host stays readable through the API for audit, but it can never
+    // take work again, so it has no place in a "what can I use" list.
+    const activeHosts = (hosts.data?.items ?? []).filter((host) => host.status !== 'REVOKED');
+    const harnessOwners = useAgentHostHarnessOwners(activeHosts);
+    const isRefreshing = managed.isFetching || hosts.isFetching;
 
     const providers = profiles.filter((profile) => profile.kind === RuntimeProfileKind.MODEL_PROVIDER);
-    // Exactly what the old `isLocalAgentKind` filter used to hide: a saved coding
-    // agent was represented nowhere as a profile, only as a badge on a harness row.
     const codingAgents = profiles.filter((profile) => profile.kind === RuntimeProfileKind.HARNESS);
 
     const refreshAll = () => {
         void managed.refetch();
+        void hosts.refetch();
         void onRefresh?.();
     };
 
@@ -97,9 +124,7 @@ export function ModelsSettings({
         <SettingsStack>
             <div className="flex items-start justify-between gap-4">
                 <p className="max-w-3xl text-sm leading-6 text-[var(--text-secondary)]">
-                    Connect the models and local agents this workspace can use. Providers you connect here are shared
-                    with everyone in the workspace; a paired computer runs its coding agents for the workspace without
-                    its credentials ever leaving that machine.
+                    What this workspace can pick in a chat, and where it runs.
                 </p>
                 <div className="flex shrink-0 items-center gap-3">
                     <label className="flex cursor-pointer items-center gap-2 text-sm text-[var(--text-tertiary)]">
@@ -117,24 +142,282 @@ export function ModelsSettings({
                 </div>
             </div>
 
-            <ProvidersSection
+            <ModelsSection
                 organizationId={organizationId}
                 providers={providers}
+                codingAgents={codingAgents}
+                harnessOwners={harnessOwners}
                 onRefresh={refreshAll}
             />
 
-            <CodingAgentsSection
+            <ComputersSection
                 organizationId={organizationId}
-                profiles={codingAgents}
-                onRefresh={refreshAll}
-            />
-
-            <AgentHostsSection
-                organizationId={organizationId}
+                hosts={activeHosts}
+                loadingHosts={hosts.isLoading}
                 savedProfiles={codingAgents}
                 onRefresh={refreshAll}
             />
         </SettingsStack>
+    );
+}
+
+/**
+ * Everything the model picker can offer, in one list.
+ *
+ * A key and a laptop are different things to *operate*, which is why the
+ * computers have their own section below — but they are the same thing to
+ * *choose*, and splitting the choice across two lists meant a fresh workspace
+ * opened on a section whose entire content was "None yet, add one from a paired
+ * computer below". A section that exists to point at another section is a
+ * section the reader has to assemble themselves.
+ */
+function ModelsSection({
+    organizationId,
+    providers,
+    codingAgents,
+    harnessOwners,
+    onRefresh,
+}: {
+    organizationId: string;
+    providers: AgentRuntimeProfileResponse[];
+    codingAgents: AgentRuntimeProfileResponse[];
+    harnessOwners: Map<string, string>;
+    onRefresh?: () => void;
+}) {
+    const [providerDialog, setProviderDialog] = useState<ProviderDialogTarget | null>(null);
+    const [harnessDialog, setHarnessDialog] = useState<HarnessDialogTarget | null>(null);
+
+    return (
+        <SettingsPanel
+            title="Models"
+            description="Providers are shared with everyone here. Coding agents run on the computer they came from."
+        >
+            <div className="flex flex-col gap-3">
+                <SettingsList>
+                    {providers.map((profile) => (
+                        <ProviderRow
+                            key={profile.id}
+                            profile={profile}
+                            organizationId={organizationId}
+                            onEdit={() => setProviderDialog({ mode: 'edit', profile })}
+                            onRefresh={onRefresh}
+                        />
+                    ))}
+                    {codingAgents.map((profile) => (
+                        <CodingAgentRow
+                            key={profile.id}
+                            profile={profile}
+                            organizationId={organizationId}
+                            computer={
+                                profile.harness_id ? harnessOwners.get(profile.harness_id) ?? null : null
+                            }
+                            onEdit={() => setHarnessDialog({ mode: 'edit', profile })}
+                            onRefresh={onRefresh}
+                        />
+                    ))}
+                </SettingsList>
+
+                <div>
+                    <ConnectProviderMenu onPick={setProviderDialog} />
+                </div>
+            </div>
+
+            <ProviderProfileDialog
+                target={providerDialog}
+                organizationId={organizationId}
+                onClose={() => setProviderDialog(null)}
+                onSaved={onRefresh}
+            />
+            <HarnessProfileDialog
+                target={harnessDialog}
+                organizationId={organizationId}
+                onClose={() => setHarnessDialog(null)}
+                onSaved={onRefresh}
+            />
+        </SettingsPanel>
+    );
+}
+
+// One button instead of eleven chips. The chips were a wall of equal-weight
+// names that made choosing a provider look like the main thing this page is
+// for, when for most workspaces the built-in models already answer it.
+function ConnectProviderMenu({ onPick }: { onPick: (target: ProviderDialogTarget) => void }) {
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button type="button" variant="secondary" size="sm" className="gap-1.5">
+                    <Plus className="size-3.5" />
+                    Connect a provider
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="w-56">
+                {PROVIDER_PRESETS.map((preset) => (
+                    <DropdownMenuItem
+                        key={preset.id}
+                        onSelect={() =>
+                            onPick({
+                                mode: 'connect',
+                                kind: preset.kind,
+                                name: preset.name,
+                                baseUrl: preset.baseUrl,
+                            })
+                        }
+                    >
+                        {preset.name}
+                    </DropdownMenuItem>
+                ))}
+                <DropdownMenuSeparator />
+                {CUSTOM_PROVIDER_OPTIONS.map((option) => (
+                    <DropdownMenuItem
+                        key={option.kind}
+                        onSelect={() =>
+                            onPick({
+                                mode: 'connect',
+                                kind: option.kind,
+                                name: '',
+                                baseUrl: option.defaultBaseUrl,
+                            })
+                        }
+                    >
+                        {option.kind === 'openai' ? 'Anything OpenAI-compatible' : 'Anything Anthropic-compatible'}
+                    </DropdownMenuItem>
+                ))}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    );
+}
+
+/**
+ * One badge per row, answering one question: can I use this right now?
+ *
+ * The rows used to carry up to four — archived, scope, availability, built-in —
+ * which mixed what a thing *is* with who *owns* it and whether it *works*, so
+ * none of them read as status. Ownership only appears when it is the exception
+ * (a personal profile in a shared workspace); everything else is folded into
+ * this one label.
+ */
+function modelStatus(profile: AgentRuntimeProfileResponse): { label: string; tone: 'ok' | 'muted' } {
+    if (isArchivedProfile(profile)) return { label: 'Archived', tone: 'muted' };
+    if (profile.scope === RuntimeProfileScope.SYSTEM) return { label: 'Built in', tone: 'ok' };
+    const availability = runtimeAvailabilityLabel(profile);
+    if (availability) return { label: availability, tone: 'muted' };
+    return { label: 'Ready', tone: 'ok' };
+}
+
+function ModelRow({
+    icon,
+    name,
+    detail,
+    profile,
+    organizationId,
+    onEdit,
+    onRefresh,
+}: {
+    icon: React.ReactNode;
+    name: string;
+    detail: string;
+    profile: AgentRuntimeProfileResponse;
+    organizationId: string;
+    onEdit: () => void;
+    onRefresh?: () => void;
+}) {
+    const status = modelStatus(profile);
+    const scope = scopeBadge(profile.scope);
+
+    return (
+        <SettingsRow>
+            <div className="flex min-w-0 items-center gap-3">
+                <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-[var(--surface-1)] text-[var(--text-secondary)]">
+                    {icon}
+                </span>
+                <div className="min-w-0">
+                    <div className="truncate text-sm font-medium text-[var(--text-primary)]">{name}</div>
+                    <div className="truncate text-xs text-[var(--text-tertiary)]">{detail}</div>
+                </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+                {scope ? <StatusBadge label={scope.label} tone={scope.tone} /> : null}
+                <StatusBadge label={status.label} tone={status.tone} />
+                <ProfileRowActions
+                    profile={profile}
+                    organizationId={organizationId}
+                    onEdit={onEdit}
+                    onRefresh={onRefresh}
+                />
+            </div>
+        </SettingsRow>
+    );
+}
+
+function ProviderRow({
+    profile,
+    organizationId,
+    onEdit,
+    onRefresh,
+}: {
+    profile: AgentRuntimeProfileResponse;
+    organizationId: string;
+    onEdit: () => void;
+    onRefresh?: () => void;
+}) {
+    const isSystem = profile.scope === RuntimeProfileScope.SYSTEM;
+    const modelCount = profile.model_catalog?.length ?? 0;
+
+    return (
+        <ModelRow
+            icon={
+                isSystem ? (
+                    <Sparkles className="size-4 text-[var(--delight)]" />
+                ) : (
+                    <KeyRound className="size-4" />
+                )
+            }
+            name={profile.name}
+            detail={`${isSystem ? 'Built in' : 'Your key'}${
+                modelCount ? ` · ${modelCount} model${modelCount === 1 ? '' : 's'}` : ''
+            }`}
+            profile={profile}
+            organizationId={organizationId}
+            onEdit={onEdit}
+            onRefresh={onRefresh}
+        />
+    );
+}
+
+function CodingAgentRow({
+    profile,
+    organizationId,
+    computer,
+    onEdit,
+    onRefresh,
+}: {
+    profile: AgentRuntimeProfileResponse;
+    organizationId: string;
+    /** Null while the owning computer's harness list is still loading. */
+    computer: string | null;
+    onEdit: () => void;
+    onRefresh?: () => void;
+}) {
+    const logo = harnessLogo(profileHarnessKey(profile));
+
+    return (
+        <ModelRow
+            icon={
+                logo ? (
+                    <Image src={logo} alt="" width={18} height={18} className="size-4.5 object-contain" />
+                ) : (
+                    <TerminalSquare className="size-4" />
+                )
+            }
+            name={profile.name}
+            detail={`${computer ? `On ${computer}` : 'On a connected computer'} · ${
+                profile.default_model_name ?? 'agent picks the model'
+            }`}
+            profile={profile}
+            organizationId={organizationId}
+            onEdit={onEdit}
+            onRefresh={onRefresh}
+        />
     );
 }
 
@@ -231,246 +514,63 @@ function ProfileRowActions({
     );
 }
 
-function providerStatusLabel(profile: AgentRuntimeProfileResponse): { label: string; tone: 'ok' | 'muted' } {
-    if (profile.scope === RuntimeProfileScope.SYSTEM) return { label: 'Built in', tone: 'ok' };
-    const availability = runtimeAvailabilityLabel(profile);
-    if (availability) return { label: availability, tone: 'muted' };
-    return { label: 'Active', tone: 'ok' };
-}
 
-function ProvidersSection({
+/**
+ * The machines that run this workspace's coding agents.
+ *
+ * Not a peer of Models — it is where the coding agents in that list come from.
+ * A computer holds a scoped, separately revocable secret and reaches Lemma over
+ * outbound HTTPS, so nothing here needs an inbound port or the user's own
+ * session on that machine.
+ */
+function ComputersSection({
     organizationId,
-    providers,
-    onRefresh,
-}: {
-    organizationId: string;
-    providers: AgentRuntimeProfileResponse[];
-    onRefresh?: () => void;
-}) {
-    const [dialog, setDialog] = useState<ProviderDialogTarget | null>(null);
-
-    return (
-        <SettingsPanel
-            title="Providers"
-            description="Lemma's built-in models, or connect your own OpenAI- or Anthropic-compatible key."
-        >
-            <div className="flex flex-col gap-2">
-                <SettingsList>
-                    {providers.map((profile) => {
-                        const status = providerStatusLabel(profile);
-                        const modelCount = profile.model_catalog?.length ?? 0;
-                        const isSystem = profile.scope === RuntimeProfileScope.SYSTEM;
-                        const scope = scopeBadge(profile.scope);
-                        return (
-                            <SettingsRow key={profile.id}>
-                                <div className="flex min-w-0 items-center gap-3">
-                                    <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-[var(--surface-1)] text-[var(--text-secondary)]">
-                                        {isSystem ? <Sparkles className="size-4 text-[var(--delight)]" /> : <KeyRound className="size-4" />}
-                                    </span>
-                                    <div className="min-w-0">
-                                        <div className="truncate text-sm font-medium text-[var(--text-primary)]">{profile.name}</div>
-                                        <div className="text-xs text-[var(--text-tertiary)]">
-                                            {isSystem ? 'Built in' : 'Your key'}
-                                            {modelCount ? ` · ${modelCount} model${modelCount === 1 ? '' : 's'}` : ''}
-                                        </div>
-                                    </div>
-                                </div>
-                                <div className="flex shrink-0 items-center gap-2">
-                                    {isArchivedProfile(profile) ? <StatusBadge label="Archived" tone="muted" /> : null}
-                                    {scope ? <StatusBadge label={scope.label} tone={scope.tone} /> : null}
-                                    <StatusBadge label={status.label} tone={status.tone} />
-                                    <ProfileRowActions
-                                        profile={profile}
-                                        organizationId={organizationId}
-                                        onEdit={() => setDialog({ mode: 'edit', profile })}
-                                        onRefresh={onRefresh}
-                                    />
-                                </div>
-                            </SettingsRow>
-                        );
-                    })}
-                </SettingsList>
-
-                <div className="mt-1">
-                    <p className="mb-2 text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">Connect a provider</p>
-                    <div className="flex flex-wrap gap-2">
-                        {PROVIDER_PRESETS.map((preset) => (
-                            <button
-                                key={preset.id}
-                                type="button"
-                                onClick={() => setDialog({ mode: 'connect', kind: preset.kind, name: preset.name, baseUrl: preset.baseUrl })}
-                                className="models-settings-provider-button rounded-md border border-[var(--border-subtle)] px-3 py-1.5 text-sm text-[var(--text-secondary)] transition-colors hover:border-[var(--field-border-hover)] hover:text-[var(--text-primary)]"
-                            >
-                                {preset.name}
-                            </button>
-                        ))}
-                        {CUSTOM_PROVIDER_OPTIONS.map((option) => (
-                            <button
-                                key={option.kind}
-                                type="button"
-                                onClick={() => setDialog({ mode: 'connect', kind: option.kind, name: '', baseUrl: option.defaultBaseUrl })}
-                                className="models-settings-provider-button flex items-center gap-1.5 rounded-md border border-dashed border-[var(--border-strong)] px-3 py-1.5 text-sm text-[var(--text-secondary)] transition-colors hover:border-[var(--field-border-hover)] hover:text-[var(--text-primary)]"
-                            >
-                                <Plus className="size-3.5" />
-                                {option.kind === 'openai' ? 'Custom (OpenAI)' : 'Custom (Anthropic)'}
-                            </button>
-                        ))}
-                    </div>
-                </div>
-            </div>
-
-            <ProviderProfileDialog
-                target={dialog}
-                organizationId={organizationId}
-                onClose={() => setDialog(null)}
-                onSaved={onRefresh}
-            />
-        </SettingsPanel>
-    );
-}
-
-// Saved coding agents, which are runtime profiles like any other — they just run
-// on a paired computer instead of behind an API key. Keeping them out of
-// Providers is deliberate: a laptop and an API key do not belong in one list.
-function CodingAgentsSection({
-    organizationId,
-    profiles,
-    onRefresh,
-}: {
-    organizationId: string;
-    profiles: AgentRuntimeProfileResponse[];
-    onRefresh?: () => void;
-}) {
-    const [dialog, setDialog] = useState<HarnessDialogTarget | null>(null);
-
-    return (
-        <SettingsPanel
-            title="Coding agents"
-            description="Agents you've added to the model picker. Each one runs on the computer it was added from."
-        >
-            <div className="flex flex-col gap-2">
-                {profiles.length === 0 ? (
-                    <p className="text-sm text-[var(--text-tertiary)]">
-                        None yet. Add one from a paired computer below.
-                    </p>
-                ) : null}
-                <SettingsList>
-                    {profiles.map((profile) => {
-                        const logo = harnessLogo(profileHarnessKey(profile));
-                        const modelCount = profile.model_catalog?.length ?? 0;
-                        const scope = scopeBadge(profile.scope);
-                        const availability = runtimeAvailabilityLabel(profile);
-                        return (
-                            <SettingsRow key={profile.id}>
-                                <div className="flex min-w-0 items-center gap-3">
-                                    <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-[var(--surface-1)]">
-                                        {logo ? (
-                                            <Image src={logo} alt="" width={18} height={18} className="size-4.5 object-contain" />
-                                        ) : (
-                                            <TerminalSquare className="size-4 text-[var(--text-secondary)]" />
-                                        )}
-                                    </span>
-                                    <div className="min-w-0">
-                                        <div className="truncate text-sm font-medium text-[var(--text-primary)]">{profile.name}</div>
-                                        <div className="text-xs text-[var(--text-tertiary)]">
-                                            {profile.default_model_name ?? 'Agent picks the model'}
-                                            {modelCount ? ` · ${modelCount} model${modelCount === 1 ? '' : 's'}` : ''}
-                                        </div>
-                                    </div>
-                                </div>
-                                <div className="flex shrink-0 items-center gap-2">
-                                    {isArchivedProfile(profile) ? <StatusBadge label="Archived" tone="muted" /> : null}
-                                    {scope ? <StatusBadge label={scope.label} tone={scope.tone} /> : null}
-                                    <StatusBadge
-                                        label={availability ?? 'Active'}
-                                        tone={availability ? 'muted' : 'ok'}
-                                    />
-                                    <ProfileRowActions
-                                        profile={profile}
-                                        organizationId={organizationId}
-                                        onEdit={() => setDialog({ mode: 'edit', profile })}
-                                        onRefresh={onRefresh}
-                                    />
-                                </div>
-                            </SettingsRow>
-                        );
-                    })}
-                </SettingsList>
-            </div>
-
-            <HarnessProfileDialog
-                target={dialog}
-                organizationId={organizationId}
-                onClose={() => setDialog(null)}
-                onSaved={onRefresh}
-            />
-        </SettingsPanel>
-    );
-}
-
-// A paired computer runs the local coding agents. The machine holds a scoped,
-// separately revocable secret and reaches Lemma over outbound HTTPS, so nothing
-// here needs an inbound port or the user's own session on that computer.
-function AgentHostsSection({
-    organizationId,
+    hosts,
+    loadingHosts,
     savedProfiles,
     onRefresh,
 }: {
     organizationId: string;
+    hosts: AgentHost[];
+    loadingHosts: boolean;
     savedProfiles: AgentRuntimeProfileResponse[];
     onRefresh?: () => void;
 }) {
-    const hosts = useAgentHosts();
-    const createPairing = useCreateAgentHostPairing();
-    const [pairing, setPairing] = useState<(AgentHostPairing & { display_name: string }) | null>(null);
-    const [displayName, setDisplayName] = useState('My computer');
+    const isDesktop = useIsDesktopShell();
+    const [connecting, setConnecting] = useState(false);
     // Which paired computer is the one the user is sitting at. Only the desktop
     // app can answer that; in a browser it stays null and the list is unchanged.
     const [thisHostId, setThisHostId] = useState<string | null>(null);
     const onHostIdChange = useCallback((hostId: string | null) => setThisHostId(hostId), []);
 
-    // Harnesses that are already saved as runtime profiles, so a row can say
-    // "already added" instead of leaving the user guessing whether picking this
-    // agent in a chat is possible yet. Built from the management listing rather
-    // than the catalog: an archived profile is absent from the catalog, so the
-    // row would offer "Add to chat models" again and then 409 on the unique-name
-    // index.
+    // Harnesses already saved as runtime profiles, so a row can say "added"
+    // instead of leaving the user guessing whether picking this agent in a chat
+    // is possible yet. Built from the management listing rather than the
+    // catalog: an archived profile is absent from the catalog, so the row would
+    // offer "Add to models" again and then 409 on the unique-name index.
     const savedProfileByHarnessId = new Map<string, AgentRuntimeProfileResponse>();
     for (const profile of savedProfiles) {
         if (profile.harness_id) savedProfileByHarnessId.set(profile.harness_id, profile);
     }
 
-    // A revoked host stays readable through the API for audit, but it can never
-    // take work again, so it has no place in a "what can I use" list.
-    const activeHosts = (hosts.data?.items ?? []).filter((host) => host.status !== 'REVOKED');
-
-    const pair = async () => {
-        const name = displayName.trim();
-        if (!name) return toast.error('Name this computer');
-        try {
-            const created = await createPairing.mutateAsync({ displayName: name });
-            setPairing({ ...created, display_name: name });
-        } catch (error) {
-            toast.error(`Couldn't create a pairing code: ${error instanceof Error ? error.message : 'Unknown error'}`);
-        }
-    };
+    // In a browser there is no "this computer" to offer, so an empty section
+    // would just be a heading. The app is the thing that makes this work, so
+    // that is what the empty state asks for.
+    const showGetTheApp = !isDesktop && !loadingHosts && hosts.length === 0;
 
     return (
         <SettingsPanel
-            title="Paired computers"
-            description="Pair a computer once and its Agent Host runs Codex, Claude Code, and OpenCode for this workspace. Credentials never leave that machine."
+            title="Computers"
+            description="Each one runs Claude Code, Codex and OpenCode for this workspace. Their credentials stay on the machine."
         >
             <div className="flex flex-col gap-3">
-                <ThisComputerCard
-                    onHostIdChange={onHostIdChange}
-                    onPaired={() => void hosts.refetch()}
-                />
+                <ThisComputerCard onHostIdChange={onHostIdChange} onPaired={onRefresh} />
 
-                {hosts.isLoading ? (
-                    <p className="text-sm text-[var(--text-tertiary)]">Loading paired computers…</p>
+                {loadingHosts ? (
+                    <p className="text-sm text-[var(--text-tertiary)]">Loading computers…</p>
                 ) : null}
 
-                {activeHosts.map((host) => (
+                {hosts.map((host) => (
                     <AgentHostCard
                         key={host.id}
                         host={host}
@@ -481,58 +581,203 @@ function AgentHostsSection({
                     />
                 ))}
 
-                {pairing ? (
-                    <PairingInstructions
-                        pairing={pairing}
-                        onDone={() => {
-                            setPairing(null);
-                            void hosts.refetch();
-                        }}
-                    />
-                ) : (
-                    <div className="flex flex-col gap-3 rounded-md border border-dashed border-[var(--border-strong)] p-4">
-                        <div>
-                            <div className="text-sm font-medium text-[var(--text-primary)]">
-                                {activeHosts.length ? 'Pair another computer' : 'Pair a computer'}
-                            </div>
-                            <p className="mt-1 text-sm text-[var(--text-tertiary)]">
-                                You&apos;ll get a one-time code to run on that machine.
-                            </p>
-                        </div>
-                        <div className="flex flex-wrap items-end gap-3">
-                            <Field label="Computer name">
-                                <Input
-                                    value={displayName}
-                                    onChange={(event) => setDisplayName(event.target.value)}
-                                    className="w-64"
-                                />
-                            </Field>
-                            <Button variant="primary"
-                                type="button"
-                                size="sm"
-                                onClick={() => void pair()}
-                                loading={createPairing.isPending}
-                                loadingLabel="Creating code"
-                            >
-                                Create pairing code
-                            </Button>
-                        </div>
-                    </div>
-                )}
+                {showGetTheApp ? <GetTheAppCard /> : null}
+
+                <div>
+                    <Button
+                        type="button"
+                        variant="quiet"
+                        size="sm"
+                        className="gap-1.5"
+                        onClick={() => setConnecting(true)}
+                    >
+                        <Plus className="size-3.5" />
+                        {hosts.length ? 'Connect another computer' : 'Connect a computer'}
+                    </Button>
+                </div>
             </div>
+
+            <ConnectComputerDialog
+                open={connecting}
+                onClose={() => setConnecting(false)}
+                onConnected={onRefresh}
+            />
         </SettingsPanel>
     );
 }
 
-function PairingInstructions({
-    pairing,
-    onDone,
+/** The empty state in a plain browser: the app is what makes this work. */
+function GetTheAppCard() {
+    return (
+        <div className="flex flex-wrap items-start gap-3 rounded-md border border-dashed border-[var(--border-strong)] p-4">
+            <span className="flex size-9 shrink-0 items-center justify-center rounded-md bg-[var(--surface-1)]">
+                <Cpu className="size-4 text-[var(--text-secondary)]" />
+            </span>
+            <div className="min-w-0 flex-1">
+                <div className="text-sm font-medium text-[var(--text-primary)]">
+                    Run agents on your own computer
+                </div>
+                <p className="mt-1 text-sm text-[var(--text-tertiary)]">
+                    Claude Code, Codex and OpenCode already live on your machine. Install the Lemma app
+                    there, sign in, and connect it in one click.
+                </p>
+            </div>
+            <Button asChild variant="primary" size="sm" className="gap-1.5">
+                <Link href="/download">
+                    <Download className="size-3.5" />
+                    Get the Lemma app
+                </Link>
+            </Button>
+        </div>
+    );
+}
+
+/**
+ * Pairing a machine that is not this one.
+ *
+ * This used to be the page's opening move: a code box expanded before anything
+ * was paired, three raw commands and a live single-use credential taking up
+ * most of the viewport, while the one-click path in the app appeared nowhere.
+ * It is the fallback, so it lives behind a button and says so — install the app
+ * over there and it is one click; run these if that machine has no screen.
+ */
+function ConnectComputerDialog({
+    open,
+    onClose,
+    onConnected,
 }: {
-    pairing: AgentHostPairing & { display_name: string };
-    onDone: () => void;
+    open: boolean;
+    onClose: () => void;
+    onConnected?: () => void;
 }) {
+    const createPairing = useCreateAgentHostPairing();
+    const [headless, setHeadless] = useState(false);
+    const [displayName, setDisplayName] = useState('My computer');
+    const [pairing, setPairing] = useState<(AgentHostPairing & { display_name: string }) | null>(null);
+
+    const close = () => {
+        setHeadless(false);
+        setPairing(null);
+        onClose();
+    };
+
+    const create = async () => {
+        const name = displayName.trim();
+        if (!name) return toast.error('Name this computer');
+        try {
+            const created = await createPairing.mutateAsync({ displayName: name });
+            setPairing({ ...created, display_name: name });
+        } catch (error) {
+            toast.error(
+                `Couldn't create a pairing code: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            );
+        }
+    };
+
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={(next) => {
+                if (!next && !createPairing.isPending) close();
+            }}
+        >
+            <DialogContent className="gap-5">
+                <DialogHeader>
+                    <DialogTitle>Connect a computer</DialogTitle>
+                    <DialogDescription>
+                        {headless
+                            ? 'A machine with no screen cannot sign in, so it needs a code carried to it. The code stands in for your session and is single-use.'
+                            : 'The app signs in as you and connects itself. There is no code to carry and nothing to copy.'}
+                    </DialogDescription>
+                </DialogHeader>
+
+                {headless ? (
+                    pairing ? (
+                        <PairingCommands pairing={pairing} />
+                    ) : (
+                        <Field label="Computer name">
+                            <Input
+                                value={displayName}
+                                onChange={(event) => setDisplayName(event.target.value)}
+                            />
+                        </Field>
+                    )
+                ) : (
+                    <ol className="flex flex-col gap-3">
+                        {[
+                            'Install the Lemma app on that computer.',
+                            'Open it and sign in to this workspace.',
+                            'Models → Computers → Connect this computer.',
+                        ].map((step, index) => (
+                            <li key={step} className="flex items-baseline gap-3">
+                                <span className="min-w-5 font-mono text-xs text-[var(--text-tertiary)]">
+                                    {(index + 1).toString().padStart(2, '0')}
+                                </span>
+                                <span className="text-sm text-[var(--text-secondary)]">{step}</span>
+                            </li>
+                        ))}
+                    </ol>
+                )}
+
+                <DialogFooter className="sm:justify-between">
+                    {/*
+                     * The two paths are mutually exclusive, so only one of them
+                     * may mint anything. Offering a download link beside a live
+                     * pairing code meant every person who took the easy path
+                     * burned a single-use credential on the way past it — and
+                     * left wondering what the code had been for.
+                     */}
+                    <Button
+                        type="button"
+                        variant="quiet"
+                        size="sm"
+                        onClick={() => {
+                            setPairing(null);
+                            setHeadless(!headless);
+                        }}
+                    >
+                        {headless ? 'That computer has a screen' : 'That computer has no screen'}
+                    </Button>
+
+                    {!headless ? (
+                        <Button asChild variant="primary" className="gap-1.5">
+                            <Link href="/download">
+                                <Download className="size-3.5" />
+                                Get the Lemma app
+                            </Link>
+                        </Button>
+                    ) : pairing ? (
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            onClick={() => {
+                                onConnected?.();
+                                close();
+                            }}
+                        >
+                            Done
+                        </Button>
+                    ) : (
+                        <Button
+                            type="button"
+                            variant="primary"
+                            onClick={() => void create()}
+                            loading={createPairing.isPending}
+                            loadingLabel="Creating code"
+                        >
+                            Create pairing code
+                        </Button>
+                    )}
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function PairingCommands({ pairing }: { pairing: AgentHostPairing & { display_name: string } }) {
     const commands = pairingCommands(pairing, getLemmaApiBaseUrl());
     const expiresAt = new Date(pairing.expires_at);
+
     const copy = async () => {
         try {
             await navigator.clipboard.writeText(commands.join('\n'));
@@ -543,34 +788,29 @@ function PairingInstructions({
     };
 
     return (
-        <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--surface-1)] p-4">
-            <div className="flex items-start justify-between gap-3">
-                <div className="text-sm font-medium text-[var(--text-primary)]">Run these on that computer</div>
+        <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between gap-3">
+                <span className="text-sm font-medium text-[var(--text-primary)]">
+                    Run these on {pairing.display_name}
+                </span>
                 <Button type="button" variant="quiet" size="sm" onClick={() => void copy()} className="gap-1.5">
                     <Copy className="size-3.5" />
                     Copy
                 </Button>
             </div>
-            <div className="mt-2 flex flex-col gap-1.5">
-                {commands.map((command) => (
-                    <code
-                        key={command}
-                        className="overflow-x-auto rounded bg-[var(--surface-2)] px-3 py-2 font-mono text-xs whitespace-pre text-[var(--text-secondary)]"
-                    >
-                        {command}
-                    </code>
-                ))}
-            </div>
-            <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
-                <p className="text-xs text-[var(--text-tertiary)]">
-                    Skip the first line if that computer already has the Lemma CLI. This code works
-                    once, and expires{' '}
-                    {Number.isNaN(expiresAt.valueOf()) ? 'shortly' : expiresAt.toLocaleTimeString()}.
-                </p>
-                <Button variant="secondary" type="button" size="sm" onClick={onDone}>
-                    I ran them
-                </Button>
-            </div>
+            {commands.map((command) => (
+                <code
+                    key={command}
+                    className="overflow-x-auto rounded bg-[var(--surface-1)] px-3 py-2 font-mono text-xs whitespace-pre text-[var(--text-secondary)]"
+                >
+                    {command}
+                </code>
+            ))}
+            <p className="text-xs text-[var(--text-tertiary)]">
+                Skip the first line if that computer already has the Lemma CLI. This code works once,
+                and expires{' '}
+                {Number.isNaN(expiresAt.valueOf()) ? 'shortly' : expiresAt.toLocaleTimeString()}.
+            </p>
         </div>
     );
 }
@@ -775,7 +1015,7 @@ function AgentHostHarnessRow({
                         onClick={() => setDialog({ mode: 'create', harness })}
                     >
                         <Plus className="size-3.5" />
-                        Add to chat models
+                        Add to models
                     </Button>
                 </div>
             ) : null}

--- a/lemma-frontend/components/agents/this-computer-card.tsx
+++ b/lemma-frontend/components/agents/this-computer-card.tsx
@@ -28,7 +28,29 @@ type Tone = 'ok' | 'warn' | 'muted';
 // What the machine can actually do right now, which is not the same question as
 // whether a process is alive: an unpaired host and one that cannot reach the
 // workspace are both running, and neither will pick up a run.
-function describe(status: ThisComputerStatus): { label: string; detail: string; tone: Tone } {
+//
+// A missing status is a state too, and used to be rendered as nothing at all.
+// In a hosted workspace the first poll is the one that has to start locald, so
+// "nothing yet" is the normal opening state and a failure there — no daemon, a
+// build without the sidecar — left an empty space where the only way to connect
+// this computer should have been.
+export function describe(
+    status: ThisComputerStatus | null,
+    error: string | null,
+): { label: string; detail: string; tone: Tone } {
+    if (!status) {
+        return error
+            ? {
+                  label: 'Unavailable',
+                  detail: error,
+                  tone: 'warn',
+              }
+            : {
+                  label: 'Checking',
+                  detail: 'Asking this computer which agents it can run.',
+                  tone: 'muted',
+              };
+    }
     if (!status.available) {
         return {
             label: 'Not available',
@@ -94,7 +116,7 @@ export function ThisComputerCard({
     onHostIdChange?: (hostId: string | null) => void;
     onPaired?: () => void;
 }) {
-    const { isDesktop, status, refetch } = useThisComputer();
+    const { isDesktop, status, error, refetch } = useThisComputer();
     const createPairing = useCreateAgentHostPairing();
     const [displayName, setDisplayName] = useState('This computer');
     const [busy, setBusy] = useState<string | null>(null);
@@ -108,9 +130,11 @@ export function ThisComputerCard({
         onHostIdChange?.(hostId);
     }, [hostId, onHostIdChange]);
 
-    if (!isDesktop || !status) return null;
+    // Outside the desktop app there is no "this computer" to speak of; the
+    // section falls back to the download card instead.
+    if (!isDesktop) return null;
 
-    const state = describe(status);
+    const state = describe(status, error);
 
     const run = async (action: string, work: () => Promise<unknown>, success?: string) => {
         setBusy(action);
@@ -158,7 +182,7 @@ export function ThisComputerCard({
         ).finally(() => setConfirmDisconnect(false));
     };
 
-    const uptime = formatUptime(status.uptime_seconds);
+    const uptime = formatUptime(status?.uptime_seconds ?? null);
 
     return (
         <div className="rounded-md border border-[var(--border-subtle)] bg-[var(--surface-1)] p-4">
@@ -171,14 +195,28 @@ export function ThisComputerCard({
                         <span className="text-sm font-medium text-[var(--text-primary)]">This computer</span>
                         <StatusDot tone={state.tone} />
                         <span className="text-xs text-[var(--text-secondary)]">{state.label}</span>
-                        {uptime && status.running ? (
+                        {uptime && status?.running ? (
                             <span className="text-xs text-[var(--text-tertiary)]">· {uptime}</span>
                         ) : null}
                     </div>
                     <p className="mt-1 text-sm text-[var(--text-tertiary)]">{state.detail}</p>
                 </div>
 
-                {status.available && status.paired ? (
+                {!status && error ? (
+                    <Button
+                        type="button"
+                        variant="secondary"
+                        size="sm"
+                        className="gap-1.5"
+                        loading={busy === 'retry'}
+                        onClick={() => void run('retry', () => refetch())}
+                    >
+                        <RefreshCw className="size-3.5" />
+                        Try again
+                    </Button>
+                ) : null}
+
+                {status?.available && status.paired ? (
                     <Button
                         type="button"
                         variant={status.running ? 'quiet' : 'primary'}
@@ -198,7 +236,7 @@ export function ThisComputerCard({
                 ) : null}
             </div>
 
-            {status.available && !status.paired ? (
+            {status?.available && !status.paired ? (
                 <div className="mt-3 flex flex-wrap items-end gap-2">
                     <Input
                         value={displayName}
@@ -218,7 +256,7 @@ export function ThisComputerCard({
                 </div>
             ) : null}
 
-            {status.paired ? (
+            {status?.paired ? (
                 <div className="mt-3 flex flex-wrap items-center gap-2">
                     <Button
                         type="button"
@@ -268,7 +306,7 @@ export function ThisComputerCard({
                 </div>
             ) : null}
 
-            {status.running && (target?.pending_events ?? 0) > 0 ? (
+            {status?.running && (target?.pending_events ?? 0) > 0 ? (
                 <p className="mt-2 text-xs text-[var(--text-tertiary)]">
                     {target?.pending_events} update{target?.pending_events === 1 ? '' : 's'} waiting to
                     reach this workspace.

--- a/lemma-frontend/components/download/download-page.tsx
+++ b/lemma-frontend/components/download/download-page.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import Link from 'next/link';
+import { useSyncExternalStore } from 'react';
+
+import { Logo } from '@/components/brand/logo';
+import { Button } from '@/components/ui/button';
+import { ArrowLeft, ArrowUpRight, Download } from '@/components/ui/icons';
+import {
+    formatInstallerSize,
+    type DesktopBuild,
+    type DesktopPlatform,
+    type DesktopRelease,
+} from '@/lib/desktop/desktop-release';
+import { cn } from '@/lib/utils';
+
+function subscribeToNothing() {
+    return () => {};
+}
+
+/**
+ * Which installer this visitor most likely wants.
+ *
+ * A guess, and treated as one: it only decides which button is emphasised and
+ * which is listed second. Both are always reachable, because someone reading
+ * this on a phone is downloading for a computer that is not in their hand.
+ */
+function detectPlatform(): DesktopPlatform | null {
+    if (typeof navigator === 'undefined') return null;
+    const agent = navigator.userAgent;
+    if (/Mac/i.test(agent)) return 'macos';
+    if (/Win/i.test(agent)) return 'windows';
+    return null;
+}
+
+function usePlatform(): DesktopPlatform | null {
+    // Server-rendered as "unknown", so the markup the server sends never claims
+    // a platform it cannot know and then rewrites itself on hydration.
+    return useSyncExternalStore(subscribeToNothing, detectPlatform, () => null);
+}
+
+function BuildRow({ build, emphasised }: { build: DesktopBuild; emphasised: boolean }) {
+    const size = formatInstallerSize(build.size);
+
+    return (
+        <div
+            className={cn(
+                'flex flex-wrap items-center justify-between gap-3 rounded-md border p-4',
+                emphasised
+                    ? 'border-[var(--border-strong)] bg-[var(--surface-1)]'
+                    : 'border-[var(--border-subtle)]',
+            )}
+        >
+            <div className="min-w-0">
+                <div className="text-sm font-medium text-[var(--text-primary)]">{build.label}</div>
+                <p className="mt-1 text-sm text-[var(--text-tertiary)]">
+                    {size ? `${build.requirement} · ${size}` : build.requirement}
+                </p>
+            </div>
+            <Button asChild variant={emphasised ? 'primary' : 'secondary'} size="sm" className="gap-1.5">
+                <a href={build.url}>
+                    <Download className="size-3.5" />
+                    Download
+                </a>
+            </Button>
+        </div>
+    );
+}
+
+export function DownloadPage({ release }: { release: DesktopRelease }) {
+    const platform = usePlatform();
+    // The detected platform first, so the button someone wants is the one they
+    // read first — and it is the only `primary` on the page.
+    const builds = [...release.builds].sort((left, right) => {
+        if (left.platform === right.platform) return 0;
+        if (left.platform === platform) return -1;
+        if (right.platform === platform) return 1;
+        return 0;
+    });
+
+    return (
+        <main className="min-h-screen bg-[var(--bg-canvas)] text-[var(--text-primary)]">
+            <div className="sticky top-0 z-20 border-b border-[var(--row-border)] bg-[color:color-mix(in_srgb,var(--bg-canvas)_84%,transparent)] backdrop-blur-xl">
+                <div className="mx-auto flex max-w-[1180px] items-center justify-between gap-4 px-5 py-4 sm:px-8 lg:px-10">
+                    <Link href="/" aria-label="Lemma home" className="inline-flex items-center">
+                        <Logo size="xs" variant="mark-wordmark" />
+                    </Link>
+                    <Link
+                        href="/"
+                        className="inline-flex items-center gap-2 text-sm text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]"
+                    >
+                        <ArrowLeft className="h-4 w-4" />
+                        <span>Back to home</span>
+                    </Link>
+                </div>
+            </div>
+
+            <section className="px-5 pt-12 sm:px-8 sm:pt-16 lg:px-10 lg:pt-20">
+                <div className="mx-auto max-w-[1180px]">
+                    <div className="max-w-[640px]">
+                        <p className="font-mono type-eyebrow-medium">Lemma for desktop</p>
+                        <h1 className="mt-5 [font-family:var(--font-landing-serif)] text-5xl font-normal leading-none tracking-normal text-[var(--text-primary)] sm:text-6xl">
+                            Run agents on your own computer
+                        </h1>
+                        <p className="mt-6 text-base leading-8 text-[var(--text-secondary)] sm:text-lg">
+                            Claude Code, Codex and OpenCode already live on your machine, holding your
+                            credentials and seeing your files. The Lemma app connects that computer to
+                            your workspace so agents there can pick up work, without those credentials
+                            ever leaving it.
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            {/* The download comes before the instructions on a narrow screen and
+                beside them on a wide one, so a phone does not make someone scroll
+                past the whole pitch to reach the button they came for. */}
+            <section className="px-5 pb-16 pt-10 sm:px-8 lg:px-10">
+                <div className="mx-auto grid max-w-[1180px] gap-10 lg:grid-cols-[minmax(0,1fr)_400px] lg:gap-16">
+                    <div className="order-2 max-w-[640px] lg:order-none">
+                        <ol className="space-y-5">
+                            {[
+                                'Install the app on the computer whose agents you want to use.',
+                                'Open it and sign in to the same workspace.',
+                                'Models → Paired computers → Connect this computer.',
+                            ].map((step, index) => (
+                                <li key={step} className="flex items-baseline gap-4">
+                                    <span className="min-w-6 font-mono text-xs text-[var(--text-tertiary)]">
+                                        {(index + 1).toString().padStart(2, '0')}
+                                    </span>
+                                    <span className="text-base leading-7 text-[var(--text-secondary)]">
+                                        {step}
+                                    </span>
+                                </li>
+                            ))}
+                        </ol>
+
+                        <p className="mt-10 text-sm leading-7 text-[var(--text-tertiary)]">
+                            The same app also installs a complete Lemma on your machine, if you would
+                            rather your workspace itself did not live in the cloud. You choose which on
+                            first launch, and can change it later.
+                        </p>
+                    </div>
+
+                    <aside className="order-1 lg:order-none lg:sticky lg:top-[88px] lg:self-start">
+                        <div className="surface-panel p-5">
+                            <div className="flex items-baseline justify-between gap-3">
+                                <h2 className="text-sm font-medium text-[var(--text-primary)]">
+                                    Download
+                                </h2>
+                                {release.version ? (
+                                    <span className="font-mono text-xs text-[var(--text-tertiary)]">
+                                        v{release.version}
+                                    </span>
+                                ) : null}
+                            </div>
+
+                            {builds.length ? (
+                                <div className="mt-4 flex flex-col gap-3">
+                                    {builds.map((build, index) => (
+                                        <BuildRow
+                                            key={build.platform}
+                                            build={build}
+                                            // Nothing is emphasised until the platform is known, so
+                                            // the page never pushes a Windows installer at a Mac.
+                                            emphasised={platform !== null && index === 0}
+                                        />
+                                    ))}
+                                </div>
+                            ) : (
+                                <p className="mt-4 text-sm leading-7 text-[var(--text-secondary)]">
+                                    The installer list could not be read just now. Every build is on
+                                    the releases page.
+                                </p>
+                            )}
+
+                            <a
+                                href={release.releasesUrl}
+                                className="mt-4 inline-flex items-center gap-1 text-sm text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-primary)]"
+                            >
+                                <span>All releases and checksums</span>
+                                <ArrowUpRight className="h-3.5 w-3.5" />
+                            </a>
+
+                            {builds.length ? (
+                                <p className="mt-5 border-t border-[var(--row-border)] pt-4 text-xs leading-6 text-[var(--text-tertiary)]">
+                                    Signed by Folks and Machines, Inc., and notarised by Apple on
+                                    macOS.
+                                </p>
+                            ) : null}
+                        </div>
+                    </aside>
+                </div>
+            </section>
+        </main>
+    );
+}

--- a/lemma-frontend/lib/desktop/__tests__/desktop-release.test.ts
+++ b/lemma-frontend/lib/desktop/__tests__/desktop-release.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import {
+    DESKTOP_RELEASES_URL,
+    formatInstallerSize,
+    releaseVersion,
+    selectDesktopBuilds,
+} from '../desktop-release';
+
+// A release carries far more than the app: host packs, guest runtimes, and a
+// manifest, all named `lemma-*`. Handing one of those to someone who pressed
+// "Download for macOS" is a file that cannot be opened, so the matching is
+// deliberately exact rather than a suffix guess.
+describe('desktop installers in a release', () => {
+    const assets = [
+        { name: 'lemma-local.json', browser_download_url: 'https://example.test/manifest', size: 900 },
+        {
+            name: 'lemma-host-pack-aarch64-apple-darwin.zip',
+            browser_download_url: 'https://example.test/pack',
+            size: 90_000_000,
+        },
+        {
+            name: 'Lemma_0.7.0_aarch64-online.dmg',
+            browser_download_url: 'https://example.test/mac.dmg',
+            size: 24_100_000,
+        },
+        {
+            name: 'Lemma_0.7.0_x64-online-setup.exe',
+            browser_download_url: 'https://example.test/win.exe',
+            size: 22_400_000,
+        },
+    ];
+
+    it('picks one installer per platform, macOS first', () => {
+        const builds = selectDesktopBuilds(assets);
+
+        expect(builds.map((build) => build.platform)).toEqual(['macos', 'windows']);
+        expect(builds[0].url).toBe('https://example.test/mac.dmg');
+        expect(builds[1].url).toBe('https://example.test/win.exe');
+    });
+
+    it('offers nothing rather than a runtime archive', () => {
+        expect(selectDesktopBuilds([assets[0], assets[1]])).toEqual([]);
+    });
+
+    it('skips a platform the release did not publish', () => {
+        const builds = selectDesktopBuilds([assets[2]]);
+
+        expect(builds).toHaveLength(1);
+        expect(builds[0].platform).toBe('macos');
+    });
+
+    it('ignores an asset with no download link', () => {
+        expect(selectDesktopBuilds([{ name: 'Lemma_0.7.0_aarch64-online.dmg' }])).toEqual([]);
+    });
+
+    // Everything published up to v0.6.2 is named this way. A matcher that only
+    // knew the newer name would tell every visitor there is no Mac build.
+    it('still finds the installers released before the variant suffix', () => {
+        const builds = selectDesktopBuilds([
+            { name: 'Lemma_0.6.2_aarch64.dmg', browser_download_url: 'https://example.test/old.dmg', size: 37_541_930 },
+            { name: 'Lemma_0.6.2_x64-setup.exe', browser_download_url: 'https://example.test/old.exe' },
+        ]);
+
+        expect(builds.map((build) => build.url)).toEqual([
+            'https://example.test/old.dmg',
+            'https://example.test/old.exe',
+        ]);
+    });
+
+    it('prefers the online build when a release carries both variants', () => {
+        const builds = selectDesktopBuilds([
+            { name: 'Lemma_0.7.0_aarch64-local.dmg', browser_download_url: 'https://example.test/local.dmg' },
+            { name: 'Lemma_0.7.0_aarch64-online.dmg', browser_download_url: 'https://example.test/online.dmg' },
+        ]);
+
+        expect(builds).toHaveLength(1);
+        expect(builds[0].url).toBe('https://example.test/online.dmg');
+    });
+
+    // A local-only build cannot reach a hosted workspace, and this page exists
+    // to connect a computer to one.
+    it('never offers a local-only build', () => {
+        expect(
+            selectDesktopBuilds([
+                { name: 'Lemma_0.7.0_aarch64-local.dmg', browser_download_url: 'https://example.test/local.dmg' },
+            ]),
+        ).toEqual([]);
+    });
+
+    it('treats a missing size as unknown rather than zero', () => {
+        const builds = selectDesktopBuilds([
+            { name: 'Lemma_0.7.0_aarch64-online.dmg', browser_download_url: 'https://example.test/mac.dmg' },
+        ]);
+
+        expect(builds[0].size).toBeNull();
+        expect(formatInstallerSize(builds[0].size)).toBeNull();
+    });
+});
+
+describe('release presentation', () => {
+    it('reads a version out of a tag', () => {
+        expect(releaseVersion('v0.7.0')).toBe('0.7.0');
+        expect(releaseVersion('0.7.0')).toBe('0.7.0');
+        expect(releaseVersion('')).toBeNull();
+        expect(releaseVersion(undefined)).toBeNull();
+    });
+
+    it('sizes an installer in the units a download dialog uses', () => {
+        expect(formatInstallerSize(24_100_000)).toBe('24 MB');
+        expect(formatInstallerSize(1_400_000_000)).toBe('1.4 GB');
+        expect(formatInstallerSize(0)).toBeNull();
+    });
+
+    it('always has a page to fall back to', () => {
+        expect(DESKTOP_RELEASES_URL).toContain('/releases/latest');
+    });
+});

--- a/lemma-frontend/lib/desktop/agent-host-bridge.ts
+++ b/lemma-frontend/lib/desktop/agent-host-bridge.ts
@@ -50,6 +50,17 @@ export function isDesktopAgentHostAvailable(): boolean {
     return invoker() !== null && Boolean(window.__LEMMA_DESKTOP__);
 }
 
+/**
+ * The same question without the polling.
+ *
+ * A page that only needs to know "app or browser?" — to choose between showing
+ * this machine and offering the download — should not also start a 3s poll that
+ * forks the sidecar to read its journal.
+ */
+export function useIsDesktopShell(): boolean {
+    return useSyncExternalStore(subscribeShellBridge, isDesktopAgentHostAvailable, () => false);
+}
+
 // locald answers the shell on its event stream, not as a return value, so each
 // call asks for a fresh reading and returns the newest one already in hand. A
 // poll is therefore up to one interval behind, which is why the card triggers

--- a/lemma-frontend/lib/desktop/desktop-release.ts
+++ b/lemma-frontend/lib/desktop/desktop-release.ts
@@ -1,0 +1,162 @@
+/**
+ * Where the Lemma desktop app is downloaded from.
+ *
+ * Installer names carry their version — `Lemma_0.7.0_aarch64-online.dmg` — so
+ * GitHub's `releases/latest/download/<name>` shortcut cannot address one
+ * without knowing the version first. That is the whole reason this reads the
+ * release rather than hardcoding a link: a hardcoded one goes stale on every
+ * release, and a stale installer link is worse than no link, because it looks
+ * like it worked.
+ *
+ * Every failure lands on `releasesUrl`, which is a page a person can act on.
+ */
+
+export const DESKTOP_REPOSITORY = 'lemma-work/lemma-platform';
+
+export const DESKTOP_RELEASES_URL = `https://github.com/${DESKTOP_REPOSITORY}/releases/latest`;
+
+export type DesktopPlatform = 'macos' | 'windows';
+
+export type DesktopBuild = {
+    platform: DesktopPlatform;
+    /** What the person is choosing between, not the file name. */
+    label: string;
+    /** What it needs to run, stated next to the build it applies to. */
+    requirement: string;
+    /** Direct link to the installer. */
+    url: string;
+    /** Bytes, or null when the release did not report a size. */
+    size: number | null;
+};
+
+export type DesktopRelease = {
+    /** Tag of the release these builds came from, or null when unresolved. */
+    version: string | null;
+    builds: DesktopBuild[];
+    releasesUrl: string;
+};
+
+export type ReleaseAsset = {
+    name?: unknown;
+    browser_download_url?: unknown;
+    size?: unknown;
+};
+
+// One installer per platform, chosen by the first pattern that matches
+// something.
+//
+// The suffix moved: releases up to v0.6.2 published `Lemma_<v>_aarch64.dmg`,
+// and later ones name the variant. Both are accepted so this page keeps working
+// across that boundary in either direction — a matcher that only knew the new
+// name would show "no installers" against every already-published release.
+//
+// Order is preference, not convenience: `-online` first because someone reading
+// this arrived from a hosted workspace, and the unsuffixed name second because
+// that is what the older releases called the same build. A `-local` asset
+// deliberately matches neither — it cannot connect to a hosted workspace, so
+// offering it here would be a download that cannot do the thing being asked for.
+const BUILDS: {
+    platform: DesktopPlatform;
+    label: string;
+    requirement: string;
+    patterns: RegExp[];
+}[] = [
+    {
+        platform: 'macos',
+        label: 'macOS · Apple silicon',
+        requirement: 'macOS 14 or later',
+        patterns: [/^Lemma_.+_aarch64-online\.dmg$/, /^Lemma_.+_aarch64\.dmg$/],
+    },
+    {
+        platform: 'windows',
+        label: 'Windows · x64',
+        requirement: 'Windows 10 or later',
+        patterns: [/^Lemma_.+_x64-online-setup\.exe$/, /^Lemma_.+_x64-setup\.exe$/],
+    },
+];
+
+/**
+ * The installers a release published, in a fixed platform order.
+ *
+ * Anything unrecognised is dropped rather than guessed at: the release also
+ * carries host packs, guest runtimes and a manifest, and offering one of those
+ * as "the app" would be a download that cannot be opened.
+ */
+export function selectDesktopBuilds(assets: readonly ReleaseAsset[]): DesktopBuild[] {
+    const builds: DesktopBuild[] = [];
+    for (const { platform, label, requirement, patterns } of BUILDS) {
+        let match: ReleaseAsset | undefined;
+        for (const pattern of patterns) {
+            match = assets.find(
+                (asset) =>
+                    typeof asset?.name === 'string' &&
+                    pattern.test(asset.name) &&
+                    typeof asset.browser_download_url === 'string',
+            );
+            if (match) break;
+        }
+        if (!match) continue;
+        builds.push({
+            platform,
+            label,
+            requirement,
+            url: match.browser_download_url as string,
+            size: typeof match.size === 'number' && match.size > 0 ? match.size : null,
+        });
+    }
+    return builds;
+}
+
+/** `0.7.0` from a `v0.7.0` tag, and whatever it is otherwise. */
+export function releaseVersion(tag: unknown): string | null {
+    if (typeof tag !== 'string' || !tag.trim()) return null;
+    return tag.trim().replace(/^v/, '');
+}
+
+/** `241.6 MB`, or null when the release did not say. */
+export function formatInstallerSize(bytes: number | null): string | null {
+    if (!bytes || bytes <= 0) return null;
+    const megabytes = bytes / 1_000_000;
+    return megabytes >= 1000
+        ? `${(megabytes / 1000).toFixed(1)} GB`
+        : `${megabytes.toFixed(0)} MB`;
+}
+
+/**
+ * Read the latest desktop release.
+ *
+ * Server-side and cached for an hour: unauthenticated GitHub allows 60 reads an
+ * hour per address, and a download page that rate-limits itself under load
+ * would fail exactly when it is busiest.
+ */
+export async function fetchLatestDesktopRelease(): Promise<DesktopRelease> {
+    const empty: DesktopRelease = {
+        version: null,
+        builds: [],
+        releasesUrl: DESKTOP_RELEASES_URL,
+    };
+    try {
+        const response = await fetch(
+            `https://api.github.com/repos/${DESKTOP_REPOSITORY}/releases/latest`,
+            {
+                headers: { Accept: 'application/vnd.github+json' },
+                next: { revalidate: 3600 },
+            },
+        );
+        if (!response.ok) return empty;
+        const release = (await response.json()) as {
+            tag_name?: unknown;
+            assets?: unknown;
+        };
+        const assets = Array.isArray(release.assets) ? (release.assets as ReleaseAsset[]) : [];
+        return {
+            version: releaseVersion(release.tag_name),
+            builds: selectDesktopBuilds(assets),
+            releasesUrl: DESKTOP_RELEASES_URL,
+        };
+    } catch {
+        // Network, DNS, or a shape we do not recognise. The page still renders
+        // and still sends people somewhere they can download from.
+        return empty;
+    }
+}

--- a/lemma-frontend/lib/hooks/use-agent-runtime.ts
+++ b/lemma-frontend/lib/hooks/use-agent-runtime.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
 import type {
     AgentHostHarnessResponse,
     AgentHostPairingCreated,
@@ -72,6 +72,35 @@ export const useAgentHostHarnesses = (hostId?: string | null) => {
                 ? SETTLING_REFETCH_MS
                 : SETTLED_REFETCH_MS,
     });
+};
+
+/**
+ * Which computer each published harness was found on.
+ *
+ * A saved coding agent carries only its `harness_id`, so a model list has no
+ * way to say where it runs — and "Claude Code" with no machine beside it is the
+ * one thing a person needs to know before picking it in a chat. Same query keys
+ * as `useAgentHostHarnesses`, so the per-computer cards and this share one
+ * request rather than doubling them.
+ */
+export const useAgentHostHarnessOwners = (hosts: readonly AgentHost[]) => {
+    const results = useQueries({
+        queries: hosts.map((host) => ({
+            queryKey: agentHostHarnessesQueryKey(host.id),
+            queryFn: () => getLemmaClient().agentHost.listHarnesses(host.id),
+            staleTime: 2000,
+        })),
+    });
+
+    const owners = new Map<string, string>();
+    results.forEach((result, index) => {
+        const host = hosts[index];
+        if (!host) return;
+        for (const harness of result.data?.items ?? []) {
+            owners.set(harness.id, host.display_name);
+        }
+    });
+    return owners;
 };
 
 // A paired computer belongs to the person who paired it, not to a workspace:

--- a/lemma-frontend/scripts/design-audit-baseline.json
+++ b/lemma-frontend/scripts/design-audit-baseline.json
@@ -14,7 +14,7 @@
     "rawFontSizeDeclaration": 2,
     "rawRadiusDeclaration": 0,
     "rawSpacingDeclaration": 0,
-    "multiplePrimaryButtons": 20
+    "multiplePrimaryButtons": 22
   },
   "protectedAssistant": {
     "rawButtonElements": 1

--- a/locald/Info.plist
+++ b/locald/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Linked into the daemon's __TEXT,__info_plist section by build.rs, which is the
+  only way a bare Mach-O can carry a fixed code-signing identifier.
+
+  This is not cosmetic. locald keeps the operator's secrets in the OS credential
+  vault, and macOS ties each stored item's access control to the code identity of
+  the program that created it. Given no identifier, codesign derives one from the
+  binary's own contents -- so every rebuild presents itself as a different
+  program and the user is asked to authorise access again. CFBundleIdentifier
+  here is what makes the identity outlive the bytes, including through the
+  re-signing Tauri does when it bundles the daemon as a sidecar.
+-->
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>work.lemma.locald</string>
+  <key>CFBundleName</key>
+  <string>lemma-locald</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+</dict>
+</plist>

--- a/locald/build.rs
+++ b/locald/build.rs
@@ -1,0 +1,30 @@
+use std::path::Path;
+
+/// Embed `Info.plist` so the daemon's code-signing identifier survives a rebuild.
+///
+/// macOS keys a keychain item's access control to the code identity of whoever
+/// created it. `codesign` will happily invent an identifier for a bare Mach-O
+/// that does not supply one, but it derives that identifier from the binary
+/// itself — link the same source twice and the two results claim to be different
+/// programs. locald reads the operator's secrets on every launch, so the user
+/// would be asked to re-authorise after each build.
+///
+/// A `__TEXT,__info_plist` section fixes that at the binary level: `codesign`
+/// prefers its `CFBundleIdentifier` over anything it would derive, whoever runs
+/// it and with whatever flags. That matters because the desktop bundler re-signs
+/// this daemon as a sidecar and passes no identifier of its own.
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("macos") {
+        return;
+    }
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").expect("cargo sets CARGO_MANIFEST_DIR");
+    let plist = Path::new(&manifest).join("Info.plist");
+    println!("cargo:rerun-if-changed={}", plist.display());
+    // Only the shipped binaries: tests and build scripts link their own
+    // executables, and a duplicated section would fail the link.
+    println!(
+        "cargo:rustc-link-arg-bins=-Wl,-sectcreate,__TEXT,__info_plist,{}",
+        plist.display()
+    );
+}

--- a/locald/src/daemon.rs
+++ b/locald/src/daemon.rs
@@ -76,8 +76,14 @@ impl Daemon {
         let host_processes = host_manifest
             .map(|path| HostProcessManager::load(&path, paths.root.join("logs")))
             .transpose()?;
+        // Nothing here may read the operator's secrets. Everything in `new` runs
+        // before `serve` binds the control socket, and a credential vault is
+        // entitled to stop and ask the user for authorisation first — which would
+        // hold the socket hostage while the desktop shell polls for eight seconds
+        // and then gives up with "could not connect to lemma-locald", leaving a
+        // blank window sitting behind a dialog nobody has answered yet. The
+        // backend environment is primed by `prime_backend_environment` instead.
         if let Some(manager) = host_processes.as_ref() {
-            manager.set_backend_environment(operator_config.backend_environment()?);
             if let Some((frontend_port, backend_port)) = manager.application_ports() {
                 // LAN/Public desired state is deliberately not persisted.
                 // Every daemon launch starts from the private canonical origin.
@@ -139,6 +145,7 @@ impl Daemon {
     pub fn serve(self: Arc<Self>) -> io::Result<()> {
         let listener = create_listener(&self.paths)?;
         self.write_daemon_log("locald listening")?;
+        self.prime_backend_environment();
         self.start_host_status_monitor();
         self.start_agent_host_monitor();
 
@@ -156,6 +163,35 @@ impl Daemon {
             }
         }
         Ok(())
+    }
+
+    /// Fill in the backend environment once the control socket is already up.
+    ///
+    /// Reading the operator's secrets can block on an OS credential-vault prompt,
+    /// which is why this cannot happen during `Daemon::new`. Off the accept path
+    /// the cost is invisible: the shell connects, the workspace renders, and the
+    /// prompt — if there is one — arrives over a window that already works.
+    ///
+    /// Failure here is deliberately not fatal. Every caller that starts host
+    /// processes rebuilds the environment first and surfaces its own error, so a
+    /// vault the user dismissed costs a log line rather than the daemon.
+    fn prime_backend_environment(self: &Arc<Self>) {
+        if self.host_processes.is_none() {
+            return;
+        }
+        let daemon = Arc::clone(self);
+        thread::spawn(move || {
+            let Some(manager) = daemon.host_processes.as_ref() else {
+                return;
+            };
+            match daemon.backend_environment() {
+                Ok(environment) => manager.set_backend_environment(environment),
+                Err(error) => {
+                    let _ = daemon
+                        .write_daemon_log(&format!("backend environment unavailable: {error}"));
+                }
+            }
+        });
     }
 
     fn start_agent_host_monitor(self: &Arc<Self>) {

--- a/locald/src/operator_config.rs
+++ b/locald/src/operator_config.rs
@@ -488,10 +488,18 @@ impl OperatorConfigStore {
             "SECRET_ENCRYPTION_KEYSET".into(),
             self.secret_encryption_keyset(&config.install_id)?,
         );
-        let secret_presence = self.secret_presence(&config)?;
+        // One lookup, used for both the readiness flag and the provider key
+        // below. `secret_presence` would answer the same question by reading
+        // every secret this install has, and each of those is a separate vault
+        // access on the daemon's start path.
+        let ai_api_key = self.vault.get(&config.install_id, "ai.api_key")?;
         environment.insert(
             "LEMMA_LOCAL_AI_READY".into(),
-            (readiness(&config, &secret_presence)["ai"] == "ready").to_string(),
+            ai_ready(
+                &config,
+                ai_api_key.as_deref().is_some_and(|value| !value.is_empty()),
+            )
+            .to_string(),
         );
         match config.ai.protocol.as_str() {
             "openai_compat" => {
@@ -511,9 +519,8 @@ impl OperatorConfigStore {
                         config.ai.vision_models.join(","),
                     );
                 }
-                let api_key = self
-                    .vault
-                    .get(&config.install_id, "ai.api_key")?
+                let api_key = ai_api_key
+                    .clone()
                     .or_else(|| local_no_auth(&config.ai.base_url).then(|| "lemma-local".into()));
                 if let Some(api_key) = api_key {
                     environment.insert("LEMMA_OPENAI_API_KEY".into(), api_key);
@@ -533,7 +540,7 @@ impl OperatorConfigStore {
                     "LEMMA_ANTHROPIC_MODEL_NAMES".into(),
                     config.ai.models.join(","),
                 );
-                if let Some(api_key) = self.vault.get(&config.install_id, "ai.api_key")? {
+                if let Some(api_key) = ai_api_key.clone() {
                     environment.insert("LEMMA_ANTHROPIC_API_KEY".into(), api_key);
                 }
             }
@@ -786,12 +793,22 @@ fn snapshot_value(config: OperatorConfig, secret_presence: BTreeMap<String, bool
     })
 }
 
-fn readiness(config: &OperatorConfig, secrets: &BTreeMap<String, bool>) -> Value {
-    let ai_ready = config.ai.protocol != "unconfigured"
+/// Whether the AI profile is usable, given only whether its key is stored.
+///
+/// Split out from `readiness` so a caller that needs this one answer can pay for
+/// the one secret it rests on. Reading the whole presence map to reach it means
+/// a vault round trip per configured secret, and on macOS each stored item
+/// carries its own access control — so the discarded lookups are not merely
+/// wasted, they are a queue of authorisation prompts.
+fn ai_ready(config: &OperatorConfig, api_key_present: bool) -> bool {
+    config.ai.protocol != "unconfigured"
         && !config.ai.default_model.is_empty()
         && config.ai.last_validated_at_unix_ms.is_some()
-        && (local_no_auth(&config.ai.base_url)
-            || secrets.get("ai.api_key").copied().unwrap_or(false));
+        && (local_no_auth(&config.ai.base_url) || api_key_present)
+}
+
+fn readiness(config: &OperatorConfig, secrets: &BTreeMap<String, bool>) -> Value {
+    let ai_ready = ai_ready(config, secrets.get("ai.api_key").copied().unwrap_or(false));
     json!({
         "ai": if ai_ready { "ready" } else { "needs_setup" },
         "integrations": if config.integrations.composio_enabled
@@ -1030,6 +1047,39 @@ mod tests {
         }
     }
 
+    /// A vault that remembers what was asked of it, and in what order.
+    #[derive(Default)]
+    struct CountingVault {
+        inner: MemoryVault,
+        reads: Mutex<Vec<String>>,
+    }
+
+    impl CountingVault {
+        fn reads_of(&self, name: &str) -> usize {
+            self.reads
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|read| *read == name)
+                .count()
+        }
+    }
+
+    impl SecretVault for CountingVault {
+        fn get(&self, install_id: &str, name: &str) -> io::Result<Option<String>> {
+            self.reads.lock().unwrap().push(name.to_owned());
+            self.inner.get(install_id, name)
+        }
+
+        fn set(&self, install_id: &str, name: &str, value: &str) -> io::Result<()> {
+            self.inner.set(install_id, name, value)
+        }
+
+        fn delete(&self, install_id: &str, name: &str) -> io::Result<()> {
+            self.inner.delete(install_id, name)
+        }
+    }
+
     struct FixedModelProviderProbe;
 
     impl ModelProviderProbe for FixedModelProviderProbe {
@@ -1193,6 +1243,57 @@ mod tests {
         assert!(!fs::read_to_string(root.path().join("operator.json"))
             .unwrap()
             .contains("secret-key"));
+    }
+
+    #[test]
+    fn rendering_the_backend_environment_reads_each_secret_at_most_once() {
+        // On macOS every stored secret carries its own access control, and the
+        // vault answers one item at a time. A second read of the same secret is
+        // therefore not a wasted function call, it is a second authorisation
+        // prompt in front of someone who is trying to open the app. This once
+        // cost every configured secret twice over: `secret_presence` walked all
+        // sixteen names to decide a single readiness boolean, and the loop that
+        // renders the environment then read the same items again.
+        let root = tempdir().unwrap();
+        let vault = Arc::new(CountingVault::default());
+        let store =
+            OperatorConfigStore::load_with_vault(root.path().join("operator.json"), vault.clone())
+                .unwrap();
+        let mut config: OperatorConfig =
+            serde_json::from_value(store.snapshot().unwrap()["config"].clone()).unwrap();
+        config.ai = AiProfile {
+            protocol: "openai_compat".into(),
+            base_url: "https://api.openai.com/v1".into(),
+            default_model: "gpt-test".into(),
+            models: vec!["gpt-test".into()],
+            vision_models: vec![],
+            ..Default::default()
+        };
+        store
+            .apply(ApplyOperatorConfig {
+                config,
+                secrets: BTreeMap::from([
+                    ("ai.api_key".into(), Some("secret-key".into())),
+                    ("surfaces.slack_bot_token".into(), Some("xoxb-test".into())),
+                ]),
+            })
+            .unwrap();
+
+        vault.reads.lock().unwrap().clear();
+        let environment = store.backend_environment().unwrap();
+
+        // Still renders everything the backend depends on.
+        assert_eq!(environment["LEMMA_OPENAI_API_KEY"], "secret-key");
+        assert_eq!(environment["SLACK_BOT_TOKEN"], "xoxb-test");
+        assert_eq!(environment["LEMMA_LOCAL_AI_READY"], "true");
+
+        for name in SECRET_NAMES {
+            assert!(
+                vault.reads_of(name) <= 1,
+                "{name} was read {} times while rendering the backend environment",
+                vault.reads_of(name)
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Four commits, all about a local machine and a Lemma workspace agreeing on what is running and who asked for it.

## Quit and keychain

- **`lemma agent-host` / locald stop re-authorising your own secrets.** The daemon's keychain access is keyed to its code-signing identifier, and Tauri re-signs sidecars without one of their own — so every release asked the user to re-approve access to secrets they already owned.
- **Quit stops the local server, and says what that stops.** The daemon deliberately outlives the app, so it cannot infer a full quit from its own shutdown; the `desktop.release` handshake is what closes an open LAN or public tunnel too.
- Local development release manifest digests refreshed.

## Models settings

The page answered one question three times. "What can answer a chat here?" has two answers — a model behind a key, or a coding agent on a computer — but it was split across **Providers**, **Coding agents** and **Paired computers**, so a fresh workspace opened on a section whose entire content was *"None yet. Add one from a paired computer below."*

**Three sections become two.** Coding agents move into **Models**, which is the list the user is actually building, each row labelled with the computer it runs on. **Paired computers** becomes **Computers** — not a peer concept, but where those agents come from.

**Pairing was the page's opening move**: a code box expanded before anything was paired, three raw commands and a live single-use credential taking most of the viewport, while the one-click path in the desktop app appeared nowhere. It now sits behind a button and asks which machine *before* minting anything:

- a computer with a screen installs the app and signs itself in — no code is created at all;
- only the headless branch mints one, and the copy says why a code exists.

Offering a download link beside a live pairing code meant everyone taking the easy path burned a credential on the way past it.

**Badges.** Rows carried up to four — archived, scope, availability, built-in — mixing what a thing *is* with who *owns* it and whether it *works*, so none read as status. One badge now answers "can I use this"; ownership is marked only when it is the exception. The eleven equal-weight provider chips become one menu.

## Two fixes behind that redesign

**The "This computer" card rendered nothing when its status was missing.** In a hosted workspace the first poll is the one that starts locald, so "nothing yet" is the normal opening state — and any failure past it left blank space exactly where the only Connect button should be, with the error caught into a field the card never read. It now says *Checking* while the shell answers, and reports what went wrong when it does not.

**A browser had no path at all** — no "this computer" to offer, and no mention of the app that makes it work. `/download` resolves the latest release from GitHub hourly and falls back to the releases page when that read fails or a platform has no build. It accepts both the current asset name and the `-online` one this branch introduces: a matcher that knew only the new name would tell every visitor there is no Mac build until the next release ships.

## Notes for review

- `design-audit-baseline.json` moves `multiplePrimaryButtons` 20 → 22. The connect dialog's two primaries are in mutually exclusive branches, which `design.md` §8 permits and the audit files as informational — but the counter did move.
- The frontend work was verified against fabricated data on a scratch route (since deleted) and the real GitHub releases API. It was **not** exercised against a live backend, so the data flow through `useAgentHostHarnessOwners` is typechecked but not run.
- The branch is behind `main`; no rebase attempted.
- Typecheck, lint, 404 unit tests and `design:audit:ci` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
