### PR TITLE
Stop adopting another build's daemon, and let a menu item say when it failed

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -889,6 +889,31 @@ fn runtime_info_snapshot() -> RuntimeInfo {
     }
 }
 
+/// Whether the daemon on the socket is the one this build ships.
+///
+/// Version and API revision are not enough: replacing an installed app leaves
+/// the previous bundle's daemon running — from `~/.Trash`, once macOS has moved
+/// it — holding the control socket, reporting the same `0.7.0` and the same
+/// revision, and supervising the *previous* release's runtime. The hosted path
+/// used to accept whatever was listening, so a new app adopted that daemon,
+/// sent it Agent Host commands it answered from stale state, and started a
+/// local stack out of the old host pack that could never come up.
+///
+/// A daemon that does not say which binary it is answers this with `false`,
+/// which is the right answer: every build that does not report it predates the
+/// field, and is therefore not this one.
+fn locald_is_this_build(hello: &Value, expected_executable: Option<&std::path::Path>) -> bool {
+    if hello["daemon_api_revision"].as_u64() != Some(REQUIRED_LOCALD_API_REVISION) {
+        return false;
+    }
+    let Some(expected) = expected_executable else {
+        // No packaged sidecar to compare against — a source checkout running
+        // whatever it built. Identity is the developer's business there.
+        return true;
+    };
+    hello["executable"].as_str() == Some(path_identity(expected).as_str())
+}
+
 fn locald_matches_host_pack(
     hello: &Value,
     required_release: Option<&str>,
@@ -949,12 +974,20 @@ fn ensure_locald(app: &AppHandle) -> Result<(), String> {
 
     let required_root = host_pack_root();
     let required_release = required_root.as_deref().and_then(host_pack_release);
+    let expected_executable = locald_binary();
+    // The host pack says which runtime it serves; the executable says which
+    // build is serving it. A daemon left over from a replaced app bundle can
+    // satisfy the first and still be the wrong process.
+    let acceptable = |hello: &Value| {
+        locald_is_this_build(hello, expected_executable.as_deref())
+            && locald_matches_host_pack(
+                hello,
+                required_release.as_deref(),
+                required_root.as_deref(),
+            )
+    };
     if let Ok(connection) = connect_locald() {
-        if locald_matches_host_pack(
-            &connection.hello,
-            required_release.as_deref(),
-            required_root.as_deref(),
-        ) {
+        if acceptable(&connection.hello) {
             install_locald_connection(app, connection);
             return Ok(());
         }
@@ -965,13 +998,7 @@ fn ensure_locald(app: &AppHandle) -> Result<(), String> {
     let mut last_error = "daemon did not create its control endpoint".to_string();
     for _ in 0..80 {
         match connect_locald() {
-            Ok(connection)
-                if locald_matches_host_pack(
-                    &connection.hello,
-                    required_release.as_deref(),
-                    required_root.as_deref(),
-                ) =>
-            {
+            Ok(connection) if acceptable(&connection.hello) => {
                 install_locald_connection(app, connection);
                 return Ok(());
             }
@@ -986,9 +1013,16 @@ fn ensure_locald(app: &AppHandle) -> Result<(), String> {
 /// Bring up locald for a workspace that has no local stack.
 ///
 /// A hosted workspace still wants the Agent Host on this machine, and locald is
-/// what supervises it. Unlike the local path this downloads nothing and accepts
-/// whatever daemon is already listening: with no host pack there is no release
-/// to match, and locald without one only holds its socket and the sidecar.
+/// what supervises it. Unlike the local path this downloads nothing: with no
+/// host pack there is no release to match, and locald without one only holds
+/// its socket and the sidecar.
+///
+/// It does still insist the daemon be this build's. It used to accept whatever
+/// was listening, and "whatever" turned out to include the previous app
+/// bundle's daemon, still running from the Trash after an update, supervising
+/// the previous release's runtime. Adopting it made the Agent Host controls
+/// report and command stale state, and left a local start booting a runtime the
+/// installed app had already replaced.
 fn ensure_locald_without_host_pack(app: &AppHandle) -> Result<(), String> {
     let shell: State<Shell> = app.state();
     if shell.locald_writer.lock().unwrap().is_some() {
@@ -999,19 +1033,24 @@ fn ensure_locald_without_host_pack(app: &AppHandle) -> Result<(), String> {
         return Ok(());
     }
 
+    let expected = locald_binary();
     if let Ok(connection) = connect_locald() {
-        install_locald_connection(app, connection);
-        return Ok(());
+        if locald_is_this_build(&connection.hello, expected.as_deref()) {
+            install_locald_connection(app, connection);
+            return Ok(());
+        }
+        replace_locald(connection)?;
     }
 
     spawn_locald()?;
     let mut last_error = "daemon did not create its control endpoint".to_string();
     for _ in 0..80 {
         match connect_locald() {
-            Ok(connection) => {
+            Ok(connection) if locald_is_this_build(&connection.hello, expected.as_deref()) => {
                 install_locald_connection(app, connection);
                 return Ok(());
             }
+            Ok(_) => last_error = "another build's daemon holds the control socket".into(),
             Err(error) => last_error = error,
         }
         std::thread::sleep(Duration::from_millis(100));
@@ -1284,22 +1323,32 @@ fn emit_runtime_install_error(app: &AppHandle, message: &str) {
     show_splash(app);
 }
 
-fn spawn_locald() -> Result<(), String> {
-    let root = runtime_root();
-    let have_checkout = root.join("locald/Cargo.toml").exists();
-    let locald_bin = std::env::var("LEMMA_DESKTOP_LOCALD_BIN")
+/// The daemon binary this build starts.
+///
+/// Shared with the identity check rather than duplicated: comparing a running
+/// daemon against a *different* resolution than the one that spawns it is how a
+/// dev run — where `LEMMA_DESKTOP_LOCALD_BIN` overrides the sidecar — would
+/// reject the very daemon it had just started, forever.
+fn locald_binary() -> Option<PathBuf> {
+    std::env::var("LEMMA_DESKTOP_LOCALD_BIN")
         .ok()
         .map(PathBuf::from)
         .filter(|p| p.exists())
         .or_else(bundled_locald)
         .or_else(|| {
-            let candidate = root.join(if cfg!(windows) {
+            let candidate = runtime_root().join(if cfg!(windows) {
                 "locald/target/debug/lemma-locald.exe"
             } else {
                 "locald/target/debug/lemma-locald"
             });
             candidate.exists().then_some(candidate)
-        });
+        })
+}
+
+fn spawn_locald() -> Result<(), String> {
+    let root = runtime_root();
+    let have_checkout = root.join("locald/Cargo.toml").exists();
+    let locald_bin = locald_binary();
 
     let mut command = match &locald_bin {
         Some(bin) => Command::new(bin),
@@ -3534,6 +3583,104 @@ fn desktop_vibrancy_enabled() -> bool {
 /// Off by default: action colour is the brand violet, and letting the OS accent
 /// overwrite it would hand the product's one loud colour to a system preference.
 /// The reader stays wired up because "tint the app to my Mac" is a plausible
+/// What switching connection will do, in the terms the person is about to live
+/// with.
+///
+/// The switch used to happen on the press. Choosing Local starts the private
+/// runtime — a VM boot, an image pull on a cold machine, and a ninety-second
+/// health gate before it will say whether it worked — and choosing Hosted takes
+/// the workspace away from the stack still running on this Mac. Neither is a
+/// thing to do because a menu item was next to the one you meant.
+fn connection_switch_prompt(current: &str, running: bool) -> (String, String, String) {
+    if current == "local" {
+        (
+            "Use the hosted workspace?".into(),
+            if running {
+                "Lemma keeps running on this Mac and your local pods stay where they are — this window just stops pointing at them. Use this menu item again to come back."
+            } else {
+                "This window will point at the hosted workspace instead of this Mac. Your local pods stay where they are. Use this menu item again to come back."
+            }
+            .into(),
+            "Use Hosted".into(),
+        )
+    } else {
+        (
+            "Run Lemma on this Mac?".into(),
+            "Starting the local stack boots a private Linux runtime and waits for its database, cache, and auth service. On a cold machine that takes a few minutes, and the window will show the splash until it is ready."
+                .into(),
+            "Start Local".into(),
+        )
+    }
+}
+
+/// Ask before switching, then switch and say so if it fails.
+fn confirm_then_switch_connection(app: AppHandle) {
+    let current = current_mode(&app);
+    if current == "undecided" {
+        show_splash(&app);
+        return;
+    }
+    let running = {
+        let shell: State<Shell> = app.state();
+        let ui = shell.ui.lock().unwrap();
+        ui.running
+    };
+    let (title, body, confirm) = connection_switch_prompt(&current, running);
+    let handle = app.clone();
+    app.dialog()
+        .message(body)
+        .title(title)
+        .kind(MessageDialogKind::Warning)
+        .buttons(MessageDialogButtons::OkCancelCustom(
+            confirm,
+            "Cancel".into(),
+        ))
+        .show(move |confirmed| {
+            if !confirmed {
+                return;
+            }
+            let inner = handle.clone();
+            menu_attempt(&inner, "Switch connection", || {
+                choose_connection_mode(handle).map(|_| ())
+            });
+        });
+}
+
+/// Whether the Agent Host is running, as the tray last understood it.
+fn agent_host_is_running(app: &AppHandle) -> bool {
+    let shell: State<Shell> = app.state();
+    let ui = shell.ui.lock().unwrap();
+    ui.agent_host_running
+}
+
+/// Say so when a menu action fails.
+///
+/// Every arm of `handle_menu_action` used to discard its `Result`, so a menu
+/// item could not report a failure even in principle: a local start that spent
+/// ninety seconds failing to reach the private runtime, or an Agent Host
+/// command that never left the shell, both looked exactly like a dead button.
+/// The daemon wrote the reason to its log and the person pressing the item was
+/// told nothing.
+fn report_action_failure(app: &AppHandle, action: &str, error: &str) {
+    append_bounded_log(
+        &launch_log_path(),
+        &format!("menu {action} failed: {error}"),
+    );
+    app.dialog()
+        .message(error)
+        .title(action)
+        .kind(MessageDialogKind::Warning)
+        .buttons(MessageDialogButtons::Ok)
+        .show(|_| {});
+}
+
+/// Run a menu action, and surface whatever it has to say about failing.
+fn menu_attempt(app: &AppHandle, action: &str, work: impl FnOnce() -> Result<(), String>) {
+    if let Err(error) = work() {
+        report_action_failure(app, action, &error);
+    }
+}
+
 /// setting to offer later — it just is not the default identity.
 fn desktop_system_accent_enabled() -> bool {
     std::env::var("LEMMA_DESKTOP_SYSTEM_ACCENT").as_deref() == Ok("1")
@@ -3636,7 +3783,8 @@ fn handle_menu_action(app: &AppHandle, id: &str) {
     let app = app.clone();
     match id {
         "open" | "home" => {
-            let _ = open_app(app);
+            let handle = app.clone();
+            menu_attempt(&handle, "Open Lemma", || open_app(app).map(|_| ()));
         }
         "login" => {
             tauri::async_runtime::spawn(async move {
@@ -3659,19 +3807,27 @@ fn handle_menu_action(app: &AppHandle, id: &str) {
             }
         }
         "start" => {
-            let _ = start_impl(app);
+            let handle = app.clone();
+            menu_attempt(&handle, "Start Lemma", || start_impl(app).map(|_| ()));
         }
         "stop" => {
-            let _ = stop_impl(app, Some(false));
+            let handle = app.clone();
+            menu_attempt(&handle, "Stop Lemma", || {
+                stop_impl(app, Some(false)).map(|_| ())
+            });
         }
         "stop-all" => {
-            let _ = stop_impl(app, Some(true));
+            let handle = app.clone();
+            menu_attempt(&handle, "Stop Lemma completely", || {
+                stop_impl(app, Some(true)).map(|_| ())
+            });
         }
         "restart" => {
-            let _ = restart_impl(app);
+            let handle = app.clone();
+            menu_attempt(&handle, "Restart Lemma", || restart_impl(app).map(|_| ()));
         }
         "mode" => {
-            let _ = choose_connection_mode(app);
+            confirm_then_switch_connection(app);
         }
         "autostart" => {
             let autolaunch = app.autolaunch();
@@ -3682,7 +3838,7 @@ fn handle_menu_action(app: &AppHandle, id: &str) {
             }
         }
         "control" => {
-            let _ = show_control_center(&app);
+            menu_attempt(&app, "Local settings", || show_control_center(&app));
         }
         "control-ai" => {
             let _ = show_control_center_page(&app, Some("ai"));
@@ -3694,7 +3850,12 @@ fn handle_menu_action(app: &AppHandle, id: &str) {
             let _ = show_control_center_page(&app, Some("diagnostics"));
         }
         "agent-host-toggle" => {
-            let _ = toggle_agent_host_from_tray(&app);
+            let action = if agent_host_is_running(&app) {
+                "Turn Agent Host off"
+            } else {
+                "Turn Agent Host on"
+            };
+            menu_attempt(&app, action, || toggle_agent_host_from_tray(&app));
         }
         "agent-host-log" => {
             let _ = reveal_path(&agent_host_log_path());
@@ -4700,6 +4861,62 @@ mod tests {
             .skip(1)
             .filter_map(|rest| rest.split('"').next().map(str::to_string))
             .collect()
+    }
+
+    #[test]
+    fn a_daemon_from_a_replaced_app_bundle_is_not_this_build() {
+        let expected = std::path::Path::new("/Applications/Lemma.app/Contents/MacOS/lemma-locald");
+        let this_build = json!({
+            "daemon_api_revision": REQUIRED_LOCALD_API_REVISION,
+            "executable": path_identity(expected),
+        });
+        assert!(locald_is_this_build(&this_build, Some(expected)));
+
+        // The failure this exists for. Updating the app moves the previous
+        // bundle to the Trash; its daemon keeps running and keeps the socket,
+        // reporting the same version and the same revision as the one that
+        // replaced it.
+        let from_the_trash = json!({
+            "daemon_api_revision": REQUIRED_LOCALD_API_REVISION,
+            "daemon_version": env!("CARGO_PKG_VERSION"),
+            "executable": "/Users/someone/.Trash/Lemma 4.23.56 PM.app/Contents/MacOS/lemma-locald",
+        });
+        assert!(
+            !locald_is_this_build(&from_the_trash, Some(expected)),
+            "a daemon running from another bundle must be replaced, not adopted",
+        );
+
+        // Every build older than the field predates the check, so silence is a
+        // mismatch rather than a pass.
+        let before_the_field = json!({ "daemon_api_revision": REQUIRED_LOCALD_API_REVISION });
+        assert!(!locald_is_this_build(&before_the_field, Some(expected)));
+
+        let wrong_revision = json!({
+            "daemon_api_revision": REQUIRED_LOCALD_API_REVISION + 1,
+            "executable": path_identity(expected),
+        });
+        assert!(!locald_is_this_build(&wrong_revision, Some(expected)));
+
+        // A source checkout has no packaged sidecar to be, and its daemon is
+        // whatever the developer just built.
+        assert!(locald_is_this_build(&before_the_field, None));
+    }
+
+    #[test]
+    fn switching_connection_says_what_it_is_about_to_do() {
+        let (title, body, confirm) = connection_switch_prompt("hosted", false);
+        assert_eq!(title, "Run Lemma on this Mac?");
+        assert_eq!(confirm, "Start Local");
+        // The ninety-second health gate is the whole reason this prompt exists:
+        // the press used to be followed by silence for minutes.
+        assert!(body.contains("takes a few minutes"), "{body}");
+
+        let (title, body, confirm) = connection_switch_prompt("local", true);
+        assert_eq!(title, "Use the hosted workspace?");
+        assert_eq!(confirm, "Use Hosted");
+        assert!(body.contains("keeps running on this Mac"), "{body}");
+        // Leaving must never read as destroying: the pods stay.
+        assert!(body.contains("stay where they are"), "{body}");
     }
 
     #[test]

--- a/locald/src/daemon.rs
+++ b/locald/src/daemon.rs
@@ -407,6 +407,16 @@ impl Daemon {
                 "daemon_version": DAEMON_VERSION,
                 "daemon_api_revision": DAEMON_API_REVISION,
                 "pid": std::process::id(),
+                // Which binary is actually serving this socket, resolved through
+                // the filesystem rather than argv. A replaced app bundle keeps
+                // running from wherever its executable went — ~/.Trash, in the
+                // case this was written for — and the shell has no other way to
+                // tell that the daemon answering it is not the one it ships.
+                // Same version, same API revision, different build.
+                "executable": std::env::current_exe()
+                    .and_then(|path| std::fs::canonicalize(&path).or(Ok(path)))
+                    .ok()
+                    .map(|path| path.to_string_lossy().into_owned()),
                 "compatibility_supervisor": self.managed_runtime.is_none(),
                 "mode": if self.managed_runtime.is_some() {
                     "managed-local"


### PR DESCRIPTION
Found while diagnosing "none of the buttons do anything" on a freshly installed build. All three symptoms trace to one daemon.

## The daemon was the previous app bundle's, running from the Trash

```
lemma-locald 20735 → /Users/…/.Trash/Lemma 4.23.56 PM.app/Contents/MacOS/lemma-locald
```

Started two days before the app that adopted it. Replacing `Lemma.app` moves the old bundle to the Trash; its daemon keeps executing from there and keeps `control.sock`, reporting the same `0.7.0` and the same `daemon_api_revision` as the build that replaced it, while supervising the *previous* release's host pack.

`ensure_locald_without_host_pack` accepted it, by design and in writing — "with no host pack there is no release to match". The consequences, from that machine's own logs:

- Agent Host controls read and commanded stale state; today's `events.jsonl` has only `agent-host.status`, no start/stop, while the tray offered "Turn Agent Host Off" for a host the daemon reported as `running=false`.
- Switching to Local booted the old host pack's runtime and failed after 90 seconds: `private runtime services did not become reachable within 90 seconds: PostgreSQL (192.168.64.21:5432), Redis, SuperTokens; last error: No route to host (os error 65)`.
- The runtime on disk stayed at the old build's digest, because nothing in the hosted path asks for the installed app's own.

locald now reports `executable` in its hello — `current_exe`, canonicalized, so it names where the binary actually is rather than where it was launched from. Both ensure paths require it to match this build's before adopting a daemon, and `replace_locald` otherwise. A daemon that doesn't report the field predates it and is therefore not this build. The check uses `locald_binary()`, the same resolution `spawn_locald` uses, so a dev run overriding `LEMMA_DESKTOP_LOCALD_BIN` can't reject the daemon it just started.

## A menu item could not report a failure

Every arm of `handle_menu_action` discarded its `Result` — `let _ = choose_connection_mode(app)`, `let _ = toggle_agent_host_from_tray(&app)`, and so on. A 90-second infrastructure failure and a command that never left the shell were indistinguishable from a dead button. Failures now name the action in a dialog and go to the launch log.

## Switching connection asks first

Choosing Local boots a VM and waits on its database, cache and auth service — minutes on a cold machine. Choosing Hosted takes the window away from a stack still running here. The prompt states which is about to happen, and says the local pods stay where they are, so leaving doesn't read as destroying.

## Testing

- `cargo test --manifest-path desktop/Cargo.toml --locked` — 62 passed, including new cases for the Trash-bundle daemon, a daemon predating the field, a wrong API revision, the source-checkout exemption, and both switch prompts.
- `cargo test --manifest-path locald/Cargo.toml --locked` — 88 passed.
- `cargo fmt --check` and `clippy -D warnings` add nothing beyond main's existing 14 diffs / 3 lints under Rust 1.96 (locald is clean on both).

Not fixed here: the tray label itself is refreshed only by incoming status events, so it can still be stale relative to the daemon between polls. Worth a follow-up now that a wrong press at least says something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)