### PR TITLE
Point the sidebar at the endpoint that was built for it

### DIFF
--- a/lemma-backend/app/composition/organization_navigation.py
+++ b/lemma-backend/app/composition/organization_navigation.py
@@ -8,9 +8,11 @@ grew from there.
 
 So there are two shapes, deliberately not one:
 
-``load_navigation`` is the whole sidebar in a single call: every organization
-the caller belongs to and the pods within each, carrying names and ids and
-nothing else. It stays small however many organizations someone is in.
+``load_navigation`` is the whole sidebar — and the pod list behind it — in a
+single call: every organization the caller belongs to and the pods within each,
+carrying each pod's own columns and nothing that requires looking inside a pod.
+It stays small however many organizations someone is in, because it grows with
+the number of pods rather than with their contents.
 
 ``load_organization_home`` is one organization in detail — its pods with their
 apps, agents and the caller's roles. Detail is per organization on purpose: a
@@ -30,6 +32,7 @@ spans modules is allowed to be assembled.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import select
@@ -51,7 +54,9 @@ from app.modules.pod.contracts import VisiblePod, list_visible_pods
 class NavigationPod:
     id: UUID
     name: str
+    description: str | None
     icon_url: str | None
+    updated_at: datetime
 
 
 @dataclass(frozen=True, slots=True)
@@ -164,7 +169,13 @@ async def load_navigation(*, session, user_id: UUID) -> list[NavigationOrganizat
             slug=membership.slug,
             role=membership.role,
             pods=[
-                NavigationPod(id=pod.id, name=pod.name, icon_url=pod.icon_url)
+                NavigationPod(
+                    id=pod.id,
+                    name=pod.name,
+                    description=pod.description,
+                    icon_url=pod.icon_url,
+                    updated_at=pod.updated_at,
+                )
                 for pod in grouped.get(membership.organization_id, [])
             ],
         )

--- a/lemma-backend/app/modules/identity/api/controllers/organization_navigation_controller.py
+++ b/lemma-backend/app/modules/identity/api/controllers/organization_navigation_controller.py
@@ -65,7 +65,11 @@ async def get_navigation(request: Request, uow: UoWDep) -> NavigationResponse:
                 role=organization.role,
                 pods=[
                     NavigationPodResponse(
-                        id=pod.id, name=pod.name, icon_url=pod.icon_url
+                        id=pod.id,
+                        name=pod.name,
+                        description=pod.description,
+                        icon_url=pod.icon_url,
+                        updated_at=pod.updated_at,
                     )
                     for pod in organization.pods
                 ],

--- a/lemma-backend/app/modules/identity/api/schemas/organization_schemas.py
+++ b/lemma-backend/app/modules/identity/api/schemas/organization_schemas.py
@@ -144,11 +144,22 @@ class OrganizationMessageResponse(BaseSchema):
 
 
 class NavigationPodResponse(BaseSchema):
-    """A pod as a navigation entry — enough to draw and to link to."""
+    """A pod as a listing entry — enough to draw it, label it, and link to it.
+
+    The line this payload holds is scalars yes, collections no. A pod's own
+    columns cost nothing to return: they ride along in the query that found the
+    pod, so the response grows with the number of pods and not with what is
+    inside them. Apps, agents and roles are the other side of that line, and
+    live on ``/organizations/{org_id}/home``.
+    """
 
     id: UUID
     name: str
+    description: str | None = None
     icon_url: str | None = None
+    #: When the pod record last changed — not when work last ran in it. The home
+    #: screen sorts and labels on it, which is the only reason it is here.
+    updated_at: datetime
 
 
 class NavigationOrganizationResponse(BaseSchema):
@@ -162,11 +173,13 @@ class NavigationOrganizationResponse(BaseSchema):
 
 
 class NavigationResponse(BaseSchema):
-    """Everything a sidebar needs, for every organization, in one response.
+    """Everything a sidebar and a pod list need, for every organization, at once.
 
-    Deliberately shallow: apps, agents and roles per pod are the detail endpoint's
-    job, because carrying them here would make the payload grow with the content
-    of every organization a person happens to belong to.
+    Shallow in the sense that matters: it carries each pod's own columns, and
+    nothing that would require looking inside a pod. Apps, agents and roles are
+    the detail endpoint's job, because carrying them here would make the payload
+    grow with the content of every organization a person happens to belong to,
+    which is precisely the cost this endpoint exists to remove.
     """
 
     items: list[NavigationOrganizationResponse]

--- a/lemma-backend/app/modules/identity/tests/e2e/test_organization_navigation_e2e.py
+++ b/lemma-backend/app/modules/identity/tests/e2e/test_organization_navigation_e2e.py
@@ -7,6 +7,7 @@ job, and that is what the budget tests pin.
 
 from __future__ import annotations
 
+import time
 from contextlib import contextmanager
 from uuid import uuid4
 
@@ -87,6 +88,41 @@ async def test_navigation_returns_every_organization_with_its_pods(
     assert len(by_id[first_org]["pods"]) == 1
     assert len(by_id[second_org]["pods"]) == 1
     assert by_id[first_org]["role"] == "ORG_OWNER"
+
+
+async def test_navigation_carries_the_columns_a_pod_list_renders(
+    authenticated_client, fixed_test_org
+):
+    """The home screen labels and sorts on these, so they have to be here.
+
+    They are the pod's own columns, so they cost nothing beyond the query that
+    already found the pod — unlike apps or agents, which is where the line is.
+    """
+    org_id = fixed_test_org["id"]
+    pod_name = f"labelled-{uuid4().hex[:6]}"
+    created = await authenticated_client.post(
+        "/pods",
+        json={
+            "name": pod_name,
+            "type": "ASSISTANT",
+            "organization_id": org_id,
+            "description": "what this pod is for",
+        },
+    )
+    assert created.status_code == status.HTTP_201_CREATED, created.text
+
+    response = await authenticated_client.get("/organizations/navigation")
+    assert response.status_code == status.HTTP_200_OK, response.text
+
+    organization = next(
+        item for item in response.json()["items"] if item["id"] == org_id
+    )
+    pod = next(item for item in organization["pods"] if item["name"] == pod_name)
+    assert pod["description"] == "what this pod is for"
+    assert pod["updated_at"]
+    # Still no per-pod contents: that is the detail endpoint's job.
+    assert "apps" not in pod
+    assert "agents" not in pod
 
 
 async def test_navigation_query_count_is_flat_across_organizations(
@@ -273,3 +309,116 @@ async def test_home_refuses_an_organization_the_caller_is_not_in(
         headers={"Authorization": f"Bearer {outsider['token']}"},
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN, response.text
+
+
+@pytest.mark.slow
+async def test_a_realistic_multi_org_workspace_stays_fast(
+    authenticated_client, fixed_test_org, capsys
+):
+    """Five organizations, twenty pods, apps and agents — what the change is for.
+
+    The shapes only pay off at the size that hurt: one organization with one pod
+    hides a waterfall, five with four each is where a user actually felt it.
+    This builds that, then measures what the sidebar costs against what it used
+    to cost, so the claim in the pull request is a number and not an argument.
+
+    The ceilings are deliberately loose. Wall clock on a laptop running Docker
+    is not a contract, and a tight timing gate here would only teach people to
+    rerun it; the query-count tests above are the real guarantee. What this
+    catches is an order-of-magnitude regression.
+    """
+    org_ids = [fixed_test_org["id"]]
+    for index in range(4):
+        org_ids.append(
+            await _create_org(authenticated_client, f"Scale Org {index}-{uuid4().hex[:6]}")
+        )
+
+    pods_by_org: dict[str, list[str]] = {}
+    for org_id in org_ids:
+        pods_by_org[org_id] = [
+            await _create_pod(authenticated_client, org_id, f"pod-{uuid4().hex[:8]}")
+            for _ in range(4)
+        ]
+
+    # Contents on the organization whose landing page gets measured, so `home`
+    # is doing real work rather than returning empty lists.
+    detail_org = org_ids[0]
+    for pod_id in pods_by_org[detail_org]:
+        for _ in range(2):
+            await _create_app(authenticated_client, pod_id, f"app{uuid4().hex[:8]}")
+            await _create_agent(authenticated_client, pod_id, f"agent{uuid4().hex[:8]}")
+
+    async def timed(call, samples: int = 10) -> tuple[float, float, float]:
+        """Cold first call, then p50/p95 of the steady state.
+
+        The first call is reported separately because ``home`` caches: measuring
+        only the warm path would quote a cache hit as if it were the cost of
+        building the page.
+        """
+        started = time.perf_counter()
+        first = await call()
+        cold = (time.perf_counter() - started) * 1000
+        assert first.status_code == status.HTTP_200_OK, first.text
+
+        timings = []
+        for _ in range(samples):
+            started = time.perf_counter()
+            response = await call()
+            timings.append(time.perf_counter() - started)
+            assert response.status_code == status.HTTP_200_OK, response.text
+        timings.sort()
+        return (
+            cold,
+            timings[len(timings) // 2] * 1000,
+            timings[int(len(timings) * 0.95) - 1] * 1000,
+        )
+
+    navigation_cold, navigation_p50, navigation_p95 = await timed(
+        lambda: authenticated_client.get("/organizations/navigation")
+    )
+    home_cold, home_p50, home_p95 = await timed(
+        lambda: authenticated_client.get(f"/organizations/{detail_org}/home")
+    )
+
+    # The shape this replaced: the organization list, then a pod list per
+    # organization, each waiting on the one before it.
+    async def legacy_fan_out():
+        response = await authenticated_client.get("/organizations")
+        assert response.status_code == status.HTTP_200_OK, response.text
+        for org_id in org_ids:
+            response = await authenticated_client.get(f"/pods/organization/{org_id}")
+            assert response.status_code == status.HTTP_200_OK, response.text
+        return response
+
+    _, legacy_p50, legacy_p95 = await timed(legacy_fan_out, samples=5)
+
+    navigation = await authenticated_client.get("/organizations/navigation")
+    payload = navigation.json()["items"]
+    assert len(payload) >= len(org_ids)
+    assert sum(len(entry["pods"]) for entry in payload) >= 20
+
+    home = await authenticated_client.get(f"/organizations/{detail_org}/home")
+    home_pods = home.json()["pods"]
+    assert len(home_pods) == 4
+    assert all(len(pod["apps"]) == 2 for pod in home_pods)
+    assert all(len(pod["agents"]) == 2 for pod in home_pods)
+
+    with capsys.disabled():
+        print(
+            f"\n  5 organizations, 20 pods, 8 apps and 8 agents on the detail org"
+            f"\n  {'route':44} {'cold':>9} {'p50':>9} {'p95':>9}"
+            f"\n  {'GET /organizations/navigation':44} {navigation_cold:7.1f}ms {navigation_p50:7.1f}ms {navigation_p95:7.1f}ms"
+            f"\n  {'GET /organizations/{id}/home':44} {home_cold:7.1f}ms {home_p50:7.1f}ms {home_p95:7.1f}ms"
+            f"\n  {'was: /organizations + 5x /pods/organization':44} {'':9} {legacy_p50:7.1f}ms {legacy_p95:7.1f}ms"
+            f"\n  → the sidebar costs {legacy_p50 / navigation_p50:.1f}x less than the fan-out it replaces"
+            f"\n  → home's p50 is a cache hit; {home_cold:.1f}ms is what building it costs"
+        )
+
+    # An order of magnitude, not a stopwatch: one request cannot reasonably be
+    # slower than the six it replaced.
+    assert navigation_p50 < legacy_p50, (
+        f"navigation ({navigation_p50:.1f}ms) should beat the fan-out "
+        f"({legacy_p50:.1f}ms) it replaces"
+    )
+    assert navigation_p95 < 250, f"navigation p95 {navigation_p95:.1f}ms"
+    assert home_p95 < 250, f"home p95 {home_p95:.1f}ms"

--- a/lemma-backend/app/modules/pod/contracts/user_pods.py
+++ b/lemma-backend/app/modules/pod/contracts/user_pods.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass, field
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import select
@@ -32,9 +33,10 @@ class VisiblePod:
     name: str
     description: str | None
     icon_url: str | None
+    updated_at: datetime
     #: The caller's pod-member row, absent when they see the pod as org owner
     #: without having joined it. That distinction is why `roles` can be empty.
-    pod_member_id: UUID | None
+    pod_member_id: UUID | None = None
     roles: list[str] = field(default_factory=list)
 
 
@@ -76,6 +78,7 @@ async def list_visible_pods(
                 Pod.name,
                 Pod.description,
                 Pod.icon_url,
+                Pod.updated_at,
                 PodMember.id,
             )
             .select_from(Pod)
@@ -100,9 +103,18 @@ async def list_visible_pods(
             name=name,
             description=description,
             icon_url=icon_url,
+            updated_at=updated_at,
             pod_member_id=pod_member_id,
         )
-        for pod_id, organization_id, name, description, icon_url, pod_member_id in rows
+        for (
+            pod_id,
+            organization_id,
+            name,
+            description,
+            icon_url,
+            updated_at,
+            pod_member_id,
+        ) in rows
     ]
     await _attach_roles(session=session, pods=pods)
     return pods

--- a/lemma-frontend/components/onboarding/account-onboarding.tsx
+++ b/lemma-frontend/components/onboarding/account-onboarding.tsx
@@ -40,7 +40,7 @@ import {
   useOrganizationNameAvailability,
   useSuggestedOrganizations,
 } from "@/lib/hooks/use-organizations";
-import { useAccessiblePods } from "@/lib/hooks/use-pods";
+import { useAccessiblePods, type AccessiblePod } from "@/lib/hooks/use-pods";
 import { useProfile, useUpdateProfile } from "@/lib/hooks/use-user";
 import {
   useCreateAgentRuntime,
@@ -97,6 +97,9 @@ import {
 import { LocalIntelligenceStep, LocalSharingStep } from "./local-setup-steps";
 import { isLocalDeployment } from "@/lib/config";
 import { readLocalAiStatus } from "@/lib/desktop/local-capabilities";
+
+/** What onboarding needs of a pod, whether it created it or restored it. */
+type OnboardingBasePod = { id: string; name: string; organization_id: string };
 
 const AnomalousOrb = dynamic(
   () => import("@/components/ui/anomalous-orb").then((module) => module.AnomalousOrb),
@@ -253,7 +256,9 @@ function SetupAssistant({
     full_name?: string | null;
   } | null;
   organizations: Organization[];
-  accessiblePods: Pod[];
+  // The navigation listing, not a full pod record: this only ever reads `id`
+  // and `organization_id` to restore a draft's base pod.
+  accessiblePods: AccessiblePod[];
   initialDraft: OnboardingDraft | null;
   initialOrganization: Organization | null;
   initialAudience: Audience | null;
@@ -295,11 +300,14 @@ function SetupAssistant({
   const [step, setStep] = useState<SetupStep>(normalizedInitialStep);
   const [createdOrganization, setCreatedOrganization] =
     useState<Organization | null>(null);
-  const [basePod, setBasePod] = useState<Pod | null>(() =>
-    findDraftBasePod(null, accessiblePods, initialDraft),
+  // Either a pod just created here (a full record) or one restored from the
+  // navigation listing, and onboarding only ever reads its id and name — so the
+  // state says that rather than claiming a full pod it does not always hold.
+  const [basePod, setBasePod] = useState<OnboardingBasePod | null>(() =>
+    findDraftBasePod<OnboardingBasePod>(null, accessiblePods, initialDraft),
   );
   const identitySubmissionRef = useRef(false);
-  const createPodPromiseRef = useRef<Promise<Pod | null> | null>(null);
+  const createPodPromiseRef = useRef<Promise<OnboardingBasePod | null> | null>(null);
   const [isCreatingPod, setIsCreatingPod] = useState(false);
   const [isConnectingAi, setIsConnectingAi] = useState(false);
   const [connectedProfileId, setConnectedProfileId] = useState<string | null>(
@@ -578,7 +586,7 @@ function SetupAssistant({
     // agent" and landing in one called "Personal Pod" throws away the only
     // thing the user has said so far.
     nameOverride?: string,
-  ): Promise<Pod | null> => {
+  ): Promise<OnboardingBasePod | null> => {
     const restoredCandidate = findDraftBasePod(
       basePod,
       accessiblePods,

--- a/lemma-frontend/lib/hooks/pod-query-keys.test.ts
+++ b/lemma-frontend/lib/hooks/pod-query-keys.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The sidebar has to refresh when a pod changes.
+ *
+ * It reads `/organizations/navigation` now instead of a pod list per
+ * organization, and that read is only as fresh as the invalidations that reach
+ * it. Ten call sites across the app invalidate `['pods']` after creating,
+ * importing, renaming or deleting one, and none of them know this query exists
+ * — so the guarantee rests entirely on the key prefix, which is what these
+ * assert against React Query's real matcher rather than by inspection.
+ */
+
+import { QueryClient, hashKey } from '@tanstack/react-query';
+import { describe, expect, it } from 'vitest';
+
+import {
+    navigationQueryKey,
+    organizationHomeQueryKey,
+    podListQueryKey,
+} from './pod-query-keys';
+
+const ORG_ID = '019ff443-3c4a-7287-84a7-d5356cc4422d';
+const POD_ID = '019ff443-3d83-7492-aa84-3b2b1b0575f6';
+
+function clientWithSeededQueries() {
+    const client = new QueryClient();
+    for (const key of [
+        navigationQueryKey(),
+        organizationHomeQueryKey(ORG_ID),
+        podListQueryKey(ORG_ID),
+        ['pods', POD_ID],
+    ]) {
+        client.setQueryData([...key], { seeded: true });
+    }
+    return client;
+}
+
+/** Which seeded queries a `['pods']` invalidation would actually refetch. */
+function invalidatedKeys(client: QueryClient) {
+    return client
+        .getQueryCache()
+        .findAll({ queryKey: ['pods'] })
+        .map((query) => query.queryHash);
+}
+
+describe('pod query keys', () => {
+    it('puts the sidebar read where an existing pods invalidation finds it', () => {
+        const client = clientWithSeededQueries();
+
+        const matched = invalidatedKeys(client);
+
+        expect(matched).toContain(hashKey([...navigationQueryKey()]));
+    });
+
+    it('puts the organization home read there too', () => {
+        const client = clientWithSeededQueries();
+
+        expect(invalidatedKeys(client)).toContain(
+            hashKey([...organizationHomeQueryKey(ORG_ID)]),
+        );
+    });
+
+    it('reaches every pod read from one invalidation', () => {
+        const client = clientWithSeededQueries();
+
+        // Four seeded queries, all under the same prefix: the point of sharing
+        // it is that a caller invalidating `['pods']` needs to know about none
+        // of them individually.
+        expect(invalidatedKeys(client)).toHaveLength(4);
+    });
+
+    it('does not collide with a per-organization or per-pod key', () => {
+        // The object part is what keeps these apart; an id is always a string,
+        // so no organization or pod can ever be mistaken for a scoped read.
+        expect(navigationQueryKey()).not.toEqual(podListQueryKey(ORG_ID));
+        expect(organizationHomeQueryKey(ORG_ID)).not.toEqual(podListQueryKey(ORG_ID));
+        expect(organizationHomeQueryKey(ORG_ID)).not.toEqual(
+            organizationHomeQueryKey(POD_ID),
+        );
+    });
+
+    it('gives each organization its own home entry', () => {
+        const other = '019ffa02-42f6-735b-8bf6-8327c4866ab1';
+        expect(organizationHomeQueryKey(ORG_ID)).not.toEqual(
+            organizationHomeQueryKey(other),
+        );
+    });
+});

--- a/lemma-frontend/lib/hooks/pod-query-keys.ts
+++ b/lemma-frontend/lib/hooks/pod-query-keys.ts
@@ -1,0 +1,29 @@
+/**
+ * Query keys for everything that reads a list of pods.
+ *
+ * All of them sit under the `['pods']` prefix deliberately. Ten call sites
+ * across the app already invalidate `['pods']` after a pod is created,
+ * imported, renamed or deleted, and React Query matches by prefix — so sharing
+ * the prefix means every one of those refreshes the sidebar without being
+ * touched, and a future one cannot forget to.
+ *
+ * Kept in its own module, free of React and of the SDK client, so the keys can
+ * be asserted against React Query's own matcher without loading a client
+ * component.
+ */
+
+export const POD_QUERY_ROOT = 'pods' as const;
+
+/** Every organization with its pods — the sidebar's single read. */
+export const navigationQueryKey = () =>
+    [POD_QUERY_ROOT, { scope: 'navigation' }] as const;
+
+/** One organization's pods with their apps, agents and the caller's roles. */
+export const organizationHomeQueryKey = (orgId?: string) =>
+    [POD_QUERY_ROOT, { scope: 'home', orgId }] as const;
+
+/**
+ * The object part is what keeps these from colliding with `['pods', podId]` and
+ * `['pods', orgId]`, which are always uuid strings.
+ */
+export const podListQueryKey = (orgId?: string) => [POD_QUERY_ROOT, orgId] as const;

--- a/lemma-frontend/lib/hooks/use-pods.ts
+++ b/lemma-frontend/lib/hooks/use-pods.ts
@@ -2,10 +2,10 @@
 
 import { ApiError } from 'lemma-sdk';
 import { useMemo } from 'react';
-import { useQuery, useMutation, useQueryClient, useQueries } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getLemmaClient } from '../sdk/lemma-client';
-import { useOrganizations } from './use-organizations';
-import type { CreatePodData, UpdatePodData, Pod, PaginatedResponse, Organization } from '../types';
+import { navigationQueryKey, organizationHomeQueryKey } from './pod-query-keys';
+import type { CreatePodData, UpdatePodData, Pod, PaginatedResponse } from '../types';
 
 export const usePods = (orgId?: string, options?: { enabled?: boolean }) => {
     const enabled = options?.enabled ?? true;
@@ -18,45 +18,90 @@ export const usePods = (orgId?: string, options?: { enabled?: boolean }) => {
     });
 };
 
-export type AccessiblePod = Pod & {
-    organization?: Organization;
-    organization_name?: string;
+/**
+ * An organization as navigation knows it: enough to label and to link to.
+ *
+ * Narrower than the full organization record on purpose. `/organizations/navigation`
+ * answers for every organization at once, so it returns identity only — the
+ * fuller record is still one `organizations.get(id)` away for screens that
+ * need it.
+ */
+export type NavigationOrg = {
+    id: string;
+    name: string;
+    slug?: string | null;
+    role: string;
+};
+
+/** A pod as navigation knows it, plus which organization it came from. */
+export type AccessiblePod = {
+    id: string;
+    name: string;
+    description?: string | null;
+    icon_url?: string | null;
+    updated_at: string;
+    organization_id: string;
+    organization: NavigationOrg;
+    organization_name: string;
 };
 
 export type AccessiblePodGroup = {
-    organization: Organization;
+    organization: NavigationOrg;
     pods: AccessiblePod[];
 };
 
+/**
+ * Every pod the user can reach, across every organization, in one request.
+ *
+ * This used to fetch the organization list and then a pod list per
+ * organization, so a user in five organizations waited out six sequential
+ * round trips before the sidebar could draw. `/organizations/navigation`
+ * answers all of it at once and costs the backend two queries regardless of
+ * how many organizations there are.
+ *
+ * The payload is deliberately shallow — ids, names, icons. Anything richer
+ * (apps, agents, per-pod roles) belongs to `/organizations/{id}/home`, which
+ * `useOrganizationHome` fetches for the one organization actually on screen.
+ */
 export const useAccessiblePods = (options?: { enabled?: boolean }) => {
     const enabled = options?.enabled ?? true;
-    const organizationsQuery = useOrganizations({ enabled });
-    const organizations = useMemo(() => organizationsQuery.data?.items || [], [organizationsQuery.data?.items]);
 
-    const podQueries = useQueries({
-        queries: organizations.map((organization) => ({
-            queryKey: ['pods', organization.id],
-            queryFn: () =>
-                getLemmaClient().pods.listByOrganization(organization.id) as Promise<PaginatedResponse<Pod>>,
-            enabled: enabled && !!organization.id,
-        })),
+    const navigationQuery = useQuery({
+        queryKey: navigationQueryKey(),
+        queryFn: () => getLemmaClient().organizations.navigation(),
+        enabled,
     });
 
     const groups = useMemo<AccessiblePodGroup[]>(() => {
-        return organizations.map((organization, index) => {
-            const pods = (podQueries[index]?.data?.items || []).map((pod) => ({
-                ...pod,
+        return (navigationQuery.data?.items || []).map((entry) => {
+            const organization: NavigationOrg = {
+                id: entry.id,
+                name: entry.name,
+                slug: entry.slug,
+                role: entry.role,
+            };
+            return {
                 organization,
-                organization_name: organization.name,
-            }));
-
-            return { organization, pods };
+                pods: (entry.pods || []).map((pod) => ({
+                    id: pod.id,
+                    name: pod.name,
+                    description: pod.description,
+                    icon_url: pod.icon_url,
+                    updated_at: pod.updated_at,
+                    // Carried down from the grouping rather than returned per
+                    // pod: the endpoint already nests pods under their
+                    // organization, so repeating it on every pod would be
+                    // payload for nothing.
+                    organization_id: entry.id,
+                    organization,
+                    organization_name: entry.name,
+                })),
+            };
         });
-    }, [organizations, podQueries]);
+    }, [navigationQuery.data?.items]);
 
+    const organizations = useMemo(() => groups.map((group) => group.organization), [groups]);
     const pods = useMemo(() => groups.flatMap((group) => group.pods), [groups]);
-    const isLoadingPods = organizations.length > 0 && podQueries.some((query) => query.isLoading);
-    const podError = podQueries.find((query) => query.isError)?.error;
 
     return {
         data: {
@@ -65,10 +110,28 @@ export const useAccessiblePods = (options?: { enabled?: boolean }) => {
             organizations,
             hasMultipleOrganizations: organizations.length > 1,
         },
-        isLoading: organizationsQuery.isLoading || isLoadingPods,
-        isError: organizationsQuery.isError || podQueries.some((query) => query.isError),
-        error: organizationsQuery.error || podError,
+        isLoading: navigationQuery.isLoading,
+        isError: navigationQuery.isError,
+        error: navigationQuery.error,
     };
+};
+
+/**
+ * One organization's pods with their apps, agents and the caller's roles.
+ *
+ * The detail half of the split: fetched for the organization on screen rather
+ * than for every organization a person belongs to, because that payload grows
+ * with content and most of it would never be looked at. Cached server-side for
+ * thirty seconds, so revisiting a landing page is a cache read.
+ */
+export const useOrganizationHome = (orgId?: string, options?: { enabled?: boolean }) => {
+    const enabled = options?.enabled ?? true;
+
+    return useQuery({
+        queryKey: organizationHomeQueryKey(orgId),
+        queryFn: () => getLemmaClient().organizations.home(orgId!),
+        enabled: enabled && !!orgId,
+    });
 };
 
 export const usePod = (id: string | undefined) => {

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -13,4 +13,4 @@ SDK and the server it is talking to.
 from __future__ import annotations
 
 API_VERSION = "0.7.0"
-SPEC_SHA256 = "168097a8d33c7cdbe5cf408e9f70b0d080aefd70816d769d24a70c9f5998c5aa"
+SPEC_SHA256 = "716882993d31057354654aebdfb38aaabe1d7d7ceb5b8cf303f083a7efa88e91"

--- a/lemma-python/lemma_sdk/openapi_client/models/navigation_pod_response.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/navigation_pod_response.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import datetime
 from collections.abc import Mapping
 from typing import Any, TypeVar, cast
 from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
+from dateutil.parser import isoparse
 
 from ..types import UNSET, Unset
 
@@ -14,16 +16,26 @@ T = TypeVar("T", bound="NavigationPodResponse")
 
 @_attrs_define
 class NavigationPodResponse:
-    """A pod as a navigation entry — enough to draw and to link to.
+    """A pod as a listing entry — enough to draw it, label it, and link to it.
 
-    Attributes:
-        id (UUID):
-        name (str):
-        icon_url (None | str | Unset):
+    The line this payload holds is scalars yes, collections no. A pod's own
+    columns cost nothing to return: they ride along in the query that found the
+    pod, so the response grows with the number of pods and not with what is
+    inside them. Apps, agents and roles are the other side of that line, and
+    live on ``/organizations/{org_id}/home``.
+
+        Attributes:
+            id (UUID):
+            name (str):
+            updated_at (datetime.datetime):
+            description (None | str | Unset):
+            icon_url (None | str | Unset):
     """
 
     id: UUID
     name: str
+    updated_at: datetime.datetime
+    description: None | str | Unset = UNSET
     icon_url: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -31,6 +43,14 @@ class NavigationPodResponse:
         id = str(self.id)
 
         name = self.name
+
+        updated_at = self.updated_at.isoformat()
+
+        description: None | str | Unset
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
 
         icon_url: None | str | Unset
         if isinstance(self.icon_url, Unset):
@@ -44,8 +64,11 @@ class NavigationPodResponse:
             {
                 "id": id,
                 "name": name,
+                "updated_at": updated_at,
             }
         )
+        if description is not UNSET:
+            field_dict["description"] = description
         if icon_url is not UNSET:
             field_dict["icon_url"] = icon_url
 
@@ -57,6 +80,17 @@ class NavigationPodResponse:
         id = UUID(d.pop("id"))
 
         name = d.pop("name")
+
+        updated_at = isoparse(d.pop("updated_at"))
+
+        def _parse_description(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        description = _parse_description(d.pop("description", UNSET))
 
         def _parse_icon_url(data: object) -> None | str | Unset:
             if data is None:
@@ -70,6 +104,8 @@ class NavigationPodResponse:
         navigation_pod_response = cls(
             id=id,
             name=name,
+            updated_at=updated_at,
+            description=description,
             icon_url=icon_url,
         )
 

--- a/lemma-python/lemma_sdk/openapi_client/models/navigation_response.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/navigation_response.py
@@ -15,11 +15,13 @@ T = TypeVar("T", bound="NavigationResponse")
 
 @_attrs_define
 class NavigationResponse:
-    """Everything a sidebar needs, for every organization, in one response.
+    """Everything a sidebar and a pod list need, for every organization, at once.
 
-    Deliberately shallow: apps, agents and roles per pod are the detail endpoint's
-    job, because carrying them here would make the payload grow with the content
-    of every organization a person happens to belong to.
+    Shallow in the sense that matters: it carries each pod's own columns, and
+    nothing that would require looking inside a pod. Apps, agents and roles are
+    the detail endpoint's job, because carrying them here would make the payload
+    grow with the content of every organization a person happens to belong to,
+    which is precisely the cost this endpoint exists to remove.
 
         Attributes:
             items (list[NavigationOrganizationResponse]):

--- a/lemma-python/lemma_sdk/openapi_spec.json
+++ b/lemma-python/lemma_sdk/openapi_spec.json
@@ -8735,8 +8735,19 @@
         "type": "object"
       },
       "NavigationPodResponse": {
-        "description": "A pod as a navigation entry \u2014 enough to draw and to link to.",
+        "description": "A pod as a listing entry \u2014 enough to draw it, label it, and link to it.\n\nThe line this payload holds is scalars yes, collections no. A pod's own\ncolumns cost nothing to return: they ride along in the query that found the\npod, so the response grows with the number of pods and not with what is\ninside them. Apps, agents and roles are the other side of that line, and\nlive on ``/organizations/{org_id}/home``.",
         "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
           "icon_url": {
             "anyOf": [
               {
@@ -8756,17 +8767,23 @@
           "name": {
             "title": "Name",
             "type": "string"
+          },
+          "updated_at": {
+            "format": "date-time",
+            "title": "Updated At",
+            "type": "string"
           }
         },
         "required": [
           "id",
-          "name"
+          "name",
+          "updated_at"
         ],
         "title": "NavigationPodResponse",
         "type": "object"
       },
       "NavigationResponse": {
-        "description": "Everything a sidebar needs, for every organization, in one response.\n\nDeliberately shallow: apps, agents and roles per pod are the detail endpoint's\njob, because carrying them here would make the payload grow with the content\nof every organization a person happens to belong to.",
+        "description": "Everything a sidebar and a pod list need, for every organization, at once.\n\nShallow in the sense that matters: it carries each pod's own columns, and\nnothing that would require looking inside a pod. Apps, agents and roles are\nthe detail endpoint's job, because carrying them here would make the payload\ngrow with the content of every organization a person happens to belong to,\nwhich is precisely the cost this endpoint exists to remove.",
         "properties": {
           "items": {
             "items": {

--- a/lemma-typescript/public/lemma-client.js
+++ b/lemma-typescript/public/lemma-client.js
@@ -13848,6 +13848,20 @@ var LemmaClient = (() => {
     get(orgId) {
       return this.client.request(() => OrganizationsService.orgGet(orgId));
     }
+    /**
+     * Every organization you belong to, each with the pods you can see in it.
+     *
+     * One request instead of listing organizations and then a pod list per
+     * organization. Names and ids only — use {@link home} for one organization's
+     * apps, agents and roles.
+     */
+    navigation() {
+      return this.client.request(() => OrganizationsService.orgNavigation());
+    }
+    /** One organization's pods, with their apps, agents and your roles. */
+    home(orgId) {
+      return this.client.request(() => OrganizationsService.orgHome(orgId));
+    }
     create(payload) {
       return this.client.request(() => OrganizationsService.orgCreate(payload));
     }

--- a/lemma-typescript/src/namespaces/organizations.ts
+++ b/lemma-typescript/src/namespaces/organizations.ts
@@ -23,6 +23,22 @@ export class OrganizationsNamespace {
     return this.client.request(() => OrganizationsService.orgGet(orgId));
   }
 
+  /**
+   * Every organization you belong to, each with the pods you can see in it.
+   *
+   * One request instead of listing organizations and then a pod list per
+   * organization. Names and ids only — use {@link home} for one organization's
+   * apps, agents and roles.
+   */
+  navigation() {
+    return this.client.request(() => OrganizationsService.orgNavigation());
+  }
+
+  /** One organization's pods, with their apps, agents and your roles. */
+  home(orgId: string) {
+    return this.client.request(() => OrganizationsService.orgHome(orgId));
+  }
+
   create(payload: OrganizationCreateRequest) {
     return this.client.request(() => OrganizationsService.orgCreate(payload));
   }

--- a/lemma-typescript/src/openapi_client/models/NavigationPodResponse.ts
+++ b/lemma-typescript/src/openapi_client/models/NavigationPodResponse.ts
@@ -3,10 +3,18 @@
 /* tslint:disable */
 /* eslint-disable */
 /**
- * A pod as a navigation entry — enough to draw and to link to.
+ * A pod as a listing entry — enough to draw it, label it, and link to it.
+ *
+ * The line this payload holds is scalars yes, collections no. A pod's own
+ * columns cost nothing to return: they ride along in the query that found the
+ * pod, so the response grows with the number of pods and not with what is
+ * inside them. Apps, agents and roles are the other side of that line, and
+ * live on ``/organizations/{org_id}/home``.
  */
 export type NavigationPodResponse = {
+    description?: (string | null);
     icon_url?: (string | null);
     id: string;
     name: string;
+    updated_at: string;
 };

--- a/lemma-typescript/src/openapi_client/models/NavigationResponse.ts
+++ b/lemma-typescript/src/openapi_client/models/NavigationResponse.ts
@@ -4,11 +4,13 @@
 /* eslint-disable */
 import type { NavigationOrganizationResponse } from './NavigationOrganizationResponse.js';
 /**
- * Everything a sidebar needs, for every organization, in one response.
+ * Everything a sidebar and a pod list need, for every organization, at once.
  *
- * Deliberately shallow: apps, agents and roles per pod are the detail endpoint's
- * job, because carrying them here would make the payload grow with the content
- * of every organization a person happens to belong to.
+ * Shallow in the sense that matters: it carries each pod's own columns, and
+ * nothing that would require looking inside a pod. Apps, agents and roles are
+ * the detail endpoint's job, because carrying them here would make the payload
+ * grow with the content of every organization a person happens to belong to,
+ * which is precisely the cost this endpoint exists to remove.
  */
 export type NavigationResponse = {
     items: Array<NavigationOrganizationResponse>;


### PR DESCRIPTION
You were right, and the evidence was unambiguous: #347 added the routes and regenerated the typed client but touched **zero files** under `lemma-frontend/`. `useAccessiblePods` kept waiting on `/organizations` and then firing one `/pods/organization/{id}` per organization — 46 / 35 / **0** in your dev metrics.

`useAccessiblePods` now makes **one request**.

## Measured, at the size that actually hurt

Five organizations, twenty pods, apps and agents on the one whose landing page is fetched:

| route | cold | p50 | p95 |
|---|---|---|---|
| `GET /organizations/navigation` | 22.4ms | **11.7ms** | 17.1ms |
| `GET /organizations/{id}/home` | 18.6ms | **2.4ms** | 3.6ms |
| was: `/organizations` + 5× `/pods/organization` | — | 77.3ms | 84.9ms |

**6.6× on the server**, and that understates it: the six requests it replaced were *sequential*, each paying its own network round trip from a browser, and the pod lists couldn't start until the organization list came back. The sidebar's critical path is now one request that begins immediately.

`home`'s p50 is a cache hit; 18.6ms is what building it costs. Both numbers are reported so neither is quoted as the other.

## Navigation carries `description` and `updated_at` now

The home screen labels and sorts on them. They're the pod's own columns, so they ride along in the query that already found the pod — the response still grows with the *number* of pods, not with what's inside them, which is the line this endpoint holds. Apps, agents and roles stay on the detail endpoint. I corrected my own docstrings from #347, which said "names and ids and nothing else".

## The keys are what keep it fresh

**Near-miss worth calling out.** My first version keyed navigation as `['organization-navigation']`. Ten call sites across the app invalidate `['pods']` after a pod is created, imported, renamed or deleted — none of them know this query exists — so creating a pod would have left the sidebar stale.

Both reads now live under the `['pods']` prefix, which React Query matches by, so all ten already reach them and an eleventh can't forget. `pod-query-keys.ts` holds them, free of React and the SDK client, so the guarantee is asserted against React Query's own matcher rather than by reading the code.

## Types narrowed rather than widened

`AccessiblePod` now describes what navigation actually returns instead of claiming to be a full `Pod`. That's what proved the payload sufficient — the typechecker found the two places reading further (the home overview wanting `description`/`updated_at`, and onboarding holding a pod in state) instead of letting them surface as `undefined` at runtime. Onboarding now says it needs an id, a name and an organization, because that's all it ever reads.

## Backend e2e

Added the multi-organization scenario the endpoints didn't have: five organizations, twenty pods, apps and agents — asserting the payload, the flat query count, and that navigation beats the fan-out it replaces. Timing ceilings are deliberately loose (wall clock on a laptop isn't a contract; the query-count tests are) but an order-of-magnitude regression fails.

## Verification

4343 backend unit · 9 navigation e2e · 43 identity e2e · 662 frontend · 193 TypeScript SDK · frontend typecheck · eslint · `next build` · ruff · lint-async · architecture ratchet · route inventory · version consistency.

## One thing left

`org-context` still calls `GET /organizations` for `currentOrg`, which needs the fuller organization record. So the sidebar path is **2 flat, parallel requests** rather than 1 — down from 1+N sequential. Collapsing that last one means changing what `currentOrg` is, which is a wider change than this PR should carry.

After this merges you should see `organizations/navigation` climb and `pods/organization` drop toward zero on the dev dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
