### PR TITLE
Let a dispatched Desktop build attach the DMG it just notarized

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -299,6 +299,16 @@ jobs:
       - name: Upload online DMG to release
         uses: softprops/action-gh-release@v2
         with:
+          # Name the tag rather than letting the action infer it. On
+          # `release: published` it reads the tag off the event payload, but on
+          # `workflow_dispatch` there is no release in the payload and it falls
+          # back to `github.ref` — `refs/heads/main` for a dispatch, which is
+          # not a tag, so the upload failed with "GitHub Releases requires a
+          # tag" *after* the DMG had been built, signed, notarized and
+          # verified. Dispatch is how a release is repaired when the publish
+          # event does not fire (a release created by GITHUB_TOKEN does not
+          # trigger workflows), so that path has to be able to attach.
+          tag_name: v${{ steps.version.outputs.version }}
           files: desktop/target/release/release-artifacts/Lemma_*_aarch64-*.dmg
 
       - name: Remove temporary signing keychain
@@ -311,6 +321,16 @@ jobs:
     # official release build for a tag that has no version in it.
     if: startsWith(github.event.release.tag_name || format('v{0}', inputs.version), 'v')
     runs-on: windows-latest
+    # Same posture as release-local-images.yml: this installer is built and kept
+    # for whoever is testing it and is never attached to a release, so a missing
+    # certificate must not fail the run. Signing happens when the secrets exist
+    # and is skipped, loudly, when they do not. `secrets` cannot be read from a
+    # step `if`, so availability resolves once here.
+    env:
+      WINDOWS_SIGNING_AVAILABLE: >-
+        ${{ secrets.WINDOWS_CERTIFICATE != ''
+        && secrets.WINDOWS_CERTIFICATE_PASSWORD != ''
+        && secrets.WINDOWS_TIMESTAMP_URL != '' }}
 
     steps:
       - name: Checkout
@@ -393,7 +413,18 @@ jobs:
         with:
           targets: x86_64-pc-windows-msvc
 
+      - name: Report unsigned Windows build
+        if: env.WINDOWS_SIGNING_AVAILABLE != 'true'
+        shell: bash
+        run: |
+          echo "::warning title=Windows Desktop build is unsigned::\
+          WINDOWS_CERTIFICATE, WINDOWS_CERTIFICATE_PASSWORD and \
+          WINDOWS_TIMESTAMP_URL are not all configured. This installer is \
+          built unsigned and is not attached to the release. macOS is \
+          unaffected."
+
       - name: Import Windows code-signing certificate
+        if: env.WINDOWS_SIGNING_AVAILABLE == 'true'
         id: windows-signing
         uses: ./.github/actions/setup-windows-signing
         with:
@@ -402,6 +433,7 @@ jobs:
           timestamp-url: ${{ secrets.WINDOWS_TIMESTAMP_URL }}
 
       - name: Configure Tauri Authenticode signing
+        if: env.WINDOWS_SIGNING_AVAILABLE == 'true'
         shell: python
         env:
           CERTIFICATE_THUMBPRINT: ${{ steps.windows-signing.outputs.thumbprint }}
@@ -483,6 +515,7 @@ jobs:
         run: desktop/scripts/build-sidecar.ps1
 
       - name: Sign native runtime bridge
+        if: env.WINDOWS_SIGNING_AVAILABLE == 'true'
         shell: pwsh
         env:
           CERTIFICATE_THUMBPRINT: ${{ steps.windows-signing.outputs.thumbprint }}
@@ -527,6 +560,7 @@ jobs:
             "target/release/release-artifacts/Lemma_${env:VERSION}_x64-online-setup.exe"
 
       - name: Verify Authenticode signatures
+        if: env.WINDOWS_SIGNING_AVAILABLE == 'true'
         shell: pwsh
         run: |
           $paths = @(


### PR DESCRIPTION
## What changes

A Desktop release build started from `workflow_dispatch` can attach the DMG it
produced. Windows signing becomes conditional on a certificate existing, the
same way #369 made it conditional for the host pack.

## Why

The v0.7.0 Desktop run built, signed, notarized, stapled **and verified** the
macOS disk image, then failed on the last step:

```
##[error]⚠️ GitHub Releases requires a tag
```

`Upload online DMG to release` passed `files:` and nothing else. On
`release: published` the action reads the tag off the event payload; on
`workflow_dispatch` there is no release in the payload, so it falls back to
`github.ref` — `refs/heads/main` — which is not a tag. **That path could never
attach anything**, and because no artifact is retained, a complete signed and
notarized build was discarded at the finish line.

Dispatch is not a corner case here. A release created by a workflow using
`GITHUB_TOKEN` does not emit `release: published`, so none of the publish
workflows fire and dispatch is the only way to attach — which is exactly how
v0.7.0 had to be released. The tag is now named explicitly, matching what
`release-local-images.yml` already does.

Windows failed separately, on `Import Windows code-signing certificate`, for the
reason #369 documented: `WINDOWS_CERTIFICATE`, `WINDOWS_CERTIFICATE_PASSWORD`
and `WINDOWS_TIMESTAMP_URL` have never existed. This workflow's own header says
the Windows installer "is never attached to the release, because attaching it is
what makes it an offer of support" — so a missing certificate should not fail
the run.

## How to verify

```bash
python -c "import yaml; yaml.safe_load(open('.github/workflows/release-desktop.yml'))"
```

Resolved conditions:

```
Report unsigned Windows build        env.WINDOWS_SIGNING_AVAILABLE != 'true'
Import Windows code-signing cert     env.WINDOWS_SIGNING_AVAILABLE == 'true'
Configure Tauri Authenticode signing env.WINDOWS_SIGNING_AVAILABLE == 'true'
Sign native runtime bridge           env.WINDOWS_SIGNING_AVAILABLE == 'true'
Verify Authenticode signatures       env.WINDOWS_SIGNING_AVAILABLE == 'true'
Build Windows sidecars               (ungated — still builds)
Keep the Windows installer artifact  (ungated — testers still get it)
Remove Windows code-signing cert     always() && steps.windows-signing.outcome == 'success'

Upload online DMG to release         tag_name: v${{ steps.version.outputs.version }}
```

The build and artifact steps stay ungated on purpose, so an unsigned installer
is still produced. The cleanup step needed no change: when the import skips, its
`outcome` is `skipped`, not `success`.

## Checklist

- [x] Lint, typecheck, and architecture gates pass locally — one workflow file,
      no application code
- [x] **Security** — no secret is logged; the warning names the three variables
      and prints no values
- [x] **Rollback** — revert the commit. CI-only, no runtime or schema effect

## Compatibility and rollback notes

No application code, API, SDK, schema or migration is touched, so `v0.7.0` at
`462f1ed3` remains the qualified commit — only how it is built and attached
changes.

**Deliberate consequence:** until the three secrets are configured, the Windows
installer is built unsigned. It is not attached to releases, so this reaches
only testers who pull the workflow artifact. Setting the secrets restores
signing with no further code change.
