### PR TITLE
Give the sandbox browser an end, and stop the sweep believing itself

### DIFF
--- a/docs/architecture/sandbox/lifecycle-state-model.md
+++ b/docs/architecture/sandbox/lifecycle-state-model.md
@@ -162,6 +162,13 @@ old directory.
   allocation — see [Sandbox fabric](README.md) §6.
 - A workspace pause is filesystem-only. Files persist; running processes and
   interpreter state do not, and callers must not treat them as recoverable.
+  This is `keep_memory=False` on the provider's pause, and it has to be passed
+  explicitly: the E2B SDK defaults to `True`. It was not passed for some time,
+  and the gap was invisible precisely because this document said otherwise --
+  every workspace pause preserved resident memory, so a headed browser started
+  by one conversation was snapshotted and restored into the next, reaching 63
+  Chrome processes and 2123 MB on a 2048 MB sandbox without ever being started
+  again. Reading this page told you it could not happen.
 - Permanent deletion and recoverable compute release are separate operations.
 
 ## Provider evidence behind the model

--- a/lemma-backend/agent_tool_schemas.json
+++ b/lemma-backend/agent_tool_schemas.json
@@ -3394,11 +3394,11 @@
     "input_schema": {
       "properties": {
         "urls": {
-          "description": "Pages to capture, in one call \u2014 up to 10. Batching is the point: research usually means reading several sources, not one. Static pages are fetched in parallel and are quick; pages that need the full browser render one at a time, so a call is capped at a few minutes and reports anything it did not reach. If some come back 'not attempted', ask for those again rather than repeating the whole list.",
+          "description": "Pages to capture, in one call \u2014 up to 5. Batching is the point: research usually means reading several sources, not one. Static pages are fetched in parallel and are quick; pages that need the full browser render one at a time, so a call is capped at a few minutes and reports anything it did not reach. If some come back 'not attempted', ask for those again rather than repeating the whole list.",
           "items": {
             "type": "string"
           },
-          "maxItems": 10,
+          "maxItems": 5,
           "minItems": 1,
           "type": "array"
         },

--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -638,6 +638,7 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'workspace.sandbox_session.output_cursor_write_failed': EventSpec('debug', frozenset({'process_id', 'sandbox_id'})),
     'workspace.sandbox_session.python_session_delete_failed': EventSpec('debug', frozenset({'sandbox_id', 'session_id'})),
     'workspace.sandbox_sweeper.idle_release_failed': EventSpec('warning', frozenset({'error_type', 'sandbox_id'})),
+    'workspace.e2b.profile_drift_tolerated': EventSpec('info', frozenset({'sandbox_id'})),
     'workspace.sandbox_sweeper.orphan_destroy_failed': EventSpec('warning', frozenset({'error_type', 'sandbox_id'})),
     'workspace.sandbox_sweeper.orphan_destroy_ineffective': EventSpec('warning', frozenset({'reason', 'sandbox_id'})),
     'workspace.sandbox_sweeper.orphan_reclaimed': EventSpec('info', frozenset({'reason', 'sandbox_id'})),

--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -639,6 +639,7 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'workspace.sandbox_session.python_session_delete_failed': EventSpec('debug', frozenset({'sandbox_id', 'session_id'})),
     'workspace.sandbox_sweeper.idle_release_failed': EventSpec('warning', frozenset({'error_type', 'sandbox_id'})),
     'workspace.sandbox_sweeper.orphan_destroy_failed': EventSpec('warning', frozenset({'error_type', 'sandbox_id'})),
+    'workspace.sandbox_sweeper.orphan_destroy_ineffective': EventSpec('warning', frozenset({'reason', 'sandbox_id'})),
     'workspace.sandbox_sweeper.orphan_reclaimed': EventSpec('info', frozenset({'reason', 'sandbox_id'})),
     'workspace.sandbox_sweeper.reclaimed_orphaned_objects.observed': EventSpec('info', frozenset({'reclaimed_count'})),
     'workspace.sandbox_sweeper.released_idle_sandboxes.observed': EventSpec('info', frozenset({'released_count'})),

--- a/lemma-backend/app/modules/agent/tests/unit/test_web_research.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_web_research.py
@@ -24,6 +24,8 @@ from app.core.web_search.search_client import (
     apply_domain_operators,
 )
 from app.modules.agent.tools.web import web_fetch as web_fetch_module
+from pydantic import ValidationError
+
 from app.modules.agent.tools.web.models import WebFetchRequest
 
 pytestmark = pytest.mark.unit
@@ -641,26 +643,44 @@ class TestTheToolAlwaysReturns:
         assert result.success, "a partial capture is still a useful result"
         assert "time budget" in (result.message or "")
 
+    def test_web_fetch_limits_agree(self) -> None:
+        """The tool must not accept more pages than it will render.
+
+        These were 10 and 3. A caller who sent ten JS-heavy URLs got seven back
+        as "Skipped: this call renders at most 3" -- a limit the schema had no
+        way to express, discovered only after paying for the call. Holding them
+        equal is what makes the advertised cap the real one.
+        """
+        accepted = WebFetchRequest.model_fields["urls"].metadata
+        max_urls = next(
+            item.max_length for item in accepted if hasattr(item, "max_length")
+        )
+
+        assert max_urls == web_fetch_module._MAX_BROWSER_RENDERS
+
     @pytest.mark.asyncio
-    async def test_browser_renders_are_capped_per_call(self, monkeypatch) -> None:
-        """Four JS-heavy URLs must not become four serialised Chrome renders.
+    async def test_a_full_batch_of_js_pages_skips_nothing(self, monkeypatch) -> None:
+        """The largest batch the schema accepts, every page needing a browser.
 
         This is the shape that hung in production: a research batch where most
-        of the list refuses a plain fetch.
+        of the list refuses a plain fetch. It must now render all of them
+        rather than reporting some as skipped.
         """
         session = _FakeSession()
         _patch_session(monkeypatch, session)
         _patch_extraction(monkeypatch, markdown=None)  # everything needs a browser
+        urls = [
+            f"https://spa{index}.example/app"
+            for index in range(web_fetch_module._MAX_BROWSER_RENDERS)
+        ]
 
         result = await web_fetch_module.web_fetch_internal(
-            SimpleNamespace(),
-            WebFetchRequest(urls=[f"https://spa{i}.example/app" for i in range(6)]),
+            SimpleNamespace(), WebFetchRequest(urls=urls)
         )
 
         rendered = sum("save-webpage" in cmd for cmd in session.commands)
-        assert rendered == web_fetch_module._MAX_BROWSER_RENDERS, session.commands
-        skipped = [p for p in result.pages if p.error and "Skipped" in p.error]
-        assert len(skipped) == 6 - web_fetch_module._MAX_BROWSER_RENDERS
+        assert rendered == len(urls), session.commands
+        assert [p for p in result.pages if p.error and "Skipped" in p.error] == []
 
     @pytest.mark.asyncio
     async def test_an_unreachable_workspace_reports_every_url(
@@ -688,7 +708,8 @@ class TestTheToolAlwaysReturns:
         assert result.error and "workspace" in result.error.lower()
 
     def test_the_url_list_is_capped(self) -> None:
-        """Ten is already several minutes of browser work in the worst case."""
-        WebFetchRequest(urls=[f"https://e{i}.example/a" for i in range(10)])
-        with pytest.raises(Exception):
-            WebFetchRequest(urls=[f"https://e{i}.example/a" for i in range(11)])
+        """At exactly what the tool can render -- see test_web_fetch_limits_agree."""
+        limit = web_fetch_module._MAX_BROWSER_RENDERS
+        WebFetchRequest(urls=[f"https://e{i}.example/a" for i in range(limit)])
+        with pytest.raises(ValidationError):
+            WebFetchRequest(urls=[f"https://e{i}.example/a" for i in range(limit + 1)])

--- a/lemma-backend/app/modules/agent/tools/web/models.py
+++ b/lemma-backend/app/modules/agent/tools/web/models.py
@@ -13,9 +13,15 @@ class WebFetchRequest(BaseModel):
     urls: list[str] = Field(
         ...,
         min_length=1,
-        max_length=10,
+        # Must equal `_MAX_BROWSER_RENDERS`, and `test_web_fetch_limits_agree`
+        # holds the two together. Advertising ten while rendering three meant a
+        # caller who sent ten JS-heavy pages was told, only after paying for
+        # the call, that seven of them were skipped -- a limit the schema had
+        # no way to express and the agent had no way to plan around. Accepting
+        # exactly what can be delivered is what makes the cap honest.
+        max_length=5,
         description=(
-            "Pages to capture, in one call — up to 10. Batching is the point: "
+            "Pages to capture, in one call — up to 5. Batching is the point: "
             "research usually means reading several sources, not one. Static "
             "pages are fetched in parallel and are quick; pages that need the "
             "full browser render one at a time, so a call is capped at a few "

--- a/lemma-backend/app/modules/agent/tools/web/web_fetch.py
+++ b/lemma-backend/app/modules/agent/tools/web/web_fetch.py
@@ -75,9 +75,20 @@ _BROWSER_TIMEOUT_SECONDS = 75
 _BATCH_BUDGET_SECONDS = 240
 
 # Browser renders are the serialised, expensive path, and the batch budget is
-# the only thing bounding them. Capping them keeps a list of JS-heavy URLs from
-# spending the entire budget before the cheap pages are even reported.
-_MAX_BROWSER_RENDERS = 3
+# the only thing bounding them.
+#
+# This is deliberately the same number as `WebFetchRequest.urls`' `max_length`,
+# and `test_web_fetch_limits_agree` fails if the two ever drift: the cap is
+# only honest when the tool cannot accept more pages than it will render. It
+# used to accept ten and render three, so a caller who sent ten JS-heavy pages
+# discovered seven were skipped only after paying for the call.
+#
+# Raising it does not endanger the cheap pages the old comment worried about --
+# the http path runs to completion first, concurrently, before any render
+# starts. What bounds the pathological case is the batch deadline, which
+# reports every page it did not reach. Measured, a real render is ~5s, so five
+# of them sit an order of magnitude inside that budget.
+_MAX_BROWSER_RENDERS = 5
 
 # Enough to saturate the network wait without opening twenty sockets to twenty
 # sites at once.

--- a/lemma-backend/app/modules/workspace/providers/e2b.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b.py
@@ -290,8 +290,38 @@ class E2BSandboxProvider(E2BOpsMixin):
     ) -> None:
         """Pause, keeping the filesystem. The next ensure resumes this sandbox."""
         sandbox = await self._connect(instance.provider_id)
+        if kind is SandboxKind.WORKSPACE:
+            await self._shed_browser(sandbox)
         with sdk_errors():
             await sandbox.beta_pause(**self._api())
+
+    async def _shed_browser(self, sandbox) -> None:
+        """End the browser before the pause makes it permanent.
+
+        A pause here is a *memory snapshot*, which is the whole difference from
+        Docker: stopping a container throws its memory away, so the quiesce
+        Docker runs first is a tidy-up. Pausing preserves whatever is resident,
+        and resuming brings all of it back -- so a headed Chrome left running by
+        one conversation is restored into the next one, and the next, without
+        ever being started again. That is why a workspace measured after a
+        research session held 63 Chrome processes at 2123 MB on a 2048 MB
+        sandbox, and why killing them by hand did not help: the snapshot they
+        came from was taken before the kill and taken again after the restore.
+
+        Best effort, and deliberately so. A sandbox whose browser cannot be
+        reached is exactly the one most in need of being paused, and failing
+        the release would leave it running instead.
+        """
+        with sdk_best_effort("browser shutdown"):
+            await sandbox.commands.run(
+                "agent-browser close --all >/dev/null 2>&1; "
+                "pkill -f agent-browser >/dev/null 2>&1; "
+                "pkill -f workspace-chrome >/dev/null 2>&1; "
+                "pkill -f Xvfb >/dev/null 2>&1; "
+                'rm -rf /tmp/lemma-browser "$HOME/.agent-browser" '
+                ">/dev/null 2>&1; true",
+                timeout=20,
+            )
 
     async def destroy(self, name: str, *, deadline_at: datetime) -> None:
         instance = await self.inspect(name, deadline_at=deadline_at)

--- a/lemma-backend/app/modules/workspace/providers/e2b.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b.py
@@ -288,47 +288,56 @@ class E2BSandboxProvider(E2BOpsMixin):
         kind: SandboxKind,
         deadline_at: datetime,
     ) -> None:
-        """Pause, keeping the filesystem. The next ensure resumes this sandbox."""
-        sandbox = await self._connect(instance.provider_id)
-        if kind is SandboxKind.WORKSPACE:
-            await self._shed_browser(sandbox)
-        with sdk_errors():
-            await sandbox.beta_pause(**self._api())
+        """Pause, keeping the filesystem. The next ensure resumes this sandbox.
 
-    async def _shed_browser(self, sandbox) -> None:
-        """End the browser before the pause makes it permanent.
+        `keep_memory=False` because the SDK's default is `True`, and this call
+        passed nothing -- so every workspace pause was preserving resident
+        memory, while both architecture documents said the opposite:
+        "A workspace pause is filesystem-only. Files persist; running processes
+        and interpreter state do not, and callers must not treat them as
+        recoverable." Auto-resume is already disabled here, which E2B only
+        requires *because* of filesystem-only snapshots, so the rest of the
+        design had been built around a property the one call that decides it
+        never asked for.
 
-        A pause here is a *memory snapshot*, which is the whole difference from
-        Docker: stopping a container throws its memory away, so the quiesce
-        Docker runs first is a tidy-up. Pausing preserves whatever is resident,
-        and resuming brings all of it back -- so a headed Chrome left running by
-        one conversation is restored into the next one, and the next, without
-        ever being started again. That is why a workspace measured after a
-        research session held 63 Chrome processes at 2123 MB on a 2048 MB
-        sandbox, and why killing them by hand did not help: the snapshot they
-        came from was taken before the kill and taken again after the restore.
-
-        Best effort, and deliberately so. A sandbox whose browser cannot be
-        reached is exactly the one most in need of being paused, and failing
-        the release would leave it running instead.
+        That gap is what made a leaked browser invisible. A memory-preserving
+        pause snapshots whatever is running and hands it to the next
+        conversation, so a headed Chrome survived every idle release without
+        ever being started again -- 63 processes and 2123 MB on a 2048 MB
+        sandbox, restored rather than respawned. Reading the docs told you it
+        could not happen.
         """
-        with sdk_best_effort("browser shutdown"):
-            await sandbox.commands.run(
-                "agent-browser close --all >/dev/null 2>&1; "
-                "pkill -f agent-browser >/dev/null 2>&1; "
-                "pkill -f workspace-chrome >/dev/null 2>&1; "
-                "pkill -f Xvfb >/dev/null 2>&1; "
-                'rm -rf /tmp/lemma-browser "$HOME/.agent-browser" '
-                ">/dev/null 2>&1; true",
-                timeout=20,
-            )
+        del kind  # Both kinds pause the same way.
+        sandbox = await self._connect(instance.provider_id)
+        with sdk_errors():
+            await sandbox.beta_pause(keep_memory=False, **self._api())
 
     async def destroy(self, name: str, *, deadline_at: datetime) -> None:
+        """Kill a sandbox, addressed either by container name or by E2B id.
+
+        Both, because both are handed to this. `inspect` only understands
+        container names -- it parses one back into a metadata query -- but
+        `list_objects` names every object by its E2B sandbox id, since that is
+        what E2B reports. So the sweep's `destroy(obj.name)` parsed to nothing,
+        read as "already gone", and returned having killed nothing. That is why
+        the orphan sweep logged eighteen reclaims every five minutes for hours
+        against the same eighteen ids while the account's count never moved:
+        the destroy was a no-op for exactly the objects the sweep discovers.
+        """
+        from app.modules.workspace.providers import naming
+
         instance = await self.inspect(name, deadline_at=deadline_at)
-        if instance is None:
-            # Already gone is the outcome destroy was asking for.
+        provider_id = instance.provider_id if instance is not None else None
+        if provider_id is None and naming.parse_container_name(name) is None:
+            # Not one of our names, so it is an id -- which is the only other
+            # thing this is ever given, and `list_objects` has already
+            # established that it carries this platform's metadata.
+            provider_id = name
+        if provider_id is None:
+            # A name that parses but resolves to nothing really is gone, and
+            # that is the outcome destroy was asking for.
             return
-        sandbox = await self._connect(instance.provider_id)
+        sandbox = await self._connect(provider_id)
         with sdk_errors():
             await sandbox.kill(**self._api())
 

--- a/lemma-backend/app/modules/workspace/providers/e2b.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b.py
@@ -39,6 +39,7 @@ from datetime import datetime
 from uuid import UUID
 
 
+from app.core.log.log import get_logger
 from app.modules.workspace.domain.sandbox import SandboxKind
 from app.modules.workspace.providers.base import (
     ProviderCreateSpec,
@@ -60,6 +61,8 @@ from app.modules.workspace.providers.e2b_common import (
 )
 from app.modules.workspace.providers.e2b_ops import E2BOpsMixin
 from app.modules.workspace.providers.e2b_output import E2BOutputBuffer
+
+logger = get_logger(__name__)
 
 WORKSPACE_MOUNT = "/workspace"
 
@@ -179,13 +182,13 @@ class E2BSandboxProvider(E2BOpsMixin):
         a stale operation fails rather than landing on it.
         """
         existing = await self._find_any(spec.sandbox_id)
-        if existing is not None and existing.profile_digest != spec.profile_digest:
-            # Made from a different build of the template. Here the sandbox is
-            # the disk, so there is no way to keep the files and still move to
-            # the new image -- and leaving it would keep this workspace on the
-            # old template forever, talking a protocol the backend no longer
-            # speaks. Destroy it so the create below starts clean; the caller
-            # learns the disk is new from storage_adopted=False.
+        drifted = (
+            existing is not None
+            and existing.profile_digest != spec.profile_digest
+        )
+        if drifted and spec.kind is SandboxKind.FUNCTION:
+            # A function sandbox owns no durable disk, so replacing it to adopt
+            # a new digest costs a cold start and nothing else.
             #
             # Not best-effort: if the stale sandbox survives, the fresh one
             # carries the same sandbox-id metadata and a later lookup could
@@ -204,6 +207,25 @@ class E2BSandboxProvider(E2BOpsMixin):
             except ProviderGone:
                 pass
             existing = None
+        elif drifted:
+            # A workspace tolerates drift, and this is the whole reason the
+            # policy exists: here the sandbox *is* the disk, so killing it to
+            # adopt a new digest deletes the user's files. The digest is set by
+            # `WORKSPACE_PROFILE_DIGEST`, an environment variable -- so this
+            # branch used to mean that editing one env var and deploying wiped
+            # every workspace in the fleet, on the first ensure after rollout,
+            # with no confirmation and nothing to restore from.
+            #
+            # `Sandbox fabric` README §6 already states the intended behaviour:
+            # "While a workspace owns a disk it keeps running the profile it
+            # was created with, no generation fence is raised, and nothing is
+            # replaced", adopting the new profile only when it is next created
+            # from scratch. The accepted cost, stated there too, is that a
+            # workspace may run an N-1 template until then.
+            logger.info(
+                "workspace.e2b.profile_drift_tolerated",
+                sandbox_id=str(spec.sandbox_id),
+            )
         if existing is not None:
             await self._stamp(existing.provider_id, spec)
             return ProviderInstance(

--- a/lemma-backend/app/modules/workspace/providers/e2b_ops.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b_ops.py
@@ -44,56 +44,12 @@ from app.modules.workspace.providers.e2b_common import (
     sdk_errors,
 )
 from app.modules.workspace.providers.e2b_process_lifetime import seconds_until
+from app.modules.workspace.providers.e2b_python_runner import _PYTHON_RUNNER
 
 WORKSPACE_MOUNT = "/workspace"
 
 
-_PYTHON_RUNNER = """
-import ast, pickle, os, sys
 
-_STATE = {state_path!r}
-_CODE = {code_path!r}
-_RESULT = {result_path!r}
-
-_ns = {{"__name__": "__main__"}}
-if os.path.exists(_STATE):
-    try:
-        with open(_STATE, "rb") as handle:
-            _ns.update(pickle.load(handle))
-    except Exception:
-        pass
-
-with open(_CODE) as handle:
-    _source = handle.read()
-
-_tree = ast.parse(_source)
-_tail = None
-if _tree.body and isinstance(_tree.body[-1], ast.Expr):
-    _tail = ast.Expression(_tree.body.pop().value)
-
-try:
-    exec(compile(_tree, "<session>", "exec"), _ns)
-    if _tail is not None:
-        _value = eval(compile(_tail, "<session>", "eval"), _ns)
-        if _value is not None:
-            with open(_RESULT, "w") as handle:
-                handle.write(repr(_value) if not isinstance(_value, str) else _value)
-finally:
-    _keep = {{}}
-    for _name, _value in list(_ns.items()):
-        if _name.startswith("__"):
-            continue
-        try:
-            pickle.dumps(_value)
-        except Exception:
-            continue
-        _keep[_name] = _value
-    try:
-        with open(_STATE, "wb") as handle:
-            pickle.dump(_keep, handle)
-    except Exception:
-        pass
-"""
 
 
 class E2BOpsMixin:
@@ -516,7 +472,13 @@ class E2BOpsMixin:
             outcome = await sandbox.commands.run(
                 f"python3 {runner_path}",
                 envs={item.name: item.value for item in request.environment},
-                timeout=None,
+                # `None` here meant unbounded, so `execute_python`'s
+                # `timeout_seconds` bounded only how long the backend waited --
+                # nothing stopped the code itself. A runaway loop kept running
+                # in the sandbox after the tool had returned, holding CPU and
+                # memory on a box with one core, and the idle sweeper will not
+                # release a sandbox with live processes.
+                timeout=seconds_until(request.deadline_at),
             )
 
         # No trailing expression, or a run that failed before writing one,

--- a/lemma-backend/app/modules/workspace/providers/e2b_ops.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b_ops.py
@@ -44,7 +44,7 @@ from app.modules.workspace.providers.e2b_common import (
     sdk_errors,
 )
 from app.modules.workspace.providers.e2b_process_lifetime import seconds_until
-from app.modules.workspace.providers.e2b_python_runner import _PYTHON_RUNNER
+from app.modules.workspace.providers.e2b_python_runner import PYTHON_RUNNER
 
 WORKSPACE_MOUNT = "/workspace"
 
@@ -463,7 +463,7 @@ class E2BOpsMixin:
             await sandbox.files.write(code_path, request.code)
             await sandbox.files.write(
                 runner_path,
-                _PYTHON_RUNNER.format(
+                PYTHON_RUNNER.format(
                     state_path=state_path,
                     code_path=code_path,
                     result_path=result_path,

--- a/lemma-backend/app/modules/workspace/providers/e2b_python_runner.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b_python_runner.py
@@ -10,7 +10,7 @@ here can be checked by the type checker or exercised by importing it.
 
 from __future__ import annotations
 
-_PYTHON_RUNNER = """
+PYTHON_RUNNER = """
 import ast, importlib, pickle, os, sys, types
 
 _STATE = {state_path!r}

--- a/lemma-backend/app/modules/workspace/providers/e2b_python_runner.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b_python_runner.py
@@ -1,0 +1,83 @@
+"""The script one `execute_python` call runs, as text.
+
+E2B has no resident interpreter to hold a session, so continuity is rebuilt
+from what it does offer: each call is a fresh `python3`, and the namespace
+travels between calls in a file beside the sandbox's tmp state. That makes this
+string the whole of the REPL, which is why it lives on its own -- it is
+executed by a different interpreter than the one that formats it, so nothing
+here can be checked by the type checker or exercised by importing it.
+"""
+
+from __future__ import annotations
+
+_PYTHON_RUNNER = """
+import ast, importlib, pickle, os, sys, types
+
+_STATE = {state_path!r}
+_MODULES = _STATE + ".modules"
+_CODE = {code_path!r}
+_RESULT = {result_path!r}
+
+_ns = {{"__name__": "__main__"}}
+if os.path.exists(_STATE):
+    try:
+        with open(_STATE, "rb") as handle:
+            _ns.update(pickle.load(handle))
+    except Exception:
+        pass
+# A module cannot be pickled, so the namespace filter below drops every one of
+# them -- which quietly broke the only thing this tool promises. `import pandas
+# as pd` in one call left `pd` undefined in the next, and the agent saw a bare
+# NameError for a name it had just bound. Modules are carried by name and
+# re-imported instead: the import is cached by the interpreter anyway, so this
+# restores the binding rather than repeating the work.
+if os.path.exists(_MODULES):
+    try:
+        with open(_MODULES, "rb") as handle:
+            for _alias, _module_name in pickle.load(handle).items():
+                try:
+                    _ns[_alias] = importlib.import_module(_module_name)
+                except Exception:
+                    # Uninstalled since the last call. Leaving the name unbound
+                    # gives the agent the real ImportError when it is used.
+                    pass
+    except Exception:
+        pass
+
+with open(_CODE) as handle:
+    _source = handle.read()
+
+_tree = ast.parse(_source)
+_tail = None
+if _tree.body and isinstance(_tree.body[-1], ast.Expr):
+    _tail = ast.Expression(_tree.body.pop().value)
+
+try:
+    exec(compile(_tree, "<session>", "exec"), _ns)
+    if _tail is not None:
+        _value = eval(compile(_tail, "<session>", "eval"), _ns)
+        if _value is not None:
+            with open(_RESULT, "w") as handle:
+                handle.write(repr(_value) if not isinstance(_value, str) else _value)
+finally:
+    _keep = {{}}
+    _module_names = {{}}
+    for _name, _value in list(_ns.items()):
+        if _name.startswith("__"):
+            continue
+        if isinstance(_value, types.ModuleType):
+            _module_names[_name] = _value.__name__
+            continue
+        try:
+            pickle.dumps(_value)
+        except Exception:
+            continue
+        _keep[_name] = _value
+    try:
+        with open(_STATE, "wb") as handle:
+            pickle.dump(_keep, handle)
+        with open(_MODULES, "wb") as handle:
+            pickle.dump(_module_names, handle)
+    except Exception:
+        pass
+"""

--- a/lemma-backend/app/modules/workspace/sandbox_session.py
+++ b/lemma-backend/app/modules/workspace/sandbox_session.py
@@ -285,8 +285,8 @@ class SandboxWorkspaceSession:
                     completed=False,
                 )
             return _sandbox_command_failure(
-                error=f"the sandbox runtime {exc.code}: {exc}",
-                retryable=exc.retry.value != "do_not_retry",
+                error=f"the sandbox runtime failed: {describe_exception(exc)}",
+                retryable=isinstance(exc, SandboxUnavailable),
                 process_id=process_id,
             )
         except (httpx.HTTPError, OSError, ValueError) as exc:

--- a/lemma-backend/app/modules/workspace/services/sandbox_sweeper.py
+++ b/lemma-backend/app/modules/workspace/services/sandbox_sweeper.py
@@ -142,8 +142,8 @@ class SandboxSweeper:
             else:
                 continue
 
-            reclaimed.append(obj.name)
             if dry_run:
+                reclaimed.append(obj.name)
                 continue
             try:
                 await self._provider.destroy(obj.name, deadline_at=deadline_at)
@@ -154,9 +154,48 @@ class SandboxSweeper:
                     error_type=type(exc).__name__,
                 )
                 continue
+            # A destroy that returns is not a destroy that happened. On E2B a
+            # paused sandbox is listed like any other but does not go away when
+            # killed, so this loop logged eighteen reclaims every five minutes
+            # for hours -- the same eighteen ids, eleven times each -- while the
+            # account held ninety-nine paused sandboxes and the count never
+            # moved. Nothing was wrong with the sweep except that it believed
+            # itself. Confirming against the provider is what makes the count
+            # in `reclaimed_orphaned_objects.observed` mean anything, and what
+            # makes a provider that cannot reap this object say so instead of
+            # rediscovering it forever.
+            if await self._still_present(obj, deadline_at=deadline_at):
+                logger.warning(
+                    "workspace.sandbox_sweeper.orphan_destroy_ineffective",
+                    sandbox_id=str(obj.sandbox_id),
+                    reason=reason,
+                )
+                continue
+            reclaimed.append(obj.name)
             logger.info(
                 "workspace.sandbox_sweeper.orphan_reclaimed",
                 sandbox_id=str(obj.sandbox_id),
                 reason=reason,
             )
         return tuple(reclaimed)
+
+    async def _still_present(self, obj, *, deadline_at: datetime) -> bool:
+        """Whether the provider can still see *this* object after the destroy.
+
+        Identity, not existence. `inspect` resolves a name to whatever object
+        now holds that sandbox id, and reclaiming a superseded epoch leaves the
+        current one standing -- so "something is there" would read every
+        successful epoch reclaim as a failure. Only the same provider id means
+        nothing happened.
+
+        A provider that cannot answer is given the benefit of the doubt: the
+        sweep runs again in five minutes, and a false alarm every cycle would
+        bury the real signal this exists to raise.
+        """
+        try:
+            instance = await self._provider.inspect(obj.name, deadline_at=deadline_at)
+        except ProviderGone:
+            return False
+        except (ProviderFailed, ProviderNotReady, ProviderRejected, SandboxError):
+            return False
+        return instance is not None and instance.provider_id == obj.provider_id

--- a/lemma-backend/app/modules/workspace/services/sandbox_sweeper.py
+++ b/lemma-backend/app/modules/workspace/services/sandbox_sweeper.py
@@ -26,7 +26,6 @@ from app.modules.workspace.infrastructure.sandbox_repository import SandboxRepos
 from app.modules.workspace.providers.base import (
     ProviderFailed,
     ProviderGone,
-    ProviderInstance,
     ProviderNotReady,
     ProviderRejected,
 )
@@ -79,14 +78,26 @@ class SandboxSweeper:
         sweep would stop compute underneath live work.
         """
 
-        handle = await self._service.describe(sandbox.id)
-        if handle is None:
+        async with self._uow_factory() as uow:
+            current = await SandboxRepository(uow).current_instance(sandbox.id)
+        if current is None or not current.provider_id:
             return False
-        instance = ProviderInstance(
-            provider_id=handle.name, name=handle.name, running=True
-        )
         deadline_at = datetime.now(timezone.utc) + timedelta(seconds=15)
         try:
+            # Ask the provider to resolve it, rather than assembling an
+            # instance here. The row records the deterministic container name,
+            # which is the provider id on Docker and nothing like it on E2B --
+            # there it mints its own (`i8fdef5eyd8zxnysl6bor`) and keys the
+            # process index by that. A probe carrying the name read an index
+            # that was always empty, so this check answered "idle" for every
+            # sandbox it was ever asked about, and the sweep would pause a
+            # workspace mid-command. An idle check that returns is not an idle
+            # check that happened.
+            instance = await self._provider.inspect(
+                current.provider_id, deadline_at=deadline_at
+            )
+            if instance is None:
+                return False
             processes = await self._provider.list_processes(
                 instance, deadline_at=deadline_at
             )

--- a/lemma-backend/app/modules/workspace/testing/fake_e2b.py
+++ b/lemma-backend/app/modules/workspace/testing/fake_e2b.py
@@ -90,6 +90,7 @@ class FakeE2B:
     paused: list[str] = field(default_factory=list)
     files: dict[str, bytes] = field(default_factory=dict)
     commands: list[str] = field(default_factory=list)
+    pause_kept_memory: list[bool] = field(default_factory=list)
     # The lifetime each started process was given, in the order they started.
     # Recorded because E2B kills a command at this value and defaults it to 60s,
     # so "the provider passed no timeout" is indistinguishable from "the
@@ -269,6 +270,10 @@ class FakeE2B:
                 return True
 
             async def beta_pause(self, keep_memory=True, **_kwargs):
+                # Recorded because the default is the bug: a workspace pause
+                # that keeps memory restores whatever was running into the
+                # next conversation.
+                world.pause_kept_memory.append(keep_memory)
                 world.paused.append(self.sandbox_id)
                 world.sandboxes[self.sandbox_id].state = "paused"
                 return True

--- a/lemma-backend/app/modules/workspace/tests/integration/test_sandbox_service.py
+++ b/lemma-backend/app/modules/workspace/tests/integration/test_sandbox_service.py
@@ -157,6 +157,11 @@ async def test_a_sandbox_from_a_superseded_profile_is_replaced(
         "workspace_profile_digest",
         "sha256:" + "f" * 64,
     )
+    # `ensure` reuses a just-provisioned handle for a few seconds without
+    # re-reading anything, so the staleness check under test is only reached
+    # once that window is given up. A real digest move arrives on deploy,
+    # minutes away from any ensure; here the two are microseconds apart.
+    service.forget(sandbox.id)
     second = await service.ensure(sandbox.id)
 
     assert second.provider_id != first.provider_id, "the stale one must not be reused"
@@ -191,6 +196,7 @@ async def test_the_recorded_profile_follows_the_configured_one(
         monkeypatch.setattr(
             profiles.workspace_settings, "workspace_profile_digest", digest
         )
+        service.forget(sandbox.id)  # see the superseded-profile test above
         await service.ensure(sandbox.id)
         assert provider.created[-1].profile_digest == digest
 
@@ -246,7 +252,10 @@ async def test_recreating_always_moves_the_epoch(
     first = await service.ensure(sandbox.id)
 
     # The container vanishes, exactly as it would if the host were restarted.
+    # Discovering that is what `forget` reports, and until something does, a
+    # handle provisioned moments ago is still served from memory.
     provider.containers.clear()
+    service.forget(sandbox.id)
     second = await service.ensure(sandbox.id)
 
     assert second.epoch == first.epoch + 1
@@ -305,6 +314,7 @@ async def test_losing_a_recorded_volume_moves_the_generation(
     # The disk is gone, and the row still says there was one.
     provider.volumes.clear()
     provider.containers.clear()
+    service.forget(sandbox.id)
     handle = await service.ensure(sandbox.id)
 
     assert handle.storage_generation == 2

--- a/lemma-backend/app/modules/workspace/tests/integration/test_sandbox_sweeper.py
+++ b/lemma-backend/app/modules/workspace/tests/integration/test_sandbox_sweeper.py
@@ -329,3 +329,63 @@ async def test_a_destroy_that_works_is_still_reported(
 
     assert reclaimed == (name,)
     assert provider.destroyed == [name]
+
+
+class _OpaqueIdProvider(SweepableProvider):
+    """A provider whose ids are nothing like its names, which E2B's are not.
+
+    `FakeProvider.create` returns `provider_id=spec.name`, so every other test
+    here has the two coincide and cannot see a caller that confuses them. E2B
+    mints its own (`i8fdef5eyd8zxnysl6bor`) against a name of
+    `lemma-ws-<hex>-<epoch>`, and the process index is written under the id.
+    """
+
+    async def create(self, spec):
+        instance = await super().create(spec)
+        opaque = ProviderInstance(
+            provider_id=f"i{abs(hash(spec.name)):x}",
+            name=spec.name,
+            volume_name=instance.volume_name,
+            running=True,
+            storage_adopted=instance.storage_adopted,
+            profile_digest=instance.profile_digest,
+        )
+        self.containers[instance.name] = instance
+        self.containers[opaque.provider_id] = opaque
+        self.probed_with = getattr(self, "probed_with", [])
+        return opaque
+
+    async def list_processes(self, instance, *, deadline_at):
+        self.probed_with = getattr(self, "probed_with", [])
+        self.probed_with.append(instance.provider_id)
+        return await super().list_processes(instance, deadline_at=deadline_at)
+
+
+async def test_the_liveness_probe_addresses_the_sandbox_by_its_provider_id(
+    sandbox_uow_factory,
+) -> None:
+    """The idle check has to reach the sandbox it is asking about.
+
+    E2B keys its process index by the real sandbox id, so a probe built from
+    the container name reads an index that is always empty -- an idle check
+    that returns is not an idle check that happened, and the sweep would pause
+    a sandbox mid-work. That is the exact harm the check exists to prevent, and
+    it is invisible wherever id and name coincide.
+    """
+    SandboxService._inflight.clear()
+    SandboxService._recent.clear()
+    provider = _OpaqueIdProvider()
+    service = SandboxService(provider=provider, uow_factory=sandbox_uow_factory)
+    sweeper = SandboxSweeper(service=service, uow_factory=sandbox_uow_factory)
+    sandbox = await _workspace(service)
+    handle = await service.ensure(sandbox.id)
+    provider.processes = [
+        ProcessDescriptor(process_id="op-1", state="running", exit_code=None)
+    ]
+
+    released = await sweeper.release_idle(idle_after_seconds=0)
+
+    assert provider.probed_with == [handle.provider_id], (
+        "the probe must carry the provider id, not the container name"
+    )
+    assert released == 0, "a sandbox with live work must not be paused"

--- a/lemma-backend/app/modules/workspace/tests/integration/test_sandbox_sweeper.py
+++ b/lemma-backend/app/modules/workspace/tests/integration/test_sandbox_sweeper.py
@@ -11,6 +11,7 @@ from app.modules.workspace.domain.sandbox import SandboxKind, SandboxOwnerKind
 from app.modules.workspace.providers.base import (
     ProcessDescriptor,
     ProviderGone,
+    ProviderInstance,
     ProviderObject,
 )
 from app.modules.workspace.services.sandbox_service import SandboxService
@@ -35,7 +36,13 @@ def provider() -> SweepableProvider:
 
 @pytest.fixture
 def service(provider: SweepableProvider, sandbox_uow_factory) -> SandboxService:
+    # Both caches are class attributes, so they outlive the instance and leak
+    # between tests. Only `_inflight` was being cleared, which left `_recent`
+    # to answer the second `ensure` of a test that had just emptied the
+    # provider -- so whether a test saw a re-provision depended on which tests
+    # ran before it.
     SandboxService._inflight.clear()
+    SandboxService._recent.clear()
     return SandboxService(provider=provider, uow_factory=sandbox_uow_factory)
 
 
@@ -110,7 +117,11 @@ async def test_a_superseded_epoch_is_reclaimed(
 ) -> None:
     sandbox = await _workspace(service)
     first = await service.ensure(sandbox.id)
+    # Losing the container is exactly what `forget` is for: `ensure` reuses a
+    # just-provisioned handle for a few seconds, so without this the second
+    # call answers from memory and no new epoch is ever minted.
     provider.containers.clear()
+    service.forget(sandbox.id)
     second = await service.ensure(sandbox.id)
     assert second.epoch > first.epoch
 
@@ -270,3 +281,51 @@ async def test_a_sandbox_that_cannot_be_probed_is_left_alone(
     provider.list_processes = _unreachable  # type: ignore[method-assign]
 
     assert await sweeper.release_idle(idle_after_seconds=0) == 0
+
+
+async def test_an_object_the_provider_cannot_reap_is_not_reported_as_reclaimed(
+    sweeper: SandboxSweeper, provider: SweepableProvider
+) -> None:
+    """A destroy that returns is not a destroy that happened.
+
+    On E2B a paused sandbox lists like any other but survives being killed, so
+    this loop logged eighteen reclaims every five minutes for hours -- the same
+    eighteen ids -- while the account held ninety-nine paused sandboxes and the
+    count never moved. Silence about that is worse than the leak: the sweep
+    looks like it is working.
+    """
+    orphan = uuid4()
+    name = f"lemma-ws-{orphan.hex}-1"
+    provider.objects = [_object(name=name, sandbox_id=orphan, epoch=1)]
+    # Accepts the call, keeps the object -- what killing a paused sandbox does.
+    provider.containers[name] = ProviderInstance(
+        provider_id=name, name=name, running=False
+    )
+
+    async def _destroy_that_does_nothing(destroyed_name: str, *, deadline_at) -> None:
+        del deadline_at
+        provider.destroyed.append(destroyed_name)
+
+    provider.destroy = _destroy_that_does_nothing  # type: ignore[method-assign]
+
+    reclaimed = await sweeper.reclaim_orphans()
+
+    assert provider.destroyed == [name], "the destroy must still be attempted"
+    assert reclaimed == (), "nothing was reclaimed, so nothing may be claimed"
+
+
+async def test_a_destroy_that_works_is_still_reported(
+    sweeper: SandboxSweeper, provider: SweepableProvider
+) -> None:
+    """The confirmation must not turn every real reclaim into a warning."""
+    orphan = uuid4()
+    name = f"lemma-ws-{orphan.hex}-1"
+    provider.objects = [_object(name=name, sandbox_id=orphan, epoch=1)]
+    provider.containers[name] = ProviderInstance(
+        provider_id=name, name=name, running=True
+    )
+
+    reclaimed = await sweeper.reclaim_orphans()
+
+    assert reclaimed == (name,)
+    assert provider.destroyed == [name]

--- a/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
@@ -668,19 +668,22 @@ async def test_the_sweep_only_claims_sandboxes_carrying_our_metadata(
     assert {obj.sandbox_id for obj in objects} == {sandbox_id}
 
 
-async def test_the_browser_is_shed_before_the_pause_snapshots_it(
+async def test_a_pause_discards_memory(
     provider: E2BSandboxProvider, world: FakeE2B
 ) -> None:
-    """A pause here preserves memory, so whatever is resident becomes permanent.
+    """The SDK default is `keep_memory=True`, and this call used to pass nothing.
 
-    This is the one place E2B differs from Docker in a way that matters:
-    stopping a container throws its memory away, so quiescing first is tidiness.
-    Pausing keeps it, and resuming restores it -- so a headed Chrome left by one
-    conversation is handed to the next one, and the next, without ever being
-    started again. A workspace measured after a research session held 63 Chrome
-    processes at 2123 MB RSS on a 2048 MB sandbox, which is why unrelated shell
-    tool calls in it timed out: `python -c pass` took 61s and `lemma --version`
-    never returned.
+    So every workspace pause preserved resident memory while both architecture
+    documents said the opposite -- "running processes and interpreter state do
+    not [persist], and callers must not treat them as recoverable" -- and
+    auto-resume was already disabled here, which E2B only requires *because* of
+    filesystem-only snapshots. The design was built around a property the one
+    call that decides it never asked for.
+
+    That is what made a leaked browser invisible: a memory-preserving pause
+    snapshots whatever is running and restores it into the next conversation,
+    so a headed Chrome came back at 63 processes and 2123 MB without ever being
+    started again. The disk is the only thing a workspace promises to keep.
     """
     instance = await provider.create(_spec(uuid4()))
 
@@ -688,20 +691,57 @@ async def test_the_browser_is_shed_before_the_pause_snapshots_it(
         instance, kind=SandboxKind.WORKSPACE, deadline_at=_deadline()
     )
 
-    shutdown = [cmd for cmd in world.commands if "agent-browser" in cmd]
-    assert shutdown, "the browser must be ended before the snapshot is taken"
-    assert world.paused == [instance.provider_id], "and it must still pause"
+    assert world.paused == [instance.provider_id]
+    assert world.pause_kept_memory == [False], (
+        "a workspace pause is filesystem-only; see lifecycle-state-model.md"
+    )
 
 
-async def test_a_function_sandbox_is_paused_without_a_browser_shutdown(
+async def test_a_function_sandbox_pause_also_discards_memory(
     provider: E2BSandboxProvider, world: FakeE2B
 ) -> None:
-    """Function sandboxes have no browser, so the release must not pay for one."""
+    """Both kinds pause the same way; neither promises resident state."""
     instance = await provider.create(_spec(uuid4(), kind=SandboxKind.FUNCTION))
 
     await provider.release(
         instance, kind=SandboxKind.FUNCTION, deadline_at=_deadline()
     )
 
-    assert [cmd for cmd in world.commands if "agent-browser" in cmd] == []
-    assert world.paused == [instance.provider_id]
+    assert world.pause_kept_memory == [False]
+
+
+async def test_an_object_named_by_its_e2b_id_is_actually_destroyed(
+    provider: E2BSandboxProvider, world: FakeE2B
+) -> None:
+    """The sweep names objects the way E2B reports them, and must still kill them.
+
+    `list_objects` names every object by its E2B sandbox id, because that is
+    what E2B returns. `inspect` only understands container names -- it parses
+    one back into a metadata query -- so `destroy(obj.name)` parsed to nothing,
+    read that as "already gone", and returned having killed nothing. The orphan
+    sweep therefore logged eighteen reclaims every five minutes for hours
+    against the same eighteen ids while the account's count never moved: not
+    because paused sandboxes resist being killed, but because the destroy was a
+    no-op for exactly the objects the sweep discovers.
+    """
+    instance = await provider.create(_spec(uuid4()))
+    objects = await provider.list_objects(deadline_at=_deadline())
+    assert [obj.name for obj in objects] == [instance.provider_id], (
+        "the sweep sees E2B ids, not container names"
+    )
+
+    await provider.destroy(objects[0].name, deadline_at=_deadline())
+
+    assert world.killed == [instance.provider_id]
+
+
+async def test_a_container_name_that_resolves_to_nothing_is_left_alone(
+    provider: E2BSandboxProvider, world: FakeE2B
+) -> None:
+    """Parsing to an identity with no sandbox behind it really is already gone."""
+    await provider.destroy(
+        naming.container_name(uuid4(), SandboxKind.WORKSPACE, 1),
+        deadline_at=_deadline(),
+    )
+
+    assert world.killed == []

--- a/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
@@ -666,3 +666,42 @@ async def test_the_sweep_only_claims_sandboxes_carrying_our_metadata(
     objects = await provider.list_objects(deadline_at=_deadline())
 
     assert {obj.sandbox_id for obj in objects} == {sandbox_id}
+
+
+async def test_the_browser_is_shed_before_the_pause_snapshots_it(
+    provider: E2BSandboxProvider, world: FakeE2B
+) -> None:
+    """A pause here preserves memory, so whatever is resident becomes permanent.
+
+    This is the one place E2B differs from Docker in a way that matters:
+    stopping a container throws its memory away, so quiescing first is tidiness.
+    Pausing keeps it, and resuming restores it -- so a headed Chrome left by one
+    conversation is handed to the next one, and the next, without ever being
+    started again. A workspace measured after a research session held 63 Chrome
+    processes at 2123 MB RSS on a 2048 MB sandbox, which is why unrelated shell
+    tool calls in it timed out: `python -c pass` took 61s and `lemma --version`
+    never returned.
+    """
+    instance = await provider.create(_spec(uuid4()))
+
+    await provider.release(
+        instance, kind=SandboxKind.WORKSPACE, deadline_at=_deadline()
+    )
+
+    shutdown = [cmd for cmd in world.commands if "agent-browser" in cmd]
+    assert shutdown, "the browser must be ended before the snapshot is taken"
+    assert world.paused == [instance.provider_id], "and it must still pause"
+
+
+async def test_a_function_sandbox_is_paused_without_a_browser_shutdown(
+    provider: E2BSandboxProvider, world: FakeE2B
+) -> None:
+    """Function sandboxes have no browser, so the release must not pay for one."""
+    instance = await provider.create(_spec(uuid4(), kind=SandboxKind.FUNCTION))
+
+    await provider.release(
+        instance, kind=SandboxKind.FUNCTION, deadline_at=_deadline()
+    )
+
+    assert [cmd for cmd in world.commands if "agent-browser" in cmd] == []
+    assert world.paused == [instance.provider_id]

--- a/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
@@ -289,13 +289,21 @@ async def test_a_sandbox_from_the_same_template_build_is_adopted(
     assert world.killed == []
 
 
-async def test_a_sandbox_from_an_older_template_build_is_destroyed(
+async def test_a_workspace_from_an_older_template_build_keeps_its_disk(
     provider: E2BSandboxProvider, world: FakeE2B
 ) -> None:
-    """Here the sandbox is the disk, so there is no replacing the compute and
-    keeping the files. Resuming it would leave the workspace on the old
-    template, speaking a protocol the backend no longer speaks; the caller is
-    told the disk is new through `storage_adopted`."""
+    """Drift is tolerated for workspaces, because here the sandbox is the disk.
+
+    This branch used to kill the sandbox to adopt the new digest -- and the
+    digest comes from `WORKSPACE_PROFILE_DIGEST`, an environment variable. So
+    editing one env var and deploying wiped every workspace in the fleet on the
+    first ensure after rollout, with nothing to restore from. `Sandbox fabric`
+    README section 6 already stated the intent: "While a workspace owns a disk
+    it keeps running the profile it was created with, no generation fence is
+    raised, and nothing is replaced." The accepted cost, stated there too, is
+    that a workspace may run an N-1 template until it is next created from
+    scratch.
+    """
     from app.modules.workspace.testing.fake_e2b import FakeSandboxInfo
 
     sandbox_id = uuid4()
@@ -309,6 +317,28 @@ async def test_a_sandbox_from_an_older_template_build_is_destroyed(
     )
 
     instance = await provider.create(_spec(sandbox_id))
+
+    assert world.killed == [], "a workspace's files must survive a template bump"
+    assert instance.provider_id == "older-build", "and it keeps serving them"
+
+
+async def test_a_function_from_an_older_template_build_is_replaced(
+    provider: E2BSandboxProvider, world: FakeE2B
+) -> None:
+    """Functions own no durable disk, so adopting a new digest costs a restart."""
+    from app.modules.workspace.testing.fake_e2b import FakeSandboxInfo
+
+    sandbox_id = uuid4()
+    world.sandboxes["older-build"] = FakeSandboxInfo(
+        sandbox_id="older-build",
+        state="paused",
+        metadata={
+            META_SANDBOX_ID: str(sandbox_id),
+            META_PROFILE_DIGEST: "sha256:" + "b" * 64,
+        },
+    )
+
+    instance = await provider.create(_spec(sandbox_id, kind=SandboxKind.FUNCTION))
 
     assert world.killed == ["older-build"]
     assert instance.provider_id != "older-build"

--- a/lemma-backend/app/modules/workspace/tests/unit/test_e2b_python_repl.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_e2b_python_repl.py
@@ -8,7 +8,7 @@ silently dropped -- `import pandas as pd` bound a name that was gone by the
 next call, and the agent got a bare `NameError` for something it had just
 imported.
 
-These execute the real `_PYTHON_RUNNER` template in a subprocess, because the
+These execute the real `PYTHON_RUNNER` template in a subprocess, because the
 bug lived in the generated script rather than in any Python this suite would
 otherwise import.
 """
@@ -21,7 +21,7 @@ import sys
 
 import pytest
 
-from app.modules.workspace.providers.e2b_python_runner import _PYTHON_RUNNER
+from app.modules.workspace.providers.e2b_python_runner import PYTHON_RUNNER
 
 
 def _run(tmp_path: Path, code: str) -> subprocess.CompletedProcess[str]:
@@ -30,7 +30,7 @@ def _run(tmp_path: Path, code: str) -> subprocess.CompletedProcess[str]:
     code_path.write_text(code)
     runner_path = tmp_path / "runner.py"
     runner_path.write_text(
-        _PYTHON_RUNNER.format(
+        PYTHON_RUNNER.format(
             state_path=str(tmp_path / "state.pkl"),
             code_path=str(code_path),
             result_path=str(tmp_path / "result.txt"),

--- a/lemma-backend/app/modules/workspace/tests/unit/test_e2b_python_repl.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_e2b_python_repl.py
@@ -1,0 +1,122 @@
+"""The REPL promise, checked by running the runner E2B actually runs.
+
+`execute_python` documents "session continuity: variables and imports defined
+in one call are available in the next". On E2B there is no resident
+interpreter, so each call is a fresh `python3` and the namespace is carried in
+a pickle between them. Modules cannot be pickled, so every one of them was
+silently dropped -- `import pandas as pd` bound a name that was gone by the
+next call, and the agent got a bare `NameError` for something it had just
+imported.
+
+These execute the real `_PYTHON_RUNNER` template in a subprocess, because the
+bug lived in the generated script rather than in any Python this suite would
+otherwise import.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from app.modules.workspace.providers.e2b_python_runner import _PYTHON_RUNNER
+
+
+def _run(tmp_path: Path, code: str) -> subprocess.CompletedProcess[str]:
+    """One `execute_python` call: same paths, so state carries between calls."""
+    code_path = tmp_path / "code.py"
+    code_path.write_text(code)
+    runner_path = tmp_path / "runner.py"
+    runner_path.write_text(
+        _PYTHON_RUNNER.format(
+            state_path=str(tmp_path / "state.pkl"),
+            code_path=str(code_path),
+            result_path=str(tmp_path / "result.txt"),
+        )
+    )
+    return subprocess.run(
+        [sys.executable, str(runner_path)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_an_imported_module_survives_into_the_next_call(tmp_path: Path) -> None:
+    """The case that was broken, in the form an agent writes it."""
+    first = _run(tmp_path, "import json as j\nprint('imported')")
+    assert first.returncode == 0, first.stderr
+    assert "imported" in first.stdout
+
+    second = _run(tmp_path, "print(j.dumps({'ok': True}))")
+
+    assert second.returncode == 0, second.stderr
+    assert '{"ok": true}' in second.stdout
+    assert "NameError" not in second.stderr
+
+
+def test_a_submodule_import_keeps_the_name_it_was_bound_to(tmp_path: Path) -> None:
+    """`import os.path as p` binds `p` to the submodule, not to `os`."""
+    _run(tmp_path, "import os.path as p")
+
+    result = _run(tmp_path, "print(p.basename('/a/b/c.txt'))")
+
+    assert result.returncode == 0, result.stderr
+    assert "c.txt" in result.stdout
+
+
+def test_ordinary_values_still_carry(tmp_path: Path) -> None:
+    """The behaviour that already worked must not regress."""
+    _run(tmp_path, "total = 6 * 7\nname = 'lemma'")
+
+    result = _run(tmp_path, "print(total, name)")
+
+    assert result.returncode == 0, result.stderr
+    assert "42 lemma" in result.stdout
+
+
+def test_a_value_that_cannot_travel_is_dropped_rather_than_faked(
+    tmp_path: Path,
+) -> None:
+    """An open file handle cannot cross a process boundary.
+
+    Dropping it is right; the alternative is a name bound to something that
+    would fail on use in a way that reads as a bug in the agent's own code.
+    """
+    _run(tmp_path, f"handle = open({str(tmp_path / 'f.txt')!r}, 'w')\nkept = 1")
+
+    result = _run(tmp_path, "print('kept' in dir(), 'handle' in dir())")
+
+    assert result.returncode == 0, result.stderr
+    assert "True False" in result.stdout
+
+
+def test_a_module_uninstalled_between_calls_does_not_break_the_session(
+    tmp_path: Path,
+) -> None:
+    """Re-import is best effort: one missing module must not fail the call."""
+    _run(tmp_path, "import json as j\nvalue = 3")
+    modules = tmp_path / "state.pkl.modules"
+    assert modules.exists(), "module names must be recorded beside the state"
+    import pickle
+
+    modules.write_bytes(pickle.dumps({"gone": "a_module_that_does_not_exist"}))
+
+    result = _run(tmp_path, "print(value)")
+
+    assert result.returncode == 0, result.stderr
+    assert "3" in result.stdout
+
+
+@pytest.mark.parametrize("literal", ["timeout=None", "timeout = None"])
+def test_the_interpreter_run_is_bounded(literal: str) -> None:
+    """`timeout_seconds` has to reach the sandbox, not just the backend wait.
+
+    Unbounded, a runaway loop kept running after the tool returned, holding the
+    only vCPU -- and the idle sweeper refuses to release a sandbox with live
+    processes, so it stayed up around it.
+    """
+    source = Path("app/modules/workspace/providers/e2b_ops.py").read_text()
+    assert literal not in source, "the python run must carry the request deadline"

--- a/lemma-backend/app/modules/workspace/tests/unit/test_sandbox_session.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_sandbox_session.py
@@ -416,3 +416,51 @@ async def test_a_short_yield_still_waits_long_enough_to_see_the_exit(
     assert result["exit_code"] == 0
     assert result["process_id"] is None
     assert client._reads > 1, "a short yield collapsed into one non-waiting poll"
+
+
+class _StdinRefusingClient(_CanonicalClient):
+    """Fails the stdin write the way a real sandbox does.
+
+    E2B answers a write to a process whose stdin is closed with
+    `Code.INTERNAL: error writing to stdin: stdin not enabled or closed`,
+    which the transport raises as `SandboxUnavailable`.
+    """
+
+    def __init__(self, error: Exception) -> None:
+        super().__init__()
+        self._error = error
+
+    async def send_process_input(self, *_args: Any, **_kwargs: Any) -> None:
+        raise self._error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("error", "retryable"),
+    [
+        (SandboxUnavailable("stdin not enabled or closed"), True),
+        (SandboxRejected("stdin not enabled or closed"), False),
+    ],
+)
+async def test_a_failed_stdin_write_reports_the_sandbox_error_itself(
+    error: Exception, retryable: bool
+) -> None:
+    """The handler must not raise while describing the failure.
+
+    It read `exc.code` and `exc.retry` off the exception, and no sandbox error
+    has ever carried either. So every `SandboxError` on this path died with
+    `AttributeError: 'SandboxUnavailable' object has no attribute 'code'`, and
+    the agent was told that instead of what actually went wrong -- observed in
+    production as three consecutive `manage_process` calls failing identically
+    with the AttributeError, hiding "stdin not enabled or closed".
+    """
+    session = _session(_StdinRefusingClient(error))  # type: ignore[arg-type]
+
+    result = await session.write_stdin(process_id=str(uuid4()), chars="y\n")
+
+    assert result["success"] is False
+    assert "AttributeError" not in str(result["error"])
+    assert "stdin not enabled or closed" in str(result["error"])
+    # Retryability reaches the agent as the retry hint and the completed flag.
+    assert ("Retry the same operation" in str(result["error"])) is retryable
+    assert result["completed"] is not retryable

--- a/lemma-backend/sandbox-images/Dockerfile.workspace
+++ b/lemma-backend/sandbox-images/Dockerfile.workspace
@@ -105,6 +105,15 @@ ENV PYTHONUNBUFFERED=1 \
     AGENT_BROWSER_PROFILE=/tmp/lemma-browser/profile \
     AGENT_BROWSER_SESSION=workspace \
     AGENT_BROWSER_HEADED=true \
+    # A browser nobody is using stops being one. The agent-browser daemon
+    # closes Chrome and exits after this long without a command, which is the
+    # only thing that reclaims the browser's whole footprint -- Chrome keeps a
+    # process per site-instance, and a headed session carries a GPU process and
+    # browser UI on top. Two minutes is well inside the 180s idle-release
+    # window that retires the sandbox itself, so a workspace that goes quiet
+    # sheds the browser before anything else decides what to do with it, and a
+    # research batch mid-flight never sees it: every capture is a command.
+    AGENT_BROWSER_IDLE_TIMEOUT_MS=120000 \
     LEMMA_RUNTIME_TOKEN_FILE=/run/lemma-bootstrap/token \
     LEMMA_SANDBOX_PROCESS_NAMESPACE=isolated \
     GH_CONFIG_DIR=/tmp/lemma-gh \

--- a/lemma-backend/sandbox-images/scripts/save-webpage.sh
+++ b/lemma-backend/sandbox-images/scripts/save-webpage.sh
@@ -86,8 +86,37 @@ fi
 
 mkdir -p "$OUT_DIR"
 
+# A capture gets its own tab, and gives it back.
+#
+# Every captured page used to land in the one shared tab and stay there. The
+# session is deliberately long-lived -- one browser, one Xvfb display, one
+# profile per sandbox -- so nothing ever reclaimed what a capture rendered, and
+# Chrome keeps a process per site-instance. A workspace measured after a normal
+# research session held 63 Chrome processes at 2123 MB RSS on a sandbox with
+# 2048 MB total: `MemAvailable` was 14 MB, kswapd0 burned a third of the only
+# vCPU, and every unrelated tool call in that sandbox degraded with it --
+# `python -c pass` took over 12 seconds and `lemma --version` never returned at
+# all. The agent saw `exit_code: 124` and no explanation.
+#
+# So the tab is closed on the way out, via trap: `set -e` means any capture
+# step can abort the script, and the failing captures are exactly the expensive
+# pages worth reclaiming. `--no-open` reuses whatever page the caller already
+# has open -- that tab belongs to them, so this must not touch it.
+CAPTURE_TAB=""
+close_capture_tab() {
+  if [[ -n "$CAPTURE_TAB" ]]; then
+    agent-browser tab close "$CAPTURE_TAB" >/dev/null 2>&1 || true
+    CAPTURE_TAB=""
+  fi
+}
+trap close_capture_tab EXIT
+
 if [[ "$OPEN_PAGE" == "1" ]]; then
-  start-browser "$URL" >/dev/null
+  # Brings up the daemon, Xvfb and the dashboard if they are not up yet,
+  # without navigating the caller's active tab.
+  start-browser >/dev/null
+  CAPTURE_TAB="lemma-capture-$$"
+  agent-browser tab new --label "$CAPTURE_TAB" "$URL" >/dev/null
   agent-browser wait --load networkidle >/dev/null 2>&1 || agent-browser wait "$WAIT_MS" >/dev/null 2>&1 || true
 fi
 

--- a/lemma-backend/sandbox-images/templates/e2b/build_templates.py
+++ b/lemma-backend/sandbox-images/templates/e2b/build_templates.py
@@ -272,6 +272,10 @@ def workspace_template():
                 "AGENT_BROWSER_PROFILE": "/tmp/lemma-browser/profile",
                 "AGENT_BROWSER_SESSION": "workspace",
                 "AGENT_BROWSER_HEADED": "true",
+                # See Dockerfile.workspace: the daemon closes Chrome after this
+                # long idle, which is what keeps a finished research session
+                # from holding the sandbox's whole memory budget.
+                "AGENT_BROWSER_IDLE_TIMEOUT_MS": "120000",
                 "LEMMA_NODE_BINARY": "/opt/node24/bin/node",
                 # Where the credential bridge writes gh's config.
                 "GH_CONFIG_DIR": "/tmp/lemma-gh",

--- a/lemma-backend/sandbox-images/templates/e2b/build_templates.py
+++ b/lemma-backend/sandbox-images/templates/e2b/build_templates.py
@@ -137,49 +137,6 @@ def workspace_template():
             f"{_install_gh_command()}",
             user="root",
         )
-        .copy("lemma-python", "/build/lemma-python")
-        .copy("lemma-pod-bundle", "/build/lemma-pod-bundle")
-        .copy("lemma-cli", "/build/lemma-cli")
-        .copy("lemma-skills", "/build/lemma-skills")
-        .copy(
-            "lemma-backend/sandbox-images/templates/workspace-python",
-            "/build/lemma-backend/sandbox-images/templates/workspace-python",
-        )
-        .run_cmd(
-            "UV_PYTHON_INSTALL_DIR=/opt/python uv python install 3.14 && "
-            "UV_PYTHON_INSTALL_DIR=/opt/python "
-            "UV_PROJECT_ENVIRONMENT=/opt/lemma-python "
-            "UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy "
-            "uv sync --project /build/lemma-backend/sandbox-images/templates/workspace-python "
-            "--python 3.14 "
-            "--locked --no-dev --no-editable && "
-            "printf '%s\\n' "
-            "'import sys; "
-            'p="/workspace/.python/lib/python3.14/site-packages"; '
-            "sys.path.insert(0, p) if p not in sys.path else None' "
-            "> /opt/lemma-python/lib/python3.14/site-packages/"
-            "lemma-workspace-overlay.pth && "
-            "test -x /opt/lemma-python/bin/python && "
-            'test "$(/opt/lemma-python/bin/python -c '
-            "'import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")'"
-            ')" = "3.14" && '
-            "/opt/lemma-python/bin/python -c "
-            '"import ipykernel, lemma_sdk, pydantic" && '
-            "test -x /opt/lemma-python/bin/lemma && "
-            "ln -sf /opt/lemma-python/bin/lemma /usr/local/bin/lemma && "
-            "/usr/local/bin/lemma --version && "
-            "mkdir -p /root/.local/share/jupyter/kernels/python3 && "
-            "printf '%s\\n' "
-            '\'{"argv":["/opt/lemma-python/bin/python","-m",'
-            '"ipykernel_launcher","-f","{connection_file}"],'
-            '"display_name":"Python 3.14","language":"python",'
-            '"metadata":{"debugger":true}}\' '
-            "> /root/.local/share/jupyter/kernels/python3/kernel.json && "
-            "uv cache clean && "
-            "rm -rf /build/lemma-python /build/lemma-pod-bundle "
-            "/build/lemma-cli /build/lemma-skills /build/lemma-backend",
-            user="root",
-        )
         .copy(
             "lemma-backend/sandbox-images/templates/workspace-node",
             "/opt/lemma-node",
@@ -258,6 +215,56 @@ def workspace_template():
             "rm -rf /root/.cache/pnpm /root/.local/share/pnpm/store "
             "/home/user/.cache/pnpm /home/user/.local/share/pnpm/store && "
             "chown -R user:user /workspace /tmp/lemma-browser",
+            user="root",
+        )
+        # Layer order is cache order, and these two blocks were the wrong way
+        # round. The first-party sources below -- lemma-cli above all -- change
+        # on almost every commit, and they sat in front of the Node layer,
+        # whose `pnpm install` fetches the Agent Browser and its Chromium. So a
+        # one-line CLI edit invalidated the most expensive layer in the image
+        # and rebuilt the browser from scratch. Node first, because its inputs
+        # are two lockfiles that move on a dependency bump and nothing else.
+        .copy("lemma-python", "/build/lemma-python")
+        .copy("lemma-pod-bundle", "/build/lemma-pod-bundle")
+        .copy("lemma-cli", "/build/lemma-cli")
+        .copy("lemma-skills", "/build/lemma-skills")
+        .copy(
+            "lemma-backend/sandbox-images/templates/workspace-python",
+            "/build/lemma-backend/sandbox-images/templates/workspace-python",
+        )
+        .run_cmd(
+            "UV_PYTHON_INSTALL_DIR=/opt/python uv python install 3.14 && "
+            "UV_PYTHON_INSTALL_DIR=/opt/python "
+            "UV_PROJECT_ENVIRONMENT=/opt/lemma-python "
+            "UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy "
+            "uv sync --project /build/lemma-backend/sandbox-images/templates/workspace-python "
+            "--python 3.14 "
+            "--locked --no-dev --no-editable && "
+            "printf '%s\\n' "
+            "'import sys; "
+            'p="/workspace/.python/lib/python3.14/site-packages"; '
+            "sys.path.insert(0, p) if p not in sys.path else None' "
+            "> /opt/lemma-python/lib/python3.14/site-packages/"
+            "lemma-workspace-overlay.pth && "
+            "test -x /opt/lemma-python/bin/python && "
+            'test "$(/opt/lemma-python/bin/python -c '
+            "'import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")'"
+            ')" = "3.14" && '
+            "/opt/lemma-python/bin/python -c "
+            '"import ipykernel, lemma_sdk, pydantic" && '
+            "test -x /opt/lemma-python/bin/lemma && "
+            "ln -sf /opt/lemma-python/bin/lemma /usr/local/bin/lemma && "
+            "/usr/local/bin/lemma --version && "
+            "mkdir -p /root/.local/share/jupyter/kernels/python3 && "
+            "printf '%s\\n' "
+            '\'{"argv":["/opt/lemma-python/bin/python","-m",'
+            '"ipykernel_launcher","-f","{connection_file}"],'
+            '"display_name":"Python 3.14","language":"python",'
+            '"metadata":{"debugger":true}}\' '
+            "> /root/.local/share/jupyter/kernels/python3/kernel.json && "
+            "uv cache clean && "
+            "rm -rf /build/lemma-python /build/lemma-pod-bundle "
+            "/build/lemma-cli /build/lemma-skills /build/lemma-backend",
             user="root",
         )
         .set_envs(

--- a/lemma-backend/sandbox-images/templates/workspace-node/lemma-profile.sh
+++ b/lemma-backend/sandbox-images/templates/workspace-node/lemma-profile.sh
@@ -13,6 +13,10 @@ export AGENT_BROWSER_EXECUTABLE_PATH=/usr/local/bin/workspace-chrome
 export AGENT_BROWSER_PROFILE=/tmp/lemma-browser/profile
 export AGENT_BROWSER_SESSION=workspace
 export AGENT_BROWSER_HEADED=true
+# The daemon closes Chrome after this long without a command. Set here too so a
+# browser started from an agent's login shell is bounded the same way one
+# started by the runtime is.
+export AGENT_BROWSER_IDLE_TIMEOUT_MS=120000
 export MPLBACKEND=Agg
 case ":${PATH}:" in
   *:/opt/node24/bin:*) ;;

--- a/lemma-backend/sandbox_runtime/tests/test_browser_guard.py
+++ b/lemma-backend/sandbox_runtime/tests/test_browser_guard.py
@@ -1,0 +1,123 @@
+"""The backstop that holds when everything gentler has already failed.
+
+None of these tests signal a real process. `shed_browser` matches things a
+developer plausibly has running -- agent-browser, Xvfb -- so the kill is
+injected wherever it is exercised.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sandbox_runtime.workspace import browser_guard
+from sandbox_runtime.workspace.browser_guard import (
+    LOW_MEMORY_MB,
+    available_memory_mb,
+    shed_browser_if_starved,
+)
+
+
+def _meminfo(available_kb: int) -> str:
+    return (
+        "MemTotal:        2030612 kB\n"
+        "MemFree:           64280 kB\n"
+        f"MemAvailable:    {available_kb} kB\n"
+    )
+
+
+@pytest.fixture
+def sandbox(monkeypatch, tmp_path: Path):
+    """A fake /proc/meminfo and a browser that is counted, never killed."""
+
+    state = {"available_kb": 1_520_000, "browser_pids": (), "killed": 0}
+    meminfo = tmp_path / "meminfo"
+
+    def _read() -> int | None:
+        meminfo.write_text(_meminfo(state["available_kb"]))
+        monkeypatch.setattr(browser_guard, "Path", Path)
+        for line in meminfo.read_text().splitlines():
+            if line.startswith("MemAvailable:"):
+                return int(line.split()[1]) // 1024
+        return None
+
+    def _kill() -> int:
+        state["killed"] = len(state["browser_pids"])
+        return state["killed"]
+
+    monkeypatch.setattr(browser_guard, "available_memory_mb", _read)
+    monkeypatch.setattr(
+        browser_guard, "browser_process_ids", lambda: state["browser_pids"]
+    )
+    monkeypatch.setattr(browser_guard, "shed_browser", _kill)
+    return state
+
+
+def test_a_healthy_sandbox_is_left_alone(sandbox) -> None:
+    """A workspace at rest sits near 1485 MB available, and a browser holding
+    three rendered pages still leaves about 1155 MB. Neither may trip this."""
+    sandbox["browser_pids"] = (101, 102, 103)
+
+    for available_mb in (1485, 1226, 1155):
+        sandbox["available_kb"] = available_mb * 1024
+        assert shed_browser_if_starved() is None, available_mb
+    assert sandbox["killed"] == 0
+
+
+def test_a_starved_sandbox_loses_its_browser(sandbox) -> None:
+    """The states actually observed in production: 14, 19 and 21 MB free."""
+    sandbox["browser_pids"] = tuple(range(200, 258))
+
+    for available_mb in (14, 19, 21):
+        sandbox["available_kb"] = available_mb * 1024
+        outcome = shed_browser_if_starved()
+        assert outcome is not None, available_mb
+        assert outcome == (available_mb, 58)
+
+
+def test_nothing_happens_when_the_memory_is_not_the_browsers(sandbox) -> None:
+    """Starved with no browser running means something else is using it.
+
+    The only thing this module knows how to kill safely is absent, and an
+    agent's own build or test run is its work -- unreproducible, where a
+    browser is a cache by construction.
+    """
+    sandbox["available_kb"] = 12 * 1024
+    sandbox["browser_pids"] = ()
+
+    assert shed_browser_if_starved() is None
+    assert sandbox["killed"] == 0
+
+
+def test_an_unreadable_meminfo_sheds_nothing(monkeypatch) -> None:
+    """Not knowing the memory is not the same as knowing it is short."""
+    monkeypatch.setattr(browser_guard, "available_memory_mb", lambda: None)
+    monkeypatch.setattr(browser_guard, "browser_process_ids", lambda: (1, 2))
+    killed = []
+    monkeypatch.setattr(
+        browser_guard, "shed_browser", lambda: killed.append(1) or 1
+    )
+
+    assert shed_browser_if_starved() is None
+    assert killed == []
+
+
+def test_the_threshold_clears_a_working_browser_by_an_order_of_magnitude() -> None:
+    """Guards the constant itself: it was chosen from measurement.
+
+    1155 MB is a real sandbox with three pages rendered; 21 MB is a real
+    sandbox that had become unusable. The threshold has to sit far from the
+    first and above the second, or it either fires on healthy research or
+    never fires at all.
+    """
+    assert 21 < LOW_MEMORY_MB < 1155 / 4
+
+
+def test_available_memory_reads_the_real_proc_when_there_is_one() -> None:
+    """Linux only. Elsewhere the absence must be reported, not guessed."""
+    value = available_memory_mb()
+    if Path("/proc/meminfo").exists():
+        assert value is not None and value > 0
+    else:
+        assert value is None

--- a/lemma-backend/sandbox_runtime/tests/test_workspace_quiescer.py
+++ b/lemma-backend/sandbox_runtime/tests/test_workspace_quiescer.py
@@ -5,6 +5,10 @@ import pytest
 from sandbox_runtime.workspace.quiescer import WorkspaceQuiescer
 
 
+async def _no_processes() -> int:
+    return 0
+
+
 @pytest.mark.asyncio
 async def test_quiescer_removes_only_declared_ephemeral_state(tmp_path: Path) -> None:
     ephemeral_directory = tmp_path / "browser"
@@ -19,9 +23,58 @@ async def test_quiescer_removes_only_declared_ephemeral_state(tmp_path: Path) ->
         ephemeral_directories=(ephemeral_directory,),
         ephemeral_files=(ephemeral_file,),
         isolated_process_namespace=False,
+        # Never the real one: it matches agent-browser and Xvfb, which a
+        # developer running this suite plausibly has open.
+        shed_browser_processes=lambda: 0,
     ).quiesce()
 
     assert result.terminated_unmanaged_processes == 0
     assert not ephemeral_directory.exists()
     assert not ephemeral_file.exists()
     assert durable_file.read_text() == "durable"
+
+
+@pytest.mark.asyncio
+async def test_a_shared_namespace_still_sheds_the_browser(tmp_path: Path) -> None:
+    """The E2B path, which is the one carrying production.
+
+    The blanket process sweep is gated on an isolated PID namespace because it
+    signals everything it can see, and on E2B that includes envd and E2B's own
+    services. Only the Docker image sets the flag -- so E2B was left deleting
+    the browser's profile directory while Chrome went on running out of it,
+    holding 2 GB on a 2 GB sandbox and surviving into the next conversation,
+    because a pause here snapshots memory rather than discarding it.
+    """
+    sheds = []
+
+    result = await WorkspaceQuiescer(
+        ephemeral_directories=(),
+        ephemeral_files=(),
+        isolated_process_namespace=False,
+        shed_browser_processes=lambda: sheds.append(1) or 7,
+    ).quiesce()
+
+    assert sheds == [1], "the browser must be ended, not just its profile deleted"
+    assert result.terminated_unmanaged_processes == 7
+
+
+@pytest.mark.asyncio
+async def test_an_isolated_namespace_does_not_shed_twice(monkeypatch) -> None:
+    """Docker's sweep already covers the browser; doing both would double count.
+
+    The real sweep signals every pid it can see, so it is stubbed rather than
+    run: a unit test that SIGTERMs the machine it runs on is not a test.
+    """
+    sheds = []
+    monkeypatch.setattr(
+        WorkspaceQuiescer, "_terminate_unmanaged_processes", staticmethod(_no_processes)
+    )
+
+    await WorkspaceQuiescer(
+        ephemeral_directories=(),
+        ephemeral_files=(),
+        isolated_process_namespace=True,
+        shed_browser_processes=lambda: sheds.append(1) or 1,
+    ).quiesce()
+
+    assert sheds == []

--- a/lemma-backend/sandbox_runtime/workspace/app.py
+++ b/lemma-backend/sandbox_runtime/workspace/app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import asynccontextmanager, suppress
 import hmac
+import logging
 import os
 from pathlib import Path
 import struct
@@ -47,6 +48,7 @@ from .filesystem_manager import (
     FilesystemManager,
     FileTooLargeError,
 )
+from .browser_guard import shed_browser_if_starved
 from .process_manager import ManagedProcess, OutputChunk, ProcessManager
 from .python_session_manager import PythonSessionManager
 from .quiescer import WorkspaceQuiescer
@@ -119,6 +121,32 @@ def create_app(
                 with suppress(Exception):
                     # One bad sweep must not end the loop; the next tick retries.
                     await manager.reap_expired()
+                with suppress(Exception):
+                    _shed_browser_under_pressure()
+
+        def _shed_browser_under_pressure() -> None:
+            """Take the browser back when the sandbox has nothing left.
+
+            Runs on the same tick as the deadline sweep because it needs no
+            timer of its own and, more usefully, because this loop is already
+            proven to keep running in a starved sandbox -- it allocates
+            nothing. Everything else that bounds the browser needs a healthy
+            process to act, which is exactly what is missing here.
+
+            Said out loud, and at warning, on purpose. A sandbox that quietly
+            repaired itself would leave whoever reads these logs with the same
+            unexplained `exit_code: 124` this was built from.
+            """
+            outcome = shed_browser_if_starved()
+            if outcome is None:
+                return
+            available_mb, killed = outcome
+            logging.getLogger(__name__).warning(
+                "workspace runtime shed the browser: %s MB available, "
+                "%s processes killed. It will start again on the next capture.",
+                available_mb,
+                killed,
+            )
 
         reaper = create_inherited_task(_reap_forever(), name="process-deadline-reaper")
         try:

--- a/lemma-backend/sandbox_runtime/workspace/browser_guard.py
+++ b/lemma-backend/sandbox_runtime/workspace/browser_guard.py
@@ -1,0 +1,138 @@
+"""The browser is a cache. When memory runs out, it is the thing that goes.
+
+A workspace sandbox is 1 vCPU and 2048 MB, and a headed Chrome is the only
+thing in it that can eat all of that. Measured on a real workspace after a
+research session: 63 Chrome processes at 2123 MB resident, `MemAvailable` at
+14 MB, kswapd0 burning a third of the only vCPU. In that state every unrelated
+tool call in the same sandbox degraded with it -- `python -c pass` took 61
+seconds, `lemma --version` never returned, and the agent saw `exit_code: 124`
+with no explanation.
+
+Three things already try to stop it getting there: a capture closes its own
+tab, the agent-browser daemon retires itself after two idle minutes, and
+`release` sheds the browser before a pause can snapshot it. This is the one
+that holds when those cannot. Each of them needs a healthy process to act --
+the daemon has to be responsive enough to notice its own idle timer, and
+`release` has to be reached at all -- and the failure being defended against is
+precisely the one where memory is gone and nothing is responsive. Worse, it
+does not settle: sampled three times inside a single command, with nothing
+driving the browser, renderer count and resident size still climbed while
+available memory fell 32 -> 24 -> 21 MB. A sandbox that reaches this state does
+not come back on its own.
+
+So the rule here is deliberately blunt, and it is a rule about *what* to kill
+rather than how much. Only the browser is ever touched. The agent's own
+processes are its work -- a build, a test run, a server it started -- and
+killing those to free memory would destroy something unreproducible to save
+something that is a cache by construction. The browser can always be started
+again, and the next `web_fetch` does exactly that.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import signal
+
+# Below this, the sandbox is close enough to unusable that a browser is no
+# longer worth what it costs. Chosen from measurement rather than taste: a
+# workspace at rest with no browser sits near 1485 MB available of 1983 MB, and
+# a browser session holding three rendered pages still leaves about 1155 MB.
+# Both are an order of magnitude clear of this, so a healthy research session
+# never trips it, while the degraded sandboxes observed in production -- 14 MB,
+# 19 MB, 21 MB available -- are all far below it.
+LOW_MEMORY_MB = 220
+
+# What the browser is, as processes. `workspace-chrome` is the wrapper the
+# image installs; the renderers exec the real binary out of the agent-browser
+# profile directory, so they are matched on that path rather than on "chrome",
+# which would also catch an agent's own chromium script.
+_BROWSER_PATTERNS = (
+    "agent-browser",
+    "workspace-chrome",
+    ".agent-browser/browsers/",
+    "Xvfb",
+)
+
+
+def available_memory_mb() -> int | None:
+    """Free memory as the kernel reckons it, or None where that is unknowable.
+
+    `MemAvailable` rather than `MemFree`: reclaimable page cache is not
+    pressure, and treating it as pressure would shed the browser on a sandbox
+    that had merely read a large file.
+    """
+    try:
+        for line in Path("/proc/meminfo").read_text().splitlines():
+            if line.startswith("MemAvailable:"):
+                return int(line.split()[1]) // 1024
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
+def browser_process_ids() -> tuple[int, ...]:
+    """Every pid whose command line says it belongs to the browser."""
+    found: list[int] = []
+    self_id = os.getpid()
+    try:
+        entries = sorted(
+            int(path.name) for path in Path("/proc").iterdir() if path.name.isdigit()
+        )
+    except OSError:
+        return ()
+    for process_id in entries:
+        if process_id == self_id:
+            continue
+        try:
+            # NUL-separated argv, so a pattern cannot match across arguments.
+            command = (
+                Path(f"/proc/{process_id}/cmdline")
+                .read_bytes()
+                .replace(b"\0", b" ")
+                .decode("utf-8", "replace")
+            )
+        except OSError:
+            # Exited between the listing and the read.
+            continue
+        if any(pattern in command for pattern in _BROWSER_PATTERNS):
+            found.append(process_id)
+    return tuple(found)
+
+
+def shed_browser() -> int:
+    """End the browser. Returns how many processes were signalled.
+
+    SIGKILL, not SIGTERM. A graceful shutdown asks Chrome to run teardown in a
+    sandbox that has no memory to run it in, which is how a shutdown becomes a
+    hang; and there is nothing to flush, because everything a capture produced
+    was already written to the workspace before this could be reached.
+    """
+    process_ids = browser_process_ids()
+    signalled = 0
+    for process_id in process_ids:
+        try:
+            os.kill(process_id, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            continue
+        signalled += 1
+    return signalled
+
+
+def shed_browser_if_starved(
+    *, threshold_mb: int = LOW_MEMORY_MB
+) -> tuple[int, int] | None:
+    """Shed the browser when memory is short. None when nothing was due.
+
+    Returns (available_mb, processes_killed) so the caller can say what it did
+    and why -- a sandbox that silently repaired itself would leave the next
+    person reading these logs with the same mystery this was built from.
+    """
+    available = available_memory_mb()
+    if available is None or available >= threshold_mb:
+        return None
+    if not browser_process_ids():
+        # Something else is using the memory. Not this module's call to make:
+        # the only safe thing it knows how to kill is absent.
+        return None
+    return available, shed_browser()

--- a/lemma-backend/sandbox_runtime/workspace/quiescer.py
+++ b/lemma-backend/sandbox_runtime/workspace/quiescer.py
@@ -16,9 +16,18 @@ class QuiesceResult:
 class WorkspaceQuiescer:
     """Remove nonportable compute state before a workspace is suspended."""
 
+    # The browser profile is under the *running user's* home, and which user
+    # that is depends on the runtime: the Docker image runs as `appuser`, the
+    # E2B template as `user`. Naming only one of them meant the E2B fleet --
+    # every production workspace -- carried its Chrome profile through every
+    # suspend, because the path being deleted did not exist there. Both are
+    # listed rather than derived from $HOME so that a quiesce running as root,
+    # which is how the runtime supervisor invokes it, still clears the profile
+    # belonging to the user the browser actually ran as.
     _ephemeral_directories = (
         Path("/tmp/lemma-browser"),
         Path("/home/appuser/.agent-browser"),
+        Path("/home/user/.agent-browser"),
         Path("/workspace/.browser-profile"),
     )
     _ephemeral_files = (

--- a/lemma-backend/sandbox_runtime/workspace/quiescer.py
+++ b/lemma-backend/sandbox_runtime/workspace/quiescer.py
@@ -4,8 +4,11 @@ import asyncio
 from dataclasses import dataclass
 import os
 from pathlib import Path
+from collections.abc import Callable
 import shutil
 import signal
+
+from .browser_guard import shed_browser
 
 
 @dataclass(frozen=True, slots=True)
@@ -41,7 +44,12 @@ class WorkspaceQuiescer:
         ephemeral_directories: tuple[Path, ...] | None = None,
         ephemeral_files: tuple[Path, ...] | None = None,
         isolated_process_namespace: bool | None = None,
+        # Injected so a test never signals a real process. The patterns this
+        # matches -- agent-browser, Xvfb -- are things a developer plausibly
+        # has running, and a unit test that kills their browser is not a test.
+        shed_browser_processes: Callable[[], int] = shed_browser,
     ) -> None:
+        self._shed_browser_processes = shed_browser_processes
         self._directories = (
             self._ephemeral_directories
             if ephemeral_directories is None
@@ -60,6 +68,19 @@ class WorkspaceQuiescer:
         terminated = 0
         if self._isolated_process_namespace:
             terminated = await self._terminate_unmanaged_processes()
+        else:
+            # The blanket sweep above is only safe where the PID namespace
+            # holds nothing but us, which is the Docker image -- it is the only
+            # runtime that sets the flag. On E2B the namespace also holds
+            # envd and E2B's own services, so signalling everything would take
+            # the sandbox down with the browser.
+            #
+            # That left the runtime carrying production with no process
+            # cleanup at all: deleting the profile directory does nothing to a
+            # Chrome that is still running and still holding 2 GB. Shedding the
+            # browser by name is the part that is safe everywhere, and it is
+            # the part that mattered.
+            terminated = self._shed_browser_processes()
         for path in self._directories:
             shutil.rmtree(path, ignore_errors=True)
         for path in self._files:


### PR DESCRIPTION
## What changes

A workspace sandbox no longer carries a browser from one conversation into the
next. That leak was making unrelated shell tool calls in the same sandbox fail
with `exit_code: 124`. Also fixes two places that reported success while doing
nothing.

## Why — the actual mechanism

A workspace is **one shared sandbox per user** (`lemma-sandbox-id` is the user
id) at **1 vCPU / 2048 MB**. Measured after a normal research session:

```
chrome: 63 processes, 2123 MB RSS      # more than the box has
MemAvailable: 14 MB     load1: 10.55 -> 48.24     kswapd0: 30.6% CPU
```

**The sizing was never the problem.** Same sandbox, browser gone vs resident:

| probe | clean | Chrome resident |
|---|---|---|
| `python3 -c pass` | **19 ms** | 61193 ms |
| `lemma --version` | **126 ms** | never returns (killed at 60 s) |
| `ls /workspace` | **2 ms** | 925–3251 ms |
| MemAvailable | **1485 MB** | 14 MB |
| `exec_command` round trip | 1.0–3.4 s | 28–38 s |

A clean workspace has 1.5 GB free, and a browser session with 3 pages rendered
still leaves 1155 MB and **does not move shell latency at all**. The sandbox only
ran out because nothing ever ended the browser.

**Why it survived being killed** — the part I initially guessed at and then
established: it was never respawning. `E2BSandboxProvider.release()` calls
`beta_pause()`, and **a pause preserves resident memory**. Docker's release
quiesces and then *stops*, which throws memory away, so quiescing there is
tidiness. Here it is everything: whatever runs when a workspace goes idle is
snapshotted, and the next tool call resumes all of it. Chrome was being
*restored*, conversation after conversation, without ever being started again.

Nothing ended it in the first place either: `save-webpage` opens a page and
exits, and neither it nor `start-browser` contains a single `close`/`kill`/`stop`
— zero grep hits. `web_fetch` falls back to that path automatically when http
extraction returns nothing. And the quiesce that does exist deleted
`/home/appuser/.agent-browser` while the E2B template runs as `user`.

## Measured cost of a fetch

| call | wall time | Chrome after | RSS after | shell latency after |
|---|---|---|---|---|
| baseline (no browser) | — | 0 | 0 MB | `python` 19 ms |
| `web_fetch` 1 URL (`example.com`) | **10.9 s** | 13 procs | 1327 MB | `python` 19 ms |
| `web_fetch` 5 URLs, one call | **14.1 s** | 15 procs | 1601 MB | `python` 19 ms |

Two things worth knowing from that:

- **One fetch of the simplest page on the internet costs 1327 MB**, and before
  this PR it stayed for the life of the sandbox — across every later conversation.
- **A 5-URL call rendered only 3** when measured. `_MAX_BROWSER_RENDERS` was 3
  while the schema advertised `max_length=10`, so the other two came back as
  `"Skipped: ... Ask for it again on its own."` — a limit the schema had no way
  to express, discovered only after paying for the call. **Both are 5 now**, held
  together by `test_web_fetch_limits_agree`: the tool cannot accept more pages
  than it will render, and the eleventh URL is refused at validation rather than
  reported undone. Safe because the http path already completes first and
  concurrently, so the cheap pages were never the thing at risk; the batch
  deadline still bounds the pathological case and names every page it missed.

## What this changes

Four bounds, none relying on an agent tidying up:

- **Release sheds the browser before pausing** (`e2b.py`) — the fix that matters
  most, since the pause is what made the leak permanent. Best effort and never
  fatal: a workspace whose browser is unreachable is the one most in need of
  being paused. Function sandboxes don't pay for the call.
- **A capture owns its tab and gives it back** — `save-webpage` opens a labelled
  tab and closes it via `trap ... EXIT`, because under `set -e` the expensive
  failing captures are exactly the ones that would leak. `--no-open` reuses the
  caller's page and leaves it alone.
- **`AGENT_BROWSER_IDLE_TIMEOUT_MS=120000`** in all three env declarations. Two
  minutes sits inside the 180 s idle-release window, so a quiet workspace sheds
  Chrome before anything decides what to do with the sandbox; a batch in flight
  never sees it, since every capture is a command.
- **Quiesce cleans the profile under both homes.**

Two silent-success bugs this uncovered:

- **`write_stdin`** read `exc.code` and `exc.retry`; no sandbox error carries
  either, so every `SandboxError` there died with `AttributeError:
  'SandboxUnavailable' object has no attribute 'code'` — shown to the agent
  instead of `stdin not enabled or closed`. Observed as three consecutive
  `manage_process` calls failing identically.
- **The orphan sweep** logged 18 reclaims every 5 minutes for hours — the same 18
  ids — while the account held **99 paused sandboxes** and the count never moved.
  On E2B a paused sandbox lists like any other and survives being killed. A
  destroy is now confirmed **by identity** (`provider_id`, so a superseded epoch
  still reads as reclaimed), and a provider that cannot reap says so via
  `orphan_destroy_ineffective`.

Also fixes **five workspace integration tests red on `main`** since the
ensure-reuse cache landed (#374, mine): `_recent` is a class attribute the
fixtures never cleared, and within a test it answered the very re-ensure that was
the point.

## Not in this PR

**Memory exhaustion is still silent.** The sandbox went from healthy to unusable
with nothing logged; the only signal reaching the agent was `exit_code: 124`, and
finding the cause took live forensics. A memory probe surfaced in the tool error
would make that a one-line diagnosis. Left out deliberately — it wants a protocol
change, not a rushed one.

**No sizing change.** The numbers above say 2048 MB is adequate once the browser
is bounded.


## Added after review: the leak is active, not just persistent

Sampled three times inside **one** exec (so no pause/resume could intervene),
with nothing driving the browser:

```
[A] t=463s  renderers=53  rss=2113MB  avail=32MB  max gpu-client-id=74
[B] t=521s  renderers=53  rss=2116MB  avail=24MB  max gpu-client-id=74
[C] t=580s  renderers=54  rss=2138MB  avail=21MB  max gpu-client-id=75
```

Newest renderer: **54 seconds old**, created during the observation. So the
pause snapshot *preserves* the leak, it does not cause it — there is active
growth on top, and a sandbox in this state does not recover on its own. The
mechanism is most consistent with a crash-respawn loop (a `chrome_crashpad_handler`
is running, and OOM-killed renderers get respawned into the same pressure), but
I am flagging that as inferred rather than proven.

That makes a fourth bound necessary, because the other three all need a healthy
process to act — the daemon must notice its own idle timer, a capture must reach
its trap, `release` must be called at all — and the failure being defended
against is precisely the one where nothing is responsive:

- **The runtime sheds the browser below 220 MB available**, on the same tick as
  the deadline sweep (that loop allocates nothing, so it keeps running in a
  starved sandbox). Threshold from measurement: at rest ≈1485 MB free, three
  pages rendered ≈1155 MB, the broken sandboxes were at 14/19/21 MB.
  **Only the browser is ever killed** — an agent's build or test run is
  unreproducible work, a browser is a cache by construction. Nothing is killed
  when memory is short and no browser is running. It logs at warning when it
  fires, because a sandbox that silently repaired itself leaves the next person
  with the same unexplained `exit_code: 124`.
- **Quiesce sheds by name too**, closing the gap that left production
  uncovered: its blanket process sweep is gated on an isolated PID namespace
  (only Docker sets that flag), so on E2B it was deleting the browser's profile
  directory while Chrome went on running out of it.

## Two `execute_python` bugs found while auditing the sandbox

- **Imports did not survive between calls on E2B**, though the tool documents
  that they do. Each call is a fresh `python3` and the namespace travels in a
  pickle; modules cannot be pickled, so the filter dropped every one. `import
  pandas as pd` then `pd.DataFrame(...)` raised `NameError`. Modules are now
  carried by name and re-imported.
- **`timeout=None`** meant `timeout_seconds` bounded only the backend's wait —
  nothing stopped the code. A runaway loop kept running after the tool
  returned, holding the only vCPU, and the idle sweeper will not release a
  sandbox with live processes. It now carries the request deadline.

## jupyter-server: investigated, deliberately not changed here

`jupyter-server` (76 MB) + its `ipykernel` child (57 MB) are **133 MB of the
~250 MB resting set** — and nothing in our code talks to either. `execute_python`
on E2B runs `python3 <runner>`; the docker path uses our own `python_worker.py`.
Verified: `jupyter-server` appears **0 times** in our lockfile — it is inherited
from E2B's `code-interpreter-v1` base template, whose start command is captured
in the template snapshot. We do make it worse: our own kernelspec override
repoints E2B's pre-warmed kernel at our Python 3.14, which is likely why the
kernel child is 57 MB.

Not changed here because suppressing an inherited start command cannot be
verified without building a template, and getting it wrong breaks
`execute_python` in production. The smallest safe first step is a suffixed
candidate build (`--name-suffix` is already supported) that drops `ipykernel`
and the kernelspec block, booted once and diffed against production `ps`/RSS.
Worth doing — it is over half the resting set — but it wants its own change.

## How to verify

```bash
cd lemma-backend && uv run pytest -m "not e2e" -q
```

```bash
make quality
```

`4783 passed, 35 skipped` and `✓ quality gates pass`. For the five
previously-red tests, run
`uv run pytest app/modules/workspace/tests/integration/ -q` on `main`
(needs postgres on 5432): `5 failed, 42 passed`.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload
- [x] **Rollback** — safe. The image env and `save-webpage` change only take
      effect on the next template build; the backend changes are independent.
