### PR TITLE
Make a document read like a document: one measure, a reading mode that works, and a page worth printing

### DIFF
--- a/lemma-frontend/app/pod/[id]/layout.tsx
+++ b/lemma-frontend/app/pod/[id]/layout.tsx
@@ -713,7 +713,10 @@ function PodShell({
                             ) : null}
                             <div
                                 className={cn(
-                                    "pod-shell-topbar-title flex min-w-0 items-center gap-2 text-base font-semibold leading-7 text-[var(--text-primary)]",
+                                    // Medium, not semibold: the bar names where you
+                                    // are, it does not headline it. Bold here made
+                                    // the filename shout over the document under it.
+                                    "pod-shell-topbar-title flex min-w-0 items-center gap-2 text-base font-medium leading-7 text-[var(--text-primary)]",
                                     "transition-opacity duration-[var(--dur-panel)] ease-[var(--ease-standard)]",
                                     // Kept mounted rather than removed, so handing the
                                     // title back and forth cross-fades instead of

--- a/lemma-frontend/components/documents/document-save-state.test.ts
+++ b/lemma-frontend/components/documents/document-save-state.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    describeAutosaveStatus,
+    isAutosavedPreviewType,
+    shouldShowSaveButton,
+} from './document-save-state';
+
+describe('isAutosavedPreviewType', () => {
+    it('autosaves prose', () => {
+        expect(isAutosavedPreviewType('markdown')).toBe(true);
+    });
+
+    it('leaves source files to the writer', () => {
+        // The exact bytes are the point in these, so a timer must not decide
+        // when a half-typed one lands.
+        expect(isAutosavedPreviewType('json')).toBe(false);
+        expect(isAutosavedPreviewType('code')).toBe(false);
+        expect(isAutosavedPreviewType('html')).toBe(false);
+    });
+
+    it('does not claim types it has never seen', () => {
+        expect(isAutosavedPreviewType('pdf')).toBe(false);
+        expect(isAutosavedPreviewType('')).toBe(false);
+    });
+});
+
+describe('describeAutosaveStatus', () => {
+    it('says nothing about a document that was only read', () => {
+        expect(describeAutosaveStatus({ state: 'idle', hasUnsavedChanges: false })).toBeNull();
+    });
+
+    it('reports a failure over everything else', () => {
+        expect(describeAutosaveStatus({ state: 'error', hasUnsavedChanges: true })).toEqual({
+            label: "Couldn't save",
+            tone: 'error',
+        });
+    });
+
+    it('shows the write in flight', () => {
+        // Still dirty while the request is out — the in-flight state wins, or
+        // every save would flicker through "Unsaved changes" on its way to
+        // "Saved".
+        expect(describeAutosaveStatus({ state: 'saving', hasUnsavedChanges: true })).toEqual({
+            label: 'Saving…',
+            tone: 'quiet',
+        });
+    });
+
+    it('admits to edits that have not landed yet', () => {
+        expect(describeAutosaveStatus({ state: 'idle', hasUnsavedChanges: true })).toEqual({
+            label: 'Unsaved changes',
+            tone: 'quiet',
+        });
+    });
+
+    it('does not keep claiming "Saved" once you type again', () => {
+        expect(describeAutosaveStatus({ state: 'saved', hasUnsavedChanges: true })?.label).toBe(
+            'Unsaved changes'
+        );
+        expect(describeAutosaveStatus({ state: 'saved', hasUnsavedChanges: false })?.label).toBe(
+            'Saved'
+        );
+    });
+});
+
+describe('shouldShowSaveButton', () => {
+    it('appears for source files with pending edits', () => {
+        expect(shouldShowSaveButton({ previewType: 'json', canWrite: true, hasUnsavedChanges: true })).toBe(true);
+    });
+
+    it('stays away from documents that save themselves', () => {
+        expect(shouldShowSaveButton({ previewType: 'markdown', canWrite: true, hasUnsavedChanges: true })).toBe(false);
+    });
+
+    it('stays away when there is nothing to save', () => {
+        expect(shouldShowSaveButton({ previewType: 'json', canWrite: true, hasUnsavedChanges: false })).toBe(false);
+    });
+
+    it('stays away from a reader who cannot write', () => {
+        expect(shouldShowSaveButton({ previewType: 'json', canWrite: false, hasUnsavedChanges: true })).toBe(false);
+    });
+});

--- a/lemma-frontend/components/documents/document-save-state.ts
+++ b/lemma-frontend/components/documents/document-save-state.ts
@@ -1,0 +1,76 @@
+/**
+ * Who saves a document, and what the reader is told about it.
+ *
+ * Prose writes itself back the way an agent's prompt does — you type, you pause,
+ * it is on disk — because a Save button on a paragraph is a chore, and losing a
+ * paragraph to a closed tab is worse. Source files do not: a half-typed JSON
+ * object is not a state anyone wants persisted on a 700ms timer, and the person
+ * editing one is used to deciding when it lands.
+ *
+ * Split out from the viewer because it is a set of pure decisions the component
+ * around it makes hard to see, and because this is the file that changes when a
+ * new preview type arrives.
+ */
+
+/** How long typing has to stop before an autosaved document is written. */
+export const AUTOSAVE_DELAY_MS = 700;
+
+export type DocumentSaveState = 'idle' | 'saving' | 'saved' | 'error';
+
+/**
+ * Preview types that write themselves back.
+ *
+ * Markdown only. The editor round-trips through TipTap, so saving rewrites the
+ * body in TipTap's markdown dialect — harmless for prose, and the reason this
+ * cannot quietly extend to files where the exact bytes are the point.
+ */
+export function isAutosavedPreviewType(previewType: string): boolean {
+    return previewType === 'markdown';
+}
+
+export type DocumentSaveStatus = {
+    label: string;
+    /** Errors are the only state worth colouring; the rest is a whisper. */
+    tone: 'quiet' | 'error';
+};
+
+/**
+ * The one line of status an autosaved document shows, or nothing.
+ *
+ * "Saved" only appears after a save this session — a document you have only
+ * read has nothing to report, and announcing it would imply you changed
+ * something. Unsaved edits say so rather than staying silent, so a stalled
+ * network is visible before you close the tab.
+ */
+export function describeAutosaveStatus({
+    state,
+    hasUnsavedChanges,
+}: {
+    state: DocumentSaveState;
+    hasUnsavedChanges: boolean;
+}): DocumentSaveStatus | null {
+    if (state === 'error') return { label: "Couldn't save", tone: 'error' };
+    if (state === 'saving') return { label: 'Saving…', tone: 'quiet' };
+    if (hasUnsavedChanges) return { label: 'Unsaved changes', tone: 'quiet' };
+    if (state === 'saved') return { label: 'Saved', tone: 'quiet' };
+    return null;
+}
+
+/**
+ * Whether the explicit Save button belongs in the header.
+ *
+ * It is for the file types that do not save themselves, and only once there is
+ * something to save — a button that is present and disabled reads as a feature
+ * that is broken rather than a verb that is not needed yet.
+ */
+export function shouldShowSaveButton({
+    previewType,
+    canWrite,
+    hasUnsavedChanges,
+}: {
+    previewType: string;
+    canWrite: boolean;
+    hasUnsavedChanges: boolean;
+}): boolean {
+    return canWrite && hasUnsavedChanges && !isAutosavedPreviewType(previewType);
+}

--- a/lemma-frontend/components/documents/document-skeleton.tsx
+++ b/lemma-frontend/components/documents/document-skeleton.tsx
@@ -16,7 +16,9 @@ import { Skeleton, SkeletonText } from '@/components/shared/loading';
 /** The body fill — used on its own inside the settled viewer while a preview renders. */
 export function DocumentBodySkeleton() {
     return (
-        <div className="min-h-[220px] space-y-3" aria-hidden="true">
+        // Filled at the document's own measure, so the first paragraph lands
+        // where the placeholder line above it already was.
+        <div className="document-page min-h-[220px] space-y-3 px-2 py-5 sm:px-4" aria-hidden="true">
             <SkeletonText lines={4} />
             <SkeletonText lines={3} />
         </div>

--- a/lemma-frontend/components/documents/document-viewer.tsx
+++ b/lemma-frontend/components/documents/document-viewer.tsx
@@ -11,28 +11,44 @@ import {
     Download,
     Eye,
     File as FileIcon,
+    FileText,
     Maximize2,
     Minimize2,
+    Printer,
     Save,
     Share2,
-    Trash2,
 } from '@/components/ui/icons';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
+import { DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { DestructiveConfirmationDialog } from '@/components/shared/destructive-confirmation-dialog';
+import { DestructiveResourceActionItem, ResourceActionsMenu } from '@/components/shared/resource-actions-menu';
 import { ResourceShareButton, ResourceVisibilityBadge, type ResourceVisibilityValue } from '@/components/shared/resource-visibility';
 import { usePodTopbar } from '@/components/pod/pod-topbar-context';
 import { resourceAllows } from '@/lib/authz/resource-actions';
 import { isPersonalPath } from '@/lib/files/doc-sections';
 import { FileIndexStatusBadge } from '@/components/documents/file-index-status-badge';
-import { MarkdownAttachmentControl, canAttachDocumentMarkdown } from '@/components/documents/markdown-attachment-control';
+import {
+    MarkdownAttachmentControl,
+    canAttachDocumentMarkdown,
+    usesUserMarkdown,
+} from '@/components/documents/markdown-attachment-control';
+import {
+    AUTOSAVE_DELAY_MS,
+    describeAutosaveStatus,
+    isAutosavedPreviewType,
+    shouldShowSaveButton,
+    type DocumentSaveState,
+} from '@/components/documents/document-save-state';
 import { useDatastoreFile, useDeleteDatastoreFile } from '@/lib/hooks/use-datastores';
 import { getLemmaClient } from '@/lib/sdk/lemma-client';
 import {
+    canPrintDocument,
     getDocumentPreviewType,
     getOfficePreviewKind,
+    printFileName,
     renderDocxPreview,
     renderPdfPreview,
 } from '@/components/documents/preview-renderers';
@@ -40,7 +56,7 @@ import { DocumentFrontmatter } from '@/components/documents/document-frontmatter
 import { joinFrontmatter, splitFrontmatter } from '@/lib/files/frontmatter';
 import { MarkdownEditor } from './markdown-editor';
 import { DocumentBodySkeleton, DocumentSkeleton } from '@/components/documents/document-skeleton';
-import { StepLoader } from '@/components/brand/loader';
+import { cn } from '@/lib/utils';
 
 interface DocumentViewerProps {
     podId: string;
@@ -335,8 +351,9 @@ export function DocumentViewer({
     const [isLoadingContent, setIsLoadingContent] = useState(false);
     const [loadError, setLoadError] = useState<string | null>(null);
     const [textViewMode, setTextViewMode] = useState<TextViewMode>('preview');
-    const [isFullscreen, setIsFullscreen] = useState(false);
-    const [isFullscreenSupported, setIsFullscreenSupported] = useState(false);
+    const [isReading, setIsReading] = useState(false);
+    const [isAttachmentOpen, setIsAttachmentOpen] = useState(false);
+    const [saveState, setSaveState] = useState<DocumentSaveState>('idle');
     const viewerShellRef = useRef<HTMLDivElement | null>(null);
 
     const documentPath = doc?.path || fileId;
@@ -381,6 +398,8 @@ export function DocumentViewer({
         setImagePreviewUrl(null);
         setHtmlPreviewDocument(null);
         setTextViewMode(previewType === 'html' ? 'preview' : 'source');
+        // "Saved" belongs to the document you saved, not to the next one.
+        setSaveState('idle');
 
         const load = async () => {
             try {
@@ -480,37 +499,121 @@ export function DocumentViewer({
     ), [docxPreview]);
 
 
-    useEffect(() => {
-        setIsFullscreenSupported(Boolean(document.fullscreenEnabled));
-
-        const handleFullscreenChange = () => {
-            setIsFullscreen(document.fullscreenElement === viewerShellRef.current);
-        };
-
-        document.addEventListener('fullscreenchange', handleFullscreenChange);
-        return () => {
-            document.removeEventListener('fullscreenchange', handleFullscreenChange);
-        };
+    /**
+     * Reading mode is in-app state; browser full screen is a bonus on top.
+     *
+     * It used to be the other way round, and that is why the docs section
+     * shipped a full screen with no chrome in it: those controls render into the
+     * pod topbar, which lives outside the element being promoted, so the reader
+     * got a document with no header, no save, and no exit but Esc. An overlay
+     * this component owns behaves the same whether or not the surrounding frame
+     * was ever granted full screen.
+     */
+    const exitReading = useCallback(() => {
+        setIsReading(false);
+        if (typeof document !== 'undefined' && document.fullscreenElement) {
+            void document.exitFullscreen().catch(() => undefined);
+        }
     }, []);
 
-    const handleToggleFullscreen = useCallback(async () => {
-        const target = viewerShellRef.current;
-        if (!target || !document.fullscreenEnabled) {
-            toast.error('Full screen is not available');
+    const handleToggleReading = useCallback(() => {
+        if (isReading) {
+            exitReading();
             return;
         }
 
-        try {
-            if (document.fullscreenElement) {
-                await document.exitFullscreen();
-                return;
-            }
-
-            await target.requestFullscreen();
-        } catch {
-            toast.error('Could not enter full screen');
+        setIsReading(true);
+        // Best effort: the overlay is already covering the app, so a frame that
+        // refuses full screen costs the browser chrome and nothing else.
+        if (document.fullscreenEnabled) {
+            void viewerShellRef.current?.requestFullscreen().catch(() => undefined);
         }
+    }, [exitReading, isReading]);
+
+    useEffect(() => {
+        if (!isReading) return;
+
+        // Esc is the reflex, and inside an in-app overlay it is not the
+        // browser's to handle. When full screen *is* active the browser exits it
+        // without ever dispatching the key, which the change listener catches.
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') exitReading();
+        };
+        const handleFullscreenChange = () => {
+            if (!document.fullscreenElement) setIsReading(false);
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        document.addEventListener('fullscreenchange', handleFullscreenChange);
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown);
+            document.removeEventListener('fullscreenchange', handleFullscreenChange);
+        };
+    }, [exitReading, isReading]);
+
+    /**
+     * Print, which is also how you get a PDF: every desktop browser and iOS
+     * offers "Save as PDF" from its own print dialog, so the page does the work
+     * and the platform supplies the file. Nothing to render twice, nothing to
+     * keep in sync with what the screen shows.
+     */
+    const handlePrint = useCallback(() => {
+        // Said now, not after: the browser reports when its dialog closes but
+        // never whether a file was written, so "Saved" would be a guess that is
+        // wrong every time someone cancels. This acknowledges the click and
+        // names the one choice in the dialog that produces a file.
+        toast('Opening print — choose "Save as PDF" for a file');
+        // A frame's delay so the toast paints before the modal dialog blocks.
+        requestAnimationFrame(() => window.print());
     }, []);
+
+    /**
+     * Paper is white whatever the app is wearing.
+     *
+     * Browsers drop background colours when printing but keep text colours, so
+     * printing a dark-themed document lays near-white ink on a white sheet and
+     * hands you a blank-looking page. The theme class comes off for the length
+     * of the print and goes back after — the light palette is already the one
+     * that reads as ink.
+     */
+    const printedFileName = doc ? printFileName(doc.name) : '';
+
+    useEffect(() => {
+        const root = document.documentElement;
+        let restoreDark = false;
+        let previousTitle = '';
+
+        const handleBeforePrint = () => {
+            restoreDark = root.classList.contains('dark');
+            if (restoreDark) root.classList.remove('dark');
+
+            // The page title is where browsers get the default "Save as PDF"
+            // filename, so while the dialog is open the tab is named after the
+            // document rather than after the route it happens to be on.
+            if (printedFileName) {
+                previousTitle = document.title;
+                document.title = printedFileName;
+            }
+        };
+        const handleAfterPrint = () => {
+            if (restoreDark) root.classList.add('dark');
+            restoreDark = false;
+            if (previousTitle) {
+                document.title = previousTitle;
+                previousTitle = '';
+            }
+        };
+
+        window.addEventListener('beforeprint', handleBeforePrint);
+        window.addEventListener('afterprint', handleAfterPrint);
+        return () => {
+            window.removeEventListener('beforeprint', handleBeforePrint);
+            window.removeEventListener('afterprint', handleAfterPrint);
+            // A print started and never finished must not leave the app light,
+            // or the tab wearing a document's name after you have left it.
+            handleAfterPrint();
+        };
+    }, [printedFileName]);
 
     const handleDownload = useCallback(async () => {
         if (!doc) return;
@@ -548,23 +651,80 @@ export function DocumentViewer({
         );
     }, [canDeleteDocument, datastoreName, deleteDocument, doc, documentPath, onClose, onDeleted, podId]);
 
-    const handleSave = useCallback(async () => {
+    /**
+     * One write, however it was asked for.
+     *
+     * The run counter is what keeps a slow save from undoing a fast one: two
+     * writes can be in flight when you keep typing through an autosave, and only
+     * the last one may report what is now on disk.
+     */
+    const saveRunRef = useRef(0);
+    const persist = useCallback(async (content: string) => {
         if (!doc || !isTextEditable || !canWriteDocument) return;
 
+        const run = ++saveRunRef.current;
+        setSaveState('saving');
         try {
-            const blob = new Blob([docContent], { type: inferTextMimeType(doc.name) });
+            const blob = new Blob([content], { type: inferTextMimeType(doc.name) });
             await getLemmaClient(podId).files.update(documentPath, {
                 file: blob,
                 name: doc.name,
             });
-            setOriginalContent(docContent);
+            if (saveRunRef.current !== run) return;
+            setOriginalContent(content);
+            setSaveState('saved');
+        } catch {
+            if (saveRunRef.current !== run) return;
+            setSaveState('error');
+            throw new Error('save failed');
+        }
+    }, [canWriteDocument, doc, documentPath, isTextEditable, podId]);
+
+    const handleSave = useCallback(async () => {
+        try {
+            await persist(docContent);
             toast.success('File saved');
         } catch {
             toast.error('Failed to save file');
         }
-    }, [canWriteDocument, doc, docContent, documentPath, isTextEditable, podId]);
+    }, [docContent, persist]);
 
     const hasUnsavedChanges = Boolean(doc && isTextEditable && docContent !== originalContent);
+    const isAutosaving = canWriteDocument && isAutosavedPreviewType(previewType);
+
+    /**
+     * Prose saves itself once typing stops, the way an agent's prompt does.
+     *
+     * Only ever fires behind a real edit: the editor emits changes when it has
+     * focus, so a document you opened and read is never rewritten — which
+     * matters because the round-trip through the editor normalises the markdown
+     * to its own dialect.
+     */
+    useEffect(() => {
+        if (!isAutosaving || !hasUnsavedChanges) return;
+
+        const timer = setTimeout(() => {
+            void persist(docContent).catch(() => undefined);
+        }, AUTOSAVE_DELAY_MS);
+        return () => clearTimeout(timer);
+    }, [docContent, hasUnsavedChanges, isAutosaving, persist]);
+
+    /**
+     * Closing the tab mid-pause must not cost the last sentence. Held in a ref
+     * so the unmount effect below never re-runs on a keystroke.
+     */
+    const pendingSaveRef = useRef<(() => void) | null>(null);
+    useEffect(() => {
+        pendingSaveRef.current = isAutosaving && hasUnsavedChanges
+            ? () => { void persist(docContent).catch(() => undefined); }
+            : null;
+    }, [docContent, hasUnsavedChanges, isAutosaving, persist]);
+
+    useEffect(() => () => pendingSaveRef.current?.(), []);
+
+    const autosaveStatus = isAutosaving
+        ? describeAutosaveStatus({ state: saveState, hasUnsavedChanges })
+        : null;
     const canToggleTextView = previewType === 'html';
     const isTextSourceMode = !canToggleTextView || textViewMode === 'source';
     const textModeToggleLabel = textViewMode === 'preview' ? 'Source' : 'Preview';
@@ -617,20 +777,35 @@ export function DocumentViewer({
         }
     }, [doc, docContent, fileBlob, isTextEditable]);
 
+    /**
+     * Reading a document is the common case, so the header is not a toolbar.
+     *
+     * Inline: what changes the document's state (save, or the note that it saved
+     * itself), what changes the view (reading mode, source), and who can see it.
+     * Everything else — copy, download, the markdown override, delete — is a
+     * verb you reach for occasionally and can afford to open a menu for.
+     */
     const headerActions = useMemo(() => (
         <TooltipProvider>
             <div className="flex shrink-0 items-center gap-1">
             {extraActions}
-            {canWriteDocument && canAttachDocumentMarkdown(previewType) ? (
-                <MarkdownAttachmentControl
-                    podId={podId}
-                    datastoreName={datastoreName}
-                    filePath={documentPath}
-                    metadata={doc?.metadata}
-                    disabled={!doc}
-                />
+            {autosaveStatus ? (
+                <span
+                    className={cn(
+                        'px-1 text-xs',
+                        autosaveStatus.tone === 'error'
+                            ? 'text-[var(--state-error)]'
+                            : 'text-[var(--text-tertiary)]'
+                    )}
+                    // Announced politely: it is a reassurance, not an
+                    // interruption in the middle of a sentence.
+                    role="status"
+                    aria-live="polite"
+                >
+                    {autosaveStatus.label}
+                </span>
             ) : null}
-            {canWriteDocument && hasUnsavedChanges && (
+            {shouldShowSaveButton({ previewType, canWrite: canWriteDocument, hasUnsavedChanges }) && (
                 <Button variant="primary"
                     size="sm"
                     className="h-8 gap-1.5 px-3 text-xs font-medium"
@@ -647,30 +822,14 @@ export function DocumentViewer({
                         variant="quiet"
                         size="icon"
                         className="h-8 w-8 rounded"
-                        onClick={() => void handleToggleFullscreen()}
-                        disabled={!isFullscreenSupported}
-                        aria-label={isFullscreen ? 'Exit full screen' : 'Enter full screen'}
+                        onClick={handleToggleReading}
+                        disabled={!doc}
+                        aria-label="Read full screen"
                     >
-                        {isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+                        <Maximize2 className="h-4 w-4" />
                     </Button>
                 </TooltipTrigger>
-                <TooltipContent>{isFullscreen ? 'Exit full screen' : 'Full screen'}</TooltipContent>
-            </Tooltip>
-            <Tooltip>
-                <TooltipTrigger asChild>
-                    <Button
-                        type="button"
-                        variant="quiet"
-                        size="icon"
-                        className="h-8 w-8 rounded"
-                        onClick={() => void handleCopyContent()}
-                        disabled={!doc || isLoadingContent}
-                        aria-label="Copy content"
-                    >
-                        <CopyCheck className="h-4 w-4" />
-                    </Button>
-                </TooltipTrigger>
-                <TooltipContent>Copy content</TooltipContent>
+                <TooltipContent>Read full screen</TooltipContent>
             </Tooltip>
             {/* Personal files promote instead of sharing: `/me` is an alias for
                 whoever is reading, so they have no address that means the same
@@ -723,45 +882,56 @@ export function DocumentViewer({
                     <TooltipContent>{textModeToggleLabel}</TooltipContent>
                 </Tooltip>
             ) : null}
-            <Tooltip>
-                <TooltipTrigger asChild>
-                    <Button
-                        variant="quiet"
-                        size="icon"
-                        className="h-8 w-8 rounded"
-                        onClick={() => void handleDownload()}
-                        disabled={!doc}
-                        aria-label="Download"
+            <ResourceActionsMenu ariaLabel="More document actions">
+                <DropdownMenuItem
+                    disabled={!doc || isLoadingContent}
+                    onSelect={() => void handleCopyContent()}
+                >
+                    <CopyCheck className="mr-2 h-4 w-4" />
+                    Copy content
+                </DropdownMenuItem>
+                <DropdownMenuItem disabled={!doc} onSelect={() => void handleDownload()}>
+                    <Download className="mr-2 h-4 w-4" />
+                    Download
+                </DropdownMenuItem>
+                {/* Named for what it does, not for the file it can produce. The
+                    dialog this opens is the browser's, and "Save as PDF" is one
+                    of the destinations in it — so calling this "Export as PDF"
+                    would promise a file landing in the pod. It does not. */}
+                {canPrintDocument(previewType) ? (
+                    <DropdownMenuItem
+                        disabled={!doc || isLoadingContent}
+                        onSelect={handlePrint}
                     >
-                        <Download className="h-4 w-4" />
-                    </Button>
-                </TooltipTrigger>
-                <TooltipContent>Download</TooltipContent>
-            </Tooltip>
-            {canDeleteDocument ? (
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <Button
-                            variant="quiet"
-                            size="icon"
-                            className="h-8 w-8 rounded text-[var(--state-error)] hover:text-[var(--state-error)]"
-                            onClick={() => setShowDeleteDialog(true)}
+                        <Printer className="mr-2 h-4 w-4" />
+                        Print or save as PDF
+                    </DropdownMenuItem>
+                ) : null}
+                {canWriteDocument && canAttachDocumentMarkdown(previewType) ? (
+                    <DropdownMenuItem disabled={!doc} onSelect={() => setIsAttachmentOpen(true)}>
+                        <FileText className="mr-2 h-4 w-4" />
+                        {usesUserMarkdown(doc?.metadata) ? 'Using your markdown' : 'Attach your markdown'}
+                    </DropdownMenuItem>
+                ) : null}
+                {canDeleteDocument ? (
+                    <>
+                        <DropdownMenuSeparator />
+                        <DestructiveResourceActionItem
                             disabled={!doc || isDeleting}
-                            aria-label="Delete"
+                            onSelect={() => setShowDeleteDialog(true)}
                         >
-                            {isDeleting ? <StepLoader size="sm" /> : <Trash2 className="h-4 w-4" />}
-                        </Button>
-                    </TooltipTrigger>
-                    <TooltipContent>Delete</TooltipContent>
-                </Tooltip>
-            ) : null}
+                            Delete file
+                        </DestructiveResourceActionItem>
+                    </>
+                ) : null}
+            </ResourceActionsMenu>
             </div>
         </TooltipProvider>
     ), [
+        autosaveStatus,
         canDeleteDocument,
         canToggleTextView,
         canWriteDocument,
-        datastoreName,
         doc,
         documentPath,
         documentShareUrl,
@@ -770,13 +940,12 @@ export function DocumentViewer({
         previewType,
         handleCopyContent,
         handleDownload,
+        handlePrint,
         handleSave,
         handleShareVisibilityChange,
-        handleToggleFullscreen,
+        handleToggleReading,
         hasUnsavedChanges,
         isDeleting,
-        isFullscreen,
-        isFullscreenSupported,
         isLoadingContent,
         podId,
         textModeToggleLabel,
@@ -821,9 +990,45 @@ export function DocumentViewer({
         || (pdfPreviewError instanceof Error ? pdfPreviewError.message : null)
         || (docxPreviewError instanceof Error ? docxPreviewError.message : null);
 
+    /**
+     * Reading mode is read-only, and that is the point rather than a shortcut.
+     * The chrome that saves, shares and deletes is gone from the screen, so the
+     * mode should not also accept edits it has no way to acknowledge.
+     */
+    const isEditable = canWriteDocument && !isReading;
+
     return (
-        <div ref={viewerShellRef} className="document-viewer-shell relative flex h-full min-h-0 flex-col bg-[var(--card-bg)]">
-            {headerMode === 'inline' ? (
+        <div
+            ref={viewerShellRef}
+            className={cn(
+                'document-viewer-shell relative flex h-full min-h-0 flex-col',
+                isReading ? 'bg-[var(--bg-canvas)]' : 'bg-[var(--card-bg)]'
+            )}
+            data-reading={isReading ? 'true' : undefined}
+        >
+            {isReading ? (
+                <TooltipProvider>
+                    <div className="document-reading-exit">
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <Button
+                                    type="button"
+                                    variant="quiet"
+                                    size="icon"
+                                    className="h-8 w-8 rounded"
+                                    onClick={exitReading}
+                                    aria-label="Exit reading mode"
+                                >
+                                    <Minimize2 className="h-4 w-4" />
+                                </Button>
+                            </TooltipTrigger>
+                            <TooltipContent side="left">Exit reading mode — Esc</TooltipContent>
+                        </Tooltip>
+                    </div>
+                </TooltipProvider>
+            ) : null}
+
+            {headerMode === 'inline' && !isReading ? (
                 <div className="context-row flex-wrap items-center justify-between gap-2 px-3 py-2">
                 <div className="min-w-0 flex items-center gap-2">
                     {onClose ? (
@@ -864,17 +1069,20 @@ export function DocumentViewer({
 
                 {!isLoadingPreview && !previewError && (
                     previewType === 'markdown' ? (
-                        <div className="mx-auto max-w-4xl px-2 py-5 sm:px-4">
+                        // One column, one left edge. The frontmatter and the
+                        // prose used to sit in boxes of different widths, which
+                        // is what made a plain document look crooked.
+                        <div className="document-page px-2 py-5 sm:px-4">
                             <DocumentFrontmatter
                                 content={docContent}
                                 path={documentPath}
-                                editable={canWriteDocument}
+                                editable={isEditable}
                                 onChange={setDocContent}
                             />
                             <MarkdownEditor
                                 content={markdownBody}
-                                onChange={canWriteDocument ? handleMarkdownBodyChange : () => undefined}
-                                editable={canWriteDocument}
+                                onChange={isEditable ? handleMarkdownBodyChange : () => undefined}
+                                editable={isEditable}
                                 className="min-h-[70vh]"
                                 editorClassName="min-h-[70vh]"
                                 readableProse
@@ -893,9 +1101,9 @@ export function DocumentViewer({
                             className="document-viewer-source-field h-[78vh] w-full resize-none rounded-md border border-[color:var(--field-border)] bg-[var(--field-bg)] p-3 font-mono text-xs leading-5 text-[var(--text-secondary)] focus:outline-none"
                             value={docContent}
                             onChange={(event) => {
-                                if (canWriteDocument) setDocContent(event.target.value);
+                                if (isEditable) setDocContent(event.target.value);
                             }}
-                            readOnly={!canWriteDocument}
+                            readOnly={!isEditable}
                             spellCheck={false}
                         />
                     ) : previewType === 'image' ? (
@@ -982,6 +1190,20 @@ export function DocumentViewer({
                 isPending={isDeleting}
                 onConfirm={handleDelete}
             /> : null}
+
+            {/* Rendered here rather than inside the menu that opens it: a menu
+                unmounts on select, and would take a dialog nested in it along. */}
+            {canWriteDocument && canAttachDocumentMarkdown(previewType) ? (
+                <MarkdownAttachmentControl
+                    podId={podId}
+                    datastoreName={datastoreName}
+                    filePath={documentPath}
+                    metadata={doc.metadata}
+                    open={isAttachmentOpen}
+                    onOpenChange={setIsAttachmentOpen}
+                    showTrigger={false}
+                />
+            ) : null}
         </div>
     );
 }

--- a/lemma-frontend/components/documents/markdown-attachment-control.tsx
+++ b/lemma-frontend/components/documents/markdown-attachment-control.tsx
@@ -25,26 +25,44 @@ export function canAttachDocumentMarkdown(previewType: string): boolean {
     return MARKDOWN_ATTACHABLE_PREVIEW_TYPES.has(previewType);
 }
 
+/** Whether this document's agent-facing text is one someone uploaded. */
+export function usesUserMarkdown(metadata?: Record<string, unknown> | null): boolean {
+    return metadata?.markdown_source === 'user';
+}
+
 export function MarkdownAttachmentControl({
     podId,
     datastoreName,
     filePath,
     metadata,
     disabled,
+    open: controlledOpen,
+    onOpenChange,
+    showTrigger = true,
 }: {
     podId: string;
     datastoreName: string;
     filePath: string;
     metadata?: Record<string, unknown> | null;
     disabled?: boolean;
+    /**
+     * Drive the dialog from outside when the way in is somewhere this component
+     * cannot render — a menu item, say, whose menu unmounts on select and would
+     * take a dialog nested inside it along.
+     */
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+    showTrigger?: boolean;
 }) {
-    const [open, setOpen] = useState(false);
+    const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+    const open = controlledOpen ?? uncontrolledOpen;
+    const setOpen = onOpenChange ?? setUncontrolledOpen;
     const [markdownFile, setMarkdownFile] = useState<File | null>(null);
     const [imageFiles, setImageFiles] = useState<File[]>([]);
     const { mutate: attach, isPending: isAttaching } = useAttachDocumentMarkdown();
     const { mutate: detach, isPending: isDetaching } = useDetachDocumentMarkdown();
 
-    const isUserMarkdown = metadata?.markdown_source === 'user';
+    const isUserMarkdown = usesUserMarkdown(metadata);
     const assetNames = Array.isArray(metadata?.markdown_asset_names)
         ? (metadata.markdown_asset_names as string[])
         : [];
@@ -86,22 +104,24 @@ export function MarkdownAttachmentControl({
 
     return (
         <>
-            <Tooltip>
-                <TooltipTrigger asChild>
-                    <Button
-                        type="button"
-                        variant="quiet"
-                        size="icon"
-                        className={cn('h-8 w-8 rounded', isUserMarkdown && 'text-[var(--action-primary)]')}
-                        onClick={() => setOpen(true)}
-                        disabled={disabled}
-                        aria-label="Document markdown"
-                    >
-                        <FileText className="h-4 w-4" />
-                    </Button>
-                </TooltipTrigger>
-                <TooltipContent>{isUserMarkdown ? 'Using your markdown' : 'Attach your markdown'}</TooltipContent>
-            </Tooltip>
+            {showTrigger ? (
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <Button
+                            type="button"
+                            variant="quiet"
+                            size="icon"
+                            className={cn('h-8 w-8 rounded', isUserMarkdown && 'text-[var(--action-primary)]')}
+                            onClick={() => setOpen(true)}
+                            disabled={disabled}
+                            aria-label="Document markdown"
+                        >
+                            <FileText className="h-4 w-4" />
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{isUserMarkdown ? 'Using your markdown' : 'Attach your markdown'}</TooltipContent>
+                </Tooltip>
+            ) : null}
 
             <Dialog
                 open={open}

--- a/lemma-frontend/components/documents/markdown-editor.tsx
+++ b/lemma-frontend/components/documents/markdown-editor.tsx
@@ -65,23 +65,16 @@ export function MarkdownEditor({
     const editor = useEditor({
         extensions: [
             StarterKit,
+            // Marker classes only. How a table looks belongs to the document
+            // stylesheet, which sets it as data rather than as a boxed form;
+            // utilities pinned here would fight those rules cell by cell.
             Table.configure({
                 resizable: true,
-                HTMLAttributes: {
-                    class: 'lemma-markdown-table my-4 w-full border-collapse text-sm',
-                },
+                HTMLAttributes: { class: 'lemma-markdown-table' },
             }),
             TableRow,
-            TableHeader.configure({
-                HTMLAttributes: {
-                    class: 'border border-[var(--border-subtle)] bg-[var(--surface-2)] px-3 py-2 text-left text-xs font-semibold text-[var(--text-primary)]',
-                },
-            }),
-            TableCell.configure({
-                HTMLAttributes: {
-                    class: 'border border-[var(--border-subtle)] px-3 py-2 align-top',
-                },
-            }),
+            TableHeader,
+            TableCell,
             Placeholder.configure({
                 placeholder,
             }),

--- a/lemma-frontend/components/documents/preview-renderers.test.ts
+++ b/lemma-frontend/components/documents/preview-renderers.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { pdfRenderPixelRatio } from './preview-renderers';
+import {
+    canPrintDocument,
+    getDocumentPreviewType,
+    pdfRenderPixelRatio,
+    printFileName,
+} from './preview-renderers';
 
 describe('pdfRenderPixelRatio', () => {
     it('supersamples PDFs even on a 1x display', () => {
@@ -14,5 +19,64 @@ describe('pdfRenderPixelRatio', () => {
 
     it('uses a safe fallback for invalid ratios', () => {
         expect(pdfRenderPixelRatio(Number.NaN)).toBe(1.5);
+    });
+});
+
+describe('canPrintDocument', () => {
+    it('prints the prose the viewer typeset itself', () => {
+        expect(canPrintDocument('markdown')).toBe(true);
+    });
+
+    it('leaves a PDF to Download', () => {
+        // The file is already the artefact; re-printing a rasterised page
+        // through the browser hands over something worse than the bytes.
+        expect(canPrintDocument('pdf')).toBe(false);
+    });
+
+    it('stays away from previews the page cannot lay out', () => {
+        // An HTML preview lives in a sandboxed iframe, and office files and
+        // images are rendered from opaque blobs.
+        expect(canPrintDocument('html')).toBe(false);
+        expect(canPrintDocument('office')).toBe(false);
+        expect(canPrintDocument('image')).toBe(false);
+        expect(canPrintDocument('code')).toBe(false);
+        expect(canPrintDocument('json')).toBe(false);
+        expect(canPrintDocument('unsupported')).toBe(false);
+    });
+});
+
+describe('printFileName', () => {
+    it('drops the extension the browser is about to replace', () => {
+        // Otherwise the saved copy is `Zapdata_Proposal.md.pdf`.
+        expect(printFileName('Zapdata_Proposal.md')).toBe('Zapdata_Proposal');
+    });
+
+    it('keeps a name that has no extension', () => {
+        expect(printFileName('CHANGELOG')).toBe('CHANGELOG');
+    });
+
+    it('drops only the last extension', () => {
+        expect(printFileName('notes.2026.md')).toBe('notes.2026');
+    });
+
+    it('never empties a dotfile', () => {
+        // The leading dot opens the name rather than closing it, so treating it
+        // as an extension would save the file with no name at all.
+        expect(printFileName('.gitignore')).toBe('.gitignore');
+    });
+
+    it('ignores surrounding whitespace', () => {
+        expect(printFileName('  Proposal.md  ')).toBe('Proposal');
+    });
+});
+
+describe('getDocumentPreviewType', () => {
+    it('reads markdown by either extension', () => {
+        expect(getDocumentPreviewType('/docs/proposal.md')).toBe('markdown');
+        expect(getDocumentPreviewType('/docs/proposal.markdown')).toBe('markdown');
+    });
+
+    it('ignores case', () => {
+        expect(getDocumentPreviewType('/Docs/Deep/Zapdata_Proposal.MD')).toBe('markdown');
     });
 });

--- a/lemma-frontend/components/documents/preview-renderers.ts
+++ b/lemma-frontend/components/documents/preview-renderers.ts
@@ -188,6 +188,38 @@ export function getDocumentPreviewType(filePath: string): DocumentPreviewType {
     return 'unsupported';
 }
 
+/**
+ * Whether this document has a printable page behind it.
+ *
+ * Markdown only, and the restraint is the point. Print here means "lay the
+ * rendered page out on paper", which is a thing the viewer can honestly do for
+ * prose it typeset itself. A PDF is already the artefact — Download hands over
+ * the real bytes rather than a browser's re-print of a rasterised page. Office
+ * files and images are the same story, and an HTML preview lives in a sandboxed
+ * iframe the parent page cannot lay out at all.
+ */
+export function canPrintDocument(previewType: DocumentPreviewType): boolean {
+    return previewType === 'markdown';
+}
+
+/**
+ * What a printed copy of this document should be called.
+ *
+ * Browsers seed the "Save as PDF" filename from the page title, so without this
+ * a proposal saves as whatever the route was named. The extension goes because
+ * the browser appends its own — `Zapdata_Proposal.md.pdf` reads like a mistake.
+ */
+export function printFileName(documentName: string): string {
+    const trimmed = documentName.trim();
+    const lastDot = trimmed.lastIndexOf('.');
+
+    // `<= 0` covers both "no extension" and a leading dot, where the dot opens a
+    // hidden file's name rather than closing one — `.gitignore` must not print
+    // as the empty string.
+    if (lastDot <= 0) return trimmed;
+    return trimmed.slice(0, lastDot);
+}
+
 export function getOfficePreviewKind(filePath: string): OfficePreviewKind {
     const lowerPath = filePath.toLowerCase();
     if (lowerPath.endsWith('.docx')) return 'docx';

--- a/lemma-frontend/components/ui/icons.ts
+++ b/lemma-frontend/components/ui/icons.ts
@@ -172,6 +172,7 @@ export {
     Sidebar as PanelLeftOpen,
     SidebarSimple as PanelRightClose,
     Layout as PanelsTopLeft,
+    Printer,
     PuzzlePiece as Puzzle,
     Receipt as ReceiptText,
     ArrowsClockwise as RefreshCw,

--- a/lemma-frontend/styles/features/surfaces.css
+++ b/lemma-frontend/styles/features/surfaces.css
@@ -749,6 +749,27 @@
     border-left: 1px solid color-mix(in srgb, var(--border-subtle) 38%, transparent);
   }
 }
+}
+
+/* ===========================================================================
+   READING A DOCUMENT
+
+   In the utilities layer, and that is the whole point. Everything below used
+   to live in @layer components alongside the rest of this file, where
+   Tailwind Typography — which ships in @layer utilities — beat every one of
+   its declarations no matter how specific they were. Only the properties
+   `prose` happens not to set (font-family, the --tw-prose-* variables, the
+   code and rule colours) ever reached the screen.
+
+   So the document viewer was never styled by the block that claimed to style
+   it. What readers actually got was stock Typography: a 36px/800 hero for the
+   first heading, 24px/700 under it, magazine margins, and a table padded like
+   a settings form — inside a working pane. That is the whole of "everything
+   seems weird", and no amount of editing those rules in place would have
+   changed a pixel. `.agent-instructions-prose` is in the utilities layer for
+   exactly this reason, which is why the prompt page reads correctly today.
+   =========================================================================== */
+@layer utilities {
 
 .lemma-markdown-editor {
   --lemma-markdown-text: color-mix(in srgb, var(--text-primary) 93%, var(--text-secondary));
@@ -774,13 +795,12 @@
   --tw-prose-th-borders: var(--border-default);
   --tw-prose-td-borders: var(--border-subtle);
 
-  max-width: 76ch;
-  margin-inline: auto;
+  max-width: none;
   color: var(--lemma-markdown-text);
   font-family: var(--font-document-family);
-  font-size: var(--text-sm);
+  font-size: var(--text-base);
   font-weight: 400;
-  line-height: 1.62;
+  line-height: var(--leading-relaxed);
 }
 
 .dark .lemma-markdown-editor {
@@ -802,56 +822,73 @@
 }
 
 .lemma-markdown-editor.prose p {
-  margin-block: 0.72em;
+  margin-block: var(--space-4);
 }
 
+/* ---------------------------------------------------------------------------
+   The ladder
+
+   Nothing in a document is bold. Headings lead by size and by the air above
+   them — the space over a heading is several times the space under it, which
+   is what binds it to the paragraph it introduces. Weight is held at 500 all
+   the way down, including `strong`, so an emphasised phrase mid-sentence can
+   never out-shout the heading it sits beneath.
+
+   The steps are 24 / 20 / 16 / 16 over a 16px body. The bottom two rungs are
+   the body's own size and separate on tone: past the third level a document
+   is listing, not sectioning, and a fourth distinct size would be a fiction.
+   --------------------------------------------------------------------------- */
+
 .lemma-markdown-editor.prose h1 {
-  margin: 0 0 0.72em;
+  margin: 0 0 var(--space-3);
   color: var(--lemma-markdown-heading);
-  font-family: var(--font-landing-serif), Georgia, serif;
-  font-size: var(--text-2xl);
-  font-weight: 400;
+  font-family: var(--font-document-family);
+  font-size: var(--text-xl);
+  font-weight: 500;
   letter-spacing: 0;
-  line-height: 1.18;
+  line-height: var(--leading-tight);
   text-wrap: balance;
 }
 
 .lemma-markdown-editor.prose h2 {
-  margin: 1.65rem 0 0.5rem;
+  margin: var(--space-10) 0 var(--space-2);
   color: var(--lemma-markdown-heading);
   font-family: var(--font-document-family);
-  font-size: var(--text-base);
-  font-weight: 600;
+  font-size: var(--text-lg);
+  font-weight: 500;
   letter-spacing: 0;
-  line-height: 1.32;
+  line-height: var(--leading-snug);
 }
 
 .lemma-markdown-editor.prose h3 {
-  margin: 1.35rem 0 0.38rem;
-  color: var(--lemma-markdown-muted);
+  margin: var(--space-7) 0 var(--space-1-5);
+  color: var(--lemma-markdown-heading);
   font-family: var(--font-document-family);
-  font-size: var(--text-sm);
-  font-weight: 600;
-  letter-spacing: 0.035em;
-  line-height: 1.35;
-  text-transform: uppercase;
+  font-size: var(--text-base);
+  font-weight: 500;
+  letter-spacing: 0;
+  line-height: var(--leading-snug);
 }
 
 .lemma-markdown-editor.prose h4,
 .lemma-markdown-editor.prose h5,
 .lemma-markdown-editor.prose h6 {
-  margin: 1.2rem 0 0.3rem;
-  color: var(--lemma-markdown-heading);
+  margin: var(--space-5) 0 var(--space-1);
+  color: var(--lemma-markdown-muted);
   font-family: var(--font-document-family);
-  font-size: var(--text-sm);
-  font-weight: 600;
+  font-size: var(--text-base);
+  font-weight: 500;
   letter-spacing: 0;
-  line-height: 1.4;
+  line-height: var(--leading-normal);
+}
+
+.lemma-markdown-editor.prose :is(h1, h2, h3, h4, h5, h6):first-child {
+  margin-top: 0;
 }
 
 .lemma-markdown-editor.prose strong {
   color: var(--lemma-markdown-heading);
-  font-weight: 600;
+  font-weight: 500;
 }
 
 .lemma-markdown-editor.prose a {
@@ -861,12 +898,25 @@
   text-underline-offset: 0.18em;
 }
 
-/* Lists intentionally defer to Tailwind Typography (`prose`) for spacing and
-   markers, so they share the airy rhythm of the body copy. `prose` lives in
-   @layer utilities and this file is @layer components, so any list override
-   here would lose to `prose` anyway and only half-apply (that was the old
-   "numbers floating above the text" bug). The marker tone is themed via
-   --tw-prose-counters / --tw-prose-bullets on .lemma-markdown-editor above. */
+/* Lists sit on the paragraph rhythm rather than Typography's looser one; the
+   marker tone still comes from --tw-prose-counters / --tw-prose-bullets above.
+   These rules used to be omitted deliberately, because from @layer components
+   they could only ever half-apply — that was the old "numbers floating above
+   the text" bug. From here they land whole. */
+
+.lemma-markdown-editor.prose :is(ul, ol) {
+  margin-block: var(--space-4);
+  padding-left: var(--space-6);
+}
+
+.lemma-markdown-editor.prose li {
+  margin-block: var(--space-1);
+  padding-left: var(--space-1);
+}
+
+.lemma-markdown-editor.prose li > :is(p, ul, ol) {
+  margin-block: var(--space-1);
+}
 
 .lemma-markdown-editor.prose blockquote {
   margin-block: 1em;
@@ -899,21 +949,270 @@
 }
 
 .lemma-markdown-editor.prose hr {
-  margin-block: 1.5rem;
+  margin-block: var(--space-8);
   border-color: var(--lemma-markdown-rule);
 }
 
+/* ---------------------------------------------------------------------------
+   Tables are data, not prose
+
+   A boxed grid with a filled header row and a paragraph's worth of padding in
+   every cell is a settings form. It made a seven-row fee table taller than the
+   screen and heavier than the argument around it.
+
+   So: one step down in size, rules only between rows, no vertical lines, no
+   fill behind the header, and rows tight enough that the table is something
+   you take in at once. The header earns its place by tone, not by weight.
+   --------------------------------------------------------------------------- */
+
 .lemma-markdown-editor.prose .lemma-markdown-table {
+  margin-block: var(--space-5);
+  border-collapse: collapse;
+  width: 100%;
   font-size: var(--text-sm);
-  line-height: 1.55;
+  line-height: var(--leading-normal);
 }
 
-.document-viewer-shell:fullscreen {
-  width: 100vw;
-  height: 100vh;
-  height: 100dvh;
-  background: var(--card-bg);
+.lemma-markdown-editor.prose .lemma-markdown-table :is(th, td) {
+  border: 0;
+  border-bottom: 1px solid var(--lemma-markdown-rule);
+  padding: var(--space-2) var(--space-3);
+  vertical-align: top;
+  text-align: left;
 }
+
+/* First column carries the row's subject, so it starts at the text's own left
+   edge instead of a cell's worth of indent in from it. */
+.lemma-markdown-editor.prose .lemma-markdown-table :is(th, td):first-child {
+  padding-left: 0;
+}
+
+.lemma-markdown-editor.prose .lemma-markdown-table :is(th, td):last-child {
+  padding-right: 0;
+}
+
+.lemma-markdown-editor.prose .lemma-markdown-table th {
+  border-bottom-color: var(--lemma-markdown-marker);
+  background: transparent;
+  color: var(--lemma-markdown-muted);
+  font-size: var(--text-xs);
+  font-weight: 500;
+}
+
+.lemma-markdown-editor.prose .lemma-markdown-table tbody tr:last-child :is(th, td) {
+  border-bottom: 0;
+}
+
+.lemma-markdown-editor.prose .lemma-markdown-table p {
+  margin-block: 0;
+}
+
+/* ---------------------------------------------------------------------------
+   THE DOCUMENT PAGE — one measure, one left edge
+
+   The body used to nest two competing widths: a `max-w-4xl` wrapper around a
+   prose block that centred itself again at 76ch. The frontmatter and its rule
+   ran the full 896px while the sentences under them stopped at ~540 — two
+   left edges on one page, which is most of why the viewer read as crooked.
+   The page owns the measure now and the prose fills it.
+
+   `ch` is sized off the document text here on purpose, so the frontmatter row
+   (set smaller) still stops at the same pixel as the paragraphs below it.
+   --------------------------------------------------------------------------- */
+
+.document-page {
+  max-width: 46rem;
+  margin-inline: auto;
+}
+
+/* ---------------------------------------------------------------------------
+   READING MODE
+
+   In-app state first, browser fullscreen second. `requestFullscreen` alone was
+   never enough: the docs section renders its controls into the pod topbar,
+   which lives outside the element being promoted, so going fullscreen there
+   produced a document with no header, no save, and no way out but Esc. The
+   overlay below is what actually covers the screen, so the mode works the same
+   inside an iframe that was never granted fullscreen.
+
+   The type and the measure do not change here. The working pane already sets
+   a document the way it should be read; reading mode's job is to take away
+   what is around it, not to hand you a different document.
+   --------------------------------------------------------------------------- */
+
+/* 40, not 50: dialogs and menus portal to the end of `body` at 50 and must
+   still stack above this. */
+.document-viewer-shell[data-reading='true'] {
+  position: fixed;
+  z-index: 40;
+  inset: 0;
+  background: var(--bg-canvas);
+}
+
+.document-viewer-shell[data-reading='true'] .document-page {
+  padding-block: var(--space-16);
+}
+
+/* Quiet, not hidden. A hover-only reveal would be unreachable on touch, and
+   Esc is not discoverable enough to be the only way back. */
+.document-reading-exit {
+  position: absolute;
+  z-index: 1;
+  top: var(--space-4);
+  right: var(--space-4);
+  opacity: 0.45;
+  transition: opacity var(--dur-fast) var(--ease-standard);
+}
+
+.document-reading-exit:hover,
+.document-reading-exit:focus-within {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .document-reading-exit {
+    transition: none;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+   ON PAPER
+
+   Print is the PDF story: every desktop browser and iOS offers "Save as PDF"
+   from its own print dialog, so the honest thing to build is a page worth
+   printing rather than a converter that re-renders the document a second way.
+   The reading column is already that page — one measure, no chrome — so this
+   only has to get the application out of the way.
+
+   Two things make a naive print of this app come out wrong, and both are
+   handled below.
+
+   First, the app paints. `visibility: hidden` on everything, then visible again
+   from the page down, so the sidebar, the bar and the menus stop printing
+   without any of them having to be named — a list of chrome selectors would go
+   stale the first time the shell changes.
+
+   Second, the app scrolls. The document sits inside a pane with a fixed height
+   and `overflow: auto`, and paper has no fold to scroll past: printed as-is you
+   get the first screenful and nothing after it. Taking the page absolute out of
+   a statically-positioned shell makes the initial containing block its
+   container, so no ancestor's overflow can clip it and the whole document
+   flows across as many sheets as it needs.
+   --------------------------------------------------------------------------- */
+
+/* Everything here is `!important`, which in any other block would be a smell.
+   Print is the exception: this is not one more voice in the cascade, it is a
+   different medium taking over from a screen layout built out of utilities,
+   inline styles and unlayered base rules. There is no later author rule that
+   should ever win, and the failures when one does are invisible until someone
+   prints — which is how the first two attempts at this shipped wrong. */
+@media print {
+  body * {
+    visibility: hidden !important;
+  }
+
+  .document-page,
+  .document-page * {
+    visibility: visible !important;
+  }
+
+  /* `body *` reaches the body's descendants and nothing else — not the root,
+     not the body, and not the body's own pseudo-elements. All three paint, so
+     all three needed naming:
+       · `body` carries the warm canvas colour, and with no background on `html`
+         it propagates to the sheet itself — that is the block of ink behind
+         every page.
+       · `body::before` and `body::after` are two fixed decorative layers, an
+         atmosphere wash and a noise grain that blends over what is under it. A
+         fixed layer repeats on every page, so the grain lands on all of them.
+     Static as well as unpainted: `body` is positioned, which makes it the
+     containing block for the absolute page below instead of the page box. */
+  html,
+  body {
+    position: static !important;
+    background: none !important;
+    min-height: 0 !important;
+  }
+
+  body::before,
+  body::after {
+    display: none !important;
+  }
+
+  /* Static so the absolutely-positioned page below escapes it entirely —
+     position, not just overflow, is what decides who gets to clip. The reading
+     overlay is `fixed` at higher specificity, so it has to be named here or a
+     print started from reading mode keeps its viewport-sized box. */
+  .document-viewer-shell,
+  .document-viewer-shell[data-reading='true'] {
+    position: static !important;
+    height: auto !important;
+    max-height: none !important;
+    overflow: visible !important;
+  }
+
+  /* Screen ink is mixed to sit on a warm canvas. The same greys on white paper
+     read as haze, so the document prints at full strength. */
+  .document-page .lemma-markdown-editor {
+    --lemma-markdown-text: var(--text-primary);
+    --lemma-markdown-heading: var(--text-primary);
+    --lemma-markdown-muted: var(--text-secondary);
+    --lemma-markdown-marker: var(--text-secondary);
+    --lemma-markdown-rule: var(--border-default);
+  }
+
+  /* The sheet is white. Browsers drop backgrounds by default, but "background
+     graphics" is one checkbox away in every print dialog, and with it on the
+     warm canvas prints as a solid block of ink behind every page — which is
+     not a document anyone wants to hand over. Forced, because the fills come
+     from utilities of equal specificity and this is not a cascade to lose. */
+  .document-page,
+  .document-page * {
+    background: none !important;
+    box-shadow: none !important;
+  }
+
+  /* Absolute out of a now-static ancestry, so the containing block is the page
+     box itself: no ancestor can clip it and nothing above it on screen can push
+     it down the first sheet. `relative` on the shell is a Tailwind utility of
+     equal specificity to the rule that unsets it, which is exactly the kind of
+     tie this block refuses to leave to source order. */
+  .document-page {
+    position: absolute !important;
+    top: 0 !important;
+    left: 0 !important;
+    width: 100% !important;
+    max-width: none !important;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+
+  /* The paper supplies the margin; the screen's centred measure would only
+     add a second one inside it. */
+  @page {
+    margin: 18mm;
+  }
+
+  /* Nothing is orphaned from what it introduces: a heading never ends a sheet,
+     and a row never splits down the middle of its own numbers. */
+  .document-page :is(h1, h2, h3, h4, h5, h6) {
+    break-after: avoid;
+    break-inside: avoid;
+  }
+
+  .document-page :is(tr, li, blockquote, pre) {
+    break-inside: avoid;
+  }
+
+  .document-page .lemma-markdown-table thead {
+    display: table-header-group;
+  }
+}
+
+}
+/* End of the document-reading utilities layer. */
+
+@layer components {
 
 /* ---------------------------------------------------------------------------
    Surface setup modal.

--- a/lemma-frontend/styles/primitives.css
+++ b/lemma-frontend/styles/primitives.css
@@ -565,7 +565,7 @@
 
 .pod-shell-topbar-title {
   font-family: var(--font-body-family);
-  font-weight: 600;
+  font-weight: 500;
   letter-spacing: 0;
 }
 

--- a/lemma-frontend/vitest.config.ts
+++ b/lemma-frontend/vitest.config.ts
@@ -24,6 +24,13 @@ export default defineConfig({
             // Which kinds need an address typed in, and how an install reads
             // back as a line of text. Pure predicates over the catalog.
             'components/connectors/connector-utils.{test,spec}.ts',
+            // Which file types write themselves back, and the one line of
+            // status that says so. Decisions, not DOM.
+            'components/documents/document-save-state.{test,spec}.ts',
+            // Which file types the viewer can lay out on paper, and how a path
+            // maps to a preview. The heavy renderers alongside them are all
+            // behind dynamic imports, so the module loads fine under node.
+            'components/documents/preview-renderers.{test,spec}.ts',
             // Step ordering for local onboarding. Named file by file, like the
             // agent-runtime helpers above, so this stays a list of pure-logic
             // modules rather than becoming a glob over components.


### PR DESCRIPTION
## The cascade bug underneath everything

The doc viewer was never styled by the block that claimed to style it. Its rules lived in `@layer components`; Tailwind Typography ships in `@layer utilities` and beat every one of them no matter how specific. Only the properties `prose` happens *not* to set — `font-family`, the `--tw-prose-*` variables, the code and rule colours — ever reached the screen.

What readers actually got was stock Typography: a 36px/800 hero for the first heading, 24px/700 under it, magazine margins, and a table padded like a settings form — inside a working pane. That is the whole of "everything seems weird", and no amount of editing those rules in place would have changed a pixel. `.agent-instructions-prose` is in the utilities layer for exactly this reason, which is why the prompt page reads correctly today.

Moving the block to `@layer utilities` is the fix, and it is why every rule below it changes a pixel for the first time.

## With the rules landing, the design

- **Nothing is bold.** Headings lead by size and by the air above them — the space over a heading is several times the space under it. Weight holds at 500 all the way down, including `strong`, so an emphasised phrase mid-sentence can never out-shout the heading it sits beneath. The pod topbar title comes down to medium for the same reason: the bar names where you are, it does not headline it, and bold there made the filename shout over the document.
- **Tables are data, not prose.** Rules between rows, no vertical lines, no fill behind the header, rows tight enough to take in at once. A boxed grid with a filled header row made a seven-row fee table taller than the screen.
- **One left edge.** The page nested a `max-w-4xl` wrapper around a prose block that re-centred itself at 76ch — frontmatter running the full 896px over sentences that stopped at ~540. Two left edges on one page is most of why the viewer read as crooked.
- **Lists sit on the paragraph rhythm.** These rules used to be omitted deliberately, because from `@layer components` they could only half-apply — that was the old "numbers floating above the text" bug.

## Reading mode

In-app state first, browser fullscreen second. It was the other way round, and that shipped a full screen with no chrome in it: the viewer's controls render into the pod topbar, which lives *outside* the promoted element, so the reader got a document with no header, no save, and no way out but Esc. An overlay the component owns behaves the same inside an iframe that was never granted fullscreen.

## Print, which is how you get a PDF

Every desktop browser and iOS offers "Save as PDF" from its own print dialog, so the honest thing to build is a page worth printing rather than a converter that re-renders the document a second way. Two things make a naive print of this app come out wrong:

- **It paints.** Cleared by `visibility` from the body down rather than by a list of chrome selectors, which would go stale the first time the shell changes.
- **It scrolls.** The document sits in a pane with fixed height and `overflow: auto`; printed as-is you get the first screenful and nothing after it. The page goes absolute out of a now-static ancestry so no ancestor's overflow can clip it.

The dark theme comes off for the length of the print — browsers keep text colours while dropping backgrounds, so a dark document prints near-white ink on white paper. Print is limited to markdown on purpose: a PDF is already the artefact and Download hands over the real bytes; an HTML preview lives in a sandboxed iframe the parent cannot lay out at all.

## Also

Prose autosaves the way an agent prompt does and says so in one quiet line; source files keep their explicit Save, because a half-typed JSON object is not a state anyone wants persisted on a 700ms timer. Those decisions move to `document-save-state.ts`, which is the file that changes when a new preview type arrives.

## Verification

- `npm run check` (design audit, lint, typecheck, edu-anchors) — pass
- `npm test` — 481 tests pass, including new `document-save-state` and extended `preview-renderers` coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)