### PR TITLE
Serve apps again, let GitHub connect like an app, and drop the flag that faked org-supplied Composio

### DIFF
--- a/lemma-backend/app/modules/apps/api/schemas/app_schemas.py
+++ b/lemma-backend/app/modules/apps/api/schemas/app_schemas.py
@@ -47,7 +47,7 @@ class AppResponse(BaseModel):
     source_archive_path: Optional[str] = None
     current_release_id: Optional[UUID] = None
     status: AppStatus
-    visibility: str = "POD"
+    visibility: str = "PUBLIC"
     created_at: Any
     updated_at: Any
 

--- a/lemma-backend/app/modules/apps/domain/entities.py
+++ b/lemma-backend/app/modules/apps/domain/entities.py
@@ -38,7 +38,8 @@ class AppEntity(BaseModel):
     source_archive_path: str | None = None
     current_release_id: UUID | None = None
     status: AppStatus = AppStatus.DRAFT
-    visibility: str = "POD"
+    # PUBLIC, not POD -- see the note on ``AppModel.visibility``.
+    visibility: str = "PUBLIC"
     allowed_actions: list[str] = Field(default_factory=list)
     created_at: datetime | None = None
     updated_at: datetime | None = None

--- a/lemma-backend/app/modules/apps/infrastructure/models.py
+++ b/lemma-backend/app/modules/apps/infrastructure/models.py
@@ -29,7 +29,12 @@ class AppModel(UUIDAuditBase):
     source_archive_path: Mapped[str | None] = mapped_column(String, nullable=True)
     current_release_id: Mapped[UUID | None] = mapped_column(nullable=True)
     status: Mapped[AppStatus] = mapped_column(String, nullable=False, default=AppStatus.DRAFT)
-    visibility: Mapped[str] = mapped_column(String(30), default="POD", nullable=False)
+    # Apps default to PUBLIC, unlike every other resource. An app is a shell --
+    # HTML and JS -- whose data calls are authorized on their own; the SDK's
+    # AppGate turns a denial into a sign-in or request-access screen. Defaulting
+    # to POD made that shell unreachable on its own public host, so a deployed
+    # app 404'd until someone found the share dialog.
+    visibility: Mapped[str] = mapped_column(String(30), default="PUBLIC", nullable=False)
 
     def to_entity(self) -> AppEntity:
         return AppEntity.model_validate(self)

--- a/lemma-backend/app/modules/apps/tests/unit/test_app_service.py
+++ b/lemma-backend/app/modules/apps/tests/unit/test_app_service.py
@@ -55,10 +55,12 @@ async def _get_public_app_asset(service, public_slug, *, asset_path=None):
 @pytest.mark.asyncio
 @pytest.mark.parametrize("visibility", ["POD", "PERSONAL", "RESTRICTED", "", "NONSENSE"])
 async def test_public_slug_route_serves_only_apps_published_to_everyone(visibility):
-    """`/public/apps` has no session, and apps default to POD.
+    """`/public/apps` has no session, so only a PUBLIC app belongs on it.
 
-    Serving on slug alone meant every uploaded app was readable by anyone who
-    guessed the slug, which is kebab-cased from the app name.
+    Apps are created PUBLIC now, so reaching this refusal takes a deliberate
+    narrowing in the share dialog -- and that narrowing has to hold, or the
+    dialog's "pod only" is decoration. An empty or unrecognized stored value is
+    not PUBLIC either: it is refused rather than read as the default.
     """
     repo = AsyncMock()
     storage = AsyncMock()
@@ -78,6 +80,50 @@ async def test_public_slug_route_serves_only_apps_published_to_everyone(visibili
 
     # Nothing was read from storage before the refusal.
     storage.read_file.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_created_app_is_public_and_reaches_the_public_slug_route():
+    """The default has to be the one the public route accepts.
+
+    These two live in different modules, and when they disagreed every app
+    404'd on the host it was deployed to. Asserting the default string is not
+    enough -- this walks a created app back through the serving gate, so the
+    pair cannot drift apart again.
+    """
+    repo = AsyncMock()
+    storage = AsyncMock()
+    service = AppService(repo, Mock(return_value=storage), AsyncMock())
+
+    pod_id, user_id = uuid4(), uuid4()
+    repo.get_by_name.return_value = None
+    repo.get_by_public_slug.return_value = None
+    repo.create.side_effect = lambda entity: entity
+
+    created = await service.create_app_with_context(
+        AppEntity(
+            pod_id=pod_id, user_id=user_id, name="Task Flow", public_slug="taskflow"
+        ),
+        user_id,
+        ctx=allow_all_context(user_id=user_id, pod_id=pod_id),
+    )
+
+    assert created.visibility == "PUBLIC"
+
+    created.id = uuid4()
+    created.current_release_id = uuid4()
+    repo.get_by_public_slug.return_value = created
+    repo.get_release.return_value = AppReleaseEntity(
+        id=created.current_release_id,
+        app_id=created.id,
+        version="v1",
+        dist_root_path="releases/v1/dist/",
+    )
+    storage.read_file.return_value = b"<html><body>flow</body></html>"
+
+    asset = await _get_public_app_asset(service, "taskflow")
+
+    assert asset.is_entrypoint is True
 
 
 async def _delete_app(service, pod_id, name, user_id, ctx=None):

--- a/lemma-backend/app/modules/connectors/api/schemas/__init__.py
+++ b/lemma-backend/app/modules/connectors/api/schemas/__init__.py
@@ -61,7 +61,6 @@ class ConnectorKindResponseSchema(BaseModel):
     package_name: Optional[str] = None
     # `composio` only.
     toolkit_slug: Optional[str] = None
-    supports_org_custom_auth_config: bool = False
 
 
 # Connector Schemas

--- a/lemma-backend/app/modules/connectors/domain/auth_config.py
+++ b/lemma-backend/app/modules/connectors/domain/auth_config.py
@@ -26,6 +26,21 @@ class AuthConfigSource(str, enum.Enum):
     ORG_CUSTOM = "ORG_CUSTOM"
 
 
+# Composio brokers every one of its toolkits through Lemma's own Composio
+# account -- one process-global ``COMPOSIO_API_KEY`` (connectors/config.py).
+# There is no per-org Composio key, so a Composio install is always
+# SYSTEM_DEFAULT.
+#
+# Two layers enforce this, and they are not redundant: the service check runs
+# on create, the kind installer also runs on the update path. They share these
+# constants so the two can't drift into saying different things.
+COMPOSIO_SYSTEM_CREDENTIALS_ONLY = (
+    "Composio installs use Lemma's Composio credentials; org-supplied "
+    "credentials are not supported."
+)
+COMPOSIO_ORG_CUSTOM_REASON = "org_custom_not_supported_for_composio"
+
+
 class AuthConfigEntity(Entity):
     """One organization's install of a connector.
 

--- a/lemma-backend/app/modules/connectors/domain/connector.py
+++ b/lemma-backend/app/modules/connectors/domain/connector.py
@@ -179,11 +179,29 @@ class PackageKindSpec(KindSpecBase):
 
 
 class ComposioKindSpec(KindSpecBase):
+    """A toolkit Composio brokers on Lemma's behalf.
+
+    Always system-credentialed: every Composio toolkit runs on Lemma's own
+    Composio account, so ``system_default_available`` is always True and an
+    install is always SYSTEM_DEFAULT (see
+    ``COMPOSIO_SYSTEM_CREDENTIALS_ONLY``). A ``supports_org_custom_auth_config``
+    flag used to sit here promising the opposite; it was hardcoded False by the
+    only thing that produced it, force-set False again on read, and rejected
+    two layers earlier than the one branch that consulted it -- so it never
+    carried information. ``supports_org_custom_oauth`` on the base class is the
+    real "org may bring its own client" flag, and it belongs to the kinds that
+    can honour it.
+
+    ``auth_config_schema`` is NOT an org install form here: for a non-OAuth
+    toolkit the catalog fills it with the *end user's* credential fields
+    (derived from Composio's ``connected_account_initiation``), which is what
+    the connect dialog renders.
+    """
+
     kind: Literal[ConnectorKind.COMPOSIO] = ConnectorKind.COMPOSIO
     auth_scheme: AuthScheme = AuthScheme.OAUTH2
     toolkit_slug: str
     system_default_available: bool = True
-    supports_org_custom_auth_config: bool = False
 
 
 class HttpKindSpec(KindSpecBase):
@@ -231,10 +249,6 @@ class ConnectorEntity(BaseModel):
     composio_toolkit_slug: str | None = Field(
         None,
         description="Runtime-only Composio toolkit slug selected by auth config.",
-    )
-    composio_auth_config_id: str | None = Field(
-        None,
-        description="Runtime-only Composio auth config id selected by auth config.",
     )
     is_active: bool = Field(default=True, description="Whether the connector is active")
     created_at: datetime.datetime | None = Field(None, description="Created at")

--- a/lemma-backend/app/modules/connectors/domain/kinds.py
+++ b/lemma-backend/app/modules/connectors/domain/kinds.py
@@ -37,7 +37,6 @@ class ResolvedInstall:
     config: dict[str, Any]
     config_source: AuthConfigSource
     spec: KindSpec
-    composio_auth_config_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/lemma-backend/app/modules/connectors/infrastructure/kinds/brokered_kinds.py
+++ b/lemma-backend/app/modules/connectors/infrastructure/kinds/brokered_kinds.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from app.modules.connectors.domain.auth_config import AuthConfigSource
+from app.modules.connectors.domain.auth_config import (
+    COMPOSIO_ORG_CUSTOM_REASON,
+    COMPOSIO_SYSTEM_CREDENTIALS_ONLY,
+    AuthConfigSource,
+)
 from app.modules.connectors.domain.connector import KindSpec, kind_to_provider
 from app.modules.connectors.domain.errors import ConnectorValidationError
 from app.modules.connectors.domain.kinds import ExecutionRequest
@@ -26,10 +30,13 @@ class ComposioInstaller:
         config: dict[str, Any],
         config_source: AuthConfigSource,
     ) -> dict[str, Any]:
+        # Also reached on the update path, which the service-layer check in
+        # `_validate_auth_config_request` never sees -- so this is a second
+        # guard, not a duplicate one. Both raise the same shared message.
         if config_source == AuthConfigSource.ORG_CUSTOM:
             raise ConnectorValidationError(
-                "Composio installs use Composio-managed credentials.",
-                details={"reason": "org_custom_not_supported_for_composio"},
+                COMPOSIO_SYSTEM_CREDENTIALS_ONLY,
+                details={"reason": COMPOSIO_ORG_CUSTOM_REASON},
             )
         return validate_install_config(spec, config, config_source)
 

--- a/lemma-backend/app/modules/connectors/infrastructure/repositories/connector_repository.py
+++ b/lemma-backend/app/modules/connectors/infrastructure/repositories/connector_repository.py
@@ -31,7 +31,6 @@ class ConnectorRepository(
             exclude={
                 "oauth2_config",
                 "composio_toolkit_slug",
-                "composio_auth_config_id",
                 "created_at",
                 "updated_at",
             },

--- a/lemma-backend/app/modules/connectors/services/auth/composio_auth_provider.py
+++ b/lemma-backend/app/modules/connectors/services/auth/composio_auth_provider.py
@@ -187,16 +187,20 @@ class ComposioAuthProvider(AuthProviderInterface):
         *,
         custom_auth_scheme: str | None = None,
     ) -> str:
-        """Reuse the connector's Composio auth config, else create one.
+        """Create the Composio auth config this connect will run under.
 
         OAuth apps use Composio-managed credentials (``use_composio_managed_auth``).
         Credential-managed apps (API key / no-auth) have no managed credentials, so
         they need ``use_custom_auth`` with the explicit scheme; the per-account key
-        is supplied at ``initiate`` time.
+        is supplied at ``initiate`` time. Note ``use_custom_auth`` is about the
+        *toolkit's* auth scheme, not about who owns the Composio account -- that is
+        always Lemma.
+
+        A ``connector.composio_auth_config_id`` reuse hook used to short-circuit
+        this. It could never fire: the id had to arrive in an install's config,
+        and a Composio install is always SYSTEM_DEFAULT, whose config is then
+        validated against a closed empty schema that rejects the key.
         """
-        auth_config_id = connector.composio_auth_config_id
-        if auth_config_id:
-            return auth_config_id
         if custom_auth_scheme is not None:
             options: dict[str, Any] = {
                 "type": "use_custom_auth",

--- a/lemma-backend/app/modules/connectors/services/connector_service.py
+++ b/lemma-backend/app/modules/connectors/services/connector_service.py
@@ -14,6 +14,8 @@ from app.modules.connectors.domain.account import (
     OAuthCredentials,
 )
 from app.modules.connectors.domain.auth_config import (
+    COMPOSIO_ORG_CUSTOM_REASON,
+    COMPOSIO_SYSTEM_CREDENTIALS_ONLY,
     AuthConfigEntity,
     AuthConfigSource,
 )
@@ -340,10 +342,6 @@ class ConnectorService:
         if provider == AuthProvider.COMPOSIO.value:
             capability = self._composio_capability(connector)
             updates["composio_toolkit_slug"] = capability.toolkit_slug
-            if provider_config.get("composio_auth_config_id"):
-                updates["composio_auth_config_id"] = provider_config[
-                    "composio_auth_config_id"
-                ]
 
         return connector.model_copy(update=updates)
 
@@ -428,24 +426,18 @@ class ConnectorService:
                 )
                 continue
             if isinstance(capability, ComposioProviderCapability):
+                # Composio runs on Lemma's own Composio account, so the system
+                # default is always there.
+                #
+                # `auth_config_schema` is deliberately left as the catalog
+                # stored it. For a non-OAuth toolkit it is the *account's*
+                # credential form, not an org install config, so replacing it
+                # with `default_auth_config_schema` (client_id/client_secret)
+                # or blanking it to None would empty the connect dialog for
+                # every API-key toolkit -- freshdesk, metabase, posthog and the
+                # rest -- with no error to show for it.
                 capabilities.append(
-                    capability.model_copy(
-                        update={
-                            "system_default_available": True,
-                            "supports_org_custom_auth_config": False,
-                            "auth_config_schema": (
-                                capability.auth_config_schema
-                                if capability.auth_config_schema is not None
-                                else (
-                                    default_auth_config_schema(
-                                        capability.auth_scheme, connector.id
-                                    )
-                                    if capability.supports_org_custom_auth_config
-                                    else None
-                                )
-                            ),
-                        }
-                    )
+                    capability.model_copy(update={"system_default_available": True})
                 )
                 continue
             capabilities.append(capability)
@@ -468,7 +460,8 @@ class ConnectorService:
         if kind is ConnectorKind.COMPOSIO:
             if config_source != AuthConfigSource.SYSTEM_DEFAULT:
                 raise ConnectorValidationError(
-                    "Composio auth configs only support system default credentials in v1."
+                    COMPOSIO_SYSTEM_CREDENTIALS_ONLY,
+                    details={"reason": COMPOSIO_ORG_CUSTOM_REASON},
                 )
             return
 

--- a/lemma-backend/app/modules/connectors/tests/unit/test_composio_auth_provider.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_composio_auth_provider.py
@@ -208,11 +208,12 @@ async def test_connect_with_credentials_initiates_api_key_connection():
                 auth_scheme=AuthScheme.API_KEY,
             )
         ],
-        composio_auth_config_id="ac_existing",
     )
 
     initiate = MagicMock(return_value=SimpleNamespace(id="ca_new_connection"))
-    auth_configs = SimpleNamespace(create=MagicMock())
+    auth_configs = SimpleNamespace(
+        create=MagicMock(return_value=SimpleNamespace(id="ac_created"))
+    )
     composio = SimpleNamespace(
         connected_accounts=SimpleNamespace(initiate=initiate),
         auth_configs=auth_configs,
@@ -231,12 +232,22 @@ async def test_connect_with_credentials_initiates_api_key_connection():
 
     assert isinstance(credentials, ComposioCredentials)
     assert credentials.connection_id == "ca_new_connection"
-    # Reused the existing auth config (no create call) and passed an API_KEY config
-    # with no callback_url (non-OAuth flow).
-    auth_configs.create.assert_not_called()
+    # An API-key toolkit has no Composio-managed credentials, so its auth config
+    # is created with `use_custom_auth` and the toolkit's own scheme. This is
+    # about the TOOLKIT's auth, not about who owns the Composio account -- that
+    # is always Lemma. The end user's key rides on `initiate`, below.
+    auth_configs.create.assert_called_once()
+    _, create_kwargs = auth_configs.create.call_args
+    assert create_kwargs["toolkit"] == "airtable"
+    assert create_kwargs["options"] == {
+        "type": "use_custom_auth",
+        "auth_scheme": "API_KEY",
+    }
+
+    # ...and passed an API_KEY config with no callback_url (non-OAuth flow).
     initiate.assert_called_once()
     _, kwargs = initiate.call_args
-    assert kwargs["auth_config_id"] == "ac_existing"
+    assert kwargs["auth_config_id"] == "ac_created"
     assert kwargs["user_id"] == str(user_id)
     assert "callback_url" not in kwargs
     assert kwargs["config"]["auth_scheme"] == "API_KEY"

--- a/lemma-backend/app/modules/connectors/tests/unit/test_connector_service.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_connector_service.py
@@ -24,7 +24,11 @@ from app.modules.connectors.domain.connector import (
 from app.modules.connectors.domain.connector_operation import (
     ConnectorOperationEntity,
 )
-from app.modules.connectors.domain.auth_config import AuthConfigEntity, AuthConfigSource
+from app.modules.connectors.domain.auth_config import (
+    COMPOSIO_ORG_CUSTOM_REASON,
+    AuthConfigEntity,
+    AuthConfigSource,
+)
 from app.modules.connectors.domain.connect_request import ConnectRequestEntity
 from app.modules.connectors.domain.connect_request import ConnectRequestStatus
 from app.modules.connectors.domain.errors import (
@@ -298,6 +302,92 @@ async def test_create_composio_auth_config_allows_system_default_without_env_key
     assert result.config_source == AuthConfigSource.SYSTEM_DEFAULT
     auth_config_repo.create.assert_awaited_once()
     uow.commit.assert_awaited_once()
+
+
+async def test_create_composio_auth_config_refuses_org_custom_credentials():
+    """Composio runs on Lemma's Composio account; an org cannot bring its own.
+
+    This rejection has guarded the create path since the beginning and nothing
+    asserted it -- while a `supports_org_custom_auth_config` flag sat on the
+    Composio spec implying the opposite. The flag is gone; this is the fact it
+    was pretending to express.
+    """
+    app = ConnectorEntity(
+        id="dropbox",
+        provider_capabilities=[ComposioProviderCapability(toolkit_slug="dropbox")],
+    )
+    auth_config_repo = AsyncMock(
+        get_active_by_org_and_app=AsyncMock(return_value=None),
+    )
+    uow = AsyncMock()
+    service = _service(
+        uow=uow,
+        connector_repository=AsyncMock(get=AsyncMock(return_value=app)),
+        auth_config_repository=auth_config_repo,
+    )
+
+    with pytest.raises(ConnectorValidationError) as excinfo:
+        await service.create_auth_config(
+            user_id=uuid4(),
+            organization_id=ORG_ID,
+            connector_id="dropbox",
+            kind=ConnectorKind.COMPOSIO.value,
+            config_source=AuthConfigSource.ORG_CUSTOM.value,
+            config={"client_id": "x", "client_secret": "y"},
+        )
+
+    assert excinfo.value.details["reason"] == COMPOSIO_ORG_CUSTOM_REASON
+    # Refused before anything was written, not rolled back after.
+    auth_config_repo.create.assert_not_awaited()
+    uow.commit.assert_not_awaited()
+
+
+async def test_composio_api_key_toolkit_keeps_its_credential_form():
+    """The enrichment must not touch a Composio spec's `auth_config_schema`.
+
+    For a non-OAuth toolkit that field is the *end user's* credential form, not
+    an org install config. Blanking it to None -- or replacing it with the
+    client_id/client_secret default -- empties the connect dialog for every
+    API-key toolkit (freshdesk, metabase, posthog...) with nothing to show for
+    it, which is exactly the shape of bug a "simplify this branch" edit makes.
+    """
+    credential_form = {
+        "type": "object",
+        "required": ["generic_api_key"],
+        "properties": {"generic_api_key": {"type": "string"}},
+        "additionalProperties": False,
+    }
+    app = ConnectorEntity(
+        id="freshdesk",
+        provider_capabilities=[
+            ComposioProviderCapability(
+                toolkit_slug="freshdesk",
+                auth_scheme=AuthScheme.API_KEY,
+                auth_config_schema=credential_form,
+            )
+        ],
+    )
+    service = _service(connector_repository=AsyncMock(get=AsyncMock(return_value=app)))
+
+    enriched = await service.get_connector("freshdesk")
+    spec = enriched.capability_for(AuthProvider.COMPOSIO)
+
+    assert spec.auth_config_schema == credential_form
+    # Always on: Lemma's Composio key is the only one there is.
+    assert spec.system_default_available is True
+
+    # An OAuth2 toolkit legitimately carries none, and must not acquire one.
+    oauth_app = ConnectorEntity(
+        id="hubspot",
+        provider_capabilities=[ComposioProviderCapability(toolkit_slug="hubspot")],
+    )
+    oauth_service = _service(
+        connector_repository=AsyncMock(get=AsyncMock(return_value=oauth_app))
+    )
+    oauth_spec = (await oauth_service.get_connector("hubspot")).capability_for(
+        AuthProvider.COMPOSIO
+    )
+    assert oauth_spec.auth_config_schema is None
 
 
 async def test_initiate_connect_request_allows_reauth_for_unusable_account():

--- a/lemma-backend/app/modules/connectors/tests/unit/test_import_connector_catalog.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_import_connector_catalog.py
@@ -577,8 +577,10 @@ async def test_sync_composio_catalog_keeps_composio_operations_for_non_native_ap
     assert _providers(entity) == [AuthProvider.COMPOSIO]
     capability = _capability(entity, AuthProvider.COMPOSIO)
     assert capability.toolkit_slug == "hubspot"
+    # Always true: every Composio toolkit runs on Lemma's own Composio account.
     assert capability.system_default_available is True
-    assert capability.supports_org_custom_auth_config is False
+    # None only because HubSpot is OAuth2 here. A non-OAuth toolkit carries the
+    # end user's credential form in this field -- see the API_KEY case below.
     assert capability.auth_config_schema is None
 
     upsert_operation.assert_awaited_once()

--- a/lemma-backend/app/modules/connectors/tests/unit/test_kind_registry.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_kind_registry.py
@@ -14,8 +14,12 @@ from uuid import uuid4
 
 import pytest
 
-from app.modules.connectors.domain.auth_config import AuthConfigSource
+from app.modules.connectors.domain.auth_config import (
+    COMPOSIO_ORG_CUSTOM_REASON,
+    AuthConfigSource,
+)
 from app.modules.connectors.domain.connector import (
+    ComposioKindSpec,
     ConnectorKind,
     McpKindSpec,
     PackageKindSpec,
@@ -68,6 +72,33 @@ def _install(kind: ConnectorKind, config: dict | None = None) -> ResolvedInstall
         config=config or {},
         config_source=AuthConfigSource.SYSTEM_DEFAULT,
         spec=specs.get(kind, PackageKindSpec()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_composio_installer_refuses_org_supplied_credentials():
+    """The second guard on "Composio uses Lemma's Composio account".
+
+    Not a duplicate of the service-layer check: this one also runs on the
+    *update* path, which never reaches `_validate_auth_config_request`. It had
+    no coverage at all, while a `supports_org_custom_auth_config` flag on the
+    Composio spec advertised the opposite of what it enforces.
+    """
+    installer = _registry().get(ConnectorKind.COMPOSIO).installer
+    spec = ComposioKindSpec(toolkit_slug="gmail")
+
+    with pytest.raises(ConnectorValidationError) as excinfo:
+        await installer.validate_install(
+            spec=spec, config={}, config_source=AuthConfigSource.ORG_CUSTOM
+        )
+    assert excinfo.value.details["reason"] == COMPOSIO_ORG_CUSTOM_REASON
+
+    # The system default is the only way in, and it still works.
+    assert (
+        await installer.validate_install(
+            spec=spec, config={}, config_source=AuthConfigSource.SYSTEM_DEFAULT
+        )
+        == {}
     )
 
 

--- a/lemma-backend/app/modules/pod_bundle/infrastructure/app_builder.py
+++ b/lemma-backend/app/modules/pod_bundle/infrastructure/app_builder.py
@@ -319,7 +319,11 @@ class AppStepRunner:
                             name=name,
                             public_slug=slug,
                             description=manifest.get("description"),
-                            visibility=manifest.get("visibility") or "POD",
+                            # A manifest that says nothing takes the app default
+                            # (PUBLIC), not the platform-wide POD: an imported
+                            # bundle should serve on its host like a hand-created
+                            # app does.
+                            visibility=manifest.get("visibility") or "PUBLIC",
                         ),
                         user_id,
                         ctx=ctx,

--- a/lemma-backend/migrations/versions/2026-08-10_apps_public_by_default_0015.py
+++ b/lemma-backend/migrations/versions/2026-08-10_apps_public_by_default_0015.py
@@ -1,0 +1,54 @@
+"""Make a deployed app reachable again: apps are PUBLIC by default.
+
+An app is served to anonymous browsers at ``<public_slug>.<app_base_domain>``,
+and the ``/public/apps`` route behind that host now refuses anything whose
+visibility is not PUBLIC. Apps defaulted to POD, so every app ever created --
+through the API, the widget promotion flow, or a pod bundle import -- was
+stored POD and 404'd on its own URL. The shell being anonymous is the design:
+it is HTML and JS, its data calls are authorized on their own, and the SDK's
+AppGate turns a denial into a sign-in or request-access screen.
+
+The default now lives at PUBLIC (``AppModel.visibility``), which fixes apps
+created from here on. This backfill fixes the ones already stored.
+
+Only ``POD`` rows are moved. POD was the silent default nobody chose: the API
+applied it when a request omitted ``visibility``, and no UI ever offered it as
+a deliberate "pod only" answer for an app. PERSONAL and RESTRICTED are
+different -- both require someone to have opened the share dialog and picked
+them -- so they are left exactly as they are, and an owner who wants an app off
+the public internet can still choose one of them.
+
+Downgrade cannot separate a backfilled row from one an owner later set to
+PUBLIC on purpose, so it does not try; it only restores the column default's
+old meaning by leaving the data alone.
+
+Revision ID: 0015_apps_public_by_default
+Revises: 0014_workspace_sandboxes
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0015_apps_public_by_default"
+down_revision = "0014_workspace_sandboxes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            UPDATE apps
+               SET visibility = 'PUBLIC',
+                   updated_at = now()
+             WHERE upper(coalesce(visibility, '')) IN ('POD', 'ALL', '')
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # Intentionally empty -- see the module docstring.
+    pass

--- a/lemma-backend/scripts/import_connector_catalog.py
+++ b/lemma-backend/scripts/import_connector_catalog.py
@@ -672,7 +672,6 @@ def _composio_provider_capability(
         toolkit_slug=toolkit_slug,
         auth_config_schema=auth_config_schema,
         system_default_available=True,
-        supports_org_custom_auth_config=False,
         profile_operation_names=profile_operation_names,
     )
 

--- a/lemma-frontend/app/pod/[id]/app/pages/page.tsx
+++ b/lemma-frontend/app/pod/[id]/app/pages/page.tsx
@@ -240,7 +240,7 @@ export default function AppPagesRoute({ params }: { params: Promise<{ id: string
 
                                 <div className="mt-3 flex items-center justify-between gap-2 text-xs text-[var(--text-tertiary)]">
                                     <div className="flex min-w-0 items-center gap-3">
-                                        <ResourceVisibilityBadge visibility={page.visibility} resourceLabel="apps" hideWhenDefault />
+                                        <ResourceVisibilityBadge visibility={page.visibility} resourceLabel="apps" resourceType="app" hideWhenDefault />
                                         {updatedLabel ? <span className="truncate">Updated {updatedLabel}</span> : null}
                                     </div>
                                     <div className="flex shrink-0 items-center gap-1">

--- a/lemma-frontend/components/connectors/connector-utils.test.ts
+++ b/lemma-frontend/components/connectors/connector-utils.test.ts
@@ -10,6 +10,7 @@ import {
     getManagedConfigCopy,
     getTenantConfiguredConnectors,
     getTenantConfiguredKindSpec,
+    hasSystemDefault,
     isTenantConfigured,
     requiresInstallConfig,
     supportsCustomConfig,
@@ -128,6 +129,43 @@ describe('an OAuth connector served over http', () => {
         const byoApi = { ...githubKind, auth_scheme: AuthScheme.API_KEY };
         expect(getKindDescription(ConnectorKind.HTTP, byoApi as KindSpec)).toContain('OpenAPI');
         expect(requiresInstallConfig(byoApi as KindSpec)).toBe(true);
+    });
+
+    it('is not something the org supplies an address for', () => {
+        // The regression this guards: `http` is a tenant-configured kind, so
+        // GitHub was routed to the databases/APIs/MCP flow — Connect opened the
+        // "add a connection" form asking for an address, and the
+        // Lemma's-app-or-your-own choice was never reachable. Every other
+        // GitHub assertion above passed the whole time, because none of them
+        // went through this classifier.
+        expect(isTenantConfigured(githubKind as KindSpec)).toBe(false);
+
+        // Still true without a platform client: the org owes an OAuth app, not
+        // an address, so it must not fall back into the connection flow.
+        expect(
+            isTenantConfigured({ ...githubKind, system_default_available: false } as KindSpec),
+        ).toBe(false);
+
+        // A genuine bring-your-own API over http is unchanged.
+        expect(
+            isTenantConfigured({ ...githubKind, auth_scheme: AuthScheme.API_KEY } as KindSpec),
+        ).toBe(true);
+    });
+
+    it('stays in the catalog grid instead of the connections section', () => {
+        const catalog = [
+            connector('github', [githubKind]),
+            connector('sql', [sqlKind]),
+        ];
+        expect(getTenantConfiguredConnectors(catalog).map((app) => app.id)).toEqual(['sql']);
+        expect(getTenantConfiguredKindSpec(catalog[0])).toBeNull();
+    });
+
+    it('offers the Lemma-or-your-own choice', () => {
+        // What the user actually sees: "Use Lemma's" with a "Use my own"
+        // button beside it, rather than a form demanding a client id.
+        expect(hasSystemDefault(githubKind as KindSpec)).toBe(true);
+        expect(supportsCustomConfig(githubKind as KindSpec)).toBe(true);
     });
 });
 

--- a/lemma-frontend/components/connectors/connector-utils.test.ts
+++ b/lemma-frontend/components/connectors/connector-utils.test.ts
@@ -5,6 +5,7 @@ import type { Connector } from '@/lib/types';
 import {
     canConnectWithDefaults,
     describeInstallTarget,
+    getCredentialSchema,
     getKindDescription,
     getKindLabel,
     getManagedConfigCopy,
@@ -166,6 +167,61 @@ describe('an OAuth connector served over http', () => {
         // button beside it, rather than a form demanding a client id.
         expect(hasSystemDefault(githubKind as KindSpec)).toBe(true);
         expect(supportsCustomConfig(githubKind as KindSpec)).toBe(true);
+    });
+});
+
+/**
+ * A Composio toolkit that authenticates with the third party's own API key
+ * (freshdesk, metabase, posthog...). Its `config_schema` is the *end user's*
+ * credential form, derived by the catalog importer from Composio's
+ * `connected_account_initiation` fields — not an org install config.
+ */
+const composioApiKeyKind = {
+    kind: ConnectorKind.COMPOSIO,
+    auth_scheme: AuthScheme.API_KEY,
+    system_default_available: true,
+    supports_org_custom_oauth: false,
+    config_schema: {
+        type: 'object',
+        required: ['generic_api_key'],
+        properties: { generic_api_key: { type: 'string' } },
+    },
+} satisfies Partial<KindSpec> as Partial<KindSpec>;
+
+const composioOAuthKind = {
+    kind: ConnectorKind.COMPOSIO,
+    auth_scheme: AuthScheme.OAUTH2,
+    system_default_available: true,
+    supports_org_custom_oauth: false,
+} satisfies Partial<KindSpec> as Partial<KindSpec>;
+
+describe('a Composio toolkit', () => {
+    it('goes straight to the credential form instead of Advanced setup', () => {
+        // The regression this guards: the API-key form's required fields read
+        // as an org install config, so Connect opened Advanced setup instead of
+        // asking for the key.
+        expect(requiresInstallConfig(composioApiKeyKind as KindSpec)).toBe(false);
+        expect(canConnectWithDefaults(composioApiKeyKind as KindSpec)).toBe(true);
+    });
+
+    it('never offers "Use my own" — the backend rejects org credentials', () => {
+        // Composio runs on Lemma's Composio account. Offering the choice
+        // produced a button whose only outcome was a 400.
+        expect(supportsCustomConfig(composioApiKeyKind as KindSpec)).toBe(false);
+        expect(supportsCustomConfig(composioOAuthKind as KindSpec)).toBe(false);
+    });
+
+    it('still renders the account credential form', () => {
+        // The fix must not reach the API-key connect dialog, which sources its
+        // fields here rather than through the two predicates above.
+        expect(getCredentialSchema(composioApiKeyKind as KindSpec)).toEqual(
+            composioApiKeyKind.config_schema,
+        );
+    });
+
+    it('leaves the OAuth toolkit connecting in one click, as before', () => {
+        expect(requiresInstallConfig(composioOAuthKind as KindSpec)).toBe(false);
+        expect(canConnectWithDefaults(composioOAuthKind as KindSpec)).toBe(true);
     });
 });
 

--- a/lemma-frontend/components/connectors/connector-utils.ts
+++ b/lemma-frontend/components/connectors/connector-utils.ts
@@ -104,8 +104,33 @@ export const schemaHasFields = (schema: JsonSchemaLike | null): boolean =>
 export const hasSystemDefault = (capability: ConnectorKindSpec | null): boolean =>
     Boolean(capability?.system_default_available);
 
-export const isTenantConfigured = (capability: ConnectorKindSpec | null): boolean =>
-    Boolean(capability && TENANT_CONFIGURED_KINDS.has(String(capability.kind)));
+/**
+ * A kind alone stopped being enough to describe an install once a first-party
+ * OAuth connector shipped over the http kind. GitHub is `http`, but nobody
+ * points Lemma at a GitHub spec — they sign in.
+ */
+export const isOAuthOverHttp = (
+    kind: string,
+    capability: ConnectorKindSpec | null,
+): boolean => kind === KIND.HTTP && capability?.auth_scheme === 'OAUTH2';
+
+/**
+ * True when *the org supplies the address* for this install.
+ *
+ * The kind alone is not the answer. `http` covers both "point Lemma at an
+ * OpenAPI spec" and a first-party OAuth connector that merely happens to speak
+ * HTTP (GitHub), whose operations carry their own server_url and whose OAuth
+ * client Lemma owns. Classifying the latter as tenant-configured sent it down
+ * the databases/APIs/MCP path: Connect opened the "add a connection" form
+ * asking for an address, the catalog grid dropped it into the Connections
+ * section, and the Lemma's-app-or-your-own choice was never reachable.
+ */
+export const isTenantConfigured = (capability: ConnectorKindSpec | null): boolean => {
+    if (!capability) return false;
+    const kind = String(capability.kind);
+    if (!TENANT_CONFIGURED_KINDS.has(kind)) return false;
+    return !isOAuthOverHttp(kind, capability);
+};
 
 /**
  * True when an install of this kind cannot exist until the org fills in a config.
@@ -189,14 +214,6 @@ export const formatKindName = (kind: string): string => {
         .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
         .join(' ');
 };
-
-/**
- * A kind alone stopped being enough to describe an install once a first-party
- * OAuth connector shipped over the http kind. GitHub is `http`, but nobody
- * points Lemma at a GitHub spec — they sign in.
- */
-const isOAuthOverHttp = (kind: string, capability: ConnectorKindSpec | null): boolean =>
-    kind === KIND.HTTP && capability?.auth_scheme === 'OAUTH2';
 
 export const getKindLabel = (kind: string, capability: ConnectorKindSpec | null): string => {
     if (kind === KIND.COMPOSIO) return 'Composio (recommended)';

--- a/lemma-frontend/components/connectors/connector-utils.ts
+++ b/lemma-frontend/components/connectors/connector-utils.ts
@@ -115,6 +115,16 @@ export const isOAuthOverHttp = (
 ): boolean => kind === KIND.HTTP && capability?.auth_scheme === 'OAUTH2';
 
 /**
+ * Composio brokers this toolkit on Lemma's behalf.
+ *
+ * Always Lemma's own Composio account — there is no per-org Composio key, and
+ * the backend rejects an org-supplied install outright. Anything that offers
+ * the org a choice has to check this first.
+ */
+export const isComposio = (capability: ConnectorKindSpec | null): boolean =>
+    String(capability?.kind ?? '') === KIND.COMPOSIO;
+
+/**
  * True when *the org supplies the address* for this install.
  *
  * The kind alone is not the answer. `http` covers both "point Lemma at an
@@ -142,6 +152,13 @@ export const isTenantConfigured = (capability: ConnectorKindSpec | null): boolea
  */
 export const requiresInstallConfig = (capability: ConnectorKindSpec | null): boolean => {
     if (!capability) return false;
+    // A Composio install carries no org config at all: it runs on Lemma's
+    // Composio account. What its `config_schema` holds for an API-key toolkit
+    // is the *account's* credential form (see `getCredentialSchema`), which
+    // Connect collects after the install exists — reading it as an install
+    // config sent every such connector to Advanced setup instead of the
+    // credential dialog, and offered it a "Use my own" that always 400s.
+    if (isComposio(capability)) return false;
     // For an OAuth kind the config schema describes the org's own OAuth app —
     // opt-in, and unnecessary when the platform's client is available. This
     // mirrors the backend, which validates an OAuth system-default install
@@ -167,6 +184,11 @@ export const canConnectWithDefaults = (capability: ConnectorKindSpec | null): bo
 
 export const supportsCustomConfig = (capability: ConnectorKindSpec | null): boolean => {
     if (!capability) return false;
+    // Composio brokers every toolkit through Lemma's own Composio account, so
+    // there is no org-supplied anything to offer. Without this, an API-key
+    // toolkit reaches the branch below and renders "Use my own" — a button
+    // whose only outcome is a 400 from the backend.
+    if (isComposio(capability)) return false;
     const hasConfigFields = schemaHasFields(getConfigSchema(capability));
     if (!hasConfigFields) return false;
     // For an OAuth kind the config schema describes the org's *own OAuth app*,
@@ -174,13 +196,7 @@ export const supportsCustomConfig = (capability: ConnectorKindSpec | null): bool
     // describes the connection itself, so having fields is the whole condition
     // — gating those on an OAuth flag left sql/mcp/http with no way in at all.
     if (capability.auth_scheme !== 'OAUTH2') return true;
-    if ('supports_org_custom_oauth' in capability) {
-        return Boolean(capability.supports_org_custom_oauth);
-    }
-    if ('supports_org_custom_auth_config' in capability) {
-        return Boolean(capability.supports_org_custom_auth_config);
-    }
-    return true;
+    return Boolean(capability.supports_org_custom_oauth);
 };
 
 /** True when this connector has any Advanced (non-default kind / custom config) option worth surfacing. */

--- a/lemma-frontend/components/share/guest-resource-view.tsx
+++ b/lemma-frontend/components/share/guest-resource-view.tsx
@@ -49,7 +49,11 @@ export function GuestResourceView({
                     <span className="text-xs font-medium uppercase tracking-wide text-[var(--text-tertiary)]">
                         {getShareKindCopy(kind).noun}
                     </span>
-                    <ResourceVisibilityBadge visibility={preview.visibility} hideWhenDefault={false} />
+                    <ResourceVisibilityBadge
+                        visibility={preview.visibility}
+                        resourceType={kind === 'app' ? 'app' : undefined}
+                        hideWhenDefault={false}
+                    />
                 </div>
                 <h1 className="mt-1.5 truncate font-display text-2xl font-semibold text-[var(--text-primary)]">
                     {displayName}

--- a/lemma-frontend/components/shared/resource-visibility.tsx
+++ b/lemma-frontend/components/shared/resource-visibility.tsx
@@ -31,6 +31,7 @@ import { cn } from '@/lib/utils';
 // component's React/Query surface; re-exported below so existing importers of
 // `ResourceVisibilityValue` / `normalizeResourceVisibility` are unaffected.
 import {
+    defaultVisibilityFor,
     normalizeResourceVisibility,
     reachesOutsidePod,
     VISIBILITY_VALUES,
@@ -38,6 +39,7 @@ import {
 } from '@/lib/share/resource-visibility';
 
 export {
+    defaultVisibilityFor,
     normalizeResourceVisibility,
     reachesOutsidePod,
     VISIBILITY_VALUES,
@@ -139,6 +141,7 @@ function toResourceLabel(resourceLabel?: string) {
 export function getResourceVisibilityCopy(
     value?: string | null,
     resourceLabel?: string,
+    resourceType?: ShareableResourceType | null,
 ): ResourceVisibilityCopy {
     const visibility = normalizeResourceVisibility(value);
     const resources = toResourceLabel(resourceLabel);
@@ -166,6 +169,23 @@ export function getResourceVisibilityCopy(
     }
 
     if (visibility === 'PUBLIC') {
+        // An app is the one resource where PUBLIC really does mean the open
+        // internet: the page is served by public host to browsers with no
+        // session at all. Everywhere else authorization still runs against a
+        // signed-in principal, so PUBLIC waives pod scope rather than opening
+        // the resource up. Two different promises, so two different sentences
+        // -- this is the copy someone reads before deciding.
+        if (resourceType === 'app') {
+            return {
+                value: visibility,
+                label: 'On the web',
+                shortDescription: 'Anyone with the link',
+                description:
+                    'Anyone with the link can load this app, no sign-in needed. Its data still requires access — visitors are asked to sign in or request it.',
+                icon: Globe2,
+                className: 'state-badge-warning',
+            };
+        }
         return {
             value: visibility,
             // Not anonymous: authorization still runs against a signed-in
@@ -258,23 +278,29 @@ const VISIBILITY_TONE: Record<string, string> = {
 export function ResourceVisibilityBadge({
     visibility,
     resourceLabel,
+    resourceType,
     className,
     compact = false,
     hideWhenDefault,
 }: {
     visibility?: string | null;
     resourceLabel?: string;
+    /** Which kind of resource this is. Decides both the PUBLIC wording and which level counts as the default worth hiding — apps differ on both. */
+    resourceType?: ShareableResourceType | null;
     className?: string;
     compact?: boolean;
-    /** When the value is the default (pod workspace), render nothing. Defaults to `compact` — dense list rows hide the common case so only exceptions stand out. */
+    /** When the value is this resource's default, render nothing. Defaults to `compact` — dense list rows hide the common case so only exceptions stand out. */
     hideWhenDefault?: boolean;
 }) {
-    const copy = getResourceVisibilityCopy(visibility, resourceLabel);
+    const copy = getResourceVisibilityCopy(visibility, resourceLabel, resourceType);
     const Icon = copy.icon;
     const tone = VISIBILITY_TONE[copy.value] ?? 'text-[var(--text-tertiary)]';
     const shouldHideDefault = hideWhenDefault ?? compact;
 
-    if (shouldHideDefault && copy.value === 'POD') {
+    // Per resource, not a hardcoded POD: apps are created PUBLIC, so hiding POD
+    // there would silence the badge on exactly the app someone deliberately
+    // took off the web, while flagging every untouched one.
+    if (shouldHideDefault && copy.value === defaultVisibilityFor(resourceType)) {
         return null;
     }
 
@@ -403,8 +429,8 @@ export function ResourceShareButton({
     const selectedAccess = accessLevels.find((level) => level.value === selectedAccessLevel) || accessLevels[0];
     const accessQueryKey = ['pods', podId, 'resources', resourceType, resourceId, 'access'];
     const optionCopies = useMemo(
-        () => options.map((option) => getResourceVisibilityCopy(option, resourceLabel)),
-        [options, resourceLabel],
+        () => options.map((option) => getResourceVisibilityCopy(option, resourceLabel, resourceType)),
+        [options, resourceLabel, resourceType],
     );
     const { data: accessData, isLoading: isAccessLoading } = useQuery({
         queryKey: accessQueryKey,

--- a/lemma-frontend/lib/share/resource-visibility.test.ts
+++ b/lemma-frontend/lib/share/resource-visibility.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+    defaultVisibilityFor,
     normalizeResourceVisibility,
     reachesOutsidePod,
     VISIBILITY_VALUES,
@@ -34,6 +35,19 @@ describe('normalizeResourceVisibility', () => {
 describe('VISIBILITY_VALUES', () => {
     it('runs narrow to wide', () => {
         expect(VISIBILITY_VALUES).toEqual(['PERSONAL', 'POD', 'RESTRICTED', 'PUBLIC']);
+    });
+});
+
+describe('defaultVisibilityFor', () => {
+    it('is PUBLIC for apps and POD for everything else', () => {
+        // Mirrors the backend: apps are created PUBLIC because they are served
+        // on their own public host, every other resource starts POD. A badge
+        // that hides the wrong "default" reads as the opposite of the truth.
+        expect(defaultVisibilityFor('app')).toBe('PUBLIC');
+        expect(defaultVisibilityFor('agent')).toBe('POD');
+        expect(defaultVisibilityFor('datastore_table')).toBe('POD');
+        expect(defaultVisibilityFor(undefined)).toBe('POD');
+        expect(defaultVisibilityFor(null)).toBe('POD');
     });
 });
 

--- a/lemma-frontend/lib/share/resource-visibility.ts
+++ b/lemma-frontend/lib/share/resource-visibility.ts
@@ -54,3 +54,21 @@ export function normalizeResourceVisibility(value?: string | null): ResourceVisi
 export function reachesOutsidePod(value: ResourceVisibilityValue): boolean {
     return REACHES_OUTSIDE_POD.includes(value);
 }
+
+/**
+ * What the backend stores when nobody picks a level.
+ *
+ * Apps are the exception: an app is deployed to its own public host and the
+ * page itself is served to anonymous browsers, so the backend creates it
+ * PUBLIC (its data calls are still authorized one by one, and the SDK's
+ * AppGate turns a denial into sign-in or request-access). Everything else
+ * starts POD.
+ *
+ * Callers use this to decide whether a stored value is worth showing: a badge
+ * that flags the default is noise, and — worse, after apps flipped — a badge
+ * that stays silent on the *narrowed* case tells the reader the opposite of
+ * what is true.
+ */
+export function defaultVisibilityFor(resourceType?: string | null): ResourceVisibilityValue {
+    return resourceType === 'app' ? 'PUBLIC' : 'POD';
+}

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -13,4 +13,4 @@ SDK and the server it is talking to.
 from __future__ import annotations
 
 API_VERSION = "0.7.0"
-SPEC_SHA256 = "9c116dd6807499918f9b969add3c471e83e1df9b1e38a9ab74cb347fea1261d8"
+SPEC_SHA256 = "61a0925413fce117e7aca3c78921615c4986f858afb329ca8052f66de49308ce"

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -13,4 +13,4 @@ SDK and the server it is talking to.
 from __future__ import annotations
 
 API_VERSION = "0.7.0"
-SPEC_SHA256 = "83199b34dfaba1b70d4be657ba5038f3360d5cb07fd0d91563f7562c8b4790aa"
+SPEC_SHA256 = "9c116dd6807499918f9b969add3c471e83e1df9b1e38a9ab74cb347fea1261d8"

--- a/lemma-python/lemma_sdk/openapi_client/models/app_detail_response.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/app_detail_response.py
@@ -30,7 +30,7 @@ class AppDetailResponse:
         current_release_id (None | Unset | UUID):
         description (None | str | Unset):
         source_archive_path (None | str | Unset):
-        visibility (str | Unset):  Default: 'POD'.
+        visibility (str | Unset):  Default: 'PUBLIC'.
     """
 
     created_at: Any
@@ -46,7 +46,7 @@ class AppDetailResponse:
     current_release_id: None | Unset | UUID = UNSET
     description: None | str | Unset = UNSET
     source_archive_path: None | str | Unset = UNSET
-    visibility: str | Unset = "POD"
+    visibility: str | Unset = "PUBLIC"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/lemma-python/lemma_sdk/openapi_client/models/connector_kind_response_schema.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/connector_kind_response_schema.py
@@ -41,7 +41,6 @@ class ConnectorKindResponseSchema:
             discovery (str | Unset):  Default: 'none'.
             oauth2_defaults (None | OAuth2DefaultsResponseSchema | Unset):
             package_name (None | str | Unset):
-            supports_org_custom_auth_config (bool | Unset):  Default: False.
             supports_org_custom_oauth (bool | Unset):  Default: False.
             system_default_available (bool | Unset):  Default: False.
             toolkit_slug (None | str | Unset):
@@ -56,7 +55,6 @@ class ConnectorKindResponseSchema:
     discovery: str | Unset = "none"
     oauth2_defaults: None | OAuth2DefaultsResponseSchema | Unset = UNSET
     package_name: None | str | Unset = UNSET
-    supports_org_custom_auth_config: bool | Unset = False
     supports_org_custom_oauth: bool | Unset = False
     system_default_available: bool | Unset = False
     toolkit_slug: None | str | Unset = UNSET
@@ -115,8 +113,6 @@ class ConnectorKindResponseSchema:
         else:
             package_name = self.package_name
 
-        supports_org_custom_auth_config = self.supports_org_custom_auth_config
-
         supports_org_custom_oauth = self.supports_org_custom_oauth
 
         system_default_available = self.system_default_available
@@ -146,10 +142,6 @@ class ConnectorKindResponseSchema:
             field_dict["oauth2_defaults"] = oauth2_defaults
         if package_name is not UNSET:
             field_dict["package_name"] = package_name
-        if supports_org_custom_auth_config is not UNSET:
-            field_dict["supports_org_custom_auth_config"] = (
-                supports_org_custom_auth_config
-            )
         if supports_org_custom_oauth is not UNSET:
             field_dict["supports_org_custom_oauth"] = supports_org_custom_oauth
         if system_default_available is not UNSET:
@@ -257,10 +249,6 @@ class ConnectorKindResponseSchema:
 
         package_name = _parse_package_name(d.pop("package_name", UNSET))
 
-        supports_org_custom_auth_config = d.pop(
-            "supports_org_custom_auth_config", UNSET
-        )
-
         supports_org_custom_oauth = d.pop("supports_org_custom_oauth", UNSET)
 
         system_default_available = d.pop("system_default_available", UNSET)
@@ -282,7 +270,6 @@ class ConnectorKindResponseSchema:
             discovery=discovery,
             oauth2_defaults=oauth2_defaults,
             package_name=package_name,
-            supports_org_custom_auth_config=supports_org_custom_auth_config,
             supports_org_custom_oauth=supports_org_custom_oauth,
             system_default_available=system_default_available,
             toolkit_slug=toolkit_slug,

--- a/lemma-python/lemma_sdk/openapi_spec.json
+++ b/lemma-python/lemma_sdk/openapi_spec.json
@@ -2555,7 +2555,7 @@
             "type": "string"
           },
           "visibility": {
-            "default": "POD",
+            "default": "PUBLIC",
             "title": "Visibility",
             "type": "string"
           }

--- a/lemma-python/lemma_sdk/openapi_spec.json
+++ b/lemma-python/lemma_sdk/openapi_spec.json
@@ -3792,11 +3792,6 @@
             ],
             "title": "Package Name"
           },
-          "supports_org_custom_auth_config": {
-            "default": false,
-            "title": "Supports Org Custom Auth Config",
-            "type": "boolean"
-          },
           "supports_org_custom_oauth": {
             "default": false,
             "title": "Supports Org Custom Oauth",

--- a/lemma-typescript/src/openapi_client/models/ConnectorKindResponseSchema.ts
+++ b/lemma-typescript/src/openapi_client/models/ConnectorKindResponseSchema.ts
@@ -24,7 +24,6 @@ export type ConnectorKindResponseSchema = {
     kind: ConnectorKind;
     oauth2_defaults?: (OAuth2DefaultsResponseSchema | null);
     package_name?: (string | null);
-    supports_org_custom_auth_config?: boolean;
     supports_org_custom_oauth?: boolean;
     system_default_available?: boolean;
     toolkit_slug?: (string | null);


### PR DESCRIPTION
Three fixes. The first is the outage; the other two are the same underlying shape — a resource classified as something it isn't, sending it down the wrong flow.

---

# 1. Apps 404'd on their own URL

```json
{"message":"App with public slug 'taskflow' not found","code":"APP_NOT_FOUND"}
```

[#310](https://github.com/lemma-work/lemma-platform/pull/310) added a visibility gate to the public app-serving route — only a `PUBLIC` app may be served to the anonymous browsers that reach `<public_slug>.<app_base_domain>`. But apps were created with the platform-wide default of `POD`, so the gate refused **every app ever created**. You couldn't open one without first finding the share dialog and flipping it by hand.

**The gate is right; the default was wrong.** An app is a shell — HTML and JS. Its data calls are authorized one by one, and the SDK's `AppGate`/`AuthGuard` turn a denial into a sign-in or "Request access" screen. The shell being anonymous is the design.

So the default moves to `PUBLIC` (model, entity, response schema, pod-bundle importer). An explicit narrowing still 404s. Migration `0015` backfills **only `POD`/`ALL`/empty** — the silent default nobody chose; `PERSONAL` and `RESTRICTED` each require a deliberate pick and are left alone. Downgrade is a no-op: it can't tell a backfilled row from a deliberate `PUBLIC`.

Two pieces of frontend copy read backwards after the flip: the badge hid `POD` as "the default" (which would have gone **silent on exactly the app someone took off the web**), and the `PUBLIC` wording claimed "Anyone signed in" — true everywhere except apps, which really are served with no session. Both fixed.

**How it shipped:** `test_app_assets_support_private_and_public_asset_routes` has asserted anonymous serving since the initial release and has been red since #310, because `.github/workflows/e2e.yml` is **not a required check**. Worth adding those shards to branch protection — not in this PR.

**Consequence worth knowing:** `PUBLIC` also grants `app.read` to any signed-in account operating in that pod's context (this is what makes request-access work for non-members), and bundle contents are internet-readable. This is the pre-#310 behavior.

---

# 2. GitHub connected like a database

`isTenantConfigured` answered on the **kind alone**, and `http` is one of the three kinds whose address the org supplies. GitHub — the first first-party OAuth connector served over `http` — was therefore classified as "a thing you point Lemma at": Connect opened the *add a connection* dialog asking for an address, and the catalog grid moved GitHub into the Connections section beside the databases.

The "Use Lemma's / Use my own" choice lives in Advanced setup, which that path never reaches. So it wasn't rendering wrong — nothing ever rendered it.

The classifier now excludes OAuth-over-http, a distinction this module already drew (`isOAuthOverHttp` existed for the labels; `requiresInstallConfig` had its own guard with a comment describing exactly this case). **The backend needed nothing** — `system_default_available` already comes back `true` from `CONNECTOR_GITHUB_CLIENT_ID`/`SECRET`.

---

# 3. `supports_org_custom_auth_config` — not a duplicate, just dead

It read like a twin of `supports_org_custom_oauth` in every response. It wasn't:

- **`supports_org_custom_oauth`** — on the base spec, every kind, **enforced**.
- **`supports_org_custom_auth_config`** — Composio-only, and carried **no information**: its only producer hardcoded `False`, the catalog couldn't override it, the read path force-set `False` again, and the single branch consulting it was unreachable.

It looked duplicated because the response model is flat, so a Composio-only field serialized onto every kind — including GitHub's `http`, where it was meaningless.

Even set `True` it would have changed nothing: ORG_CUSTOM for Composio is rejected two layers earlier. Composio brokers every toolkit through Lemma's own account — one process-global `COMPOSIO_API_KEY`, no per-org key, none planned. **The flag advertised the opposite of what the system enforces.**

That fact is now stated once (`COMPOSIO_SYSTEM_CREDENTIALS_ONLY`) and shared by both rejection sites. They stay two — the service check runs on create, the installer also runs on update, which never reaches the service check. Neither had a single test; both do now. The unreachable `composio_auth_config_id` reuse hook goes too.

### The trap in this one

A Composio spec's `auth_config_schema` is **not** an org install form. For a non-OAuth toolkit the catalog fills it with the *end user's* credential fields. Blanking it — the obvious simplification when collapsing that branch — silently empties the connect dialog for `freshdesk`, `metabase`, `mixpanel`, `posthog` and every other API-key toolkit, with no error. Verified against real rows; the enrichment leaves it alone and a test pins it.

### The live bug this exposed

Those same API-key Composio connectors had their required credential fields read as an org install config, so **Connect opened Advanced setup instead of asking for the key** — and Advanced offered "Use my own", which posts ORG_CUSTOM and gets a 400. A Composio kind now requires no install config and offers no custom config. The credential form is untouched (sourced via `getCredentialSchema`). This is a user-visible behavior change, not just cleanup.

`use_custom_auth` in the Composio provider reads like org-supplied credentials but isn't — it's how API-key toolkits get an auth config at all. Left verbatim, and now covered by the rewritten provider test.

No migration: stored rows still carrying the key parse and drop it (`extra="ignore"`), verified against real `freshdesk` and `github` rows.

---

## Verification

- 529 backend connector + surfaces unit tests; 113 connector e2e; 115 app tests including both e2e serving paths
- 629 frontend tests; typecheck and lint clean
- OpenAPI freshness + version consistency green (all 9 at 0.7.0, no bump); Python SDK regenerated, TS regenerated from the committed spec
- All 15 migrations apply cleanly to an empty DB; `0015` verified against a real `0014` schema and a local dev DB
- **Every new test group confirmed to fail without its fix**, not merely pass with it

One pre-existing failure, unrelated and present on a clean tree: `test_composio_kind_real_e2e.py::test_a_bogus_connection_is_reported_as_unauthorized` fails without `COMPOSIO_API_KEY` because the skip guard sits on the `composio_client` fixture while that test only takes `dispatcher`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)