### PR TITLE
Make the delivery marker a statement Postgres will accept, and stop the recovery sweep churning

### DIFF
--- a/lemma-backend/app/composition/pod_delivery.py
+++ b/lemma-backend/app/composition/pod_delivery.py
@@ -63,6 +63,39 @@ AUTONOMOUS_ORIGINS = frozenset(
     {OriginKind.SCHEDULE, OriginKind.DATA_TRIGGER, OriginKind.CONNECTOR}
 )
 
+#: Claim activation for a pod, exactly once.
+#:
+#: The ``NOT (... ? 'delivered_at')`` guard is what makes it once-only: two
+#: workers processing two outcomes for the same pod at the same instant both run
+#: this, and only one gets a row back.
+#:
+#: The casts are load-bearing, not decoration. ``jsonb_build_object`` declares
+#: its arguments as ``"any"``, so PostgreSQL cannot infer a type for a bound
+#: parameter and asyncpg raises ``IndeterminateDatatypeError`` before the
+#: statement runs at all. Without them this never wrote the marker, so the guard
+#: never became false and every later outcome retried it forever.
+#:
+#: ``CAST(x AS text)`` rather than ``x::text``: SQLAlchemy's ``text()`` scans for
+#: ``:name`` and reads the second colon of ``::text`` as a bind parameter called
+#: ``text``, which turns the statement into a syntax error. The ``'{}'::jsonb``
+#: literals below are unaffected because no bind parameter precedes them.
+#:
+#: Kept as a module constant so the e2e test binds the same statement production
+#: does. A copy in the test would have passed while this failed.
+DELIVERY_CLAIM_SQL = """
+UPDATE pods
+SET config = jsonb_set(
+    coalesce(config, '{}'::jsonb),
+    '{analytics}',
+    coalesce(config->'analytics', '{}'::jsonb)
+        || jsonb_build_object('delivered_at', CAST(:now AS text), 'via', CAST(:via AS text)),
+    true
+)
+WHERE id = :pod_id
+  AND NOT (coalesce(config->'analytics', '{}'::jsonb) ? 'delivered_at')
+RETURNING id
+"""
+
 _CACHE_KEY = "analytics:pod-delivered:{pod_id}"
 
 
@@ -121,21 +154,7 @@ async def maybe_emit_pod_delivered(
     created_at = None
     async with uow_factory() as uow:
         claimed = await uow.session.scalar(
-            text(
-                """
-                UPDATE pods
-                SET config = jsonb_set(
-                    coalesce(config, '{}'::jsonb),
-                    '{analytics}',
-                    coalesce(config->'analytics', '{}'::jsonb)
-                        || jsonb_build_object('delivered_at', :now, 'via', :via),
-                    true
-                )
-                WHERE id = :pod_id
-                  AND NOT (coalesce(config->'analytics', '{}'::jsonb) ? 'delivered_at')
-                RETURNING id
-                """
-            ),
+            text(DELIVERY_CLAIM_SQL),
             {
                 "pod_id": pod_id,
                 "now": datetime.now(timezone.utc).isoformat(),

--- a/lemma-backend/app/composition/schedule_run_recovery.py
+++ b/lemma-backend/app/composition/schedule_run_recovery.py
@@ -162,11 +162,32 @@ class ScheduleRunRecoveryService:
                 # The target is alive and has not finished. Nothing to reconcile
                 # -- the ledger is already right -- so this is reported as what
                 # it is rather than counted as work.
+                #
+                # And when the ledger is already right, nothing is written. The
+                # write bumps `updated_at`, the DISPATCHED arm selects on
+                # `updated_at < now - DISPATCH_RECONCILE_AFTER`, and that window
+                # is exactly the cron interval -- so an unconditional write here
+                # re-armed the row for the very next pass, forever. At BATCH_SIZE
+                # rows and a five-minute cron that is 28,800 updates a day, none
+                # of which could move a row out of the query that found it.
+                #
+                # The repair is still made when there is one: a row left FAILED
+                # or half-started while its target really runs. A row that needs
+                # nothing is simply re-read next cycle -- one indexed, capped
+                # read -- and resolves the moment its target reports an outcome.
+                needs_repair = (
+                    run.status != ScheduleRunStatus.DISPATCHED.value
+                    or run.completed_at is not None
+                    or run.error_type is not None
+                    or run.error_code is not None
+                )
+                still_running += 1
+                if not needs_repair:
+                    continue
                 run.status = ScheduleRunStatus.DISPATCHED.value
                 run.completed_at = None
                 run.error_type = None
                 run.error_code = None
-                still_running += 1
                 continue
 
             if self._too_late_to_redeliver(run, now):

--- a/lemma-backend/app/core/tests/e2e/test_pod_delivery_marker_e2e.py
+++ b/lemma-backend/app/core/tests/e2e/test_pod_delivery_marker_e2e.py
@@ -1,0 +1,135 @@
+"""The delivery-marker statement has to be one PostgreSQL will accept.
+
+``pod.delivered`` is claimed with a hand-written ``UPDATE`` against a JSONB
+column, and the tests around it only ever exercised ``qualifies()`` -- the pure
+predicate. Nothing ran the SQL, so a statement the server refuses to plan shipped
+green through every gate and surfaced only when the feature was switched on in
+development.
+
+Two traps, and the statement hit both:
+
+* ``jsonb_build_object`` declares its arguments ``"any"``, so PostgreSQL cannot
+  infer a type for a bound parameter and asyncpg raises
+  ``IndeterminateDatatypeError`` before the statement runs.
+* Writing the cast as ``:now::text`` does not fix it, because SQLAlchemy's
+  ``text()`` scans for ``:name`` and reads the second colon as a bind parameter
+  called ``text``. It has to be ``CAST(:now AS text)``.
+
+Failing silently was the worse half. The claim is guarded by
+``NOT (... ? 'delivered_at')`` so it marks a pod once -- but a statement that
+always raises never writes the marker, so the guard never became false and every
+later outcome tried again. And since the raise escaped the consumer's handler,
+the inbox retried the whole projection, re-emitting events that had already been
+emitted before it.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+
+from app.composition.pod_delivery import DELIVERY_CLAIM_SQL, DeliveryVia
+from app.modules.test_support.e2e import fixtures as e2e_fixtures
+
+# Re-bound per file, the way the sibling outbox test does it: these are module
+# attributes rather than a plugin, so each file that wants a database says so.
+test_network = e2e_fixtures.test_network
+postgres_container = e2e_fixtures.postgres_container
+redis_container = e2e_fixtures.redis_container
+supertokens_container = e2e_fixtures.supertokens_container
+test_database_url = e2e_fixtures.test_database_url
+test_redis_url = e2e_fixtures.test_redis_url
+e2e_settings = e2e_fixtures.e2e_settings
+db_manager = e2e_fixtures.db_manager
+db_session = e2e_fixtures.db_session
+sandbox_reachable_backend = e2e_fixtures.sandbox_reachable_backend
+worker = e2e_fixtures.worker
+test_app = e2e_fixtures.test_app
+async_client = e2e_fixtures.async_client
+fixed_test_user = e2e_fixtures.fixed_test_user
+authenticated_client = e2e_fixtures.authenticated_client
+fixed_test_org = e2e_fixtures.fixed_test_org
+
+pytestmark = [pytest.mark.e2e]
+
+
+async def _create_pod(client, org_id: str) -> str:
+    response = await client.post(
+        "/pods",
+        json={
+            "name": f"delivery-{uuid4().hex[:8]}",
+            "type": "ASSISTANT",
+            "organization_id": org_id,
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+def _params(pod_id, via: DeliveryVia) -> dict:
+    return {
+        "pod_id": pod_id,
+        "now": datetime.now(timezone.utc).isoformat(),
+        "via": via.value,
+    }
+
+
+async def test_the_delivery_claim_is_a_statement_postgres_can_plan(db_session) -> None:
+    """The regression itself.
+
+    No pod is needed: an ``UPDATE`` matching no row still has to be planned, and
+    planning is exactly what used to fail.
+    """
+    await db_session.execute(
+        text(DELIVERY_CLAIM_SQL), _params(uuid4(), DeliveryVia.AGENT_RUN)
+    )
+
+
+async def test_the_first_outcome_claims_activation_and_later_ones_do_not(
+    db_session, authenticated_client, fixed_test_org
+) -> None:
+    """The guard is the whole design: many outcomes, one activation."""
+    pod_id = await _create_pod(authenticated_client, fixed_test_org["id"])
+
+    first = await db_session.scalar(
+        text(DELIVERY_CLAIM_SQL), _params(pod_id, DeliveryVia.SCHEDULE_RUN)
+    )
+    second = await db_session.scalar(
+        text(DELIVERY_CLAIM_SQL), _params(pod_id, DeliveryVia.AGENT_RUN)
+    )
+
+    assert str(first) == pod_id, "the first qualifying outcome must win the claim"
+    assert second is None, "a later outcome must not re-announce activation"
+
+    stored = await db_session.scalar(
+        text("SELECT config -> 'analytics' FROM pods WHERE id = :id"), {"id": pod_id}
+    )
+    assert stored["delivered_at"], "the timestamp is what makes the guard hold"
+    assert stored["via"] == DeliveryVia.SCHEDULE_RUN.value, (
+        "via records which outcome got there first, not the most recent one"
+    )
+
+
+async def test_claiming_preserves_whatever_else_the_pod_config_holds(
+    db_session, authenticated_client, fixed_test_org
+) -> None:
+    """`config` is the pod's own settings blob, not analytics' scratch space."""
+    pod_id = await _create_pod(authenticated_client, fixed_test_org["id"])
+    await db_session.execute(
+        text("UPDATE pods SET config = CAST(:cfg AS jsonb) WHERE id = :id"),
+        {"id": pod_id, "cfg": '{"theme": "dark"}'},
+    )
+    await db_session.commit()
+
+    await db_session.execute(
+        text(DELIVERY_CLAIM_SQL), _params(pod_id, DeliveryVia.SURFACE_MESSAGE)
+    )
+
+    config = await db_session.scalar(
+        text("SELECT config FROM pods WHERE id = :id"), {"id": pod_id}
+    )
+    assert config["theme"] == "dark", "activation must not clobber pod settings"
+    assert config["analytics"]["via"] == DeliveryVia.SURFACE_MESSAGE.value


### PR DESCRIPTION
Two independent defects found by running the analytics plane in development. They are unrelated subsystems and sit as two separate commits — happy to split into two PRs if you would rather review them apart.

## 1. `pod.delivered` never marked anything, and duplicated events doing it

Every claim failed with `IndeterminateDatatypeError`. `jsonb_build_object` declares its arguments `"any"`, so PostgreSQL cannot infer a type for a bound parameter and refuses to plan the statement.

It could not self-heal: the claim is guarded by `NOT (... ? 'delivered_at')` so it marks a pod once, and a statement that always raises never writes the marker, so the guard never became false.

**The damage was not limited to the marker.** The raise escapes the consumer's `record()` closure, and `emit("agent_run.completed", ...)` runs *before* it — so the inbox retried the whole projection and re-emitted an event already sent. Six hours of dev logs: 27 failures, three `agent.run.completed` events on `analytics.agent`, each retried nine times, **all three dead-lettered**.

`:now::text` is not the fix, which is the trap behind the trap — SQLAlchemy's `text()` reads the second colon of `::text` as a bind parameter named `text`. It has to be `CAST(:now AS text)`.

The statement is now a `DELIVERY_CLAIM_SQL` constant so the test binds the one production uses; a copy in the test would have passed while this failed. Three e2e tests run it against a real database: it plans, it claims once and only once, and it leaves the rest of the pod's `config` alone.

**How it shipped green:** the tests exercised `qualifies()`, a pure predicate, and nothing ever ran the SQL.

## 2. `recover_schedule_runs` could never converge

The DISPATCHED arm selects on `updated_at < now - DISPATCH_RECONCILE_AFTER`, that window is five minutes, and the cron interval is also five minutes — so a row the sweep merely looked at was guaranteed eligible again on the next pass.

What made it eligible was the sweep itself. The `target_exists` branch rewrote status and cleared error fields **without setting `target_outcome`**, the column the query filters on, so nothing about the write could move the row out of the query that found it. Its only lasting effect was bumping `updated_at`. At `BATCH_SIZE` rows × 288 runs/day that is **28,800 updates a day that cannot change anything**. Dev shows `reconciled` at 15, then 16, every five minutes, never falling.

A target that exists and has not finished is not something to reconcile; it is something to wait for. The branch now writes only a genuine correction — a row left FAILED or half-started while its target really runs — and does nothing when the row already says what it should.

## Verification

`make quality` green. 447 backend core unit, 341 across the schedule and workflow suites, plus the three new e2e tests against a real Postgres. Pre-existing unrelated failures, reproduced on a clean tree: `test_composio_kind_real_e2e` needs `COMPOSIO_API_KEY`, and `test_full_real_e2e.py` is gated behind the `provider` marker for real third-party credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)