### PR TITLE
Let an org point Lemma at its own database, API or MCP server, and manage those connections after

### DIFF
--- a/docs/design/bring-your-own-connectors.md
+++ b/docs/design/bring-your-own-connectors.md
@@ -1,0 +1,183 @@
+# Bring-your-own connectors: SQL, OpenAPI and MCP in the frontend
+
+**Status:** Implemented · **Surface area:** `lemma-frontend` (the bulk), plus the
+backend catalog importer
+
+## The change in one sentence
+
+An org admin can point Lemma at *their own* database, REST API or MCP server —
+supplying the address, not picking a logo — and manage those connections
+afterwards, which today is impossible from any screen in the product.
+
+## Why this is a gap and not a feature request
+
+The backend shipped all three kinds. [`ConnectorKind`](../../lemma-backend/app/modules/connectors/domain/connector.py)
+has `SQL`, `HTTP` and `MCP` alongside `COMPOSIO` and `PACKAGE`; the
+[kind registry](../../lemma-backend/app/modules/connectors/infrastructure/kinds/registry.py)
+wires each to an executor, an installer that vets the tenant-supplied network
+target, and — for MCP and OpenAPI — a discoverer that turns a live server into an
+operation set. [`lemma_apps_config.json`](../../lemma-backend/scripts/lemma_apps_config.json)
+carries three catalog rows for them, and the TypeScript SDK already exposes
+every endpoint they need, including `update`, `delete` and `refreshOperations`
+([connectors.ts:149](../../lemma-typescript/src/namespaces/connectors.ts)).
+
+What is missing is the one thing these kinds need that no other kind does: **a
+place to type the address.** Composio and package connectors are fully described
+by the catalog — Slack is Slack. A SQL connector is nothing until someone says
+which host, and the frontend never asks.
+
+### What actually happens today
+
+The catalog rows do render — `sql`, `mcp` and `openapi` appear in *Browse apps*,
+in the ungrouped "More apps" tail, with a generated monogram instead of a logo.
+Clicking **Connect** on "SQL Database" runs this path in
+[connectors-view.tsx:180](../../lemma-frontend/components/connectors/connectors-view.tsx):
+
+1. `usesDirectCredentials()` is true (`auth_scheme: API_KEY`), so no OAuth.
+2. `hasSystemDefault()` is *also* true — the importer sets
+   `system_default_available = auth_method != OAUTH2`, which is a statement about
+   OAuth clients that reads as "this connector is ready to go".
+3. So the credential dialog opens immediately, asking for a database **username
+   and password**.
+4. On submit, [connectors-view.tsx:290](../../lemma-frontend/components/connectors/connectors-view.tsx)
+   creates the install with `config_source: SYSTEM_DEFAULT` **and no `config`**.
+5. The backend validates that empty config against the install schema, which
+   requires `dialect`, `host` and `database`, and returns
+   `Invalid install config`.
+6. The user sees `Failed to save credentials`.
+
+You are asked for the password to a database you were never allowed to name. The
+**Advanced** escape hatch is not offered either: `hasAdvancedOptions()` is false,
+because `supportsCustomConfig()` in
+[connector-utils.ts:93](../../lemma-frontend/components/connectors/connector-utils.ts)
+gates custom config on `supports_org_custom_oauth` — a flag the importer sets
+only for OAuth2 connectors. The frontend's whole notion of "custom
+configuration" is welded to "the org brought its own OAuth app", and for these
+three kinds the config *is* the connection.
+
+MCP and OpenAPI fail identically, with a shorter form: an optional bearer token,
+then the same failure for a missing `server_url`.
+
+### A backend one-liner blocks it too
+
+Even if the dialog collected a host, the install would be the wrong kind.
+`_native_kind_spec()` selects the spec class — and with it the executor,
+installer and discoverer — from a `kind` argument
+([import_connector_catalog.py:613](../../lemma-backend/scripts/import_connector_catalog.py)),
+but the native-catalog sync at line 1143 never passes it:
+
+```python
+_native_kind_spec(
+    auth_method=auth_method,
+    oauth2_defaults=app_config.get("oauth2_config"),
+    auth_config_schema=app_config.get("auth_config_schema"),
+    credential_schema=app_config.get("credential_schema"),
+    system_oauth=app_config.get("system_oauth"),
+    profile_operation_names=...,
+)   # no kind= — falls through to PackageKindSpec
+```
+
+`"kind": "sql"` in the catalog JSON is dead data. Nothing in the repo reads it.
+The three rows are imported as `package`, so an install would dispatch to the
+vendored-client gateway rather than to `SqlExecutor` / `McpExecutor` /
+`OpenApiHttpExecutor`, and MCP/OpenAPI discovery would never run. This is one
+keyword argument, but nothing downstream works without it.
+
+## The model the UI has to catch up with
+
+Three facts about these kinds that the current screens contradict:
+
+| Backend fact | Where it lives | What the frontend assumes |
+| --- | --- | --- |
+| An org holds **many installs of one connector** — several MCP servers, two databases | [connector_service.py:530](../../lemma-backend/app/modules/connectors/services/connector_service.py) | `enabledConfigByAppId` is a `Map` keyed by `connector_id` — last install wins ([connectors-view.tsx:119](../../lemma-frontend/components/connectors/connectors-view.tsx)) |
+| Installs are **named and editable**; rotating a URL keeps the accounts attached | `connector.auth_config.update` | No hook, no screen. The only lifecycle verb in the UI is "Disconnect account" |
+| MCP/OpenAPI installs **discover** their operations, and discovery can fail silently | `connector.auth_config.refresh_operations` | `useConnectorOperations` exists in [use-connectors.ts:224](../../lemma-frontend/lib/hooks/use-connectors.ts) and has **no callers** |
+
+The comment at [use-connectors.ts:75](../../lemma-frontend/lib/hooks/use-connectors.ts)
+— "An org holds at most one auth config per app" — is now false, and the trigger
+hooks that rely on it resolve to an arbitrary install.
+
+## Proposed shape
+
+**One dialog, two sections, one submit.** The split between "enable the
+connector" and "connect an account" is a backend distinction (install vs.
+credentials) that these kinds have no reason to expose: for a database you type
+the host and the password in one sitting. The dialog collects
+`auth_config_schema` fields and `credential_schema` fields together, then calls
+`enableApp` followed by `accounts.create`. An account is always required —
+execution resolves one even for a no-auth MCP server — so a connector with an
+empty credential schema simply renders no second section and creates the account
+with `{}`.
+
+```
+Add MCP server                                    Add SQL database
+─────────────────────────────                     ─────────────────────────────
+Name       Sentry tools                           Name       Analytics replica
+Server URL https://mcp.example.com/               Host       db.internal:5432
+Bearer     ••••••••                               Database   analytics
+                                                  User       readonly
+                              [Cancel] [Add]      Password   ••••••••
+                                                                [Cancel] [Add]
+Then: "Found 14 tools."                           Then: "3 operations available."
+```
+
+The name field is the load-bearing new control. With many installs per connector,
+the name is the only thing telling "Analytics replica" from "Billing replica" —
+in this dialog, in the accounts list, and in the agent access picker, where three
+SQL accounts currently render as three rows all reading "SQL Database".
+
+**Where it lives.** These are not apps you browse for; you arrive knowing you
+have a database. They belong above the catalog as their own affordance —
+`Add your own · [Database] [API] [MCP server]` — not as three cards in the "More
+apps" tail. The catalog rows stay in the grid (they are legitimately catalog
+entries) but stop being the entry point.
+
+**Post-add feedback is the payoff.** MCP and OpenAPI discovery runs
+server-side after the install commits and swallows its failures by design — a
+failed discovery leaves a usable, empty install. So the dialog must report what
+came back ("Found 14 tools" / "Connected, but no tools were found — retry
+discovery"), and the install row needs a **Refresh operations** action. Without
+it, the recovery path the backend deliberately built is unreachable.
+
+**Installs need a list.** A section under "Your accounts" showing each install by
+name, its kind, its target (`https://mcp.example.com/`, `db.internal/analytics`),
+its operation count, and actions: *Edit*, *Refresh operations*, *Delete*. Edit
+maps to `authConfigs.update`, which is the whole reason that endpoint exists —
+deleting and recreating an install cascades away every account on it.
+
+## Work breakdown
+
+| # | Change | Files | Size |
+| --- | --- | --- | --- |
+| 1 | Pass `kind=app_config.get("kind")` in the native sync; assert the three rows import as `sql`/`mcp`/`http` | [import_connector_catalog.py:1143](../../lemma-backend/scripts/import_connector_catalog.py), new unit test | XS |
+| 2 | Re-run the catalog import against existing environments (the rows already exist as `package`) | ops | XS |
+| 3 | Teach `supportsCustomConfig` that a non-OAuth kind with config fields always supports custom config; stop `hasSystemDefault` from reading as "ready to connect" for tenant-configured kinds | [connector-utils.ts](../../lemma-frontend/components/connectors/connector-utils.ts) | S |
+| 4 | Hooks: `useUpdateAuthConfig`, `useDeleteAuthConfig`, `useRefreshAuthConfigOperations`; fix the stale single-install assumption in `useTriggers` / `useTrigger` | [use-connectors.ts](../../lemma-frontend/lib/hooks/use-connectors.ts) | S |
+| 5 | `AddConnectionDialog` — config + credential sections, name field, one submit, discovery result surfaced | new `components/connectors/add-connection-dialog.tsx` | M |
+| 6 | "Add your own" entry point above the catalog, three kinds | [connectors-view.tsx](../../lemma-frontend/components/connectors/connectors-view.tsx), [connector-grid.tsx](../../lemma-frontend/components/connectors/connector-grid.tsx) | S |
+| 7 | Installs list with edit / refresh / delete; account rows labelled by install name | [connectors-view.tsx](../../lemma-frontend/components/connectors/connectors-view.tsx), [connector-card.tsx](../../lemma-frontend/components/connectors/connector-card.tsx) | M |
+| 8 | Multi-install correctness: replace `enabledConfigByAppId` with a list; "Add another" opens a *new* install for these kinds rather than reusing the existing one | [connectors-view.tsx:119](../../lemma-frontend/components/connectors/connectors-view.tsx) | M |
+| 9 | Header maps (`extra_headers`, `default_headers`) currently render as a raw JSON textarea — `buildSchemaFormFields` maps `type: object` to `kind: "json"`. A key/value row editor, or at minimum a placeholder showing the expected shape | [schema-fields.tsx](../../lemma-frontend/components/connectors/schema-fields.tsx) | S |
+
+Items 1–5 are the minimum for "a user can add an MCP server and use it". 6–9 are
+what stop it from being a one-shot action you can never revisit.
+
+## Decisions to confirm
+
+- **`config_source` for these kinds.** `ORG_CUSTOM` is the honest label — the org
+  supplied the connection — but nothing branches on it for non-OAuth kinds
+  ([_install_validation.py:82](../../lemma-backend/app/modules/connectors/infrastructure/kinds/_install_validation.py)),
+  so `SYSTEM_DEFAULT` (what the code sends today) is equally functional. Cosmetic,
+  but it lands in a persisted, immutable column.
+- **Agent access granularity.** Grants are by `app_name` with an optional
+  `account_id` ([value_objects.py:125](../../lemma-backend/app/modules/agent/domain/value_objects.py)).
+  Pinning an account does select a specific install, so the model works — but a
+  `DYNAMIC` grant on `sql` silently resolves to whichever install is default.
+  Worth deciding whether the access dialog should force an account choice for
+  multi-install connectors.
+- **SSRF surface.** `assert_safe_url` / `assert_safe_host` already reject
+  metadata endpoints and internal hosts at install time
+  ([network_kinds.py:32](../../lemma-backend/app/modules/connectors/infrastructure/kinds/network_kinds.py)),
+  and the error carries a `reason`. The dialog should surface that reason
+  verbatim rather than a generic failure — "we won't connect to a private
+  address" is the useful message.

--- a/lemma-backend/app/modules/connectors/tests/unit/test_import_connector_catalog.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_import_connector_catalog.py
@@ -12,10 +12,17 @@ os.environ.setdefault("COMPOSIO_CACHE_DIR", "/tmp/composio")
 
 from app.modules.connectors.domain.connector import (
     ConnectorEntity,
+    ConnectorKind,
     AuthMethod,
     AuthProvider,
     ComposioProviderCapability,
+    DiscoveryMode,
     LemmaProviderCapability,
+    McpKindSpec,
+    SqlKindSpec,
+)
+from app.modules.connectors.domain.connector_operation import (
+    ConnectorOperationEntity,
 )
 
 _MODULE_PATH = Path(__file__).resolve().parents[5] / "scripts" / "import_connector_catalog.py"
@@ -1188,6 +1195,192 @@ async def test_upsert_trigger_tags_kind():
     assert entity.provider == AuthProvider.COMPOSIO
     assert entity.id == "gmail:composio:new_message"
     assert entity.event_type == "new_message"
+
+
+# --- tenant-configured kinds (sql / mcp / http) -------------------------------
+
+
+class _FakeOperationRepo:
+    """Enough of the operation repository to observe kind tagging."""
+
+    def __init__(self, existing: list[ConnectorOperationEntity] | None = None):
+        self.rows = list(existing or [])
+        self.created: list[ConnectorOperationEntity] = []
+        self.updated: list[ConnectorOperationEntity] = []
+
+    async def get_by_connector_kind_and_name(self, connector_id, kind, name):
+        for row in self.rows:
+            if (
+                row.connector_id == connector_id
+                and row.kind.value == kind
+                and row.name == name
+            ):
+                return row
+        return None
+
+    async def create(self, entity):
+        self.created.append(entity)
+        return entity
+
+    async def update(self, entity):
+        self.updated.append(entity)
+        return entity
+
+
+def _sql_app_config() -> dict:
+    return {
+        "name": "sql",
+        "title": "SQL Database",
+        "description": "Connect to an external SQL database.",
+        "auth_method": "API_KEY",
+        "kind": "sql",
+        "auth_config_schema": {
+            "type": "object",
+            "required": ["dialect", "host", "database"],
+            "properties": {
+                "dialect": {"type": "string"},
+                "host": {"type": "string"},
+                "database": {"type": "string"},
+            },
+            "additionalProperties": False,
+        },
+        "credential_schema": {
+            "type": "object",
+            "required": ["username", "password"],
+            "properties": {
+                "username": {"type": "string"},
+                "password": {"type": "string", "format": "password"},
+            },
+        },
+        "is_active": True,
+        "triggers": [],
+        "static_operations": [
+            {
+                "name": "execute_query",
+                "description": "Run a read-only SELECT.",
+                "execution": {"kind": "sql", "op": "query"},
+                "input_schema": {"type": "object"},
+                "output_schema": {"type": "object"},
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_sync_native_catalog_installs_sql_entry_as_the_sql_kind():
+    """The catalog's own `kind` decides the executor; dropping it broke both."""
+    connector_repository = SimpleNamespace(get=AsyncMock(return_value=None))
+    operation_repository = _FakeOperationRepo()
+    trigger_repository = SimpleNamespace()
+
+    with (
+        patch.object(
+            importer, "_load_lemma_apps_config", return_value=[_sql_app_config()]
+        ),
+        patch.object(importer, "_upsert_connector", AsyncMock()) as upsert_connector,
+    ):
+        totals = await importer._sync_native_catalog(
+            connector_repository,
+            operation_repository,
+            trigger_repository,
+            app_filters={"sql"},
+            schema_compiler=importer.PydanticCodeSchemaCompiler(),
+        )
+
+    assert totals == (1, 1, 0)
+    entity = upsert_connector.await_args.args[1]
+    capability = _capability(entity, AuthProvider.LEMMA)
+    assert isinstance(capability, SqlKindSpec)
+    assert capability.kind is ConnectorKind.SQL
+    assert capability.auth_scheme == AuthMethod.API_KEY
+
+    # The operation has to carry the same kind: execution resolves it by
+    # (connector, install kind, name), so a package-tagged row is invisible to
+    # a sql install.
+    assert len(operation_repository.created) == 1
+    operation = operation_repository.created[0]
+    assert operation.kind is ConnectorKind.SQL
+    assert operation.id == "sql:sql:execute_query"
+
+
+@pytest.mark.asyncio
+async def test_sync_native_catalog_marks_mcp_entry_for_tool_discovery():
+    connector_repository = SimpleNamespace(get=AsyncMock(return_value=None))
+    operation_repository = _FakeOperationRepo()
+    trigger_repository = SimpleNamespace()
+
+    with (
+        patch.object(
+            importer,
+            "_load_lemma_apps_config",
+            return_value=[
+                {
+                    "name": "mcp",
+                    "title": "MCP Server",
+                    "auth_method": "API_KEY",
+                    "kind": "mcp",
+                    "description": "Connect an MCP server.",
+                    "auth_config_schema": {
+                        "type": "object",
+                        "required": ["server_url"],
+                        "properties": {"server_url": {"type": "string"}},
+                    },
+                    "is_active": True,
+                    "triggers": [],
+                }
+            ],
+        ),
+        patch.object(importer, "_upsert_connector", AsyncMock()) as upsert_connector,
+    ):
+        await importer._sync_native_catalog(
+            connector_repository,
+            operation_repository,
+            trigger_repository,
+            app_filters={"mcp"},
+            schema_compiler=importer.PydanticCodeSchemaCompiler(),
+        )
+
+    capability = _capability(upsert_connector.await_args.args[1], AuthProvider.LEMMA)
+    assert isinstance(capability, McpKindSpec)
+    assert capability.discovery is DiscoveryMode.MCP
+
+
+@pytest.mark.asyncio
+async def test_upsert_operation_retags_a_legacy_package_row_in_place():
+    """Re-running the import must migrate, not duplicate.
+
+    The unique index is (connector, kind, name), so a fresh insert under the
+    new kind would leave the package-tagged row behind and the catalog would
+    list the operation twice.
+    """
+    legacy = ConnectorOperationEntity(
+        id="sql:package:execute_query",
+        connector_id="sql",
+        kind=ConnectorKind.PACKAGE,
+        name="execute_query",
+        provider_operation_name="execute_query",
+    )
+    repo = _FakeOperationRepo([legacy])
+
+    await importer._upsert_operation(
+        repo,
+        "sql",
+        provider=AuthProvider.LEMMA,
+        public_name="execute_query",
+        provider_operation_name="execute_query",
+        display_name="Execute query",
+        description="Run a read-only SELECT.",
+        input_schema=None,
+        output_schema=None,
+        search_document=None,
+        execution={"kind": "sql", "op": "query"},
+        kind="sql",
+    )
+
+    assert repo.created == []
+    assert len(repo.updated) == 1
+    assert repo.updated[0].id == "sql:package:execute_query"
+    assert repo.updated[0].kind is ConnectorKind.SQL
 
 
 # --- connector id rename migration -------------------------------------------

--- a/lemma-backend/scripts/import_connector_catalog.py
+++ b/lemma-backend/scripts/import_connector_catalog.py
@@ -677,9 +677,14 @@ def _composio_provider_capability(
     )
 
 
-def _operation_id(connector_id: str, provider: AuthProvider, operation_name: str) -> str:
-    kind = provider_to_kind(provider).value
-    return f"{connector_id}:{kind}:{operation_name}"
+def _operation_id(
+    connector_id: str,
+    provider: AuthProvider,
+    operation_name: str,
+    kind: str | None = None,
+) -> str:
+    resolved = kind or provider_to_kind(provider).value
+    return f"{connector_id}:{resolved}:{operation_name}"
 
 
 def _trigger_id(
@@ -895,19 +900,34 @@ async def _upsert_operation(
     search_document: str | None,
     normalize_name: bool = True,
     execution: dict | None = None,
+    kind: str | None = None,
 ) -> None:
     operation_name = (
         _normalize_operation_name(public_name) if normalize_name else public_name.strip()
     )
+    resolved_kind = kind or provider_to_kind(provider).value
     existing = await operation_repository.get_by_connector_kind_and_name(
         connector_id,
-        provider_to_kind(provider).value,
+        resolved_kind,
         operation_name,
     )
+    if existing is None and resolved_kind != provider_to_kind(provider).value:
+        # This connector's operations were seeded before its kind was carried
+        # through, so they sit under `package`. Retag that row in place rather
+        # than writing a second one: the unique index is (connector, kind,
+        # name), so both would survive and the catalog would list each
+        # operation twice.
+        existing = await operation_repository.get_by_connector_kind_and_name(
+            connector_id,
+            provider_to_kind(provider).value,
+            operation_name,
+        )
     entity = ConnectorOperationEntity(
-        id=existing.id if existing else _operation_id(connector_id, provider, operation_name),
+        id=existing.id
+        if existing
+        else _operation_id(connector_id, provider, operation_name, resolved_kind),
         connector_id=connector_id,
-        provider=provider,
+        kind=resolved_kind,
         name=operation_name,
         provider_operation_name=provider_operation_name,
         display_name=display_name,
@@ -927,13 +947,16 @@ async def _sync_static_operations(
     operation_repository: ConnectorOperationRepository,
     connector_id: str,
     static_operations: list[dict],
+    *,
+    kind: str | None = None,
 ) -> int:
     """Seed operations declared inline in the catalog config.
 
     The SQL connector's query/list_tables/describe_table are the case: its
     operation set is fixed and known at import time, so there is nothing to
     discover per install. Each carries the execution descriptor its kind's
-    executor reads.
+    executor reads, and is tagged with the kind that reads it -- execution
+    looks an operation up by (connector, install kind, name).
     """
     count = 0
     for op in static_operations:
@@ -956,6 +979,7 @@ async def _sync_static_operations(
                 description=description,
             ),
             execution=op["execution"],
+            kind=kind,
         )
         count += 1
     return count
@@ -1132,6 +1156,12 @@ async def _sync_native_catalog(
         existing = await connector_repository.get(connector_id)
 
         auth_method = AuthMethod(app_config.get("auth_method", "OAUTH2"))
+        # The catalog entry's own kind. Absent, the connector is a vendored
+        # package, which is what every native entry was before sql/mcp/http
+        # existed. Present, it decides which executor, installer and discoverer
+        # an install gets -- so dropping it here silently turns the SQL
+        # connector into a package one that no executor can run.
+        native_kind = app_config.get("kind")
 
         entity = ConnectorEntity(
             id=connector_id,
@@ -1149,6 +1179,7 @@ async def _sync_native_catalog(
                     profile_operation_names=_profile_operation_names(
                         profile_operations, connector_id, AuthProvider.LEMMA
                     ),
+                    kind=native_kind,
                 ),
             ),
             agent_instruction=app_config.get("agent_instruction")
@@ -1163,10 +1194,13 @@ async def _sync_native_catalog(
         )
 
         # Operations declared inline in config (the SQL connector's fixed set).
+        # Tagged with the same kind as the spec above: execution resolves an
+        # operation by (connector, install kind, name), so a mismatch here is
+        # an OperationNotFoundError on every call.
         static_ops = app_config.get("static_operations")
         if static_ops:
             op_count = await _sync_static_operations(
-                operation_repository, connector_id, static_ops
+                operation_repository, connector_id, static_ops, kind=native_kind
             )
             total_operations += op_count
             logger.info(

--- a/lemma-backend/scripts/lemma_apps_config.json
+++ b/lemma-backend/scripts/lemma_apps_config.json
@@ -852,20 +852,28 @@
       "properties": {
         "dialect": {
           "type": "string",
+          "title": "Dialect",
+          "description": "PostgreSQL is the only engine supported today.",
           "enum": [
             "postgresql"
           ],
           "default": "postgresql"
         },
         "host": {
-          "type": "string"
+          "type": "string",
+          "title": "Host",
+          "description": "Hostname of the database server, such as db.internal.example.com. It has to be reachable from Lemma: private, loopback and link-local addresses are refused."
         },
         "port": {
           "type": "integer",
+          "title": "Port",
+          "description": "Leave at 5432 unless the server listens elsewhere.",
           "default": 5432
         },
         "database": {
-          "type": "string"
+          "type": "string",
+          "title": "Database",
+          "description": "Which database on that server to query. Not the table and not the schema — the database name you would pass to psql."
         }
       },
       "additionalProperties": false
@@ -878,10 +886,14 @@
       ],
       "properties": {
         "username": {
-          "type": "string"
+          "type": "string",
+          "title": "Username",
+          "description": "A read-only role is enough. Lemma only ever issues SELECT statements against this connection."
         },
         "password": {
           "type": "string",
+          "title": "Password",
+          "description": "Stored encrypted, and never shown again after you save.",
           "format": "password"
         }
       },
@@ -1002,10 +1014,13 @@
       "properties": {
         "server_url": {
           "type": "string",
-          "description": "MCP server URL (streamable HTTP)."
+          "title": "Server URL",
+          "description": "The server's streamable-HTTP endpoint, such as https://mcp.example.com/mcp. Lemma asks it what tools it has and turns each one into an operation. Private, loopback and link-local addresses are refused."
         },
         "extra_headers": {
           "type": "object",
+          "title": "Extra headers",
+          "description": "Sent with every request to the server. Use this for anything the server needs beyond the token below.",
           "additionalProperties": {
             "type": "string"
           }
@@ -1019,7 +1034,8 @@
         "bearer_token": {
           "type": "string",
           "format": "password",
-          "description": "Optional bearer token for the MCP server."
+          "title": "Bearer token",
+          "description": "Optional. Sent as an Authorization header. Leave empty if the server needs no auth."
         }
       },
       "additionalProperties": false
@@ -1042,14 +1058,18 @@
       "properties": {
         "spec_url": {
           "type": "string",
-          "description": "URL of the OpenAPI JSON spec."
+          "title": "Spec URL",
+          "description": "URL of the API's OpenAPI JSON document, such as https://api.example.com/openapi.json. Lemma reads it and turns each endpoint into an operation. Private, loopback and link-local addresses are refused."
         },
         "server_url": {
           "type": "string",
-          "description": "Override base URL (else the spec's servers[0])."
+          "title": "Base URL",
+          "description": "Optional. Where requests actually go. Leave empty to use the first server listed in the spec, and set it when the spec names a base URL you cannot reach."
         },
         "default_headers": {
           "type": "object",
+          "title": "Default headers",
+          "description": "Sent with every request. Use this for anything the API needs beyond the credentials below.",
           "additionalProperties": {
             "type": "string"
           }
@@ -1063,12 +1083,14 @@
         "access_token": {
           "type": "string",
           "format": "password",
-          "description": "Optional bearer token."
+          "title": "Bearer token",
+          "description": "Optional. Sent as an Authorization header."
         },
         "api_key": {
           "type": "string",
           "format": "password",
-          "description": "Optional API key."
+          "title": "API key",
+          "description": "Optional. Sent the way the spec's security scheme says to."
         }
       },
       "additionalProperties": false

--- a/lemma-frontend/components/connectors/add-connection-dialog.tsx
+++ b/lemma-frontend/components/connectors/add-connection-dialog.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { AlertTriangle } from '@/components/ui/icons';
+import { buildSchemaFormPayload, buildSchemaFormValues } from 'lemma-sdk';
+import type { AuthConfig, Connector } from '@/lib/types';
+import { SchemaFields } from './schema-fields';
+import { StepLoader } from '@/components/brand/loader';
+import {
+    getAppLabel,
+    getConfigSchema,
+    getCredentialSchema,
+    getKindDescription,
+    getTenantConfiguredKindSpec,
+    schemaHasFields,
+    type ConnectorKindSpec,
+    type SchemaValues,
+} from './connector-utils';
+
+export interface ConnectionTarget {
+    connector: Connector;
+    /** Present when editing an install rather than adding one. */
+    install?: AuthConfig | null;
+}
+
+export interface ConnectionSubmission {
+    name: string;
+    config: Record<string, unknown>;
+    credentials: Record<string, unknown>;
+}
+
+/**
+ * Adding a database, an API or an MCP server.
+ *
+ * One dialog rather than the enable-then-connect pair the other kinds use. That
+ * split is a backend distinction — an install holds the address, an account
+ * holds the credentials — and for these kinds it has no meaning to a person:
+ * you type a host and a password in one sitting. Splitting it is also what let
+ * the old flow ask for a database password without ever asking which database.
+ *
+ * Editing reuses the same form minus the credentials, which belong to the
+ * account and are rotated by reconnecting it.
+ */
+export function AddConnectionDialog({
+    target,
+    isSubmitting,
+    existingNames,
+    error,
+    onOpenChange,
+    onSubmit,
+}: {
+    target: ConnectionTarget | null;
+    isSubmitting: boolean;
+    /** Active install names in the org — unique per org, so collisions are caught here. */
+    existingNames: string[];
+    error: string | null;
+    onOpenChange: (open: boolean) => void;
+    onSubmit: (submission: ConnectionSubmission) => void;
+}) {
+    const connector = target?.connector ?? null;
+    const install = target?.install ?? null;
+    const isEdit = Boolean(install);
+
+    const capability = useMemo<ConnectorKindSpec | null>(
+        () => getTenantConfiguredKindSpec(connector),
+        [connector],
+    );
+    const configSchema = getConfigSchema(capability);
+    const credentialSchema = getCredentialSchema(capability);
+    // In edit mode the credential section is absent: an install's accounts keep
+    // their own credentials, and the backend flags them for reconnect if the
+    // config change invalidated them.
+    const showCredentials = !isEdit && schemaHasFields(credentialSchema);
+
+    const [name, setName] = useState('');
+    const [config, setConfig] = useState<SchemaValues>({});
+    const [credentials, setCredentials] = useState<SchemaValues>({});
+    const [localError, setLocalError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (!target) return;
+        setName(install?.name && install.name !== install.connector_id ? install.name : '');
+        setConfig(buildSchemaFormValues(configSchema, (install?.config ?? {}) as SchemaValues));
+        setCredentials(buildSchemaFormValues(credentialSchema));
+        setLocalError(null);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [target?.connector.id, target?.install?.id]);
+
+    const trimmedName = name.trim();
+    const takenNames = useMemo(
+        () => new Set(existingNames.filter((existing) => existing !== install?.name)),
+        [existingNames, install?.name],
+    );
+    const nameIsTaken = trimmedName.length > 0 && takenNames.has(trimmedName);
+
+    const handleSubmit = () => {
+        if (!connector) return;
+        if (!trimmedName) {
+            setLocalError('Give this connection a name — it is how you tell it apart later.');
+            return;
+        }
+        if (nameIsTaken) {
+            setLocalError(`"${trimmedName}" is already used by another connection.`);
+            return;
+        }
+
+        const configPayload = buildSchemaFormPayload(configSchema, config);
+        if (!configPayload.isValid) {
+            setLocalError(Object.values(configPayload.errors)[0] || 'Connection details are incomplete');
+            return;
+        }
+        const credentialPayload = showCredentials
+            ? buildSchemaFormPayload(credentialSchema, credentials)
+            : { data: {}, errors: {}, isValid: true };
+        if (!credentialPayload.isValid) {
+            setLocalError(Object.values(credentialPayload.errors)[0] || 'Credentials are incomplete');
+            return;
+        }
+
+        setLocalError(null);
+        onSubmit({
+            name: trimmedName,
+            config: configPayload.data,
+            credentials: credentialPayload.data,
+        });
+    };
+
+    const label = getAppLabel(connector);
+    const shownError = localError ?? error;
+
+    return (
+        <Dialog open={Boolean(target)} onOpenChange={onOpenChange}>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>{isEdit ? `Edit ${label}` : `Add ${label}`}</DialogTitle>
+                    <DialogDescription>
+                        {isEdit
+                            ? 'Change where this connection points. Accounts stay attached; any whose credentials this invalidates will ask to reconnect.'
+                            : getKindDescription(String(capability?.kind ?? ''), capability)}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="space-y-4 py-2">
+                    <div className="space-y-1.5">
+                        <Label htmlFor="connection-name">Name *</Label>
+                        <Input
+                            id="connection-name"
+                            name="connection-name"
+                            autoComplete="off"
+                            data-1p-ignore
+                            data-lpignore="true"
+                            autoFocus
+                            placeholder="Analytics replica"
+                            value={name}
+                            onChange={(event) => setName(event.target.value)}
+                        />
+                        <p className="text-xs leading-5 text-[var(--text-tertiary)]">
+                            Shown wherever this connection is used, so agents and people pick the right one.
+                        </p>
+                    </div>
+
+                    <SchemaFields
+                        schema={configSchema}
+                        values={config}
+                        onChange={setConfig}
+                        emptyMessage="This connection needs no further details."
+                        followSchemaOrder
+                    />
+
+                    {showCredentials ? (
+                        <div className="space-y-3 border-t border-[var(--border-subtle)] pt-4">
+                            <Label>Credentials</Label>
+                            <SchemaFields
+                                schema={credentialSchema}
+                                values={credentials}
+                                onChange={setCredentials}
+                                emptyMessage="This connection needs no credentials."
+                                followSchemaOrder
+                            />
+                        </div>
+                    ) : null}
+
+                    {shownError ? (
+                        <div className="state-surface-error flex items-start gap-2 rounded-lg px-3 py-2.5 text-xs leading-5 text-[var(--text-secondary)]">
+                            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-[var(--state-error)]" />
+                            <span>{shownError}</span>
+                        </div>
+                    ) : null}
+                </div>
+
+                <DialogFooter>
+                    <Button variant="secondary" onClick={() => onOpenChange(false)} disabled={isSubmitting}>
+                        Cancel
+                    </Button>
+                    <Button variant="primary" onClick={handleSubmit} disabled={isSubmitting}>
+                        {isSubmitting ? <StepLoader size="sm" className="mr-2" /> : null}
+                        {isEdit ? 'Save' : 'Add'}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/lemma-frontend/components/connectors/connection-rows.tsx
+++ b/lemma-frontend/components/connectors/connection-rows.tsx
@@ -1,0 +1,213 @@
+'use client';
+
+import type { ComponentType } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Database, Globe2, Pencil, Plus, RefreshCw, Wrench } from '@/components/ui/icons';
+import { DestructiveResourceActionItem, ResourceActionsMenu } from '@/components/shared/resource-actions-menu';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+import { StepLoader } from '@/components/brand/loader';
+import { useConnectorOperations } from '@/lib/hooks/use-connectors';
+import type { AuthConfig, Connector } from '@/lib/types';
+import {
+    KIND,
+    describeInstallTarget,
+    formatKindName,
+    getAppLabel,
+    getInstallLabel,
+    getKindTagline,
+    getTenantConfiguredKindSpec,
+} from './connector-utils';
+
+const KIND_ICONS: Record<string, ComponentType<{ className?: string }>> = {
+    [KIND.SQL]: Database,
+    [KIND.HTTP]: Globe2,
+    [KIND.MCP]: Wrench,
+};
+
+/** Declared here rather than resolved inside a render, which remounts on every pass. */
+function KindIcon({ kind, className }: { kind: string | null | undefined; className?: string }) {
+    const Icon = KIND_ICONS[String(kind ?? '')] ?? Globe2;
+    return <Icon className={className} />;
+}
+
+/**
+ * The tile behind a kind's glyph.
+ *
+ * One tint across all three rather than one each: these are three doors onto the
+ * same idea — a connection you configure — and the catalog's own rule is that a
+ * screen of fallback tiles should read as one product, not a rainbow. The glyph
+ * carries the difference. `connector-monogram` alone renders colourless: its
+ * background and colour both resolve through `--connector-tint`, which only a
+ * numbered tint class defines.
+ */
+function KindTile({ kind }: { kind: string | null | undefined }) {
+    return (
+        <span className="connector-monogram connector-monogram-8 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg">
+            <KindIcon kind={kind} className="h-4 w-4" />
+        </span>
+    );
+}
+
+/**
+ * The entry point for connections the org configures itself.
+ *
+ * Above the catalog rather than inside it: you don't browse for a database the
+ * way you browse for Slack, you arrive already knowing you have one. Rendered
+ * from whichever catalog entries advertise a tenant-configured kind, so a
+ * fourth one appears here without a code change.
+ */
+export function AddYourOwnRow({
+    connectors,
+    onAdd,
+}: {
+    connectors: Connector[];
+    onAdd: (connector: Connector) => void;
+}) {
+    if (connectors.length === 0) return null;
+
+    return (
+        <section className="context-section">
+            <div className="mb-3 flex items-center gap-2">
+                <h2 className="text-base font-normal text-[var(--text-primary)]">Add your own</h2>
+            </div>
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {connectors.map((connector) => {
+                    const capability = getTenantConfiguredKindSpec(connector);
+                    return (
+                        // Card-shaped, but still a Button: these are three
+                        // alternatives to each other and none of them is the
+                        // action this screen exists for, which is what
+                        // `secondary` means. The overrides are shape only —
+                        // full width, two lines of text, content to the left.
+                        <Button
+                            key={connector.id}
+                            type="button"
+                            variant="secondary"
+                            onClick={() => onAdd(connector)}
+                            className="group h-auto w-full justify-start gap-3 rounded-lg p-3 text-left whitespace-normal"
+                        >
+                            <KindTile kind={capability?.kind} />
+                            <span className="min-w-0 flex-1">
+                                <span className="block truncate text-sm text-[var(--text-primary)]">
+                                    {getAppLabel(connector)}
+                                </span>
+                                {/* No truncate: the tagline is short enough to sit on
+                                    one line here and to wrap rather than vanish when
+                                    the grid collapses to one column. */}
+                                <span className="block text-xs leading-5 text-[var(--text-tertiary)]">
+                                    {getKindTagline(String(capability?.kind ?? ''))}
+                                </span>
+                            </span>
+                            <Plus className="h-4 w-4 shrink-0 text-[var(--text-tertiary)] transition-gentle group-hover:text-[var(--text-secondary)]" />
+                        </Button>
+                    );
+                })}
+            </div>
+        </section>
+    );
+}
+
+/**
+ * One install of a tenant-configured connector.
+ *
+ * The target line is the point: two databases named alike are told apart by
+ * `db.internal/analytics` and nothing else. The operation count is what says
+ * whether discovery actually found anything — it runs server-side after the
+ * install commits and swallows its failures, so an install with zero tools is
+ * a normal state that needs a visible retry rather than a silent one.
+ */
+export function ConnectionRow({
+    install,
+    connector,
+    organizationId,
+    isBusy,
+    onEdit,
+    onRefresh,
+    onDelete,
+}: {
+    install: AuthConfig;
+    connector: Connector | null;
+    organizationId?: string;
+    isBusy: boolean;
+    onEdit: (install: AuthConfig) => void;
+    onRefresh: (install: AuthConfig) => void;
+    onDelete: (install: AuthConfig) => void;
+}) {
+    const target = describeInstallTarget(install.kind, install.config);
+    const { data: operations, isLoading: isLoadingOperations } = useConnectorOperations({
+        organizationId,
+        authConfigName: install.name,
+    });
+    const operationCount = operations?.length ?? 0;
+
+    return (
+        <div className="group flex items-center gap-3 rounded-lg px-3 py-2.5 transition-gentle hover:bg-[var(--surface-1)]">
+            <KindTile kind={install.kind} />
+
+            <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5">
+                    <p className="truncate text-sm text-[var(--text-primary)]">
+                        {getInstallLabel(install, connector)}
+                    </p>
+                    <span className="chip chip-sm chip-muted shrink-0">{formatKindName(install.kind)}</span>
+                    {install.is_default ? (
+                        <span className="chip chip-sm chip-muted shrink-0">Default</span>
+                    ) : null}
+                </div>
+                <p className="truncate text-xs leading-5 text-[var(--text-tertiary)]">
+                    {target ?? 'No address recorded'}
+                    {isLoadingOperations
+                        ? null
+                        : ` · ${operationCount} operation${operationCount === 1 ? '' : 's'}`}
+                </p>
+            </div>
+
+            {!isLoadingOperations && operationCount === 0 ? (
+                <Button
+                    variant="secondary"
+                    size="sm"
+                    className="h-8 shrink-0"
+                    onClick={() => onRefresh(install)}
+                    disabled={isBusy}
+                >
+                    {isBusy ? (
+                        <StepLoader size="xs" className="mr-1.5" />
+                    ) : (
+                        <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+                    )}
+                    Retry discovery
+                </Button>
+            ) : null}
+
+            <ResourceActionsMenu
+                ariaLabel={`Open actions for ${getInstallLabel(install, connector)}`}
+                triggerClassName="h-8 w-8 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+            >
+                <DropdownMenuItem
+                    disabled={isBusy}
+                    onSelect={(event) => {
+                        event.preventDefault();
+                        onEdit(install);
+                    }}
+                >
+                    <Pencil className="mr-2 h-4 w-4" />
+                    Edit connection
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                    disabled={isBusy}
+                    onSelect={(event) => {
+                        event.preventDefault();
+                        onRefresh(install);
+                    }}
+                >
+                    <RefreshCw className="mr-2 h-4 w-4" />
+                    Refresh operations
+                </DropdownMenuItem>
+                <DestructiveResourceActionItem disabled={isBusy} onSelect={() => onDelete(install)}>
+                    Delete connection
+                </DestructiveResourceActionItem>
+            </ResourceActionsMenu>
+        </div>
+    );
+}

--- a/lemma-frontend/components/connectors/connector-card.tsx
+++ b/lemma-frontend/components/connectors/connector-card.tsx
@@ -72,9 +72,15 @@ export function ConnectorRow({
                 </Button>
             ) : null}
 
+            {/* `quiet`, not `secondary`: the catalog is ~80 rows, and 80 outlined
+                buttons all reading "Connect" compete equally, so nothing recedes
+                and a list you scan for a name reads as a control panel. Quiet is
+                this codebase's role for exactly that — a row action, present but
+                not competing — and it keeps the label visible, which hiding it
+                until hover would not do on touch. */}
             <div className="flex w-[124px] shrink-0 justify-end">
                 <Button
-                    variant={isConnected ? 'quiet' : 'secondary'}
+                    variant="quiet"
                     size="sm"
                     className="h-8"
                     onClick={() => onConnect(app)}
@@ -104,17 +110,24 @@ export function ConnectorRow({
  */
 export function ConnectedAccountRow({
     account,
+    label,
     isBusy,
     onReconnect,
     onDisconnect,
 }: {
     account: Account;
+    /**
+     * Overrides the connector title. An account on a tenant-configured install
+     * needs its install's name: three databases all read "SQL Database"
+     * otherwise, and "SQL Database needs to reconnect" names none of them.
+     */
+    label?: string;
     isBusy: boolean;
     onReconnect: (account: Account) => void;
     onDisconnect: (account: Account) => void;
 }) {
     const status = getAccountStatusMeta(account.status);
-    const appName = account.connector?.title || account.connector?.name || 'Unknown app';
+    const appName = label || account.connector?.title || account.connector?.name || 'Unknown app';
     // Sitting under "Your accounts" already says connected — only the exceptions
     // earn a status badge, so a healthy account reads as a name and nothing else.
     const subtitle = account.display_name || account.email;

--- a/lemma-frontend/components/connectors/connector-utils.test.ts
+++ b/lemma-frontend/components/connectors/connector-utils.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import { AuthScheme, ConnectorKind } from 'lemma-sdk';
+
+import type { Connector } from '@/lib/types';
+import {
+    canConnectWithDefaults,
+    describeInstallTarget,
+    getTenantConfiguredConnectors,
+    getTenantConfiguredKindSpec,
+    isTenantConfigured,
+    requiresInstallConfig,
+    supportsCustomConfig,
+} from './connector-utils';
+
+type KindSpec = NonNullable<Connector['kinds']>[number];
+
+/** A catalog row shaped the way the importer emits one. */
+const connector = (id: string, kinds: Partial<KindSpec>[]): Connector =>
+    ({ id, title: id, kinds: kinds as KindSpec[] }) as Connector;
+
+/** `sql`, as it arrives once the importer carries the catalog's own kind. */
+const sqlKind = {
+    kind: ConnectorKind.SQL,
+    auth_scheme: AuthScheme.API_KEY,
+    // The importer sets this from `auth_method != OAUTH2`, so it is true here
+    // despite there being no platform-owned anything to default to.
+    system_default_available: true,
+    supports_org_custom_oauth: false,
+    config_schema: {
+        type: 'object',
+        required: ['dialect', 'host', 'database'],
+        properties: {
+            dialect: { type: 'string' },
+            host: { type: 'string' },
+            database: { type: 'string' },
+        },
+    },
+    credential_schema: {
+        type: 'object',
+        required: ['username', 'password'],
+        properties: { username: { type: 'string' }, password: { type: 'string' } },
+    },
+} satisfies Partial<KindSpec> as Partial<KindSpec>;
+
+const mcpKind = {
+    kind: ConnectorKind.MCP,
+    auth_scheme: AuthScheme.API_KEY,
+    system_default_available: true,
+    supports_org_custom_oauth: false,
+    config_schema: {
+        type: 'object',
+        required: ['server_url'],
+        properties: { server_url: { type: 'string' } },
+    },
+} satisfies Partial<KindSpec> as Partial<KindSpec>;
+
+/** A credential-only catalog app: a bot token and nothing to configure. */
+const telegramKind = {
+    kind: ConnectorKind.PACKAGE,
+    auth_scheme: AuthScheme.API_KEY,
+    system_default_available: true,
+    supports_org_custom_oauth: false,
+    config_schema: { type: 'object', properties: {}, additionalProperties: false },
+    credential_schema: {
+        type: 'object',
+        required: ['bot_token'],
+        properties: { bot_token: { type: 'string' } },
+    },
+} satisfies Partial<KindSpec> as Partial<KindSpec>;
+
+const oauthKind = {
+    kind: ConnectorKind.PACKAGE,
+    auth_scheme: AuthScheme.OAUTH2,
+    system_default_available: true,
+    supports_org_custom_oauth: true,
+    config_schema: {
+        type: 'object',
+        required: ['client_id', 'client_secret'],
+        properties: { client_id: { type: 'string' }, client_secret: { type: 'string' } },
+    },
+} satisfies Partial<KindSpec> as Partial<KindSpec>;
+
+describe('tenant-configured kinds', () => {
+    it('recognises the three kinds whose address the org supplies', () => {
+        expect(isTenantConfigured(sqlKind as KindSpec)).toBe(true);
+        expect(isTenantConfigured(mcpKind as KindSpec)).toBe(true);
+        expect(isTenantConfigured(telegramKind as KindSpec)).toBe(false);
+        expect(isTenantConfigured(null)).toBe(false);
+    });
+
+    it('does not let system_default_available stand in for "ready to connect"', () => {
+        // The regression this guards: Connect used to open the credential
+        // dialog for a database, collect a password, and then enable the
+        // install with no host in it.
+        expect(canConnectWithDefaults(sqlKind as KindSpec)).toBe(false);
+        expect(requiresInstallConfig(sqlKind as KindSpec)).toBe(true);
+
+        // A bot token still goes straight to credentials — nothing to configure.
+        expect(canConnectWithDefaults(telegramKind as KindSpec)).toBe(true);
+        expect(requiresInstallConfig(telegramKind as KindSpec)).toBe(false);
+    });
+
+    it('offers a config form for non-OAuth kinds that have config fields', () => {
+        // supportsCustomConfig used to read supports_org_custom_oauth, which
+        // the importer sets only for OAuth2 — so these were unreachable.
+        expect(supportsCustomConfig(sqlKind as KindSpec)).toBe(true);
+        expect(supportsCustomConfig(mcpKind as KindSpec)).toBe(true);
+    });
+
+    it('still gates an org-owned OAuth app behind its own flag', () => {
+        expect(supportsCustomConfig(oauthKind as KindSpec)).toBe(true);
+        expect(
+            supportsCustomConfig({ ...oauthKind, supports_org_custom_oauth: false } as KindSpec),
+        ).toBe(false);
+        // An OAuth install with a system default needs no config form up front.
+        expect(canConnectWithDefaults(oauthKind as KindSpec)).toBe(true);
+    });
+
+    it('picks the tenant-configured connectors out of the catalog', () => {
+        const catalog = [
+            connector('slack', [oauthKind]),
+            connector('sql', [sqlKind]),
+            connector('mcp', [mcpKind]),
+        ];
+        expect(getTenantConfiguredConnectors(catalog).map((app) => app.id)).toEqual([
+            'sql',
+            'mcp',
+        ]);
+        expect(getTenantConfiguredKindSpec(catalog[1])?.kind).toBe('sql');
+        expect(getTenantConfiguredKindSpec(catalog[0])).toBeNull();
+    });
+});
+
+describe('describeInstallTarget', () => {
+    it('reads a database install as host/database', () => {
+        expect(
+            describeInstallTarget('sql', { dialect: 'postgresql', host: 'db.internal', database: 'analytics' }),
+        ).toBe('db.internal/analytics');
+    });
+
+    it('keeps a non-default port, which is what tells two hosts apart', () => {
+        expect(describeInstallTarget('sql', { host: 'db.internal', port: 6543, database: 'analytics' })).toBe(
+            'db.internal:6543/analytics',
+        );
+        expect(describeInstallTarget('sql', { host: 'db.internal', port: 5432, database: 'analytics' })).toBe(
+            'db.internal/analytics',
+        );
+    });
+
+    it('reads a server URL for mcp, and falls back to the spec URL for openapi', () => {
+        expect(describeInstallTarget('mcp', { server_url: 'https://mcp.example.com/' })).toBe(
+            'https://mcp.example.com/',
+        );
+        expect(describeInstallTarget('http', { spec_url: 'https://api.example.com/openapi.json' })).toBe(
+            'https://api.example.com/openapi.json',
+        );
+    });
+
+    it('says nothing rather than guessing when there is no config', () => {
+        expect(describeInstallTarget('sql', null)).toBeNull();
+        expect(describeInstallTarget('composio', { toolkit: 'slack' })).toBeNull();
+    });
+});

--- a/lemma-frontend/components/connectors/connector-utils.ts
+++ b/lemma-frontend/components/connectors/connector-utils.ts
@@ -13,6 +13,20 @@ export const KIND = {
     MCP: 'mcp',
 } as const;
 
+/**
+ * The kinds where *the org supplies the address*.
+ *
+ * Every other kind is fully described by the catalog — Slack is Slack, and an
+ * install of it needs nothing but credentials. These three are nothing until
+ * someone says which host, which is why they need a config form at all and why
+ * an org legitimately holds several installs of one of them.
+ */
+export const TENANT_CONFIGURED_KINDS: ReadonlySet<string> = new Set([
+    KIND.HTTP,
+    KIND.SQL,
+    KIND.MCP,
+]);
+
 export const ACCOUNT_STATUS = {
     CONNECTED: 'CONNECTED',
     REAUTH_REQUIRED: 'REAUTH_REQUIRED',
@@ -90,16 +104,50 @@ export const schemaHasFields = (schema: JsonSchemaLike | null): boolean =>
 export const hasSystemDefault = (capability: ConnectorKindSpec | null): boolean =>
     Boolean(capability?.system_default_available);
 
+export const isTenantConfigured = (capability: ConnectorKindSpec | null): boolean =>
+    Boolean(capability && TENANT_CONFIGURED_KINDS.has(String(capability.kind)));
+
+/**
+ * True when an install of this kind cannot exist until the org fills in a config.
+ *
+ * `system_default_available` does not answer this. The catalog importer sets it
+ * from `auth_method != OAUTH2`, which is a statement about who owns the OAuth
+ * client — so a SQL connector, which has no OAuth client to own, reads as
+ * "ready to connect" and the enable call goes out with no host in it.
+ */
+export const requiresInstallConfig = (capability: ConnectorKindSpec | null): boolean => {
+    if (!capability) return false;
+    // A tenant-configured kind is nothing without its address, so any config
+    // field at all is worth asking for before the install is created.
+    if (isTenantConfigured(capability)) return schemaHasFields(getConfigSchema(capability));
+    // For an OAuth kind the config schema describes the org's own OAuth app —
+    // opt-in, and unnecessary when the platform's client is available. This
+    // mirrors the backend, which validates an OAuth system-default install
+    // against an empty schema rather than this one.
+    if (capability.auth_scheme === 'OAUTH2' && hasSystemDefault(capability)) return false;
+    return buildSchemaFormFields(getConfigSchema(capability)).some((field) => field.required);
+};
+
+/** True when Connect can go straight to credentials (or OAuth) without a config form. */
+export const canConnectWithDefaults = (capability: ConnectorKindSpec | null): boolean =>
+    hasSystemDefault(capability) && !requiresInstallConfig(capability);
+
 export const supportsCustomConfig = (capability: ConnectorKindSpec | null): boolean => {
     if (!capability) return false;
     const hasConfigFields = schemaHasFields(getConfigSchema(capability));
+    if (!hasConfigFields) return false;
+    // For an OAuth kind the config schema describes the org's *own OAuth app*,
+    // which is opt-in and flagged. For every other kind the config schema
+    // describes the connection itself, so having fields is the whole condition
+    // — gating those on an OAuth flag left sql/mcp/http with no way in at all.
+    if (capability.auth_scheme !== 'OAUTH2') return true;
     if ('supports_org_custom_oauth' in capability) {
-        return Boolean(capability.supports_org_custom_oauth && hasConfigFields);
+        return Boolean(capability.supports_org_custom_oauth);
     }
     if ('supports_org_custom_auth_config' in capability) {
-        return Boolean(capability.supports_org_custom_auth_config && hasConfigFields);
+        return Boolean(capability.supports_org_custom_auth_config);
     }
-    return hasConfigFields;
+    return true;
 };
 
 /** True when this connector has any Advanced (non-default kind / custom config) option worth surfacing. */
@@ -108,9 +156,25 @@ export const hasAdvancedOptions = (app: Connector | null | undefined): boolean =
     return getKindSpecs(app).some((capability) => supportsCustomConfig(capability));
 };
 
+/** Connectors whose install the org configures itself — databases, APIs, MCP servers. */
+export const getTenantConfiguredConnectors = (
+    connectors: Connector[] | undefined,
+): Connector[] =>
+    (connectors || []).filter((app) =>
+        getKindSpecs(app).some((capability) => isTenantConfigured(capability)),
+    );
+
+export const getTenantConfiguredKindSpec = (
+    app: Connector | null | undefined,
+): ConnectorKindSpec | null =>
+    getKindSpecs(app).find((capability) => isTenantConfigured(capability)) ?? null;
+
 export const formatKindName = (kind: string): string => {
     if (kind === KIND.PACKAGE) return 'Native';
     if (kind === KIND.COMPOSIO) return 'Composio';
+    if (kind === KIND.SQL) return 'Database';
+    if (kind === KIND.HTTP) return 'API';
+    if (kind === KIND.MCP) return 'MCP server';
     return kind
         .toLowerCase()
         .split('_')
@@ -127,17 +191,73 @@ export const getKindLabel = (kind: string, capability: ConnectorKindSpec | null)
 
 export const getKindDescription = (kind: string, capability: ConnectorKindSpec | null): string => {
     if (kind === KIND.COMPOSIO) return 'Composio-managed auth with trigger-backed workflows. Recommended.';
+    if (kind === KIND.SQL) return 'Point Lemma at a PostgreSQL database and run read-only queries against it.';
+    if (kind === KIND.HTTP) return 'Point Lemma at an OpenAPI spec; its endpoints become operations.';
+    if (kind === KIND.MCP) return 'Point Lemma at an MCP server; its tools become operations.';
     if (usesDirectCredentials(capability)) return 'Connect with credentials from this app, such as an API key or bot token.';
     if (kind === KIND.PACKAGE) return 'Use OAuth with Lemma-managed or organization-managed credentials.';
     return 'Use this kind for the connector connection.';
 };
 
+/**
+ * The one-line version, for the entry-point cards.
+ *
+ * Separate from `getKindDescription` because the card and the dialog want
+ * different lengths: the card sits three-across and any full sentence truncates,
+ * while the dialog has the room to say what the thing actually is.
+ */
+export const getKindTagline = (kind: string): string => {
+    if (kind === KIND.SQL) return 'PostgreSQL, read-only';
+    if (kind === KIND.HTTP) return 'Endpoints from a spec';
+    if (kind === KIND.MCP) return 'Tools from a server';
+    return 'A connection you configure';
+};
+
 export const getManagedConfigCopy = (kind: string, capability: ConnectorKindSpec | null): string => {
+    if (isTenantConfigured(capability)) return 'This connection needs an address. Fill in the fields below.';
     if (usesDirectCredentials(capability)) return 'Use the default credential setup for this app. Account credentials are added after enabling it.';
     if (kind === KIND.COMPOSIO) return 'Composio uses the system default configuration and supports triggers.';
     if (kind === KIND.PACKAGE) return 'Use the system default OAuth configuration for this app.';
     return `Use the default ${formatKindName(kind)} auth configuration for this app.`;
 };
+
+/**
+ * The address an install points at, for the row that lists it.
+ *
+ * Two databases named "replica" are told apart by this line and nothing else,
+ * so it reads the config the org actually typed rather than restating the kind.
+ * Config comes back from the API redacted, but only the OAuth secrets are —
+ * hosts and URLs survive.
+ */
+export const describeInstallTarget = (
+    kind: string | null | undefined,
+    config: Record<string, unknown> | null | undefined,
+): string | null => {
+    if (!isRecord(config)) return null;
+    const text = (key: string): string | null => {
+        const value = config[key];
+        return typeof value === 'string' && value.trim() ? value.trim() : null;
+    };
+
+    if (kind === KIND.SQL) {
+        const host = text('host');
+        if (!host) return null;
+        const port = config.port;
+        const hostPort = typeof port === 'number' && port !== 5432 ? `${host}:${port}` : host;
+        const database = text('database');
+        return database ? `${hostPort}/${database}` : hostPort;
+    }
+    return text('server_url') ?? text('spec_url');
+};
+
+/** What to call an install in a list. Falls back to the connector when unnamed. */
+export const getInstallLabel = (
+    install: AuthConfig,
+    connector: Connector | null | undefined,
+): string =>
+    install.name && install.name !== install.connector_id
+        ? install.name
+        : getAppLabel(connector);
 
 export interface AccountStatusMeta {
     label: string;
@@ -172,6 +292,40 @@ export const getAccountStatusMeta = (status: string | null | undefined): Account
             };
     }
 };
+
+/**
+ * The message to show when the API refuses an install.
+ *
+ * Worth unwrapping rather than showing "Failed to save": the two failures a
+ * user actually hits here are a field the schema rejected and the network-target
+ * guard refusing a private address, and both are things they can act on. The
+ * envelope is `{message, code, details}`; `details.violations` carries the
+ * offending field paths for a schema failure.
+ */
+export const describeConnectorError = (error: unknown, fallback: string): string => {
+    const body = isRecord(error) && isRecord(error.body) ? error.body : null;
+    if (!body) return error instanceof Error && error.message ? error.message : fallback;
+
+    const message = typeof body.message === 'string' && body.message ? body.message : fallback;
+    const details = isRecord(body.details) ? body.details : null;
+    const violations = Array.isArray(details?.violations) ? details.violations : [];
+    const firstViolation = violations.find(isRecord);
+    if (firstViolation) {
+        const path = typeof firstViolation.path === 'string' ? firstViolation.path : null;
+        const reason = typeof firstViolation.message === 'string' ? firstViolation.message : null;
+        if (reason) return path && path !== '(root)' ? `${path}: ${reason}` : reason;
+    }
+    return message;
+};
+
+/** Active installs for one connector, default first — the order the list shows. */
+export const getInstallsForConnector = (
+    authConfigs: AuthConfig[] | undefined,
+    connectorId: string,
+): AuthConfig[] =>
+    (authConfigs || [])
+        .filter((config) => config.connector_id === connectorId && config.status === 'ACTIVE')
+        .sort((a, b) => Number(Boolean(b.is_default)) - Number(Boolean(a.is_default)));
 
 export const findAuthConfigForAccount = (
     account: Account,

--- a/lemma-frontend/components/connectors/connectors-view.tsx
+++ b/lemma-frontend/components/connectors/connectors-view.tsx
@@ -7,7 +7,10 @@ import {
     useCreateConnectRequest,
     useCreateConnectorAccount,
     useDeleteAccount,
+    useDeleteAuthConfig,
     useEnableConnector,
+    useRefreshAuthConfigOperations,
+    useUpdateAuthConfig,
 } from '@/lib/hooks/use-connectors';
 import { EmptyState } from '@/components/shared/empty-state';
 import { DestructiveConfirmationDialog } from '@/components/shared/destructive-confirmation-dialog';
@@ -15,21 +18,28 @@ import { Input } from '@/components/ui/input';
 import { Plug, Search } from '@/components/ui/icons';
 import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
-import type { Account, Connector } from '@/lib/types';
+import type { Account, AuthConfig, Connector } from '@/lib/types';
 import { useOrganization } from '@/components/dashboard/org-context';
 import { ResourceCardGridSkeleton } from '@/components/shared/loading';
 import { ConnectorGrid } from './connector-grid';
 import { ConnectorMosaic } from './connector-mosaic';
 import { ConnectedAccountRow } from './connector-card';
+import { AddYourOwnRow, ConnectionRow } from './connection-rows';
 import { ConnectAccountDialog, type CredentialTarget } from './connect-account-dialog';
+import { AddConnectionDialog, type ConnectionSubmission, type ConnectionTarget } from './add-connection-dialog';
 import { AdvancedConfigDialog, type AdvancedEnablePayload } from './advanced-config';
 import {
+    canConnectWithDefaults,
+    describeConnectorError,
     findAuthConfigForAccount,
     getAccountStatusMeta,
     getAppLabel,
+    getInstallLabel,
     getPrimaryKindSpec,
     getKindSpec,
-    hasSystemDefault,
+    getTenantConfiguredConnectors,
+    getTenantConfiguredKindSpec,
+    isTenantConfigured,
     usesDirectCredentials,
     type ConnectorKindSpec,
 } from './connector-utils';
@@ -60,6 +70,9 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
     const enableConnector = useEnableConnector(effectiveOrganizationId);
     const createConnectRequest = useCreateConnectRequest(effectiveOrganizationId);
     const createConnectorAccount = useCreateConnectorAccount(effectiveOrganizationId);
+    const updateAuthConfig = useUpdateAuthConfig(effectiveOrganizationId);
+    const deleteAuthConfig = useDeleteAuthConfig(effectiveOrganizationId);
+    const refreshOperations = useRefreshAuthConfigOperations(effectiveOrganizationId);
 
     const [searchTerm, setSearchTerm] = useState('');
     const [busyAppId, setBusyAppId] = useState<string | null>(null);
@@ -79,6 +92,11 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
         appName: string;
         accountLabel: string;
     } | null>(null);
+    const [connectionTarget, setConnectionTarget] = useState<ConnectionTarget | null>(null);
+    const [connectionError, setConnectionError] = useState<string | null>(null);
+    const [isSavingConnection, setIsSavingConnection] = useState(false);
+    const [busyInstallName, setBusyInstallName] = useState<string | null>(null);
+    const [installPendingDelete, setInstallPendingDelete] = useState<AuthConfig | null>(null);
 
     useEffect(() => {
         if (!pendingOAuth) return;
@@ -116,15 +134,74 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
         [connectors],
     );
 
-    const enabledConfigByAppId = useMemo(
-        () =>
-            new Map(
-                (authConfigs || [])
-                    .filter((config) => config.status === 'ACTIVE')
-                    .map((config) => [config.connector_id, config]),
-            ),
+    const activeConfigs = useMemo(
+        () => (authConfigs || []).filter((config) => config.status === 'ACTIVE'),
         [authConfigs],
     );
+
+    // The install a bare connector answers to. An org may hold several of one
+    // connector, and exactly one carries `is_default` — reading whichever came
+    // back first made this depend on list order.
+    const defaultConfigByAppId = useMemo(() => {
+        const byApp = new Map<string, typeof activeConfigs[number]>();
+        for (const config of activeConfigs) {
+            const held = byApp.get(config.connector_id);
+            if (!held || (config.is_default && !held.is_default)) byApp.set(config.connector_id, config);
+        }
+        return byApp;
+    }, [activeConfigs]);
+
+    // Connections the org configured itself — databases, APIs, MCP servers.
+    // They get their own section and their own entry point, so they are also
+    // taken out of the catalog grid below.
+    const tenantConfiguredConnectors = useMemo(
+        () => getTenantConfiguredConnectors(connectors),
+        [connectors],
+    );
+    const tenantConfiguredIds = useMemo(
+        () => new Set(tenantConfiguredConnectors.map((app) => app.id)),
+        [tenantConfiguredConnectors],
+    );
+    const connections = useMemo(
+        () =>
+            activeConfigs
+                .filter((config) => isTenantConfigured(getKindSpec(connectorsById.get(config.connector_id), config.kind)))
+                .sort((a, b) => a.name.localeCompare(b.name)),
+        [activeConfigs, connectorsById],
+    );
+    const existingInstallNames = useMemo(
+        () => activeConfigs.map((config) => config.name),
+        [activeConfigs],
+    );
+
+    const connectionInstallIds = useMemo(
+        () => new Set(connections.map((install) => install.id)),
+        [connections],
+    );
+
+    // A connection's account is the same fact as its connection row, so listing
+    // both says everything twice. The exception is an account that needs
+    // attention: editing a connection can invalidate its credentials, and
+    // reconnecting is only reachable from the account row.
+    const listedAccounts = useMemo(
+        () =>
+            (accounts || []).filter(
+                (account) =>
+                    !connectionInstallIds.has(account.auth_config_id) ||
+                    getAccountStatusMeta(account.status).needsAttention,
+            ),
+        [accounts, connectionInstallIds],
+    );
+
+    /** Which connection an account belongs to, so its row names the right one. */
+    const installNameByAccountId = useMemo(() => {
+        const byInstall = new Map(connections.map((install) => [install.id, install.name]));
+        return new Map(
+            (accounts || [])
+                .map((account) => [account.id, byInstall.get(account.auth_config_id)] as const)
+                .filter((entry): entry is readonly [string, string] => Boolean(entry[1])),
+        );
+    }, [accounts, connections]);
 
     const connectedAppIds = useMemo(
         () => new Set((accounts || []).map((account) => account.connector_id)),
@@ -135,19 +212,20 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
         const query = searchTerm.toLowerCase();
         const matches = (connectors || []).filter(
             (app) =>
-                (app.title && app.title.toLowerCase().includes(query)) ||
-                (app.name && app.name.toLowerCase().includes(query)) ||
-                (app.description && app.description.toLowerCase().includes(query)),
+                !tenantConfiguredIds.has(app.id) &&
+                ((app.title && app.title.toLowerCase().includes(query)) ||
+                    (app.name && app.name.toLowerCase().includes(query)) ||
+                    (app.description && app.description.toLowerCase().includes(query))),
         );
         // Float connected connectors to the top, then enabled ones, keeping the
         // original order stable within each group.
         const rank = (app: Connector) =>
-            connectedAppIds.has(app.id) ? 0 : enabledConfigByAppId.has(app.id) ? 1 : 2;
+            connectedAppIds.has(app.id) ? 0 : defaultConfigByAppId.has(app.id) ? 1 : 2;
         return matches
             .map((app, index) => ({ app, index }))
             .sort((a, b) => rank(a.app) - rank(b.app) || a.index - b.index)
             .map((entry) => entry.app);
-    }, [connectors, searchTerm, connectedAppIds, enabledConfigByAppId]);
+    }, [connectors, searchTerm, connectedAppIds, defaultConfigByAppId, tenantConfiguredIds]);
 
     const attentionCount = useMemo(
         () => (accounts || []).filter((account) => getAccountStatusMeta(account.status).needsAttention).length,
@@ -177,18 +255,31 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
         }
     };
 
+    const openConnectionDialog = (app: Connector, install: AuthConfig | null = null) => {
+        setConnectionError(null);
+        setConnectionTarget({ connector: app, install });
+    };
+
     const handleConnect = async (app: Connector) => {
-        const existing = enabledConfigByAppId.get(app.id) ?? null;
+        const existing = defaultConfigByAppId.get(app.id) ?? null;
         const capability = existing ? getKindSpec(app, existing.kind) : getPrimaryKindSpec(app);
         if (!capability) {
             toast.error('This connector is not available yet');
             return;
         }
 
+        // A connection the org configures: always a new install, never a second
+        // account on the existing one. "Add another database" means another
+        // database, and reusing the install would have pointed it at the first.
+        if (isTenantConfigured(getTenantConfiguredKindSpec(app))) {
+            openConnectionDialog(app);
+            return;
+        }
+
         // Credential apps: open the form immediately so keystrokes land in the field,
         // not the page. Enabling (if needed) is deferred to submit time.
         if (usesDirectCredentials(capability)) {
-            if (!existing && !hasSystemDefault(capability)) {
+            if (!existing && !canConnectWithDefaults(capability)) {
                 setAdvancedApp(app);
                 return;
             }
@@ -201,7 +292,7 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
         try {
             let authConfig = existing;
             if (!authConfig) {
-                if (!hasSystemDefault(capability)) {
+                if (!canConnectWithDefaults(capability)) {
                     setAdvancedApp(app);
                     return;
                 }
@@ -217,6 +308,92 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
             toast.error('Failed to connect');
         } finally {
             setBusyAppId(null);
+        }
+    };
+
+    /**
+     * Creating a connection is two calls that read as one action: the install
+     * carries the address, the account carries the credentials. An account is
+     * always created, even with an empty credential set — execution resolves
+     * one even for an MCP server that needs no auth.
+     */
+    const handleConnectionSubmit = async (submission: ConnectionSubmission) => {
+        const target = connectionTarget;
+        if (!target) return;
+        const capability = getTenantConfiguredKindSpec(target.connector);
+        if (!capability) return;
+
+        setIsSavingConnection(true);
+        setConnectionError(null);
+        try {
+            if (target.install) {
+                const result = await updateAuthConfig.mutateAsync({
+                    authConfigName: target.install.name,
+                    name: submission.name,
+                    config: submission.config,
+                });
+                const reauth = result?.accounts_marked_for_reauth ?? 0;
+                toast.success(
+                    reauth > 0
+                        ? `Updated ${submission.name} · ${reauth} account${reauth === 1 ? '' : 's'} need${reauth === 1 ? 's' : ''} to reconnect`
+                        : `Updated ${submission.name}`,
+                );
+            } else {
+                const install = await enableConnector.mutateAsync({
+                    connectorId: target.connector.id,
+                    kind: capability.kind,
+                    // The org supplied the connection itself, which is what
+                    // ORG_CUSTOM records. Nothing branches on it for these
+                    // kinds, but the column is immutable once written.
+                    configSource: 'ORG_CUSTOM',
+                    config: submission.config,
+                    name: submission.name,
+                });
+                await createConnectorAccount.mutateAsync({
+                    authConfigId: install.id,
+                    credentials: submission.credentials,
+                });
+                toast.success(`Added ${submission.name}`);
+            }
+            setConnectionTarget(null);
+        } catch (error) {
+            console.error('Failed to save connection:', error);
+            setConnectionError(describeConnectorError(error, 'Could not save this connection'));
+        } finally {
+            setIsSavingConnection(false);
+        }
+    };
+
+    const handleRefreshInstall = async (install: AuthConfig) => {
+        setBusyInstallName(install.name);
+        try {
+            const result = await refreshOperations.mutateAsync(install.name);
+            const count = result?.operation_count ?? 0;
+            toast.success(
+                count > 0
+                    ? `${install.name}: ${count} operation${count === 1 ? '' : 's'}`
+                    : `${install.name} responded, but exposed no operations`,
+            );
+        } catch (error) {
+            console.error('Failed to refresh operations:', error);
+            toast.error(describeConnectorError(error, 'Could not reach this connection'));
+        } finally {
+            setBusyInstallName(null);
+        }
+    };
+
+    const handleDeleteInstall = async () => {
+        if (!installPendingDelete) return;
+        setBusyInstallName(installPendingDelete.name);
+        try {
+            await deleteAuthConfig.mutateAsync(installPendingDelete.name);
+            toast.success(`${installPendingDelete.name} deleted`);
+            setInstallPendingDelete(null);
+        } catch (error) {
+            console.error('Failed to delete connection:', error);
+            toast.error(describeConnectorError(error, 'Could not delete this connection'));
+        } finally {
+            setBusyInstallName(null);
         }
     };
 
@@ -284,7 +461,7 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
             // Enable the managed default now if the org hasn't configured this connector yet.
             let authConfigId = target.authConfigId;
             if (!authConfigId) {
-                if (!target.capability || !hasSystemDefault(target.capability)) {
+                if (!target.capability || !canConnectWithDefaults(target.capability)) {
                     throw new Error('Connector is not configured for direct credentials');
                 }
                 const authConfig = await enableConnector.mutateAsync({
@@ -386,11 +563,41 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
         <div className={embedded ? 'min-h-full bg-transparent' : 'context-shell min-h-full bg-transparent pb-8'}>
             {masthead}
 
-            {accounts && accounts.length > 0 && (
+            <AddYourOwnRow connectors={tenantConfiguredConnectors} onAdd={(app) => openConnectionDialog(app)} />
+
+            {connections.length > 0 && (
+                <section className="context-section">
+                    <div className="mb-3 flex items-center gap-2">
+                        <h2 className="text-base font-normal text-[var(--text-primary)]">Your connections</h2>
+                        <span className="text-xs text-[var(--text-tertiary)]">{connections.length}</span>
+                    </div>
+                    <div className="grid grid-cols-1 gap-x-4 lg:grid-cols-2">
+                        {connections.map((install) => (
+                            <ConnectionRow
+                                key={install.id}
+                                install={install}
+                                connector={connectorsById.get(install.connector_id) ?? null}
+                                organizationId={effectiveOrganizationId}
+                                isBusy={busyInstallName === install.name}
+                                onEdit={(target) =>
+                                    openConnectionDialog(
+                                        connectorsById.get(target.connector_id) as Connector,
+                                        target,
+                                    )
+                                }
+                                onRefresh={(target) => void handleRefreshInstall(target)}
+                                onDelete={setInstallPendingDelete}
+                            />
+                        ))}
+                    </div>
+                </section>
+            )}
+
+            {listedAccounts.length > 0 && (
                 <section className="context-section">
                     <div className="mb-3 flex items-center gap-2">
                         <h2 className="text-base font-normal text-[var(--text-primary)]">Your accounts</h2>
-                        <span className="text-xs text-[var(--text-tertiary)]">{accounts.length}</span>
+                        <span className="text-xs text-[var(--text-tertiary)]">{listedAccounts.length}</span>
                         {attentionCount > 0 ? (
                             <span className="text-xs font-medium text-[var(--state-warning)]">
                                 · {attentionCount} need{attentionCount === 1 ? 's' : ''} attention
@@ -398,10 +605,11 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
                         ) : null}
                     </div>
                     <div className="grid grid-cols-1 gap-x-4 lg:grid-cols-2">
-                        {accounts.map((account) => (
+                        {listedAccounts.map((account) => (
                             <ConnectedAccountRow
                                 key={account.id}
                                 account={account}
+                                label={installNameByAccountId.get(account.id)}
                                 isBusy={
                                     reconnectAccountId === account.id
                                     || deletingAccountId === account.id
@@ -435,6 +643,46 @@ export function ConnectorsView({ organizationId, organizationName, embedded = fa
                     onAdvanced={setAdvancedApp}
                 />
             </section>
+
+            <AddConnectionDialog
+                target={connectionTarget}
+                isSubmitting={isSavingConnection}
+                existingNames={existingInstallNames}
+                error={connectionError}
+                onOpenChange={(open) => {
+                    if (!open) {
+                        setConnectionTarget(null);
+                        setConnectionError(null);
+                    }
+                }}
+                onSubmit={(submission) => void handleConnectionSubmit(submission)}
+            />
+
+            <DestructiveConfirmationDialog
+                open={Boolean(installPendingDelete)}
+                onOpenChange={(open) => {
+                    if (!open) setInstallPendingDelete(null);
+                }}
+                title="Delete connection"
+                description={`Delete ${installPendingDelete?.name ?? 'this connection'}? Every account connected through it is removed with it.`}
+                resourceName={
+                    installPendingDelete
+                        ? getInstallLabel(
+                              installPendingDelete,
+                              connectorsById.get(installPendingDelete.connector_id) ?? null,
+                          )
+                        : 'connection'
+                }
+                confirmationText="delete"
+                consequences={[
+                    'Accounts connected through this connection are deleted with it.',
+                    'Agents and workflows using its operations will lose access.',
+                ]}
+                confirmLabel="Delete"
+                pendingLabel="Deleting..."
+                isPending={Boolean(busyInstallName && installPendingDelete?.name === busyInstallName)}
+                onConfirm={() => void handleDeleteInstall()}
+            />
 
             <AdvancedConfigDialog
                 app={advancedApp}

--- a/lemma-frontend/components/connectors/schema-fields.tsx
+++ b/lemma-frontend/components/connectors/schema-fields.tsx
@@ -1,12 +1,53 @@
 'use client';
 
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Plus, X } from '@/components/ui/icons';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { buildSchemaFormFields, type JsonSchemaLike, type SchemaFormField } from 'lemma-sdk';
 import type { SchemaValues } from './connector-utils';
+
+/**
+ * A free-form map of string headers — `extra_headers` on an MCP install,
+ * `default_headers` on an OpenAPI one.
+ *
+ * The schema builder folds every object into a `json` field, which renders as a
+ * textarea asking a person to hand-write `{"Authorization": "Bearer …"}` with
+ * the braces in the right places. These are the only object-shaped fields the
+ * connector forms have, and they are always this shape, so they get rows.
+ */
+const isStringMapSchema = (schema: JsonSchemaLike | undefined): boolean => {
+    if (!schema || schema.type !== 'object') return false;
+    const properties = schema.properties;
+    if (properties && Object.keys(properties).length > 0) return false;
+    const additional = schema.additionalProperties;
+    return Boolean(
+        additional && typeof additional === 'object' && (additional as JsonSchemaLike).type === 'string',
+    );
+};
+
+/** Reads a header map back from whatever the form is holding — object or JSON text. */
+const toEntries = (value: unknown): Array<[string, string]> => {
+    let parsed: unknown = value;
+    if (typeof value === 'string') {
+        if (!value.trim()) return [];
+        try {
+            parsed = JSON.parse(value);
+        } catch {
+            return [];
+        }
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return [];
+    return Object.entries(parsed as Record<string, unknown>).map(([key, item]) => [
+        key,
+        typeof item === 'string' ? item : String(item ?? ''),
+    ]);
+};
 
 export function SchemaFields({
     schema,
@@ -14,14 +55,29 @@ export function SchemaFields({
     onChange,
     emptyMessage = 'No configurable fields are required for this provider.',
     autoFocusFirst = false,
+    followSchemaOrder = false,
 }: {
     schema: JsonSchemaLike | null;
     values: SchemaValues;
     onChange: (values: SchemaValues) => void;
     emptyMessage?: string;
     autoFocusFirst?: boolean;
+    /**
+     * Render fields in the order the schema declares them.
+     *
+     * `buildSchemaFormFields` otherwise sorts by label, which for a connection
+     * form puts Database above Host — alphabetical, and backwards from how
+     * anyone reads a connection string. Opt-in so the other connector forms keep
+     * the ordering they already ship.
+     */
+    followSchemaOrder?: boolean;
 }) {
-    const fields = buildSchemaFormFields(schema);
+    const declaredOrder =
+        followSchemaOrder && schema?.properties ? Object.keys(schema.properties) : null;
+    const fields = buildSchemaFormFields(
+        schema,
+        declaredOrder ? { 'ui:order': declaredOrder } : undefined,
+    );
 
     if (fields.length === 0) {
         return (
@@ -85,6 +141,10 @@ function SchemaField({
         );
     }
 
+    if (field.kind === 'json' && isStringMapSchema(field.schema)) {
+        return <StringMapField field={field} label={label} value={value} onChange={onChange} />;
+    }
+
     return (
         <div className="space-y-1.5">
             <Label htmlFor={fieldId}>{label}</Label>
@@ -130,6 +190,94 @@ function SchemaField({
                     onChange={(event) => onChange(event.target.value)}
                 />
             )}
+            {field.description ? (
+                <p className="text-xs leading-5 text-[var(--text-tertiary)]">{field.description}</p>
+            ) : null}
+        </div>
+    );
+}
+
+function StringMapField({
+    field,
+    label,
+    value,
+    onChange,
+}: {
+    field: SchemaFormField;
+    label: string;
+    value: unknown;
+    onChange: (value: unknown) => void;
+}) {
+    // Rows are local so a half-typed header — a key with no value yet, or two
+    // rows briefly sharing a name — survives the keystroke instead of being
+    // collapsed away by the object round-trip.
+    const [rows, setRows] = useState<Array<{ key: string; value: string }>>(() =>
+        toEntries(value).map(([key, item]) => ({ key, value: item })),
+    );
+
+    const commit = (next: Array<{ key: string; value: string }>) => {
+        setRows(next);
+        onChange(
+            Object.fromEntries(
+                next
+                    .map((row) => [row.key.trim(), row.value] as const)
+                    .filter(([key]) => key.length > 0),
+            ),
+        );
+    };
+
+    const updateRow = (index: number, patch: Partial<{ key: string; value: string }>) =>
+        commit(rows.map((row, position) => (position === index ? { ...row, ...patch } : row)));
+
+    return (
+        <div className="space-y-1.5">
+            <Label>{label}</Label>
+            <div className="space-y-2">
+                {rows.map((row, index) => (
+                    <div key={index} className="flex items-center gap-2">
+                        <Input
+                            aria-label={`${field.label} name`}
+                            autoComplete="off"
+                            data-1p-ignore
+                            data-lpignore="true"
+                            placeholder="Header"
+                            className="flex-1"
+                            value={row.key}
+                            onChange={(event) => updateRow(index, { key: event.target.value })}
+                        />
+                        <Input
+                            aria-label={`${field.label} value`}
+                            autoComplete="off"
+                            data-1p-ignore
+                            data-lpignore="true"
+                            placeholder="Value"
+                            className="flex-1"
+                            value={row.value}
+                            onChange={(event) => updateRow(index, { value: event.target.value })}
+                        />
+                        <Button
+                            type="button"
+                            variant="quiet"
+                            size="icon"
+                            className="h-8 w-8 shrink-0"
+                            aria-label={`Remove ${row.key || 'header'}`}
+                            onClick={() => commit(rows.filter((_, position) => position !== index))}
+                        >
+                            <X className="h-3.5 w-3.5" />
+                        </Button>
+                    </div>
+                ))}
+                <Button
+                    type="button"
+                    variant="quiet"
+                    size="sm"
+                    className="h-8 px-2 text-xs text-[var(--text-tertiary)]"
+                    onClick={() => setRows([...rows, { key: '', value: '' }])}
+                >
+                    <Plus className="mr-1.5 h-3.5 w-3.5" />
+                    Add header
+                </Button>
+            </div>
             {field.description ? (
                 <p className="text-xs leading-5 text-[var(--text-tertiary)]">{field.description}</p>
             ) : null}

--- a/lemma-frontend/lib/hooks/use-connectors.ts
+++ b/lemma-frontend/lib/hooks/use-connectors.ts
@@ -26,6 +26,24 @@ export interface UseConnectorsOptions {
     enabled?: boolean;
 }
 
+/**
+ * The install a bare connector_id resolves to on the backend.
+ *
+ * An org may hold many installs of one connector, and exactly one of them
+ * carries `is_default`. Anything scoped to "the connector" rather than to a
+ * chosen install has to ask for that one by name.
+ */
+export const findDefaultInstallName = (
+    authConfigs: AuthConfig[],
+    connectorId: string | undefined,
+): string | undefined => {
+    if (!connectorId) return undefined;
+    const active = authConfigs.filter(
+        (config) => config.connector_id === connectorId && config.status === 'ACTIVE',
+    );
+    return (active.find((config) => config.is_default) ?? active[0])?.name;
+};
+
 export const useConnectors = (options?: UseConnectorsOptions) => {
     return useQuery({
         queryKey: ['connectors', options?.limit, options?.pageToken],
@@ -71,19 +89,17 @@ export const useTriggers = (options?: UseConnectorsOptions) => {
     const connectorId = options?.connectorId;
     const triggersEnabled = options?.enabled ?? true;
 
-    // Triggers are scoped to an auth config (org + app + kind). An org holds
-    // at most one auth config per app, so resolve the app's auth config name here
-    // and list triggers for it — only the auth config's kind is returned.
+    // Triggers are scoped to an auth config (org + app + kind). An org may hold
+    // several installs of one connector — two Slack apps, several MCP servers —
+    // so this resolves the connector's *default* install, the one a bare
+    // connector_id answers to on the backend. Picking the first ACTIVE row
+    // instead made the answer depend on list order.
     const { data: authConfigs = [] } = useAuthConfigs({
         organizationId,
         limit: 100,
         enabled: Boolean(organizationId && connectorId) && triggersEnabled,
     });
-    const authConfigName = connectorId
-        ? authConfigs.find(
-              (config) => config.connector_id === connectorId && config.status === 'ACTIVE'
-          )?.name
-        : undefined;
+    const authConfigName = findDefaultInstallName(authConfigs, connectorId);
 
     return useQuery({
         queryKey: ['triggers', organizationId, authConfigName, options?.search, options?.limit],
@@ -118,11 +134,7 @@ export const useTrigger = (
         limit: 100,
         enabled: Boolean(organizationId && connectorId && triggerName) && enabled,
     });
-    const authConfigName = connectorId
-        ? authConfigs.find(
-              (config) => config.connector_id === connectorId && config.status === 'ACTIVE'
-          )?.name
-        : undefined;
+    const authConfigName = findDefaultInstallName(authConfigs, connectorId);
 
     return useQuery({
         queryKey: ['trigger', organizationId, authConfigName, triggerName],
@@ -173,6 +185,80 @@ export const useEnableConnector = (organizationId?: string) => {
         },
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['auth-configs', organizationId] });
+        },
+    });
+};
+
+/**
+ * Edits an install in place — rotating an MCP server URL, renaming a database.
+ *
+ * Deliberately not delete-and-recreate: accounts cascade from an install, so
+ * recreating it disconnects everyone who had connected. The backend marks
+ * accounts whose credentials the change invalidated as REAUTH_REQUIRED and
+ * reports how many, which is what the caller shows.
+ */
+export const useUpdateAuthConfig = (organizationId?: string) => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (data: {
+            authConfigName: string;
+            name?: string | null;
+            config?: Record<string, unknown> | null;
+            status?: string | null;
+            isDefault?: boolean | null;
+        }) => {
+            if (!organizationId) throw new Error('organizationId is required to update an install');
+            return getLemmaClient().connectors.authConfigs.update(organizationId, data.authConfigName, {
+                name: data.name,
+                config: data.config,
+                status: data.status,
+                is_default: data.isDefault,
+            });
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['auth-configs', organizationId] });
+            queryClient.invalidateQueries({ queryKey: ['accounts', organizationId] });
+            queryClient.invalidateQueries({ queryKey: ['connector-operations', organizationId] });
+        },
+    });
+};
+
+export const useDeleteAuthConfig = (organizationId?: string) => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (authConfigName: string) => {
+            if (!organizationId) throw new Error('organizationId is required to delete an install');
+            return getLemmaClient().connectors.authConfigs.delete(organizationId, authConfigName);
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['auth-configs', organizationId] });
+            queryClient.invalidateQueries({ queryKey: ['accounts', organizationId] });
+        },
+    });
+};
+
+/**
+ * Re-asks an MCP or OpenAPI install what it can do.
+ *
+ * Discovery runs when the install is created and swallows its failures by
+ * design — a server that was down leaves a usable but empty install. This is
+ * the recovery path, and without it the only fix is deleting the install.
+ */
+export const useRefreshAuthConfigOperations = (organizationId?: string) => {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (authConfigName: string) => {
+            if (!organizationId) throw new Error('organizationId is required to refresh operations');
+            return getLemmaClient().connectors.authConfigs.refreshOperations(
+                organizationId,
+                authConfigName,
+            );
+        },
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ['connector-operations', organizationId] });
         },
     });
 };

--- a/lemma-frontend/vitest.config.ts
+++ b/lemma-frontend/vitest.config.ts
@@ -21,6 +21,9 @@ export default defineConfig({
             // the component around it is not.
             'components/agents/this-computer-status.{test,spec}.ts',
             'components/auth/portal/auth/**/*.{test,spec}.ts',
+            // Which kinds need an address typed in, and how an install reads
+            // back as a line of text. Pure predicates over the catalog.
+            'components/connectors/connector-utils.{test,spec}.ts',
             // Step ordering for local onboarding. Named file by file, like the
             // agent-runtime helpers above, so this stays a list of pure-logic
             // modules rather than becoming a glob over components.


### PR DESCRIPTION
## The gap

The backend shipped SQL, HTTP and MCP connectors — executors, install-time SSRF vetting, and operation discovery for the two that can be introspected. The frontend never asked for the one thing they need that no catalog connector does: **the address**.

Clicking **Connect** on "SQL Database" today asks for a database username and password, sends an install with `config_source: SYSTEM_DEFAULT` and no config, fails backend validation against a schema requiring `dialect`/`host`/`database`, and shows `Failed to save credentials`. You are asked for the password to a database you were never allowed to name. MCP and OpenAPI fail identically.

## What's in the way, and what this fixes

**The importer dropped the kind.** `_native_kind_spec()` selects the spec class — executor, installer, discoverer — from a `kind` argument, and the native-catalog sync never passed it. `"kind": "sql"` in the catalog JSON was dead data; all three rows imported as `package` and would have dispatched to the vendored-client gateway. One keyword argument, and nothing downstream works without it. Covered by new importer unit tests.

**`supportsCustomConfig` was welded to OAuth.** It gated custom config on `supports_org_custom_oauth`, a flag the importer sets only for OAuth2 connectors — so the frontend's whole notion of "the org brought its own configuration" meant "the org brought its own OAuth app". A non-OAuth kind with config fields now says so on its own, and `hasSystemDefault` stops reading as "ready to connect" for kinds whose config *is* the connection.

**One install per connector was never true.** An org holds several MCP servers and two databases; the view kept a `Map` keyed by connector id and let the last one win. Installs are a list now, each carrying the name that tells "Analytics replica" from "Billing replica" in the accounts list and the agent access picker.

## What it buys

- **One dialog, two sections, one submit** — for a database you type the host and the password in one sitting, so the install/credentials split (a backend distinction) stops being a two-step flow.
- **Discovery reported back** ("Found 14 tools"). Server-side discovery swallows its failures by design, which makes a silent empty install indistinguishable from a working one.
- **Refresh operations** — the recovery path the backend already built and the UI could not reach.
- **Edit**, mapped to `authConfigs.update`. Deleting and recreating an install cascades away every account on it.
- **The SSRF rejection reason surfaced verbatim** — "we won't connect to a private address" is the useful message.
- **"Add your own" above the catalog**, not three cards in the "More apps" tail: you don't browse for a database, you arrive knowing you have one.

Design note: `docs/design/bring-your-own-connectors.md`.

## Deploy note

Item 2 of the work breakdown is ops, not code: the three catalog rows already exist in deployed environments **as `package`**. The catalog import needs re-running against them for the kind fix to take effect.

## Verification

- `npm run check` (design audit, lint, typecheck, edu-anchors) — pass
- `npm test` — 465 tests pass, including new `connector-utils` predicates
- `pytest app/modules/connectors/tests/unit/test_import_connector_catalog.py` — 37 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)