### PR TITLE
Landing page: new hero tagline — 'Where software builds itself.'

### DIFF
--- a/lemma-frontend/app/page.tsx
+++ b/lemma-frontend/app/page.tsx
@@ -11,7 +11,7 @@ import {
  * The shared preview is the first thing anyone sees — tab title, Slack unfurl,
  * social card. It carries the same thesis as the hero, not a second one.
  */
-const SITE_TITLE = "The software you need doesn't exist yet.";
+const SITE_TITLE = "Where software builds itself.";
 const SITE_DESCRIPTION =
     'Your coding agent can write it. Lemma turns it into something your team can actually use — and run anywhere.';
 

--- a/lemma-frontend/components/landing/landing-page.tsx
+++ b/lemma-frontend/components/landing/landing-page.tsx
@@ -97,9 +97,9 @@ export default function LandingPage() {
               The runtime for agent-built software
             </p>
             <h1 className="lp-hero-headline" id="hero-title">
-              The software you need
+              Where software
               <span className="lp-hl-line">
-                <span className="lp-hl-accent">doesn&apos;t exist yet.</span>
+                <span className="lp-hl-accent">builds itself.</span>
               </span>
             </h1>
             <p className="lp-subhead">

--- a/lemma-frontend/lib/share/social-card.test.ts
+++ b/lemma-frontend/lib/share/social-card.test.ts
@@ -10,7 +10,7 @@ describe('social-card', () => {
     it('keeps the site promise concise', () => {
         expect(resolveSocialCardCopy({ variant: 'site' })).toEqual({
             eyebrow: 'THE RUNTIME FOR AGENT-BUILT SOFTWARE',
-            title: "The software you need doesn't exist yet.",
+            title: "Where software builds itself.",
             detail: 'Your coding agent can write it. Lemma makes it something your team can actually use.',
             label: 'lemma.work',
         });

--- a/lemma-frontend/lib/share/social-card.ts
+++ b/lemma-frontend/lib/share/social-card.ts
@@ -77,7 +77,7 @@ const VARIANT_COPY: Record<
 > = {
     site: {
         eyebrow: 'THE RUNTIME FOR AGENT-BUILT SOFTWARE',
-        title: "The software you need doesn't exist yet.",
+        title: "Where software builds itself.",
         detail: 'Your coding agent can write it. Lemma makes it something your team can actually use.',
         label: 'lemma.work',
         accent: '#5f61d8',


### PR DESCRIPTION
## What
Replaces the landing page hero tagline **`The software you need doesn't exist yet.`** with:

> **Where software builds itself.**

The old line sold the *problem* (negative, no product, no beneficiary). The new one is positive and frames Lemma as **the runtime** — where agent-built software becomes real. It also reads cleanly as the tab title and social card (no longer a dangling negative fragment).

## Files touched (kept consistent everywhere the tagline lives)
- `lemma-frontend/components/landing/landing-page.tsx` — hero `<h1>`, keeps the two-line accent: **Where software / *builds itself.***
- `lemma-frontend/app/page.tsx` — `SITE_TITLE` used for metadata, OpenGraph, Twitter
- `lemma-frontend/lib/share/social-card.ts` — shared preview / social card title
- `lemma-frontend/lib/share/social-card.test.ts` — test fixture updated to match

The existing hero subhead (`Your coding agent can write it…`) is unchanged, per review.

## Verification
- `npx vitest run lib/share/social-card.test.ts` → **4/4 passed** (fixture matches production copy).

## Notes / intentionally untouched
- `surface-modal.tsx` line 79 is an internal diagram comment, not user-facing copy.
- Blog post `why-your-team-software-does-not-exist.mdx` keeps its editorial title (not the landing tagline).