### PR TITLE
Read list responses the way they are shaped, and stop the share sheet from taking every pod route down

### DIFF
--- a/lemma-frontend/components/agents/agent-test-panel.tsx
+++ b/lemma-frontend/components/agents/agent-test-panel.tsx
@@ -20,7 +20,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { AssistantExperienceView } from '@/components/lemma/assistant/assistant-experience';
 import type { AssistantControllerView } from '@/components/lemma/assistant/assistant-types';
 import { Agent, ConnectorMode } from '@/lib/types';
-import type { Message } from '@/lib/types';
 import { cn } from '@/lib/utils';
 import {
     isRecord,
@@ -221,10 +220,7 @@ export function AgentTestPanel({
     const settledConversationRef = useRef<string | null>(null);
     const handledOpenRequestRef = useRef<string | number | null>(null);
     const { data: rawMessagesData, refetch: refetchRawMessages } = useMessages(podId, openedConversationId || '', { limit: 100 });
-    const rawMessages = useMemo(
-        () => (rawMessagesData as { items?: Message[] } | undefined)?.items || [],
-        [rawMessagesData],
-    );
+    const rawMessages = useMemo(() => rawMessagesData?.items ?? [], [rawMessagesData]);
     const activeConversation = useMemo(
         () => controller.conversations.find((conversation) => conversation.id === openedConversationId) ?? null,
         [controller.conversations, openedConversationId],

--- a/lemma-frontend/components/ai/pod-assistant.tsx
+++ b/lemma-frontend/components/ai/pod-assistant.tsx
@@ -254,7 +254,7 @@ function PodAssistantSurface({
     }));
 
     const seenFiles = new Set<string>();
-    const fileMentions = ((filesData as { items?: unknown[] } | undefined)?.items || [])
+    const fileMentions = (filesData?.items ?? [])
       .map(getFileMentionPath)
       .filter((path) => {
         if (!path || seenFiles.has(path)) return false;

--- a/lemma-frontend/components/bundle/share-sheet.tsx
+++ b/lemma-frontend/components/bundle/share-sheet.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import Link from 'next/link';
+import type { DatastoreDirectoryTreeNode } from 'lemma-sdk';
 import { ArrowUpRight, Copy, Download, FileText, Github, Share2 } from '@/components/ui/icons';
 import { toast } from 'sonner';
 
@@ -176,16 +177,13 @@ export function ShareSheet({ podId, podName, open, onOpenChange, canPublish = tr
      *  what naming folders exists to avoid. */
     const folderPaths = useMemo(() => {
         const out: string[] = [];
-        const walk = (node: unknown) => {
-            if (!node || typeof node !== 'object') return;
-            const entry = node as { path?: string; kind?: string; children?: unknown[] };
-            const path = entry.path ?? '';
-            if (String(entry.kind ?? '').toUpperCase() === 'FOLDER' && path && path !== '/') {
-                out.push(path);
+        const walk = (node: DatastoreDirectoryTreeNode) => {
+            if (node.kind.toUpperCase() === 'FOLDER' && node.path && node.path !== '/') {
+                out.push(node.path);
             }
-            for (const child of entry.children ?? []) walk(child);
+            for (const child of node.children ?? []) walk(child);
         };
-        walk((folderTree as { root?: unknown } | undefined)?.root ?? folderTree);
+        if (folderTree) walk(folderTree.tree);
         return Array.from(new Set(out)).sort();
     }, [folderTree]);
 

--- a/lemma-frontend/components/bundle/share-sheet.tsx
+++ b/lemma-frontend/components/bundle/share-sheet.tsx
@@ -165,11 +165,11 @@ export function ShareSheet({ podId, podName, open, onOpenChange, canPublish = tr
     const defaultRepo = useMemo(() => toRepoSlug(podName || 'my-pod') || 'my-pod', [podName]);
     const tableNames = useMemo(
         () =>
-            ((tables as { name?: string }[] | undefined) ?? [])
-                .map((t) => t.name)
-                .filter((name): name is string => Boolean(name))
+            (tables?.items ?? [])
+                .map((table) => table.name)
+                .filter((name) => Boolean(name))
                 .sort(),
-        [tables],
+        [tables?.items],
     );
     /** Every folder in the tree, flattened to full paths so a nested one can be
      *  picked on its own. The pod root is not offered: "everything" is exactly


### PR DESCRIPTION
## What broke

Every `/pod/[id]` route rendered the error boundary — "This page couldn't load" — with one line in the console:

```
Uncaught TypeError: (w ?? []).map is not a function
```

Introduced in #322.

## Why

`useTables` returns a cursor page, `{ items: Table[], … }`, not an array. `ShareSheet` was the only one of eight call sites that read it as an array, and an inline cast hid that from `tsc`:

```ts
((tables as { name?: string }[] | undefined) ?? []).map((t) => t.name)
```

The cast claims "array or undefined", which makes `?? []` look like the safe fallback it isn't. At runtime `tables` is an object, `??` passes it through untouched, and `.map` doesn't exist.

Three things escalate that from a broken dialog to a dead route:

1. `WorkspaceSidebar` mounts `<ShareSheet>` unconditionally, and the sidebar lives in the pod layout — so it renders on every pod route, sheet open or not.
2. `enabled: open` doesn't keep it away from the data. The query key `['tables', podId]` is shared, pod home fills it via `usePodStartSignals`, and a disabled query still returns cached data. The moment tables land in the cache, the closed sheet renders and throws.
3. The throw is during render, so the route error boundary eats the whole page.

Pod home is what populates the cache, which is why it presented as "the chat page is down".

## The second bug, found by removing the cast idiom

An array method is loud when it's handed the wrong shape. The same idiom — a hand-written cast asserting what the real type already describes — was in two other places, and in a third it had failed **silently**:

```ts
walk((folderTree as { root?: unknown } | undefined)?.root ?? folderTree);
```

`files.tree()` returns `{ files_per_directory, root_path, tree }`. There is no `root`, so the `?? folderTree` fallback walked the response envelope itself — no `kind`, no `children`, nothing pushed. **The publish flow's folder picker has been offering an empty list since #322.** It now walks `folderTree.tree` typed as `DatastoreDirectoryTreeNode`, so the traversal is checked against the schema rather than asserted past it.

The other two casts were merely redundant, which is exactly the hazard: a cast that agrees with the type today is what stops the compiler objecting when the type changes tomorrow. `useMessages` already returns `PaginatedResponse<Message>` and `useDatastoreFiles` already returns `FileListResponse`; both call sites read `.items` off the real type now.

## Scope of the sweep

I inferred each list hook's real shape from how the majority of its call sites read it, then flagged the outliers across every file in `app/`, `components/` and `lib/`. Exactly one page-read-as-array remained — the one fixed here. I also checked the other seven frontend PRs from the last two days (#303, #306, #307, #308, #315, #318, #323, #324) for the same class; they're clean. In particular `useGithubProjects` (#307) looks similar but is safe: `useAccounts`/`useAuthConfigs` unwrap via `select`, and its own `queryFn` guards with `Array.isArray`.

## Follow-up not taken here

The underlying trap is that list hooks disagree: the connector hooks `select` down to a bare array, the datastore/agent hooks hand back the whole page, and nothing marks which is which at the call site. Normalizing that touches dozens of `.items` consumers and would discard cursor information, so it belongs in its own change.

Ten places also do `foo?.items.find(...)` — optional on the outer object, assumed on the inner array. They're safe today because `items` is non-optional in the generated client, and left alone.

## Testing

- `npx tsc --noEmit --skipLibCheck --incremental false` — 0 errors
- `npx vitest run` — 66 files, 631 tests, all pass
- `npx eslint` on all three changed files — clean

No regression test: `vitest.config.ts` includes component tests by explicit filename only, so a spec under `components/bundle/` would silently never run. Both bugs sit at a data-shape boundary that the tight `include` list exists to keep out of that suite.

## Rollback

Revert the two commits. Three components, no schema, API or config surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
