### PR TITLE
Stop the transcript losing the bottom, and give a reader's place a row to hold

### DIFF
--- a/lemma-frontend/components/lemma/assistant/assistant-experience-conversation.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-experience-conversation.tsx
@@ -22,6 +22,7 @@ import {
   collectDisplayResourceCardsByRow,
 } from "./assistant-message-group";
 import { ThinkingIndicator } from "./assistant-parts";
+import { TRANSCRIPT_ROW_ATTRIBUTE } from "./use-transcript-scroll";
 
 type CompletedRunTraceGroups = ReturnType<typeof collectCompletedRunTraceGroups>;
 type InlineStatus = { label?: string; shimmer?: boolean } | null | undefined;
@@ -102,7 +103,11 @@ export function AssistantDisplayRow({
   const isInsideRollup = completedRunTraceGroups.groupedIndexes.has(index);
 
   return (
-    <div key={row.id || index} className={cn((compactAfterAssistant || compactActiveRunTrace) && !isInsideRollup && "-mt-3")}>
+    <div
+      key={row.id || index}
+      {...{ [TRANSCRIPT_ROW_ATTRIBUTE]: "" }}
+      className={cn((compactAfterAssistant || compactActiveRunTrace) && !isInsideRollup && "-mt-3")}
+    >
       {index === inlineRunStatusRowIndex ? (
         <div className="mb-3">
           <RunTraceHeader

--- a/lemma-frontend/components/lemma/assistant/use-transcript-scroll.ts
+++ b/lemma-frontend/components/lemma/assistant/use-transcript-scroll.ts
@@ -25,6 +25,18 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
+/**
+ * Marks one message row. The reader's place is kept by remembering the row
+ * under their eyes, so this has to sit on the rows themselves: anchoring
+ * anything that wraps *all* of them cannot work, because a wrapper's top edge
+ * does not move when content inside it changes height, and the shift the
+ * restore is looking for is always zero.
+ *
+ * One row per mark, and never a mark inside a mark: the search below relies on
+ * these being a flat sequence in document order.
+ */
+export const TRANSCRIPT_ROW_ATTRIBUTE = "data-transcript-row";
+
 /** How close to the bottom still counts as the bottom. */
 const AT_BOTTOM_EPSILON = 40;
 /** Scroll offset under which the transcript asks for older messages. */
@@ -111,16 +123,29 @@ export function useTranscriptScroll({
   /** The topmost row still on screen — what the reader is looking at. */
   const captureAnchor = useCallback(() => {
     const el = containerRef.current;
-    const content = el?.firstElementChild;
-    if (!el || !content) return;
-    for (const row of Array.from(content.children)) {
-      const offset = offsetOf(el, row);
-      if (offset + row.getBoundingClientRect().height > 0) {
-        anchorRef.current = { node: row, offset };
-        return;
+    if (!el) return;
+    const rows = el.querySelectorAll(`[${TRANSCRIPT_ROW_ATTRIBUTE}]`);
+    const top = el.getBoundingClientRect().top;
+
+    // The rows are one column in document order, so "already scrolled past"
+    // only flips once on the way down: the topmost row still on screen is a
+    // dozen measurements away rather than one per row. Worth the search — this
+    // runs on every scroll event a reader generates, over a transcript that can
+    // be hundreds of rows long, and each measurement is a layout read.
+    let low = 0;
+    let high = rows.length - 1;
+    let anchor: { node: Element; offset: number } | null = null;
+    while (low <= high) {
+      const mid = (low + high) >> 1;
+      const box = rows[mid].getBoundingClientRect();
+      if (box.bottom > top) {
+        anchor = { node: rows[mid], offset: box.top - top };
+        high = mid - 1;
+      } else {
+        low = mid + 1;
       }
     }
-    anchorRef.current = null;
+    anchorRef.current = anchor;
   }, []);
 
   const onScroll = useCallback(() => {
@@ -174,6 +199,15 @@ export function useTranscriptScroll({
   // means the page moved under them, and their line is put back where it was —
   // Safari has no scroll anchoring, and this container turns Chrome's off with
   // `overflow-anchor: none`.
+  //
+  // The scroller itself is watched alongside its content, because the bottom
+  // also moves when the *window* changes height. The composer below this
+  // transcript grows and shrinks constantly — a second typed line, a plan
+  // summary, an approval card — and every pixel it takes comes out of this
+  // viewport. That shortens the distance to the bottom without changing the
+  // content or moving scrollTop, so neither a resize of the content nor a
+  // scroll event is emitted: following would silently stop at the bottom and
+  // leave the newest messages under the fold.
   useEffect(() => {
     const el = containerRef.current;
     const content = el?.firstElementChild;
@@ -185,14 +219,23 @@ export function useTranscriptScroll({
         return;
       }
       const anchor = anchorRef.current;
-      if (!anchor?.node.isConnected) return;
+      if (!anchor) return;
+      // The row they were on can be unmounted out from under them — a run
+      // folding its trace away takes its rows with it. Nothing can be restored
+      // to a row that no longer exists, so take a fresh one rather than leaving
+      // a dead anchor to fail every reflow from here on.
+      if (!anchor.node.isConnected) {
+        captureAnchor();
+        return;
+      }
       const shift = offsetOf(el, anchor.node) - anchor.offset;
       if (Math.abs(shift) < 1) return;
       write(el.scrollTop + shift);
     });
     observer.observe(content);
+    observer.observe(el);
     return () => observer.disconnect();
-  }, [write]);
+  }, [captureAnchor, write]);
 
   // A different conversation starts at its newest message.
   useEffect(() => {
@@ -206,21 +249,32 @@ export function useTranscriptScroll({
     return () => cancelAnimationFrame(frame);
   }, [activeConversationId, setFollowing, write]);
 
-  // Prepending older messages must not move the viewport. The height delta is
-  // added back so the row the reader was on stays under their eyes.
+  // Prepending older messages must not move the viewport. The row the reader
+  // was on is put back where it was, rather than adding back the height the
+  // load happened to bring: a run in flight adds its own height while the fetch
+  // is in the air, so the delta between "before" and "after" is not the older
+  // messages alone. Anchoring also keeps working when the prepended block
+  // settles late — an image or a widget that reports its size a few frames
+  // afterwards moves the same row again, and the resize observer above corrects
+  // it against this same anchor.
   const preserveAcross = useCallback(async (load: () => Promise<boolean>) => {
-    const el = containerRef.current;
-    const beforeTop = el?.scrollTop ?? 0;
-    const beforeHeight = el?.scrollHeight ?? 0;
-
+    captureAnchor();
     const didLoad = await load();
-    if (!didLoad || !el) return didLoad;
+    if (!didLoad) return didLoad;
 
     await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-    const next = containerRef.current;
-    if (next) write(beforeTop + (next.scrollHeight - beforeHeight));
+    const el = containerRef.current;
+    if (!el) return didLoad;
+    if (followRef.current) {
+      write(el.scrollHeight);
+      return didLoad;
+    }
+    const anchor = anchorRef.current;
+    if (!anchor?.node.isConnected) return didLoad;
+    const shift = offsetOf(el, anchor.node) - anchor.offset;
+    if (Math.abs(shift) >= 1) write(el.scrollTop + shift);
     return didLoad;
-  }, [write]);
+  }, [captureAnchor, write]);
 
   return { containerRef, onScroll, isFollowing, scrollToBottom, preserveAcross };
 }


### PR DESCRIPTION
## What changes

Following the bottom of a conversation holds through a whole run, and a reader
who has scrolled up keeps the row under their eyes when the page reflows above
them.

Three things were broken, and #352 fixed none of them because it fixed the
question above these:

- **The anchor was never a row.** `captureAnchor` walked the children of the
  scroller's first element child — which is the width wrapper, one div holding
  the entire transcript. A wrapper's top edge does not move when content inside
  it changes height, so the shift the restore looks for came out as zero on
  every reflow and the restore never fired once. Rows now carry
  `data-transcript-row` and the topmost one on screen is found by binary search
  over them (this runs on every reader scroll, and a rect per row is a layout
  read per row).
- **The viewport was never watched.** The composer sits below the transcript
  and takes height out of it — a second typed line, a plan summary, an approval
  card opening. Content does not change and `scrollTop` does not change, so
  there is no content resize and no scroll event, and nothing tells the hook the
  bottom just moved 204px away. The scroller is now observed alongside its
  content.
- **Prepending older messages measured a height delta one frame after the
  fetch.** Anything settling later — an image, a widget reporting its iframe
  height — moved the same rows again with nothing left to correct it, and a run
  in flight added its own height into the same subtraction. It restores by
  anchor now.

## Why

The transcript still threw readers to an earlier message mid-run. #352 replaced
distance-from-bottom with tracked intent, which was the right change and is
still standing — but every part of that hook that depends on knowing *where*
the reader is was measuring a wrapper, and every part that depends on noticing
the bottom moved was only listening to content.

None of this is Safari-only in mechanism. The container sets
`overflow-anchor: none`, which puts Chrome in the same no-scroll-anchoring
regime — which is why all of it reproduces in headless Chrome.

## How to verify

Driven against the real hook in a synthetic transcript in headless Chrome —
17 scenarios, each asking one question: did the page move under a reader who
had not touched it?

| | before | after |
|---|---|---|
| scenarios that moved the page under the reader | 9 / 17 | 2 / 17 |
| worst drift behind the bottom during a full run | 176px | 0px |
| approval card opens in the composer | 204px behind the bottom | holds |
| one typed line in the composer | 24px behind | holds |
| widget above the reader reports its height | thrown `hist-19` → `hist-16` | holds, 0px |
| a run above the reader folds its trace | thrown `hist-19` → `hist-31` | holds, 0px |
| older messages prepend, then lay out late | thrown to `older-*` | holds, 0px |

The 2 remaining are the same case: content *below* the reader collapses until
the transcript is shorter than their scroll offset. There is no offset left to
restore — confirmed numerically that they land at `scrollHeight - clientHeight`,
the furthest point that still exists.

```bash
cd lemma-frontend && npx tsc --noEmit --pretty false --skipLibCheck
cd lemma-frontend && npx eslint components/lemma/assistant/use-transcript-scroll.ts components/lemma/assistant/assistant-experience-conversation.tsx
cd lemma-frontend && npx vitest run          # 75 files, 711 tests passed
cd lemma-frontend && npm run design:audit:ci # productStrict=0 protectedAssistant=1
```

## Checklist

- [ ] Tests cover the behavioral change — **not in this PR, see below**
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

Frontend only, no API or schema surface. Revertable on its own.

One thing a reviewer should weigh: **this class of bug has now regressed
twice and nothing in the repo guards it.** The harness that produced the table
above drives the real hook in headless Chrome and catches all seven fixed
cases; it is deliberately not in this PR, because `vitest.config.ts` says in as
many words "pure-logic unit tests only (no component/DOM stack)", and adding a
browser-test stack is a decision that belongs to a reviewer rather than to this
fix. Happy to land it as a follow-up if that reads as the right call.
