### PR TITLE
Show the Slack channels an agent answers in, rather than one chip that hides them

### DIFF
--- a/docs/design/slack-channels-as-reach.md
+++ b/docs/design/slack-channels-as-reach.md
@@ -1,0 +1,131 @@
+# Slack reach is a channel, not a bot
+
+**Status:** Implemented · **Surface area:** `lemma-frontend` only — no API, no migration
+
+## The change in one sentence
+
+On Slack, the thing an agent is reachable *at* is a channel, so the chips on an agent page become `#sales` `#support` `+ Add channel` instead of one `Slack` chip hiding a routing table nobody opens.
+
+## Why
+
+[Surfaces move into Agents](surfaces-into-agents.md) gave every platform the same journey: pick an identity, connect it, see proof. That shape is right for Telegram and WhatsApp, where the identity *is* the question — Lemma's number or your own, and once answered there is exactly one place the agent is reachable.
+
+Slack inverts both halves. Its identity question has one answer, forever. Its reach is plural.
+
+**1. Slack has no identity fork, but the UI shows one anyway.**
+[`has_native_credentials`](lemma-backend/app/modules/agent_surfaces/services/credential_resolver.py:71) branches on WhatsApp, Telegram and Resend and returns `False` for everything else, so `supported_credential_modes` for Slack is `[CUSTOM]` on every deployment. Meanwhile [registry.ts:159](lemma-frontend/lib/surfaces/registry.ts:159) advertises *"Lemma's Slack app · Nothing to register yourself · **Fastest**"*, and [`blockedReason`](lemma-frontend/lib/surfaces/catalog.ts:71) renders it disabled as *"Not available on this deployment."* The option labelled **Fastest** can never be picked. The other option, *"Your workspace's own app · Your Slack app and branding"*, describes something that doesn't happen either — the flow installs **Lemma's** Slack app via OAuth. Both rows are wrong, and the step they live in has nothing to decide.
+
+**2. The capability users actually want already ships, and is unreachable.**
+[`SurfaceChannelRoute`](lemma-backend/app/modules/agent_surfaces/domain/entities.py:97) carries `agent_name`, and [`_resolve_route_agent`](lemma-backend/app/modules/agent_surfaces/services/ingress_service.py:1891) resolves it per inbound event. An org can run `#sales → sales-agent`, `#support → support-agent`, `#eng → eng-agent` behind one bot **today**. It is buried in a post-creation Configure step whose empty state reads *"No channels yet. Invite the Slack bot to one, then reopen this."* ([surface-configure-step.tsx:147](lemma-frontend/components/surfaces/surface-configure-step.tsx:147)) — a dead end offered to someone who has not been told why they'd want to.
+
+**3. The chip disappears exactly when it should multiply.**
+[agent-surfaces-row.tsx:53](lemma-frontend/components/surfaces/agent-surfaces-row.tsx:53) — `if (reached.has(platform)) return false` — hides a platform's connect chip once the agent has one. For an identity platform that is right: a second WhatsApp chip would mean a second number. For Slack it is backwards. Channels are additive, and this line is the single reason problem 2 is invisible.
+
+**4. The one hard limit is silent.**
+A DM has no channel, so `_resolve_route` finds nothing and falls through to `surface.agent_id` ([ingress_service.py:1912](lemma-backend/app/modules/agent_surfaces/services/ingress_service.py:1912)). One DM agent per workspace, org-wide. Nothing in the UI says so. Setting an agent as the Slack responder silently takes DMs away from whichever agent had them.
+
+## On the word "channel"
+
+The prior doc argues the row is labelled **Surfaces**, not "Channels", and reserves channel for *"a narrower job: an actual Slack or Teams channel, which a surface can route to a different agent."*
+
+This proposal does not reopen that. It is that narrower job, taken literally. Nothing is renamed: `surface` stays the noun for *where an agent is reachable*, `SurfaceChannelRoute` stays the internal type. The claim is only that on Slack the surface has never been the unit a user manipulates — the channel is — and the chips should show the unit.
+
+## Current state
+
+| Piece | What it does today | Disposition |
+| --- | --- | --- |
+| [registry.ts:159](lemma-frontend/lib/surfaces/registry.ts:159) `identityOptions` for SLACK | Two rows, one permanently disabled, one factually wrong | **Replace** with a single install line |
+| [agent-surfaces-row.tsx:53](lemma-frontend/components/surfaces/agent-surfaces-row.tsx:53) `reached.has(platform)` filter | Hides the chip after the first surface | **Branch** on `capabilities.channelRoutes` |
+| [surface-configure-step.tsx:131](lemma-frontend/components/surfaces/surface-configure-step.tsx:131) `Channel routing` block | The real feature, post-creation only | **Promote** to the connect journey |
+| [surface-connect-step.tsx:103](lemma-frontend/components/surfaces/surface-connect-step.tsx:103) account dropdown | *"Which slack workspace should this run on?"* → link to `/connectors` | **Keep**, but reached once per workspace, not per agent |
+| [`SurfaceIdentityStep`](lemma-frontend/components/surfaces/surface-identity-step.tsx) for SLACK | Asks a question with one always-disabled answer | **Skip** when `channelRoutes` |
+| `surface.agent_id` on a Slack surface | The DM route, unnamed and invisible | **Render** as a row named *Direct messages* |
+| [setup_guides.py:108](lemma-backend/app/modules/agent_surfaces/domain/setup_guides.py:108) Slack Event Subscriptions action | Good copy, never emitted (gated on `ORG_CUSTOM`) | **Leave** — see *Out of scope* |
+
+## Target information architecture
+
+**Agent detail.** The reach row shows channels, and the plus never leaves.
+
+```
+Reachable   [#sales]  [#support]  [Direct messages]  [+ Add channel]  [Telegram ○]  [WhatsApp ○]
+            ▲ a Slack channel routed to this agent   ▲ always offered once Slack is installed
+```
+
+**Another agent's page**, where DMs are already taken — the constraint renders as state, not as a failed save:
+
+```
+Reachable   [#eng]  [+ Add channel]  [Direct messages · Answered by sales-agent]
+                                     ▲ disabled, names the holder, links to it
+```
+
+This is the pattern [catalog.ts:76](lemma-frontend/lib/surfaces/catalog.ts:76) already uses for a claimed system credential, applied to the one Slack constraint that is real.
+
+**Pod level** (`/ai`). Slack rolls up as a routing table — channel → agent — which is the question an admin has and maps 1:1 to `config.channels`. Not a list of surfaces.
+
+## The two moments, separated
+
+Today both are crammed into one per-agent modal. They are not the same moment and do not recur at the same rate.
+
+| | Install | Add a channel |
+| --- | --- | --- |
+| **Scope** | Once per Slack workspace, org-wide | Every time an agent should answer somewhere new |
+| **Who** | Someone who can install a Slack app | Whoever owns the agent |
+| **Where** | Connectors, or first run | The agent's reach row |
+| **Asks** | nothing — it's an OAuth install | which channel, which agent |
+
+After the install, "connect Slack" should never be asked again. The only Slack question left is *which channel*.
+
+## Generalizing
+
+The discriminator exists: `capabilities.channelRoutes` in [registry.ts](lemma-frontend/lib/surfaces/registry.ts:175).
+
+- **`true`** (Slack, Teams) → identity is a one-time install; reach is N channels; the modal opens on a channel picker.
+- **`false`** (WhatsApp, Telegram, Gmail, Outlook, Resend) → today's journey, unchanged. Identity is the choice; reach is one thing.
+
+One branch on a flag already in the registry, not a Slack special case.
+
+Telegram groups are the near-miss that stays on the identity side: they have no allow-list, because being added to the group *is* the authorization ([entities.py:510](lemma-backend/app/modules/agent_surfaces/domain/entities.py:510)). There is no channel to add, so there is nothing to pick.
+
+## Truths the UI must convey
+
+1. **One bot identity per workspace.** Every agent answers as the same `@Lemma`. Different agents, one face. Say it once at install; don't repeat it per channel.
+2. **In a channel, an agent speaks only when mentioned or in a thread it joined** ([entities.py:518](lemma-backend/app/modules/agent_surfaces/domain/entities.py:518)). Already stated in the Configure block; it moves with the feature.
+3. **One agent answers DMs, org-wide.** The only hard Slack limit, and today the only one that is invisible.
+4. **A channel must have the bot in it.** Enumeration comes from `GET .../surfaces/{name}/channels`, which only sees channels the bot has joined — so "invite the bot first" is a real precondition, not a nag. It belongs *before* the empty picker, not as its empty state.
+5. **A route naming a deleted agent silently falls back to the surface default** ([ingress_service.py:1906](lemma-backend/app/modules/agent_surfaces/services/ingress_service.py:1906)). Worth surfacing as a warning on the route row rather than leaving it to be discovered by a wrong answer.
+
+## API: what exists, what's missing
+
+**Sufficient today, entirely.** `GET /pods/{id}/surfaces/{name}/channels` ([surface_controller.py:478](lemma-backend/app/modules/agent_surfaces/api/controllers/surface_controller.py:478)) enumerates; the existing surface update writes `config.channels`; `_resolve_route_agent` already routes. Nothing to add, nothing to migrate.
+
+That is the argument for doing this now rather than alongside the harder Slack work: it is a frontend change to make a shipped backend capability findable.
+
+## What shipped
+
+**Phase 1 — Tell the truth.** Slack's `identityOptions` is `null`, so the modal skips the identity step entirely and opens on the workspace picker. *Removes the permanently-greyed "Fastest" option — the single most confusing thing in the flow.*
+
+**Phase 2 — Channels as chips.** `SurfaceChips` renders one chip per reach for a `channelRoutes` surface and an `Add channel` chip that never disappears. The chip carries an `add-channel` intent that opens the modal on routing with a blank row already assigned to the agent whose page you came from. The invite-the-bot precondition moved out of the empty state into the section itself.
+
+**Phase 3 — DMs as a chip.** `DirectMessagesHeldChip` names the agent that holds a workspace's DMs and links to it, on every agent that doesn't. *Makes the one real limit legible.*
+
+**Phase 4 — Pod roll-up, narrowed.** `/ai` counts **places** rather than installs — "3 places", with the tooltip naming them (`Direct messages · #sales · #deals`) — on both the agent cards and the Pod Assistant card. A full channel → agent table on `/ai` was **not** built: it needs the overflow answer in open question 3 first, and the count already fixes the roll-up's specific lie (one Slack workspace reading as "1 surface" when it reaches an agent in six places).
+
+**Not in the plan, found while building.** `usePodAutomation.defaultSurfaces` filtered on `surfaceUsesDefaultAgent`, which asks who answers DMs. A workspace whose DMs belong to another agent but which routes `#general` to nobody in particular *does* reach the pod assistant, and was invisible there. It now filters on `surfaceReachesDefaultAgent`, symmetric with `surfacesForAgent`.
+
+**Verification.** Typecheck, lint, design audit, 517 unit tests, and a production build all pass. New pure-logic tests cover the reach model (`lib/utils/__tests__/surfaces.test.ts`) and pin the registry invariant that a channel platform offers no identity fork. The change was **not** exercised in a browser: `make dev` needs `make init` to provision a database and secrets, and rendering these chips needs a real Slack workspace installed against a running stack.
+
+## Open questions
+
+1. **Where does the install live?** Connectors is correct by scope (org-wide, once) but invisible to someone standing on an agent page. A first-run interstitial inside the channel flow that hands off to connectors and returns may be worth the complexity — or may just be the account dropdown that exists. *Recommendation: ship Phase 2 with the existing dropdown, revisit if it's where people stall.*
+2. **Should Teams follow immediately?** Same `channelRoutes: true` shape, but Teams also has admin consent, which is an identity-shaped question Slack doesn't have. The branch may not be as clean there.
+3. **Does a channel chip belong on the agent page or the pod page?** Both are argued above. An agent in fifteen channels makes the reach row unreadable, and there is no overflow design.
+
+## Out of scope
+
+Anything that changes what Slack can do, as opposed to what users can find:
+
+- **Genuine bring-your-own Slack apps.** Blocked on [`_verify_slack_signature`](lemma-backend/app/modules/agent_surfaces/services/webhook_security_service.py:279) HMAC-ing against one deployment-wide `SLACK_SIGNING_SECRET`, plus the shared `/surfaces/webhooks/slack` URL. Real backend work; own doc.
+- **A second bot identity per workspace.** Requires the above.
+- **Multiple agents on Slack DMs.** Needs an addressing mechanism that doesn't exist for any 1:1 platform.
+- **Socket Mode.** `app_token` has no reachable source for a CUSTOM Slack surface, so the receiver skips. Separate bug.
+- **`SLACK_BOT_TOKEN`** ([config.py:63](lemma-backend/app/modules/agent_surfaces/config.py:63)), declared and read nowhere. Delete it or wire it, in whichever doc takes on the above.

--- a/lemma-frontend/app/pod/[id]/ai/page.tsx
+++ b/lemma-frontend/app/pod/[id]/ai/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { use, useMemo, useState } from 'react';
+import { use, useCallback, useMemo, useState } from 'react';
 import Link from 'next/link';
 import {
     Bot,
@@ -37,6 +37,7 @@ import type { Agent, UpdateAgentData, Workflow } from '@/lib/types';
 import { NodeType } from '@/lib/types';
 import { formatAgentName } from '@/lib/utils/agents';
 import { getAgentNodeName } from '@/lib/utils/flow-node-config';
+import { surfaceReaches } from '@/lib/utils/surfaces';
 
 type AgentFilter = 'all' | 'workflows' | 'scheduled';
 
@@ -73,7 +74,23 @@ export default function AgentsPage({
     const { data: flowsData, isPending: flowsPending } = useFlows(canReadWorkflows ? podId : undefined);
     // Surfaces that fall to the pod default assistant (the virtual Super Agent).
     const automation = usePodAutomation(podId, { schedules: false, surfaces: canUseSurfaces });
-    const defaultSurfaceCount = automation.defaultSurfaces.length;
+    // Reach is counted in *places*, not installs: one Slack workspace can reach
+    // an agent in its DMs and in five channels, and "1 surface" would say the
+    // opposite of what is true.
+    const reachFor = useCallback(
+        (agentName: string | null) => {
+            const surfaces = agentName === null
+                ? automation.defaultSurfaces
+                : automation.surfacesForAgent(agentName);
+            const reaches = surfaces.flatMap((surface) => surfaceReaches(surface, agentName));
+            return {
+                count: reaches.length,
+                label: reaches.map((reach) => reach.label).join(' · '),
+            };
+        },
+        [automation],
+    );
+    const defaultReach = reachFor(null);
     const { mutate: deleteAgent, isPending: isDeletingAgent } = useDeleteAgent();
     const updateAgent = useUpdateAgent();
     const [agentFilter, setAgentFilter] = useState<AgentFilter>('all');
@@ -179,7 +196,7 @@ export default function AgentsPage({
                 label="Loading agents"
                 skeleton={(
                     <section className="resource-index-grid resource-index-grid-md-2 resource-index-grid-xl-3 sm:grid-cols-2 xl:grid-cols-3">
-                        {canUseSurfaces ? <PodAssistantCard podId={podId} surfaceCount={defaultSurfaceCount} /> : null}
+                        {canUseSurfaces ? <PodAssistantCard podId={podId} reachCount={defaultReach.count} reachLabel={defaultReach.label} /> : null}
                         <ResourceCardSkeleton />
                         <ResourceCardSkeleton />
                         {canUseSurfaces ? null : <ResourceCardSkeleton />}
@@ -187,7 +204,7 @@ export default function AgentsPage({
                 )}
                 empty={(
                     <section className="resource-index-grid resource-index-grid-md-2 resource-index-grid-xl-3 sm:grid-cols-2 xl:grid-cols-3">
-                        {canUseSurfaces ? <PodAssistantCard podId={podId} surfaceCount={defaultSurfaceCount} /> : null}
+                        {canUseSurfaces ? <PodAssistantCard podId={podId} reachCount={defaultReach.count} reachLabel={defaultReach.label} /> : null}
                         <EmptyState
                             variant="region"
                             className="col-span-full"
@@ -210,7 +227,7 @@ export default function AgentsPage({
             >
                 <section className="resource-index-grid resource-index-grid-md-2 resource-index-grid-xl-3 sm:grid-cols-2 xl:grid-cols-3">
                     {canUseSurfaces && agentFilter === 'all' ? (
-                        <PodAssistantCard podId={podId} surfaceCount={defaultSurfaceCount} />
+                        <PodAssistantCard podId={podId} reachCount={defaultReach.count} reachLabel={defaultReach.label} />
                     ) : null}
                     {filteredAgents.map((agent) => (
                         <AgentProfileCard
@@ -219,6 +236,7 @@ export default function AgentsPage({
                             podId={podId}
                             activeScheduleCount={schedules.filter((schedule) => schedule.agent_name === agent.name && schedule.is_active !== false).length}
                             workflowCount={agentUsage.get(agent.name)?.size || 0}
+                            reach={reachFor(agent.name)}
                             onDelete={setAgentPendingDelete}
                             canUpdate={resourceAllows(agent, 'agent.update', canUpdateAgent)}
                             canDelete={resourceAllows(agent, 'agent.delete', canDeleteAgent)}
@@ -308,8 +326,13 @@ function AgentStat({ icon: Icon, value, label }: { icon: LemmaIcon; value: numbe
 }
 
 // The pod's default responder, rendered as a first-class card even though it
-// has no agent row. Its surfaces are the ones not assigned to any agent.
-function PodAssistantCard({ podId, surfaceCount }: { podId: string; surfaceCount: number }) {
+// has no agent row. What falls to it is anything nobody else claimed — a surface
+// with no responder, or a channel routed to no agent in particular.
+function PodAssistantCard({ podId, reachCount, reachLabel }: {
+    podId: string;
+    reachCount: number;
+    reachLabel: string;
+}) {
     return (
         <Link
             href={`/pod/${podId}/ai/assistant`}
@@ -330,10 +353,10 @@ function PodAssistantCard({ podId, surfaceCount }: { podId: string; surfaceCount
             </div>
 
             <div className="mt-3 flex items-center justify-between gap-2 text-xs text-[var(--text-tertiary)]">
-                {surfaceCount > 0 ? (
-                    <span className="inline-flex items-center gap-1" title={`${surfaceCount} unassigned surface${surfaceCount === 1 ? '' : 's'}`}>
+                {reachCount > 0 ? (
+                    <span className="inline-flex items-center gap-1" title={reachLabel}>
                         <MessageCircle className="h-3.5 w-3.5" aria-hidden />
-                        {surfaceCount} surface{surfaceCount === 1 ? '' : 's'}
+                        {reachCount} place{reachCount === 1 ? '' : 's'}
                     </span>
                 ) : null}
                 <span className="inline-flex items-center gap-1 font-medium text-[var(--text-secondary)] transition-gentle group-hover:translate-x-0.5">
@@ -350,6 +373,7 @@ function AgentProfileCard({
     podId,
     activeScheduleCount,
     workflowCount,
+    reach,
     onDelete,
     canUpdate,
     canDelete,
@@ -359,6 +383,8 @@ function AgentProfileCard({
     podId: string;
     activeScheduleCount: number;
     workflowCount: number;
+    /** Places this agent answers — DMs and channels, named in the tooltip. */
+    reach: { count: number; label: string };
     onDelete: (agent: Agent) => void;
     canUpdate: boolean;
     canDelete: boolean;
@@ -418,7 +444,12 @@ function AgentProfileCard({
                     {activeScheduleCount > 0 ? (
                         <AgentStat icon={CalendarClock} value={activeScheduleCount} label={`${activeScheduleCount} active schedule${activeScheduleCount === 1 ? '' : 's'}`} />
                     ) : null}
-                    {connectionCount === 0 && workflowCount === 0 && activeScheduleCount === 0 ? (
+                    {reach.count > 0 ? (
+                        // Named rather than counted in the tooltip: "3 places" is
+                        // only useful once you can see it means #sales and #deals.
+                        <AgentStat icon={MessageCircle} value={reach.count} label={`Reachable in ${reach.label}`} />
+                    ) : null}
+                    {connectionCount === 0 && workflowCount === 0 && activeScheduleCount === 0 && reach.count === 0 ? (
                         <span>Ready to set up</span>
                     ) : null}
                 </div>

--- a/lemma-frontend/components/surfaces/agent-surfaces-row.tsx
+++ b/lemma-frontend/components/surfaces/agent-surfaces-row.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { MessageCircle, Plus } from '@/components/ui/icons';
 
 import { SurfaceModal, type SurfaceModalTarget } from '@/components/surfaces/surface-modal';
@@ -16,6 +17,9 @@ import {
     getSurfaceIdentity,
     getSurfacePlatformKey,
     getSurfaceStatus,
+    surfaceAnswersDirectMessages,
+    surfaceDirectMessageAgent,
+    surfaceReaches,
 } from '@/lib/utils/surfaces';
 import type { AssistantSurface } from '@/lib/types';
 import { cn } from '@/lib/utils';
@@ -28,6 +32,12 @@ import { cn } from '@/lib/utils';
  * connected elsewhere in the pod is no reason to send someone to *that* surface:
  * this agent gets its own bot, routed to itself. Both stay on the page, because
  * the agent is the context that decides who answers.
+ *
+ * Slack and Teams are the exception, and the reason `channelRoutes` exists. One
+ * workspace install reaches this agent in as many channels as you route to it,
+ * so the install is not the unit anyone thinks in — the channel is. Those
+ * surfaces render a chip per channel and keep offering "add another", where an
+ * identity platform renders one chip and stops.
  */
 export function AgentSurfacesRow({
     podId,
@@ -48,7 +58,9 @@ export function AgentSurfacesRow({
 
     const reached = new Set(surfaces.map((surface) => getSurfacePlatformKey(surface)));
     // Only offer platforms this deployment can actually run — a WhatsApp chip on
-    // an install with no Meta credentials is a dead end.
+    // an install with no Meta credentials is a dead end. A channel platform that
+    // is already installed keeps its own "add channel" chip beside its channels
+    // instead, so it drops out here either way.
     const connectable = SURFACE_PLATFORM_ORDER.filter((platform) => {
         if (reached.has(platform)) return false;
         if (!catalog) return true;
@@ -62,14 +74,16 @@ export function AgentSurfacesRow({
                 {label ? <span className="text-sm text-[var(--text-secondary)]">{label}</span> : null}
 
                 {surfaces.map((surface) => (
-                    <ReachChip
+                    <SurfaceChips
                         key={surface.id ?? surface.name}
+                        podId={podId}
                         surface={surface}
                         reachFor={agentName}
-                        onOpen={() =>
+                        onOpen={(intent) =>
                             setTarget({
                                 platform: getSurfacePlatformKey(surface) as SurfacePlatformValue,
                                 surfaceName: surface.name,
+                                ...(intent ? { intent } : {}),
                             })
                         }
                     />
@@ -94,16 +108,83 @@ export function AgentSurfacesRow({
     );
 }
 
+/**
+ * One surface's chips: a single chip for an identity platform, one per channel
+ * for a channel platform.
+ *
+ * The DM chip is the one that can be *absent while still mattering* — a Slack
+ * workspace has exactly one agent on its DMs, so on every other agent the right
+ * thing to show is who holds them, not nothing.
+ */
+function SurfaceChips({
+    podId,
+    surface,
+    reachFor,
+    onOpen,
+}: {
+    podId: string;
+    surface: AssistantSurface;
+    reachFor: string | null;
+    onOpen: (intent?: 'add-channel') => void;
+}) {
+    const platform = getSurfacePlatformKey(surface);
+    const definition = getSurfaceDefinition(platform);
+
+    if (!definition?.capabilities.channelRoutes) {
+        return <ReachChip surface={surface} reachFor={reachFor} onOpen={() => onOpen()} />;
+    }
+
+    const reaches = surfaceReaches(surface, reachFor);
+    const holdsDirectMessages = surfaceAnswersDirectMessages(surface, reachFor);
+
+    return (
+        <>
+            {reaches.map((reach) => (
+                <ReachChip
+                    key={reach.key}
+                    surface={surface}
+                    reachFor={reachFor}
+                    labelOverride={reach.label}
+                    onOpen={() => onOpen()}
+                />
+            ))}
+
+            {holdsDirectMessages ? null : (
+                <DirectMessagesHeldChip
+                    podId={podId}
+                    platformLabel={definition.label}
+                    holder={surfaceDirectMessageAgent(surface)}
+                />
+            )}
+
+            <AddChannelChip
+                platformLabel={definition.label}
+                // Named, because a pod can hold two workspaces of the same
+                // platform and then this chip appears twice — identical on the
+                // face of it, pointing at different installs.
+                workspaceLabel={
+                    surface.reach?.handle || getSurfaceIdentity(surface) || definition.label
+                }
+                logoSrc={definition.logoSrc}
+                onOpen={() => onOpen('add-channel')}
+            />
+        </>
+    );
+}
+
 const chipClass =
     'inline-flex max-w-[240px] items-center gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--card-bg)] py-1 pl-1 pr-2.5 shadow-[var(--shadow-xs)] transition-colors hover:border-[var(--border-strong)]';
 
 function ReachChip({
     surface,
     reachFor,
+    labelOverride,
     onOpen,
 }: {
     surface: AssistantSurface;
     reachFor: string | null;
+    /** What this chip stands for, when it isn't the whole surface — `#sales`. */
+    labelOverride?: string;
     onOpen: () => void;
 }) {
     const platform = getSurfacePlatformKey(surface);
@@ -118,7 +199,7 @@ function ReachChip({
                 <button type="button" onClick={onOpen} className={cn('resource-chip-button', chipClass, 'custom-focus-ring')}>
                     <PlatformMark platform={platform} logoSrc={definition?.logoSrc} />
                     <span className="truncate text-sm font-medium text-[var(--text-primary)]">
-                        {identity || definition?.label || platform}
+                        {labelOverride || identity || definition?.label || platform}
                     </span>
                     <span
                         className={cn(
@@ -134,8 +215,108 @@ function ReachChip({
                 </button>
             </TooltipTrigger>
             <TooltipContent>
-                {status.label} · {describeReach(surface, reachFor)}
+                {/* A chip standing for one channel already says what it reaches, so
+                    the tooltip spends itself on what the chip dropped: which
+                    workspace that channel lives in. */}
+                {status.label} · {labelOverride
+                    ? identity || definition?.label || platform
+                    : describeReach(surface, reachFor)}
                 {deepLink ? ` · ${deepLink.replace(/^https?:\/\//, '')}` : ''}
+            </TooltipContent>
+        </Tooltip>
+    );
+}
+
+/**
+ * The DMs of a channel platform, when another agent answers them.
+ *
+ * A Slack workspace routes DMs to exactly one agent — there is no channel in a
+ * DM to route on — so on every other agent this is the shape of the constraint.
+ * Naming the holder and linking to it is the same move the catalog makes for a
+ * claimed system credential: render the limit as state, never as a failed save.
+ */
+function DirectMessagesHeldChip({
+    podId,
+    platformLabel,
+    holder,
+}: {
+    podId: string;
+    platformLabel: string;
+    /** `null` = the pod default assistant. */
+    holder: string | null;
+}) {
+    const holderLabel = holder || 'the pod assistant';
+    const href = holder
+        ? `/pod/${podId}/agents/${encodeURIComponent(holder)}`
+        : `/pod/${podId}/ai/assistant`;
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <Link
+                    href={href}
+                    className={cn(chipClass, 'custom-focus-ring border-dashed opacity-60 transition-opacity hover:opacity-100')}
+                >
+                    <MessageCircle className="ml-1 h-4 w-4 shrink-0 text-[var(--text-tertiary)]" aria-hidden />
+                    <span className="truncate text-sm font-medium text-[var(--text-secondary)]">
+                        Direct messages
+                    </span>
+                </Link>
+            </TooltipTrigger>
+            <TooltipContent>
+                {platformLabel} direct messages are answered by {holderLabel}. One agent
+                takes them for the whole workspace.
+            </TooltipContent>
+        </Tooltip>
+    );
+}
+
+/**
+ * Adds another channel to a workspace that is already installed.
+ *
+ * Labelled rather than icon-only, because this is the affordance the old row
+ * hid: once a platform was reached its connect chip disappeared, which is right
+ * for a number and wrong for a workspace whose whole point is that channels are
+ * additive.
+ */
+function AddChannelChip({
+    platformLabel,
+    workspaceLabel,
+    logoSrc,
+    onOpen,
+}: {
+    platformLabel: string;
+    /** Which install this adds to — the workspace handle, or the platform name
+     * when the surface has no resolved reach yet. */
+    workspaceLabel: string;
+    logoSrc?: string;
+    onOpen: () => void;
+}) {
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <button
+                    type="button"
+                    onClick={onOpen}
+                    // The visible text is deliberately short; the label carries the
+                    // workspace, so two of these chips are distinguishable without
+                    // hovering either.
+                    aria-label={`Add a ${platformLabel} channel from ${workspaceLabel}`}
+                    className={cn(
+                        'resource-chip-button custom-focus-ring inline-flex items-center gap-1.5 rounded-lg border border-dashed border-[var(--border-subtle)] py-1 pl-2 pr-2.5 text-sm font-medium text-[var(--text-secondary)] transition-colors hover:border-[var(--border-strong)] hover:text-[var(--text-primary)]',
+                    )}
+                >
+                    {logoSrc ? (
+                        <Image src={logoSrc} alt="" width={14} height={14} className="object-contain opacity-70" aria-hidden="true" />
+                    ) : (
+                        <Plus className="h-3.5 w-3.5" aria-hidden />
+                    )}
+                    Add channel
+                </button>
+            </TooltipTrigger>
+            <TooltipContent>
+                Route another channel in {workspaceLabel} to this agent. It answers there
+                when mentioned, or in a thread it already joined.
             </TooltipContent>
         </Tooltip>
     );

--- a/lemma-frontend/components/surfaces/surface-configure-step.tsx
+++ b/lemma-frontend/components/surfaces/surface-configure-step.tsx
@@ -50,6 +50,7 @@ export function SurfaceConfigureStep({
     onDraftChange,
     availableChannels,
     isLoadingChannels,
+    defaultRouteAgent = null,
 }: {
     definition: SurfacePlatformDefinition;
     surface: AssistantSurface;
@@ -58,6 +59,9 @@ export function SurfaceConfigureStep({
     onDraftChange: (patch: Partial<ConfigureDraft>) => void;
     availableChannels: AvailableChannel[];
     isLoadingChannels: boolean;
+    /** Agent a newly added route answers as — the one whose page opened this.
+     * `null` falls to the pod default, which is right for the pod assistant. */
+    defaultRouteAgent?: string | null;
 }) {
     const { channelRoutes, senderFilters } = definition.capabilities;
 
@@ -133,8 +137,16 @@ export function SurfaceConfigureStep({
                     <div>
                         <p className="text-sm font-medium text-[var(--text-primary)]">Channel routing</p>
                         <p className="mt-1 text-xs leading-5 text-[var(--text-secondary)]">
-                            Point a channel at a different agent. In channels an agent speaks only when
-                            mentioned, or in a thread it already joined.
+                            Point a channel at its own agent — several agents can answer in one
+                            workspace. In channels an agent speaks only when mentioned, or in a
+                            thread it already joined.
+                        </p>
+                        {/* The precondition belongs here, not in the empty state: someone
+                            looking at a short list needs it just as much as someone
+                            looking at none, and by then it reads as an explanation
+                            rather than an instruction. */}
+                        <p className="mt-1 text-xs leading-5 text-[var(--text-tertiary)]">
+                            Only channels the {definition.label} bot has been invited to appear here.
                         </p>
                     </div>
 
@@ -144,7 +156,7 @@ export function SurfaceConfigureStep({
                         </div>
                     ) : availableChannels.length === 0 && draft.channels.length === 0 ? (
                         <p className="text-xs leading-5 text-[var(--text-tertiary)]">
-                            No channels yet. Invite the {definition.label} bot to one, then reopen this.
+                            Invite it to a channel in {definition.label}, then reopen this.
                         </p>
                     ) : (
                         <>
@@ -185,7 +197,7 @@ export function SurfaceConfigureStep({
                                             {
                                                 channel_id: next?.id ?? '',
                                                 channel_name: next?.name ?? '',
-                                                agent_name: null,
+                                                agent_name: defaultRouteAgent,
                                             },
                                         ],
                                     });

--- a/lemma-frontend/components/surfaces/surface-modal.tsx
+++ b/lemma-frontend/components/surfaces/surface-modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Image from 'next/image';
 import { useQueryClient } from '@tanstack/react-query';
 import {
@@ -94,6 +94,12 @@ export interface SurfaceModalTarget {
     platform: SurfacePlatformValue;
     /** Present when configuring an existing surface. */
     surfaceName?: string;
+    /**
+     * `add-channel` opens an installed workspace straight on its routing with a
+     * blank row waiting, so "add a channel" is one click from the agent page
+     * rather than a settings page you have to read first.
+     */
+    intent?: 'add-channel';
 }
 
 export function SurfaceModal({
@@ -147,6 +153,10 @@ export function SurfaceModal({
     const [draft, setDraft] = useState<ConfigureDraft>(emptyDraft());
     const [messageUserId, setMessageUserId] = useState('');
     const [messageBody, setMessageBody] = useState('');
+    // Set when the modal is opened on `add-channel`, cleared the moment the draft
+    // effect acts on it — a ref rather than state so seeding can't run twice as
+    // the surface resolves.
+    const pendingChannelRow = useRef(false);
 
     // Polls only while a hand-off is in flight; the hook stops itself on
     // COMPLETE/FAILED. Declared before `existingSurface` because a managed
@@ -195,7 +205,9 @@ export function SurfaceModal({
 
     // Entering the modal decides the starting state once: an existing surface
     // opens on whatever it still needs, a new one on its first question.
-    const targetKey = target ? `${target.platform}:${target.surfaceName ?? ''}` : null;
+    const targetKey = target
+        ? `${target.platform}:${target.surfaceName ?? ''}:${target.intent ?? ''}`
+        : null;
     useEffect(() => {
         if (!targetKey || !definition) return;
         setError(null);
@@ -205,6 +217,9 @@ export function SurfaceModal({
         setCreatedSurface(null);
 
         if (target?.surfaceName) {
+            // Consumed by the draft effect below, which is the only place that
+            // knows the surface's existing routes to append to.
+            pendingChannelRow.current = target.intent === 'add-channel';
             setStep('configure');
             return;
         }
@@ -225,7 +240,19 @@ export function SurfaceModal({
     }, [hasOutstandingSetup, target?.surfaceName]);
 
     useEffect(() => {
-        if (existingSurface) setDraft(draftFromSurface(existingSurface));
+        if (!existingSurface) return;
+        const base = draftFromSurface(existingSurface);
+        if (pendingChannelRow.current) {
+            pendingChannelRow.current = false;
+            // Routed to the agent whose page opened this, because that is the
+            // whole reason someone clicked "add channel" from there.
+            setDraft({ ...base, channels: [...base.channels, blankChannelRow(agentName)] });
+            return;
+        }
+        setDraft(base);
+        // `agentName` is fixed for the life of a modal target; re-reading it here
+        // would only rebuild the draft and discard edits in flight.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [existingSurface]);
 
     // The manager bot creates the surface server-side, so completion arrives by
@@ -602,6 +629,7 @@ export function SurfaceModal({
                                 onDraftChange={patchDraft}
                                 availableChannels={availableChannels}
                                 isLoadingChannels={isLoadingChannels}
+                                defaultRouteAgent={agentName}
                             />
                         </div>
                     ) : null}
@@ -734,6 +762,12 @@ function defaultMode(entry: Parameters<typeof hasSystemIdentity>[0]): SurfaceIde
     // No fork to offer: run on the Lemma-managed identity when this deployment
     // has one (Resend), otherwise an account is the only way in.
     return hasSystemIdentity(entry) ? 'SYSTEM' : 'CUSTOM';
+}
+
+/** An unfilled route row. The channel is picked in the modal; the agent is not,
+ * because the page that opened it already answered that. */
+function blankChannelRow(agentName: string | null) {
+    return { channel_id: '', channel_name: '', agent_name: agentName };
 }
 
 function emptyDraft(): ConfigureDraft {

--- a/lemma-frontend/lib/hooks/use-pod-automation.ts
+++ b/lemma-frontend/lib/hooks/use-pod-automation.ts
@@ -5,7 +5,7 @@ import { useMemo } from 'react';
 import { usePodSurfaces } from './use-pod-surfaces';
 import { useSchedules } from './use-schedules';
 import { getScheduleTargetKind } from '@/lib/utils/schedules';
-import { surfaceReachesAgent, surfaceUsesDefaultAgent } from '@/lib/utils/surfaces';
+import { surfaceReachesAgent, surfaceReachesDefaultAgent } from '@/lib/utils/surfaces';
 import type { AssistantSurface, Schedule } from '@/lib/types';
 
 // One pod-wide schedule query, keyed identically to the schedules page and
@@ -68,7 +68,7 @@ export function usePodAutomation(
                 (schedule) => getScheduleTargetKind(schedule) === 'workflow' && schedule.workflow_name === workflowName,
             ),
         surfacesForAgent: (agentName) => surfaces.filter((surface) => surfaceReachesAgent(surface, agentName)),
-        defaultSurfaces: surfaces.filter(surfaceUsesDefaultAgent),
+        defaultSurfaces: surfaces.filter(surfaceReachesDefaultAgent),
     }), [
         schedules,
         surfaces,

--- a/lemma-frontend/lib/surfaces/__tests__/registry.test.ts
+++ b/lemma-frontend/lib/surfaces/__tests__/registry.test.ts
@@ -59,6 +59,18 @@ describe('surface registry', () => {
         expect(telegram.journey).toBeUndefined();
     });
 
+    it('offers no identity fork where reach is a channel', () => {
+        // A workspace is installed once and then carries many channels, so the
+        // question "whose bot is this" has one answer and does not belong in the
+        // journey. Slack's fork used to render a permanently disabled "Fastest"
+        // option, because the catalog never reports a Lemma-managed Slack bot.
+        for (const platform of SURFACE_PLATFORM_ORDER) {
+            const definition = getSurfaceDefinition(platform)!;
+            if (!definition.capabilities.channelRoutes) continue;
+            expect(definition.identityOptions, platform).toBeNull();
+        }
+    });
+
     it('names the agent in second-person copy, and the pod assistant otherwise', () => {
         expect(forAgent('Make {agent} reachable', 'Ops')).toBe('Make Ops reachable');
         expect(forAgent('Make {agent} reachable', null)).toBe('Make the pod assistant reachable');

--- a/lemma-frontend/lib/surfaces/registry.ts
+++ b/lemma-frontend/lib/surfaces/registry.ts
@@ -58,8 +58,15 @@ export interface SurfacePlatformDefinition {
     };
     accountLabel: string;
     capabilities: {
-        /** Slack/Teams: per-channel routes, configurable only once the surface
-         * exists (channel enumeration needs the connected account). */
+        /**
+         * Slack/Teams: reach is a *channel*, not the bot.
+         *
+         * One workspace install carries many channels, each routable to its own
+         * agent, so the agent page shows a chip per channel and keeps offering
+         * "add another" — where an identity platform shows one chip and stops.
+         * Routes are configurable only once the surface exists, because
+         * enumerating channels needs the connected account.
+         */
         channelRoutes: boolean;
         /** Gmail/Outlook/Resend: sender filters decide what becomes pod work. */
         senderFilters: boolean;
@@ -155,21 +162,15 @@ const DEFINITIONS: SurfacePlatformDefinition[] = [
         label: 'Slack',
         logoSrc: '/surfaces/slack.png',
         promise: 'Let people reach {agent} in Slack',
-        connectHint: 'Answers DMs, plus any Slack channel you route here.',
-        identityOptions: [
-            {
-                mode: 'SYSTEM',
-                title: 'Lemma’s Slack app',
-                detail: 'Install Lemma into your workspace. Nothing to register yourself.',
-                hint: 'Fastest',
-            },
-            {
-                mode: 'CUSTOM',
-                title: 'Your workspace’s own app',
-                detail: 'Your Slack app and branding. You’ll point its events at Lemma.',
-                hint: '~10 min',
-            },
-        ],
+        connectHint: 'Install Lemma in your workspace, then route channels to agents.',
+        // No identity fork, because Slack has no second identity to offer. The
+        // catalog never reports a Lemma-managed Slack bot (`has_native_credentials`
+        // has no Slack branch), and a workspace's own app can't receive events
+        // while inbound signatures verify against one deployment-wide signing
+        // secret. What connecting actually does is install Lemma's Slack app into
+        // a workspace — asked once per workspace, so there is nothing to fork on.
+        // Reach is then per *channel*, not per bot: see `capabilities.channelRoutes`.
+        identityOptions: null,
         accountLabel: 'Slack workspace',
         capabilities: {
             channelRoutes: true,

--- a/lemma-frontend/lib/utils/__tests__/surfaces.test.ts
+++ b/lemma-frontend/lib/utils/__tests__/surfaces.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    describeReach,
+    surfaceAnswersDirectMessages,
+    surfaceDirectMessageAgent,
+    surfaceReaches,
+    surfaceReachesDefaultAgent,
+} from '@/lib/utils/surfaces';
+import type { AssistantSurface } from '@/lib/types';
+
+/** A Slack surface: one workspace install, DMs owned by one agent, N routes. */
+function slack(
+    dmAgent: string | null,
+    channels: Array<{ channel_id?: string; channel_name?: string; agent_name?: string | null }> = [],
+): AssistantSurface {
+    return {
+        name: 'slack',
+        surface_type: 'SLACK',
+        agent_name: dmAgent,
+        uses_default_agent: dmAgent === null,
+        config: { channels },
+    } as unknown as AssistantSurface;
+}
+
+describe('surface reaches', () => {
+    it('lists direct messages and every channel routed to the agent', () => {
+        const surface = slack('sales-agent', [
+            { channel_id: 'C1', channel_name: 'sales', agent_name: 'sales-agent' },
+            { channel_id: 'C2', channel_name: 'support', agent_name: 'support-agent' },
+            { channel_id: 'C3', channel_name: 'deals', agent_name: 'sales-agent' },
+        ]);
+
+        expect(surfaceReaches(surface, 'sales-agent').map((reach) => reach.label)).toEqual([
+            'Direct messages',
+            '#sales',
+            '#deals',
+        ]);
+    });
+
+    it('gives another agent its channels without the workspace DMs', () => {
+        const surface = slack('sales-agent', [
+            { channel_id: 'C2', channel_name: 'support', agent_name: 'support-agent' },
+        ]);
+
+        const reaches = surfaceReaches(surface, 'support-agent');
+        expect(reaches.map((reach) => reach.label)).toEqual(['#support']);
+        // The limit that used to be invisible: one agent holds a workspace's DMs.
+        expect(surfaceAnswersDirectMessages(surface, 'support-agent')).toBe(false);
+        expect(surfaceDirectMessageAgent(surface)).toBe('sales-agent');
+    });
+
+    it('reads an unrouted channel as the pod default assistant', () => {
+        const surface = slack('sales-agent', [
+            { channel_id: 'C9', channel_name: 'general', agent_name: null },
+        ]);
+
+        expect(surfaceReaches(surface, null).map((reach) => reach.label)).toEqual(['#general']);
+        // Would be missed by a DM-only filter, which is why `defaultSurfaces`
+        // asks about reach rather than about the responder.
+        expect(surfaceReachesDefaultAgent(surface)).toBe(true);
+        expect(surfaceDirectMessageAgent(surface)).toBe('sales-agent');
+    });
+
+    it('hands the pod default assistant the DMs when no agent claims them', () => {
+        const surface = slack(null);
+        expect(surfaceAnswersDirectMessages(surface, null)).toBe(true);
+        expect(surfaceDirectMessageAgent(surface)).toBeNull();
+        expect(surfaceReaches(surface, 'sales-agent')).toEqual([]);
+    });
+
+    it('prefixes a channel name once, whether or not it arrives with one', () => {
+        const surface = slack(null, [
+            { channel_id: 'C1', channel_name: '#already', agent_name: null },
+            { channel_id: 'C2', channel_name: 'bare', agent_name: null },
+            // No name — the id is all we can show, and showing nothing would
+            // silently drop a route that really does deliver messages.
+            { channel_id: 'C3', agent_name: null },
+        ]);
+
+        expect(surfaceReaches(surface, null).map((reach) => reach.label)).toEqual([
+            'Direct messages',
+            '#already',
+            '#bare',
+            '#C3',
+        ]);
+    });
+
+    it('keys channels distinctly so exploded chips stay stable', () => {
+        const surface = slack(null, [
+            { channel_id: 'C1', channel_name: 'a', agent_name: null },
+            { channel_id: 'C2', channel_name: 'b', agent_name: null },
+        ]);
+
+        const keys = surfaceReaches(surface, null).map((reach) => reach.key);
+        expect(new Set(keys).size).toBe(keys.length);
+    });
+
+    it('still describes reach as one line for the tooltip', () => {
+        const surface = slack('sales-agent', [
+            { channel_id: 'C1', channel_name: 'sales', agent_name: 'sales-agent' },
+        ]);
+
+        expect(describeReach(surface, 'sales-agent')).toBe('Direct messages · #sales');
+        expect(describeReach(surface, 'nobody')).toBe('Routed here');
+    });
+});

--- a/lemma-frontend/lib/utils/surfaces.ts
+++ b/lemma-frontend/lib/utils/surfaces.ts
@@ -52,6 +52,18 @@ export function surfaceUsesDefaultAgent(surface: AssistantSurface): boolean {
     return surface.uses_default_agent ?? !surface.agent_name;
 }
 
+/**
+ * A surface reaches the pod default assistant when it answers its direct
+ * messages *or* routes a channel with no agent of its own.
+ *
+ * The channel half matters on Slack and Teams, where a workspace whose DMs
+ * belong to one agent can still route `#general` to the pod assistant — which
+ * `surfaceUsesDefaultAgent` alone would read as "not reached here".
+ */
+export function surfaceReachesDefaultAgent(surface: AssistantSurface): boolean {
+    return surfaceReaches(surface, null).length > 0;
+}
+
 /** The surface's own address — a phone number, bot handle, workspace name, etc. */
 export function getSurfaceIdentity(surface: AssistantSurface): string | null {
     const identity = surface.surface_identity_username?.trim();
@@ -82,23 +94,88 @@ export function getSurfaceDeepLink(surface: AssistantSurface): string | null {
 }
 
 /**
+ * One distinct place a surface reaches an agent.
+ *
+ * On Slack and Teams a single workspace install carries many of these — the
+ * bot's DMs plus every channel routed by name — and they are what a person
+ * thinks in ("#sales"), not the install. Identity platforms have exactly one.
+ */
+export interface SurfaceReach {
+    /** Stable across renders; also what the modal targets. */
+    key: string;
+    kind: 'dm' | 'channel';
+    /** Chip text. Channels arrive already prefixed with `#`. */
+    label: string;
+    /** Set when `kind` is `channel`. */
+    channelId?: string;
+}
+
+/** Display form of a route's channel, or null when it names neither id nor name. */
+function channelLabel(route: { channel_id?: string | null; channel_name?: string | null }): string | null {
+    const name = route.channel_name || route.channel_id;
+    if (!name) return null;
+    return name.startsWith('#') ? name : `#${name}`;
+}
+
+/**
+ * Every place this surface reaches one agent. `reachFor` is the agent name whose
+ * perspective we render; `null` means the pod default assistant.
+ *
+ * DMs come first because they are the surface's own address — the thing that
+ * exists before anyone routes anything.
+ */
+export function surfaceReaches(
+    surface: AssistantSurface,
+    reachFor: string | null,
+): SurfaceReach[] {
+    const reaches: SurfaceReach[] = [];
+    if (surfaceAnswersDirectMessages(surface, reachFor)) {
+        reaches.push({ key: 'dm', kind: 'dm', label: 'Direct messages' });
+    }
+
+    for (const route of surface.config?.channels ?? []) {
+        const routed = reachFor === null ? !route.agent_name : route.agent_name === reachFor;
+        if (!routed) continue;
+        const label = channelLabel(route);
+        if (!label) continue;
+        reaches.push({
+            key: `channel:${route.channel_id || label}`,
+            kind: 'channel',
+            label,
+            channelId: route.channel_id || undefined,
+        });
+    }
+
+    return reaches;
+}
+
+/** Whether this agent is the one that answers the surface's direct messages. */
+export function surfaceAnswersDirectMessages(
+    surface: AssistantSurface,
+    reachFor: string | null,
+): boolean {
+    return reachFor === null
+        ? surfaceUsesDefaultAgent(surface)
+        : surface.agent_name === reachFor;
+}
+
+/**
+ * The agent that answers this surface's DMs, for naming the holder to everyone
+ * else. `null` means the pod default assistant.
+ *
+ * A surface has exactly one — DMs carry no channel to route on, so they always
+ * fall to `surface.agent_name`. That is the one hard limit on a Slack workspace,
+ * and naming the holder is how it stops being invisible.
+ */
+export function surfaceDirectMessageAgent(surface: AssistantSurface): string | null {
+    return surfaceUsesDefaultAgent(surface) ? null : surface.agent_name ?? null;
+}
+
+/**
  * Short reach description for a surface from one perspective. `reachFor` is the
  * agent name whose perspective we render; `null` means the pod default assistant.
  */
 export function describeReach(surface: AssistantSurface, reachFor: string | null): string {
-    const parts: string[] = [];
-    const isDefaultResponder = reachFor === null
-        ? surfaceUsesDefaultAgent(surface)
-        : surface.agent_name === reachFor;
-    if (isDefaultResponder) parts.push('Direct messages');
-
-    const routes = (surface.config?.channels ?? []).filter((route) =>
-        reachFor === null ? !route.agent_name : route.agent_name === reachFor,
-    );
-    for (const route of routes) {
-        const name = route.channel_name || route.channel_id;
-        if (name) parts.push(name.startsWith('#') ? name : `#${name}`);
-    }
-
+    const parts = surfaceReaches(surface, reachFor).map((reach) => reach.label);
     return parts.join(' · ') || 'Routed here';
 }


### PR DESCRIPTION
Slack already routes each channel to its own agent — [`SurfaceChannelRoute`](lemma-backend/app/modules/agent_surfaces/domain/entities.py#L97) carries `agent_name` and [`_resolve_route_agent`](lemma-backend/app/modules/agent_surfaces/services/ingress_service.py#L1891) resolves it per inbound event. An org can run `sales-agent` in `#sales` and `support-agent` in `#support` **today**, behind one bot. Nothing in the UI said so.

Design doc: [`docs/design/slack-channels-as-reach.md`](docs/design/slack-channels-as-reach.md).

## Why it was hidden

Slack was rendered as an identity platform. Identity is the spine of the Telegram/WhatsApp journey — *whose number is this* — and Slack has one answer, forever:

- `has_native_credentials` has no Slack branch, so the catalog never reports a Lemma-managed bot. The `SYSTEM` row rendered as **"Lemma's Slack app · Fastest"** and was permanently disabled.
- The `CUSTOM` row said *"Your Slack app and branding"*, but the flow installs **Lemma's** Slack app. A genuinely custom app can't receive events anyway while `_verify_slack_signature` HMACs against one deployment-wide `SLACK_SIGNING_SECRET`.

Both rows were wrong, and the step they lived in had nothing to decide. Meanwhile the real feature sat in a post-creation Configure step whose empty state told you to go invite a bot and come back.

## What changed

- Slack's `identityOptions` is `null` — the modal opens on the workspace picker.
- A `channelRoutes` surface renders **one chip per reach** plus an `Add channel` chip that no longer disappears. The old `reached` filter is right for a phone number and backwards for a workspace.
- `Add channel` opens routing with a blank row **already assigned to the agent whose page you came from**.
- **Direct messages** render as a chip naming the agent that holds them, on every agent that isn't it. One agent takes a workspace's DMs org-wide — previously silent, so setting a Slack responder quietly took DMs from whoever had them.
- `/ai` counts **places**, not installs, so one workspace reaching an agent in six channels stops reading as "1 surface".

### Unplanned fix found on the way

`usePodAutomation.defaultSurfaces` filtered on `surfaceUsesDefaultAgent`, which asks who answers DMs. A workspace whose DMs belong to another agent but which routes `#general` to nobody in particular *does* reach the pod assistant, and was invisible on its page. Now filters on `surfaceReachesDefaultAgent`, symmetric with `surfacesForAgent`.

## Scope

Frontend only — no API change, no migration. `GET .../surfaces/{name}/channels` already enumerates and the surface update already writes `config.channels`.

Deliberately **not** in this PR (each needs backend work, listed in the doc's *Out of scope*): bring-your-own Slack apps, a second bot identity per workspace, multiple agents on Slack DMs, Socket Mode's unreachable `app_token`, and the dead `SLACK_BOT_TOKEN`. A full channel → agent table on `/ai` is also deferred — it needs the overflow answer in open question 3.

## Verification

Typecheck, lint, design audit, 517 unit tests, and a production build all pass. New pure-logic tests cover the reach model (`lib/utils/__tests__/surfaces.test.ts`) and pin the registry invariant that a channel platform offers no identity fork.

⚠️ **Not exercised in a browser.** `make dev` needs `make init` to provision a database and secrets, and rendering these chips needs a real Slack workspace installed against a running stack. The repo is pure-logic tests by design (no DOM stack), so component rendering is unverified until someone runs it — worth a manual pass on an agent page with a Slack workspace connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)