### PR TITLE
Point the E2B templates at where the sandbox sources actually live

### DIFF
--- a/lemma-backend/sandbox-images/templates/e2b/README.md
+++ b/lemma-backend/sandbox-images/templates/e2b/README.md
@@ -1,6 +1,6 @@
 # E2B templates
 
-AgentBox uses two immutable E2B template builds:
+Sandbox provisioning uses two immutable E2B template builds:
 
 - `lemma-agentbox-workspace` extends E2B Code Interpreter with a locked authoring
   environment (including the Lemma SDK), Node 24, pnpm, uv, LiteParse, and
@@ -18,15 +18,20 @@ ephemeral because the provider allocation is destroyed after the configured idle
 period.
 
 The returned template and build IDs must both be configured outside this source
-repository. AgentBox combines them as
-`<template_id>:<build_id>` so a mutable tag can never change a running profile.
+repository. The deployment combines them as `<template_id>:<build_id>` so a
+mutable tag can never change a running profile -- the workspace settings take a
+single template string (`E2B_WORKSPACE_TEMPLATE` / `E2B_FUNCTION_TEMPLATE`), so
+whatever sets them is what does the pinning.
+
+Run it from `lemma-backend`; the builder copies from the monorepo root, which it
+resolves from its own location.
 
 ```bash
-cd agentbox
+cd lemma-backend
 set -a
-source ../lemma-backend/.env
+source .env
 set +a
-.venv/bin/python templates/e2b/build_templates.py --target all
+.venv/bin/python sandbox-images/templates/e2b/build_templates.py --target all
 ```
 
 The script prints identifiers and effective resource values only. It does not

--- a/lemma-backend/sandbox-images/templates/e2b/build_templates.py
+++ b/lemma-backend/sandbox-images/templates/e2b/build_templates.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from e2b import Template, default_build_logger, wait_for_port
 
 
-REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
 UV_VERSION = "0.11.31"
 UV_LINUX_X64_SHA256 = "8cc1cd82d434ec565376f98bd938d4b715b5791a80ff2d3aa78821cf85091b4b"
 NODE_VERSION = "24.18.0"
@@ -117,15 +117,15 @@ def workspace_template():
         .copy("lemma-cli", "/build/lemma-cli")
         .copy("lemma-skills", "/build/lemma-skills")
         .copy(
-            "agentbox/templates/workspace-python",
-            "/build/agentbox/templates/workspace-python",
+            "lemma-backend/sandbox-images/templates/workspace-python",
+            "/build/lemma-backend/sandbox-images/templates/workspace-python",
         )
         .run_cmd(
             "UV_PYTHON_INSTALL_DIR=/opt/python uv python install 3.14 && "
             "UV_PYTHON_INSTALL_DIR=/opt/python "
             "UV_PROJECT_ENVIRONMENT=/opt/agentbox-python "
             "UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy "
-            "uv sync --project /build/agentbox/templates/workspace-python "
+            "uv sync --project /build/lemma-backend/sandbox-images/templates/workspace-python "
             "--python 3.14 "
             "--locked --no-dev --no-editable && "
             "printf '%s\\n' "
@@ -152,11 +152,11 @@ def workspace_template():
             "> /root/.local/share/jupyter/kernels/python3/kernel.json && "
             "uv cache clean && "
             "rm -rf /build/lemma-python /build/lemma-pod-bundle "
-            "/build/lemma-cli /build/lemma-skills /build/agentbox",
+            "/build/lemma-cli /build/lemma-skills /build/lemma-backend",
             user="root",
         )
         .copy(
-            "agentbox/templates/workspace-node",
+            "lemma-backend/sandbox-images/templates/workspace-node",
             "/opt/agentbox-node",
         )
         .run_cmd(
@@ -174,7 +174,7 @@ def workspace_template():
             user="root",
         )
         .copy(
-            "agentbox/scripts/agentbox-node-tool",
+            "lemma-backend/sandbox-images/scripts/agentbox-node-tool",
             "/usr/local/lib/agentbox-node-tool",
             mode=0o755,
         )
@@ -192,27 +192,27 @@ def workspace_template():
             user="user",
         )
         .copy(
-            "agentbox/templates/workspace-node/agentbox-profile.sh",
+            "lemma-backend/sandbox-images/templates/workspace-node/agentbox-profile.sh",
             "/etc/profile.d/agentbox-node.sh",
             mode=0o644,
         )
         .copy(
-            "agentbox/templates/workspace-python/agentbox-profile.sh",
+            "lemma-backend/sandbox-images/templates/workspace-python/agentbox-profile.sh",
             "/etc/profile.d/agentbox-python.sh",
             mode=0o644,
         )
         .copy(
-            "agentbox/scripts/start-browser.sh",
+            "lemma-backend/sandbox-images/scripts/start-browser.sh",
             "/usr/local/bin/start-browser",
             mode=0o755,
         )
         .copy(
-            "agentbox/scripts/save-webpage.sh",
+            "lemma-backend/sandbox-images/scripts/save-webpage.sh",
             "/usr/local/bin/save-webpage",
             mode=0o755,
         )
         .copy(
-            "agentbox/scripts/webpage-to-markdown.mjs",
+            "lemma-backend/sandbox-images/scripts/webpage-to-markdown.mjs",
             "/opt/agentbox-node/webpage-to-markdown.mjs",
             mode=0o755,
         )
@@ -273,38 +273,37 @@ def function_template():
         )
         .copy("lemma-python", "/build/lemma-python")
         .copy(
-            "agentbox/templates/function-python",
-            "/build/agentbox/templates/function-python",
+            "lemma-backend/sandbox-images/templates/function-python",
+            "/build/lemma-backend/sandbox-images/templates/function-python",
         )
         .run_cmd(
             f"{_install_uv_command()} && "
             "UV_PROJECT_ENVIRONMENT=/opt/agentbox-function "
             "UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy "
-            "uv sync --project /build/agentbox/templates/function-python "
+            "uv sync --project /build/lemma-backend/sandbox-images/templates/function-python "
             "--locked --no-dev --no-editable && "
             "uv cache clean && "
-            "rm -rf /build/lemma-python /build/agentbox",
+            "rm -rf /build/lemma-python /build/lemma-backend",
             user="root",
         )
-        .copy("agentbox/agentbox/__init__.py", "/app/agentbox/__init__.py")
         .copy(
-            "agentbox/agentbox/event_catalog.py",
-            "/app/agentbox/event_catalog.py",
+            "lemma-backend/sandbox_runtime/__init__.py",
+            "/app/sandbox_runtime/__init__.py",
         )
         .copy(
-            "agentbox/agentbox/observability.py",
-            "/app/agentbox/observability.py",
+            "lemma-backend/sandbox_runtime/tasks.py",
+            "/app/sandbox_runtime/tasks.py",
         )
         .copy(
-            "agentbox/agentbox/function_runtime",
-            "/app/agentbox/function_runtime",
+            "lemma-backend/sandbox_runtime/function",
+            "/app/sandbox_runtime/function",
         )
         .copy(
-            "agentbox/scripts/lemma-function-runtime",
+            "lemma-backend/sandbox-images/scripts/lemma-function-runtime",
             "/usr/local/bin/lemma-function-runtime",
             mode=0o755,
         )
-        .run_cmd("python -m compileall -q /app/agentbox", user="root")
+        .run_cmd("python -m compileall -q /app/sandbox_runtime", user="root")
         .set_envs(
             {
                 "PYTHONUNBUFFERED": "1",

--- a/lemma-backend/sandbox_runtime/tests/test_e2b_template_sources_exist.py
+++ b/lemma-backend/sandbox_runtime/tests/test_e2b_template_sources_exist.py
@@ -1,0 +1,64 @@
+"""Every path the E2B templates copy must exist in the repository.
+
+Deliberately parses the builder as text instead of importing it. The other two
+E2B template tests `importorskip("e2b")`, so they are skipped in the unit job
+and only run in the conformance workflow -- and they drive the builder through
+a recording fake that never touches the filesystem. That combination is how the
+templates came to reference `agentbox/...` for a whole release after `agentbox/`
+was deleted: nothing that ran on every commit ever resolved a copy source.
+
+This test needs no SDK and no network, so it runs everywhere and fails the
+moment a source path stops existing.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+BUILDER = (
+    Path(__file__).resolve().parents[2]
+    / "sandbox-images"
+    / "templates"
+    / "e2b"
+    / "build_templates.py"
+)
+
+
+def _repository_root() -> Path:
+    """The root the builder itself resolves, not one assumed here.
+
+    Computed the same way `build_templates.REPOSITORY_ROOT` is, so moving the
+    builder without updating its `parents[...]` fails this test rather than
+    silently pointing the whole build one directory too low.
+    """
+    text = BUILDER.read_text(encoding="utf-8")
+    match = re.search(
+        r"REPOSITORY_ROOT = Path\(__file__\)\.resolve\(\)\.parents\[(\d+)\]", text
+    )
+    assert match is not None, "builder no longer declares REPOSITORY_ROOT"
+    return BUILDER.resolve().parents[int(match.group(1))]
+
+
+def test_repository_root_is_the_monorepo_root() -> None:
+    root = _repository_root()
+    assert (root / "lemma-python").is_dir()
+    assert (root / "lemma-backend" / "sandbox-images").is_dir()
+
+
+def test_every_copied_source_exists() -> None:
+    root = _repository_root()
+    sources = sorted(set(re.findall(r'\.copy\(\s*"([^"]+)"', BUILDER.read_text())))
+    assert sources, "expected the builder to copy something"
+    missing = [rel for rel in sources if not (root / rel).exists()]
+    assert not missing, f"E2B templates copy paths that do not exist: {missing}"
+
+
+def test_function_runtime_lands_where_its_entrypoint_imports_it() -> None:
+    """`lemma-function-runtime` does `sys.path.insert(0, "/app")` and imports
+    `sandbox_runtime.function.runner`, so the copy destination is a contract
+    with that script, not a detail."""
+    text = BUILDER.read_text(encoding="utf-8")
+    assert '"/app/sandbox_runtime/__init__.py"' in text
+    assert '"/app/sandbox_runtime/function"' in text
+    assert "/app/agentbox" not in text


### PR DESCRIPTION
#295 moved the E2B builder from `agentbox/templates/e2b/` to
`lemma-backend/sandbox-images/templates/e2b/` and deleted `agentbox/`, but the
builder kept both its old depth and its old paths. The template build has been
broken at HEAD since:

    ValueError: No files found in .../lemma-backend/lemma-python
      build_templates.py:115 in workspace_template
        .copy("lemma-python", "/build/lemma-python")

Two faults, either one fatal.

`REPOSITORY_ROOT` is `parents[3]`. That was the monorepo root at the old depth
and is `lemma-backend/` at the new one, so `file_context_path` — and therefore
every single copy — resolved one directory too low. Now `parents[4]`.

Fourteen copies still named paths under `agentbox/`, which the same commit
deleted. They are repointed to match the Dockerfiles, which are the authority
here because they build the same two images and were updated:
`sandbox-images/templates/*`, `sandbox-images/scripts/*`, and
`lemma-backend/sandbox_runtime/*`.

The function template's destination mattered as much as its source. It wrote
`/app/agentbox/...`, while `scripts/lemma-function-runtime` does
`sys.path.insert(0, "/app")` and imports `sandbox_runtime.function.runner` — so
even a build that found its sources would have produced an image whose
entrypoint died on import. It now lays down `/app/sandbox_runtime/` exactly as
`Dockerfile.function` does. `event_catalog.py` and `observability.py` are
dropped rather than repointed: the runtime no longer has them.

## Why nothing caught this

Both existing E2B template tests `importorskip("e2b")`, so they are skipped in
the unit job and only run in the conformance workflow — and they drive the
builder through a recording fake that records `.copy()` calls without ever
resolving one. A source path could name anything at all and both would pass.
That is the same shape as the Desktop-orphan bug #295 itself describes: the
fake agreed with the code rather than with reality.

`test_e2b_template_sources_exist.py` closes it. It parses the builder as text —
no SDK, no network, so it runs on every commit — derives `REPOSITORY_ROOT` the
way the builder does rather than assuming it, and resolves every copy source on
disk. Reverting either fault fails it: `parents[3]` alone reports all 17 paths
missing.

Also refreshes the README, which still said `cd agentbox`.

Found by a real release build: [lemma-app run 31294379866](https://github.com/lemma-work/lemma-app/actions/runs/31294379866) failed at `Carry forward or rebuild immutable E2B templates` with all three container images having built successfully.

Verification: all 17 copy sources resolve on disk; the new test passes, and reverting either fault fails it (`parents[3]` alone reports all 17 missing). A live build against the E2B API is the real proof and runs in the release build once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)