### PR TITLE
Give a local agent's pod a model, its tools their names, and its permissions a memory

### DIFF
--- a/desktop/agent-host/src/acp.rs
+++ b/desktop/agent-host/src/acp.rs
@@ -20,7 +20,7 @@ use serde_json::{Map, Value};
 use tokio::sync::watch;
 
 use crate::adapters::ResolvedAdapter;
-use crate::permissions::{PermissionDecision, PermissionGate};
+use crate::permissions::{AlwaysAllowOffer, AlwaysAllowScope, PermissionDecision, PermissionGate};
 use crate::protocol::{ConfigOption, EventType, JsonMap, RunSpec, RunState};
 
 #[derive(Clone)]
@@ -202,6 +202,22 @@ impl AgentDriver for AcpDriver {
                             });
                         return responder.respond(RequestPermissionResponse::new(outcome));
                     }
+                    // An "always" the user already gave for exactly this scope
+                    // is answered here, without asking again. The agent's own
+                    // rule lives in an adapter process that is new every run,
+                    // and is set only once the answer arrives — so without this
+                    // the same grant is asked for on the next message, and once
+                    // more for every call of a parallel batch.
+                    let always = always_allow_offer(&request);
+                    if let Some(offer) = always.as_ref().filter(|offer| {
+                        permission_gate.is_granted(&offer.scope)
+                    }) {
+                        return responder.respond(RequestPermissionResponse::new(
+                            RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(
+                                offer.option_id.clone(),
+                            )),
+                        ));
+                    }
                     let payload = permission_payload(&request);
                     // Without a toolCallId every request in a session would
                     // collapse onto one gate key, so concurrent prompts would
@@ -224,7 +240,7 @@ impl AgentDriver for AcpDriver {
                     // Hold the agent's request open until Lemma answers. The
                     // gate denies on timeout, so this cannot hang forever.
                     let decision = permission_gate
-                        .wait(permission_run_id, request_id, permission_timeout)
+                        .wait(permission_run_id, request_id, permission_timeout, always)
                         .await;
                     let outcome = match decision {
                         PermissionDecision::Allow { option_id } => request
@@ -679,11 +695,13 @@ fn permission_payload(request: &RequestPermissionRequest) -> JsonMap {
         .collect()
 }
 
-/// The name Lemma's run-scoped MCP server is registered under.
+/// The stem every name of Lemma's run-scoped MCP server starts with.
 ///
-/// Kept next to the matcher because that is the only thing tying the two
-/// together: `runtime.rs` registers `McpServerStdio::new(SCOPED_MCP_SERVER, …)`
-/// and this is how a permission request is recognised as belonging to it.
+/// The server is registered under the name Lemma publishes for the run —
+/// `lemma_tools` — and this is the stem shared by that name and the one older
+/// hosts registered (`lemma`), which is what the matcher below anchors on. It
+/// is also the fallback `runtime.rs` registers under when a run carries no
+/// server name of its own.
 pub(crate) const SCOPED_MCP_SERVER: &str = "lemma";
 
 /// Is this the agent asking permission to use one of *our* tools?
@@ -768,6 +786,26 @@ fn permission_tool_candidates(value: &Value) -> impl Iterator<Item = &str> {
     ]
     .into_iter()
     .flatten()
+}
+
+/// The always-allow this request offers, named by the scope it would grant.
+///
+/// The agent writes that name from the permission rules it would install — the
+/// difference between "Always Allow all Bash" and "Always Allow
+/// WebFetch(domain:github.com)" is the whole grant — so it is both what the
+/// user is shown and what a later request has to match to be covered by it.
+fn always_allow_offer(request: &RequestPermissionRequest) -> Option<AlwaysAllowOffer> {
+    request
+        .options
+        .iter()
+        .find(|option| option.kind == PermissionOptionKind::AllowAlways)
+        .map(|option| AlwaysAllowOffer {
+            scope: AlwaysAllowScope {
+                session_id: request.session_id.to_string(),
+                label: option.name.trim().to_owned(),
+            },
+            option_id: option.option_id.to_string(),
+        })
 }
 
 /// Does the tool being requested belong to Lemma's own MCP server?

--- a/desktop/agent-host/src/acp.rs
+++ b/desktop/agent-host/src/acp.rs
@@ -765,15 +765,18 @@ fn names_known_scoped_tool(value: &Value, scoped_tools: &HashSet<String>) -> boo
     }
     permission_tool_candidates(value).any(|name| {
         let name = name.trim().to_ascii_lowercase();
-        let bare = name
-            .rsplit_once("__")
-            .map_or(name.as_str(), |(_, tail)| tail)
-            .trim();
-        scoped_tools.contains(name.as_str()) || scoped_tools.contains(bare)
+        let bare = scoped_tool_name(&name).map(str::to_ascii_lowercase);
+        scoped_tools.contains(name.as_str())
+            || bare.is_some_and(|bare| scoped_tools.contains(bare.as_str()))
     })
 }
 
 /// Every field of a permission request that might carry the tool's identity.
+///
+/// `_meta` is included because it is where an adapter puts the real name when
+/// the title is written for a human: Claude Code reports
+/// `_meta.claudeCode.toolName`, and this reads any vendor's key rather than
+/// that one convention.
 fn permission_tool_candidates(value: &Value) -> impl Iterator<Item = &str> {
     [
         value.pointer("/toolCall/title").and_then(Value::as_str),
@@ -786,6 +789,16 @@ fn permission_tool_candidates(value: &Value) -> impl Iterator<Item = &str> {
     ]
     .into_iter()
     .flatten()
+    .chain(meta_tool_names(value.pointer("/toolCall/_meta")))
+    .chain(meta_tool_names(value.get("_meta")))
+}
+
+/// `_meta.<vendor>.toolName`, for whatever vendor keys the payload carries.
+fn meta_tool_names(meta: Option<&Value>) -> impl Iterator<Item = &str> {
+    meta.and_then(Value::as_object)
+        .into_iter()
+        .flat_map(|meta| meta.values())
+        .filter_map(|vendor| vendor.get("toolName").and_then(Value::as_str))
 }
 
 /// The always-allow this request offers, named by the scope it would grant.
@@ -808,20 +821,53 @@ fn always_allow_offer(request: &RequestPermissionRequest) -> Option<AlwaysAllowO
         })
 }
 
+/// The names Lemma's run-scoped MCP server is known by.
+///
+/// `lemma_tools` is the one every run publishes and the one the server is
+/// registered under. The others are names Lemma itself shipped earlier — a
+/// hyphenated config, and the bare `lemma` this host used before it registered
+/// the run's published name — and are still in stored conversations. Longest
+/// first, so `lemma_tools` is read as itself and not as `lemma` plus `_tools`.
+const SCOPED_MCP_SERVER_NAMES: [&str; 3] = ["lemma_tools", "lemma-tools", SCOPED_MCP_SERVER];
+
+/// How an agent marks a name as coming from an MCP server at all.
+const MCP_MARKERS: [&str; 3] = ["mcp__", "mcp.", "mcp/"];
+
+/// What may join a server name to a tool name. No `-`: `lemma-tools` is a
+/// server name in its own right above, and treating `-` as a separator would
+/// read someone else's `lemma-corp` server as ours.
+const NAMESPACE_SEPARATORS: [char; 4] = ['_', '.', '/', ':'];
+
 /// Does the tool being requested belong to Lemma's own MCP server?
 ///
-/// Agents namespace MCP tools differently — `mcp__lemma__read_table`,
-/// `lemma__read_table`, `lemma.read_table`, `lemma/read_table` — so this looks
-/// for the server name followed by a separator rather than assuming one
-/// convention. Anchored at the start so a user's tool that merely mentions
-/// "lemma" somewhere does not get silently auto-approved.
+/// Agents namespace MCP tools differently — `mcp__lemma_tools__read_table`,
+/// `lemma_tools.read_table`, `lemma/read_table` — so this looks for one of our
+/// server names followed by a separator rather than assuming a convention.
+/// Anchored at the start, and matched whole: a user's own tool that merely
+/// mentions Lemma, or their own server called `lemma-corp`, is theirs to
+/// approve.
 fn names_scoped_mcp_tool(value: &Value) -> bool {
-    permission_tool_candidates(value).any(|name| {
-        let name = name.trim().to_ascii_lowercase();
-        // `mcp__` is the common prefix agents add before the server name.
-        let name = name.strip_prefix("mcp__").unwrap_or(&name);
-        name.strip_prefix(SCOPED_MCP_SERVER)
-            .is_some_and(|rest| rest.starts_with(['_', '.', '/', ':', '-']))
+    permission_tool_candidates(value).any(|name| scoped_tool_name(name).is_some())
+}
+
+/// The tool's own name with our namespace removed, or `None` if the name is
+/// not one of ours.
+fn scoped_tool_name(name: &str) -> Option<&str> {
+    let name = name.trim();
+    // `to_ascii_lowercase` is length-preserving, so offsets taken from the
+    // lowercased copy index the original correctly.
+    let lowered = name.to_ascii_lowercase();
+    let without_marker = MCP_MARKERS
+        .iter()
+        .find(|marker| lowered.starts_with(**marker))
+        .map_or(name, |marker| &name[marker.len()..]);
+    let lowered = without_marker.to_ascii_lowercase();
+    SCOPED_MCP_SERVER_NAMES.iter().find_map(|server| {
+        let rest = lowered.strip_prefix(server)?;
+        rest.starts_with(NAMESPACE_SEPARATORS).then(|| {
+            without_marker[without_marker.len() - rest.len()..]
+                .trim_start_matches(NAMESPACE_SEPARATORS)
+        })
     })
 }
 
@@ -1325,7 +1371,14 @@ mod scoped_mcp_approval_tests {
         // An agent that does not set it — OpenCode — made every Lemma tool
         // call raise an approval card the user had to click through.
         for name in [
+            // The name every run publishes, and the one the server is
+            // registered under.
+            "mcp__lemma_tools__lemma_read_table",
+            "mcp.lemma_tools.lemma_read_table",
+            "lemma_tools.read_table",
+            // Names older builds produced, still in stored conversations.
             "mcp__lemma__read_table",
+            "mcp__lemma-tools__read_table",
             "lemma__read_table",
             "lemma.read_table",
             "lemma/read_table",
@@ -1339,6 +1392,18 @@ mod scoped_mcp_approval_tests {
     }
 
     #[test]
+    fn the_real_name_is_read_from_meta_when_the_title_is_for_a_human() {
+        // Agents write the title for a person and put the tool's actual name in
+        // `_meta`; a Lemma tool called by a subagent arrives exactly like this.
+        assert!(names_scoped_mcp_tool(&json!({
+            "toolCall": {
+                "title": "Reading the customers table",
+                "_meta": {"claudeCode": {"toolName": "mcp__lemma_tools__lemma_read_table"}}
+            }
+        })));
+    }
+
+    #[test]
     fn someone_elses_tool_is_never_auto_approved() {
         // Anchored at the start on purpose: auto-approving anything that
         // merely mentions Lemma would hand away the user's decision.
@@ -1348,6 +1413,10 @@ mod scoped_mcp_approval_tests {
             "bash",
             "write_file",
             "my-lemma-helper",
+            // Someone else's server whose name merely starts with ours. The
+            // server name is matched whole, so this is theirs to approve.
+            "mcp__lemma-corp__delete_everything",
+            "lemma-corp.delete_everything",
         ] {
             assert!(
                 !names_scoped_mcp_tool(&json!({"toolCall": {"title": name}})),

--- a/desktop/agent-host/src/permissions.rs
+++ b/desktop/agent-host/src/permissions.rs
@@ -9,13 +9,37 @@
 //! command. A request that is never answered is denied when its timeout
 //! elapses, so a forgotten prompt cannot pin an adapter open forever.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tokio::sync::oneshot;
 use uuid::Uuid;
+
+/// One "always allow", in the agent's own words, for one provider session.
+///
+/// The label is the name the agent gave its always-allow option — `Always Allow
+/// all WebSearch`, `Always Allow WebFetch(domain:en.wikipedia.org)`. The agent
+/// writes it from the permission rules it would install, so two requests
+/// offering the same label would install the same rules: it is the scope the
+/// user actually consented to, and the only description of it either side has.
+///
+/// Keyed by session because a grant belongs to the conversation it was given
+/// in, not to the machine.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct AlwaysAllowScope {
+    pub session_id: String,
+    pub label: String,
+}
+
+/// An always-allow the agent offered on one request: its scope, and the option
+/// id that selects it on *this* request.
+#[derive(Clone, Debug)]
+pub struct AlwaysAllowOffer {
+    pub scope: AlwaysAllowScope,
+    pub option_id: String,
+}
 
 /// What Lemma decided about one permission request.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -40,12 +64,67 @@ type PendingRequests = HashMap<PendingKey, PendingRequest>;
 struct PendingRequest {
     generation: u64,
     sender: oneshot::Sender<PermissionDecision>,
+    /// The always-allow this request offered, if it offered one. Kept so a
+    /// decision can be recognised as an "always" and so a grant given to one
+    /// request can release its siblings.
+    always: Option<AlwaysAllowOffer>,
+}
+
+impl PendingRequest {
+    /// The scope this decision grants "always" to, if that is what it is.
+    ///
+    /// A decision is an "always" only when it selects the option the agent
+    /// labelled as one — never inferred from the wording of the decision, which
+    /// Lemma's own approval vocabulary would only approximate.
+    fn granted_scope(&self, decision: &PermissionDecision) -> Option<AlwaysAllowScope> {
+        let always = self.always.as_ref()?;
+        match decision {
+            PermissionDecision::Allow { option_id } if *option_id == always.option_id => {
+                Some(always.scope.clone())
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Take every parked request the given grant now covers, with the option id
+/// that grants it on each one.
+fn take_matching(
+    pending: &mut PendingRequests,
+    scope: &AlwaysAllowScope,
+) -> Vec<(PendingRequest, String)> {
+    let keys: Vec<PendingKey> = pending
+        .iter()
+        .filter(|(_, waiting)| {
+            waiting
+                .always
+                .as_ref()
+                .is_some_and(|always| always.scope == *scope)
+        })
+        .map(|(key, _)| key.clone())
+        .collect();
+    keys.into_iter()
+        .filter_map(|key| {
+            let waiting = pending.remove(&key)?;
+            let option_id = waiting.always.as_ref()?.option_id.clone();
+            Some((waiting, option_id))
+        })
+        .collect()
 }
 
 #[derive(Clone, Default)]
 pub struct PermissionGate {
     pending: Arc<Mutex<PendingRequests>>,
     generations: Arc<AtomicU64>,
+    /// What the user has said "always" to, per provider session.
+    ///
+    /// The agent's own always-allow lives in the adapter process, which is
+    /// started fresh for every run and keeps the rule in memory, so an agent
+    /// asked again on the next message — and again for each call of a parallel
+    /// batch, since those are all in flight before any answer arrives. An
+    /// "always" the user has to give repeatedly is not one, so the grant is
+    /// held here, outside any single run, and answered from here.
+    granted: Arc<Mutex<HashSet<AlwaysAllowScope>>>,
 }
 
 impl PermissionGate {
@@ -54,12 +133,24 @@ impl PermissionGate {
         Self::default()
     }
 
+    /// Has the user already said "always" to exactly this scope?
+    #[must_use]
+    pub fn is_granted(&self, scope: &AlwaysAllowScope) -> bool {
+        self.granted
+            .lock()
+            .expect("permission gate poisoned")
+            .contains(scope)
+    }
+
     /// Park a request and wait for a decision, denying on timeout.
+    ///
+    /// `always` is the always-allow option this request offered, if any.
     pub async fn wait(
         &self,
         run_id: Uuid,
         request_id: String,
         timeout: Duration,
+        always: Option<AlwaysAllowOffer>,
     ) -> PermissionDecision {
         let (sender, receiver) = oneshot::channel();
         let generation = self.generations.fetch_add(1, Ordering::Relaxed);
@@ -67,7 +158,11 @@ impl PermissionGate {
             let mut pending = self.pending.lock().expect("permission gate poisoned");
             // A duplicate request id replaces the old waiter; dropping its
             // sender resolves that one as a denial.
-            let waiting = PendingRequest { generation, sender };
+            let waiting = PendingRequest {
+                generation,
+                sender,
+                always,
+            };
             pending.insert((run_id, request_id.clone()), waiting);
         }
         let decision = match tokio::time::timeout(timeout, receiver).await {
@@ -81,12 +176,34 @@ impl PermissionGate {
 
     /// Deliver a decision. Returns false when nothing was waiting for it,
     /// which happens for a duplicate or late resolution.
+    ///
+    /// An "always" answer is remembered for its session and applied to every
+    /// other request already parked for the same scope, so a user who granted
+    /// one call of a parallel batch does not answer the rest of the batch by
+    /// hand.
     #[must_use = "a false result means nothing was waiting for this decision"]
     pub fn resolve(&self, run_id: Uuid, request_id: &str, decision: PermissionDecision) -> bool {
-        let waiting = {
+        let (waiting, siblings) = {
             let mut pending = self.pending.lock().expect("permission gate poisoned");
-            pending.remove(&(run_id, request_id.to_owned()))
+            let waiting = pending.remove(&(run_id, request_id.to_owned()));
+            let scope = waiting
+                .as_ref()
+                .and_then(|waiting| waiting.granted_scope(&decision));
+            let siblings = match scope {
+                Some(scope) => {
+                    self.granted
+                        .lock()
+                        .expect("permission gate poisoned")
+                        .insert(scope.clone());
+                    take_matching(&mut pending, &scope)
+                }
+                None => Vec::new(),
+            };
+            (waiting, siblings)
         };
+        for (sibling, option_id) in siblings {
+            let _ = sibling.sender.send(PermissionDecision::Allow { option_id });
+        }
         match waiting {
             Some(waiting) => waiting.sender.send(decision).is_ok(),
             None => false,
@@ -103,6 +220,17 @@ impl PermissionGate {
     #[cfg(test)]
     pub(crate) fn parked(&self) -> usize {
         self.pending.lock().expect("permission gate poisoned").len()
+    }
+
+    /// Forget every grant given in one provider session.
+    ///
+    /// Not called on a run boundary: a grant outliving the run it was given in
+    /// is the whole point. This is for a session that is gone.
+    pub fn forget_session(&self, session_id: &str) {
+        self.granted
+            .lock()
+            .expect("permission gate poisoned")
+            .retain(|scope| scope.session_id != session_id);
     }
 
     /// Remove this waiter's own entry, leaving a newer one for the same key
@@ -129,6 +257,22 @@ mod tests {
         }
     }
 
+    fn offer(session: &str, label: &str) -> AlwaysAllowOffer {
+        AlwaysAllowOffer {
+            scope: AlwaysAllowScope {
+                session_id: session.to_owned(),
+                label: label.to_owned(),
+            },
+            option_id: "allow_always".to_owned(),
+        }
+    }
+
+    fn always() -> PermissionDecision {
+        PermissionDecision::Allow {
+            option_id: "allow_always".to_owned(),
+        }
+    }
+
     /// Let spawned waiters run until the gate holds `count` parked requests.
     async fn parked_at_least(gate: &PermissionGate, count: usize) {
         for _ in 0..10_000 {
@@ -147,7 +291,7 @@ mod tests {
         let waiter = {
             let gate = gate.clone();
             tokio::spawn(async move {
-                gate.wait(run_id, "req-1".to_owned(), Duration::from_secs(5))
+                gate.wait(run_id, "req-1".to_owned(), Duration::from_secs(5), None)
                     .await
             })
         };
@@ -181,6 +325,7 @@ mod tests {
                 Uuid::now_v7(),
                 "req-1".to_owned(),
                 Duration::from_millis(20),
+                None,
             )
             .await;
         assert_eq!(decision, PermissionDecision::Deny);
@@ -199,7 +344,7 @@ mod tests {
         let waiter = {
             let gate = gate.clone();
             tokio::spawn(async move {
-                gate.wait(run_id, "req-1".to_owned(), Duration::from_secs(5))
+                gate.wait(run_id, "req-1".to_owned(), Duration::from_secs(5), None)
                     .await
             })
         };
@@ -224,7 +369,7 @@ mod tests {
         let spawn_waiter = || {
             let gate = gate.clone();
             tokio::spawn(async move {
-                gate.wait(run_id, "same-key".to_owned(), Duration::from_secs(30))
+                gate.wait(run_id, "same-key".to_owned(), Duration::from_secs(30), None)
                     .await
             })
         };
@@ -261,7 +406,7 @@ mod tests {
         let spawn_waiter = || {
             let gate = gate.clone();
             tokio::spawn(async move {
-                gate.wait(run_id, "same-key".to_owned(), Duration::from_secs(30))
+                gate.wait(run_id, "same-key".to_owned(), Duration::from_secs(30), None)
                     .await
             })
         };
@@ -289,11 +434,209 @@ mod tests {
         let waiter = {
             let gate = gate.clone();
             tokio::spawn(async move {
-                gate.wait(run_id, "req-1".to_owned(), Duration::from_millis(20))
+                gate.wait(run_id, "req-1".to_owned(), Duration::from_millis(20), None)
                     .await
             })
         };
         assert_eq!(waiter.await.unwrap(), PermissionDecision::Deny);
         assert_eq!(gate.parked(), 0);
+    }
+
+    /// "Always" has to mean always, and the agent cannot make it mean that: its
+    /// rule lives in an adapter process started fresh for every run, and is
+    /// installed only once the answer arrives. So a grant given on Monday's
+    /// message was asked for again on Tuesday's, and a grant given to one call
+    /// of a parallel batch was asked for again by every other call in it.
+    mod always_allow {
+        use super::*;
+
+        #[tokio::test]
+        async fn a_granted_scope_is_remembered_for_its_session() {
+            let gate = PermissionGate::new();
+            let run_id = Uuid::now_v7();
+            let scope = offer("session-a", "Always Allow all WebSearch").scope;
+            assert!(!gate.is_granted(&scope));
+
+            let waiter = {
+                let gate = gate.clone();
+                tokio::spawn(async move {
+                    gate.wait(
+                        run_id,
+                        "req-1".to_owned(),
+                        Duration::from_secs(5),
+                        Some(offer("session-a", "Always Allow all WebSearch")),
+                    )
+                    .await
+                })
+            };
+            parked_at_least(&gate, 1).await;
+            assert!(gate.resolve(run_id, "req-1", always()));
+
+            assert_eq!(waiter.await.unwrap(), always());
+            assert!(gate.is_granted(&scope));
+        }
+
+        #[tokio::test]
+        async fn allowing_once_grants_nothing() {
+            let gate = PermissionGate::new();
+            let run_id = Uuid::now_v7();
+            let waiter = {
+                let gate = gate.clone();
+                tokio::spawn(async move {
+                    gate.wait(
+                        run_id,
+                        "req-1".to_owned(),
+                        Duration::from_secs(5),
+                        Some(offer("session-a", "Always Allow all WebSearch")),
+                    )
+                    .await
+                })
+            };
+            parked_at_least(&gate, 1).await;
+            assert!(gate.resolve(run_id, "req-1", allow()));
+            let _ = waiter.await.unwrap();
+
+            assert!(!gate.is_granted(&offer("session-a", "Always Allow all WebSearch").scope));
+        }
+
+        #[tokio::test]
+        async fn a_grant_releases_the_rest_of_a_parallel_batch() {
+            // Four fetches of the same domain go out together, so all four are
+            // asking before any of them is answered. Answering one "always"
+            // answers them all; without this the user clicks four times for the
+            // grant they already gave.
+            let gate = PermissionGate::new();
+            let run_id = Uuid::now_v7();
+            let label = "Always Allow WebFetch(domain:en.wikipedia.org)";
+            let siblings: Vec<_> = ["req-2", "req-3", "req-4"]
+                .into_iter()
+                .map(|request_id| {
+                    let gate = gate.clone();
+                    tokio::spawn(async move {
+                        gate.wait(
+                            run_id,
+                            request_id.to_owned(),
+                            Duration::from_secs(5),
+                            Some(offer("session-a", label)),
+                        )
+                        .await
+                    })
+                })
+                .collect();
+            let answered = {
+                let gate = gate.clone();
+                tokio::spawn(async move {
+                    gate.wait(
+                        run_id,
+                        "req-1".to_owned(),
+                        Duration::from_secs(5),
+                        Some(offer("session-a", label)),
+                    )
+                    .await
+                })
+            };
+            parked_at_least(&gate, 4).await;
+
+            assert!(gate.resolve(run_id, "req-1", always()));
+
+            assert_eq!(answered.await.unwrap(), always());
+            for sibling in siblings {
+                assert_eq!(sibling.await.unwrap(), always());
+            }
+        }
+
+        #[tokio::test]
+        async fn a_narrower_scope_still_asks() {
+            // "Always Allow WebFetch(domain:github.com)" is not consent for
+            // another domain, and the agent says so in the label it wrote.
+            let gate = PermissionGate::new();
+            let run_id = Uuid::now_v7();
+            let other = {
+                let gate = gate.clone();
+                tokio::spawn(async move {
+                    gate.wait(
+                        run_id,
+                        "req-2".to_owned(),
+                        Duration::from_secs(5),
+                        Some(offer(
+                            "session-a",
+                            "Always Allow WebFetch(domain:evil.test)",
+                        )),
+                    )
+                    .await
+                })
+            };
+            let granted = {
+                let gate = gate.clone();
+                tokio::spawn(async move {
+                    gate.wait(
+                        run_id,
+                        "req-1".to_owned(),
+                        Duration::from_secs(5),
+                        Some(offer(
+                            "session-a",
+                            "Always Allow WebFetch(domain:github.com)",
+                        )),
+                    )
+                    .await
+                })
+            };
+            parked_at_least(&gate, 2).await;
+
+            assert!(gate.resolve(run_id, "req-1", always()));
+            let _ = granted.await.unwrap();
+
+            assert!(!other.is_finished(), "a different scope was answered for");
+            assert!(gate.resolve(run_id, "req-2", PermissionDecision::Deny));
+            assert_eq!(other.await.unwrap(), PermissionDecision::Deny);
+        }
+
+        #[tokio::test]
+        async fn another_conversation_does_not_inherit_the_grant() {
+            let gate = PermissionGate::new();
+            let run_id = Uuid::now_v7();
+            let waiter = {
+                let gate = gate.clone();
+                tokio::spawn(async move {
+                    gate.wait(
+                        run_id,
+                        "req-1".to_owned(),
+                        Duration::from_secs(5),
+                        Some(offer("session-a", "Always Allow all Bash")),
+                    )
+                    .await
+                })
+            };
+            parked_at_least(&gate, 1).await;
+            assert!(gate.resolve(run_id, "req-1", always()));
+            let _ = waiter.await.unwrap();
+
+            assert!(!gate.is_granted(&offer("session-b", "Always Allow all Bash").scope));
+        }
+
+        #[tokio::test]
+        async fn a_session_that_is_gone_takes_its_grants_with_it() {
+            let gate = PermissionGate::new();
+            let run_id = Uuid::now_v7();
+            let waiter = {
+                let gate = gate.clone();
+                tokio::spawn(async move {
+                    gate.wait(
+                        run_id,
+                        "req-1".to_owned(),
+                        Duration::from_secs(5),
+                        Some(offer("session-a", "Always Allow all Bash")),
+                    )
+                    .await
+                })
+            };
+            parked_at_least(&gate, 1).await;
+            assert!(gate.resolve(run_id, "req-1", always()));
+            let _ = waiter.await.unwrap();
+
+            gate.forget_session("session-a");
+
+            assert!(!gate.is_granted(&offer("session-a", "Always Allow all Bash").scope));
+        }
     }
 }

--- a/desktop/agent-host/src/runtime.rs
+++ b/desktop/agent-host/src/runtime.rs
@@ -725,8 +725,23 @@ impl TargetWorker {
                 prune_stale_scratch(parent);
             }
             std::fs::create_dir_all(&scratch)?;
+            // The name Lemma published for this run's server, not a name of our
+            // own. An agent namespaces every MCP tool with the server it came
+            // from, so registering a different name here made the same tool
+            // arrive as `mcp__lemma__lemma_exec_command` on this path and
+            // `mcp__lemma_tools__lemma_exec_command` on every other one — one
+            // tool with two names, which is exactly what the readers of those
+            // names cannot tell apart.
+            let scoped_server_name = spec
+                .mcp
+                .get("server_name")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .unwrap_or(crate::acp::SCOPED_MCP_SERVER)
+                .to_owned();
             let mcp_server = McpServer::Stdio(
-                McpServerStdio::new(crate::acp::SCOPED_MCP_SERVER, mcp_bridge_executable)
+                McpServerStdio::new(scoped_server_name, mcp_bridge_executable)
                     .args(vec![
                         "--data-dir".to_owned(),
                         paths.root.to_string_lossy().into_owned(),
@@ -2668,7 +2683,7 @@ mod target_worker_tests {
         let handle = tokio::spawn(async move {
             let _ = tokio::time::timeout(
                 Duration::from_millis(20),
-                gate.wait(run_id, "call-1".to_owned(), Duration::from_secs(600)),
+                gate.wait(run_id, "call-1".to_owned(), Duration::from_secs(600), None),
             )
             .await;
             Ok(())
@@ -2767,7 +2782,7 @@ mod target_worker_tests {
         // which is long enough to register a request nobody will answer.
         let gate = harness.worker.permissions.clone();
         let late = tokio::spawn(async move {
-            gate.wait(run_id, "late".to_owned(), Duration::from_secs(600))
+            gate.wait(run_id, "late".to_owned(), Duration::from_secs(600), None)
                 .await
         });
         while harness.worker.permissions.parked() == 0 {

--- a/desktop/agent-host/tests/lemma_mcp_e2e.rs
+++ b/desktop/agent-host/tests/lemma_mcp_e2e.rs
@@ -391,7 +391,11 @@ async fn an_agent_run_discovers_and_calls_a_lemma_tool_through_the_host() {
     );
     let mcp_servers = served[0];
     assert_eq!(mcp_servers.len(), 1);
-    assert_eq!(mcp_servers[0]["name"], "lemma");
+    // The name Lemma published for this run, not one the host chose. An agent
+    // namespaces every MCP tool with the server it came from, so a name of our
+    // own here would make the same tool arrive under two names depending on
+    // which path ran it — and nothing reading those names could tell.
+    assert_eq!(mcp_servers[0]["name"], "lemma_tools");
     let args = mcp_servers[0]["args"]
         .as_array()
         .unwrap()

--- a/desktop/agent-host/tests/permission_flow_e2e.rs
+++ b/desktop/agent-host/tests/permission_flow_e2e.rs
@@ -421,7 +421,7 @@ async fn a_decision_cannot_resolve_another_runs_request() {
         let waiting = Arc::clone(&waiting);
         tokio::spawn(async move {
             waiting.store(true, Ordering::SeqCst);
-            gate.wait(mine, "call-1".to_owned(), Duration::from_secs(5))
+            gate.wait(mine, "call-1".to_owned(), Duration::from_secs(5), None)
                 .await
         })
     };

--- a/lemma-backend/app/modules/agent/domain/agent_host_permissions.py
+++ b/lemma-backend/app/modules/agent/domain/agent_host_permissions.py
@@ -39,7 +39,9 @@ _REJECT_KINDS = {"rejectonce", "rejectalways"}
 
 def _normalized_kind(value: object) -> str:
     """Fold ``allow_once`` / ``allowOnce`` / ``ALLOW_ONCE`` to one spelling."""
-    return "".join(character for character in str(value or "").lower() if character.isalnum())
+    return "".join(
+        character for character in str(value or "").lower() if character.isalnum()
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -101,6 +103,7 @@ def permission_approval_tool_args(
     payload: JsonObject,
     *,
     request_id: str,
+    tool_name: str | None = None,
 ) -> JsonObject:
     """Build ``request_approval`` arguments from an ACP permission payload.
 
@@ -108,11 +111,17 @@ def permission_approval_tool_args(
     (``title`` / ``reason`` / ``tool_name``) so every renderer — web cards and
     the surface approval plan alike — needs no Agent Host special case. There
     is no ``args`` key: nothing here is executed by Lemma.
+
+    ``tool_name`` is the name the caller already resolved for the tool call this
+    request belongs to, so the card and the call it interrupts say the same
+    word. Without one, the payload's own ``kind`` is the fallback — a category
+    ("fetch", "execute") rather than a name, which is why the caller resolving
+    it properly is preferred.
     """
     tool_call = payload.get("toolCall")
     tool_call = tool_call if isinstance(tool_call, dict) else {}
     title = _first_string(tool_call, "title") or "The local agent needs permission"
-    tool_name = _first_string(tool_call, "kind", "title") or "native tool"
+    tool_name = tool_name or _first_string(tool_call, "kind", "title") or "native tool"
     reason = _first_string(payload, "message", "reason")
     return {
         "title": title,
@@ -139,6 +148,7 @@ def permission_approval_events(
     sequence: int,
     payload: JsonObject,
     metadata: JsonObject,
+    tool_name: str | None = None,
 ) -> list[AgentEvent]:
     """The events one parked ACP permission request becomes.
 
@@ -155,7 +165,11 @@ def permission_approval_events(
             data=MessageDraft.of_tool_call(
                 tool_name="request_approval",
                 tool_call_id=tool_call_id,
-                tool_args=permission_approval_tool_args(payload, request_id=request_id),
+                tool_args=permission_approval_tool_args(
+                    payload,
+                    request_id=request_id,
+                    tool_name=tool_name,
+                ),
                 metadata=metadata,
             ),
             agent_run_id=agent_run_id,

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_events.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_events.py
@@ -16,6 +16,7 @@ from uuid import UUID
 from app.modules.agent.domain.agent_host import AgentHostEventType, AgentHostRunState
 from app.modules.agent.domain.agent_host_permissions import (
     permission_approval_events,
+    permission_approval_tool_call_id,
 )
 from app.modules.agent.domain.value_objects import (
     AgentEvent,
@@ -66,6 +67,7 @@ __all__ = [
     "is_terminal_event",
     "terminal_event",
 ]
+
 
 @dataclass(frozen=True, slots=True)
 class AgentHostEventEnvelope:
@@ -467,14 +469,34 @@ class AgentHostEventNormalizer:
         already have; see ``domain.agent_host_permissions`` for the shape and for
         why this pause emits no WAITING event.
         """
+        request_id = row.object_id or f"permission-{row.sequence}"
+        tool_call = payload.get("toolCall")
+        # Tracked like any other open call, so a run that ends without an answer
+        # closes it. An approval card outlives its run otherwise: the host is no
+        # longer holding the request — its own timeout denied it — but the card
+        # still offers buttons, and pressing one lands on a run that ended hours
+        # ago. Answering it *does* write a return, and a synthesized return
+        # never replaces a real one, so this closes only the abandoned ones.
+        self.tool_calls[permission_approval_tool_call_id(request_id)] = (
+            "request_approval"
+        )
         return [
             *self._flush_messages(final=False),
             *permission_approval_events(
                 agent_run_id=self.agent_run_id,
-                request_id=row.object_id or f"permission-{row.sequence}",
+                request_id=request_id,
                 sequence=row.sequence,
                 payload=payload,
                 metadata=metadata,
+                # The call this request interrupts was already reported, and its
+                # name resolved; prefer the name that call is showing under to
+                # the ACP category the permission payload carries.
+                tool_name=self.tool_calls.get(request_id)
+                or (
+                    tool_name_from_payload(tool_call)
+                    if isinstance(tool_call, dict)
+                    else None
+                ),
             ),
         ]
 

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_tool_payload.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_tool_payload.py
@@ -13,6 +13,7 @@ passes through here.
 from __future__ import annotations
 
 from app.modules.agent.domain.value_objects import JsonObject, JsonValue
+from app.modules.agent.infrastructure.mcp import normalize_local_mcp_tool_name
 
 _MAX_TOOL_STRING_CHARACTERS = 4_096
 _MAX_TOOL_COLLECTION_ITEMS = 32
@@ -27,18 +28,62 @@ def first_present(payload: JsonObject, *keys: str) -> object:
 
 
 def tool_name_from_payload(payload: JsonObject) -> str:
+    """The tool's own name, in the spelling the rest of Lemma uses.
+
+    ACP's ``ToolCall`` has no required name field, so the name has to be found
+    among several optional ones — and the answer decides how the call renders,
+    because every label, icon and contextual card is keyed on the tool name.
+
+    ``_meta`` is checked before ``kind`` because ``kind`` is a *category*, not
+    an identity: every web search, page fetch and MCP call an agent makes
+    arrives as ``fetch`` / ``other``, so reading it as the name collapsed
+    unrelated tools into one and lost the only word worth showing. Claude Code
+    reports the real name under ``_meta.claudeCode.toolName``, and this reads
+    any vendor's ``_meta.<vendor>.toolName`` rather than that one convention.
+
+    The result is normalized, so a Lemma MCP tool a local agent calls as
+    ``mcp__lemma__lemma_exec_command`` is the same ``exec_command`` the pod
+    agent calls directly. Third-party MCP names are left alone.
+    """
+    return normalize_local_mcp_tool_name(_reported_tool_name(payload))
+
+
+def _reported_tool_name(payload: JsonObject) -> str:
     for key in ("name", "tool_name"):
         value = payload.get(key)
         if isinstance(value, str) and value.strip():
             return value.strip()
+    meta_name = _meta_tool_name(payload.get("_meta"))
+    if meta_name:
+        return meta_name
     kind = payload.get("kind")
     if isinstance(kind, str) and kind.strip():
         normalized = kind.strip().lower()
-        return "exec_command" if normalized == "execute" else normalized
+        if normalized == "execute":
+            return "exec_command"
+        # "other" is the ACP kind for everything an adapter has no category
+        # for — every MCP tool included. It names nothing, so the title (which
+        # for those calls *is* the tool name) is the better answer.
+        if normalized != "other":
+            return normalized
     title = payload.get("title")
     if isinstance(title, str) and title.strip():
         return title.strip()
     return "tool"
+
+
+def _meta_tool_name(meta: object) -> str | None:
+    """Read ``_meta.<vendor>.toolName`` from an ACP payload's extension point."""
+    if not isinstance(meta, dict):
+        return None
+    for value in meta.values():
+        if not isinstance(value, dict):
+            continue
+        for key in ("toolName", "tool_name"):
+            candidate = value.get(key)
+            if isinstance(candidate, str) and candidate.strip():
+                return candidate.strip()
+    return None
 
 
 def tool_metadata(metadata: JsonObject, payload: JsonObject) -> JsonObject:

--- a/lemma-backend/app/modules/agent/infrastructure/mcp.py
+++ b/lemma-backend/app/modules/agent/infrastructure/mcp.py
@@ -26,7 +26,9 @@ _SERVER_NAMES = tuple(
 # so recovering Lemma's name is: drop the MCP marker, drop our server name,
 # drop whatever separator joined them.
 _MCP_MARKERS = ("mcp__", "mcp.", "mcp/")
-_NAMESPACE_SEPARATORS = "_./:-"
+# No `-`: `lemma-tools` is a server name in its own right above, and treating
+# `-` as a separator would read someone else's `lemma-corp` server as ours.
+_NAMESPACE_SEPARATORS = "_./:"
 
 
 def strip_provider_namespace(tool_name: str) -> str:

--- a/lemma-backend/app/modules/agent/infrastructure/mcp.py
+++ b/lemma-backend/app/modules/agent/infrastructure/mcp.py
@@ -6,16 +6,51 @@ LEMMA_MCP_SERVER_NAME = "lemma_tools"
 LEMMA_TOOL_PREFIX = "lemma_"
 LEMMA_MCP_TOKEN_ENV = "LEMMA_MCP_TOKEN"
 LEMMA_MCP_AUTHORIZATION_ENV = "LEMMA_MCP_AUTHORIZATION"
-LEMMA_PROVIDER_TOOL_PREFIXES = (
-    f"mcp.{LEMMA_MCP_SERVER_NAME}.",
-    f"mcp__{LEMMA_MCP_SERVER_NAME}__",
-    f"{LEMMA_MCP_SERVER_NAME}_",
-    f"{LEMMA_MCP_SERVER_NAME}.",
-    "mcp.lemma-tools.",
-    "mcp__lemma-tools__",
-    "lemma-tools_",
-    "lemma-tools.",
+
+# Server names whose tools are ours. One name is the contract: every run
+# publishes `LEMMA_MCP_SERVER_NAME`, and every path — pod agent, local agent
+# over ACP — registers the server under it. The others are names Lemma itself
+# shipped before that was true (a hyphenated MCP config, and bare `lemma` from
+# Agent Host builds that named the server locally instead of using the run's).
+# They still sit in stored conversations, so reading them keeps working;
+# nothing writes them any more. Longest first, so `lemma_tools` is recognised
+# as itself rather than as `lemma` followed by `_tools`.
+_SERVER_NAMES = tuple(
+    sorted((LEMMA_MCP_SERVER_NAME, "lemma-tools", "lemma"), key=len, reverse=True)
 )
+
+# An agent namespaces an MCP tool with the server it came from, and does it in
+# whatever shape it likes: `mcp__lemma_tools__lemma_exec_command`,
+# `lemma_tools.lemma_exec_command`. The namespace carries no meaning of its own
+# — it is there so one agent's `exec_command` cannot collide with another's —
+# so recovering Lemma's name is: drop the MCP marker, drop our server name,
+# drop whatever separator joined them.
+_MCP_MARKERS = ("mcp__", "mcp.", "mcp/")
+_NAMESPACE_SEPARATORS = "_./:-"
+
+
+def strip_provider_namespace(tool_name: str) -> str:
+    """Drop the MCP namespace an agent added, if the server named is ours.
+
+    Returns the name unchanged when it is not — a third-party
+    ``mcp__github__create_issue`` is not a Lemma tool and must not be renamed
+    into one.
+    """
+    candidate = tool_name
+    for marker in _MCP_MARKERS:
+        if candidate.startswith(marker):
+            candidate = candidate[len(marker) :]
+            break
+    for name in _SERVER_NAMES:
+        if not candidate.startswith(name):
+            continue
+        remainder = candidate[len(name) :]
+        without_separator = remainder.lstrip(_NAMESPACE_SEPARATORS)
+        # A separator has to follow the server name, or `lemmatize` would read
+        # as the `lemma` server's `tize`.
+        if without_separator != remainder:
+            return without_separator
+    return tool_name
 
 
 def exported_tool_name(tool_name: str) -> str:
@@ -31,17 +66,18 @@ def normalize_exported_tool_name(tool_name: str) -> str:
 
 
 def normalize_local_mcp_tool_name(tool_name: str) -> str:
-    normalized = tool_name
-    for prefix in LEMMA_PROVIDER_TOOL_PREFIXES:
-        if normalized.startswith(prefix):
-            normalized = normalized[len(prefix) :]
-            break
-    return normalize_exported_tool_name(normalized)
+    """The canonical Lemma name for a tool, however an agent spelled it.
+
+    ``mcp__lemma_tools__lemma_exec_command`` and ``exec_command`` are the same
+    tool, and everything that reads a tool name — cards, icons, approvals,
+    analytics — has to see the same one either way.
+    """
+    return normalize_exported_tool_name(strip_provider_namespace(tool_name))
 
 
 def is_provider_scoped_lemma_mcp_tool_name(tool_name: object) -> bool:
-    return isinstance(tool_name, str) and tool_name.startswith(
-        LEMMA_PROVIDER_TOOL_PREFIXES
+    return (
+        isinstance(tool_name, str) and strip_provider_namespace(tool_name) != tool_name
     )
 
 
@@ -54,7 +90,7 @@ def looks_like_lemma_mcp_payload(payload: object) -> bool:
             or payload.get("mcp_server")
             or payload.get("mcpServer")
         )
-        if server_name == LEMMA_MCP_SERVER_NAME:
+        if server_name in _SERVER_NAMES:
             return True
         for key in ("toolName", "tool_name", "tool", "name"):
             value = payload.get(key)

--- a/lemma-backend/app/modules/agent/services/run_message_writer.py
+++ b/lemma-backend/app/modules/agent/services/run_message_writer.py
@@ -51,11 +51,43 @@ class RunMessageWriter:
         draft = draft.model_copy(update={"metadata": metadata})
 
         async with self.uow_factory() as uow:
-            return await ConversationRepository(uow).append_message(
+            repository = ConversationRepository(uow)
+            existing = await self._answered_already(
+                repository,
+                conversation_id=conversation_id,
+                draft=draft,
+            )
+            if existing is not None:
+                return existing
+            return await repository.append_message(
                 conversation_id=conversation_id,
                 agent_run_id=agent_run_id,
                 draft=draft,
             )
+
+    @staticmethod
+    async def _answered_already(
+        repository: ConversationRepository,
+        *,
+        conversation_id: UUID,
+        draft: MessageDraft,
+    ) -> Message | None:
+        """The real return for a call a synthesized one is about to close.
+
+        A run ending closes every tool call it left open, so a user who answered
+        an approval and *then* watched the run fail would get a second return
+        for it — the card flipping back from what they decided to "the run ended
+        before this was answered". A synthesized return never overwrites a real
+        one; it exists precisely for the calls that never got one.
+        """
+        if draft.kind != MessageKind.TOOL_RETURN or not draft.tool_call_id:
+            return None
+        if not (draft.metadata or {}).get("synthetic_tool_return"):
+            return None
+        return await repository.get_tool_return(
+            conversation_id=conversation_id,
+            tool_call_id=draft.tool_call_id,
+        )
 
     def output_data_from_event(self, event: AgentEvent) -> JsonValue | None:
         """Extract terminal output from a MESSAGE event, if present."""

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_host_normalizer.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_host_normalizer.py
@@ -219,6 +219,107 @@ class TestMetadata:
         assert "agent-message" not in str(ids)
 
 
+class TestToolNames:
+    """What a tool call is *called*, which is what every card and icon keys on.
+
+    The payloads here are the ones a real Claude Code run emits over ACP, taken
+    from a desktop install's event journal: no `name` field anywhere, the real
+    name under `_meta.claudeCode.toolName`, and a `kind` that is a category
+    rather than a name.
+    """
+
+    def _call(self, payload: dict) -> str:
+        n = _normalizer()
+        out = n.normalize(
+            _event(1, AgentHostEventType.TOOL_CALL_UPSERT, payload, object_id="c1")
+        )
+        return _messages(out)[0].data.tool_name
+
+    def test_a_lemma_mcp_tool_is_the_tool_the_pod_agent_calls(self) -> None:
+        """The whole point: one tool, one name. A local agent namespaces Lemma's
+        run-scoped MCP server, so the same tool the pod agent calls as
+        `pod_write_file` arrived as `mcp__lemma__lemma_pod_write_file` and
+        rendered as its own unrecognised tool, with no icon and no card."""
+        assert (
+            self._call(
+                {
+                    "_meta": {
+                        "claudeCode": {"toolName": "mcp__lemma__lemma_pod_write_file"}
+                    },
+                    "title": "mcp__lemma__lemma_pod_write_file",
+                    "toolCallId": "c1",
+                }
+            )
+            == "pod_write_file"
+        )
+
+    def test_every_namespacing_shape_lands_on_the_same_tool(self) -> None:
+        for reported in (
+            "mcp__lemma__lemma_exec_command",
+            "mcp__lemma_tools__lemma_exec_command",
+            "lemma__lemma_exec_command",
+            "lemma_exec_command",
+            "exec_command",
+        ):
+            assert self._call({"title": reported}) == "exec_command", reported
+
+    def test_a_third_party_mcp_tool_keeps_its_own_name(self) -> None:
+        assert (
+            self._call({"title": "mcp__github__create_issue"})
+            == "mcp__github__create_issue"
+        )
+
+    def test_the_real_name_beats_the_acp_category(self) -> None:
+        """`kind` is `fetch` for a web search, a page fetch and anything else an
+        adapter files under it, so reading it as the name showed every one of
+        them as "Fetch" — and made the approval card name a category too."""
+        assert (
+            self._call(
+                {
+                    "_meta": {"claudeCode": {"toolName": "WebSearch"}},
+                    "kind": "fetch",
+                    "title": "Web search",
+                }
+            )
+            == "WebSearch"
+        )
+
+    def test_a_category_is_still_better_than_a_human_title(self) -> None:
+        """Without `_meta` the title is whatever the adapter wrote for a human —
+        for Bash that is the command itself — so `kind` still comes first."""
+        assert self._call({"kind": "execute", "title": "npm test"}) == "exec_command"
+
+    def test_other_is_not_a_name(self) -> None:
+        """`other` is the kind adapters give everything they have no category
+        for, MCP tools included. Recorded as the name it collapsed them all."""
+        assert self._call({"kind": "other", "title": "lemma_read_table"}) == "read_table"
+
+    def test_the_approval_card_names_the_tool_it_interrupts(self) -> None:
+        n = _normalizer()
+        n.normalize(
+            _event(
+                1,
+                AgentHostEventType.TOOL_CALL_UPSERT,
+                {"_meta": {"claudeCode": {"toolName": "WebSearch"}}, "kind": "fetch"},
+                object_id="toolu_1",
+            )
+        )
+        out = n.normalize(
+            _event(
+                2,
+                AgentHostEventType.PERMISSION_REQUEST,
+                {
+                    "toolCall": {"toolCallId": "toolu_1", "kind": "fetch", "title": "x"},
+                    "options": [{"optionId": "allow", "kind": "allow_once"}],
+                },
+                object_id="toolu_1",
+            )
+        )
+
+        calls = [m for m in _messages(out) if m.data.tool_call_id is not None]
+        assert calls[0].data.tool_args["tool_name"] == "WebSearch"
+
+
 class TestToolCalls:
     def test_tool_call_and_return_are_emitted_once(self) -> None:
         n = _normalizer()
@@ -313,6 +414,40 @@ class TestToolCalls:
         )
         assert any(m for m in _messages(out))
         assert out[-1].type is AgentEventType.ERROR
+
+    def test_an_unanswered_permission_is_closed_at_terminal(self) -> None:
+        """A card whose run is gone must stop offering buttons.
+
+        The host is no longer holding the request — its own timeout denied it
+        half an hour in — so the only thing left to press was a button that
+        lands on a dead run. One user pressed "Always allow" on a card four
+        hours after the run behind it had failed, and nothing happened.
+        """
+        n = _normalizer()
+        n.normalize(
+            _event(
+                1,
+                AgentHostEventType.PERMISSION_REQUEST,
+                {
+                    "toolCall": {"toolCallId": "perm-1", "title": "Web search"},
+                    "options": [{"optionId": "allow", "kind": "allow_once"}],
+                },
+                object_id="perm-1",
+            )
+        )
+
+        out = n.normalize(_event(2, AgentHostEventType.TERMINAL, {"state": "FAILED"}))
+
+        returns = [
+            message
+            for message in _messages(out)
+            if message.data.tool_call_id == "agent-host-permission:perm-1"
+        ]
+        assert [message.data.tool_name for message in returns] == ["request_approval"]
+        assert returns[0].data.tool_result["success"] is False
+        # What every renderer already keys on to draw an unanswered interaction
+        # as spent rather than live.
+        assert returns[0].data.tool_result["interaction_fallback"] is True
 
 
 class TestTerminalMapping:

--- a/lemma-backend/app/modules/agent/tests/unit/test_mcp_tool_names.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_mcp_tool_names.py
@@ -1,0 +1,66 @@
+"""One tool, one name, however the agent calling it spells that name.
+
+Every agent namespaces MCP tools with the server they came from, and each does
+it differently. The namespace is collision avoidance and nothing else, so a
+reader — a chat card, an icon, an approval, a usage record — has to see the same
+`exec_command` whether the call came from a pod agent or from Claude Code
+running on someone's laptop.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.modules.agent.infrastructure.mcp import (
+    LEMMA_MCP_SERVER_NAME,
+    exported_tool_name,
+    is_provider_scoped_lemma_mcp_tool_name,
+    normalize_local_mcp_tool_name,
+)
+
+
+class TestNamespacesLemmaOwns:
+    @pytest.mark.parametrize(
+        "reported",
+        [
+            "mcp__lemma_tools__lemma_exec_command",
+            "mcp.lemma_tools.lemma_exec_command",
+            "lemma_tools.lemma_exec_command",
+            "lemma_tools_lemma_exec_command",
+            # Names older builds produced: a hyphenated server, and the Agent
+            # Host's own `lemma` before it registered the run's published name.
+            "mcp__lemma-tools__lemma_exec_command",
+            "mcp__lemma__lemma_exec_command",
+            "lemma__lemma_exec_command",
+            # Already canonical, with and without the tool prefix.
+            "lemma_exec_command",
+            "exec_command",
+        ],
+    )
+    def test_every_spelling_is_the_same_tool(self, reported: str) -> None:
+        assert normalize_local_mcp_tool_name(reported) == "exec_command"
+
+    def test_the_published_server_name_round_trips(self) -> None:
+        """What a run publishes and what a name normalizes from are one thing."""
+        wire_name = f"mcp__{LEMMA_MCP_SERVER_NAME}__{exported_tool_name('read_table')}"
+
+        assert normalize_local_mcp_tool_name(wire_name) == "read_table"
+
+
+class TestNamespacesLemmaDoesNotOwn:
+    def test_a_third_party_mcp_tool_keeps_its_name(self) -> None:
+        assert (
+            normalize_local_mcp_tool_name("mcp__github__create_issue")
+            == "mcp__github__create_issue"
+        )
+        assert not is_provider_scoped_lemma_mcp_tool_name("mcp__github__create_issue")
+
+    def test_a_word_starting_with_lemma_is_not_a_namespace(self) -> None:
+        """The server name has to be followed by a separator. Without that check
+        `lemmatize_text` reads as the `lemma` server's `tize_text`."""
+        assert normalize_local_mcp_tool_name("lemmatize_text") == "lemmatize_text"
+        assert not is_provider_scoped_lemma_mcp_tool_name("lemmatize_text")
+
+    def test_a_native_tool_is_left_alone(self) -> None:
+        for native in ("WebSearch", "Bash", "read_file"):
+            assert normalize_local_mcp_tool_name(native) == native

--- a/lemma-backend/app/modules/agent/tests/unit/test_mcp_tool_names.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_mcp_tool_names.py
@@ -55,6 +55,16 @@ class TestNamespacesLemmaDoesNotOwn:
         )
         assert not is_provider_scoped_lemma_mcp_tool_name("mcp__github__create_issue")
 
+    def test_someone_elses_server_named_after_us_is_still_theirs(self) -> None:
+        """The server name is matched whole. `lemma-corp` is not `lemma`."""
+        assert (
+            normalize_local_mcp_tool_name("mcp__lemma-corp__delete_everything")
+            == "mcp__lemma-corp__delete_everything"
+        )
+        assert not is_provider_scoped_lemma_mcp_tool_name(
+            "lemma-corp.delete_everything"
+        )
+
     def test_a_word_starting_with_lemma_is_not_a_namespace(self) -> None:
         """The server name has to be followed by a separator. Without that check
         `lemmatize_text` reads as the `lemma` server's `tize_text`."""

--- a/lemma-backend/app/modules/agent/tests/unit/test_run_message_writer.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_run_message_writer.py
@@ -1,0 +1,100 @@
+"""A synthesized tool return never overwrites a real one.
+
+Closing a run's open tool calls is what stops an abandoned approval card from
+offering buttons forever. It runs at terminal, though, which is *after* a user
+who answered the card already has their decision written — so without this the
+answer they gave would be replaced by "the run ended before this was answered".
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from uuid import uuid7
+
+from app.modules.agent.domain.value_objects import MessageDraft
+from app.modules.agent.services.run_message_writer import RunMessageWriter
+
+
+class _Repository:
+    def __init__(self, existing: object | None) -> None:
+        self.existing = existing
+        self.appended: list[MessageDraft] = []
+
+    async def get_tool_return(self, *, conversation_id, tool_call_id):  # noqa: ARG002
+        return self.existing
+
+    async def append_message(self, *, conversation_id, agent_run_id, draft):  # noqa: ARG002
+        self.appended.append(draft)
+        return draft
+
+
+def _writer(monkeypatch, repository: _Repository) -> RunMessageWriter:
+    @asynccontextmanager
+    async def uow_factory():
+        yield object()
+
+    monkeypatch.setattr(
+        "app.modules.agent.services.run_message_writer.ConversationRepository",
+        lambda _uow: repository,
+    )
+    return RunMessageWriter(uow_factory)
+
+
+def _synthetic_return() -> MessageDraft:
+    return MessageDraft.of_tool_return(
+        tool_name="request_approval",
+        tool_call_id="agent-host-permission:toolu_1",
+        tool_result={"success": False, "error": "The agent run failed."},
+        metadata={"synthetic_tool_return": True},
+    )
+
+
+async def test_a_decision_already_recorded_is_left_alone(monkeypatch) -> None:
+    repository = _Repository(existing="the user's decision")
+    writer = _writer(monkeypatch, repository)
+
+    saved = await writer.persist(
+        conversation_id=uuid7(),
+        agent_run_id=uuid7(),
+        data=_synthetic_return(),
+    )
+
+    assert saved == "the user's decision"
+    assert repository.appended == []
+
+
+async def test_a_call_nobody_answered_is_closed(monkeypatch) -> None:
+    repository = _Repository(existing=None)
+    writer = _writer(monkeypatch, repository)
+
+    await writer.persist(
+        conversation_id=uuid7(),
+        agent_run_id=uuid7(),
+        data=_synthetic_return(),
+    )
+
+    assert [draft.tool_call_id for draft in repository.appended] == [
+        "agent-host-permission:toolu_1"
+    ]
+
+
+async def test_an_ordinary_tool_return_is_written_without_a_lookup(
+    monkeypatch,
+) -> None:
+    """The check is scoped to synthesized returns: every other return is a fact
+    the harness just produced, and paying a query for each one would slow the
+    hot path to protect a case that cannot happen there."""
+    repository = _Repository(existing="would be found if it looked")
+    writer = _writer(monkeypatch, repository)
+
+    await writer.persist(
+        conversation_id=uuid7(),
+        agent_run_id=uuid7(),
+        data=MessageDraft.of_tool_return(
+            tool_name="exec_command",
+            tool_call_id="toolu_1",
+            tool_result={"success": True},
+        ),
+    )
+
+    assert len(repository.appended) == 1

--- a/lemma-frontend/components/onboarding/account-onboarding.tsx
+++ b/lemma-frontend/components/onboarding/account-onboarding.tsx
@@ -44,10 +44,9 @@ import { useAccessiblePods } from "@/lib/hooks/use-pods";
 import { useProfile, useUpdateProfile } from "@/lib/hooks/use-user";
 import {
   useCreateAgentRuntime,
-  useManagedAgentRuntimes,
   useUpdatePodDefaultAgentRuntime,
 } from "@/lib/hooks/use-agent-runtime";
-import { RuntimeProfileKind, RuntimeProfileStatus } from "lemma-sdk";
+import { adoptableLocalAgent } from "@/lib/desktop/local-agent-default";
 import {
   OrganizationInvitationStatus,
   OrganizationJoinPolicy,
@@ -346,11 +345,6 @@ function SetupAssistant({
     },
   );
   const activeOrganization = createdOrganization || initialOrganization;
-  // Only queried on a local install, and only to answer "is there exactly one
-  // coding agent to adopt as this pod's default".
-  const localRuntimeProfiles = useManagedAgentRuntimes(
-    isLocal ? activeOrganization?.id : null,
-  );
 
   // Keep the name we show on the identity step to one that is still free. This
   // is for honest copy only — the create itself re-walks the ladder against the
@@ -635,7 +629,7 @@ function SetupAssistant({
         // pointed at the installation provider, which on a local install is
         // usually unconfigured — so a user who deliberately chose Claude Code
         // got "check the agent runtime configuration" on their first message.
-        await adoptLocalAgentAsPodDefault(pod.id);
+        await adoptLocalAgentAsPodDefault(pod);
         saveOnboardingDraft({
           organizationId: organization.id,
           basePodId: pod.id,
@@ -671,18 +665,30 @@ function SetupAssistant({
    * did pick an agent, that agent becomes the default or they are told the pod
    * has no model — never left to discover it by sending a message.
    */
-  const adoptLocalAgentAsPodDefault = async (podId: string) => {
+  const adoptLocalAgentAsPodDefault = async (pod: Pod) => {
     if (!isLocal) return;
     // A configured provider already answers as the system default; the pod
     // needs nothing of its own.
     if ((await readLocalAiStatus()) === "ready") return;
 
-    const agents = (localRuntimeProfiles.data?.items ?? []).filter(
-      (profile) =>
-        profile.kind === RuntimeProfileKind.HARNESS
-        && profile.status === RuntimeProfileStatus.ACTIVE,
-    );
-    if (!agents.length) {
+    // Read the agents now, from the server, rather than from a cached listing.
+    // The agent this is here to adopt was created seconds ago, in the step
+    // before this one, so any cache old enough to still be warm is old enough
+    // to predate it — which is exactly how this silently adopted nothing and
+    // left pods failing on "No LLM model is configured on this server".
+    let agent: { id: string; name: string } | null = null;
+    try {
+      const profiles = await getLemmaClient().agentRuntime.listProfiles(
+        pod.organization_id,
+      );
+      agent = adoptableLocalAgent(profiles.items);
+    } catch {
+      // Unreachable server: the pod exists and setup continues. The workspace
+      // banner covers a pod with no model, and the composer's picker is the
+      // way out of it.
+      return;
+    }
+    if (!agent) {
       // Nothing was configured at all — the deferred path. The workspace
       // banner is already saying so, so this stays quiet rather than
       // repeating it at pod creation.
@@ -690,17 +696,14 @@ function SetupAssistant({
     }
 
     try {
-      // Whichever came first, deterministically. With several to choose from
-      // the composer's picker is where someone changes their mind; what must
-      // not happen is the pod opening with no default at all.
       await updatePodDefaultRuntime.mutateAsync({
-        podId,
-        runtime: { profile_id: agents[0].id },
+        podId: pod.id,
+        runtime: { profile_id: agent.id },
       });
     } catch (error) {
       // Loud, because the pod does not work without this.
       toast.error(
-        `${agents[0].name} could not be set as this pod's model: `
+        `${agent.name} could not be set as this pod's model: `
           + `${error instanceof Error ? error.message : "unknown error"}. `
           + "Pick a model in the composer before sending a message.",
       );

--- a/lemma-frontend/lib/assistant/__tests__/assistant-tool-names.test.ts
+++ b/lemma-frontend/lib/assistant/__tests__/assistant-tool-names.test.ts
@@ -9,6 +9,13 @@ describe('normalizeToolNameForDisplay', () => {
         expect(normalizeToolNameForDisplay('lemma_tools_lemma_display_resource')).toBe('display_resource');
         expect(normalizeToolNameForDisplay('commandExecution')).toBe('command_execution');
     });
+
+    it('renders an Agent Host run of a Lemma tool as that tool', () => {
+        // Namespaced under the Agent Host's server name, which is how every
+        // Lemma tool call from a local agent arrives.
+        expect(normalizeToolNameForDisplay('mcp__lemma__lemma_exec_command')).toBe('exec_command');
+        expect(normalizeToolNameForDisplay('mcp__lemma__lemma_pod_write_file')).toBe('pod_write_file');
+    });
 });
 
 describe('toolIconKind', () => {
@@ -19,5 +26,6 @@ describe('toolIconKind', () => {
         expect(toolIconKind('pod_write_record')).toBe('data');
         expect(toolIconKind('spawn_subagent')).toBe('agent');
         expect(toolIconKind('unknown_custom_tool')).toBe('tool');
+        expect(toolIconKind('mcp__lemma__lemma_exec_command')).toBe('terminal');
     });
 });

--- a/lemma-frontend/lib/desktop/__tests__/local-agent-default.test.ts
+++ b/lemma-frontend/lib/desktop/__tests__/local-agent-default.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { adoptableLocalAgent } from '@/lib/desktop/local-agent-default';
+
+/**
+ * A local install's first pod has to open with a model that answers. Setting one
+ * up in onboarding and then creating a pod that has none is the failure this
+ * picks the agent for — the pod's first message died on "No LLM model is
+ * configured on this server", with the agent sitting right there unused.
+ */
+const agent = (over: Record<string, unknown> = {}) => ({
+    id: 'agent-1',
+    name: 'Claude Code',
+    kind: 'HARNESS',
+    status: 'ACTIVE',
+    created_at: '2026-08-12T04:31:40Z',
+    ...over,
+});
+
+describe('adoptableLocalAgent', () => {
+    it('adopts the coding agent onboarding just configured', () => {
+        expect(adoptableLocalAgent([agent()])?.id).toBe('agent-1');
+    });
+
+    it('takes the one set up first when there are several', () => {
+        // Stable across refetches: the listing's order is the server's, and two
+        // runs of onboarding must not adopt different agents from one list.
+        const picked = adoptableLocalAgent([
+            agent({ id: 'later', created_at: '2026-08-12T09:00:00Z' }),
+            agent({ id: 'first', created_at: '2026-08-12T04:00:00Z' }),
+        ]);
+
+        expect(picked?.id).toBe('first');
+    });
+
+    it('ignores a provider profile, which answers as the system default anyway', () => {
+        expect(adoptableLocalAgent([agent({ kind: 'PROVIDER' })])).toBeNull();
+    });
+
+    it('ignores an archived agent, which cannot be selected for a run', () => {
+        expect(adoptableLocalAgent([agent({ status: 'ARCHIVED' })])).toBeNull();
+    });
+
+    it('adopts nothing when setup was deferred', () => {
+        expect(adoptableLocalAgent([])).toBeNull();
+        expect(adoptableLocalAgent(undefined)).toBeNull();
+    });
+});

--- a/lemma-frontend/lib/desktop/local-agent-default.ts
+++ b/lemma-frontend/lib/desktop/local-agent-default.ts
@@ -1,0 +1,38 @@
+import { RuntimeProfileKind, RuntimeProfileStatus } from "lemma-sdk";
+
+/**
+ * Which coding agent a freshly created pod should answer with.
+ *
+ * A pod with no default runtime falls back to the installation provider, which
+ * on a local install is usually unconfigured — the first message then dies on
+ * "No LLM model is configured on this server" and the pod is useless from the
+ * moment it is made. So a local install that has an agent adopts it.
+ *
+ * Whichever was created first, deterministically. With several to choose from,
+ * the composer's picker is where someone changes their mind; what must not
+ * happen is the pod opening with no default at all.
+ */
+export type AdoptableProfile = {
+    id: string;
+    name: string;
+    kind?: string | null;
+    status?: string | null;
+    created_at?: string | null;
+};
+
+export function adoptableLocalAgent<T extends AdoptableProfile>(
+    profiles: readonly T[] | null | undefined,
+): T | null {
+    const agents = (profiles ?? []).filter(
+        (profile) =>
+            profile.kind === RuntimeProfileKind.HARNESS
+            && profile.status === RuntimeProfileStatus.ACTIVE,
+    );
+    if (agents.length < 2) return agents[0] ?? null;
+    // The listing's order is the server's, not a promise. Sorting by creation
+    // keeps "the agent they set up first" stable across refetches, so two runs
+    // of onboarding cannot adopt different agents from the same list.
+    return [...agents].sort((left, right) =>
+        (left.created_at ?? "").localeCompare(right.created_at ?? ""),
+    )[0];
+}

--- a/lemma-frontend/lib/hooks/use-agent-runtime.ts
+++ b/lemma-frontend/lib/hooks/use-agent-runtime.ts
@@ -174,6 +174,13 @@ export const useAgentRuntimes = (organizationId?: string | null) => {
 
 export const useAgentRuntimeCatalog = useAgentRuntimes;
 
+// Every profile mutation invalidates the whole 'agent-runtime' tree: the catalog
+// (a rename or archive changes which models the composer offers), the management
+// listing, and the single-profile query the open dialog is reading.
+const invalidateAgentRuntime = (queryClient: ReturnType<typeof useQueryClient>) => {
+    queryClient.invalidateQueries({ queryKey: ['agent-runtime'] });
+};
+
 export const useCreateAgentRuntime = () => {
     const queryClient = useQueryClient();
 
@@ -185,9 +192,14 @@ export const useCreateAgentRuntime = () => {
             organizationId: string;
             request: Parameters<ReturnType<typeof getLemmaClient>['agentRuntime']['createRuntime']>[1];
         }) => getLemmaClient().agentRuntime.createRuntime(organizationId, request),
-        onSuccess: (_, variables) => {
-            queryClient.invalidateQueries({ queryKey: agentRuntimeQueryKey(variables.organizationId) });
-        },
+        // The whole 'agent-runtime' tree, like every other profile mutation
+        // below. Invalidating only the catalog key left the management listing
+        // — a *different* key by design — holding a snapshot taken before this
+        // profile existed, so a screen that had just created an agent could not
+        // see it. Onboarding was one: it adopted the agent it had made a moment
+        // earlier as the new pod's default, found an empty list, and created
+        // the pod with no model at all.
+        onSuccess: () => invalidateAgentRuntime(queryClient),
     });
 };
 
@@ -224,13 +236,6 @@ export const useAgentRuntimeProfile = (
         enabled: Boolean(organizationId) && Boolean(profileId),
         staleTime: 15000,
     });
-};
-
-// Every profile mutation invalidates the whole 'agent-runtime' tree: the catalog
-// (a rename or archive changes which models the composer offers), the management
-// listing, and the single-profile query the open dialog is reading.
-const invalidateAgentRuntime = (queryClient: ReturnType<typeof useQueryClient>) => {
-    queryClient.invalidateQueries({ queryKey: ['agent-runtime'] });
 };
 
 export const useUpdateAgentRuntime = () => {

--- a/lemma-typescript/public/lemma-ui.js
+++ b/lemma-typescript/public/lemma-ui.js
@@ -963,25 +963,27 @@ var LemmaUI = (() => {
   };
 
   // src/core/agent/tool-names.ts
-  var LEMMA_MCP_TOOL_PREFIXES = [
-    "mcp.lemma_tools.",
-    "mcp__lemma_tools__",
-    "lemma_tools_",
-    "lemma_tools.",
-    "mcp.lemma-tools.",
-    "mcp__lemma-tools__",
-    "lemma-tools_",
-    "lemma-tools."
-  ];
-  function normalizeAgentToolName(toolName) {
-    let normalized = toolName.trim();
-    const lower = normalized.toLowerCase();
-    const providerPrefix = LEMMA_MCP_TOOL_PREFIXES.find((prefix) => lower.startsWith(prefix));
-    if (providerPrefix) normalized = normalized.slice(providerPrefix.length);
-    if (normalized.toLowerCase().startsWith("lemma_")) {
-      normalized = normalized.slice("lemma_".length);
+  var LEMMA_MCP_SERVER_NAME = "lemma_tools";
+  var LEMMA_MCP_SERVER_NAMES = [LEMMA_MCP_SERVER_NAME, "lemma-tools", "lemma"].sort(
+    (left, right) => right.length - left.length
+  );
+  var MCP_MARKERS = ["mcp__", "mcp.", "mcp/"];
+  var NAMESPACE_SEPARATORS = /^[_./:-]+/;
+  function stripProviderNamespace(toolName) {
+    let candidate = toolName;
+    const marker = MCP_MARKERS.find((value) => candidate.toLowerCase().startsWith(value));
+    if (marker) candidate = candidate.slice(marker.length);
+    for (const name of LEMMA_MCP_SERVER_NAMES) {
+      if (!candidate.toLowerCase().startsWith(name)) continue;
+      const remainder = candidate.slice(name.length);
+      const withoutSeparator = remainder.replace(NAMESPACE_SEPARATORS, "");
+      if (withoutSeparator !== remainder) return withoutSeparator;
     }
-    return normalized;
+    return toolName;
+  }
+  function normalizeAgentToolName(toolName) {
+    const normalized = stripProviderNamespace(toolName.trim());
+    return normalized.toLowerCase().startsWith("lemma_") ? normalized.slice("lemma_".length) : normalized;
   }
 
   // src/core/agent/output.ts

--- a/lemma-typescript/public/lemma-ui.js
+++ b/lemma-typescript/public/lemma-ui.js
@@ -968,7 +968,7 @@ var LemmaUI = (() => {
     (left, right) => right.length - left.length
   );
   var MCP_MARKERS = ["mcp__", "mcp.", "mcp/"];
-  var NAMESPACE_SEPARATORS = /^[_./:-]+/;
+  var NAMESPACE_SEPARATORS = /^[_./:]+/;
   function stripProviderNamespace(toolName) {
     let candidate = toolName;
     const marker = MCP_MARKERS.find((value) => candidate.toLowerCase().startsWith(value));

--- a/lemma-typescript/src/__tests__/agent-display.test.ts
+++ b/lemma-typescript/src/__tests__/agent-display.test.ts
@@ -74,6 +74,16 @@ describe("normalizeAgentToolName", () => {
     expect(normalizeAgentToolName("mcp__github__create_issue")).toBe("mcp__github__create_issue");
     expect(normalizeAgentToolName("commandExecution")).toBe("commandExecution");
   });
+
+  it("reads the Agent Host's shorter server name as the same server", () => {
+    // A local agent is handed the run-scoped server as `lemma`, not
+    // `lemma_tools`, so its calls arrive namespaced that way and have to land
+    // on the same tool as the pod agent's — same card, same icon, same name.
+    expect(normalizeAgentToolName("mcp__lemma__lemma_pod_write_file")).toBe("pod_write_file");
+    expect(normalizeAgentToolName("mcp.lemma.lemma_display_resource")).toBe("display_resource");
+    expect(normalizeAgentToolName("lemma__lemma_ask_user")).toBe("ask_user");
+    expect(normalizeAgentToolName("lemma/lemma_exec_command")).toBe("exec_command");
+  });
 });
 
 describe("parseAssistantStreamEvent completed", () => {

--- a/lemma-typescript/src/__tests__/agent-display.test.ts
+++ b/lemma-typescript/src/__tests__/agent-display.test.ts
@@ -84,6 +84,13 @@ describe("normalizeAgentToolName", () => {
     expect(normalizeAgentToolName("lemma__lemma_ask_user")).toBe("ask_user");
     expect(normalizeAgentToolName("lemma/lemma_exec_command")).toBe("exec_command");
   });
+
+  it("leaves someone else's server named after ours alone", () => {
+    // The server name is matched whole: `lemma-corp` is not `lemma`.
+    expect(normalizeAgentToolName("mcp__lemma-corp__delete_everything")).toBe(
+      "mcp__lemma-corp__delete_everything",
+    );
+  });
 });
 
 describe("parseAssistantStreamEvent completed", () => {

--- a/lemma-typescript/src/core/agent/tool-names.ts
+++ b/lemma-typescript/src/core/agent/tool-names.ts
@@ -18,8 +18,12 @@ const LEMMA_MCP_SERVER_NAMES = [LEMMA_MCP_SERVER_NAME, "lemma-tools", "lemma"].s
 /** How agents mark a name as coming from an MCP server at all. */
 const MCP_MARKERS = ["mcp__", "mcp.", "mcp/"] as const;
 
-/** Whatever character joined the server name to the tool name. */
-const NAMESPACE_SEPARATORS = /^[_./:-]+/;
+/**
+ * Whatever character joined the server name to the tool name. No `-`:
+ * `lemma-tools` is a server name in its own right above, and treating `-` as a
+ * separator would read someone else's `lemma-corp` server as ours.
+ */
+const NAMESPACE_SEPARATORS = /^[_./:]+/;
 
 /**
  * Drop the MCP namespace an agent added, when the server named is Lemma's.

--- a/lemma-typescript/src/core/agent/tool-names.ts
+++ b/lemma-typescript/src/core/agent/tool-names.ts
@@ -1,23 +1,55 @@
-const LEMMA_MCP_TOOL_PREFIXES = [
-  "mcp.lemma_tools.",
-  "mcp__lemma_tools__",
-  "lemma_tools_",
-  "lemma_tools.",
-  "mcp.lemma-tools.",
-  "mcp__lemma-tools__",
-  "lemma-tools_",
-  "lemma-tools.",
-] as const;
+/** The name every run publishes for Lemma's own MCP server. */
+const LEMMA_MCP_SERVER_NAME = "lemma_tools";
+
+/**
+ * Server names whose tools are Lemma's.
+ *
+ * One name is the contract: every run publishes `lemma_tools`, and every path —
+ * pod agent, local agent over ACP — registers the server under it. The rest are
+ * names Lemma itself shipped earlier (a hyphenated MCP config, and bare `lemma`
+ * from Agent Host builds that named the server locally instead of using the
+ * run's) and still sit in stored conversations. Longest first, so `lemma_tools`
+ * reads as itself rather than as `lemma` followed by `_tools`.
+ */
+const LEMMA_MCP_SERVER_NAMES = [LEMMA_MCP_SERVER_NAME, "lemma-tools", "lemma"].sort(
+  (left, right) => right.length - left.length,
+);
+
+/** How agents mark a name as coming from an MCP server at all. */
+const MCP_MARKERS = ["mcp__", "mcp.", "mcp/"] as const;
+
+/** Whatever character joined the server name to the tool name. */
+const NAMESPACE_SEPARATORS = /^[_./:-]+/;
+
+/**
+ * Drop the MCP namespace an agent added, when the server named is Lemma's.
+ *
+ * The namespace means nothing on its own — it is there so one agent's
+ * `exec_command` cannot collide with another's — so removing it is what turns a
+ * provider's spelling back into the name Lemma uses everywhere else. A
+ * third-party `mcp__github__create_issue` is left exactly as it is.
+ */
+function stripProviderNamespace(toolName: string): string {
+  let candidate = toolName;
+  const marker = MCP_MARKERS.find((value) => candidate.toLowerCase().startsWith(value));
+  if (marker) candidate = candidate.slice(marker.length);
+
+  for (const name of LEMMA_MCP_SERVER_NAMES) {
+    if (!candidate.toLowerCase().startsWith(name)) continue;
+    const remainder = candidate.slice(name.length);
+    const withoutSeparator = remainder.replace(NAMESPACE_SEPARATORS, "");
+    // A separator has to follow the server name, or `lemmatize` would read as
+    // the `lemma` server's `tize`.
+    if (withoutSeparator !== remainder) return withoutSeparator;
+  }
+  return toolName;
+}
 
 /** Convert a provider-scoped Lemma MCP tool name to Lemma's canonical name.
  * Provider-native and third-party MCP tool names are intentionally unchanged. */
 export function normalizeAgentToolName(toolName: string): string {
-  let normalized = toolName.trim();
-  const lower = normalized.toLowerCase();
-  const providerPrefix = LEMMA_MCP_TOOL_PREFIXES.find((prefix) => lower.startsWith(prefix));
-  if (providerPrefix) normalized = normalized.slice(providerPrefix.length);
-  if (normalized.toLowerCase().startsWith("lemma_")) {
-    normalized = normalized.slice("lemma_".length);
-  }
-  return normalized;
+  const normalized = stripProviderNamespace(toolName.trim());
+  return normalized.toLowerCase().startsWith("lemma_")
+    ? normalized.slice("lemma_".length)
+    : normalized;
 }


### PR DESCRIPTION
Four defects a desktop install hits once the agent is Claude Code running locally. Every one is reconstructed from a real machine's own data — its backend log, its Agent Host journal, and the conversation rows its runs left behind — not from reading the code.

## A pod created in onboarding had no model

Onboarding sets up a coding agent, creates the first pod, and adopts that agent as the pod's default. The adoption read the agent list from a React Query cache nothing refreshed: `useCreateAgentRuntime` invalidated only the catalog key, while the adoption read the management listing — a different key by design, `staleTime: 30000`. The agent was created **14 seconds** before the pod, so the list was warm, empty of it, and the adoption took its "nothing was configured" path in silence.

Evidence from the affected install: `POST …/agent-runtime/profiles` 201 at 04:31:40, `POST /pods` 201 at 04:31:54, and **no `PUT /pods/{pod_id}` anywhere in the log**. The pod row's config is `{"join_policy": "INVITE_ONLY"}` — no `default_runtime`. Two conversations then failed in ~1s with `No LLM model is configured on this server…`, and the third only worked because the user picked the agent by hand in the composer.

- The create mutation invalidates the whole `agent-runtime` tree, like every other profile mutation already did.
- Adoption reads profiles from the server, not from any cache. A pod with no model is a hard failure, not a place to trust a cache that was warm before the thing it looks for existed.
- Which agent is adopted is now a pure, tested function: first created, active, harness.

## Lemma's own tools arrived under another name

The Agent Host handed the run-scoped MCP server to the agent under a name it made up locally (`lemma`) instead of the one the run publishes (`lemma_tools`). A tool the pod agent calls as `pod_write_file` was stored as `mcp__lemma__lemma_pod_write_file` — an unrecognised tool to every reader that keys on the name: no icon, no card, no contextual rendering. That row is in the install's database.

Fixed at the source: the host registers the name Lemma published. The normalizers stop growing a table of literal prefixes and instead strip any namespace shape for our own server — the namespace exists only to avoid collisions between agents' tools, so removing it is a rule, not a list. Names older builds wrote stay readable, since they sit in stored conversations.

The name was also being lost before that. ACP's `ToolCall` carries no name field, so the reader fell back to `kind` — a category, not an identity: `fetch` for a web search and a page fetch alike, `other` for every MCP tool. It now reads `_meta.<vendor>.toolName`, where Claude Code puts the real name, and the approval card names the tool it interrupts rather than its category.

## "Always allow" did not mean always

The agent's always-allow rule lives in an adapter process started fresh for every run, and is installed only when the answer arrives. So the grant was asked for again on the next message — and again by every other call of a parallel batch. The install shows four consecutive `APPROVE_FOR_SESSION` decisions for one domain within four seconds.

The host now remembers the scope the user consented to, in the agent's own words (`Always Allow WebFetch(domain:en.wikipedia.org)`), per provider session. A later request offering that same scope is answered from the grant; requests already parked for it are released by it. A narrower scope, a different session, and allow-once all still ask.

## An approval card outlived its run

A run ending with a permission unanswered left a card still offering buttons, while the host had long since denied the request on its own 30-minute timeout. In this install a user pressed one four hours after the run behind it had failed. The card is now closed when its run ends, like any other unfinished tool call, and a synthesized return never overwrites the real one a decision already wrote.

## Testing

- `lemma-backend`: 789 agent unit tests pass, including new coverage for tool-name resolution from real captured ACP payloads, namespace normalization, the stale-approval sweep, and the synthesized-return guard. `ruff check`, `ruff format`, and the architecture ratchet pass.
- `desktop/agent-host`: 103 lib tests pass, including six new always-allow tests (grant, allow-once grants nothing, parallel-batch release, narrower scope still asks, session isolation, forgetting a session). `cargo fmt` and `clippy --all-targets` clean.
- `lemma-frontend`: 657 tests pass; `tsc --noEmit` and eslint clean on changed files.
- `lemma-typescript`: 191 tests pass; committed bundle regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: every Lemma tool is approved, whatever the agent calls it

Lemma's own MCP tools are authorised by the run's agent token before the agent ever sees them, so an approval card for one asks a question that was already answered. The host has auto-approved them for a while — but only for the spellings it could recognise, and a local agent kept finding new ones.

- The name is now read from `_meta.<vendor>.toolName` as well as the fields already checked. That is where an adapter puts the real name when the title is written for a person; a Lemma tool called by a subagent arrives exactly like that.
- One namespace rule, shared by the host, the backend and the SDK: strip the MCP marker, then one of our server names, then the separator between them. It replaces a hand-rolled `strip_prefix` that knew only `mcp__` and the bare `lemma` — and it recognises `lemma_tools`, the name the server is actually registered under as of the first commit.
- Matching the server name whole closes a false positive in the old check: `mcp__lemma-corp__delete_everything` was auto-approved because it started with `lemma` plus a separator. Someone else's server keeps its own approval card, and `-` is no longer read as a separator in any of the three implementations.

Native tools (Bash on the user's own machine, WebFetch, WebSearch) still prompt — that is what the card is for.
