### PR TITLE
Stop an unshippable platform blocking the one we ship

### DIFF
--- a/.github/workflows/release-local-images.yml
+++ b/.github/workflows/release-local-images.yml
@@ -378,6 +378,22 @@ jobs:
     name: Build native host pack (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
     needs: [merge, infra-digests]
+    # Windows signing is best-effort. macOS is the platform this project ships:
+    # the Windows installer is built and kept for whoever is testing it, and is
+    # deliberately never attached to a release, because attaching it is what
+    # makes it an offer of support. Hard-failing the Windows pack when no
+    # certificate is configured therefore blocks the release of the platform we
+    # *do* ship on the one we do not — which is exactly what happened on the
+    # v0.7.0 tag, the first time this path ran with `publish` true.
+    #
+    # `secrets` cannot be read from a step `if`, so the availability test is
+    # resolved once here, where the job `env` can see it, and compared as a
+    # string below.
+    env:
+      WINDOWS_SIGNING_AVAILABLE: >-
+        ${{ secrets.WINDOWS_CERTIFICATE != ''
+        && secrets.WINDOWS_CERTIFICATE_PASSWORD != ''
+        && secrets.WINDOWS_TIMESTAMP_URL != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -418,10 +434,24 @@ jobs:
         with:
           node-version-file: .nvmrc
 
+      - name: Report unsigned Windows host pack
+        if: >-
+          matrix.target == 'x86_64-pc-windows-msvc' &&
+          (github.event_name == 'push' || inputs.publish) &&
+          env.WINDOWS_SIGNING_AVAILABLE != 'true'
+        shell: bash
+        run: |
+          echo "::warning title=Windows host pack is unsigned::\
+          WINDOWS_CERTIFICATE, WINDOWS_CERTIFICATE_PASSWORD and \
+          WINDOWS_TIMESTAMP_URL are not all configured, so this host pack is \
+          published unsigned. macOS is unaffected. Set the three secrets to \
+          restore signing."
+
       - name: Import Windows host-pack signing certificate
         if: >-
           matrix.target == 'x86_64-pc-windows-msvc' &&
-          (github.event_name == 'push' || inputs.publish)
+          (github.event_name == 'push' || inputs.publish) &&
+          env.WINDOWS_SIGNING_AVAILABLE == 'true'
         id: windows-signing
         uses: ./.github/actions/setup-windows-signing
         with:
@@ -510,7 +540,8 @@ jobs:
       - name: Sign downloadable Windows host runtime
         if: >-
           matrix.target == 'x86_64-pc-windows-msvc' &&
-          (github.event_name == 'push' || inputs.publish)
+          (github.event_name == 'push' || inputs.publish) &&
+          env.WINDOWS_SIGNING_AVAILABLE == 'true'
         shell: pwsh
         env:
           CERTIFICATE_THUMBPRINT: ${{ steps.windows-signing.outputs.thumbprint }}


### PR DESCRIPTION
## What changes

Windows host-pack signing becomes conditional on a certificate actually being
configured. With the three secrets present it signs exactly as before. Without
them the pack is built and published **unsigned**, and the job emits a warning
annotation, instead of failing the release.

This unblocks the macOS Desktop build and the GitHub release. Windows stays
what it already was — experimental, built for testers, never attached to a
release.

## Why

The `v0.7.0` tag failed its release build on **Build native host pack
(x86_64-pc-windows-msvc)**:

> `A certificate, password, and timestamp URL are required for Windows signing.`

`WINDOWS_CERTIFICATE`, `WINDOWS_CERTIFICATE_PASSWORD` and
`WINDOWS_TIMESTAMP_URL` have never existed in this repository.

Nothing caught it earlier because both signing steps are gated on
`github.event_name == 'push' || inputs.publish`. Every run before the tag was a
branch-test dispatch with `publish` false, which skips them — so **the first
time this path ever executed was the release it then blocked**. The 14 August
dispatch built the Windows pack fine, precisely because it never signed.

The blast radius is the whole release. `host-packs` is a matrix and `Publish
release manifest` needs the entire job, so one failed leg skipped the manifest:

- no release object, so no `lemma-local.json` and no host packs attached
- `release: published` never fired, so **none** of the four publish workflows ran
- `release-desktop` downloads `lemma-local.json` from the release, so the macOS
  DMG could not be built either

macOS built fine. Both guest runtimes built fine. All eight images built and
merged. One unshippable platform took down everything.

`release-desktop.yml` already states the intent — Windows "is never attached to
the release, because attaching it is what makes it an offer of support." Hard
-failing the release for it inverts that. An unsigned pack for a platform we do
not ship is the correct trade against not shipping macOS at all.

`secrets` cannot be read from a step `if`, so availability is resolved once in
the job `env` and compared as a string.

## How to verify

```bash
python -c "import yaml; yaml.safe_load(open('.github/workflows/release-local-images.yml'))"
```

Resolved conditions on the four Windows steps:

```
Report unsigned Windows host pack   … && env.WINDOWS_SIGNING_AVAILABLE != 'true'
Import Windows signing certificate  … && env.WINDOWS_SIGNING_AVAILABLE == 'true'
Sign downloadable Windows runtime   … && env.WINDOWS_SIGNING_AVAILABLE == 'true'
Remove Windows signing certificate  always() && … && steps.windows-signing.outcome == 'success'
```

The cleanup step needed no change: when the import is skipped its `outcome` is
`skipped`, not `success`, so it correctly does not run.

With no secrets configured (today's state) the two signing steps skip, the
warning step fires, `host-packs` succeeds, and `Publish release manifest`
becomes reachable.

## Checklist

- [x] Lint, typecheck, and architecture gates pass locally — no application code
      is touched; the change is one workflow file
- [x] **Security** — no secret is logged or echoed. The warning names the three
      variables but prints no values, and signing material is still only read
      inside the steps that use it
- [x] **Rollback** — revert the commit. CI-only, no runtime or schema effect

## Compatibility and rollback notes

No application code, API, SDK, schema or migration is touched, so the `v0.7.0`
tag at `462f1ed3` remains the qualified commit — this only changes how that
commit is *built*.

**Deliberate consequence:** until the three secrets are configured, the release
manifest advertises an **unsigned** Windows host pack. Accepted for now because
Windows Desktop is experimental and is not attached to releases. Setting
`WINDOWS_CERTIFICATE`, `WINDOWS_CERTIFICATE_PASSWORD` and
`WINDOWS_TIMESTAMP_URL` restores signing with no further code change.
