### PR TITLE
Ask before creating the query role, so the repair path can run without CREATEROLE

### DIFF
--- a/lemma-backend/app/modules/datastore/infrastructure/query_role.py
+++ b/lemma-backend/app/modules/datastore/infrastructure/query_role.py
@@ -33,23 +33,46 @@ class QueryRoleGrants:
         return sanitize_identifier(datastore_settings.datastore_query_role)
 
     async def ensure_role(self) -> None:
-        """Idempotently create the read-only, RLS-subject query role.
+        """Idempotently establish the read-only, RLS-subject query role.
 
         The role is ``NOLOGIN`` (entered only via ``SET ROLE``) and granted to
         the connecting role so a non-superuser app role can switch into it.
+
+        Both statements are *probed before they are issued*, because PostgreSQL
+        checks the ``CREATEROLE`` privilege before it checks for a duplicate:
+        ``CREATE ROLE`` on an existing role raises ``insufficient_privilege``,
+        not ``duplicate_object``, so the exception guard below cannot catch it.
+        An app role that is merely a member of an already-provisioned query
+        role — the least privilege this mechanism can run on — would otherwise
+        fail here on every call, taking ``try_grant`` and the ``backfill_grants``
+        repair path down with it. Asking first costs two catalog lookups and
+        makes the no-op case a genuine no-op.
         """
         if self._role_ready:
             return
         role = self._role()
         async with self._engine.begin() as conn:
-            await conn.execute(
-                text(
-                    f'DO $$ BEGIN CREATE ROLE "{role}" '
-                    "NOLOGIN NOSUPERUSER NOBYPASSRLS; "
-                    "EXCEPTION WHEN duplicate_object THEN NULL; END $$"
-                )
+            exists = await conn.execute(
+                text("SELECT 1 FROM pg_roles WHERE rolname = :role"),
+                {"role": role},
             )
-            await conn.execute(text(f'GRANT "{role}" TO CURRENT_USER'))
+            if exists.scalar() is None:
+                # Still guarded: two API processes can reach this together.
+                await conn.execute(
+                    text(
+                        f'DO $$ BEGIN CREATE ROLE "{role}" '
+                        "NOLOGIN NOSUPERUSER NOBYPASSRLS; "
+                        "EXCEPTION WHEN duplicate_object THEN NULL; END $$"
+                    )
+                )
+            # 'MEMBER', not 'USAGE': ad-hoc queries reach the role through
+            # SET LOCAL ROLE, which inherited privileges alone do not permit.
+            member = await conn.execute(
+                text("SELECT pg_has_role(CURRENT_USER, :role, 'MEMBER')"),
+                {"role": role},
+            )
+            if not member.scalar():
+                await conn.execute(text(f'GRANT "{role}" TO CURRENT_USER'))
         self._role_ready = True
 
     async def try_grant(self, schema_name: str, table_name: str | None = None) -> None:
@@ -78,7 +101,7 @@ class QueryRoleGrants:
                     )
         except Exception:  # noqa: BLE001
             logger.warning(
-                'datastore.query_role.grant.degraded',
+                "datastore.query_role.grant.degraded",
                 schema_name=schema_name,
                 table_name=table_name,
                 exc_info=True,

--- a/lemma-backend/app/modules/datastore/tests/unit/test_ddl_safety.py
+++ b/lemma-backend/app/modules/datastore/tests/unit/test_ddl_safety.py
@@ -30,6 +30,19 @@ from app.modules.datastore.infrastructure.sql_identifiers import (
 KNOWN = {"price", "qty", "name", "discount"}
 
 
+class _CatalogResult:
+    """Answers the query role's catalog probes as a provisioned deployment.
+
+    ``ensure_role`` asks whether the role exists and whether the connecting
+    role is a member before it issues DDL. A bare ``AsyncMock`` answers with a
+    truthy coroutine, which happens to take the same branch but leaves the
+    fake unable to describe any other deployment.
+    """
+
+    def scalar(self) -> bool:
+        return True
+
+
 @pytest.mark.parametrize(
     "expr",
     [
@@ -143,7 +156,7 @@ def test_enum_check_clause_quotes_options_safely() -> None:
 
 @pytest.mark.asyncio
 async def test_schema_provisioning_takes_shared_bootstrap_lock_before_create() -> None:
-    connection = SimpleNamespace(execute=AsyncMock())
+    connection = SimpleNamespace(execute=AsyncMock(return_value=_CatalogResult()))
 
     @asynccontextmanager
     async def begin():
@@ -171,7 +184,7 @@ async def test_schema_provisioning_grants_usage_to_the_query_role() -> None:
     table, so a pod provisioned after the last API start answered every ad-hoc
     query with "permission denied for schema".
     """
-    connection = SimpleNamespace(execute=AsyncMock())
+    connection = SimpleNamespace(execute=AsyncMock(return_value=_CatalogResult()))
 
     @asynccontextmanager
     async def begin():
@@ -204,10 +217,17 @@ async def test_schema_provisioning_survives_a_failed_grant() -> None:
     """
     calls: list[str] = []
 
+    class _Missing:
+        def scalar(self) -> None:
+            return None
+
     async def execute(statement, *args):
         calls.append(str(statement))
         if "GRANT" in str(statement) or "CREATE ROLE" in str(statement):
             raise PermissionError("insufficient privilege")
+        # Neither the role nor the membership exists, and neither can be
+        # established: the deployment this test is named for.
+        return _Missing()
 
     connection = SimpleNamespace(execute=execute)
 

--- a/lemma-backend/app/modules/datastore/tests/unit/test_query_role.py
+++ b/lemma-backend/app/modules/datastore/tests/unit/test_query_role.py
@@ -1,0 +1,167 @@
+"""The query role must be establishable without the power to create roles.
+
+An app role that is only a *member* of an already-provisioned query role is the
+least privilege this mechanism can run on, and it is what a managed Postgres
+deployment tends to hand out. These tests pin that case: every privileged
+statement is probed before it is issued, so the common no-op costs two catalog
+lookups instead of an ``insufficient_privilege`` error.
+"""
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import pytest
+
+from app.modules.datastore.config import datastore_settings
+from app.modules.datastore.infrastructure.query_role import QueryRoleGrants
+
+ROLE = datastore_settings.datastore_query_role
+
+
+class _Result:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar(self):
+        return self._value
+
+
+class _Connection:
+    """Records SQL, answers the two catalog probes, and can refuse DDL.
+
+    ``forbid`` models a role without ``CREATEROLE``: PostgreSQL rejects the
+    statement outright rather than reporting the object as a duplicate.
+    """
+
+    def __init__(self, *, role_exists: bool, is_member: bool, forbid: tuple = ()):
+        self.role_exists = role_exists
+        self.is_member = is_member
+        self.forbid = forbid
+        self.statements: list[str] = []
+
+    async def execute(self, statement, params=None):
+        sql = str(statement)
+        self.statements.append(sql)
+        for fragment in self.forbid:
+            if fragment in sql:
+                raise PermissionError(
+                    "permission denied to create role\n"
+                    "DETAIL: Only roles with the CREATEROLE attribute may "
+                    "create roles."
+                )
+        if "pg_roles" in sql:
+            return _Result(1 if self.role_exists else None)
+        if "pg_has_role" in sql:
+            return _Result(self.is_member)
+        return _Result(None)
+
+
+def _grants(connection: _Connection) -> QueryRoleGrants:
+    @asynccontextmanager
+    async def begin():
+        yield connection
+
+    return QueryRoleGrants(SimpleNamespace(begin=begin))
+
+
+def _issued(connection: _Connection, fragment: str) -> bool:
+    return any(fragment in statement for statement in connection.statements)
+
+
+@pytest.mark.asyncio
+async def test_existing_role_and_membership_issue_no_privileged_statement() -> None:
+    """The regression: a provisioned role must not be re-created.
+
+    ``CREATE ROLE`` on an existing role raises ``insufficient_privilege``
+    before it can raise ``duplicate_object``, so the exception guard never
+    fires and every caller inherits the failure.
+    """
+    connection = _Connection(
+        role_exists=True,
+        is_member=True,
+        forbid=("CREATE ROLE", "TO CURRENT_USER"),
+    )
+
+    await _grants(connection).ensure_role()
+
+    assert not _issued(connection, "CREATE ROLE")
+    assert not _issued(connection, "TO CURRENT_USER")
+
+
+@pytest.mark.asyncio
+async def test_a_missing_role_is_created_and_granted() -> None:
+    connection = _Connection(role_exists=False, is_member=False)
+
+    await _grants(connection).ensure_role()
+
+    assert _issued(connection, f'CREATE ROLE "{ROLE}"')
+    assert _issued(connection, "duplicate_object")
+    assert _issued(connection, f'GRANT "{ROLE}" TO CURRENT_USER')
+
+
+@pytest.mark.asyncio
+async def test_membership_is_granted_when_the_role_already_exists() -> None:
+    """Provisioned by an operator, not yet reachable by the app role."""
+    connection = _Connection(role_exists=True, is_member=False)
+
+    await _grants(connection).ensure_role()
+
+    assert not _issued(connection, "CREATE ROLE")
+    assert _issued(connection, f'GRANT "{ROLE}" TO CURRENT_USER')
+
+
+@pytest.mark.asyncio
+async def test_membership_is_probed_for_set_role_not_inherited_privileges() -> None:
+    """Ad-hoc queries enter the role via ``SET LOCAL ROLE``, which needs
+    MEMBER; USAGE would report success on a role that cannot be entered."""
+    connection = _Connection(role_exists=True, is_member=True)
+
+    await _grants(connection).ensure_role()
+
+    assert _issued(connection, "'MEMBER'")
+
+
+@pytest.mark.asyncio
+async def test_backfill_repairs_without_the_power_to_create_roles() -> None:
+    """The repair path calls ``ensure_role`` first and used to die there.
+
+    Two code paths were dead for one reason: pods got no grant at creation
+    because ``try_grant`` swallowed the failure, and startup never repaired
+    them because this one re-raised it.
+    """
+    connection = _Connection(
+        role_exists=True,
+        is_member=True,
+        forbid=("CREATE ROLE",),
+    )
+
+    await _grants(connection).backfill_grants()
+
+    assert _issued(connection, "FOR s IN SELECT nspname FROM pg_namespace")
+
+
+@pytest.mark.asyncio
+async def test_pod_schemas_grant_at_creation_without_the_power_to_create_roles() -> (
+    None
+):
+    connection = _Connection(
+        role_exists=True,
+        is_member=True,
+        forbid=("CREATE ROLE",),
+    )
+
+    await _grants(connection).try_grant("pod_abc", "widgets")
+
+    assert _issued(connection, f'GRANT USAGE ON SCHEMA "pod_abc" TO "{ROLE}"')
+    assert _issued(connection, f'GRANT SELECT ON "pod_abc"."widgets" TO "{ROLE}"')
+
+
+@pytest.mark.asyncio
+async def test_the_catalog_is_probed_once_per_process() -> None:
+    connection = _Connection(role_exists=True, is_member=True)
+    grants = _grants(connection)
+
+    await grants.ensure_role()
+    await grants.ensure_role()
+
+    assert sum("pg_roles" in s for s in connection.statements) == 1


### PR DESCRIPTION
## What changes

`ensure_role()` now probes the catalog before it issues either privileged
statement. A deployment whose app role is only a *member* of an
already-provisioned query role can establish the role, grant pod schemas at
creation, and run the startup backfill — none of which worked before.

## Why

The guard on `CREATE ROLE` was the wrong guard:

```
permission denied to create role
DETAIL: Only roles with the CREATEROLE attribute may create roles.
[SQL: DO $$ BEGIN CREATE ROLE "lemma_datastore_query" ...
      EXCEPTION WHEN duplicate_object THEN NULL; END $$]
```

PostgreSQL checks the CREATEROLE privilege *before* it checks for a duplicate,
so an existing role raises `insufficient_privilege` — which
`EXCEPTION WHEN duplicate_object` does not catch. `ensure_role()` therefore
threw on every call, and both callers died with it:

- `try_grant()` caught it, logged `datastore.query_role.grant.degraded`, and
  left the pod schema with no ACL at creation
- `backfill_grants()` calls `ensure_role()` first, so the repair path that
  exists to fix precisely that never ran

Two code paths, one cause. This is why repeated API restarts never repaired
the affected schemas in our development cluster — the fix in #363 is correct
but sits downstream of a call that could not return.

The environments differed only in this attribute: production's `lemma_datastore`
has CREATEROLE and development's does not, which is why production's pod ACLs
are clean and development's are not. Granting the attribute in development
would also have worked, but CREATEROLE on the app's login role is a real
privilege — on PG < 16 it can alter and grant membership in essentially any
non-superuser role, including a BYPASSRLS one — and this module exists
specifically to make RLS enforceable against the app's own connection. It also
would not necessarily have been sufficient: on PG 16+ CREATEROLE only confers
ADMIN OPTION on roles that role created, so `GRANT ... TO CURRENT_USER` on an
operator-provisioned role can still fail.

The module docstring already promised this behavior — "a deployment whose app
role cannot create or grant roles must still be able to create pods and
tables". The code now implements it.

## How to verify

```bash
make quality
uv run --project lemma-backend pytest lemma-backend/app/modules/datastore/tests/unit -q
```

`make quality` prints `✓ quality gates pass`; the datastore unit suite reports
`488 passed, 1 skipped` (`markitdown` is not installed locally).

New tests in `test_query_role.py` pin the behavior with a connection fake that
refuses `CREATE ROLE` outright, the way a role without the attribute does:

- an existing role and existing membership issue no privileged statement
- a missing role is still created, still under the duplicate guard for the
  two-process race
- membership is granted when an operator provisioned the role
- `backfill_grants()` reaches its GRANT loop without CREATEROLE — the path
  that was dead
- `try_grant()` grants schema and table without CREATEROLE
- the catalog is probed once per process

Three connection fakes in `test_ddl_safety.py` answered the new probes with a
truthy `AsyncMock` coroutine or `None`. They passed either way, but for the
wrong reason; they now describe the deployment each test is named for.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — narrows what the deployment needs rather than widening it:
      the app role no longer needs CREATEROLE to provision RLS grants. No new
      secret in a log or response.
- [x] **Rollback** — plain revert. It restores the previous failure mode on
      deployments without CREATEROLE and is a no-op on deployments with it.

## Compatibility and rollback notes

No migration and no API change. `ensure_role()` adds two catalog reads on the
first call per process and skips two DDL statements that were previously
issued unconditionally; deployments where the app role *does* hold CREATEROLE
see identical end state via a cheaper path.

One thing this does not address, flagged rather than fixed here:
`backfill_grants()` grants every pod schema inside a single `DO` block, so one
bad schema aborts the whole repair.
