### PR TITLE
Deliver the message on every surface #303 broke, and catch the next one

### DIFF
--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -177,6 +177,7 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'agent_surfaces.ingress_service.surface_lifecycle_handling.diagnostic': EventSpec('debug', frozenset({'surface_id'})),
     'agent_surfaces.ingress_service.surface_channel_setup_handling.diagnostic': EventSpec('debug', frozenset({'surface_id'})),
     'agent_surfaces.ingress_service.surface_home_apps.diagnostic': EventSpec('debug', frozenset({'surface_id'})),
+    'agent_surfaces.ingress_service.surface_progress_no_egress_target.diagnostic': EventSpec('debug', frozenset({'conversation_id'})),
     'agent_surfaces.ingress_service.surface_progress_update_conversation_s.diagnostic': EventSpec('debug', frozenset({'conversation_id'})),
     'agent_surfaces.ingress_service.surface_request_approval_native_render.diagnostic': EventSpec('debug', frozenset({'conversation_id'})),
     'agent_surfaces.ingress_service.surface_request_approval_not_delivered.diagnostic': EventSpec('debug', frozenset({'conversation_id'})),

--- a/lemma-backend/app/modules/agent_surfaces/config.py
+++ b/lemma-backend/app/modules/agent_surfaces/config.py
@@ -65,6 +65,17 @@ class SurfaceSettings(BaseSettings):
         default=None,
         description="Slack signing secret for verifying native Slack webhook requests",
     )
+    slack_app_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "App id of this deployment's own Slack app (the 'A0…' Slack shows on "
+            "the app's Basic Information page). Inbound events name the app they "
+            "came from, and the shared webhook may also serve orgs running their "
+            "own Slack app, so this is how an event is matched to us rather than "
+            "to them. An account connected through OAuth stores its own app id, "
+            "which wins; this is the fallback for one that did not."
+        ),
+    )
     slack_home_logo_url: Optional[str] = Field(
         default=None,
         description=(

--- a/lemma-backend/app/modules/agent_surfaces/platforms/base.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/base.py
@@ -167,6 +167,83 @@ class BaseSurfaceAdapter:
         del payload, headers
         return None
 
+    # The in-chat set-up flow. Only Slack drives configuration from inside the
+    # chat app today, but `SurfaceConfigurationMixin` calls all of these on
+    # whichever adapter the inbound webhook resolved to — so they are part of
+    # the adapter contract, not Slack's private surface. Declared here with
+    # inert defaults: a platform that cannot configure itself in-chat answers
+    # "not mine" to the parse and "didn't do it" to the rest.
+    async def parse_channel_setup(
+        self, payload: dict[str, Any], headers: dict[str, str] | None = None
+    ) -> dict[str, Any] | None:
+        """Parse a payload belonging to the in-chat set-up flow. Default: the
+        platform drives set-up from the web UI only → None, so the caller keeps
+        treating the payload as an ordinary message."""
+        del payload, headers
+        return None
+
+    async def channel_name(
+        self, *, credentials: dict[str, Any], channel_id: str
+    ) -> str | None:
+        """Human-readable name for a channel. Default: unknown."""
+        del credentials, channel_id
+        return None
+
+    async def open_channel_setup_modal(
+        self,
+        *,
+        credentials: dict[str, Any],
+        trigger_id: str,
+        channel_id: str,
+        channel_label: str | None,
+        agent_names: list[str],
+        surface_id: str | None = None,
+    ) -> bool:
+        """Ask, in-chat, which agent answers in a channel. Default: unsupported."""
+        del credentials, trigger_id, channel_id, channel_label, agent_names
+        del surface_id
+        return False
+
+    async def open_dm_agent_modal(
+        self,
+        *,
+        credentials: dict[str, Any],
+        trigger_id: str,
+        agent_names: list,
+        current: str | None,
+        surface_id: str | None = None,
+    ) -> bool:
+        """Ask, in-chat, which agent answers a person's DMs. Default: unsupported."""
+        del credentials, trigger_id, agent_names, current, surface_id
+        return False
+
+    async def send_starter_prompt(
+        self, *, credentials: dict[str, Any], user_id: str, prompt: str
+    ) -> bool:
+        """Offer an opening prompt to a new user. Default: unsupported."""
+        del credentials, user_id, prompt
+        return False
+
+    async def publish_home_view(
+        self,
+        *,
+        credentials: dict[str, Any],
+        user_id: str,
+        pod_name: str | None,
+        dm_agent_name: str | None,
+        channel_routes: list,
+        agents: list | None = None,
+        apps: list | None = None,
+        workspace_url: str | None = None,
+        logo_url: str | None = None,
+        surface_choices: list[tuple[str, str]] | None = None,
+        access_message: str | None = None,
+    ) -> bool:
+        """Render the app's home tab. Default: the platform has no home tab."""
+        del credentials, user_id, pod_name, dm_agent_name, channel_routes
+        del agents, apps, workspace_url, logo_url, surface_choices, access_message
+        return False
+
     async def send_channel_setup_prompt(
         self,
         *,

--- a/lemma-backend/app/modules/agent_surfaces/platforms/teams/adapter.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/teams/adapter.py
@@ -482,8 +482,12 @@ class TeamsSurfaceAdapter(BaseSurfaceAdapter):
         event: ParsedInboundSurfaceEvent,
         progress_text: str,
         progress_handle: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
-        del credentials
+        # Accepted and unused: the PUT edits an activity this bot already owns,
+        # so there is no author to set. Declared because the shared caller
+        # passes it to whichever adapter answers.
+        del credentials, metadata
         tenant_id = event.tenant_id
         conversation_id = event.reply_target.get("conversation_id")
         if not tenant_id or not conversation_id:

--- a/lemma-backend/app/modules/agent_surfaces/platforms/telegram/adapter.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/telegram/adapter.py
@@ -209,7 +209,12 @@ class TelegramSurfaceAdapter(BaseSurfaceAdapter):
         event: ParsedInboundSurfaceEvent,
         progress_text: str,
         progress_handle: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
+        # Accepted and unused: Slack authors its stream under the agent's name,
+        # Telegram edits a message the bot already owns. Declared because the
+        # shared caller passes it to whichever adapter answers.
+        del metadata
         return await TelegramPlatformService(credentials).stream_progress(
             event, progress_text, progress_handle
         )

--- a/lemma-backend/app/modules/agent_surfaces/services/credential_resolver.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/credential_resolver.py
@@ -178,7 +178,7 @@ class SurfaceCredentialResolver:
                 )
             except Exception:
                 logger.debug(
-                    'agent_surfaces.credential_resolver.could_not_refresh_credentials_account.diagnostic',
+                    "agent_surfaces.credential_resolver.could_not_refresh_credentials_account.diagnostic",
                     account_id=account_id,
                 )
                 payload = dict(stored)
@@ -242,6 +242,14 @@ class SurfaceCredentialResolver:
         signing_secret = self._slack_secret_for_auth_config(
             auth_config, uses_custom_app=uses_custom_app
         )
+        if app_id is None and not uses_custom_app:
+            # An account on this deployment's own app that never stored an app id
+            # — connected before we recorded it, or through a broker that drops
+            # the field. We know which app it is: ours. Guessing is only safe
+            # here; a custom app's id is the org's and cannot be inferred, so it
+            # stays None and the surface is skipped as a verification candidate
+            # rather than answering to our app's events.
+            app_id = surface_settings.slack_app_id
         return SlackWebhookCredentials(
             app_id=app_id,
             signing_secret=signing_secret,
@@ -256,9 +264,12 @@ class SurfaceCredentialResolver:
         raw_response = (
             stored.get("raw_response") if isinstance(stored, dict) else None
         ) or {}
-        return str(
-            raw_response.get("app_id") or raw_response.get("api_app_id") or ""
-        ).strip() or None
+        return (
+            str(
+                raw_response.get("app_id") or raw_response.get("api_app_id") or ""
+            ).strip()
+            or None
+        )
 
     async def _slack_auth_config(self, auth_config_id):
         if auth_config_id is None:
@@ -292,7 +303,7 @@ class SurfaceCredentialResolver:
             )
         except Exception:
             logger.debug(
-                'agent_surfaces.credential_resolver.could_not_resolve_provider_account.diagnostic'
+                "agent_surfaces.credential_resolver.could_not_resolve_provider_account.diagnostic"
             )
             return None
         if auth_config is None:

--- a/lemma-backend/app/modules/agent_surfaces/services/progress_events.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/progress_events.py
@@ -132,6 +132,27 @@ def _assistant_text_from_event(event: AgentEvent) -> str | None:
     return text or None
 
 
+def _assistant_text_was_all_reasoning(event: AgentEvent) -> bool:
+    """True when the model's answer was reasoning and nothing else.
+
+    ``_assistant_text_from_event`` returns None both for "this event carries no
+    answer" and for "it carried one, and stripping the reasoning left nothing".
+    Only the second is a lost answer: the model wrote `<think>` and stopped
+    there, so the turn ends with the surface holding an empty string. Telling
+    those apart is what lets delivery say something rather than nothing.
+    """
+    if event.type != AgentEventType.MESSAGE:
+        return False
+    data = event.data
+    if not isinstance(data, MessageDraft):
+        return False
+    role = data.role.value if isinstance(data.role, MessageRole) else str(data.role)
+    if role != MessageRole.ASSISTANT.value or data.kind != MessageKind.TEXT:
+        return False
+    raw = (data.text or "").strip()
+    return bool(raw) and not strip_thinking_tokens(raw)
+
+
 def _find_comment(value: object) -> str | None:
     if not isinstance(value, dict):
         return None

--- a/lemma-backend/app/modules/agent_surfaces/services/progress_observer.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/progress_observer.py
@@ -30,6 +30,7 @@ from app.modules.agent_surfaces.services.ingress_service import (
 from app.modules.agent_surfaces.services.token_stream import TokenStreamMixin
 from app.modules.agent_surfaces.services.progress_events import (
     _assistant_text_from_event,
+    _assistant_text_was_all_reasoning,
     _email_reply_tool_called,
     _is_agent_host_permission_event,
     _is_final_answer_event,
@@ -137,6 +138,10 @@ class SurfaceAgentRunProgressObserver(TokenStreamMixin):
         # (``<think>…</think>``), and a tag can straddle two deltas — so the
         # filter has to be stateful across the whole run.
         self._think_filter = ThinkingStreamFilter()
+        # Set when an answer sanitized away to nothing, which is the one case
+        # where "no text to deliver" means an answer was lost rather than never
+        # written. See ``_deliver_final_answer``.
+        self._answer_was_all_reasoning = False
         self._rendered_waiting_tool_calls: set[tuple[str, str]] = set()
 
     async def on_run_started(
@@ -201,6 +206,12 @@ class SurfaceAgentRunProgressObserver(TokenStreamMixin):
         # Assistant text is buffered, never sent mid-run, so intermediate
         # narration cannot leak as a separate chat message. The final answer is
         # delivered once on on_run_finished.
+        if _assistant_text_was_all_reasoning(event):
+            # The model wrote reasoning and stopped. Stripping it is right, but
+            # it leaves nothing to send, and a turn that ends in silence reads
+            # as the agent ignoring the person. Remembered so delivery can say
+            # so instead.
+            self._answer_was_all_reasoning = True
         assistant_text = _assistant_text_from_event(event)
         if assistant_text is not None:
             if _is_final_answer_event(event):
@@ -472,6 +483,16 @@ class SurfaceAgentRunProgressObserver(TokenStreamMixin):
         if platform in _EMAIL_PLATFORMS and self._email_reply_tool_called:
             return
         message = (self._final_answer_text or self._buffered_text or "").strip()
+        if not message and self._answer_was_all_reasoning:
+            # An answer existed and sanitizing removed all of it, so the run
+            # "succeeded" with nothing to show. Saying nothing is the one
+            # outcome the person cannot act on — they cannot tell it from the
+            # agent never having seen the message, and will ask again into the
+            # same silence. Say the turn produced nothing instead.
+            message = (
+                "I thought that through but never wrote the answer. "
+                "Ask me again and I'll give it another go."
+            )
         if not message:
             return
         try:

--- a/lemma-backend/app/modules/agent_surfaces/services/surface_progress.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/surface_progress.py
@@ -37,6 +37,14 @@ class SurfaceProgressMixin:
         """
         target = await self._resolve_egress_target(conversation_id)
         if target is None:
+            # Silent until now, and indistinguishable from a platform that
+            # simply has no live progress — so a conversation that cannot
+            # resolve its surface just never showed progress and said nothing
+            # about why.
+            logger.debug(
+                "agent_surfaces.ingress_service.surface_progress_no_egress_target.diagnostic",
+                conversation_id=conversation_id,
+            )
             return progress_handle
         try:
             # Author the stream as the agent: the answer that closes this same

--- a/lemma-backend/app/modules/agent_surfaces/services/webhook_security_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/webhook_security_service.py
@@ -178,8 +178,8 @@ class SurfaceWebhookSecurityService:
                 surface.webhook_secret or surface_settings.slack_signing_secret
             )
             if self._credential_resolver is not None:
-                credentials = (
-                    await self._credential_resolver.slack_webhook_credentials(surface)
+                credentials = await self._credential_resolver.slack_webhook_credentials(
+                    surface
                 )
                 signing_secret = credentials.signing_secret
             self._verify_slack_signature(
@@ -214,18 +214,31 @@ class SurfaceWebhookSecurityService:
                     )
                 ),
             )
-        if not normalized_app_id:
-            raise SurfaceWebhookAuthenticationError(
-                "Slack request is missing api_app_id"
-            )
-        matching = [
-            candidate
-            for candidate in candidates
-            if hmac.compare_digest(candidate.app_id, normalized_app_id)
-        ]
-        if not matching:
+        # The signature is the authentication: only the app holding the secret
+        # can produce one. The app id merely says *which* secret to try first,
+        # which matters when an org runs its own Slack app alongside ours in the
+        # same workspace. So a request that does not name an app is not
+        # rejected — every secret bound to the workspace is tried, and one has
+        # to verify. Narrowing by app id when we have it keeps the common case
+        # to a single HMAC and keeps the reported app honest.
+        matching = (
+            [
+                candidate
+                for candidate in candidates
+                if hmac.compare_digest(candidate.app_id, normalized_app_id)
+            ]
+            if normalized_app_id
+            else list(candidates)
+        )
+        if not matching and normalized_app_id:
+            # Named an app we hold no secret for. Falling back to every other
+            # candidate would be answering for an app we were not addressed as.
             raise SurfaceWebhookAuthenticationError(
                 "Slack request targets an unknown app for this workspace"
+            )
+        if not matching:
+            raise SurfaceWebhookAuthenticationError(
+                "No Slack app is configured for this workspace"
             )
         last_error: SurfaceWebhookAuthenticationError | None = None
         for candidate in matching:
@@ -236,7 +249,9 @@ class SurfaceWebhookSecurityService:
                     signing_secret=candidate.signing_secret,
                 )
                 return VerifiedSlackIngress(
-                    app_id=normalized_app_id,
+                    # Unnamed request: report the app whose secret verified it,
+                    # so downstream never sees an empty app id.
+                    app_id=normalized_app_id or candidate.app_id,
                     receiver_surface_ids=candidate.receiver_surface_ids,
                 )
             except SurfaceWebhookAuthenticationError as exc:
@@ -340,7 +355,7 @@ class SurfaceWebhookSecurityService:
                 )
             except Exception:
                 logger.debug(
-                    'agent_surfaces.webhook_security_service.could_not_resolve_whatsapp_credentials.diagnostic',
+                    "agent_surfaces.webhook_security_service.could_not_resolve_whatsapp_credentials.diagnostic",
                     account_id=surface.account_id,
                     exc_info=True,
                 )

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/helpers.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/helpers.py
@@ -68,6 +68,12 @@ REAL_TEAMS_TENANT_ID = "1b5c589f-1718-42c8-8244-166fbe5dd8fc"
 REAL_TEAMS_THREAD_ID = "1776236638028"
 E2E_RUNTIME_PROFILE_NAME = "Surface E2E Runtime"
 E2E_RUNTIME_MODEL_NAME = "surface-e2e-model"
+# The Slack app every E2E account belongs to. Real Slack stamps this on both
+# sides — `app_id` on the OAuth response we store, `api_app_id` on every event
+# and interaction it sends — and verification matches one against the other.
+# One constant so a payload built here can never name a different app than the
+# account it is answering for.
+E2E_SLACK_APP_ID = "A0123456"
 
 
 @pytest_asyncio.fixture
@@ -352,7 +358,7 @@ async def _ensure_connector_account(
     if connector_id == "slack":
         credentials = dict(credentials)
         raw_response = dict(credentials.get("raw_response") or {})
-        raw_response.setdefault("app_id", "A0123456")
+        raw_response.setdefault("app_id", E2E_SLACK_APP_ID)
         credentials["raw_response"] = raw_response
     await _ensure_connector(db_session, connector_id, provider=provider)
     kind = provider_to_kind(provider).value

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/mock_infrastructure.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/mock_infrastructure.py
@@ -1323,14 +1323,48 @@ def slack_delivered(store: MockPlatformMessageStore) -> list[str]:
     """
     delivered: list[str] = []
     for platform, message in store.get_ordered("SLACK", "SLACK_STREAM_APPEND"):
-        if platform == "SLACK":
-            parts = [message.get("text"), message.get("blocks")]
-        else:
-            parts = [message.get("chunks")]
-        joined = "\n".join(str(part) for part in parts if part)
+        joined = _slack_reply_text(platform, message)
         if joined:
             delivered.append(joined)
     return delivered
+
+
+def _slack_reply_text(platform: str, message: dict) -> str:
+    parts = (
+        [message.get("text"), message.get("blocks")]
+        if platform == "SLACK"
+        else [message.get("chunks")]
+    )
+    return "\n".join(str(part) for part in parts if part)
+
+
+def slack_delivered_calls(store: MockPlatformMessageStore) -> list[dict]:
+    """The raw Slack calls that carried a reply, in arrival order.
+
+    ``slack_delivered`` is the text; this is for the handful of assertions
+    that need the call itself — which channel it went to, or how many replies
+    there were. Both posted messages and stream appends carry ``channel``.
+    """
+    return [
+        message
+        for platform, message in store.get_ordered("SLACK", "SLACK_STREAM_APPEND")
+        if _slack_reply_text(platform, message)
+    ]
+
+
+async def wait_for_slack_replies(
+    store: MockPlatformMessageStore,
+    min_count: int = 1,
+    timeout_seconds: float = 30.0,
+) -> list[dict]:
+    """Wait until at least ``min_count`` replies reach Slack by any transport."""
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    while asyncio.get_running_loop().time() < deadline:
+        calls = slack_delivered_calls(store)
+        if len(calls) >= min_count:
+            return calls
+        await asyncio.sleep(0.2)
+    return slack_delivered_calls(store)
 
 
 async def wait_for_slack_text(

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/mock_infrastructure.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/mock_infrastructure.py
@@ -44,15 +44,31 @@ class MockPlatformMessageStore:
 
     def __init__(self) -> None:
         self._messages: dict[str, list[dict]] = {}
+        # One reply can reach a platform by more than one call — Slack posts a
+        # plain message but streams an answer — so "what did the user see, and
+        # in what order?" cannot be answered from a single bucket. The arrival
+        # log keeps that order across buckets.
+        self._arrivals: list[tuple[str, dict]] = []
 
     def add(self, platform: str, message: dict) -> None:
         self._messages.setdefault(platform, []).append(message)
+        self._arrivals.append((platform, message))
 
     def get_all(self, platform: str) -> list[dict]:
         return list(self._messages.get(platform, []))
 
+    def get_ordered(self, *platforms: str) -> list[tuple[str, dict]]:
+        """Messages across the given buckets, in the order they arrived."""
+        wanted = set(platforms)
+        return [
+            (platform, message)
+            for platform, message in self._arrivals
+            if not wanted or platform in wanted
+        ]
+
     def clear(self) -> None:
         self._messages.clear()
+        self._arrivals.clear()
 
 
 class FakeComposioServer:
@@ -1291,6 +1307,51 @@ def build_resend_svix_headers(
         "svix-signature": f"v1,{signature}",
         "Content-Type": "application/json",
     }
+
+
+def slack_delivered(store: MockPlatformMessageStore) -> list[str]:
+    """Every user-visible string Slack was asked to show, in arrival order.
+
+    Slack carries a reply three ways now, and all three moved under these
+    tests at least once: ``chat.postMessage`` text, the markdown ``blocks`` of
+    that same message (the body lives there, and ``text`` is only the
+    notification preview), and ``chat.appendStream`` chunks when the answer
+    closes the live stream opened at run start. Reading any single one of them
+    reports "nothing was delivered" for a reply the user can see perfectly
+    well. One entry per message, so counting entries counts replies rather
+    than the fields a reply happens to occupy.
+    """
+    delivered: list[str] = []
+    for platform, message in store.get_ordered("SLACK", "SLACK_STREAM_APPEND"):
+        if platform == "SLACK":
+            parts = [message.get("text"), message.get("blocks")]
+        else:
+            parts = [message.get("chunks")]
+        joined = "\n".join(str(part) for part in parts if part)
+        if joined:
+            delivered.append(joined)
+    return delivered
+
+
+async def wait_for_slack_text(
+    store: MockPlatformMessageStore,
+    needle: str,
+    timeout_seconds: float = 30.0,
+) -> list[str]:
+    """Wait until ``needle`` reaches Slack by any transport; return all of it.
+
+    Waiting on one bucket is what made these tests flaky-looking: the prompt
+    lands as a posted message immediately, so a wait on posted messages
+    returns straight away and the assertion runs before the streamed answer
+    has arrived.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout_seconds
+    while asyncio.get_running_loop().time() < deadline:
+        delivered = slack_delivered(store)
+        if any(needle in text for text in delivered):
+            return delivered
+        await asyncio.sleep(0.2)
+    return slack_delivered(store)
 
 
 async def wait_for_messages(

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_ask_user_matrix_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_ask_user_matrix_e2e.py
@@ -55,6 +55,7 @@ from app.modules.agent_surfaces.tests.e2e.mock_infrastructure import (
     build_telegram_secret_headers,
     build_whatsapp_signature_headers,
     wait_for_messages,
+    wait_for_slack_text,
 )
 from app.modules.agent_surfaces.tests.e2e.scripted_llm import (
     process_ingress_and_run_scripted,
@@ -249,8 +250,12 @@ async def test_ask_user_native_slack_blocks_then_resumes_with_answer(
         agent_name=context.agent_name,
     )
 
-    slack_messages = await wait_for_messages(message_store, "SLACK", min_count=2)
-    assert "Thanks — recorded your answer." in slack_messages[-1]["text"]
+    delivered = await wait_for_slack_text(
+        message_store, "Thanks — recorded your answer."
+    )
+    assert any("Thanks — recorded your answer." in text for text in delivered), (
+        f"the resumed run never reached Slack: {delivered}"
+    )
 
     # Proof the mechanism gives that the old fake harness never could: the REAL
     # AskUserResponse shape flowed through persisted history.
@@ -326,8 +331,11 @@ async def test_ask_user_slack_native_failure_falls_back_to_text_and_typed_reply(
     assert isinstance(context, SurfaceChatContext)
     failed = message_store.get_all("SLACK_FAILED")
     assert failed[-1]["error"] == "invalid_blocks"
-    fallback_messages = await wait_for_messages(message_store, "SLACK", min_count=1)
-    fallback = fallback_messages[-1]["text"]
+    # Every question and the multi-select hint have to survive the degrade —
+    # in the body, which is the markdown block; `text` is only the
+    # notification preview and is truncated.
+    delivered = await wait_for_slack_text(message_store, "1. Which incident priorities")
+    fallback = "\n".join(delivered)
     assert "1. Which incident priorities" in fallback
     assert "Critical — Page the on-call engineer immediately. (recommended)" in fallback
     assert "2. Which response channel" in fallback
@@ -346,8 +354,12 @@ async def test_ask_user_slack_native_failure_falls_back_to_text_and_typed_reply(
     )
     assert isinstance(resumed, SurfaceChatContext)
 
-    slack_messages = await wait_for_messages(message_store, "SLACK", min_count=2)
-    assert slack_messages[-1]["text"] == "Incident notification preferences saved."
+    delivered = await wait_for_slack_text(
+        message_store, "Incident notification preferences saved."
+    )
+    assert any(
+        "Incident notification preferences saved." in text for text in delivered
+    ), f"the typed answer never resumed the run: {delivered}"
     messages = await _messages_for_conversation(
         authenticated_client,
         pod_id=pod_id,

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_ask_user_matrix_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_ask_user_matrix_e2e.py
@@ -32,6 +32,7 @@ from app.modules.agent_surfaces.events.handlers import build_surface_event_handl
 from app.modules.agent_surfaces.infrastructure.models import AgentSurface
 from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
 from app.modules.agent_surfaces.tests.e2e.helpers import (
+    E2E_SLACK_APP_ID,
     REAL_TEAMS_CHANNEL_ID,
     REAL_TEAMS_TENANT_ID,
     REAL_TEAMS_THREAD_ID,
@@ -128,6 +129,7 @@ def _slack_ask_user_submission_payload(
     """
     return {
         "type": "block_actions",
+        "api_app_id": E2E_SLACK_APP_ID,
         "user": {"id": user_id},
         "team": {"id": "T0123456"},
         "channel": {"id": channel_id},

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_display_resource_matrix_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_display_resource_matrix_e2e.py
@@ -74,7 +74,10 @@ from app.modules.agent_surfaces.tests.e2e.helpers import (
     _telegram_payload,
     _whatsapp_payload,
 )
-from app.modules.agent_surfaces.tests.e2e.mock_infrastructure import wait_for_messages
+from app.modules.agent_surfaces.tests.e2e.mock_infrastructure import (
+    wait_for_messages,
+    wait_for_slack_text,
+)
 from app.modules.agent_surfaces.tests.e2e.scripted_llm import (
     process_ingress_and_run_scripted,
     script_display_resource,
@@ -461,13 +464,12 @@ async def test_display_resource_slack_routes_pod_resource_catalog_to_deep_links(
     assert "incident-dashboard" in rendered
     assert "daily-triage" in rendered
     assert "%2Freports%2Fquarterly.pdf" in rendered
-    assert (
-        sum(
-            message.get("text") == "The incident catalog is ready."
-            for message in slack_messages
-        )
-        == 1
+    delivered = await wait_for_slack_text(
+        message_store, "The incident catalog is ready."
     )
+    assert (
+        sum("The incident catalog is ready." in text for text in delivered) == 1
+    ), f"the final answer must land exactly once, got {delivered}"
 
 
 async def test_display_resource_teams_file_always_falls_back_to_link(

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_full_real_surface_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_full_real_surface_e2e.py
@@ -52,7 +52,9 @@ from app.modules.agent_surfaces.tests.e2e.mock_infrastructure import (
     build_slack_signature_headers,
     build_telegram_secret_headers,
     build_whatsapp_signature_headers,
+    slack_delivered,
     wait_for_messages,
+    wait_for_slack_replies,
 )
 from app.modules.connectors.domain.connector import AuthProvider
 from app.modules.schedule.domain.events.schedule import ScheduleFired
@@ -61,7 +63,12 @@ from app.modules.schedule.domain.schedule import ScheduleType
 pytestmark = pytest.mark.e2e
 
 # Worker + queued run round-trip. Real-LLM mode can be slower, so keep room.
-REAL_REPLY_TIMEOUT = 180.0
+# Must stay well under the shard's pytest-timeout (120s in CI), or a reply
+# that never arrives kills the test before the wait returns — turning every
+# delivery failure into an opaque "Timeout (>120.0s)" with no clue which
+# assertion was waiting or what did arrive. A real worker round trip is
+# seconds; this only has to outlast a slow runner, not the whole test.
+REAL_REPLY_TIMEOUT = 60.0
 _RESEND_SIGNING_SECRET = "whsec_" + base64.b64encode(
     b"resend-e2e-signing-secret"
 ).decode("ascii")
@@ -421,12 +428,13 @@ async def test_slack_signed_webhook_is_deduplicated_and_replies_via_worker(
     )
     assert first.status_code == duplicate.status_code == 200
 
-    messages = await wait_for_messages(
-        message_store, "SLACK", min_count=1, timeout_seconds=REAL_REPLY_TIMEOUT
+    # Two identical webhooks, one reply — whichever way Slack carried it.
+    replies = await wait_for_slack_replies(
+        message_store, min_count=1, timeout_seconds=REAL_REPLY_TIMEOUT
     )
-    assert len(messages) == 1
-    assert messages[0]["channel"] == "D0123456"
-    assert str(messages[0].get("text") or "").strip()
+    assert len(replies) == 1, f"the duplicate was not deduplicated: {replies}"
+    assert replies[0]["channel"] == "D0123456"
+    assert "".join(slack_delivered(message_store)).strip()
 
     conversation = await _conversation_by_external_thread(
         authenticated_client,
@@ -526,11 +534,8 @@ async def test_slack_channel_attachment_and_history_are_persisted_via_worker(
         timeout_seconds=REAL_REPLY_TIMEOUT,
     )
     assert replies[-1]["channel"] == "C-SUPPORT"
-    await wait_for_messages(
-        message_store,
-        "SLACK",
-        min_count=1,
-        timeout_seconds=REAL_REPLY_TIMEOUT,
+    await wait_for_slack_replies(
+        message_store, min_count=1, timeout_seconds=REAL_REPLY_TIMEOUT
     )
 
     conversation = await _conversation_by_external_thread(
@@ -650,13 +655,11 @@ async def test_slack_native_socket_receiver_acknowledges_and_replies_via_worker(
     )
     runner_task = asyncio.create_task(runner.run())
     try:
-        messages = await wait_for_messages(
-            message_store,
-            "SLACK",
-            min_count=1,
-            timeout_seconds=REAL_REPLY_TIMEOUT,
+        replies = await wait_for_slack_replies(
+            message_store, min_count=1, timeout_seconds=REAL_REPLY_TIMEOUT
         )
-        assert messages[-1]["channel"] == "D0123456"
+        assert replies, "the socket receiver's run never replied to Slack"
+        assert replies[-1]["channel"] == "D0123456"
         assert acknowledgements == ["surface-e2e-envelope-1"]
     finally:
         runner_task.cancel()

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_multi_tool_turn_matrix_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_multi_tool_turn_matrix_e2e.py
@@ -37,7 +37,10 @@ from app.modules.agent_surfaces.tests.e2e.helpers import (
     _telegram_payload,
     _whatsapp_payload,
 )
-from app.modules.agent_surfaces.tests.e2e.mock_infrastructure import wait_for_messages
+from app.modules.agent_surfaces.tests.e2e.mock_infrastructure import (
+    wait_for_messages,
+    wait_for_slack_text,
+)
 from app.modules.agent_surfaces.tests.e2e.scripted_llm import (
     process_ingress_and_run_scripted,
     script_display_resource,
@@ -121,18 +124,22 @@ async def test_multi_tool_turn_slack_widget_then_say_then_one_final_answer(
     )
 
     # Widget landed before the voice note, which landed before the final
-    # answer — three distinct SLACK messages, in that order.
-    slack_messages = await wait_for_messages(message_store, "SLACK", min_count=1)
-    widget_index = next(
-        i for i, m in enumerate(slack_messages) if "blocks" in m or "attachments" in m
-    )
+    # answer. The widget is posted and the answer is streamed, so "in that
+    # order" spans two Slack APIs — hence arrival order, not one bucket's index.
+    delivered = await wait_for_slack_text(message_store, "All done.")
     uploads = await wait_for_messages(
         message_store, "SLACK_FILE_UPLOAD_URL", min_count=1
     )
     assert uploads
-    final_texts = [m for m in slack_messages if m.get("text") == "All done."]
-    assert len(final_texts) == 1, "final answer must be delivered exactly once"
-    assert slack_messages.index(final_texts[0]) > widget_index
+    finals = [i for i, text in enumerate(delivered) if "All done." in text]
+    assert len(finals) == 1, (
+        f"final answer must be delivered exactly once, got {len(finals)} "
+        f"in {delivered}"
+    )
+    widget_index = next(
+        i for i, text in enumerate(delivered) if "A widget is ready." in text
+    )
+    assert finals[0] > widget_index
 
 
 async def test_multi_tool_turn_teams_two_widgets_then_one_final_answer(

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_request_approval_matrix_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_request_approval_matrix_e2e.py
@@ -57,7 +57,10 @@ from app.modules.agent_surfaces.tests.e2e.helpers import (
     _telegram_payload,
     _whatsapp_payload,
 )
-from app.modules.agent_surfaces.tests.e2e.mock_infrastructure import wait_for_messages
+from app.modules.agent_surfaces.tests.e2e.mock_infrastructure import (
+    wait_for_messages,
+    wait_for_slack_text,
+)
 from app.modules.agent_surfaces.tests.e2e.scripted_llm import (
     process_ingress_and_run_scripted,
     resume_latest_scripted_run,
@@ -275,8 +278,12 @@ async def test_request_approval_slack_native_buttons_then_resumes_on_approve(
         approval_id=_TOOL_CALL_ID,
     )
 
-    slack_messages = await wait_for_messages(message_store, "SLACK", min_count=2)
-    assert "Done — approved and executed." in slack_messages[-1]["text"]
+    delivered = await wait_for_slack_text(
+        message_store, "Done — approved and executed."
+    )
+    assert any("Done — approved and executed." in text for text in delivered), (
+        f"the resumed run never reached Slack: {delivered}"
+    )
 
     messages = await _messages_for_conversation(
         authenticated_client, pod_id=pod_id, conversation_id=conversation_id
@@ -371,8 +378,10 @@ async def test_request_approval_slack_native_deny_skips_wrapped_tool(
         approval_id=_TOOL_CALL_ID,
     )
 
-    slack_messages = await wait_for_messages(message_store, "SLACK", min_count=2)
-    assert "Okay, cancelled." in slack_messages[-1]["text"]
+    delivered = await wait_for_slack_text(message_store, "Okay, cancelled.")
+    assert any("Okay, cancelled." in text for text in delivered), (
+        f"the resumed run never reached Slack: {delivered}"
+    )
 
     messages = await _messages_for_conversation(
         authenticated_client, pod_id=pod_id, conversation_id=conversation_id
@@ -457,8 +466,10 @@ async def test_request_approval_slack_typed_deny_skips_wrapped_tool(
         script=None,
     )
 
-    slack_messages = await wait_for_messages(message_store, "SLACK", min_count=2)
-    assert "Okay, cancelled." in slack_messages[-1]["text"]
+    delivered = await wait_for_slack_text(message_store, "Okay, cancelled.")
+    assert any("Okay, cancelled." in text for text in delivered), (
+        f"the resumed run never reached Slack: {delivered}"
+    )
 
     messages = await _messages_for_conversation(
         authenticated_client, pod_id=pod_id, conversation_id=conversation_id

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_request_approval_matrix_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_request_approval_matrix_e2e.py
@@ -38,6 +38,7 @@ from app.modules.agent_surfaces.platforms.teams.parser import (
 )
 from app.modules.agent_surfaces.tests.e2e.helpers import (
     E2E_RUNTIME_MODEL_NAME,
+    E2E_SLACK_APP_ID,
     REAL_TEAMS_CHANNEL_ID,
     REAL_TEAMS_TENANT_ID,
     REAL_TEAMS_THREAD_ID,
@@ -166,6 +167,7 @@ def _slack_approval_submission_payload(
     """A Slack block_actions submission tapping a native approval button."""
     return {
         "type": "block_actions",
+        "api_app_id": E2E_SLACK_APP_ID,
         "user": {"id": user_id},
         "team": {"id": "T0123456"},
         "channel": {"id": channel_id},

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_adapter_contract.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_adapter_contract.py
@@ -81,3 +81,44 @@ def test_adapter_implements_the_required_core(platform, adapter, method):
 async def test_channel_setup_is_answerable_by_every_platform(platform, adapter):
     """The specific regression: this is called on every inbound webhook."""
     assert await adapter.parse_channel_setup({}, {}) is None
+
+
+@pytest.mark.parametrize("platform, adapter", _registered_adapters())
+def test_adapter_overrides_accept_every_argument_the_base_declares(platform, adapter):
+    """An override must take what the shared caller is entitled to pass.
+
+    Names alone are not the contract. #303 added `metadata` to
+    `stream_progress` on the base and on Slack, and the Telegram and Teams
+    overrides kept the old signature — so every progress update on those two
+    raised TypeError into a broad `except`, and live progress silently stopped
+    working on both. Nothing failed; it just went quiet.
+    """
+    mismatches: list[str] = []
+    for name, base_method in inspect.getmembers(
+        BaseSurfaceAdapter, inspect.isfunction
+    ):
+        if name.startswith("_"):
+            continue
+        override = getattr(type(adapter), name, None)
+        if override is None or override is base_method:
+            continue
+        base_params = inspect.signature(base_method).parameters
+        override_params = inspect.signature(override).parameters
+        if any(
+            p.kind is inspect.Parameter.VAR_KEYWORD for p in override_params.values()
+        ):
+            continue
+        missing = [
+            param
+            for param, spec in base_params.items()
+            if spec.kind is inspect.Parameter.KEYWORD_ONLY
+            and param not in override_params
+        ]
+        if missing:
+            mismatches.append(f"{name}() is missing {missing}")
+    assert not mismatches, (
+        f"{platform} overrides drift from BaseSurfaceAdapter: {mismatches}. The "
+        "shared caller passes what the base declares, so a narrower override "
+        "raises TypeError at runtime — swallowed wherever the call is "
+        "best-effort."
+    )

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_adapter_contract.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_adapter_contract.py
@@ -1,0 +1,83 @@
+"""The adapter contract: what shared code may call on any platform.
+
+`SurfaceConfigurationMixin` and the ingress service reach for an adapter by
+platform and call methods on whatever comes back. Nothing checked that every
+adapter could answer those calls, so #303 added `parse_channel_setup` to Slack
+alone and every Telegram and WhatsApp webhook raised `AttributeError` in the
+worker — retried, dead-lettered, and the message reached nobody.
+
+The rule these tests enforce: a method one adapter exposes publicly is part of
+the contract and belongs on `BaseSurfaceAdapter`, with a default for platforms
+that cannot do it. Anything genuinely private to one platform is underscored
+and shared code cannot reach it.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from app.modules.agent_surfaces.infrastructure.adapters.registry import (
+    SurfacePlatformAdapterRegistry,
+)
+from app.modules.agent_surfaces.platforms.base import BaseSurfaceAdapter
+
+# Every adapter must implement these itself; the base deliberately declares no
+# default, because a platform that cannot do them is not a surface at all.
+REQUIRED_OF_EVERY_ADAPTER = (
+    "parse_inbound_event",
+    "send_message",
+    "add_processing_indicator",
+    "fetch_sender_profile",
+)
+
+
+def _registered_adapters() -> list[tuple[str, object]]:
+    registry = SurfacePlatformAdapterRegistry()
+    return [
+        (platform, registry.get(platform)) for platform in registry.list_platforms()
+    ]
+
+
+def _public_methods(cls: type) -> set[str]:
+    return {
+        name
+        for name, value in vars(cls).items()
+        if not name.startswith("_") and callable(value)
+    }
+
+
+@pytest.mark.parametrize("platform, adapter", _registered_adapters())
+def test_adapter_exposes_nothing_shared_code_cannot_call(platform, adapter):
+    """A public adapter method must be on the base, so any platform answers it."""
+    base_surface = {
+        name for name, _ in inspect.getmembers(BaseSurfaceAdapter, callable)
+    }
+    undeclared = sorted(
+        name
+        for cls in type(adapter).__mro__
+        if cls is not BaseSurfaceAdapter and issubclass(cls, BaseSurfaceAdapter)
+        for name in _public_methods(cls)
+        if name not in base_surface and name not in REQUIRED_OF_EVERY_ADAPTER
+    )
+    assert not undeclared, (
+        f"{platform} exposes {undeclared} but BaseSurfaceAdapter does not declare "
+        "them. Shared services call adapters by platform, so a method only one "
+        "adapter has raises AttributeError on every other. Add it to the base "
+        "with an inert default, or make it private to this adapter."
+    )
+
+
+@pytest.mark.parametrize("platform, adapter", _registered_adapters())
+@pytest.mark.parametrize("method", REQUIRED_OF_EVERY_ADAPTER)
+def test_adapter_implements_the_required_core(platform, adapter, method):
+    assert callable(getattr(adapter, method, None)), (
+        f"{platform} does not implement {method}(), which every surface needs."
+    )
+
+
+@pytest.mark.parametrize("platform, adapter", _registered_adapters())
+async def test_channel_setup_is_answerable_by_every_platform(platform, adapter):
+    """The specific regression: this is called on every inbound webhook."""
+    assert await adapter.parse_channel_setup({}, {}) is None

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_progress_observer.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_progress_observer.py
@@ -497,6 +497,51 @@ async def test_progress_observer_strips_inline_thinking_tags_from_text():
     assert "Let me check that." in delivered
 
 
+async def test_progress_observer_speaks_when_the_answer_was_only_reasoning():
+    """A model that writes `<think>` and stops must not end the turn in silence.
+
+    Seen live on Slack: the model emitted an unclosed thinking block and no
+    answer, stripping correctly reduced it to "", and the run completed having
+    sent nothing — the placeholder was even deleted. The person cannot tell
+    that from being ignored, so they ask again into the same silence.
+    """
+    service = _SurfaceService()
+    observer = _observer(service)
+    conversation = SimpleNamespace(id=uuid4(), metadata={"surface_platform": "SLACK"})
+
+    # Unclosed on purpose: this is what the model actually sent.
+    open_tag = chr(60) + "think" + chr(62)
+    raw_text = f"{open_tag}\nUser asks what I can do. Keep it short."
+
+    await observer.on_event(
+        _assistant(MessageDraft.of_text(raw_text)),
+        conversation,
+        SimpleNamespace(),
+    )
+    await observer.on_run_finished(conversation, SimpleNamespace())
+
+    assert len(service.messages) == 1, "the turn must not end in silence"
+    delivered = service.messages[0]["message"]
+    assert "think" not in delivered.lower()
+    assert "User asks what I can do" not in delivered
+
+
+async def test_progress_observer_stays_quiet_when_there_was_no_answer_at_all():
+    """The counterpart: nothing written is not the same as an answer lost.
+
+    A run that produced no assistant text has nothing to apologise for — tool
+    output and reply tools deliver on their own paths — so the fallback above
+    must not fire and add a spurious message.
+    """
+    service = _SurfaceService()
+    observer = _observer(service)
+    conversation = SimpleNamespace(id=uuid4(), metadata={"surface_platform": "SLACK"})
+
+    await observer.on_run_finished(conversation, SimpleNamespace())
+
+    assert service.messages == []
+
+
 async def test_progress_observer_strips_thinking_tags_and_resets_on_tool():
     """Inline thinking tags in intermediate narration are stripped, and the
     pre-tool narration is still discarded when a tool runs."""

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_surface_config.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_surface_config.py
@@ -16,6 +16,7 @@ EXPECTED = [
     ("microsoft_bot_openid_config_url", "MICROSOFT_BOT_OPENID_CONFIG_URL", None),
     ("microsoft_bot_app_name", "MICROSOFT_BOT_APP_NAME", None),
     ("slack_signing_secret", "SLACK_SIGNING_SECRET", None),
+    ("slack_app_id", "SLACK_APP_ID", None),
     ("slack_app_token", "SLACK_APP_TOKEN", None),
     ("slack_home_logo_url", "SLACK_HOME_LOGO_URL", None),
     ("whatsapp_access_token", "WHATSAPP_ACCESS_TOKEN", None),


### PR DESCRIPTION
#303 made Slack a first-class surface. It also broke three other platforms and Slack itself, in four ways that share one shape — and the twelve tests that caught it were dismissed as noise because the shard was already red with eleven older Teams failures.

All four were found by running the failures rather than reasoning about them, and three were confirmed against a live Slack workspace.

## The bugs

**Telegram and WhatsApp inbound were dead.** `SurfaceConfigurationMixin.try_handle_channel_setup` calls `adapter.parse_channel_setup` on every inbound webhook, and only Slack defined it. Every Telegram and WhatsApp message raised `AttributeError` in the worker, retried, and dead-lettered. It was never one method: that mixin calls six that only Slack had — `channel_name`, `open_channel_setup_modal`, `open_dm_agent_modal`, `publish_home_view`, `send_starter_prompt` were the same landmine, spared only because `parse_channel_setup` returns before reaching them.

**Telegram and Teams live progress was dead.** `stream_progress` gained a `metadata` parameter on the base and on Slack; the other two overrides kept the old signature, so the shared caller raised `TypeError` into a best-effort `except Exception` that logs at debug.

**Slack silently dropped answers.** Seen live: the model wrote an unclosed `<think>` and stopped without writing an answer. Stripping reasoning is correct and the unclosed branch correctly took the whole message — leaving the surface holding `""`, which it delivered as nothing while deleting the placeholder it had opened. The person cannot tell that from being ignored, and asks again into the same silence. "Sanitized away" and "never had anything" are now distinguished; only the first says something.

**Slack could lock out a workspace.** `api_app_id` was a hard gate with no fallback, contrary to #303's own commit message ("falling back to the deployment's only when none runs its own app"). But the signature is the authentication — the app id only says which secret to try first, which matters when an org runs its own Slack app beside ours. An unnamed request now tries every secret bound to the workspace, and an account on our own app that never stored an id falls back to the new `SLACK_APP_ID`. A custom app's id stays `None` rather than being guessed: inferring it would have that surface answer for events addressed to a different app.

## Why nothing caught them

Nothing checked adapters against the interface shared code calls. `test_adapter_contract` now asserts that a method one adapter exposes publicly is declared on the base, and that an override accepts every keyword argument the base declares — the missing-method and missing-parameter variants of the same defect. Both checks were verified to fail against the real pre-fix code.

`REAL_REPLY_TIMEOUT` was 180s under a 120s pytest-timeout, so any delivery failure died as `Timeout (>120.0s)` in `selectors.py`, naming no assertion. Three tests read as hangs for a day on the strength of it. Now 60s.

## The test failures were real, and were not bugs

#303 moved where a Slack reply lives three times, all deliberate and all better: the final answer from `chat.postMessage` to the chunks that close a live stream, the body from `text` into the markdown block, and `text` down to a truncated notification preview. Every assertion naming a transport read this as "nothing was delivered" for replies users could see fine.

So the assertions now ask what reached the user. `slack_delivered` merges posted text, blocks and stream chunks into one entry per reply; `wait_for_slack_text` waits for content by any of them, fixing a real race where a wait on posted messages returned the instant the prompt landed. The store gained an arrival log because "the widget came before the answer" now spans two Slack APIs.

## Verification

Surfaces e2e shard, run as CI does (`-n 2 --dist loadscope`, `timeout=120`):

| | before | after |
|---|---|---|
| failures | 23 | 11 |
| wall clock | 634s | 166s |

The 11 remaining are an exact name-for-name match with the Teams baseline that predates #303 — no more, no fewer. 668 backend unit tests pass; lint clean.

## Reviewer notes

- **Teams is deliberately untouched.** Those 11 failures are older than #303 and are the next PR. They reproduce locally, so it is ordinary debugging.
- **`SLACK_APP_ID` is new and unset.** It is only the fallback for an account with no stored app id; deployments whose accounts carry one are unaffected.
- **One broad catch is left in place.** `send_progress_update_for_conversation` still catches `Exception` and logs at debug, which is what hid bug two. #303 narrowed its other new catches to `SQLAlchemyError` and missed this one; its sibling two methods down is narrowed. Changing failure behaviour on a path this PR already fixes deserves its own change.
- **Backend E2E is not a required check**, which is how this merged red in the first place. Worth turning on once Teams is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)