### PR TITLE
Give Agent Host tool calls their arguments back, and stop a message waiting 4s to start

### DIFF
--- a/desktop/agent-host/src/acp.rs
+++ b/desktop/agent-host/src/acp.rs
@@ -301,7 +301,7 @@ impl AgentDriver for AcpDriver {
                 // lets the agent answer "what did I just say" instead of meeting
                 // the user again every turn.
                 let mut established = None;
-                let resumed = resume_session_id.is_some();
+                let attempted_resume = resume_session_id.is_some();
                 if let Some(existing) = resume_session_id {
                     match connection
                         .send_request(
@@ -324,6 +324,18 @@ impl AgentDriver for AcpDriver {
                         ),
                     }
                 }
+                // Captured against the branch it describes, so the two cannot
+                // drift. `attempted_resume` is not the same fact: it says what
+                // this run meant to do, and is decided before the load. Only
+                // this says what the agent is actually holding — and a load
+                // that failed leaves a session that is new no matter what Lemma
+                // expected, which is exactly the case that has to keep its
+                // instructions.
+                let origin = if established.is_some() {
+                    SessionOrigin::Loaded
+                } else {
+                    SessionOrigin::New
+                };
                 let (session_id, config_options) = if let Some(established) = established {
                     established
                 } else {
@@ -352,7 +364,8 @@ impl AgentDriver for AcpDriver {
                         tracing::info!(
                             harness = %adapter_key,
                             published = published_config_options.len(),
-                            resumed,
+                            attempted_resume,
+                            origin = origin.as_str(),
                             "session reported no configuration; using the probed options"
                         );
                     }
@@ -468,7 +481,7 @@ impl AgentDriver for AcpDriver {
                 let turn = connection
                     .send_request(PromptRequest::new(
                         session_id.clone(),
-                        prompt_blocks(&run_spec),
+                        prompt_blocks(&run_spec, origin),
                     ))
                     .block_task();
                 tokio::pin!(turn);
@@ -647,8 +660,16 @@ fn build_agent(adapter: &ResolvedAdapter) -> AcpAgent {
 /// or an embedded resource means silently dropped: `PromptRequest` takes a
 /// `Vec<ContentBlock>` precisely so those can travel, and a block this build
 /// cannot parse falls back to its text rather than disappearing.
-fn prompt_blocks(spec: &RunSpec) -> Vec<ContentBlock> {
-    let mut blocks = vec![ContentBlock::Text(TextContent::new(render_prompt(spec)))];
+fn prompt_blocks(spec: &RunSpec, origin: SessionOrigin) -> Vec<ContentBlock> {
+    let mut blocks = Vec::new();
+    let text = render_prompt(spec, origin);
+    // Only when there is something to say. The system block used to guarantee
+    // this was non-empty, and now that it is conditional an image-only turn on
+    // a resumed session would otherwise open with an empty text block — which
+    // not every adapter accepts.
+    if !text.is_empty() {
+        blocks.push(ContentBlock::Text(TextContent::new(text)));
+    }
     blocks.extend(spec.prompt.iter().filter_map(structured_block));
     blocks
 }
@@ -672,9 +693,46 @@ fn structured_block(value: &Value) -> Option<ContentBlock> {
     }
 }
 
-fn render_prompt(spec: &RunSpec) -> String {
+/// Whether the session this turn is about to prompt was opened or resumed.
+///
+/// Not the same question as "did Lemma ask us to resume": a provider is free to
+/// forget a session, so a resume Lemma expected can still end in a new one.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum SessionOrigin {
+    New,
+    Loaded,
+}
+
+impl SessionOrigin {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::New => "new",
+            Self::Loaded => "loaded",
+        }
+    }
+}
+
+/// Whether this turn has to carry Lemma's instructions.
+///
+/// A conversation is one provider session, and the session keeps its own
+/// history — so instructions delivered on the turn that opened it are still
+/// there on every later turn. Re-sending them each time put another copy of a
+/// multi-kilobyte block into the provider's transcript per message, which the
+/// model then re-reads in full on every turn after.
+///
+/// Two independent reasons to send them anyway, and both matter. A new session
+/// has never seen them — including the case Lemma cannot predict, where a
+/// `session/load` it expected to succeed failed and left us with a fresh
+/// session that has neither history nor instructions. And Lemma asks outright
+/// when the instructions have changed since the session was told them, because
+/// a user can edit an agent mid-conversation.
+fn sends_instructions(spec: &RunSpec, origin: SessionOrigin) -> bool {
+    origin == SessionOrigin::New || spec.instructions_every_turn()
+}
+
+fn render_prompt(spec: &RunSpec, origin: SessionOrigin) -> String {
     let mut sections = Vec::new();
-    if !spec.system_prompt.trim().is_empty() {
+    if sends_instructions(spec, origin) && !spec.system_prompt.trim().is_empty() {
         sections.push(format!(
             "<system>\n{}\n</system>",
             spec.system_prompt.trim()
@@ -714,7 +772,15 @@ fn extract_text(value: &Value) -> Option<String> {
     }
 }
 
-fn normalize_session_update(
+/// One ACP session update as the event Lemma stores.
+///
+/// Public so `tests/wire_contract.rs` can hold it to the same shared fixture
+/// the backend's tool-call reader is held to. The two halves are separable and
+/// both load-bearing: this one promises that nothing an adapter reported is
+/// dropped on the way, and the backend's promises that it is read back out of
+/// the fields it landed in.
+#[must_use]
+pub fn normalize_session_update(
     update: &agent_client_protocol::schema::v1::SessionUpdate,
 ) -> Option<(EventType, Option<String>, JsonMap)> {
     let mut value = serde_json::to_value(update).ok()?;
@@ -1322,7 +1388,7 @@ mod tests {
             }),
         ];
 
-        let blocks = prompt_blocks(&spec);
+        let blocks = prompt_blocks(&spec, SessionOrigin::New);
 
         assert_eq!(blocks.len(), 2, "expected the text block and the image");
         assert!(matches!(blocks[0], ContentBlock::Text(_)));
@@ -1340,7 +1406,7 @@ mod tests {
         spec.system_prompt = "Be brief.".to_owned();
         spec.prompt = vec![serde_json::json!({"type": "text", "text": "Hello."})];
 
-        let blocks = prompt_blocks(&spec);
+        let blocks = prompt_blocks(&spec, SessionOrigin::New);
 
         assert_eq!(blocks.len(), 1);
         let ContentBlock::Text(text) = &blocks[0] else {
@@ -1348,6 +1414,71 @@ mod tests {
         };
         assert!(text.text.contains("Be brief."));
         assert!(text.text.contains("Hello."));
+    }
+
+    fn spec_delivered_once() -> RunSpec {
+        let mut spec = spec_resuming(Some("sess-1"));
+        spec.system_prompt_delivery = Some(crate::protocol::NEW_SESSION_ONLY.to_owned());
+        spec
+    }
+
+    /// A conversation is one provider session, and that session keeps its own
+    /// history — so instructions delivered when it opened are still there.
+    #[test]
+    fn a_resumed_turn_leaves_out_instructions_the_session_already_has() {
+        let rendered = render_prompt(&spec_delivered_once(), SessionOrigin::Loaded);
+
+        assert_eq!(rendered, "Hello");
+        assert!(!rendered.contains("<system>"));
+    }
+
+    /// The case Lemma cannot predict, and the reason this decision lives here.
+    ///
+    /// A provider is free to forget a session, so a `session/load` Lemma fully
+    /// expected to succeed can still leave us opening a fresh one. That session
+    /// has never seen the instructions, and Lemma has no way to know in
+    /// advance — deciding this at dispatch would produce a turn with neither
+    /// history nor instructions, which is the worst outcome available.
+    #[test]
+    fn a_session_that_had_to_be_recreated_still_gets_its_instructions() {
+        let rendered = render_prompt(&spec_delivered_once(), SessionOrigin::New);
+
+        assert!(
+            rendered.contains("<system>"),
+            "a session opened after a failed load has never seen them"
+        );
+    }
+
+    /// Absent or unrecognised means send them. An older Lemma does not set the
+    /// field at all, and a newer one may name a policy this build predates;
+    /// both have to degrade to the behaviour that is merely wasteful rather
+    /// than the one that silently un-instructs the agent.
+    #[test]
+    fn an_unknown_delivery_policy_still_sends_the_instructions() {
+        let mut absent = spec_resuming(Some("sess-1"));
+        absent.system_prompt_delivery = None;
+        assert!(render_prompt(&absent, SessionOrigin::Loaded).contains("<system>"));
+
+        let mut unknown = spec_resuming(Some("sess-1"));
+        unknown.system_prompt_delivery = Some("EVERY_THIRD_TUESDAY".to_owned());
+        assert!(render_prompt(&unknown, SessionOrigin::Loaded).contains("<system>"));
+    }
+
+    /// With the system block conditional, a turn can now render to nothing —
+    /// and an empty leading text block is not something every adapter accepts.
+    #[test]
+    fn a_resumed_image_only_turn_sends_no_empty_text_block() {
+        let mut spec = spec_delivered_once();
+        spec.prompt = vec![serde_json::json!({
+            "type": "image",
+            "data": "aGk=",
+            "mimeType": "image/png",
+        })];
+
+        let blocks = prompt_blocks(&spec, SessionOrigin::Loaded);
+
+        assert_eq!(blocks.len(), 1, "only the image should have been sent");
+        assert!(matches!(blocks[0], ContentBlock::Image(_)));
     }
 
     /// A block shape this build cannot parse must not take the turn down with
@@ -1360,7 +1491,7 @@ mod tests {
             serde_json::json!({"type": "something_new", "payload": 1}),
         ];
 
-        let blocks = prompt_blocks(&spec);
+        let blocks = prompt_blocks(&spec, SessionOrigin::New);
 
         assert_eq!(blocks.len(), 1);
     }
@@ -1390,13 +1521,14 @@ mod tests {
             context: JsonMap::new(),
             mcp: serde_json::Value::Null,
             run_deadline: chrono::Utc::now(),
+            system_prompt_delivery: None,
         }
     }
 
     #[test]
     fn prompt_rendering_keeps_system_and_text() {
         assert_eq!(
-            render_prompt(&spec_resuming(None)),
+            render_prompt(&spec_resuming(None), SessionOrigin::New),
             "<system>\nBe exact.\n</system>\n\nHello"
         );
     }

--- a/desktop/agent-host/src/journal.rs
+++ b/desktop/agent-host/src/journal.rs
@@ -1241,6 +1241,7 @@ mod tests {
                 "authorization": "Bearer test"
             }),
             run_deadline: Utc::now() + ChronoDuration::minutes(5),
+            system_prompt_delivery: None,
         };
         let payload = serde_json::to_value(&spec).unwrap();
         let command = Command {

--- a/desktop/agent-host/src/main.rs
+++ b/desktop/agent-host/src/main.rs
@@ -429,6 +429,7 @@ async fn main() -> anyhow::Result<()> {
                 context: JsonMap::new(),
                 mcp: Value::Null,
                 run_deadline: chrono::Utc::now() + chrono::Duration::minutes(10),
+                system_prompt_delivery: None,
             };
             let outcome = AcpDriver
                 .run(

--- a/desktop/agent-host/src/protocol.rs
+++ b/desktop/agent-host/src/protocol.rs
@@ -253,6 +253,27 @@ pub struct RunSpec {
     #[serde(default)]
     pub mcp: Value,
     pub run_deadline: DateTime<Utc>,
+    /// Whether Lemma still needs this turn to carry `system_prompt`.
+    ///
+    /// `NEW_SESSION_ONLY` means the session Lemma expects to resume has already
+    /// been told these exact instructions, so a resumed turn can leave them
+    /// out; anything else, including absent, means send them. Deliberately a
+    /// loose string rather than a typed enum: an unrecognised value has to
+    /// degrade to "send them", and a run spec that fails to deserialize is a
+    /// run that never happens at all.
+    #[serde(default)]
+    pub system_prompt_delivery: Option<String>,
+}
+
+/// The one value that lets a turn leave the instructions out.
+pub const NEW_SESSION_ONLY: &str = "NEW_SESSION_ONLY";
+
+impl RunSpec {
+    /// Whether Lemma wants the instructions on this turn regardless of session.
+    #[must_use]
+    pub fn instructions_every_turn(&self) -> bool {
+        self.system_prompt_delivery.as_deref() != Some(NEW_SESSION_ONLY)
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/desktop/agent-host/src/runtime.rs
+++ b/desktop/agent-host/src/runtime.rs
@@ -413,9 +413,9 @@ struct TargetWorker {
     probes: HashMap<String, ProbedHarness>,
     active_runs: HashMap<Uuid, ActiveRun>,
     permissions: PermissionGate,
-    /// Runs whose event batches Lemma has rejected, and how often. Kept per
-    /// run so one unhappy run cannot stop the target's poll loop.
-    event_rejections: HashMap<Uuid, u32>,
+    /// Event delivery, shared with the task that drives it. Behind a lock so a
+    /// shutdown flush and the delivery task cannot send the same batch twice.
+    flusher: Arc<tokio::sync::Mutex<EventFlusher>>,
     /// Runs whose liveness checkpoints Lemma refuses, and how many more polls
     /// they sit out before trying again. Their leases meanwhile fall to the
     /// server's own expiry recovery; their terminal states are never given up
@@ -447,6 +447,153 @@ struct TargetWorker {
         mpsc::UnboundedSender<Option<ProbedHarnesses>>,
         mpsc::UnboundedReceiver<Option<ProbedHarnesses>>,
     ),
+}
+
+/// Delivery of journaled events to Lemma, off the poll loop.
+///
+/// Owns everything that delivery touches — the journal, the client, and how
+/// often each run's batches have been refused — so it can run as its own task
+/// while the poll loop holds its poll open.
+///
+/// That separation is the whole point. Flushing used to be an arm of the same
+/// `select!` as the poll, so every event a run streamed abandoned the poll in
+/// flight and opened a new one. The server had no idea the old one was gone and
+/// held it for the rest of its 25 seconds: one host streaming a single answer
+/// was measured stacking 26 concurrent polls, against exactly one while idle.
+struct EventFlusher {
+    target_id: Uuid,
+    journal: Journal,
+    client: TargetClient,
+    /// Runs whose event batches Lemma has rejected, and how often. Kept per
+    /// run so one unhappy run cannot stop delivery for every other.
+    rejections: HashMap<Uuid, u32>,
+}
+
+impl EventFlusher {
+    /// Hand journaled events to Lemma, keeping each run's failures to itself.
+    ///
+    /// Only a target-level failure -- unreachable, unauthenticated, throttled,
+    /// server fault -- is returned as an error. A batch Lemma rejects on its own
+    /// merits belongs to exactly one run, so it is contained there: the poll
+    /// loop must still poll, because the poll is what heartbeats the lease of
+    /// every *other* run on this host.
+    async fn flush(&mut self) -> anyhow::Result<()> {
+        let target_id = self.target_id;
+        // Runs whose remaining batches this pass must leave alone, because the
+        // journal no longer matches the batches read at the top of the loop.
+        let mut stale = HashSet::new();
+        for batch in self.journal.pending_events(target_id, 1024)? {
+            let Some(first) = batch.events.first() else {
+                continue;
+            };
+            let (run_id, lease_epoch) = (first.run_id, first.lease_epoch);
+            if stale.contains(&run_id) {
+                continue;
+            }
+            if self.rejections.get(&run_id).copied().unwrap_or(0) >= MAX_EVENT_REJECTIONS {
+                let dropped = self
+                    .journal
+                    .discard_events(target_id, run_id, lease_epoch)?;
+                stale.insert(run_id);
+                tracing::warn!(
+                    %run_id,
+                    dropped,
+                    "dropping events Lemma will not accept for this run"
+                );
+                continue;
+            }
+            match self.client.append_events(&batch).await {
+                Ok(ack) => {
+                    self.rejections.remove(&run_id);
+                    self.journal.acknowledge_events(target_id, &ack)?;
+                }
+                Err(error) if error.is_request_rejected() => {
+                    stale.insert(run_id);
+                    self.reject_run_events(run_id, lease_epoch, &error)?;
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Ok(())
+    }
+
+    /// Contain a run whose event batch Lemma refused.
+    ///
+    /// The first refusal is treated as a lost server-side stream, which is the
+    /// only recoverable cause: the stream is transient and its watermark drops
+    /// to zero when it is evicted, so it starts expecting sequence 1 again from
+    /// a run that is far past it. Replaying the run's retained events answers
+    /// exactly that, and is safe against every other cause because the server
+    /// keeps the first write for a sequence it already holds.
+    fn reject_run_events(
+        &mut self,
+        run_id: Uuid,
+        lease_epoch: u32,
+        error: &crate::api::ApiError,
+    ) -> anyhow::Result<()> {
+        let rejections = self.rejections.entry(run_id).or_default();
+        *rejections += 1;
+        if *rejections >= MAX_EVENT_REJECTIONS {
+            tracing::error!(
+                %run_id,
+                error = %redact_error(&error.to_string()),
+                "Lemma rejected this run's events after a replay; giving up on its transcript"
+            );
+            return Ok(());
+        }
+        let replayed = self
+            .journal
+            .rewind_acknowledgements(self.target_id, run_id, lease_epoch)?;
+        tracing::warn!(
+            %run_id,
+            replayed,
+            error = %redact_error(&error.to_string()),
+            "Lemma rejected this run's events; replaying its journaled history"
+        );
+        Ok(())
+    }
+}
+
+/// Deliver events as they are journaled, until the host shuts down.
+///
+/// A run's output reaching Lemma is not something the poll loop should be able
+/// to delay, and not something that should be able to disturb the poll: this
+/// waits on the same `events_ready` the run tasks raise, and takes the lock the
+/// shutdown flush also takes, so the two can never be in flight together.
+///
+/// Failures are logged and retried rather than reported: the poll loop is the
+/// one authority on whether this target is reachable, and having two writers of
+/// the connection state produced an ONLINE/OFFLINE flap between them.
+async fn deliver_events(
+    flusher: Arc<tokio::sync::Mutex<EventFlusher>>,
+    events_ready: Arc<tokio::sync::Notify>,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    let mut retry = RETRY_MIN;
+    loop {
+        tokio::select! {
+            () = events_ready.notified() => {}
+            _ = shutdown.changed() => return,
+        }
+        if *shutdown.borrow() {
+            return;
+        }
+        match flusher.lock().await.flush().await {
+            Ok(()) => retry = RETRY_MIN,
+            Err(error) => {
+                tracing::debug!(%error, "could not deliver Agent Host events; retrying");
+                tokio::select! {
+                    () = tokio::time::sleep(retry) => {}
+                    _ = shutdown.changed() => return,
+                }
+                retry = (retry * 2).min(RETRY_MAX);
+                // Nothing consumed the notification that brought us here, so
+                // re-raise it: the events are still pending and the next pass
+                // has to be woken by something.
+                events_ready.notify_one();
+            }
+        }
+    }
 }
 
 /// One run in flight, and the two ways it can be stopped.
@@ -497,6 +644,12 @@ impl TargetWorker {
         let client = TargetClient::new(target.clone(), installation_id)?;
         journal.register_target(target.target_id)?;
         let draining = target.draining;
+        let flusher = Arc::new(tokio::sync::Mutex::new(EventFlusher {
+            target_id: target.target_id,
+            journal: journal.clone(),
+            client: client.clone(),
+            rejections: HashMap::new(),
+        }));
         Ok(Self {
             target,
             client,
@@ -512,7 +665,7 @@ impl TargetWorker {
             probes: HashMap::new(),
             active_runs: HashMap::new(),
             permissions: PermissionGate::new(),
-            event_rejections: HashMap::new(),
+            flusher,
             refused_heartbeats: HashMap::new(),
             draining,
             refresh_due: std::time::Instant::now(),
@@ -527,6 +680,21 @@ impl TargetWorker {
 
     async fn run(mut self) -> anyhow::Result<()> {
         self.recover_interrupted_runs()?;
+        // Event delivery runs alongside the poll rather than competing with it.
+        // Aborted at the end of this function; the shutdown path takes the same
+        // lock and does the last flush itself, so nothing in the journal is left
+        // behind by stopping it.
+        let delivery = tokio::spawn(deliver_events(
+            Arc::clone(&self.flusher),
+            Arc::clone(&self.events_ready),
+            self.shutdown.clone(),
+        ));
+        let outcome = self.poll_loop().await;
+        delivery.abort();
+        outcome
+    }
+
+    async fn poll_loop(&mut self) -> anyhow::Result<()> {
         let mut retry = RETRY_MIN;
         // Cloned out of `self` once, so the select below can await it without
         // borrowing `self` twice. A `watch` receiver tracks versions rather than
@@ -558,6 +726,11 @@ impl TargetWorker {
                 self.refresh_harnesses();
                 self.refresh_due = std::time::Instant::now() + HARNESS_REFRESH_INTERVAL;
             }
+            // `deliver_events` is what normally sends these, and it does so
+            // without waiting for the loop to come back around. This pass is
+            // the backstop and the connection check: it is the one place a
+            // delivery failure is turned into OFFLINE, because two writers of
+            // that state flapped it between them.
             if let Err(error) = self.flush_events().await {
                 self.note_offline(&error.to_string())?;
                 self.wait_retry(retry).await;
@@ -578,17 +751,18 @@ impl TargetWorker {
             // is not something that happens on a schedule, it is something that
             // happens when the poll returns.
             //
-            // Both of the other arms abandon a poll that is mid-flight, which is
-            // the point of them and costs nothing: the poll is a lease-based
-            // pull, so anything the server was about to hand over is handed over
-            // by the next one.
-            let events_ready = Arc::clone(&self.events_ready);
+            // Waking here abandons the poll in flight. That is cheap for the
+            // host — the poll is a lease-based pull, so anything the server was
+            // about to hand over comes back on the next one — but it is not free
+            // for the server, which goes on holding the abandoned poll for the
+            // rest of its hold. So an arm has to be worth a stranded poll.
+            //
+            // A run's streamed output emphatically is not: it arrives dozens of
+            // times per turn, and putting it here stacked 26 concurrent polls
+            // against one idle. It has its own task now — see `deliver_events`.
+            // An agent being installed or removed happens approximately never.
             let polled = tokio::select! {
-                // A run finishing inside the hold used to have its output sit in
-                // the journal until the poll returned — the agent answered in 8s
-                // and the conversation still waited 20+.
                 result = self.poll_target(capacity) => Some(result),
-                () = events_ready.notified() => None,
                 // The agents on this machine changed. This is what makes
                 // `DISK_SCAN_INTERVAL` mean what it says: the scan itself was
                 // always cheap, but it used to be *reached* once per iteration,
@@ -1607,87 +1781,9 @@ impl TargetWorker {
         settled
     }
 
-    /// Hand journaled events to Lemma, keeping each run's failures to itself.
-    ///
-    /// Only a target-level failure -- unreachable, unauthenticated, throttled,
-    /// server fault -- is returned as an error. A batch Lemma rejects on its own
-    /// merits belongs to exactly one run, so it is contained there: the caller
-    /// must still poll, because the poll is what heartbeats the lease of every
-    /// *other* run on this host.
+    /// Hand journaled events to Lemma. See [`EventFlusher::flush`].
     async fn flush_events(&mut self) -> anyhow::Result<()> {
-        let target_id = self.target.target_id;
-        // Runs whose remaining batches this pass must leave alone, because the
-        // journal no longer matches the batches read at the top of the loop.
-        let mut stale = HashSet::new();
-        for batch in self.journal.pending_events(target_id, 1024)? {
-            let Some(first) = batch.events.first() else {
-                continue;
-            };
-            let (run_id, lease_epoch) = (first.run_id, first.lease_epoch);
-            if stale.contains(&run_id) {
-                continue;
-            }
-            if self.event_rejections.get(&run_id).copied().unwrap_or(0) >= MAX_EVENT_REJECTIONS {
-                let dropped = self
-                    .journal
-                    .discard_events(target_id, run_id, lease_epoch)?;
-                stale.insert(run_id);
-                tracing::warn!(
-                    %run_id,
-                    dropped,
-                    "dropping events Lemma will not accept for this run"
-                );
-                continue;
-            }
-            match self.client.append_events(&batch).await {
-                Ok(ack) => {
-                    self.event_rejections.remove(&run_id);
-                    self.journal.acknowledge_events(target_id, &ack)?;
-                }
-                Err(error) if error.is_request_rejected() => {
-                    stale.insert(run_id);
-                    self.reject_run_events(run_id, lease_epoch, &error)?;
-                }
-                Err(error) => return Err(error.into()),
-            }
-        }
-        Ok(())
-    }
-
-    /// Contain a run whose event batch Lemma refused.
-    ///
-    /// The first refusal is treated as a lost server-side stream, which is the
-    /// only recoverable cause: the stream is transient and its watermark drops
-    /// to zero when it is evicted, so it starts expecting sequence 1 again from
-    /// a run that is far past it. Replaying the run's retained events answers
-    /// exactly that, and is safe against every other cause because the server
-    /// keeps the first write for a sequence it already holds.
-    fn reject_run_events(
-        &mut self,
-        run_id: Uuid,
-        lease_epoch: u32,
-        error: &crate::api::ApiError,
-    ) -> anyhow::Result<()> {
-        let rejections = self.event_rejections.entry(run_id).or_default();
-        *rejections += 1;
-        if *rejections >= MAX_EVENT_REJECTIONS {
-            tracing::error!(
-                %run_id,
-                error = %redact_error(&error.to_string()),
-                "Lemma rejected this run's events after a replay; giving up on its transcript"
-            );
-            return Ok(());
-        }
-        let replayed =
-            self.journal
-                .rewind_acknowledgements(self.target.target_id, run_id, lease_epoch)?;
-        tracing::warn!(
-            %run_id,
-            replayed,
-            error = %redact_error(&error.to_string()),
-            "Lemma rejected this run's events; replaying its journaled history"
-        );
-        Ok(())
+        self.flusher.lock().await.flush().await
     }
 
     async fn reap_finished(&mut self) {
@@ -2341,7 +2437,7 @@ mod target_worker_tests {
     use tokio::sync::{Semaphore, watch};
     use uuid::Uuid;
 
-    use super::TargetWorker;
+    use super::{TargetWorker, deliver_events};
     use crate::acp::{AcpCallbacks, AcpProbeOutcome, AcpRunOutcome, AcpRunRequest, AgentDriver};
     use crate::adapters::{AdapterManifest, ResolvedAdapter};
     use crate::config::{HostPaths, TargetConfig};
@@ -2544,6 +2640,7 @@ mod target_worker_tests {
                 context: JsonMap::new(),
                 mcp: serde_json::json!({}),
                 run_deadline: Utc::now() + chrono::Duration::minutes(5),
+                system_prompt_delivery: None,
             };
             let command = Command {
                 command_id: Uuid::new_v4(),
@@ -2597,6 +2694,101 @@ mod target_worker_tests {
         fn drop(&mut self) {
             self.server.abort();
         }
+    }
+
+    /// Wait for `predicate`, or fail rather than hang.
+    async fn within(budget: Duration, what: &str, predicate: impl Fn() -> bool) {
+        let deadline = tokio::time::Instant::now() + budget;
+        while tokio::time::Instant::now() < deadline {
+            if predicate() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("timed out waiting for {what}");
+    }
+
+    /// The finding: a run's output reached Lemma only by abandoning the poll.
+    ///
+    /// Delivery used to be an arm of the same `select!` as the poll, so every
+    /// event a run streamed cancelled the poll in flight and opened a new one.
+    /// The server never learned the old one was gone and held it for the rest
+    /// of its 25 seconds — one host streaming a single answer stacked 26
+    /// concurrent polls against exactly one while idle.
+    ///
+    /// This drives delivery with no poll running at all, which is only a
+    /// meaningful thing to ask because the two are now independent.
+    #[tokio::test]
+    async fn a_runs_events_reach_lemma_with_no_poll_involved() {
+        let harness = Harness::new().await;
+        let run_id = harness.seed_run(3);
+
+        let (_shutdown_tx, shutdown) = watch::channel(false);
+        let delivery = tokio::spawn(deliver_events(
+            Arc::clone(&harness.worker.flusher),
+            Arc::clone(&harness.worker.events_ready),
+            shutdown,
+        ));
+        // Exactly what a run task does the moment it journals an event.
+        harness.worker.events_ready.notify_one();
+
+        within(Duration::from_secs(5), "the run's events to reach Lemma", || {
+            harness.accepted().get(&run_id) == Some(&3)
+        })
+        .await;
+        assert!(harness.pending(run_id).is_empty());
+
+        // And it keeps serving. A run streams for its whole turn, so delivering
+        // the first batch and then going quiet until the poll came back is the
+        // same defect in a different place.
+        for _ in 0..4 {
+            harness
+                .journal
+                .append_event(
+                    harness.target_id,
+                    run_id,
+                    1,
+                    EventType::AgentMessageChunk,
+                    None,
+                    JsonMap::new(),
+                )
+                .unwrap();
+        }
+        harness.worker.events_ready.notify_one();
+
+        within(Duration::from_secs(5), "later events to reach Lemma", || {
+            harness.accepted().get(&run_id) == Some(&7)
+        })
+        .await;
+        assert!(harness.pending(run_id).is_empty());
+
+        delivery.abort();
+    }
+
+    /// Shutting the loop down must not strand what the journal still holds.
+    ///
+    /// The delivery task is aborted when the poll loop ends, so the last flush
+    /// belongs to the shutdown path. Both take the same lock, which is what
+    /// stops them sending one batch twice.
+    #[tokio::test]
+    async fn events_journaled_after_delivery_stops_are_still_sent() {
+        let mut harness = Harness::new().await;
+
+        let (shutdown_tx, shutdown) = watch::channel(false);
+        let delivery = tokio::spawn(deliver_events(
+            Arc::clone(&harness.worker.flusher),
+            Arc::clone(&harness.worker.events_ready),
+            shutdown,
+        ));
+        let _ = shutdown_tx.send(true);
+        let _ = delivery.await;
+
+        // Journaled with nothing left running to notice.
+        let run_id = harness.seed_run(2);
+        harness.worker.flush_events().await.unwrap();
+
+        assert_eq!(harness.accepted().get(&run_id), Some(&2));
+        assert!(harness.pending(run_id).is_empty());
     }
 
     /// The finding: one run Lemma refuses used to abort the whole flush and
@@ -3215,6 +3407,7 @@ mod stream_upsert_tests {
             context: JsonMap::new(),
             mcp: Value::Null,
             run_deadline: Utc::now() + chrono::Duration::minutes(5),
+            system_prompt_delivery: None,
         };
         let command = Command {
             command_id: Uuid::new_v4(),

--- a/desktop/agent-host/src/runtime.rs
+++ b/desktop/agent-host/src/runtime.rs
@@ -2732,9 +2732,11 @@ mod target_worker_tests {
         // Exactly what a run task does the moment it journals an event.
         harness.worker.events_ready.notify_one();
 
-        within(Duration::from_secs(5), "the run's events to reach Lemma", || {
-            harness.accepted().get(&run_id) == Some(&3)
-        })
+        within(
+            Duration::from_secs(5),
+            "the run's events to reach Lemma",
+            || harness.accepted().get(&run_id) == Some(&3),
+        )
         .await;
         assert!(harness.pending(run_id).is_empty());
 
@@ -2756,9 +2758,11 @@ mod target_worker_tests {
         }
         harness.worker.events_ready.notify_one();
 
-        within(Duration::from_secs(5), "later events to reach Lemma", || {
-            harness.accepted().get(&run_id) == Some(&7)
-        })
+        within(
+            Duration::from_secs(5),
+            "later events to reach Lemma",
+            || harness.accepted().get(&run_id) == Some(&7),
+        )
         .await;
         assert!(harness.pending(run_id).is_empty());
 

--- a/desktop/agent-host/tests/acp_process_e2e.rs
+++ b/desktop/agent-host/tests/acp_process_e2e.rs
@@ -122,6 +122,7 @@ async fn official_sdk_negotiates_probes_config_and_streams_a_prompt() {
                     context: BTreeMap::new(),
                     mcp: Value::Null,
                     run_deadline: chrono::Utc::now() + chrono::Duration::minutes(1),
+                    system_prompt_delivery: None,
                 },
                 scratch_directory: directory.path().join("run"),
                 mcp_server: None,

--- a/desktop/agent-host/tests/fixtures/wire_contract.json
+++ b/desktop/agent-host/tests/fixtures/wire_contract.json
@@ -13,7 +13,16 @@
     "event_text`. These must agree exactly: the host accumulates streamed text",
     "with one and the backend re-accumulates it with the other, and the two",
     "buffers are reconciled at every segment boundary. A disagreement does not",
-    "raise anything -- it silently truncates a persisted message."
+    "raise anything -- it silently truncates a persisted message.",
+    "",
+    "`tool_calls` is the sequence an adapter really sends for one tool use.",
+    "The host copies each ACP update's fields through verbatim; the backend",
+    "reads the arguments and the result back out of them. Nothing checked that",
+    "the two agreed, and they did not: a streaming adapter opens a call with",
+    "`rawInput: {}` and sends the real arguments moments later on a",
+    "status-less `tool_call_update`, which the backend dropped. Every streamed",
+    "tool call rendered with empty arguments, and views built from them had",
+    "nothing to build from."
   ],
   "event_types": [
     "run_state",
@@ -33,49 +42,79 @@
   "text_extraction": [
     {
       "name": "a plain text field",
-      "payload": { "text": "hello" },
+      "payload": {
+        "text": "hello"
+      },
       "text": "hello"
     },
     {
       "name": "a delta field when there is no text",
-      "payload": { "delta": "hello" },
+      "payload": {
+        "delta": "hello"
+      },
       "text": "hello"
     },
     {
       "name": "text wins over delta",
-      "payload": { "text": "kept", "delta": "ignored" },
+      "payload": {
+        "text": "kept",
+        "delta": "ignored"
+      },
       "text": "kept"
     },
     {
       "name": "content as a bare string",
-      "payload": { "content": "hello" },
+      "payload": {
+        "content": "hello"
+      },
       "text": "hello"
     },
     {
       "name": "content as a text block",
-      "payload": { "content": { "type": "text", "text": "hello" } },
+      "payload": {
+        "content": {
+          "type": "text",
+          "text": "hello"
+        }
+      },
       "text": "hello"
     },
     {
       "name": "an image block carries no text",
       "payload": {
-        "content": { "type": "image", "data": "aGk=", "mimeType": "image/png" }
+        "content": {
+          "type": "image",
+          "data": "aGk=",
+          "mimeType": "image/png"
+        }
       },
       "text": ""
     },
     {
       "name": "a content list is not walked",
-      "payload": { "content": [{ "type": "text", "text": "hello" }] },
+      "payload": {
+        "content": [
+          {
+            "type": "text",
+            "text": "hello"
+          }
+        ]
+      },
       "text": ""
     },
     {
       "name": "a non-string text field is not text",
-      "payload": { "text": 5 },
+      "payload": {
+        "text": 5
+      },
       "text": ""
     },
     {
       "name": "a non-string text field still falls through to delta",
-      "payload": { "text": 5, "delta": "hello" },
+      "payload": {
+        "text": 5,
+        "delta": "hello"
+      },
       "text": "hello"
     },
     {
@@ -85,8 +124,89 @@
     },
     {
       "name": "an unrelated payload",
-      "payload": { "status": "COMPLETED", "toolCallId": "c1" },
+      "payload": {
+        "status": "COMPLETED",
+        "toolCallId": "c1"
+      },
       "text": ""
+    }
+  ],
+  "tool_calls": [
+    {
+      "name": "a streamed MCP call, as claude-agent-acp sends it",
+      "$comment": "Captured from claude-agent-acp 0.62.0 calling a Lemma MCP tool. The opening rawInput is empty because the model has not written the input yet; the third update carries nothing but the call's id.",
+      "updates": [
+        {
+          "sessionUpdate": "tool_call",
+          "toolCallId": "call-1",
+          "status": "pending",
+          "rawInput": {},
+          "title": "lemma_display_resource"
+        },
+        {
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "call-1",
+          "rawInput": {
+            "request": {
+              "type": "WIDGET",
+              "content": "<div>hello</div>"
+            }
+          },
+          "title": "lemma_display_resource"
+        },
+        {
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "call-1"
+        },
+        {
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "call-1",
+          "status": "completed",
+          "rawOutput": {
+            "content": [
+              {
+                "type": "text",
+                "text": "{\"success\": true, \"url\": \"https://x/y\"}"
+              }
+            ]
+          }
+        }
+      ],
+      "tool_args": {
+        "request": {
+          "type": "WIDGET",
+          "content": "<div>hello</div>"
+        }
+      },
+      "tool_result": {
+        "success": true,
+        "url": "https://x/y"
+      }
+    },
+    {
+      "name": "a call whose arguments are complete when it opens",
+      "$comment": "An adapter that does not stream its input announces the call once, with everything. Nothing is held and nothing is refined.",
+      "updates": [
+        {
+          "sessionUpdate": "tool_call",
+          "toolCallId": "call-2",
+          "status": "pending",
+          "rawInput": {
+            "path": "README.md"
+          },
+          "title": "read_file"
+        },
+        {
+          "sessionUpdate": "tool_call_update",
+          "toolCallId": "call-2",
+          "status": "completed",
+          "rawOutput": "# Lemma"
+        }
+      ],
+      "tool_args": {
+        "path": "README.md"
+      },
+      "tool_result": "# Lemma"
     }
   ]
 }

--- a/desktop/agent-host/tests/latency_bench.rs
+++ b/desktop/agent-host/tests/latency_bench.rs
@@ -1,0 +1,525 @@
+//! Where a turn's wall clock goes between Lemma and a real local agent.
+//!
+//! Not a correctness test — a measurement. It stands a control plane in front
+//! of the real `HostRuntime` and timestamps every hop, in two modes:
+//!
+//! * `fast` — the poll answers immediately (what the hermetic tests use).
+//! * `real` — the poll behaves like `agent_host_controller.poll`: it holds for
+//!   `POLL_HOLD` when idle, wakes on a poke, and answers a poll carrying
+//!   control updates with `poll_after_ms=1000`.
+//!
+//! It measures the host's own hops only. "The user sent a message" is a
+//! dispatch simulated inside this test, so nothing here covers the backend
+//! pipeline a real message travels first.
+//!
+//! ```text
+//! LEMMA_REAL_AGENT_HOST_DATA_DIR=... cargo test --test latency_bench -- --ignored --nocapture
+//! ```
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::routing::{post, put};
+use axum::{Json, Router};
+use chrono::Utc;
+use lemma_agent_host::config::HostPaths;
+use lemma_agent_host::protocol::{Event, EventBatch, EventType, JsonMap, RunSpec};
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use uuid::Uuid;
+
+mod support;
+
+const HOST_SECRET: &str = "latency-bench-host-secret-with-entropy";
+/// What the real backend answers a poll that carried control updates.
+const CONTROL_UPDATE_BACKOFF_MS: u64 = 1_000;
+const POLL_HOLD: Duration = Duration::from_secs(25);
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    Fast,
+    Real,
+}
+
+/// One hop, stamped when it happened.
+#[derive(Clone, Debug)]
+struct Hop {
+    at: Duration,
+    what: String,
+}
+
+#[derive(Clone)]
+struct BenchState {
+    mode: Mode,
+    started: Instant,
+    host_id: Uuid,
+    user_id: Uuid,
+    run_id: Uuid,
+    harness_key: String,
+    prompt: String,
+    mcp: Value,
+    published: Arc<Mutex<Option<(Uuid, String)>>>,
+    /// Set by the test when it "sends the message", i.e. dispatches the run.
+    dispatch_at: Arc<Mutex<Option<Instant>>>,
+    start_sent: Arc<AtomicBool>,
+    hops: Arc<Mutex<Vec<Hop>>>,
+    events: Arc<Mutex<Vec<Event>>>,
+    polls: Arc<Mutex<Vec<(Duration, Duration)>>>,
+    /// Last state each run checkpointed, so a repeated heartbeat is not news.
+    checkpoint_states: Arc<Mutex<std::collections::HashMap<String, String>>>,
+}
+
+impl BenchState {
+    fn mark(&self, what: impl Into<String>) {
+        self.hops.lock().unwrap().push(Hop {
+            at: self.started.elapsed(),
+            what: what.into(),
+        });
+    }
+}
+
+fn require_auth(headers: &HeaderMap) -> Result<(), StatusCode> {
+    let value = headers
+        .get("authorization")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    (value == format!("Bearer {HOST_SECRET}"))
+        .then_some(())
+        .ok_or(StatusCode::UNAUTHORIZED)
+}
+
+async fn pairing(State(state): State<BenchState>, Json(_body): Json<Value>) -> Json<Value> {
+    Json(json!({
+        "host_id": state.host_id,
+        "user_id": state.user_id,
+        "organization_id": null,
+        "host_secret": HOST_SECRET,
+    }))
+}
+
+async fn publish(
+    State(state): State<BenchState>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Result<Json<Value>, StatusCode> {
+    require_auth(&headers)?;
+    let snapshots = body["harnesses"].as_array().cloned().unwrap_or_default();
+    let items = snapshots
+        .iter()
+        .map(|snapshot| {
+            let id = Uuid::new_v4();
+            if snapshot["harness_key"].as_str() == Some(state.harness_key.as_str())
+                && snapshot["health"].as_str() == Some("READY")
+            {
+                let mut published = state.published.lock().unwrap();
+                if published.is_none() {
+                    state.mark("harness published READY");
+                }
+                *published = Some((
+                    id,
+                    snapshot["config_revision"].as_str().unwrap_or("").to_owned(),
+                ));
+            }
+            json!({
+                "id": id,
+                "harness_key": snapshot["harness_key"],
+                "adapter_version": snapshot["adapter_version"],
+                "config_revision": snapshot["config_revision"],
+            })
+        })
+        .collect::<Vec<_>>();
+    Ok(Json(json!({"items": items})))
+}
+
+fn start_command(state: &BenchState, harness_id: Uuid, revision: String) -> Value {
+    let payload = serde_json::to_value(RunSpec {
+        agent_run_id: state.run_id,
+        conversation_id: Uuid::new_v4(),
+        harness_id,
+        profile_revision: revision,
+        model_name: None,
+        config_selections: JsonMap::new(),
+        system_prompt: "Follow the runtime instructions exactly.".to_owned(),
+        prompt: vec![json!({"type": "text", "text": state.prompt})],
+        resume_session_id: None,
+        context: std::collections::BTreeMap::new(),
+        mcp: state.mcp.clone(),
+        run_deadline: Utc::now() + chrono::Duration::minutes(5),
+        system_prompt_delivery: None,
+    })
+    .unwrap();
+    json!({
+        "command_id": Uuid::new_v4(),
+        "kind": "START_RUN",
+        "created_at": Utc::now(),
+        "expires_at": Utc::now() + chrono::Duration::minutes(4),
+        "run_id": state.run_id,
+        "lease_epoch": 1,
+        "payload": payload,
+    })
+}
+
+/// Whether the run has been dispatched and the `START_RUN` is still owed.
+fn owed_start(state: &BenchState) -> Option<Value> {
+    let dispatched = state.dispatch_at.lock().unwrap().is_some();
+    if !dispatched {
+        return None;
+    }
+    let published = state.published.lock().unwrap().clone();
+    let (harness_id, revision) = published?;
+    if state.start_sent.swap(true, Ordering::SeqCst) {
+        return None;
+    }
+    state.mark("control plane handed START_RUN to the poll");
+    Some(start_command(state, harness_id, revision))
+}
+
+async fn poll(
+    State(state): State<BenchState>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Result<Json<Value>, StatusCode> {
+    require_auth(&headers)?;
+    let opened = state.started.elapsed();
+    // What `agent_host_dispatch_repository.poll_commands` calls `progressed`:
+    // an acknowledgement, or a checkpoint that *advanced* a run's state. A
+    // repeated heartbeat for a run already in that state is not news, which is
+    // the whole reason a host with work in flight is still allowed to long-poll.
+    let acknowledged = body["acknowledged_command_ids"]
+        .as_array()
+        .is_some_and(|items| !items.is_empty());
+    let mut advanced = false;
+    if let Some(checkpoints) = body["checkpoints"].as_array() {
+        let mut seen = state.checkpoint_states.lock().unwrap();
+        for checkpoint in checkpoints {
+            let run = checkpoint["run_id"].as_str().unwrap_or_default().to_owned();
+            let reported = checkpoint["state"].as_str().unwrap_or_default().to_owned();
+            if seen.insert(run, reported.clone()).as_deref() != Some(reported.as_str()) {
+                advanced = true;
+            }
+        }
+    }
+    let progressed = acknowledged || advanced;
+
+    if let Some(command) = owed_start(&state) {
+        state.polls.lock().unwrap().push((opened, state.started.elapsed()));
+        return Ok(Json(json!({
+            "protocol_version": 2,
+            "host_status": "ONLINE",
+            "commands": [command],
+            "poll_after_ms": 0,
+        })));
+    }
+
+    if state.mode == Mode::Real && progressed {
+        state.polls.lock().unwrap().push((opened, state.started.elapsed()));
+        return Ok(Json(json!({
+            "protocol_version": 2,
+            "host_status": "ONLINE",
+            "commands": [],
+            "poll_after_ms": CONTROL_UPDATE_BACKOFF_MS,
+        })));
+    }
+
+    if state.mode == Mode::Real {
+        // Idle: hold like the real backend, waking early only for a dispatch.
+        let deadline = Instant::now() + POLL_HOLD;
+        loop {
+            if let Some(command) = owed_start(&state) {
+                state.polls.lock().unwrap().push((opened, state.started.elapsed()));
+                return Ok(Json(json!({
+                    "protocol_version": 2,
+                    "host_status": "ONLINE",
+                    "commands": [command],
+                    "poll_after_ms": 0,
+                })));
+            }
+            if Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    state.polls.lock().unwrap().push((opened, state.started.elapsed()));
+    Ok(Json(json!({
+        "protocol_version": 2,
+        "host_status": "ONLINE",
+        "commands": [],
+        "poll_after_ms": if state.mode == Mode::Fast { 25 } else { 0 },
+    })))
+}
+
+async fn append_events(
+    State(state): State<BenchState>,
+    headers: HeaderMap,
+    Json(body): Json<Value>,
+) -> Result<Json<Value>, StatusCode> {
+    require_auth(&headers)?;
+    let batch: EventBatch = serde_json::from_value(body).unwrap();
+    let last = batch.events.last().unwrap();
+    let response = json!({
+        "run_id": last.run_id,
+        "lease_epoch": last.lease_epoch,
+        "acked_through": last.sequence,
+    });
+    {
+        let mut events = state.events.lock().unwrap();
+        let had_text = events
+            .iter()
+            .any(|event| event.event_type == EventType::AgentMessageChunk);
+        let brings_text = batch
+            .events
+            .iter()
+            .any(|event| event.event_type == EventType::AgentMessageChunk);
+        if !had_text && brings_text {
+            state.mark("first assistant text reached Lemma");
+        }
+        if batch
+            .events
+            .iter()
+            .any(|event| event.event_type == EventType::Terminal)
+        {
+            state.mark("terminal reached Lemma");
+        }
+        state.mark(format!("events:append batch of {}", batch.events.len()));
+        events.extend(batch.events);
+    }
+    Ok(Json(response))
+}
+
+struct Bench {
+    state: BenchState,
+    base_url: url::Url,
+}
+
+impl Bench {
+    async fn start(mode: Mode, harness: &str, prompt: &str, mcp: Value) -> Self {
+        let state = BenchState {
+            mcp,
+            mode,
+            started: Instant::now(),
+            host_id: Uuid::new_v4(),
+            user_id: Uuid::new_v4(),
+            run_id: Uuid::new_v4(),
+            harness_key: harness.to_owned(),
+            prompt: prompt.to_owned(),
+            published: Arc::new(Mutex::new(None)),
+            dispatch_at: Arc::new(Mutex::new(None)),
+            start_sent: Arc::new(AtomicBool::new(false)),
+            hops: Arc::new(Mutex::new(Vec::new())),
+            events: Arc::new(Mutex::new(Vec::new())),
+            polls: Arc::new(Mutex::new(Vec::new())),
+            checkpoint_states: Arc::new(Mutex::new(std::collections::HashMap::new())),
+        };
+        let app = Router::new()
+            .route("/agent-host/pairings:complete", post(pairing))
+            .route("/agent-host/harnesses", put(publish))
+            .route("/agent-host/poll", post(poll))
+            .route("/agent-host/events:append", post(append_events))
+            .with_state(state.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        Self {
+            state,
+            base_url: url::Url::parse(&format!("http://{address}/")).unwrap(),
+        }
+    }
+
+    fn saw_terminal(&self) -> bool {
+        self.state
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|event| event.event_type == EventType::Terminal)
+    }
+
+    async fn wait_until(&self, what: &str, budget: Duration, predicate: impl Fn(&Self) -> bool) {
+        let deadline = Instant::now() + budget;
+        while Instant::now() < deadline {
+            if predicate(self) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("timed out waiting for {what}; hops={:?}", self.state.hops.lock().unwrap());
+    }
+}
+
+async fn start_host(root: &std::path::Path, bench: &Bench, adapters: &std::path::Path) -> tokio::task::JoinHandle<anyhow::Result<()>> {
+    let paths = HostPaths::under(root);
+    paths.ensure().unwrap();
+    #[cfg(unix)]
+    {
+        let _ = std::fs::remove_dir_all(&paths.adapters);
+        std::os::unix::fs::symlink(adapters, &paths.adapters).unwrap();
+    }
+    let installation_id = Uuid::new_v4().to_string();
+    let target = lemma_agent_host::api::TargetClient::pair(
+        bench.base_url.clone(),
+        "latency-bench-pairing-code",
+        "Bench host",
+        &installation_id,
+        true,
+    )
+    .await
+    .unwrap();
+    let config = lemma_agent_host::config::HostConfig {
+        installation_id,
+        targets: vec![target],
+        max_runs: 1,
+    };
+    config.save(&paths).unwrap();
+    let runtime = lemma_agent_host::runtime::HostRuntime::new(config, paths)
+        .unwrap()
+        .with_mcp_bridge_executable(PathBuf::from(env!("CARGO_BIN_EXE_lemma-agent-host")));
+    tokio::spawn(runtime.serve())
+}
+
+async fn measure(mode: Mode, harness: &str, prompt: &str) {
+    let source = HostPaths::under(
+        std::env::var_os("LEMMA_REAL_AGENT_HOST_DATA_DIR")
+            .map(PathBuf::from)
+            .expect("set LEMMA_REAL_AGENT_HOST_DATA_DIR"),
+    );
+    let directory = TempDir::new().unwrap();
+    // A run-scoped MCP endpoint, because the host refuses a START_RUN without
+    // one — and because standing the bridge up is part of what a turn pays for.
+    let endpoint = support::LemmaMcpEndpoint::start(support::McpTransport::StatelessJson).await;
+    let bench = Bench::start(mode, harness, prompt, endpoint.run_configuration()).await;
+    let host = start_host(directory.path(), &bench, &source.adapters).await;
+
+    // Wait for the host to be idle and paired: the harness published and the
+    // poll loop settled. This is what the desktop app looks like when the user
+    // is sitting in front of a conversation about to type.
+    bench
+        .wait_until("the harness to publish", Duration::from_secs(90), |bench| {
+            bench.state.published.lock().unwrap().is_some()
+        })
+        .await;
+    // Let the loop enter a held poll, so the dispatch below has to interrupt a
+    // real idle wait rather than landing on a loop that happens to be spinning.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    // "The user pressed enter."
+    let dispatch = Instant::now();
+    *bench.state.dispatch_at.lock().unwrap() = Some(dispatch);
+    bench.state.mark("user sent the message (run dispatched)");
+
+    bench
+        .wait_until("the run to finish", Duration::from_secs(240), Bench::saw_terminal)
+        .await;
+    host.abort();
+
+    let hops = bench.state.hops.lock().unwrap().clone();
+    let dispatch_at = hops
+        .iter()
+        .find(|hop| hop.what.starts_with("user sent"))
+        .map(|hop| hop.at)
+        .unwrap();
+    println!("\n=== mode={} harness={harness} ===", match mode {
+        Mode::Fast => "fast",
+        Mode::Real => "real",
+    });
+    for hop in &hops {
+        if hop.at < dispatch_at && !hop.what.starts_with("harness") {
+            continue;
+        }
+        let relative = hop.at.checked_sub(dispatch_at);
+        match relative {
+            Some(delta) => println!("  +{:7.3}s  {}", delta.as_secs_f64(), hop.what),
+            None => println!("  ({:7.3}s before dispatch)  {}", dispatch_at.saturating_sub(hop.at).as_secs_f64(), hop.what),
+        }
+    }
+    let appends = hops
+        .iter()
+        .filter(|hop| hop.what.starts_with("events:append"))
+        .map(|hop| hop.at)
+        .collect::<Vec<_>>();
+    let batches = appends.len();
+    let mut gaps = appends
+        .windows(2)
+        .map(|pair| pair[1].saturating_sub(pair[0]).as_secs_f64())
+        .collect::<Vec<_>>();
+    gaps.sort_by(f64::total_cmp);
+    if !gaps.is_empty() {
+        println!(
+            "  batch gaps: median {:.3}s  p90 {:.3}s  max {:.3}s  (n={})",
+            gaps[gaps.len() / 2],
+            gaps[(gaps.len() * 9 / 10).min(gaps.len() - 1)],
+            gaps[gaps.len() - 1],
+            gaps.len(),
+        );
+    }
+    println!(
+        "  events delivered: {}",
+        bench.state.events.lock().unwrap().len()
+    );
+    // The number that mattered. A wake of the poll loop abandons the poll in
+    // flight, and the server goes on holding the abandoned one for the rest of
+    // its hold — so a host that re-polls per streamed event stacks them. Peak
+    // concurrency is what the control plane actually pays; on a real backend a
+    // single streamed answer was measured reaching 26, against one when idle.
+    let polls = bench.state.polls.lock().unwrap();
+    let during = polls
+        .iter()
+        .filter(|(opened, _)| *opened >= dispatch_at)
+        .count();
+    let mut edges = Vec::new();
+    for (opened, closed) in polls.iter() {
+        edges.push((*opened, 1_i32));
+        edges.push((*closed, -1));
+    }
+    edges.sort();
+    let (mut open_now, mut peak) = (0, 0);
+    for (_, delta) in edges {
+        open_now += delta;
+        peak = peak.max(open_now);
+    }
+    println!(
+        "  polls opened: {} total, {during} after dispatch; peak concurrent: {peak}",
+        polls.len()
+    );
+    let first_text = hops
+        .iter()
+        .find(|hop| hop.what.starts_with("first assistant text"))
+        .map(|hop| hop.at.saturating_sub(dispatch_at));
+    let terminal = hops
+        .iter()
+        .find(|hop| hop.what.starts_with("terminal"))
+        .map(|hop| hop.at.saturating_sub(dispatch_at));
+    println!("  ---");
+    println!("  time to first assistant text at Lemma: {first_text:?}");
+    println!("  time to terminal at Lemma:             {terminal:?}");
+    println!("  event batches delivered:               {batches}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "measurement; spends real provider quota"]
+async fn turn_latency_with_a_fast_control_plane() {
+    let harness = std::env::var("LEMMA_BENCH_HARNESS").unwrap_or_else(|_| "claude-code".to_owned());
+    measure(Mode::Fast, &harness, &bench_prompt()).await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "measurement; spends real provider quota"]
+async fn turn_latency_with_a_realistic_control_plane() {
+    let harness = std::env::var("LEMMA_BENCH_HARNESS").unwrap_or_else(|_| "claude-code".to_owned());
+    measure(Mode::Real, &harness, &bench_prompt()).await;
+}
+
+/// The turn to measure. Short by default, so the number is startup overhead;
+/// `LEMMA_BENCH_PROMPT` swaps in a long one to measure streaming cadence.
+fn bench_prompt() -> String {
+    std::env::var("LEMMA_BENCH_PROMPT")
+        .unwrap_or_else(|_| "Reply with exactly: PONG".to_owned())
+}

--- a/desktop/agent-host/tests/latency_bench.rs
+++ b/desktop/agent-host/tests/latency_bench.rs
@@ -122,7 +122,10 @@ async fn publish(
                 }
                 *published = Some((
                     id,
-                    snapshot["config_revision"].as_str().unwrap_or("").to_owned(),
+                    snapshot["config_revision"]
+                        .as_str()
+                        .unwrap_or("")
+                        .to_owned(),
                 ));
             }
             json!({
@@ -207,7 +210,11 @@ async fn poll(
     let progressed = acknowledged || advanced;
 
     if let Some(command) = owed_start(&state) {
-        state.polls.lock().unwrap().push((opened, state.started.elapsed()));
+        state
+            .polls
+            .lock()
+            .unwrap()
+            .push((opened, state.started.elapsed()));
         return Ok(Json(json!({
             "protocol_version": 2,
             "host_status": "ONLINE",
@@ -217,7 +224,11 @@ async fn poll(
     }
 
     if state.mode == Mode::Real && progressed {
-        state.polls.lock().unwrap().push((opened, state.started.elapsed()));
+        state
+            .polls
+            .lock()
+            .unwrap()
+            .push((opened, state.started.elapsed()));
         return Ok(Json(json!({
             "protocol_version": 2,
             "host_status": "ONLINE",
@@ -231,7 +242,11 @@ async fn poll(
         let deadline = Instant::now() + POLL_HOLD;
         loop {
             if let Some(command) = owed_start(&state) {
-                state.polls.lock().unwrap().push((opened, state.started.elapsed()));
+                state
+                    .polls
+                    .lock()
+                    .unwrap()
+                    .push((opened, state.started.elapsed()));
                 return Ok(Json(json!({
                     "protocol_version": 2,
                     "host_status": "ONLINE",
@@ -246,7 +261,11 @@ async fn poll(
         }
     }
 
-    state.polls.lock().unwrap().push((opened, state.started.elapsed()));
+    state
+        .polls
+        .lock()
+        .unwrap()
+        .push((opened, state.started.elapsed()));
     Ok(Json(json!({
         "protocol_version": 2,
         "host_status": "ONLINE",
@@ -351,11 +370,18 @@ impl Bench {
             }
             tokio::time::sleep(Duration::from_millis(5)).await;
         }
-        panic!("timed out waiting for {what}; hops={:?}", self.state.hops.lock().unwrap());
+        panic!(
+            "timed out waiting for {what}; hops={:?}",
+            self.state.hops.lock().unwrap()
+        );
     }
 }
 
-async fn start_host(root: &std::path::Path, bench: &Bench, adapters: &std::path::Path) -> tokio::task::JoinHandle<anyhow::Result<()>> {
+async fn start_host(
+    root: &std::path::Path,
+    bench: &Bench,
+    adapters: &std::path::Path,
+) -> tokio::task::JoinHandle<anyhow::Result<()>> {
     let paths = HostPaths::under(root);
     paths.ensure().unwrap();
     #[cfg(unix)]
@@ -416,7 +442,11 @@ async fn measure(mode: Mode, harness: &str, prompt: &str) {
     bench.state.mark("user sent the message (run dispatched)");
 
     bench
-        .wait_until("the run to finish", Duration::from_secs(240), Bench::saw_terminal)
+        .wait_until(
+            "the run to finish",
+            Duration::from_secs(240),
+            Bench::saw_terminal,
+        )
         .await;
     host.abort();
 
@@ -426,10 +456,13 @@ async fn measure(mode: Mode, harness: &str, prompt: &str) {
         .find(|hop| hop.what.starts_with("user sent"))
         .map(|hop| hop.at)
         .unwrap();
-    println!("\n=== mode={} harness={harness} ===", match mode {
-        Mode::Fast => "fast",
-        Mode::Real => "real",
-    });
+    println!(
+        "\n=== mode={} harness={harness} ===",
+        match mode {
+            Mode::Fast => "fast",
+            Mode::Real => "real",
+        }
+    );
     for hop in &hops {
         if hop.at < dispatch_at && !hop.what.starts_with("harness") {
             continue;
@@ -437,7 +470,11 @@ async fn measure(mode: Mode, harness: &str, prompt: &str) {
         let relative = hop.at.checked_sub(dispatch_at);
         match relative {
             Some(delta) => println!("  +{:7.3}s  {}", delta.as_secs_f64(), hop.what),
-            None => println!("  ({:7.3}s before dispatch)  {}", dispatch_at.saturating_sub(hop.at).as_secs_f64(), hop.what),
+            None => println!(
+                "  ({:7.3}s before dispatch)  {}",
+                dispatch_at.saturating_sub(hop.at).as_secs_f64(),
+                hop.what
+            ),
         }
     }
     let appends = hops
@@ -520,6 +557,5 @@ async fn turn_latency_with_a_realistic_control_plane() {
 /// The turn to measure. Short by default, so the number is startup overhead;
 /// `LEMMA_BENCH_PROMPT` swaps in a long one to measure streaming cadence.
 fn bench_prompt() -> String {
-    std::env::var("LEMMA_BENCH_PROMPT")
-        .unwrap_or_else(|_| "Reply with exactly: PONG".to_owned())
+    std::env::var("LEMMA_BENCH_PROMPT").unwrap_or_else(|_| "Reply with exactly: PONG".to_owned())
 }

--- a/desktop/agent-host/tests/latency_bench.rs
+++ b/desktop/agent-host/tests/latency_bench.rs
@@ -377,6 +377,10 @@ impl Bench {
     }
 }
 
+#[cfg_attr(
+    windows,
+    expect(unused_variables, reason = "adapter reuse is a unix symlink")
+)]
 async fn start_host(
     root: &std::path::Path,
     bench: &Bench,

--- a/desktop/agent-host/tests/lemma_mcp_e2e.rs
+++ b/desktop/agent-host/tests/lemma_mcp_e2e.rs
@@ -143,6 +143,7 @@ fn journal_run(paths: &HostPaths, target_id: Uuid, run_id: Uuid, mcp: Value) {
         context: JsonMap::new(),
         mcp,
         run_deadline: Utc::now() + chrono::Duration::minutes(5),
+        system_prompt_delivery: None,
     };
     let command = Command {
         command_id: Uuid::new_v4(),

--- a/desktop/agent-host/tests/permission_flow_e2e.rs
+++ b/desktop/agent-host/tests/permission_flow_e2e.rs
@@ -372,6 +372,7 @@ async fn an_unanswered_request_is_denied_when_the_timeout_elapses() {
                     context: JsonMap::new(),
                     mcp: Value::Null,
                     run_deadline: Utc::now() + chrono::Duration::minutes(2),
+                    system_prompt_delivery: None,
                 },
                 scratch_directory: scratch.path().join("run"),
                 mcp_server: None,

--- a/desktop/agent-host/tests/real_harness_e2e.rs
+++ b/desktop/agent-host/tests/real_harness_e2e.rs
@@ -116,6 +116,7 @@ async fn authenticated_harnesses_stream_real_answers_over_acp() {
                             context: BTreeMap::new(),
                             mcp: Value::Null,
                             run_deadline: chrono::Utc::now() + chrono::Duration::minutes(5),
+                            system_prompt_delivery: None,
                         },
                         scratch_directory: paths
                             .root
@@ -218,6 +219,7 @@ async fn one_turn(
                     context: BTreeMap::new(),
                     mcp: Value::Null,
                     run_deadline: Utc::now() + chrono::Duration::minutes(5),
+                    system_prompt_delivery: None,
                 },
                 // The caller's directory, not one invented here. A provider
                 // is entitled to refuse to load a session into a different cwd
@@ -389,6 +391,7 @@ async fn codex_native_image_generation_creates_a_publishable_artifact() {
                 context: JsonMap::new(),
                 mcp: Value::Null,
                 run_deadline: Utc::now() + chrono::Duration::minutes(10),
+                system_prompt_delivery: None,
             },
             scratch_directory: scratch.path().to_path_buf(),
             mcp_server: None,
@@ -751,6 +754,7 @@ async fn poll(
                 "authorization": "Bearer unused-real-control-e2e-secret",
             }),
             run_deadline: Utc::now() + chrono::Duration::minutes(5),
+            system_prompt_delivery: None,
         })
         .unwrap();
         vec![json!({
@@ -1002,6 +1006,7 @@ async fn a_real_agent_stops_on_session_cancel_and_keeps_its_session() {
                         context: BTreeMap::new(),
                         mcp: Value::Null,
                         run_deadline: Utc::now() + chrono::Duration::minutes(5),
+                        system_prompt_delivery: None,
                     },
                     scratch_directory: scratch.clone(),
                     mcp_server: None,

--- a/desktop/agent-host/tests/support/mod.rs
+++ b/desktop/agent-host/tests/support/mod.rs
@@ -788,6 +788,7 @@ async fn poll(
             context: BTreeMap::new(),
             mcp: state.mcp.clone(),
             run_deadline: Utc::now() + chrono::Duration::minutes(3),
+            system_prompt_delivery: None,
         })
         .unwrap();
         commands.push(json!({

--- a/desktop/agent-host/tests/wire_contract.rs
+++ b/desktop/agent-host/tests/wire_contract.rs
@@ -95,6 +95,63 @@ fn every_event_type_is_exhaustive() {
     }
 }
 
+/// The host must hand every field of a tool-call update through untouched.
+///
+/// This side owns only half the promise — the backend reads the arguments and
+/// the result back out of what lands here, and asserts that half against the
+/// same fixture. What the host has to guarantee is that nothing is dropped on
+/// the way: `rawInput` on a refining update is the only place a streamed call's
+/// arguments ever appear, so an update this normalizer declined to forward
+/// would leave them unrecoverable no matter what the backend did.
+#[test]
+fn tool_call_updates_survive_normalization() {
+    for case in contract()["tool_calls"]
+        .as_array()
+        .expect("tool_calls is a list")
+    {
+        let name = case["name"].as_str().unwrap_or("unnamed");
+        for update in case["updates"].as_array().expect("updates is a list") {
+            let parsed = serde_json::from_value(update.clone())
+                .unwrap_or_else(|error| panic!("case {name:?}: unparseable update: {error}"));
+            let (_, object_id, payload) = lemma_agent_host::acp::normalize_session_update(&parsed)
+                .unwrap_or_else(|| panic!("case {name:?}: {update} was dropped"));
+
+            assert_eq!(
+                object_id.as_deref(),
+                update["toolCallId"].as_str(),
+                "case {name:?}: the call's id did not survive"
+            );
+            for field in ["rawInput", "rawOutput", "title"] {
+                let Some(expected) = update.get(field) else {
+                    continue;
+                };
+                assert_eq!(
+                    payload.get(field),
+                    Some(expected),
+                    "case {name:?}: {field} did not survive normalization"
+                );
+            }
+            // `status` is the exception, and only in one direction. ACP makes
+            // `pending` the default and serde skips defaults, so an opening
+            // call arrives with no status at all — which is fine, because
+            // "pending" tells the backend nothing it does not already know from
+            // the call opening. A *terminal* status is the opposite: it is the
+            // only signal that the call is closed and its result is final, so
+            // losing one would leave the call open forever and the run would
+            // synthesize a return saying it never finished.
+            if let Some(status) = update["status"].as_str()
+                && status != "pending"
+            {
+                assert_eq!(
+                    payload.get("status").and_then(Value::as_str),
+                    Some(status),
+                    "case {name:?}: a terminal status did not survive normalization"
+                );
+            }
+        }
+    }
+}
+
 #[test]
 fn chunk_text_matches_the_contract() {
     for case in contract()["text_extraction"]

--- a/lemma-backend/app/app.py
+++ b/lemma-backend/app/app.py
@@ -327,6 +327,13 @@ class RequestObserverMiddleware:
     QUIET_PATHS = frozenset(
         {"/health", "/health/live", "/health/ready", "/health/capabilities", "/livez"}
     )
+    # Routes that are supposed to take a long time. A long poll answers when it
+    # has news or when its hold expires, so a slow one is the design working:
+    # every completed idle poll logged a warning, and on one local stack 311 of
+    # 314 slow-request warnings were healthy 25-second polls. A warning that
+    # fires on the normal case is not a signal, and it buried the three that
+    # meant something.
+    HELD_ROUTES = frozenset({"/agent-host/poll"})
 
     def __init__(self, app):
         self.app = app
@@ -484,7 +491,10 @@ class RequestObserverMiddleware:
                             if streaming and response_started_at is not None
                             else (finished_at - started_at)
                         )
-                        if elapsed >= self.SLOW_SECONDS:
+                        if (
+                            elapsed >= self.SLOW_SECONDS
+                            and fields["route"] not in self.HELD_ROUTES
+                        ):
                             fields["duration_ms"] = round(elapsed * 1000, 1)
                             fields["latency_kind"] = (
                                 "time_to_first_byte" if streaming else "total"

--- a/lemma-backend/app/core/infrastructure/events/config.py
+++ b/lemma-backend/app/core/infrastructure/events/config.py
@@ -36,7 +36,7 @@ class EventTransportSettings(BaseSettings):
         ),
     )
     outbox_listen_enabled: bool = Field(
-        default=False,
+        default=True,
         description=(
             "Wake the outbox dispatcher with PostgreSQL LISTEN/NOTIFY instead "
             "of waiting out the idle backoff. The notification is only a hint: "
@@ -44,18 +44,26 @@ class EventTransportSettings(BaseSettings):
             "turning this off restores timer-driven behaviour exactly. "
             "Requires a direct connection -- a transaction-mode pooler in "
             "front of PostgreSQL silently swallows session-scoped LISTEN, "
-            "which degrades to fallback latency rather than breaking."
+            "which degrades to fallback latency rather than breaking. "
+            "On by default because the backoff it replaces is the dominant "
+            "term in how long a chat message waits before anything happens: "
+            "an idle dispatcher sits at outbox_idle_poll_max_seconds, and a "
+            "message landing mid-sleep waits out the remainder. Measured "
+            "against a local stack, that was 1.4-4.1s per message."
         ),
     )
     outbox_listen_fallback_poll_seconds: float = Field(
-        default=30.0,
+        default=5.0,
         ge=0.5,
         description=(
             "Idle wait when a wake listener is attached. This is the worst-case "
             "delivery latency if every notification is lost -- a dropped "
             "listener, or a pooler that ate the LISTEN -- so it is a recovery "
             "bound, not a performance number. Ignored while "
-            "outbox_listen_enabled is false."
+            "outbox_listen_enabled is false. Deliberately no higher than "
+            "outbox_idle_poll_max_seconds: attaching a listener must never "
+            "make a deployment whose LISTEN is silently swallowed slower than "
+            "the backoff ladder it replaced."
         ),
     )
     # Whole seconds: asyncpg's connect() types its timeout as an int.

--- a/lemma-backend/app/core/infrastructure/events/tests/unit/test_outbox_wake.py
+++ b/lemma-backend/app/core/infrastructure/events/tests/unit/test_outbox_wake.py
@@ -166,3 +166,30 @@ async def test_dispatcher_without_a_wake_still_sleeps_on_the_ladder() -> None:
     started = loop.time()
     await dispatcher._idle_wait(0.05)  # noqa: SLF001
     assert loop.time() - started >= 0.04
+
+
+def test_the_wake_listener_is_on_by_default() -> None:
+    """The backoff ladder is what a chat message waits out before anything runs.
+
+    An idle dispatcher climbs to ``outbox_idle_poll_max_seconds`` and a message
+    landing mid-sleep waits out the remainder; measured against a local stack
+    that was 1.4-4.1s per message, ahead of every other term in the turn. The
+    listener removes it, and the fallback poll means turning it on cannot lose
+    an event -- only find it sooner.
+    """
+    assert event_transport_settings.outbox_listen_enabled
+
+
+def test_attaching_a_listener_cannot_be_slower_than_the_ladder_it_replaces() -> None:
+    """The fallback is a recovery bound, and must not become a regression.
+
+    A transaction-mode pooler swallows session-scoped LISTEN silently, so a
+    deployment behind one gets the fallback rather than the wake. If that
+    fallback were longer than the ladder, switching the listener on would make
+    exactly those deployments slower -- which is the one outcome a hint is not
+    allowed to have.
+    """
+    assert (
+        event_transport_settings.outbox_listen_fallback_poll_seconds
+        <= event_transport_settings.outbox_idle_poll_max_seconds
+    )

--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -101,6 +101,7 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'agent.web_fetch.batch_deadline_reached.degraded': EventSpec('warning', frozenset({'captured', 'requested'})),
     'agent.web_fetch.failed': EventSpec('debug', frozenset()),
     'agent.web_fetch.http_path_crashed.degraded': EventSpec('warning', frozenset({'error_type'})),
+    'agent.tools.image_payload.downscale_skipped.diagnostic': EventSpec('debug', frozenset({'error_type'})),
     'agent.web_fetch.http_path_failed.diagnostic': EventSpec('debug', frozenset({'error_type'})),
     'agent.web_fetch.session_failed.degraded': EventSpec('warning', frozenset({'error_type'})),
     'agent.web_fetch.url_refused.refused': EventSpec('warning', frozenset({'reason'})),

--- a/lemma-backend/app/modules/agent/api/controllers/agent_host_controller.py
+++ b/lemma-backend/app/modules/agent/api/controllers/agent_host_controller.py
@@ -13,7 +13,7 @@ import contextlib
 from typing import Annotated
 from uuid import UUID, uuid7
 
-from fastapi import APIRouter, Header, HTTPException, status
+from fastapi import APIRouter, Header, HTTPException, Request, status
 
 from app.core.api.dependencies import CurrentUser, UoWDep
 from app.core.infrastructure.channels.channel_service import get_channel_service
@@ -30,6 +30,7 @@ from app.modules.agent.api.agent_host_schemas import (
 )
 from app.modules.agent.domain.agent_host import (
     AGENT_HOST_PROTOCOL_VERSION,
+    AgentHostCommand,
     AgentHostEventAck,
     AgentHostEventBatch,
     AgentHostPairingComplete,
@@ -324,6 +325,7 @@ async def self_revoke_agent_host(
 )
 async def poll_agent_host_commands(
     request: AgentHostPollRequest,
+    http_request: Request,
     authorization: Annotated[str | None, Header()] = None,
 ) -> AgentHostPollResponse:
     """Long-poll for commands, carrying the host's control updates up.
@@ -380,8 +382,40 @@ async def poll_agent_host_commands(
             ),
         )
 
-    # Idle path: wait for a poke, falling back to a slow re-query so a missed
-    # poke only delays delivery by a few seconds.
+    return AgentHostPollResponse(
+        protocol_version=negotiated_protocol,
+        host_status=host_status,
+        commands=await _await_commands(
+            host_id=host_id,
+            deadline=deadline,
+            loop=loop,
+            available_run_slots=request.capacity.available_runs,
+            http_request=http_request,
+        ),
+    )
+
+
+async def _await_commands(
+    *,
+    host_id: UUID,
+    deadline: float,
+    loop: asyncio.AbstractEventLoop,
+    available_run_slots: int,
+    http_request: Request,
+) -> list[AgentHostCommand]:
+    """Hold the poll until there is something to say, or the hold expires.
+
+    Waits for a poke, falling back to a slow re-query so a missed poke only
+    delays delivery by a few seconds rather than a whole hold.
+
+    It also watches for the host going away. A host abandons a poll whenever it
+    has something else to do, and nothing here used to notice — so each
+    abandoned poll went on holding a task and a Redis subscription for the rest
+    of its 25 seconds. One host streaming a single answer was measured stacking
+    26 of them, against exactly one while idle. Noticing keeps that cost
+    proportional to how many hosts there are rather than to how talkative their
+    agents are.
+    """
     channel_service = await get_channel_service()
     async with channel_service.subscribe([host_poke_channel(host_id)]) as pokes:
         poke = aiter(pokes)
@@ -396,11 +430,7 @@ async def poll_agent_host_commands(
             while True:
                 remaining = deadline - loop.time()
                 if remaining <= 0:
-                    return AgentHostPollResponse(
-                        protocol_version=negotiated_protocol,
-                        host_status=host_status,
-                        commands=[],
-                    )
+                    return []
                 if waiting is None:
                     waiting = asyncio.ensure_future(anext(poke))
                 done, _ = await asyncio.wait(
@@ -414,11 +444,14 @@ async def poll_agent_host_commands(
                     try:
                         finished.result()
                     except StopAsyncIteration:
-                        return AgentHostPollResponse(
-                            protocol_version=negotiated_protocol,
-                            host_status=host_status,
-                            commands=[],
-                        )
+                        return []
+                elif await http_request.is_disconnected():
+                    # Nobody is left to answer. Checked only on a quiet round,
+                    # so it costs nothing on the path that matters and cannot
+                    # discard a poke already in hand: a command handed out here
+                    # would be marked DELIVERED to a host that will never read
+                    # it, and wait out its lease before anyone tried again.
+                    return []
                 if loop.time() >= deadline:
                     continue
                 async with _uow_factory() as uow:
@@ -428,15 +461,11 @@ async def poll_agent_host_commands(
                         acknowledged_command_ids=[],
                         checkpoints=[],
                         rejections=[],
-                        available_run_slots=request.capacity.available_runs,
+                        available_run_slots=available_run_slots,
                     )
                     await uow.commit()
                 if commands:
-                    return AgentHostPollResponse(
-                        protocol_version=negotiated_protocol,
-                        host_status=host_status,
-                        commands=commands,
-                    )
+                    return list(commands)
         finally:
             # The response is on its way out; nothing will read the poke now.
             if waiting is not None:

--- a/lemma-backend/app/modules/agent/capabilities/assembler.py
+++ b/lemma-backend/app/modules/agent/capabilities/assembler.py
@@ -49,6 +49,7 @@ from app.modules.agent.domain.prompts import (
     load_messaging_prompt,
     load_skills_prompt,
     load_speech_prompt,
+    load_user_interaction_prompt,
     load_workspace_cli_prompt,
 )
 from app.modules.agent.domain.value_objects import AgentToolset
@@ -56,6 +57,9 @@ from app.modules.agent.services.run_phase_spans import run_phase
 from app.modules.agent.tools.graceful_toolset import GracefulToolset
 from app.modules.agent.tools.registry import EXTRA_TOOLSET_OBJECTS
 from app.modules.agent.tools.skills.pydantic_adapter import skills_toolset
+from app.modules.agent.tools.user_interaction.pydantic_adapter import (
+    user_interaction_toolset,
+)
 from app.modules.agent.tools.speech.pydantic_adapter import speech_toolset
 from app.modules.agent.tools.messaging.pydantic_adapter import messaging_toolset
 from app.modules.agent.tools.web.pydantic_adapter import web_search_toolset
@@ -88,6 +92,7 @@ _INSTRUCTED_TOOLSETS: tuple[tuple[object, str, Callable[[], str]], ...] = (
     (skills_toolset, "skills", load_skills_prompt),
     (speech_toolset, "speech", load_speech_prompt),
     (messaging_toolset, "messaging", load_messaging_prompt),
+    (user_interaction_toolset, "user_interaction", load_user_interaction_prompt),
 )
 
 

--- a/lemma-backend/app/modules/agent/domain/agent_host.py
+++ b/lemma-backend/app/modules/agent/domain/agent_host.py
@@ -312,6 +312,12 @@ class AgentHostPollRequest(BaseModel):
     )
 
 
+# The one delivery policy that lets a turn leave the instructions out. Matches
+# `protocol::NEW_SESSION_ONLY` in the host; the host treats anything else,
+# including absent, as "send them", so the two cannot disagree dangerously.
+NEW_SESSION_ONLY = "NEW_SESSION_ONLY"
+
+
 class AgentHostRunSpec(BaseModel):
     agent_run_id: UUID
     conversation_id: UUID
@@ -324,6 +330,18 @@ class AgentHostRunSpec(BaseModel):
     resume_session_id: str | None = Field(default=None, max_length=512)
     context: JsonObject = Field(default_factory=dict)
     run_deadline: datetime
+    system_prompt_delivery: str | None = Field(
+        default=None,
+        max_length=32,
+        description=(
+            "Whether the host still has to carry system_prompt into the "
+            "session. NEW_SESSION_ONLY means the session this run expects to "
+            "resume has already been told exactly these instructions, so a "
+            "resumed turn may leave them out; the host still sends them if it "
+            "ends up opening a new session, which is the case Lemma cannot "
+            "predict. Absent means send them every turn."
+        ),
+    )
 
 
 class AgentHostCommand(BaseModel):
@@ -391,209 +409,3 @@ class AgentHostEventAck(BaseModel):
     run_id: UUID
     lease_epoch: int
     acked_through: int = Field(ge=0)
-
-
-def _agent_host_options_by_key(
-    config_options: list[object],
-) -> dict[str, dict[str, object]]:
-    """Index a harness's options by both the names a selection may use."""
-    options_by_key: dict[str, dict[str, object]] = {}
-    for raw_option in config_options:
-        if not isinstance(raw_option, dict):
-            continue
-        option_id = str(raw_option.get("id") or "").strip()
-        category = str(raw_option.get("category") or "").strip()
-        if option_id:
-            options_by_key[option_id] = raw_option
-        if category:
-            options_by_key[category] = raw_option
-    return options_by_key
-
-
-def validate_agent_host_selections(
-    *,
-    config_options: list[object],
-    selections: JsonObject,
-) -> JsonObject:
-    """Validate provider-owned selections without translating their values."""
-    options_by_key = _agent_host_options_by_key(config_options)
-
-    normalized: JsonObject = {}
-    for key, value in selections.items():
-        normalized_key = str(key).strip()
-        option = options_by_key.get(normalized_key)
-        if option is None:
-            raise ValueError(f"Unknown Agent Host configuration selection: {key}")
-        option_category = str(option.get("category") or "").strip()
-        if option_category == "model":
-            raise ValueError("Model must be configured through default_model_name")
-        if option_category in _PLATFORM_OWNED_OPTION_CATEGORIES:
-            # Approval/sandbox presets and turn-to-turn collaboration are
-            # Lemma's, not a per-profile choice: approvals must be answered the
-            # same way whichever harness runs, and a conversation already maps
-            # to one session. Dropped rather than rejected so a profile saved
-            # before this rule stays editable; the harness keeps applying its
-            # own safe default, which is what the built-in harness does too.
-            continue
-        # Deny-list first, then membership - the order ``selection_is_allowed``
-        # uses in acp.rs. It matters: harnesses *do* enumerate their
-        # permission modes, so a value like ``bypassPermissions`` is a legal
-        # member of the option's own list and the host refuses it anyway.
-        # Checking membership first would let exactly the common case through,
-        # to save cleanly and then fail at session setup on the first run.
-        if _is_disallowed_policy_selection(option, value):
-            raise ValueError(
-                f"That value is not allowed for Agent Host configuration: {key}"
-            )
-        allowed_values = _agent_host_option_values(option.get("options"))
-        if allowed_values and value not in allowed_values:
-            raise ValueError(
-                f"Invalid value for Agent Host configuration selection: {key}"
-            )
-        normalized[normalized_key] = value
-    return normalized
-
-
-def validate_agent_host_model(
-    *,
-    config_options: list[object],
-    model_name: str | None,
-) -> str | None:
-    if model_name is None:
-        return None
-    normalized = model_name.strip()
-    if not normalized:
-        raise ValueError("default_model_name cannot be empty")
-    model_options: list[object] = []
-    has_model_option = False
-    for raw_option in config_options:
-        if not isinstance(raw_option, dict):
-            continue
-        if str(raw_option.get("category") or "").strip() != "model":
-            continue
-        has_model_option = True
-        model_options.extend(_agent_host_option_values(raw_option.get("options")))
-    if not has_model_option or normalized not in model_options:
-        raise ValueError("default_model_name is not offered by this harness")
-    return normalized
-
-
-class AgentHostSelectionRefused(ValueError):
-    """A carried-over selection the re-published harness must not be given."""
-
-
-def carry_agent_host_selections(
-    *,
-    config_options: list[object],
-    selections: JsonObject,
-) -> JsonObject:
-    """Carry saved selections across a harness re-publish, dropping what moved.
-
-    The lenient sibling of :func:`validate_agent_host_selections`, for the one
-    caller that is not a user pressing Save: a run already in flight whose
-    harness re-published a different set of options underneath it. There, a
-    selection the harness no longer offers is news about the harness, not a
-    mistake by the person -- refusing it would fail a run over a value nobody
-    chose to change.
-
-    So an unknown key and a value that is no longer a member are *dropped*, and
-    the harness applies its own default for them.
-
-    A policy-bearing value is the exception and still refuses, by raising:
-    ``_is_disallowed_policy_selection`` is what stops a stored profile turning
-    off the human-approval gate, and "the harness changed" is not a reason to
-    stop enforcing it. The caller fails the run rather than dispatching it.
-    """
-    options_by_key = _agent_host_options_by_key(config_options)
-    carried: JsonObject = {}
-    for key, value in selections.items():
-        normalized_key = str(key).strip()
-        option = options_by_key.get(normalized_key)
-        if option is None:
-            continue
-        option_category = str(option.get("category") or "").strip()
-        if option_category == "model" or option_category in (
-            _PLATFORM_OWNED_OPTION_CATEGORIES
-        ):
-            continue
-        if _is_disallowed_policy_selection(option, value):
-            raise AgentHostSelectionRefused(
-                f"That value is not allowed for Agent Host configuration: {key}"
-            )
-        allowed_values = _agent_host_option_values(option.get("options"))
-        if allowed_values and value not in allowed_values:
-            continue
-        carried[normalized_key] = value
-    return carried
-
-
-def carry_agent_host_model(
-    *,
-    config_options: list[object],
-    model_name: str | None,
-) -> str | None:
-    """The pinned model if the re-published harness still offers it, else None.
-
-    ``None`` means "let the harness use its own default", which is what an
-    unpinned profile already sends. Unlike :func:`validate_agent_host_model`
-    this never raises: a model is a preference, not a permission, and the
-    codebase already treats it that way when a profile is edited
-    (``runtime_profile_editor`` clears a stale pin rather than refusing) and
-    when one is dispatched (``_selected_model`` falls back to the catalog).
-    """
-    if model_name is None:
-        return None
-    try:
-        return validate_agent_host_model(
-            config_options=config_options, model_name=model_name
-        )
-    except ValueError:
-        return None
-
-
-# Mirrors the Agent Host's own policy filter (desktop/agent-host/src/acp.rs:569-600):
-# an option whose id or category mentions one of these governs what the coding
-# agent is allowed to do without asking.
-# Settings the platform owns, so a profile may not carry them. `mode` is the
-# approval and sandboxing preset, and approvals are Lemma's job - a run asks, a
-# human answers, identically whichever harness executes. `collaboration_mode`
-# decides how state carries across turns, which the conversation already fixes
-# by mapping to one session.
-_PLATFORM_OWNED_OPTION_CATEGORIES = frozenset({"mode", "collaboration_mode"})
-
-_POLICY_OPTION_MARKERS = ("mode", "permission", "approval", "sandbox")
-_DISALLOWED_POLICY_VALUES = frozenset(
-    {
-        "bypasspermissions",
-        "agentfullaccess",
-        "fullaccess",
-        "acceptedits",
-        "yolo",
-        "auto",
-    }
-)
-
-
-def _is_disallowed_policy_selection(option: dict[str, object], value: object) -> bool:
-    if not isinstance(value, str):
-        return False
-    identity = f"{option.get('id') or ''} {option.get('category') or ''}".lower()
-    if not any(marker in identity for marker in _POLICY_OPTION_MARKERS):
-        return False
-    normalized = "".join(ch for ch in value if ch.isalnum()).lower()
-    return normalized in _DISALLOWED_POLICY_VALUES
-
-
-def _agent_host_option_values(raw_options: object) -> list[object]:
-    if not isinstance(raw_options, list):
-        return []
-    values: list[object] = []
-    for item in raw_options:
-        if not isinstance(item, dict):
-            values.append(item)
-            continue
-        if "value" in item:
-            values.append(item["value"])
-        elif "id" in item:
-            values.append(item["id"])
-    return values

--- a/lemma-backend/app/modules/agent/domain/agent_host_selections.py
+++ b/lemma-backend/app/modules/agent/domain/agent_host_selections.py
@@ -1,0 +1,218 @@
+"""Validating and carrying a runtime profile's Agent Host selections.
+
+Split out of ``agent_host`` because it answers a different question. That module
+is the wire contract — what a host and Lemma say to each other. This is policy
+over one harness's published options: whether a selection is allowed at all, and
+which of a profile's selections survive the harness republishing its options
+with different values.
+"""
+
+from __future__ import annotations
+
+from app.modules.agent.domain.value_objects import JsonObject
+
+
+def _agent_host_options_by_key(
+    config_options: list[object],
+) -> dict[str, dict[str, object]]:
+    """Index a harness's options by both the names a selection may use."""
+    options_by_key: dict[str, dict[str, object]] = {}
+    for raw_option in config_options:
+        if not isinstance(raw_option, dict):
+            continue
+        option_id = str(raw_option.get("id") or "").strip()
+        category = str(raw_option.get("category") or "").strip()
+        if option_id:
+            options_by_key[option_id] = raw_option
+        if category:
+            options_by_key[category] = raw_option
+    return options_by_key
+
+
+def validate_agent_host_selections(
+    *,
+    config_options: list[object],
+    selections: JsonObject,
+) -> JsonObject:
+    """Validate provider-owned selections without translating their values."""
+    options_by_key = _agent_host_options_by_key(config_options)
+
+    normalized: JsonObject = {}
+    for key, value in selections.items():
+        normalized_key = str(key).strip()
+        option = options_by_key.get(normalized_key)
+        if option is None:
+            raise ValueError(f"Unknown Agent Host configuration selection: {key}")
+        option_category = str(option.get("category") or "").strip()
+        if option_category == "model":
+            raise ValueError("Model must be configured through default_model_name")
+        if option_category in _PLATFORM_OWNED_OPTION_CATEGORIES:
+            # Approval/sandbox presets and turn-to-turn collaboration are
+            # Lemma's, not a per-profile choice: approvals must be answered the
+            # same way whichever harness runs, and a conversation already maps
+            # to one session. Dropped rather than rejected so a profile saved
+            # before this rule stays editable; the harness keeps applying its
+            # own safe default, which is what the built-in harness does too.
+            continue
+        # Deny-list first, then membership - the order ``selection_is_allowed``
+        # uses in acp.rs. It matters: harnesses *do* enumerate their
+        # permission modes, so a value like ``bypassPermissions`` is a legal
+        # member of the option's own list and the host refuses it anyway.
+        # Checking membership first would let exactly the common case through,
+        # to save cleanly and then fail at session setup on the first run.
+        if _is_disallowed_policy_selection(option, value):
+            raise ValueError(
+                f"That value is not allowed for Agent Host configuration: {key}"
+            )
+        allowed_values = _agent_host_option_values(option.get("options"))
+        if allowed_values and value not in allowed_values:
+            raise ValueError(
+                f"Invalid value for Agent Host configuration selection: {key}"
+            )
+        normalized[normalized_key] = value
+    return normalized
+
+
+def validate_agent_host_model(
+    *,
+    config_options: list[object],
+    model_name: str | None,
+) -> str | None:
+    if model_name is None:
+        return None
+    normalized = model_name.strip()
+    if not normalized:
+        raise ValueError("default_model_name cannot be empty")
+    model_options: list[object] = []
+    has_model_option = False
+    for raw_option in config_options:
+        if not isinstance(raw_option, dict):
+            continue
+        if str(raw_option.get("category") or "").strip() != "model":
+            continue
+        has_model_option = True
+        model_options.extend(_agent_host_option_values(raw_option.get("options")))
+    if not has_model_option or normalized not in model_options:
+        raise ValueError("default_model_name is not offered by this harness")
+    return normalized
+
+
+class AgentHostSelectionRefused(ValueError):
+    """A carried-over selection the re-published harness must not be given."""
+
+
+def carry_agent_host_selections(
+    *,
+    config_options: list[object],
+    selections: JsonObject,
+) -> JsonObject:
+    """Carry saved selections across a harness re-publish, dropping what moved.
+
+    The lenient sibling of :func:`validate_agent_host_selections`, for the one
+    caller that is not a user pressing Save: a run already in flight whose
+    harness re-published a different set of options underneath it. There, a
+    selection the harness no longer offers is news about the harness, not a
+    mistake by the person -- refusing it would fail a run over a value nobody
+    chose to change.
+
+    So an unknown key and a value that is no longer a member are *dropped*, and
+    the harness applies its own default for them.
+
+    A policy-bearing value is the exception and still refuses, by raising:
+    ``_is_disallowed_policy_selection`` is what stops a stored profile turning
+    off the human-approval gate, and "the harness changed" is not a reason to
+    stop enforcing it. The caller fails the run rather than dispatching it.
+    """
+    options_by_key = _agent_host_options_by_key(config_options)
+    carried: JsonObject = {}
+    for key, value in selections.items():
+        normalized_key = str(key).strip()
+        option = options_by_key.get(normalized_key)
+        if option is None:
+            continue
+        option_category = str(option.get("category") or "").strip()
+        if option_category == "model" or option_category in (
+            _PLATFORM_OWNED_OPTION_CATEGORIES
+        ):
+            continue
+        if _is_disallowed_policy_selection(option, value):
+            raise AgentHostSelectionRefused(
+                f"That value is not allowed for Agent Host configuration: {key}"
+            )
+        allowed_values = _agent_host_option_values(option.get("options"))
+        if allowed_values and value not in allowed_values:
+            continue
+        carried[normalized_key] = value
+    return carried
+
+
+def carry_agent_host_model(
+    *,
+    config_options: list[object],
+    model_name: str | None,
+) -> str | None:
+    """The pinned model if the re-published harness still offers it, else None.
+
+    ``None`` means "let the harness use its own default", which is what an
+    unpinned profile already sends. Unlike :func:`validate_agent_host_model`
+    this never raises: a model is a preference, not a permission, and the
+    codebase already treats it that way when a profile is edited
+    (``runtime_profile_editor`` clears a stale pin rather than refusing) and
+    when one is dispatched (``_selected_model`` falls back to the catalog).
+    """
+    if model_name is None:
+        return None
+    try:
+        return validate_agent_host_model(
+            config_options=config_options, model_name=model_name
+        )
+    except ValueError:
+        return None
+
+
+# Mirrors the Agent Host's own policy filter (desktop/agent-host/src/acp.rs:569-600):
+# an option whose id or category mentions one of these governs what the coding
+# agent is allowed to do without asking.
+# Settings the platform owns, so a profile may not carry them. `mode` is the
+# approval and sandboxing preset, and approvals are Lemma's job - a run asks, a
+# human answers, identically whichever harness executes. `collaboration_mode`
+# decides how state carries across turns, which the conversation already fixes
+# by mapping to one session.
+_PLATFORM_OWNED_OPTION_CATEGORIES = frozenset({"mode", "collaboration_mode"})
+
+_POLICY_OPTION_MARKERS = ("mode", "permission", "approval", "sandbox")
+_DISALLOWED_POLICY_VALUES = frozenset(
+    {
+        "bypasspermissions",
+        "agentfullaccess",
+        "fullaccess",
+        "acceptedits",
+        "yolo",
+        "auto",
+    }
+)
+
+
+def _is_disallowed_policy_selection(option: dict[str, object], value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    identity = f"{option.get('id') or ''} {option.get('category') or ''}".lower()
+    if not any(marker in identity for marker in _POLICY_OPTION_MARKERS):
+        return False
+    normalized = "".join(ch for ch in value if ch.isalnum()).lower()
+    return normalized in _DISALLOWED_POLICY_VALUES
+
+
+def _agent_host_option_values(raw_options: object) -> list[object]:
+    if not isinstance(raw_options, list):
+        return []
+    values: list[object] = []
+    for item in raw_options:
+        if not isinstance(item, dict):
+            values.append(item)
+            continue
+        if "value" in item:
+            values.append(item["value"])
+        elif "id" in item:
+            values.append(item["id"])
+    return values

--- a/lemma-backend/app/modules/agent/domain/prompts.py
+++ b/lemma-backend/app/modules/agent/domain/prompts.py
@@ -28,6 +28,7 @@ _WEB_SEARCH_PROMPT_PATH = _PROMPT_DIR / "web_search.md"
 _TODO_PROMPT_PATH = _PROMPT_DIR / "todo.md"
 _SPEECH_PROMPT_PATH = _PROMPT_DIR / "speech.md"
 _MESSAGING_PROMPT_PATH = _PROMPT_DIR / "messaging.md"
+_USER_INTERACTION_PROMPT_PATH = _PROMPT_DIR / "user_interaction.md"
 _AGENT_HOST_RUNTIME_PROMPT_PATH = _PROMPT_DIR / "agent_host_runtime.md"
 
 # Per-toolset prompt fragments, in the order they should appear in the system
@@ -44,6 +45,15 @@ FRAGMENT_BY_TOOLSET: dict[AgentToolset, Path] = {
     AgentToolset.SPEECH: _SPEECH_PROMPT_PATH,
     AgentToolset.TODO: _TODO_PROMPT_PATH,
     AgentToolset.MESSAGING: _MESSAGING_PROMPT_PATH,
+    # `display_resource` had no fragment on either path for a long time, on the
+    # theory that the tool's own description was enough. It is enough for an
+    # in-process run, where that description is a first-class tool definition
+    # and nothing competes with it. It is not enough for a coding agent driven
+    # through Agent Host, which meets the same text as one MCP tool among its
+    # own file and shell tools, underneath its own system prompt telling it to
+    # behave like a coding agent — so it answered in prose and never showed
+    # anything. Convention belongs in the instructions, not only in a schema.
+    AgentToolset.USER_INTERACTION: _USER_INTERACTION_PROMPT_PATH,
 }
 
 
@@ -83,6 +93,10 @@ def load_messaging_prompt() -> str:
 
 def load_speech_prompt() -> str:
     return _read_required_prompt(_SPEECH_PROMPT_PATH)
+
+
+def load_user_interaction_prompt() -> str:
+    return _read_required_prompt(_USER_INTERACTION_PROMPT_PATH)
 
 
 def load_agent_host_runtime_prompt() -> str:

--- a/lemma-backend/app/modules/agent/infrastructure/agent_host_admission.py
+++ b/lemma-backend/app/modules/agent/infrastructure/agent_host_admission.py
@@ -24,6 +24,8 @@ from app.modules.agent.domain.agent_host import (
     AgentHostHarnessHealth,
     AgentHostRunSpec,
     AgentHostRunState,
+)
+from app.modules.agent.domain.agent_host_selections import (
     validate_agent_host_selections,
 )
 from app.modules.agent.infrastructure.agent_host_repository import (

--- a/lemma-backend/app/modules/agent/infrastructure/agent_host_command_remint.py
+++ b/lemma-backend/app/modules/agent/infrastructure/agent_host_command_remint.py
@@ -29,6 +29,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.log.log import get_logger
 from app.modules.agent.domain.agent_host import (
     AgentHostHarnessHealth,
+)
+from app.modules.agent.domain.agent_host_selections import (
     AgentHostSelectionRefused,
     carry_agent_host_model,
     carry_agent_host_selections,

--- a/lemma-backend/app/modules/agent/infrastructure/agent_host_session_memory.py
+++ b/lemma-backend/app/modules/agent/infrastructure/agent_host_session_memory.py
@@ -12,6 +12,7 @@ Both halves live here so the read and the write cannot drift apart.
 
 from __future__ import annotations
 
+import hashlib
 from uuid import UUID
 
 from sqlalchemy import select
@@ -62,15 +63,43 @@ async def remember_provider_session(
     if binding is None:
         return False
     conversation_id, harness_id = binding
-    # Stored with the harness that opened it. A Codex rollout id means nothing
-    # to Claude Code, so a conversation moved to another harness starts a fresh
-    # session there instead of failing a load every turn.
-    binding_value = {"harness_id": str(harness_id), "session_id": session_id}
     repository = ConversationRepository(uow)
     stored = await repository.get_conversation_metadata_key(
         conversation_id,
         AGENT_HOST_SESSION_METADATA_KEY,
     )
+    stored = stored if isinstance(stored, dict) else {}
+    # Stored with the harness that opened it. A Codex rollout id means nothing
+    # to Claude Code, so a conversation moved to another harness starts a fresh
+    # session there instead of failing a load every turn.
+    binding_value: JsonObject = {
+        "harness_id": str(harness_id),
+        "session_id": session_id,
+    }
+    # This checkpoint is the host reporting that it prompted, so it is also the
+    # proof that the instructions dispatched with the run reached the session.
+    # Promoted here rather than recorded at dispatch: a run that died before it
+    # prompted — host offline, expired command, adapter that would not start —
+    # delivered nothing, and marking those instructions delivered would keep
+    # every later turn skipping them, silently losing a user's edit for the rest
+    # of the conversation.
+    pending = stored.get("pending_instructions")
+    delivered = stored.get("instructions_digest")
+    promoted = (
+        isinstance(pending, dict)
+        and pending.get("run_id") == str(checkpoint.run_id)
+        and isinstance(pending.get("digest"), str)
+    )
+    if promoted:
+        delivered = pending["digest"]
+    elif pending is not None:
+        # Someone else's promise, still owed. This value is rebuilt from
+        # scratch on every checkpoint, so anything not carried forward here is
+        # silently dropped — and dropping a pending promise would leave the run
+        # that made it unable to record what it delivered.
+        binding_value["pending_instructions"] = pending
+    if isinstance(delivered, str) and delivered:
+        binding_value["instructions_digest"] = delivered
     if stored == binding_value:
         return False
     await repository.set_conversation_metadata_key(
@@ -79,6 +108,65 @@ async def remember_provider_session(
         binding_value,
     )
     return True
+
+
+def instructions_digest(system_prompt: str) -> str:
+    """A stable fingerprint of the instructions a run is dispatching.
+
+    Taken over the exact string that lands on the run spec, not over the pieces
+    it was assembled from, so any change a user can make — agent instructions,
+    conversation instructions, the granted-resource brief — moves it.
+    """
+    return hashlib.sha256(system_prompt.encode("utf-8")).hexdigest()
+
+
+async def record_pending_instructions(
+    uow: SqlAlchemyUnitOfWork,
+    *,
+    conversation_id: UUID,
+    run_id: UUID,
+    digest: str,
+) -> None:
+    """Note which run is carrying which instructions, pending its delivery.
+
+    A promise, not a record: :func:`remember_provider_session` turns it into one
+    when the host reports that it actually prompted.
+    """
+    repository = ConversationRepository(uow)
+    stored = await repository.get_conversation_metadata_key(
+        conversation_id,
+        AGENT_HOST_SESSION_METADATA_KEY,
+    )
+    binding = dict(stored) if isinstance(stored, dict) else {}
+    binding["pending_instructions"] = {"run_id": str(run_id), "digest": digest}
+    await repository.set_conversation_metadata_key(
+        conversation_id,
+        AGENT_HOST_SESSION_METADATA_KEY,
+        binding,
+    )
+
+
+async def instructions_already_delivered(
+    uow: SqlAlchemyUnitOfWork,
+    *,
+    conversation_id: UUID,
+    harness_id: UUID,
+    digest: str,
+) -> bool:
+    """Whether this session has already been told exactly these instructions.
+
+    False for anything uncertain — no binding, another harness, no digest
+    recorded, or a digest that has moved. The failure this guards against is
+    an agent quietly running without its instructions, so every ambiguous case
+    resolves toward sending them again.
+    """
+    stored = await ConversationRepository(uow).get_conversation_metadata_key(
+        conversation_id,
+        AGENT_HOST_SESSION_METADATA_KEY,
+    )
+    if not isinstance(stored, dict) or stored.get("harness_id") != str(harness_id):
+        return False
+    return stored.get("instructions_digest") == digest
 
 
 async def resume_session_id(

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_dispatch.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_dispatch.py
@@ -15,7 +15,7 @@ from uuid import UUID
 from app.core.crypto import get_secret_cipher
 from app.core.infrastructure.db.uow_factory import UnitOfWorkFactory
 from app.core.log.log import get_logger
-from app.modules.agent.domain.agent_host import AgentHostRunSpec
+from app.modules.agent.domain.agent_host import NEW_SESSION_ONLY, AgentHostRunSpec
 from app.modules.agent.domain.context import AgentContext
 from app.modules.agent.domain.entities import Agent, Conversation, Message
 from app.modules.agent.domain.prompts import load_agent_host_runtime_prompt
@@ -170,6 +170,27 @@ agent: Agent,
     encrypted_mcp = await get_secret_cipher().encrypt_json_async(mcp)
     if encrypted_mcp is None:
         raise RuntimeError("could not encrypt MCP configuration")
+    # A conversation is one provider session, and a session keeps its own
+    # history — so instructions delivered when it opened are still there on
+    # every later turn. Re-sending them each time put another copy of a
+    # multi-kilobyte block into the provider's transcript per message, which it
+    # then re-read in full on every turn after that. Skipped only when this
+    # exact text is already known to have reached this session; the host still
+    # sends it if it ends up opening a new one.
+    system_prompt = str(
+        prompt.get("system_prompt") or prompt.get("recovery_system_prompt") or ""
+    )
+    digest = agent_host_session_memory.instructions_digest(system_prompt)
+    system_prompt_delivery: str | None = None
+    if resume_session_id is not None:
+        async with uow_factory() as uow:
+            if await agent_host_session_memory.instructions_already_delivered(
+                uow,
+                conversation_id=conversation.id,
+                harness_id=harness_id,
+                digest=digest,
+            ):
+                system_prompt_delivery = NEW_SESSION_ONLY
     dispatched_at = datetime.now(timezone.utc)
     timeout_seconds, credential_bounded = credential_bounded_timeout(
         configured_seconds=event_timeout_seconds,
@@ -185,11 +206,8 @@ agent: Agent,
             profile_revision=config_revision,
             model_name=run_config.model_name,
             config_selections=run_config.config_selections,
-            system_prompt=str(
-                prompt.get("system_prompt")
-                or prompt.get("recovery_system_prompt")
-                or ""
-            ),
+            system_prompt=system_prompt,
+            system_prompt_delivery=system_prompt_delivery,
             prompt=[{"type": "text", "text": str(prompt.get("user_prompt") or "")}],
             resume_session_id=resume_session_id,
             context={
@@ -207,6 +225,16 @@ agent: Agent,
             run_spec=run_spec,
             encrypted_mcp_payload=encrypted_mcp,
             command_ttl_seconds=run_config.wait_timeout_seconds,
+        )
+        # A promise, committed with the command it belongs to. It becomes a
+        # record only when the host reports that it prompted, so a run that
+        # dies on the way out does not leave these instructions marked
+        # delivered and skipped for the rest of the conversation.
+        await agent_host_session_memory.record_pending_instructions(
+            uow,
+            conversation_id=conversation.id,
+            run_id=agent_run_id,
+            digest=digest,
         )
         await uow.commit()
     await poke_host(host_id)

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_events.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_events.py
@@ -353,13 +353,19 @@ class AgentHostEventNormalizer:
             )
         if object_id in self.tool_calls.closed:
             return []
+        # A call still holding its arguments has to be announced before its
+        # return, or the conversation gets a result for something it never saw
+        # start. It is handed this payload because for a call that was never
+        # refined, the closing update is the only thing that ever named the tool
+        # or carried its input.
+        opening = self._announce_tool_call(
+            self.tool_calls.release(object_id, payload, metadata)
+        )
+        # Read after the release, so the return is named whatever the call was
+        # finally announced as rather than the placeholder it opened with.
         tool_name = self.tool_calls.open_calls.get(
             object_id, tool_name_from_payload(payload)
         )
-        # A call still holding its arguments has to be announced before its
-        # return, or the conversation gets a result for something it never saw
-        # start.
-        opening = self._announce_tool_call(self.tool_calls.release(object_id))
         self.tool_calls.close(object_id)
         raw_result = first_present(payload, "result", "rawOutput")
         if status == "COMPLETED":

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_events.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_events.py
@@ -37,13 +37,16 @@ from app.modules.agent.infrastructure.harnesses.streaming import TextStreamBuffe
 from app.modules.agent.infrastructure.harnesses.tool_returns import (
     missing_tool_return_events,
 )
+from app.modules.agent.infrastructure.harnesses.agent_host_tool_calls import (
+    ToolCallLedger,
+)
 from app.modules.agent.infrastructure.harnesses.agent_host_tool_payload import (
     bounded_tool_value,
     first_present,
     json_object,
-    tool_args,
     tool_metadata,
     tool_name_from_payload,
+    unwrap_mcp_content,
 )
 from app.modules.agent.infrastructure.harnesses.agent_host_final_answer_stream import (
     final_answer_metadata,
@@ -98,13 +101,7 @@ class AgentHostEventNormalizer:
         self._thought = _Segment(kind="thinking")
         self.token_buffer = TextStreamBuffer()
         self._token_kind: str | None = None
-        self.tool_calls: dict[str, str] = {}
-        self.closed_tool_calls: set[str] = set()
-        # ACP's ToolCall has no required id field, so an adapter is free to
-        # report a call and its completion with nothing tying them together.
-        # See :meth:`_tool_object_id`.
-        self._anonymous_tool_calls = 0
-        self._open_anonymous_tool_call: str | None = None
+        self.tool_calls = ToolCallLedger()
         # Whether this run owes a structured final answer, and against what.
         # Gates the text fallback: scraping JSON out of an ordinary chat reply
         # would invent structured results that were never claimed.
@@ -151,12 +148,16 @@ class AgentHostEventNormalizer:
         if event_type is AgentHostEventType.AGENT_THOUGHT_UPSERT:
             return self._upsert(self._thought, row, payload)
         if event_type is AgentHostEventType.TOOL_CALL_UPSERT:
-            call_id = self._tool_object_id(row, opening=True)
-            return self._tool_call_upsert(
-                row, call_id, payload, {**metadata, "agent_host_object_id": call_id}
+            call_id = self.tool_calls.object_id(row.object_id, opening=True)
+            announced = self.tool_calls.open(
+                call_id,
+                payload,
+                {**metadata, "agent_host_object_id": call_id},
+                sequence=row.sequence,
             )
+            return self._announce_tool_call(announced)
         if event_type is AgentHostEventType.TOOL_CALL_UPDATE:
-            call_id = self._tool_object_id(row, opening=False)
+            call_id = self.tool_calls.object_id(row.object_id, opening=False)
             return self._tool_call_update(
                 row, call_id, payload, {**metadata, "agent_host_object_id": call_id}
             )
@@ -224,6 +225,28 @@ class AgentHostEventNormalizer:
             data={"kind": kind, "data": text},
             agent_run_id=self.agent_run_id,
         )
+
+    def _announce_tool_call(
+        self, announced: tuple[MessageDraft, int] | None
+    ) -> list[AgentEvent]:
+        """Turn a call the ledger decided is ready into a durable message.
+
+        The ledger owns *when*; this owns *how*, which is why the draft carries
+        the sequence it was first reported at rather than the one that happened
+        to settle it — a call belongs where the agent made it.
+        """
+        if announced is None:
+            return []
+        draft, sequence = announced
+        return [
+            *self._drain_tokens(),
+            AgentEvent(
+                type=AgentEventType.MESSAGE,
+                data=draft,
+                agent_run_id=self.agent_run_id,
+                sequence=sequence,
+            ),
+        ]
 
     def _drain_tokens(self) -> list[AgentEvent]:
         kind = self._token_kind
@@ -312,62 +335,6 @@ class AgentHostEventNormalizer:
 
     # ------------------------------------------------------------- tool calls
 
-    def _tool_object_id(self, row: AgentHostEventEnvelope, *, opening: bool) -> str:
-        """The id a tool call and its later update must agree on.
-
-        ACP's ``ToolCall`` carries no required identifier, so an adapter can
-        report a call and its completion with nothing linking them. The old
-        fallback was the event sequence, which is different for the two events
-        by definition: the call was therefore never closed — it was swept at
-        the end as an abandoned call — and the update emitted a result for an
-        id nobody held.
-
-        With no id on the wire the only correlation available is order, so an
-        untagged update is attributed to the untagged call still open. That is
-        a heuristic, and it is exactly as good as the information the adapter
-        gave us; ``acp.rs`` reaches for the same one when a permission request
-        arrives without a tool-call id.
-        """
-        if row.object_id:
-            return row.object_id
-        if opening:
-            self._anonymous_tool_calls += 1
-            self._open_anonymous_tool_call = (
-                f"anonymous-tool-call-{self._anonymous_tool_calls}"
-            )
-            return self._open_anonymous_tool_call
-        return (
-            self._open_anonymous_tool_call
-            or f"anonymous-tool-call-{max(self._anonymous_tool_calls, 1)}"
-        )
-
-    def _tool_call_upsert(
-        self,
-        row: AgentHostEventEnvelope,
-        object_id: str,
-        payload: JsonObject,
-        metadata: JsonObject,
-    ) -> list[AgentEvent]:
-        tool_name = tool_name_from_payload(payload)
-        if object_id in self.tool_calls:
-            return []
-        self.tool_calls[object_id] = tool_name
-        events = self._drain_tokens()
-        events.append(
-            AgentEvent(
-                type=AgentEventType.MESSAGE,
-                data=MessageDraft.of_tool_call(
-                    tool_name=tool_name,
-                    tool_call_id=object_id,
-                    tool_args=tool_args(payload, tool_name),
-                    metadata=tool_metadata(metadata, payload),
-                ),
-                agent_run_id=self.agent_run_id,
-                sequence=row.sequence,
-            )
-        )
-        return events
-
     def _tool_call_update(
         self,
         row: AgentHostEventEnvelope,
@@ -376,15 +343,24 @@ class AgentHostEventNormalizer:
         metadata: JsonObject,
     ) -> list[AgentEvent]:
         status = str(payload.get("status") or "").upper()
-        if (
-            status not in {"COMPLETED", "FAILED", "CANCELLED", "DENIED"}
-            or object_id in self.closed_tool_calls
-        ):
+        if status not in {"COMPLETED", "FAILED", "CANCELLED", "DENIED"}:
+            # Not a closing update. Claude Code sends the complete `rawInput`
+            # here, with no status at all, once the model finishes writing it —
+            # so dropping these was what left every streamed tool call showing
+            # `{}` for its arguments.
+            return self._announce_tool_call(
+                self.tool_calls.refine(object_id, payload, metadata)
+            )
+        if object_id in self.tool_calls.closed:
             return []
-        tool_name = self.tool_calls.get(object_id, tool_name_from_payload(payload))
-        self.closed_tool_calls.add(object_id)
-        if object_id == self._open_anonymous_tool_call:
-            self._open_anonymous_tool_call = None
+        tool_name = self.tool_calls.open_calls.get(
+            object_id, tool_name_from_payload(payload)
+        )
+        # A call still holding its arguments has to be announced before its
+        # return, or the conversation gets a result for something it never saw
+        # start.
+        opening = self._announce_tool_call(self.tool_calls.release(object_id))
+        self.tool_calls.close(object_id)
         raw_result = first_present(payload, "result", "rawOutput")
         if status == "COMPLETED":
             # Read the RAW value, before bounding. `_bounded_tool_value` truncates
@@ -398,13 +374,14 @@ class AgentHostEventNormalizer:
                 record = final_answer_record(event_text(payload))
             if record is not None:
                 self.adopt_final_answer(record, tool_call_id=object_id)
-        result = bounded_tool_value(raw_result)
+        result = bounded_tool_value(unwrap_mcp_content(raw_result))
         if status != "COMPLETED":
             result = {
                 "success": False,
                 "error": str(payload.get("error") or status.lower()),
             }
         return [
+            *opening,
             *self._drain_tokens(),
             AgentEvent(
                 type=AgentEventType.MESSAGE,
@@ -420,15 +397,22 @@ class AgentHostEventNormalizer:
         ]
 
     def close_outstanding(self, terminal: AgentEvent) -> list[AgentEvent]:
-        outstanding = {
-            tool_call_id: tool_name
-            for tool_call_id, tool_name in self.tool_calls.items()
-            if tool_call_id not in self.closed_tool_calls
-        }
-        return missing_tool_return_events(
-            outstanding_tool_calls=outstanding,
-            terminal_event=terminal,
-        )
+        # Held calls first: a run that ends mid-turn still has to show what the
+        # agent had started, and each one needs its opening on the record before
+        # `missing_tool_return_events` synthesizes the return that closes it.
+        released = [
+            event
+            for announced in self.tool_calls.release_all()
+            for event in self._announce_tool_call(announced)
+        ]
+        outstanding = self.tool_calls.outstanding()
+        return [
+            *released,
+            *missing_tool_return_events(
+                outstanding_tool_calls=outstanding,
+                terminal_event=terminal,
+            ),
+        ]
 
     # ---------------------------------------------------------------- other
 
@@ -489,7 +473,7 @@ class AgentHostEventNormalizer:
         # still offers buttons, and pressing one lands on a run that ended hours
         # ago. Answering it *does* write a return, and a synthesized return
         # never replaces a real one, so this closes only the abandoned ones.
-        self.tool_calls[permission_approval_tool_call_id(request_id)] = (
+        self.tool_calls.open_calls[permission_approval_tool_call_id(request_id)] = (
             "request_approval"
         )
         return [
@@ -503,7 +487,7 @@ class AgentHostEventNormalizer:
                 # The call this request interrupts was already reported, and its
                 # name resolved; prefer the name that call is showing under to
                 # the ACP category the permission payload carries.
-                tool_name=self.tool_calls.get(request_id)
+                tool_name=self.tool_calls.open_calls.get(request_id)
                 or (
                     tool_name_from_payload(tool_call)
                     if isinstance(tool_call, dict)

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_tool_calls.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_tool_calls.py
@@ -1,0 +1,207 @@
+"""Which tool calls a run has open, and when each becomes durable.
+
+Split out of the normalizer because it is a state machine with its own rules,
+and the normalizer's job is only to turn what it decides into events.
+
+The rule that shapes all of it: a conversation message is appended, never
+revised. A streaming adapter surfaces a tool call at ``content_block_start``,
+before the model has finished writing its input, so the first report carries
+``rawInput: {}`` and the real arguments follow moments later on a status-less
+update. Announcing the call immediately therefore pinned ``{}`` as its
+arguments for the life of the conversation, and any view built from them had
+nothing to build from. So a call whose arguments are still in flight is *held*
+until they arrive — which the adapter always does before the tool runs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from app.modules.agent.domain.value_objects import JsonObject, MessageDraft
+from app.modules.agent.infrastructure.harnesses.agent_host_tool_payload import (
+    raw_tool_args,
+    tool_args,
+    tool_metadata,
+    tool_name_from_payload,
+)
+
+
+def _is_empty(value: object) -> bool:
+    return isinstance(value, (dict, list, str)) and len(value) == 0
+
+
+@dataclass(slots=True)
+class _HeldToolCall:
+    """A tool call announced before its arguments were written.
+
+    Holds the best payload seen so far. Successive updates are folded in rather
+    than replacing it, because an adapter refines a call in pieces — one update
+    carries the arguments, the next only a title, a third nothing but its id —
+    and a plain overwrite would let the emptiest of them win.
+    """
+
+    tool_name: str
+    payload: JsonObject
+    metadata: JsonObject
+    sequence: int
+
+    def arguments_settled(self) -> bool:
+        """Whether this call is ready to go on the durable record.
+
+        Reports *empty* arguments and reports *no* arguments are different
+        claims. An adapter that names the keys and leaves them empty is saying
+        "not written yet". An adapter that omits them is saying nothing about
+        arguments at all, and waiting for a refinement it will never send would
+        hold the call until the turn ended.
+
+        A call that really was invoked with nothing is the one case this reads
+        wrongly, and it costs only lateness: :meth:`ToolCallLedger.release`
+        announces it when the call closes.
+        """
+        arguments = raw_tool_args(self.payload)
+        if arguments is None:
+            return True
+        return not _is_empty(arguments)
+
+    def absorb(self, payload: JsonObject, metadata: JsonObject) -> None:
+        """Fold a later report of the same call into this one.
+
+        Empty and null fields are skipped rather than written: an adapter sends
+        several refinements per call, and the ones carrying nothing must not
+        undo the one that carried the arguments.
+        """
+        for key, value in payload.items():
+            if value is None:
+                continue
+            if key in {"arguments", "args", "rawInput"} and _is_empty(value):
+                continue
+            self.payload[key] = value
+        self.metadata.update(metadata)
+        refined = tool_name_from_payload(self.payload)
+        if refined and refined != "tool":
+            self.tool_name = refined
+
+    def draft(self, object_id: str) -> MessageDraft:
+        return MessageDraft.of_tool_call(
+            tool_name=self.tool_name,
+            tool_call_id=object_id,
+            tool_args=tool_args(self.payload, self.tool_name),
+            metadata=tool_metadata(self.metadata, self.payload),
+        )
+
+
+@dataclass(slots=True)
+class ToolCallLedger:
+    """Every tool call this run has opened, and how far each one has got."""
+
+    #: Announced calls, by id, holding the name each was announced under.
+    open_calls: dict[str, str] = field(default_factory=dict)
+    closed: set[str] = field(default_factory=set)
+    #: Calls whose arguments have not arrived yet. See the module docstring.
+    held: dict[str, _HeldToolCall] = field(default_factory=dict)
+    # ACP's ToolCall has no required id field, so an adapter is free to report a
+    # call and its completion with nothing tying them together. See
+    # :meth:`object_id`.
+    anonymous_seen: int = 0
+    anonymous_open: str | None = None
+
+    def object_id(self, reported: str | None, *, opening: bool) -> str:
+        """The id a tool call and its later update must agree on.
+
+        ACP's ``ToolCall`` carries no required identifier, so an adapter can
+        report a call and its completion with nothing linking them. The old
+        fallback was the event sequence, which is different for the two events
+        by definition: the call was therefore never closed — it was swept at
+        the end as an abandoned call — and the update emitted a result for an
+        id nobody held.
+
+        With no id on the wire the only correlation available is order, so an
+        untagged update is attributed to the untagged call still open. That is
+        a heuristic, and it is exactly as good as the information the adapter
+        gave us; ``acp.rs`` reaches for the same one when a permission request
+        arrives without a tool-call id.
+        """
+        if reported:
+            return reported
+        if opening:
+            self.anonymous_seen += 1
+            self.anonymous_open = f"anonymous-tool-call-{self.anonymous_seen}"
+            return self.anonymous_open
+        return self.anonymous_open or f"anonymous-tool-call-{max(self.anonymous_seen, 1)}"
+
+    def open(
+        self,
+        object_id: str,
+        payload: JsonObject,
+        metadata: JsonObject,
+        *,
+        sequence: int,
+    ) -> tuple[MessageDraft, int] | None:
+        """Take a reported tool call, announcing it if it is ready."""
+        if object_id in self.open_calls:
+            # A second opening for a call already announced. Adapters re-surface
+            # a call rather than inventing a new id, so this is a refinement in
+            # everything but name; treat it as one.
+            return self.refine(object_id, payload, metadata)
+        held = _HeldToolCall(
+            tool_name=tool_name_from_payload(payload),
+            payload=dict(payload),
+            metadata=dict(metadata),
+            sequence=sequence,
+        )
+        self.open_calls[object_id] = held.tool_name
+        if held.arguments_settled():
+            return self._announce(object_id, held)
+        self.held[object_id] = held
+        return None
+
+    def refine(
+        self, object_id: str, payload: JsonObject, metadata: JsonObject
+    ) -> tuple[MessageDraft, int] | None:
+        """Fold a status-less update into the call it refines."""
+        held = self.held.get(object_id)
+        if held is None:
+            # Already announced; nothing left to correct, because the message is
+            # on the durable record.
+            return None
+        held.absorb(payload, metadata)
+        if not held.arguments_settled():
+            return None
+        return self._announce(object_id, held)
+
+    def release(self, object_id: str) -> tuple[MessageDraft, int] | None:
+        """Announce a call whose arguments never arrived, so it is not lost.
+
+        A call is held only while its arguments are still being written. If the
+        turn ends first — the agent was cancelled, the adapter died, the tool
+        genuinely takes no arguments — the call still happened and still owes
+        the conversation a card.
+        """
+        held = self.held.get(object_id)
+        return self._announce(object_id, held) if held is not None else None
+
+    def release_all(self) -> list[tuple[MessageDraft, int]]:
+        return [
+            announced
+            for object_id in list(self.held)
+            if (announced := self.release(object_id)) is not None
+        ]
+
+    def close(self, object_id: str) -> None:
+        self.closed.add(object_id)
+        if object_id == self.anonymous_open:
+            self.anonymous_open = None
+
+    def outstanding(self) -> dict[str, str]:
+        return {
+            object_id: tool_name
+            for object_id, tool_name in self.open_calls.items()
+            if object_id not in self.closed
+        }
+
+    def _announce(
+        self, object_id: str, held: _HeldToolCall
+    ) -> tuple[MessageDraft, int]:
+        self.held.pop(object_id, None)
+        self.open_calls[object_id] = held.tool_name
+        return held.draft(object_id), held.sequence

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_tool_calls.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_tool_calls.py
@@ -169,16 +169,33 @@ class ToolCallLedger:
             return None
         return self._announce(object_id, held)
 
-    def release(self, object_id: str) -> tuple[MessageDraft, int] | None:
+    def release(
+        self,
+        object_id: str,
+        payload: JsonObject | None = None,
+        metadata: JsonObject | None = None,
+    ) -> tuple[MessageDraft, int] | None:
         """Announce a call whose arguments never arrived, so it is not lost.
 
         A call is held only while its arguments are still being written. If the
         turn ends first — the agent was cancelled, the adapter died, the tool
         genuinely takes no arguments — the call still happened and still owes
         the conversation a card.
+
+        ``payload`` is the update doing the releasing, and is folded in first.
+        The closing update is frequently the only one that ever named the tool
+        or carried its input: releasing without reading it announced the call as
+        an anonymous ``tool`` with ``{}`` for arguments while the answer to both
+        sat in the very event that triggered the release. Only the fields a call
+        reads are used; a result on the same payload is ignored here and handled
+        by the caller.
         """
         held = self.held.get(object_id)
-        return self._announce(object_id, held) if held is not None else None
+        if held is None:
+            return None
+        if payload is not None:
+            held.absorb(payload, metadata or {})
+        return self._announce(object_id, held)
 
     def release_all(self) -> list[tuple[MessageDraft, int]]:
         return [

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_tool_calls.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_tool_calls.py
@@ -158,14 +158,31 @@ class ToolCallLedger:
     def refine(
         self, object_id: str, payload: JsonObject, metadata: JsonObject
     ) -> tuple[MessageDraft, int] | None:
-        """Fold a status-less update into the call it refines."""
+        """Fold a status-less update into the call it refines.
+
+        Announces only once the arguments have stopped arriving, which is the
+        same shape the in-process harness has: a tool call is one part, streamed
+        in deltas and emitted whole when the model finishes writing it.
+
+        An adapter streams a call's input in pieces, and each piece is a
+        *complete prefix of the fields written so far* rather than the whole
+        thing — a `write_file` was observed arriving as `{path}` and only then
+        as `{path, content}`, 1126 characters later. Announcing on the first
+        non-empty piece therefore published a call missing most of its input,
+        and a conversation message is appended, never revised. So an update that
+        carries arguments only folds them in; the one that carries *none* is the
+        signal that the input is final, and is what releases the call. It still
+        arrives before the tool runs, so the card is not delayed behind
+        execution. If an adapter never sends one, the close releases it anyway.
+        """
         held = self.held.get(object_id)
         if held is None:
             # Already announced; nothing left to correct, because the message is
             # on the durable record.
             return None
+        still_writing = raw_tool_args(payload) is not None
         held.absorb(payload, metadata)
-        if not held.arguments_settled():
+        if still_writing or not held.arguments_settled():
             return None
         return self._announce(object_id, held)
 

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_tool_payload.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_tool_payload.py
@@ -2,15 +2,19 @@
 
 Adapters vary in where they put a tool call's name, arguments, and result, so
 these probe several shapes rather than assuming one. ``bounded_tool_value`` is
-the guard that keeps a pathological payload — a megabyte of stdout, a deeply
+the guard that keeps a pathological *result* — a megabyte of stdout, a deeply
 nested object — from being persisted verbatim into a conversation message.
 
 That bounding is lossy on purpose, so anything that must survive intact (a
 structured final answer, say) has to be read from the raw payload *before* it
 passes through here.
+
+Arguments are deliberately exempt: see :func:`unbounded_tool_value`.
 """
 
 from __future__ import annotations
+
+import json
 
 from app.modules.agent.domain.value_objects import JsonObject, JsonValue
 from app.modules.agent.infrastructure.mcp import normalize_local_mcp_tool_name
@@ -95,15 +99,45 @@ def tool_metadata(metadata: JsonObject, payload: JsonObject) -> JsonObject:
     return result
 
 
+def raw_tool_args(payload: JsonObject) -> object:
+    """The arguments this payload reports, before any normalisation.
+
+    Separate from :func:`tool_args` because merging successive ACP updates has
+    to compare what each one *carried*, and cannot do that against a value that
+    has already been rewritten for one tool's spelling.
+    """
+    return first_present(payload, "arguments", "args", "rawInput")
+
+
 def tool_args(payload: JsonObject, tool_name: str) -> JsonValue:
-    value = first_present(payload, "arguments", "args", "rawInput")
+    value = raw_tool_args(payload)
     if tool_name == "exec_command" and isinstance(value, dict):
         normalized = dict(value)
         command = normalized.pop("command", None)
         if "cmd" not in normalized and isinstance(command, str):
             normalized["cmd"] = command
         value = normalized
-    return bounded_tool_value(value)
+    return unbounded_tool_value(value)
+
+
+def unbounded_tool_value(value: object) -> JsonValue:
+    """A tool's arguments, coerced to JSON-safe types but never truncated.
+
+    Bounding a *result* is a guard against a megabyte of stdout. Bounding the
+    *arguments* is data loss: they are what the conversation renders and what a
+    view is built from. ``display_resource(type="WIDGET")`` carries its whole
+    HTML document in ``content``, far past ``_MAX_TOOL_STRING_CHARACTERS``, so
+    the bound replaced the widget with a placeholder and left the card nothing
+    to render. The in-process harness stores arguments unbounded; this is the
+    same promise, so a conversation reads the same either way.
+    """
+    if isinstance(value, dict):
+        return {str(key): unbounded_tool_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [unbounded_tool_value(item) for item in value]
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    return str(value)
 
 
 def bounded_tool_value(value: object, *, depth: int = 0) -> JsonValue:
@@ -138,6 +172,37 @@ def bounded_tool_value(value: object, *, depth: int = 0) -> JsonValue:
     if value is None or isinstance(value, (bool, int, float)):
         return value
     return str(value)
+
+
+def unwrap_mcp_content(value: object) -> object:
+    """An MCP tool's own return value, out of the content blocks carrying it.
+
+    An adapter reports an MCP call's ``rawOutput`` as the MCP envelope — a list
+    of content blocks — while the in-process harness stores what the tool
+    actually returned. That difference is not cosmetic: the frontend reads a
+    result as an object, so an envelope arrives as ``{"output": [...]}`` and
+    every field the caller wanted (a served view's ``url``, a ``success`` flag)
+    is a level too deep to find.
+
+    Only the unambiguous case is unwrapped — a single text block whose text is
+    a JSON object. Anything else is the tool's answer as given: a genuinely
+    multi-part result is not an envelope around one value, and guessing which
+    part was meant would lose the rest.
+    """
+    blocks = value.get("content") if isinstance(value, dict) else value
+    if not isinstance(blocks, list) or len(blocks) != 1:
+        return value
+    block = blocks[0]
+    if not isinstance(block, dict) or block.get("type") != "text":
+        return value
+    text = block.get("text")
+    if not isinstance(text, str):
+        return value
+    try:
+        decoded = json.loads(text)
+    except (TypeError, ValueError):
+        return value
+    return decoded if isinstance(decoded, dict) else value
 
 
 def json_object(value: object) -> JsonObject:

--- a/lemma-backend/app/modules/agent/prompts/user_interaction.md
+++ b/lemma-backend/app/modules/agent/prompts/user_interaction.md
@@ -1,0 +1,26 @@
+## Showing your work
+
+Lemma conversations are not a terminal. When the useful answer is more than a
+sentence or two of prose, show it with `display_resource` instead of describing
+it. Several values, a set of records, statuses, a comparison, a timeline, a
+chart, a document you produced — all of these read as something the user can
+look at, not as a paragraph about what they would see.
+
+Two habits carry most of it:
+
+- **After you create or change a pod resource, display it.** A table you filled,
+  a workflow you wired, a file you published — show the thing, rather than
+  reporting that it now exists.
+- **When the user asks for something you had to look up or compute, show the
+  result.** Prose that recites numbers is the weaker version of a `WIDGET` that
+  lays them out.
+
+Set `type`, and `name` for a named pod resource — omit `name` to show every
+resource of that type. `FILE` takes a *pod* path, so upload a deliverable with
+`lemma files upload` first and never pass a workspace path. `WIDGET` takes
+exactly one of `content` or `public_url`; load the `lemma-widget` skill before
+your first widget, and build an app instead when the UI needs React, routing, or
+real state.
+
+`display_resource` only displays. Use `ask_user` when you need the user to
+choose, and `request_approval` when you need permission to proceed.

--- a/lemma-backend/app/modules/agent/services/mcp_content.py
+++ b/lemma-backend/app/modules/agent/services/mcp_content.py
@@ -23,6 +23,19 @@ from mcp.types import ImageContent, TextContent
 # image is dropped and the structured payload still gets through.
 MAX_MCP_IMAGE_BYTES = 5 * 1024 * 1024
 
+# The same ceiling again, applied to a whole result rather than one image.
+#
+# `pod_view_document_pages` returns one image per page and takes an unbounded
+# page range, so "render pages 1 to 30" produced thirty images that were each
+# individually under the per-image limit. Agent Host reads a tool result through
+# a stdio bridge that caps a response at 8 MiB (`MAX_MCP_RESPONSE_BYTES` in
+# `mcp_bridge.rs`), and base64 adds a third on top — so a request like that blew
+# the cap and the agent got an opaque size error instead of the pages, losing
+# the structured payload with them. Budgeting here keeps the encoded response
+# inside what the bridge accepts: 5 MiB of image is about 6.7 MiB encoded, which
+# leaves room for the JSON envelope and the text block beside it.
+MAX_MCP_IMAGE_BYTES_TOTAL = 5 * 1024 * 1024
+
 
 def _binary_parts(result: object) -> list[tuple[bytes, str]]:
     """Image payloads carried by a pydantic-ai ``ToolReturn``, if any."""
@@ -44,14 +57,27 @@ def _binary_parts(result: object) -> list[tuple[bytes, str]]:
 
 
 def image_contents(result: object) -> list[ImageContent]:
-    return [
-        ImageContent(
-            type="image",
-            data=base64.b64encode(data).decode("ascii"),
-            mimeType=media_type,
+    """Every image in ``result`` that fits the budget, in order.
+
+    Truncating is the lesser loss. A result the client refuses outright takes
+    the structured payload down with it, so surplus images are dropped and
+    whatever fits — plus the text — still reaches the agent. Pages arrive in
+    order, so the ones kept are the ones asked for first.
+    """
+    contents: list[ImageContent] = []
+    budget = MAX_MCP_IMAGE_BYTES_TOTAL
+    for data, media_type in _binary_parts(result):
+        if len(data) > budget:
+            continue
+        budget -= len(data)
+        contents.append(
+            ImageContent(
+                type="image",
+                data=base64.b64encode(data).decode("ascii"),
+                mimeType=media_type,
+            )
         )
-        for data, media_type in _binary_parts(result)
-    ]
+    return contents
 
 
 def text_content(payload: Any) -> TextContent:

--- a/lemma-backend/app/modules/agent/services/runtime_profile_editor.py
+++ b/lemma-backend/app/modules/agent/services/runtime_profile_editor.py
@@ -13,7 +13,7 @@ from uuid import UUID
 
 from pydantic import HttpUrl
 
-from app.modules.agent.domain.agent_host import (
+from app.modules.agent.domain.agent_host_selections import (
     validate_agent_host_model,
     validate_agent_host_selections,
 )

--- a/lemma-backend/app/modules/agent/services/runtime_profile_service.py
+++ b/lemma-backend/app/modules/agent/services/runtime_profile_service.py
@@ -19,6 +19,8 @@ from app.modules.agent.domain.agent_host import (
     AgentHostHarnessHealth,
     AgentHostStatus,
     effective_agent_host_status,
+)
+from app.modules.agent.domain.agent_host_selections import (
     validate_agent_host_model,
     validate_agent_host_selections,
 )

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_host_config_selections.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_host_config_selections.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 
 import pytest
 
-from app.modules.agent.domain.agent_host import validate_agent_host_selections
+from app.modules.agent.domain.agent_host_selections import (
+    validate_agent_host_selections,
+)
 
 
 def _option(**overrides: object) -> dict[str, object]:

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_host_instruction_delivery.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_host_instruction_delivery.py
@@ -1,0 +1,163 @@
+"""Deciding whether a turn still has to carry Lemma's instructions.
+
+A conversation is one provider session and a session keeps its own history, so
+instructions delivered when it opened are still there on every later turn.
+Re-sending them each time put another copy of a multi-kilobyte block into the
+provider's transcript per message, which the model then re-read in full on
+every turn after that.
+
+The decision is split deliberately. Lemma answers "has this session already
+been told exactly this text", which only it can know because a user can edit an
+agent mid-conversation. The host answers "is this session actually new", which
+only it can know because a provider is free to forget a session and turn an
+expected resume into a fresh one. Neither side can answer both, and a design
+where either decided alone has a case that runs the agent with no instructions
+at all.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4, uuid7
+
+import pytest
+
+from app.modules.agent.domain.agent_host import (
+    NEW_SESSION_ONLY,
+    AgentHostRunCheckpoint,
+    AgentHostRunSpec,
+    AgentHostRunState,
+)
+from app.modules.agent.infrastructure import agent_host_session_memory as memory
+
+
+def test_the_digest_moves_when_the_instructions_do() -> None:
+    """Taken over the text that lands on the spec, so any edit a user can make
+    — agent instructions, conversation instructions, the granted-resource
+    brief — shows up as a different fingerprint."""
+    base = memory.instructions_digest("# Instructions\nBe exact.")
+
+    assert base == memory.instructions_digest("# Instructions\nBe exact.")
+    assert base != memory.instructions_digest("# Instructions\nBe brief.")
+    assert base != memory.instructions_digest("")
+
+
+class _Repository:
+    """The two conversation-metadata calls this module makes, in memory."""
+
+    def __init__(self, stored: object = None) -> None:
+        self.stored = stored
+
+    async def get_conversation_metadata_key(self, *_args, **_kwargs) -> object:
+        return self.stored
+
+    async def set_conversation_metadata_key(
+        self, _conversation_id, _key, value
+    ) -> None:
+        self.stored = value
+
+
+@pytest.fixture
+def repository(monkeypatch: pytest.MonkeyPatch) -> _Repository:
+    instance = _Repository()
+    monkeypatch.setattr(memory, "ConversationRepository", lambda _uow: instance)
+    return instance
+
+
+@pytest.mark.anyio
+async def test_only_the_same_text_on_the_same_harness_counts_as_delivered(
+    repository: _Repository,
+) -> None:
+    harness_id = uuid4()
+    repository.stored = {
+        "harness_id": str(harness_id),
+        "session_id": "sess-1",
+        "instructions_digest": "abc",
+    }
+
+    async def delivered(*, digest: str, harness: object = harness_id) -> bool:
+        return await memory.instructions_already_delivered(
+            object(),
+            conversation_id=uuid4(),
+            harness_id=harness,
+            digest=digest,
+        )
+
+    assert await delivered(digest="abc")
+    # Every uncertain case resolves toward sending them again: the failure this
+    # guards against is an agent quietly running without its instructions.
+    assert not await delivered(digest="changed")
+    assert not await delivered(digest="abc", harness=uuid4())
+
+    repository.stored = {"harness_id": str(harness_id), "session_id": "sess-1"}
+    assert not await delivered(digest="abc")
+
+    repository.stored = None
+    assert not await delivered(digest="abc")
+
+
+def test_the_host_is_told_to_send_them_unless_lemma_says_otherwise() -> None:
+    """The wire default is the safe one. An older Lemma does not set the field
+    at all, so a host reading a spec it did not expect keeps today's
+    behaviour."""
+    spec = AgentHostRunSpec(
+        agent_run_id=uuid7(),
+        conversation_id=uuid4(),
+        harness_id=uuid4(),
+        profile_revision="rev",
+        system_prompt="Be exact.",
+        prompt=[{"type": "text", "text": "Hello"}],
+        run_deadline=__import__("datetime").datetime.now(
+            __import__("datetime").timezone.utc
+        ),
+    )
+
+    assert spec.system_prompt_delivery is None
+    assert spec.model_copy(
+        update={"system_prompt_delivery": NEW_SESSION_ONLY}
+    ).system_prompt_delivery == NEW_SESSION_ONLY
+
+
+def _checkpoint(run_id, session_id: str) -> AgentHostRunCheckpoint:
+    return AgentHostRunCheckpoint(
+        run_id=run_id,
+        lease_epoch=1,
+        state=AgentHostRunState.RUNNING,
+        detail={"provider_session_id": session_id},
+    )
+
+
+@pytest.mark.anyio
+async def test_instructions_count_as_delivered_only_once_the_host_prompted(
+    monkeypatch: pytest.MonkeyPatch, repository: _Repository
+) -> None:
+    """Record delivery, not intent.
+
+    A run that dies before it prompts — host offline, expired command, an
+    adapter that would not start — delivered nothing. Marking its instructions
+    delivered at dispatch would make every later turn skip them, silently
+    losing a user's edit for the rest of the conversation.
+    """
+    conversation_id, harness_id = uuid4(), uuid4()
+    dispatched_run, other_run = uuid7(), uuid7()
+
+    class _Result:
+        def one_or_none(self):
+            return (conversation_id, harness_id)
+
+    class _Session:
+        async def execute(self, *_args, **_kwargs):
+            return _Result()
+
+    uow = type("_Uow", (), {"session": _Session()})()
+
+    await memory.record_pending_instructions(
+        uow, conversation_id=conversation_id, run_id=dispatched_run, digest="abc"
+    )
+    assert "instructions_digest" not in repository.stored
+
+    # A checkpoint from some other run proves nothing about this promise.
+    await memory.remember_provider_session(uow, _checkpoint(other_run, "sess-1"))
+    assert "instructions_digest" not in repository.stored
+
+    await memory.remember_provider_session(uow, _checkpoint(dispatched_run, "sess-1"))
+    assert repository.stored["instructions_digest"] == "abc"

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_host_normalizer.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_host_normalizer.py
@@ -381,13 +381,62 @@ class TestToolCalls:
                 object_id="call-1",
             )
         )
+        # The update that carries no arguments is the input's full stop.
+        settled = n.normalize(
+            _event(3, AgentHostEventType.TOOL_CALL_UPDATE, {}, object_id="call-1")
+        )
 
         # Nothing durable while the arguments are still being written; a message
         # is appended and never revised, so announcing `{}` would pin `{}`.
         assert _messages(opened) == []
-        calls = _messages(refined)
+        assert _messages(refined) == []
+        calls = _messages(settled)
         assert len(calls) == 1
         assert calls[0].data.tool_args == {"request": request}
+
+    def test_a_call_is_announced_only_once_its_input_stops_growing(self) -> None:
+        """An adapter streams a call's input as a growing prefix of its fields.
+
+        Observed on the wire for a real `write_file`: `{path}` first, then
+        `{path, content}` with 1126 more characters. Announcing on the first
+        non-empty piece published a call missing most of its input, and a
+        conversation message is appended rather than revised, so that was
+        final. The update carrying no arguments at all is what says the input
+        is done — and it still arrives before the tool runs.
+        """
+        n = _normalizer()
+        document = "# Report\n" + ("detail " * 200)
+
+        def feed(sequence: int, payload: dict) -> list:
+            return _messages(
+                n.normalize(
+                    _event(
+                        sequence,
+                        AgentHostEventType.TOOL_CALL_UPDATE,
+                        payload,
+                        object_id="call-1",
+                    )
+                )
+            )
+
+        n.normalize(
+            _event(
+                1,
+                AgentHostEventType.TOOL_CALL_UPSERT,
+                {"rawInput": {}},
+                object_id="call-1",
+            )
+        )
+        assert feed(2, {"rawInput": {"path": "report.md"}}) == []
+        assert feed(3, {"rawInput": {"path": "report.md", "content": document}}) == []
+        # The input has stopped arriving; now the call is worth writing down.
+        announced = feed(4, {})
+
+        assert len(announced) == 1
+        assert announced[0].data.tool_args == {
+            "path": "report.md",
+            "content": document,
+        }
 
     def test_a_later_empty_update_does_not_erase_the_arguments(self) -> None:
         """An adapter sends several refinements, and most of them carry nothing.
@@ -413,8 +462,11 @@ class TestToolCalls:
                 object_id="call-1",
             )
         )
-        trailing = n.normalize(
-            _event(3, AgentHostEventType.TOOL_CALL_UPDATE, {}, object_id="call-1")
+        # The argument-less update ends the input and releases the call.
+        trailing = _messages(
+            n.normalize(
+                _event(3, AgentHostEventType.TOOL_CALL_UPDATE, {}, object_id="call-1")
+            )
         )
         closed = n.normalize(
             _event(
@@ -425,10 +477,10 @@ class TestToolCalls:
             )
         )
 
-        # The call was already announced with real arguments; the empty update
-        # adds nothing and must not produce a second card.
-        assert trailing == []
-        assert len(_messages(closed)) == 1
+        assert len(trailing) == 1
+        assert trailing[0].data.tool_args == {"path": "README.md"}
+        # And the close adds only the return, never a second call card.
+        assert [m.data.kind for m in _messages(closed)] == [MessageKind.TOOL_RETURN]
 
     def test_a_call_released_at_its_close_reads_the_closing_update(self) -> None:
         """The closing update is often the first thing that names a tool.
@@ -509,7 +561,7 @@ class TestToolCalls:
                 object_id="call-1",
             )
         )
-        refined = n.normalize(
+        n.normalize(
             _event(
                 2,
                 AgentHostEventType.TOOL_CALL_UPDATE,
@@ -517,8 +569,11 @@ class TestToolCalls:
                 object_id="call-1",
             )
         )
+        settled = n.normalize(
+            _event(3, AgentHostEventType.TOOL_CALL_UPDATE, {}, object_id="call-1")
+        )
 
-        assert _messages(refined)[0].data.tool_args["request"]["content"] == document
+        assert _messages(settled)[0].data.tool_args["request"]["content"] == document
 
     def test_an_mcp_result_is_the_value_the_tool_returned(self) -> None:
         """An adapter reports an MCP call's output as the MCP envelope, while

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_host_normalizer.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_host_normalizer.py
@@ -430,6 +430,45 @@ class TestToolCalls:
         assert trailing == []
         assert len(_messages(closed)) == 1
 
+    def test_a_call_released_at_its_close_reads_the_closing_update(self) -> None:
+        """The closing update is often the first thing that names a tool.
+
+        A call held for arguments that never came was announced from its
+        opening alone — an anonymous ``tool`` with ``{}`` — while the name and
+        the input sat in the very event that triggered the release. Both cards
+        then disagreed with what actually ran.
+        """
+        n = _normalizer()
+        n.normalize(
+            _event(
+                1,
+                AgentHostEventType.TOOL_CALL_UPSERT,
+                {"rawInput": {}},
+                object_id="call-1",
+            )
+        )
+        closed = n.normalize(
+            _event(
+                2,
+                AgentHostEventType.TOOL_CALL_UPDATE,
+                {
+                    "status": "COMPLETED",
+                    "_meta": {"claudeCode": {"toolName": "read_file"}},
+                    "rawInput": {"path": "README.md"},
+                    "rawOutput": "# Lemma",
+                },
+                object_id="call-1",
+            )
+        )
+
+        call, result = (m.data for m in _messages(closed))
+        assert call.kind is MessageKind.TOOL_CALL
+        assert call.tool_name == "read_file"
+        assert call.tool_args == {"path": "README.md"}
+        # And the return agrees with it, rather than with the placeholder the
+        # call opened under.
+        assert result.tool_name == "read_file"
+
     def test_a_call_whose_arguments_never_arrive_is_still_announced(self) -> None:
         """Holding is for arguments in flight, never a way to lose a call.
 

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_host_normalizer.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_host_normalizer.py
@@ -12,7 +12,7 @@ import json
 from uuid import uuid7
 
 from app.modules.agent.domain.agent_host import AgentHostEventType, AgentHostRunState
-from app.modules.agent.domain.value_objects import AgentEventType
+from app.modules.agent.domain.value_objects import AgentEventType, MessageKind
 from app.modules.agent.infrastructure.harnesses.agent_host_events import (
     AgentHostEventEnvelope,
     AgentHostEventNormalizer,
@@ -350,6 +350,192 @@ class TestToolCalls:
         assert len(_messages(opened)) == 1
         assert duplicate == []
         assert len(_messages(closed)) == 1
+
+    def test_a_streamed_call_keeps_the_arguments_that_arrive_after_it(self) -> None:
+        """The sequence a streaming adapter really sends, in order.
+
+        Claude Code surfaces the call at ``content_block_start``, before the
+        model has written its input, so the first ``tool_call`` carries
+        ``rawInput: {}``. The real arguments follow on a ``tool_call_update``
+        with no status at all — which the normalizer used to drop, because only
+        terminal statuses were treated as news. Every streamed tool call
+        therefore rendered with empty arguments for the life of the
+        conversation, and anything built from them had nothing to build from.
+        """
+        n = _normalizer()
+        request = {"type": "WIDGET", "content": "<div>hello</div>"}
+
+        opened = n.normalize(
+            _event(
+                1,
+                AgentHostEventType.TOOL_CALL_UPSERT,
+                {"rawInput": {}, "status": "pending", "title": "display_resource"},
+                object_id="call-1",
+            )
+        )
+        refined = n.normalize(
+            _event(
+                2,
+                AgentHostEventType.TOOL_CALL_UPDATE,
+                {"rawInput": {"request": request}, "title": "display_resource"},
+                object_id="call-1",
+            )
+        )
+
+        # Nothing durable while the arguments are still being written; a message
+        # is appended and never revised, so announcing `{}` would pin `{}`.
+        assert _messages(opened) == []
+        calls = _messages(refined)
+        assert len(calls) == 1
+        assert calls[0].data.tool_args == {"request": request}
+
+    def test_a_later_empty_update_does_not_erase_the_arguments(self) -> None:
+        """An adapter sends several refinements, and most of them carry nothing.
+
+        Observed on the wire: the update carrying ``rawInput`` is followed
+        immediately by one holding only the call's id. Folding that in
+        naively puts the empty value back and loses what was just learned.
+        """
+        n = _normalizer()
+        n.normalize(
+            _event(
+                1,
+                AgentHostEventType.TOOL_CALL_UPSERT,
+                {"rawInput": {}},
+                object_id="call-1",
+            )
+        )
+        n.normalize(
+            _event(
+                2,
+                AgentHostEventType.TOOL_CALL_UPDATE,
+                {"rawInput": {"path": "README.md"}},
+                object_id="call-1",
+            )
+        )
+        trailing = n.normalize(
+            _event(3, AgentHostEventType.TOOL_CALL_UPDATE, {}, object_id="call-1")
+        )
+        closed = n.normalize(
+            _event(
+                4,
+                AgentHostEventType.TOOL_CALL_UPDATE,
+                {"status": "COMPLETED", "rawOutput": "ok"},
+                object_id="call-1",
+            )
+        )
+
+        # The call was already announced with real arguments; the empty update
+        # adds nothing and must not produce a second card.
+        assert trailing == []
+        assert len(_messages(closed)) == 1
+
+    def test_a_call_whose_arguments_never_arrive_is_still_announced(self) -> None:
+        """Holding is for arguments in flight, never a way to lose a call.
+
+        If the turn ends while a call is still held — cancelled, adapter died,
+        or a tool genuinely invoked with nothing — the call happened and the
+        conversation still owes it a card, ahead of the return that closes it.
+        """
+        n = _normalizer()
+        n.normalize(
+            _event(
+                1,
+                AgentHostEventType.TOOL_CALL_UPSERT,
+                {"rawInput": {}, "title": "read_file"},
+                object_id="call-1",
+            )
+        )
+        finished = n.normalize(
+            _event(2, AgentHostEventType.TERMINAL, {"state": "FAILED"})
+        )
+
+        kinds = [m.data.kind for m in _messages(finished)]
+        assert MessageKind.TOOL_CALL in kinds
+        assert kinds.index(MessageKind.TOOL_CALL) < kinds.index(MessageKind.TOOL_RETURN)
+
+    def test_widget_arguments_are_not_truncated(self) -> None:
+        """Bounding a result guards against a megabyte of stdout. Bounding the
+        arguments is data loss: a WIDGET carries its whole document in
+        ``content``, and the 4096-character ceiling replaced it with a
+        placeholder, leaving the view nothing to render."""
+        n = _normalizer()
+        document = "<div>" + ("x" * 20_000) + "</div>"
+
+        n.normalize(
+            _event(
+                1,
+                AgentHostEventType.TOOL_CALL_UPSERT,
+                {"rawInput": {}},
+                object_id="call-1",
+            )
+        )
+        refined = n.normalize(
+            _event(
+                2,
+                AgentHostEventType.TOOL_CALL_UPDATE,
+                {"rawInput": {"request": {"type": "WIDGET", "content": document}}},
+                object_id="call-1",
+            )
+        )
+
+        assert _messages(refined)[0].data.tool_args["request"]["content"] == document
+
+    def test_an_mcp_result_is_the_value_the_tool_returned(self) -> None:
+        """An adapter reports an MCP call's output as the MCP envelope, while
+        the in-process harness stores what the tool returned. The frontend reads
+        a result as an object, so the envelope arrived as ``{"output": [...]}``
+        and the served view's ``url`` was a level too deep to find."""
+        n = _normalizer()
+        n.normalize(
+            _event(1, AgentHostEventType.TOOL_CALL_UPSERT, {}, object_id="call-1")
+        )
+        closed = n.normalize(
+            _event(
+                2,
+                AgentHostEventType.TOOL_CALL_UPDATE,
+                {
+                    "status": "COMPLETED",
+                    "rawOutput": {
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": '{"success": true, "url": "https://x/y"}',
+                            }
+                        ]
+                    },
+                },
+                object_id="call-1",
+            )
+        )
+
+        assert _messages(closed)[0].data.tool_result == {
+            "success": True,
+            "url": "https://x/y",
+        }
+
+    def test_a_multi_part_mcp_result_is_left_alone(self) -> None:
+        """Only the unambiguous envelope is unwrapped. A genuinely multi-part
+        result is not a wrapper around one value, and picking a part would lose
+        the rest."""
+        n = _normalizer()
+        blocks = [
+            {"type": "text", "text": '{"a": 1}'},
+            {"type": "text", "text": '{"b": 2}'},
+        ]
+        n.normalize(
+            _event(1, AgentHostEventType.TOOL_CALL_UPSERT, {}, object_id="call-1")
+        )
+        closed = n.normalize(
+            _event(
+                2,
+                AgentHostEventType.TOOL_CALL_UPDATE,
+                {"status": "COMPLETED", "rawOutput": {"content": blocks}},
+                object_id="call-1",
+            )
+        )
+
+        assert _messages(closed)[0].data.tool_result == {"content": blocks}
 
     def test_an_untagged_call_and_its_update_are_the_same_call(self) -> None:
         """ACP's ToolCall has no required id, so an adapter can report a call

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_host_wire_contract.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_host_wire_contract.py
@@ -18,9 +18,15 @@ import json
 from pathlib import Path
 
 import pytest
+from uuid import uuid7
 
 from app.modules.agent.domain.agent_host import AgentHostEventType
-from app.modules.agent.infrastructure.harnesses.agent_host_events import event_text
+from app.modules.agent.domain.value_objects import AgentEventType, MessageKind
+from app.modules.agent.infrastructure.harnesses.agent_host_events import (
+    AgentHostEventEnvelope,
+    AgentHostEventNormalizer,
+    event_text,
+)
 
 
 def _contract() -> dict:
@@ -61,3 +67,49 @@ def test_the_event_type_enum_matches_the_contract() -> None:
 )
 def test_event_text_matches_the_contract(case: dict) -> None:
     assert event_text(case["payload"]) == case["text"]
+
+
+@pytest.mark.parametrize(
+    "case",
+    CONTRACT["tool_calls"],
+    ids=[case["name"] for case in CONTRACT["tool_calls"]],
+)
+def test_a_tool_call_arrives_with_its_arguments_and_its_result(case: dict) -> None:
+    """The other half of the tool-call contract.
+
+    The host's half, asserted in ``wire_contract.rs``, is that nothing an
+    adapter reported is dropped on the way here. This half is that what arrived
+    is actually read: the arguments out of whichever field carried them, and an
+    MCP result out of the envelope around it. Both halves are needed and
+    neither is sufficient — the arguments did reach this process, in
+    ``rawInput`` on a status-less update, and were thrown away on arrival.
+    """
+    normalizer = AgentHostEventNormalizer(agent_run_id=uuid7(), model_name="test")
+    messages = [
+        event
+        for sequence, update in enumerate(case["updates"], start=1)
+        for event in normalizer.normalize(
+            AgentHostEventEnvelope(
+                sequence=sequence,
+                type=(
+                    AgentHostEventType.TOOL_CALL_UPSERT.value
+                    if update["sessionUpdate"] == "tool_call"
+                    else AgentHostEventType.TOOL_CALL_UPDATE.value
+                ),
+                object_id=update.get("toolCallId"),
+                payload={
+                    key: value
+                    for key, value in update.items()
+                    if key not in {"sessionUpdate", "toolCallId"}
+                },
+            )
+        )
+        if event.type is AgentEventType.MESSAGE
+    ]
+
+    calls = [m for m in messages if m.data.kind is MessageKind.TOOL_CALL]
+    returns = [m for m in messages if m.data.kind is MessageKind.TOOL_RETURN]
+    assert len(calls) == 1, "one tool use must render as exactly one call"
+    assert len(returns) == 1, "one tool use must render as exactly one return"
+    assert calls[0].data.tool_args == case["tool_args"]
+    assert returns[0].data.tool_result == case["tool_result"]

--- a/lemma-backend/app/modules/agent/tests/unit/test_capabilities.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_capabilities.py
@@ -113,6 +113,32 @@ def test_web_search_capability_bundles_tool_and_prompt():
     assert "Web research" in cap.get_instructions()
 
 
+def test_showing_your_work_is_taught_on_both_paths():
+    """`display_resource` needs prose, not only a tool schema.
+
+    In-process runs get this fragment through a capability and remote harnesses
+    get it through ``FRAGMENT_BY_TOOLSET``; the two lists are maintained
+    separately, and for a long time ``USER_INTERACTION`` was in neither. The
+    tool's own description was the whole of its guidance, which is enough when
+    it is a first-class tool definition and nothing competes with it — and not
+    enough for a coding agent that meets it as one MCP tool underneath its own
+    system prompt. It answered in prose and never displayed anything.
+    """
+    from app.modules.agent.capabilities.assembler import _instructions_for
+    from app.modules.agent.domain.prompts import FRAGMENT_BY_TOOLSET
+    from app.modules.agent.tools.user_interaction.pydantic_adapter import (
+        user_interaction_toolset,
+    )
+
+    guidance = _instructions_for(user_interaction_toolset)
+    assert guidance is not None, "the in-process path lost the fragment"
+    assert "display_resource" in guidance[1]()
+
+    remote = FRAGMENT_BY_TOOLSET.get(AgentToolset.USER_INTERACTION)
+    assert remote is not None, "the remote-harness path lost the fragment"
+    assert "display_resource" in remote.read_text()
+
+
 @pytest.mark.anyio
 async def test_assembler_returns_capabilities_for_every_visible_toolset():
     from app.modules.agent.capabilities.assembler import build_lemma_harness_tooling

--- a/lemma-backend/app/modules/agent/tests/unit/test_image_payload.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_image_payload.py
@@ -1,0 +1,71 @@
+"""Sizing an image for the model that is going to downscale it anyway."""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+from PIL import Image
+
+from app.modules.agent.tools.image_payload import (
+    VISION_MAX_LONG_EDGE,
+    downscale_for_vision,
+)
+
+
+def _png(width: int, height: int, mode: str = "RGB") -> bytes:
+    buffer = io.BytesIO()
+    Image.new(mode, (width, height), (200, 40, 40)).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def test_a_large_photo_is_shrunk_to_what_the_model_reads() -> None:
+    """The saving is the point: pixels past the model's own ceiling are paid
+    for in tokens on the way in and discarded on arrival."""
+    original = _png(4000, 3000)
+
+    payload, media_type = downscale_for_vision(original, "image/png")
+
+    assert media_type == "image/jpeg"
+    assert len(payload) < len(original)
+    with Image.open(io.BytesIO(payload)) as shrunk:
+        assert max(shrunk.size) == VISION_MAX_LONG_EDGE
+        assert shrunk.width / shrunk.height == pytest.approx(4 / 3, rel=0.01)
+
+
+def test_an_image_already_small_enough_is_left_alone() -> None:
+    original = _png(800, 600)
+
+    payload, media_type = downscale_for_vision(original, "image/png")
+
+    assert payload == original
+    assert media_type == "image/png"
+
+
+def test_transparency_is_flattened_rather_than_blackened() -> None:
+    """JPEG has no alpha, so an un-flattened RGBA turns its transparent
+    regions black — which changes what the model sees."""
+    original = _png(3000, 3000, mode="RGBA")
+
+    payload, media_type = downscale_for_vision(original, "image/png")
+
+    assert media_type == "image/jpeg"
+    with Image.open(io.BytesIO(payload)) as shrunk:
+        assert shrunk.mode == "RGB"
+
+
+def test_an_animation_keeps_its_frames() -> None:
+    frames = [Image.new("P", (2000, 2000), 0), Image.new("P", (2000, 2000), 1)]
+    buffer = io.BytesIO()
+    frames[0].save(buffer, format="GIF", save_all=True, append_images=frames[1:])
+    original = buffer.getvalue()
+
+    assert downscale_for_vision(original, "image/gif") == (original, "image/gif")
+
+
+def test_something_unreadable_is_shown_rather_than_dropped() -> None:
+    """A tool that cannot resize an image should still show it."""
+    assert downscale_for_vision(b"not an image", "image/png") == (
+        b"not an image",
+        "image/png",
+    )

--- a/lemma-backend/app/modules/agent/tests/unit/test_mcp_content.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_mcp_content.py
@@ -1,0 +1,73 @@
+"""Turning a tool result into MCP content a remote harness can actually read.
+
+Both bridges once rendered every result as text, so `view_image` and
+`pod_view_document_pages` reached a vision-capable agent as JSON describing a
+picture it could not see. These cover the other half: that the images which do
+go out fit inside what the client on the far end will accept.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.modules.agent.services.mcp_content import (
+    MAX_MCP_IMAGE_BYTES,
+    MAX_MCP_IMAGE_BYTES_TOTAL,
+    image_contents,
+)
+
+
+@dataclass
+class _Binary:
+    data: bytes
+    media_type: str
+
+
+@dataclass
+class _Result:
+    content: list[_Binary]
+
+
+def _png(size: int) -> _Binary:
+    return _Binary(data=b"x" * size, media_type="image/png")
+
+
+def test_images_are_returned_in_order() -> None:
+    result = _Result([_png(10), _png(20)])
+
+    contents = image_contents(result)
+
+    assert [c.type for c in contents] == ["image", "image"]
+    assert [c.mimeType for c in contents] == ["image/png", "image/png"]
+
+
+def test_one_oversized_image_is_dropped_without_taking_the_others() -> None:
+    result = _Result([_png(MAX_MCP_IMAGE_BYTES + 1), _png(32)])
+
+    assert len(image_contents(result)) == 1
+
+
+def test_a_long_page_range_is_truncated_rather_than_refused() -> None:
+    """The failure this prevents is an opaque one.
+
+    ``pod_view_document_pages`` returns one image per page and takes an
+    unbounded range, so thirty pages that each clear the per-image limit still
+    added up past what Agent Host's stdio bridge accepts for a whole response —
+    and the agent got a size error instead of the pages, with the structured
+    payload lost alongside them. Sending the pages that fit is the lesser loss,
+    and they are the ones asked for first.
+    """
+    page = MAX_MCP_IMAGE_BYTES_TOTAL // 4
+    result = _Result([_png(page) for _ in range(30)])
+
+    contents = image_contents(result)
+
+    assert len(contents) == 4, "the budget should stop after four whole pages"
+    encoded = sum(len(c.data) for c in contents)
+    # Base64 adds a third, and the bridge measures the encoded response.
+    assert encoded < 8 * 1024 * 1024
+
+
+def test_a_result_with_no_images_produces_none() -> None:
+    assert image_contents(_Result([])) == []
+    assert image_contents(object()) == []

--- a/lemma-backend/app/modules/agent/tools/image_payload.py
+++ b/lemma-backend/app/modules/agent/tools/image_payload.py
@@ -1,0 +1,82 @@
+"""Sizing an image for a model that is going to downscale it anyway.
+
+Vision models consume images at a bounded resolution — around 1568px on the
+long edge — and shrink anything larger on receipt. Sending the original is
+therefore paid for twice and read once: tokens and upload time for pixels the
+model discards, and, for a remote harness, a base64 payload a third larger
+again on a stdio bridge with a fixed response ceiling.
+
+The PDF page renderer already works this way (``pdf_render_max_long_edge``).
+This is the same policy for images that arrive as files rather than as rendered
+pages, so both routes to a model's eyes cost the same.
+"""
+
+from __future__ import annotations
+
+import io
+
+from PIL import Image
+
+from app.core.log.log import get_logger
+
+logger = get_logger(__name__)
+
+# Matches ``datastore_settings.pdf_render_max_long_edge``. Deliberately a
+# constant rather than an import: agent tools do not reach into another
+# module's internals, and the number is a property of the models, not of PDFs.
+VISION_MAX_LONG_EDGE = 1568
+VISION_JPEG_QUALITY = 80
+
+# Formats where re-encoding loses something the model may need: an animation, or
+# a vector that has no pixels to resize in the first place.
+_LEAVE_ALONE = {"image/gif", "image/svg+xml"}
+
+
+def downscale_for_vision(content: bytes, media_type: str) -> tuple[bytes, str]:
+    """Shrink an image to what a model will actually look at.
+
+    Returns the original bytes and media type unchanged whenever shrinking is
+    not obviously right — an unreadable file, an animation, a vector, or an
+    image already small enough. Never raises: a tool that cannot resize an
+    image should still show it.
+    """
+    if media_type in _LEAVE_ALONE:
+        return content, media_type
+    try:
+        with Image.open(io.BytesIO(content)) as image:
+            if getattr(image, "n_frames", 1) > 1:
+                return content, media_type
+            if max(image.size) <= VISION_MAX_LONG_EDGE:
+                return content, media_type
+            ratio = VISION_MAX_LONG_EDGE / max(image.size)
+            resized = image.resize(
+                (
+                    max(1, round(image.width * ratio)),
+                    max(1, round(image.height * ratio)),
+                ),
+                Image.LANCZOS,
+            )
+            # JPEG has no alpha; flatten onto white so transparency reads
+            # cleanly rather than turning black.
+            if resized.mode not in ("RGB", "L"):
+                resized = resized.convert("RGB")
+            buffer = io.BytesIO()
+            resized.save(
+                buffer, format="JPEG", quality=VISION_JPEG_QUALITY, optimize=True
+            )
+    # Everything Pillow raises for an image it will not decode: a format it does
+    # not recognise or a truncated file (both `OSError`), a bad parameter, and a
+    # decompression bomb. Showing the image beats resizing it, so none of them
+    # is a reason to fail the tool.
+    except (OSError, ValueError, Image.DecompressionBombError) as exc:
+        logger.debug(
+            "agent.tools.image_payload.downscale_skipped.diagnostic",
+            error_type=type(exc).__name__,
+        )
+        return content, media_type
+
+    shrunk = buffer.getvalue()
+    # A re-encode that made things worse is not worth having.
+    if len(shrunk) >= len(content):
+        return content, media_type
+    return shrunk, "image/jpeg"

--- a/lemma-backend/app/modules/agent/tools/workspace_cli/workspace_cli.py
+++ b/lemma-backend/app/modules/agent/tools/workspace_cli/workspace_cli.py
@@ -9,6 +9,7 @@ from app.core.errors.describe import describe_exception
 from app.core.log.log import get_logger
 from app.modules.agent.domain.vision import AgentVisionMode
 from app.modules.agent.tools.context import BaseAgentContext
+from app.modules.agent.tools.image_payload import downscale_for_vision
 from app.modules.agent.tools.vision_delegation import describe_single_image
 from app.modules.agent.tools.file_access import (
     read_pod_file_bytes,
@@ -557,14 +558,19 @@ async def view_image_internal(
             source=source,
         )
 
-    if len(content) > MAX_VIEW_IMAGE_BYTES:
+    # Sized for the model before it is measured against the limit. A phone
+    # photo is several megabytes of pixels the model shrinks on arrival and
+    # never looks at — so refusing it and telling the agent to go and compress
+    # it was work nobody needed to do, on an image we were about to shrink
+    # ourselves. What is left after this is what a limit should be judging.
+    payload, payload_media_type = downscale_for_vision(content, media_type)
+    if len(payload) > MAX_VIEW_IMAGE_BYTES:
         return ViewImageResponse(
             success=False,
             error=(
-                f"Image is {len(content) // 1024} KB, over the "
-                f"{MAX_VIEW_IMAGE_BYTES // (1024 * 1024)} MB limit. Downscale or "
-                "compress it first (e.g. with `execute_python` in the workspace) "
-                "before viewing."
+                f"Image is {len(payload) // 1024} KB even after downscaling, "
+                f"over the {MAX_VIEW_IMAGE_BYTES // (1024 * 1024)} MB limit. "
+                "Crop it or split it up before viewing."
             ),
             file_path=file_path,
             media_type=media_type,
@@ -578,10 +584,12 @@ async def view_image_internal(
     if getattr(ctx, "vision_mode", AgentVisionMode.UNAVAILABLE) is not (
         AgentVisionMode.DIRECT
     ):
+        # The delegate is a vision model too, and pays the same way for pixels
+        # past its own ceiling.
         return await describe_single_image(
             ctx,
-            data=content,
-            media_type=media_type,
+            data=payload,
+            media_type=payload_media_type,
             file_path=file_path,
             source=source,
             instructions=request.instructions,
@@ -597,7 +605,7 @@ async def view_image_internal(
             size_bytes=len(content),
         ),
         content=[
-            BinaryContent(data=content, media_type=media_type),
+            BinaryContent(data=payload, media_type=payload_media_type),
         ],
     )
 


### PR DESCRIPTION
## What changes

Four fixes to how a conversation behaves when it runs through Agent Host rather
than the in-process agent.

- **Tool calls keep their arguments.** `display_resource` widgets render again
  instead of showing `Raw input JSON: {}` with nothing to draw.
- **Agents are told the Lemma display convention.** `display_resource` had no
  prompt guidance on either path; now it has a fragment both paths get.
- **Lemma's instructions are delivered once per provider session** rather than
  re-sent on every turn.
- **A message reaches the host in well under a second** instead of 3.4–4.1s, and
  a streaming run no longer strands long polls on the server.

## Why

Measured against a running desktop install rather than reasoned about.

**Empty tool arguments.** A streaming adapter surfaces a tool call at
`content_block_start`, before the model has written its input, then sends the
real arguments on a status-less `tool_call_update`. `_tool_call_update` dropped
anything without a terminal status, so the arguments were thrown away — and
because a conversation message is appended and never revised, `{}` was pinned
for the life of the call. Captured from `claude-agent-acp` 0.62.0:

| t | update | status | rawInput |
|---|---|---|---|
| 7.18 | `tool_call` | pending | `{}` |
| 7.58 | `tool_call_update` | *none* | the real arguments — **dropped** |
| 7.60 | `tool_call_update` | *none* | absent |
| 7.60 | `tool_call_update` | completed | `rawOutput` |

Two more defects in the same path: arguments were truncated at 4096 characters
(well under a widget's HTML), and an MCP result was stored as the content-block
envelope rather than the value the tool returned, putting `url` a level deeper
than any reader looks.

**No display guidance.** `AgentToolset.USER_INTERACTION` was in neither
`FRAGMENT_BY_TOOLSET` nor the in-process `_INSTRUCTED_TOOLSETS`, so the tool's
docstring was its entire guidance. That is enough as a first-class tool
definition with no competing persona, and not enough for a coding agent that
meets it as one MCP tool underneath its own system prompt.

**Instructions every turn.** A conversation maps to one durable provider session
that is resumed each turn, so turn N carried N copies of a ~16KB block in the
provider's own transcript.

**Dispatch latency.** Correlating `POST /messages` against the Agent Host
journal across seven real runs: 3.39s, 3.86s, 3.86s, 3.78s, 1.38s, 4.10s, 3.38s
before the host saw anything. `outbox_listen_enabled` defaulted false, so the
dispatcher waited out an idle backoff capped at 5s and the `pg_notify` already
being issued was discarded.

**Stranded polls.** Event delivery was an arm of the same `select!` as the poll,
so every streamed event abandoned the poll in flight and the server — parked in
`asyncio.wait` — held it for the rest of its 25s. One host streaming a single
answer reached 26 concurrent polls, against exactly one when idle.

## How to verify

```bash
make quality
cd lemma-backend && uv run pytest -m "not e2e" -q
cd lemma-backend && uv run pytest app/modules/agent/tests/e2e/test_agent_host_transport_e2e.py app/modules/agent/tests/e2e/test_agent_host_seam_e2e.py -q
cd desktop && cargo test -p lemma-agent-host
```

`make quality` → `✓ quality gates pass`. Backend `4878 passed, 49 skipped`.
Agent-host e2e `18 passed`. Rust: 132 lib tests plus every e2e binary green.

**Real execution against a live Claude Code**, the whole `real_harness_e2e`
suite — 9 passed, 181s:

```bash
cd desktop/agent-host && LEMMA_REAL_AGENT_HOST_DATA_DIR="$HOME/Library/Application Support/Lemma/agent-host" \
  LEMMA_REAL_AGENT_E2E_AGENTS=claude-code \
  cargo test --test real_harness_e2e -- --ignored --nocapture --test-threads=1
```

The two that matter most here:

- `a_conversation_keeps_one_provider_session_across_turns` — resumed and
  answered `"Ada"` from history, so a turn that no longer carries the
  instructions has not lost its context.
- `a_session_the_provider_has_forgotten_still_answers` — fell back to a new
  session and still answered, which is the path a backend-only decision would
  have left with neither history nor instructions.

Plus real MCP tool discovery and call, native-tool approval, denial, and
cancel-then-resume.

**The reported bug, end to end.** A `display_resource` WIDGET call captured live
off `claude-agent-acp` 0.62.0 and replayed through the real normalizer yields
one call card and one return card, with everything the widget renderer reads:

```
tool_name  : display_resource
tool_args  : {"request": {"type": "WIDGET", "content": "<div>hello</div>"}}
tool_result: {"success": true, "url": "https://…/widget/abc123", "resourceType": "WIDGET"}
```

Before this change `tool_args` was `{}` and `tool_result` was the raw
content-block envelope. That same captured sequence is now the shared
`wire_contract.json` fixture, asserted from both Rust and Python.

**Poll churn**, through the codex harness with a 60-line streamed answer
(`desktop/agent-host/tests/latency_bench.rs`, `#[ignore]`d):

126 events delivered in 43 batches at 19ms median gaps, **1 poll after
dispatch**. Delivery is now independent of the poll rather than driving it.

The dispatch-latency fix is covered by unit tests on the wake path; the
before-numbers above came from `locald/logs/backend.log` correlated with
`journal.sqlite3`, and re-running that correlation after a stack restart is how
to confirm it in place.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **API surface** — no OpenAPI change; the new run-spec field is an internal
      command payload, and spec freshness is verified by `make quality`
- [x] **Compatibility** — see below
- [x] **Security** — no new secret in a log, response, or queued payload
- [x] **Rollback** — see below

## Compatibility and rollback notes

No migration. The new `system_prompt_delivery` field is optional in both
directions: an older host ignores it and keeps sending instructions every turn,
and a newer host reading a spec without it does the same. Unrecognised values
degrade to "send them" rather than failing to deserialize, because a run spec
that fails to parse is a run that never happens.

`outbox_listen_enabled` now defaults true. It is a hint, not a delivery channel —
the fallback poll still runs and still delivers everything — so setting
`OUTBOX_LISTEN_ENABLED=false` restores the previous timer-driven behaviour
exactly. `outbox_listen_fallback_poll_seconds` drops 30s → 5s so a deployment
behind a transaction-mode pooler that swallows session-scoped `LISTEN` cannot
end up slower than the ladder it replaced.

Two extractions were needed to stay under the architecture ratchet, and are pure
moves: `agent_host_selections.py` out of `domain/agent_host.py`, and
`agent_host_tool_calls.py` out of the events normalizer.

Revertable as a single commit; nothing persists a new shape except the
conversation-metadata binding, which gains optional keys that older code ignores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
