### PR TITLE
Show an app presented in a conversation as the app, not as a workspace inside a pane

### DIFF
--- a/lemma-frontend/components/app/app-launch.tsx
+++ b/lemma-frontend/components/app/app-launch.tsx
@@ -24,6 +24,13 @@ interface AppFrameProps {
     url: string;
     visibility?: string | null;
     canShare?: boolean;
+    /**
+     * What draws around the frame. `bar` claims the shell's context bar, for a
+     * pane the app owns. `none` draws the frame alone, for a pane that already
+     * has a header — the conversation stage, where claiming the shell bar would
+     * rename the conversation still being read beside it.
+     */
+    chrome?: 'bar' | 'none';
 }
 
 export function AppFrame({
@@ -34,6 +41,7 @@ export function AppFrame({
     url,
     visibility,
     canShare = false,
+    chrome = 'bar',
 }: AppFrameProps) {
     const queryClient = useQueryClient();
     const { resolvedTheme } = useTheme();
@@ -95,79 +103,81 @@ export function AppFrame({
 
     return (
         <div className="embedded-canvas relative flex h-full w-full flex-col overflow-hidden text-[var(--text-primary)]">
-            <ResourceHeader
-                title={title}
-                backHref={`/pod/${podId}/app/pages`}
-                backLabel="Apps"
-                actions={(
-                    <TooltipProvider>
-                        <div className="flex shrink-0 items-center gap-1">
-                            <Tooltip>
-                                <TooltipTrigger asChild>
-                                    <Button type="button" variant="quiet" size="icon" className="h-8 w-8 rounded" onClick={reloadFrame} aria-label="Reload app">
-                                        <RefreshCw className="h-4 w-4" />
-                                    </Button>
-                                </TooltipTrigger>
-                                <TooltipContent>Reload app</TooltipContent>
-                            </Tooltip>
-                            <Tooltip>
-                                <TooltipTrigger asChild>
-                                    <Button type="button" variant="quiet" size="icon" className="h-8 w-8 rounded" onClick={copyLink} aria-label="Copy app link">
-                                        <Copy className="h-4 w-4" />
-                                    </Button>
-                                </TooltipTrigger>
-                                <TooltipContent>Copy app link</TooltipContent>
-                            </Tooltip>
-                            {canShare ? (
-                                <ResourceShareButton
-                                    value={visibility}
-                                    podId={podId}
-                                    resourceType="app"
-                                    resourceId={appId}
-                                    resourceLabel="apps"
-                                    resourceName={title}
-                                    shareUrl={typeof window === 'undefined'
-                                        ? undefined
-                                        : buildResourceShareUrl(
-                                            `${window.location.pathname}${window.location.search}${window.location.hash}`,
-                                            window.location.origin,
-                                        ) ?? undefined}
-                                    onChange={handleShareVisibilityChange}
-                                    disabled={!appId || !appName}
-                                    trigger={({ openShare, disabled }) => (
-                                        <Tooltip>
-                                            <TooltipTrigger asChild>
-                                                <Button
-                                                    type="button"
-                                                    variant="quiet"
-                                                    size="icon"
-                                                    className="h-8 w-8 rounded"
-                                                    onClick={openShare}
-                                                    disabled={disabled}
-                                                    aria-label="Share app"
-                                                >
-                                                    <Share2 className="h-4 w-4" />
-                                                </Button>
-                                            </TooltipTrigger>
-                                            <TooltipContent>Share app</TooltipContent>
-                                        </Tooltip>
-                                    )}
-                                />
-                            ) : null}
-                            <Tooltip>
-                                <TooltipTrigger asChild>
-                                    <Button asChild variant="quiet" size="icon" className="h-8 w-8 rounded" aria-label="Open app in new tab">
-                                        <a href={url} target="_blank" rel="noreferrer">
-                                            <ExternalLink className="h-4 w-4" />
-                                        </a>
-                                    </Button>
-                                </TooltipTrigger>
-                                <TooltipContent>Open app in new tab</TooltipContent>
-                            </Tooltip>
-                        </div>
-                    </TooltipProvider>
-                )}
-            />
+            {chrome === 'bar' ? (
+                <ResourceHeader
+                    title={title}
+                    backHref={`/pod/${podId}/app/pages`}
+                    backLabel="Apps"
+                    actions={(
+                        <TooltipProvider>
+                            <div className="flex shrink-0 items-center gap-1">
+                                <Tooltip>
+                                    <TooltipTrigger asChild>
+                                        <Button type="button" variant="quiet" size="icon" className="h-8 w-8 rounded" onClick={reloadFrame} aria-label="Reload app">
+                                            <RefreshCw className="h-4 w-4" />
+                                        </Button>
+                                    </TooltipTrigger>
+                                    <TooltipContent>Reload app</TooltipContent>
+                                </Tooltip>
+                                <Tooltip>
+                                    <TooltipTrigger asChild>
+                                        <Button type="button" variant="quiet" size="icon" className="h-8 w-8 rounded" onClick={copyLink} aria-label="Copy app link">
+                                            <Copy className="h-4 w-4" />
+                                        </Button>
+                                    </TooltipTrigger>
+                                    <TooltipContent>Copy app link</TooltipContent>
+                                </Tooltip>
+                                {canShare ? (
+                                    <ResourceShareButton
+                                        value={visibility}
+                                        podId={podId}
+                                        resourceType="app"
+                                        resourceId={appId}
+                                        resourceLabel="apps"
+                                        resourceName={title}
+                                        shareUrl={typeof window === 'undefined'
+                                            ? undefined
+                                            : buildResourceShareUrl(
+                                                `${window.location.pathname}${window.location.search}${window.location.hash}`,
+                                                window.location.origin,
+                                            ) ?? undefined}
+                                        onChange={handleShareVisibilityChange}
+                                        disabled={!appId || !appName}
+                                        trigger={({ openShare, disabled }) => (
+                                            <Tooltip>
+                                                <TooltipTrigger asChild>
+                                                    <Button
+                                                        type="button"
+                                                        variant="quiet"
+                                                        size="icon"
+                                                        className="h-8 w-8 rounded"
+                                                        onClick={openShare}
+                                                        disabled={disabled}
+                                                        aria-label="Share app"
+                                                    >
+                                                        <Share2 className="h-4 w-4" />
+                                                    </Button>
+                                                </TooltipTrigger>
+                                                <TooltipContent>Share app</TooltipContent>
+                                            </Tooltip>
+                                        )}
+                                    />
+                                ) : null}
+                                <Tooltip>
+                                    <TooltipTrigger asChild>
+                                        <Button asChild variant="quiet" size="icon" className="h-8 w-8 rounded" aria-label="Open app in new tab">
+                                            <a href={url} target="_blank" rel="noreferrer">
+                                                <ExternalLink className="h-4 w-4" />
+                                            </a>
+                                        </Button>
+                                    </TooltipTrigger>
+                                    <TooltipContent>Open app in new tab</TooltipContent>
+                                </Tooltip>
+                            </div>
+                        </TooltipProvider>
+                    )}
+                />
+            ) : null}
 
             <div className="embedded-canvas relative min-h-0 flex-1 overflow-hidden">
                 {!frameLoaded && !frameFailed ? (

--- a/lemma-frontend/components/pod/conversation-presentation-stage.tsx
+++ b/lemma-frontend/components/pod/conversation-presentation-stage.tsx
@@ -5,12 +5,20 @@ import { useRouter } from 'next/navigation';
 import { Maximize2, PanelRightClose } from '@/components/ui/icons';
 import { useEffect, useRef, type ReactNode } from 'react';
 
+import { useApp } from '@/components/app/app-context';
+import { AppFrame } from '@/components/app/app-launch';
+import { StepLoader } from '@/components/brand/loader';
+import { EmptyState } from '@/components/shared/empty-state';
 import { Button } from '@/components/ui/button';
+import { PanelsTopLeft } from '@/components/ui/icons';
 import {
     buildConversationStageEmbedHref,
     buildConversationStandaloneResourceHref,
+    conversationStageAppSlug,
     resolveConversationStageNavigationHref,
 } from '@/lib/assistant/conversation-presentation';
+import { formatWorkspaceAppTitle } from '@/lib/pods/workspace-tabs';
+import type { AppPageRef } from '@/lib/types/app';
 
 function decodeLabel(value: string | null | undefined): string {
     if (!value) return '';
@@ -38,6 +46,52 @@ function presentationTitle(resourceHref: string): string {
     return 'Presented view';
 }
 
+/**
+ * The app itself, in the pane — no workspace around it. The stage's own header
+ * already names the app and holds the close and full-view controls, so the frame
+ * draws without the context bar it would otherwise claim from the conversation.
+ */
+function StageAppBody({
+    podId,
+    page,
+    title,
+    isLoading,
+}: {
+    podId: string;
+    page: AppPageRef | null;
+    title: string;
+    isLoading: boolean;
+}) {
+    if (page?.url) {
+        return (
+            <AppFrame
+                podId={podId}
+                appId={page.id}
+                appName={page.appName || page.title}
+                title={title}
+                url={page.url}
+                visibility={page.visibility}
+                chrome="none"
+            />
+        );
+    }
+
+    return (
+        <div className="absolute inset-0 flex items-center justify-center">
+            {isLoading ? (
+                <StepLoader size="sm" />
+            ) : (
+                <EmptyState
+                    variant="region"
+                    icon={<PanelsTopLeft className="h-5 w-5" />}
+                    title="App unavailable"
+                    description="This app didn't return a web app URL. Try opening it again from the Apps list."
+                />
+            )}
+        </div>
+    );
+}
+
 export function ConversationPresentationStage({
     podId,
     resourceHref,
@@ -51,7 +105,15 @@ export function ConversationPresentationStage({
 }) {
     const router = useRouter();
     const iframeRef = useRef<HTMLIFrameElement | null>(null);
-    const embedHref = buildConversationStageEmbedHref(resourceHref);
+    const { pages, isLoading: appsLoading } = useApp();
+    // An app is presented in place rather than framed: the stage already sits
+    // inside the pod's `AppProvider`, so it can mount the app's own frame
+    // directly instead of re-loading the workspace to reach `AppFrameHost`.
+    const appSlug = conversationStageAppSlug(resourceHref, podId);
+    const appPage = appSlug
+        ? pages.find((page) => page.slug === appSlug) ?? null
+        : null;
+    const embedHref = appSlug ? null : buildConversationStageEmbedHref(resourceHref);
     const standaloneHref = buildConversationStandaloneResourceHref(resourceHref);
 
     useEffect(() => {
@@ -67,9 +129,27 @@ export function ConversationPresentationStage({
         return () => window.removeEventListener('message', handleMessage);
     }, [podId, router]);
 
-    if (!embedHref || !standaloneHref) return children;
+    // The app's own record names it the way the tab strip does ("Ledger"), so the
+    // pane stops printing the raw slug back at the reader.
+    const title = appPage
+        ? formatWorkspaceAppTitle(appPage.title || appPage.slug)
+        : presentationTitle(resourceHref);
 
-    const title = presentationTitle(resourceHref);
+    const stageBody = appSlug ? (
+        <StageAppBody podId={podId} page={appPage} title={title} isLoading={appsLoading} />
+    ) : embedHref ? (
+        <iframe
+            key={embedHref}
+            ref={iframeRef}
+            src={embedHref}
+            title={title}
+            className="absolute inset-0 block h-full min-h-0 w-full border-0 bg-[var(--pod-main-bg)]"
+            allow="clipboard-read; clipboard-write; fullscreen"
+            referrerPolicy="strict-origin-when-cross-origin"
+        />
+    ) : null;
+
+    if (!stageBody || !standaloneHref) return children;
 
     return (
         <div className="conversation-presentation-layout grid h-full min-h-0 min-w-0 overflow-hidden">
@@ -105,15 +185,7 @@ export function ConversationPresentationStage({
                     </Button>
                 </header>
                 <div className="relative min-h-0 flex-1 overflow-hidden">
-                    <iframe
-                        key={embedHref}
-                        ref={iframeRef}
-                        src={embedHref}
-                        title={title}
-                        className="absolute inset-0 block h-full min-h-0 w-full border-0 bg-[var(--pod-main-bg)]"
-                        allow="clipboard-read; clipboard-write; fullscreen"
-                        referrerPolicy="strict-origin-when-cross-origin"
-                    />
+                    {stageBody}
                 </div>
             </section>
         </div>

--- a/lemma-frontend/lib/assistant/__tests__/conversation-presentation.test.ts
+++ b/lemma-frontend/lib/assistant/__tests__/conversation-presentation.test.ts
@@ -6,6 +6,7 @@ import {
     buildConversationStageNavigationMessage,
     buildConversationStandaloneResourceHref,
     buildResourceShareUrl,
+    conversationStageAppSlug,
     normalizeConversationPresentedResourceHref,
     removeConversationPresentationParam,
     resolveConversationStageNavigationHref,
@@ -85,6 +86,26 @@ describe('conversation presentation routes', () => {
             '/pod/p1/data?tab=projects&embed=conversation-stage&assistant=docked&presentation=side',
             'http://localhost:3000',
         )).toBe('http://localhost:3000/pod/p1/data?tab=projects');
+    });
+
+    it('names the app a presented resource points at, so the stage skips the frame', () => {
+        expect(conversationStageAppSlug('/pod/p1/app/view?page=ledger', 'p1')).toBe('ledger');
+        expect(conversationStageAppSlug(
+            '/pod/p1/app/view?page=ledger&assistantConversationId=c1',
+            'p1',
+        )).toBe('ledger');
+    });
+
+    it('only treats a same-pod app view with a slug as an app', () => {
+        // The apps index, and a view route that lost its slug, are pages of their
+        // own — framing them is still correct, so they must not read as an app.
+        expect(conversationStageAppSlug('/pod/p1/app/pages', 'p1')).toBeNull();
+        expect(conversationStageAppSlug('/pod/p1/app/view', 'p1')).toBeNull();
+        expect(conversationStageAppSlug('/pod/p1/app/view?page=', 'p1')).toBeNull();
+        expect(conversationStageAppSlug('/pod/p1/app/view?page=%20', 'p1')).toBeNull();
+        expect(conversationStageAppSlug('/pod/p2/app/view?page=ledger', 'p1')).toBeNull();
+        expect(conversationStageAppSlug('/pod/p1/data?tab=orders', 'p1')).toBeNull();
+        expect(conversationStageAppSlug('https://example.com/pod/p1/app/view?page=ledger', 'p1')).toBeNull();
     });
 
     it('removes only the presentation state when returning to chat', () => {

--- a/lemma-frontend/lib/assistant/conversation-presentation.ts
+++ b/lemma-frontend/lib/assistant/conversation-presentation.ts
@@ -5,6 +5,7 @@ export const CONVERSATION_STAGE_NAVIGATION_MESSAGE_TYPE = 'lemma:conversation-st
 
 const ASSISTANT_CONVERSATION_PARAM = 'assistantConversationId';
 const WIDGET_VIEW_SUFFIX = '/widgets/view';
+const APP_VIEW_SUFFIX = '/app/view';
 
 function localResourceUrl(href: string): URL | null {
     if (!href || !href.startsWith('/')) return null;
@@ -81,6 +82,26 @@ export function normalizeConversationPresentedResourceHref(
     if (url.pathname.startsWith(`${podBase}/conversations`)) return null;
 
     return hrefFromLocalUrl(url);
+}
+
+/**
+ * The app slug a presented resource names, or null when it is not an app.
+ *
+ * An app is the one presented type whose surface belongs to the pod *layout*
+ * rather than to its own page — `/app/view` is an empty placeholder and the live
+ * iframe lives in `AppFrameHost`, above the router. Framing that route to reach
+ * the host boots a second copy of the entire workspace inside the stage, and
+ * mounts the app's own iframe under it: three levels deep to show one app. The
+ * stage reads the slug instead and renders the app frame itself.
+ */
+export function conversationStageAppSlug(
+    resourceHref: string,
+    podId: string,
+): string | null {
+    const url = localResourceUrl(resourceHref);
+    if (!url) return null;
+    if (url.pathname !== `/pod/${encodeURIComponent(podId)}${APP_VIEW_SUFFIX}`) return null;
+    return url.searchParams.get('page')?.trim() || null;
 }
 
 export function buildConversationPresentationHref({


### PR DESCRIPTION
## Three levels deep to show one app

An app is the one presented resource whose surface belongs to the pod **layout** rather than to its own page: `/app/view` is an empty placeholder and the live iframe lives in `AppFrameHost`, above the router.

So framing that route to reach the host booted a second copy of the entire workspace inside the stage — sidebar, topbar, tab strip — and mounted the app's own iframe under it. Beside the conversation that asked for it.

## The fix

The stage already sits inside the pod's `AppProvider`, so it reads the slug off the presented href and mounts the app's frame itself.

`AppFrame` grows a `chrome` prop for this. `none` draws the frame alone, because the stage's own header already names the app and holds the close and full-view controls — claiming the shell's context bar would rename the conversation still being read beside it. `bar` is the default and is what every existing call site gets.

The pane also stops printing the raw slug back at the reader: the app's record names it the way the tab strip does ("Ledger", not `ledger`).

## `conversationStageAppSlug` is deliberately narrow

The apps index and a view route that lost its slug are pages of their own, and framing those is still correct — so they must not read as an app. Same for a cross-pod href or an absolute URL. Covered by tests.

## Verification

- `npm run check` (design audit, lint, typecheck, edu-anchors) — pass
- `npm test` — 458 tests pass, including the new slug-resolution cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)