### PR TITLE
Stop billing a finished command for the whole yield window

### DIFF
--- a/lemma-backend/app/modules/workspace/providers/e2b_ops.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b_ops.py
@@ -22,6 +22,7 @@ from sandbox_runtime.protocol import (
     FileStat,
     ProcessOutputChannel,
     ProcessOutputSnapshot,
+    ProcessState,
     PythonExecutionState,
     PythonResult,
     PythonSessionRef,
@@ -47,6 +48,21 @@ from app.modules.workspace.providers.e2b_process_lifetime import seconds_until
 from app.modules.workspace.providers.e2b_python_runner import PYTHON_RUNNER
 
 WORKSPACE_MOUNT = "/workspace"
+
+# A process that has stopped will produce no further output, so a reader
+# waiting for more has nothing left to wait for.
+_FINISHED_PROCESS_STATES = frozenset(
+    {
+        ProcessState.SUCCEEDED,
+        ProcessState.FAILED,
+        ProcessState.CANCELLED,
+        ProcessState.TIMED_OUT,
+    }
+)
+
+
+def _has_finished(snapshot: ProcessOutputSnapshot) -> bool:
+    return snapshot.state in _FINISHED_PROCESS_STATES
 
 
 
@@ -234,18 +250,30 @@ class E2BOpsMixin:
         deadline_at: datetime,
     ) -> ProcessOutputSnapshot:
         snapshot = await self._output.read(process_id, after_sequence=after_sequence)
-        if snapshot.chunks or wait_seconds <= 0:
+        if snapshot.chunks or wait_seconds <= 0 or _has_finished(snapshot):
             return snapshot
 
         # Nothing new yet. Poll the buffer rather than holding an E2B stream
         # open, so a caller that goes away costs nothing.
+        #
+        # Waking on the exit as well as on output is what makes this bounded by
+        # the command instead of by the yield window. Exit is recorded by a
+        # separate watcher task, so it almost always lands *after* the last
+        # chunk: the collector's first poll took the output while the state was
+        # still RUNNING, came back, saw a non-terminal state and polled again --
+        # and this loop then had no new bytes to wait for and no reason to stop,
+        # so it slept out the whole remaining window. Every command that printed
+        # something and then exited paid that in full. Measured on a real
+        # workspace, `lemma tables list` ran in 771 ms and the tool call around
+        # it took 23-39 s, which agents read as a hang: they poll, give up, kill
+        # the process and start again.
         deadline = asyncio.get_running_loop().time() + wait_seconds
         while asyncio.get_running_loop().time() < deadline:
             await asyncio.sleep(0.1)
             snapshot = await self._output.read(
                 process_id, after_sequence=after_sequence
             )
-            if snapshot.chunks:
+            if snapshot.chunks or _has_finished(snapshot):
                 break
         return snapshot
 

--- a/lemma-backend/app/modules/workspace/services/sandbox_sweeper.py
+++ b/lemma-backend/app/modules/workspace/services/sandbox_sweeper.py
@@ -23,6 +23,7 @@ from datetime import datetime, timedelta, timezone
 from app.core.log.log import get_logger
 from app.modules.workspace.domain.sandbox import SandboxDesiredState
 from app.modules.workspace.infrastructure.sandbox_repository import SandboxRepository
+from app.modules.workspace.process_output import TERMINAL_PROCESS_STATES
 from app.modules.workspace.providers.base import (
     ProviderFailed,
     ProviderGone,
@@ -106,7 +107,14 @@ class SandboxSweeper:
             # An unreachable sandbox is not evidence that it is idle, and
             # releasing on a failed probe is the mistake this guards against.
             return True
-        return any(p.exit_code is None for p in processes)
+        # State, not exit code. A cancelled process on E2B is recorded with
+        # `exit_code=None` (`e2b_output.record_cancelled`), so reading busy-ness
+        # off the exit code made every process an agent killed pin its sandbox
+        # as busy for the hour the buffer retains it -- and the idle sweep never
+        # released it. Agents kill processes exactly when a tool call looks
+        # stuck, which is how this compounded: the sandbox that frustrated
+        # someone was then the one that could never be reclaimed.
+        return any(not _has_stopped(p) for p in processes)
 
     async def reclaim_orphans(self, *, dry_run: bool = False) -> tuple[str, ...]:
         """Destroy provider objects no live sandbox row accounts for.
@@ -210,3 +218,23 @@ class SandboxSweeper:
         except (ProviderFailed, ProviderNotReady, ProviderRejected, SandboxError):
             return False
         return instance is not None and instance.provider_id == obj.provider_id
+
+
+def _has_stopped(process) -> bool:
+    """Whether this process is over, by either signal the providers give.
+
+    Both are needed, and neither alone is enough. E2B records a cancelled
+    process with `exit_code=None` (`e2b_output.record_cancelled`), so the exit
+    code alone made every process an agent killed pin its sandbox as busy for
+    the hour the output buffer retains it -- and agents kill processes exactly
+    when a tool call looks stuck, so the sandbox that had just frustrated
+    someone was then the one the idle sweep could never reclaim. The state
+    alone is not enough either: `ProcessDescriptor.state` is typed `object`,
+    and a provider that reports a state this module does not know would read as
+    running forever.
+    """
+    if process.exit_code is not None:
+        return True
+    return process.state in TERMINAL_PROCESS_STATES or str(
+        getattr(process.state, "value", process.state)
+    ) in {state.value for state in TERMINAL_PROCESS_STATES}

--- a/lemma-backend/app/modules/workspace/tests/integration/test_sandbox_sweeper.py
+++ b/lemma-backend/app/modules/workspace/tests/integration/test_sandbox_sweeper.py
@@ -389,3 +389,27 @@ async def test_the_liveness_probe_addresses_the_sandbox_by_its_provider_id(
         "the probe must carry the provider id, not the container name"
     )
     assert released == 0, "a sandbox with live work must not be paused"
+
+
+async def test_a_killed_process_does_not_pin_its_sandbox_forever(
+    sweeper: SandboxSweeper, provider: SweepableProvider, service: SandboxService
+) -> None:
+    """Busy-ness is a state, not an absent exit code.
+
+    E2B records a cancelled process with `exit_code=None`
+    (`e2b_output.record_cancelled`), so reading busy-ness off the exit code made
+    every process an agent killed pin its sandbox as busy for the hour the
+    output buffer retains it, and the idle sweep never released it. Agents kill
+    processes exactly when a tool call looks stuck -- so the sandbox that had
+    just frustrated someone was then the one that could never be reclaimed.
+    """
+    sandbox = await _workspace(service)
+    handle = await service.ensure(sandbox.id)
+    provider.processes = [
+        ProcessDescriptor(process_id="op-1", state="cancelled", exit_code=None)
+    ]
+
+    released = await sweeper.release_idle(idle_after_seconds=0)
+
+    assert released == 1, "a sandbox whose only process was killed is idle"
+    assert handle.provider_id in provider.released

--- a/lemma-backend/app/modules/workspace/tests/unit/test_e2b_output_wait.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_e2b_output_wait.py
@@ -1,0 +1,93 @@
+"""A finished command must not be billed the whole yield window.
+
+The reader woke on new output and on nothing else. Exit is recorded by a
+separate watcher task, so it lands *after* the last chunk: the collector's
+first poll took the output while the state was still RUNNING, came back, saw a
+non-terminal state and polled again -- and this loop then had no new bytes to
+wait for and no reason to stop, so it slept out the remaining window. Every
+command that printed something and then exited paid that in full.
+
+Measured on a real workspace: `lemma tables list` ran in 771 ms while the tool
+call around it took 23-39 s. Agents read that as a hang -- they poll, give up,
+kill the process and start over -- which is what it looked like from the UI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from sandbox_runtime.protocol import ProcessOutputSnapshot, ProcessState
+from app.modules.workspace.providers.e2b_ops import E2BOpsMixin
+
+
+class _Buffer:
+    """Reports a process that has already exited, with its output drained."""
+
+    def __init__(self, state: ProcessState) -> None:
+        self.state = state
+        self.reads = 0
+
+    async def read(self, process_id: str, *, after_sequence: int):
+        del process_id, after_sequence
+        self.reads += 1
+        return ProcessOutputSnapshot(
+            chunks=(),
+            next_sequence=1,
+            truncated_before_sequence=None,
+            state=self.state,
+            exit_code=0 if self.state is ProcessState.SUCCEEDED else 1,
+        )
+
+
+class _Ops(E2BOpsMixin):
+    def __init__(self, buffer: _Buffer) -> None:
+        self._output = buffer
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "state",
+    [
+        ProcessState.SUCCEEDED,
+        ProcessState.FAILED,
+        ProcessState.CANCELLED,
+        ProcessState.TIMED_OUT,
+    ],
+)
+async def test_a_finished_process_returns_at_once(state: ProcessState) -> None:
+    buffer = _Buffer(state)
+    ops = _Ops(buffer)
+
+    started = asyncio.get_running_loop().time()
+    snapshot = await ops.read_process_output(
+        object(),  # type: ignore[arg-type]
+        process_id="op-1",
+        after_sequence=5,
+        wait_seconds=30.0,
+        deadline_at=None,  # type: ignore[arg-type]
+    )
+    elapsed = asyncio.get_running_loop().time() - started
+
+    assert snapshot.state is state
+    assert elapsed < 1.0, f"waited {elapsed:.1f}s for a process that had exited"
+
+
+@pytest.mark.asyncio
+async def test_a_running_process_with_no_output_still_waits() -> None:
+    """The wait is what makes a quiet long-running command cost one request."""
+    buffer = _Buffer(ProcessState.RUNNING)
+    ops = _Ops(buffer)
+
+    started = asyncio.get_running_loop().time()
+    await ops.read_process_output(
+        object(),  # type: ignore[arg-type]
+        process_id="op-1",
+        after_sequence=5,
+        wait_seconds=0.4,
+        deadline_at=None,  # type: ignore[arg-type]
+    )
+
+    assert asyncio.get_running_loop().time() - started >= 0.3
+    assert buffer.reads > 1, "it must keep looking while the process is alive"


### PR DESCRIPTION
## What changes

Every `exec_command` that printed output and then exited was charged the full
30-second yield window. `lemma tables list` runs in **771 ms** inside a real
workspace; the tool call around it took **23–39 s**.

## Why

[`e2b_ops.py` `read_process_output`](lemma-backend/app/modules/workspace/providers/e2b_ops.py)
woke on new output bytes and on nothing else:

```python
while asyncio.get_running_loop().time() < deadline:
    await asyncio.sleep(0.1)
    snapshot = await self._output.read(process_id, after_sequence=after_sequence)
    if snapshot.chunks:      # never checks whether the process exited
        break
```

Process exit is recorded by a **separate watcher task** (`_watch_for_exit`), so it
lands *after* the last output chunk. The sequence:

1. Command prints its output and exits (~700 ms).
2. The collector's first poll takes the output — state is still `RUNNING`.
3. The collector sees a non-terminal state and polls again.
4. This loop now has no new bytes to wait for and **no reason to stop**, so it
   sleeps out the entire remaining window (`_POLL_YIELD_MS = 30_000`).

From outside that is indistinguishable from a hang, and agents treated it as one:
poll, conclude the process is stuck, kill it, retry — and the retry pays the same
30 s, so the run never converges.

Measured in a live dev workspace:

| probe | real | as the agent saw it |
|---|---|---|
| `lemma --version` | 188 ms | — |
| `lemma tables list` | 771 ms / 695 ms | 23–39 s, reported "still running" |
| `lemma pods describe` | 1365 ms | 38.9 s |

## The fix

Return as soon as the process has finished, not only when new bytes arrive. A
*running* process with no output still waits — that property is worth keeping,
since it makes a quiet ten-minute build cost one request rather than six hundred.

## Why nothing caught it

Every existing test asserted on **what** came back; none on **how long it took**.
The new tests assert elapsed time, which is the only way this bug is visible. Same
lesson as the `provider_id`/`name` bugs in #378: the fixtures made the broken case
indistinguishable from the working one.

## How to verify

```bash
cd lemma-backend && uv run pytest app/modules/workspace/ -q -m "not e2e"
```

```bash
make quality
```

`200 passed` and `✓ quality gates pass` locally.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Rollback** — safe; single condition on a read path, no schema or API change

---

## Second fix: a killed process pinned its sandbox forever

Same audit, same shape, and it compounds with the above. `sandbox_sweeper._is_busy`
read busy-ness off the exit code, but E2B records a cancelled process with
`exit_code=None` (`e2b_output.record_cancelled`). So **every process an agent
killed pinned its sandbox as busy for the hour the output buffer retains it**,
and the idle sweep never released it.

Agents kill processes exactly when a tool call looks stuck — which, before the
first fix, was every command that printed output and exited. The sandbox that had
just frustrated someone was then the one that could never be reclaimed, stayed
running, and went on holding its memory.

Both signals are now accepted; neither alone suffices. The exit code misses
cancellation; the state alone would miss a provider reporting something this
module does not know, since `ProcessDescriptor.state` is typed `object`.

## Audit: four more of this shape, NOT fixed here

Each is a wait whose exit condition is incomplete. I verified the two E2B ones
directly; the rest are cited but unconfirmed by me. **Worth their own PRs.**

1. **`sandbox_service.py:341-356` `_await_claim` never re-reads the instance row.**
   It waits for the container to appear, but `_provision` marks the row `ERROR`
   on all three failure branches (`:429/:435/:439`) and nothing observes that.
   With `_CLAIM_TIMEOUT_SECONDS = 180`, a create that fails 10 s in leaves
   **~170 s** of 0.25 s polling before returning. User-visible: the first
   `exec_command` in a pod whose create failed on another replica hangs ~3 min.

2. **`docker_ops.py:341-347` and `:362-371` — readiness polls never check the
   container died.** ECONNREFUSED maps to `WorkspaceRuntimeError`, so a container
   that started and exited is indistinguishable from one still booting: ~1000
   attempts over the 300 s ensure deadline. The missing check exists 20 lines
   away at `docker.py:333-337`. Docker only (dev/self-host).

3. **`callable_tool_factory.py:376-386` — JOB function poll ceiling is unrelated
   to the run deadline, and the fall-through lies.** Poll ceiling is 300 s;
   `function_job_deadline_seconds` defaults to **600 s**. On fall-through,
   `:260-261` sees `status=RUNNING, error=None` and raises
   `RuntimeError("Function … failed")` — the agent waits 5 minutes and is told
   the function failed *while it is still running*.

4. **`outbox.py:143-159` — the wake fires on insert only.** `_mark_failed`,
   lease expiry and `replay_outbox_event` all mature rows without a NOTIFY, so a
   retry waits out `outbox_listen_fallback_poll_seconds = 30` instead of ~1 s.
   Note the inversion: with the listener **off** the same retry lands in ~0.5 s.
   Currently gated — `outbox_listen_enabled` defaults `False` — so this is a
   prerequisite for turning the listener on, not a live bug.

Two more the audit flagged that I could not confirm: an uncapped provider
`Retry-After` in `harnesses/pydantic_ai.py:293-297` (local backoff caps at 6 s,
the provider value does not, and `should_stop()` is sampled before the sleep);
and `worker_pool.py:136-142` waiting on `readline()` EOF, which a user function's
subprocess can hold open by inheriting fd 1.
