### PR TITLE
Stop paying for CI twice, and run the jobs that cover the change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,12 @@ jobs:
               - 'Makefile'
               - 'tests/**'
               - 'scripts/check_version_consistency.py'
+              # tests/ imports these two as modules, so they are covered by a
+              # job that took twenty seconds and did not run for them. Editing
+              # prepare_desktop_test_runtime.py started the ninety-minute
+              # desktop job and skipped the test that reads it.
+              - 'scripts/build_local_host_pack.py'
+              - 'scripts/prepare_desktop_test_runtime.py'
               # These tests assert on the env names the backend settings read,
               # so the drift they exist to catch lands in the settings module,
               # not only in the Makefile that writes it.
@@ -282,6 +288,8 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: lemma-typescript/package-lock.json
       # Shared with release-lemma-typescript.yml, so what a release verifies
       # cannot drift from what a pull request does.
       - uses: ./.github/actions/verify-typescript-sdk
@@ -300,8 +308,11 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version-file: .nvmrc
-      - name: Install uv
-        run: pip install uv
+          cache: npm
+          cache-dependency-path: lemma-typescript/package-lock.json
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
       - name: Regenerate Python client from committed spec
         working-directory: lemma-python
         run: OPENAPI_FILE=lemma_sdk/openapi_spec.json bash scripts/generate_openapi_client.sh
@@ -328,7 +339,10 @@ jobs:
     name: Frontend lint, design audit, test
     timeout-minutes: 30
     needs: changes
-    if: needs.changes.outputs.frontend == 'true'
+    # Also on an SDK change: the frontend typechecks against lemma-typescript,
+    # so an SDK signature change breaks `npm run check` here while only
+    # "Frontend build" was watching for it.
+    if: needs.changes.outputs.frontend == 'true' || needs.changes.outputs.typescript == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -452,8 +466,9 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"
-      - name: Install uv
-        run: pip install uv
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
       - name: Install lemma-cli from local checkout
         run: uv tool install --force ./lemma-cli
       - name: lemma --version
@@ -480,6 +495,24 @@ jobs:
           $env:PATH = "$lemmaBin;$env:PATH"
           lemma doctor 2>&1
           # doctor may exit 1 if no server; just verify it doesn't crash
+      # Absorbed from windows-cli-smoke.yml, which ran a second Windows runner
+      # on every push to main to assert these two and nothing else this job did
+      # not already cover.
+      - name: lemma servers list / auth status
+        run: |
+          $ErrorActionPreference = "Stop"
+          $lemmaBin = uv tool dir --bin
+          $env:PATH = "$lemmaBin;$env:PATH"
+          lemma servers list
+          if ($LASTEXITCODE -ne 0) { throw "lemma servers list exited $LASTEXITCODE" }
+          # auth status exits 1 when logged out — that is expected; it just must
+          # not crash with a Windows-incompatibility error.
+          lemma auth status
+          if ($LASTEXITCODE -notin 0, 1) { throw "lemma auth status exited $LASTEXITCODE" }
+          # `auth status` leaves $LASTEXITCODE at 1 when logged out, and pwsh
+          # hands the step whatever it holds at the end. Say so explicitly.
+          Write-Host "smoke commands ok"
+          exit 0
       - name: Validate install.ps1
         shell: pwsh
         run: |

--- a/.github/workflows/windows-cli-smoke.yml
+++ b/.github/workflows/windows-cli-smoke.yml
@@ -9,17 +9,16 @@ name: Windows CLI smoke
 # supervised by Lemma Desktop now and has no CLI, so the Windows coverage that
 # matters for it is the desktop build check in ci.yml.
 #
+# CI's "Windows CLI smoke test" job covers the same install path on every pull
+# request and every push that touches the CLI, and it now runs this workflow's
+# `servers list` / `auth status` assertions too. So this no longer runs on push:
+# it was a second Windows runner per merge, checking a subset of what had
+# already passed.
+#
 # Triggers:
-#   * push to main           — post-merge gate (only when CLI files change)
-#   * PR labelled `windows-ci`— opt-in per-PR run (add the label to test a branch)
+#   * PR labelled `windows-ci`— opt-in run for a branch CI's path filter misses
 #   * manual workflow_dispatch
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'lemma-cli/**'
-      - 'lemma-skills/**'
-      - '.github/workflows/windows-cli-smoke.yml'
   pull_request:
     types: [labeled]
   workflow_dispatch:
@@ -34,10 +33,9 @@ concurrency:
 jobs:
   windows-cli-smoke:
     name: Windows CLI smoke
-    # Always on push/dispatch; on PRs only when the `windows-ci` label is present.
+    # Always on dispatch; on PRs only when the `windows-ci` label is present.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' ||
       (github.event_name == 'pull_request' &&
        github.event.action == 'labeled' &&
        github.event.label.name == 'windows-ci')


### PR DESCRIPTION
> Rebased onto `main` after #367 merged; this targets `main` directly now.

## What changes

A pass over the whole CI setup, starting from measured timings rather than
guesses. Measured on the last full run (`workflow_dispatch`, everything
unskipped, 10 minutes wall clock):

| job | time | where it goes |
| --- | --- | --- |
| Windows desktop build check | 9m | sidecars 156s, NSIS bundler 260s, tests 64s, clippy 13s |
| Desktop workspace (macOS) | 5m | sidecars 93s, DMG 152s, tests 41s, clippy 14s |
| lemma-backend unit | 3m | |
| everything else | ≤1m each | |

Cargo cache restores in 28–60s and is working. The two long poles are the
sidecar and bundler builds — real work, not overhead — so **nothing here tries
to shorten them**. What this fixes is duplicated work and jobs that did not run
for the change that broke them.

### Waste removed

- `windows-cli-smoke.yml` ran a **second Windows runner on every push to main**
  to assert `lemma servers list` and `lemma auth status` — a subset of what
  CI's own Windows job had already checked on the same commit. Those two
  assertions move into that job; the workflow keeps its `windows-ci` label and
  `workflow_dispatch` triggers for branches CI's path filter does not reach.
- `TypeScript SDK checks` and `Codegen drift gate` set up Node with no npm
  cache, refetching the dependency tree every run. The frontend jobs have always
  cached it.
- Two jobs installed uv with `pip install uv` instead of `astral-sh/setup-uv`,
  so neither cached the download or the resolver's work.

### Coverage gaps closed

- `tests/` imports `scripts/build_local_host_pack.py` and
  `scripts/prepare_desktop_test_runtime.py` as modules, but neither path was in
  the `repo_tooling` filter. Editing the latter started the **90-minute desktop
  job** and skipped the **20-second test** that actually reads it.
- `Frontend lint, design audit, test` ran only on `lemma-frontend` changes,
  while the frontend typechecks against `lemma-typescript`. An SDK signature
  change could break `npm run check` with only `Frontend build` watching.

## Why

Per-pull-request CI is 2–4 minutes today because the paths filter is doing its
job, so the wins available are not in making jobs faster — they are in not
running the same Windows job twice per merge, not refetching what a cache would
hold, and making sure the cheap job that covers a file is the one that runs
when it changes.

## How to verify

```bash
# All workflows and actions parse:
uv run --with pyyaml python3 -c "
import yaml, pathlib
for p in sorted(pathlib.Path('.github').rglob('*.yml')): yaml.safe_load(p.read_text())
print('yaml ok')"

# The numbers above, from the last full run:
gh run view 31877705984 --json jobs \
  --jq '.jobs[] | [(((.completedAt|fromdate)-(.startedAt|fromdate))/60|floor), .name] | @tsv'
```

This PR's own CI run exercises the changed filters and the Windows job.

## Checklist

- [x] Tests cover the behavioral change — CI configuration only; the moved
      Windows assertions are unchanged in content
- [x] Lint, typecheck, and architecture gates pass locally — no application code
      changed

## Compatibility and rollback notes

Configuration only; reverting restores the previous behaviour exactly. The one
coverage judgement worth a second opinion: dropping `windows-cli-smoke.yml`'s
push trigger assumes CI's `Windows CLI smoke test` job (path filter
`python_sdk`, which includes `lemma-cli/**` and `lemma-skills/**`) covers every
push the smoke workflow used to catch. Its old path filter was a strict subset
of that, so it should — but it is the one change here that removes a run rather
than adding one.

## Not in this PR — needs your call

Repo settings, not files. `protect-main` currently requires exactly **one**
status check to merge: `lemma-backend unit`. Everything else — the quality
gates, migrations, SDK tests, frontend, desktop, codegen drift, security,
e2e — can be red and the pull request still merges.

`CI passed` is built to be the required check: it fails on `failure` or
`cancelled` and tolerates `skipped`, so it stays green on genuinely unaffected
areas. Making it required (and adding e2e once its flakiness is settled) would
close the gap that #367 works around at release time.

