### PR TITLE
Verify each release artifact in the run that publishes it

### DIFF
--- a/.github/actions/verify-cli-distributions/action.yml
+++ b/.github/actions/verify-cli-distributions/action.yml
@@ -1,0 +1,48 @@
+name: Verify lemma-terminal distributions
+description: Assert a built sdist/wheel pair carries what PyPI cannot supply, and imports where no checkout exists.
+
+# What users install is a built artifact, and its two most important contents --
+# the agent skills and lemma_pod_bundle -- exist in it only because setup.py
+# copies them in. No test that reads the source tree can see that fail. CI runs
+# this on a clean-checkout build; the release workflow runs it on the exact
+# distributions it is about to upload.
+
+inputs:
+  dist-dir:
+    description: Directory holding the built sdist and wheel.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # dist-dir is repository-relative, and the working directory is pinned to the
+    # workspace rather than inherited: release-lemma-terminal.yml builds from
+    # lemma-cli/.
+    - name: Distributions carry what PyPI cannot supply
+      working-directory: ${{ github.workspace }}
+      shell: bash
+      run: python scripts/check_cli_wheel.py "${{ inputs.dist-dir }}"
+
+    - name: Install the wheel where no checkout exists and import it
+      # The failure mode this catches is a user's, not a builder's: the wheel
+      # resolves and installs happily and then raises ModuleNotFoundError on
+      # first use. --no-deps keeps this a packaging check rather than a
+      # resolution one (the lemma-sdk pin names the release being cut, which
+      # is not on PyPI until minutes after the wheel is), and /tmp keeps the
+      # repository off sys.path so an import can only come from the wheel.
+      shell: bash
+      env:
+        DIST_DIR: ${{ inputs.dist-dir }}
+      run: |
+        set -euo pipefail
+        rm -rf /tmp/wheel-check
+        python -m venv /tmp/wheel-check
+        /tmp/wheel-check/bin/pip install --no-deps "${GITHUB_WORKSPACE}/${DIST_DIR}"/*.whl
+        cd /tmp && /tmp/wheel-check/bin/python -c "
+        import pathlib, lemma_pod_bundle
+        from lemma_pod_bundle import layout
+        skills = pathlib.Path(lemma_pod_bundle.__file__).parent.parent / 'lemma_cli' / 'skills'
+        found = sorted(p.parent.name for p in skills.glob('*/SKILL.md'))
+        assert found, f'no skills installed under {skills}'
+        print(f'imported lemma_pod_bundle, {len(found)} skills present: {found}')
+        "

--- a/.github/actions/verify-python-sdk/action.yml
+++ b/.github/actions/verify-python-sdk/action.yml
@@ -1,0 +1,49 @@
+name: Verify Python SDK and CLI
+description: Lockfile, editable install, and the offline suites for lemma-python, lemma-cli, and lemma-pod-bundle.
+
+# The caller sets up Python; this owns everything after that. CI runs it as the
+# "Python SDK + CLI tests" job, and both PyPI release workflows run it against
+# the release commit -- CI's path filter skips that job on a backend-only
+# release commit, so a green CI run for the release SHA is not evidence these
+# tests ever executed for it.
+#
+# Run it before any release-time version rewrite: `uv lock --check` compares the
+# lockfile against the version in pyproject.toml.
+
+runs:
+  using: composite
+  steps:
+    - uses: astral-sh/setup-uv@v5
+
+    # Every path below is repository-relative, and the working directory is
+    # pinned to the workspace rather than inherited: release-lemma-python.yml
+    # runs its own steps from lemma-python/.
+    - name: Check Python SDK lockfile
+      working-directory: ${{ github.workspace }}/lemma-python
+      shell: bash
+      run: uv lock --check
+
+    - name: Install SDK + CLI
+      working-directory: ${{ github.workspace }}
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ./lemma-python
+        pip install -e ./lemma-pod-bundle
+        pip install -e ./lemma-cli
+        pip install pytest pytest-asyncio
+
+    - name: Test (CLI + Python SDK, offline only)
+      # Run each package's tests as a separate pytest invocation so each
+      # resolves its own pyproject.toml (markers, strict-markers, rootdir).
+      # A single combined run picks lemma-cli's config (strict-markers with
+      # only `unit`/`e2e`), which rejects lemma-python's `connector`/`integration`
+      # markers. Splitting also lets us exclude docker-only suites per package:
+      # lemma-cli e2e tests need postgres/redis/supertokens containers, and
+      # lemma-python integration tests need a live Lemma API + LEMMA_TOKEN.
+      working-directory: ${{ github.workspace }}
+      shell: bash
+      run: |
+        pytest lemma-cli/tests -m "not e2e"
+        pytest lemma-python/tests -m "not integration"
+        pytest lemma-pod-bundle/tests

--- a/.github/actions/verify-typescript-sdk/action.yml
+++ b/.github/actions/verify-typescript-sdk/action.yml
@@ -1,0 +1,51 @@
+name: Verify TypeScript SDK
+description: Typechecks, committed-bundle freshness, and unit tests for lemma-typescript.
+
+# The caller sets up Node; this owns everything after that. CI runs it as the
+# "TypeScript SDK checks" job, and release-lemma-typescript.yml runs it against
+# the release commit -- CI's path filter skips that job on a backend-only
+# release commit, so a green CI run for the release SHA is not evidence these
+# checks ever executed for it.
+#
+# Run it before `npm version` rewrites package.json: the SDK_VERSION check and
+# the committed-bundle diff both read the tree as committed.
+
+runs:
+  using: composite
+  steps:
+    - name: Install dependencies
+      working-directory: ${{ github.workspace }}/lemma-typescript
+      shell: bash
+      run: npm ci
+
+    - name: Typecheck (src)
+      working-directory: ${{ github.workspace }}/lemma-typescript
+      shell: bash
+      run: npx tsc --noEmit -p tsconfig.json
+
+    - name: Typecheck (tests)
+      working-directory: ${{ github.workspace }}/lemma-typescript
+      shell: bash
+      run: npx tsc --noEmit -p tsconfig.test.json
+
+    - name: SDK_VERSION matches package.json
+      working-directory: ${{ github.workspace }}/lemma-typescript
+      shell: bash
+      run: |
+        PKG=$(node -p "require('./package.json').version")
+        SRC=$(grep -oE '"[0-9]+\.[0-9]+\.[0-9]+"' src/version.ts | head -1 | tr -d '"')
+        echo "package.json=$PKG version.ts=$SRC"
+        test "$PKG" = "$SRC" || { echo "::error::src/version.ts SDK_VERSION ($SRC) != package.json version ($PKG)"; exit 1; }
+
+    - name: Browser bundle is fresh
+      working-directory: ${{ github.workspace }}/lemma-typescript
+      shell: bash
+      run: |
+        npm run build:bundle
+        git diff --exit-code public/lemma-client.js \
+          || { echo "::error::Committed public/lemma-client.js is stale — run 'npm run build:bundle' and commit"; exit 1; }
+
+    - name: Unit tests
+      working-directory: ${{ github.workspace }}/lemma-typescript
+      shell: bash
+      run: npx vitest run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,29 +232,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - uses: astral-sh/setup-uv@v5
-      - name: Check Python SDK lockfile
-        working-directory: lemma-python
-        run: uv lock --check
-      - name: Install SDK + CLI
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ./lemma-python
-          pip install -e ./lemma-pod-bundle
-          pip install -e ./lemma-cli
-          pip install pytest pytest-asyncio
-      - name: Test (CLI + Python SDK, offline only)
-        # Run each package's tests as a separate pytest invocation so each
-        # resolves its own pyproject.toml (markers, strict-markers, rootdir).
-        # A single combined run picks lemma-cli's config (strict-markers with
-        # only `unit`/`e2e`), which rejects lemma-python's `connector`/`integration`
-        # markers. Splitting also lets us exclude docker-only suites per package:
-        # lemma-cli e2e tests need postgres/redis/supertokens containers, and
-        # lemma-python integration tests need a live Lemma API + LEMMA_TOKEN.
-        run: |
-          pytest lemma-cli/tests -m "not e2e"
-          pytest lemma-python/tests -m "not integration"
-          pytest lemma-pod-bundle/tests
+      # Shared with release-lemma-python.yml and release-lemma-terminal.yml, so
+      # what a release verifies cannot drift from what a pull request does.
+      - uses: ./.github/actions/verify-python-sdk
 
   cli-packaging:
     name: lemma-terminal wheel (clean checkout)
@@ -279,26 +259,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip build
           python -m build
-      - name: Distributions carry what PyPI cannot supply
-        run: python scripts/check_cli_wheel.py lemma-cli/dist
-      - name: Install the wheel where no checkout exists and import it
-        # The failure mode this catches is a user's, not a builder's: the wheel
-        # resolves and installs happily and then raises ModuleNotFoundError on
-        # first use. --no-deps keeps this a packaging check rather than a
-        # resolution one (the lemma-sdk pin names the release being cut, which
-        # is not on PyPI until minutes after the wheel is), and /tmp keeps the
-        # repository off sys.path so an import can only come from the wheel.
-        run: |
-          python -m venv /tmp/wheel-check
-          /tmp/wheel-check/bin/pip install --no-deps lemma-cli/dist/*.whl
-          cd /tmp && /tmp/wheel-check/bin/python -c "
-          import pathlib, lemma_pod_bundle
-          from lemma_pod_bundle import layout
-          skills = pathlib.Path(lemma_pod_bundle.__file__).parent.parent / 'lemma_cli' / 'skills'
-          found = sorted(p.parent.name for p in skills.glob('*/SKILL.md'))
-          assert found, f'no skills installed under {skills}'
-          print(f'imported lemma_pod_bundle, {len(found)} skills present: {found}')
-          "
+      # Shared with release-lemma-terminal.yml, which runs it on the exact
+      # distributions it is about to upload.
+      - uses: ./.github/actions/verify-cli-distributions
+        with:
+          dist-dir: lemma-cli/dist
 
   typescript-sdk:
     name: TypeScript SDK checks
@@ -306,32 +271,14 @@ jobs:
     needs: changes
     if: needs.changes.outputs.typescript == 'true'
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: lemma-typescript
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
-      - run: npm ci
-      - name: Typecheck (src)
-        run: npx tsc --noEmit -p tsconfig.json
-      - name: Typecheck (tests)
-        run: npx tsc --noEmit -p tsconfig.test.json
-      - name: SDK_VERSION matches package.json
-        run: |
-          PKG=$(node -p "require('./package.json').version")
-          SRC=$(grep -oE '"[0-9]+\.[0-9]+\.[0-9]+"' src/version.ts | head -1 | tr -d '"')
-          echo "package.json=$PKG version.ts=$SRC"
-          test "$PKG" = "$SRC" || { echo "::error::src/version.ts SDK_VERSION ($SRC) != package.json version ($PKG)"; exit 1; }
-      - name: Browser bundle is fresh
-        run: |
-          npm run build:bundle
-          git diff --exit-code public/lemma-client.js \
-            || { echo "::error::Committed public/lemma-client.js is stale — run 'npm run build:bundle' and commit"; exit 1; }
-      - name: Unit tests
-        run: npx vitest run
+      # Shared with release-lemma-typescript.yml, so what a release verifies
+      # cannot drift from what a pull request does.
+      - uses: ./.github/actions/verify-typescript-sdk
 
   codegen-drift:
     name: Codegen drift gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,15 @@ jobs:
               - 'lemma-stack/**'
               - 'install.sh'
               - 'install.ps1'
+              # The composite actions these jobs are made of. Without these
+              # entries a change to what CI *checks* triggers nothing that runs
+              # it, and the release workflows that share them find out first.
+              - '.github/actions/verify-python-sdk/**'
+              - '.github/actions/verify-cli-distributions/**'
               - '.github/workflows/ci.yml'
             typescript:
               - 'lemma-typescript/**'
+              - '.github/actions/verify-typescript-sdk/**'
               - '.github/workflows/ci.yml'
             frontend:
               - 'lemma-frontend/**'
@@ -808,6 +814,9 @@ jobs:
       - backend-lint
       - backend-migration
       - python-sdk
+      # Was missing: a wheel that ships without its skills or lemma_pod_bundle
+      # failed this job and "CI passed" stayed green.
+      - cli-packaging
       - typescript-sdk
       - codegen-drift
       - frontend-check

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -135,8 +135,28 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      # The Agent Host's ACP integration tests spawn a scripted Python agent over
+      # stdio, and panic outright when there is no interpreter to spawn.
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      # The same gate CI's "Desktop workspace" job applies, applied here because
+      # CI's path filter skips that job whenever the release commit did not touch
+      # desktop/** -- a backend-only release commit is the common case -- and CI
+      # is green anyway, because "CI passed" treats a skipped suite as passing.
+      # rustfmt compiles nothing, so it runs before the cache is warm; clippy and
+      # the tests wait for the sidecars below, because tauri-build resolves the
+      # externalBin sidecars at build-script time.
+      - name: Check formatting
+        working-directory: desktop
+        run: cargo fmt --all --check
 
       - name: Cache cargo
         uses: actions/cache@v4
@@ -200,6 +220,14 @@ jobs:
 
       - name: Build native local sidecars
         run: desktop/scripts/build-sidecar.sh
+
+      - name: Lint
+        working-directory: desktop
+        run: cargo clippy --workspace --locked --all-targets -- -D warnings
+
+      - name: Test
+        working-directory: desktop
+        run: cargo test --workspace --locked
 
       - name: Sign virtualization helper with its entitlement
         shell: bash

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -166,7 +166,12 @@ jobs:
             ~/.cargo/git
             desktop/target
           key: desktop-cargo-${{ runner.os }}-${{ hashFiles('desktop/Cargo.lock') }}
-          restore-keys: desktop-cargo-${{ runner.os }}-
+          # Falls back to CI's cache from main. Releases are rare, so this key is
+          # cold most times it is read; CI's is warm from the last merge, and the
+          # lockfile hash still decides whether the restore is usable.
+          restore-keys: |
+            desktop-cargo-${{ runner.os }}-
+            desktop-ci-cargo-${{ runner.os }}-
 
       - name: Download and verify native runtime artifacts
         shell: bash

--- a/.github/workflows/release-lemma-python.yml
+++ b/.github/workflows/release-lemma-python.yml
@@ -40,6 +40,15 @@ jobs:
         with:
           python-version: "3.14"
 
+      # The run that publishes the artifact is the run that tests it. CI's path
+      # filter skips "Python SDK + CLI tests" whenever the release commit did not
+      # touch these packages -- a backend-only release commit is the common case
+      # -- and CI is green anyway, because "CI passed" treats a skipped suite as
+      # passing. So a CI run for this SHA proves nothing about this wheel.
+      # Before the version rewrite below: `uv lock --check` reads pyproject.toml.
+      - name: Verify Python SDK and CLI
+        uses: ./.github/actions/verify-python-sdk
+
       # Every Lemma-owned component must name the release version. Branches no
       # longer bump versions one by one — that forced a number nobody had
       # released to climb per-PR and conflict on every schema-touching branch —

--- a/.github/workflows/release-lemma-terminal.yml
+++ b/.github/workflows/release-lemma-terminal.yml
@@ -37,6 +37,16 @@ jobs:
         with:
           python-version: "3.14"
 
+      # The run that publishes the artifact is the run that tests it. CI's path
+      # filter skips "Python SDK + CLI tests" whenever the release commit did not
+      # touch these packages -- a backend-only release commit is the common case
+      # -- and CI is green anyway, because "CI passed" treats a skipped suite as
+      # passing. So a CI run for this SHA proves nothing about this wheel.
+      # Before the version rewrite below: `uv lock --check` reads pyproject.toml,
+      # and the rewrite pins lemma-sdk to a version not yet on PyPI.
+      - name: Verify Python SDK and CLI
+        uses: ./.github/actions/verify-python-sdk
+
       - name: Set package version from release tag
         shell: python
         env:
@@ -79,10 +89,13 @@ jobs:
         run: python -m build
 
       # Skills, lemma_pod_bundle, and no unpublished distribution in
-      # Requires-Dist — the same check CI runs on every pull request that
-      # touches the CLI, so a release is never the first build anyone verified.
+      # Requires-Dist, then an import from a venv with no checkout in sight —
+      # the same checks CI runs on every pull request that touches the CLI, so a
+      # release is never the first build anyone verified.
       - name: Verify the distributions carry what PyPI cannot supply
-        run: python scripts/check_cli_wheel.py lemma-cli/dist
+        uses: ./.github/actions/verify-cli-distributions
+        with:
+          dist-dir: lemma-cli/dist
 
       - name: Check distribution
         working-directory: lemma-cli

--- a/.github/workflows/release-lemma-typescript.yml
+++ b/.github/workflows/release-lemma-typescript.yml
@@ -49,6 +49,15 @@ jobs:
       - name: Use npm with trusted publishing support
         run: npm install --global npm@11.18.0
 
+      # The run that publishes the package is the run that checks it. CI's path
+      # filter skips "TypeScript SDK checks" whenever the release commit did not
+      # touch lemma-typescript -- a backend-only release commit is the common
+      # case -- and CI is green anyway, because "CI passed" treats a skipped
+      # suite as passing. Before `npm version` below: the SDK_VERSION check and
+      # the committed-bundle diff read the tree as committed.
+      - name: Verify TypeScript SDK
+        uses: ./.github/actions/verify-typescript-sdk
+
       # See the note in release-lemma-python.yml: consistency is enforced at
       # release time, in one place, instead of per-PR version bumps. It covers
       # every component, where the src/version.ts check below sees only this one
@@ -87,9 +96,9 @@ jobs:
       - name: Build package
         run: npm run build
 
-      - name: Run unit tests
-        run: npm test
-
+      # Unit tests ran in "Verify TypeScript SDK" above, against the same
+      # sources -- vitest runs src, not dist, and `npm version` touches nothing
+      # it reads.
       - name: Verify registry blocks
         run: npm run registry:check
 

--- a/docs/security/release-checklist.md
+++ b/docs/security/release-checklist.md
@@ -14,6 +14,13 @@
       unresolved high/critical findings.
 - [ ] A protected-environment run for the release commit is successful and less
       than seven days old.
+- [ ] Each release workflow verified its own artifact before publishing: the two
+      PyPI workflows ran the Python SDK/CLI suites and the distribution checks,
+      the npm workflow ran the TypeScript typechecks, bundle-freshness diff and
+      unit tests, and the Desktop workflow ran the workspace fmt, clippy and
+      tests. These run inside the publishing job, so no separate CI dispatch is
+      required — but a release commit whose CI run shows those suites as
+      *skipped* is expected, not a finding.
 - [ ] Migration-first rolling sequence and worker-drain requirements are in the
       release notes.
 - [ ] Every resolved issue entry contains implementation and exact test evidence.


### PR DESCRIPTION
## What changes

Each of the four release workflows now verifies its own artifact inside the job
that publishes it, instead of publishing on the strength of a CI run that may
never have tested it.

The checks live in three composite actions that `ci.yml` and the release
workflows both call, so release-time and pull-request-time verification cannot
drift apart:

| action | what it asserts | called by |
| --- | --- | --- |
| `verify-python-sdk` | `uv lock --check`, editable install, the three offline pytest suites | CI `Python SDK + CLI tests`, `release-lemma-python`, `release-lemma-terminal` |
| `verify-cli-distributions` | `check_cli_wheel.py`, plus installing the wheel in a venv where no checkout exists and importing it | CI `lemma-terminal wheel (clean checkout)`, `release-lemma-terminal` |
| `verify-typescript-sdk` | typecheck src + tests, `SDK_VERSION` agreement, committed browser bundle is fresh, vitest | CI `TypeScript SDK checks`, `release-lemma-typescript` |

`release-desktop` gains the workspace `cargo fmt --check`, clippy and tests it
never ran. `release-lemma-typescript` loses its standalone `npm test` step — the
composite runs the same vitest against the same sources, and `npm version`
touches nothing vitest reads.

**No pull request pays for any of this.** `ci.yml` runs exactly the steps it ran
before, now by reference; the only added work is on release runs.

## Why

`ci.yml`'s paths-filter skips `Python SDK + CLI tests`, `TypeScript SDK checks`,
`lemma-terminal wheel (clean checkout)` and `Desktop workspace` whenever the
release commit did not touch those trees — a backend-only release commit, which
is the common case (f5fafad4, the v0.7.0 release commit, is one).

The aggregate `CI passed` job is green anyway. It fails only on `failure` or
`cancelled`, so a skipped suite reads as a pass — by design, but it means a
green CI badge on a release SHA is not evidence those suites ran.

The four release workflows gated only on `require-backend-protected-e2e`, and
`release-lemma-python` / `release-lemma-terminal` ran no test suite at all. Net
effect: `pip install lemma-sdk` and `pip install lemma-terminal` could be
published from a commit where their own tests had never executed. For v0.7.0
this was covered by hand-dispatching a full CI run (`workflow_dispatch` has no
base to diff against, so it runs everything) — a manual step, not a gate.

### The alternative, and why not

Requiring a successful CI run for the release SHA cannot work as stated: a run
whose suites all skipped is green, so the gate would be a no-op. The version
that inspects per-job conclusions would then fail on every backend-only release
commit — after the tag is public — with recovery being a manual CI dispatch and
a release re-run. Verifying inline keeps release day deterministic: one run,
no external precondition, and nothing reaches PyPI or npm if a check fails.

`require-backend-protected-e2e` keeps its shape and its seven-day freshness
window. A protected environment is the one thing a release job cannot run for
itself, which is exactly why that gate takes evidence from elsewhere and these
do not.

## How to verify

```bash
# The composites are the CI steps, moved. Diff them against what ci.yml ran before:
git show HEAD --stat
git diff HEAD~1 -- .github/workflows/ci.yml

# Every workflow and action still parses:
uv run --with pyyaml python3 -c "
import yaml, pathlib
for p in sorted(pathlib.Path('.github').rglob('*.yml')): yaml.safe_load(p.read_text())
print('yaml ok')"
```

The composites' contents are unchanged from the CI steps they replace, so this
PR's own CI run exercises all three. The release paths are exercised at the next
release; `workflow_dispatch` on any of the four is available to try one sooner.

## Checklist

- [x] Tests cover the behavioral change — the change *is* test wiring; the
      moved steps run unchanged in this PR's CI
- [x] Lint, typecheck, and architecture gates pass locally — no application code
      changed; workflow YAML parses

## Compatibility and rollback notes

Nothing to migrate. Reverting restores the previous gating exactly; the composite
actions are additive and unreferenced once the workflow diffs are reverted.

One operational note for release day: `release-desktop` now compiles the
workspace for clippy and tests before building the DMG. On the last full CI run
the equivalent macOS job took 5 minutes with a warm cargo cache; the release job
uses its own cache key, so expect it to be slower the first time and comparable
after.
