### PR TITLE
Notarize the disk image, not just the app inside it

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -237,6 +237,30 @@ jobs:
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
+
+      # Tauri notarizes and staples the .app, then builds the DMG from it and
+      # only *signs* the DMG -- it never submits the DMG itself. An unstapled
+      # DMG still passes Gatekeeper while Apple is reachable, because the app
+      # inside carries its own ticket, but it fails closed on a machine that is
+      # offline or behind a filtering proxy. Submitting the disk image too costs
+      # seconds (everything inside it is already notarized) and makes the
+      # download self-contained.
+      - name: Notarize and staple the disk image
+        shell: bash
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          dmg="$(ls desktop/target/release/release-artifacts/Lemma_*_aarch64-online.dmg)"
+          xcrun notarytool submit "${dmg}" \
+            --apple-id "${APPLE_ID}" \
+            --password "${APPLE_PASSWORD}" \
+            --team-id "${APPLE_TEAM_ID}" \
+            --wait
+          xcrun stapler staple "${dmg}"
+
       - name: Verify Developer ID signatures and notarization staples
         shell: bash
         run: |

--- a/.github/workflows/release-local-images.yml
+++ b/.github/workflows/release-local-images.yml
@@ -995,6 +995,30 @@ jobs:
           mv "${dmg[0]}" \
             "target/release/release-artifacts/Lemma-nightly-${SHA:0:8}_aarch64.dmg"
 
+
+      # Tauri notarizes and staples the .app, then builds the DMG from it and
+      # only *signs* the DMG -- it never submits the DMG itself. An unstapled
+      # DMG still passes Gatekeeper while Apple is reachable, because the app
+      # inside carries its own ticket, but it fails closed on a machine that is
+      # offline or behind a filtering proxy. Submitting the disk image too costs
+      # seconds (everything inside it is already notarized) and makes the
+      # download self-contained.
+      - name: Notarize and staple the disk image
+        shell: bash
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          dmg="$(ls desktop/target/release/release-artifacts/*.dmg)"
+          xcrun notarytool submit "${dmg}" \
+            --apple-id "${APPLE_ID}" \
+            --password "${APPLE_PASSWORD}" \
+            --team-id "${APPLE_TEAM_ID}" \
+            --wait
+          xcrun stapler staple "${dmg}"
+
       # Proved here so a tester never meets it as "Lemma is damaged".
       - name: Verify signature and notarization
         shell: bash


### PR DESCRIPTION
The nightly build reached its own verification and failed on `does not have a ticket stapled to it`.

The log shows exactly why: Tauri signs the sidecars and app, notarizes the app (`Notarizing Finished with status Accepted`), staples it, then bundles the DMG from the stapled app and only **signs** the disk image. It never submits the DMG, so there's no ticket to staple.

An unstapled DMG still passes Gatekeeper while Apple is reachable — the app inside carries its own ticket — but fails closed for a tester who's offline or behind a filtering proxy. Submitting the image costs seconds since its contents are already notarized.

`release-desktop.yml` gets the same step: it asserts the DMG staple too, so the **next real release would have failed identically**. The last release predates this Tauri version, which is why it hasn't been hit.