### PR TITLE
Let a self-hosted workspace reach this computer, and stop polling a machine that is not coming back

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -593,12 +593,37 @@ fn hosted_url() -> String {
 /// The workspace origins `capabilities/workspace.json` already covers.
 const SHIPPED_WORKSPACE_ORIGINS: &[&str] = &["http://app.lemma.localhost:*", "https://lemma.work"];
 
-/// A capability granting the overridden workspace origin the same single
-/// command the shipped one gets, or `None` when nothing is overridden.
+/// The shipped workspace capability, read at compile time so the override below
+/// cannot drift from it.
 ///
-/// Only the origin varies. The permission list must stay identical to
-/// `capabilities/workspace.json`, so a dev build can never reach further into
-/// the shell than a packaged one.
+/// It did drift. The override was written when the shipped capability granted a
+/// single command; the Agent Host and provider commands were added to the file
+/// alone, and every non-shipped origin — a self-hosted workspace, a dev server —
+/// lost the Computers card and the provider steps to `Command
+/// agent_host_status not allowed by ACL`, with nothing the user could do about
+/// it. Reading the list is what keeps the two the same next time.
+const SHIPPED_WORKSPACE_CAPABILITY: &str = include_str!("../capabilities/workspace.json");
+
+/// The permissions the shipped workspace origins get.
+///
+/// Panics on a malformed capability, which is a build-time fact rather than a
+/// runtime one: the file is compiled in, so a bad edit fails the first test that
+/// touches this rather than reaching a user.
+fn shipped_workspace_permissions() -> Vec<Value> {
+    serde_json::from_str::<Value>(SHIPPED_WORKSPACE_CAPABILITY)
+        .expect("capabilities/workspace.json is valid JSON")["permissions"]
+        .as_array()
+        .expect("capabilities/workspace.json grants an array of permissions")
+        .clone()
+}
+
+/// A capability granting the overridden workspace origin the same commands the
+/// shipped one gets, or `None` when nothing is overridden.
+///
+/// Only the origin varies. The permission list is taken from
+/// `capabilities/workspace.json` itself, so a dev or self-hosted build can
+/// never reach further into the shell than a packaged one — nor, as it did,
+/// less far.
 fn overridden_workspace_capability() -> Option<String> {
     let configured = ["LEMMA_DESKTOP_HOSTED_URL", "LEMMA_DESKTOP_LOCAL_URL"]
         .into_iter()
@@ -632,11 +657,11 @@ fn workspace_capability_for(configured: impl Iterator<Item = String>) -> Option<
     Some(
         json!({
             "identifier": "workspace-override-capability",
-            "description": "Development or self-hosted workspace origin, granted the same single command as the shipped one.",
+            "description": "Development or self-hosted workspace origin, granted the same commands as the shipped one.",
             "local": false,
             "webviews": ["main"],
             "remote": {"urls": urls},
-            "permissions": ["allow-open-control-center"],
+            "permissions": shipped_workspace_permissions(),
         })
         .to_string(),
     )
@@ -2876,7 +2901,22 @@ fn toggle_agent_host_from_tray(app: &AppHandle) -> Result<(), String> {
 /// Reachability, not liveness. A running host that is unpaired or cannot reach
 /// its workspace takes no work, so reporting it as simply "on" would be a lie
 /// the user only discovers when a run never starts.
-fn agent_host_tray_label(available: bool, running: bool, paired: bool, connected: bool) -> String {
+///
+/// "Reconnecting" is a claim about a connection that is coming back, and it was
+/// made for every disconnected state — including a host paired to a workspace
+/// that is simply not there any more, which is what a local pairing becomes the
+/// moment the local stack stops. That host retries for days behind a word that
+/// promises the opposite, so a failed last attempt now says so. The journal
+/// carries the error of the latest attempt only, cleared on a connect, so this
+/// distinguishes "trying" from "tried and failed" rather than remembering an
+/// old failure forever.
+fn agent_host_tray_label(
+    available: bool,
+    running: bool,
+    paired: bool,
+    connected: bool,
+    unreachable: bool,
+) -> String {
     if !available {
         "Agent Host: not installed".into()
     } else if !running {
@@ -2885,6 +2925,8 @@ fn agent_host_tray_label(available: bool, running: bool, paired: bool, connected
         "Agent Host: not paired".into()
     } else if connected {
         "Agent Host: connected".into()
+    } else if unreachable {
+        "Agent Host: workspace unreachable".into()
     } else {
         "Agent Host: reconnecting…".into()
     }
@@ -2898,16 +2940,25 @@ fn refresh_agent_host_tray(app: &AppHandle, status: &Value) {
     let available = status.get("available").and_then(Value::as_bool) == Some(true);
     let running = status.get("running").and_then(Value::as_bool) == Some(true);
     let paired = status.get("paired").and_then(Value::as_bool) == Some(true);
-    let connected = status
-        .get("targets")
-        .and_then(Value::as_array)
-        .is_some_and(|targets| {
-            targets.iter().any(|target| {
-                target.get("connection_state").and_then(Value::as_str) == Some("ONLINE")
+    let targets = status.get("targets").and_then(Value::as_array);
+    let connected = targets.is_some_and(|targets| {
+        targets
+            .iter()
+            .any(|target| target.get("connection_state").and_then(Value::as_str) == Some("ONLINE"))
+    });
+    // Every paired workspace failed its last attempt: nothing here is on its way
+    // back, whatever the retry loop is still doing.
+    let unreachable = targets.is_some_and(|targets| {
+        !targets.is_empty()
+            && targets.iter().all(|target| {
+                target
+                    .get("last_error")
+                    .and_then(Value::as_str)
+                    .is_some_and(|error| !error.trim().is_empty())
             })
-        });
+    });
 
-    let state = agent_host_tray_label(available, running, paired, connected);
+    let state = agent_host_tray_label(available, running, paired, connected, unreachable);
 
     {
         let shell: State<Shell> = app.state();
@@ -4656,26 +4707,39 @@ mod tests {
         // Each of these is a live process that cannot take work, and the old
         // process-only status called them all "running".
         assert_eq!(
-            agent_host_tray_label(true, true, false, false),
+            agent_host_tray_label(true, true, false, false, false),
             "Agent Host: not paired",
         );
         assert_eq!(
-            agent_host_tray_label(true, true, true, false),
+            agent_host_tray_label(true, true, true, false, false),
             "Agent Host: reconnecting…",
         );
         assert_eq!(
-            agent_host_tray_label(true, true, true, true),
+            agent_host_tray_label(true, true, true, true, false),
             "Agent Host: connected",
         );
         assert_eq!(
-            agent_host_tray_label(true, false, true, false),
+            agent_host_tray_label(true, false, true, false, false),
             "Agent Host: off"
         );
         // A build without the sidecar cannot be switched on, so say so rather
         // than offering a toggle that always fails.
         assert_eq!(
-            agent_host_tray_label(false, false, false, false),
+            agent_host_tray_label(false, false, false, false, false),
             "Agent Host: not installed",
+        );
+        // The state this distinction was added for: a workspace that answered
+        // yesterday and is not there today. "Reconnecting" for a week is a
+        // promise the retry loop cannot keep.
+        assert_eq!(
+            agent_host_tray_label(true, true, true, false, true),
+            "Agent Host: workspace unreachable",
+        );
+        // Connected wins over a stale error on another target: one workspace
+        // failing does not stop this computer taking work from the other.
+        assert_eq!(
+            agent_host_tray_label(true, true, true, true, true),
+            "Agent Host: connected",
         );
     }
 
@@ -4774,7 +4838,7 @@ mod tests {
     }
 
     #[test]
-    fn an_overridden_workspace_origin_gets_the_same_single_command() {
+    fn an_overridden_workspace_origin_gets_the_same_commands() {
         let capability_for = |values: &[&str]| {
             workspace_capability_for(values.iter().map(|value| value.to_string()))
         };
@@ -4792,10 +4856,23 @@ mod tests {
             capability["remote"]["urls"],
             json!(["https://staging.lemma.work", "http://127.0.0.1:3711"]),
         );
+        // Read from the shipped file rather than restated here: a hardcoded copy
+        // is exactly what drifted, and an assertion that has to be remembered
+        // catches nothing.
+        let shipped: Value =
+            serde_json::from_str(SHIPPED_WORKSPACE_CAPABILITY).expect("valid shipped capability");
         assert_eq!(
-            capability["permissions"],
-            json!(["allow-open-control-center"]),
-            "an override must not reach further than the shipped capability",
+            capability["permissions"], shipped["permissions"],
+            "an override must reach neither further nor less far than the shipped capability",
+        );
+        // The one this drift actually cost, named so the regression reads as
+        // the symptom it produced.
+        assert!(
+            capability["permissions"]
+                .as_array()
+                .expect("permissions are an array")
+                .contains(&json!("allow-agent-host-status")),
+            "a self-hosted workspace must be able to ask this computer for its status",
         );
         assert_eq!(capability["local"], json!(false));
     }

--- a/lemma-frontend/components/agents/this-computer-card.tsx
+++ b/lemma-frontend/components/agents/this-computer-card.tsx
@@ -16,7 +16,7 @@ import { getLemmaApiBaseUrl } from '@/lib/sdk/lemma-client';
 import { useCreateAgentHostPairing } from '@/lib/hooks/use-agent-runtime';
 import { allowAutoConnect, declineAutoConnect } from '@/lib/desktop/auto-connect';
 import { cn } from '@/lib/utils';
-import { describeThisComputer, type Tone } from './this-computer-status';
+import { describeThisComputer, selectWorkspaceTarget, type Tone } from './this-computer-status';
 
 export type ThisComputerState = {
     /** The paired-computer id the backend knows this machine by, if any. */
@@ -57,7 +57,12 @@ export function ThisComputerCard({
     const [busy, setBusy] = useState<string | null>(null);
     const [confirmDisconnect, setConfirmDisconnect] = useState(false);
 
-    const target: AgentHostTarget | undefined = status?.targets[0];
+    // This workspace's pairing, not whichever one happens to be first: a Mac
+    // paired to its own local stack and then opened against a hosted workspace
+    // has two, and only one of them is what this card is about.
+    const workspaceUrl = getLemmaApiBaseUrl();
+    const target: AgentHostTarget | null = selectWorkspaceTarget(status?.targets ?? [], workspaceUrl);
+    const pairedHere = Boolean(target);
     const hostId = target?.host_id ?? null;
     // Tell the paired-computer list which card is this machine, so it can label
     // that one instead of listing the same machine twice.
@@ -69,7 +74,7 @@ export function ThisComputerCard({
     // section falls back to the download card instead.
     if (!isDesktop) return null;
 
-    const state = describeThisComputer(status, error);
+    const state = describeThisComputer(status, error, workspaceUrl);
 
     const run = async (action: string, work: () => Promise<unknown>, success?: string) => {
         setBusy(action);
@@ -151,7 +156,7 @@ export function ThisComputerCard({
                     </Button>
                 ) : null}
 
-                {status?.available && status.paired ? (
+                {status?.available && pairedHere ? (
                     <Button
                         type="button"
                         variant={status.running ? 'quiet' : 'primary'}
@@ -171,7 +176,7 @@ export function ThisComputerCard({
                 ) : null}
             </div>
 
-            {status?.available && !status.paired ? (
+            {status?.available && !pairedHere ? (
                 <div className="mt-3 flex flex-wrap items-end gap-2">
                     <Input
                         value={displayName}
@@ -191,7 +196,7 @@ export function ThisComputerCard({
                 </div>
             ) : null}
 
-            {status?.paired ? (
+            {pairedHere ? (
                 <div className="mt-3 flex flex-wrap items-center gap-2">
                     <Button
                         type="button"

--- a/lemma-frontend/components/agents/this-computer-card.tsx
+++ b/lemma-frontend/components/agents/this-computer-card.tsx
@@ -10,83 +10,18 @@ import {
     agentHostBridge,
     useThisComputer,
     type AgentHostTarget,
-    type ThisComputerStatus,
 } from '@/lib/desktop/agent-host-bridge';
 import { DestructiveConfirmationDialog } from '@/components/shared/destructive-confirmation-dialog';
 import { getLemmaApiBaseUrl } from '@/lib/sdk/lemma-client';
 import { useCreateAgentHostPairing } from '@/lib/hooks/use-agent-runtime';
 import { allowAutoConnect, declineAutoConnect } from '@/lib/desktop/auto-connect';
 import { cn } from '@/lib/utils';
+import { describeThisComputer, type Tone } from './this-computer-status';
 
 export type ThisComputerState = {
     /** The paired-computer id the backend knows this machine by, if any. */
     hostId: string | null;
 };
-
-type Tone = 'ok' | 'warn' | 'muted';
-
-// What the machine can actually do right now, which is not the same question as
-// whether a process is alive: an unpaired host and one that cannot reach the
-// workspace are both running, and neither will pick up a run.
-//
-// A missing status is a state too, and used to be rendered as nothing at all.
-// In a hosted workspace the first poll is the one that has to start locald, so
-// "nothing yet" is the normal opening state and a failure there — no daemon, a
-// build without the sidecar — left an empty space where the only way to connect
-// this computer should have been.
-export function describe(
-    status: ThisComputerStatus | null,
-    error: string | null,
-): { label: string; detail: string; tone: Tone } {
-    if (!status) {
-        return error
-            ? {
-                  label: 'Unavailable',
-                  detail: error,
-                  tone: 'warn',
-              }
-            : {
-                  label: 'Checking',
-                  detail: 'Asking this computer which agents it can run.',
-                  tone: 'muted',
-              };
-    }
-    if (!status.available) {
-        return {
-            label: 'Not available',
-            detail: 'This build of Lemma does not include the Agent Host.',
-            tone: 'muted',
-        };
-    }
-    if (!status.paired) {
-        return {
-            label: 'Not connected',
-            detail: 'Connect this computer to run Claude Code, Codex, and other local agents here.',
-            tone: 'muted',
-        };
-    }
-    if (!status.running) {
-        return {
-            label: 'Off',
-            detail: 'Turn it on to let this workspace send work to this computer.',
-            tone: 'muted',
-        };
-    }
-    const target = status.targets[0];
-    if (target?.connection_state === 'ONLINE') {
-        const runs = target.active_runs ?? 0;
-        return {
-            label: 'Connected',
-            detail: runs > 0 ? `Running ${runs} ${runs === 1 ? 'task' : 'tasks'} now.` : 'Ready for work.',
-            tone: 'ok',
-        };
-    }
-    return {
-        label: 'Reconnecting',
-        detail: target?.last_error || status.last_error || 'Trying to reach this workspace.',
-        tone: 'warn',
-    };
-}
 
 function StatusDot({ tone }: { tone: Tone }) {
     return (
@@ -134,7 +69,7 @@ export function ThisComputerCard({
     // section falls back to the download card instead.
     if (!isDesktop) return null;
 
-    const state = describe(status, error);
+    const state = describeThisComputer(status, error);
 
     const run = async (action: string, work: () => Promise<unknown>, success?: string) => {
         setBusy(action);

--- a/lemma-frontend/components/agents/this-computer-status.test.ts
+++ b/lemma-frontend/components/agents/this-computer-status.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { describeThisComputer } from '@/components/agents/this-computer-status';
+import {
+    describeThisComputer,
+    selectWorkspaceTarget,
+} from '@/components/agents/this-computer-status';
 import type { ThisComputerStatus } from '@/lib/desktop/agent-host-bridge';
 
 const status = (overrides: Partial<ThisComputerStatus> = {}): ThisComputerStatus =>
@@ -13,8 +16,11 @@ const status = (overrides: Partial<ThisComputerStatus> = {}): ThisComputerStatus
         ...overrides,
     }) as ThisComputerStatus;
 
+const WORKSPACE = 'https://asur.work';
+
 const target = (overrides: Record<string, unknown> = {}) =>
     ({
+        url: WORKSPACE,
         connection_state: 'OFFLINE',
         last_error: null,
         active_runs: null,
@@ -23,13 +29,14 @@ const target = (overrides: Record<string, unknown> = {}) =>
 
 describe('describeThisComputer', () => {
     it('says what it is doing before the first reading arrives', () => {
-        expect(describeThisComputer(null, null).label).toBe('Checking');
+        expect(describeThisComputer(null, null, WORKSPACE).label).toBe('Checking');
     });
 
     it('reports a live connection and its load', () => {
         const described = describeThisComputer(
             status({ targets: [target({ connection_state: 'ONLINE', active_runs: 2 })] }),
             null,
+            WORKSPACE,
         );
         expect(described.label).toBe('Connected');
         expect(described.detail).toBe('Running 2 tasks now.');
@@ -50,6 +57,7 @@ describe('describeThisComputer', () => {
                 ],
             }),
             null,
+            WORKSPACE,
         );
         expect(described.label).toBe('Unreachable');
         expect(described.detail).toContain('app.lemma.localhost:56608');
@@ -59,8 +67,50 @@ describe('describeThisComputer', () => {
     it('still says reconnecting while an attempt is genuinely in flight', () => {
         // Nothing recorded against the latest attempt: it is trying, and the next
         // reading may well be Connected.
-        const described = describeThisComputer(status({ targets: [target()] }), null);
+        const described = describeThisComputer(status({ targets: [target()] }), null, WORKSPACE);
         expect(described.label).toBe('Reconnecting');
         expect(described.detail).toBe('Trying to reach this workspace.');
+    });
+
+    it('ignores a pairing that belongs to another workspace', () => {
+        // The failure this came from: a Mac paired to its own local stack, then
+        // opened against a hosted workspace. The local pairing is real and is
+        // failing, but it is not this workspace's, so this workspace is simply
+        // not connected — and the card must offer to connect it rather than
+        // reporting someone else's dead URL and hiding the button.
+        const described = describeThisComputer(
+            status({
+                targets: [
+                    target({
+                        url: 'http://app.lemma.localhost:56608',
+                        last_error: 'error sending request for url',
+                    }),
+                ],
+            }),
+            null,
+            WORKSPACE,
+        );
+        expect(described.label).toBe('Not connected');
+        expect(described.detail).toContain('Connect this computer');
+    });
+});
+
+describe('selectWorkspaceTarget', () => {
+    it('picks the pairing for this workspace out of several', () => {
+        const mine = target({ url: WORKSPACE, target_id: 'mine' });
+        const theirs = target({ url: 'http://app.lemma.localhost:56608', target_id: 'theirs' });
+        expect(selectWorkspaceTarget([theirs, mine], WORKSPACE)?.target_id).toBe('mine');
+    });
+
+    it('matches on origin, so a path or trailing slash still pairs up', () => {
+        expect(selectWorkspaceTarget([target({ url: 'https://asur.work/' })], WORKSPACE)).not.toBeNull();
+    });
+
+    it('never matches a target with no url, rather than guessing it is ours', () => {
+        expect(selectWorkspaceTarget([target({ url: null })], WORKSPACE)).toBeNull();
+    });
+
+    it('has no answer when the workspace url is unreadable', () => {
+        expect(selectWorkspaceTarget([target()], 'not a url')).toBeNull();
     });
 });

--- a/lemma-frontend/components/agents/this-computer-status.test.ts
+++ b/lemma-frontend/components/agents/this-computer-status.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { describeThisComputer } from '@/components/agents/this-computer-status';
+import type { ThisComputerStatus } from '@/lib/desktop/agent-host-bridge';
+
+const status = (overrides: Partial<ThisComputerStatus> = {}): ThisComputerStatus =>
+    ({
+        available: true,
+        running: true,
+        paired: true,
+        last_error: null,
+        targets: [],
+        ...overrides,
+    }) as ThisComputerStatus;
+
+const target = (overrides: Record<string, unknown> = {}) =>
+    ({
+        connection_state: 'OFFLINE',
+        last_error: null,
+        active_runs: null,
+        ...overrides,
+    }) as ThisComputerStatus['targets'][number];
+
+describe('describeThisComputer', () => {
+    it('says what it is doing before the first reading arrives', () => {
+        expect(describeThisComputer(null, null).label).toBe('Checking');
+    });
+
+    it('reports a live connection and its load', () => {
+        const described = describeThisComputer(
+            status({ targets: [target({ connection_state: 'ONLINE', active_runs: 2 })] }),
+            null,
+        );
+        expect(described.label).toBe('Connected');
+        expect(described.detail).toBe('Running 2 tasks now.');
+    });
+
+    it('calls a failed last attempt unreachable rather than reconnecting', () => {
+        // The state this exists for: a computer paired to a local workspace whose
+        // stack has since stopped. It retries forever and never returns, the tray
+        // says "workspace unreachable" for the same reading, and the card saying
+        // "Reconnecting" sent people to wait rather than to Disconnect.
+        const described = describeThisComputer(
+            status({
+                targets: [
+                    target({
+                        last_error:
+                            'Agent Host HTTP request failed: error sending request for url (http://app.lemma.localhost:56608/agent-host/poll)',
+                    }),
+                ],
+            }),
+            null,
+        );
+        expect(described.label).toBe('Unreachable');
+        expect(described.detail).toContain('app.lemma.localhost:56608');
+        expect(described.tone).toBe('warn');
+    });
+
+    it('still says reconnecting while an attempt is genuinely in flight', () => {
+        // Nothing recorded against the latest attempt: it is trying, and the next
+        // reading may well be Connected.
+        const described = describeThisComputer(status({ targets: [target()] }), null);
+        expect(described.label).toBe('Reconnecting');
+        expect(described.detail).toBe('Trying to reach this workspace.');
+    });
+});

--- a/lemma-frontend/components/agents/this-computer-status.ts
+++ b/lemma-frontend/components/agents/this-computer-status.ts
@@ -1,0 +1,75 @@
+import type { ThisComputerStatus } from '@/lib/desktop/agent-host-bridge';
+
+export type Tone = 'ok' | 'warn' | 'muted';
+
+export type DescribedStatus = { label: string; detail: string; tone: Tone };
+
+// What the machine can actually do right now, which is not the same question as
+// whether a process is alive: an unpaired host and one that cannot reach the
+// workspace are both running, and neither will pick up a run.
+//
+// A missing status is a state too, and used to be rendered as nothing at all.
+// In a hosted workspace the first poll is the one that has to start locald, so
+// "nothing yet" is the normal opening state and a failure there — no daemon, a
+// build without the sidecar — left an empty space where the only way to connect
+// this computer should have been.
+//
+// Lives beside the card rather than in it so it can be tested as the pure
+// function it is, like `agent-runtime-helpers` next door: the card is a client
+// component and the unit suite deliberately loads no React.
+export function describeThisComputer(
+    status: ThisComputerStatus | null,
+    error: string | null,
+): DescribedStatus {
+    if (!status) {
+        return error
+            ? {
+                  label: 'Unavailable',
+                  detail: error,
+                  tone: 'warn',
+              }
+            : {
+                  label: 'Checking',
+                  detail: 'Asking this computer which agents it can run.',
+                  tone: 'muted',
+              };
+    }
+    if (!status.available) {
+        return {
+            label: 'Not available',
+            detail: 'This build of Lemma does not include the Agent Host.',
+            tone: 'muted',
+        };
+    }
+    if (!status.paired) {
+        return {
+            label: 'Not connected',
+            detail: 'Connect this computer to run Claude Code, Codex, and other local agents here.',
+            tone: 'muted',
+        };
+    }
+    if (!status.running) {
+        return {
+            label: 'Off',
+            detail: 'Turn it on to let this workspace send work to this computer.',
+            tone: 'muted',
+        };
+    }
+    const target = status.targets[0];
+    if (target?.connection_state === 'ONLINE') {
+        const runs = target.active_runs ?? 0;
+        return {
+            label: 'Connected',
+            detail: runs > 0 ? `Running ${runs} ${runs === 1 ? 'task' : 'tasks'} now.` : 'Ready for work.',
+            tone: 'ok',
+        };
+    }
+    // The same distinction the tray makes, in the same words: a failed last
+    // attempt is not a reconnection in progress. A local pairing whose stack has
+    // stopped never comes back on its own, and calling that "Reconnecting" for
+    // days sends people to wait instead of to Disconnect.
+    const failure = target?.last_error || status.last_error;
+    return failure
+        ? { label: 'Unreachable', detail: failure, tone: 'warn' }
+        : { label: 'Reconnecting', detail: 'Trying to reach this workspace.', tone: 'warn' };
+}

--- a/lemma-frontend/components/agents/this-computer-status.ts
+++ b/lemma-frontend/components/agents/this-computer-status.ts
@@ -1,8 +1,42 @@
-import type { ThisComputerStatus } from '@/lib/desktop/agent-host-bridge';
+import type { AgentHostTarget, ThisComputerStatus } from '@/lib/desktop/agent-host-bridge';
 
 export type Tone = 'ok' | 'warn' | 'muted';
 
 export type DescribedStatus = { label: string; detail: string; tone: Tone };
+
+const originOf = (url: string | null): string | null => {
+    if (!url) return null;
+    try {
+        return new URL(url).origin;
+    } catch {
+        return null;
+    }
+};
+
+/**
+ * The pairing that belongs to the workspace being looked at, if any.
+ *
+ * A computer can be paired to several workspaces at once — that is what
+ * `targets` is — but the card read `targets[0]` and every control was gated on
+ * `paired`, meaning "paired to anything". Open a hosted workspace on a Mac that
+ * had been paired to its own local stack and the card described the *local*
+ * pairing: it reported a dead workspace as this one's status, "Recheck agents"
+ * re-polled a URL this workspace has never heard of, and because it looked
+ * paired, the one-press "Connect this computer" was hidden — leaving only the
+ * dialog for pairing some *other* machine, which asks you to install the app you
+ * are already looking at.
+ *
+ * A target with no URL matches nothing: it cannot be shown to be this
+ * workspace's, and guessing wrong is what this fixes.
+ */
+export function selectWorkspaceTarget(
+    targets: readonly AgentHostTarget[],
+    workspaceUrl: string | null,
+): AgentHostTarget | null {
+    const workspace = originOf(workspaceUrl);
+    if (!workspace) return null;
+    return targets.find((target) => originOf(target.url) === workspace) ?? null;
+}
 
 // What the machine can actually do right now, which is not the same question as
 // whether a process is alive: an unpaired host and one that cannot reach the
@@ -20,6 +54,7 @@ export type DescribedStatus = { label: string; detail: string; tone: Tone };
 export function describeThisComputer(
     status: ThisComputerStatus | null,
     error: string | null,
+    workspaceUrl: string | null,
 ): DescribedStatus {
     if (!status) {
         return error
@@ -41,7 +76,12 @@ export function describeThisComputer(
             tone: 'muted',
         };
     }
-    if (!status.paired) {
+    // Not "paired to something" — paired to the workspace on screen. A pairing
+    // that belongs to another workspace is that workspace's business, and
+    // reporting it here is how a dead local stack came to be this workspace's
+    // status.
+    const target = selectWorkspaceTarget(status.targets, workspaceUrl);
+    if (!target) {
         return {
             label: 'Not connected',
             detail: 'Connect this computer to run Claude Code, Codex, and other local agents here.',
@@ -55,7 +95,6 @@ export function describeThisComputer(
             tone: 'muted',
         };
     }
-    const target = status.targets[0];
     if (target?.connection_state === 'ONLINE') {
         const runs = target.active_runs ?? 0;
         return {

--- a/lemma-frontend/lib/desktop/agent-host-bridge.ts
+++ b/lemma-frontend/lib/desktop/agent-host-bridge.ts
@@ -98,6 +98,9 @@ export const agentHostBridge = {
     openLog: () => call('agent_host_open_log'),
 };
 
+/** The longest a run of failing status calls backs off to. */
+const MAX_BACKOFF_INTERVAL_MS = 60_000;
+
 /**
  * Poll this computer's Agent Host while the page is visible.
  *
@@ -117,30 +120,47 @@ export function useThisComputer(intervalMs = 3000) {
     );
 
     const poll = useCallback(async () => {
-        if (!isDesktopAgentHostAvailable()) return;
+        if (!isDesktopAgentHostAvailable()) return true;
         try {
             const next = readStatus(await agentHostBridge.status());
             if (next) setStatus(next);
             setError(null);
+            return true;
         } catch (cause) {
             setError(cause instanceof Error ? cause.message : String(cause));
+            return false;
         }
     }, []);
 
     useEffect(() => {
         if (!isDesktop) return;
-        let timer: ReturnType<typeof setInterval> | null = null;
-        // Deferred rather than called inline: the first reading arrives through
-        // setState, and React forbids that synchronously inside an effect.
-        const first = setTimeout(() => void poll(), 0);
-        const start = () => {
-            if (timer === null) timer = setInterval(() => void poll(), intervalMs);
+        let timer: ReturnType<typeof setTimeout> | null = null;
+        let stopped = false;
+        // A failing call is not a slow one: an ACL rejection, a missing sidecar,
+        // or a daemon that will not start answers immediately and answers the
+        // same way every time. At a flat interval that is twenty forked sidecar
+        // reads a minute producing one unchanged error, for as long as the page
+        // is open, so each consecutive failure doubles the wait. One success
+        // puts it straight back on the interval it was asked for.
+        let failures = 0;
+        const delay = () =>
+            failures === 0
+                ? intervalMs
+                : Math.min(intervalMs * 2 ** failures, MAX_BACKOFF_INTERVAL_MS);
+        const tick = async () => {
+            const ok = await poll();
+            if (stopped) return;
+            failures = ok ? 0 : failures + 1;
+            timer = setTimeout(() => void tick(), delay());
         };
         const stop = () => {
             if (timer !== null) {
-                clearInterval(timer);
+                clearTimeout(timer);
                 timer = null;
             }
+        };
+        const start = () => {
+            if (timer === null && !stopped) timer = setTimeout(() => void tick(), 0);
         };
         // A background tab has nobody watching, and each poll forks the sidecar
         // to read its journal.
@@ -149,13 +169,16 @@ export function useThisComputer(intervalMs = 3000) {
                 stop();
                 return;
             }
-            void poll();
+            // Coming back is a reason to try again now: whatever was failing may
+            // have been fixed in the meantime, and the person is looking at it.
+            failures = 0;
+            stop();
             start();
         };
         document.addEventListener('visibilitychange', onVisibility);
         if (!document.hidden) start();
         return () => {
-            clearTimeout(first);
+            stopped = true;
             document.removeEventListener('visibilitychange', onVisibility);
             stop();
         };

--- a/lemma-frontend/lib/hooks/__tests__/use-agent-runtime.test.ts
+++ b/lemma-frontend/lib/hooks/__tests__/use-agent-runtime.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
+import { AgentHostStatus } from 'lemma-sdk';
 import type { AgentHostResponse } from 'lemma-sdk';
 
 import { isArriving } from '@/lib/hooks/use-agent-runtime';
 
-const host = (overrides: Partial<AgentHostResponse>): AgentHostResponse =>
-    ({
+const host = (overrides: Partial<AgentHostResponse>): AgentHostResponse => ({
         capacity: {},
         created_at: new Date(Date.now() - 7 * 24 * 3600 * 1000).toISOString(),
         display_name: 'This computer',
@@ -14,30 +14,30 @@ const host = (overrides: Partial<AgentHostResponse>): AgentHostResponse =>
         last_seen_at: null,
         protocol_version: 1,
         revoked_at: null,
-        status: 'OFFLINE',
+        status: AgentHostStatus.OFFLINE,
         updated_at: new Date().toISOString(),
         user_id: 'user-1',
         ...overrides,
-    }) as AgentHostResponse;
+});
 
 const secondsAgo = (seconds: number) => new Date(Date.now() - seconds * 1000).toISOString();
 
 describe('isArriving', () => {
     it('leaves an online machine alone', () => {
-        expect(isArriving(host({ status: 'ONLINE', last_seen_at: secondsAgo(1) }))).toBe(false);
-    });
+        expect(isArriving(host({ status: AgentHostStatus.ONLINE, last_seen_at: secondsAgo(1) }))).toBe(false);
+});
 
     it('watches a machine that checked in moments ago', () => {
         // Coming back from a restart or a network blip: the next poll is likely
         // to show it online, which is what the fast interval is for.
         expect(isArriving(host({ last_seen_at: secondsAgo(5) }))).toBe(true);
-    });
+});
 
     it('watches a pairing that has never checked in yet', () => {
         // Paired seconds ago from the terminal or the onboarding step; it has
         // nothing to report until its first poll lands.
         expect(isArriving(host({ created_at: secondsAgo(5), last_seen_at: null }))).toBe(true);
-    });
+});
 
     it('stops watching a machine that has been quiet for a long time', () => {
         // The regression this exists for. "Not online" was read as "settling",
@@ -46,14 +46,14 @@ describe('isArriving', () => {
         // twice a second for as long as it stayed open, and the per-host
         // harness queries multiplied that by the number of machines.
         expect(isArriving(host({ last_seen_at: secondsAgo(600) }))).toBe(false);
-    });
+});
 
     it('stops watching an old pairing that never checked in at all', () => {
         expect(isArriving(host({ last_seen_at: null }))).toBe(false);
-    });
+});
 
     it('treats an unreadable timestamp as quiet rather than arriving', () => {
         // A malformed date must not become an infinite fast poll.
         expect(isArriving(host({ last_seen_at: 'not a date' }))).toBe(false);
-    });
+});
 });

--- a/lemma-frontend/lib/hooks/__tests__/use-agent-runtime.test.ts
+++ b/lemma-frontend/lib/hooks/__tests__/use-agent-runtime.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentHostResponse } from 'lemma-sdk';
+
+import { isArriving } from '@/lib/hooks/use-agent-runtime';
+
+const host = (overrides: Partial<AgentHostResponse>): AgentHostResponse =>
+    ({
+        capacity: {},
+        created_at: new Date(Date.now() - 7 * 24 * 3600 * 1000).toISOString(),
+        display_name: 'This computer',
+        host_release: '0.7.0',
+        id: 'host-1',
+        installation_id: 'install-1',
+        last_seen_at: null,
+        protocol_version: 1,
+        revoked_at: null,
+        status: 'OFFLINE',
+        updated_at: new Date().toISOString(),
+        user_id: 'user-1',
+        ...overrides,
+    }) as AgentHostResponse;
+
+const secondsAgo = (seconds: number) => new Date(Date.now() - seconds * 1000).toISOString();
+
+describe('isArriving', () => {
+    it('leaves an online machine alone', () => {
+        expect(isArriving(host({ status: 'ONLINE', last_seen_at: secondsAgo(1) }))).toBe(false);
+    });
+
+    it('watches a machine that checked in moments ago', () => {
+        // Coming back from a restart or a network blip: the next poll is likely
+        // to show it online, which is what the fast interval is for.
+        expect(isArriving(host({ last_seen_at: secondsAgo(5) }))).toBe(true);
+    });
+
+    it('watches a pairing that has never checked in yet', () => {
+        // Paired seconds ago from the terminal or the onboarding step; it has
+        // nothing to report until its first poll lands.
+        expect(isArriving(host({ created_at: secondsAgo(5), last_seen_at: null }))).toBe(true);
+    });
+
+    it('stops watching a machine that has been quiet for a long time', () => {
+        // The regression this exists for. "Not online" was read as "settling",
+        // so a computer paired to a workspace it can no longer reach — a local
+        // stack that has since stopped, say — kept the Models page fetching
+        // twice a second for as long as it stayed open, and the per-host
+        // harness queries multiplied that by the number of machines.
+        expect(isArriving(host({ last_seen_at: secondsAgo(600) }))).toBe(false);
+    });
+
+    it('stops watching an old pairing that never checked in at all', () => {
+        expect(isArriving(host({ last_seen_at: null }))).toBe(false);
+    });
+
+    it('treats an unreadable timestamp as quiet rather than arriving', () => {
+        // A malformed date must not become an infinite fast poll.
+        expect(isArriving(host({ last_seen_at: 'not a date' }))).toBe(false);
+    });
+});

--- a/lemma-frontend/lib/hooks/use-agent-runtime.ts
+++ b/lemma-frontend/lib/hooks/use-agent-runtime.ts
@@ -42,6 +42,25 @@ export type AgentHostPairing = AgentHostPairingCreated;
 // while anything is still settling, then back off once every machine is online.
 const SETTLING_REFETCH_MS = 2000;
 const SETTLED_REFETCH_MS = 20000;
+// "Not online" was read as "settling", so a machine that is offline for a
+// reason that will not resolve on its own — a workspace it can no longer reach,
+// a computer that is switched off — kept the whole Models page fetching twice a
+// second for as long as it was open. Settling is a transition, and a transition
+// has a recent check-in behind it: a machine that has just paired has not been
+// seen at all yet, and one that is coming back was seen moments ago. Anything
+// quiet for longer than this is a state, not a transition.
+const ARRIVING_WINDOW_MS = 90_000;
+/** Empty-list polls at the fast interval before harness discovery is given up on. */
+const EMPTY_HARNESS_FAST_POLLS = ARRIVING_WINDOW_MS / SETTLING_REFETCH_MS;
+
+export const isArriving = (host: AgentHost): boolean => {
+    if (host.status === 'ONLINE') return false;
+    // A pairing that has never checked in is dated from its creation, so a
+    // machine still booting is watched closely and one paired last week is not.
+    const since = host.last_seen_at ?? host.created_at;
+    const at = Date.parse(since);
+    return Number.isNaN(at) ? false : Date.now() - at < ARRIVING_WINDOW_MS;
+};
 
 export const useAgentHosts = () => {
     return useQuery({
@@ -52,7 +71,11 @@ export const useAgentHosts = () => {
         refetchInterval: (query) => {
             const items = query.state.data?.items ?? [];
             const live = items.filter((host) => host.status !== 'REVOKED');
-            const settling = live.length === 0 || live.some((host) => host.status !== 'ONLINE');
+            // An empty list has nothing to date, and a machine paired from a
+            // terminal has to be able to appear on its own, so it keeps the
+            // fast interval: the poll is one small request and there are no
+            // per-host requests behind it.
+            const settling = live.length === 0 || live.some(isArriving);
             return settling ? SETTLING_REFETCH_MS : SETTLED_REFETCH_MS;
         },
     });
@@ -66,11 +89,22 @@ export const useAgentHostHarnesses = (hostId?: string | null) => {
         staleTime: 2000,
         refetchOnWindowFocus: true,
         // Discovery probes each installed agent, so the list arrives a little
-        // after the machine itself does. An empty list is "still looking".
-        refetchInterval: (query) =>
-            (query.state.data?.items?.length ?? 0) === 0
+        // after the machine itself does. An empty list is "still looking" —
+        // but only for as long as looking is plausible. An offline computer
+        // publishes nothing ever, and asking it every two seconds forever is
+        // how one unreachable machine became a request a second across the
+        // page's per-host queries.
+        //
+        // Counted in polls rather than elapsed time: `dataUpdatedAt` moves with
+        // every successful poll, so a clock reading here would always be two
+        // seconds old and the fast interval would never end.
+        refetchInterval: (query) => {
+            const items = query.state.data?.items ?? [];
+            if (items.length > 0) return SETTLED_REFETCH_MS;
+            return query.state.dataUpdateCount < EMPTY_HARNESS_FAST_POLLS
                 ? SETTLING_REFETCH_MS
-                : SETTLED_REFETCH_MS,
+                : SETTLED_REFETCH_MS;
+        },
     });
 };
 

--- a/lemma-frontend/vitest.config.ts
+++ b/lemma-frontend/vitest.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
         environment: 'node',
         include: [
             'components/agents/agent-runtime-helpers.{test,spec}.ts',
+            // What the Computers card says about this machine, extracted from the
+            // card for the same reason as the helpers above: the logic is pure,
+            // the component around it is not.
+            'components/agents/this-computer-status.{test,spec}.ts',
             'components/auth/portal/auth/**/*.{test,spec}.ts',
             // Step ordering for local onboarding. Named file by file, like the
             // agent-runtime helpers above, so this stays a list of pure-logic


### PR DESCRIPTION
Three faults met in one screen — a Computers card reading `Unavailable — Command agent_host_status not allowed by ACL` on a self-hosted origin, a tray stuck on `reconnecting…` for two days, and a Models page fetching twice a second behind both.

## The capability drifted

`workspace_capability_for` was written in #247, when `capabilities/workspace.json` granted a single command. #271 added the Agent Host and provider commands **to the file alone**, so the generated override for any other origin still granted only `allow-open-control-center`. Every origin that isn't `lemma.work` or `app.lemma.localhost` — which is precisely what a dev server or a self-hosted install is — lost the whole Computers card and the provider onboarding steps to an ACL rejection.

The function's own doc comment already stated the invariant ("must stay identical to `capabilities/workspace.json`"); nothing enforced it. The override now reads the shipped permission list via `include_str!`, and the test compares against that file instead of restating the list, since the hardcoded copy is what drifted.

## "Reconnecting…" for a workspace that is gone

The tray said `reconnecting…` for every disconnected state, including a host paired to a workspace that no longer exists — what a local pairing becomes as soon as the local stack stops. Observed in the wild: a host retrying `http://app.lemma.localhost:56608` every 15 minutes for two days while the tray promised a reconnection that could never happen.

A paired target whose last attempt failed now reads `workspace unreachable`. The journal writes `last_error` on every attempt and clears it on a connect, so this distinguishes *trying* from *tried and failed* rather than remembering an old failure forever. A connected target still wins, so one dead workspace doesn't mask a live one.

## Polling that never backed off

`refetchInterval` read "not ONLINE" as "still settling". A machine offline for a reason that won't resolve on its own kept the hosts query, every per-host harness query, and the desktop bridge's forked-sidecar read running at 2s and 3s intervals for as long as the page stayed open.

- Arrival is judged from `last_seen_at`, falling back to `created_at` for a pairing that has never checked in — the case the fast interval was added for in the first place.
- The empty-harness fast path is bounded by poll count rather than a clock, because `dataUpdatedAt` moves with every poll and a time comparison there would never expire.
- The bridge doubles its wait after each consecutive failure, capped at 60s, and resets on a success or on the window becoming visible. An unchanged error now costs one call a minute instead of twenty.

## Testing

- `cargo test --locked` in `desktop/` — 60 passed.
- `tsc --noEmit`, `eslint`, and vitest on the touched files; six new cases cover the arrival predicate, including the regression (a machine quiet for ten minutes is no longer "settling") and an unparseable timestamp.

Not addressed here: `desktop/` fails `cargo fmt --check` (14 hunks) and `clippy -D warnings` (3 lints) on **main** under Rust 1.96, all in untouched code. It'll bite when CI's `stable` moves; kept out of this PR so the diff stays readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)