### PR TITLE
Put backend events on the people who caused them, not on a machine actor

### DIFF
--- a/lemma-backend/app/composition/analytics_consumer.py
+++ b/lemma-backend/app/composition/analytics_consumer.py
@@ -351,7 +351,7 @@ async def on_pod_event(
             parsed_deleted = PodDeletedEvent.model_validate(event)
             emit(
                 "pod.deleted",
-                actor=AnalyticsActor.autonomous(ActorType.SYSTEM),
+                actor=_actor_or_system(parsed_deleted.deleted_by_user_id),
                 origin=origin,
                 organization_id=parsed_deleted.organization_id,
                 pod_id=parsed_deleted.pod_id,
@@ -439,7 +439,7 @@ async def on_function_event(
         parsed = FunctionCreatedEvent.model_validate(event)
         emit(
             "function.created",
-            actor=AnalyticsActor.autonomous(ActorType.SYSTEM),
+            actor=_actor_or_system(parsed.user_id),
             origin=_origin_of(event),
             pod_id=parsed.pod_id,
             properties={"pod_id": parsed.pod_id, "function_id": parsed.function_id},
@@ -638,7 +638,15 @@ async def on_schedule_event(
             return
         emit(
             "schedule_run.completed",
-            actor=AnalyticsActor.autonomous(ActorType.SYSTEM),
+            # Delegated, not autonomous: the run is unattended but it is done for
+            # somebody, and `DELEGATED_USER_WORKLOAD` is exactly the case where
+            # the work belongs on a human's timeline while staying
+            # distinguishable from what they did themselves.
+            actor=(
+                AnalyticsActor.delegated(delegated_by_user_id=completed.user_id)
+                if completed.user_id
+                else AnalyticsActor.autonomous(ActorType.SYSTEM)
+            ),
             origin=origin,
             pod_id=completed.pod_id,
             properties={
@@ -768,7 +776,7 @@ async def on_surface_event(
             return
         emit(
             "surface.connected",
-            actor=AnalyticsActor.autonomous(ActorType.SYSTEM),
+            actor=_actor_or_system(parsed.connected_by_user_id),
             origin=_origin_of(event),
             pod_id=parsed.pod_id,
             properties={

--- a/lemma-backend/app/core/analytics/emitter.py
+++ b/lemma-backend/app/core/analytics/emitter.py
@@ -129,16 +129,30 @@ class AnalyticsActor:
 AUTONOMOUS_DISTINCT_ID: str = "lemma:autonomous"
 
 
-def _resolve_distinct_id(actor: AnalyticsActor) -> str:
+def _resolve_distinct_id(actor: AnalyticsActor, *, event: str) -> str:
     """Whose timeline this event belongs on.
 
-    Autonomous work has no person on it. Rather than invent one, it all lands on
-    a single constant machine actor -- see ``AUTONOMOUS_DISTINCT_ID``.
+    The machine actor is a last resort, not a default. Almost nothing the backend
+    does is unattributed: requests are authenticated, and unattended work --
+    a schedule firing, a trigger on an RLS row -- is still done *for* somebody
+    and belongs on their timeline as ``DELEGATED_USER_WORKLOAD``. Genuinely
+    anonymous traffic is a browser thing.
+
+    So falling through to the machine actor is reported. It shipped silently
+    once and put connector executions, scheduled runs, function creations, pod
+    deletions and surface connections on a fake person instead of the people who
+    caused them -- and nothing said so, because the fallback looked like a
+    design choice rather than a gap.
     """
     if actor.user_id:
         return actor.user_id
     if actor.anonymous_id:
         return actor.anonymous_id
+    logger.warning(
+        "analytics.actor.unattributed",
+        analytic_event=event,
+        actor_type=actor.actor_type.value,
+    )
     return AUTONOMOUS_DISTINCT_ID
 
 
@@ -200,7 +214,7 @@ def emit(
     org = str(organization_id) if organization_id else None
     pod = str(pod_id) if pod_id else None
 
-    distinct_id = _resolve_distinct_id(actor)
+    distinct_id = _resolve_distinct_id(actor, event=name)
 
     allowed = spec.properties
     payload: dict[str, str | int | float | bool] = {}

--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -22,6 +22,9 @@ EVENT_CATALOG: dict[str, EventSpec] = {
         "warning", frozenset({"status", "count", "error_type"})
     ),
     "analytics.buffer.overflowed": EventSpec("warning", frozenset({"count"})),
+    "analytics.actor.unattributed": EventSpec(
+        "warning", frozenset({"analytic_event", "actor_type"})
+    ),
     "analytics.flush.failed": EventSpec("warning", frozenset({"error_type"})),
     "analytics.pod_delivered.cache_unavailable": EventSpec("debug", frozenset()),
     "analytics.app_session.cache_unavailable": EventSpec("debug", frozenset()),

--- a/lemma-backend/app/modules/agent_surfaces/domain/entities.py
+++ b/lemma-backend/app/modules/agent_surfaces/domain/entities.py
@@ -304,12 +304,16 @@ class AgentSurfaceEntity(AggregateRoot):
         )
         # `SurfaceRepository.create` already drains this via `_collect_events`;
         # the entity simply never recorded anything.
+        from app.core.authorization.current import get_current_context
+
+        actor = get_current_context()
         entity.add_event(
             SurfaceConnectedEvent(
                 surface_id=entity.id,
                 pod_id=pod_id,
                 platform=resolved.value,
                 agent_id=agent_id,
+                connected_by_user_id=getattr(actor, "user_id", None),
             )
         )
         return entity

--- a/lemma-backend/app/modules/agent_surfaces/domain/events.py
+++ b/lemma-backend/app/modules/agent_surfaces/domain/events.py
@@ -27,6 +27,10 @@ class SurfaceConnectedEvent(DomainEvent):
     pod_id: UUID
     platform: str
     agent_id: UUID | None = None
+    #: Who connected it, from the request's authorization context. Absent for the
+    #: mailbox provisioned automatically with an agent, which is the one case
+    #: where nobody connected anything.
+    connected_by_user_id: UUID | None = None
 
     @classmethod
     def stream_name(cls) -> str:

--- a/lemma-backend/app/modules/connectors/domain/analytics.py
+++ b/lemma-backend/app/modules/connectors/domain/analytics.py
@@ -39,7 +39,15 @@ def operation_execution_recorded(
     finally:
         emit(
             "connector.operation_executed",
-            actor=AnalyticsActor.autonomous(ActorType.SYSTEM),
+            actor=(
+                AnalyticsActor.user(resolved.acting_user_id)
+                if resolved.acting_user_id
+                # Only when the plan genuinely has no person behind it. Every
+                # request-driven execution does, and attributing those to the
+                # machine actor made "who is using connectors?" unanswerable.
+                else AnalyticsActor.autonomous(ActorType.SYSTEM)
+            ),
+            organization_id=resolved.organization_id,
             properties={
                 "connector_id": resolved.connector_id,
                 "provider": resolved.provider,

--- a/lemma-backend/app/modules/connectors/domain/execution_plan.py
+++ b/lemma-backend/app/modules/connectors/domain/execution_plan.py
@@ -37,3 +37,8 @@ class ResolvedConnectorExecution:
     account_id: UUID | None = None
     account_user_id: UUID | None = None
     organization_id: UUID | None = None
+    #: Who asked for this operation. Distinct from ``account_user_id``, which is
+    #: whoever owns the connected account -- a pod member can run an operation
+    #: through an account somebody else connected, and analytics wants the person
+    #: who acted, not the person who set it up.
+    acting_user_id: UUID | None = None

--- a/lemma-backend/app/modules/connectors/services/connector_operation_service.py
+++ b/lemma-backend/app/modules/connectors/services/connector_operation_service.py
@@ -583,6 +583,7 @@ class ConnectorOperationService:
             api_url=api_url,
             account_id=getattr(account, "id", None),
             account_user_id=getattr(account, "user_id", None),
+            acting_user_id=user_id,
             organization_id=getattr(account, "organization_id", None),
         )
 

--- a/lemma-backend/app/modules/function/domain/events.py
+++ b/lemma-backend/app/modules/function/domain/events.py
@@ -16,6 +16,9 @@ class FunctionCreatedEvent(DomainEvent):
     event_type: str = "function.created"
     function_id: UUID
     pod_id: UUID
+    #: Whoever created it. The row has always carried this; the event did not,
+    #: so every function landed in analytics attributed to the machine actor.
+    user_id: UUID | None = None
 
     @classmethod
     def stream_name(cls) -> str:

--- a/lemma-backend/app/modules/function/infrastructure/repositories.py
+++ b/lemma-backend/app/modules/function/infrastructure/repositories.py
@@ -67,7 +67,13 @@ class FunctionRepository(FunctionRepositoryPort):
         # the row exists by this point, so an event that fires is an event that
         # committed.
         self.uow.collect_events(
-            [FunctionCreatedEvent(function_id=model.id, pod_id=model.pod_id)]
+            [
+                FunctionCreatedEvent(
+                    function_id=model.id,
+                    pod_id=model.pod_id,
+                    user_id=getattr(model, "user_id", None),
+                )
+            ]
         )
         return model.to_entity()
 

--- a/lemma-backend/app/modules/pod/domain/events.py
+++ b/lemma-backend/app/modules/pod/domain/events.py
@@ -50,6 +50,11 @@ class PodDeletedEvent(DomainEvent):
     event_type: str = "pod.deleted"
     pod_id: UUID
     organization_id: UUID
+    #: Who deleted it -- read from the request's authorization context, not from
+    #: the pod's own ``user_id``: an admin can delete a pod somebody else built,
+    #: and attributing that to the creator would be a false statement rather than
+    #: a missing one.
+    deleted_by_user_id: UUID | None = None
 
     @classmethod
     def stream_name(cls) -> str:

--- a/lemma-backend/app/modules/pod/domain/pod_entities.py
+++ b/lemma-backend/app/modules/pod/domain/pod_entities.py
@@ -115,13 +115,16 @@ class PodEntity(AggregateRoot):
 
     def mark_deleted(self) -> None:
         """Soft delete aggregate and emit deletion event for downstream cleanup."""
+        from app.core.authorization.current import get_current_context
         from app.modules.pod.domain.events import PodDeletedEvent
 
+        actor = get_current_context()
         self.is_deleted = True
         self.add_event(
             PodDeletedEvent(
                 pod_id=self.id,
                 organization_id=self.organization_id,
+                deleted_by_user_id=getattr(actor, "user_id", None),
             )
         )
 

--- a/lemma-backend/app/modules/schedule/domain/events/schedule.py
+++ b/lemma-backend/app/modules/schedule/domain/events/schedule.py
@@ -49,14 +49,23 @@ class ScheduleDeleted(ScheduleLifecycleEvent):
 class ScheduleRunCompleted(ScheduleEvent):
     """One scheduled run reached a terminal outcome.
 
-    Not a lifecycle event: it says nothing about the schedule's definition, and
-    it carries no ``user_id`` because a scheduled run has no person on it -- the
-    whole point of a schedule is that it runs when nobody is there.
+    Not a lifecycle event: it says nothing about the schedule's definition.
+
+    It does carry a person. Nobody is *watching* a scheduled run, which is not
+    the same as nobody being behind it: the work is done for the schedule's
+    owner, or -- for a datastore trigger on an RLS table -- for whoever owns the
+    row that fired it. Reporting these as machine work took every scheduled
+    outcome off its owner's timeline.
     """
 
     event_type: str = "schedule.run.completed"
     pod_id: UUID | None = None
     status: str
+    #: Who the run was for. The ledger row carries the row owner for a datastore
+    #: trigger on an RLS table and the schedule owner otherwise, so this is a real
+    #: person in almost every case -- a scheduled run is unattended, not
+    #: unattributed.
+    user_id: UUID | None = None
 
 
 class ScheduleDeactivated(ScheduleLifecycleEvent):

--- a/lemma-backend/app/modules/schedule/services/run_outcome_service.py
+++ b/lemma-backend/app/modules/schedule/services/run_outcome_service.py
@@ -69,6 +69,9 @@ class ScheduleRunOutcomeService:
                     schedule_type=schedule.schedule_type,
                     pod_id=schedule.pod_id,
                     status=status.value,
+                    # The run's own owner first: for a datastore trigger that is
+                    # the row owner, who is not the schedule owner.
+                    user_id=getattr(schedule_run, "user_id", None) or schedule.user_id,
                 )
             ]
         )


### PR DESCRIPTION
`connector.operation_executed` showed up in PostHog attributed to `lemma:autonomous` while a real person had asked for it. Auditing the rest of the catalog found the same mistake in four more places, with one shared cause: the machine actor was reached for whenever the *event* lacked a user, without asking whether a user was available at all.

Almost nothing this backend does is unattributed. Requests are authenticated, and unattended work is still done **for** somebody.

## What was wrong

| Event | Was | Now |
|---|---|---|
| `connector.operation_executed` | machine actor | the caller |
| `schedule_run.completed` | machine actor | delegated to the run's owner |
| `function.created` | machine actor | the creator |
| `pod.deleted` | machine actor | whoever deleted it |
| `surface.connected` | machine actor | whoever connected it |

**`connector.operation_executed`** — `ResolvedConnectorExecution` did not carry the caller, but the resolve phase that builds it takes `user_id` and dropped it. Now carried as `acting_user_id`, deliberately distinct from the existing `account_user_id`: a pod member can run an operation through an account somebody else connected, and the person who acted is the one analytics wants.

**`schedule_run.completed`** — this was the interesting one. `schedule_runs.user_id` already holds the row owner for a datastore trigger on an RLS table, and the schedule owner otherwise. Nobody *watching* a scheduled run is not the same as nobody being behind it, so it is now `DELEGATED_USER_WORKLOAD` — exactly the case the design has for work that belongs on a human's timeline while staying distinguishable from what they did themselves.

**`pod.deleted`** and **`surface.connected`** take the acting person from the request's authorization context, the same way `DomainEvent` already takes `origin` from a contextvar. Read from the context rather than from the pod's own `user_id` on purpose: an admin can delete a pod somebody else built, and attributing that to the creator would be a false statement rather than a missing one.

## The property that actually failed

The fallback was silent, which is why five of these shipped together. `_resolve_distinct_id` now reports when it reaches the machine actor — a default that looks like a design choice hides a gap. Anything backend-side still unattributed will say so instead of quietly writing `lemma:autonomous`.

Genuinely anonymous traffic is a browser concern; `share_link.viewed`, which is client-emitted, remains the only anonymous entry in the catalog.

## Verification

`make quality` green on top of `2d3cffb4`. 482 core unit plus the schedule outcome suite; the full run before rebasing covered 1490 across core, pod and agent_surfaces.

Existing `lemma:autonomous` rows already in PostHog are not re-attributed retroactively — dev has only a handful and no production key is live, so I have left them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)