### PR TITLE
Let a start path hand the pod's own composer an unfinished sentence, instead of asking for a brief in a worse one

### DIFF
--- a/lemma-frontend/app/create-pod/page.tsx
+++ b/lemma-frontend/app/create-pod/page.tsx
@@ -1,123 +1,20 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-import { toast } from "sonner";
+import { useSearchParams } from "next/navigation";
 
 import { ProtectedRoute } from "@/components/auth/protected-route";
-import { useOrganization } from "@/components/dashboard/org-context";
-import { StartStep } from "@/components/onboarding/account-onboarding-steps";
-import {
-  derivePodNameFromIntent,
-  startPathLaunchConfig,
-  type OnboardingStartDetails,
-  type OnboardingStartPath,
-} from "@/components/onboarding/account-onboarding-helpers";
-import { WaitingScreen } from "@/components/shared/loading";
-import { FIRST_RUN_DELIGHT } from "@/lib/recipes/recipes";
-import {
-  normalizeRemixSource,
-  remixSourceLabel,
-} from "@/lib/remix/app-remix";
-import { getLemmaClient } from "@/lib/sdk/lemma-client";
+import { CreatePodScreen } from "@/components/pod/create-pod-screen";
 
 export default function CreatePodPage() {
   return (
     <ProtectedRoute>
-      <CreatePodScreen />
+      <CreatePodRoute />
     </ProtectedRoute>
   );
 }
 
-function CreatePodScreen() {
-  const router = useRouter();
+function CreatePodRoute() {
   const searchParams = useSearchParams();
-  const { currentOrg, isLoading } = useOrganization();
-  const [isCreating, setIsCreating] = useState(false);
-  const remixSource = normalizeRemixSource(searchParams.get("remixSource"));
 
-  const handleChoosePath = async (
-    path: OnboardingStartPath,
-    details: OnboardingStartDetails,
-  ) => {
-    if (path === "templates") {
-      router.push("/templates");
-      return true;
-    }
-    if (path === "coding-agents") return false;
-
-    if (!currentOrg) {
-      toast.error("Create or join an organization before creating a pod");
-      return false;
-    }
-
-    setIsCreating(true);
-    try {
-      const config = startPathLaunchConfig(path, details);
-      const assistantMessage = remixSource
-        ? [
-            config.message,
-            `Use ${remixSource} as the reference experience. Inspect it before building, preserve the interaction mechanics that matter, and make the result Lemma-native rather than a visual copy.`,
-          ].join("\n\n")
-        : config.message;
-      const podName = derivePodNameFromIntent(details.brief);
-      const pod = await getLemmaClient().pods.create({
-        name: podName,
-        description: details.brief.trim(),
-        organization_id: currentOrg.id,
-      });
-      const params = new URLSearchParams({
-        assistantMessage,
-        conversationInstructions: [
-          FIRST_RUN_DELIGHT,
-          `The pod already exists: ${pod.name}. Do not create another pod. Build only inside this pod. Treat the user's structured brief as authoritative, inspect existing resources first, and create the smallest complete working version for the selected surface.`,
-        ].join("\n\n"),
-        conversationMetadata: JSON.stringify({
-          source: "create_screen",
-          intent: config.intent,
-          first_run: true,
-          pod_id: pod.id,
-          start_path: path,
-          remix_source: remixSource,
-        }),
-      });
-
-      router.push(`/pod/${pod.id}/conversations/new?${params.toString()}`);
-      return true;
-    } catch (error) {
-      const message =
-        error instanceof Error && error.message
-          ? error.message
-          : "Failed to create pod";
-      toast.error(message);
-      setIsCreating(false);
-      return false;
-    }
-  };
-
-  if (isLoading) {
-    return (
-      <main className="setup-shell flex min-h-screen items-center justify-center px-4">
-        <WaitingScreen
-          title="Opening create"
-          description="Finding your current organization."
-          className="w-full max-w-lg"
-        />
-      </main>
-    );
-  }
-
-  return (
-    <StartStep
-      isCreating={isCreating}
-      onChoosePath={handleChoosePath}
-      onBack={() => router.push("/home")}
-      initialPath={remixSource ? "internal-app" : undefined}
-      initialBrief={
-        remixSource
-          ? `Recreate the useful app experience from ${remixSourceLabel(remixSource)} inside Lemma`
-          : ""
-      }
-    />
-  );
+  return <CreatePodScreen remixSource={searchParams.get("remixSource")} />;
 }

--- a/lemma-frontend/app/pod/[id]/conversations/[conversationId]/page.tsx
+++ b/lemma-frontend/app/pod/[id]/conversations/[conversationId]/page.tsx
@@ -25,6 +25,7 @@ import { useAgent, useAgents } from '@/lib/hooks/use-agents';
 import { useConversation } from '@/lib/hooks/use-assistants';
 import { usePod } from '@/lib/hooks/use-pods';
 import { usePodAccess } from '@/lib/hooks/use-pod-access';
+import { parseConversationMetadataParam } from '@/lib/pods/composer-launch';
 import { withSettingsReturnPath } from '@/lib/navigation/settings-return';
 import type { AgentRuntimeConfig } from '@/lib/types';
 
@@ -38,16 +39,6 @@ function waitForConversationReset() {
             window.requestAnimationFrame(() => resolve());
         });
     });
-}
-
-function parseConversationMetadata(value: string | null): Record<string, unknown> | null {
-    if (!value) return null;
-    try {
-        const parsed = JSON.parse(value);
-        return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed as Record<string, unknown> : null;
-    } catch {
-        return null;
-    }
 }
 
 export default function PodConversationPage({
@@ -85,7 +76,7 @@ export default function PodConversationPage({
     );
     const conversationInstructions = searchParams.get('conversationInstructions');
     const conversationMetadata = useMemo(
-        () => parseConversationMetadata(searchParams.get('conversationMetadata')),
+        () => parseConversationMetadataParam(searchParams.get('conversationMetadata')),
         [searchParams]
     );
     const isNewConversation = conversationId === 'new';

--- a/lemma-frontend/app/pod/[id]/layout.tsx
+++ b/lemma-frontend/app/pod/[id]/layout.tsx
@@ -26,6 +26,7 @@ import { getLemmaClient } from "@/lib/sdk/lemma-client";
 import { usePod } from "@/lib/hooks/use-pods";
 import { usePodContext } from "@/lib/hooks/use-pod-context";
 import { usePodAccess } from "@/lib/hooks/use-pod-access";
+import { parseConversationMetadataParam } from "@/lib/pods/composer-launch";
 import { clearLastOpenedPodId, writeLastOpenedPodId } from "@/lib/pods/last-opened-pod";
 import { getWorkspaceTabAfterClose, getWorkspaceTabHref } from "@/lib/pods/workspace-tabs";
 import {
@@ -75,17 +76,6 @@ function formatDisplayName(value: string | null | undefined) {
         .join(" ");
 }
 
-function parseConversationMetadataParam(value: string | null): Record<string, unknown> | undefined {
-    if (!value) return undefined;
-    try {
-        const parsed = JSON.parse(value);
-        return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-            ? parsed as Record<string, unknown>
-            : undefined;
-    } catch {
-        return undefined;
-    }
-}
 
 function getPodSectionLabel(podId: string, pathname: string) {
     const section = pathname.replace(`/pod/${podId}`, "").split("/").filter(Boolean)[0];
@@ -291,7 +281,7 @@ function PodShell({
     const conversationInstructions = searchParams.get("conversationInstructions");
     const conversationMetadata = searchParams.get("conversationMetadata");
     const parsedConversationMetadata = useMemo(
-        () => parseConversationMetadataParam(conversationMetadata),
+        () => parseConversationMetadataParam(conversationMetadata) ?? undefined,
         [conversationMetadata]
     );
     const assistantConversationId = searchParams.get("assistantConversationId");

--- a/lemma-frontend/app/pod/[id]/page.tsx
+++ b/lemma-frontend/app/pod/[id]/page.tsx
@@ -2,13 +2,14 @@
 
 import { use, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { ArrowRight, ArrowUp, ChevronDown, ChevronUp, Plus, UserPlus, X } from '@/components/ui/icons';
 
 import { useAIAssistant } from '@/components/ai/ai-assistant-context';
 import { ProtectedRoute } from '@/components/auth/protected-route';
 import { resolveDefaultAgentRuntime } from '@/components/agents/agent-runtime-helpers';
 import { RuntimeModelPicker } from '@/components/lemma/assistant/model-picker';
+import { PodNewWorkspace } from '@/components/pod/pod-new-workspace';
 import { StarterThemePicker } from '@/components/recipes/starter-theme-card';
 import { Button } from '@/components/ui/button';
 import { FEATURED_STARTER_THEMES } from '@/lib/recipes/recipes';
@@ -26,6 +27,7 @@ import { usePod } from '@/lib/hooks/use-pods';
 import { usePodAccess } from '@/lib/hooks/use-pod-access';
 import { usePodJoinRequests } from '@/lib/hooks/use-pod-join-requests';
 import { usePodSurfaces } from '@/lib/hooks/use-pod-surfaces';
+import { buildScopedConversationHref } from '@/lib/assistant/conversation-composer-context';
 import { useSchedules } from '@/lib/hooks/use-schedules';
 import { PodHomePresence } from '@/components/pod/pod-home-presence';
 import { cn } from '@/lib/utils';
@@ -36,6 +38,7 @@ import {
     resolvePodHomeStarterMode,
     type PodHomeResourceSignals,
 } from '@/lib/pods/pod-home-starters';
+import { readComposerLaunch, stripComposerLaunchParams } from '@/lib/pods/composer-launch';
 import type { AgentRuntimeConfig, Conversation } from '@/lib/types';
 import { StepLoader } from '@/components/brand/loader';
 import { Skeleton } from '@/components/shared/loading';
@@ -78,10 +81,11 @@ interface ComposerLaunchAnimation {
 
 function PodBlankChatHome({ podId }: { podId: string }) {
     const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
     const assistant = useAIAssistant();
     const podAccess = usePodAccess(podId);
     const { data: pod } = usePod(podId);
-    const { launchRecipe } = useLaunchRecipe(podId, { podName: pod?.name });
     const { data: runtimeCatalog } = useAgentRuntimes(pod?.organization_id);
     const canWriteConversations = podAccess.can('conversation.write');
     const canReadAgents = podAccess.can('agent.read');
@@ -110,6 +114,12 @@ function PodBlankChatHome({ podId }: { podId: string }) {
     const submittedFromConversationRef = useRef<string | null>(null);
     const launchFrameRef = useRef<number | null>(null);
     const launchTimerRef = useRef<number | null>(null);
+    // A composer launch arrives as URL params, is consumed once, and is stripped
+    // from the URL. Refs rather than state because nothing renders from them and
+    // a re-render mid-send must not drop the framing off the message in flight.
+    const composerLaunchSeededRef = useRef(false);
+    const launchInstructionsRef = useRef<string | null>(null);
+    const launchMetadataRef = useRef<Record<string, unknown> | null>(null);
 
     const isLaunchingComposer = launchAnimation !== null;
     const isBlankingHome = isLaunchingComposer || isRouteHandoff;
@@ -148,6 +158,43 @@ function PodBlankChatHome({ podId }: { podId: string }) {
         const timer = window.setTimeout(() => setShowHomePanels(true), HOME_PANELS_DEFER_MS);
         return () => window.clearTimeout(timer);
     }, []);
+
+    /** Caret after the stem's trailing space, so the next keystroke continues it. */
+    const focusComposerAtEnd = () => {
+        window.requestAnimationFrame(() => {
+            const input = composerInputRef.current;
+            if (!input) return;
+            input.focus();
+            input.setSelectionRange(input.value.length, input.value.length);
+        });
+    };
+
+    /** A shortcut tile hands over an unfinished sentence; it never sends one. */
+    const prepareComposerPrompt = (prompt: string) => {
+        setDraft(prompt);
+        focusComposerAtEnd();
+    };
+
+    // Arriving from a start path: the composer opens holding the start of a
+    // sentence, cursor at the end, and nothing is sent. Once only — the params
+    // come straight back off the URL so a refresh cannot re-seed a draft the
+    // user already cleared.
+    useEffect(() => {
+        if (composerLaunchSeededRef.current) return;
+        const launch = readComposerLaunch(searchParams);
+        if (!launch) return;
+
+        composerLaunchSeededRef.current = true;
+        if (launch.draft) setDraft(launch.draft);
+        launchInstructionsRef.current = launch.instructions ?? null;
+        launchMetadataRef.current = launch.metadata ?? null;
+
+        const nextQuery = stripComposerLaunchParams(searchParams);
+        router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname);
+
+        // After the replace, so the focus is not stolen by the re-render.
+        focusComposerAtEnd();
+    }, [pathname, router, searchParams]);
 
     useEffect(() => {
         const previousConversationId = submittedFromConversationRef.current;
@@ -245,7 +292,15 @@ function PodBlankChatHome({ podId }: { podId: string }) {
         setIsSending(true);
         try {
             assistant.clearMessages();
-            await assistant.sendMessage(message, { forceNewConversation: true });
+            await assistant.sendMessage(message, {
+                forceNewConversation: true,
+                instructions: launchInstructionsRef.current || undefined,
+                conversationMetadata: launchMetadataRef.current ?? undefined,
+            });
+            // The framing belonged to the sentence they just finished, not to
+            // the pod. Everything after this is an ordinary message.
+            launchInstructionsRef.current = null;
+            launchMetadataRef.current = null;
             setDraft('');
         } catch (error) {
             setLaunchAnimation(null);
@@ -278,40 +333,18 @@ function PodBlankChatHome({ podId }: { podId: string }) {
                 )}
             >
                 {showStarterHome ? (
-                    <section className="w-full">
-                        <div className="max-w-3xl">
-                            <p className="type-eyebrow-mono text-[var(--text-tertiary)]">Start inside this pod</p>
-                            <h1 className="mt-3 text-3xl font-semibold leading-tight tracking-tight text-[var(--text-primary)] sm:text-4xl">
-                                What should {pod?.name || 'this pod'} become?
-                            </h1>
-                            <p className="mt-3 max-w-2xl text-base leading-7 text-[var(--text-secondary)]">
-                                Choose a direction, then pick a concrete starting point inside it. Lemma builds the app, agent, data, and connections together — all inside this pod.
-                            </p>
-                        </div>
-                        <div className="mt-7">
-                            <StarterThemePicker
-                                themes={FEATURED_STARTER_THEMES}
-                                onLaunch={(recipe, message) => launchRecipe(recipe, { message })}
-                            />
-                        </div>
-                        <div className="mt-5 flex items-center justify-between gap-4">
-                            <p className="text-sm text-[var(--text-tertiary)]">Explore a family first. Choose the concrete build inside.</p>
-                            <Link
-                                href={`/pod/${podId}/recipes`}
-                                className="custom-focus-ring inline-flex shrink-0 items-center gap-1.5 text-sm font-medium text-[var(--text-primary)]"
-                            >
-                                See every starting point
-                                <ArrowRight className="h-4 w-4" />
-                            </Link>
-                        </div>
-                        <div className="my-8 flex items-center gap-3 text-xs text-[var(--text-tertiary)]">
-                            <span className="h-px flex-1 bg-[var(--border-subtle)]" />
-                            or describe your own
-                            <span className="h-px flex-1 bg-[var(--border-subtle)]" />
-                        </div>
+                    <section className="w-full max-w-3xl">
+                        <p className="type-eyebrow-mono text-[var(--text-tertiary)]">Start inside this pod</p>
+                        <h1 className="mt-3 text-2xl font-medium leading-tight tracking-tight text-[var(--text-primary)] sm:text-3xl">
+                            What should {pod?.name || 'this pod'} become?
+                        </h1>
                     </section>
                 ) : null}
-                <div className="w-full max-w-3xl">
+                {/* The composer sits directly under the question it answers.
+                    It used to be last, below a themed picker, a prompt list and
+                    two captions explaining them — so the screen asked three
+                    times and buried the one field that takes any answer. */}
+                <div className={cn('w-full max-w-3xl', showStarterHome && 'mt-6')}>
                     {showStarterHome ? null : (
                         <p className="pod-home-eyebrow mb-3.5">{pod?.name || 'This pod'}</p>
                     )}
@@ -413,6 +446,29 @@ function PodBlankChatHome({ podId }: { podId: string }) {
                         </div>
                     )}
                 </div>
+                {/* The same launcher the new-conversation screen uses, in the same
+                    place relative to the composer: shortcuts under the box you
+                    type in. Home used to grow its own for the identical job —
+                    taller themed tabs, a second prompt list, and two captions
+                    explaining both — which is what made this read as three
+                    screens asking the same question. */}
+                {showStarterHome ? (
+                    <section className="mt-8 w-full max-w-3xl">
+                        <PodNewWorkspace
+                            podId={podId}
+                            selectedAgentName={null}
+                            onPreparePrompt={prepareComposerPrompt}
+                            onSelectAgent={(agentName) =>
+                                router.push(buildScopedConversationHref({
+                                    podId,
+                                    conversationId: 'new',
+                                    agentName,
+                                }))
+                            }
+                            placement="below-composer"
+                        />
+                    </section>
+                ) : null}
                 {/* Nothing until we know which home this is. A fresh pod shows the
                     starter section above and no activity region at all, so drawing
                     the activity skeleton first promised a panel that never arrived

--- a/lemma-frontend/components/onboarding/account-onboarding-helpers.ts
+++ b/lemma-frontend/components/onboarding/account-onboarding-helpers.ts
@@ -38,12 +38,15 @@ export type OnboardingStartPath =
   | "internal-app"
   | "agent-skin"
   | "coding-agents"
-  | "templates";
-export type OnboardingStartDetails = {
-  brief: string;
-  secondaryBrief?: string;
-  codingAgent?: CodingAgentKind;
-};
+  | "templates"
+  // An empty pod, and nothing else. The way out of every guided path, for
+  // anyone who already knows what they are doing.
+  | "blank";
+/** A start path that seeds the pod's own composer rather than a form. */
+export type ComposerStartPath = Extract<
+  OnboardingStartPath,
+  "telegram" | "chatgpt" | "internal-app" | "agent-skin"
+>;
 export type CodingAgentKind = "codex" | "claude-code" | "opencode";
 
 export function codingAgentStarterPrompt(agent: CodingAgentKind) {
@@ -67,22 +70,39 @@ First inspect this repository and explain, in one short paragraph, the most usef
 Ask only one question if the repository does not make the intended outcome clear. Work through the ${agentName} session you are already running in.`;
 }
 
-export function startPathLaunchConfig(
-  path: Exclude<OnboardingStartPath, "templates" | "coding-agents">,
-  details: OnboardingStartDetails,
-) {
-  const brief = details.brief.trim();
-  const secondaryBrief = details.secondaryBrief?.trim();
-
+/**
+ * What a start path hands to the pod, now that it no longer collects a brief.
+ *
+ * A path used to be a form: pick a card, fill a textarea, and we baked the
+ * answer into one long prompt and sent it. That textarea was a second, worse
+ * composer — no attachments, no model picker, no agent scope, and disabled
+ * until you typed. So a path now produces two things instead:
+ *
+ * - `stem`, an unfinished sentence the real composer opens with, cursor at the
+ *   end. The user finishes it where they can also attach a file or change model.
+ * - `instructions`, the durable framing that used to surround the brief. It
+ *   rides along as the conversation's background instructions, so it shapes the
+ *   build without being something the user has to read or write.
+ * - `podName`, because picking a path already says what the pod is. Falling back
+ *   to "Untitled pod" after someone pressed "Telegram agent" throws away the one
+ *   thing they just told us. Only used when they did not type a name themselves.
+ *
+ * Nothing is sent until they press enter.
+ */
+export function startPathComposerLaunch(path: ComposerStartPath): {
+  intent: string;
+  podName: string;
+  stem: string;
+  instructions: string;
+} {
   if (path === "telegram") {
     return {
       intent: "telegram_agent_companion_app",
-      message: [
-        "Build a Telegram agent and a companion app inside this pod.",
-        `Use these as the agent's custom operating instructions: ${brief}`,
-        secondaryBrief
-          ? `The companion app should keep this organized: ${secondaryBrief}`
-          : "The companion app should turn the agent's messages and actions into a useful, persistent view.",
+      podName: "Telegram Agent",
+      stem: "Build a Telegram agent and companion app that ",
+      instructions: [
+        "Treat the user's message as the agent's custom operating instructions.",
+        "The companion app should turn the agent's messages and actions into a useful, persistent view.",
         "Create the smallest working version, with believable sample data. Then guide me through connecting Telegram. Do not claim Telegram is connected until the connector is actually authorized.",
       ].join("\n\n"),
     };
@@ -91,9 +111,10 @@ export function startPathLaunchConfig(
   if (path === "chatgpt") {
     return {
       intent: "external_ai_pod_mcp",
-      message: [
+      podName: "ChatGPT Work State",
+      stem: "Keep this work state current so ChatGPT or Claude can continue it: ",
+      instructions: [
         "Set up this pod so ChatGPT or Claude can keep real work state updated through the pod-scoped Lemma MCP surface.",
-        `The work that should stay current is: ${brief}`,
         "Create the durable tables, files, and views needed for that state, seed a useful first version, and preserve clear ownership and history.",
         "Then guide me through connecting my external AI client to this pod's MCP surface. Do not pretend the external connection is complete before it is authorized and tested.",
       ].join("\n\n"),
@@ -101,35 +122,26 @@ export function startPathLaunchConfig(
   }
 
   if (path === "agent-skin") {
-    const agentName =
-      details.codingAgent === "claude-code"
-        ? "Claude Code"
-        : details.codingAgent === "opencode"
-          ? "OpenCode"
-          : "Codex";
-
     return {
       intent: "local_agent_workspace_skin",
-      message: [
-        `Build a persistent Lemma workspace skin around ${agentName}.`,
-        `The state and controls that should remain visible between local-agent sessions are: ${brief}`,
-        secondaryBrief
-          ? `People should be able to steer the agent through: ${secondaryBrief}`
-          : "Give people a clear place to inspect state, steer the work, and revisit outputs without reading a terminal transcript.",
+      podName: "Coding Agent Pod",
+      stem: "Put a persistent workspace around my coding agent showing ",
+      instructions: [
+        "Build a persistent Lemma workspace skin around the user's local coding agent. Ask which one they run — Codex, Claude Code, or OpenCode — if they have not said.",
+        "Give people a clear place to inspect state, steer the work, and revisit outputs without reading a terminal transcript.",
         "Keep the local coding agent as the executor. Build the durable state, app surfaces, run history, and artifacts around it in Lemma, using the Agent Host and MCP boundary where supported.",
-        `Then guide me through connecting ${agentName}. Do not claim the local agent is connected until its runtime is available, authorized, and tested.`,
+        "Then guide me through connecting that agent. Do not claim the local agent is connected until its runtime is available, authorized, and tested.",
       ].join("\n\n"),
     };
   }
 
   return {
     intent: "internal_ai_app",
-    message: [
+    podName: "Internal App",
+    stem: "Build an internal app that lets my team ",
+    instructions: [
       "Build an internal AI app inside this pod.",
-      `The team should be able to: ${brief}`,
-      secondaryBrief
-        ? `The primary users are: ${secondaryBrief}`
-        : "Keep the first version focused on one clear user and one repeated decision or workflow.",
+      "Keep the first version focused on one clear user and one repeated decision or workflow.",
       "Put the app in front and the agents behind it. Create the durable state, approval points, and believable sample data needed to make the first version immediately usable.",
     ].join("\n\n"),
   };

--- a/lemma-frontend/components/onboarding/account-onboarding-steps.tsx
+++ b/lemma-frontend/components/onboarding/account-onboarding-steps.tsx
@@ -8,6 +8,7 @@ import {
   Building2,
   Check,
   CheckCircle2,
+  Circle,
   Code2,
   Copy,
   KeyRound,
@@ -71,8 +72,8 @@ import {
   type Audience,
   type CodingAgentKind,
   type BuildPath,
+  type ComposerStartPath,
   type ConnectChoice,
-  type OnboardingStartDetails,
   type OnboardingStartPath,
   type SetupStep,
   type TeamKind,
@@ -837,7 +838,7 @@ function ConnectOptionCard({
 }
 
 const START_PATHS: Array<{
-  id: Exclude<OnboardingStartPath, "coding-agents" | "templates">;
+  id: ComposerStartPath;
   title: string;
   description: string;
   tone: "channel" | "tools" | "app" | "coding";
@@ -873,7 +874,7 @@ const START_PATHS: Array<{
 ];
 
 const SUPPORT_PATHS: Array<{
-  id: Extract<OnboardingStartPath, "coding-agents" | "templates">;
+  id: Extract<OnboardingStartPath, "coding-agents" | "templates" | "blank">;
   title: string;
   description: string;
   icon: React.ComponentType<{ className?: string }>;
@@ -889,6 +890,14 @@ const SUPPORT_PATHS: Array<{
     title: "Explore templates",
     description: "Start from a complete, proven shape",
     icon: Boxes,
+  },
+  // The way past all of it. Someone who already knows what a pod is should not
+  // have to pick a theme to get one.
+  {
+    id: "blank",
+    title: "Start with an empty pod",
+    description: "Skip the guided start and build from inside",
+    icon: Circle,
   },
 ];
 
@@ -935,41 +944,37 @@ function StartPathIllustration({
   );
 }
 
+/**
+ * The first-run fork: four ways a pod gets used, and the ways past them.
+ *
+ * A card used to open a second screen with a required textarea before anything
+ * was created. That box was the worst place in the product to describe what you
+ * wanted — no attachments, no model picker, no pod to look at, and a disabled
+ * button until you typed. Picking a card now creates the pod and seeds the
+ * pod's own composer with the start of a sentence instead.
+ */
 export function StartStep({
   isCreating,
   onChoosePath,
   onBack,
-  initialPath,
-  initialBrief = "",
 }: {
   isCreating: boolean;
-  onChoosePath: (
-    path: OnboardingStartPath,
-    details: OnboardingStartDetails,
-  ) => Promise<boolean>;
+  onChoosePath: (path: OnboardingStartPath) => Promise<boolean>;
   onBack?: () => void;
-  initialPath?: Exclude<OnboardingStartPath, "templates">;
-  initialBrief?: string;
   steps?: SetupStep[];
 }) {
-  const [selectedPath, setSelectedPath] =
-    useState<Exclude<OnboardingStartPath, "templates"> | null>(
-      initialPath ?? null,
-    );
+  // Only the coding-agent pathway still has a screen behind it: it hands over a
+  // prompt to paste elsewhere, which is not something a composer can do.
+  const [showCodingAgents, setShowCodingAgents] = useState(false);
   const [pendingPath, setPendingPath] = useState<OnboardingStartPath | null>(null);
-  const [brief, setBrief] = useState(initialBrief);
-  const [secondaryBrief, setSecondaryBrief] = useState("");
   const [codingAgent, setCodingAgent] = useState<CodingAgentKind>("codex");
   const [promptCopied, setPromptCopied] = useState(false);
 
-  const choosePath = async (
-    path: OnboardingStartPath,
-    details: OnboardingStartDetails,
-  ) => {
+  const choosePath = async (path: OnboardingStartPath) => {
     if (isCreating || pendingPath) return;
     setPendingPath(path);
     try {
-      const isNavigating = await onChoosePath(path, details);
+      const isNavigating = await onChoosePath(path);
       if (isNavigating) return;
       setPendingPath(null);
     } catch {
@@ -977,17 +982,16 @@ export function StartStep({
     }
   };
 
-  if (selectedPath) {
-    if (selectedPath === "coding-agents") {
-      const starterPrompt = codingAgentStarterPrompt(codingAgent);
+  if (showCodingAgents) {
+    const starterPrompt = codingAgentStarterPrompt(codingAgent);
 
-      return (
-        <SetupStandalonePage
-          onBack={() => {
-            setSelectedPath(null);
-            setPromptCopied(false);
-          }}
-        >
+    return (
+      <SetupStandalonePage
+        onBack={() => {
+          setShowCodingAgents(false);
+          setPromptCopied(false);
+        }}
+      >
           <div className="m-auto w-full max-w-2xl pb-12">
             <p className="setup-first-run-eyebrow">Coding agent pathway</p>
             <h1 className="mt-3 font-display text-2xl font-medium leading-tight tracking-tight text-[var(--text-primary)] sm:text-3xl">
@@ -1070,179 +1074,6 @@ export function StartStep({
             </Button>
           </div>
         </SetupStandalonePage>
-      );
-    }
-
-    const detailCopy = {
-      telegram: {
-        eyebrow: "Telegram agent + app",
-        title: "What should your agent do?",
-        description:
-          "Write the instructions it should operate by. Lemma will turn them into the agent's custom instructions, then build the companion app around the resulting work.",
-        label: "Agent instructions",
-        placeholder:
-          "Example: Capture every voice note and message, classify it as an idea, task, or person, and ask one follow-up question when context is missing.",
-        secondaryLabel: "What should the companion app keep organized?",
-        secondaryPlaceholder:
-          "Example: A searchable logbook with people, ideas, tasks, and weekly review.",
-        action: "Build agent + app",
-      },
-      chatgpt: {
-        eyebrow: "External AI + Lemma MCP",
-        title: "What work should your AI keep updated?",
-        description:
-          "Lemma will create the durable work state. ChatGPT or Claude can read it, update it, and continue where they left off through the pod's MCP surface.",
-        label: "Work state",
-        placeholder:
-          "Example: Keep my fundraising pipeline current—investors, last interaction, open questions, next step, and anything that is going stale.",
-        secondaryLabel: null,
-        secondaryPlaceholder: null,
-        action: "Create shared work state",
-      },
-      "internal-app": {
-        eyebrow: "Internal AI app",
-        title: "What should the app help your team do?",
-        description:
-          "Start with one repeated job or decision. Lemma will build the app in front, with agents and durable state behind it.",
-        label: "The job to be done",
-        placeholder:
-          "Example: Review inbound partnership requests, enrich each company, recommend an owner, and prepare an approve-or-reject decision.",
-        secondaryLabel: "Who will use it?",
-        secondaryPlaceholder:
-          "Example: Partnerships and operations",
-        action: "Build internal app",
-      },
-      "agent-skin": {
-        eyebrow: "Local agent workspace",
-        title: "What should stay visible around your agent?",
-        description:
-          "The local agent remains the executor. Lemma becomes the persistent product surface around it—state, controls, outputs, and history that survive each terminal session.",
-        label: "Persistent workspace",
-        placeholder:
-          "Example: The current plan, task queue, run status, decisions, generated artifacts, and everything waiting for my review.",
-        secondaryLabel: "How should people steer it?",
-        secondaryPlaceholder:
-          "Example: Approve the plan, reprioritize tasks, retry a failed step, and review generated work.",
-        action: "Build agent workspace",
-      },
-    }[selectedPath];
-
-    return (
-      <SetupStandalonePage
-        onBack={() => {
-          if (pendingPath) return;
-          setSelectedPath(null);
-          setBrief("");
-          setSecondaryBrief("");
-        }}
-      >
-        <div className="m-auto w-full max-w-2xl pb-12">
-          <p className="setup-first-run-eyebrow">{detailCopy.eyebrow}</p>
-          <h1 className="mt-3 font-display text-2xl font-medium leading-tight tracking-tight text-[var(--text-primary)] sm:text-3xl">
-            {detailCopy.title}
-          </h1>
-          <p className="mt-3 max-w-xl text-sm leading-6 text-[var(--text-secondary)]">
-            {detailCopy.description}
-          </p>
-
-          {selectedPath === "agent-skin" ? (
-            <div className="mt-7">
-              <Label className="text-sm text-[var(--text-secondary)]">
-                Local agent
-              </Label>
-              <div className="mt-2 grid grid-cols-3 gap-2">
-                {[
-                  { id: "codex" as const, label: "Codex" },
-                  { id: "claude-code" as const, label: "Claude Code" },
-                  { id: "opencode" as const, label: "OpenCode" },
-                ].map((agent) => (
-                  <Button
-                    key={agent.id}
-                    type="button"
-                    variant="quiet"
-                    data-active={codingAgent === agent.id}
-                    onClick={() => setCodingAgent(agent.id)}
-                    className="setup-detail-choice h-11 justify-between px-3 text-sm"
-                  >
-                    {agent.label}
-                    {codingAgent === agent.id ? (
-                      <Check className="h-4 w-4 text-[var(--action-primary)]" />
-                    ) : null}
-                  </Button>
-                ))}
-              </div>
-            </div>
-          ) : null}
-
-          <div className="mt-7">
-            <Label
-              htmlFor="start-path-brief"
-              className="text-sm text-[var(--text-secondary)]"
-            >
-              {detailCopy.label}
-            </Label>
-            <Textarea
-              id="start-path-brief"
-              autoFocus
-              rows={6}
-              value={brief}
-              onChange={(event) => setBrief(event.target.value)}
-              placeholder={detailCopy.placeholder}
-              className="setup-detail-textarea mt-2 resize-none text-sm leading-6"
-            />
-          </div>
-
-          {detailCopy.secondaryLabel ? (
-            <div className="mt-5">
-              <Label
-                htmlFor="start-path-secondary"
-                className="text-sm text-[var(--text-secondary)]"
-              >
-                {detailCopy.secondaryLabel}
-                <span className="ml-1 font-normal text-[var(--text-tertiary)]">
-                  optional
-                </span>
-              </Label>
-              <Input
-                id="start-path-secondary"
-                value={secondaryBrief}
-                onChange={(event) => setSecondaryBrief(event.target.value)}
-                placeholder={detailCopy.secondaryPlaceholder || undefined}
-                className="setup-detail-input mt-2 h-11 text-sm"
-              />
-            </div>
-          ) : null}
-
-          {selectedPath === "chatgpt" ? (
-            <div className="setup-mcp-note mt-5 flex items-start gap-3 px-4 py-3">
-              <span className="setup-mcp-pill mt-0.5">MCP</span>
-              <p className="text-xs leading-5 text-[var(--text-secondary)]">
-                The pod remains the source of truth. Connecting an external AI
-                gives it scoped tools to work with that state—it does not copy
-                the work into a disposable chat.
-              </p>
-            </div>
-          ) : null}
-
-          <Button variant="primary"
-            type="button"
-            onClick={() =>
-              void choosePath(selectedPath, {
-                brief,
-                secondaryBrief,
-                codingAgent,
-              })
-            }
-            loading={pendingPath === selectedPath}
-            loadingLabel="Preparing your pod"
-            disabled={!brief.trim() || isCreating || Boolean(pendingPath)}
-            className="setup-primary-action !flex mt-6 h-11 w-full gap-2 text-sm font-medium"
-          >
-            {detailCopy.action}
-            <ArrowRight className="h-4 w-4" />
-          </Button>
-        </div>
-      </SetupStandalonePage>
     );
   }
 
@@ -1262,20 +1093,21 @@ export function StartStep({
 
         <div className="mx-auto mt-7 grid max-w-5xl gap-3 sm:grid-cols-2">
           {START_PATHS.map((path) => {
+            const isPending = pendingPath === path.id;
             return (
               <Button
                 key={path.id}
                 type="button"
                 variant="quiet"
-                onClick={() => setSelectedPath(path.id)}
-                disabled={isCreating}
+                onClick={() => void choosePath(path.id)}
+                disabled={isCreating || Boolean(pendingPath)}
                 data-tone={path.tone}
                 className="setup-route-card group h-auto min-h-64 flex-col items-stretch justify-start whitespace-normal p-0 text-left"
               >
                 <StartPathIllustration path={path.id} />
                 <span className="flex items-start gap-4 px-5 pb-5 pt-4">
                   <span className="min-w-0 flex-1">
-                    <span className="block text-sm font-semibold text-[var(--text-primary)]">
+                    <span className="block text-sm font-medium text-[var(--text-primary)]">
                       {path.title}
                     </span>
                     <span className="mt-1 block max-w-md text-xs leading-5 text-[var(--text-secondary)]">
@@ -1283,7 +1115,11 @@ export function StartStep({
                     </span>
                   </span>
                   <span className="setup-route-arrow mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-full">
-                    <ArrowRight className="h-3.5 w-3.5" />
+                    {isPending ? (
+                      <StepLoader size="sm" />
+                    ) : (
+                      <ArrowRight className="h-3.5 w-3.5" />
+                    )}
                   </span>
                 </span>
               </Button>
@@ -1291,7 +1127,7 @@ export function StartStep({
           })}
         </div>
 
-        <div className="mx-auto mt-4 grid max-w-3xl gap-2 sm:grid-cols-2">
+        <div className="mx-auto mt-4 grid max-w-5xl gap-2 sm:grid-cols-3">
           {SUPPORT_PATHS.map((path) => {
             const Icon = path.icon;
             const isPending = pendingPath === path.id;
@@ -1302,10 +1138,10 @@ export function StartStep({
                 variant="quiet"
                 onClick={() => {
                   if (path.id === "coding-agents") {
-                    setSelectedPath(path.id);
+                    setShowCodingAgents(true);
                     return;
                   }
-                  void choosePath("templates", { brief: "" });
+                  void choosePath(path.id);
                 }}
                 disabled={isCreating || Boolean(pendingPath)}
                 className="setup-support-path h-auto justify-start gap-3 whitespace-normal px-4 py-3.5 text-left"
@@ -1318,7 +1154,7 @@ export function StartStep({
                   )}
                 </span>
                 <span className="min-w-0">
-                  <span className="block text-xs font-semibold text-[var(--text-primary)]">
+                  <span className="block text-xs font-medium text-[var(--text-primary)]">
                     {path.title}
                   </span>
                   <span className="mt-0.5 block text-xs text-[var(--text-tertiary)]">

--- a/lemma-frontend/components/onboarding/account-onboarding.tsx
+++ b/lemma-frontend/components/onboarding/account-onboarding.tsx
@@ -23,6 +23,7 @@ import {
   readOnboardingSkippedFirstPod,
   subscribeToOnboardingSkippedFirstPod,
 } from "@/lib/pods/onboarding-skip";
+import { buildComposerLaunchHref } from "@/lib/pods/composer-launch";
 import {
   clearOnboardingDraft,
   findDraftBasePod,
@@ -73,13 +74,12 @@ import {
   personalWorkspaceName,
   setupStepsForAudience,
   splitName,
-  startPathLaunchConfig,
+  startPathComposerLaunch,
   teamLabelForKind,
   previousOnboardingStep,
   resolveOnboardingStartStep,
   type Audience,
   type ConnectChoice,
-  type OnboardingStartDetails,
   type OnboardingStartPath,
   type SetupStep,
   type TeamKind,
@@ -530,6 +530,10 @@ function SetupAssistant({
     audienceForPod: Audience,
     teamName = "",
     organizationOverride?: Organization | null,
+    // What the chosen start path calls this pod. Picking "Build a Telegram
+    // agent" and landing in one called "Personal Pod" throws away the only
+    // thing the user has said so far.
+    nameOverride?: string,
   ): Promise<Pod | null> => {
     const restoredCandidate = findDraftBasePod(
       basePod,
@@ -565,7 +569,8 @@ function SetupAssistant({
           return null;
         }
 
-        const podName = podNameForAudience(audienceForPod, teamName);
+        const podName =
+          nameOverride || podNameForAudience(audienceForPod, teamName);
         const pod = await getLemmaClient().pods.create({
           name: podName,
           description:
@@ -816,29 +821,17 @@ function SetupAssistant({
     }
   };
 
-  const openBuildConversation = (pod: Pod, message: string, metadataIntent: string) => {
-    const params = new URLSearchParams({
-      assistantMessage: message,
-      conversationInstructions: [
-        FIRST_RUN_DELIGHT,
-        `The pod already exists: ${pod.name}. Do not create another pod. Use the user-visible message as the goal and build inside the current pod. Inspect existing resources first, reuse anything that fits, seed believable sample data, and wire any surface or connector that fits how they already work.`,
-      ].join("\n\n"),
-      conversationMetadata: JSON.stringify({
-        source: "onboarding",
-        intent: metadataIntent,
-        first_run: true,
-        pod_id: pod.id,
-      }),
-    });
-    clearOnboardingDraft();
-    router.push(`/pod/${pod.id}/conversations/new?${params.toString()}`);
-  };
-
-  const handleChooseStartPath = async (
-    path: OnboardingStartPath,
-    details: OnboardingStartDetails,
-  ) => {
-    const pod = basePod || (await createBasePod("personal"));
+  const handleChooseStartPath = async (path: OnboardingStartPath) => {
+    // Resolved before the pod exists, because it is what the pod gets called.
+    // A pod restored from a draft keeps the name it already has — this only
+    // ever names a pod being created right now.
+    const launch =
+      path === "templates" || path === "coding-agents" || path === "blank"
+        ? null
+        : startPathComposerLaunch(path);
+    const pod =
+      basePod ||
+      (await createBasePod("personal", "", undefined, launch?.podName));
     if (!pod) return false;
 
     if (path === "templates") {
@@ -855,8 +848,31 @@ function SetupAssistant({
       });
     }
 
-    const config = startPathLaunchConfig(path, details);
-    openBuildConversation(pod, config.message, config.intent);
+    clearOnboardingDraft();
+
+    // Nothing to say on their behalf. The pod's own home already asks the
+    // question better than a form could.
+    if (!launch) {
+      router.push(`/pod/${pod.id}`);
+      return true;
+    }
+
+    router.push(
+      buildComposerLaunchHref(pod.id, {
+        draft: launch.stem,
+        instructions: [
+          FIRST_RUN_DELIGHT,
+          launch.instructions,
+          `The pod already exists: ${pod.name}. Do not create another pod. Build inside the current pod. Inspect existing resources first, reuse anything that fits, seed believable sample data, and wire any surface or connector that fits how they already work.`,
+        ].join("\n\n"),
+        metadata: {
+          source: "onboarding",
+          intent: launch.intent,
+          first_run: true,
+          pod_id: pod.id,
+        },
+      }),
+    );
     return true;
   };
 

--- a/lemma-frontend/components/pod/create-pod-screen.tsx
+++ b/lemma-frontend/components/pod/create-pod-screen.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { useOrganization } from "@/components/dashboard/org-context";
+import { SetupShell, SetupStandalonePage } from "@/components/onboarding/account-onboarding-chrome";
+import {
+  startPathComposerLaunch,
+  type ComposerStartPath,
+} from "@/components/onboarding/account-onboarding-helpers";
+import { StepLoader } from "@/components/brand/loader";
+import { WaitingScreen } from "@/components/shared/loading";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ArrowRight, Boxes } from "@/components/ui/icons";
+import { buildComposerLaunchHref } from "@/lib/pods/composer-launch";
+import { normalizeRemixSource, remixSourceLabel } from "@/lib/remix/app-remix";
+import { getLemmaClient } from "@/lib/sdk/lemma-client";
+
+/**
+ * Making a pod, for someone who has already made one.
+ *
+ * This route used to render the first-run screen verbatim — four illustrated
+ * themes and a required brief — so a returning user replayed onboarding to get
+ * their fifth pod, and could not get an empty one at all. The primitive is a
+ * name and a button. Everything else is optional, and lives one route later:
+ * a fresh pod's home already asks what it should become, with the starter
+ * themes and the real composer under the question.
+ *
+ * The chips are the same start paths as first run, minus the form. They create
+ * the pod under the name in the field, then seed that composer with the start
+ * of a sentence — see `startPathComposerLaunch`.
+ */
+
+const DEFAULT_POD_NAME = "Untitled pod";
+
+const START_CHIPS: Array<{ id: ComposerStartPath; label: string }> = [
+  { id: "telegram", label: "Telegram agent" },
+  { id: "internal-app", label: "Internal app" },
+  { id: "chatgpt", label: "ChatGPT + MCP" },
+  { id: "agent-skin", label: "Coding agent skin" },
+];
+
+/** What each button is waiting on, so only the pressed one shows a spinner. */
+type PendingAction = ComposerStartPath | "create" | "templates";
+
+export function CreatePodScreen({ remixSource: rawRemixSource }: { remixSource: string | null }) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { currentOrg, isLoading } = useOrganization();
+  const remixSource = normalizeRemixSource(rawRemixSource);
+  const [name, setName] = useState(
+    remixSource ? `Remix of ${remixSourceLabel(remixSource)}` : "",
+  );
+  const [pending, setPending] = useState<PendingAction | null>(null);
+
+  /**
+   * Every button here is "create the pod, then go somewhere in it". The pod is
+   * the point; the destination is the difference. `pending` stays set on
+   * success so the screen does not flash back to idle behind the navigation.
+   *
+   * `fallbackName` is what a start path would call this pod. It only applies to
+   * an empty field — a name the user typed always wins.
+   */
+  const createAndGo = async (
+    action: PendingAction,
+    destination: (podId: string) => string,
+    fallbackName = DEFAULT_POD_NAME,
+  ) => {
+    if (pending) return;
+    if (!currentOrg) {
+      toast.error("Create or join an organization before creating a pod");
+      return;
+    }
+
+    setPending(action);
+    try {
+      const pod = await getLemmaClient().pods.create({
+        name: name.trim() || fallbackName,
+        organization_id: currentOrg.id,
+      });
+      queryClient.invalidateQueries({ queryKey: ["pods"] });
+      router.push(destination(pod.id));
+    } catch (error) {
+      toast.error(
+        error instanceof Error && error.message
+          ? error.message
+          : "Failed to create pod",
+      );
+      setPending(null);
+    }
+  };
+
+  const startFromPath = (path: ComposerStartPath) => {
+    const launch = startPathComposerLaunch(path);
+    void createAndGo(
+      path,
+      (podId) =>
+        buildComposerLaunchHref(podId, {
+          draft: launch.stem,
+          instructions: remixSource
+            ? [
+                launch.instructions,
+                `Use ${remixSource} as the reference experience. Inspect it before building, preserve the interaction mechanics that matter, and make the result Lemma-native rather than a visual copy.`,
+              ].join("\n\n")
+            : launch.instructions,
+          metadata: {
+            source: "create_screen",
+            intent: launch.intent,
+            start_path: path,
+            remix_source: remixSource,
+          },
+        }),
+      launch.podName,
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <main className="setup-shell flex min-h-screen items-center justify-center px-4">
+        <WaitingScreen
+          title="Opening create"
+          description="Finding your current organization."
+          className="w-full max-w-lg"
+        />
+      </main>
+    );
+  }
+
+  return (
+    <SetupShell fullBleed>
+      <SetupStandalonePage onBack={() => router.push("/home")}>
+        <div className="m-auto w-full max-w-xl pb-12">
+          <h1 className="font-display text-2xl font-medium leading-tight tracking-tight text-[var(--text-primary)] sm:text-3xl">
+            New pod
+          </h1>
+          <p className="mt-3 text-sm leading-6 text-[var(--text-secondary)]">
+            {remixSource
+              ? `Starting from ${remixSourceLabel(remixSource)}. Name the pod, then say what it should become inside it.`
+              : "Name it and go. You can say what it should become once you are inside."}
+          </p>
+
+          <form
+            className="mt-7"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void createAndGo("create", (podId) => `/pod/${podId}`);
+            }}
+          >
+            <Label
+              htmlFor="create-pod-name"
+              className="text-sm text-[var(--text-secondary)]"
+            >
+              Name
+            </Label>
+            <Input
+              id="create-pod-name"
+              autoFocus
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder={DEFAULT_POD_NAME}
+              disabled={Boolean(pending)}
+              className="setup-detail-input mt-2 h-11 text-sm"
+            />
+
+            <Button
+              variant="quiet"
+              type="submit"
+              loading={pending === "create"}
+              loadingLabel="Creating pod"
+              disabled={Boolean(pending)}
+              className="setup-primary-action !flex mt-5 h-11 w-full gap-2 text-sm font-medium"
+            >
+              Create pod
+              <ArrowRight className="h-4 w-4" />
+            </Button>
+          </form>
+
+          <div className="my-7 flex items-center gap-3 text-xs text-[var(--text-tertiary)]">
+            <span className="h-px flex-1 bg-[var(--border-subtle)]" />
+            or start from
+            <span className="h-px flex-1 bg-[var(--border-subtle)]" />
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            {START_CHIPS.map((chip) => (
+              <Button
+                key={chip.id}
+                type="button"
+                variant="quiet"
+                onClick={() => startFromPath(chip.id)}
+                disabled={Boolean(pending)}
+                className="setup-detail-choice h-9 w-auto gap-2 px-3 text-sm font-normal"
+              >
+                {pending === chip.id ? <StepLoader size="sm" /> : null}
+                {chip.label}
+              </Button>
+            ))}
+            {/* Creates the pod first. It used to leave for the global template
+                gallery, so backing out of that left you with nothing. */}
+            <Button
+              type="button"
+              variant="quiet"
+              onClick={() =>
+                void createAndGo("templates", (podId) => `/pod/${podId}/recipes`)
+              }
+              disabled={Boolean(pending)}
+              className="setup-detail-choice h-9 w-auto gap-2 px-3 text-sm font-normal"
+            >
+              {pending === "templates" ? (
+                <StepLoader size="sm" />
+              ) : (
+                <Boxes className="h-4 w-4" />
+              )}
+              Explore templates
+            </Button>
+          </div>
+
+          <p className="mt-4 text-xs leading-5 text-[var(--text-tertiary)]">
+            These create the pod and open it with the first sentence started for
+            you. Nothing is sent until you send it. Leave the name blank and the
+            one you pick names the pod.
+          </p>
+        </div>
+      </SetupStandalonePage>
+    </SetupShell>
+  );
+}

--- a/lemma-frontend/components/pod/pod-new-workspace.tsx
+++ b/lemma-frontend/components/pod/pod-new-workspace.tsx
@@ -111,7 +111,17 @@ const BUILD_THEME_TILES = TILES_PER_ROW - 1;
 const POD_TILES = TILES_PER_ROW * 2 - 1;
 const MAX_PROMPT_ROWS = 2;
 
-// A FIXED height, not a floor. The launcher and the composer are centred as one
+/**
+ * Where the launcher sits relative to the composer, which is the only thing
+ * that changes between its two homes.
+ *
+ * `empty-state` — the new-conversation screen, launcher ABOVE the composer.
+ * `below-composer` — pod home, where the composer is the hero and this is the
+ * tray under it.
+ */
+export type PodNewWorkspacePlacement = 'empty-state' | 'below-composer';
+
+// A FIXED height, not a floor. Above the composer the two are centred as one
 // group, so a panel taller than its neighbour moves the whole block — including
 // the pod line and the tabs you are aiming at — every time you switch tabs.
 //
@@ -122,6 +132,10 @@ const MAX_PROMPT_ROWS = 2;
 // scrollbar in the Create panel and clipped its caption. `overflow-y-auto`
 // stays as the safety net for anything longer still.
 const PANEL_HEIGHT = 'h-72 overflow-y-auto';
+
+// Below the composer there is nothing above to shove around, so the lock buys
+// nothing and costs a block of dead space under every short panel.
+const PANEL_HEIGHT_NATURAL = 'min-h-0';
 
 function formatPodName(value: string | null | undefined) {
     const cleaned = (value || '').replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
@@ -326,13 +340,19 @@ export function PodNewWorkspace({
     selectedAgentName,
     onPreparePrompt,
     onSelectAgent,
+    placement = 'empty-state',
 }: {
     podId: string;
     /** Agent the composer is currently scoped to, or `null` for the pod default. */
     selectedAgentName: string | null;
     onPreparePrompt: (prompt: string) => void;
     onSelectAgent: (agentName: string | null) => void;
+    placement?: PodNewWorkspacePlacement;
 }) {
+    // Below the composer the pod is already named by the heading above it, and
+    // nothing sits above the panel for a height change to disturb.
+    const isBelowComposer = placement === 'below-composer';
+    const panelHeight = isBelowComposer ? PANEL_HEIGHT_NATURAL : PANEL_HEIGHT;
     const assistant = useAIAssistant();
     const podAccess = usePodAccess(podId);
     const { data: pod } = usePod(podId);
@@ -380,6 +400,7 @@ export function PodNewWorkspace({
 
     return (
         <div className="flex w-full flex-col gap-3 text-[var(--text-primary)]">
+            {isBelowComposer ? null : (
             <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1.5">
                 {podName ? (
                     <span className="text-sm font-medium text-[var(--text-primary)]">{podName}</span>
@@ -410,6 +431,7 @@ export function PodNewWorkspace({
                     </>
                 )}
             </div>
+            )}
 
             <Tabs value={activeTab} onValueChange={(value) => setTab(value as LauncherTab)} className="min-w-0">
                 <TabsList>
@@ -420,7 +442,7 @@ export function PodNewWorkspace({
                 </TabsList>
 
                 {/* A floor under every panel keeps the composer still between tabs. */}
-                <TabsContent value="build" className={PANEL_HEIGHT}>
+                <TabsContent value="build" className={panelHeight}>
                     <BuildPanel
                         podId={podId}
                         disabled={disabled}
@@ -432,7 +454,7 @@ export function PodNewWorkspace({
                     />
                 </TabsContent>
 
-                <TabsContent value="create" className={PANEL_HEIGHT}>
+                <TabsContent value="create" className={panelHeight}>
                     <TileGrid>
                         {CREATE_FORMATS.map((format) => (
                             <LauncherTile
@@ -449,7 +471,7 @@ export function PodNewWorkspace({
                 </TabsContent>
 
                 {hasDo ? (
-                    <TabsContent value="do" className={PANEL_HEIGHT}>
+                    <TabsContent value="do" className={panelHeight}>
                         <TileGrid>
                             {doTiles.map((tile) => (
                                 <LauncherTile
@@ -492,7 +514,7 @@ export function PodNewWorkspace({
                 ) : null}
 
                 {hasContinue ? (
-                    <TabsContent value="continue" className={PANEL_HEIGHT}>
+                    <TabsContent value="continue" className={panelHeight}>
                         <TileGrid>
                             {continueRows.map((conversation) => (
                                 <LauncherTile

--- a/lemma-frontend/lib/pods/composer-launch.test.ts
+++ b/lemma-frontend/lib/pods/composer-launch.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    buildComposerLaunchHref,
+    parseConversationMetadataParam,
+    readComposerLaunch,
+    stripComposerLaunchParams,
+} from './composer-launch';
+
+function queryOf(href: string) {
+    return new URLSearchParams(href.slice(href.indexOf('?') + 1));
+}
+
+describe('composer launch', () => {
+    it('round-trips a draft, its instructions, and its metadata', () => {
+        const href = buildComposerLaunchHref('pod-1', {
+            draft: 'Build a Telegram agent and companion app that ',
+            instructions: 'Treat the message as the agent instructions.',
+            metadata: { source: 'create_screen', intent: 'telegram_agent_companion_app' },
+        });
+
+        expect(href.startsWith('/pod/pod-1?')).toBe(true);
+        expect(readComposerLaunch(queryOf(href))).toEqual({
+            draft: 'Build a Telegram agent and companion app that ',
+            instructions: 'Treat the message as the agent instructions.',
+            metadata: { source: 'create_screen', intent: 'telegram_agent_companion_app' },
+        });
+    });
+
+    it('keeps the trailing space that puts the caret mid-sentence', () => {
+        const href = buildComposerLaunchHref('pod-1', { draft: 'Build an app that ' });
+
+        // URLSearchParams encodes a trailing space as "+", which decodes back.
+        // Losing it would leave the caret jammed against the last word.
+        expect(readComposerLaunch(queryOf(href))?.draft).toBe('Build an app that ');
+    });
+
+    it('is nothing to seed when the pod was opened normally', () => {
+        expect(readComposerLaunch(new URLSearchParams(''))).toBeNull();
+        expect(readComposerLaunch(new URLSearchParams('tab=build'))).toBeNull();
+    });
+
+    it('strips only its own params, so the rest of the URL survives', () => {
+        const params = new URLSearchParams(
+            'tab=build&composerDraft=hello&conversationInstructions=framing&conversationMetadata=%7B%7D',
+        );
+
+        expect(stripComposerLaunchParams(params)).toBe('tab=build');
+        // The source must not be mutated — the effect still reads it afterward.
+        expect(params.get('composerDraft')).toBe('hello');
+    });
+
+    it('drops metadata it cannot trust rather than failing the navigation', () => {
+        expect(parseConversationMetadataParam('not json')).toBeNull();
+        expect(parseConversationMetadataParam('[1,2]')).toBeNull();
+        expect(parseConversationMetadataParam('"a string"')).toBeNull();
+        expect(parseConversationMetadataParam(null)).toBeNull();
+        expect(parseConversationMetadataParam('{"pod_id":"p1"}')).toEqual({ pod_id: 'p1' });
+    });
+
+    it('still seeds framing when a path carries instructions but no sentence', () => {
+        const href = buildComposerLaunchHref('pod-1', { draft: '', instructions: 'framing' });
+
+        expect(readComposerLaunch(queryOf(href))).toEqual({
+            draft: '',
+            instructions: 'framing',
+            metadata: undefined,
+        });
+    });
+});

--- a/lemma-frontend/lib/pods/composer-launch.ts
+++ b/lemma-frontend/lib/pods/composer-launch.ts
@@ -1,0 +1,98 @@
+/**
+ * Handing a pod an unfinished sentence instead of a sent message.
+ *
+ * `assistantMessage` was the only way to arrive at a pod with intent, and it
+ * always fires: the layout reads it and sends immediately. That is right when
+ * the user has already said what they want, and wrong every other time — it
+ * spends a model turn on a sentence they never wrote, in a pod they have not
+ * seen yet.
+ *
+ * A composer launch is the quiet version. `composerDraft` seeds the pod's own
+ * composer and stops there, cursor at the end, while `conversationInstructions`
+ * waits with it and rides along on whatever the user eventually sends. It never
+ * survives that first message: background framing for the build is not standing
+ * policy for the pod.
+ */
+
+export const COMPOSER_DRAFT_PARAM = "composerDraft";
+export const CONVERSATION_INSTRUCTIONS_PARAM = "conversationInstructions";
+export const CONVERSATION_METADATA_PARAM = "conversationMetadata";
+
+export const COMPOSER_LAUNCH_PARAMS = [
+  COMPOSER_DRAFT_PARAM,
+  CONVERSATION_INSTRUCTIONS_PARAM,
+  CONVERSATION_METADATA_PARAM,
+] as const;
+
+export interface ComposerLaunch {
+  /** An unfinished sentence for the user to complete. Never sent on its own. */
+  draft: string;
+  /** Background framing carried by the first message only. */
+  instructions?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Shared by every route that reads a conversation launch out of the URL.
+ * Anything that is not a JSON object is dropped rather than guessed at — a
+ * malformed param should cost the metadata, not the navigation.
+ */
+export function parseConversationMetadataParam(
+  value: string | null,
+): Record<string, unknown> | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Pod home, with the composer already holding the start of a sentence. */
+export function buildComposerLaunchHref(
+  podId: string,
+  launch: ComposerLaunch,
+): string {
+  const params = new URLSearchParams({
+    [COMPOSER_DRAFT_PARAM]: launch.draft,
+  });
+  if (launch.instructions) {
+    params.set(CONVERSATION_INSTRUCTIONS_PARAM, launch.instructions);
+  }
+  if (launch.metadata) {
+    params.set(CONVERSATION_METADATA_PARAM, JSON.stringify(launch.metadata));
+  }
+
+  return `/pod/${encodeURIComponent(podId)}?${params.toString()}`;
+}
+
+/** Reads a launch back out of a pod-home URL. Null when there is nothing to seed. */
+export function readComposerLaunch(
+  params: URLSearchParams,
+): ComposerLaunch | null {
+  const draft = params.get(COMPOSER_DRAFT_PARAM);
+  const instructions = params.get(CONVERSATION_INSTRUCTIONS_PARAM);
+  if (!draft && !instructions) return null;
+
+  return {
+    draft: draft || "",
+    instructions: instructions || undefined,
+    metadata:
+      parseConversationMetadataParam(params.get(CONVERSATION_METADATA_PARAM)) ??
+      undefined,
+  };
+}
+
+/**
+ * The same URL with the launch params removed, for the `router.replace` that
+ * follows seeding. Without it a refresh re-seeds a draft the user already
+ * cleared, and a second conversation inherits the first one's framing.
+ */
+export function stripComposerLaunchParams(params: URLSearchParams): string {
+  const next = new URLSearchParams(params.toString());
+  for (const param of COMPOSER_LAUNCH_PARAMS) next.delete(param);
+  return next.toString();
+}

--- a/lemma-frontend/lib/pods/onboarding-steps.test.ts
+++ b/lemma-frontend/lib/pods/onboarding-steps.test.ts
@@ -11,7 +11,7 @@ import {
   previousOnboardingStep,
   resolveOnboardingStartStep,
   setupStepsForAudience,
-  startPathLaunchConfig,
+  startPathComposerLaunch,
 } from "@/components/onboarding/account-onboarding-helpers";
 import { workDomainFromEmail } from "@/lib/utils/organization-slugs";
 
@@ -107,31 +107,72 @@ describe("onboarding step paths", () => {
     expect(generatedOrganizationName("ada@example.com", 1)).not.toBe(generated);
   });
 
-  it("turns the Telegram brief into agent instructions and app state", () => {
-    const config = startPathLaunchConfig("telegram", {
-      brief: "Capture voice notes and ask when context is missing.",
-      secondaryBrief: "A searchable logbook of ideas and tasks.",
-    });
+  it("hands the composer an unfinished sentence, not a sent message", () => {
+    // The trailing space is the point: the caret lands after it, so the user is
+    // completing a sentence rather than editing one.
+    for (const path of [
+      "telegram",
+      "chatgpt",
+      "internal-app",
+      "agent-skin",
+    ] as const) {
+      const launch = startPathComposerLaunch(path);
 
-    expect(config.intent).toBe("telegram_agent_companion_app");
-    expect(config.message).toContain(
-      "custom operating instructions: Capture voice notes",
+      expect(launch.stem).toMatch(/ $/);
+      expect(launch.stem.trim().length).toBeGreaterThan(0);
+      expect(launch.instructions.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("names the pod after the path, so nothing lands as Untitled pod", () => {
+    // Pressing a start path is the one thing the user has told us at that
+    // point. Falling back to the placeholder name would discard it.
+    const names = (
+      ["telegram", "chatgpt", "internal-app", "agent-skin"] as const
+    ).map((path) => startPathComposerLaunch(path).podName);
+
+    for (const name of names) {
+      expect(name.trim()).toBe(name);
+      expect(name).not.toMatch(/untitled/i);
+      expect(name.length).toBeGreaterThan(0);
+    }
+    // Distinct, so two start paths never produce two identically named pods.
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("keeps the Telegram agent and its companion app as one build", () => {
+    const launch = startPathComposerLaunch("telegram");
+
+    expect(launch.intent).toBe("telegram_agent_companion_app");
+    expect(launch.podName).toBe("Telegram Agent");
+    expect(launch.stem).toBe("Build a Telegram agent and companion app that ");
+    expect(launch.instructions).toContain(
+      "the agent's custom operating instructions",
     );
-    expect(config.message).toContain(
-      "companion app should keep this organized: A searchable logbook",
+    expect(launch.instructions).toContain(
+      "Do not claim Telegram is connected until the connector is actually authorized",
     );
   });
 
   it("frames ChatGPT as an MCP client of durable pod state", () => {
-    const config = startPathLaunchConfig("chatgpt", {
-      brief: "Keep the fundraising pipeline current.",
-    });
+    const launch = startPathComposerLaunch("chatgpt");
 
-    expect(config.intent).toBe("external_ai_pod_mcp");
-    expect(config.message).toContain("pod-scoped Lemma MCP surface");
-    expect(config.message).toContain("durable tables, files, and views");
-    expect(config.message).toContain(
+    expect(launch.intent).toBe("external_ai_pod_mcp");
+    expect(launch.instructions).toContain("pod-scoped Lemma MCP surface");
+    expect(launch.instructions).toContain("durable tables, files, and views");
+    expect(launch.instructions).toContain(
       "Do not pretend the external connection is complete",
+    );
+  });
+
+  it("puts the app in front of the agents for an internal build", () => {
+    const launch = startPathComposerLaunch("internal-app");
+
+    expect(launch.intent).toBe("internal_ai_app");
+    expect(launch.podName).toBe("Internal App");
+    expect(launch.stem).toBe("Build an internal app that lets my team ");
+    expect(launch.instructions).toContain(
+      "Put the app in front and the agents behind it",
     );
   });
 
@@ -145,15 +186,16 @@ describe("onboarding step paths", () => {
   });
 
   it("keeps a local-agent skin distinct from the coding build pathway", () => {
-    const config = startPathLaunchConfig("agent-skin", {
-      brief: "Plans, tasks, run status, artifacts, and review state.",
-      secondaryBrief: "Approve plans and retry failed work.",
-      codingAgent: "opencode",
-    });
+    const launch = startPathComposerLaunch("agent-skin");
 
-    expect(config.intent).toBe("local_agent_workspace_skin");
-    expect(config.message).toContain("workspace skin around OpenCode");
-    expect(config.message).toContain("Keep the local coding agent as the executor");
-    expect(config.message).toContain("Approve plans and retry failed work");
+    expect(launch.intent).toBe("local_agent_workspace_skin");
+    expect(launch.instructions).toContain(
+      "Keep the local coding agent as the executor",
+    );
+    // The three-button picker went away with the brief screen; the agent asks
+    // instead, so no path can silently build for the wrong one.
+    expect(launch.instructions).toContain(
+      "Codex, Claude Code, or OpenCode",
+    );
   });
 });

--- a/lemma-frontend/scripts/design-audit-baseline.json
+++ b/lemma-frontend/scripts/design-audit-baseline.json
@@ -14,7 +14,7 @@
     "rawFontSizeDeclaration": 8,
     "rawRadiusDeclaration": 0,
     "rawSpacingDeclaration": 0,
-    "multiplePrimaryButtons": 22,
+    "multiplePrimaryButtons": 21,
     "headerSlotPrimaryButtons": 0
   },
   "protectedAssistant": {


### PR DESCRIPTION
## The brief was a second, worse composer

Picking "Telegram agent" opened a screen with a required textarea. That box was the worst place in the product to describe what you wanted: no attachments, no model picker, no agent scope, no pod to look at, and a disabled button until you typed. Then it baked the answer into one long prompt and sent it — a model turn spent on a sentence the user never wrote, in a pod they had not seen yet.

## What a start path produces now

Three things, and it sends none of them:

- **A stem** — an unfinished sentence the pod's own composer opens holding, cursor at the end. The sentence gets finished where a file can be attached and the model can be changed.
- **Instructions** — the durable framing that used to surround the brief, riding along as the conversation's background instructions so it shapes the build without being something anyone has to read or write.
- **A pod name** — because pressing "Telegram agent" already said what the pod is, and falling back to "Untitled pod" throws away the one thing the user just told us. Only used when they did not type a name themselves.

`composerDraft` is the quiet counterpart to `assistantMessage`, which always fires. It seeds and stops. The instructions ride the first message and are gone after it — background framing for a build is not standing policy for the pod. The params are stripped from the URL on the way in, so a refresh cannot re-seed a draft the user already cleared and a second conversation cannot inherit the first one's framing.

`parseConversationMetadataParam` was duplicated verbatim in the pod layout and the conversation page; it moves next to the launch helpers both of them now use.

## /create-pod stops replaying first run

It rendered the onboarding screen verbatim, so a returning user picked an illustrated theme to get their fifth pod — and could not get an empty one at all. The primitive is a name and a button, with the same start paths as chips beside it. First run gains **"Start with an empty pod"** for the same reason: someone who already knows what a pod is should not have to pick a theme to get one.

The coding-agent pathway keeps its screen. It hands over a prompt to paste elsewhere, which is not something a composer can do.

## Pod home asked its question three times

A heading, a themed picker with its own caption, a prompt list with another, and the composer last, under all of it. The composer moves directly under the question it answers, and the launcher below it is `PodNewWorkspace` — the same component the new-conversation screen uses — rather than a second one grown for the identical job. It takes a `placement` prop: above the composer the fixed panel height stops a tab switch from moving the block you are aiming at; below it there is nothing above to shove around, so the lock only buys dead space.

## Note on the design-audit baseline

`multiplePrimaryButtons` drops 22 → 21 (the removed detail screen's "Build agent + app" primary). The self-test asserts an exact match, so the baseline is updated in the same commit.

## Verification

- `npm run check` (design audit, lint, typecheck, edu-anchors) — pass
- `npm test` — 465 tests pass, including new `composer-launch` round-trip coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)