### PR TITLE
Charge the poll safety margin to the deadline, not to the caller's yield

### DIFF
--- a/lemma-backend/app/modules/workspace/process_output.py
+++ b/lemma-backend/app/modules/workspace/process_output.py
@@ -61,13 +61,18 @@ async def collect_process_output(
         # output appears, so a quiet 30s wait costs one request, not thirty.
         # The safety margin is load-bearing — the HTTP timeout comes off the
         # same deadline, and asking the server to hold longer than the
-        # client waits turns "still running" into a transport error.
-        window = (deadline_at - datetime.now(timezone.utc)).total_seconds()
+        # client waits turns "still running" into a transport error. It is
+        # charged against the deadline alone. Taking it out of the caller's
+        # yield window as well put a cliff at the margin: any yield at or
+        # under a second became a single non-waiting poll, so a command that
+        # finished in milliseconds still came back "still running" and cost
+        # the caller another round trip to find out otherwise.
+        window = (
+            deadline_at - datetime.now(timezone.utc)
+        ).total_seconds() - _POLL_SAFETY_MARGIN_SECONDS
         if yield_seconds is not None:
             window = min(window, yield_seconds - elapsed)
-        wait_seconds = (
-            min(window, _MAX_OUTPUT_WAIT_SECONDS) - _POLL_SAFETY_MARGIN_SECONDS
-        )
+        wait_seconds = min(window, _MAX_OUTPUT_WAIT_SECONDS)
         if wait_seconds <= 0:
             # A very short yield still wants whatever is already buffered, so
             # read once — but never twice, or this becomes the busy loop it

--- a/lemma-backend/app/modules/workspace/tests/unit/test_sandbox_session.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_sandbox_session.py
@@ -384,3 +384,35 @@ async def test_transport_failure_returns_operation_identity_without_blind_replay
     assert result["completed"] is False
     assert UUID(result["process_id"])
     assert "transport failed" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("yield_time_ms", [200, 500, 1000, 1500])
+async def test_a_short_yield_still_waits_long_enough_to_see_the_exit(
+    yield_time_ms: int,
+) -> None:
+    """A yield at or under the transport safety margin used to wait not at all.
+
+    The margin exists so the server is never asked to hold a response longer
+    than the client will wait for it, and it is charged against the deadline.
+    It was also being taken out of the caller's yield window, which put a
+    cliff at exactly one second: `min(window, MAX) - MARGIN` went to zero, the
+    collector took a single non-waiting poll and returned, and a command that
+    had finished in milliseconds still reported itself as running. The agent
+    then paid another round trip to learn otherwise, and the real-sandbox E2E
+    that asserts completion on a one-second yield failed or passed on a race.
+
+    `_CanonicalClient` reports RUNNING first and SUCCEEDED second, so seeing
+    the exit at all requires that the collector poll more than once.
+    """
+    client = _CanonicalClient()
+    session = _session(client)
+
+    result = await session.exec_command(
+        cmd="printf done", yield_time_ms=yield_time_ms
+    )
+
+    assert result["completed"] is True, result
+    assert result["exit_code"] == 0
+    assert result["process_id"] is None
+    assert client._reads > 1, "a short yield collapsed into one non-waiting poll"


### PR DESCRIPTION
## What changes

A sandbox command run with a short yield waits for its window again. Any
`yield_time_ms` at or under one second previously returned immediately without
waiting at all, so a command that finished in milliseconds still reported
`completed=false` with a `process_id`, and the caller paid a second round trip
to learn it was already done.

## Why

#335 gave the output collector a one-second safety margin so the sandbox is
never asked to hold a response for longer than the client will wait for it.
The margin is right, but it was subtracted from `min(deadline_window,
yield_window)` instead of from the deadline alone. That put a cliff at exactly
the margin:

| `yield_time_ms` | polls | `completed` | time spent waiting |
| --- | --- | --- | --- |
| 500 | 1 | `false` | 0.0s |
| 1000 | 1 | `false` | 0.0s |
| 1001 | 2 | `true` | — |

At or under 1000ms, `min(window, MAX) - MARGIN` goes to zero, the collector
takes the single non-waiting poll the guard allows, and returns. This is the
same wasted turn #340 removed elsewhere, reintroduced on the general path.

It also made `test_agent_workspace_cli_tools_execute_through_a_real_sandbox` a
race. It asserts completion on a tty command with a 1000ms yield — exactly on
the cliff — so it passed only when the process happened to exit before that one
instant poll. **It is the sole failure blocking the 0.7.0 release**, which gates
on a fresh `backend-protected-e2e` run for the release commit: it failed twice
in a row on `f5fafad4`
([1](https://github.com/lemma-work/lemma-platform/actions/runs/31877560081)),
and has failed every protected run since #335 landed on 11 August.

The margin protects the transport, and the HTTP timeout derives from the
deadline rather than from the yield — so it is now charged against the deadline
alone. The server is still never asked to hold past `deadline − margin`, still
floored at zero when the deadline is already inside the margin.

## How to verify

```bash
cd lemma-backend
uv run pytest app/modules/workspace/tests/unit/test_sandbox_session.py -q -k short_yield
# 4 passed  (200/500/1000/1500)

uv run pytest app/modules/workspace app/modules/agent/tests/unit -q -m "not e2e"
# 1036 passed, 26 skipped

cd .. && make quality
# ✓ quality gates pass
```

Reverting only `process_output.py` and re-running the new test fails the three
cases at or under the margin and passes 1500, which is the cliff itself:

```
FAILED ...test_a_short_yield_still_waits_long_enough_to_see_the_exit[200]
FAILED ...test_a_short_yield_still_waits_long_enough_to_see_the_exit[500]
FAILED ...test_a_short_yield_still_waits_long_enough_to_see_the_exit[1000]
3 failed, 1 passed
```

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload; no
      authorization surface touched
- [x] **Rollback** — revert the commit. The change is one arithmetic expression
      with no stored state and no schema, so a revert restores the previous
      behaviour exactly.

## Compatibility and rollback notes

No API, SDK, or schema change — nothing regenerated. The only observable
difference is that a short-yield poll now waits its window instead of returning
instantly, which is what the parameter already promised. Callers that relied on
the immediate return still work: they receive `completed=true` and a `null`
`process_id` where they previously received `completed=false` and an id, which
is the documented shape for a finished process.
