### PR TITLE
Load a conversation once and keep it, and show the branch its agent works on

### DIFF
--- a/docs/design/conversation-messages.md
+++ b/docs/design/conversation-messages.md
@@ -1,0 +1,376 @@
+# A conversation is one list, loaded once
+
+**Status:** Proposed · **Surface area:** `lemma-frontend` + `lemma-typescript` — no backend changes
+
+## The change in one sentence
+
+Every surface that shows conversation messages reads them from one store that
+already has everything, instead of four surfaces each fetching the transcript two
+or three times and patching the copies together on every render.
+
+## Why chat feels like it is constantly reloading
+
+The backend's message model is clean: one flat row, one `kind`
+([`MessageKind`](../../lemma-backend/app/modules/agent/domain/value_objects.py#L273) —
+`TEXT`, `NOTIFICATION`, `THINKING`, `TOOL_CALL`, `TOOL_RETURN`), tool fields at
+the top level, no nested content object. The SDK maps that faithfully. Nothing is
+wrong below the React layer.
+
+Above it, four independent things believe they own the transcript:
+
+| Layer | Owns | Fetches messages? |
+| --- | --- | --- |
+| Route (`conversations/[conversationId]/page.tsx`) | the id in the URL | no |
+| `AIAssistantProvider` | `?assistantConversationId`, open/closed, load gating | **yes** |
+| `useAssistantController` (SDK) | `activeConversationId`, mapped messages | **yes** |
+| `useAssistantSession` (SDK) | the live stream, raw message store | **yes** |
+
+They coordinate by writing to each other and then waiting for React to settle.
+Two functions exist whose entire body is a double `requestAnimationFrame` —
+[`waitForControllerReset`](../../lemma-frontend/components/ai/ai-assistant-context.tsx#L242)
+and [`waitForConversationReset`](../../lemma-frontend/app/pod/[id]/conversations/[conversationId]/page.tsx#L33) —
+used as a synchronisation primitive between two state machines that should have
+been one. That is the shape of the whole problem.
+
+## Every surface that renders a conversation message
+
+Nine, across three different hydration strategies. This is the inventory the plan
+has to satisfy — a fix that only lands on the main route leaves six surfaces
+behind.
+
+**Through `AIAssistantProvider` (one controller, shared):**
+
+1. `/pod/[id]/conversations/[conversationId]` — the main chat
+2. `/pod/[id]/conversations/new` — same component, different lifecycle
+3. [`PodAssistantSidebar`](../../lemma-frontend/components/ai/pod-assistant.tsx#L462) — the docked side panel
+4. [`ConversationPresentationStage`](../../lemma-frontend/components/pod/conversation-presentation-stage.tsx) — chat beside a presented resource
+
+**Their own controller instance, bypassing the provider entirely:**
+
+5. [`agent-test-panel.tsx:201`](../../lemma-frontend/components/agents/agent-test-panel.tsx#L201) — the agent page's "try it"
+6. [`run-steps.tsx:76`](../../lemma-frontend/components/flows/run-detail/run-steps.tsx#L76) — an agent step inside a flow run
+
+**A fourth path entirely:**
+
+7. SDK [`AgentThread`](../../lemma-typescript/src/react/AgentThread.tsx) → `useConversationMessages` — what customer apps embed
+
+**List views (titles only, but same cache):**
+
+8. [`pod-conversation-list.tsx`](../../lemma-frontend/components/conversations/pod-conversation-list.tsx)
+9. [`recent-conversations.tsx`](../../lemma-frontend/components/pod/recent-conversations.tsx)
+
+Plus [`PodAssistant`](../../lemma-frontend/components/ai/pod-assistant.tsx#L320) — a
+140-line floating variant, exported and **rendered by nothing**. Dead.
+
+Surfaces (Slack, Telegram, WhatsApp, Teams) render server-side through
+[`platforms/rendering.py`](../../lemma-backend/app/modules/agent_surfaces/platforms/rendering.py)
+and are out of scope here, but they are the reason the message model is flat and
+kind-discriminated. Keep it that way.
+
+## The specific breakages
+
+### 1. The transcript is fetched twice, and the second copy does nothing
+
+The controller already returns fully-formed messages.
+[`mapConversationMessage`](../../lemma-typescript/src/react/useAssistantController.ts#L452-L468)
+passes through `metadata`, `message_metadata`, `kind`, `tool_call_id`,
+`tool_name`, `tool_args`, and `tool_result`. And
+[`mapConversationMessages`](../../lemma-typescript/src/react/useAssistantController.ts#L490-L505)
+already merges each `TOOL_RETURN` into its originating `TOOL_CALL`, setting
+`state: "result"` and the result payload, then drops the return row.
+
+The frontend does it again anyway.
+[`ai-assistant-context.tsx:420`](../../lemma-frontend/components/ai/ai-assistant-context.tsx#L420)
+opens a second `useQuery` for the same 100 messages, and
+[`hydrateToolReturnMessages`](../../lemma-frontend/components/ai/ai-assistant-context.tsx#L92)
+walks every message to set `state` and `result` — to the values they already
+hold.
+
+It is worse than redundant. The hydration matches on `toolCallId`, and the merged
+invocation still carries that id, so `changed` flips true whenever the
+conversation contains **any** tool call. Every evaluation therefore returns a new
+array with new object identities for every message. `displayMessages` is a
+dependency of `sendMessage`, `retryFailedMessage`, `resolveUserApproval`, the
+auto-navigation effect, and the `contextValue` memo — so the entire context value
+changes identity, re-rendering every `useAIAssistant` consumer in the app: the pod
+layout, both sidebars, the pod home page, the widgets page, the app pages route.
+
+> **Verify before deleting.** This is read from source, not observed. One-line
+> check: log `changed` inside `hydrateToolReturnMessages` against a conversation
+> with tool calls. If it is always true and the invocations are already
+> `state: "result"`, the layer is confirmed dead.
+
+### 2. …and refetched again after every single run
+
+[`ai-assistant-context.tsx:635`](../../lemma-frontend/components/ai/ai-assistant-context.tsx#L635)
+refetches all 100 messages every time `controller.isLoading` goes false — i.e.
+after every agent turn.
+[`resolveUserApproval`](../../lemma-frontend/components/ai/ai-assistant-context.tsx#L782)
+fires another. The data is already in the store; the stream delivered it.
+
+### 3. Opening a conversation always blanks the screen first
+
+[`useAssistantController.ts:1318`](../../lemma-typescript/src/react/useAssistantController.ts#L1318)
+calls `clearRuntimeMessages()` and sets `isLoadingMessages` **unconditionally**,
+before checking whether the transcript is already in hand. So every conversation
+switch is content → blank → skeleton → content, warm cache or not. This is the
+single most-felt reload in the product, and it fires on every click in the
+history list.
+
+### 4. Sending the first message navigates you out from under the stream
+
+You compose at `/conversations/new`. The controller creates the conversation, the
+reply starts streaming, and
+[`page.tsx:216`](../../lemma-frontend/app/pod/[id]/conversations/[conversationId]/page.tsx#L216)
+`router.replace`s to the real id mid-flight. The `assistantMessage` launch path
+([`:223-256`](../../lemma-frontend/app/pod/[id]/conversations/[conversationId]/page.tsx#L223))
+does the same thing again, and has to `closeAssistant` → `clearMessages` → await
+two animation frames → `sendMessage` → `router.replace` to get through it.
+
+### 5. Load gating is a five-variable expression nobody can hold in their head
+
+`isControllerEnabled`, `controllerGates`, `shouldPrepareSideViewMessages`,
+`activeConversationMessagesCached`, `readySideViewMessageLoadGeneration ===
+sideViewMessageLoadGeneration` — resolving to
+[`shouldLoadActiveConversationMessages`](../../lemma-frontend/components/ai/ai-assistant-context.tsx#L406).
+The comment above it documents a bug being worked around: *"the gate dips to false
+for a render, the controller drops its messages, and the side view shows a
+'Loading messages' spinner before re-hydrating identical data."* That bug is
+breakage #3. The gate is scaffolding around it.
+
+### 6. Conversation identity is two-way bound to the URL
+
+The provider writes `?assistantConversationId` in an effect
+([`:500-557`](../../lemma-frontend/components/ai/ai-assistant-context.tsx#L500)) and
+reads it back to call `openConversation` in another
+([`:480-498`](../../lemma-frontend/components/ai/ai-assistant-context.tsx#L480)),
+guarded by two refs (`suppressAssistantUrlRestoreRef`,
+`skipNextAssistantUrlSyncRef`) that exist purely to break the loop. Meanwhile the
+route owns the id for surfaces 1–2 and the query param owns it for 3–4, so the
+same fact is stored in two places with different lifetimes.
+
+### 7. The app teleports you away mid-read
+
+[`ai-assistant-context.tsx:697`](../../lemma-frontend/components/ai/ai-assistant-context.tsx#L697):
+if a tool result carries a `resourceId`, `setTimeout(..., 500)` navigates you off
+the conversation. A half-second delayed jump, deduplicated by a `Set` of seen tool
+call ids and an `allowAutoNavigationRef` latch because it kept firing on replayed
+history. The display-resource cards already give people a deliberate way in.
+
+### 8. Scroll is hand-driven and fights the user
+
+[`assistant-experience.tsx:333`](../../lemma-frontend/components/lemma/assistant/assistant-experience.tsx#L333)
+calls `scrollIntoView` on every message change, switching between `"auto"` and
+`"smooth"` depending on whether a run is active;
+[`:350`](../../lemma-frontend/components/lemma/assistant/assistant-experience.tsx#L350)
+force-pins on every conversation change; `handleSubmit` fires a third scroll.
+During streaming that is a scroll animation per token flush.
+
+### 9. The agent panel hydrates three times and concatenates the result
+
+[`agent-test-panel.tsx`](../../lemma-frontend/components/agents/agent-test-panel.tsx)
+runs its own `useAssistantController` (:201), *plus* `useConversationMessages`
+(:207), *plus* a react-query `useMessages` (:223) — three fetches of one
+transcript. It merges two of them by id into a synthetic `controllerView` (:232),
+then builds `finalOutputMessages` (:252) by **concatenating raw and mapped
+messages** — two copies of the same conversation in one array, deduplicated
+nowhere. It only escapes visible duplication because the consumer reads the last
+assistant text rather than rendering the list.
+
+### 10. Long answers have no hierarchy, and tables are unreadable
+
+[`assistant-experience-helpers.tsx:188`](../../lemma-frontend/components/lemma/assistant/assistant-experience-helpers.tsx#L188):
+`h1`, `h2`, and `h3` all render as `<p className="text-sm font-semibold">`. Every
+heading in a structured answer is identical 14px bold text. `design.md` is
+explicit that hierarchy comes from **size and the space above, never from
+weight** — this does the exact inverse, and flattens a well-organised answer into
+one undifferentiated block.
+
+[`:222`](../../lemma-frontend/components/lemma/assistant/assistant-experience-helpers.tsx#L222):
+tables get `min-w-max`, so a single prose cell turns the table into a horizontal
+scroller inside a chat column — nothing ever wraps. Every `th`/`td` gets a full
+`border`, producing a grid of boxes against a design system whose first rule is
+*alpha hairline rules, not borders*.
+
+This is not an accident of taste. The design audit **exempts** chat from
+enforcement — `strictEnforcedExcludesProtectedAssistantUi: true`, with the seven
+`assistant-experience-*` files listed as protected. Chat is the only surface in
+the product the design system does not police, and it shows.
+
+### 11. Everything moves at once the moment a run ends
+
+Five layout changes fire in the same commit when `isRunActive` flips false, none
+of them coordinated with the others:
+
+1. **The trace collapses.** `collectCompletedRunTraceGroups` folds the finished
+   run's rows, and [`CompletedRunTraceGroup`](../../lemma-frontend/components/lemma/assistant/assistant-message-group.tsx#L51)
+   opens `useState(false)` — so the thinking and tool steps that were on screen a
+   frame earlier are re-parented into a collapsed group and vanish.
+2. **The tool rollup expands.** `shouldShowHeader` included `isRunActive`, so a
+   short run showed a collapsed "Working" line while running and unfurled its
+   tool cards on completion — growing at the same instant (1) shrank.
+3. **Every text block grows.** `showActions={!withinTrace && !isCurrentRunActive}`
+   added a copy/timestamp bar per block, its own comment admitting it had moved a
+   streaming-time gap to completion time.
+4. **Rows remount.** Re-parenting into the group throws away everything the
+   reader had expanded.
+5. **The viewport slides.** The scroll effect used `"auto"` while busy and
+   `"smooth"` otherwise, so a scroll animation played only at the end.
+
+### 12. The answer blinks out between the stream and the durable message
+
+[`useAssistantRuntime`](../../lemma-typescript/src/react/useAssistantRuntime.ts)
+mirrors session messages into its store through an effect, which runs *after*
+commit. The session clears its streamed token buffer the moment the durable
+message upserts. For one commit the buffer is empty and the durable message has
+not been mirrored — so the text is in neither, and disappears.
+
+This was known for reasoning: `resolveStreamingThinking` is a hand-built bridge
+holding the last streamed thought until its durable `THINKING` message lands, and
+`streaming-thinking-handoff.test.ts` pins it. Answer text has the identical gap
+and no bridge. The fix is the shared cause, not a second bridge: merge the
+session's view into the store at derive time so the message is present in the
+commit it arrives.
+
+## The target
+
+**One store.** `useAssistantSession` holds raw API messages — history and
+streamed, upserted by id
+([`upsertConversationMessage`](../../lemma-typescript/src/assistant-events.ts#L168)).
+That is already the single source of truth; it just is not treated as one.
+`useAssistantController` derives mapped messages from it. Nothing above the
+controller fetches messages, ever.
+
+**One owner of "which conversation".** The route owns it where there is a route
+(surfaces 1–4). The component owns it where there is not (5–7). The controller
+follows; it never pushes back. `?assistantConversationId` is deleted — the docked
+sidebar reads the route's id, and its open/closed state is UI state, not identity.
+
+**Transcripts are replaced, not blanked.** Switching conversations keeps the old
+list on screen until the new one resolves; loading is a fill, not a screen — the
+same rule [loading-and-empty-states.md](./loading-and-empty-states.md) already
+established for the rest of the product.
+
+**One renderer.** All nine surfaces render through `AssistantExperienceView` with
+one markdown component map, held to the same design audit as everything else.
+
+## The plan
+
+Ordered so each phase is independently shippable and independently revertable.
+
+### Phase 0 — Confirm (half a day)
+
+Instrument `hydrateToolReturnMessages` and the agent panel's merge; confirm both
+are no-ops on a real conversation with tool calls, approvals, and a display
+resource. Capture a before-trace: fetch count and render count for opening a
+30-message conversation, cold and warm. Everything after this is measured against
+that number.
+
+### Phase 1 — Delete the duplicate hydration (1 day, `lemma-frontend`)
+
+Remove `rawMessagesQuery`, `hydrateToolReturnMessages`, `rawToolReturnPayload`,
+and `normalizedToolResult` from the provider; `displayMessages` becomes
+`controller.messages`. Remove `useMessages` + `controllerView` +
+`finalOutputMessages` from the agent panel. If Phase 0 finds a field the mapper
+genuinely drops, fix it **in the mapper**, not in a consumer.
+
+*Kills breakages 1, 2, 9. Removes two 100-message fetches per conversation and one
+per completed run, and stops the whole-app re-render cascade.*
+
+### Phase 2 — Keep the transcript on screen (1–2 days, `lemma-typescript`)
+
+In `selectConversation`, only `clearRuntimeMessages()` when the target
+conversation's messages are not already in the store; when they are, swap
+`activeConversationId` and skip the loading state. Add a `messages` selector keyed
+by conversation so the store can hold more than one transcript.
+
+Then the load gate collapses: `shouldLoadActiveConversationMessages` becomes
+`enabled`, and `sideViewMessageLoadGeneration` /
+`readySideViewMessageLoadGeneration` / `activeConversationMessagesCached` all go.
+
+*Kills breakages 3 and 5. This is the one people will feel most.*
+
+### Phase 3 — One owner of conversation identity (2–3 days)
+
+Delete `ASSISTANT_CONVERSATION_PARAM` and both URL-sync effects, and with them
+`suppressAssistantUrlRestoreRef` and `skipNextAssistantUrlSyncRef`. The sidebar
+takes the conversation id as a prop from the route.
+
+Make `/conversations/new` a real state rather than a route that redirects: the
+route renders the composer, `sendMessage` creates the conversation, and the id is
+swapped with `history.replaceState` — no `router.replace`, no remount, no double
+rAF. Both `waitForXReset` helpers get deleted.
+
+Fold the `assistantMessage` launch path into the same mechanism.
+
+*Kills breakages 4 and 6.*
+
+### Phase 4 — Stop moving things (1 day)
+
+Delete the auto-navigate-on-tool-result block and its two refs and blocklist.
+Replace the `scrollIntoView` effects with CSS bottom-pinning plus one explicit
+"jump to latest" affordance, so streaming never fights a user who has scrolled up.
+
+*Kills breakages 7 and 8.*
+
+### Phase 5 — Make it read well (1 day)
+
+Real heading scale (size and leading, weight stays 500 per `design.md`). Tables
+that wrap by default, hairline rules instead of gridlines, horizontal scroll only
+when genuinely needed. Then **remove the assistant exemption from the design
+audit** and burn down whatever it reports.
+
+*Kills breakage 10, and stops it recurring.*
+
+### Phase 6 — Converge the stragglers (1–2 days)
+
+Point `run-steps` and `agent-test-panel` at a shared read-only transcript hook
+rather than a full controller each. Decide `AgentThread`'s relationship to
+`useAssistantController` — today it is a separate path with separate behaviour,
+which means customer apps get a different chat from the one we ship. Delete the
+unrendered `PodAssistant`.
+
+## What gets deleted
+
+Approximate, from the current tree:
+
+| Thing | Where | Lines |
+| --- | --- | --- |
+| `hydrateToolReturnMessages` + helpers + query | `ai-assistant-context.tsx` | ~110 |
+| URL sync + restore effects + refs | `ai-assistant-context.tsx` | ~85 |
+| Auto-navigation on tool result | `ai-assistant-context.tsx` | ~60 |
+| Load-gate generation machinery | `ai-assistant-context.tsx` | ~45 |
+| `waitForControllerReset` / `waitForConversationReset` | both files | ~22 |
+| Triple hydration + concat | `agent-test-panel.tsx` | ~50 |
+| Unrendered floating assistant | `pod-assistant.tsx` | ~140 |
+| Manual scroll effects | `assistant-experience.tsx` | ~40 |
+
+Roughly 550 lines out of the ~13,800 in the chat path. The count that matters
+more is effects: of the 36 `useEffect`s across the four layers, the phases above
+remove about a third — five of the provider's eight (URL restore, URL sync, raw
+refetch, auto-navigation, side-view generation), two of the route's five, and
+both manual scroll effects. Every one of them is a place where two layers were
+negotiating over the same fact.
+
+## How we know it worked
+
+- Opening a cached conversation: **zero** network requests, **zero** blank frames.
+- Opening a cold conversation: one request, one skeleton, one paint.
+- Completing a run: zero refetches.
+- Sending the first message in a new conversation: no remount, no route change
+  visible to the reader, stream never interrupts.
+- Scrolling up during a stream: the view stays where you put it.
+- `npm run design:audit` passes with the assistant exemption removed.
+- Render count for a 30-message transcript with tools, versus the Phase 0 baseline.
+
+## Open questions
+
+1. **`AgentThread` and the SDK's public surface.** `useConversationMessages`,
+   `useAssistantSession`, and `useAssistantController` are all exported. Phase 2
+   changes controller behaviour; is that a breaking change for embedders, or is
+   the controller effectively internal today?
+2. **Multi-transcript store size.** Keeping previous transcripts resident is what
+   makes Phase 2 work. Cap it — LRU of 3? — or let react-query own eviction?
+3. **Does anything actually want auto-navigation?** Removing it in Phase 4
+   assumes not. Worth confirming against the onboarding flows that pass
+   `?assistantMessage`, which are the most likely dependents.

--- a/lemma-frontend/app/pod/[id]/conversations/[conversationId]/page.tsx
+++ b/lemma-frontend/app/pod/[id]/conversations/[conversationId]/page.tsx
@@ -23,7 +23,6 @@ import {
 } from '@/lib/assistant/conversation-presentation';
 import { useAgentRuntimes } from '@/lib/hooks/use-agent-runtime';
 import { useAgent, useAgents } from '@/lib/hooks/use-agents';
-import { useConversation } from '@/lib/hooks/use-assistants';
 import { usePod } from '@/lib/hooks/use-pods';
 import { usePodAccess } from '@/lib/hooks/use-pod-access';
 import { parseConversationMetadataParam } from '@/lib/pods/composer-launch';
@@ -82,21 +81,19 @@ export default function PodConversationPage({
     );
     const isNewConversation = conversationId === 'new';
     const newConversationScopeKey = scopedAgentName ?? '__pod_default__';
-    const { data: fetchedConversation } = useConversation(
-        podId,
-        isNewConversation ? '' : conversationId,
-    );
     const newWorkspaceRef = useRef<HTMLDivElement>(null);
     const newRouteScopeRef = useRef<string | null>(null);
     const ignoredConversationIdAfterNewRef = useRef<string | null>(null);
     const openedConversationIdRef = useRef<string | null>(openedConversationId);
     const handledAssistantMessageRef = useRef<string | null>(null);
-    const listedConversation = useMemo(() => {
+    // Opening the route conversation makes the controller fetch it and keep it
+    // in this list, so reading it from there is the same record a second
+    // request would have returned — one route, one GET of the conversation.
+    const activeConversation = useMemo(() => {
         const resolvedConversationId = isNewConversation ? null : conversationId;
         if (!resolvedConversationId) return null;
         return assistant.conversations.find((conversation) => conversation.id === resolvedConversationId) ?? null;
     }, [assistant.conversations, conversationId, isNewConversation]);
-    const activeConversation = listedConversation ?? fetchedConversation ?? null;
     const agents = useMemo(() => agentsData?.items ?? [], [agentsData?.items]);
     const persistedAgentName = useMemo(
         () => resolveConversationAgentName(activeConversation?.agent_id, agents),

--- a/lemma-frontend/app/pod/[id]/page.tsx
+++ b/lemma-frontend/app/pod/[id]/page.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { ArrowRight, ArrowUp, ChevronDown, ChevronUp, Plus, UserPlus, X } from '@/components/ui/icons';
 
 import { useAIAssistant } from '@/components/ai/ai-assistant-context';
+import { ProjectBranchChip } from '@/components/lemma/assistant/project-branch';
 import { ProjectPicker } from '@/components/lemma/assistant/project-picker';
 import { useGithubProjects } from '@/lib/hooks/use-github-projects';
 import { ProtectedRoute } from '@/components/auth/protected-route';
@@ -444,6 +445,15 @@ function PodBlankChatHome({ podId }: { podId: string }) {
                                 connectHref={`/pod/${encodeURIComponent(podId)}/connectors`}
                             />
                         ) : null}
+                        {canWriteConversations && assistant.pendingProject ? (
+                            <ProjectBranchChip
+                                project={assistant.pendingProject}
+                                onChange={(ref) => assistant.setPendingProject({
+                                    ...assistant.pendingProject!,
+                                    ref,
+                                })}
+                            />
+                        ) : null}
                         <button
                             type="submit"
                             aria-label="Send"
@@ -570,7 +580,12 @@ function PodHomePanelsSkeleton() {
 function PodJoinRequestsHomePanel({ podId }: { podId: string }) {
     const podAccess = usePodAccess(podId);
     const canManageMembers = podAccess.can('pod.member.manage');
-    const { data, isLoading } = usePodJoinRequests(podId, 'PENDING');
+    // Pod home renders for everyone, so this has to stay off the wire until the
+    // permission is known. `can()` is false while permissions are still loading,
+    // which is the answer we want: ask once, after we know we are allowed to.
+    const { data, isLoading } = usePodJoinRequests(podId, 'PENDING', {
+        enabled: canManageMembers,
+    });
     const requests = data?.items || [];
 
     if (!canManageMembers || isLoading || requests.length === 0) return null;

--- a/lemma-frontend/components/agents/agent-test-panel.tsx
+++ b/lemma-frontend/components/agents/agent-test-panel.tsx
@@ -5,7 +5,6 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useAssistantController, useConversationMessages } from 'lemma-sdk/react';
 import { useAgent } from '@/lib/hooks/use-agents';
-import { useMessages } from '@/lib/hooks/use-assistants';
 import { useAccounts, useConnectors, useAuthConfigs, useCreateConnectRequest } from '@/lib/hooks/use-connectors';
 import { usePod } from '@/lib/hooks/use-pods';
 import { getLemmaClient } from '@/lib/sdk/lemma-client';
@@ -219,38 +218,16 @@ export function AgentTestPanel({
     const openConversation = controller.openConversation;
     const settledConversationRef = useRef<string | null>(null);
     const handledOpenRequestRef = useRef<string | number | null>(null);
-    const { data: rawMessagesData, refetch: refetchRawMessages } = useMessages(podId, openedConversationId || '', { limit: 100 });
-    const rawMessages = useMemo(() => rawMessagesData?.items ?? [], [rawMessagesData]);
     const activeConversation = useMemo(
         () => controller.conversations.find((conversation) => conversation.id === openedConversationId) ?? null,
         [controller.conversations, openedConversationId],
     );
-    const controllerView = useMemo<AssistantControllerView>(() => {
-        const base = controller as unknown as AssistantControllerView;
-        const rawById = new Map(rawMessages.map((message) => [message.id, message]));
-
-        return {
-            ...base,
-            messages: base.messages.map((message) => {
-                const raw = rawById.get(message.id);
-                if (!raw) return message;
-
-                return {
-                    ...message,
-                    metadata: (raw.metadata as Record<string, unknown> | null | undefined) ?? message.metadata,
-                    message_metadata: (raw.message_metadata as Record<string, unknown> | null | undefined) ?? message.message_metadata,
-                    tool_name: raw.tool_name ?? message.tool_name,
-                    tool_call_id: raw.tool_call_id ?? message.tool_call_id,
-                };
-            }),
-        };
-    }, [controller, rawMessages]);
-    const finalOutputMessages = useMemo(
-        () => [...rawMessages, ...controllerView.messages],
-        [controllerView.messages, rawMessages],
-    );
+    // The controller's messages already carry `metadata`, `tool_name`, and
+    // `tool_call_id` straight from the API, so there is no raw copy to fetch and
+    // patch on top of them. See docs/design/conversation-messages.md.
+    const controllerView = controller as unknown as AssistantControllerView;
     const conversationOutputText = conversationMessages.finalOutputText || conversationMessages.outputText;
-    const assistantText = conversationOutputText || latestAssistantText(finalOutputMessages);
+    const assistantText = conversationOutputText || latestAssistantText(controller.messages);
     const parsedOutput = taskConversationOutput(activeConversation);
 
     useEffect(() => {
@@ -288,11 +265,8 @@ export function AgentTestPanel({
 
         if (settledConversationRef.current === conversationId) return;
         settledConversationRef.current = conversationId;
-        void Promise.allSettled([
-            refetchRawMessages(),
-            refreshConversationMessages({ conversationId, limit: 100 }),
-        ]);
-    }, [controller.isOpenedConversationRunning, controller.openedConversationId, refetchRawMessages, refreshConversationMessages]);
+        void refreshConversationMessages({ conversationId, limit: 100 });
+    }, [controller.isOpenedConversationRunning, controller.openedConversationId, refreshConversationMessages]);
 
     useEffect(() => {
         const conversationId = controller.openedConversationId;
@@ -307,10 +281,7 @@ export function AgentTestPanel({
             timeoutId = setTimeout(() => {
                 if (cancelled) return;
                 attempts += 1;
-                void Promise.allSettled([
-                    refetchRawMessages(),
-                    refreshConversationMessages({ conversationId, limit: 100 }),
-                ]).finally(() => {
+                void refreshConversationMessages({ conversationId, limit: 100 }).finally(() => {
                     if (!cancelled && attempts < 6) refreshUntilOutputArrives();
                 });
             }, attempts === 0 ? 450 : 900);
@@ -328,7 +299,6 @@ export function AgentTestPanel({
         controller.openedConversationId,
         hasOutputSchema,
         parsedOutput,
-        refetchRawMessages,
         refreshConversationMessages,
     ]);
 
@@ -363,10 +333,7 @@ export function AgentTestPanel({
             await controller.sendMessage(formatAgentRunInput(payload), { forceNewConversation: true });
             const conversationId = controller.openedConversationId;
             if (conversationId) {
-                void Promise.allSettled([
-                    refetchRawMessages(),
-                    refreshConversationMessages({ conversationId, limit: 100 }),
-                ]);
+                void refreshConversationMessages({ conversationId, limit: 100 });
             }
         } catch (error) {
             console.error('Failed to start agent run:', error);

--- a/lemma-frontend/components/ai/ai-assistant-context.tsx
+++ b/lemma-frontend/components/ai/ai-assistant-context.tsx
@@ -2,7 +2,6 @@
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { AgentRuntimeConfig, AvailableModelInfo } from 'lemma-sdk';
 import {
     useAssistantController,
@@ -13,7 +12,7 @@ import {
     type AssistantToolInvocation as SdkAssistantToolInvocation,
 } from 'lemma-sdk/react';
 import type { AssistantContext, PodContext, AIAction } from '@/lib/types/ai';
-import type { Conversation, ConversationModel, Message as RawConversationMessage } from '@/lib/types';
+import type { Conversation, ConversationModel } from '@/lib/types';
 import { getLemmaClient } from '@/lib/sdk/lemma-client';
 import {
     buildDisplayResourceHref,
@@ -48,92 +47,6 @@ export type ToolInvocation = SdkAssistantToolInvocation;
 export type StreamingTool = SdkAssistantStreamingTool;
 export type PendingFileUpload = SdkAssistantPendingFileUpload;
 export type AssistantMessagePart = SdkAssistantMessagePart;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return !!value && typeof value === 'object' && !Array.isArray(value);
-}
-
-function normalizedToolResult(value: unknown): Record<string, unknown> {
-    if (isRecord(value)) return value;
-    if (typeof value === 'undefined' || value === null) return {};
-    return { output: value };
-}
-
-function rawToolReturnPayload(message: RawConversationMessage): {
-    toolCallId: string;
-    toolName?: string;
-    result: Record<string, unknown>;
-} | null {
-    const metadata = isRecord(message.metadata) ? message.metadata : null;
-    const messageMetadata = isRecord(message.message_metadata) ? message.message_metadata : null;
-    // Flat message shape: tool fields live at the top level of the message.
-    const kind = typeof message.kind === 'string'
-        ? message.kind
-        : metadata?.message_type ?? messageMetadata?.message_type;
-    const isToolReturn = kind === 'TOOL_RETURN' || kind === 'tool_return' || message.role === 'tool';
-
-    if (!isToolReturn) return null;
-
-    const toolCallId = (typeof message.tool_call_id === 'string' ? message.tool_call_id : undefined)
-        ?? metadata?.tool_call_id ?? messageMetadata?.tool_call_id;
-    if (typeof toolCallId !== 'string' || !toolCallId.trim()) return null;
-
-    const toolName = (typeof message.tool_name === 'string' ? message.tool_name : undefined)
-        ?? metadata?.tool_name ?? messageMetadata?.tool_name;
-    const rawResult = message.tool_result ?? metadata?.result ?? messageMetadata?.result;
-
-    return {
-        toolCallId,
-        toolName: typeof toolName === 'string' && toolName.trim() ? toolName : undefined,
-        result: normalizedToolResult(rawResult),
-    };
-}
-
-function hydrateToolReturnMessages(
-    messages: SdkAssistantRenderableMessage[],
-    rawMessages: RawConversationMessage[],
-): SdkAssistantRenderableMessage[] {
-    if (messages.length === 0 || rawMessages.length === 0) return messages;
-
-    const rawReturnsByToolCallId = new Map<string, NonNullable<ReturnType<typeof rawToolReturnPayload>>>();
-    rawMessages.forEach((message) => {
-        const payload = rawToolReturnPayload(message);
-        if (payload) rawReturnsByToolCallId.set(payload.toolCallId, payload);
-    });
-
-    if (rawReturnsByToolCallId.size === 0) return messages;
-
-    let changed = false;
-    const nextMessages = messages.map((message) => {
-        const hydrateInvocation = (invocation: SdkAssistantToolInvocation): SdkAssistantToolInvocation => {
-            const payload = rawReturnsByToolCallId.get(invocation.toolCallId);
-            if (!payload) return invocation;
-            changed = true;
-            return {
-                ...invocation,
-                toolName: invocation.toolName === 'tool' && payload.toolName ? payload.toolName : invocation.toolName,
-                state: 'result',
-                result: payload.result,
-            };
-        };
-        const nextToolInvocations = message.toolInvocations?.map(hydrateInvocation);
-        const nextParts = message.parts?.map((part) => (
-            part.type === 'tool'
-                ? { ...part, toolInvocation: hydrateInvocation(part.toolInvocation) }
-                : part
-        ));
-
-        if (nextToolInvocations === message.toolInvocations && nextParts === message.parts) return message;
-
-        return {
-            ...message,
-            toolInvocations: nextToolInvocations,
-            parts: nextParts,
-        };
-    });
-
-    return changed ? nextMessages : messages;
-}
 
 interface AIAssistantContextType {
     isOpen: boolean;
@@ -271,8 +184,6 @@ export function AIAssistantProvider({
     const [isOpen, setIsOpen] = useState(false);
     const [hasActivatedController, setHasActivatedController] = useState(false);
     const [lastCreatedResource, setLastCreatedResource] = useState<{ type: string; id: string } | null>(null);
-    const [sideViewMessageLoadGeneration, setSideViewMessageLoadGeneration] = useState(0);
-    const [readySideViewMessageLoadGeneration, setReadySideViewMessageLoadGeneration] = useState(-1);
     const [pendingProject, setPendingProjectState] = useState<ProjectSelection | null>(null);
     // Mirrored into a ref so `sendMessage` can read the current selection
     // without taking it as a dependency and changing identity on every pick.
@@ -363,50 +274,10 @@ export function AIAssistantProvider({
         || hasAssistantLaunchRequest
     );
     const controllerGates = resolveAssistantControllerGates(isProviderEnabled, isControllerEnabled);
-    const shouldPrepareSideViewMessages = isProviderEnabled && !isConversationRoute && isOpen;
 
-    const queryClient = useQueryClient();
-    // When the side view opens for a conversation whose transcript is already
-    // cached (e.g. clicking a display resource from the conversation page), load
-    // it immediately instead of deferring. The deferral keeps a *cold* first paint
-    // smooth, but with a warm cache it just makes the messages visibly reload.
-    const activeConversationMessagesCached = Boolean(
-        conversationScope.podId
-        && urlAssistantConversationId
-        && queryClient.getQueryData([
-            'assistant-raw-conversation-messages',
-            conversationScope.podId,
-            urlAssistantConversationId,
-        ]),
-    );
-
-    useEffect(() => {
-        if (!shouldPrepareSideViewMessages) {
-            return;
-        }
-
-        // Give sidebar and display-resource side views a clean first paint before hydrating transcripts.
-        let frameId = window.requestAnimationFrame(() => {
-            frameId = window.requestAnimationFrame(() => {
-                setReadySideViewMessageLoadGeneration(sideViewMessageLoadGeneration);
-            });
-        });
-
-        return () => {
-            window.cancelAnimationFrame(frameId);
-        };
-    }, [shouldPrepareSideViewMessages, sideViewMessageLoadGeneration]);
-
-    // Keep loading enabled continuously whenever the transcript is already cached
-    // — including the brief window after navigation where the side panel hasn't
-    // re-opened yet (isOpen false). Without this, the gate dips to false for a
-    // render, the controller drops its messages, and the side view shows a
-    // "Loading messages" spinner before re-hydrating identical data. Cold opens
-    // (no cache) still defer for a clean first paint.
-    const shouldLoadActiveConversationMessages = isConversationRoute
-        || activeConversationMessagesCached
-        || (shouldPrepareSideViewMessages && readySideViewMessageLoadGeneration === sideViewMessageLoadGeneration);
-
+    // The controller loads a transcript once and keeps the last few resident, so
+    // there is nothing left to gate: deferring the load only ever bought a clean
+    // first paint against a store that used to discard itself. It no longer does.
     const controller = useAssistantController({
         client: controllerClient,
         podId: conversationScope.podId ?? undefined,
@@ -414,29 +285,9 @@ export function AIAssistantProvider({
         organizationId: conversationScope.organizationId ?? undefined,
         enabled: controllerGates.enabled,
         autoLoad: controllerGates.autoLoad,
-        autoLoadMessages: shouldLoadActiveConversationMessages,
+        autoLoadMessages: isControllerEnabled,
     });
 
-    const rawMessagesQuery = useQuery({
-        queryKey: ['assistant-raw-conversation-messages', conversationScope.podId, controller.openedConversationId],
-        queryFn: async () => {
-            if (!conversationScope.podId || !controller.openedConversationId) {
-                return [] as RawConversationMessage[];
-            }
-            const response = await controllerClient.conversations.messages.list(
-                controller.openedConversationId,
-                {
-                    pod_id: conversationScope.podId,
-                    limit: 100,
-                },
-            );
-            return (response.items || []) as RawConversationMessage[];
-        },
-        enabled: !!conversationScope.podId && !!controller.openedConversationId && isControllerEnabled && shouldLoadActiveConversationMessages,
-        refetchOnWindowFocus: false,
-    });
-    const rawMessages = useMemo(() => rawMessagesQuery.data ?? [], [rawMessagesQuery.data]);
-    const refetchRawMessages = rawMessagesQuery.refetch;
     const controllerRef = useRef(controller);
 
     useEffect(() => {
@@ -454,7 +305,6 @@ export function AIAssistantProvider({
         setHasActivatedController(true);
         if (isOpenRef.current) return;
         isOpenRef.current = true;
-        setSideViewMessageLoadGeneration((generation) => generation + 1);
         setIsOpen(true);
     }, [onOpenAssistant]);
     const closeAssistant = useCallback((options?: { skipUrlSync?: boolean; suppressUrlRestore?: boolean }) => {
@@ -471,7 +321,6 @@ export function AIAssistantProvider({
             if (next) {
                 onOpenAssistant?.();
                 setHasActivatedController(true);
-                setSideViewMessageLoadGeneration((generation) => generation + 1);
             }
             return next;
         });
@@ -627,16 +476,10 @@ export function AIAssistantProvider({
         }
     }, [navigateToResolvedResource, pathname, podContext?.pod?.id, router, urlAssistantConversationId]);
 
-    const displayMessages = useMemo(
-        () => hydrateToolReturnMessages(controller.messages, rawMessages),
-        [controller.messages, rawMessages],
-    );
-
-    useEffect(() => {
-        if (!shouldLoadActiveConversationMessages) return;
-        if (!controller.openedConversationId || controller.isLoading) return;
-        void refetchRawMessages();
-    }, [controller.openedConversationId, controller.isLoading, refetchRawMessages, shouldLoadActiveConversationMessages]);
+    // The controller's messages are the transcript. There is no second copy to
+    // merge and nothing to refetch when a run ends: the stream already delivered
+    // every message, tool returns folded into their calls.
+    const displayMessages = controller.messages;
 
     useEffect(() => {
         const successfulTools = latestSuccessfulToolInvocations(displayMessages);
@@ -779,8 +622,7 @@ export function AIAssistantProvider({
         markToolInvocationsSeen(seenAutoNavigationToolCallIds.current, displayMessages);
         allowAutoNavigationRef.current = true;
         await controllerRef.current.resolveUserApproval(approvalId, decision, response);
-        await refetchRawMessages();
-    }, [displayMessages, refetchRawMessages]);
+    }, [displayMessages]);
 
     const pendingActions = useMemo(() => controller.pendingActions as AIAction[], [controller.pendingActions]);
     const completedActions = useMemo(() => controller.completedActions as AIAction[], [controller.completedActions]);

--- a/lemma-frontend/components/conversations/conversation-composer-context.tsx
+++ b/lemma-frontend/components/conversations/conversation-composer-context.tsx
@@ -8,6 +8,7 @@ import type {
 import { useAIAssistant } from '@/components/ai/ai-assistant-context';
 import { resolveRuntimeModelName, shortModelName } from '@/components/agents/agent-runtime-helpers';
 import { RuntimeModelPicker } from '@/components/lemma/assistant/model-picker';
+import { ProjectBranchChip } from '@/components/lemma/assistant/project-branch';
 import { ProjectPicker } from '@/components/lemma/assistant/project-picker';
 import type { ProjectSelection } from '@/lib/assistant/project-selection';
 import { useGithubProjects } from '@/lib/hooks/use-github-projects';
@@ -81,16 +82,22 @@ export function ConversationComposerContext({
                     {modelLabel}
                 </span>
                 {boundProject ? (
-                    <ProjectPicker
-                        value={boundProject}
-                        onChange={() => undefined}
-                        projects={[]}
-                        isConnected
-                        isLoadingProjects={false}
-                        readOnly
-                        connectHref="#"
-                        className="h-auto px-0"
-                    />
+                    <>
+                        <ProjectPicker
+                            value={boundProject}
+                            onChange={() => undefined}
+                            projects={[]}
+                            isConnected
+                            isLoadingProjects={false}
+                            readOnly
+                            connectHref="#"
+                            className="h-auto px-0"
+                        />
+                        {/* The branch is settled, but what happened to it is not:
+                            a pull request can open, fill up and merge while this
+                            conversation is still going. */}
+                        <ProjectBranchChip project={boundProject} readOnly />
+                    </>
                 ) : null}
             </div>
         );
@@ -152,6 +159,12 @@ export function ConversationComposerContext({
                         accountId={githubProjects.accountId}
                         connectHref={`/pod/${encodeURIComponent(podId)}/connectors`}
                     />
+                    {pendingProject ? (
+                        <ProjectBranchChip
+                            project={pendingProject}
+                            onChange={(ref) => setPendingProject({ ...pendingProject, ref })}
+                        />
+                    ) : null}
                 </>
             ) : null}
         </div>

--- a/lemma-frontend/components/lemma/assistant/assistant-experience-conversation.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-experience-conversation.tsx
@@ -75,21 +75,34 @@ export function AssistantDisplayRow({
     && previousRow?.message.role === "assistant"
     && !rowHasToolActivity
     && !previousRowHasToolActivity;
-  // The live run trace (consecutive assistant rows in the active run — text,
-  // tool steps, thoughts) should read as one tight sequence rather than
-  // turn-spaced rows, so tighten it the same way consecutive plain-text rows
-  // are. Completed runs fold under "Worked for …" and keep their own spacing.
-  const rowInActiveRun = !!isRunActive && row.message.role === "assistant"
+  // A run's trace (consecutive assistant rows — text, tool steps, thoughts)
+  // reads as one tight sequence rather than turn-spaced rows.
+  //
+  // Deliberately not a function of `isRunActive`: keying spacing off whether the
+  // run happens to be live meant the same transcript was tight while you watched
+  // it and loose after a reload. What a row is does not change; how far it sits
+  // from its neighbour should not either.
+  const rowInLatestRun = row.message.role === "assistant"
     && rowIsAfterIndex(row, currentRunLatestUserIndex);
-  const previousRowInActiveRun = !!isRunActive && !!previousRow && previousRow.message.role === "assistant"
+  const previousRowInLatestRun = !!previousRow && previousRow.message.role === "assistant"
     && rowIsAfterIndex(previousRow, currentRunLatestUserIndex);
-  const compactActiveRunTrace = rowInActiveRun && previousRowInActiveRun;
+  const compactActiveRunTrace = rowInLatestRun && previousRowInLatestRun;
   const displayResourceCards = displayResourceCardsByRow.get(index) || [];
   // Rows folded under a "Worked for …" rollup are trace, not the final answer.
-  const withinTrace = completedRunTraceGroups.groupedIndexes.has(index);
+  // Trace is about what a row *is*, not about whether its run happens to be
+  // folded. The most recent run never folds, so keying this off `groupedIndexes`
+  // alone left its narration rendering at answer weight — which is why a turn
+  // that talked before acting read as two answers.
+  const withinTrace = completedRunTraceGroups.traceIndexes.has(index);
+  // Spacing asks a different question from styling. `withinTrace` is about what
+  // a row *is*; this is about whether it already sits inside a rollup that owns
+  // its spacing. Guarding the compaction on `withinTrace` — after that flag was
+  // widened to cover unfolded runs — turned it off for the whole live trace, so
+  // every step stood a full turn-gap from the one before it.
+  const isInsideRollup = completedRunTraceGroups.groupedIndexes.has(index);
 
   return (
-    <div key={row.id || index} className={cn((compactAfterAssistant || compactActiveRunTrace) && !withinTrace && "-mt-3")}>
+    <div key={row.id || index} className={cn((compactAfterAssistant || compactActiveRunTrace) && !isInsideRollup && "-mt-3")}>
       {index === inlineRunStatusRowIndex ? (
         <div className="mb-3">
           <RunTraceHeader

--- a/lemma-frontend/components/lemma/assistant/assistant-experience-helpers.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-experience-helpers.tsx
@@ -273,7 +273,18 @@ export function defaultMessageContent({ message }: AssistantMessageRenderArgs): 
   const segments = splitAssistantMessageSegments(displayContent);
 
   return (
-    <div className={cn("min-w-0 overflow-hidden break-words text-sm font-normal leading-6 tracking-normal text-[var(--text-primary)]", isUserMessage ? "max-w-prose" : "max-w-full")}>
+    <div className={cn(
+      "min-w-0 overflow-hidden break-words text-sm font-normal leading-relaxed tracking-normal text-[var(--text-primary)]",
+      // What the agent *says* is set one way, whenever it says it.
+      //
+      // This used to depend on whether the message was currently the run's last
+      // text — which is a fact about the run's progress, not about the message.
+      // So an answer streamed in as muted italic "narration" and snapped to
+      // roman ink the moment the run ended. The distinction that matters is
+      // speech vs thought, and that never changes: thoughts are `THINKING`
+      // messages and render as reasoning, which is the one italic voice here.
+      isUserMessage ? "max-w-prose" : "max-w-full",
+    )}>
       {segments.map((segment, index) => (
         segment.kind === "json" ? (
           <AssistantJsonBlock key={`json-${index}`} json={segment.json} isUserMessage={isUserMessage} />

--- a/lemma-frontend/components/lemma/assistant/assistant-experience.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-experience.tsx
@@ -24,8 +24,6 @@ import {
   findPendingUserApprovalInvocation,
   latestPlanSummary,
   latestUserIndex,
-  messageTextContent,
-  rowIsAfterIndex,
 } from "lemma-sdk";
 import { cn } from "@/lib/utils";
 import type {
@@ -49,7 +47,6 @@ import {
 import {
   currentRunStatusLabel,
   currentToolStatusLabel,
-  resolveThinkingOwner,
   isInlineToolStatusAlreadyVisible,
   stringifyAssistantError,
 } from "./assistant-format";
@@ -336,14 +333,13 @@ export function AssistantExperienceView({
     const el = messagesContainerRef.current;
     if (!el) return;
 
+    // Always instant. Following the bottom of a growing transcript is not an
+    // animation — it is the viewport staying where it already was. Switching to
+    // "smooth" once the run settled meant every turn ended with a slide the
+    // reader did not ask for, on top of the layout settling at the same moment.
+    // Smooth belongs to the explicit jump-to-latest control, and nowhere else.
     if (isPinnedToBottomRef.current) {
-      if (isConversationBusy) {
-        scrollToLatest("auto");
-      } else {
-        requestAnimationFrame(() => {
-          scrollToLatest("smooth");
-        });
-      }
+      scrollToLatest("auto");
     }
   }, [controllerMessages, isConversationBusy, scrollToLatest]);
 
@@ -361,6 +357,7 @@ export function AssistantExperienceView({
   }, [draft, resizeComposer]);
 
   const displayMessageRows = useMemo(() => buildDisplayMessageRows(controllerMessages), [controllerMessages]);
+
   const completedRunTraceGroups = useMemo(
     () => collectCompletedRunTraceGroups(displayMessageRows, controllerMessages, isRunActive),
     [controllerMessages, displayMessageRows, isRunActive],
@@ -398,13 +395,6 @@ export function AssistantExperienceView({
   useEffect(() => {
     setIsPlanHidden(false);
   }, [activeConversationId, latestUserMessageId, planIdentity]);
-  const lastAssistantTextHasContent = useMemo(() => {
-    if (controllerMessages.length === 0) return false;
-    const lastMsg = controllerMessages[controllerMessages.length - 1];
-    if (lastMsg.role !== "assistant") return false;
-    return messageTextContent(lastMsg).length > 0;
-  }, [controllerMessages]);
-
   const inlineRunStatus = useMemo(
     () => currentRunStatusLabel({
       messages: controllerMessages,
@@ -528,18 +518,11 @@ export function AssistantExperienceView({
   const headerTone: AssistantSurfaceTone = resolvedChromeStyle === "elevated" ? "default" : resolvedChromeStyle === "flat" ? "flat" : "subtle";
   const composerTone: AssistantSurfaceTone = resolvedChromeStyle === "flat" ? "flat" : resolvedChromeStyle === "subtle" ? "subtle" : "default";
   const currentRunLatestUserIndex = latestUserIndex(controllerMessages);
-  const thinkingOwner = resolveThinkingOwner({
-    rows: displayMessageRows,
-    latestUser: currentRunLatestUserIndex,
-    hasRunStatus: !!inlineRunStatus,
-  });
-  // Progress labels ("Working for 12s", "Waiting for your input") describe the
-  // run rather than competing for the word "Thinking", so they stay whoever
-  // owns the thought. Only the bare placeholder yields.
-  const showThinkingStatus = !!inlineRunStatus
-    && (inlineRunStatus.label !== "Thinking"
-      ? true
-      : thinkingOwner === "run-status" && !lastAssistantTextHasContent);
+  // No arbitration left to do. Nothing in the transcript competes for the word
+  // "Thinking" any more — a streaming thought renders as prose and a tool group
+  // renders as "Ran 3 commands" — so this line simply shows whenever the run is
+  // doing something.
+  const showThinkingStatus = !!inlineRunStatus;
   const showInlineStatus = statusPlacement === "inline" && showThinkingStatus;
   const showComposerStatus = statusPlacement === "composer" && showThinkingStatus;
   const uploadStatusLabel = controller.isUploadingFiles
@@ -577,10 +560,15 @@ export function AssistantExperienceView({
     }),
     [activeConversationId, controllerMessages, displayMessageRows, displayResourcePodId, isConversationBusy],
   );
-  const inlineRunStatusRowIndex = showInlineStatus
-    ? displayMessageRows.findIndex((row) => row.message.role === "assistant" && rowIsAfterIndex(row, currentRunLatestUserIndex))
-    : -1;
-  const showInlineStatusAtBottom = showInlineStatus && inlineRunStatusRowIndex < 0;
+  // One indicator, at the end of the transcript, and nowhere else.
+  //
+  // There used to be three placements — a header injected above the first row of
+  // the live run, a line at the bottom, and a separate tool status — each with
+  // its own suppression rules, and they still collided: a streaming thought drew
+  // "Thinking" in its own card while one of these drew "Thinking" underneath it.
+  // Content blocks say what they are; this line says what the run is doing.
+  const inlineRunStatusRowIndex = -1;
+  const showInlineStatusAtBottom = showInlineStatus;
   const showInlineToolStatus = statusPlacement === "inline"
     && !!inlineToolStatus
     && !showInlineStatusAtBottom

--- a/lemma-frontend/components/lemma/assistant/assistant-format.ts
+++ b/lemma-frontend/components/lemma/assistant/assistant-format.ts
@@ -7,12 +7,10 @@ import {
   dedupToolInvocations,
   findPendingUserApprovalInvocation,
   formatDurationCompact,
-  isRunClosingMessage,
   isPlanToolName,
   isToolInvocationActive,
   latestUserIndex,
   messageHasToolActivity,
-  messageTextContent,
   messageTimeMs,
   normalizeAgentToolName,
   planStepsFromToolInvocation,
@@ -174,6 +172,35 @@ export function toolCallPrimaryLabel(toolName: string, args: ToolCardArgs): stri
   }
 
   return formatToolDisplayName(toolName);
+}
+
+/**
+ * The same label, split so a tool line can be set in two tones.
+ *
+ * A row rendered in one flat colour is a blob the eye has to read word by word.
+ * Split into what was done and what it was done to — "Terminal command" ·
+ * "npm test" — the line scans in one pass, the way "Edited display.ts" does.
+ * A row whose label is the agent's own description of the step is already that
+ * sentence, so it is all object and takes no verb.
+ */
+export function toolCallLabelParts(toolName: string, args: ToolCardArgs): { verb?: string; object: string } {
+  const comment = commentLabelFromArgs(args);
+  if (comment) return { object: comment };
+
+  const normalized = normalizeToolNameForDisplay(toolName);
+  if (isCommandDetailTool(normalized)) {
+    const cmd = firstToolArgString(args, ["cmd", "command"]);
+    if (cmd) return { verb: formatToolDisplayName(toolName), object: formatCommandPreview(cmd) };
+    const chars = asString(toolArg(args, "chars"));
+    if (chars) {
+      return {
+        verb: formatToolDisplayName(toolName),
+        object: truncateLabel(chars.replace(/\s+/g, " ").trim(), 48),
+      };
+    }
+  }
+
+  return { object: formatToolDisplayName(toolName) };
 }
 
 export function formatActiveToolSummary(toolName: string, args: ToolCardArgs): string {
@@ -359,28 +386,23 @@ export function currentRunStatusLabel({
 
   if (!isConversationBusy) return null;
 
-  const currentAssistantRows = rows.filter((row) => row.message.role === "assistant" && rowIsAfterIndex(row, latestUser));
   const currentMessages = messages.slice(latestUser + 1);
   const assistantMessages = currentMessages.filter((message) => message.role === "assistant");
-  const hasClosingAnswer = assistantMessages.some(isRunClosingMessage);
-  const hasAssistantText = assistantMessages.some((message) => messageTextContent(message).length > 0);
   const hasToolActivity = assistantMessages.some(messageHasToolActivity);
 
-  if (currentAssistantRows.length === 0) {
-    return { label: "Thinking", shimmer: true };
+  // A busy run always says so. This used to fall through to `null` whenever the
+  // run had produced rows but not yet both text and tool activity — which is
+  // most of a run that is only calling tools — so the transcript sat there with
+  // nothing moving and no indication anything was happening.
+  const startMs = assistantMessages
+    .map(messageTimeMs)
+    .find((value): value is number => value !== null);
+
+  if (hasToolActivity && startMs) {
+    return { label: `Working for ${formatDurationCompact(Math.max(1000, nowMs - startMs))}`, shimmer: false };
   }
 
-  if (assistantMessages.length > 0 && hasAssistantText && hasToolActivity && !hasClosingAnswer) {
-    const startMs = assistantMessages
-      .filter(messageHasToolActivity)
-      .map(messageTimeMs)
-      .find((value): value is number => value !== null);
-    if (startMs) {
-      return { label: `Working for ${formatDurationCompact(Math.max(1000, nowMs - startMs))}`, shimmer: false };
-    }
-  }
-
-  return null;
+  return { label: "Thinking", shimmer: true };
 }
 
 export function currentToolStatusLabel({
@@ -477,47 +499,6 @@ export function isInlineToolStatusAlreadyVisible({
   return false;
 }
 
-/** Which element gets to say "Thinking" for the current run.
- *
- * Three places can render that word - the run-status placeholder near the
- * composer, a reasoning card's summary, and a tool rollup's collapsed header -
- * and any two of them on screen at once read as the assistant thinking twice.
- * They are ranked rather than individually suppressed so exactly one wins:
- *
- * - `reasoning` whenever a thought is streaming. It owns the label because it
- *   is the one the user can click to watch the tokens arrive.
- * - `tool-rollup` when the run is working through tools. Its header already
- *   summarizes the activity and collapses the thought behind it.
- * - `run-status` only when the run has produced nothing to attach a label to.
- */
-export type ThinkingOwner = "reasoning" | "tool-rollup" | "run-status";
-
-export function resolveThinkingOwner({
-  rows,
-  latestUser,
-  hasRunStatus,
-}: {
-  rows: DisplayMessageRow[];
-  latestUser: number;
-  hasRunStatus: boolean;
-}): ThinkingOwner | null {
-  const currentRows = rows.filter((row) => (
-    row.message.role === "assistant" && rowIsAfterIndex(row, latestUser)
-  ));
-
-  const hasStreamingReasoning = currentRows.some((row) => row.message.parts?.some((part) => (
-    part.type === "reasoning" && part.state === "streaming"
-  )));
-  if (hasStreamingReasoning) return "reasoning";
-
-  const hasToolActivity = currentRows.some((row) => (
-    (row.message.toolInvocations?.length || 0) > 0
-    || row.message.parts?.some((part) => part.type === "tool")
-  ));
-  if (hasToolActivity) return "tool-rollup";
-
-  return hasRunStatus ? "run-status" : null;
-}
 
 export function getActiveToolBanner(messages: AssistantRenderableMessage[]): ActiveToolBanner | null {
   const displayMessages = prepareMessagesForDisplay(messages).map((entry) => entry.message);

--- a/lemma-frontend/components/lemma/assistant/assistant-message-group.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-message-group.tsx
@@ -184,7 +184,12 @@ export function MessageGroup({
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex flex-col gap-2">
+      {/* The blocks in a turn — a thought, a tool rollup, a paragraph of answer —
+          are separate beats and need room to read as such. At `gap-2` a
+          four-line thought sat half a line from the tool row after it, so a run
+          arrived as one wall of grey. The rows *inside* a rollup stay tight:
+          they are a list, and a list should look like one. */}
+      <div className="flex flex-col gap-4">
         {foldReasoningIntoRunRollup ? (
           <ToolActivityRollup
             key={`${message.id}-run-trace`}
@@ -248,10 +253,12 @@ export function MessageGroup({
                 key={part.id}
                 text={trimmedText}
                 timestamp={blockIndex === lastTextBlockIndex ? messageTimestamp : null}
-                // While the run is live, drop the hover copy/timestamp bar: its
-                // reserved height shows up as inconsistent gaps between streaming
-                // blocks. It returns once the run settles.
-                showActions={!withinTrace && !isCurrentRunActive}
+                // Not gated on the run being live. The bar is invisible until
+                // hover either way, so gating it on `isCurrentRunActive` bought
+                // nothing and cost a layout shift in every text block at the
+                // moment the run ended. Whether a block is trace is settled when
+                // it renders, so this height never changes under the reader.
+                showActions={!withinTrace}
               >
                 {contentNode}
               </TextBlockWithCopy>

--- a/lemma-frontend/components/lemma/assistant/assistant-parts.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-parts.tsx
@@ -265,6 +265,75 @@ export function EmptyState({
   );
 }
 
+/**
+ * The one line style for anything collapsible in the transcript.
+ *
+ * A run rollup ("Worked for 1m 7s"), a thought ("Thought"), a tool group
+ * ("Terminal command ×8") are the same object to a reader: a summary you can
+ * open. They had four separate implementations — two chevron sizes, one with no
+ * chevron at all, one with a rule under it — so a single turn showed four
+ * treatments of one idea. One component, one size, one colour, one chevron.
+ */
+export function TraceDisclosureLine({
+  label,
+  isExpanded,
+  onToggle,
+  shimmer = false,
+  rule = false,
+}: {
+  label: string;
+  isExpanded?: boolean;
+  onToggle?: () => void;
+  shimmer?: boolean;
+  rule?: boolean;
+}) {
+  const body = (
+    <>
+      {shimmer
+        ? <ThinkingIndicator label={label} shimmer />
+        : <span className="min-w-0 break-words">{label}</span>}
+      {onToggle ? (
+        <ChevronDown
+          className={cn(
+            "size-3.5 shrink-0 text-[var(--text-tertiary)] transition-transform",
+            !isExpanded && "-rotate-90",
+          )}
+          aria-hidden="true"
+        />
+      ) : null}
+    </>
+  );
+
+  const lineClassName = "lemma-assistant-run-trace-header flex w-fit max-w-full items-center gap-1.5 border-0 bg-transparent p-0 text-left text-sm leading-5 text-[var(--text-secondary)] transition-colors";
+
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      {onToggle ? (
+        <button
+          type="button"
+          className={cn(lineClassName, "cursor-pointer hover:text-[var(--text-primary)]")}
+          onClick={onToggle}
+          aria-expanded={isExpanded}
+        >
+          {body}
+        </button>
+      ) : (
+        <div className={lineClassName}>{body}</div>
+      )}
+      {/* A hairline, not a divider. This separates a run's trace from the answer
+          under it — a hint of structure, not a horizontal rule drawn across the
+          reading column. At full `--row-border` it read as the heavier of the
+          two, louder than the label it sits beneath. */}
+      {rule ? (
+        <div
+          className="h-px w-full bg-[color:color-mix(in_srgb,var(--row-border)_45%,transparent)]"
+          aria-hidden="true"
+        />
+      ) : null}
+    </div>
+  );
+}
+
 export function ReasoningPartCard({
   text,
   isStreaming,
@@ -276,30 +345,45 @@ export function ReasoningPartCard({
   durationMs?: number;
   showSummary?: boolean;
 }) {
-  const label = reasoningPartLabel(isStreaming, durationMs);
+  const label = reasoningPartLabel(false, durationMs);
+  // Italic, muted, and set as prose — the same voice whether the thought is
+  // arriving or being re-read, so opening one does not change its typeface.
+  // Identical to trace narration in `defaultMessageContent`, deliberately: a
+  // thought and a line of narration are the same agent talking to itself on the
+  // way to an answer, and rendering them as two different things was part of why
+  // a run read as a stack of unrelated fragments.
   const content = (
-    <div className={cn(showSummary && "mt-1 border-l border-[color:var(--row-border)] pl-4")}>
-      <pre className="whitespace-pre-wrap font-mono text-xs text-[var(--text-secondary)]">{text}</pre>
-    </div>
+    <p className={cn(
+      "whitespace-pre-wrap break-words text-sm italic leading-relaxed text-[var(--text-secondary)]",
+      showSummary && "mt-1",
+    )}>
+      {text}
+    </p>
   );
 
   if (!showSummary) return content;
 
+  // A thought that is still arriving is shown, not filed. It used to render as a
+  // closed drawer labelled "Thinking" — beside a transcript whose one activity
+  // indicator also said "Thinking", which is where the doubled label came from.
+  // While it streams, the prose is the indicator.
+  if (isStreaming) return content;
+
+  return <CollapsedThought label={label}>{content}</CollapsedThought>;
+}
+
+function CollapsedThought({ label, children }: { label: string; children: ReactNode }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
   return (
-    <details className="group flex flex-col gap-1">
-      <summary className="flex w-fit cursor-pointer list-none items-center gap-1.5 text-sm leading-5 text-[var(--text-secondary)] [&::-webkit-details-marker]:hidden">
-        {isStreaming ? (
-          <ThinkingIndicator label={label} shimmer />
-        ) : (
-          <span className="font-normal text-[var(--text-secondary)]">{label}</span>
-        )}
-        <ChevronDown
-          className="-rotate-90 size-3.5 shrink-0 text-[var(--text-tertiary)] transition-transform group-open:rotate-0"
-          aria-hidden="true"
-        />
-      </summary>
-      {content}
-    </details>
+    <div className="flex flex-col gap-1">
+      <TraceDisclosureLine
+        label={label}
+        isExpanded={isExpanded}
+        onToggle={() => setIsExpanded((previous) => !previous)}
+      />
+      {isExpanded ? children : null}
+    </div>
   );
 }
 

--- a/lemma-frontend/components/lemma/assistant/assistant-tool-details.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-tool-details.tsx
@@ -16,7 +16,7 @@ import {
   isRenderableUserInteractionInvocation,
   userApprovalResolvedDecision,
 } from "lemma-sdk";
-import { Check, ChevronDown, Copy } from "@/components/ui/icons";
+import { Check, Copy } from "@/components/ui/icons";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
@@ -30,10 +30,11 @@ import {
   humanizeKey,
   pickPreferredEntries,
   summarizeToolPayload,
+  toolCallLabelParts,
   toolCallPrimaryLabel,
 } from "./assistant-format";
 import { DetailsWithCopy, contextualToolDetails } from "./assistant-tool-cards";
-import { ReasoningPartCard, ThinkingIndicator } from "./assistant-parts";
+import { ReasoningPartCard, TraceDisclosureLine } from "./assistant-parts";
 import { SubagentActivityRollup } from "./assistant-subagent-activity";
 import { isSubagentLifecycleToolName } from "@/lib/assistant/subagent-activity";
 import {
@@ -56,7 +57,6 @@ import type {
   ToolCardResult,
   UserApprovalDecision,
 } from "./assistant-experience";
-import { ToolCallIcon } from "./assistant-tool-icon";
 
 export function ToolDetailsPanel({
   toolCallId,
@@ -289,28 +289,26 @@ function InlineToolCall({
   const resultData = (invocation.result || {}) as ToolCardResult;
   const isExecuting = isToolInvocationActive(invocation);
   const isFailed = !isExecuting && invocation.state === "result" && resultData.success === false;
-  const primaryLabel = toolCallPrimaryLabel(invocation.toolName, invocation.args);
+  const { verb, object } = toolCallLabelParts(invocation.toolName, invocation.args);
 
   return (
     <button
       type="button"
       onClick={onClick}
-      className="lemma-assistant-inline-tool-button inline-flex max-w-full items-center gap-2 border-0 bg-transparent p-0 text-left transition-colors"
+      className="lemma-assistant-inline-tool-button inline-flex max-w-full items-baseline gap-1.5 border-0 bg-transparent p-0 text-left transition-colors"
       data-state={isExecuting ? "executing" : isFailed ? "failed" : "complete"}
       data-selected={isSelected}
     >
-      <ToolCallIcon
-        toolName={invocation.toolName}
-        className="size-3.5 shrink-0 text-current opacity-80"
-      />
-      <span
-        className={cn(
-          "min-w-0 truncate",
-          isExecuting && "lemma-assistant-thinking-shimmer bg-clip-text text-transparent animate-[lemma-skeleton-breathe_1.5s_ease-in-out_infinite]",
-        )}
-      >
-        {primaryLabel}
-      </span>
+      {/* No icon. A glyph in front of every row added a column of noise down the
+          left of the trace without saying anything the label did not, and it was
+          the widest source of crowding once a run had a dozen steps.
+
+          Wraps, and reads the same whether or not it is the one running: a
+          per-row shimmer made the executing row a different weight and colour
+          from the rows above it, so a list of tool calls never looked like one
+          list. Activity is the transcript's single bottom indicator's job. */}
+      {verb ? <span className="shrink-0 opacity-70">{verb}</span> : null}
+      <span className="min-w-0 break-words">{object}</span>
       {isFailed ? (
         <span
           className="shrink-0 text-xs font-medium leading-none text-[var(--state-error)]"
@@ -328,15 +326,8 @@ export function pluralize(count: number, singular: string, plural = `${singular}
   return `${count} ${count === 1 ? singular : plural}`;
 }
 
-function joinActivityPhrases(phrases: string[]): string {
-  if (phrases.length <= 1) return phrases[0] ?? "";
-  if (phrases.length === 2) return `${phrases[0]} and ${phrases[1]}`;
-  return `${phrases.slice(0, -1).join(", ")} and ${phrases[phrases.length - 1]}`;
-}
-
-/** A human "did x, y and z" line for a block of tool calls — tallied by the
- * tool's display name (so repeats collapse to "×N"), preserving call order,
- * and capped so a long block reads "a, b, c, d +K more" instead of a wall. */
+/** A one-line summary for a block of tool calls: the tool's own name when the
+ * block is all one kind ("Terminal command ×3"), otherwise a plain count. */
 function formatToolActivitySummary(toolParts: Array<Extract<AssistantMessagePart, { type: "tool" }>>): string | null {
   if (toolParts.length === 0) return null;
 
@@ -356,12 +347,11 @@ function formatToolActivitySummary(toolParts: Array<Extract<AssistantMessagePart
     return count > 1 ? `${name} ×${count}` : name;
   };
 
-  const MAX_NAMED = 4;
-  if (order.length <= MAX_NAMED) {
-    return joinActivityPhrases(order.map(phraseFor));
-  }
-  const shown = order.slice(0, MAX_NAMED).map(phraseFor);
-  return `${shown.join(", ")} +${order.length - MAX_NAMED} more`;
+  // One kind of tool names itself ("Terminal command ×3"). Several kinds used to
+  // be glued together — "Updated plan and Terminal command ×2" — which is longer
+  // than the rows it summarises and harder to read than counting them.
+  if (order.length === 1) return phraseFor(order[0]);
+  return `Ran ${pluralize(toolParts.length, "step")}`;
 }
 
 type ToolActivityPart = Extract<AssistantMessagePart, { type: "tool" }>;
@@ -410,39 +400,16 @@ export function RunTraceHeader({
   isInteractive?: boolean;
   onToggle?: () => void;
 }) {
-  const content = (
-    <>
-      <span className="min-w-0 truncate">{label}</span>
-      {isInteractive ? (
-        <ChevronDown
-          className={cn(
-            "size-4 shrink-0 text-[var(--text-tertiary)] transition-transform",
-            !isExpanded && "-rotate-90",
-          )}
-          aria-hidden="true"
-        />
-      ) : null}
-    </>
-  );
-
+  // The run rollup is the same disclosure line as a thought or a tool group; it
+  // is only distinguished by the rule under it, which separates a whole run's
+  // trace from the answer that follows.
   return (
-    <div className="flex min-w-0 flex-col gap-2">
-      {isInteractive ? (
-        <button
-          type="button"
-          className="lemma-assistant-run-trace-header flex w-fit max-w-full items-center gap-1.5 border-0 bg-transparent p-0 text-left transition-colors"
-          onClick={onToggle}
-          aria-expanded={isExpanded}
-        >
-          {content}
-        </button>
-      ) : (
-        <div className="lemma-assistant-run-trace-header flex w-fit max-w-full items-center gap-1.5">
-          {content}
-        </div>
-      )}
-      <div className="h-px w-full bg-[var(--row-border)]" aria-hidden="true" />
-    </div>
+    <TraceDisclosureLine
+      label={label}
+      isExpanded={isExpanded}
+      onToggle={isInteractive ? onToggle : undefined}
+      rule
+    />
   );
 }
 
@@ -470,6 +437,9 @@ export function ToolActivityRollup({
 }) {
   const [activeDetailId, setActiveDetailId] = useState<string | null>(null);
   const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null);
+  // Closed, and it stays closed until the reader opens it. The header line above
+  // names what happened ("Ran 3 commands"), which is the summary — the cards are
+  // the detail behind it.
   const [isExpanded, setIsExpanded] = useState(false);
   const subagentToolParts = detailParts.filter((part): part is ToolActivityPart => (
     part.type === "tool" && isSubagentLifecycleToolName(part.toolInvocation.toolName)
@@ -499,9 +469,16 @@ export function ToolActivityRollup({
     const resultData = (invocation.result || {}) as ToolCardResult;
     return invocation.state !== "result" && !userApprovalResolvedDecision(resultData);
   });
-  const shouldShowHeader = hasRunHeader
-    || hasLongToolGroup
-    || (Boolean(isRunActive) && !hasPendingUserInteraction);
+  // A header summarises several things. One tool call is already its own
+  // summary, so wrapping it in "Terminal command ⌄" asks the reader to open a
+  // drawer to find the single line it was hiding.
+  //
+  // Deliberately not a function of `isRunActive`: that made a rollup unfurl its
+  // cards the instant a run ended. What a rollup looks like depends only on how
+  // much it holds, which does not change when the run does.
+  void hasRunHeader;
+  void hasLongToolGroup;
+  const shouldShowHeader = visibleDetailParts.length + subagentToolParts.length > 1;
   const failedCount = toolParts.filter((part) => (
     part.toolInvocation.state === "result"
     && !isLongRunningToolResult(part.toolInvocation)
@@ -620,28 +597,26 @@ export function ToolActivityRollup({
           onToggle={() => setIsExpanded((prev) => !prev)}
         />
       ) : shouldShowHeader ? (
-        <button
-          type="button"
-          className="lemma-assistant-tool-rollup-toggle-button inline-flex max-w-full cursor-pointer items-center gap-2.5 border-0 bg-transparent p-0 text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]"
-          onClick={() => setIsExpanded((prev) => !prev)}
-          aria-expanded={isTraceExpanded}
-          aria-label={isTraceExpanded ? "Hide tool activity details" : "Show tool activity details"}
-        >
-          {isWorking ? (
-            <ThinkingIndicator label={collapsedSummary} shimmer />
-          ) : (
-            <span className="truncate text-sm">{collapsedSummary}</span>
-          )}
-        </button>
+        <TraceDisclosureLine
+          label={collapsedSummary}
+          isExpanded={isTraceExpanded}
+          onToggle={() => setIsExpanded((prev) => !prev)}
+        />
       ) : null}
 
       {!shouldShowHeader || isTraceExpanded ? (
+        // No frame here. A tool's own detail card already draws one — a terminal
+        // card brings its own chrome, title bar and status — so wrapping the
+        // group in a second box produced a box inside a box inside a box. The
+        // group's extent is shown by the indent below and by its header above,
+        // both of which cost nothing.
         <div className={cn(
-          "flex flex-col gap-1.5",
+          "flex flex-col gap-1",
           isSingleDetail && "gap-1",
+          shouldShowHeader && "border-l border-[color:var(--row-border)] pl-3",
         )}>
           {activityBlocks.length === 1 && activityBlocks[0].type === "tool-group" ? (
-            <div className="flex flex-col gap-1.5">
+            <div className="flex flex-col gap-1">
               {activityBlocks[0].parts.map(renderToolActivityPart)}
             </div>
           ) : activityBlocks.map((block) => {
@@ -667,7 +642,7 @@ export function ToolActivityRollup({
 
             if (hasUnresolvedApproval) {
               return (
-                <div key={block.id} className="flex flex-col gap-1.5">
+                <div key={block.id} className="flex flex-col gap-1">
                   {block.parts.map(renderToolActivityPart)}
                 </div>
               );
@@ -675,7 +650,7 @@ export function ToolActivityRollup({
 
             if (block.parts.length <= 2) {
               return (
-                <div key={block.id} className="flex flex-col gap-1.5">
+                <div key={block.id} className="flex flex-col gap-1">
                   {block.parts.map(renderToolActivityPart)}
                 </div>
               );
@@ -684,16 +659,14 @@ export function ToolActivityRollup({
             const groupSummary = formatToolActivitySummary(block.parts) || `Used ${pluralize(block.parts.length, "tool")}`;
             const isGroupSelected = expandedGroupId === block.id;
             return (
-              <div key={block.id} className="flex flex-col gap-1.5">
-                <button
-                  type="button"
-                  onClick={() => setExpandedGroupId((prev) => (prev === block.id ? null : block.id))}
-                  className="lemma-assistant-tool-group-button inline-flex max-w-full items-center gap-2 border-0 bg-transparent p-0 text-left text-sm text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]"
-                >
-                  <span className="truncate">{groupSummary}</span>
-                </button>
+              <div key={block.id} className="flex flex-col gap-1">
+                <TraceDisclosureLine
+                  label={groupSummary}
+                  isExpanded={isGroupSelected}
+                  onToggle={() => setExpandedGroupId((prev) => (prev === block.id ? null : block.id))}
+                />
                 {isGroupSelected ? (
-                  <div className="flex flex-col gap-1.5">
+                  <div className="flex flex-col gap-1">
                     {block.parts.map(renderToolActivityPart)}
                   </div>
                 ) : null}

--- a/lemma-frontend/components/lemma/assistant/project-branch.tsx
+++ b/lemma-frontend/components/lemma/assistant/project-branch.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+/**
+ * Where in a project a conversation is working, next to which project it is.
+ *
+ * The chip names the branch; opening it says what is happening on that branch —
+ * the pull request it is in, how big that pull request is, and the two places
+ * you would go next (GitHub's compare view, or opening the pull request itself).
+ *
+ * Before a conversation exists the branch is a choice, and picking one changes
+ * what gets cloned. After it exists the branch is a fact: the checkout is on
+ * disk and an agent is working in it, so the list is gone and the panel is a
+ * readout. The same component does both, because it is the same information.
+ *
+ * Everything here is what GitHub knows. It cannot see uncommitted work in the
+ * agent's checkout, so nothing in it may be phrased as if it can.
+ */
+
+import { useState } from "react";
+
+import { StepLoader } from "@/components/brand/loader";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Check,
+  ChevronDown,
+  ExternalLink,
+  GitBranch,
+  GitPullRequest,
+} from "@/components/ui/icons";
+import { cn } from "@/lib/utils";
+import {
+  compareBranchUrl,
+  pullRequestDiffstat,
+  pullRequestStateLabel,
+  pullRequestTitleFromBranch,
+  type ProjectPullRequest,
+} from "@/lib/github/project-branch";
+import {
+  useBranchPullRequest,
+  useCreatePullRequest,
+  useRepoBranches,
+} from "@/lib/hooks/use-github-branches";
+import type { ProjectSelection } from "@/lib/assistant/project-selection";
+
+const CHIP_CLASS =
+  "inline-flex h-8 min-w-0 max-w-[11rem] items-center gap-1.5 rounded-md px-2 text-xs text-[var(--text-secondary)]";
+
+/** Merged is the one state worth a colour; the rest read fine as plain text. */
+const STATE_CLASS: Record<ProjectPullRequest["state"], string> = {
+  draft: "text-[var(--text-tertiary)]",
+  open: "text-[var(--status-success-text,var(--text-secondary))]",
+  merged: "text-[var(--accent-primary,var(--text-secondary))]",
+  closed: "text-[var(--text-tertiary)]",
+};
+
+function Diffstat({ pullRequest }: { pullRequest: ProjectPullRequest }) {
+  const diffstat = pullRequestDiffstat(pullRequest);
+  if (!diffstat) return null;
+  return (
+    <span className="shrink-0 tabular-nums text-[var(--text-tertiary)]">
+      <span className="text-[var(--status-success-text,var(--text-secondary))]">
+        +{diffstat.additions.toLocaleString()}
+      </span>{" "}
+      <span className="text-[var(--status-danger-text,var(--text-secondary))]">
+        −{diffstat.deletions.toLocaleString()}
+      </span>
+    </span>
+  );
+}
+
+function PullRequestSummary({
+  pullRequest,
+  project,
+}: {
+  pullRequest: ProjectPullRequest;
+  project: ProjectSelection;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 text-xs">
+        <GitPullRequest className="size-3.5 shrink-0 text-[var(--text-tertiary)]" />
+        <span className="text-[var(--text-secondary)]">#{pullRequest.number}</span>
+        <span className={cn("shrink-0", STATE_CLASS[pullRequest.state])}>
+          {pullRequestStateLabel(pullRequest.state)}
+        </span>
+        <span className="ml-auto">
+          <Diffstat pullRequest={pullRequest} />
+        </span>
+      </div>
+      <p className="truncate text-sm text-[var(--text-primary)]" title={pullRequest.title}>
+        {pullRequest.title}
+      </p>
+      <div className="flex items-center gap-3 text-xs">
+        {pullRequest.url ? (
+          <a
+            className="inline-flex items-center gap-1 text-[var(--text-secondary)] hover:underline"
+            href={pullRequest.url}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Pull request <ExternalLink className="size-3" />
+          </a>
+        ) : null}
+        {pullRequest.base ? (
+          <a
+            className="inline-flex items-center gap-1 text-[var(--text-secondary)] hover:underline"
+            href={compareBranchUrl(
+              project.owner,
+              project.repo,
+              pullRequest.base,
+              pullRequest.head || project.ref || "",
+            )}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Compare branch <ExternalLink className="size-3" />
+          </a>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function CreatePullRequestForm({
+  project,
+  defaultBranch,
+  onDone,
+}: {
+  project: ProjectSelection;
+  defaultBranch: string;
+  onDone: () => void;
+}) {
+  const [title, setTitle] = useState(() =>
+    pullRequestTitleFromBranch(project.ref || ""),
+  );
+  const create = useCreatePullRequest(project);
+
+  return (
+    <form
+      className="space-y-2"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (!title.trim() || create.isPending) return;
+        create.mutate(
+          { title: title.trim(), base: defaultBranch },
+          { onSuccess: onDone },
+        );
+      }}
+    >
+      <Input
+        value={title}
+        onChange={(event) => setTitle(event.target.value)}
+        placeholder="Pull request title"
+        aria-label="Pull request title"
+        className="h-8 text-xs"
+      />
+      <p className="text-xs text-[var(--text-tertiary)]">
+        {project.ref} → {defaultBranch}. Only what is pushed will be in it.
+      </p>
+      {create.error ? (
+        <p className="text-xs text-[var(--status-danger-text,var(--text-secondary))]">
+          GitHub refused it. The branch may not be pushed yet, or a pull request
+          may already exist.
+        </p>
+      ) : null}
+      <Button
+        type="submit"
+        size="sm"
+        variant="secondary"
+        className="w-full"
+        disabled={!title.trim() || create.isPending}
+      >
+        {create.isPending ? "Opening…" : "Open pull request"}
+      </Button>
+    </form>
+  );
+}
+
+/**
+ * What is happening on this branch, or the offer to start it.
+ *
+ * Its own component so that the half-typed title in the form belongs to one
+ * branch: the chip keys this on the branch, so switching branches unmounts the
+ * form rather than carrying it across.
+ */
+function BranchPullRequest({
+  project,
+  enabled,
+}: {
+  project: ProjectSelection;
+  enabled: boolean;
+}) {
+  const [composing, setComposing] = useState(false);
+  const { defaultBranch } = useRepoBranches(project, { enabled });
+  const { pullRequest, isLoading } = useBranchPullRequest(project, { enabled });
+
+  if (isLoading) {
+    return (
+      <p className="flex items-center gap-2 text-xs text-[var(--text-tertiary)]">
+        <StepLoader size="xs" />
+        Checking for a pull request…
+      </p>
+    );
+  }
+  if (pullRequest) {
+    return <PullRequestSummary pullRequest={pullRequest} project={project} />;
+  }
+  if (composing && defaultBranch) {
+    return (
+      <CreatePullRequestForm
+        project={project}
+        defaultBranch={defaultBranch}
+        onDone={() => setComposing(false)}
+      />
+    );
+  }
+  // Offered only once we know the base, and never for the base itself.
+  const canOpen = defaultBranch !== undefined && project.ref !== defaultBranch;
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-[var(--text-tertiary)]">
+        No pull request for this branch.
+      </p>
+      {canOpen ? (
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          className="w-full"
+          onClick={() => setComposing(true)}
+        >
+          Open a pull request
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+export interface ProjectBranchChipProps {
+  project: ProjectSelection;
+  /** Switching branches changes what gets cloned, so only before a run starts. */
+  onChange?: (branch: string) => void;
+  readOnly?: boolean;
+  className?: string;
+}
+
+export function ProjectBranchChip({
+  project,
+  onChange,
+  readOnly = false,
+  className,
+}: ProjectBranchChipProps) {
+  const [open, setOpen] = useState(false);
+
+  // Only ask GitHub about a branch while someone is looking at it.
+  const { branches, isLoading: isLoadingBranches } = useRepoBranches(project, {
+    enabled: open,
+  });
+  const branch = project.ref;
+
+  if (!branch) return null;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="quiet"
+          className={cn(CHIP_CLASS, "shrink", className)}
+          aria-label={`Branch: ${branch}`}
+          title={branch}
+        >
+          <GitBranch className="size-3.5 shrink-0" />
+          <span className="truncate">{branch}</span>
+          <ChevronDown className="size-3 shrink-0 text-[var(--text-tertiary)]" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[20rem] p-0">
+        {!readOnly ? (
+          <Command>
+            <CommandInput placeholder="Switch branch…" />
+            <CommandList className="max-h-48">
+              <CommandEmpty>
+                {isLoadingBranches ? "Loading branches…" : "No branches found."}
+              </CommandEmpty>
+              <CommandGroup heading="Branch">
+                {branches.map((name) => (
+                  <CommandItem
+                    key={name}
+                    value={name}
+                    onSelect={() => {
+                      onChange?.(name);
+                      setOpen(false);
+                    }}
+                  >
+                    <span className="flex-1 truncate">{name}</span>
+                    {name === branch ? <Check className="ml-2 size-3.5 shrink-0" /> : null}
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        ) : null}
+
+        <div
+          className={cn(
+            "space-y-3 p-3",
+            !readOnly && "border-t border-[var(--border-subtle)]",
+          )}
+        >
+          {readOnly ? (
+            <div className="flex items-center gap-1.5 text-xs text-[var(--text-secondary)]">
+              <GitBranch className="size-3.5 shrink-0" />
+              <span className="truncate">{branch}</span>
+            </div>
+          ) : null}
+
+          <BranchPullRequest
+            key={`${project.owner}/${project.repo}#${branch}`}
+            project={project}
+            enabled={open}
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/lemma-frontend/components/lemma/assistant/project-picker.tsx
+++ b/lemma-frontend/components/lemma/assistant/project-picker.tsx
@@ -39,14 +39,13 @@ import { projectLabel, type ProjectSelection } from "@/lib/assistant/project-sel
 const CHIP_CLASS =
   "inline-flex h-8 min-w-0 max-w-[14rem] items-center gap-1.5 rounded-md px-2 text-xs text-[var(--text-secondary)]";
 
+// The branch is deliberately absent: `ProjectBranchChip` sits next to this one
+// and names it, and printing it in both places says the same thing twice.
 function ChipBody({ project }: { project: ProjectSelection | null }) {
   return project ? (
     <>
       <Github className="size-3.5 shrink-0" />
       <span className="truncate">{projectLabel(project)}</span>
-      {project.ref ? (
-        <span className="hidden shrink-0 text-[var(--text-tertiary)] sm:inline">{project.ref}</span>
-      ) : null}
     </>
   ) : (
     <>

--- a/lemma-frontend/components/pod/pod-new-workspace.tsx
+++ b/lemma-frontend/components/pod/pod-new-workspace.tsx
@@ -125,13 +125,13 @@ export type PodNewWorkspacePlacement = 'empty-state' | 'below-composer';
 // group, so a panel taller than its neighbour moves the whole block — including
 // the pod line and the tabs you are aiming at — every time you switch tabs.
 //
-// Sized for the worst realistic panel, not the average one: two rows of tiles
-// whose titles have wrapped to the second line line-clamp allows, plus a
-// caption. Tiles are ~104px with a one-line title and ~124px with two, so two
-// wrapped rows plus a caption is ~282. Undershooting this is what put a
-// scrollbar in the Create panel and clipped its caption. `overflow-y-auto`
-// stays as the safety net for anything longer still.
-const PANEL_HEIGHT = 'h-72 overflow-y-auto';
+// Sized for the worst realistic panel, not the average one: Do, at two rows of
+// tiles whose titles have wrapped to the second line line-clamp allows, plus
+// the row that unscopes the composer. Measured, not guessed — a tile is 94px
+// with a one-line title and 112px with two, so that worst case is 272.
+// Undershooting this is what put a scrollbar in the Create panel and clipped
+// its caption. `overflow-y-auto` stays as the safety net for anything longer.
+const PANEL_HEIGHT = 'h-[17.5rem] overflow-y-auto';
 
 // Below the composer there is nothing above to shove around, so the lock buys
 // nothing and costs a block of dead space under every short panel.
@@ -151,18 +151,18 @@ function TileIconBox({ spec, muted }: { spec: LauncherTileSpec; muted?: boolean 
 
     if (muted) {
         return (
-            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)] text-[var(--text-tertiary)]">
-                <Icon className="h-4 w-4" strokeWidth={1.8} />
+            <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)] text-[var(--text-tertiary)]">
+                <Icon className="h-3.5 w-3.5" strokeWidth={1.8} />
             </span>
         );
     }
 
     return (
-        <span className="recipe-icon-tile h-8 w-8 shrink-0 rounded-lg" data-accent={spec.accent ?? 'intelligence'}>
+        <span className="recipe-icon-tile h-7 w-7 shrink-0 rounded-lg" data-accent={spec.accent ?? 'intelligence'}>
             {spec.image ? (
-                <Image src={spec.image.src} alt="" aria-hidden width={18} height={18} className="object-contain" />
+                <Image src={spec.image.src} alt="" aria-hidden width={16} height={16} className="object-contain" />
             ) : (
-                <Icon className="h-4 w-4" strokeWidth={1.8} />
+                <Icon className="h-3.5 w-3.5" strokeWidth={1.8} />
             )}
         </span>
     );
@@ -188,14 +188,14 @@ function LauncherTile({
         <>
             <TileIconBox spec={spec} muted={muted} />
             <span className="flex w-full min-w-0 flex-col items-start gap-0.5">
-                <span className="line-clamp-2 w-full text-left text-sm leading-5 text-[var(--text-primary)]">{spec.title}</span>
-                <span className="w-full truncate text-left text-xs text-[var(--text-tertiary)]">{spec.hint}</span>
+                <span className="line-clamp-2 w-full text-left text-sm leading-tight text-[var(--text-primary)]">{spec.title}</span>
+                <span className="w-full truncate text-left text-xs leading-4 text-[var(--text-tertiary)]">{spec.hint}</span>
             </span>
         </>
     );
     // `whitespace-normal` is load-bearing: Button's base sets `whitespace-nowrap`,
     // which silently clips every title mid-word instead of letting it wrap.
-    const className = 'h-auto min-h-24 w-full flex-col items-start justify-start gap-2.5 whitespace-normal rounded-lg p-3 text-left font-normal data-[selected=true]:border-[color:var(--action-primary)]';
+    const className = 'h-auto min-h-20 w-full flex-col items-start justify-start gap-2 whitespace-normal rounded-lg p-2.5 text-left font-normal data-[selected=true]:border-[color:var(--action-primary)]';
 
     if (href) {
         return (
@@ -267,8 +267,13 @@ function BuildPanel({
     onLaunchThemePrompt: (theme: StarterTheme, recipeId: string, prompt: string) => void;
 }) {
     const themes = FEATURED_STARTER_THEMES.slice(0, BUILD_THEME_TILES);
-    const [activeThemeId, setActiveThemeId] = useState(themes[0]?.id);
-    const activeTheme = themes.find((theme) => theme.id === activeThemeId) ?? themes[0];
+    // Nothing is chosen until someone chooses it. The prompts below still need a
+    // theme to come from, so they fall back to the first one — but DRAWING that
+    // fallback as selected told everyone opening a new tab that a choice they
+    // never made had already been made for them, and the first tile has no
+    // claim to being the answer.
+    const [chosenThemeId, setChosenThemeId] = useState<string | null>(null);
+    const activeTheme = themes.find((theme) => theme.id === chosenThemeId) ?? themes[0];
 
     if (!activeTheme) return null;
 
@@ -293,8 +298,8 @@ function BuildPanel({
                             icon: LayoutDashboard,
                             image: THEME_LOGOS[theme.id],
                         }}
-                        selected={theme.id === activeTheme.id}
-                        onSelect={() => setActiveThemeId(theme.id)}
+                        selected={theme.id === chosenThemeId}
+                        onSelect={() => setChosenThemeId(theme.id)}
                     />
                 ))}
                 <LauncherTile

--- a/lemma-frontend/components/ui/icons.ts
+++ b/lemma-frontend/components/ui/icons.ts
@@ -54,6 +54,7 @@ export {
     FolderPlus,
     Footprints,
     GitBranch,
+    GitPullRequest,
     Handshake,
     Headphones,
     Image,

--- a/lemma-frontend/lib/assistant/__tests__/inline-tool-status.test.ts
+++ b/lemma-frontend/lib/assistant/__tests__/inline-tool-status.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { AssistantRenderableMessage, AssistantToolInvocation } from "lemma-sdk/react";
+import { buildDisplayMessageRows } from "lemma-sdk";
 import {
   currentToolStatusLabel,
   isInlineToolStatusAlreadyVisible,
-  resolveThinkingOwner,
+  currentRunStatusLabel,
   type InlineToolStatus,
 } from "@/components/lemma/assistant/assistant-format";
 import type { DisplayMessageRow } from "@/components/lemma/assistant/assistant-experience";
@@ -128,93 +129,67 @@ describe("inline tool-status handoff", () => {
   });
 });
 
-describe("who owns the Thinking label", () => {
-  function reasoningRow(state: "streaming" | "done", sourceIndex = 1): DisplayMessageRow {
-    const message: AssistantRenderableMessage = {
-      id: `reasoning-message-${state}`,
+// The arbitration this file used to test is gone. Nothing in the transcript
+// competes for the word "Thinking" any more — a streaming thought renders as
+// prose and a tool group renders as one "Ran 3 commands" line — so there is one
+// status line and its only job is never to go quiet mid-run.
+describe("the run status line", () => {
+  function assistantToolMessage(sequence: number): AssistantRenderableMessage {
+    return {
+      id: `tool-message-${sequence}`,
       role: "assistant",
       content: "",
       createdAt: new Date("2026-07-11T00:00:01.000Z"),
-      parts: [{
-        id: `reasoning-part-${state}`,
-        type: "reasoning",
-        text: state === "streaming" ? "Inspecting the workspace" : "Inspected the workspace",
-        state,
+      toolInvocations: [{
+        toolCallId: `call-${sequence}`,
+        toolName: "list_tables",
+        args: {},
+        state: "call",
       }],
     };
-
-    return { id: `reasoning-row-${state}`, message, sourceIndexes: [sourceIndex] };
   }
 
-  it("gives a streaming thought the label, so the placeholder yields", () => {
-    expect(resolveThinkingOwner({
-      rows: [reasoningRow("streaming")],
-      latestUser: 0,
-      hasRunStatus: true,
-    })).toBe("reasoning");
-  });
+  const userMessage: AssistantRenderableMessage = {
+    id: "user-1",
+    role: "user",
+    content: "list the tables",
+    createdAt: new Date("2026-07-11T00:00:00.000Z"),
+  };
 
-  it("gives the tool rollup the label once tools are running", () => {
-    const row = toolRow({
-      toolCallId: "call-1",
-      toolName: "list_tables",
-      args: {},
-      state: "call",
+  const nowMs = new Date("2026-07-11T00:00:09.000Z").getTime();
+
+  it("says something while the run is only calling tools", () => {
+    // The old implementation returned null here — a run working through tools
+    // with no assistant text yet — so the transcript showed no sign of life.
+    const messages = [userMessage, assistantToolMessage(1)];
+    const status = currentRunStatusLabel({
+      messages,
+      rows: buildDisplayMessageRows(messages),
+      isConversationBusy: true,
+      nowMs,
     });
 
-    expect(resolveThinkingOwner({
-      rows: [row],
-      latestUser: 0,
-      hasRunStatus: true,
-    })).toBe("tool-rollup");
+    expect(status).not.toBeNull();
+    expect(status?.label).toMatch(/^Working for /);
   });
 
-  it("still prefers the thought when a run has both a thought and tools", () => {
-    const tool = toolRow({
-      toolCallId: "call-2",
-      toolName: "list_tables",
-      args: {},
-      state: "call",
-    }, 2);
-
-    expect(resolveThinkingOwner({
-      rows: [reasoningRow("streaming"), tool],
-      latestUser: 0,
-      hasRunStatus: true,
-    })).toBe("reasoning");
+  it("says Thinking before the run has produced anything", () => {
+    const messages = [userMessage];
+    expect(currentRunStatusLabel({
+      messages,
+      rows: buildDisplayMessageRows(messages),
+      isConversationBusy: true,
+      nowMs,
+    })).toEqual({ label: "Thinking", shimmer: true });
   });
 
-  it("falls back to the run-status placeholder while the run is still empty", () => {
-    expect(resolveThinkingOwner({
-      rows: [],
-      latestUser: 0,
-      hasRunStatus: true,
-    })).toBe("run-status");
-  });
-
-  it("hands the label back to the placeholder once the thought settles", () => {
-    // The durable THINKING message renders "Thought for Ns", not "Thinking",
-    // so it no longer competes for the streaming label.
-    expect(resolveThinkingOwner({
-      rows: [reasoningRow("done")],
-      latestUser: 0,
-      hasRunStatus: true,
-    })).toBe("run-status");
-  });
-
-  it("ignores reasoning that belongs to an earlier run", () => {
-    expect(resolveThinkingOwner({
-      rows: [reasoningRow("streaming")],
-      latestUser: 1,
-      hasRunStatus: true,
-    })).toBe("run-status");
-  });
-
-  it("names nobody when there is no run status to place", () => {
-    expect(resolveThinkingOwner({
-      rows: [],
-      latestUser: 0,
-      hasRunStatus: false,
+  it("goes quiet once the run is no longer busy", () => {
+    const messages = [userMessage, assistantToolMessage(1)];
+    expect(currentRunStatusLabel({
+      messages,
+      rows: buildDisplayMessageRows(messages),
+      isConversationBusy: false,
+      nowMs,
     })).toBeNull();
   });
 });

--- a/lemma-frontend/lib/github/project-branch.test.ts
+++ b/lemma-frontend/lib/github/project-branch.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    branchNamesFromExecution,
+    compareBranchUrl,
+    defaultBranchFromExecution,
+    orderBranches,
+    pullRequestDetailFromExecution,
+    pullRequestDiffstat,
+    pullRequestFromExecution,
+    pullRequestTitleFromBranch,
+} from './project-branch';
+
+/** One pull request as `pulls_list` returns it, trimmed to what we read. */
+const listed = {
+    number: 316,
+    title: 'Fix the surface regressions',
+    html_url: 'https://github.com/lemma-work/lemma-platform/pull/316',
+    state: 'closed',
+    draft: false,
+    merged_at: '2026-08-11T09:58:09Z',
+    base: { ref: 'main' },
+    head: { ref: 'fix-303-surface-regressions' },
+};
+
+describe('branches', () => {
+    it('reads names out of the branch list', () => {
+        expect(
+            branchNamesFromExecution({
+                result: [{ name: 'main' }, { name: 'fix-303' }, { protected: true }],
+            }),
+        ).toEqual(['main', 'fix-303']);
+    });
+
+    it('reads the default branch off the repo', () => {
+        expect(defaultBranchFromExecution({ result: { default_branch: 'main' } })).toBe('main');
+        expect(defaultBranchFromExecution({ result: [] })).toBeUndefined();
+    });
+
+    it('puts the current branch first, then the default', () => {
+        expect(
+            orderBranches(['alpha', 'main', 'fix-303', 'zeta'], {
+                current: 'fix-303',
+                defaultBranch: 'main',
+            }),
+        ).toEqual(['fix-303', 'main', 'alpha', 'zeta']);
+    });
+
+    it('ignores pins that are not in the list', () => {
+        expect(orderBranches(['main'], { current: 'gone', defaultBranch: 'main' })).toEqual([
+            'main',
+        ]);
+    });
+
+    it('lists the default branch once when that is also the current one', () => {
+        expect(
+            orderBranches(['alpha', 'main'], { current: 'main', defaultBranch: 'main' }),
+        ).toEqual(['main', 'alpha']);
+    });
+});
+
+describe('the pull request on a branch', () => {
+    it('calls a closed-but-merged pull request merged', () => {
+        expect(pullRequestFromExecution({ result: [listed] })).toMatchObject({
+            number: 316,
+            state: 'merged',
+            base: 'main',
+            head: 'fix-303-surface-regressions',
+        });
+    });
+
+    it('distinguishes draft, open and abandoned', () => {
+        const state = (overrides: Record<string, unknown>) =>
+            pullRequestFromExecution({ result: [{ ...listed, merged_at: null, ...overrides }] })
+                ?.state;
+        expect(state({ draft: true })).toBe('draft');
+        expect(state({ state: 'open' })).toBe('open');
+        expect(state({ state: 'closed' })).toBe('closed');
+    });
+
+    it('is null when the branch has none, and when the call did not answer', () => {
+        expect(pullRequestFromExecution({ result: [] })).toBeNull();
+        expect(pullRequestFromExecution({ result: { message: 'Not Found' } })).toBeNull();
+        expect(pullRequestFromExecution(undefined)).toBeNull();
+    });
+
+    it('takes totals from the detail call', () => {
+        const detailed = pullRequestDetailFromExecution({
+            result: { ...listed, additions: 1662, deletions: 575, changed_files: 3 },
+        });
+        expect(pullRequestDiffstat(detailed!)).toEqual({ additions: 1662, deletions: 575 });
+    });
+
+    it('shows no diffstat when the totals never arrived', () => {
+        // +0 −0 would be a claim about the branch; absent is the truth.
+        expect(pullRequestDiffstat(pullRequestFromExecution({ result: [listed] })!)).toBeNull();
+    });
+});
+
+describe('what the panel links to', () => {
+    it('compares head against base', () => {
+        expect(compareBranchUrl('lemma-work', 'lemma-platform', 'main', 'fix/303')).toBe(
+            'https://github.com/lemma-work/lemma-platform/compare/main...fix%2F303',
+        );
+    });
+
+    it('reads a branch name as a title', () => {
+        expect(pullRequestTitleFromBranch('fix-303-surface-regressions')).toBe(
+            'Fix 303 surface regressions',
+        );
+        expect(pullRequestTitleFromBranch('deepak/add_branch_picker')).toBe(
+            'Add branch picker',
+        );
+    });
+});

--- a/lemma-frontend/lib/github/project-branch.ts
+++ b/lemma-frontend/lib/github/project-branch.ts
@@ -1,0 +1,163 @@
+/**
+ * The branch a conversation works on, and the pull request that branch is in.
+ *
+ * A project answers "which repository"; this answers "and where in it". Both
+ * come back through connector operations, so what arrives is GitHub's own JSON
+ * inside the execution envelope (`{ result }`) — these read it into the two
+ * shapes the UI actually renders, and nothing wider.
+ *
+ * This is *pushed* state. It is what GitHub knows, not what is on disk in the
+ * agent's checkout: a branch with uncommitted work looks identical here to one
+ * without. Every label built from it has to stay true under that reading.
+ *
+ * Kept free of React so the parsing is testable on its own.
+ */
+
+import type { OperationExecutionResponse } from 'lemma-sdk';
+
+/** GitHub splits this across three fields; one closed set is easier to render. */
+export type PullRequestState = 'draft' | 'open' | 'merged' | 'closed';
+
+export interface ProjectPullRequest {
+    number: number;
+    title: string;
+    url: string;
+    state: PullRequestState;
+    base: string;
+    head: string;
+    /**
+     * Only the detail call carries these — the list endpoint omits them
+     * entirely, so absent means "not fetched yet", never "no changes".
+     */
+    additions?: number;
+    deletions?: number;
+    changedFiles?: number;
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+    value && typeof value === 'object' && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : null;
+
+const asString = (value: unknown): string | undefined =>
+    typeof value === 'string' && value.trim() ? value : undefined;
+
+const asCount = (value: unknown): number | undefined =>
+    typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+
+/** `repos_list_branches` — names only; the picker never shows anything else. */
+export const branchNamesFromExecution = (
+    response: OperationExecutionResponse | undefined,
+): string[] => {
+    const items = response?.result;
+    if (!Array.isArray(items)) return [];
+    return items
+        .map((item) => asString(asRecord(item)?.name))
+        .filter((name): name is string => Boolean(name));
+};
+
+/** `repos_get` — the base a new pull request should target. */
+export const defaultBranchFromExecution = (
+    response: OperationExecutionResponse | undefined,
+): string | undefined => asString(asRecord(response?.result)?.default_branch);
+
+/**
+ * The branch's own branch first, then the repo's default, then the rest.
+ *
+ * Both are one click away from being what you want next, and a list of two
+ * hundred alphabetical branches buries them.
+ */
+export const orderBranches = (
+    names: string[],
+    options: { current?: string; defaultBranch?: string } = {},
+): string[] => {
+    const pinned: string[] = [];
+    for (const name of [options.current, options.defaultBranch]) {
+        // A conversation sitting on the default branch names it twice; pinning
+        // it twice would render the same branch twice in the list.
+        if (name && names.includes(name) && !pinned.includes(name)) pinned.push(name);
+    }
+    return [...pinned, ...names.filter((name) => !pinned.includes(name))];
+};
+
+const pullRequestState = (record: Record<string, unknown>): PullRequestState => {
+    // `merged_at` is the only honest signal: a merged pull request reports
+    // `state: "closed"` like an abandoned one, and the two mean opposite things.
+    if (asString(record.merged_at)) return 'merged';
+    if (record.draft === true) return 'draft';
+    return record.state === 'closed' ? 'closed' : 'open';
+};
+
+const toPullRequest = (value: unknown): ProjectPullRequest | null => {
+    const record = asRecord(value);
+    const number = asCount(record?.number);
+    if (!record || number === undefined) return null;
+    return {
+        number,
+        title: asString(record.title) || `#${number}`,
+        url: asString(record.html_url) || '',
+        state: pullRequestState(record),
+        base: asString(asRecord(record.base)?.ref) || '',
+        head: asString(asRecord(record.head)?.ref) || '',
+        additions: asCount(record.additions),
+        deletions: asCount(record.deletions),
+        changedFiles: asCount(record.changed_files),
+    };
+};
+
+/**
+ * `pulls_list` for one branch, newest first — the pull request that branch is
+ * currently in. A branch reopened after a merge has two; the caller asked for
+ * the most recently updated, and that is the one worth showing.
+ */
+export const pullRequestFromExecution = (
+    response: OperationExecutionResponse | undefined,
+): ProjectPullRequest | null => {
+    const items = response?.result;
+    if (!Array.isArray(items)) return null;
+    for (const item of items) {
+        const pullRequest = toPullRequest(item);
+        if (pullRequest) return pullRequest;
+    }
+    return null;
+};
+
+/** `pulls_get` or `pulls_create` — a single pull request, totals included. */
+export const pullRequestDetailFromExecution = (
+    response: OperationExecutionResponse | undefined,
+): ProjectPullRequest | null => toPullRequest(response?.result);
+
+export const pullRequestStateLabel = (state: PullRequestState): string =>
+    ({ draft: 'Draft', open: 'Open', merged: 'Merged', closed: 'Closed' })[state];
+
+/**
+ * A diffstat only when both halves are known. Rendering `+0 −0` for a pull
+ * request whose totals never arrived states something false about the branch.
+ */
+export const pullRequestDiffstat = (
+    pullRequest: ProjectPullRequest,
+): { additions: number; deletions: number } | null =>
+    pullRequest.additions === undefined || pullRequest.deletions === undefined
+        ? null
+        : { additions: pullRequest.additions, deletions: pullRequest.deletions };
+
+/** GitHub's compare view for a branch against its base. */
+export const compareBranchUrl = (
+    owner: string,
+    repo: string,
+    base: string,
+    head: string,
+): string =>
+    `https://github.com/${owner}/${repo}/compare/${encodeURIComponent(base)}...${encodeURIComponent(head)}`;
+
+/** A branch name read as a sentence: the title a person would have typed. */
+export const pullRequestTitleFromBranch = (branch: string): string => {
+    const words = branch
+        .split('/')
+        .pop()!
+        .replace(/[-_]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+    if (!words) return branch;
+    return words.charAt(0).toUpperCase() + words.slice(1);
+};

--- a/lemma-frontend/lib/hooks/use-assistants.ts
+++ b/lemma-frontend/lib/hooks/use-assistants.ts
@@ -169,14 +169,6 @@ export function useScopedConversations(scope: ConversationScope, params?: { limi
     });
 }
 
-export function useConversation(podId: string, id: string) {
-    return useQuery({
-        queryKey: ['conversations', podId, id],
-        queryFn: () => getLemmaClient(podId || undefined).conversations.get(id, { pod_id: podId }) as Promise<Conversation>,
-        enabled: !!podId && !!id,
-    });
-}
-
 export function useCreateConversation() {
     const queryClient = useQueryClient();
 
@@ -227,23 +219,6 @@ export function useCreateScopedConversation() {
 }
 
 // Messages
-export function useMessages(podId: string, conversationId: string, params?: { limit?: number; cursor?: string }) {
-    return useQuery({
-        queryKey: ['conversations', podId, conversationId, 'messages', params],
-        queryFn: async () => {
-            const response = await getLemmaClient().conversations.messages.list(
-                conversationId,
-                {
-                    limit: params?.limit,
-                    page_token: params?.cursor,
-                }
-            );
-            return asPaginatedArray<Message>(response);
-        },
-        enabled: !!podId && !!conversationId,
-    });
-}
-
 export function useConversationMessages(conversationId: string, params?: { limit?: number; cursor?: string }) {
     return useQuery({
         queryKey: ['conversations', conversationId, 'messages', params],

--- a/lemma-frontend/lib/hooks/use-github-branches.ts
+++ b/lemma-frontend/lib/hooks/use-github-branches.ts
@@ -1,0 +1,189 @@
+'use client';
+
+/**
+ * What a conversation's branch looks like on GitHub.
+ *
+ * The project picker answers "which repository". These answer the rest of the
+ * question a person asks while an agent works in it: which branch am I on, what
+ * else could I switch to, and is there a pull request for this yet.
+ *
+ * Everything here reads through the same curated connector operations the agent
+ * itself would use, so what the panel shows is exactly the access the run has.
+ * All of it is *pushed* state — see `lib/github/project-branch`.
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+    branchNamesFromExecution,
+    defaultBranchFromExecution,
+    orderBranches,
+    pullRequestDetailFromExecution,
+    pullRequestFromExecution,
+    type ProjectPullRequest,
+} from '@/lib/github/project-branch';
+import { useGithubConnection } from '@/lib/hooks/use-github-projects';
+import type { ProjectSelection } from '@/lib/assistant/project-selection';
+
+/** Enough to hold any repo a person browses by name; beyond it, search. */
+const BRANCH_PAGE_SIZE = 100;
+
+export interface RepoBranchesState {
+    /** The current branch first, then the default, then the rest. */
+    branches: string[];
+    defaultBranch?: string;
+    isLoading: boolean;
+    error: unknown;
+}
+
+export function useRepoBranches(
+    project: ProjectSelection | null,
+    options?: { enabled?: boolean },
+): RepoBranchesState {
+    const connection = useGithubConnection({ enabled: options?.enabled ?? true });
+    const enabled = Boolean(connection.canExecute && project);
+
+    const { data, isLoading, error } = useQuery({
+        queryKey: [
+            'github-branches',
+            connection.organizationId,
+            connection.accountId,
+            project?.owner,
+            project?.repo,
+        ],
+        queryFn: async () => {
+            const target = { owner: project!.owner, repo: project!.repo };
+            // Two calls, one loading state: the default branch is both the base
+            // a new pull request wants and the branch worth listing near the top.
+            const [branches, repo] = await Promise.all([
+                connection.execute('repos_list_branches', {
+                    ...target,
+                    per_page: BRANCH_PAGE_SIZE,
+                }),
+                connection.execute('repos_get', target),
+            ]);
+            return {
+                names: branchNamesFromExecution(branches),
+                defaultBranch: defaultBranchFromExecution(repo),
+            };
+        },
+        enabled,
+        // A branch list goes stale the moment someone pushes, but re-reading it
+        // on every popover open costs more than being a minute behind.
+        staleTime: 60 * 1000,
+    });
+
+    return {
+        branches: orderBranches(data?.names ?? [], {
+            current: project?.ref,
+            defaultBranch: data?.defaultBranch,
+        }),
+        defaultBranch: data?.defaultBranch,
+        isLoading: enabled && isLoading,
+        error,
+    };
+}
+
+export interface BranchPullRequestState {
+    /** Null once we've looked and there is none — not the same as loading. */
+    pullRequest: ProjectPullRequest | null;
+    isLoading: boolean;
+    error: unknown;
+}
+
+export function useBranchPullRequest(
+    project: ProjectSelection | null,
+    options?: { enabled?: boolean },
+): BranchPullRequestState {
+    const connection = useGithubConnection({ enabled: options?.enabled ?? true });
+    const branch = project?.ref;
+    const enabled = Boolean(connection.canExecute && project && branch);
+
+    const { data, isLoading, error } = useQuery({
+        queryKey: pullRequestQueryKey(connection.organizationId, project),
+        queryFn: async () => {
+            const target = { owner: project!.owner, repo: project!.repo };
+            const listed = pullRequestFromExecution(
+                await connection.execute('pulls_list', {
+                    ...target,
+                    // `user:ref` is the filter's own format, and `all` because a
+                    // merged pull request is the most useful thing to say about
+                    // a branch whose work is already done.
+                    head: `${project!.owner}:${branch}`,
+                    state: 'all',
+                    sort: 'updated',
+                    direction: 'desc',
+                    per_page: 1,
+                }),
+            );
+            if (!listed) return null;
+            // The list endpoint carries no totals, so the diffstat costs a
+            // second call — worth it, since the numbers are half the point.
+            const detailed = pullRequestDetailFromExecution(
+                await connection.execute('pulls_get', {
+                    ...target,
+                    pull_number: listed.number,
+                }),
+            );
+            return detailed ?? listed;
+        },
+        enabled,
+        staleTime: 60 * 1000,
+    });
+
+    return {
+        pullRequest: data ?? null,
+        isLoading: enabled && isLoading,
+        error,
+    };
+}
+
+const pullRequestQueryKey = (
+    organizationId: string | undefined,
+    project: ProjectSelection | null,
+) => ['github-branch-pull-request', organizationId, project?.owner, project?.repo, project?.ref];
+
+export interface CreatePullRequestInput {
+    title: string;
+    base: string;
+    body?: string;
+    draft?: boolean;
+}
+
+/**
+ * Opening the pull request for the branch this conversation is on.
+ *
+ * The one write on this path, and it publishes: it is wired to an explicit
+ * submit, never to opening a panel. On success the branch's pull request query
+ * is seeded with what GitHub returned, so the chip is right immediately rather
+ * than after a refetch.
+ */
+export function useCreatePullRequest(project: ProjectSelection | null) {
+    const connection = useGithubConnection();
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: async (input: CreatePullRequestInput) => {
+            if (!project?.ref) throw new Error('A branch is required to open a pull request');
+            return pullRequestDetailFromExecution(
+                await connection.execute('pulls_create', {
+                    owner: project.owner,
+                    repo: project.repo,
+                    body: {
+                        title: input.title,
+                        head: project.ref,
+                        base: input.base,
+                        ...(input.body ? { body: input.body } : {}),
+                        ...(input.draft ? { draft: true } : {}),
+                    },
+                }),
+            );
+        },
+        onSuccess: (pullRequest) => {
+            queryClient.setQueryData(
+                pullRequestQueryKey(connection.organizationId, project),
+                pullRequest,
+            );
+        },
+    });
+}

--- a/lemma-frontend/lib/hooks/use-github-projects.test.ts
+++ b/lemma-frontend/lib/hooks/use-github-projects.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { projectsFromExecution } from './use-github-projects';
+
+/** One repo as GitHub returns it, trimmed to the fields the picker reads. */
+const repo = {
+    name: 'lemma-platform',
+    full_name: 'lemma-work/lemma-platform',
+    private: false,
+    default_branch: 'main',
+    pushed_at: '2026-08-11T09:58:09Z',
+    updated_at: '2026-08-11T09:58:32Z',
+    owner: { login: 'lemma-work' },
+};
+
+describe('projects from a connector execution', () => {
+    it('reads the repos out of the result envelope', () => {
+        expect(projectsFromExecution({ result: [repo] })).toEqual([
+            {
+                owner: 'lemma-work',
+                repo: 'lemma-platform',
+                fullName: 'lemma-work/lemma-platform',
+                ref: 'main',
+                private: false,
+                updatedAt: '2026-08-11T09:58:09Z',
+            },
+        ]);
+    });
+
+    it('falls back to the full name when the owner block is missing', () => {
+        expect(
+            projectsFromExecution({
+                result: [{ full_name: 'lemma-work/lemma-app', private: true }],
+            }),
+        ).toEqual([
+            {
+                owner: 'lemma-work',
+                repo: 'lemma-app',
+                fullName: 'lemma-work/lemma-app',
+                ref: undefined,
+                private: true,
+                updatedAt: undefined,
+            },
+        ]);
+    });
+
+    it('drops entries that name no repo', () => {
+        expect(projectsFromExecution({ result: [{ private: false }, repo] })).toHaveLength(1);
+    });
+
+    it.each([
+        ['no response', undefined],
+        ['an empty envelope', { result: undefined }],
+        ['a non-list result', { result: { message: 'Bad credentials' } }],
+    ])('lists nothing for %s', (_label, response) => {
+        expect(projectsFromExecution(response as never)).toEqual([]);
+    });
+});

--- a/lemma-frontend/lib/hooks/use-github-projects.ts
+++ b/lemma-frontend/lib/hooks/use-github-projects.ts
@@ -16,6 +16,8 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import type { OperationExecutionResponse } from 'lemma-sdk';
 
 import { useOrganization } from '@/components/dashboard/org-context';
 import { findDefaultInstallName, useAccounts, useAuthConfigs } from '@/lib/hooks/use-connectors';
@@ -62,25 +64,52 @@ const toProject = (item: RepoListItem): GithubProject | null => {
 };
 
 /**
+ * An execution answers with `{ result }`: the operation's own response body,
+ * which for this one is GitHub's array of repos. Anything else — an error
+ * payload, a shape we have never seen — lists nothing rather than guessing.
+ */
+export const projectsFromExecution = (
+    response: OperationExecutionResponse | undefined,
+): GithubProject[] => {
+    const items = response?.result;
+    if (!Array.isArray(items)) return [];
+    return (items as RepoListItem[])
+        .map(toProject)
+        .filter((project): project is GithubProject => project !== null);
+};
+
+/**
  * `payload` is passed through to the operation, so these are GitHub's own
  * parameter names. Sorted by push date because the repo you worked in an hour
  * ago is overwhelmingly the one you mean now.
  */
 const LIST_PAYLOAD = { per_page: REPO_PAGE_SIZE, sort: 'pushed', affiliation: 'owner,collaborator,organization_member' };
 
-export interface GithubProjectsState {
-    /** True once we know an account exists — the picker offers repos. */
-    isConnected: boolean;
-    /** False only while we don't yet know; keeps the chip from flickering. */
-    isResolved: boolean;
+/**
+ * The one GitHub account this workspace acts as, and the way to use it.
+ *
+ * Every GitHub read the UI does — repos, branches, the pull request on a branch
+ * — goes through the same three facts: which org, which install, which account.
+ * Resolving them once here is what lets the callers below be about GitHub
+ * instead of about connector plumbing.
+ */
+export interface GithubConnection {
+    organizationId?: string;
+    authConfigName?: string;
     accountId?: string;
-    projects: GithubProject[];
-    isLoadingProjects: boolean;
-    /** A failed list is worth saying out loud: it usually means revoked access. */
-    error: unknown;
+    /** True once we know an account exists. */
+    isConnected: boolean;
+    /** False only while we don't yet know; keeps chips from flickering. */
+    isResolved: boolean;
+    /** All three facts are in hand, so an operation can actually run. */
+    canExecute: boolean;
+    execute: (
+        operationName: string,
+        payload: Record<string, unknown>,
+    ) => Promise<OperationExecutionResponse>;
 }
 
-export function useGithubProjects(options?: { enabled?: boolean }): GithubProjectsState {
+export function useGithubConnection(options?: { enabled?: boolean }): GithubConnection {
     const enabled = options?.enabled ?? true;
     const { currentOrg } = useOrganization();
     const organizationId = currentOrg?.id;
@@ -99,31 +128,67 @@ export function useGithubProjects(options?: { enabled?: boolean }): GithubProjec
 
     const account = accounts[0];
     const authConfigName = findDefaultInstallName(authConfigs, GITHUB_CONNECTOR_ID);
-    const canList = Boolean(enabled && organizationId && account?.id && authConfigName);
+    const accountId = account?.id;
+    const canExecute = Boolean(enabled && organizationId && accountId && authConfigName);
+
+    const execute = useCallback(
+        (operationName: string, payload: Record<string, unknown>) =>
+            getLemmaClient().connectors.operations.execute(
+                {
+                    organizationId: organizationId as string,
+                    authConfigName: authConfigName as string,
+                },
+                operationName,
+                payload,
+                accountId,
+            ),
+        [organizationId, authConfigName, accountId],
+    );
+
+    return {
+        organizationId,
+        authConfigName,
+        accountId,
+        isConnected: Boolean(accountId),
+        isResolved: Boolean(organizationId) && accountsFetched,
+        canExecute,
+        execute,
+    };
+}
+
+export interface GithubProjectsState {
+    /** True once we know an account exists — the picker offers repos. */
+    isConnected: boolean;
+    /** False only while we don't yet know; keeps the chip from flickering. */
+    isResolved: boolean;
+    accountId?: string;
+    projects: GithubProject[];
+    isLoadingProjects: boolean;
+    /** A failed list is worth saying out loud: it usually means revoked access. */
+    error: unknown;
+}
+
+export function useGithubProjects(options?: { enabled?: boolean }): GithubProjectsState {
+    const connection = useGithubConnection(options);
+    const { organizationId, authConfigName, accountId, canExecute, execute } = connection;
 
     const { data, isLoading, error } = useQuery({
-        queryKey: ['github-projects', organizationId, authConfigName, account?.id],
-        queryFn: async () => {
-            const response = await getLemmaClient().connectors.operations.execute(
-                { organizationId: organizationId as string, authConfigName: authConfigName as string },
-                'repos_list_for_authenticated_user',
-                LIST_PAYLOAD,
-                account?.id,
-            );
-            const items = (response as { data?: unknown })?.data;
-            return Array.isArray(items) ? (items as RepoListItem[]) : [];
-        },
-        enabled: canList,
+        queryKey: ['github-projects', organizationId, authConfigName, accountId],
+        queryFn: async () =>
+            projectsFromExecution(
+                await execute('repos_list_for_authenticated_user', LIST_PAYLOAD),
+            ),
+        enabled: canExecute,
         // Repos change far more slowly than a picker gets opened.
         staleTime: 5 * 60 * 1000,
     });
 
     return {
-        isConnected: Boolean(account?.id),
-        isResolved: Boolean(organizationId) && accountsFetched,
-        accountId: account?.id,
-        projects: (data ?? []).map(toProject).filter((project): project is GithubProject => project !== null),
-        isLoadingProjects: canList && isLoading,
+        isConnected: connection.isConnected,
+        isResolved: connection.isResolved,
+        accountId,
+        projects: data ?? [],
+        isLoadingProjects: canExecute && isLoading,
         error,
     };
 }

--- a/lemma-frontend/lib/hooks/use-pod-join-requests.test.ts
+++ b/lemma-frontend/lib/hooks/use-pod-join-requests.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { ApiError } from 'lemma-sdk';
+
+import { shouldRetryJoinRequestsFetch } from './use-pod-join-requests';
+
+describe('join-requests retry policy', () => {
+    it.each([401, 403, 404])('stops on %i, which is an answer', (statusCode) => {
+        expect(
+            shouldRetryJoinRequestsFetch(0, new ApiError(statusCode, 'Forbidden')),
+        ).toBe(false);
+    });
+
+    it('stops when the pod says the role is insufficient', () => {
+        expect(
+            shouldRetryJoinRequestsFetch(
+                0,
+                new ApiError(403, 'Forbidden', 'INSUFFICIENT_ROLE'),
+            ),
+        ).toBe(false);
+    });
+
+    it('retries a server error, which may well be a flake', () => {
+        expect(shouldRetryJoinRequestsFetch(0, new ApiError(500, 'Boom'))).toBe(true);
+    });
+
+    it('gives up on a server error after two tries', () => {
+        expect(shouldRetryJoinRequestsFetch(2, new ApiError(500, 'Boom'))).toBe(false);
+    });
+});

--- a/lemma-frontend/lib/hooks/use-pod-join-requests.ts
+++ b/lemma-frontend/lib/hooks/use-pod-join-requests.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ApiError } from 'lemma-sdk';
 import { getLemmaClient } from '../sdk/lemma-client';
 import { OrganizationRole, PodRole } from '../types';
 
@@ -35,7 +36,41 @@ interface ApproveJoinRequestInput {
     organizationId?: string;
 }
 
-export const usePodJoinRequests = (podId: string, status: PodJoinRequestStatus = 'PENDING') => {
+/**
+ * A refusal is an answer, not a flake: this caller is not allowed to see join
+ * requests, and asking three more times cannot change that. Without this the
+ * client default (`retry: 3`) turns one refused request into four, and since a
+ * failed query caches no data, `staleTime` never suppresses the burst — every
+ * remount replays it.
+ */
+export function shouldRetryJoinRequestsFetch(failureCount: number, error: unknown): boolean {
+    if (error instanceof ApiError) {
+        if (
+            error.statusCode === 401 ||
+            error.statusCode === 403 ||
+            error.statusCode === 404 ||
+            error.code === 'INSUFFICIENT_ROLE'
+        ) {
+            return false;
+        }
+    }
+
+    return failureCount < 2;
+}
+
+/**
+ * Listing join requests needs `pod.member.manage`. Callers that render the list
+ * behind that permission must gate the *fetch* on it too, via `enabled` — a
+ * permission check that only guards the JSX still lets every ordinary member
+ * ask the server a question it will answer with 403.
+ */
+export const usePodJoinRequests = (
+    podId: string,
+    status: PodJoinRequestStatus = 'PENDING',
+    options: { enabled?: boolean } = {}
+) => {
+    const { enabled = true } = options;
+
     return useQuery({
         queryKey: ['pods', podId, 'join-requests', status],
         queryFn: () =>
@@ -49,7 +84,8 @@ export const usePodJoinRequests = (podId: string, status: PodJoinRequestStatus =
                     },
                 }
             ),
-        enabled: !!podId,
+        enabled: !!podId && enabled,
+        retry: shouldRetryJoinRequestsFetch,
     });
 };
 

--- a/lemma-frontend/styles/features/assistant-overrides.css
+++ b/lemma-frontend/styles/features/assistant-overrides.css
@@ -231,30 +231,44 @@
   }
 }
 
+/* ── The three voices of a turn ──────────────────────────────────────────────
+   A transcript answers three questions — what did it conclude, what was it
+   working through, and what did it actually run — and it used to answer all
+   three in one grey at one size, so a long run arrived as a flat ladder.
+
+   The fix is not a type scale. Sizes that step apart turn one turn into two
+   typographic systems stacked on each other, which is how this last went
+   wrong: 12px mono steps under 16px answers read as two different products.
+
+   Everything stays at 14px. The whole hierarchy is ink:
+
+     Answer      primary    roman     the conclusion — the only thing at full ink
+     Narration   secondary  italic    the working-out, including thoughts
+     Step        tertiary   roman     what actually ran
+     Group       tertiary   roman     structure, skimmed past
+
+   Three levels of grey and one italic. Nothing jumps, and the eye can still
+   find the answer without reading a word. */
+
+/* A step: what the agent ran. Recessive, and the same size as everything else. */
 .lemma-assistant-inline-tool-button,
 .lemma-assistant-inline-approval-button {
-  color: var(--text-secondary);
-  font-family: var(--font-body-family);
-  font-size: var(--text-xs);
-  font-weight: 400;
-  letter-spacing: 0;
-  line-height: 1.25rem;
-}
-
-.lemma-assistant-inline-tool-button:hover,
-.lemma-assistant-inline-tool-button[data-selected="true"],
-.lemma-assistant-inline-approval-button:hover,
-.lemma-assistant-inline-approval-button[data-selected="true"] {
-  color: var(--text-primary);
-}
-
-.lemma-assistant-run-trace-header {
-  color: var(--text-secondary);
+  color: var(--text-tertiary);
   font-family: var(--font-body-family);
   font-size: var(--text-sm);
   font-weight: 400;
   letter-spacing: 0;
-  line-height: 1.5rem;
+  line-height: 1.5;
+}
+
+/* A group label: structure, not content — same ink as the steps it heads. */
+.lemma-assistant-run-trace-header {
+  color: var(--text-tertiary);
+  font-family: var(--font-body-family);
+  font-size: var(--text-sm);
+  font-weight: 400;
+  letter-spacing: 0;
+  line-height: 1.5;
 }
 
 button.lemma-assistant-run-trace-header:hover {

--- a/lemma-typescript/src/__tests__/agent-display.test.ts
+++ b/lemma-typescript/src/__tests__/agent-display.test.ts
@@ -398,6 +398,9 @@ describe("collectCompletedRunTraceGroups", () => {
       text("n1", "Let me grab the session items."),
       tool("t2", { toolCallId: "c2", toolName: "build_session", args: {}, state: "result", result: {} }),
       text("final", "We're live. Here's card 1 of 12."),
+      // A later turn, so the run above is no longer the most recent one and folds.
+      { id: "u2", role: "user", content: "thanks" },
+      text("ack", "Any time."),
     ];
     const rows = buildDisplayMessageRows(messages);
     const { groupsByStartIndex, groupedIndexes } = collectCompletedRunTraceGroups(rows, messages, false);
@@ -419,13 +422,15 @@ describe("collectCompletedRunTraceGroups", () => {
       text("n2", "Now I've got everything I need."),
       tool("t3", { toolCallId: "c3", toolName: "build_session", args: {}, state: "result", result: {} }),
       text("final", "We're live."),
+      { id: "u2", role: "user", content: "thanks" },
+      text("ack", "Any time."),
     ];
     const rows = buildDisplayMessageRows(messages);
     const { groupsByStartIndex } = collectCompletedRunTraceGroups(rows, messages, false);
     expect(groupsByStartIndex.size).toBe(1);
   });
 
-  it("never folds the active/streaming run", () => {
+  it("folds the most recent run once it finishes, but not while it runs", () => {
     const streaming: AssistantRenderableMessage[] = [
       { id: "u", role: "user", content: "go" },
       tool("t1", { toolCallId: "c1", toolName: "search_cards", args: {}, state: "result", result: {} }),
@@ -435,7 +440,7 @@ describe("collectCompletedRunTraceGroups", () => {
     const streamingRows = buildDisplayMessageRows(streaming);
     expect(collectCompletedRunTraceGroups(streamingRows, streaming, true).groupsByStartIndex.size).toBe(0);
 
-    // The same shape, now finished with an answer, folds into one group.
+    // Finished: it folds under "Worked for …" like any other completed run.
     const done: AssistantRenderableMessage[] = [
       ...streaming.slice(0, 3),
       tool("t2", { toolCallId: "c2", toolName: "build_session", args: {}, state: "result", result: {} }),
@@ -443,6 +448,15 @@ describe("collectCompletedRunTraceGroups", () => {
     ];
     const doneRows = buildDisplayMessageRows(done);
     expect(collectCompletedRunTraceGroups(doneRows, done, false).groupsByStartIndex.size).toBe(1);
+
+    // …and stays folded once a later turn exists.
+    const superseded: AssistantRenderableMessage[] = [
+      ...done,
+      { id: "u2", role: "user", content: "thanks" },
+      text("ack", "Any time."),
+    ];
+    const supersededRows = buildDisplayMessageRows(superseded);
+    expect(collectCompletedRunTraceGroups(supersededRows, superseded, false).groupsByStartIndex.size).toBe(1);
   });
 });
 

--- a/lemma-typescript/src/__tests__/assistant-runtime-retention.test.ts
+++ b/lemma-typescript/src/__tests__/assistant-runtime-retention.test.ts
@@ -1,0 +1,237 @@
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+import type { ConversationMessage } from "../types.js";
+import {
+  useAssistantRuntime,
+  type UseAssistantRuntimeResult,
+} from "../react/useAssistantRuntime.js";
+
+// The store used to prune to the open conversation on every switch, so going
+// back to a conversation you had just been reading meant a blank frame, a
+// skeleton, and a refetch of messages that had been in memory a moment earlier.
+// These cases pin the retention window that replaced it.
+//
+// See docs/design/conversation-messages.md.
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const roots: Root[] = [];
+
+afterEach(() => {
+  act(() => {
+    roots.splice(0).forEach((root) => root.unmount());
+  });
+});
+
+function message(id: string, conversationId: string): ConversationMessage {
+  return {
+    id,
+    role: "user",
+    kind: "TEXT",
+    text: id,
+    created_at: new Date(Date.UTC(2026, 0, 1)).toISOString(),
+    conversation_id: conversationId,
+  } as ConversationMessage;
+}
+
+/** Mount the runtime and return a handle that can re-render with a new conversation. */
+function mountRuntime(options?: { retainConversations?: number }) {
+  let latest: UseAssistantRuntimeResult | null = null;
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  roots.push(root);
+
+  function Probe({ conversationId }: { conversationId: string | null }) {
+    latest = useAssistantRuntime({
+      conversationId,
+      retainConversations: options?.retainConversations,
+    });
+    return null;
+  }
+
+  const render = (conversationId: string | null) => {
+    act(() => {
+      root.render(createElement(Probe, { conversationId }));
+    });
+  };
+
+  return {
+    render,
+    get current(): UseAssistantRuntimeResult {
+      if (!latest) throw new Error("Runtime is not mounted.");
+      return latest;
+    },
+    idsFor(conversationId: string) {
+      return this.current.runtimeMessages
+        .filter((entry) => (entry as { conversation_id?: string }).conversation_id === conversationId)
+        .map((entry) => entry.id);
+    },
+  };
+}
+
+describe("useAssistantRuntime retention", () => {
+  it("keeps a transcript when you switch away and back", () => {
+    const runtime = mountRuntime();
+    runtime.render("c1");
+    act(() => {
+      runtime.current.replaceLoadedMessages([message("m1", "c1"), message("m2", "c1")]);
+    });
+
+    runtime.render("c2");
+    act(() => {
+      runtime.current.replaceLoadedMessages([message("m3", "c2")]);
+    });
+
+    // The point of the whole change: c1 is still resident while c2 is open.
+    expect(runtime.current.hasConversationMessages("c1")).toBe(true);
+    expect(runtime.idsFor("c1")).toEqual(["m1", "m2"]);
+
+    runtime.render("c1");
+    expect(runtime.idsFor("c1")).toEqual(["m1", "m2"]);
+  });
+
+  it("loading one conversation does not evict the others", () => {
+    const runtime = mountRuntime();
+    runtime.render("c1");
+    act(() => {
+      runtime.current.replaceLoadedMessages([message("m1", "c1")]);
+    });
+
+    runtime.render("c2");
+    act(() => {
+      runtime.current.replaceLoadedMessages([message("m2", "c2")]);
+    });
+
+    expect(runtime.idsFor("c1")).toEqual(["m1"]);
+    expect(runtime.idsFor("c2")).toEqual(["m2"]);
+  });
+
+  it("evicts the least recently opened past the retention window", () => {
+    const runtime = mountRuntime({ retainConversations: 2 });
+
+    for (const id of ["c1", "c2"]) {
+      runtime.render(id);
+      act(() => {
+        runtime.current.replaceLoadedMessages([message(`m-${id}`, id)]);
+      });
+    }
+
+    runtime.render("c3");
+    act(() => {
+      runtime.current.replaceLoadedMessages([message("m-c3", "c3")]);
+    });
+
+    // c1 is the oldest of three in a window of two.
+    expect(runtime.current.hasConversationMessages("c1")).toBe(false);
+    expect(runtime.current.hasConversationMessages("c2")).toBe(true);
+    expect(runtime.current.hasConversationMessages("c3")).toBe(true);
+  });
+
+  it("re-opening refreshes recency rather than aging out", () => {
+    const runtime = mountRuntime({ retainConversations: 2 });
+
+    for (const id of ["c1", "c2"]) {
+      runtime.render(id);
+      act(() => {
+        runtime.current.replaceLoadedMessages([message(`m-${id}`, id)]);
+      });
+    }
+
+    // Touch c1 again, so c2 becomes the oldest.
+    runtime.render("c1");
+    runtime.render("c3");
+    act(() => {
+      runtime.current.replaceLoadedMessages([message("m-c3", "c3")]);
+    });
+
+    expect(runtime.current.hasConversationMessages("c1")).toBe(true);
+    expect(runtime.current.hasConversationMessages("c2")).toBe(false);
+  });
+
+  it("clear() drops everything, including retained transcripts", () => {
+    const runtime = mountRuntime();
+    runtime.render("c1");
+    act(() => {
+      runtime.current.replaceLoadedMessages([message("m1", "c1")]);
+    });
+    runtime.render("c2");
+
+    act(() => {
+      runtime.current.clear();
+    });
+
+    expect(runtime.current.runtimeMessages).toEqual([]);
+    expect(runtime.current.hasConversationMessages("c1")).toBe(false);
+  });
+
+  it("closing the open conversation keeps the store warm", () => {
+    const runtime = mountRuntime();
+    runtime.render("c1");
+    act(() => {
+      runtime.current.replaceLoadedMessages([message("m1", "c1")]);
+    });
+
+    runtime.render(null);
+
+    expect(runtime.current.hasConversationMessages("c1")).toBe(true);
+  });
+});
+
+// The session mirrors its messages into the store through an effect, so for one
+// commit a message that has already arrived is not in the store yet. That gap is
+// what made the assistant's answer blink out as a turn ended. The store now
+// merges the session's view at derive time.
+describe("useAssistantRuntime session handoff", () => {
+  function mountWithSession() {
+    let latest: UseAssistantRuntimeResult | null = null;
+    const container = document.createElement("div");
+    const root = createRoot(container);
+    roots.push(root);
+
+    function Probe({ sessionMessages }: { sessionMessages: ConversationMessage[] }) {
+      latest = useAssistantRuntime({
+        conversationId: "c1",
+        sessionConversationId: "c1",
+        sessionMessages,
+      });
+      return null;
+    }
+
+    return {
+      render(sessionMessages: ConversationMessage[]) {
+        act(() => {
+          root.render(createElement(Probe, { sessionMessages }));
+        });
+      },
+      get ids(): string[] {
+        if (!latest) throw new Error("Runtime is not mounted.");
+        return latest.runtimeMessages.map((entry) => entry.id);
+      },
+    };
+  }
+
+  it("surfaces a session message the mirror effect skipped", () => {
+    const runtime = mountWithSession();
+    const a = message("a", "c1");
+    runtime.render([a]);
+    expect(runtime.ids).toContain("a");
+
+    // The mirror effect early-returns when the *last* session message id is
+    // unchanged, so an insert before it is never mirrored into state.
+    const b = message("b", "c1");
+    runtime.render([b, a]);
+
+    expect(runtime.ids).toContain("b");
+    expect(runtime.ids).toContain("a");
+  });
+
+  it("returns the store untouched once the session view is already mirrored", () => {
+    const runtime = mountWithSession();
+    const a = message("a", "c1");
+    runtime.render([a]);
+    const first = runtime.ids;
+    runtime.render([a]);
+    expect(runtime.ids).toEqual(first);
+  });
+});

--- a/lemma-typescript/src/__tests__/completed-run-trace-folding.test.ts
+++ b/lemma-typescript/src/__tests__/completed-run-trace-folding.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDisplayMessageRows,
+  collectCompletedRunTraceGroups,
+} from "../core/agent/display.js";
+import type { AssistantRenderableMessage } from "../core/agent/renderable.js";
+
+// Folding is a property of the transcript, not of how the reader reached it.
+// The most recent run stays open — folding it the instant it ended was the
+// largest jerk in the transcript, and deciding by "did this session watch it"
+// made a live conversation render differently from the same one reloaded.
+//
+// See docs/design/conversation-messages.md.
+
+const RUN_ID = "run-1";
+
+let clock = 0;
+function at(): Date {
+  clock += 1000;
+  return new Date(Date.UTC(2026, 0, 1) + clock);
+}
+
+function user(id: string, content: string): AssistantRenderableMessage {
+  return { id, role: "user", content, createdAt: at(), kind: "TEXT" };
+}
+
+function toolTurn(id: string, runId: string | null): AssistantRenderableMessage {
+  return {
+    id,
+    role: "assistant",
+    content: "",
+    createdAt: at(),
+    kind: "TOOL_CALL",
+    agent_run_id: runId,
+    toolInvocations: [{
+      toolCallId: `${id}-call`,
+      toolName: "pod_tables",
+      args: {},
+      state: "result",
+      result: { ok: true },
+    }],
+    parts: [{
+      id: `${id}-tool`,
+      type: "tool",
+      toolInvocation: {
+        toolCallId: `${id}-call`,
+        toolName: "pod_tables",
+        args: {},
+        state: "result",
+        result: { ok: true },
+      },
+    }],
+  };
+}
+
+function answer(id: string, content: string, runId: string | null): AssistantRenderableMessage {
+  return { id, role: "assistant", content, createdAt: at(), kind: "TEXT", agent_run_id: runId };
+}
+
+/** A finished run that did tool work and then answered. */
+function finishedRun(runId: string | null) {
+  return [
+    user("u1", "list the tables"),
+    toolTurn("a1", runId),
+    answer("a2", "You have two tables.", runId),
+  ];
+}
+
+function foldingFor(messages: AssistantRenderableMessage[], isRunActive = false) {
+  const rows = buildDisplayMessageRows(messages);
+  return collectCompletedRunTraceGroups(rows, messages, isRunActive);
+}
+
+describe("collectCompletedRunTraceGroups", () => {
+  it("folds a finished run under its duration", () => {
+    const groups = foldingFor(finishedRun(RUN_ID));
+
+    expect(groups.groupsByStartIndex.size).toBe(1);
+    for (const group of groups.groupsByStartIndex.values()) {
+      expect(group.label).toMatch(/^Worked/);
+    }
+    expect(groups.groupedIndexes.size).toBeGreaterThan(0);
+  });
+
+  it("leaves a run that is still going open", () => {
+    // While it works, its steps are the thing being read — and the transcript's
+    // own status line already says it is working.
+    expect(foldingFor(finishedRun(RUN_ID), true).groupsByStartIndex.size).toBe(0);
+    expect(foldingFor(finishedRun(RUN_ID), true).groupedIndexes.size).toBe(0);
+  });
+
+  it("folds every finished run in the transcript, not just the older ones", () => {
+    const messages = [
+      ...finishedRun("run-old"),
+      user("u2", "and again"),
+      toolTurn("b1", RUN_ID),
+      answer("b2", "Same two.", RUN_ID),
+    ];
+
+    expect(foldingFor(messages).groupsByStartIndex.size).toBe(2);
+  });
+
+  it("renders a finished run the same however the reader got to it", () => {
+    // The rule reads only the transcript — no session state, no "did this tab
+    // watch it" — which is what makes a reload look like what was already there.
+    const messages = finishedRun(RUN_ID);
+    const first = foldingFor(messages);
+    const second = foldingFor(messages);
+
+    expect([...second.groupedIndexes]).toEqual([...first.groupedIndexes]);
+    expect([...second.traceIndexes]).toEqual([...first.traceIndexes]);
+    expect([...second.groupsByStartIndex.keys()]).toEqual([...first.groupsByStartIndex.keys()]);
+  });
+
+  it("keeps an earlier run folded while a later one is running", () => {
+    const messages = [
+      ...finishedRun("run-old"),
+      user("u2", "and again"),
+      toolTurn("b1", RUN_ID),
+    ];
+
+    // The older run folds; the live one does not.
+    expect(foldingFor(messages, true).groupsByStartIndex.size).toBe(1);
+    expect(foldingFor(messages, true).groupsByStartIndex.has(1)).toBe(true);
+  });
+});
+
+describe("buildDisplayMessageRows keys", () => {
+  it("keeps a collapsible row's id stable as the cluster grows", () => {
+    const one = buildDisplayMessageRows([user("u1", "go"), toolTurn("a1", RUN_ID)]);
+    const two = buildDisplayMessageRows([user("u1", "go"), toolTurn("a1", RUN_ID), toolTurn("a2", RUN_ID)]);
+
+    const idOf = (rows: ReturnType<typeof buildDisplayMessageRows>) =>
+      rows.find((row) => row.message.role === "assistant")?.id;
+
+    // A second tool arriving must not re-key the row and remount it mid-run.
+    expect(idOf(one)).toBeDefined();
+    expect(idOf(one)).toBe(idOf(two));
+  });
+});
+
+describe("a run that is still going", () => {
+  // Every row of a live run is working-out. Designating one of them the answer
+  // just because it is currently last gives it the answer's weight and its
+  // copy/timestamp footer, mid-run, between two tool groups.
+  const live = [
+    user("u1", "check the pod"),
+    toolTurn("a1", RUN_ID),
+    answer("a2", "Let me pull the pod inventory in parallel.", RUN_ID),
+    toolTurn("a3", RUN_ID),
+  ];
+
+  it("treats every row as trace while it runs", () => {
+    const rows = buildDisplayMessageRows(live);
+    const { traceIndexes } = collectCompletedRunTraceGroups(rows, live, true);
+
+    const assistantRows = rows
+      .map((row, index) => ({ row, index }))
+      .filter(({ row }) => row.message.role === "assistant");
+
+    expect(assistantRows.length).toBeGreaterThan(0);
+    for (const { index } of assistantRows) {
+      expect(traceIndexes.has(index)).toBe(true);
+    }
+  });
+
+  it("names an answer once the run settles", () => {
+    const rows = buildDisplayMessageRows(live);
+    const { traceIndexes } = collectCompletedRunTraceGroups(rows, live, false);
+
+    const lastAssistantIndex = rows.reduce(
+      (last, row, index) => (row.message.role === "assistant" ? index : last),
+      -1,
+    );
+    // The closing row is the answer, so it is the one row that is not trace.
+    const closingIndex = rows.reduce(
+      (last, row, index) => (row.message.role === "assistant" && row.message.content ? index : last),
+      -1,
+    );
+    expect(lastAssistantIndex).toBeGreaterThan(-1);
+    expect(traceIndexes.has(closingIndex)).toBe(false);
+  });
+});

--- a/lemma-typescript/src/__tests__/conversation-message-mapping.test.ts
+++ b/lemma-typescript/src/__tests__/conversation-message-mapping.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import { mapConversationMessages } from "../react/useAssistantController.js";
+import type { AssistantRenderableMessage, AssistantToolInvocation } from "../core/agent/renderable.js";
+
+// The transcript is mapped once, here. Three consumers used to re-fetch the raw
+// messages and merge tool returns a second time on top of this output, on the
+// belief that the mapper dropped them. These cases pin what the mapper actually
+// produces, so that belief cannot come back.
+//
+// See docs/design/conversation-messages.md.
+
+let clock = 0;
+function at(): string {
+  clock += 1000;
+  return new Date(Date.UTC(2026, 0, 1, 0, 0, 0) + clock).toISOString();
+}
+
+function userText(id: string, text: string) {
+  return { id, role: "user", kind: "TEXT", text, created_at: at(), conversation_id: "c1" } as never;
+}
+
+function assistantText(id: string, text: string) {
+  return { id, role: "assistant", kind: "TEXT", text, created_at: at(), conversation_id: "c1" } as never;
+}
+
+function toolCall(id: string, toolCallId: string, toolName: string, args: Record<string, unknown>) {
+  return {
+    id,
+    role: "assistant",
+    kind: "TOOL_CALL",
+    tool_call_id: toolCallId,
+    tool_name: toolName,
+    tool_args: args,
+    created_at: at(),
+    conversation_id: "c1",
+  } as never;
+}
+
+function toolReturn(id: string, toolCallId: string, toolName: string, result: unknown) {
+  return {
+    id,
+    role: "tool",
+    kind: "TOOL_RETURN",
+    tool_call_id: toolCallId,
+    tool_name: toolName,
+    tool_result: result,
+    created_at: at(),
+    conversation_id: "c1",
+  } as never;
+}
+
+function allInvocations(messages: AssistantRenderableMessage[]): AssistantToolInvocation[] {
+  return messages.flatMap((message) => message.toolInvocations ?? []);
+}
+
+describe("mapConversationMessages", () => {
+  it("folds a TOOL_RETURN into its originating TOOL_CALL", () => {
+    const mapped = mapConversationMessages([
+      userText("m1", "list the tables"),
+      toolCall("m2", "call-1", "pod_tables", { datastore: "main" }),
+      toolReturn("m3", "call-1", "pod_tables", { tables: ["orders", "customers"] }),
+      assistantText("m4", "You have two tables."),
+    ]);
+
+    const invocations = allInvocations(mapped);
+    expect(invocations).toHaveLength(1);
+    expect(invocations[0]).toMatchObject({
+      toolCallId: "call-1",
+      toolName: "pod_tables",
+      state: "result",
+      args: { datastore: "main" },
+      result: { tables: ["orders", "customers"] },
+    });
+  });
+
+  it("leaves nothing for a second tool-return merge to do", () => {
+    const mapped = mapConversationMessages([
+      userText("m1", "check both"),
+      toolCall("m2", "call-1", "pod_tables", {}),
+      toolReturn("m3", "call-1", "pod_tables", { ok: true }),
+      toolCall("m4", "call-2", "pod_records", { table: "orders" }),
+      toolReturn("m5", "call-2", "pod_records", { count: 12 }),
+      assistantText("m6", "Done."),
+    ]);
+
+    // This is the invariant the deleted `hydrateToolReturnMessages` violated:
+    // every invocation is already resolved, so re-applying the raw returns
+    // could only rewrite each value to itself.
+    const invocations = allInvocations(mapped);
+    expect(invocations).toHaveLength(2);
+    for (const invocation of invocations) {
+      expect(invocation.state).toBe("result");
+      expect(invocation.result).toBeDefined();
+    }
+    expect(invocations.map((invocation) => invocation.result)).toEqual([
+      { ok: true },
+      { count: 12 },
+    ]);
+  });
+
+  it("passes the flat message fields through untouched", () => {
+    const mapped = mapConversationMessages([
+      toolCall("m1", "call-1", "pod_tables", { datastore: "main" }),
+    ]);
+
+    // The fields three consumers re-fetched raw messages to recover.
+    expect(mapped[0]).toMatchObject({
+      kind: "TOOL_CALL",
+      tool_call_id: "call-1",
+      tool_name: "pod_tables",
+    });
+    expect(mapped[0].tool_args).toEqual({ datastore: "main" });
+  });
+
+  it("keeps a tool return that never had a matching call", () => {
+    const mapped = mapConversationMessages([
+      userText("m1", "resume"),
+      toolReturn("m2", "orphan-1", "pod_tables", { tables: [] }),
+    ]);
+
+    const invocations = allInvocations(mapped);
+    expect(invocations).toHaveLength(1);
+    expect(invocations[0]).toMatchObject({
+      toolCallId: "orphan-1",
+      state: "result",
+      result: { tables: [] },
+    });
+  });
+
+  it("normalizes a non-object tool result rather than dropping it", () => {
+    const mapped = mapConversationMessages([
+      toolCall("m1", "call-1", "pod_query", {}),
+      toolReturn("m2", "call-1", "pod_query", "42 rows"),
+    ]);
+
+    expect(allInvocations(mapped)[0]).toMatchObject({
+      state: "result",
+      result: { output: "42 rows" },
+    });
+  });
+
+  it("recovers the tool name from the return when the call was generic", () => {
+    const mapped = mapConversationMessages([
+      toolCall("m1", "call-1", "tool", {}),
+      toolReturn("m2", "call-1", "pod_tables", { ok: true }),
+    ]);
+
+    expect(allInvocations(mapped)[0].toolName).toBe("pod_tables");
+  });
+});

--- a/lemma-typescript/src/__tests__/conversation-open-fetches.test.ts
+++ b/lemma-typescript/src/__tests__/conversation-open-fetches.test.ts
@@ -1,0 +1,160 @@
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LemmaClient } from "../client.js";
+import type { Conversation } from "../types.js";
+import { useAssistantController, type UseAssistantControllerResult } from "../react/index.js";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const roots: Root[] = [];
+
+function conversation(id: string, status: string): Conversation {
+  return {
+    id,
+    pod_id: "pod-1",
+    title: id,
+    status,
+    created_at: "2026-07-15T12:00:00.000Z",
+    updated_at: "2026-07-15T12:00:00.000Z",
+  } as Conversation;
+}
+
+function fakeClient(items: Conversation[]) {
+  const encoder = new TextEncoder();
+  const list = vi.fn(async () => ({ items, limit: 30, next_page_token: null, total: items.length }));
+  const get = vi.fn(async (id: string) => (
+    items.find((item) => item.id === id) ?? conversation(id, "WAITING")
+  ));
+  const messagesList = vi.fn(async () => ({ items: [], limit: 100, next_page_token: null }));
+  const resumeStream = vi.fn(async () => new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode('data: {"type":"completed"}\n\n'));
+      controller.close();
+    },
+  }));
+
+  const client = {
+    podId: "pod-1",
+    withPod() {
+      return this;
+    },
+    conversations: {
+      list,
+      get,
+      create: vi.fn(),
+      listModels: vi.fn(async () => ({ items: [] })),
+      messages: { list: messagesList },
+      sendMessageStream: vi.fn(),
+      retryFailedRun: vi.fn(),
+      resumeStream,
+      stopRun: vi.fn(),
+      update: vi.fn(),
+    },
+  } as unknown as LemmaClient;
+
+  return { client, get, list, messagesList, resumeStream };
+}
+
+async function render(element: ReturnType<typeof createElement>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  await act(async () => {
+    root.render(element);
+    await Promise.resolve();
+  });
+  return root;
+}
+
+async function settle() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+afterEach(async () => {
+  while (roots.length > 0) {
+    const root = roots.pop();
+    if (!root) continue;
+    await act(async () => root.unmount());
+  }
+  document.body.innerHTML = "";
+});
+
+async function openConversation(client: LemmaClient, conversationId: string) {
+  const controller = { current: null as UseAssistantControllerResult | null };
+
+  function Harness() {
+    controller.current = useAssistantController({
+      client,
+      podId: "pod-1",
+      autoLoadMessages: true,
+    });
+    return null;
+  }
+
+  await render(createElement(Harness));
+  await settle();
+  await act(async () => controller.current?.openConversation(conversationId));
+  await settle();
+  await settle();
+  return controller;
+}
+
+describe("opening a conversation", () => {
+  it("reads the conversation once", async () => {
+    const { client, get, messagesList } = fakeClient([conversation("older", "WAITING")]);
+
+    await openConversation(client, "older");
+
+    // The transcript load used to be followed by a resume probe that fetched
+    // the same conversation again purely to read its status.
+    expect(get.mock.calls).toEqual([["older", { pod_id: "pod-1" }]]);
+    expect(messagesList).toHaveBeenCalledOnce();
+  });
+
+  it("resumes a running conversation without reading it twice", async () => {
+    const { client, get, resumeStream } = fakeClient([conversation("live", "RUNNING")]);
+    // Counted when the resume starts, not at the end: a finished run syncs the
+    // conversation once more, and that read is the run's, not the open's.
+    let readsBeforeResume = -1;
+    resumeStream.mockImplementationOnce(async () => {
+      readsBeforeResume = get.mock.calls.length;
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('data: {"type":"completed"}\n\n'));
+          controller.close();
+        },
+      });
+    });
+
+    await openConversation(client, "live");
+
+    expect(resumeStream).toHaveBeenCalledOnce();
+    expect(readsBeforeResume).toBe(1);
+  });
+
+  it("falls back to the session probe when the open fetch failed", async () => {
+    const { client, get, resumeStream } = fakeClient([conversation("live", "RUNNING")]);
+    get.mockRejectedValueOnce(new Error("Network unavailable"));
+    let readsBeforeResume = -1;
+    resumeStream.mockImplementationOnce(async () => {
+      readsBeforeResume = get.mock.calls.length;
+      return new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('data: {"type":"completed"}\n\n'));
+          controller.close();
+        },
+      });
+    });
+
+    await openConversation(client, "live");
+
+    // Nothing to hand over, so the session asks for the conversation itself
+    // rather than assuming the run is dead.
+    expect(resumeStream).toHaveBeenCalledOnce();
+    expect(readsBeforeResume).toBe(2);
+  });
+});

--- a/lemma-typescript/src/core/agent/display.ts
+++ b/lemma-typescript/src/core/agent/display.ts
@@ -617,7 +617,11 @@ export function buildDisplayMessageRows(messages: AssistantRenderableMessage[]):
     }
 
     if (cluster.length === 1) {
-      rows.push({ id: message.id, message, sourceIndexes: clusterSourceIndexes });
+      // Same id shape as the multi-message cluster below. A lone collapsible
+      // message keyed by `message.id` would be re-keyed to `tool-cluster-…` the
+      // moment a second one joined it, remounting the row mid-run and throwing
+      // away whatever the reader had expanded.
+      rows.push({ id: `tool-cluster-${message.id}`, message, sourceIndexes: clusterSourceIndexes });
       i = j - 1;
       continue;
     }
@@ -692,6 +696,25 @@ function rowSourceTimesMs(row: DisplayMessageRow, messages: AssistantRenderableM
  * everything before it. The active/streaming run is never folded — its work
  * stays visible while it runs (pass `isRunActive`).
  */
+/**
+ * Fold finished runs under a "Worked for …" rollup — except the most recent one,
+ * which always stays open.
+ *
+ * The rule is a property of the transcript, not of how the reader got to it.
+ * That matters twice. Folding a run at the moment it ends is the single largest
+ * jerk in the transcript: the thinking and tool steps that were on screen a
+ * frame earlier are re-parented into a collapsed group and vanish, taking the
+ * scroll position with them. And keying the decision off which runs *this
+ * session* happened to watch — the first attempt at fixing that — meant the same
+ * conversation rendered one way live and another way after a reload.
+ *
+ * The last run is the one being read, live or not, so it is the one left open.
+ *
+ * `traceIndexes` is computed for *every* run, folded or not: it marks the rows
+ * that are a run's working-out rather than its answer. An unfolded run still
+ * needs that distinction, or its intermediate narration renders at the same
+ * weight as the answer and reads as a second answer.
+ */
 export function collectCompletedRunTraceGroups(
   rows: DisplayMessageRow[],
   messages: AssistantRenderableMessage[],
@@ -699,9 +722,12 @@ export function collectCompletedRunTraceGroups(
 ): {
   groupsByStartIndex: Map<number, CompletedRunTraceGroupState>;
   groupedIndexes: Set<number>;
+  /** Assistant rows that are working-out rather than a run's answer. */
+  traceIndexes: Set<number>;
 } {
   const groupsByStartIndex = new Map<number, CompletedRunTraceGroupState>();
   const groupedIndexes = new Set<number>();
+  const traceIndexes = new Set<number>();
 
   let index = 0;
   while (index < rows.length) {
@@ -718,19 +744,38 @@ export function collectCompletedRunTraceGroups(
     }
     index = blockEnd + 1;
 
-    // Never collapse the live run — its activity should stay visible while working.
-    if (isRunActive && blockEnd === rows.length - 1) continue;
-
     // The final answer is the last run-closing (real answer / text) row; the
     // trace before it is what folds. No closing row → a pure-tool run folds whole.
+    //
+    // A run that is still going has no answer yet. Without this, the newest line
+    // of narration is provisionally "the answer" simply by being last, so it is
+    // set at answer weight and given the answer's copy/timestamp footer — which
+    // then sits stranded in the middle of the run as more tool calls arrive, and
+    // is demoted again the moment the next line of narration lands.
+    const isLiveRun = isRunActive && blockEnd === rows.length - 1;
     let answerIndex = -1;
-    for (let i = blockEnd; i >= blockStart; i -= 1) {
+    for (let i = blockEnd; i >= blockStart && !isLiveRun; i -= 1) {
       if (isRunClosingMessage(rows[i].message)) {
         answerIndex = i;
         break;
       }
     }
     const foldEnd = answerIndex === -1 ? blockEnd : answerIndex - 1;
+
+    // Everything before the answer is this run's working-out, whether or not the
+    // run folds.
+    for (let i = blockStart; i <= foldEnd; i += 1) {
+      traceIndexes.add(i);
+    }
+
+    // The most recent run stays open, running or finished. `isRunActive` is no
+    // longer consulted: if it were, this block would fold the instant the run
+    // ended, which is the jerk, and it would also make a live transcript differ
+    // from the same transcript reloaded.
+    // Every finished run folds under "Worked for …", the most recent included.
+    // Only a run that is still going stays open — while it works, its steps are
+    // the thing being read.
+    if (isRunActive && blockEnd === rows.length - 1) continue;
     if (foldEnd < blockStart) continue; // answer is the whole run; nothing to fold
 
     // Only fold runs that actually did work (tool activity); time the rollup.
@@ -760,7 +805,7 @@ export function collectCompletedRunTraceGroups(
     }
   }
 
-  return { groupsByStartIndex, groupedIndexes };
+  return { groupsByStartIndex, groupedIndexes, traceIndexes };
 }
 
 function rowIsAfterIndex(row: DisplayMessageRow, index: number): boolean {

--- a/lemma-typescript/src/react/useAssistantController.ts
+++ b/lemma-typescript/src/react/useAssistantController.ts
@@ -469,7 +469,12 @@ function mapConversationMessage(
   };
 }
 
-function mapConversationMessages(messages: AssistantApiConversationMessage[]): AssistantRenderableMessage[] {
+// Exported for tests. Consumers must not re-merge tool returns on top of this:
+// a TOOL_RETURN is already folded into its originating TOOL_CALL below, so a
+// second pass finds invocations that are already `state: "result"` and rewrites
+// them to the values they hold — producing fresh object identities on every
+// render for no gain. See docs/design/conversation-messages.md.
+export function mapConversationMessages(messages: AssistantApiConversationMessage[]): AssistantRenderableMessage[] {
   const mappedMessages: AssistantRenderableMessage[] = [];
   const pendingToolCalls = new Map<string, AssistantToolInvocation>();
 
@@ -679,17 +684,28 @@ export function useAssistantController({
   const [isUploadingFiles, setIsUploadingFiles] = useState(false);
   const [pendingFileUploads, setPendingFileUploads] = useState<AssistantPendingFileUpload[]>([]);
   const [olderMessagesCursor, setOlderMessagesCursor] = useState<string | null>(null);
+  // Pagination position per conversation. A retained transcript is not reloaded
+  // when you return to it, so without this its cursor would stay null and
+  // "Load earlier activity" would vanish from a conversation that has more.
+  const olderMessagesCursorsRef = useRef<Map<string, string | null>>(new Map());
 
   const activeConversationIdRef = useRef<string | null>(null);
   const conversationsRef = useRef<Conversation[]>([]);
   const heldStreamingThinkingRef = useRef<HeldStreamingThinking | null>(null);
   const isStreamingRef = useRef(false);
   const sessionIsStreamingRef = useRef(false);
-  const lastAutoLoadedConversationIdRef = useRef<string | null>(null);
+  // Which conversations have had their history loaded in this session. A set,
+  // not a single "last" id: the runtime store retains several transcripts, so
+  // re-opening one that is still resident must not trigger a second load.
+  const loadedConversationIdsRef = useRef<Set<string>>(new Set());
   const loadingConversationIdRef = useRef<string | null>(null);
   const skipInitialLoadConversationIdsRef = useRef<Set<string>>(new Set());
+  // The detail fetch each open starts, kept by id so the transcript load that
+  // races it can read the answer instead of asking for it again. Values never
+  // reject — a failed fetch resolves to null, which reads as "we do not know".
+  const conversationDetailsRef = useRef<Map<string, Promise<Conversation | null>>>(new Map());
   const loadConversationMessagesRef = useRef<((conversationId: string) => Promise<AssistantApiConversationMessage[] | null>) | null>(null);
-  const resumeIfRunningRef = useRef<((conversationId?: string | null) => Promise<boolean>) | null>(null);
+  const resumeConversationIfRunningRef = useRef<((conversationId: string) => Promise<boolean>) | null>(null);
 
   const scope = useMemo<AssistantConversationScope>(() => ({
     podId: podId ?? null,
@@ -756,6 +772,7 @@ export function useAssistantController({
     appendOptimisticUserMessage,
     replaceLoadedMessages,
     mergeMessages,
+    hasConversationMessages,
     clear: clearRuntimeMessages,
   } = useAssistantRuntime({
     conversationId: activeConversationId,
@@ -805,15 +822,26 @@ export function useAssistantController({
     const knownConversation = conversationsRef.current.find(
       (conversation) => conversation.id === conversationId,
     );
-    const detail = await client.conversations.get(conversationId, {
+    const request = client.conversations.get(conversationId, {
       pod_id: knownConversation?.pod_id ?? scope.podId ?? undefined,
     });
+    conversationDetailsRef.current.set(conversationId, request.catch(() => null));
+    const detail = await request;
     setConversations((previous) => sortConversationsByUpdatedAt([
       detail,
       ...previous.filter((conversation) => conversation.id !== detail.id),
     ]));
     return detail;
   }, [client, scope.podId]);
+
+  // Resuming is only ever about a conversation that is still running, and the
+  // open path has just fetched the record that says whether it is. Waiting on
+  // that fetch costs nothing it was not already waiting on, and hands the
+  // session the answer instead of leaving it to fetch the same record again.
+  const resumeConversationIfRunning = useCallback(async (conversationId: string): Promise<boolean> => {
+    const knownConversation = await conversationDetailsRef.current.get(conversationId);
+    return (await sessionResumeIfRunning(conversationId, { knownConversation })) ?? false;
+  }, [sessionResumeIfRunning]);
 
   const setConversationModel = useCallback(async (model: ConversationModel | null, runtime?: AgentRuntimeConfig | null) => {
     const nextRuntime = typeof runtime === "undefined"
@@ -999,8 +1027,8 @@ export function useAssistantController({
   }, [loadConversationMessages]);
 
   useEffect(() => {
-    resumeIfRunningRef.current = sessionResumeIfRunning;
-  }, [sessionResumeIfRunning]);
+    resumeConversationIfRunningRef.current = resumeConversationIfRunning;
+  }, [resumeConversationIfRunning]);
 
   useEffect(() => {
     activeConversationIdRef.current = activeConversationId;
@@ -1124,6 +1152,11 @@ export function useAssistantController({
 
   useEffect(() => {
     if (!activeConversationId) return;
+    olderMessagesCursorsRef.current.set(activeConversationId, olderMessagesCursor);
+  }, [activeConversationId, olderMessagesCursor]);
+
+  useEffect(() => {
+    if (!activeConversationId) return;
     const activeConversation = conversations.find((conversation) => conversation.id === activeConversationId);
     if (!activeConversation) return;
     setConversationModelState(activeConversation.model ?? null);
@@ -1138,9 +1171,11 @@ export function useAssistantController({
       sessionCancel();
       clearRuntimeMessages();
       activeConversationIdRef.current = null;
-      lastAutoLoadedConversationIdRef.current = null;
+      loadedConversationIdsRef.current.clear();
+      olderMessagesCursorsRef.current.clear();
       loadingConversationIdRef.current = null;
       skipInitialLoadConversationIdsRef.current.clear();
+      conversationDetailsRef.current.clear();
       setActiveConversationId(null);
       setAvailableModels([]);
       setConversationModelState(null);
@@ -1157,9 +1192,11 @@ export function useAssistantController({
     }
 
     activeConversationIdRef.current = null;
-    lastAutoLoadedConversationIdRef.current = null;
+    loadedConversationIdsRef.current.clear();
+    olderMessagesCursorsRef.current.clear();
     loadingConversationIdRef.current = null;
     skipInitialLoadConversationIdsRef.current.clear();
+    conversationDetailsRef.current.clear();
     setActiveConversationId(null);
     setConversationModelState(null);
     setConversationRuntimeState(null);
@@ -1178,18 +1215,21 @@ export function useAssistantController({
   }, [autoLoad, enabled, historyScopeKey, loadConversations]);
 
   useEffect(() => {
+    // Having no conversation open is not a reason to forget the ones already
+    // loaded — `messages` is filtered by the active id, so a retained transcript
+    // is invisible until it is asked for again. Only leaving the scope entirely
+    // (handled by the scope effect above) drops the store.
     if (!enabled || !activeConversationId) {
-      clearRuntimeMessages();
-      lastAutoLoadedConversationIdRef.current = null;
       loadingConversationIdRef.current = null;
       setOlderMessagesCursor(null);
       setIsLoadingMessages(false);
       return;
     }
 
+    // Deferred loading, not discarded loading. This branch used to clear the
+    // store, so a gate that dipped false for one render made the side view
+    // re-fetch and re-paint a transcript it already had.
     if (!autoLoadMessages) {
-      clearRuntimeMessages();
-      lastAutoLoadedConversationIdRef.current = null;
       loadingConversationIdRef.current = null;
       setOlderMessagesCursor(null);
       setIsLoadingMessages(false);
@@ -1198,11 +1238,11 @@ export function useAssistantController({
 
     if (skipInitialLoadConversationIdsRef.current.has(activeConversationId)) {
       skipInitialLoadConversationIdsRef.current.delete(activeConversationId);
-      lastAutoLoadedConversationIdRef.current = activeConversationId;
+      loadedConversationIdsRef.current.add(activeConversationId);
       return;
     }
 
-    if (lastAutoLoadedConversationIdRef.current === activeConversationId) {
+    if (loadedConversationIdsRef.current.has(activeConversationId)) {
       return;
     }
     if (loadingConversationIdRef.current === activeConversationId) {
@@ -1215,9 +1255,9 @@ export function useAssistantController({
       setOlderMessagesCursor(null);
       await loadConversationMessagesRef.current?.(activeConversationId);
       if (cancelled) return;
-      lastAutoLoadedConversationIdRef.current = activeConversationId;
+      loadedConversationIdsRef.current.add(activeConversationId);
       try {
-        await resumeIfRunningRef.current?.(activeConversationId);
+        await resumeConversationIfRunningRef.current?.(activeConversationId);
       } catch (error) {
         if (cancelled) return;
         setLocalError((prev) => prev || (error instanceof Error ? error.message : "Failed to resume conversation"));
@@ -1287,7 +1327,7 @@ export function useAssistantController({
 
       if (
         loadingConversationIdRef.current === conversationId
-        || lastAutoLoadedConversationIdRef.current === conversationId
+        || loadedConversationIdsRef.current.has(conversationId)
       ) {
         return;
       }
@@ -1297,7 +1337,7 @@ export function useAssistantController({
       setOlderMessagesCursor(null);
       setIsLoadingMessages(true);
       void loadConversationMessagesRef.current?.(conversationId)
-        .then(() => resumeIfRunningRef.current?.(conversationId))
+        .then(() => resumeConversationIfRunningRef.current?.(conversationId))
         .catch((error) => {
           setLocalError((prev) => prev || (error instanceof Error ? error.message : "Failed to resume conversation"));
         })
@@ -1305,20 +1345,26 @@ export function useAssistantController({
           if (loadingConversationIdRef.current === conversationId) {
             loadingConversationIdRef.current = null;
           }
-          lastAutoLoadedConversationIdRef.current = conversationId;
+          loadedConversationIdsRef.current.add(conversationId);
         });
       return;
     }
 
     setLocalError(null);
     activeConversationIdRef.current = conversationId;
-    lastAutoLoadedConversationIdRef.current = null;
     loadingConversationIdRef.current = null;
-    setOlderMessagesCursor(null);
-    clearRuntimeMessages();
-    setIsLoadingMessages(Boolean(conversationId && autoLoadMessages));
+    // The store keeps the last few transcripts, so switching to one that is
+    // still resident is a swap, not a load: no wipe, and no loading state to
+    // paint a skeleton over messages we are holding.
+    const isResident = hasConversationMessages(conversationId);
+    setOlderMessagesCursor(
+      isResident && conversationId
+        ? olderMessagesCursorsRef.current.get(conversationId) ?? null
+        : null,
+    );
+    setIsLoadingMessages(Boolean(conversationId && autoLoadMessages && !isResident));
     setActiveConversationId(conversationId);
-  }, [autoLoadMessages, clearRuntimeMessages, refreshConversationDetail, sessionCancel]);
+  }, [autoLoadMessages, hasConversationMessages, refreshConversationDetail, sessionCancel]);
 
   const openConversation = useCallback((conversationId: string) => {
     selectConversation(conversationId);
@@ -1332,9 +1378,11 @@ export function useAssistantController({
     stop();
     clearRuntimeMessages();
     activeConversationIdRef.current = null;
-    lastAutoLoadedConversationIdRef.current = null;
+    loadedConversationIdsRef.current.clear();
+    olderMessagesCursorsRef.current.clear();
     loadingConversationIdRef.current = null;
     skipInitialLoadConversationIdsRef.current.clear();
+    conversationDetailsRef.current.clear();
     setActiveConversationId(null);
     setLocalError(null);
     setOlderMessagesCursor(null);
@@ -1371,7 +1419,7 @@ export function useAssistantController({
       ...prev.filter((conversation) => conversation.id !== createdConversation.id),
     ]));
     activeConversationIdRef.current = createdConversation.id;
-    lastAutoLoadedConversationIdRef.current = createdConversation.id;
+    loadedConversationIdsRef.current.add(createdConversation.id);
     loadingConversationIdRef.current = null;
     skipInitialLoadConversationIdsRef.current.add(createdConversation.id);
     setActiveConversationId(createdConversation.id);

--- a/lemma-typescript/src/react/useAssistantRuntime.ts
+++ b/lemma-typescript/src/react/useAssistantRuntime.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ConversationMessage } from "../types.js";
 
 type RuntimeConversationMessage = ConversationMessage & { conversation_id?: string };
@@ -7,6 +7,11 @@ export interface UseAssistantRuntimeOptions {
   conversationId?: string | null;
   sessionConversationId?: string | null;
   sessionMessages?: ConversationMessage[];
+  /**
+   * How many recently-opened conversations keep their messages in the store.
+   * Re-opening one of these is instant and silent; anything older reloads.
+   */
+  retainConversations?: number;
 }
 
 export interface UseAssistantRuntimeResult {
@@ -17,8 +22,17 @@ export interface UseAssistantRuntimeResult {
   ) => ConversationMessage;
   replaceLoadedMessages: (messages: ConversationMessage[]) => void;
   mergeMessages: (messages: ConversationMessage[]) => void;
+  /** Whether this conversation's transcript is already in the store. */
+  hasConversationMessages: (conversationId: string | null | undefined) => boolean;
   clear: () => void;
 }
+
+/**
+ * Enough that moving between the conversations you are actually working across
+ * never reloads, small enough that a long browsing session cannot accumulate
+ * unbounded transcripts.
+ */
+const DEFAULT_RETAINED_CONVERSATIONS = 5;
 
 function messageText(message: Pick<ConversationMessage, "text">): string {
   return typeof message.text === "string" ? message.text.trim() : "";
@@ -110,8 +124,13 @@ export function useAssistantRuntime({
   conversationId = null,
   sessionConversationId = null,
   sessionMessages = [],
+  retainConversations = DEFAULT_RETAINED_CONVERSATIONS,
 }: UseAssistantRuntimeOptions): UseAssistantRuntimeResult {
   const [runtimeMessages, setRuntimeMessages] = useState<RuntimeConversationMessage[]>([]);
+  // Mirrors the committed store so `hasConversationMessages` can answer from an
+  // event handler without taking the list as a dependency.
+  const runtimeMessagesRef = useRef<RuntimeConversationMessage[]>(runtimeMessages);
+  runtimeMessagesRef.current = runtimeMessages;
 
   const mergeMessages = useCallback((messages: ConversationMessage[]) => {
     setRuntimeMessages((previous) => {
@@ -130,17 +149,23 @@ export function useAssistantRuntime({
       .filter((message) => !conversationId || message.conversation_id === conversationId);
 
     setRuntimeMessages((previous) => {
-      const scopedPrevious = previous.filter((message) => !conversationId || message.conversation_id === conversationId);
+      // Only this conversation is replaced. Other retained transcripts are held
+      // aside and put back, so loading one conversation cannot evict the rest.
+      const belongsToAnother = (message: RuntimeConversationMessage) => (
+        !!message.conversation_id && !!conversationId && message.conversation_id !== conversationId
+      );
+      const otherConversations = previous.filter(belongsToAnother);
+      const ownConversation = previous.filter((message) => !belongsToAnother(message));
 
       // Loads can complete after optimistic appends or stream events. Merge the
       // loaded snapshot into the current runtime state so newer local messages
       // are not temporarily dropped while the server catches up.
       const merged = normalized.reduce(
         (accumulator, message) => upsertRuntimeMessage(accumulator, message),
-        scopedPrevious,
+        ownConversation,
       );
 
-      return [...merged].sort((a, b) => messageTime(a) - messageTime(b));
+      return [...otherConversations, ...merged].sort((a, b) => messageTime(a) - messageTime(b));
     });
   }, [conversationId]);
 
@@ -169,21 +194,42 @@ export function useAssistantRuntime({
   }, [conversationId]);
 
   const clear = useCallback(() => {
+    recentConversationIdsRef.current = [];
     setRuntimeMessages([]);
   }, []);
 
+  const hasConversationMessages = useCallback((targetConversationId: string | null | undefined) => {
+    if (!targetConversationId) return false;
+    return runtimeMessagesRef.current.some((message) => message.conversation_id === targetConversationId);
+  }, []);
+
+  // The store keeps the last few conversations rather than only the open one.
+  // Dropping the previous transcript on every switch is what made re-opening a
+  // conversation you were just in a full blank-and-refetch: the messages were
+  // discarded a frame before the loader was asked for them again.
   useEffect(() => {
     lastSessionMessageIdRef.current = null;
-    setRuntimeMessages((previous) => {
-      if (!conversationId) {
-        return [];
-      }
+    if (!conversationId) return;
 
-      return previous.filter((message) => message.conversation_id === conversationId);
+    const recent = [
+      conversationId,
+      ...recentConversationIdsRef.current.filter((id) => id !== conversationId),
+    ].slice(0, Math.max(1, retainConversations));
+    recentConversationIdsRef.current = recent;
+
+    const retained = new Set(recent);
+    setRuntimeMessages((previous) => {
+      const next = previous.filter((message) => (
+        // A message with no conversation of its own is in-flight local state
+        // (an optimistic user turn); it is scoped by the display filter, not here.
+        !message.conversation_id || retained.has(message.conversation_id)
+      ));
+      return next.length === previous.length ? previous : next;
     });
-  }, [conversationId]);
+  }, [conversationId, retainConversations]);
 
   const lastSessionMessageIdRef = useRef<string | null>(null);
+  const recentConversationIdsRef = useRef<string[]>([]);
 
   useEffect(() => {
     if (sessionMessages.length === 0) return;
@@ -203,11 +249,36 @@ export function useAssistantRuntime({
     mergeMessages(normalized);
   }, [conversationId, mergeMessages, sessionConversationId, sessionMessages]);
 
+  // Session messages are mirrored into state by the effect above, which runs
+  // *after* commit — so for one render a message that has already arrived is not
+  // in the store yet. That gap is why the assistant's answer blinks out as a turn
+  // ends: the session drops the streamed token buffer the moment the durable
+  // message upserts, and the durable message is still one commit away.
+  //
+  // Merging the session's view in at derive time closes the gap instead of
+  // papering over it downstream. Steady state costs nothing: once the effect has
+  // mirrored a message, its id is present and the store is returned untouched.
+  const mergedRuntimeMessages = useMemo(() => {
+    if (sessionMessages.length === 0) return runtimeMessages;
+
+    const present = new Set(runtimeMessages.map((message) => message.id));
+    const missing = sessionMessages.filter((message) => !present.has(message.id));
+    if (missing.length === 0) return runtimeMessages;
+
+    const fallbackConversationId = sessionConversationId ?? conversationId;
+    const merged = missing.reduce(
+      (accumulator, message) => upsertRuntimeMessage(accumulator, toRuntimeMessage(message, fallbackConversationId)),
+      runtimeMessages,
+    );
+    return [...merged].sort((a, b) => messageTime(a) - messageTime(b));
+  }, [conversationId, runtimeMessages, sessionConversationId, sessionMessages]);
+
   return {
-    runtimeMessages,
+    runtimeMessages: mergedRuntimeMessages,
     appendOptimisticUserMessage,
     replaceLoadedMessages,
     mergeMessages,
+    hasConversationMessages,
     clear,
   };
 }

--- a/lemma-typescript/src/react/useAssistantSession.ts
+++ b/lemma-typescript/src/react/useAssistantSession.ts
@@ -129,7 +129,10 @@ export interface UseAssistantSessionResult {
   sendMessage: (content: string, options?: SendAssistantMessageOptions) => Promise<Conversation>;
   retryFailedRun: (conversationId?: string | null) => Promise<Conversation>;
   resume: (conversationId?: string | null | ResumeAssistantOptions) => Promise<void>;
-  resumeIfRunning: (conversationId?: string | null) => Promise<boolean>;
+  resumeIfRunning: (
+    conversationId?: string | null,
+    options?: { knownConversation?: Conversation | null },
+  ) => Promise<boolean>;
   stop: (conversationId?: string | null) => Promise<void>;
   cancel: () => void;
   clearMessages: () => void;
@@ -973,19 +976,32 @@ export function useAssistantSession(options: UseAssistantSessionOptions): UseAss
     }
   }, [cancel, client, consume, conversationId, defaultScope, setConversationStatus]);
 
-  const resumeIfRunning = useCallback(async (explicitConversationId?: string | null): Promise<boolean> => {
+  const resumeIfRunning = useCallback(async (
+    explicitConversationId?: string | null,
+    options?: { knownConversation?: Conversation | null },
+  ): Promise<boolean> => {
     const id = explicitConversationId ?? conversationId;
     if (!id) return false;
     if (isStreaming) return false;
 
-    const statusKey = normalizeConversationStatus(statusRef.current);
+    // A caller that has just read the conversation can hand it over rather than
+    // make us read it again: without a hint the only way to answer "is this
+    // running?" is to go and fetch the record, which is what the caller has in
+    // its hand. Trusted only for the conversation it actually describes.
+    const knownConversation = options?.knownConversation?.id === id
+      ? options.knownConversation
+      : null;
+    const statusKey = normalizeConversationStatus(knownConversation?.status ?? statusRef.current);
     const resumeKey = `${id}:${statusKey ?? "UNKNOWN"}`;
     if (autoResumedKeyRef.current === resumeKey) {
       return false;
     }
 
-    const knownRunning = isConversationRunningStatus(statusRef.current);
-    if (!knownRunning) {
+    if (knownConversation) {
+      if (!isConversationRunningStatus(knownConversation.status)) return false;
+      setConversation(knownConversation);
+      setConversationStatus(statusKey);
+    } else if (!isConversationRunningStatus(statusRef.current)) {
       const latestConversation = await refreshConversation(id);
       if (!latestConversation || !isConversationRunningStatus(latestConversation.status)) {
         return false;
@@ -1006,7 +1022,7 @@ export function useAssistantSession(options: UseAssistantSessionOptions): UseAss
       }
       throw error;
     }
-  }, [conversationId, isStreaming, refreshConversation, resume]);
+  }, [conversationId, isStreaming, refreshConversation, resume, setConversationStatus]);
 
   const stop = useCallback(async (explicitConversationId?: string | null): Promise<void> => {
     setError(null);


### PR DESCRIPTION
## The transcript problem

Four layers each believed they owned the conversation transcript — the provider, the SDK controller, the session, and a second raw-messages query — so opening a conversation fetched it two or three times and merged the copies on every render. Two functions existed whose entire body was a double `requestAnimationFrame`, used as a synchronisation primitive between state machines that should have been one. That is the shape of the whole problem, and it is written up in [`docs/design/conversation-messages.md`](docs/design/conversation-messages.md).

## What changed

**One store.** `useAssistantRuntime` retains the last few transcripts instead of only the open one, so returning to a conversation you were just in is a swap, not a blank-and-refetch. The controller tracks loaded ids and pagination cursors per conversation to match, so "Load earlier activity" survives a round trip away.

**One copy.** The provider's raw-messages query and its `hydrateToolReturnMessages` pass are gone. `mapConversationMessages` already folds each `TOOL_RETURN` into its originating `TOOL_CALL`, so the second pass found invocations that were already `state: "result"` and rewrote them to the values they held — fresh object identities on every render, for nothing.

**No blink at the end of a turn.** Session messages are merged in at derive time rather than only through a post-commit effect. The session drops its streamed token buffer the moment the durable message upserts, and the durable message was one commit away; that gap was the answer disappearing and coming back.

**Folding is a property of the transcript, not of how you got there.** Every finished run folds under "Worked for …", only a still-running run stays open, and a reloaded conversation now renders the way it did live. Trace rows are marked whether or not the run folds, so a run's working-out never renders at answer weight and reads as a second answer.

**Fewer fetches on open.** Resuming hands the session the conversation record the open path already fetched instead of making it fetch the same row again, and the conversation route reads its record from the controller's list rather than issuing its own GET.

**Inline tool calls** lost their per-row icon and shimmer. The glyph added a column of noise without saying anything the label didn't; the shimmer gave the running row a different weight and colour from the rows above it, so a dozen steps never looked like one list. Activity is the transcript's single bottom indicator's job.

## Also in here

- **`ProjectBranchChip`** next to the project picker names the branch a conversation works on and the pull request that branch is in, read through the same curated connector operations the agent itself uses. It is pushed state — a branch with uncommitted work in the agent's checkout looks identical to one without, and every label is written to stay true under that reading.
- **`useGithubConnection`** splits out of `useGithubProjects`, resolving org / install / account once for every GitHub read instead of once per hook.
- **Join requests** are now gated on `pod.member.manage` before they hit the wire, and a 403 is no longer retried. A permission check that only guarded the JSX still let every ordinary member ask the server a question it answers with a refusal — four times, on every remount, since a failed query caches nothing for `staleTime` to suppress.

## Testing

- `lemma-typescript`: 190 tests / 24 files pass, including new suites for runtime retention, completed-run trace folding, conversation message mapping, and the fetch count on open.
- `lemma-frontend`: 651 tests / 69 files pass, including new suites for branch and pull-request parsing, project execution parsing, and join-request retry.
- `tsc --noEmit` clean on the frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)