### PR TITLE
Make the feedback categories the ones the help actually offers

### DIFF
--- a/lemma-backend/app/modules/agent/api/controllers/tool_controller.py
+++ b/lemma-backend/app/modules/agent/api/controllers/tool_controller.py
@@ -51,8 +51,8 @@ async def web_search(
     operation_id="agent.tool.report_feedback",
     summary="Agent Report Feedback",
     description=(
-        "Record a maintainer-facing feedback report about system issues, skill "
-        "issues, incorrect knowledge, or other unexpected behavior."
+        "Record a maintainer-facing feedback report about the CLI, a skill, the "
+        "platform, or the docs."
     ),
 )
 async def report_feedback(

--- a/lemma-backend/app/modules/agent/tests/e2e/test_agent_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_agent_e2e.py
@@ -2603,7 +2603,7 @@ class TestAgentToolApis:
         feedback = await authenticated_client.post(
             "/tools/report-feedback",
             json={
-                "category": "TOOLING_ISSUE",
+                "category": "cli",
                 "subject": "Tool e2e feedback",
                 "issue_encountered": "The test needs to record feedback.",
                 "expected_behavior": "Feedback is stored.",

--- a/lemma-backend/app/modules/agent/tests/e2e/test_agent_tool_boundaries_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_agent_tool_boundaries_e2e.py
@@ -98,7 +98,7 @@ async def _delegated_client(
 
 def _feedback_payload(subject: str) -> dict[str, str]:
     return {
-        "category": "TOOLING_ISSUE",
+        "category": "cli",
         "subject": f"  {subject}  ",
         "issue_encountered": "  The tool encountered a deterministic issue.  ",
         "expected_behavior": "  Feedback is stored.  ",

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_tool_controller.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_tool_controller.py
@@ -70,7 +70,7 @@ async def test_agent_report_feedback_links_delegated_agent():
     response = await tool_controller.report_feedback(
         request=request,
         data=ReportFeedbackRequest(
-            category=FeedbackCategory.TOOLING_ISSUE,
+            category=FeedbackCategory.CLI,
             subject=" Tool failed ",
             issue_encountered="The helper endpoint returned stale data.",
             expected_behavior="It should return fresh results.",

--- a/lemma-backend/app/modules/agent/tools/feedback/models.py
+++ b/lemma-backend/app/modules/agent/tools/feedback/models.py
@@ -6,19 +6,33 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 
 
+# Areas, not kinds of defect. Someone who hit a bad error message knows it came
+# from the CLI, but not whether to file it as a "tooling" or a "system" issue.
+# These values were once SCREAMING_SNAKE kinds (SYSTEM_ISSUE, TOOLING_ISSUE, …)
+# that no caller-facing surface named, while the CLI help and every skill
+# example said cli/skill/platform/docs — so each documented example was rejected
+# by the API. This is that vocabulary, made real. The docstring below is the
+# published OpenAPI schema description; keep it about what callers should send.
 class FeedbackCategory(str, Enum):
-    SYSTEM_ISSUE = "SYSTEM_ISSUE"
-    SKILL_ISSUE = "SKILL_ISSUE"
-    INCORRECT_KNOWLEDGE = "INCORRECT_KNOWLEDGE"
-    TOOLING_ISSUE = "TOOLING_ISSUE"
-    OTHER = "OTHER"
+    """Which part of Lemma the report is about."""
+
+    CLI = "cli"
+    SKILL = "skill"
+    PLATFORM = "platform"
+    DOCS = "docs"
+    OTHER = "other"
 
 
 class ReportFeedbackRequest(BaseModel):
     """Request payload for maintainer feedback reports."""
 
     category: FeedbackCategory = Field(
-        description="High-level category for the feedback report."
+        description=(
+            "Which part of Lemma the report is about: 'cli' (the lemma "
+            "command-line tool), 'skill' (a bundled skill's guidance), "
+            "'platform' (the API, runtime, or product behavior), 'docs' "
+            "(wrong or missing documentation), or 'other'."
+        )
     )
     subject: str = Field(
         min_length=3,

--- a/lemma-cli/lemma_cli/cli_core/app.py
+++ b/lemma-cli/lemma_cli/cli_core/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from enum import Enum
 from pathlib import Path
 
 import typer
@@ -210,10 +211,35 @@ def version_cmd(ctx: typer.Context) -> None:
     system.run_version(ctx)
 
 
+class FeedbackCategory(str, Enum):
+    """Which part of Lemma a feedback report is about.
+
+    Mirrors the API's `FeedbackCategory`, spelled out rather than imported:
+    this module is the startup path for every command including
+    `lemma --help`, and LAZY_GROUPS exists so nothing pulls the SDK in before
+    a command actually runs. tests/test_cli_v2.py pins these to the generated
+    enum, so the two cannot drift apart again.
+
+    Typing the flag with this enum is the fix for the original bug: the help
+    advertised `cli, skill, platform, docs` while the wire accepted only
+    SCREAMING_SNAKE names, so every advertised value failed deep in the SDK
+    with `'cli' is not a valid FeedbackCategory` and no list of what would
+    work. A wrong value is now a parse-time error that names the choices.
+    """
+
+    CLI = "cli"
+    SKILL = "skill"
+    PLATFORM = "platform"
+    DOCS = "docs"
+    OTHER = "other"
+
+
 @app.command("feedback")
 def feedback_cmd(
     ctx: typer.Context,
-    category: str = typer.Option(..., "--category", help="cli, skill, platform, docs, …"),
+    category: FeedbackCategory = typer.Option(
+        ..., "--category", help="Which part of Lemma the report is about."
+    ),
     subject: str = typer.Option(..., "--subject", help="One-line summary."),
     issue_encountered: str = typer.Option(..., "--issue-encountered"),
     expected_behavior: str = typer.Option(..., "--expected-behavior"),
@@ -225,7 +251,7 @@ def feedback_cmd(
 
     system.run_feedback(
         ctx,
-        category=category,
+        category=category.value,
         subject=subject,
         issue_encountered=issue_encountered,
         expected_behavior=expected_behavior,

--- a/lemma-cli/tests/test_cli_v2.py
+++ b/lemma-cli/tests/test_cli_v2.py
@@ -2292,6 +2292,62 @@ def test_feedback_dispatches_the_tool_api(monkeypatch):
     assert captured["suggested_next_steps"] is None
 
 
+def test_feedback_categories_match_the_api_enum():
+    """The CLI's category list must equal the API's, value for value.
+
+    `app.py` spells the categories out instead of importing them, so that
+    `lemma --help` never loads the SDK. That duplication is exactly how the
+    original bug happened: the help offered cli/skill/platform/docs while the
+    wire accepted SYSTEM_ISSUE/SKILL_ISSUE/…, and nothing compared the two.
+    This is the comparison.
+    """
+    from lemma_sdk.openapi_client.models.feedback_category import (
+        FeedbackCategory as ApiFeedbackCategory,
+    )
+
+    from lemma_cli.cli_core.app import FeedbackCategory as CliFeedbackCategory
+
+    assert {member.value for member in CliFeedbackCategory} == {
+        member.value for member in ApiFeedbackCategory
+    }
+
+
+def test_feedback_rejects_an_unknown_category_and_names_the_valid_ones():
+    """A wrong category must fail at parse time, listing what would work.
+
+    It used to reach the SDK and die on `'nope' is not a valid
+    FeedbackCategory` — no flag named, no list of accepted values — which left
+    a caller guessing at a closed set it could not see.
+    """
+    result = runner.invoke(
+        app,
+        [
+            "feedback",
+            "--category", "nope",
+            "--subject", "import aborts mid-write",
+            "--issue-encountered", "dry-run passed, import died on step 12",
+            "--expected-behavior", "dry-run catches it",
+            "--actual-behavior", "422 with no file named",
+        ],
+    )
+
+    assert result.exit_code == 2, result.output
+    output = unstyle(result.output)
+    assert "--category" in output
+    for value in ("cli", "skill", "platform", "docs", "other"):
+        assert value in output
+
+
+def test_feedback_help_lists_every_category():
+    """The help must name the categories, not trail off into an ellipsis."""
+    result = runner.invoke(app, ["feedback", "--help"])
+
+    assert result.exit_code == 0, result.output
+    output = unstyle(result.output).replace("\n", " ")
+    for value in ("cli", "skill", "platform", "docs", "other"):
+        assert value in output
+
+
 def test_apps_init_rejects_non_empty_directory(tmp_path):
     target = tmp_path / "existing"
     target.mkdir()

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -13,4 +13,4 @@ SDK and the server it is talking to.
 from __future__ import annotations
 
 API_VERSION = "0.7.0"
-SPEC_SHA256 = "461b2c05a440c0225e3d592c92452d59df8f6cd18e58c48a1640796fd072c749"
+SPEC_SHA256 = "478e05def9a482a9b68a6dc5fa4dce16fc30ae68b58612f5e0c73ef90dec11b8"

--- a/lemma-python/lemma_sdk/openapi_client/api/agent_tools/agent_tool_report_feedback.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/agent_tools/agent_tool_report_feedback.py
@@ -67,8 +67,7 @@ def sync_detailed(
 ) -> Response[ErrorResponse | ReportFeedbackResponse]:
     """Agent Report Feedback
 
-     Record a maintainer-facing feedback report about system issues, skill issues, incorrect knowledge,
-    or other unexpected behavior.
+     Record a maintainer-facing feedback report about the CLI, a skill, the platform, or the docs.
 
     Args:
         body (ReportFeedbackRequest): Request payload for maintainer feedback reports.
@@ -99,8 +98,7 @@ def sync(
 ) -> ErrorResponse | ReportFeedbackResponse | None:
     """Agent Report Feedback
 
-     Record a maintainer-facing feedback report about system issues, skill issues, incorrect knowledge,
-    or other unexpected behavior.
+     Record a maintainer-facing feedback report about the CLI, a skill, the platform, or the docs.
 
     Args:
         body (ReportFeedbackRequest): Request payload for maintainer feedback reports.
@@ -126,8 +124,7 @@ async def asyncio_detailed(
 ) -> Response[ErrorResponse | ReportFeedbackResponse]:
     """Agent Report Feedback
 
-     Record a maintainer-facing feedback report about system issues, skill issues, incorrect knowledge,
-    or other unexpected behavior.
+     Record a maintainer-facing feedback report about the CLI, a skill, the platform, or the docs.
 
     Args:
         body (ReportFeedbackRequest): Request payload for maintainer feedback reports.
@@ -156,8 +153,7 @@ async def asyncio(
 ) -> ErrorResponse | ReportFeedbackResponse | None:
     """Agent Report Feedback
 
-     Record a maintainer-facing feedback report about system issues, skill issues, incorrect knowledge,
-    or other unexpected behavior.
+     Record a maintainer-facing feedback report about the CLI, a skill, the platform, or the docs.
 
     Args:
         body (ReportFeedbackRequest): Request payload for maintainer feedback reports.

--- a/lemma-python/lemma_sdk/openapi_client/models/feedback_category.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/feedback_category.py
@@ -2,11 +2,11 @@ from enum import Enum
 
 
 class FeedbackCategory(str, Enum):
-    INCORRECT_KNOWLEDGE = "INCORRECT_KNOWLEDGE"
-    OTHER = "OTHER"
-    SKILL_ISSUE = "SKILL_ISSUE"
-    SYSTEM_ISSUE = "SYSTEM_ISSUE"
-    TOOLING_ISSUE = "TOOLING_ISSUE"
+    CLI = "cli"
+    DOCS = "docs"
+    OTHER = "other"
+    PLATFORM = "platform"
+    SKILL = "skill"
 
     def __str__(self) -> str:
         return str(self.value)

--- a/lemma-python/lemma_sdk/openapi_client/models/report_feedback_request.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/report_feedback_request.py
@@ -18,7 +18,7 @@ class ReportFeedbackRequest:
 
     Attributes:
         actual_behavior (str): What actually happened.
-        category (FeedbackCategory):
+        category (FeedbackCategory): Which part of Lemma the report is about.
         expected_behavior (str): What the caller expected to happen instead.
         issue_encountered (str): What issue, problem, or incorrect information was encountered.
         subject (str): Short subject line summarizing the report.

--- a/lemma-python/lemma_sdk/openapi_spec.json
+++ b/lemma-python/lemma_sdk/openapi_spec.json
@@ -5932,12 +5932,13 @@
         "type": "object"
       },
       "FeedbackCategory": {
+        "description": "Which part of Lemma the report is about.",
         "enum": [
-          "SYSTEM_ISSUE",
-          "SKILL_ISSUE",
-          "INCORRECT_KNOWLEDGE",
-          "TOOLING_ISSUE",
-          "OTHER"
+          "cli",
+          "skill",
+          "platform",
+          "docs",
+          "other"
         ],
         "title": "FeedbackCategory",
         "type": "string"
@@ -11087,7 +11088,7 @@
           },
           "category": {
             "$ref": "#/components/schemas/FeedbackCategory",
-            "description": "High-level category for the feedback report."
+            "description": "Which part of Lemma the report is about: 'cli' (the lemma command-line tool), 'skill' (a bundled skill's guidance), 'platform' (the API, runtime, or product behavior), 'docs' (wrong or missing documentation), or 'other'."
           },
           "expected_behavior": {
             "description": "What the caller expected to happen instead.",
@@ -31808,7 +31809,7 @@
     },
     "/tools/report-feedback": {
       "post": {
-        "description": "Record a maintainer-facing feedback report about system issues, skill issues, incorrect knowledge, or other unexpected behavior.",
+        "description": "Record a maintainer-facing feedback report about the CLI, a skill, the platform, or the docs.",
         "operationId": "agent.tool.report_feedback",
         "requestBody": {
           "content": {

--- a/lemma-skills/lemma-builder/references/cli-and-bundles.md
+++ b/lemma-skills/lemma-builder/references/cli-and-bundles.md
@@ -294,7 +294,7 @@ lemma connectors connect-requests create <connector> --auth-config-id <id>
 lemma connectors operations search|list|get|details|execute [<auth-config-or-connector>] [...]
 lemma connectors triggers list|get [<auth-config-or-connector>] [...]
 lemma surfaces list|get|upsert|enable|disable|setup|channels|available-channels|delete   # keyed by PLATFORM (slack, gmail, …)
-lemma feedback --category … --subject … --issue-encountered … --expected-behavior … --actual-behavior …
+lemma feedback --category cli|skill|platform|docs|other --subject … --issue-encountered … --expected-behavior … --actual-behavior …
 
 # apps
 lemma apps list|get|init|create|update|deploy|delete

--- a/lemma-skills/lemma-user/SKILL.md
+++ b/lemma-skills/lemma-user/SKILL.md
@@ -390,6 +390,9 @@ lemma feedback --category cli --subject "…" \
   --issue-encountered "…" --expected-behavior "…" --actual-behavior "…"
 ```
 
+`--category` is one of `cli`, `skill`, `platform`, `docs`, `other` — which part
+of Lemma the report is about.
+
 ## See also
 
 - The model → `lemma-builder/references/pod-model.md`

--- a/lemma-typescript/src/openapi_client/models/FeedbackCategory.ts
+++ b/lemma-typescript/src/openapi_client/models/FeedbackCategory.ts
@@ -2,10 +2,13 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+/**
+ * Which part of Lemma the report is about.
+ */
 export enum FeedbackCategory {
-    SYSTEM_ISSUE = 'SYSTEM_ISSUE',
-    SKILL_ISSUE = 'SKILL_ISSUE',
-    INCORRECT_KNOWLEDGE = 'INCORRECT_KNOWLEDGE',
-    TOOLING_ISSUE = 'TOOLING_ISSUE',
-    OTHER = 'OTHER',
+    CLI = 'cli',
+    SKILL = 'skill',
+    PLATFORM = 'platform',
+    DOCS = 'docs',
+    OTHER = 'other',
 }

--- a/lemma-typescript/src/openapi_client/models/ReportFeedbackRequest.ts
+++ b/lemma-typescript/src/openapi_client/models/ReportFeedbackRequest.ts
@@ -12,7 +12,7 @@ export type ReportFeedbackRequest = {
      */
     actual_behavior: string;
     /**
-     * High-level category for the feedback report.
+     * Which part of Lemma the report is about: 'cli' (the lemma command-line tool), 'skill' (a bundled skill's guidance), 'platform' (the API, runtime, or product behavior), 'docs' (wrong or missing documentation), or 'other'.
      */
     category: FeedbackCategory;
     /**

--- a/lemma-typescript/src/openapi_client/services/AgentToolsService.ts
+++ b/lemma-typescript/src/openapi_client/services/AgentToolsService.ts
@@ -12,7 +12,7 @@ import { request as __request } from '../core/request.js';
 export class AgentToolsService {
     /**
      * Agent Report Feedback
-     * Record a maintainer-facing feedback report about system issues, skill issues, incorrect knowledge, or other unexpected behavior.
+     * Record a maintainer-facing feedback report about the CLI, a skill, the platform, or the docs.
      * @param requestBody
      * @returns ReportFeedbackResponse Successful Response
      * @throws ApiError


### PR DESCRIPTION
## The bug

`lemma feedback` was impossible to file. The CLI advertised:

```
--category  TEXT  cli, skill, platform, docs, …
```

The API accepted only `SYSTEM_ISSUE | SKILL_ISSUE | INCORRECT_KNOWLEDGE | TOOLING_ISSUE | OTHER`. Zero overlap — every advertised value, and every example in the skills, was rejected.

The rejection happened client-side in `transport.call` → `body_model.from_dict`, before any HTTP request:

```
$ lemma feedback --category cli --subject "…" --issue-encountered "…" \
    --expected-behavior "…" --actual-behavior "…"
'cli' is not a valid FeedbackCategory
```

That is the entire error. No flag named, no list of accepted values. A closed set the caller cannot see, so guessing never converges — an agent burned a run cycling through plausible words and gave up, reporting the failure in its summary because the feedback channel itself was the thing that was broken.

Every documented example was broken too: `lemma-user/SKILL.md`, `lemma-builder/SKILL.md`, and `cli-and-bundles.md`.

## What changed

**The enum is the area words** — `cli`, `skill`, `platform`, `docs`, `other`.

Areas are what a reporter can actually identify. Someone who hit a bad error message knows it came from the CLI, but not whether to file it as a "tooling" or a "system" issue. It is also the vocabulary the CLI help and all three skill docs already used — the docs were right and the wire was the outlier, so this direction leaves the documented examples correct as written.

**The CLI flag is typed with the enum**, so the help enumerates the values and a wrong one fails at parse time naming the choices — where `CONVENTIONS.md` puts argument validation (exit 2):

```
│ *  --category    [cli|skill|platform|docs|other]  Which part of Lemma the report is about.
```
```
Invalid value for '--category': 'bug' is not one of 'cli', 'skill', 'platform', 'docs', 'other'.
```

**Both SDKs regenerated** through the usual pipeline (`dump_openapi_spec.py` → `generate_openapi_client.sh` ×2), spec and clients committed together per the generated-code policy. The regen touched only feedback files plus the spec stamp — no incidental churn.

## Why it shipped

`test_cli_v2.py` passed `--category cli` and asserted it round-tripped — but stubbed the SDK with a `FakeTools`, mocking away the exact layer that rejected it. The backend tests used `TOOLING_ISSUE` and passed. Both sides green, nothing testing the seam.

Three tests close it:
- the CLI's copy of the enum is pinned to the generated one (the duplication is deliberate — `app.py` is the startup path for `lemma --help` and `LAZY_GROUPS` exists so nothing loads the SDK before a command runs; now it can't drift)
- a bad category exits 2 and names the valid values
- the help lists every category

## API compatibility

**Breaking wire change** to `POST /tools/report-feedback`. The old SCREAMING_SNAKE values are now rejected. Acceptable because they never worked from any caller-facing surface — the CLI and skills only ever offered the new vocabulary, so no working caller sends the old values. Direct SDK users pinned to an older client are the only ones affected.

No migration: `agent_feedback.category` is a plain `String(32)`, so existing rows keep their old strings and nothing needs backfilling.

## Test commands

```bash
cd lemma-cli && uv run --with pytest --with ../lemma-python python -m pytest tests/ -q
```
```bash
cd lemma-backend && uv run pytest app/modules/agent/tests/unit/ -q
```

- CLI: 585 passed
- Backend agent unit: 585 passed
- Python SDK: 59 passed, 1 skipped
- Backend spec-contract (`test_openapi_extensions`, `test_sdk_integration_operations`, `test_ci_configuration_contract`): 13 passed
- Codegen-drift gates all clean — Python client, TypeScript client, L2 hooks, `x-lemma` stamp — checked against a staged baseline so the comparison matches CI
- `ruff check` / `ruff format --check` clean on changed files; `generate_route_inventory.py --check` current

Note: `test_agent_tool_controller.py` run alone fails on a SQLAlchemy `'Pod'` mapper lookup. Pre-existing test-isolation artifact, passes in the directory run, unrelated to this change.

## Security

None. No auth, authorization, or data-exposure surface changes — the endpoint's `CurrentUser` dependency and delegated-agent attribution are untouched. Input validation gets strictly tighter (the CLI now rejects at parse time what previously reached the SDK).

## Rollback

Revert the commit. No migration to unwind and no persisted state depends on the new values — the column is a free string, so rows written with `cli`/`skill`/… simply remain, readable by whatever reads them next.

## Known gap, out of scope

**Nothing reads the feedback.** `AgentFeedbackModel` is written in `tool_controller.py:65` and referenced nowhere else — no list endpoint, no admin view, no export. Filing works now, but reports land in a write-only table. That needs an authorization decision about who can read whose reports, so it is left for its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)