### PR TITLE
Show a widget at its own height, and give each one a tab it can live in

### DIFF
--- a/lemma-frontend/app/pod/[id]/layout.tsx
+++ b/lemma-frontend/app/pod/[id]/layout.tsx
@@ -212,7 +212,13 @@ function getPodScreenLabel(podId: string, pathname: string, searchParams: Search
 
     if (section === "forms" && detail === "view") return "Agent Needs Your Input";
 
-    if (section === "widgets" && detail === "view") return "Presented Widget";
+    // Widgets open one tab each, so the strip needs their names to tell them
+    // apart. The presenting card knows the name and passes it along; anything
+    // that arrives without one keeps the generic label.
+    if (section === "widgets" && detail === "view") {
+        const widgetTitle = searchParams.get("title")?.replace(/\s+/g, " ").trim();
+        return widgetTitle ? widgetTitle.slice(0, 200) : "Presented Widget";
+    }
 
     if (section === "files" || section === "docs") {
         const file = getPathBasename(searchParams.get("file"));

--- a/lemma-frontend/app/pod/[id]/widgets/view/page.tsx
+++ b/lemma-frontend/app/pod/[id]/widgets/view/page.tsx
@@ -46,7 +46,9 @@ export default function DisplayResourceWidgetPage({
     const [savedAppUrl, setSavedAppUrl] = useState<string | null>(null);
     const [saveError, setSaveError] = useState<string | null>(null);
 
-    const title = 'Widget';
+    // The presenting card passes the widget's name through, so this route and
+    // its workspace tab carry the same label the conversation used.
+    const title = searchParams.get('title')?.replace(/\s+/g, ' ').trim().slice(0, 200) || 'Widget';
     const isContentWidget = !externalSrc;
 
     const openedConversationId = assistant.openedConversationId;

--- a/lemma-frontend/components/lemma/assistant/assistant-resource-cards.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-resource-cards.tsx
@@ -16,7 +16,10 @@ import {
   extractDisplayResourceFromInvocation,
   type DisplayResourceRequest,
 } from "@/lib/assistant/display-resource";
-import { CONVERSATION_PRESENTED_RESOURCE_PARAM } from "@/lib/assistant/conversation-presentation";
+import {
+  buildConversationStandaloneResourceHref,
+  CONVERSATION_PRESENTED_RESOURCE_PARAM,
+} from "@/lib/assistant/conversation-presentation";
 import { getLemmaClient } from "@/lib/sdk/lemma-client";
 import { fileNameFromPath } from "./assistant-format";
 import { displayResourceIcon } from "./assistant-parts";
@@ -76,6 +79,18 @@ export function humanizeResourceName(value: string): string {
     .trim();
   if (!cleaned) return value;
   return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+}
+
+/** Names the widget for the pod tab strip and the topbar of its own route. */
+export function appendWidgetTabTitle(href: string | null, title: string): string | null {
+  if (!href || !title.trim()) return href;
+  try {
+    const url = new URL(href, "https://lemma.local");
+    url.searchParams.set("title", title.trim());
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return href;
+  }
 }
 
 export function displayResourceKind(request: DisplayResourceRequest): string {
@@ -349,6 +364,12 @@ export function DisplayResourceCards({
 
         if (renderWidgetInline && podId) {
           const canExpand = !!onNavigateResource && !!card.href;
+          // The pod tab strip derives itself from the URL, so opening a widget
+          // as a tab is a plain navigation to its own route — and the name has
+          // to ride along in the link, since that route cannot look it up.
+          const podTabHref = card.href
+            ? appendWidgetTabTitle(buildConversationStandaloneResourceHref(card.href), title)
+            : null;
           return (
             <InlineWidget
               key={card.toolCallId}
@@ -359,6 +380,7 @@ export function DisplayResourceCards({
               title={title}
               loadingMessages={card.request.loadingMessages}
               variant="inline"
+              podTabHref={podTabHref}
               onExpand={canExpand ? expandResource : undefined}
             />
           );

--- a/lemma-frontend/components/lemma/assistant/inline-widget.tsx
+++ b/lemma-frontend/components/lemma/assistant/inline-widget.tsx
@@ -16,6 +16,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ArrowUpRight, Maximize2, MoreHorizontal } from "@/components/ui/icons";
 import { useTheme } from "next-themes";
 
+import { Button } from "@/components/ui/button";
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -302,13 +303,17 @@ export function InlineWidget({
                 // stays out of the way until the reader goes looking for it.
                 <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
                     <DropdownMenuTrigger asChild>
-                        <button
+                        <Button
                             type="button"
+                            variant="quiet"
+                            size="icon"
                             aria-label={`${title} actions`}
                             className={cn(
-                                "absolute right-2 top-2 z-10 inline-flex size-7 items-center justify-center rounded-full",
-                                "border border-[var(--border-subtle)] bg-[var(--bg-canvas)] text-[var(--text-secondary)]",
-                                "shadow-[var(--shadow-xs)] transition-gentle hover:bg-[var(--bg-subtle)] hover:text-[var(--text-primary)] focus-ring",
+                                "absolute right-2 top-2 z-10 h-7 w-7 rounded-full",
+                                // Opaque, unlike a plain quiet button: this floats
+                                // over whatever the widget drew underneath it.
+                                "border border-[var(--border-subtle)] bg-[var(--bg-canvas)]",
+                                "shadow-[var(--shadow-xs)] hover:bg-[var(--bg-subtle)]",
                                 // Inert while hidden: the widget owns this corner
                                 // too, and an invisible button would eat its clicks.
                                 "pointer-events-none opacity-0",
@@ -317,7 +322,7 @@ export function InlineWidget({
                             )}
                         >
                             <MoreHorizontal className="size-4" />
-                        </button>
+                        </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end" className="w-52">
                         {podTabHref ? (

--- a/lemma-frontend/components/lemma/assistant/inline-widget.tsx
+++ b/lemma-frontend/components/lemma/assistant/inline-widget.tsx
@@ -6,13 +6,22 @@
 // on the API origin (isolated from this app) so its SDK works.
 //
 // Two variants:
-//   - "inline": embedded in the chat thread, height-capped with a fade + Expand.
+//   - "inline": embedded in the chat thread, rendered at its own reported height
+//               up to a viewport-relative ceiling, with a fade + Expand past it.
 //   - "full":   the standalone widgets/view page, full reported height, no cap.
 
 import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
-import { Maximize2 } from "@/components/ui/icons";
+import { ArrowUpRight, Maximize2, MoreHorizontal } from "@/components/ui/icons";
 import { useTheme } from "next-themes";
+
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 import { getLemmaClient } from "@/lib/sdk/lemma-client";
 import {
@@ -71,12 +80,42 @@ export interface InlineWidgetProps {
     title?: string;
     loadingMessages?: string[];
     variant?: "inline" | "full";
-    /** Max rendered height for the inline variant before the fade + Expand kicks in. */
+    /**
+     * Max rendered height for the inline variant. Defaults to a share of the
+     * viewport, so the widget shows in full unless it would swallow the thread.
+     */
     maxHeight?: number;
+    /**
+     * The widget's own pod route. Opening it adds a tab to the pod's workspace
+     * strip, because that strip is derived from the URL.
+     */
+    podTabHref?: string | null;
     onExpand?: () => void;
 }
 
-const INLINE_MAX_HEIGHT = 480;
+/**
+ * A widget is the answer, not a preview of one, so the ceiling exists only to
+ * keep one card from taking the whole transcript: tall enough that anything
+ * shaped like a normal widget renders whole, short enough that the next message
+ * is still reachable by scrolling rather than by paging through an iframe.
+ */
+const INLINE_VIEWPORT_SHARE = 0.85;
+const INLINE_MIN_MAX_HEIGHT = 480;
+
+function useInlineMaxHeight(explicitMaxHeight?: number): number {
+    const [viewportHeight, setViewportHeight] = useState(0);
+
+    useEffect(() => {
+        const update = () => setViewportHeight(window.innerHeight);
+        update();
+        window.addEventListener("resize", update);
+        return () => window.removeEventListener("resize", update);
+    }, []);
+
+    if (explicitMaxHeight) return explicitMaxHeight;
+    if (!viewportHeight) return INLINE_MIN_MAX_HEIGHT;
+    return Math.max(INLINE_MIN_MAX_HEIGHT, Math.round(viewportHeight * INLINE_VIEWPORT_SHARE));
+}
 
 export function InlineWidget({
     podId,
@@ -86,7 +125,8 @@ export function InlineWidget({
     title = "Widget",
     loadingMessages = [],
     variant = "inline",
-    maxHeight = INLINE_MAX_HEIGHT,
+    maxHeight,
+    podTabHref,
     onExpand,
 }: InlineWidgetProps) {
     const { resolvedTheme } = useTheme();
@@ -95,6 +135,8 @@ export function InlineWidget({
     const [heightReported, setHeightReported] = useState(false);
     const [loadedIframeSrc, setLoadedIframeSrc] = useState<string | null>(null);
     const [loadingProgress, setLoadingProgress] = useState({ key: "", index: 0 });
+    const [menuOpen, setMenuOpen] = useState(false);
+    const resolvedMaxHeight = useInlineMaxHeight(maxHeight);
 
     const resolvedExternalSrc = isHttpUrl(externalSrc);
     // An inline-content widget is served (and config-injected) by the backend; we
@@ -164,8 +206,8 @@ export function InlineWidget({
 
     const isInline = variant === "inline";
     const fullHeight = !heightReported ? 360 : reportedHeight;
-    const overflows = isInline && heightReported && reportedHeight > maxHeight;
-    const renderedHeight = isInline ? Math.min(fullHeight, maxHeight) : fullHeight;
+    const overflows = isInline && heightReported && reportedHeight > resolvedMaxHeight;
+    const renderedHeight = isInline ? Math.min(fullHeight, resolvedMaxHeight) : fullHeight;
 
     const handleIframeLoad = () => {
         if (!iframeSrc) return;
@@ -230,8 +272,10 @@ export function InlineWidget({
         );
     }
 
+    const hasMenuActions = !!podTabHref || !!onExpand;
+
     return (
-        <div className="relative overflow-hidden">
+        <div className="group relative overflow-hidden">
             <iframe
                 key={iframeSrc}
                 ref={iframeRef}
@@ -252,6 +296,52 @@ export function InlineWidget({
                     <StepLoader size="sm" />
                     {loadingMessage}
                 </div>
+            ) : null}
+            {hasMenuActions && !loading ? (
+                // Widgets draw edge to edge and own their own chrome, so this
+                // stays out of the way until the reader goes looking for it.
+                <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+                    <DropdownMenuTrigger asChild>
+                        <button
+                            type="button"
+                            aria-label={`${title} actions`}
+                            className={cn(
+                                "absolute right-2 top-2 z-10 inline-flex size-7 items-center justify-center rounded-full",
+                                "border border-[var(--border-subtle)] bg-[var(--bg-canvas)] text-[var(--text-secondary)]",
+                                "shadow-[var(--shadow-xs)] transition-gentle hover:bg-[var(--bg-subtle)] hover:text-[var(--text-primary)] focus-ring",
+                                // Inert while hidden: the widget owns this corner
+                                // too, and an invisible button would eat its clicks.
+                                "pointer-events-none opacity-0",
+                                "group-hover:pointer-events-auto group-hover:opacity-100 focus-visible:opacity-100",
+                                menuOpen && "pointer-events-auto opacity-100",
+                            )}
+                        >
+                            <MoreHorizontal className="size-4" />
+                        </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-52">
+                        {podTabHref ? (
+                            <DropdownMenuItem asChild>
+                                <Link
+                                    href={podTabHref}
+                                    className="flex cursor-pointer items-center gap-2"
+                                >
+                                    <ArrowUpRight className="size-4 text-[var(--text-tertiary)]" />
+                                    Open in new tab
+                                </Link>
+                            </DropdownMenuItem>
+                        ) : null}
+                        {onExpand ? (
+                            <DropdownMenuItem
+                                onClick={onExpand}
+                                className="flex cursor-pointer items-center gap-2"
+                            >
+                                <Maximize2 className="size-4 text-[var(--text-tertiary)]" />
+                                Open full view
+                            </DropdownMenuItem>
+                        ) : null}
+                    </DropdownMenuContent>
+                </DropdownMenu>
             ) : null}
             {overflows ? (
                 <div className="pointer-events-none absolute inset-x-0 bottom-0 flex h-20 items-end justify-center bg-gradient-to-t from-[var(--pod-main-bg)] via-[color:color-mix(in_srgb,var(--pod-main-bg)_70%,transparent)] to-transparent pb-2">

--- a/lemma-frontend/components/pod/pod-workspace-tabs.tsx
+++ b/lemma-frontend/components/pod/pod-workspace-tabs.tsx
@@ -8,6 +8,7 @@ import { ProductIcon, type ProductIconKind } from '@/components/pod/product-icon
 import { getAppAccent } from '@/lib/app/app-accent';
 import {
     getWorkspaceTabHref,
+    isWidgetWorkspaceRouteKey,
     type PodWorkspaceTab,
 } from '@/lib/pods/workspace-tabs';
 import { cn } from '@/lib/utils';
@@ -31,9 +32,15 @@ const routeTabKinds: Record<string, ProductIconKind> = {
 };
 
 function RouteTabIcon({ routeKey, active }: { routeKey: string; active: boolean }) {
+    // Each presented widget carries its own route key, so the shared widget
+    // glyph is found by shape rather than by an exact match.
+    const kind = isWidgetWorkspaceRouteKey(routeKey)
+        ? routeTabKinds.widgets
+        : routeTabKinds[routeKey];
+
     return (
         <ProductIcon
-            kind={routeTabKinds[routeKey] || 'pods'}
+            kind={kind || 'pods'}
             size="xs"
             state={active ? 'selected' : 'default'}
         />

--- a/lemma-frontend/components/pod/use-pod-workspace-tabs.ts
+++ b/lemma-frontend/components/pod/use-pod-workspace-tabs.ts
@@ -109,7 +109,13 @@ export function usePodWorkspaceTabs({
     }, [store]);
     const getSnapshot = useCallback(() => store.tabs, [store]);
     const tabs = useSyncExternalStore(subscribe, getSnapshot, () => SERVER_TABS);
-    const activeTabId = getActiveWorkspaceTabId(podId, pathname, appSlug);
+    // A presented widget is identified by its tool call, which lives in the
+    // query rather than the path, so the active-tab lookup needs both halves.
+    const currentSearchParams = useMemo(
+        () => new URLSearchParams(currentHref.split('?')[1] || ''),
+        [currentHref],
+    );
+    const activeTabId = getActiveWorkspaceTabId(podId, pathname, appSlug, currentSearchParams);
     const wasNewConversationRouteRef = useRef(false);
     const newConversationBaselineRef = useRef<string | null>(null);
     const lastConversationOutsideNewRef = useRef<string | null>(openedConversationId);

--- a/lemma-frontend/lib/pods/workspace-tabs.test.ts
+++ b/lemma-frontend/lib/pods/workspace-tabs.test.ts
@@ -220,6 +220,43 @@ describe('pod workspace tabs', () => {
         expect(getActiveWorkspaceTabId('pod-1', '/pod/pod-1/settings')).toBe('route:settings');
     });
 
+    it('gives every presented widget its own tab', () => {
+        const widgetPath = '/pod/pod-1/widgets/view';
+        const first = getActiveWorkspaceTabId(
+            'pod-1',
+            widgetPath,
+            null,
+            new URLSearchParams('toolCallId=toolu_01AAA&standalone=1'),
+        );
+        const second = getActiveWorkspaceTabId(
+            'pod-1',
+            widgetPath,
+            null,
+            new URLSearchParams('toolCallId=toolu_01BBB&standalone=1'),
+        );
+
+        expect(first).toBe('route:widget-toolu_01AAA');
+        // Two widgets are two things to hold open, not one tab that gets
+        // overwritten the second time you open one.
+        expect(second).not.toBe(first);
+
+        // Without a tool call there is no widget to key on, so it stays the
+        // plain section tab rather than inventing an identity.
+        expect(getActiveWorkspaceTabId('pod-1', widgetPath)).toBe('route:widgets');
+    });
+
+    it('keeps a widget tab pointing at its own widget', () => {
+        const tab = routeWorkspaceTab(
+            'widget-toolu_01AAA',
+            'Revenue by region',
+            '/pod/pod-1/widgets/view?toolCallId=toolu_01AAA&title=Revenue+by+region',
+        );
+
+        expect(tab.id).toBe('route:widget-toolu_01AAA');
+        expect(tab.title).toBe('Revenue by region');
+        expect(parseWorkspaceTabs(serializeWorkspaceTabs([HOME_WORKSPACE_TAB, tab]))[1]).toEqual(tab);
+    });
+
     it('does not persist stale conversation activity', () => {
         const tabs: PodWorkspaceTab[] = [
             HOME_WORKSPACE_TAB,

--- a/lemma-frontend/lib/pods/workspace-tabs.ts
+++ b/lemma-frontend/lib/pods/workspace-tabs.ts
@@ -107,6 +107,24 @@ function safeWorkspaceHref(value: string) {
     return buildConversationStandaloneResourceHref(value) ?? '/';
 }
 
+const WIDGET_VIEW_SUFFIX = '/widgets/view';
+
+/**
+ * Route tabs are keyed by section, so a section opens one tab and navigating
+ * within it moves that tab along — one Data tab, one Files tab. A presented
+ * widget is not a section: each one is its own artifact, and two of them are
+ * two things to hold open. Key those by the tool call that produced them so
+ * opening a second widget adds a tab instead of overwriting the first.
+ */
+export function widgetWorkspaceRouteKey(toolCallId: string) {
+    const cleaned = toolCallId.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '');
+    return cleaned ? `widget-${cleaned}` : 'widgets';
+}
+
+export function isWidgetWorkspaceRouteKey(routeKey: string) {
+    return routeKey.startsWith('widget-');
+}
+
 export function routeWorkspaceTab(
     routeKey: string,
     title: string,
@@ -369,6 +387,7 @@ export function getActiveWorkspaceTabId(
     podId: string,
     pathname: string,
     appSlug?: string | null,
+    searchParams?: URLSearchParams | null,
 ): string | null {
     if (pathname === `/pod/${podId}` || pathname === `/pod/${podId}/`) return HOME_WORKSPACE_TAB.id;
 
@@ -389,6 +408,11 @@ export function getActiveWorkspaceTabId(
     }
 
     const base = `/pod/${podId}`;
+    if (pathname === `${base}${WIDGET_VIEW_SUFFIX}`) {
+        const toolCallId = searchParams?.get('toolCallId')?.trim();
+        if (toolCallId) return `route:${widgetWorkspaceRouteKey(toolCallId)}`;
+    }
+
     const section = pathname.slice(base.length).split('/').filter(Boolean)[0];
     if (!section) return HOME_WORKSPACE_TAB.id;
     return `route:${getWorkspaceRouteKey(section)}`;


### PR DESCRIPTION
## What changes

An inline widget in a conversation now renders at its own height instead of being cut off at a flat 480px, and it gets an overflow menu in its top corner with **Open in new tab** (a tab in the pod's workspace strip) and **Open full view** (the existing presentation stage).

Two widgets opened as tabs are now two tabs, not one that overwrites itself.

## Why

**The height.** 480px was too small for the thing it was cutting. A metrics strip, a list, a record detail, a chart all land between roughly 400 and 900px, so the common case was seeing almost all of an answer and still having to click for the rest. A widget *is* the answer, not a preview of one.

The cap is now a share of the viewport (85%, floored at 480), so anything shaped like a normal widget renders whole and only genuinely huge ones still fade. A ceiling stays on purpose: the reported height is clamped to 2400px on arrival, and a card that tall puts the next message three screens away — you would page through an iframe to get back to the conversation. Growth after load was already handled, since the transcript anchors on the row and corrects on resize.

**The tab.** The widget had no way out of the thread except Expand, which opens the presentation stage *inside* the conversation. Opening one as a pod tab is a plain navigation, because the tab strip derives itself from the URL — but route tabs are keyed by *section* (one Data tab, one Files tab, moving along as you navigate within it). Widgets inherited that, so every widget would collapse into a single "Presented Widget" tab and opening a second would silently overwrite the first. That makes "open in new tab" untrue the second time you use it.

Widget tabs are therefore keyed by the tool call that produced them, and the widget's name rides along in the link so the strip can tell them apart. Every other section keeps section keying.

## How to verify

```bash
cd lemma-frontend && npx tsc --noEmit -p tsconfig.json && npx eslint . && npx vitest run
```

```
tsc    — clean
eslint — clean (exit 0)
vitest — 80 files passed, 792 tests passed
```

The two new cases are in `lib/pods/workspace-tabs.test.ts`: one asserts two tool calls produce two distinct tab ids (and that a widget route without a tool call falls back to the plain `route:widgets` section tab), one asserts a widget tab keeps its own href and title across the localStorage round trip.

In the app: open a conversation where the agent presented a widget, hover it, and use the 3-dot. Opening two different widgets should give you two tabs, each named after its widget rather than "Presented Widget".

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

`make quality` is backend-only (ruff, async-safety, DB connection scope, I/O hygiene), so it does not apply to this diff; the frontend gates above are the relevant ones and all pass.

## Notes for the reviewer

Two things worth a look:

1. **`getActiveWorkspaceTabId` gained a fourth parameter** (`searchParams`), because a widget is identified by its tool call and that lives in the query rather than the path. It is optional, so every existing call site and test is unaffected.

2. **The overflow-menu trigger is `pointer-events-none` while hidden.** Widgets draw edge to edge and own their top-right corner, so an invisible button sitting there would otherwise swallow clicks meant for the widget's own controls. It becomes visible and clickable on hover anywhere over the widget, and is still keyboard-focusable.

I could not verify the tab behavior end to end in a running app — it needs a signed-in session against a real pod with an agent-presented widget. Everything above is typecheck, lint, and unit coverage.

## Compatibility and rollback notes

Frontend only — no migration, no API surface change, no SDK regeneration. Widget tab ids persist to `localStorage` under the existing versioned key; the parser already drops entries it does not recognise, so a revert simply stops producing per-widget tabs and any stored ones fall away. Straight revert, nothing to coordinate.
