### PR TITLE
Give a table's columns a width, so one long value stops deciding how wide the grid is

### DIFF
--- a/lemma-frontend/components/data/datastore-table-view.tsx
+++ b/lemma-frontend/components/data/datastore-table-view.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, type ReactNode } from 'react';
+import { useCallback, useRef, useState, type ReactNode } from 'react';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { ArrowDown, ArrowUp, Plus, Filter, Trash2, Edit, MoreVertical, Maximize2, Table as TableIcon } from '@/components/ui/icons';
@@ -18,6 +18,8 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { EditableCell } from '@/components/tables/cells/editable-cell';
+import { ColumnResizeHandle } from '@/components/tables/column-resize-handle';
+import { ColumnTypeIcon } from '@/components/tables/column-type-icon';
 import { ViewSwitcher, type ViewType } from '@/components/tables/view-switcher';
 import { ResourceShareButton, ResourceVisibilityBadge, type ResourceVisibilityValue } from '@/components/shared/resource-visibility';
 import { resourceAllows } from '@/lib/authz/resource-actions';
@@ -29,6 +31,12 @@ import {
     useDeleteRecord,
     useDeleteTable,
 } from '@/lib/hooks/use-datastores';
+import {
+    ACTIONS_COLUMN_WIDTH,
+    SELECT_COLUMN_WIDTH,
+    defaultColumnWidth,
+    useTableColumnWidths,
+} from '@/lib/hooks/use-table-column-widths';
 import { useTableShortcuts } from '@/lib/hooks/use-table-shortcuts';
 import { getLemmaClient } from '@/lib/sdk/lemma-client';
 import { buildResourceShareUrl } from '@/lib/assistant/conversation-presentation';
@@ -103,6 +111,12 @@ export function DatastoreTableView({
     const [queryPageTokens, setQueryPageTokens] = useState<Array<string | null>>([null]);
     const limit = 50;
     const usesStructuredQuery = filters.length > 0 || sortField !== null;
+
+    const tableRef = useRef<HTMLTableElement>(null);
+    const { widthFor, setColumnWidth, resetColumnWidth, clampWidth } = useTableColumnWidths(
+        podId,
+        tableName
+    );
 
     useTableShortcuts({
         onNewRecord: () => {
@@ -257,9 +271,74 @@ export function DatastoreTableView({
 
     const records = (recordsData?.items as TableRecord[] | undefined) || [];
     const orderedColumns = table ? getDisplayColumns(table.columns, table.primary_key_column) : [];
-    const gridColumnCount = orderedColumns.length + 1 + (canWriteRecords ? 1 : 0) + (canUpdateTable ? 1 : 0);
+    // Select column (when writable) + the data columns + the slack column + the
+    // trailing rail that holds "add column" in the head and "expand" in a row.
+    const gridColumnCount = orderedColumns.length + 2 + (canWriteRecords ? 1 : 0);
+    // A definite width is what makes `table-layout: fixed` mean anything: CSS
+    // hands the fixed algorithm only to tables that have one, so the old
+    // `min-w-full` (a *minimum*, leaving width auto) quietly bought the
+    // automatic algorithm instead — every column as wide as its longest cell.
+    const gridWidth =
+        (canWriteRecords ? SELECT_COLUMN_WIDTH : 0) +
+        orderedColumns.reduce((total, column) => total + widthFor(column), 0) +
+        ACTIONS_COLUMN_WIDTH;
     const getRecordId = (record: TableRecord): string =>
         String(record[table?.primary_key_column || 'id'] ?? '');
+
+    /**
+     * Drag feedback, written straight to the DOM. React owns the width once the
+     * reader lets go; while they are still dragging, a state update per pointer
+     * move would re-render every cell on the page to move one edge.
+     *
+     * The commit path writes here too, so the element and the state always agree
+     * on where the drag ended — React skips a DOM write when the width it
+     * renders matches the one it rendered last, which after a drag that returns
+     * to where it started is exactly the width the element must not keep.
+     */
+    const paintColumnWidth = useCallback(
+        (columnName: string, width: number) => {
+            const grid = tableRef.current;
+            if (!grid) return;
+
+            const columns = Array.from(grid.querySelectorAll<HTMLTableColElement>('col[data-column]'));
+            const target = columns.find((column) => column.dataset.column === columnName);
+            if (!target) return;
+
+            target.style.width = `${clampWidth(width)}px`;
+            grid.style.width = `${
+                (canWriteRecords ? SELECT_COLUMN_WIDTH : 0) +
+                ACTIONS_COLUMN_WIDTH +
+                columns.reduce((total, column) => total + (Number.parseFloat(column.style.width) || 0), 0)
+            }px`;
+        },
+        [canWriteRecords, clampWidth]
+    );
+
+    const previewColumnWidth = useCallback(
+        (columnName: string, width: number) => {
+            if (tableRef.current) tableRef.current.dataset.resizing = 'true';
+            paintColumnWidth(columnName, width);
+        },
+        [paintColumnWidth]
+    );
+
+    const commitColumnWidth = useCallback(
+        (columnName: string, width: number) => {
+            if (tableRef.current) delete tableRef.current.dataset.resizing;
+            paintColumnWidth(columnName, width);
+            setColumnWidth(columnName, width);
+        },
+        [paintColumnWidth, setColumnWidth]
+    );
+
+    const restoreColumnWidth = useCallback(
+        (column: Column) => {
+            if (tableRef.current) delete tableRef.current.dataset.resizing;
+            paintColumnWidth(column.name, defaultColumnWidth(column));
+            resetColumnWidth(column.name);
+        },
+        [paintColumnWidth, resetColumnWidth]
+    );
 
     const handleSort = (columnName: string) => {
         setPage(0);
@@ -414,12 +493,35 @@ export function DatastoreTableView({
 
             <div className={embedded ? 'data-table-viewport relative flex-1 overflow-hidden bg-[var(--row-bg)]' : 'relative flex-1 overflow-auto p-2'}>
                 {currentView === 'grid' ? (
-                    <div className={embedded ? 'data-table-grid-frame h-full' : 'min-w-full inline-block align-middle h-full'}>
+                    <div className={embedded ? 'data-table-grid-frame h-full' : 'h-full'}>
                         <div className="h-full overflow-auto bg-transparent">
-                            <table className="data-table-grid min-w-full table-fixed">
+                            {/* eslint-disable no-restricted-syntax -- A column width is
+                                the runtime geometry the rule allows for: it is a number the
+                                reader chose by dragging, kept per table, and a stylesheet has
+                                no way to name it. */}
+                            <table ref={tableRef} className="data-table-grid" style={{ width: gridWidth }}>
+                                {/* Every column's width is declared once, here.
+                                    The unsized column near the end is slack: it
+                                    swallows whatever a narrow table leaves over,
+                                    so two columns stay two columns instead of
+                                    stretching to fill the pane, and the rows
+                                    still rule all the way to the frame. */}
+                                <colgroup>
+                                    {canWriteRecords ? <col style={{ width: SELECT_COLUMN_WIDTH }} /> : null}
+                                    {orderedColumns.map((column: Column) => (
+                                        <col
+                                            key={column.name}
+                                            data-column={column.name}
+                                            style={{ width: widthFor(column) }}
+                                        />
+                                    ))}
+                                    <col />
+                                    <col style={{ width: ACTIONS_COLUMN_WIDTH }} />
+                                </colgroup>
+                                {/* eslint-enable no-restricted-syntax */}
                                 <thead className="data-table-head sticky top-0 z-10 border-b border-[color:var(--row-border)] bg-[var(--card-bg)] backdrop-blur-md">
                                     <tr>
-                                        {canWriteRecords ? <th className="w-10 px-2.5 py-2 text-center">
+                                        {canWriteRecords ? <th className="px-2.5 py-2 text-center">
                                             <input
                                                 type="checkbox"
                                                 checked={selectedRows.size === records.length && records.length > 0}
@@ -428,26 +530,39 @@ export function DatastoreTableView({
                                             />
                                         </th> : null}
                                         {orderedColumns.map((column: Column) => (
-                                            <th key={column.name} className="group px-3 py-2 text-left text-xs font-normal tracking-wide text-[var(--text-tertiary)]">
-                                                <div className="flex items-center justify-between gap-2">
-                                                    <div className="flex items-center gap-1.5 cursor-pointer select-none" onClick={() => handleSort(column.name)}>
-                                                        <span className="text-[var(--text-secondary)]">{column.name}</span>
-                                                        <span className="rounded bg-[var(--bg-subtle)] px-1 py-0.5 text-xs font-normal lowercase text-[var(--text-tertiary)]">
-                                                            {column.type}
-                                                        </span>
+                                            <th
+                                                key={column.name}
+                                                scope="col"
+                                                className="group relative px-3 py-2 text-left text-xs font-normal tracking-wide text-[var(--text-tertiary)]"
+                                            >
+                                                <div className="flex items-center justify-between gap-1">
+                                                    {/* The name is what has to survive a narrow
+                                                        column, so it is the only part allowed to
+                                                        take the room: the type is a glyph, the
+                                                        sort a bare arrow, and the whole label
+                                                        clips rather than pushing the column wider. */}
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => handleSort(column.name)}
+                                                        title={`${column.name} · ${String(column.type).toLowerCase()}`}
+                                                        className="flex min-w-0 flex-1 select-none items-center gap-1.5 text-left"
+                                                    >
+                                                        <ColumnTypeIcon type={column.type} />
+                                                        <span className="truncate text-[var(--text-secondary)]">{column.name}</span>
                                                         {sortField === column.name && (
-                                                            <span className="rounded bg-[var(--action-primary-soft)] px-1 py-0.5 text-xs font-bold text-[var(--action-primary)]">
-                                                                {sortOrder === 'asc'
-                                                                    ? <ArrowUp className="size-3" aria-hidden="true" />
-                                                                    : <ArrowDown className="size-3" aria-hidden="true" />}
-                                                            </span>
+                                                            sortOrder === 'asc'
+                                                                ? <ArrowUp className="size-3 shrink-0 text-[var(--action-primary)]" aria-hidden="true" />
+                                                                : <ArrowDown className="size-3 shrink-0 text-[var(--action-primary)]" aria-hidden="true" />
                                                         )}
-                                                    </div>
+                                                    </button>
 
                                                     {canUpdateTable && column.name !== table.primary_key_column && (
                                                         <DropdownMenu>
                                                             <DropdownMenuTrigger asChild>
-                                                                <Button variant="quiet" size="icon" className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity -mr-2">
+                                                                {/* No negative margin: it used to hang into the
+                                                                    cell's right padding, which is now where the
+                                                                    resize grip lives. */}
+                                                                <Button variant="quiet" size="icon" className="h-6 w-6 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
                                                                     <MoreVertical className="h-3 w-3 text-[var(--text-tertiary)]" />
                                                                 </Button>
                                                             </DropdownMenuTrigger>
@@ -463,19 +578,30 @@ export function DatastoreTableView({
                                                         </DropdownMenu>
                                                     )}
                                                 </div>
+
+                                                <ColumnResizeHandle
+                                                    columnName={column.name}
+                                                    width={widthFor(column)}
+                                                    onPreview={previewColumnWidth}
+                                                    onCommit={commitColumnWidth}
+                                                    onReset={() => restoreColumnWidth(column)}
+                                                />
                                             </th>
                                         ))}
-                                        {canUpdateTable ? <th className="w-10 px-2.5 py-2">
-                                            <Button
-                                                variant="quiet"
-                                                size="sm"
-                                                onClick={() => setShowAddColumnDialog(true)}
-                                                className="h-7 w-7 rounded-md bg-[var(--bg-subtle)] p-0 text-[var(--text-secondary)] hover:bg-[var(--bg-muted)] hover:text-[var(--text-primary)]"
-                                                title="Add Column"
-                                            >
-                                                <Plus className="w-4 h-4" />
-                                            </Button>
-                                        </th> : null}
+                                        <th aria-hidden="true" />
+                                        <th className="px-2.5 py-2">
+                                            {canUpdateTable ? (
+                                                <Button
+                                                    variant="quiet"
+                                                    size="sm"
+                                                    onClick={() => setShowAddColumnDialog(true)}
+                                                    className="h-7 w-7 rounded-md bg-[var(--bg-subtle)] p-0 text-[var(--text-secondary)] hover:bg-[var(--bg-muted)] hover:text-[var(--text-primary)]"
+                                                    title="Add Column"
+                                                >
+                                                    <Plus className="w-4 h-4" />
+                                                </Button>
+                                            ) : null}
+                                        </th>
                                     </tr>
                                 </thead>
                                 {/* Paging and filtering keep the rows they already
@@ -571,6 +697,7 @@ export function DatastoreTableView({
                                                             )}
                                                         </td>
                                                     ))}
+                                                    <td aria-hidden="true" />
                                                     <td className="px-2.5 py-1">
                                                         <button
                                                             type="button"

--- a/lemma-frontend/components/tables/cells/editable-cell.tsx
+++ b/lemma-frontend/components/tables/cells/editable-cell.tsx
@@ -169,7 +169,7 @@ export function EditableNumberCell({ value, onSave, onCancel }: Omit<EditableCel
                 className="flex min-h-7 cursor-pointer items-center rounded-md px-1.5 py-1 transition-gentle hover:bg-[var(--bg-subtle)]"
                 onClick={() => setIsEditing(true)}
             >
-                <span className="w-full tabular-nums text-sm text-[var(--text-primary)]">
+                <span className="w-full truncate tabular-nums text-sm text-[var(--text-primary)]">
                     {originalValue || <span className="text-[var(--text-tertiary)]">—</span>}
                 </span>
             </div>
@@ -251,7 +251,7 @@ export function EditableDateCell({ value, onSave, onCancel }: Omit<EditableCellP
                 className="flex min-h-7 cursor-pointer items-center rounded-md px-1.5 py-1 transition-gentle hover:bg-[var(--bg-subtle)]"
                 onClick={() => setIsEditing(true)}
             >
-                <span className="w-full text-sm text-[var(--text-primary)]">
+                <span className="w-full truncate text-sm text-[var(--text-primary)]">
                     {displayValue || <span className="text-[var(--text-tertiary)]">—</span>}
                 </span>
             </div>
@@ -349,8 +349,11 @@ export function EditableEnumCell({
                 onClick={() => setIsEditing(true)}
             >
                 {normalizedValue ? (
-                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium shadow-[var(--shadow-xs)] ${color.bg} ${color.text}`}>
-                        {normalizedValue}
+                    // The label truncates inside the pill rather than the pill
+                    // truncating inside the cell: a chip clipped mid-curve reads
+                    // as a rendering fault, an ellipsis reads as a long value.
+                    <span className={`inline-flex min-w-0 max-w-full items-center rounded-full px-2 py-0.5 text-xs font-medium shadow-[var(--shadow-xs)] ${color.bg} ${color.text}`}>
+                        <span className="truncate">{normalizedValue}</span>
                     </span>
                 ) : (
                     <span className="text-sm text-[var(--text-tertiary)]">—</span>

--- a/lemma-frontend/components/tables/column-resize-handle.tsx
+++ b/lemma-frontend/components/tables/column-resize-handle.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useRef, useState } from 'react';
+
+/**
+ * The grip on a column's right edge.
+ *
+ * Drag moves the edge; double-click hands the column back to its default. The
+ * drag itself never goes through React state — a table holds a page of records,
+ * and re-rendering every cell on every pointer move would make the edge lag the
+ * pointer it is supposed to be following. `onPreview` writes the width straight
+ * to the `<col>` element, and only the width the reader lets go at is committed.
+ */
+interface ColumnResizeHandleProps {
+    columnName: string;
+    /** The column's width when the drag starts, in pixels. */
+    width: number;
+    onPreview: (columnName: string, width: number) => void;
+    onCommit: (columnName: string, width: number) => void;
+    onReset: (columnName: string) => void;
+}
+
+const KEYBOARD_STEP = 16;
+
+export function ColumnResizeHandle({
+    columnName,
+    width,
+    onPreview,
+    onCommit,
+    onReset,
+}: ColumnResizeHandleProps) {
+    const dragStart = useRef<{ pointerX: number; width: number } | null>(null);
+    const [isDragging, setIsDragging] = useState(false);
+
+    const widthAt = (pointerX: number): number => {
+        const start = dragStart.current;
+        if (!start) return width;
+        return start.width + (pointerX - start.pointerX);
+    };
+
+    return (
+        <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label={`Resize ${columnName} column`}
+            tabIndex={0}
+            data-dragging={isDragging ? 'true' : undefined}
+            className="data-table-column-resizer"
+            // The whole header cell sorts on click. Without this the grip would
+            // re-sort the table every time someone finished widening a column.
+            onClick={(event) => event.stopPropagation()}
+            onDoubleClick={(event) => {
+                event.stopPropagation();
+                onReset(columnName);
+            }}
+            onPointerDown={(event) => {
+                if (event.button !== 0) return;
+                event.preventDefault();
+                event.stopPropagation();
+                dragStart.current = { pointerX: event.clientX, width };
+                event.currentTarget.setPointerCapture(event.pointerId);
+                setIsDragging(true);
+            }}
+            onPointerMove={(event) => {
+                if (!dragStart.current) return;
+                onPreview(columnName, widthAt(event.clientX));
+            }}
+            onPointerUp={(event) => {
+                if (!dragStart.current) return;
+                const next = widthAt(event.clientX);
+                dragStart.current = null;
+                event.currentTarget.releasePointerCapture(event.pointerId);
+                setIsDragging(false);
+                onCommit(columnName, next);
+            }}
+            onPointerCancel={() => {
+                dragStart.current = null;
+                setIsDragging(false);
+                onCommit(columnName, width);
+            }}
+            onKeyDown={(event) => {
+                if (event.key === 'ArrowLeft') {
+                    event.preventDefault();
+                    onCommit(columnName, width - KEYBOARD_STEP);
+                } else if (event.key === 'ArrowRight') {
+                    event.preventDefault();
+                    onCommit(columnName, width + KEYBOARD_STEP);
+                } else if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    onReset(columnName);
+                }
+            }}
+        />
+    );
+}

--- a/lemma-frontend/components/tables/column-type-icon.tsx
+++ b/lemma-frontend/components/tables/column-type-icon.tsx
@@ -1,0 +1,52 @@
+import {
+    Braces,
+    Calendar,
+    CalendarClock,
+    CheckSquare,
+    FileText,
+    Hash,
+    KeyRound,
+    Link2,
+    Tag,
+    TextT,
+    User,
+    Waypoints,
+    type LemmaIcon,
+} from '@/components/ui/icons';
+
+/**
+ * A column's type, in the width a bounded header can spare.
+ *
+ * The header used to print the type as a word in a filled chip — "datetime"
+ * beside `created_at`. That reads fine in a column as wide as its longest value
+ * and not at all in a column the reader has narrowed to fit six of them on the
+ * screen. The glyph says the same thing in 14px; the word is still there, in
+ * the header's tooltip, for anyone who wants it spelled out.
+ */
+const ICON_BY_TYPE: Record<string, LemmaIcon> = {
+    TEXT: TextT,
+    INTEGER: Hash,
+    FLOAT: Hash,
+    SERIAL: Hash,
+    BOOLEAN: CheckSquare,
+    DATE: Calendar,
+    DATETIME: CalendarClock,
+    ENUM: Tag,
+    JSON: Braces,
+    UUID: KeyRound,
+    USER: User,
+    LINK: Link2,
+    FILE_PATH: FileText,
+    VECTOR: Waypoints,
+};
+
+export function ColumnTypeIcon({ type, className }: { type: string; className?: string }) {
+    const Icon = ICON_BY_TYPE[String(type).toUpperCase()] ?? TextT;
+
+    return (
+        <Icon
+            className={className ?? 'h-3.5 w-3.5 shrink-0 text-[var(--text-tertiary)]'}
+            aria-hidden="true"
+        />
+    );
+}

--- a/lemma-frontend/components/ui/icons.ts
+++ b/lemma-frontend/components/ui/icons.ts
@@ -138,6 +138,9 @@ export {
     GithubLogo as Github,
     Globe as Globe2,
     DotsSixVertical as GripVertical,
+    // A column's data type, in the width a bounded grid header can spare. The
+    // three below exist for that vocabulary: a number, a word, a label.
+    Hash,
     ClockCounterClockwise as History,
     House as Home,
     ImageSquare as ImagePlus,
@@ -195,7 +198,9 @@ export {
     Sparkle as Sparkles,
     TerminalWindow as SquareTerminal,
     Table as Table2,
+    Tag,
     TerminalWindow as TerminalSquare,
+    TextAa as TextT,
     Trash as Trash2,
     UserCircle as UserRound,
     UsersThree as UsersRound,

--- a/lemma-frontend/lib/hooks/use-table-column-widths.ts
+++ b/lemma-frontend/lib/hooks/use-table-column-widths.ts
@@ -1,0 +1,152 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import type { Column } from '@/lib/types';
+
+/**
+ * How wide a grid column is.
+ *
+ * A column is furniture with a width, not a function of whatever the widest
+ * value in it happens to be. Letting the content decide means one long note
+ * pushes every other column off the screen, and the table a reader came to scan
+ * becomes a table they have to scroll sideways through to read one row.
+ *
+ * So each column starts at a width its type usually needs, and the reader can
+ * drag it to whatever they actually want. What they drag it to is theirs to
+ * keep: the widths persist per table, in this browser, because a column width
+ * is a reading preference and not something to publish to everyone in the pod.
+ */
+
+export const MIN_COLUMN_WIDTH = 72;
+export const MAX_COLUMN_WIDTH = 720;
+
+/**
+ * The row-select checkbox and the trailing expand/add-column rail. Both are
+ * sized to their control plus its padding — the cells clip now, so a rail that
+ * is a few pixels short of its own button would shave the button.
+ */
+export const SELECT_COLUMN_WIDTH = 40;
+export const ACTIONS_COLUMN_WIDTH = 48;
+
+/**
+ * A checkbox never needs the room a paragraph does. One uniform default would
+ * spend the same span on `is_active` as on `summary`, which wastes the screen
+ * at one end and starves it at the other.
+ *
+ * The narrow end is set by the header rather than the values: a boolean's
+ * control fits in half of what is here, but `is_archived` has to stay readable
+ * above it, and a column whose own name is elided is a column nobody can scan.
+ */
+const WIDTH_BY_TYPE: Record<string, number> = {
+    BOOLEAN: 116,
+    SERIAL: 116,
+    INTEGER: 132,
+    FLOAT: 132,
+    DATE: 148,
+    ENUM: 160,
+    USER: 168,
+    LINK: 176,
+    DATETIME: 184,
+    UUID: 200,
+    FILE_PATH: 224,
+    TEXT: 232,
+    JSON: 240,
+    VECTOR: 240,
+};
+
+const FALLBACK_WIDTH = 200;
+
+function clampWidth(width: number): number {
+    return Math.min(MAX_COLUMN_WIDTH, Math.max(MIN_COLUMN_WIDTH, Math.round(width)));
+}
+
+export function defaultColumnWidth(column: Column): number {
+    return WIDTH_BY_TYPE[String(column.type).toUpperCase()] ?? FALLBACK_WIDTH;
+}
+
+function storageKeyFor(podId: string, tableName: string): string {
+    return `lemma.table-column-widths.${podId}.${tableName}`;
+}
+
+function readStoredWidths(key: string): Record<string, number> {
+    if (typeof window === 'undefined') return {};
+
+    try {
+        const raw = window.localStorage.getItem(key);
+        if (!raw) return {};
+
+        const parsed: unknown = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+
+        return Object.entries(parsed as Record<string, unknown>).reduce<Record<string, number>>(
+            (accumulator, [name, value]) => {
+                if (typeof value === 'number' && Number.isFinite(value)) {
+                    accumulator[name] = clampWidth(value);
+                }
+                return accumulator;
+            },
+            {}
+        );
+    } catch {
+        // A browser with storage denied, or a stale value written by an older
+        // shape, is not a reason to fail to draw the table. Fall back to the
+        // per-type defaults.
+        return {};
+    }
+}
+
+function writeStoredWidths(key: string, widths: Record<string, number>): void {
+    if (typeof window === 'undefined') return;
+
+    try {
+        if (Object.keys(widths).length === 0) window.localStorage.removeItem(key);
+        else window.localStorage.setItem(key, JSON.stringify(widths));
+    } catch {
+        // Same reasoning as the read: the widths are a convenience, so a full or
+        // blocked store costs this session's resizes and nothing else.
+    }
+}
+
+export function useTableColumnWidths(podId: string, tableName: string) {
+    const [widths, setWidths] = useState<Record<string, number>>({});
+
+    // Deliberately an effect and not a lazy initializer: this component renders
+    // on the server too, where `localStorage` does not exist, and seeding state
+    // from it would make the first client render disagree with the server's.
+    useEffect(() => {
+        setWidths(readStoredWidths(storageKeyFor(podId, tableName)));
+    }, [podId, tableName]);
+
+    const widthFor = useCallback(
+        (column: Column): number => widths[column.name] ?? defaultColumnWidth(column),
+        [widths]
+    );
+
+    const setColumnWidth = useCallback(
+        (columnName: string, width: number) => {
+            setWidths((previous) => {
+                const next = { ...previous, [columnName]: clampWidth(width) };
+                writeStoredWidths(storageKeyFor(podId, tableName), next);
+                return next;
+            });
+        },
+        [podId, tableName]
+    );
+
+    const resetColumnWidth = useCallback(
+        (columnName: string) => {
+            setWidths((previous) => {
+                if (!(columnName in previous)) return previous;
+
+                const next = { ...previous };
+                delete next[columnName];
+                writeStoredWidths(storageKeyFor(podId, tableName), next);
+                return next;
+            });
+        },
+        [podId, tableName]
+    );
+
+    return { widthFor, setColumnWidth, resetColumnWidth, clampWidth };
+}

--- a/lemma-frontend/scripts/design-audit-baseline.json
+++ b/lemma-frontend/scripts/design-audit-baseline.json
@@ -1,6 +1,6 @@
 {
   "informational": {
-    "rawButtonElements": 28,
+    "rawButtonElements": 29,
     "rawSwitchButtonElements": 0,
     "rawFieldElements": 3,
     "inlineEditableFieldElements": 4,

--- a/lemma-frontend/styles/features/builders-and-ledgers.css
+++ b/lemma-frontend/styles/features/builders-and-ledgers.css
@@ -497,6 +497,66 @@
   border-spacing: 0;
 }
 
+/* A column is furniture with a width, not a report on whichever cell in it
+   happens to hold the most text. The grid used to carry `table-fixed`, which
+   did nothing: CSS hands the fixed algorithm only to a table whose own width is
+   definite, and this one's was `auto` under a `min-width: 100%`. So the
+   automatic algorithm ran instead, one long note stretched its column past the
+   pane, and reading a single row meant scrolling sideways through the rest.
+
+   The widths now come from the colgroup — a per-type default the reader can
+   drag — the table is as wide as those add up to, and `min-width` only decides
+   what happens when they add up to less than the pane. Scoped to the element,
+   not the workbench, so the standalone table is governed by the same rule. */
+.data-table-grid {
+  table-layout: fixed;
+  min-width: 100%;
+}
+
+/* The width is the promise; this is what keeps it. Without it a cell's content
+   simply paints over its neighbour instead of ending in an ellipsis. */
+.data-table-grid th,
+.data-table-grid td {
+  overflow: hidden;
+}
+
+.data-table-grid[data-resizing='true'] {
+  cursor: col-resize;
+  user-select: none;
+}
+
+/* Nine pixels of grip, and one hairline of it visible. A resizer that is always
+   drawn turns the header into a picket fence; one that appears under the
+   pointer is found by everyone who goes looking for it and by no one else. */
+.data-table-column-resizer {
+  position: absolute;
+  inset-block: 0;
+  right: 0;
+  width: 9px;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.data-table-column-resizer::after {
+  content: '';
+  position: absolute;
+  inset-block: 0.25rem;
+  right: 4px;
+  width: 2px;
+  background: transparent;
+  transition: background-color 120ms ease;
+}
+
+.data-table-column-resizer:hover::after,
+.data-table-column-resizer:focus-visible::after,
+.data-table-column-resizer[data-dragging='true']::after {
+  background: var(--action-primary);
+}
+
+.data-table-column-resizer:focus-visible {
+  outline: none;
+}
+
 .data-table-workbench .data-table-head {
   box-shadow: 0 1px 0 var(--border-subtle);
 }


### PR DESCRIPTION
## The bug

The pod's grid carried `table-fixed`, and it did nothing.

```tsx
<table className="data-table-grid min-w-full table-fixed">
```

CSS hands the fixed algorithm only to a table whose own `width` is definite. `min-w-full` sets a *minimum* — width stayed `auto` — so the automatic algorithm ran and every column sized to its longest cell.

Measured on a realistic eight-column table in a 1230px pane:

| | table width | `summary` column |
|---|---|---|
| before | **2808px** | **1355px** |
| after | 1536px | 232px |

Two columns filled the screen; the other six were off it. Reading one row meant scrolling sideways through the rest.

## What changed

- **Widths are declared once, in a `<colgroup>`**, and the table carries their sum as a real px width. Defaults are per type — `boolean` 116 through `json` 240 — because one uniform width spends the same span on `is_active` as on `summary`. The narrow end is set by what the *header* needs, not the values: a column whose own name is elided can't be scanned.
- **Drag any column's right edge to resize**; double-click (or <kbd>Enter</kbd> on the focused grip) restores the default; <kbd>←</kbd>/<kbd>→</kbd> nudge it. Widths persist per table in `localStorage` — a column width is a reading preference, not something to publish to the pod. The drag writes straight to the `<col>` element and commits to React state only on release, since a state update per pointer move would re-render every cell on the page to move one edge.
- **An unsized slack column** before the actions rail absorbs the surplus, so a two-column table stays two columns instead of stretching each across half the pane — and the rows still rule to the frame's edge. Measured: `[40, 232, 232, 682, 44]`.
- **Cells clip with an ellipsis.** The number, date, and enum cells weren't. The enum label truncates *inside* its pill — a pill clipped mid-curve reads as a rendering fault where an ellipsis reads as a long value.
- **The header's type chip is a glyph.** At a width a reader has narrowed, `created_at` and `datetime` cannot both be legible. The word is still in the header's tooltip. This is the one judgment call here worth a second opinion — the alternative is keeping the chip and widening every default to fit it.

Also fixes a latent off-by-one: `gridColumnCount` counted the trailing rail twice when `canUpdateTable`, so the empty-state `colSpan` was wrong.

## Verification

Measurements and the screenshot come from headless Chromium running the shipped DOM and CSS, including a real +120px drag (`title` 232 → 352, every other column held). `tsc`, `eslint`, the design-system audit gate, and all 501 frontend tests pass — run inside this worktree, not just the tree it was authored in.

Not verified in the running app: port 3710 held a dead registration from a concurrent session, and `make dev` begins with `make stop`, which would have killed other in-flight work.

## Not in scope

- The primary column doesn't freeze on horizontal scroll. That's the next real Airtable step.
- Cells are single-line. Multi-line wrapping is a row-height control, a different change.

## Baseline

`design-audit-baseline.json` moves by one line: `rawButtonElements` 28 → 29. The sort control is now a `<button>` instead of a `<div onClick>` — a raw button element, and also a thing you can tab to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
