### PR TITLE
Ship the nightly as the small notarized DMG, not a bundled one

### DIFF
--- a/.github/workflows/release-local-images.yml
+++ b/.github/workflows/release-local-images.yml
@@ -29,7 +29,7 @@ on:
         default: true
         type: boolean
       share:
-        description: "With publish off: sign, notarize and attach the test DMG to a public prerelease so testers can install it."
+        description: "With publish off: publish the runtime to a nightly prerelease and attach a signed, notarized online DMG anyone can install."
         required: false
         default: false
         type: boolean
@@ -593,8 +593,17 @@ jobs:
           else
             image_tag="test-${GITHUB_SHA:0:12}"
           fi
+          # Where the runtime assets will live, and therefore what the manifest
+          # has to point at. A shared build publishes to its own prerelease so
+          # it never touches the version-tag release channel.
+          if [[ "${PUBLISH}" == "true" ]]; then
+            release_tag="v${version}"
+          else
+            release_tag="desktop-nightly-${GITHUB_SHA:0:8}"
+          fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "image_tag=${image_tag}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${release_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Download merged digests
         uses: actions/download-artifact@v8
@@ -630,6 +639,7 @@ jobs:
           IMAGE_TAG: ${{ steps.version.outputs.image_tag }}
           PREFIX: ${{ env.IMAGE_PREFIX }}
           REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
         run: |
           python3 - <<'PY'
           import json
@@ -641,6 +651,7 @@ jobs:
           image_tag = os.environ["IMAGE_TAG"]
           prefix = os.environ["PREFIX"]
           repository = os.environ["REPOSITORY"]
+          release_tag = os.environ["RELEASE_TAG"]
           digests = {}
           for path in Path("digests").glob("*.json"):
               entry = json.loads(path.read_text())
@@ -665,7 +676,7 @@ jobs:
               host_packs[target] = {
                   "url": (
                       f"https://github.com/{repository}/releases/download/"
-                      f"v{version}/{path.name}"
+                      f"{release_tag}/{path.name}"
                   ),
                   "sha256": digest,
                   "size": path.stat().st_size,
@@ -691,7 +702,7 @@ jobs:
               guest_runtimes[target] = {
                   "url": (
                       f"https://github.com/{repository}/releases/download/"
-                      f"v{version}/{path.name}"
+                      f"{release_tag}/{path.name}"
                   ),
                   "sha256": digest,
                   "size": path.stat().st_size,
@@ -779,6 +790,37 @@ jobs:
           # lemma-local.json asset) and must not overwrite the release body.
           generate_release_notes: ${{ github.event_name == 'push' }}
 
+      # The manifest a shared build ships points at this prerelease, so the
+      # assets have to be here before the DMG that references them is built.
+      # A prerelease never becomes "Latest", so the version-tag release channel
+      # is untouched.
+      - name: Publish runtime assets to the nightly prerelease
+        if: inputs.share && !inputs.publish
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.release_tag }}
+          SHA: ${{ github.sha }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "${TAG}" >/dev/null 2>&1; then
+            gh release create "${TAG}" \
+              --prerelease \
+              --target "${SHA}" \
+              --title "Lemma Desktop nightly — ${REF_NAME} ${SHA:0:8}" \
+              --notes "Built on demand from \`${REF_NAME}\` at ${SHA:0:8}. Apple silicon, macOS 14+.
+
+          Download the DMG below, drag Lemma to Applications, open it, and choose **Local → Install local services**. The runtime downloads from this prerelease on first launch.
+
+          Not an official release: no upgrade path and no support guarantees."
+          fi
+          gh release upload "${TAG}" \
+            lemma-local.json \
+            host-packs/lemma-host-pack-*.zip \
+            guest-runtimes/lemma-guest-runtime-*.zip \
+            --clobber
+
       - name: Upload branch-test runtime bundle
         if: github.event_name == 'workflow_dispatch' && !inputs.publish
         uses: actions/upload-artifact@v4
@@ -800,9 +842,20 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  macos-test-desktop:
-    name: Package self-contained macOS test app
-    if: github.event_name == 'workflow_dispatch' && !inputs.publish
+  # The shared build is the *online* app: the same small, signed, notarized DMG
+  # a real release ships, pointed at the nightly prerelease instead of a version
+  # tag. It has to be the online one -- Apple's notary service unpacks
+  # host-runtime.zip and rejects everything inside it, because a bundled CPython
+  # and node_modules are not Developer ID signed and never will be. So a
+  # self-contained DMG cannot be notarized, and an un-notarized DMG is refused by
+  # Gatekeeper on any machine that did not build it.
+  #
+  # Self-contained builds are a local tool now (`make desktop-dmg`), fed by the
+  # runtime artifacts this workflow already uploads. CI does not package them:
+  # half a gigabyte per run, for something nobody can hand to a tester anyway.
+  share-desktop-dmg:
+    name: Publish signed nightly macOS DMG
+    if: github.event_name == 'workflow_dispatch' && inputs.share && !inputs.publish
     runs-on: macos-14
     needs: manifest
     steps:
@@ -814,51 +867,83 @@ jobs:
         with:
           node-version: 22
 
-      - name: Setup Rust
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
 
-      - name: Cache cargo
+      - name: Cache cargo and desktop target
         uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             desktop/target
-          key: desktop-test-cargo-${{ runner.os }}-${{ hashFiles('desktop/Cargo.lock') }}
-          restore-keys: desktop-test-cargo-${{ runner.os }}-
+          key: desktop-share-cargo-${{ runner.os }}-${{ hashFiles('desktop/Cargo.lock') }}
+          restore-keys: desktop-share-cargo-${{ runner.os }}-
 
-      - name: Download macOS native host pack
-        uses: actions/download-artifact@v8
-        with:
-          name: host-pack-aarch64-apple-darwin
-          path: desktop/runtime/download
-
-      - name: Download macOS managed guest runtime
-        uses: actions/download-artifact@v8
-        with:
-          name: guest-runtime-macos-aarch64
-          path: desktop/runtime/download
-
-      - name: Download exact branch-test manifest
-        uses: actions/download-artifact@v8
-        with:
-          name: lemma-local-test-manifest-${{ github.sha }}
-          path: desktop/runtime/download
-
-      # One staging engine for CI and for `make desktop-dmg`, so a locally
-      # built test DMG and this one are produced by the same code.
-      - name: Verify and stage compressed PR test runtime
+      - name: Resolve nightly tag
+        id: tag
         shell: bash
+        run: echo "release_tag=desktop-nightly-${GITHUB_SHA:0:8}" >> "$GITHUB_OUTPUT"
+
+      - name: Require notarization credentials
+        shell: bash
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          if [[ -z "${APPLE_ID}" || -z "${APPLE_PASSWORD}" || -z "${APPLE_TEAM_ID}" ]]; then
+            echo "::error::APPLE_ID, APPLE_PASSWORD and APPLE_TEAM_ID are required to share a build." >&2
+            exit 1
+          fi
+
+      - name: Import Developer ID certificate
+        id: apple-signing
+        uses: ./.github/actions/setup-apple-signing
+        with:
+          certificate: ${{ secrets.APPLE_CERTIFICATE }}
+          certificate-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+
+      # The same verification the release build does: the app trusts this
+      # manifest to fetch its runtime, so the digests it names are checked
+      # against the bytes actually published before anything is built.
+      - name: Download and verify the published runtime manifest
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.release_tag }}
+          TARGET: aarch64-apple-darwin
+          GUEST_TARGET: macos-aarch64
         run: |
           set -euo pipefail
-          python3 scripts/prepare_desktop_test_runtime.py \
-            --artifacts-dir desktop/runtime/download \
-            --mode bundled \
-            --expect-version "${{ inputs.version }}" \
-            --host-target aarch64-apple-darwin \
-            --guest-target macos-aarch64 \
-            --stage-dir desktop/runtime/bundled \
-            --output desktop/runtime/bundled/lemma-local.json
+          mkdir -p desktop/runtime/download
+          gh release download "${TAG}" \
+            --pattern lemma-local.json \
+            --pattern "lemma-host-pack-${TARGET}.zip" \
+            --pattern "lemma-guest-runtime-${GUEST_TARGET}.zip" \
+            --dir desktop/runtime/download \
+            --clobber
+          python3 - <<'VERIFY'
+          import hashlib, json, os
+          from pathlib import Path
+          root = Path("desktop/runtime/download")
+          manifest = json.loads((root / "lemma-local.json").read_text())
+          for kind, key, name in (
+              ("host_packs", os.environ["TARGET"], "lemma-host-pack-{}.zip"),
+              ("guest_runtimes", os.environ["GUEST_TARGET"], "lemma-guest-runtime-{}.zip"),
+          ):
+              archive = root / name.format(key)
+              expected = manifest[kind][key]
+              if hashlib.sha256(archive.read_bytes()).hexdigest() != expected["sha256"]:
+                  raise SystemExit(f"{archive.name} digest mismatch")
+              if archive.stat().st_size != expected["size"]:
+                  raise SystemExit(f"{archive.name} size mismatch")
+              if not expected["url"].endswith(f"/{archive.name}"):
+                  raise SystemExit(f"{archive.name} URL does not name the asset")
+          VERIFY
+          cp desktop/runtime/download/lemma-local.json desktop/runtime/lemma-local.json
 
       - name: Bake splash concepts
         run: node desktop/scripts/extract-concepts.mjs
@@ -869,33 +954,16 @@ jobs:
       - name: Build native local sidecars
         run: desktop/scripts/build-sidecar.sh
 
-      - name: Run Desktop tests
-        working-directory: desktop
-        run: cargo test --locked
-
-      # A shared build has to open on machines that did not produce it, and an
-      # ad-hoc signature does not: Gatekeeper refuses it outright. Import the
-      # Developer ID identity so the helper, the app and the DMG all carry one
-      # Apple will accept, and so notarization below has something to staple to.
-      - name: Import Apple signing certificate
-        id: apple-signing
-        if: inputs.share
-        uses: ./.github/actions/setup-apple-signing
-        with:
-          certificate: ${{ secrets.APPLE_CERTIFICATE }}
-          certificate-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-
-      - name: Sign virtualization helper with test entitlement
+      - name: Sign virtualization helper with its entitlement
         shell: bash
         env:
-          SIGNING_IDENTITY: ${{ steps.apple-signing.outputs.signing-identity }}
+          APPLE_SIGNING_IDENTITY: ${{ steps.apple-signing.outputs.signing-identity }}
         run: |
           set -euo pipefail
           helper="desktop/binaries/lemma-vz-aarch64-apple-darwin"
-          # "-" is ad-hoc, which is fine for a build only its author installs.
-          codesign --force --options runtime \
+          codesign --force --timestamp --options runtime \
             --entitlements desktop/entitlements.plist \
-            --sign "${SIGNING_IDENTITY:--}" \
+            --sign "${APPLE_SIGNING_IDENTITY}" \
             "${helper}"
           codesign --verify --strict --verbose=2 "${helper}"
           codesign -d --entitlements :- "${helper}" 2>&1 \
@@ -905,257 +973,50 @@ jobs:
         run: |
           echo "TAURI_CLI=@tauri-apps/cli@$(tr -d '[:space:]' < desktop/scripts/tauri-cli-version.txt)" >> "$GITHUB_ENV"
 
-      - name: Build compressed macOS PR test DMG
+      - name: Build, sign and notarize the online DMG
         working-directory: desktop
         env:
-          # "-" is ad-hoc: fine for a build only its author installs, refused by
-          # Gatekeeper anywhere else. A shared build gets the real identity, and
-          # the Apple credentials beside it are what make the bundler notarize
-          # and staple as part of the same step.
-          APPLE_SIGNING_IDENTITY: ${{ steps.apple-signing.outputs.signing-identity || '-' }}
-          APPLE_ID: ${{ inputs.share && secrets.APPLE_ID || '' }}
-          APPLE_PASSWORD: ${{ inputs.share && secrets.APPLE_PASSWORD || '' }}
-          APPLE_TEAM_ID: ${{ inputs.share && secrets.APPLE_TEAM_ID || '' }}
+          APPLE_SIGNING_IDENTITY: ${{ steps.apple-signing.outputs.signing-identity }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          npx -y "$TAURI_CLI" build --config tauri.dist.conf.json
+          npx -y "$TAURI_CLI" build --config tauri.online.conf.json
+          mkdir -p target/release/release-artifacts
+          dmg=(target/release/bundle/dmg/Lemma_*_aarch64.dmg)
+          [[ "${#dmg[@]}" == 1 ]]
+          mv "${dmg[0]}" \
+            "target/release/release-artifacts/Lemma-nightly-${SHA:0:8}_aarch64.dmg"
 
-      # Proving it here means a tester never discovers it at their end, where
-      # the only symptom is a dialog telling them the app is damaged.
-      - name: Verify the shared build is notarized
-        if: inputs.share
+      # Proved here so a tester never meets it as "Lemma is damaged".
+      - name: Verify signature and notarization
         shell: bash
         run: |
           set -euo pipefail
           app="desktop/target/release/bundle/macos/Lemma.app"
           codesign --verify --deep --strict --verbose=2 "${app}"
+          codesign -dvvv "${app}" 2>&1 | grep -F "Identifier=work.lemma.desktop"
           xcrun stapler validate "${app}"
-          xcrun stapler validate desktop/target/release/bundle/dmg/Lemma_*_aarch64.dmg
+          xcrun stapler validate desktop/target/release/release-artifacts/*.dmg
 
-      - name: Verify compressed PR test application
-        shell: bash
-        run: |
-          set -euo pipefail
-          app="desktop/target/release/bundle/macos/Lemma.app"
-          test -x "${app}/Contents/MacOS/lemma-locald"
-          test -x "${app}/Contents/MacOS/lemma-runtime"
-          test -x "${app}/Contents/Resources/lemma-vz"
-          test -f "${app}/Contents/Resources/lemma-local.json"
-          test -f "${app}/Contents/Resources/host-runtime.zip"
-          test -f "${app}/Contents/Resources/guest-runtime.zip"
-          test ! -e "${app}/Contents/Resources/local-runtime"
-          test ! -e "${app}/Contents/Resources/managed-runtime"
-          app_bytes="$(du -sk "${app}" | awk '{print $1 * 1024}')"
-          test "${app_bytes}" -le "$((850 * 1024 * 1024))"
-          codesign --verify --deep --strict --verbose=2 "${app}"
-          codesign -d --entitlements :- \
-            "${app}/Contents/Resources/lemma-vz" 2>&1 \
-            | grep -F "com.apple.security.virtualization"
-          test "$(jq -r .version "${app}/Contents/Resources/lemma-local.json")" = \
-            "$(jq -r .version desktop/tauri.conf.json)"
-
-      - name: Upload compressed macOS PR test DMG
-        uses: actions/upload-artifact@v4
-        with:
-          name: lemma-desktop-macos-pr-test-${{ github.sha }}
-          path: desktop/target/release/bundle/dmg/Lemma_*_aarch64.dmg
-          if-no-files-found: error
-          retention-days: 14
-
-      # A workflow artifact needs a GitHub account and repo access to download,
-      # which is the wrong shape for handing a build to testers. A prerelease is
-      # a plain public URL, and prereleases never become "Latest", so the real
-      # release channel is untouched. release-desktop.yml ignores these tags.
-      - name: Share the DMG as a public prerelease
-        if: inputs.share
+      - name: Attach the DMG to the nightly prerelease
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SHA: ${{ github.sha }}
-          REF_NAME: ${{ github.ref_name }}
+          TAG: ${{ steps.tag.outputs.release_tag }}
         run: |
           set -euo pipefail
-          short="${SHA:0:8}"
-          tag="desktop-nightly-${short}"
-          dmg="$(ls desktop/target/release/bundle/dmg/Lemma_*_aarch64.dmg)"
-          if ! gh release view "${tag}" >/dev/null 2>&1; then
-            gh release create "${tag}" \
-              --prerelease \
-              --target "${SHA}" \
-              --title "Lemma Desktop nightly — ${REF_NAME} ${short}" \
-              --notes "$(cat <<NOTES
-          Self-contained macOS build of \`${REF_NAME}\` at ${short}, signed with
-          Developer ID and notarized, so it opens without a Gatekeeper warning.
-
-          Apple silicon, macOS 14+. Download the DMG, drag Lemma to Applications,
-          open it, and choose **Local → Install local services**.
-
-          Not an official release: it is built on demand from a branch and carries
-          no upgrade or support guarantees.
-          NOTES
-          )"
-          fi
-          gh release upload "${tag}" "${dmg}" --clobber
-          url="$(gh release view "${tag}" --json assets --jq '.assets[] | select(.name | endswith(".dmg")) | .url')"
+          dmg="$(ls desktop/target/release/release-artifacts/*.dmg)"
+          gh release upload "${TAG}" "${dmg}" --clobber
+          url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/$(basename "${dmg}")"
           {
             echo "### Lemma Desktop nightly"
             echo
             echo "[Download the DMG](${url})"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-  # The Windows half of the pair. One `publish: false` dispatch now yields both
-  # an installable macOS DMG and an installable Windows installer, cut from the
-  # same host packs, guest runtimes, and manifest.
-  windows-test-desktop:
-    name: Package self-contained Windows test app
-    if: github.event_name == 'workflow_dispatch' && !inputs.publish
-    runs-on: windows-latest
-    needs: manifest
-    defaults:
-      run:
-        shell: pwsh
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: x86_64-pc-windows-msvc
-
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            desktop/target
-          key: desktop-test-cargo-${{ runner.os }}-${{ hashFiles('desktop/Cargo.lock') }}
-          restore-keys: desktop-test-cargo-${{ runner.os }}-
-
-      - name: Download Windows native host pack
-        uses: actions/download-artifact@v8
-        with:
-          name: host-pack-x86_64-pc-windows-msvc
-          path: desktop/runtime/download
-
-      - name: Download Windows managed guest runtime
-        uses: actions/download-artifact@v8
-        with:
-          name: guest-runtime-windows-x86_64
-          path: desktop/runtime/download
-
-      - name: Download exact branch-test manifest
-        uses: actions/download-artifact@v8
-        with:
-          name: lemma-local-test-manifest-${{ github.sha }}
-          path: desktop/runtime/download
-
-      # The same staging engine the macOS job and `desktop.ps1 exe` use.
-      - name: Verify and stage compressed PR test runtime
-        run: |
-          python scripts/prepare_desktop_test_runtime.py `
-            --artifacts-dir desktop/runtime/download `
-            --mode bundled `
-            --expect-version "${{ inputs.version }}" `
-            --host-target x86_64-pc-windows-msvc `
-            --guest-target windows-x86_64 `
-            --stage-dir desktop/runtime/bundled `
-            --output desktop/runtime/bundled/lemma-local.json
-          if ($LASTEXITCODE -ne 0) { throw "Staging the bundled runtime failed" }
-
-      - name: Bake splash concepts
-        run: node desktop/scripts/extract-concepts.mjs
-
-      - name: Verify baked splash concepts are committed
-        run: git diff --exit-code desktop/ui/concepts.gen.json
-
-      - name: Build Windows sidecars
-        run: desktop/scripts/build-sidecar.ps1
-
-      - name: Run Desktop tests
-        working-directory: desktop
-        run: cargo test -p lemma-desktop --locked
-
-      - name: Read the pinned Tauri CLI
-        run: |
-          $v = (Get-Content desktop/scripts/tauri-cli-version.txt).Trim()
-          "TAURI_CLI=@tauri-apps/cli@$v" | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
-
-      - name: Build compressed Windows PR test installer
-        working-directory: desktop
-        run: |
-          npx -y $env:TAURI_CLI build --config tauri.dist.conf.json --bundles nsis
-          if ($LASTEXITCODE -ne 0) { throw "Bundled NSIS build failed" }
-
-      # A publish:false host pack is unsigned end to end, so there is no
-      # Authenticode to verify. NSIS is an LZMA self-extractor, so unlike the
-      # macOS .app the payload cannot be walked with Expand-Archive either -
-      # 7-Zip understands the container and ships on windows-latest, which makes
-      # it the only way to prove the runtime archives actually got inside.
-      - name: Verify compressed PR test installer
-        run: |
-          $ErrorActionPreference = "Stop"
-          $payload = @(
-            "desktop/target/release/lemma-desktop.exe",
-            "desktop/binaries/lemma-locald-x86_64-pc-windows-msvc.exe",
-            "desktop/binaries/lemma-agent-host-x86_64-pc-windows-msvc.exe",
-            "desktop/binaries/lemma-runtime-x86_64-pc-windows-msvc.exe",
-            "desktop/runtime/bundled/lemma-local.json",
-            "desktop/runtime/bundled/host-runtime.zip",
-            "desktop/runtime/bundled/guest-runtime.zip"
-          )
-          $bytes = ($payload | ForEach-Object {
-            if (-not (Test-Path $_)) { throw "Bundled payload is missing: $_" }
-            (Get-Item $_).Length
-          } | Measure-Object -Sum).Sum
-          # The same hard gate the bundled macOS app is held to. On Windows the
-          # installed application only exists post-install, so the staged
-          # payload is the honest analogue of `du -sk Lemma.app`.
-          if ($bytes -gt 850MB) {
-            throw "Bundled application payload is $bytes bytes; the limit is 850 MiB"
-          }
-
-          $installers = @(Get-ChildItem desktop/target/release/bundle/nsis/Lemma_*-setup.exe `
-            -ErrorAction SilentlyContinue)
-          if ($installers.Count -ne 1) {
-            throw "Expected exactly one bundled NSIS installer, found $($installers.Count)"
-          }
-          $installer = $installers[0]
-
-          $sevenZip = "$env:ProgramFiles\7-Zip\7z.exe"
-          if (Test-Path $sevenZip) {
-            $listing = & $sevenZip l $installer.FullName | Out-String
-            foreach ($entry in @("lemma-desktop.exe", "lemma-locald", "lemma-runtime",
-                                 "lemma-local.json", "host-runtime.zip", "guest-runtime.zip")) {
-              if ($listing -notmatch [regex]::Escape($entry)) {
-                throw "NSIS installer does not contain $entry"
-              }
-            }
-            Write-Host "installer contents verified with 7-Zip"
-          } else {
-            # Do not fail the build over a missing inspector: the payload check
-            # above already proves what went in. Say so, so a silently weaker
-            # gate is visible in the log.
-            Write-Warning "7-Zip not found; skipped inspecting the installer contents"
-          }
-
-          $manifest = Get-Content desktop/runtime/bundled/lemma-local.json | ConvertFrom-Json
-          $conf = Get-Content desktop/tauri.conf.json | ConvertFrom-Json
-          if ($manifest.version -ne $conf.version) {
-            throw "The bundled runtime manifest and Desktop disagree on the version"
-          }
-          Write-Host "installer verified: $($installer.Name) ($($installer.Length) bytes)"
-
-      - name: Upload compressed Windows PR test installer
-        uses: actions/upload-artifact@v4
-        with:
-          name: lemma-desktop-windows-pr-test-${{ github.sha }}
-          path: desktop/target/release/bundle/nsis/Lemma_*-setup.exe
-          if-no-files-found: error
-          retention-days: 14
+      - name: Remove temporary signing keychain
+        if: always() && steps.apple-signing.outcome == 'success'
+        run: security delete-keychain "${{ steps.apple-signing.outputs.keychain-path }}"

--- a/Makefile
+++ b/Makefile
@@ -983,9 +983,13 @@ desktop-runtime-fetch:
 # worth handing someone to try a branch — CI's build-check DMG points at
 # unresolvable URLs on purpose and refuses to install.
 #
-# Every step mirrors release-local-images.yml's macos-test-desktop job and
-# shares its staging engine, so a green local build and a green CI build mean
-# the same thing.
+# Self-contained builds live here and only here. CI used to package one too,
+# but Apple's notary service unpacks host-runtime.zip and rejects the bundled
+# CPython and node_modules inside it, so a self-contained DMG can never be
+# notarized -- which makes it useless for handing to anyone else, and not worth
+# half a gigabyte a run. CI publishes the signed online DMG instead
+# (`release-local-images.yml` with `share`); this is the one you install
+# yourself, from the runtime artifacts that workflow uploads.
 desktop-dmg:
 	@test "$$(uname -s)" = "Darwin" || ( \
 		echo "  ✗ desktop-dmg builds a macOS DMG"; \

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -218,29 +218,29 @@ they build against a placeholder manifest with unresolvable URLs, so the
 resulting app refuses to install and says so. Their artifacts are named
 `lemma-desktop-macos-buildcheck-<sha>`.
 
-For anything you intend to run, cut a **Release Local Images** run with:
-
-- `version`: the Desktop version, currently `0.7.0`;
-- `publish`: `false`.
-
-One run builds and verifies both platforms' runtimes and uploads two
-self-contained installers:
-
-```text
-lemma-desktop-macos-pr-test-<full-commit-sha>
-lemma-desktop-windows-pr-test-<full-commit-sha>
-```
+For a build someone else can install, cut a **Release Local Images** run with
+`share`:
 
 ```bash
-gh workflow run release-local-images.yml -f version=0.7.0 -f publish=false
-gh run list --workflow release-local-images.yml --branch "$(git branch --show-current)"
-
-sha="$(git rev-parse HEAD)"
-gh run download RUN_ID -n "lemma-desktop-macos-pr-test-${sha}" -D /tmp/lemma-pr
-gh run download RUN_ID -n "lemma-desktop-windows-pr-test-${sha}" -D /tmp/lemma-pr
+gh workflow run release-local-images.yml -f version=0.7.0 -f publish=false -f share=true
 ```
 
-The Windows installer is unsigned, so SmartScreen warns on first run.
+That publishes the runtime archives and the manifest to a prerelease tagged
+`desktop-nightly-<short-sha>`, then builds the **online** DMG against it —
+signed with Developer ID, notarized and stapled — and attaches it there. The
+download link is printed to the job summary. Prereleases never become "Latest",
+so the version-tag release channel is untouched.
+
+It has to be the online DMG. Apple's notary service unpacks `host-runtime.zip`
+and rejects everything inside: a bundled CPython and `node_modules` are not
+Developer ID signed and never will be. So a self-contained DMG cannot be
+notarized, and an un-notarized one is refused by Gatekeeper on any machine that
+did not build it. CI does not package self-contained apps at all — half a
+gigabyte a run, for something nobody can hand to a tester.
+
+Without `share`, a `publish: false` run still builds and verifies both
+platforms' runtimes and uploads them as workflow artifacts, which is what the
+local self-contained builds below consume.
 
 ### Or build one locally
 

--- a/desktop/scripts/desktop.ps1
+++ b/desktop/scripts/desktop.ps1
@@ -183,9 +183,10 @@ switch ($Verb) {
     # webviewInstallMode to offlineInstaller in tauri.windows.conf.json, which
     # costs about 130 MB.
     #
-    # This mirrors release-local-images.yml's windows-test-desktop job and
-    # shares its staging engine, so a green local build and a green CI build
-    # mean the same thing.
+    # Local only. CI no longer packages self-contained apps -- they cannot be
+    # notarized, because Apple inspects inside host-runtime.zip -- so this is
+    # the way to get an installable Windows build, from the runtime artifacts
+    # release-local-images.yml uploads.
     'exe' {
         Require-Command cargo 'install Rust from https://rustup.rs'
         Require-Command node 'install Node.js 22 from https://nodejs.org'

--- a/docs/design/messages-and-asks.md
+++ b/docs/design/messages-and-asks.md
@@ -1,0 +1,218 @@
+# Messages and Asks
+
+**Status:** Proposed · **Supersedes:** the design in [PR #264](https://github.com/lemma-work/lemma-platform/pull/264), treated here as a spike · **Surface area:** `agent_surfaces`, `agent`, `workflow`, one new worker, both SDKs, one inbox
+
+## The change in one sentence
+
+An agent gets exactly two verbs for reaching a human — **tell** and **ask** — sharing one delivery pipeline underneath, and *ask* reuses the two suspend/resume mechanisms Lemma already has instead of becoming a third.
+
+## Why
+
+PR #264 proved the demand and found the real bugs. It also shipped five ways to put text in front of a person, and the audience control it advertises is enforced nowhere. Both of those follow from one framing error, and the error is worth naming precisely because it is easy to make again.
+
+**#264 modelled the channel and left the intent implicit.** `notify` picks *where* a message lands. But the question that actually determines everything downstream is *what kind of act this is*:
+
+| | Does a run wait on it? | Who resolves it? | What does "delivered" mean? |
+| --- | --- | --- | --- |
+| **Tell** | never | nobody | it reached them |
+| **Ask** | yes | a named person | they answered |
+
+Those are different entities. Collapsing them means `message_person` has to say, in its own docstring, *"do not wait on it here"* — a capability defined by what it cannot do. Meanwhile the thing users asked for ("ask Priya for the PO number") is an Ask, so it stayed unbuilt and got listed under *deliberately not here*.
+
+The doc for #264 saw this coming. It worried about becoming "a fourth parallel mechanism for the same idea" and then shipped one anyway, because the framing gave it nowhere else to go.
+
+### Lemma already knows how to wait for a human. Twice.
+
+This is the fact that changes the design:
+
+- **`workflow_run_waits`** — `wait_type`, `external_ref`, `assigned_pod_member_id`, `payload`, and a partial unique index enforcing *at most one ACTIVE wait per run*. A genuinely good table. `WorkflowRunWaitType.HUMAN` is already an ask.
+- **`AgentInputRequired`** — `ask_user` and `request_approval` raise it, the run ends cleanly into WAITING, the approvals endpoint records the answer, and a fresh run replays the synthesized response from history. The resume path keys off `tool_call_id`.
+
+Neither needed to be invented. Both were skipped. A third mechanism was written instead, and it is the one that cannot resume.
+
+### The gate is on the wrong noun
+
+`SurfaceSendPolicy.audience` lives on the surface. `message_person` and `notify` are surface-independent — a schedule-born run has no surface at all. So the policy **structurally cannot** gate the thing two shipped skill docs say it gates. That is not a missing `if`; it is the field being attached to an entity that is not in the call path.
+
+Permissions attach to the thing that *has an identity*. A surface is a transport. The agent is the actor.
+
+## Three layers
+
+Separating them is the whole proposal. Each has exactly one implementation.
+
+```
+intent      Message | Ask          what kind of act this is
+   │
+delivery    Dispatch (outbox)      one row per attempt, retried, idempotent
+   │
+address     Reach                  where a person can be received
+```
+
+### Layer 1 — `Reach`: where a person can be received
+
+Keep #264's noun. It is the genuinely new and correct one: *"can this pod reach Deepak at all, and where"* had no answer before, only a three-way join. Three corrections:
+
+**Reuse `SurfacePlatform`.** `ReachKind` re-declares all seven values plus `APP`, and `for_platform()` is `cls(platform.value)` — it raises on an eighth platform, inside a `try/except: logger.debug`, so adding a platform silently stops recording reaches. The address is `(platform, surface_id)`. There is no eighth enum.
+
+**Delete `APP` as a channel.** Nothing reads it. `ensure_app_reach` writes rows that no code path consumes, because the notification is written unconditionally and `_pick_chat_reach` skips APP. It is scaffolding for a fallback that is really a *guarantee*, and a guarantee does not need a row. The inbox is Layer 3.
+
+**Every column gets a writer, or it does not ship.** #264 ships `status` with two of three values unwritten, `opted_out_at` with no writer at all, and `mark_stale_for_user` with zero callers — while `on_identity_event` clears `resolved_user_id` and leaves the reach pointing at the old address. A recycled phone number is then a cross-user delivery. Reach health is a lifecycle with real transitions:
+
+| Transition | Trigger |
+| --- | --- |
+| → `ACTIVE` | inbound DM (creates or revives; never clears opt-out) |
+| → `STALE` | `UserMobileChangedEvent` — the same handler that clears the identity cache |
+| → `BLOCKED` | a dispatch fails with a permanent platform error (403, blocked, unknown recipient) |
+| → opted out | the person says so, on their own surface or in settings |
+
+`window_expires_at` stays — WhatsApp's 24h rule is real, and holding it as data rather than a branch in the send path is one of #264's better calls.
+
+### Layer 2 — `Dispatch`: delivery is a row, not a function call
+
+This is the structural change. `NotificationService.notify` currently does membership check → reach pick → conversation resolve → persist → **platform HTTP** → write row, all inline, in one transaction. That single shape causes four separate problems:
+
+- **No fallback.** It picks one reach and stops. A blocked Telegram bot means chat delivery is dead for that person forever, silently, because nothing demotes the reach either.
+- **No idempotency.** #264 names this: a worker retry double-posts to a chat platform.
+- **HTTP inside a transaction**, holding a pooled connection across a Slack round-trip — against the grain of `execute_chat`, which explicitly scopes short UoWs *around* platform I/O.
+- **Ordering contradicts the stated invariant.** "The inbox is the delivery, chat is the enhancement" — but the row is written last, after the send. Crash in between and the phone has it, the inbox does not.
+
+Model the attempt:
+
+```
+dispatches(id, pod_id, subject_type, subject_id, reach_id, idempotency_key,
+           status, attempt, next_attempt_at, permanent_error, delivered_at)
+```
+
+`subject_type` is `MESSAGE | ASK`; `subject_id` points at the Layer-3 row. Then:
+
+1. The synchronous path writes the **subject** and the first **dispatch**, and commits. It performs no network I/O. This is where the durability guarantee actually lives, and it is now one transaction with nothing slow in it.
+2. A `streaq` worker claims the dispatch, calls the adapter, and records the outcome. `streaq_task` already defaults `max_tries`; backoff and retry are the runtime's job, not ours.
+3. A permanent failure marks the reach `BLOCKED` and enqueues a dispatch against the **next** reach. That is what "first success wins" was supposed to mean — an ordered walk with real fallback, not one attempt with a hopeful name.
+4. `idempotency_key = (subject_id, reach_id)`, unique. A retried worker cannot double-post.
+
+Delivery receipts are not a separate table written against a guess — #264's reason for deferring them. They are `dispatches`, which we need anyway.
+
+**And this forces the refactor #264 correctly identified and then deferred.** A worker dispatching from a stored address has no inbound event and never will. `SurfaceTarget.to_event()` reconstructs a fake `ParsedInboundSurfaceEvent` with `message_text=""` and a comment hoping no adapter reads it. As a temporary seam that is a defensible trade. As the permanent shape of every outbound message it is a lie the adapters will eventually believe. Do the 134-signature hoist — as its own PR, before this one, reviewable on its own merits.
+
+### Layer 3 — Intent: `Message` and `Ask`
+
+**`Message`** is one-way and terminal.
+
+```
+messages(id, pod_id, recipient_user_id, sender_user_id, agent_id,
+         title, body, attribution, origin_type, origin_id,
+         conversation_id, read_at)
+```
+
+`attribution` is a stored column, not a string the caller prepends. #264 renders it as `f"{attribution}\n\n{body}"` inside `notify` and then two of its three callers pass `None` — the `NOTIFY` executor and the HTTP endpoint. The endpoint even takes `user: CurrentUser` and does `del user`. Attribution that a caller can omit is not mandatory, and the doc calls it mandatory. Derive it server-side from the authenticated principal and the run's agent; there is no code path that supplies it.
+
+**`Ask`** is a question with an owner and an answer.
+
+```
+asks(id, pod_id, asked_of_user_id, asker_user_id, agent_id,
+     prompt, input_schema, status, answer, answered_at,
+     origin_type, origin_id, conversation_id)
+```
+
+The critical property: **`Ask` introduces no new suspend/resume machinery.** It plugs into both existing ones.
+
+*Workflow.* `WorkflowRunWaitType.HUMAN` waits get `external_ref = ask_id`. The `workflow_run_waits` row stays exactly where it is, keeping the one-ACTIVE-wait-per-run index and the whole resume path; `asks` becomes the person-facing entity it points at. Machine waits (`AGENT`, `FUNCTION`, `TIME`) are untouched, because they are not asks. `FormNodeConfig.assignee_pod_member_id` stops being a queue nothing pushes to.
+
+*Agent.* `ask_user` gains an optional `person`. When set, the ask is delivered to that person; when unset, behaviour is byte-identical to today. The pause is the same `AgentInputRequired(tool_call_id)`, the conversation goes WAITING the same way, and the resolution endpoint replays the same synthesized response — **it never cared who submitted the answer, only that it was recorded against the tool call.** Cross-member ask is a routing change, not a mechanism.
+
+So `message_person` does not exist. `ask_user(person=...)` covers asking; `notify` covers telling.
+
+#### Authority inversion, answered rather than deferred
+
+#264 named the hazard and deferred on it: B answers with data B can read, and the value lands in A's run context where RLS never authorized A to see it. The proposed fix there was "an RLS re-check against the asker," which is not implementable — you cannot re-check a free-text string against a table it was never read from.
+
+The answer is the one `FormNode` already uses: **an Ask carries an `input_schema`, and the answer is validated against it.** A returns only the fields A declared. That converts an unbounded leak into the same trust model as B forwarding an email — B can still deliberately type a secret into a free-text field, and no schema stops that. It is a real residual risk and it should be written down rather than designed around: the answer is recorded with the answerer's identity and timestamp, so it is auditable after the fact.
+
+This also kills free-text cross-member asks as the default, which is the right product default anyway: "what is the PO number" wants a field, not a chat.
+
+### The inbox is a view, not a channel
+
+Drop `notifications` as a distinct table. A person's inbox is *unread Messages + open Asks assigned to them*, and that union is better product behaviour than a single `read_at`:
+
+- A read Message stops nagging.
+- An **open Ask keeps nagging until answered**, because "I saw it" is not "I answered it". A single `notifications` table cannot express that difference, which is why #264's inbox shows a question and a report identically.
+
+`GET /inbox` returns the union, newest first. The badge is `unread messages + open asks`. Both queries hit a partial index; neither is a scan.
+
+## Where the gate lives
+
+| Capability | Gated by | Why there |
+| --- | --- | --- |
+| `surface_send_message` (reply on this surface) | `surface.config.allow_agent_replies: bool` | the tool literally only exists on a surface |
+| Tell / ask **the run's own owner** | nothing beyond running | it is the reply, to the person the work is for |
+| Tell / ask **another pod member** | `Agent.messaging_policy.audience` + `AgentToolset.MESSAGING` | the agent is the actor with an identity |
+| `POST /pods/{id}/notify`, `/asks` | new `member.notify` permission | not an act of editing agents *or* of writing conversations |
+
+Three specific consequences:
+
+**Revert `SurfaceSendPolicy` to a boolean.** #264 grew it into an audience whose third rung is enforced nowhere and whose second rung duplicates the boolean. `allow_send` was correct; it just needed a better name. An audience on a surface can only ever be wrong.
+
+**`conversation.write` is the wrong permission for `/notify`.** It sits in `POD_USER_PERMISSIONS`, so today every pod user can push unattributed text to any colleague's Slack as the pod's bot. #264's reasoning for relaxing off `agent.update` is sound — sending a message is not editing an agent — but the answer is a permission that names the act, not the nearest low-tier one that happens to exist.
+
+**Rate limiting is enforced, not modelled.** `max_messages_per_recipient_per_hour` exists in #264 as a field nothing reads. With Layer 2 it becomes a check at dispatch enqueue, keyed `(agent_id, recipient_user_id)`, in Redis — the same place every other counter in this codebase lives. A badly-prompted agent in a retry loop is the expected failure and it is cheap to stop.
+
+## Schema
+
+| | Kind | Notes |
+| --- | --- | --- |
+| `member_reaches` | new | #264's shape minus `kind` (use `platform`), minus the `APP` row |
+| `dispatches` | new | the outbox; unique on `(subject_id, reach_id)` |
+| `messages` | new | one-way, with stored `attribution` |
+| `asks` | new | `input_schema` + `answer`; `workflow_run_waits.external_ref` points here |
+| `notifications` | **not created** | superseded by the `messages` ∪ `asks` view |
+| `agent_surface_conversation_links.last_inbound_at` | new column | lifted from #264 unchanged — see below |
+| `agents.messaging_policy` | JSONB | audience moves off the surface |
+
+## What to take from #264 as-is
+
+Four changes in that branch are correct, independent of everything above, and should land now as their own small PRs rather than waiting on this design:
+
+1. **`last_inbound_at`.** The DM-reset bug is real: `_should_reset_dm_conversation` keyed off `updated_at`, which a proactive send also bumps, so an agent message would suppress the 24h reset and leak yesterday's context into today. The backfill argument holds — until that column exists, only inbound wrote the row.
+2. **Fail-closed membership.** `if self.pod_membership_port is not None` turned a wiring bug into *"any user id can be messaged"*, in both `send_to_member` and `notify`.
+3. **`can_cold_open` / `reply_window_hours`.** Pure data, no behaviour, immediately useful. "Bots can't cold-open" being a chat-platform fact rather than a universal truth is a genuine correction to [surfaces-into-agents.md](./surfaces-into-agents.md).
+4. **The conversation-hint ownership check.** An agent running as one person must not drop a colleague into its own thread. #264 gets this exactly right, with a test named after it, and the rule survives into `asks` unchanged.
+
+Also worth carrying forward, as prose rather than code: #264's honest note that `origin_type` is **provenance** being used as a proxy for **attention**, and that Lemma cannot answer "is anyone reading this". That analysis is correct and this design does not improve on it. It just narrows the blast radius — under this design a run telling its owner something is never gated on attention, because the inbox makes a redundant badge the worst case rather than a missed message.
+
+## Phasing
+
+Each phase ships alone and is useful alone.
+
+| Phase | Contents | Unlocks |
+| --- | --- | --- |
+| **0** | The four salvaged fixes above | bug fixes, no new surface area |
+| **1** | The adapter signature hoist (`SurfaceTarget` in, `event` out) | dispatch from a worker becomes honest |
+| **2** | `Reach` + `dispatches` + `messages` + inbox. **Own-owner only.** | *"tell me when the nightly run finishes"* — the headline use case |
+| **3** | `asks`: `ask_user(person=)`, FORM waits repointed, cross-member | *"ask Priya for the PO number"* — the one people actually asked for |
+| **4** | Cross-member `messages`, agent-level policy, rate limits enforced | the capability with the phishing hazard, last, on proven plumbing |
+
+Phase 2 delivers #264's headline value with none of its cross-member risk, because "a schedule tells its owner" needs no audience policy at all. The dangerous capability lands in Phase 4, on a pipeline that by then has retries, idempotency, reach demotion and receipts.
+
+## Deliberately not here
+
+**Digests.** First-success-wins solves cross-channel spam; nothing here solves ten notifications from one workflow in one minute. With `dispatches` a digest is a coalescing window on the outbox rather than a redesign, so it is cheap to add later and expensive to guess at now.
+
+**Quiet hours.** Opt-out lives on the reach. Time-of-day needs its own table and a timezone per user, which Lemma does not have. Flagged so it is not discovered later as a JSONB blob.
+
+**Templated WhatsApp cold opens.** `can_cold_open=False` for WhatsApp is a statement about *free-form*, and stays true until templates are modelled. Email already cold-opens.
+
+**Retiring `POST /surfaces/{name}/send`.** It stays. #264 is right that collapsing it would silently change what an existing path parameter means. It becomes the one *surface-specific* primitive, and the docs should say so instead of listing it as an alternative to `notify`.
+
+**Ambient notification on schedule failure.** `schedules.consecutive_failures` exists and nothing reads it. Probably the real answer to #264's open question about whether scheduled runs should notify by default — but it is a schedules feature that happens to use this pipeline, not part of building it.
+
+## Open questions
+
+1. **Does an `Ask` expire?** A workflow run blocked on an unanswered question is a run that never finishes. `workflow_run_waits` has no TTL today and the same gap exists for forms, so this is pre-existing — but cross-member asks will make it visible fast. A `due_at` plus an escalation reach is the obvious shape and is not designed here.
+2. **Is `Ask` a `ResourceType`?** It is assignable and permission-checked, which argues yes. `Message` is user-scoped and almost certainly is not. #264 raised this and it is still open.
+3. **Can an agent ask a *non-member*?** Email can address anyone, and "get a quote from this supplier" is a real request. Everything above assumes pod membership as the trust boundary. Relaxing it is a much larger conversation about what an external participant *is*, and the answer is probably a different entity.
+4. **One `messaging_policy` per agent, or per (agent, surface)?** Per-agent is proposed here because the agent is the actor. An agent that should message colleagues in Slack but never over WhatsApp is expressible as a reach-level opt-out instead — but nobody has asked for it yet, and inventing the axis before the demand is how `send_policy` ended up on the surface.
+
+## See also
+
+- [surfaces-into-agents.md](./surfaces-into-agents.md) — surfaces as a property of an agent; Truth 8 ("proactive messaging never cold-opens") is superseded by `can_cold_open`
+- [schedules-into-triggers.md](./schedules-into-triggers.md) — where the "runs as" identity model comes from, and why a schedule-born run has an owner but no reader

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -311,10 +311,11 @@ state directory if a destructive reset is intended.
 
 ## Test an unreleased pull request
 
-The `Release Local Images` workflow can be manually dispatched on a PR branch
-with `publish=false`. It produces
-`lemma-desktop-macos-pr-test-<commit>`, an ad-hoc-signed DMG containing the
-branch’s compressed, digest-verified host and guest archives.
+The `Release Local Images` workflow can be manually dispatched on any branch
+with `publish=false` and `share=true`. It publishes the branch's
+digest-verified runtime archives to a prerelease tagged
+`desktop-nightly-<short-sha>`, then attaches a signed, notarized online DMG
+built against them — installable by anyone, with no version tag cut.
 
 This is not a public offline installer. It exercises the same first-launch
 installer using trusted application resources, while infrastructure and


### PR DESCRIPTION
The first shared build failed at notarization. Apple's notary service unpacks `host-runtime.zip` and inspects inside it — the bundled CPython and sharp's `.node` binaries are "not signed with a valid Developer ID certificate", have no secure timestamp, and lack the hardened runtime. They never will: they are third-party builds we carry verbatim.

So **self-contained and notarized are mutually exclusive**, and an un-notarized DMG is refused by Gatekeeper on any machine that didn't build it. That is why the real release ships the *online* app.

## What changed

The shared build is now that same online app, aimed at a nightly prerelease instead of a version tag:

- the manifest job publishes the runtime archives + `lemma-local.json` to `desktop-nightly-<sha>`, and manifest URLs follow the release tag instead of assuming `v<version>`;
- the DMG is built against them, signed, notarized, stapled, **verified**, and attached there.

```bash
gh workflow run release-local-images.yml -f version=0.7.0 -f publish=false -f share=true
```

## Removed

Both self-contained CI packaging jobs. Half a gigabyte a run to produce something nobody can install. `make desktop-dmg` and `desktop.ps1 exe` still build them locally from the runtime artifacts this workflow uploads — the one case where an ad-hoc signature is fine.

## Not verified

The notarize-and-publish path can only be exercised by dispatching it. The verification steps inside the job are what make a failure loud.