### PR TITLE
Gate release evidence on releases, not on branch test builds

### DIFF
--- a/.github/workflows/release-local-images.yml
+++ b/.github/workflows/release-local-images.yml
@@ -72,7 +72,13 @@ jobs:
                   f"branch-test runtime {requested} does not match Desktop {desktop}"
               )
           PY
+      # Release evidence gates a release. A branch test build is explicitly not
+      # one: it is how a commit gets tried *before* it is release-qualified, and
+      # protected E2E is not a required check on main, so demanding a successful
+      # run for the exact SHA would block nearly every one of these. The version
+      # check above still runs either way.
       - name: Verify protected evidence
+        if: github.event_name == 'push' || inputs.publish
         uses: ./.github/actions/require-backend-protected-e2e
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The first shared build from main never got past the first job: `protected-e2e-gate` requires a successful backend protected E2E run for the exact SHA, and it ran unconditionally — including for `publish: false`, which publishes nothing.

That gate exists so a **release** carries release-quality evidence. A branch test build is the opposite case: it is how a commit gets tried before it is release-qualified. And protected E2E is not a required check on main, so most main commits have no run for their SHA — this would have blocked nearly every nightly, not occasionally.

Tag pushes and `publish: true` are unchanged. The branch-test version check in the same job still runs either way.