### PR TITLE
Stop the platform deleting the workspaces it is meant to keep

### DIFF
--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -639,6 +639,9 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'workspace.sandbox_session.python_session_delete_failed': EventSpec('debug', frozenset({'sandbox_id', 'session_id'})),
     'workspace.sandbox_sweeper.idle_release_failed': EventSpec('warning', frozenset({'error_type', 'sandbox_id'})),
     'workspace.e2b.profile_drift_tolerated': EventSpec('info', frozenset({'sandbox_id'})),
+    'workspace.e2b.template_drift_replacing': EventSpec(
+        'info', frozenset({'sandbox_id', 'kind', 'recorded', 'configured'})
+    ),
     'workspace.sandbox_sweeper.orphan_destroy_failed': EventSpec('warning', frozenset({'error_type', 'sandbox_id'})),
     'workspace.sandbox_sweeper.orphan_destroy_ineffective': EventSpec('warning', frozenset({'reason', 'sandbox_id'})),
     'workspace.sandbox_sweeper.orphan_reclaimed': EventSpec('info', frozenset({'reason', 'sandbox_id'})),

--- a/lemma-backend/app/modules/workspace/infrastructure/sandbox_repository.py
+++ b/lemma-backend/app/modules/workspace/infrastructure/sandbox_repository.py
@@ -313,6 +313,46 @@ class SandboxRepository:
             .values(last_used_at=utcnow())
         )
 
+    async def mark_in_use(self, sandbox_id: UUID, instance_id: UUID | None) -> None:
+        """Record that this sandbox is serving again, not merely that it was used.
+
+        Adopting a sandbox is a state change, and the resume path treated it as
+        a read: only a full provision wrote `PRESENT` back, so after the first
+        release the row kept saying RELEASED however many times the sandbox was
+        resumed and used. `list_idle` selects on `desired_state == PRESENT`, so
+        the sandbox went invisible to idle release for the rest of its life --
+        nothing stopped its compute, it ran until the provider's own timeout,
+        and on E2B the action at that timeout was to delete it.
+
+        Folded into the same statement as the activity stamp because that write
+        already happens on this path, so correcting the state costs nothing
+        extra, and because doing it as one conditional UPDATE rather than
+        read-then-write leaves no window for a concurrent release to be undone
+        by a stale value.
+        """
+        await self.session.execute(
+            update(SandboxModel)
+            .where(SandboxModel.id == sandbox_id)
+            .values(
+                last_used_at=utcnow(),
+                desired_state=SandboxDesiredState.PRESENT.value,
+                updated_at=utcnow(),
+            )
+        )
+        if instance_id is None:
+            return
+        # Never resurrect an instance that is finished with. A destroyed row
+        # describes a provider object that is gone, and marking it ready would
+        # point the next ensure at nothing.
+        await self.session.execute(
+            update(SandboxInstanceModel)
+            .where(
+                SandboxInstanceModel.id == instance_id,
+                SandboxInstanceModel.state != SandboxInstanceState.DESTROYED.value,
+            )
+            .values(state=SandboxInstanceState.READY.value, last_error=None)
+        )
+
     async def list_idle(
         self, *, idle_before: datetime, limit: int = 100
     ) -> tuple[Sandbox, ...]:

--- a/lemma-backend/app/modules/workspace/process_output.py
+++ b/lemma-backend/app/modules/workspace/process_output.py
@@ -25,12 +25,83 @@ _MAX_OUTPUT_WAIT_SECONDS = 30.0
 # the client will wait for it, so a wait never expires in transit.
 _POLL_SAFETY_MARGIN_SECONDS = 1.0
 
+# Below this a silent window says nothing: a caller that asked to wait half a
+# second and got half a second of quiet has learned only that the command is not
+# instant. The probe costs a round trip, so it is spent only on windows long
+# enough that silence is genuinely surprising.
+_SILENCE_IS_SUSPICIOUS_AFTER_SECONDS = 5.0
+
+
 TERMINAL_PROCESS_STATES = {
     ProcessState.SUCCEEDED,
     ProcessState.FAILED,
     ProcessState.CANCELLED,
     ProcessState.TIMED_OUT,
 }
+
+
+def _wait_window(*, deadline_at: datetime, yield_seconds, elapsed: float) -> float:
+    """How long to ask the server to hold this poll open.
+
+    Two clocks bound it. The deadline is the caller's transport budget and the
+    safety margin comes off it alone -- asking the server to hold longer than
+    the client waits turns "still running" into a transport error. The yield
+    window is the caller's patience, and taking the margin out of that as well
+    put a cliff at one second, where a command that finished in milliseconds
+    still came back "still running" and cost another round trip to find out
+    otherwise.
+    """
+    window = (
+        deadline_at - datetime.now(timezone.utc)
+    ).total_seconds() - _POLL_SAFETY_MARGIN_SECONDS
+    if yield_seconds is not None:
+        window = min(window, yield_seconds - elapsed)
+    return min(window, _MAX_OUTPUT_WAIT_SECONDS)
+
+
+def _drain(chunks, after_sequence: int, stdout: bytearray, stderr: bytearray) -> int:
+    """Split one poll's chunks by channel and advance the cursor past them."""
+    for chunk in chunks:
+        after_sequence = max(after_sequence, chunk.sequence)
+        if chunk.channel.value == "stderr":
+            stderr.extend(chunk.data)
+        else:
+            stdout.extend(chunk.data)
+    return after_sequence
+
+
+def _silence_is_suspicious(*, completed: bool, probe_liveness, elapsed: float) -> bool:
+    """Is a window that produced nothing worth spending a probe on?
+
+    Only when all three hold: the process is still running, someone can answer
+    the question, and the window was long enough that silence means something.
+    """
+    if completed or probe_liveness is None:
+        return False
+    return elapsed >= _SILENCE_IS_SUSPICIOUS_AFTER_SECONDS
+
+
+def _unresponsive_sandbox(operation_id: UUID) -> dict[str, Any]:
+    """What a caller is told when the sandbox itself has stopped answering.
+
+    Named as a failure rather than dressed up as a running process, because the
+    recovery is not "poll again" -- it is to restart the sandbox, and only a
+    caller that is told so can do it.
+    """
+    return {
+        "success": False,
+        "stdout": "",
+        "stderr": "",
+        "exit_code": None,
+        "completed": False,
+        "process_id": str(operation_id),
+        "error": (
+            "The sandbox stopped responding: the command produced no output and "
+            "did not finish, and a trivial probe command did not return either. "
+            "Polling again will not help. Restart the workspace sandbox and run "
+            "the command again."
+        ),
+    }
 
 
 async def collect_process_output(
@@ -41,6 +112,7 @@ async def collect_process_output(
     *,
     deadline_at: datetime,
     yield_time_ms: int | None,
+    probe_liveness=None,
 ) -> dict[str, Any]:
     started = time.monotonic()
     yield_seconds = None if yield_time_ms is None else yield_time_ms / 1000
@@ -67,12 +139,9 @@ async def collect_process_output(
         # under a second became a single non-waiting poll, so a command that
         # finished in milliseconds still came back "still running" and cost
         # the caller another round trip to find out otherwise.
-        window = (
-            deadline_at - datetime.now(timezone.utc)
-        ).total_seconds() - _POLL_SAFETY_MARGIN_SECONDS
-        if yield_seconds is not None:
-            window = min(window, yield_seconds - elapsed)
-        wait_seconds = min(window, _MAX_OUTPUT_WAIT_SECONDS)
+        wait_seconds = _wait_window(
+            deadline_at=deadline_at, yield_seconds=yield_seconds, elapsed=elapsed
+        )
         if wait_seconds <= 0:
             # A very short yield still wants whatever is already buffered, so
             # read once — but never twice, or this becomes the busy loop it
@@ -92,18 +161,31 @@ async def collect_process_output(
         )
         state = snapshot.state
         exit_code = snapshot.exit_code
-        for chunk in snapshot.chunks:
-            after_sequence = max(after_sequence, chunk.sequence)
-            if chunk.channel.value == "stderr":
-                stderr.extend(chunk.data)
-            else:
-                stdout.extend(chunk.data)
+        after_sequence = _drain(snapshot.chunks, after_sequence, stdout, stderr)
         output_cursor.remember_locally(operation_id, after_sequence)
         if state in TERMINAL_PROCESS_STATES:
             break
     completed = state in TERMINAL_PROCESS_STATES
     if after_sequence != initial_sequence:
         await output_cursor.save(operation_id, after_sequence)
+    elif _silence_is_suspicious(
+        completed=completed,
+        probe_liveness=probe_liveness,
+        elapsed=time.monotonic() - started,
+    ):
+        # Nothing at all: no byte, no exit, over a window long enough that both
+        # would be surprising. Two very different things look identical from
+        # here -- a quiet build, and a sandbox that has stopped answering -- and
+        # this reported the same "still running, no output" for both. So a
+        # wedged workspace returned success on every poll: the agent polled,
+        # gave up, killed the process, ran it again, and got another silent
+        # window. Nothing in the platform ever said the sandbox was the problem,
+        # and the only way out was for someone to notice and destroy it by hand.
+        #
+        # One trivial command tells them apart, and it is only ever paid on a
+        # window that has already told the caller nothing.
+        if not await probe_liveness():
+            return _unresponsive_sandbox(operation_id)
     # Each poll's bytes are decoded as a unit, so a chunk boundary inside
     # one poll is handled correctly. A multi-byte character split across
     # two polls still yields one replacement character; holding the partial

--- a/lemma-backend/app/modules/workspace/providers/base.py
+++ b/lemma-backend/app/modules/workspace/providers/base.py
@@ -115,6 +115,12 @@ class ProviderInstance:
     # for one made before the fence existed. Compared against the configured
     # digest to decide whether this instance may be reused.
     profile_digest: str | None = None
+    # The provider artifact this object was actually built from -- on E2B, the
+    # template. Distinct from `profile_digest`, which is a hand-maintained
+    # environment variable: this is the identity of the image that is running,
+    # so it is the only thing that can answer "is this sandbox running the code
+    # we published?". None means the object predates the stamp.
+    template: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/lemma-backend/app/modules/workspace/providers/e2b.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b.py
@@ -56,6 +56,7 @@ from app.modules.workspace.providers.e2b_common import (
     meta_profile_digest,
     meta_sandbox_id,
     meta_sandbox_kind,
+    meta_template,
     sdk_best_effort,
     sdk_errors,
 )
@@ -152,6 +153,7 @@ class E2BSandboxProvider(E2BOpsMixin):
             meta_sandbox_kind(namespace): spec.kind.value,
             meta_epoch(namespace): str(spec.epoch),
             meta_profile_digest(namespace): spec.profile_digest,
+            meta_template(namespace): self._template(spec.kind),
         }
 
     def _template(self, kind: SandboxKind) -> str:
@@ -180,8 +182,37 @@ class E2BSandboxProvider(E2BOpsMixin):
         replacement would destroy the disk, so identity alone decides, and the
         fence is the E2B sandbox id -- a genuinely new sandbox has a new id, so
         a stale operation fails rather than landing on it.
+
+        It does not ignore the template. Adopting a sandbox adopts the code
+        inside it, so a workspace that is never replaced is a workspace that can
+        never be fixed -- which is what happened, and is documented on the
+        branch below.
         """
         existing = await self._find_any(spec.sandbox_id)
+        if existing is not None and self._template_is_stale(existing, spec.kind):
+            # The sandbox is running an image we no longer publish, and on this
+            # provider the image cannot be changed underneath it: the sandbox is
+            # the disk, so adopting it means adopting its code too. Tolerating
+            # that is what pinned every workspace in the fleet to whatever
+            # template it was first created on -- 249 sandboxes across four
+            # older templates, and zero on the configured one -- so every fix
+            # shipped in the image reached nobody who already had a workspace.
+            # The workspaces that were failing were exactly the ones the fixes
+            # could never reach.
+            #
+            # Replacing costs the disk, which is why this is deliberately
+            # narrow: it fires on the template, the identity of the artifact
+            # that is running, and not on `profile_digest`, a hand-maintained
+            # environment variable whose drift is still tolerated below.
+            logger.info(
+                "workspace.e2b.template_drift_replacing",
+                sandbox_id=str(spec.sandbox_id),
+                kind=spec.kind.value,
+                recorded=existing.template or "<unstamped>",
+                configured=self._template(spec.kind),
+            )
+            await self._kill_quietly(existing.provider_id)
+            existing = None
         drifted = (
             existing is not None
             and existing.profile_digest != spec.profile_digest
@@ -189,23 +220,7 @@ class E2BSandboxProvider(E2BOpsMixin):
         if drifted and spec.kind is SandboxKind.FUNCTION:
             # A function sandbox owns no durable disk, so replacing it to adopt
             # a new digest costs a cold start and nothing else.
-            #
-            # Not best-effort: if the stale sandbox survives, the fresh one
-            # carries the same sandbox-id metadata and a later lookup could
-            # land on either. Failing the provision is better than leaving a
-            # duplicate behind.
-            #
-            # Already gone is the outcome this wanted, though, and it is a
-            # normal race -- the listing that found it can be stale, or E2B
-            # can reap it first. ProviderGone is a bare RuntimeError that
-            # `_provision` does not catch, so letting it escape would leave
-            # the instance row stuck in CREATING until the claim times out.
-            try:
-                sandbox = await self._connect(existing.provider_id)
-                with sdk_errors():
-                    await sandbox.kill(**self._api())
-            except ProviderGone:
-                pass
+            await self._kill_quietly(existing.provider_id)
             existing = None
         elif drifted:
             # A workspace tolerates drift, and this is the whole reason the
@@ -251,6 +266,35 @@ class E2BSandboxProvider(E2BOpsMixin):
             running=True,
             storage_adopted=False,
         )
+
+    def _template_is_stale(self, existing: ProviderInstance, kind: SandboxKind) -> bool:
+        """Is this sandbox running something other than what we publish now?
+
+        An unstamped sandbox counts as stale. It was created before this fence
+        existed, which means it is at least one template behind by construction
+        -- and reading "unknown" as "fine" is the exact shape of the bug this
+        replaces, where the fleet's staleness was invisible because nothing
+        recorded what it was running.
+        """
+        return existing.template != self._template(kind)
+
+    async def _kill_quietly(self, provider_id: str) -> None:
+        """Kill a sandbox we have decided to replace.
+
+        Not best-effort: if the stale sandbox survives, the fresh one carries
+        the same sandbox-id metadata and a later lookup could land on either.
+        Already gone is the outcome this wanted, though, and it is a normal
+        race -- the listing that found it can be stale, or E2B can reap it
+        first. `ProviderGone` is a bare RuntimeError that `_provision` does not
+        catch, so letting it escape would leave the instance row stuck in
+        CREATING until the claim times out.
+        """
+        try:
+            sandbox = await self._connect(provider_id)
+            with sdk_errors():
+                await sandbox.kill(**self._api())
+        except ProviderGone:
+            pass
 
     async def _stamp(self, provider_id: str, spec: ProviderCreateSpec) -> None:
         """Best effort: record the current epoch on an adopted sandbox.
@@ -491,6 +535,9 @@ class E2BSandboxProvider(E2BOpsMixin):
                 running=str(info.state).lower().endswith("running"),
                 profile_digest=metadata.get(
                     meta_profile_digest(self._config.metadata_namespace)
+                ),
+                template=metadata.get(
+                    meta_template(self._config.metadata_namespace)
                 ),
             )
         return None

--- a/lemma-backend/app/modules/workspace/providers/e2b.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b.py
@@ -57,7 +57,6 @@ from app.modules.workspace.providers.e2b_common import (
     meta_sandbox_id,
     meta_sandbox_kind,
     meta_template,
-    sdk_best_effort,
     sdk_errors,
 )
 from app.modules.workspace.providers.e2b_ops import E2BOpsMixin
@@ -163,6 +162,32 @@ class E2BSandboxProvider(E2BOpsMixin):
             else self._config.workspace_template
         )
 
+    def _lifecycle(self, kind: SandboxKind) -> dict[str, object]:
+        """What E2B does to this sandbox when its timeout runs out.
+
+        The SDK defaults `on_timeout` to `"kill"`, and this call used to pass no
+        lifecycle at all -- so every workspace was created already scheduled for
+        deletion, thirty minutes out, and on this provider deleting the sandbox
+        deletes the user's files. Nothing in the row recorded it and nothing told
+        the user; the only reason it was not a daily event is that the idle sweep
+        usually paused the sandbox first, which stops the clock. A five-minute
+        cron was the only thing standing between a long session and data loss.
+
+        `keep_memory=False` matches what `release` already does, and for the same
+        reason: a memory-preserving snapshot restores whatever was running,
+        including a browser that had exhausted the sandbox, so the exhaustion
+        became permanent across every later resume. It also rules out
+        `auto_resume`, which E2B can only offer by restoring a memory snapshot in
+        place. That trade is worth revisiting once a leak is impossible, and not
+        before.
+
+        A function sandbox owns no durable disk, so killing it on timeout costs a
+        cold start and nothing else -- but pausing is no worse and keeps one rule
+        for both kinds.
+        """
+        del kind
+        return {"on_timeout": {"action": "pause", "keep_memory": False}}
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -242,7 +267,11 @@ class E2BSandboxProvider(E2BOpsMixin):
                 sandbox_id=str(spec.sandbox_id),
             )
         if existing is not None:
-            await self._stamp(existing.provider_id, spec)
+            # Nothing is re-stamped onto the adopted sandbox. The metadata E2B
+            # holds is written once, at create, and is immutable thereafter --
+            # the SDK has no way to update it. So every reader must treat those
+            # values as "what this sandbox was created as", never as "what its
+            # row says now", and the epoch in particular is not a fence here.
             return ProviderInstance(
                 provider_id=existing.provider_id,
                 name=spec.name,
@@ -255,6 +284,7 @@ class E2BSandboxProvider(E2BOpsMixin):
             sandbox = await self._sdk.create(
                 template=self._template(spec.kind),
                 timeout=self._config.sandbox_timeout_seconds,
+                lifecycle=self._lifecycle(spec.kind),
                 metadata=self._identity_metadata(spec),
                 envs=dict(spec.env),
                 **self._api(),
@@ -295,18 +325,6 @@ class E2BSandboxProvider(E2BOpsMixin):
                 await sandbox.kill(**self._api())
         except ProviderGone:
             pass
-
-    async def _stamp(self, provider_id: str, spec: ProviderCreateSpec) -> None:
-        """Best effort: record the current epoch on an adopted sandbox.
-
-        Only bookkeeping -- identity and the fence come from the sandbox id, so
-        an SDK without metadata updates costs nothing but a stale epoch label.
-        """
-        with sdk_best_effort():
-            sandbox = await self._connect(provider_id)
-            setter = getattr(sandbox, "set_metadata", None)
-            if setter is not None:
-                await setter(self._identity_metadata(spec), **self._api())
 
     async def inspect(
         self, name: str, *, deadline_at: datetime
@@ -543,10 +561,25 @@ class E2BSandboxProvider(E2BOpsMixin):
         return None
 
     async def _connect(self, provider_id: str):
+        """Reach a sandbox, resuming it if it is paused.
+
+        The timeout is not optional. Connecting is what re-arms the lease, and
+        the SDK's own rule is that "the timeout will update only if the new
+        timeout is longer than the existing one" -- so passing nothing does not
+        mean "leave it alone", it means "five minutes", the SDK's default. A
+        workspace resumed after days therefore came back with a five-minute
+        lease, and every process inside it died together when that elapsed. That
+        is what a caller sees as three tool calls returning 502 at the same
+        instant, several minutes into a turn that was working.
+        """
         # Both arms of the old branch raised the same thing; sdk_errors is
         # what that code was spelling out by hand.
         with sdk_errors():
-            return await self._sdk.connect(provider_id, **self._api())
+            return await self._sdk.connect(
+                provider_id,
+                timeout=self._config.sandbox_timeout_seconds,
+                **self._api(),
+            )
 
 
 

--- a/lemma-backend/app/modules/workspace/providers/e2b.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b.py
@@ -58,6 +58,7 @@ from app.modules.workspace.providers.e2b_common import (
     meta_sandbox_kind,
     meta_template,
     sdk_errors,
+    every_page as _every_page,
 )
 from app.modules.workspace.providers.e2b_ops import E2BOpsMixin
 from app.modules.workspace.providers.e2b_output import E2BOutputBuffer
@@ -465,18 +466,25 @@ class E2BSandboxProvider(E2BOpsMixin):
         """
 
         found: list[ProviderObject] = []
-        with sdk_errors():
-            paginator = self._sdk.list(
-                query=self._query(
-                    metadata={
-                        meta_sandbox_kind(
-                            self._config.metadata_namespace
-                        ): SandboxKind.WORKSPACE.value
-                    }
-                ),
-                **self._api(),
-            )
-            pages = await paginator.next_items()
+        # Every kind, because the docstring above says "every sandbox carrying
+        # this platform's metadata" and this queried only workspaces -- so a
+        # function sandbox the control plane had forgotten was invisible to the
+        # sweep and billed forever, which is the one thing orphan reclamation
+        # exists to stop.
+        namespace = self._config.metadata_namespace
+        pages: list = []
+        for kind in SandboxKind:
+            with sdk_errors():
+                pages.extend(
+                    await _every_page(
+                        self._sdk.list(
+                            query=self._query(
+                                metadata={meta_sandbox_kind(namespace): kind.value}
+                            ),
+                            **self._api(),
+                        )
+                    )
+                )
 
         for info in pages:
             metadata = info.metadata or {}
@@ -532,10 +540,9 @@ class E2BSandboxProvider(E2BOpsMixin):
         self, metadata: dict[str, str]
     ) -> ProviderInstance | None:
         with sdk_errors():
-            paginator = self._sdk.list(
-                query=self._query(metadata=metadata), **self._api()
+            matches = await _every_page(
+                self._sdk.list(query=self._query(metadata=metadata), **self._api())
             )
-            matches = await paginator.next_items()
 
         # Prefer a running sandbox when several match, so a duplicate left by
         # an earlier failure does not shadow the one actually serving.

--- a/lemma-backend/app/modules/workspace/providers/e2b_common.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b_common.py
@@ -34,10 +34,24 @@ def meta_profile_digest(namespace: str) -> str:
     return f"{namespace}-profile-digest"
 
 
+def meta_template(namespace: str) -> str:
+    """Which template this sandbox was actually built from.
+
+    Recorded because it is the only honest answer to "is this workspace running
+    the image we published?". The profile digest cannot answer it: it is a
+    hand-maintained environment variable, and while it sat unchanged at its
+    default every sandbox in the fleet stayed pinned to whatever template it was
+    first created on -- including through four template releases that were
+    supposed to fix the workspaces that were failing.
+    """
+    return f"{namespace}-template"
+
+
 META_SANDBOX_ID = meta_sandbox_id(DEFAULT_METADATA_NAMESPACE)
 META_SANDBOX_KIND = meta_sandbox_kind(DEFAULT_METADATA_NAMESPACE)
 META_EPOCH = meta_epoch(DEFAULT_METADATA_NAMESPACE)
 META_PROFILE_DIGEST = meta_profile_digest(DEFAULT_METADATA_NAMESPACE)
+META_TEMPLATE = meta_template(DEFAULT_METADATA_NAMESPACE)
 
 
 

--- a/lemma-backend/app/modules/workspace/providers/e2b_common.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b_common.py
@@ -128,3 +128,22 @@ def sdk_best_effort(path: str | None = None):
         SandboxUnavailable,
     ):
         return
+
+
+async def every_page(paginator) -> list:
+    """Drain a paginated listing.
+
+    Both listings here read `next_items()` once and treated it as the whole
+    answer. The sweep is where that bites: its query is filtered only by kind,
+    so it matches the whole fleet, and one page of it was all orphan reclamation
+    ever considered -- everything past that was never reclaimed and billed for
+    as long as it existed. The account this was found in held 249 sandboxes.
+
+    Adoption's query names a single sandbox id and normally matches one result,
+    so it was far less exposed; it is drained here because a listing that can
+    paginate should be read as one, not because a specific failure is known.
+    """
+    found: list = []
+    while paginator.has_next:
+        found.extend(await paginator.next_items())
+    return found

--- a/lemma-backend/app/modules/workspace/sandbox_session.py
+++ b/lemma-backend/app/modules/workspace/sandbox_session.py
@@ -37,6 +37,7 @@ from app.modules.workspace.session_support import (
     canonical_runtime_path as _canonical_runtime_path,
     canonical_workspace_cwd,
     with_backpressure as _with_backpressure,
+    sandbox_is_responsive,
 )
 
 
@@ -45,6 +46,12 @@ logger = get_logger(__name__)
 # How long a pure output poll waits for new bytes. Bounded by write_stdin's own
 # 35s deadline.
 _POLL_YIELD_MS = 30_000
+
+# The whole budget for deciding whether a silent sandbox is still alive. Short
+# on purpose: this runs after a window that already spent 30 seconds telling the
+# caller nothing, and `echo` on a healthy sandbox answers in well under a
+# second, so anything approaching this bound is itself the answer.
+_LIVENESS_PROBE_SECONDS = 8.0
 
 # Stateful interpreters already created, by (sandbox, python session, epoch).
 #
@@ -576,6 +583,13 @@ class SandboxWorkspaceSession:
             operation_id,
             deadline_at=deadline_at,
             yield_time_ms=yield_time_ms,
+            probe_liveness=lambda: sandbox_is_responsive(
+                self.client,
+                self.logical_id,
+                cwd=self._cwd,
+                deadline=self._deadline(_LIVENESS_PROBE_SECONDS),
+                budget_seconds=_LIVENESS_PROBE_SECONDS,
+            ),
         )
 
     @staticmethod

--- a/lemma-backend/app/modules/workspace/scripts/audit_e2b_lifecycle.py
+++ b/lemma-backend/app/modules/workspace/scripts/audit_e2b_lifecycle.py
@@ -1,0 +1,96 @@
+"""What every E2B sandbox in this account does when its timeout elapses.
+
+Two uses. First, verification: `E2BSandboxProvider.create` now asks E2B to pause
+rather than kill, and this is how you confirm that newly created sandboxes
+actually carry it -- a lifecycle is chosen at create and **E2B offers no way to
+change it afterwards**, so a mistake here is permanent for every sandbox made
+while it was wrong.
+
+Second, inventory. Sandboxes created before that shipped keep the SDK default,
+`on_timeout: "kill"`, and on this provider the sandbox is the disk. They are
+also already stale by template, so the next ensure replaces them; this reports
+how many there are before that happens.
+
+Run:
+
+    uv run python -m app.modules.workspace.scripts.audit_e2b_lifecycle
+"""
+
+from __future__ import annotations
+
+import asyncio
+import collections
+import sys
+from typing import Any
+
+from app.core.config import reveal_secret
+from app.modules.workspace.config import workspace_settings
+from app.modules.workspace.providers.e2b_common import meta_sandbox_id, meta_template
+
+
+async def _iterate(paginator) -> list[Any]:
+    """Every page, not just the first.
+
+    Reading one page is a mistake this module has made before. It looks like it
+    worked and silently skips most of the fleet, which for an audit means
+    reporting a reassuring number that is not true.
+    """
+    found: list[Any] = []
+    while paginator.has_next:
+        found.extend(await paginator.next_items())
+    return found
+
+
+def _on_timeout(info) -> str:
+    lifecycle = getattr(info, "lifecycle", None) or {}
+    action = lifecycle.get("on_timeout") if hasattr(lifecycle, "get") else None
+    # Absent means the sandbox predates the field, which is the same exposure as
+    # an explicit kill -- so it must not read as "fine".
+    return str(action or "kill (unset)")
+
+
+async def main() -> int:
+    from e2b import AsyncSandbox
+    from e2b.sandbox.sandbox_api import SandboxQuery, SandboxState
+
+    api_key = reveal_secret(workspace_settings.e2b_api_key)
+    if not api_key:
+        print("E2B_API_KEY is not set", file=sys.stderr)
+        return 2
+    namespace = workspace_settings.e2b_metadata_namespace
+    owned_by_us = meta_sandbox_id(namespace)
+    template_key = meta_template(namespace)
+
+    sandboxes: list[Any] = []
+    for state in (SandboxState.RUNNING, SandboxState.PAUSED):
+        sandboxes.extend(
+            await _iterate(
+                AsyncSandbox.list(api_key=api_key, query=SandboxQuery(state=[state]))
+            )
+        )
+
+    # Namespace, not "everything in the account" -- these credentials are shared,
+    # and a report that counts a stranger's sandboxes is worse than no report.
+    ours = [s for s in sandboxes if (s.metadata or {}).get(owned_by_us)]
+    by_action = collections.Counter(_on_timeout(s) for s in ours)
+    unstamped = [s for s in ours if not (s.metadata or {}).get(template_key)]
+
+    print(f"visible in account: {len(sandboxes)}")
+    print(f"carrying the {namespace!r} namespace: {len(ours)}")
+    print("\non timeout:")
+    for action, count in sorted(by_action.items(), key=lambda kv: -kv[1]):
+        print(f"  {count:>5}  {action}")
+    print(
+        f"\nno recorded template (replaced on next ensure): {len(unstamped)}"
+    )
+    legacy = sum(count for action, count in by_action.items() if "pause" not in action)
+    if legacy:
+        print(
+            f"\n{legacy} sandbox(es) predate the pause-on-timeout lifecycle and "
+            "cannot be changed in place. They are replaced on their next ensure."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/lemma-backend/app/modules/workspace/services/sandbox_service.py
+++ b/lemma-backend/app/modules/workspace/services/sandbox_service.py
@@ -302,7 +302,7 @@ class SandboxService(SandboxVolumeMixin):
                         await self._start(sandbox, existing, deadline_at=deadline_at)
                 else:
                     span.set_attribute("lemma.ensure", "reuse")
-                await self._touch(sandbox_id)
+                await self._mark_in_use(sandbox, instance)
                 return self._handle(sandbox, existing)
 
             # No container, but a row claiming one. `begin_instance` writes the
@@ -552,6 +552,18 @@ class SandboxService(SandboxVolumeMixin):
     async def _touch(self, sandbox_id: UUID) -> None:
         async with self._uow_factory() as uow:
             await SandboxRepository(uow).touch(sandbox_id)
+            await uow.commit()
+
+    async def _mark_in_use(self, sandbox: Sandbox, instance) -> None:
+        """Adopting a sandbox is a state change; record it as one.
+
+        The reasoning, and the failure it comes from, is on
+        `SandboxRepository.mark_in_use`.
+        """
+        async with self._uow_factory() as uow:
+            await SandboxRepository(uow).mark_in_use(
+                sandbox.id, instance.id if instance is not None else None
+            )
             await uow.commit()
 
     async def _fail(self, instance_id: UUID, error: str) -> None:

--- a/lemma-backend/app/modules/workspace/services/sandbox_sweeper.py
+++ b/lemma-backend/app/modules/workspace/services/sandbox_sweeper.py
@@ -29,6 +29,7 @@ from app.modules.workspace.providers.base import (
     ProviderGone,
     ProviderNotReady,
     ProviderRejected,
+    ProviderStorageKind,
 )
 from sandbox_runtime.errors import SandboxError
 
@@ -43,6 +44,34 @@ class SandboxSweeper:
     @property
     def _provider(self):
         return self._service._provider
+
+    @property
+    def _epoch_is_a_fence(self) -> bool:
+        """Whether a behind-the-times epoch means this object is superseded.
+
+        Only where compute and storage are separate objects. `ProviderStorageKind`
+        says so itself: on SANDBOX_NATIVE "one object is both … the fence is the
+        provider's own id rather than an epoch in a name", and the E2B provider
+        repeats it -- "Adoption deliberately ignores the epoch". This sweep did
+        not, and the two readings of the same number pointed at opposite
+        conclusions about the same live sandbox.
+
+        It resolved the wrong way. The row's epoch advances on every provision,
+        including the ones that adopt an existing E2B sandbox, while the epoch
+        this compares it against is read from provider metadata that nothing can
+        update: the re-stamp is guarded on `set_metadata`, which the E2B SDK does
+        not have. So the recorded epoch was frozen at 1 while the row climbed,
+        and "epoch 1 is behind 6" became permanently true for every workspace a
+        user had kept. The sweep then called destroy on it, every five minutes,
+        and on this provider destroying the sandbox destroys the disk.
+
+        It only ever failed to delete them because destroy could not address a
+        paused sandbox -- which is a bug that has since been fixed.
+        """
+        kind = getattr(
+            self._provider, "storage_kind", ProviderStorageKind.VOLUME
+        )
+        return kind is not ProviderStorageKind.SANDBOX_NATIVE
 
     async def release_idle(self, *, idle_after_seconds: int, limit: int = 50) -> int:
         """Stop sandboxes nobody has touched recently. Keeps every disk."""
@@ -156,7 +185,9 @@ class SandboxSweeper:
                 if instance is None:
                     continue
                 reason = "superseded by the current provisioning path"
-            elif obj.epoch is not None and obj.epoch < sandbox.epoch:
+            elif self._epoch_is_a_fence and obj.epoch is not None and (
+                obj.epoch < sandbox.epoch
+            ):
                 reason = f"epoch {obj.epoch} is behind {sandbox.epoch}"
             else:
                 continue

--- a/lemma-backend/app/modules/workspace/session_support.py
+++ b/lemma-backend/app/modules/workspace/session_support.py
@@ -12,7 +12,7 @@ import asyncio
 from datetime import datetime, timezone
 import posixpath
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import httpx
 from redis.exceptions import RedisError
@@ -127,6 +127,50 @@ async def with_backpressure(operation, deadline: datetime):
             delay = min(delay * (1.5 ** min(attempt, 4)), 5.0, remaining)
             attempt += 1
             await asyncio.sleep(delay)
+
+
+async def sandbox_is_responsive(
+    client,
+    logical_id,
+    *,
+    cwd: str,
+    deadline,
+    budget_seconds: float,
+) -> bool:
+    """Can this sandbox still run the smallest command there is?
+
+    Deliberately not `inspect`. The provider answered that a wedged workspace
+    was running for the whole time it was failing every command, because from
+    outside it *was* running -- what had stopped working was executing anything
+    inside it. So the probe is an execution.
+
+    Any failure to get the expected byte back counts as unresponsive, transport
+    errors included: the caller is being told "this will not work, restart it",
+    and every one of these means exactly that.
+    """
+    probe_id = uuid4()
+    try:
+        await client.start_process(
+            WorkloadKind.WORKSPACE,
+            logical_id,
+            operation_id=probe_id,
+            argv=("/bin/echo", "-n", "ok"),
+            cwd=cwd,
+            environment=(),
+            output_limit_bytes=64,
+            deadline_at=deadline,
+        )
+        snapshot = await client.read_process_output(
+            WorkloadKind.WORKSPACE,
+            logical_id,
+            probe_id,
+            deadline_at=deadline,
+            after_sequence=0,
+            wait_seconds=max(0.5, budget_seconds - 1),
+        )
+    except (SandboxError, httpx.HTTPError, OSError):
+        return False
+    return any(b"ok" in chunk.data for chunk in snapshot.chunks)
 
 
 class OutputCursor:

--- a/lemma-backend/app/modules/workspace/testing/fake_e2b.py
+++ b/lemma-backend/app/modules/workspace/testing/fake_e2b.py
@@ -105,17 +105,45 @@ class FakeE2B:
     # the provider was passing neither.
     created_lifecycles: list[Any] = field(default_factory=list)
     connect_timeouts: list[float | None] = field(default_factory=list)
+    # Small, so every listing test crosses a page boundary.
+    list_page_size: int = 2
     _next: int = 0
 
     def sandbox_class(self):
         world = self
 
         class _Paginator:
-            def __init__(self, items):
-                self._items = items
+            """Pages, like the real one.
+
+            It used to hand back everything in a single `next_items()` and had
+            no `has_next` at all, so a provider that read one page looked
+            complete against it and truncated against the real service. Two
+            listings did exactly that, and for adoption the consequence is a
+            second sandbox created for an identity that already has one --
+            stranding the user's files in the first. The page size is small on
+            purpose: pagination should be exercised by ordinary tests, not only
+            by ones written to think about it.
+            """
+
+            def __init__(self, items, page_size: int):
+                self._items = list(items)
+                self._page_size = max(1, page_size)
+                self._offset = 0
+                self._served_any = False
+
+            @property
+            def has_next(self) -> bool:
+                if self._offset < len(self._items):
+                    return True
+                # One empty page for an empty listing, so a caller that drains
+                # gets the same "nothing here" a first read would have given.
+                return not self._served_any
 
             async def next_items(self):
-                return self._items
+                page = self._items[self._offset : self._offset + self._page_size]
+                self._offset += self._page_size
+                self._served_any = True
+                return page
 
         class _Commands:
             def __init__(self, sandbox_id: str):
@@ -265,7 +293,7 @@ class FakeE2B:
             @staticmethod
             def list(query=None, **_kwargs):
                 wanted = dict(getattr(query, "metadata", None) or {})
-                return _Paginator(
+                return _Paginator(page_size=world.list_page_size, items=
                     [
                         info
                         for info in world.sandboxes.values()

--- a/lemma-backend/app/modules/workspace/testing/fake_e2b.py
+++ b/lemma-backend/app/modules/workspace/testing/fake_e2b.py
@@ -96,6 +96,15 @@ class FakeE2B:
     # so "the provider passed no timeout" is indistinguishable from "the
     # provider asked for a minute" unless a test can see the argument.
     process_timeouts: list[float | None] = field(default_factory=list)
+    # The lifecycle each sandbox was created with, and the timeout each connect
+    # asked for. Both are recorded for the same reason as `process_timeouts`:
+    # E2B defaults them to values that destroy things -- `on_timeout: "kill"`
+    # and a five-minute lease -- so a fake that quietly accepted whatever it was
+    # given could not tell "the provider asked for this" from "the provider
+    # passed nothing". It did accept them, into `**_kwargs`, for the whole time
+    # the provider was passing neither.
+    created_lifecycles: list[Any] = field(default_factory=list)
+    connect_timeouts: list[float | None] = field(default_factory=list)
     _next: int = 0
 
     def sandbox_class(self):
@@ -223,6 +232,7 @@ class FakeE2B:
                 metadata=None,
                 envs=None,
                 volume_mounts=None,
+                lifecycle=None,
                 **_kwargs,
             ):
                 world._next += 1
@@ -236,12 +246,16 @@ class FakeE2B:
                         "metadata": dict(metadata or {}),
                         "volume_mounts": volume_mounts,
                         "envs": envs,
+                        "lifecycle": lifecycle,
+                        "timeout": timeout,
                     }
                 )
+                world.created_lifecycles.append(lifecycle)
                 return FakeAsyncSandbox(sandbox_id)
 
             @staticmethod
-            async def connect(sandbox_id, **_kwargs):
+            async def connect(sandbox_id, timeout=None, **_kwargs):
+                world.connect_timeouts.append(timeout)
                 if sandbox_id not in world.sandboxes:
                     raise NotFoundException(f"sandbox {sandbox_id} not found")
                 # Reconnecting resumes a paused sandbox, as the real SDK does.

--- a/lemma-backend/app/modules/workspace/tests/integration/test_e2b_lifecycle_real.py
+++ b/lemma-backend/app/modules/workspace/tests/integration/test_e2b_lifecycle_real.py
@@ -1,0 +1,581 @@
+"""The E2B lifecycle, end to end, against the real service and a real Redis.
+
+`test_e2b_provider_real.py` covers the provider's contract. This covers the
+*lifecycle* -- the sequence a workspace actually lives through, in order:
+created, used, paused, resumed, used again, drifted, replaced, destroyed -- and
+it does so through the real Redis-backed output buffer rather than the in-memory
+one.
+
+That last part is the point. Every real-E2B test before this substituted
+`InMemoryOutputBuffer`, so the one component that carries a command's output
+between the callback that receives it and the poll that reads it was faked in
+every test that touched the real service. Three separate production failures
+lived in exactly that seam, and none of them could have been caught.
+
+The failures this file is built from, all observed in production:
+
+* A workspace ran for days on the template it was first created with, through
+  four releases meant to fix it, because adoption compared only a hand-edited
+  profile digest. 249 sandboxes across four old templates; zero on the
+  configured one.
+* A pause preserved resident memory because the SDK default was never
+  overridden, so a leaked browser was snapshotted and restored on every resume,
+  and the sandbox's memory exhaustion became permanent.
+* A wedged sandbox started processes that never printed and never exited, and
+  every layer reported success, so agents polled a corpse until someone killed
+  the sandbox by hand.
+
+Safety, because the account is shared with production: everything here runs
+under its own metadata namespace, so no query can match a production sandbox and
+no sweep can see one. Only sandboxes these tests created are ever killed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from collections.abc import AsyncIterator
+from datetime import datetime, timedelta, timezone
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+
+from sandbox_runtime.protocol import (
+    EnvironmentVariable,
+    ProcessState,
+    StartProcessRequest,
+)
+
+from app.modules.workspace.domain.sandbox import SandboxKind
+from app.modules.workspace.providers import naming
+from app.modules.workspace.providers.base import ProviderCreateSpec
+from app.modules.workspace.providers.e2b import E2BProviderConfig, E2BSandboxProvider
+from app.modules.workspace.providers.e2b_output import E2BOutputBuffer
+
+pytestmark = [pytest.mark.integration, pytest.mark.provider, pytest.mark.asyncio]
+
+_KEY = os.getenv("E2B_API_KEY", "")
+_TEMPLATE = os.getenv("E2B_WORKSPACE_TEMPLATE", "")
+# Deliberately not the production namespace.
+_NAMESPACE = os.getenv("E2B_TEST_METADATA_NAMESPACE", "lemma-lifecycle")
+
+# What a healthy sandbox costs, measured against the real service: `echo` came
+# back in 0.36s and `lemma --version` in 0.98s, warm or resumed. These bounds
+# are several times that, because the failure they guard against is not a slow
+# command -- it is a command that returns nothing for thirty seconds.
+_TRIVIAL_COMMAND_BUDGET_SECONDS = 10.0
+_RESUME_BUDGET_SECONDS = 30.0
+
+_TERMINAL = {
+    ProcessState.SUCCEEDED,
+    ProcessState.FAILED,
+    ProcessState.CANCELLED,
+    ProcessState.TIMED_OUT,
+}
+
+
+def _deadline(seconds: int = 120) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(seconds=seconds)
+
+
+@pytest_asyncio.fixture
+async def provider() -> AsyncIterator[E2BSandboxProvider]:
+    if not _KEY or not _TEMPLATE:
+        pytest.skip("set E2B_API_KEY and E2B_WORKSPACE_TEMPLATE to run this suite")
+    instance = _build_provider(_TEMPLATE)
+    created: list[str] = []
+    instance._lifecycle_created = created  # type: ignore[attr-defined]
+    try:
+        yield instance
+    finally:
+        # Only ever sandboxes this test made.
+        for provider_id in created:
+            try:
+                sandbox = await instance._connect(provider_id)
+                await sandbox.kill(**instance._api())
+            except Exception:
+                continue
+
+
+def _build_provider(template: str) -> E2BSandboxProvider:
+    return E2BSandboxProvider(
+        E2BProviderConfig(
+            api_key=_KEY,
+            workspace_template=template,
+            function_template=template,
+            sandbox_timeout_seconds=600,
+            metadata_namespace=_NAMESPACE,
+        ),
+        # The real one. Faking this is what hid every bug in the seam it owns.
+        output=E2BOutputBuffer(key_prefix=f"workspace:e2b:lifecycle:{uuid4().hex}"),
+    )
+
+
+def _spec(sandbox_id: UUID, *, epoch: int = 1, digest: str | None = None):
+    return ProviderCreateSpec(
+        sandbox_id=sandbox_id,
+        kind=SandboxKind.WORKSPACE,
+        epoch=epoch,
+        name=naming.container_name(sandbox_id, SandboxKind.WORKSPACE, epoch),
+        image="",
+        profile_name="workspace",
+        profile_digest=digest or ("sha256:" + "a" * 64),
+        deadline_at=_deadline(),
+    )
+
+
+async def _create(provider: E2BSandboxProvider, sandbox_id: UUID, *, epoch: int = 1):
+    instance = await provider.create(_spec(sandbox_id, epoch=epoch))
+    provider._lifecycle_created.append(instance.provider_id)  # type: ignore[attr-defined]
+    return instance
+
+
+async def _run(
+    provider: E2BSandboxProvider,
+    instance,
+    command: str,
+    *,
+    wait_seconds: float = 20.0,
+) -> tuple[float, bytes, int | None, ProcessState]:
+    """Start a command and collect it the way a tool call does.
+
+    Returns the wall time as well as the output, because "did it come back" and
+    "did it come back before the agent gave up" are different questions and only
+    the second one was ever failing.
+    """
+    started = time.monotonic()
+    process_id = await provider.start_process(
+        instance,
+        StartProcessRequest(
+            operation_id=uuid4(),
+            shell_command=command,
+            argv=None,
+            cwd="/workspace",
+            environment=(EnvironmentVariable(name="LEMMA_TEST", value="1"),),
+            tty=None,
+            output_limit_bytes=256 * 1024,
+            deadline_at=_deadline(),
+            initial_input=None,
+        ),
+        deadline_at=_deadline(),
+    )
+    collected = bytearray()
+    after = 0
+    state = ProcessState.RUNNING
+    exit_code: int | None = None
+    while time.monotonic() - started < wait_seconds:
+        snapshot = await provider.read_process_output(
+            instance,
+            process_id=process_id,
+            after_sequence=after,
+            wait_seconds=min(5.0, wait_seconds),
+            deadline_at=_deadline(),
+        )
+        state = snapshot.state
+        exit_code = snapshot.exit_code
+        for chunk in snapshot.chunks:
+            after = max(after, chunk.sequence)
+            collected.extend(chunk.data)
+        if state in _TERMINAL:
+            break
+    return time.monotonic() - started, bytes(collected), exit_code, state
+
+
+# ---------------------------------------------------------------------------
+# The straight line: create, run, pause, resume, run again
+# ---------------------------------------------------------------------------
+
+
+async def test_a_new_sandbox_runs_a_command_and_reports_its_exit(
+    provider: E2BSandboxProvider,
+) -> None:
+    instance = await _create(provider, uuid4())
+    await provider.wait_ready(
+        instance, kind=SandboxKind.WORKSPACE, deadline_at=_deadline()
+    )
+
+    elapsed, output, exit_code, state = await _run(provider, instance, "echo alive")
+
+    assert b"alive" in output, output
+    assert exit_code == 0
+    assert state is ProcessState.SUCCEEDED
+    assert elapsed < _TRIVIAL_COMMAND_BUDGET_SECONDS, (
+        f"echo took {elapsed:.1f}s; a command that returns nothing for this long "
+        "is what agents read as a hang"
+    )
+
+
+async def test_a_failing_command_reports_its_exit_code_not_just_silence(
+    provider: E2BSandboxProvider,
+) -> None:
+    """A non-zero exit is a result. The SDK raises for it, and a swallowed raise
+    is indistinguishable from a process that never finished."""
+    instance = await _create(provider, uuid4())
+
+    _, output, exit_code, state = await _run(
+        provider, instance, "echo to-stderr >&2; exit 3"
+    )
+
+    assert exit_code == 3, (exit_code, output)
+    assert state is ProcessState.FAILED
+    assert b"to-stderr" in output, output
+
+
+async def test_a_paused_sandbox_keeps_its_files_and_still_runs_commands(
+    provider: E2BSandboxProvider,
+) -> None:
+    """The property production depends on, checked as a sequence rather than as
+    two separate facts: the disk survives *and* the resumed sandbox still
+    works."""
+    sandbox_id = uuid4()
+    instance = await _create(provider, sandbox_id)
+    await _run(provider, instance, "echo persisted > /workspace/marker.txt")
+
+    await provider.release(
+        instance, kind=SandboxKind.WORKSPACE, deadline_at=_deadline()
+    )
+
+    started = time.monotonic()
+    resumed = await provider.create(_spec(sandbox_id, epoch=2))
+    await provider.wait_ready(
+        resumed, kind=SandboxKind.WORKSPACE, deadline_at=_deadline()
+    )
+    resume_seconds = time.monotonic() - started
+
+    assert resumed.provider_id == instance.provider_id, (
+        "a second sandbox would strand the user's files in the first"
+    )
+    assert resumed.storage_adopted is True
+    assert resume_seconds < _RESUME_BUDGET_SECONDS, (
+        f"resume took {resume_seconds:.1f}s and every tool call pays it"
+    )
+
+    elapsed, output, exit_code, _ = await _run(
+        provider, instance, "cat /workspace/marker.txt"
+    )
+    assert b"persisted" in output, output
+    assert exit_code == 0
+    assert elapsed < _TRIVIAL_COMMAND_BUDGET_SECONDS, (
+        f"the first command after a resume took {elapsed:.1f}s -- the resumed "
+        "sandbox is the one that was failing in production, so this is the "
+        "measurement that matters"
+    )
+
+
+async def test_a_pause_does_not_carry_running_processes_across(
+    provider: E2BSandboxProvider,
+) -> None:
+    """A filesystem-only pause is what the architecture documents promise, and
+    what makes a leaked browser survivable: it dies with the pause instead of
+    being snapshotted and restored on every resume for the life of the sandbox.
+    """
+    sandbox_id = uuid4()
+    instance = await _create(provider, sandbox_id)
+    # `pgrep -f` matches the whole command line, so the shell running the count
+    # matches its own pattern. The bracket makes the pattern not match itself,
+    # which is the standard way out and the reason this is not just `pgrep -x`:
+    # that caps the process *name* at 15 characters and silently finds nothing.
+    marker = f"/tmp/lemma-mark-{uuid4().hex[:8]}.sh"
+    pattern = f"[{marker[5]}]{marker[6:]}"
+    await _run(
+        provider,
+        instance,
+        f"printf 'sleep 3600\\n' > {marker} && chmod +x {marker} && "
+        f"setsid nohup {marker} >/dev/null 2>&1 < /dev/null & echo started",
+    )
+    await asyncio.sleep(1.0)
+    # `pgrep -c` prints 0 *and* exits non-zero when nothing matches, so an `||`
+    # fallback would print the count twice.
+    _, before, _, _ = await _run(
+        provider, instance, f"pgrep -c -f '{pattern}' || true"
+    )
+    # More than one can match -- `setsid` and `nohup` both carry the script
+    # path in their command line. Only "something was running" matters here.
+    assert int(before.strip() or 0) >= 1, (
+        "the marker process did not start",
+        before,
+    )
+
+    await provider.release(
+        instance, kind=SandboxKind.WORKSPACE, deadline_at=_deadline()
+    )
+    resumed = await provider.create(_spec(sandbox_id, epoch=2))
+    await provider.wait_ready(
+        resumed, kind=SandboxKind.WORKSPACE, deadline_at=_deadline()
+    )
+
+    _, after, _, _ = await _run(
+        provider, resumed, f"pgrep -c -f '{pattern}' || true"
+    )
+    assert after.strip().startswith(b"0"), (
+        "a process survived the pause, so `keep_memory` is back on its SDK "
+        f"default and a leaked browser is now permanent: {after!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Streaming: the seam the in-memory buffer was hiding
+# ---------------------------------------------------------------------------
+
+
+async def test_output_arrives_incrementally_rather_than_all_at_the_end(
+    provider: E2BSandboxProvider,
+) -> None:
+    """An agent watching a build needs the first line before the last one."""
+    instance = await _create(provider, uuid4())
+    process_id = await provider.start_process(
+        instance,
+        StartProcessRequest(
+            operation_id=uuid4(),
+            shell_command="echo first; sleep 3; echo second",
+            argv=None,
+            cwd="/workspace",
+            environment=(),
+            tty=None,
+            output_limit_bytes=64 * 1024,
+            deadline_at=_deadline(),
+            initial_input=None,
+        ),
+        deadline_at=_deadline(),
+    )
+
+    early = await provider.read_process_output(
+        instance,
+        process_id=process_id,
+        after_sequence=0,
+        wait_seconds=8.0,
+        deadline_at=_deadline(),
+    )
+    early_output = b"".join(chunk.data for chunk in early.chunks)
+
+    assert b"first" in early_output, early_output
+    assert b"second" not in early_output, (
+        "the poll waited for the whole command instead of returning what was "
+        "already printed"
+    )
+    assert early.state not in _TERMINAL
+
+
+async def test_a_finished_command_returns_immediately_not_at_the_window(
+    provider: E2BSandboxProvider,
+) -> None:
+    """The regression from #379, held against the real service.
+
+    A command that has already exited must not cost the caller the poll window.
+    Asserting on elapsed time rather than on content is the whole point: the
+    output was always correct, and the tool call still took thirty seconds.
+    """
+    instance = await _create(provider, uuid4())
+    process_id = await provider.start_process(
+        instance,
+        StartProcessRequest(
+            operation_id=uuid4(),
+            shell_command="printf done",
+            argv=None,
+            cwd="/workspace",
+            environment=(),
+            tty=None,
+            output_limit_bytes=1024,
+            deadline_at=_deadline(),
+            initial_input=None,
+        ),
+        deadline_at=_deadline(),
+    )
+    # Let it finish and let the watcher record the exit, so the first read below
+    # is the one an agent's poll actually makes.
+    await asyncio.sleep(2.0)
+
+    started = time.monotonic()
+    snapshot = await provider.read_process_output(
+        instance,
+        process_id=process_id,
+        after_sequence=0,
+        wait_seconds=30.0,
+        deadline_at=_deadline(),
+    )
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 5.0, (
+        f"polling a finished command blocked for {elapsed:.1f}s of a 30s window"
+    )
+    assert b"done" in b"".join(chunk.data for chunk in snapshot.chunks)
+
+
+async def test_a_silent_running_command_still_reports_as_running(
+    provider: E2BSandboxProvider,
+) -> None:
+    """The other side of the same coin: waking early on an exit must not turn a
+    quiet build into a finished one."""
+    instance = await _create(provider, uuid4())
+    process_id = await provider.start_process(
+        instance,
+        StartProcessRequest(
+            operation_id=uuid4(),
+            shell_command="sleep 20",
+            argv=None,
+            cwd="/workspace",
+            environment=(),
+            tty=None,
+            output_limit_bytes=1024,
+            deadline_at=_deadline(),
+            initial_input=None,
+        ),
+        deadline_at=_deadline(),
+    )
+
+    snapshot = await provider.read_process_output(
+        instance,
+        process_id=process_id,
+        after_sequence=0,
+        wait_seconds=3.0,
+        deadline_at=_deadline(),
+    )
+
+    assert snapshot.state not in _TERMINAL
+    assert snapshot.exit_code is None
+    assert snapshot.chunks == ()
+
+
+async def test_a_killed_process_reaches_a_terminal_state(
+    provider: E2BSandboxProvider,
+) -> None:
+    """Agents kill processes exactly when a tool call looks stuck. A kill that
+    leaves the process reading as running pins the sandbox as busy for the hour
+    the buffer retains it, so the idle sweep can never reclaim it -- the sandbox
+    that just frustrated someone becomes the one that never gets cleaned up."""
+    instance = await _create(provider, uuid4())
+    process_id = await provider.start_process(
+        instance,
+        StartProcessRequest(
+            operation_id=uuid4(),
+            shell_command="sleep 300",
+            argv=None,
+            cwd="/workspace",
+            environment=(),
+            tty=None,
+            output_limit_bytes=1024,
+            deadline_at=_deadline(),
+            initial_input=None,
+        ),
+        deadline_at=_deadline(),
+    )
+    await asyncio.sleep(1.0)
+
+    await provider.terminate_process(
+        instance,
+        process_id=process_id,
+        grace_seconds=0.0,
+        deadline_at=_deadline(),
+    )
+
+    deadline = time.monotonic() + 20
+    state = ProcessState.RUNNING
+    while time.monotonic() < deadline:
+        snapshot = await provider.read_process_output(
+            instance,
+            process_id=process_id,
+            after_sequence=0,
+            wait_seconds=2.0,
+            deadline_at=_deadline(),
+        )
+        state = snapshot.state
+        if state in _TERMINAL:
+            break
+    assert state in _TERMINAL, f"a killed process still reads as {state}"
+
+
+# ---------------------------------------------------------------------------
+# Replacement: the fence that has to fire for a fix to reach anyone
+# ---------------------------------------------------------------------------
+
+
+async def test_a_sandbox_on_a_different_template_is_replaced_not_adopted(
+    provider: E2BSandboxProvider,
+) -> None:
+    """Against the real service, because this is the one that failed silently.
+
+    Adoption ignored the template entirely, so publishing a new one changed
+    nothing for anybody who already had a workspace. The fleet sat on four old
+    templates and the configured one had zero sandboxes -- through four releases
+    that were each meant to fix the workspaces that were failing.
+    """
+    sandbox_id = uuid4()
+    first = await _create(provider, sandbox_id)
+
+    # Same account, same identity, a different configured template. Nothing else
+    # changes -- which is exactly the deploy that used to be a no-op.
+    moved = _build_provider(f"{_TEMPLATE}-nonexistent-successor")
+    moved._lifecycle_created = provider._lifecycle_created  # type: ignore[attr-defined]
+
+    with pytest.raises(Exception):
+        # The successor template does not exist, so provisioning must fail --
+        # but the stale sandbox must already be gone, because leaving it would
+        # mean a later lookup could still land on it.
+        await moved.create(_spec(sandbox_id, epoch=2))
+
+    found = await provider.inspect(
+        naming.container_name(sandbox_id, SandboxKind.WORKSPACE, 1),
+        deadline_at=_deadline(),
+    )
+    assert found is None or found.provider_id != first.provider_id, (
+        "the sandbox on the old template survived, so the new template will "
+        "never reach this workspace"
+    )
+
+
+async def test_an_adopted_sandbox_keeps_reporting_the_template_it_runs(
+    provider: E2BSandboxProvider,
+) -> None:
+    """The stamp is what makes drift detectable at all. Without it every
+    sandbox reads as "unknown", and the fleet's staleness is invisible -- which
+    is how this went unnoticed for months."""
+    sandbox_id = uuid4()
+    await _create(provider, sandbox_id)
+
+    found = await provider.inspect(
+        naming.container_name(sandbox_id, SandboxKind.WORKSPACE, 1),
+        deadline_at=_deadline(),
+    )
+
+    assert found is not None
+    assert found.template == _TEMPLATE, (
+        f"created on {_TEMPLATE} but reports {found.template!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Destruction
+# ---------------------------------------------------------------------------
+
+
+async def test_a_destroyed_sandbox_is_actually_gone(
+    provider: E2BSandboxProvider,
+) -> None:
+    """A destroy that returns is not a destroy that happened. The orphan sweep
+    logged eighteen reclaims every five minutes for hours -- the same eighteen
+    ids, eleven times each -- while the account held ninety-nine paused
+    sandboxes and the count never moved."""
+    sandbox_id = uuid4()
+    instance = await _create(provider, sandbox_id)
+    name = naming.container_name(sandbox_id, SandboxKind.WORKSPACE, 1)
+
+    await provider.destroy(name, deadline_at=_deadline())
+
+    assert await provider.inspect(name, deadline_at=_deadline()) is None, (
+        f"{instance.provider_id} is still listed after destroy"
+    )
+
+
+async def test_destroying_a_sandbox_that_is_already_gone_is_not_an_error(
+    provider: E2BSandboxProvider,
+) -> None:
+    """The sweep runs on a schedule against a listing that can be stale, so this
+    race is the normal case, not an exceptional one."""
+    sandbox_id = uuid4()
+    await _create(provider, sandbox_id)
+    name = naming.container_name(sandbox_id, SandboxKind.WORKSPACE, 1)
+
+    await provider.destroy(name, deadline_at=_deadline())
+    await provider.destroy(name, deadline_at=_deadline())

--- a/lemma-backend/app/modules/workspace/tests/integration/test_e2b_lifecycle_real.py
+++ b/lemma-backend/app/modules/workspace/tests/integration/test_e2b_lifecycle_real.py
@@ -579,3 +579,29 @@ async def test_destroying_a_sandbox_that_is_already_gone_is_not_an_error(
 
     await provider.destroy(name, deadline_at=_deadline())
     await provider.destroy(name, deadline_at=_deadline())
+
+
+async def test_a_real_sandbox_is_created_to_pause_on_timeout_not_die(
+    provider: E2BSandboxProvider,
+) -> None:
+    """Against the real service, because it is unfixable if we get it wrong.
+
+    A lifecycle is chosen at create and E2B offers no way to change it
+    afterwards -- there is no `set_lifecycle`, and the connect endpoint carries
+    only a timeout. So every sandbox made while this is wrong stays wrong for as
+    long as it exists, and what "wrong" means here is that E2B deletes it, and
+    the user's files with it, the moment its timeout elapses.
+
+    That was the default. This asserts against the state E2B itself reports,
+    rather than against the argument we passed, because the argument being
+    accepted is not evidence that it was honoured.
+    """
+    sandbox_id = uuid4()
+    instance = await _create(provider, sandbox_id)
+
+    info = await provider._sdk.get_info(instance.provider_id, **provider._api())
+    lifecycle = getattr(info, "lifecycle", None) or {}
+
+    assert lifecycle.get("on_timeout") == "pause", (
+        f"E2B will kill this sandbox, and its disk, on timeout: {lifecycle!r}"
+    )

--- a/lemma-backend/app/modules/workspace/tests/integration/test_sandbox_sweeper.py
+++ b/lemma-backend/app/modules/workspace/tests/integration/test_sandbox_sweeper.py
@@ -7,7 +7,11 @@ from uuid import UUID, uuid4
 
 import pytest
 
-from app.modules.workspace.domain.sandbox import SandboxKind, SandboxOwnerKind
+from app.modules.workspace.domain.sandbox import (
+    SandboxDesiredState,
+    SandboxKind,
+    SandboxOwnerKind,
+)
 from app.modules.workspace.providers.base import (
     ProcessDescriptor,
     ProviderGone,
@@ -435,6 +439,21 @@ class _SandboxIsTheDiskProvider(SweepableProvider):
 
     storage_kind: ProviderStorageKind = ProviderStorageKind.SANDBOX_NATIVE
 
+    async def release(self, instance, *, kind, deadline_at) -> None:
+        """Pause, keeping the object -- which is what release means here.
+
+        `FakeProvider.release` pops the container, so a released sandbox
+        vanishes and the next ensure provisions a new one. That models a
+        provider where releasing destroys the disk, which is the opposite of
+        this one, and it meant no test in this file had ever taken the resume
+        path: every "release then use again" went through `_provision`, which
+        writes the row back to PRESENT and hid the bug below.
+        """
+        self.released.append(instance.name)
+        self.containers[instance.name] = ProviderInstance(
+            provider_id=instance.provider_id, name=instance.name, running=False
+        )
+
 
 async def test_an_old_epoch_never_reclaims_a_sandbox_that_is_also_the_disk(
     sandbox_uow_factory,
@@ -491,3 +510,62 @@ async def test_an_old_epoch_still_reclaims_where_the_disk_is_separate(
 
     assert reclaimed == (name,)
     assert provider.destroyed == [name]
+
+
+async def test_a_resumed_sandbox_can_be_released_again(
+    sandbox_uow_factory,
+) -> None:
+    """Idle release has to keep working, not work once.
+
+    Adopting a sandbox is a state change, and the resume path treated it as a
+    read: only `_provision` wrote `PRESENT` back, so after the first release the
+    row kept saying RELEASED however many times the sandbox was resumed and
+    used. `list_idle` selects on `desired_state == PRESENT`, so the sandbox
+    became invisible to this sweep for the rest of its life.
+
+    Nothing then stopped its compute, so it ran until E2B's own timeout -- whose
+    action was `kill`. That is how a bookkeeping omission ends in deleting the
+    user's files.
+    """
+    SandboxService._inflight.clear()
+    SandboxService._recent.clear()
+    provider = _SandboxIsTheDiskProvider()
+    service = SandboxService(provider=provider, uow_factory=sandbox_uow_factory)
+    sweeper = SandboxSweeper(service=service, uow_factory=sandbox_uow_factory)
+    sandbox = await _workspace(service)
+    await service.ensure(sandbox.id)
+
+    assert await sweeper.release_idle(idle_after_seconds=0) == 1
+
+    # Resumed and used again, the way any tool call uses it. The sandbox is
+    # still there, paused -- so this is the resume path, not a fresh provision.
+    service.forget(sandbox.id)
+    await service.ensure(sandbox.id)
+    assert len(provider.created) == 1, "the test must resume, not re-provision"
+
+    assert await sweeper.release_idle(idle_after_seconds=0) == 1, (
+        "a sandbox that was resumed and used is idle-releasable like any other"
+    )
+
+
+async def test_the_warm_path_does_not_rewrite_a_row_that_is_already_right(
+    service: SandboxService, sandbox_uow_factory
+) -> None:
+    """The repair is for a row that is wrong, not a write on every tool call.
+
+    Both values are read at the top of the ensure that needs them, so the common
+    case costs nothing extra. A write here would land on every dispatch.
+    """
+    sandbox = await _workspace(service)
+    await service.ensure(sandbox.id)
+
+    async with sandbox_uow_factory() as uow:
+        before = await SandboxRepository(uow).get(sandbox.id)
+
+    service.forget(sandbox.id)
+    await service.ensure(sandbox.id)
+
+    async with sandbox_uow_factory() as uow:
+        after = await SandboxRepository(uow).get(sandbox.id)
+
+    assert before.desired_state is after.desired_state is SandboxDesiredState.PRESENT

--- a/lemma-backend/app/modules/workspace/tests/integration/test_sandbox_sweeper.py
+++ b/lemma-backend/app/modules/workspace/tests/integration/test_sandbox_sweeper.py
@@ -13,6 +13,10 @@ from app.modules.workspace.providers.base import (
     ProviderGone,
     ProviderInstance,
     ProviderObject,
+    ProviderStorageKind,
+)
+from app.modules.workspace.infrastructure.sandbox_repository import (
+    SandboxRepository,
 )
 from app.modules.workspace.services.sandbox_service import SandboxService
 from app.modules.workspace.services.sandbox_sweeper import SandboxSweeper
@@ -413,3 +417,77 @@ async def test_a_killed_process_does_not_pin_its_sandbox_forever(
 
     assert released == 1, "a sandbox whose only process was killed is idle"
     assert handle.provider_id in provider.released
+
+
+# ---------------------------------------------------------------------------
+# Whose epoch decides anything
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SandboxIsTheDiskProvider(SweepableProvider):
+    """A provider where destroying the object destroys the user's files.
+
+    E2B works this way, and `ProviderStorageKind.SANDBOX_NATIVE` says what
+    follows from it: "one object is both … the fence is the provider's own id
+    rather than an epoch in a name".
+    """
+
+    storage_kind: ProviderStorageKind = ProviderStorageKind.SANDBOX_NATIVE
+
+
+async def test_an_old_epoch_never_reclaims_a_sandbox_that_is_also_the_disk(
+    sandbox_uow_factory,
+) -> None:
+    """The regression, and it was destroying live user workspaces.
+
+    The row's epoch advances on every provision, including the ones that adopt
+    an existing sandbox. The epoch it was compared against is read from provider
+    metadata that nothing can update -- the re-stamp was guarded on
+    `set_metadata`, which the E2B SDK does not have -- so it stayed frozen at
+    the value the first create wrote. "epoch 1 is behind 6" was therefore
+    permanently true for every workspace a user had kept, and the sweep called
+    destroy on it every five minutes. It only ever failed to delete them because
+    destroy could not address a paused sandbox, which has since been fixed.
+    """
+    provider = _SandboxIsTheDiskProvider()
+    service = SandboxService(provider=provider, uow_factory=sandbox_uow_factory)
+    sweeper = SandboxSweeper(service=service, uow_factory=sandbox_uow_factory)
+    sandbox = await _workspace(service)
+    await service.ensure(sandbox.id)
+
+    name = f"lemma-ws-{sandbox.id.hex}-1"
+    provider.objects = [_object(name=name, sandbox_id=sandbox.id, epoch=1)]
+    async with sandbox_uow_factory() as uow:
+        await SandboxRepository(uow).bump_epoch(sandbox.id)
+        await SandboxRepository(uow).bump_epoch(sandbox.id)
+
+    reclaimed = await sweeper.reclaim_orphans()
+
+    assert provider.destroyed == [], (
+        "the sweep destroyed a live workspace, and here the sandbox is the disk"
+    )
+    assert reclaimed == ()
+
+
+async def test_an_old_epoch_still_reclaims_where_the_disk_is_separate(
+    sweeper: SandboxSweeper, provider: SweepableProvider, service: SandboxService
+) -> None:
+    """The exemption must stay narrow.
+
+    On a VOLUME provider the container and the volume are different objects, so
+    a superseded container is genuinely garbage and reclaiming it costs nothing
+    but a cold start. Turning the epoch off everywhere would leak those forever.
+    """
+    sandbox = await _workspace(service)
+    await service.ensure(sandbox.id)
+
+    name = f"lemma-ws-{sandbox.id.hex}-1"
+    provider.objects = [_object(name=name, sandbox_id=sandbox.id, epoch=1)]
+    async with sweeper._uow_factory() as uow:
+        await SandboxRepository(uow).bump_epoch(sandbox.id)
+
+    reclaimed = await sweeper.reclaim_orphans()
+
+    assert reclaimed == (name,)
+    assert provider.destroyed == [name]

--- a/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
@@ -31,6 +31,7 @@ from app.modules.workspace.providers.e2b_common import (
     META_EPOCH,
     META_PROFILE_DIGEST,
     META_SANDBOX_ID,
+    META_TEMPLATE,
 )
 from app.modules.workspace.testing.fake_e2b import (
     AuthenticationException,
@@ -278,6 +279,7 @@ async def test_a_sandbox_from_the_same_template_build_is_adopted(
         metadata={
             META_SANDBOX_ID: str(sandbox_id),
             META_PROFILE_DIGEST: spec.profile_digest,
+            META_TEMPLATE: "lemma-workspace",
         },
     )
 
@@ -287,6 +289,76 @@ async def test_a_sandbox_from_the_same_template_build_is_adopted(
     assert instance.storage_adopted is True
     assert world.created == [], "a second sandbox would strand the real one"
     assert world.killed == []
+
+
+async def test_a_workspace_on_a_different_template_is_replaced(
+    provider: E2BSandboxProvider, world: FakeE2B
+) -> None:
+    """Publishing a template has to reach the workspaces that already exist.
+
+    It did not. Adoption compared only `profile_digest`, a hand-maintained
+    environment variable sitting at its default, so a workspace stayed on
+    whatever template it was first created on for as long as it lived. Measured
+    against the real account: 249 sandboxes spread over four older templates and
+    zero on the configured one, through four releases that were each meant to
+    fix the workspaces that were failing.
+    """
+    from app.modules.workspace.testing.fake_e2b import FakeSandboxInfo
+
+    sandbox_id = uuid4()
+    spec = _spec(sandbox_id)
+    world.sandboxes["on-last-months-template"] = FakeSandboxInfo(
+        sandbox_id="on-last-months-template",
+        state="paused",
+        metadata={
+            META_SANDBOX_ID: str(sandbox_id),
+            META_PROFILE_DIGEST: spec.profile_digest,
+            META_TEMPLATE: "lemma-workspace-but-older",
+        },
+    )
+
+    instance = await provider.create(spec)
+
+    assert world.killed == ["on-last-months-template"]
+    assert instance.provider_id != "on-last-months-template"
+    assert instance.storage_adopted is False
+    assert world.created[0]["template"] == "lemma-workspace"
+
+
+async def test_a_workspace_with_no_recorded_template_is_replaced(
+    provider: E2BSandboxProvider, world: FakeE2B
+) -> None:
+    """Unstamped means "created before anything recorded this", which means at
+    least one template behind by construction. Reading the absence as "fine" is
+    the shape of the original bug: the fleet's staleness was invisible because
+    nothing wrote down what any of it was running."""
+    from app.modules.workspace.testing.fake_e2b import FakeSandboxInfo
+
+    sandbox_id = uuid4()
+    spec = _spec(sandbox_id)
+    world.sandboxes["unstamped"] = FakeSandboxInfo(
+        sandbox_id="unstamped",
+        state="paused",
+        metadata={
+            META_SANDBOX_ID: str(sandbox_id),
+            META_PROFILE_DIGEST: spec.profile_digest,
+        },
+    )
+
+    instance = await provider.create(spec)
+
+    assert world.killed == ["unstamped"]
+    assert instance.storage_adopted is False
+
+
+async def test_a_created_sandbox_records_the_template_it_was_built_from(
+    provider: E2BSandboxProvider, world: FakeE2B
+) -> None:
+    """Without the stamp there is nothing to compare on the next ensure, so the
+    fence would silently never fire again."""
+    await provider.create(_spec(uuid4()))
+
+    assert world.created[0]["metadata"][META_TEMPLATE] == "lemma-workspace"
 
 
 async def test_a_workspace_from_an_older_template_build_keeps_its_disk(
@@ -313,12 +385,15 @@ async def test_a_workspace_from_an_older_template_build_keeps_its_disk(
         metadata={
             META_SANDBOX_ID: str(sandbox_id),
             META_PROFILE_DIGEST: "sha256:" + "b" * 64,
+            # On the configured template, so this isolates the digest rule from
+            # the template fence, which does replace.
+            META_TEMPLATE: "lemma-workspace",
         },
     )
 
     instance = await provider.create(_spec(sandbox_id))
 
-    assert world.killed == [], "a workspace's files must survive a template bump"
+    assert world.killed == [], "a workspace's files must survive a digest bump"
     assert instance.provider_id == "older-build", "and it keeps serving them"
 
 
@@ -359,11 +434,12 @@ async def test_a_running_match_is_preferred_over_a_paused_duplicate(
         world.sandboxes[name] = FakeSandboxInfo(
             sandbox_id=name,
             state=state,
-            # Both carry the current profile digest, so the reuse fence is
-            # satisfied and this exercises the ordering rule on its own.
+            # Both satisfy the reuse fences -- current profile digest, current
+            # template -- so this exercises the ordering rule on its own.
             metadata={
                 META_SANDBOX_ID: str(sandbox_id),
                 META_PROFILE_DIGEST: spec.profile_digest,
+                META_TEMPLATE: "lemma-workspace",
             },
         )
 

--- a/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
@@ -927,3 +927,53 @@ async def test_resuming_a_sandbox_re_arms_its_lease(
     assert all(timeout is not None for timeout in world.connect_timeouts), (
         "a connect with no timeout hands the sandbox a five-minute lease"
     )
+
+
+# ---------------------------------------------------------------------------
+# Listings, which are paginated and which this module used to read once
+# ---------------------------------------------------------------------------
+
+
+async def test_the_sweep_sees_every_page_of_the_account(
+    provider: E2BSandboxProvider, world: FakeE2B
+) -> None:
+    """Orphan reclamation reads a listing that is filtered only by kind.
+
+    So unlike adoption -- whose query names one sandbox id and comes back with
+    one result -- this one matches the whole fleet, and reading `next_items()`
+    once meant the sweep only ever considered the first page of it. Everything
+    past that was invisible: never reclaimed, and billed for as long as it
+    existed. The account this was found in held 249 sandboxes.
+    """
+    made = [uuid4() for _ in range(world.list_page_size * 2 + 1)]
+    for sandbox_id in made:
+        await provider.create(_spec(sandbox_id))
+
+    objects = await provider.list_objects(deadline_at=_deadline())
+
+    assert {obj.sandbox_id for obj in objects} == set(made)
+
+
+async def test_the_sweep_lists_function_sandboxes_too(
+    provider: E2BSandboxProvider, world: FakeE2B
+) -> None:
+    """"Every sandbox carrying this platform's metadata" has to mean every kind.
+
+    The query was hardcoded to workspaces, so a function sandbox the control
+    plane had forgotten was invisible to orphan reclamation and billed forever
+    -- which is the single thing that sweep exists to stop.
+    """
+    workspace_id = uuid4()
+    function_id = uuid4()
+    await provider.create(_spec(workspace_id))
+    await provider.create(
+        _spec(
+            function_id,
+            kind=SandboxKind.FUNCTION,
+            name=naming.container_name(function_id, SandboxKind.FUNCTION, 1),
+        )
+    )
+
+    objects = await provider.list_objects(deadline_at=_deadline())
+
+    assert {obj.sandbox_id for obj in objects} == {workspace_id, function_id}

--- a/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
@@ -851,3 +851,79 @@ async def test_a_container_name_that_resolves_to_nothing_is_left_alone(
     )
 
     assert world.killed == []
+
+
+# ---------------------------------------------------------------------------
+# The lease: what E2B does when a sandbox's timeout runs out
+# ---------------------------------------------------------------------------
+
+
+async def test_a_created_sandbox_pauses_on_timeout_rather_than_being_killed(
+    provider: E2BSandboxProvider, world: FakeE2B
+) -> None:
+    """The default is `kill`, and here killing the sandbox deletes the disk.
+
+    This call passed no lifecycle at all, so every workspace was created already
+    scheduled for deletion thirty minutes out. Nothing recorded it and nothing
+    told the user; the only reason it was not a daily event is that the idle
+    sweep usually paused the sandbox first, which stops the clock. A five-minute
+    cron was all that stood between a long session and losing every file.
+    """
+    await provider.create(_spec(uuid4()))
+
+    lifecycle = world.created[0]["lifecycle"]
+    assert lifecycle is not None, "no lifecycle means E2B kills it on timeout"
+    assert lifecycle["on_timeout"]["action"] == "pause"
+
+
+async def test_the_timeout_pause_keeps_only_the_filesystem(
+    provider: E2BSandboxProvider, world: FakeE2B
+) -> None:
+    """A memory-preserving snapshot restores whatever was running.
+
+    That is how a browser which had exhausted the sandbox became permanent: the
+    pause captured the exhaustion and every later resume restored it, so the
+    sandbox could never recover on its own. `release` already pauses this way and
+    the timeout has to agree with it, or the fleet gets both behaviours depending
+    on which one happened to fire.
+    """
+    await provider.create(_spec(uuid4()))
+
+    assert world.created[0]["lifecycle"]["on_timeout"]["keep_memory"] is False
+
+
+async def test_resuming_a_sandbox_re_arms_its_lease(
+    provider: E2BSandboxProvider, world: FakeE2B
+) -> None:
+    """Connecting is what extends the lease, and it must say by how much.
+
+    The SDK's rule is that the timeout updates "only if the new timeout is longer
+    than the existing one" -- so passing nothing is not "leave it alone", it is
+    "five minutes", the SDK's default. A workspace resumed after days came back
+    with a five-minute lease, and every process inside it died together when it
+    elapsed. From outside that looks like three tool calls returning 502 at the
+    same instant, minutes into a turn that was working.
+    """
+    from app.modules.workspace.testing.fake_e2b import FakeSandboxInfo
+
+    sandbox_id = uuid4()
+    spec = _spec(sandbox_id)
+    world.sandboxes["paused"] = FakeSandboxInfo(
+        sandbox_id="paused",
+        state="paused",
+        metadata={
+            META_SANDBOX_ID: str(sandbox_id),
+            META_PROFILE_DIGEST: spec.profile_digest,
+            META_TEMPLATE: "lemma-workspace",
+        },
+    )
+    instance = await provider.create(spec)
+
+    await provider.wait_ready(
+        instance, kind=SandboxKind.WORKSPACE, deadline_at=_deadline()
+    )
+
+    assert world.connect_timeouts, "wait_ready never connected"
+    assert all(timeout is not None for timeout in world.connect_timeouts), (
+        "a connect with no timeout hands the sandbox a five-minute lease"
+    )

--- a/lemma-backend/app/modules/workspace/tests/unit/test_unresponsive_sandbox.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_unresponsive_sandbox.py
@@ -1,0 +1,177 @@
+"""A sandbox that has stopped answering must say so, not read as "still running".
+
+The failure this covers reached users. A workspace sandbox had been alive for
+days, accumulated a leaked browser, and ran out of memory; commands still
+*started* -- E2B returned a pid in 260ms -- but nothing they printed ever came
+back and they never exited. Every layer below behaved correctly, and the tool
+call returned `success: true, completed: false, stdout: ""`.
+
+That result is indistinguishable from a quiet build, so the agent did the only
+thing it could: poll, give up, kill the process, run it again, and collect
+another silent window. Three tool calls, ninety seconds, no information. The
+sandbox was only recovered when a person noticed and destroyed it by hand.
+
+The distinguishing question is cheap -- can this sandbox still run `echo`? --
+and these tests are what make sure it is asked, and asked only when the answer
+is worth a round trip.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from sandbox_runtime.protocol import ProcessOutputSnapshot, ProcessState
+from app.modules.workspace import process_output
+from app.modules.workspace.process_output import collect_process_output
+
+pytestmark = [pytest.mark.unit, pytest.mark.asyncio]
+
+# The production threshold is five seconds, which would make every test here
+# cost that much wall clock to say nothing. The boundary itself is what these
+# exercise, so it is moved rather than waited out.
+_SUSPICIOUS_AFTER = 0.3
+
+
+@pytest.fixture(autouse=True)
+def _quick_threshold(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        process_output, "_SILENCE_IS_SUSPICIOUS_AFTER_SECONDS", _SUSPICIOUS_AFTER
+    )
+
+
+class _SilentClient:
+    """A process that never prints and never exits, answering instantly."""
+
+    def __init__(self, state: ProcessState = ProcessState.RUNNING) -> None:
+        self._state = state
+        self.polls = 0
+
+    async def read_process_output(self, *_args, **_kwargs) -> ProcessOutputSnapshot:
+        self.polls += 1
+        return ProcessOutputSnapshot(
+            chunks=(),
+            next_sequence=0,
+            truncated_before_sequence=None,
+            state=self._state,
+            exit_code=None,
+        )
+
+
+class _Cursor:
+    def __init__(self) -> None:
+        self.saved: list[int] = []
+
+    async def load(self, _operation_id) -> int:
+        return 0
+
+    def remember_locally(self, _operation_id, _sequence) -> None:
+        return None
+
+    async def save(self, _operation_id, sequence) -> None:
+        self.saved.append(sequence)
+
+
+def _deadline(seconds: float) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(seconds=seconds)
+
+
+async def _collect(client, *, yield_ms: int, probe):
+    return await collect_process_output(
+        client,
+        uuid4(),
+        _Cursor(),
+        uuid4(),
+        deadline_at=_deadline(30),
+        yield_time_ms=yield_ms,
+        probe_liveness=probe,
+    )
+
+
+async def test_a_silent_window_on_a_dead_sandbox_is_reported_as_failure() -> None:
+    probed = []
+
+    async def probe() -> bool:
+        probed.append(True)
+        return False
+
+    result = await _collect(_SilentClient(), yield_ms=500, probe=probe)
+
+    assert probed, "a fully silent window must ask whether the sandbox is alive"
+    assert result["success"] is False
+    assert result["completed"] is False
+    assert "stopped responding" in result["error"]
+    assert "Restart the workspace sandbox" in result["error"], (
+        "the caller has to be told the recovery, or it polls the corpse again"
+    )
+
+
+async def test_a_silent_window_on_a_live_sandbox_is_still_just_running() -> None:
+    """A quiet build is the common case and must not be turned into an error."""
+
+    async def probe() -> bool:
+        return True
+
+    result = await _collect(_SilentClient(), yield_ms=500, probe=probe)
+
+    assert result["success"] is True
+    assert result["completed"] is False
+    assert result["error"] is None
+
+
+async def test_a_short_window_does_not_pay_for_a_probe() -> None:
+    """Half a second of quiet says nothing, so it must not cost a round trip."""
+    probed = []
+
+    async def probe() -> bool:
+        probed.append(True)
+        return False
+
+    result = await _collect(_SilentClient(), yield_ms=100, probe=probe)
+
+    assert probed == []
+    assert result["success"] is True
+
+
+async def test_a_window_that_produced_output_is_never_probed() -> None:
+    """Bytes arriving are proof of life; asking again would be pure cost."""
+
+    class _Talking(_SilentClient):
+        """Prints once early, then goes quiet -- a build that logs a header."""
+
+        async def read_process_output(self, *_args, **_kwargs):
+            from sandbox_runtime.protocol import (
+                ProcessOutputChannel,
+                ProcessOutputChunk,
+            )
+
+            self.polls += 1
+            chunks = ()
+            if self.polls == 1:
+                chunks = (
+                    ProcessOutputChunk(
+                        sequence=1,
+                        channel=ProcessOutputChannel.STDOUT,
+                        data=b"working\n",
+                    ),
+                )
+            return ProcessOutputSnapshot(
+                chunks=chunks,
+                next_sequence=2,
+                truncated_before_sequence=None,
+                state=ProcessState.RUNNING,
+                exit_code=None,
+            )
+
+    probed = []
+
+    async def probe() -> bool:
+        probed.append(True)
+        return False
+
+    result = await _collect(_Talking(), yield_ms=500, probe=probe)
+
+    assert probed == []
+    assert result["stdout"] == "working\n"

--- a/lemma-backend/sandbox-images/scripts/save-webpage.sh
+++ b/lemma-backend/sandbox-images/scripts/save-webpage.sh
@@ -117,7 +117,20 @@ if [[ "$OPEN_PAGE" == "1" ]]; then
   start-browser >/dev/null
   CAPTURE_TAB="lemma-capture-$$"
   agent-browser tab new --label "$CAPTURE_TAB" "$URL" >/dev/null
-  agent-browser wait --load networkidle >/dev/null 2>&1 || agent-browser wait "$WAIT_MS" >/dev/null 2>&1 || true
+  # Bounded, because networkidle is a condition an ad-funded page never
+  # reaches: something is always polling. Measured on the two news sites a user
+  # actually asked for, the unbounded wait cost 32.6s and 40.0s per capture and
+  # produced byte-for-byte the same markdown as a 5s cap did in 10.3s and
+  # 32.7s. A tool call fetching two such pages renders them one at a time, so
+  # that difference is most of the minute and a half the caller waits.
+  #
+  # The cap is not a page-load timeout: whatever has loaded by then is what
+  # gets captured, and the fallback wait below still gives a slow page its
+  # settle time. Pages that do go idle are unaffected -- they reach it in well
+  # under the cap and this returns immediately.
+  timeout "${NETWORKIDLE_TIMEOUT_S:-5}" \
+    agent-browser wait --load networkidle >/dev/null 2>&1 \
+    || agent-browser wait "$WAIT_MS" >/dev/null 2>&1 || true
 fi
 
 PAGE_URL="$(agent-browser get url)"


### PR DESCRIPTION
## What changes

A workspace sandbox stops being deleted by the platform that is supposed to be
keeping it. On E2B the sandbox *is* the disk, and three separate mechanisms were
destroying user files:

* The orphan sweep was calling `destroy()` on **live** workspaces every five
  minutes.
* Every sandbox was created already scheduled for deletion, thirty minutes out.
* A resumed sandbox came back with a five-minute lease and was then killed with
  everything running inside it.

It also fixes the two bookkeeping bugs that fed them — a sandbox could be idle-
released at most once in its life, and both E2B listings read only their first
page — and the reporting gap that made a wedged sandbox invisible.

## Why

Agents in dev could not run CLI tool calls: `lemma tables list` returned after
30–39 s with empty stdout, no exit code, and `success: true`. #379 was already
deployed and working; this was something else.

The trace of the reported conversation (`772fe8347cb6d916089ff3e58ca1c719`)
shows the shape of it:

```
+1.69s   8.15s  workspace.session
+1.95s   6.90s    sandbox.ensure        <- resume from pause
+9.84s  30.65s  workspace.exec
+9.84s   0.26s    POST  200             <- start RPC returns, with a pid
                  ...30s of nothing...
+385.78s 0.35s    GET   502             <- all three streams die together
```

The command started fine — E2B returned a pid in 260 ms. Then nothing came back
for the whole window, three times, and at +385 s every in-flight process stream
returned 502 at the same instant. That was the sandbox being deleted underneath
them.

Root causes, each verified rather than inferred:

**1. The sweep judged live sandboxes by an epoch nothing could update.**
`reclaim_orphans` treats an object as superseded when the epoch in provider
metadata is behind the epoch on the row. The row's epoch advances on every
provision, including the ones that *adopt* an existing sandbox. The metadata
epoch was refreshed by `_stamp`, guarded on `getattr(sandbox, "set_metadata")` —
and `AsyncSandbox.set_metadata` does not exist in the E2B SDK (verified against
2.39.1). So the guard was always false, the metadata epoch stayed frozen at
whatever the first create wrote, and *"epoch 1 is behind 6"* was permanently
true for every workspace a user had kept.

This is what the "eighteen reclaims every five minutes for hours, the same
eighteen ids" in #378 actually was. Not orphans — live workspaces. The only
reason no data was lost is that destroy could not address a paused sandbox,
which #378 fixed.

`ProviderStorageKind` already stated the rule: SANDBOX_NATIVE is *"one object is
both … the fence is the provider's own id rather than an epoch in a name"*, and
`e2b.py` repeats it. The sweep now honours it, and `_stamp` is deleted rather
than left as a silent no-op feeding a destroy decision.

**2. `create` passed no `lifecycle`, and the SDK defaults `on_timeout` to
`"kill"`.** So every workspace was set to be deleted when its timeout elapsed.
The only thing preventing daily data loss was that the idle sweep usually paused
the sandbox first, which stops the clock — a five-minute cron standing between a
long session and total loss. It now asks E2B to pause, filesystem-only, matching
what `release` already does.

**3. `connect` passed no timeout.** The SDK's rule is that the timeout updates
*"only if the new timeout is longer than the existing one"*, so passing nothing
means five minutes, its default.

**4. Idle release could fire at most once per sandbox.** The resume path never
wrote the row back to `PRESENT`; only a full provision did, and `list_idle`
selects on `PRESENT`. After the first cycle a sandbox was invisible to the
sweep, so nothing stopped its compute and it ran until its lease — whose action
was (2).

**5. Both E2B listings read one page.** The sweep's query is filtered only by
kind, so it matches the whole fleet; one page was all orphan reclamation ever
considered. The same query was hardcoded to workspaces under a docstring
promising "every sandbox carrying this platform's metadata", so a forgotten
function sandbox was invisible and billed forever.

**6. A wedged sandbox reported success.** A window with no byte and no exit is
indistinguishable from a quiet build, and both returned
`success: true, completed: false`. So an agent's only option was to poll, give
up, kill, and retry into another silent window — which is exactly what it did,
three times. One `echo` tells them apart, spent only on a window that already
told the caller nothing.

### Why the tests did not catch any of this

Both test doubles modelled a different provider from the one carrying
production, and that is the part worth fixing beyond the bugs themselves:

* The E2B fake accepted `lifecycle` and connect's `timeout` into `**_kwargs` for
  the entire time the provider was passing neither.
* Its paginator returned everything in one call and had no `has_next` at all, so
  a provider reading one page looked complete against it.
* `FakeProvider.release` **pops** the container, so a released sandbox vanishes
  and the next ensure re-provisions — modelling a provider where releasing
  destroys the disk. Every "release then use again" therefore went through
  `_provision`, which writes `PRESENT` back and hid (4).

All three now model the real thing, and each new test was verified to fail
against the unfixed code.

## How to verify

```bash
cd lemma-backend
uv run pytest app/modules/workspace/tests/unit -q
uv run make architecture
```

Integration (needs Postgres) and the real-E2B lifecycle suite (needs E2B
credentials and a Redis):

```bash
TEST_DATABASE_URL=postgresql+asyncpg://... uv run pytest app/modules/workspace/tests/integration -q
E2B_API_KEY=... E2B_WORKSPACE_TEMPLATE=... REDIS_URL=... \
  uv run pytest app/modules/workspace/tests/integration/test_e2b_lifecycle_real.py -m "" -q
```

What they printed here: `207 passed` unit, `261 passed, 42 skipped` with
integration, `13 passed in 77s` against the live E2B service, ratchet and ruff
clean, and `4722 passed` for the full `not e2e` suite (one unrelated pre-existing
failure in `test_telegram_manager_service.py`, which also fails with this branch
stashed).

The fleet audit, against the live account:

```bash
uv run python -m app.modules.workspace.scripts.audit_e2b_lifecycle
```

```
visible in account: 249
carrying the 'lemma' namespace: 67

on timeout:
     67  kill (unset)

no recorded template (replaced on next ensure): 67
```

## Compatibility

A lifecycle is chosen at create and **E2B offers no way to change it
afterwards** — there is no `set_lifecycle`, and the connect endpoint carries
only a timeout. So the 67 existing sandboxes keep `on_timeout: kill`. They are
already stale by template and are replaced on their next ensure, which loses
their `/workspace`. That is a deliberate, agreed trade: the disk is a scratchpad
today and no persistence guarantee is offered.

## Not in this PR

Named because they were investigated and measured, not because they were
forgotten:

* **The browser rework.** I implemented per-capture browser sessions, measured
  it on the live template, and **reverted it** — it was a regression. What the
  measurements actually showed is more useful than the change would have been:

  **There is no leak across captures on the current template.** Five sequential
  `save-webpage` runs, counting `workspace-chrome` processes and their RSS:

  ```
  at boot            chrome=2  rss=0      renderers=3   avail=1531 MB
  after capture 0    chrome=3  rss=281MB  renderers=9   avail=1213 MB
  after capture 1    chrome=3  rss=281MB  renderers=10  avail=1179 MB
  after capture 4    chrome=3  rss=280MB  renderers=9   avail=1215 MB
  idle 130s          chrome=2  rss=0      renderers=3   avail=1313 MB
  ```

  Flat, and fully reclaimed once agent-browser's 120 s idle timeout fires. #378
  closed this; an earlier note of mine claiming "2 → 16 → 18 processes, reduced
  but not closed" was a measurement artifact — `pgrep -c -f chrom` also matches
  the `agent-browser` node processes that carry the chromium path in their argv.
  The 63-process / 14 MB production sandbox that started all of this was a
  pre-#378 state.

  Other findings that stand, and that shape whatever comes next:
  * One browser costs ~280–320 MB on a 2 GB sandbox, and a **second concurrent
    one fails to launch** at ~986 MB free: *"Chrome exited before providing
    DevTools URL"*. That is why per-capture isolation regressed — it added a
    second browser rather than replacing the first.
  * `agent-browser --session X close` does reclaim properly.
  * Sessions have a **shared-Chrome CDP mode**, where they share one instance
    and are distinguished by tab binding, as well as the full-isolation mode the
    numbers above measured. CDP mode is the cheaper shape if per-capture
    isolation is wanted later.
  * `AGENT_BROWSER_CONFIG` names a file that must exist; without
    `/tmp/lemma-browser/config.json`, `agent-browser open` warns and silently
    launches nothing. An earlier plan of mine called that config write redundant
    with the baked env vars. It is not.

  The open question is narrower than it looked: not "why does it leak" but "what
  does the dashboard cost on top of the browser captures already need", since
  `dashboard start` is what launches that browser today.

* **Recording the real provider id on the instance row.** `begin_instance`
  always writes the deterministic container name while `SandboxHandle` carries
  the real id, and both surface as `SandboxInfo.name`. Needs a migration.
* **Making a silent wipe impossible.** The recreated notice depends on
  `provider_volume_id` being truthy and is consumed by sessions that never
  surface it.
* **Auto-resume.** The right end state, and it deletes much of this module — but
  E2B requires memory preservation for it, and a memory-preserving pause is
  exactly what made the leaked browser permanent. It is gated on the browser
  work above.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Compatibility** — called out above
- [x] **Rollback** — revert is safe and self-contained. The lifecycle applies
      only to newly created sandboxes, so reverting stops new ones getting it
      and changes nothing about existing ones.
