### PR TITLE
Ship the pod bundle in the wheel, and verify the artifact rather than the source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,50 @@ jobs:
           pytest lemma-python/tests -m "not integration"
           pytest lemma-pod-bundle/tests
 
+  cli-packaging:
+    name: lemma-terminal wheel (clean checkout)
+    # What users install is a built artifact, and its two most important
+    # contents — the agent skills and lemma_pod_bundle — exist in it only
+    # because setup.py copies them in. No test that reads the source tree can
+    # see that fail, and a build in a tree that has built before cannot either:
+    # the copies from the previous build are still lying there. Only a build
+    # from a clean checkout tells the truth, which is what a fresh `actions/
+    # checkout` gives us, and what `uv tool install` from git gives a user.
+    timeout-minutes: 15
+    needs: changes
+    if: needs.changes.outputs.python_sdk == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - name: Build sdist + wheel the way the release does
+        working-directory: lemma-cli
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+      - name: Distributions carry what PyPI cannot supply
+        run: python scripts/check_cli_wheel.py lemma-cli/dist
+      - name: Install the wheel where no checkout exists and import it
+        # The failure mode this catches is a user's, not a builder's: the wheel
+        # resolves and installs happily and then raises ModuleNotFoundError on
+        # first use. --no-deps keeps this a packaging check rather than a
+        # resolution one (the lemma-sdk pin names the release being cut, which
+        # is not on PyPI until minutes after the wheel is), and /tmp keeps the
+        # repository off sys.path so an import can only come from the wheel.
+        run: |
+          python -m venv /tmp/wheel-check
+          /tmp/wheel-check/bin/pip install --no-deps lemma-cli/dist/*.whl
+          cd /tmp && /tmp/wheel-check/bin/python -c "
+          import pathlib, lemma_pod_bundle
+          from lemma_pod_bundle import layout
+          skills = pathlib.Path(lemma_pod_bundle.__file__).parent.parent / 'lemma_cli' / 'skills'
+          found = sorted(p.parent.name for p in skills.glob('*/SKILL.md'))
+          assert found, f'no skills installed under {skills}'
+          print(f'imported lemma_pod_bundle, {len(found)} skills present: {found}')
+          "
+
   typescript-sdk:
     name: TypeScript SDK checks
     timeout-minutes: 30

--- a/.github/workflows/release-lemma-terminal.yml
+++ b/.github/workflows/release-lemma-terminal.yml
@@ -78,41 +78,11 @@ jobs:
         working-directory: lemma-cli
         run: python -m build
 
-      - name: Verify skills are bundled
-        working-directory: lemma-cli
-        shell: bash
-        run: |
-          set -euo pipefail
-          count=$(python -c "import zipfile,glob; w=glob.glob('dist/*.whl')[0]; print(sum(1 for n in zipfile.ZipFile(w).namelist() if n.endswith('SKILL.md')))")
-          echo "SKILL.md files in wheel: $count"
-          test "$count" -ge 1 || { echo 'No skills bundled in the wheel — aborting release.'; exit 1; }
-
-      - name: Verify pod-bundle is vendored and not a PyPI dependency
-        working-directory: lemma-cli
-        shell: bash
-        run: |
-          set -euo pipefail
-          python - <<'PY'
-          import glob, sys, zipfile
-
-          wheel = glob.glob("dist/*.whl")[0]
-          zf = zipfile.ZipFile(wheel)
-          names = zf.namelist()
-
-          if "lemma_pod_bundle/__init__.py" not in names:
-              sys.exit("lemma_pod_bundle is not vendored into the wheel — aborting release.")
-
-          meta = next(n for n in names if n.endswith(".dist-info/METADATA"))
-          leaked = [
-              line
-              for line in zf.read(meta).decode().splitlines()
-              if line.startswith("Requires-Dist:") and "lemma-pod-bundle" in line
-          ]
-          if leaked:
-              sys.exit(f"lemma-pod-bundle still declared as a dependency {leaked} — aborting release.")
-
-          print("pod-bundle vendored into the wheel, no PyPI dependency — ok")
-          PY
+      # Skills, lemma_pod_bundle, and no unpublished distribution in
+      # Requires-Dist — the same check CI runs on every pull request that
+      # touches the CLI, so a release is never the first build anyone verified.
+      - name: Verify the distributions carry what PyPI cannot supply
+        run: python scripts/check_cli_wheel.py lemma-cli/dist
 
       - name: Check distribution
         working-directory: lemma-cli

--- a/lemma-cli/SETUP.md
+++ b/lemma-cli/SETUP.md
@@ -19,6 +19,26 @@ For local development from this repository (editable, picks up source changes):
 uv tool install --force --editable lemma-cli
 ```
 
+To install straight from GitHub without a checkout — an unreleased `main`, or a
+tag newer than the last PyPI publish:
+
+```bash
+uv tool install --force --python 3.14 "lemma-terminal @ git+https://github.com/lemma-work/lemma-platform.git#subdirectory=lemma-cli"
+```
+
+`main` carries the version currently being developed, and its `lemma-sdk` pin
+names that same version — which is on PyPI only from the moment that release is
+published. Until then, take the SDK from the same commit, so the two are resolved
+together instead of against the index:
+
+```bash
+uv tool install --force --python 3.14 "lemma-terminal @ git+https://github.com/lemma-work/lemma-platform.git#subdirectory=lemma-cli" --with "lemma-sdk @ git+https://github.com/lemma-work/lemma-platform.git#subdirectory=lemma-python"
+```
+
+Append `@<tag-or-commit>` before the `#` to pin a ref (e.g.
+`...lemma-platform.git@v0.6.2#subdirectory=lemma-cli`); a released tag needs no
+`--with`, since its SDK is on PyPI.
+
 > **After the SDK schema changes** (regenerating `lemma-python`), re-run the
 > `--force` install so the bundled `lemma-sdk` is rebuilt. `lemma doctor` flags
 > when the installed SDK has drifted from the server it is talking to — the exact

--- a/lemma-cli/setup.py
+++ b/lemma-cli/setup.py
@@ -112,4 +112,16 @@ class _Sdist(_sdist):
         super().run()
 
 
+# Vendor before ``setup()``, not only from the build commands above.
+# ``[tool.setuptools.packages.find]`` is resolved while the distribution's
+# configuration is read — strictly before any command runs — so a directory that
+# only appears once ``build_py`` starts is never in the discovered package list,
+# and the wheel ships without it. That failure hides itself: the copy is left
+# behind in the source tree, so the *next* build in the same tree finds it at
+# configuration time and succeeds, which is why a working local wheel and a
+# broken one from a fresh clone came out of the same command. The commands keep
+# their own call so a build that reuses a long-lived tree still refreshes the
+# copies from source.
+_vendor_all()
+
 setup(cmdclass={"build_py": _BuildPy, "sdist": _Sdist})

--- a/lemma-cli/tests/test_packaging_contract.py
+++ b/lemma-cli/tests/test_packaging_contract.py
@@ -79,3 +79,21 @@ def test_the_build_vendors_both_sources() -> None:
     assert "_vendor_pod_bundle()" in setup_py
     for command in ("build_py", "sdist"):
         assert command in setup_py, f"{command} must vendor before it packages"
+
+
+def test_vendoring_runs_before_setup_is_called() -> None:
+    """``packages.find`` runs at configuration time, before any build command.
+
+    A copy made only from ``build_py`` lands after the package list is already
+    fixed, so ``lemma_pod_bundle`` exists on disk but ships in no wheel — and
+    because the copy survives in the tree, the next build in that same tree
+    quietly succeeds. Only a build from a fresh checkout shows it, which is
+    exactly the build users get from a git install.
+    """
+    setup_py = (_CLI_ROOT / "setup.py").read_text(encoding="utf-8")
+    vendor_at_import = setup_py.index("\n_vendor_all()\n")
+    setup_call = setup_py.index("\nsetup(")
+    assert vendor_at_import < setup_call, (
+        "setup.py must call _vendor_all() at module level before setup(), or "
+        "packages.find cannot discover the vendored package."
+    )

--- a/scripts/check_cli_wheel.py
+++ b/scripts/check_cli_wheel.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""The lemma-terminal distributions must carry what PyPI cannot supply.
+
+``lemma-terminal`` imports two things that live outside ``lemma-cli/`` and are
+published nowhere: the agent skills (canonical source ``lemma-skills/``) and
+``lemma_pod_bundle`` (canonical source ``lemma-pod-bundle/``). ``setup.py``
+copies both into the package at build time, so the only thing standing between a
+user and ``ModuleNotFoundError: lemma_pod_bundle`` is that the copies actually
+reach the archive.
+
+That guarantee has now failed twice in different ways — once by shipping a wheel
+with no skills at all (0.4.1), once by vendoring from a build command that runs
+*after* ``packages.find`` has already fixed the package list, which produced a
+complete wheel on any tree where a previous build had left the copy behind and a
+broken one from a fresh clone. Both were invisible to every test that reads
+source files, because both were properties of the built artifact.
+
+So this reads the artifact. Run it against a ``dist/`` directory holding a freshly
+built wheel (and, if present, the sdist the release also publishes)::
+
+    python scripts/check_cli_wheel.py lemma-cli/dist
+
+It exits non-zero listing everything missing. Build the distributions from a
+clean checkout — a dirty tree is exactly what hides this class of bug.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_POD_BUNDLE_SOURCE = _REPO_ROOT / "lemma-pod-bundle" / "lemma_pod_bundle"
+_SKILLS_SOURCE = _REPO_ROOT / "lemma-skills"
+
+#: Distributions that exist only inside this monorepo. Any of these in
+#: Requires-Dist makes every `pip install lemma-terminal` fail on a package the
+#: index has never heard of.
+UNPUBLISHED_DISTRIBUTIONS = ("lemma-pod-bundle",)
+
+
+def _expected_pod_bundle_modules() -> set[str]:
+    return {
+        f"lemma_pod_bundle/{path.relative_to(_POD_BUNDLE_SOURCE).as_posix()}"
+        for path in _POD_BUNDLE_SOURCE.rglob("*.py")
+        if "__pycache__" not in path.parts
+    }
+
+
+def _expected_skills() -> set[str]:
+    return {
+        child.name
+        for child in _SKILLS_SOURCE.iterdir()
+        if child.is_dir() and (child / "SKILL.md").is_file()
+    }
+
+
+def _check_vendored(names: set[str], archive: str, strip: str = "") -> list[str]:
+    """Both vendored trees must be present in full, not merely non-empty."""
+    problems: list[str] = []
+    present = {name[len(strip) :] if strip and name.startswith(strip) else name for name in names}
+
+    missing_modules = sorted(_expected_pod_bundle_modules() - present)
+    if missing_modules:
+        problems.append(
+            f"{archive}: lemma_pod_bundle is not fully vendored — missing "
+            f"{missing_modules}. setup.py must vendor before setup() is called, "
+            "or packages.find never sees the directory."
+        )
+
+    shipped_skills = {
+        name.split("/")[2]
+        for name in present
+        if name.startswith("lemma_cli/skills/") and name.endswith("/SKILL.md")
+    }
+    missing_skills = sorted(_expected_skills() - shipped_skills)
+    if missing_skills:
+        problems.append(f"{archive}: skills missing from the package: {missing_skills}")
+
+    return problems
+
+
+def _check_wheel(wheel: Path) -> list[str]:
+    with zipfile.ZipFile(wheel) as archive:
+        names = set(archive.namelist())
+        problems = _check_vendored(names, wheel.name)
+
+        metadata_name = next(
+            (name for name in names if name.endswith(".dist-info/METADATA")), None
+        )
+        if metadata_name is None:
+            return [*problems, f"{wheel.name}: no METADATA in the wheel"]
+        metadata = archive.read(metadata_name).decode("utf-8")
+
+    leaked = [
+        line
+        for line in metadata.splitlines()
+        if line.startswith("Requires-Dist:")
+        and any(name in line.replace("_", "-").lower() for name in UNPUBLISHED_DISTRIBUTIONS)
+    ]
+    if leaked:
+        problems.append(
+            f"{wheel.name}: {leaked} names a distribution that is not on PyPI, so "
+            "every install would fail resolving it. Vendor it instead."
+        )
+    return problems
+
+
+def _check_sdist(sdist: Path) -> list[str]:
+    """The published wheel is built *from* the sdist, so the sdist must carry it too."""
+    with tarfile.open(sdist) as archive:
+        names = {member.name for member in archive.getmembers() if member.isfile()}
+    root = f"{sdist.name.removesuffix('.tar.gz')}/"
+    return _check_vendored(names, sdist.name, strip=root)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "dist",
+        nargs="?",
+        default=str(_REPO_ROOT / "lemma-cli" / "dist"),
+        help="directory holding the built wheel (and sdist). Default: lemma-cli/dist",
+    )
+    arguments = parser.parse_args()
+
+    dist = Path(arguments.dist)
+    wheels = sorted(dist.glob("*.whl"))
+    if not wheels:
+        print(f"No wheel found in {dist} — build it first (`python -m build`).")
+        return 1
+
+    problems: list[str] = []
+    for wheel in wheels:
+        problems.extend(_check_wheel(wheel))
+    for sdist in sorted(dist.glob("*.tar.gz")):
+        problems.extend(_check_sdist(sdist))
+
+    if problems:
+        for problem in problems:
+            print(f"✗ {problem}")
+        return 1
+
+    checked = ", ".join(path.name for path in sorted(dist.iterdir()) if path.is_file())
+    print(f"✓ skills and lemma_pod_bundle vendored, no unpublished dependency: {checked}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`uv tool install "lemma-terminal @ git+https://github.com/lemma-work/lemma-platform.git#subdirectory=lemma-cli"` installs a CLI that raises `ModuleNotFoundError: lemma_pod_bundle` on first use, and `python -m build` — the command [release-lemma-terminal.yml](.github/workflows/release-lemma-terminal.yml) runs — fails outright on a clean checkout. Both are the same mistake.

## The bug

`setup.py` vendors `lemma_pod_bundle` from the `build_py`/`sdist` commands. Those run *after* setuptools reads the project configuration, and `[tool.setuptools.packages.find]` is resolved while it reads it. On a tree where the directory does not exist yet it is not in the discovered package list, so the wheel ships without it — and the copy stays behind in the tree, so the next build there finds it at configuration time and succeeds.

Same command, same commit, different artifact:

| build | `lemma_pod_bundle` entries in wheel |
|---|---|
| 1st `uv build --wheel`, fresh clone of `main` | **0** |
| 2nd, same tree | 9 |

That is why it passed verification and reached users. The release path fails harder: `python -m build` builds the wheel from the sdist, which has no copy either, so the wheel build hits setup.py's fail-loudly branch — `ERROR Backend subprocess exited when trying to invoke build_wheel`. The next release would have failed in CI.

Vendoring now also runs at module level, before `setup()`. The command hooks keep their call so a long-lived tree still refreshes both copies from source.

## Verifying the artifact instead of the source

Every test guarding this read the source tree — `pyproject.toml` still names `lemma_pod_bundle*` in `packages.find`, setup.py still calls both vendor functions — and both assertions hold on the broken build. The property belongs to the built artifact, so `scripts/check_cli_wheel.py` opens the archive: every module of the pod-bundle package present (not merely `__init__.py`), every skill directory that exists in `lemma-skills/`, no unpublished distribution in `Requires-Dist`, and the same for the sdist the wheel is built from.

A new `cli-packaging` CI job builds both distributions from the clean checkout on every PR touching the CLI, runs that check, then installs the wheel into a bare venv outside the repository and imports `lemma_pod_bundle` — the user's failure mode, not the builder's. The release workflow's two hand-rolled verification steps are replaced by the same script, so a release is no longer the first build anyone verified.

## Installing from git

`SETUP.md` now documents it, including that `main`'s `lemma-sdk` pin names the release being developed and is on PyPI only once that release is published — until then the SDK has to come from the same commit:

```bash
uv tool install --force --python 3.14 \
  "lemma-terminal @ git+https://github.com/lemma-work/lemma-platform.git#subdirectory=lemma-cli" \
  --with "lemma-sdk @ git+https://github.com/lemma-work/lemma-platform.git#subdirectory=lemma-python"
```

## Verified

- `scripts/check_cli_wheel.py` fails on a wheel built from current `main` (all nine modules missing) and passes on this branch
- `python -m build` on a clean checkout of this branch produces both distributions; on `main` it errors
- the wheel installs into an empty venv with no repository on the path, imports the bundle, 12 skills present
- `uv tool install` from a git URL → working `lemma --version`, `lemma skills list`
- 578 CLI unit tests, ruff, `check_version_consistency.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)