### PR TITLE
Fix reported bugs and issues in connectors and other issues

### DIFF
--- a/lemma-backend/app/composition/schedule_filter.py
+++ b/lemma-backend/app/composition/schedule_filter.py
@@ -48,6 +48,17 @@ FILTER_USAGE_LIMITS = UsageLimits(
     count_tokens_before_request=True,
 )
 
+#: Characters of rendered event kept in the filter prompt.
+#:
+#: A budget, not a guess: it sits well inside ``input_tokens_limit`` above at
+#: the conservative ~3 characters per token, leaving room for the system prompt
+#: and the instruction. It exists because ``count_tokens_before_request`` is
+#: silently dropped for models that cannot pre-count (see ``usage_limits_for``),
+#: so without a bound here the limit is only enforced *after* the provider has
+#: been called and billed -- which is exactly what production was doing, up to
+#: three times per event with retries.
+_MAX_EVENT_CHARS = 60_000
+
 
 def filter_usage_limits_for(model: Model) -> UsageLimits:
     """Pick usage limits the model can actually honor."""
@@ -150,9 +161,28 @@ class SystemModelScheduleFilter:
 
     @staticmethod
     def _user_message(event_payload: dict[str, Any]) -> str:
-        return "Analyze this event:\n" + json.dumps(
-            event_payload, indent=2, default=str
-        )
+        """Render the event, bounded, because the filter's input is not ours.
+
+        This embedded the whole trigger payload with ``indent=2``. A webhook
+        body is whatever the provider chose to send, so the prompt had no upper
+        size at all -- production ran 32,653 to 100,883 tokens against a 32,000
+        limit, and every one of those runs failed *after* the model had been
+        called and billed, because the resolved system model cannot count
+        tokens before a request.
+
+        Truncating degrades the filter's judgement on a huge event. Failing
+        outright removes it entirely, silently, on every fire. The first is the
+        better trade, and the caller is told it happened.
+        """
+        rendered = json.dumps(event_payload, default=str, separators=(",", ":"))
+        if len(rendered) > _MAX_EVENT_CHARS:
+            kept = rendered[:_MAX_EVENT_CHARS]
+            dropped = len(rendered) - _MAX_EVENT_CHARS
+            rendered = (
+                f"{kept}\n\n[event truncated: {dropped} of {len(rendered)} "
+                f"characters omitted. Judge from what is shown.]"
+            )
+        return "Analyze this event:\n" + rendered
 
 
 def create_schedule_processor() -> ScheduleProcessor:

--- a/lemma-backend/app/core/log/log.py
+++ b/lemma-backend/app/core/log/log.py
@@ -426,9 +426,19 @@ class _SafeExceptionFilter(logging.Filter):
 # loud for everything else it says.
 _CLIENT_DISCONNECT_LOGGERS = ("asyncio", "uvicorn.error")
 _CLIENT_DISCONNECT_EXCEPTION = "ConnectionClosed"
-# Both markers must appear. `ConnectionClosed` alone is too broad -- it also
-# covers a socket that failed mid-write, which is worth seeing.
-_CLIENT_DISCONNECT_MARKERS = ("keepalive ping timeout", "no close frame received")
+# One marker, deliberately. This required both `keepalive ping timeout` *and*
+# `no close frame received`, which is only one of the four strings
+# `ConnectionClosed.__str__` can build. The other three still logged at ERROR:
+# 26 a day survived the filter in production, all of them the branch where the
+# client misses the pong deadline and *then* echoes a close frame -- a slow
+# client, which is exactly what this exists to ignore.
+#
+# The second marker was justified on the grounds that `ConnectionClosed` alone
+# is too broad, covering a socket that failed mid-write. That check is real but
+# it is the separate `_CLIENT_DISCONNECT_EXCEPTION` test below; the marker was
+# not carrying the weight it was credited with. A keepalive timeout is a
+# keepalive timeout however the peer chose to close.
+_CLIENT_DISCONNECT_MARKERS = ("keepalive ping timeout",)
 
 
 class _ClientDisconnectFilter(logging.Filter):

--- a/lemma-backend/app/core/tests/unit/test_client_disconnect_filter.py
+++ b/lemma-backend/app/core/tests/unit/test_client_disconnect_filter.py
@@ -19,7 +19,10 @@ import pytest
 from app.core.log import log as log_module
 from app.core.log.log import _ClientDisconnectFilter
 
-# The record production actually emits, verbatim.
+# One of four records production emits. `ConnectionClosed.__str__` builds a
+# different string depending on who closed and whether a close frame came back,
+# and only this branch happens to contain "no close frame received" -- which is
+# why a filter requiring that phrase let the other three through, 26 a day.
 _DISCONNECT = (
     "ConnectionClosedError exception in shielded future\n"
     "future: <Future finished exception=ConnectionClosedError(None, "
@@ -98,3 +101,52 @@ def test_the_filter_is_installed_ahead_of_the_exception_scrubber() -> None:
 
     kinds = [type(f).__name__ for f in handler.filters]
     assert kinds.index("_ClientDisconnectFilter") < kinds.index("_SafeExceptionFilter")
+
+
+# `websockets` renders a closed connection four ways (see
+# `websockets/exceptions.py`, `ConnectionClosed.__str__`). All four are the same
+# event -- a client that stopped answering pings -- and all four must be dropped.
+_SENT_THEN_RECEIVED = (
+    "ConnectionClosedError exception in shielded future\n"
+    "future: <Future finished exception=ConnectionClosedError(None, "
+    "Close(code=<CloseCode.INTERNAL_ERROR: 1011>, reason='keepalive ping "
+    "timeout'), None)>; then received Close(code=<CloseCode.ABNORMAL_CLOSURE: "
+    "1006>, reason='')"
+)
+_RECEIVED_NO_CLOSE_SENT = (
+    "ConnectionClosedError exception in shielded future\n"
+    "future: <Future finished exception=ConnectionClosedError(Close("
+    "code=<CloseCode.INTERNAL_ERROR: 1011>, reason='keepalive ping timeout'), "
+    "None, None)>; no close frame sent"
+)
+_RECEIVED_THEN_SENT = (
+    "ConnectionClosedError exception in shielded future\n"
+    "future: <Future finished exception=ConnectionClosedError(Close("
+    "code=<CloseCode.INTERNAL_ERROR: 1011>, reason='keepalive ping timeout'), "
+    "None, None)>; then sent Close(code=<CloseCode.NORMAL_CLOSURE: 1000>, reason='')"
+)
+
+
+@pytest.mark.parametrize(
+    "message",
+    [_SENT_THEN_RECEIVED, _RECEIVED_NO_CLOSE_SENT, _RECEIVED_THEN_SENT],
+    ids=["sent-then-received", "received-no-close-sent", "received-then-sent"],
+)
+def test_every_keepalive_timeout_phrasing_is_dropped(message):
+    """The residual. These three were reaching production error dashboards at
+    ERROR while the fourth was filtered, because the filter demanded a phrase
+    only the fourth contains."""
+    assert _ClientDisconnectFilter().filter(_record(message)) is False
+
+
+def test_a_socket_that_failed_mid_write_is_still_reported():
+    """The reason the filter is narrow at all: a ConnectionClosed that is *not*
+    a keepalive timeout is a real fault and must survive."""
+    message = (
+        "ConnectionClosedError exception in shielded future\n"
+        "future: <Future finished exception=ConnectionClosedError(None, "
+        "Close(code=<CloseCode.ABNORMAL_CLOSURE: 1006>, reason=''), None)>; "
+        "no close frame received"
+    )
+
+    assert _ClientDisconnectFilter().filter(_record(message)) is True

--- a/lemma-backend/app/modules/connectors/application/connector_operation_use_cases.py
+++ b/lemma-backend/app/modules/connectors/application/connector_operation_use_cases.py
@@ -102,7 +102,9 @@ class ConnectorOperationUseCases:
         # Only infrastructure and timeout failures feed the breaker; a rejected
         # request or a stale credential is the caller's problem and must not
         # disable the operation for everyone else.
-        scope_key = breaker_scope(resolved.connector_id, operation_name)
+        scope_key = breaker_scope(
+            resolved.connector_id, operation_name, resolved.organization_id
+        )
         await breaker_guard(scope_key)
         try:
             response = await self._attempt_with_credential_refresh(

--- a/lemma-backend/app/modules/connectors/domain/errors.py
+++ b/lemma-backend/app/modules/connectors/domain/errors.py
@@ -234,6 +234,25 @@ class OperationExecutionValidationError(OperationExecutionError):
         )
 
 
+class OperationExecutionRateLimitedError(OperationExecutionError):
+    """The provider asked the caller to slow down.
+
+    Deliberately not an infrastructure error, even though it is transient: the
+    provider is healthy and answering, the caller is simply asking too often.
+    Counting it toward the circuit breaker would let one busy caller disable an
+    operation for everyone sharing that provider, which is the opposite of what
+    a rate limit is asking for. Backing off is the caller's job.
+    """
+
+    def __init__(self, message: str, details: object | None = None):
+        super().__init__(
+            message="Connector provider is rate limiting these requests.",
+            code="OPERATION_EXECUTION_RATE_LIMITED",
+            status_code=429,
+            details=_safe_connector_details(details),
+        )
+
+
 class OperationExecutionUnauthorizedError(OperationExecutionError):
     def __init__(self, message: str, details: object | None = None):
         super().__init__(

--- a/lemma-backend/app/modules/connectors/infrastructure/adapters/composio_operation_gateway.py
+++ b/lemma-backend/app/modules/connectors/infrastructure/adapters/composio_operation_gateway.py
@@ -10,6 +10,7 @@ from app.modules.connectors.domain.errors import (
     OperationExecutionAccessDeniedError,
     OperationExecutionInfrastructureError,
     OperationExecutionNotFoundError,
+    OperationExecutionRateLimitedError,
     OperationExecutionTimeoutError,
     OperationExecutionUnauthorizedError,
     OperationExecutionValidationError,
@@ -188,8 +189,22 @@ class ComposioOperationGateway(AppOperationGatewayPort):
         (OpenWeather's "HTTP 401"), or a raised SDK exception carrying an HTTP
         status. All three land here, because the classification decides real
         behaviour -- an Unauthorized flags the account for reauth so the user is
-        prompted to reconnect, while an Infrastructure error just retries
-        forever against a connection that is never coming back.
+        prompted to reconnect, while an Infrastructure error counts toward the
+        circuit breaker and can disable the operation for everyone.
+
+        **The fallback classifies by status class, and that is the point.** This
+        ladder used to enumerate 404/401/403/400/422 and send *everything else*
+        to Infrastructure. Production found the hole: Composio answered `413
+        Upstream_PayloadTooLarge` -- an agent asked for more data than the tool
+        could return -- five times in 25 seconds. Each one was reported as
+        "provider temporarily unavailable", which invited a retry that could
+        never succeed, and the fifth opened the breaker on a provider that was
+        healthy and answering in 3.4s. Seven subsequent calls were refused.
+
+        A 4xx the provider chose to return is the caller's problem however
+        unfamiliar it is; only a 5xx, or a failure with no status at all, says
+        anything about the provider's health. Enumerating statuses one incident
+        at a time is what produced this bug, so the default now does the work.
         """
         message = f"Composio tool execution failed for '{operation_name}': {error}"
         normalized = error.lower()
@@ -205,7 +220,19 @@ class ComposioOperationGateway(AppOperationGatewayPort):
             return OperationExecutionUnauthorizedError(message, details=details)
         if matches({"forbidden", "missing_scope"}, 403):
             return OperationExecutionAccessDeniedError(message, details=details)
-        if matches({"invalid_arguments", "validation_error", "bad_request"}, 400, 422):
+        if matches({"rate_limited", "rate_limit_exceeded", "too_many_requests"}, 429):
+            return OperationExecutionRateLimitedError(message, details=details)
+        if matches(
+            {"invalid_arguments", "validation_error", "bad_request", "payload_too_large"},
+            400,
+            409,
+            413,
+            422,
+        ):
+            return OperationExecutionValidationError(message, details=details)
+        if status_code is not None and 400 <= status_code < 500:
+            # Some 4xx we have not met yet. Still the caller's, still not a
+            # reason to stop serving everybody else.
             return OperationExecutionValidationError(message, details=details)
         return OperationExecutionInfrastructureError(message, details=details)
 

--- a/lemma-backend/app/modules/connectors/infrastructure/operation_breaker.py
+++ b/lemma-backend/app/modules/connectors/infrastructure/operation_breaker.py
@@ -55,16 +55,31 @@ def _keys(scope: str) -> tuple[str, str]:
     return f"{_PREFIX}:open:{scope}", f"{_PREFIX}:fail:{scope}"
 
 
-def breaker_scope(connector_id: str, operation_name: str) -> str:
+def breaker_scope(
+    connector_id: str, operation_name: str, organization_id: object | None = None
+) -> str:
     """Identity of the thing that can be broken.
 
     Per operation, not per connector: a provider whose ``send_email`` is down
     usually still lists messages, and blocking the healthy half would turn a
-    partial outage into a total one. Not per account either — an infrastructure
-    failure is a property of the provider, and every account would otherwise
-    have to discover it separately.
+    partial outage into a total one.
+
+    **Per organization, though.** This used to be keyed on the catalog
+    connector id alone, on the reasoning that an infrastructure failure is a
+    property of the provider and every account would otherwise have to discover
+    it separately. That reasoning holds only for a single shared SaaS endpoint,
+    and it is false for the kinds where each install points somewhere different
+    — an MCP server URL comes from the install's own ``connection_config``, and
+    SQL and HTTP are the same. Two organizations pointing at two unrelated
+    servers were sharing one breaker, so one of them going down stopped the
+    other.
+
+    It is still not per account. An account-level failure is a credential
+    problem, which is classified as Unauthorized and never reaches the breaker.
     """
-    return f"{connector_id}:{operation_name}"
+    if organization_id is None:
+        return f"{connector_id}:{operation_name}"
+    return f"{organization_id}:{connector_id}:{operation_name}"
 
 
 async def guard(scope: str) -> None:

--- a/lemma-backend/app/modules/connectors/tests/unit/test_connector_operation_use_cases.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_connector_operation_use_cases.py
@@ -73,7 +73,7 @@ def _fake_scopes(monkeypatch, events):
 async def test_resolve_runs_in_phase1_and_execute_runs_after_release(events):
     # A stand-in for the real ResolvedConnectorExecution: the saga reads
     # connector_id off it when deciding what to do with a file result.
-    resolved_sentinel = SimpleNamespace(connector_id="outlook")
+    resolved_sentinel = SimpleNamespace(connector_id="outlook", organization_id=uuid4())
     response_sentinel = SimpleNamespace(result={"ok": True})
 
     class _FakeService:
@@ -249,7 +249,9 @@ async def test_a_provider_failure_on_the_credential_retry_still_trips_the_breake
         )
 
     assert len(attempts) == 2, "the credential refresh retry ran"
-    assert recorded == ["airtable:AIRTABLE_LIST_BASES"]
+    # Org-prefixed: the breaker is scoped per organization, so one tenant's
+    # provider outage cannot refuse another tenant's calls.
+    assert recorded == [f"{resolved.organization_id}:airtable:AIRTABLE_LIST_BASES"]
     # The provider fault surfaces as itself. Swapping it for the 401 would tell
     # the user to reconnect an account that is fine.
     connector_service.mark_account_reauth_required.assert_not_awaited()

--- a/lemma-backend/app/modules/connectors/tests/unit/test_operation_breaker.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_operation_breaker.py
@@ -14,6 +14,8 @@ badly-formed integration disable a working connector for every other tenant.
 
 from __future__ import annotations
 
+from uuid import uuid4
+
 import pytest
 
 from app.modules.connectors.config import connector_settings
@@ -22,11 +24,16 @@ from app.modules.connectors.domain.errors import (
     OperationExecutionCircuitOpenError,
     OperationExecutionInfrastructureError,
     OperationExecutionNotFoundError,
+    OperationExecutionRateLimitedError,
     OperationExecutionTimeoutError,
     OperationExecutionUnauthorizedError,
     OperationExecutionValidationError,
 )
 from app.modules.connectors.infrastructure import operation_breaker
+from app.modules.connectors.infrastructure.adapters.composio_operation_gateway import (
+    ComposioOperationGateway,
+)
+from app.modules.connectors.infrastructure.operation_breaker import breaker_scope
 
 
 class _FakeRedis:
@@ -221,3 +228,88 @@ def test_the_open_error_is_distinguishable_from_a_provider_failure() -> None:
 
     assert opened.code != failed.code
     assert opened.status_code == 503
+
+
+# -- what may open the breaker, and what may not ------------------------------
+#
+# The breaker exists for one thing: a provider that hangs holds an OS thread per
+# call, and refusing to *start* calls is the only mechanism that stops those
+# accumulating (see composio_operation_gateway, which measured a limiter of 2
+# serving 4 live threads). Nothing else it does is worth an outage.
+#
+# Production found the cost of getting the boundary wrong. Composio answered
+# `413 Upstream_PayloadTooLarge` five times in 25 seconds -- an agent asking a
+# tool for more data than it could return -- each was reported as "provider
+# temporarily unavailable", and the fifth opened the breaker on a provider that
+# was healthy and answering in 3.4s. Seven later calls were refused.
+
+
+def _classify(status: int | None, error: str = "boom"):
+    return ComposioOperationGateway._classify_failure(
+        "GMAIL_SEND_EMAIL", status, error, {}
+    )
+
+
+@pytest.mark.parametrize(
+    "status",
+    [400, 404, 409, 413, 422, 429, 402, 451, 418],
+    ids=["bad-request", "not-found", "conflict", "payload-too-large",
+         "unprocessable", "rate-limited", "payment-required", "legal", "unknown-4xx"],
+)
+def test_a_provider_4xx_never_opens_the_breaker(status):
+    """Whatever the provider rejected, it answered — so it is up, and this is
+    the caller's problem. 413 is the one that reached production; the rest are
+    here so the next unfamiliar status does not have to."""
+    error = _classify(status)
+
+    assert not isinstance(error, OperationExecutionInfrastructureError), (
+        f"{status} would count toward the breaker and disable the operation"
+    )
+
+
+@pytest.mark.parametrize(
+    "status",
+    [500, 502, 503, 504, None],
+    ids=["internal", "bad-gateway", "unavailable", "gateway-timeout", "no-status"],
+)
+def test_a_provider_5xx_or_a_silent_failure_does_open_the_breaker(status):
+    """The other half. These say something about the provider's health, which
+    is the only thing the breaker is for."""
+    assert isinstance(_classify(status), OperationExecutionInfrastructureError)
+
+
+def test_a_rate_limit_is_reported_as_one():
+    """429 asks the caller to slow down. Reporting it as "temporarily
+    unavailable" tells them to retry, which is the opposite."""
+    error = _classify(429)
+
+    assert isinstance(error, OperationExecutionRateLimitedError)
+    assert error.status_code == 429
+
+
+def test_payload_too_large_is_reported_as_a_rejected_request():
+    error = _classify(413, "The tool response payload is too large.")
+
+    assert isinstance(error, OperationExecutionValidationError)
+    assert error.status_code == 422
+
+
+# -- one tenant may not break another -----------------------------------------
+
+
+def test_two_organizations_do_not_share_a_breaker():
+    """The scope used to be the *catalog* connector id, so a breaker opened by
+    one tenant's traffic refused every other tenant's. For MCP, SQL and HTTP
+    kinds the endpoint is per install, so the two organizations were not even
+    talking to the same server."""
+    org_a = breaker_scope("mcp", "list_tools", uuid4())
+    org_b = breaker_scope("mcp", "list_tools", uuid4())
+
+    assert org_a != org_b
+
+
+def test_the_same_organization_shares_one_breaker_per_operation():
+    org = uuid4()
+
+    assert breaker_scope("gmail", "send", org) == breaker_scope("gmail", "send", org)
+    assert breaker_scope("gmail", "send", org) != breaker_scope("gmail", "list", org)

--- a/lemma-backend/app/modules/schedule/handlers/schedule_consumer.py
+++ b/lemma-backend/app/modules/schedule/handlers/schedule_consumer.py
@@ -14,6 +14,8 @@ from app.core.infrastructure.db.uow_factory import SessionUnitOfWorkFactory
 from app.core.infrastructure.jobs.streaq_runtime import streaq_task
 from app.modules.schedule.repositories.schedule_repository import ScheduleRepository
 from app.modules.schedule.services.run_outcome_service import ScheduleRunOutcomeService
+from pydantic_ai.exceptions import UsageLimitExceeded as PydanticAIUsageLimitExceeded
+
 from app.modules.usage.contracts import UsageLimitExceededError
 from app.core.log.log import get_logger
 from app.composition.schedule_filter import create_schedule_processor
@@ -70,7 +72,17 @@ async def handle_llm_filter_task(
             metadata=metadata,
             source_event_id=source_event_id,
         )
-    except UsageLimitExceededError:
+    except (UsageLimitExceededError, PydanticAIUsageLimitExceeded) as exc:
+        # Two unrelated classes with nearly the same name, and only one of them
+        # was caught. `UsageLimitExceededError` is ours -- the pod's billing
+        # budget. `UsageLimitExceeded` is pydantic-ai's, raised when a run
+        # exceeds `input_tokens_limit`, and it is the one production actually
+        # hits: 21 a day, every one of them an event too large for the filter's
+        # token budget. It matched nothing here, so it escaped unhandled, no
+        # ledger row was written, the breaker counted nothing, the schedule was
+        # never deactivated and the owner was never emailed. The safety net
+        # below was real and simply never applied to the failure that occurs.
+        #
         # Policy lives here, at the task boundary, not in the processor. The
         # processor raises every filter failure alike and is right to — a
         # provider blip should still reach streaq and be retried. Only this one
@@ -87,7 +99,14 @@ async def handle_llm_filter_task(
             recorded = await ScheduleRunOutcomeService(uow).record_pre_dispatch_failure(
                 schedule,
                 source_event_id=source_event_id,
-                error_type="ScheduleFilterQuotaExhausted",
+                # Distinguished, because they need different fixes: one means
+                # the pod is out of budget, the other means the triggering
+                # event was too large for the filter to read.
+                error_type=(
+                    "ScheduleFilterQuotaExhausted"
+                    if isinstance(exc, UsageLimitExceededError)
+                    else "ScheduleFilterEventTooLarge"
+                ),
             )
         logger.warning(
             "schedule.filter.quota_exhausted.degraded",

--- a/lemma-backend/app/modules/schedule/tests/test_schedule_filter_event_size.py
+++ b/lemma-backend/app/modules/schedule/tests/test_schedule_filter_event_size.py
@@ -1,0 +1,67 @@
+"""A filter failure the safety net never saw, and the payload that caused it.
+
+`schedule_consumer` catches `UsageLimitExceededError` — the pod's billing
+budget — and records it so the failure breaker can count it, deactivate the
+schedule after five, and email the owner. That net was real and never applied
+to the failure production actually hits.
+
+pydantic-ai raises its own `UsageLimitExceeded` when a run exceeds
+`input_tokens_limit`. Different class, different module, nearly the same name.
+It matched nothing, escaped unhandled, and left no ledger row — so nothing
+counted, nothing deactivated, nobody was told. 21 a day, one pod, for as long
+as anyone had been looking.
+
+The cause is that the filter prompt embedded the entire trigger payload, and a
+webhook body is whatever the provider chose to send. Observed inputs ran 32,653
+to 100,883 tokens against a 32,000 limit.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic_ai.exceptions import UsageLimitExceeded as PydanticAIUsageLimitExceeded
+
+from app.composition.schedule_filter import _MAX_EVENT_CHARS, SystemModelScheduleFilter
+from app.modules.usage.contracts import UsageLimitExceededError
+
+pytestmark = pytest.mark.unit
+
+
+def test_a_huge_event_is_truncated_rather_than_failing_the_run():
+    """Truncating degrades the filter's judgement on one event. Failing removes
+    the filter entirely, silently, on every fire."""
+    payload = {"rows": [{"i": index, "blob": "x" * 200} for index in range(2_000)]}
+
+    message = SystemModelScheduleFilter._user_message(payload)
+
+    assert len(message) < _MAX_EVENT_CHARS + 500
+    assert "event truncated" in message
+    assert "characters omitted" in message
+
+
+def test_a_small_event_is_passed_through_whole():
+    payload = {"ticket": {"id": 7, "status": "open"}}
+
+    message = SystemModelScheduleFilter._user_message(payload)
+
+    assert "event truncated" not in message
+    assert json.loads(message.removeprefix("Analyze this event:\n")) == payload
+
+
+def test_the_rendered_event_is_not_padded_with_indentation():
+    """`indent=2` inflated the token count of the one thing already too big."""
+    payload = {"a": {"b": {"c": [1, 2, 3]}}}
+
+    message = SystemModelScheduleFilter._user_message(payload)
+
+    assert "\n  " not in message
+
+
+def test_the_two_usage_exceptions_are_genuinely_unrelated():
+    """The trap, pinned. If these ever share a base class, the narrower catch
+    in schedule_consumer becomes safe again — until then it must name both."""
+    assert not issubclass(PydanticAIUsageLimitExceeded, UsageLimitExceededError)
+    assert not issubclass(UsageLimitExceededError, PydanticAIUsageLimitExceeded)
+    assert PydanticAIUsageLimitExceeded.__name__ != UsageLimitExceededError.__name__

--- a/lemma-cli/lemma_cli/cli_core/chat.py
+++ b/lemma-cli/lemma_cli/cli_core/chat.py
@@ -21,6 +21,12 @@ class StreamEvent:
     type: str
     data: Any
     agent_run_id: str | None = None
+    #: Which channel a token delta belongs to -- "text", "thinking" or "tool".
+    #: A sibling of ``data`` on the wire, not nested inside it: the server sends
+    #: ``{"type":"token","data":"...","kind":"tool"}`` and ``data`` is always a
+    #: bare string. Reading it from the wrong place is what let a tool call
+    #: reach users as answer text.
+    kind: str | None = None
 
 
 def iter_sse_events(response: Any) -> Iterable[StreamEvent]:
@@ -45,6 +51,7 @@ def iter_sse_events(response: Any) -> Iterable[StreamEvent]:
             agent_run_id=(
                 str(payload["agent_run_id"]) if payload.get("agent_run_id") else None
             ),
+            kind=str(payload["kind"]) if payload.get("kind") else None,
         )
 
     try:
@@ -85,6 +92,10 @@ def emit_stream_events(state: CliState, response: Any) -> None:
                 {
                     "type": event.type,
                     "data": event.data,
+                    # Re-emitted, or `--output json` would tell a machine
+                    # consumer that a tool call was the assistant's answer --
+                    # the same defect as the rendered path, one layer down.
+                    **({"kind": event.kind} if event.kind else {}),
                     **(
                         {"agent_run_id": event.agent_run_id}
                         if event.agent_run_id
@@ -198,7 +209,7 @@ class ChatRenderer:
     def handle(self, event: StreamEvent) -> None:
         event_type = event.type.lower()
         if event_type == "token":
-            self._token_event(event.data)
+            self._token_event(event.data, kind=event.kind)
             return
         if event_type == "message":
             self._message(event.data)
@@ -261,27 +272,35 @@ class ChatRenderer:
             console.print(Text(str(value)))
         self.printed_tokens = True
 
-    def _token_event(self, data: Any) -> None:
+    def _token_event(self, data: Any, kind: str | None = None) -> None:
         """Render only the answer channel of a token stream.
 
         Every delta the harness emits is tagged: ``text`` is the answer,
         ``thinking`` is model reasoning, and ``tool`` is the literal serialized
         call — ``{"tool_name": "pod_query", "args": {…}}`` — streamed so a UI can
-        show a tool running. The tag was never read here, so all three were
-        stringified into the answer, and a reply came back as::
+        show a tool running. Without the tag all three are stringified into the
+        answer, and a reply comes back as::
 
             I'll check the items table count.
             {"tool_name":"pod_query","args":{"sql":"SELECT COUNT(*) …"}}1
 
-        `_message` below has always kinded its payloads correctly, and the
-        surfaces token stream filters the same way
-        (``agent_surfaces/services/token_stream.py``). This path was the one that
-        did not.
+        **The tag arrives beside the payload, not inside it.** The server sends
+        ``{"type":"token","data":"…","kind":"tool"}`` with ``data`` a bare
+        string — pinned by the backend's own ``test_sse_frames`` — so the only
+        place to read it is the parsed frame. A previous fix looked for a nested
+        ``data["kind"]``, a shape the wire never produces, so it never once
+        fired and every tool call still reached the answer.
 
-        A bare string with no tag is passed through: not every runtime sends the
-        envelope, and dropping their output would trade a cosmetic bug for a
+        A delta with no tag at all is passed through: not every runtime sends
+        the envelope, and dropping their output would trade a cosmetic bug for a
         silent one.
         """
+        if kind is not None:
+            if kind != "text":
+                return
+            self._token(str(data or ""))
+            return
+        # Nested form, for a runtime that sends the envelope inside `data`.
         if isinstance(data, dict) and "kind" in data:
             if str(data.get("kind") or "") != "text":
                 return

--- a/lemma-cli/lemma_cli/tui/events.py
+++ b/lemma-cli/lemma_cli/tui/events.py
@@ -86,6 +86,11 @@ def normalize_event(event: StreamEvent) -> ChatEvent | None:
     event_type = event.type.lower()
     data = event.data
     if event_type == "token":
+        # `kind` rides beside `data` on the wire ("text", "thinking", "tool").
+        # Anything but the answer channel would otherwise be typed into the
+        # transcript as if the assistant had said it.
+        if event.kind is not None and event.kind != "text":
+            return None
         text = str(data or "")
         return Token(text) if text else None
     if event_type == "message":

--- a/lemma-cli/tests/test_chat_rendering.py
+++ b/lemma-cli/tests/test_chat_rendering.py
@@ -12,9 +12,12 @@ text once the stream ends.
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
-from lemma_cli.cli_core.chat import ChatRenderer, extract_final_result
+from lemma_cli.cli_core.chat import (
+    ChatRenderer,
+    StreamEvent,
+    extract_final_result,
+    iter_sse_events,
+)
 
 
 _TRANSCRIPT = (
@@ -56,8 +59,8 @@ def test_extract_final_result_survives_braces_inside_strings():
 def _render(tokens, *, verbose=False, capsys=None):
     renderer = ChatRenderer(agent="policy-lookup", verbose=verbose)
     for token in tokens:
-        renderer.handle(SimpleNamespace(type="token", data=token))
-    renderer.handle(SimpleNamespace(type="completed", data={"status": "COMPLETED"}))
+        renderer.handle(StreamEvent(type="token", data=token))
+    renderer.handle(StreamEvent(type="completed", data={"status": "COMPLETED"}))
     renderer.finish()
     return capsys.readouterr().out
 
@@ -88,8 +91,8 @@ def test_quiet_mode_falls_back_to_the_raw_text(capsys):
 def test_a_stopped_run_still_reports_its_status(capsys):
     """Suppressing "COMPLETED" must not also hide a run that did NOT complete."""
     renderer = ChatRenderer(agent="a", verbose=False)
-    renderer.handle(SimpleNamespace(type="token", data="partial"))
-    renderer.handle(SimpleNamespace(type="stopped", data={"status": "STOPPED"}))
+    renderer.handle(StreamEvent(type="token", data="partial"))
+    renderer.handle(StreamEvent(type="stopped", data={"status": "STOPPED"}))
     renderer.finish()
     assert "STOPPED" in capsys.readouterr().out
 
@@ -99,7 +102,7 @@ def test_a_stopped_run_still_reports_its_status(capsys):
 
 def _tokens(renderer: ChatRenderer, *payloads) -> str:
     for payload in payloads:
-        renderer.handle(SimpleNamespace(type="TOKEN", data=payload, agent_run_id=None))
+        renderer.handle(StreamEvent(type="TOKEN", data=payload, agent_run_id=None))
     return "".join(renderer.buffered)
 
 
@@ -164,9 +167,79 @@ def test_verbose_shows_the_answer_channel_only():
     """--verbose is for watching a run, not for leaking the tool envelope."""
     renderer = ChatRenderer(agent="pod agent", verbose=True)
     renderer.handle(
-        SimpleNamespace(
+        StreamEvent(
             type="TOKEN", data={"kind": "tool", "data": '{"tool_name":"x"}'}, agent_run_id=None
         )
     )
 
     assert renderer.printed_tokens is False, "a tool delta is not the answer"
+
+
+# --- the wire, not a hand-built shape ----------------------------------------
+
+
+class _SseResponse:
+    """A response that yields exactly the bytes the server sends."""
+
+    def __init__(self, *frames: str) -> None:
+        self._frames = frames
+
+    def iter_lines(self, decode_unicode: bool = False):
+        for frame in self._frames:
+            yield f"data: {frame}"
+            yield ""
+
+
+def test_a_tool_delta_never_reaches_the_answer_over_the_real_wire():
+    """The same assertion as above, driven through the actual SSE parser.
+
+    The tests above construct ``data={"kind": "tool", ...}`` — a nested shape
+    ``iter_sse_events`` can never produce. The server puts ``kind`` *beside*
+    ``data`` and makes ``data`` a bare string, pinned by the backend's own
+    ``test_sse_frames.py``. So those tests passed against a fabricated envelope
+    while every real tool call went on reaching users:
+
+        hello
+        {"tool_name":"pod_query","args":{"sql":"SELECT COUNT(*) AS count FROM items"}}332
+
+    Nothing here may hand-build a StreamEvent. That is the whole point.
+    """
+    renderer = ChatRenderer(agent="pod agent")
+    response = _SseResponse(
+        '{"type":"token","data":"hello","kind":"text"}',
+        '{"type":"token","data":"{\\"tool_name\\":\\"pod_query\\",\\"args\\":","kind":"tool"}',
+        '{"type":"token","data":"{\\"sql\\":\\"SELECT COUNT(*) AS count FROM items\\"}}","kind":"tool"}',
+        '{"type":"token","data":" There are 332.","kind":"text"}',
+    )
+
+    for event in iter_sse_events(response):
+        renderer.handle(event)
+    answer = "".join(renderer.buffered)
+
+    assert answer == "hello There are 332."
+    assert "tool_name" not in answer
+    assert "SELECT COUNT" not in answer
+
+
+def test_the_parser_carries_the_kind_tag_off_the_frame():
+    """`kind` is a sibling of `data`; reading it from inside `data` finds
+    nothing, which is why the filter that existed never once fired."""
+    response = _SseResponse('{"type":"token","data":"hi","kind":"thinking"}')
+
+    event = next(iter(iter_sse_events(response)))
+
+    assert event.kind == "thinking"
+    assert event.data == "hi", "data is a bare string on the wire, never a dict"
+
+
+def test_a_thinking_delta_over_the_wire_is_not_the_answer():
+    renderer = ChatRenderer(agent="pod agent")
+    response = _SseResponse(
+        '{"type":"token","data":"The user wants a count. I should query.","kind":"thinking"}',
+        '{"type":"token","data":"There is 1 row.","kind":"text"}',
+    )
+
+    for event in iter_sse_events(response):
+        renderer.handle(event)
+
+    assert "".join(renderer.buffered) == "There is 1 row."


### PR DESCRIPTION
## What changes

Five reported production issues. Investigating each against the logs and the
code changed the diagnosis on **every one** — none was what the report said, and
three were hiding a defect worse than the symptom.

**An agent's tool call stops reaching users as answer text.** The backend has
always tagged token frames; the CLI parser threw the tag away.

**One tenant's bad request stops disabling a connector for everyone.** Composio
returned `413 Upstream_PayloadTooLarge`; we called it "provider temporarily
unavailable", counted it as an infrastructure failure, and opened a circuit
breaker keyed globally.

**A schedule filter that fails now tells someone.** The handler caught a
different class with nearly the same name, so the dead-letter/breaker/email
safety net had never once applied to the failure that actually occurs.

**Ordinary websocket disconnects stop being logged as errors.**

## Why

| reported | what it actually was |
|---|---|
| "the server is emitting this stream untagged" | The server tags correctly — its own `test_sse_frames` pins it. `kind` is a **sibling** of `data`; the CLI filter looked *inside* `data`, a shape the wire never produces, so it never once fired. |
| "quota exhaustion fails schedule tasks silently" | Not billing quota. pydantic-ai's `input_tokens_limit`, raised as `UsageLimitExceeded` — an unrelated class to our `UsageLimitExceededError`, which is what the handler caught. |
| "a third party is failing often enough to trip the breaker" | The provider was healthy, answering in 3.4s. All five infra errors were one cause — a 413 — in a single 34-second window. |
| "26 keepalive timeouts, worth understanding" | `ConnectionClosed.__str__` has four phrasings; the filter required a phrase only one of them contains. Already deployed, already not matching. |
| "slow connector route" | 96 of 144 slow requests, **all HTTP 200** — slow successes, unrelated to the 413s. Left for a follow-up. |

Two of these were previously reported as "fixed, awaiting the production
release". That code is already in production and the symptoms persisted.

### The connector breaker is the one worth reviewing closely

It was keyed on `{connector_id}:{operation_name}` where `connector_id` is the
**global catalog** id — no org, no install. Its docstring argued an
infrastructure failure is a property of the provider, which holds for a shared
SaaS endpoint and is false for MCP/SQL/HTTP, where the endpoint comes from each
install's own `connection_config`. Two organizations pointing at unrelated
servers shared one breaker.

Alone that is survivable, because only genuine infrastructure failures were
supposed to count. But four classifiers routed client errors into that class, so
one user's oversized request became seven other people's refusals. Both halves
are fixed here; either alone leaves the blast radius.

The classifier fallback now decides by **status class** rather than enumerating
statuses — a 4xx the provider chose to return is the caller's problem however
unfamiliar it is, and only a 5xx (or no status at all) says anything about the
provider's health. Enumerating one incident at a time is what produced this bug.

The breaker itself is kept. It is the only mechanism that stops OS threads
accumulating when a provider hangs: `wait_for` frees the caller but cannot
preempt a blocking socket read, and the limiter releases its token on cancel, so
it admits the next call while the old thread is still stuck. The gateway records
the measurement — "a limiter of 2 was serving 4 live OS threads". What is fixed
is its remit, not its existence.

## How to verify

Every behavioural change was reverted to confirm the test catches it rather than
merely passing alongside it.

```bash
cd lemma-backend && uv run pytest -m "not e2e" -q
```
`4915 passed, 54 skipped`

```bash
make quality
```
`✓ quality gates pass`

```bash
cd lemma-cli && uv run pytest tests/ -q -m "not e2e"
```
`593 passed`

Reverting one line of the CLI parser fails the new wire test with exactly the
reported output:
`hello{"tool_name":"pod_query","args":{"sql":"SELECT COUNT(*) AS count FROM items"}} There are 332.`

## Tests were the reason three of these shipped

- `test_chat_rendering.py` built its own events with `data={"kind": "tool", …}` —
  a nested shape `iter_sse_events` cannot produce — so it passed against a
  fabricated envelope while production failed. It now constructs a real
  `StreamEvent` and the new cases drive literal SSE bytes.
- `test_operation_breaker.py` asserted only `issubclass` relationships between
  error classes. It pinned the taxonomy and never ran a status through a
  classifier. There is now a case per status on both sides of the line, plus a
  test that two organizations do not share a breaker.
- `test_client_disconnect_filter.py` called its fixture "the record production
  actually emits, verbatim" and used the one branch of four containing both
  required markers. All four are now fixtures.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Compatibility** — `OperationExecutionRateLimitedError` is new (429); 413/409
      and unmapped 4xx now surface as 422 rather than 503. Callers treating 503 as
      "retry" will correctly stop retrying these. No signature changed.
- [x] **Security** — the breaker key gains an organization scope, narrowing a
      cross-tenant effect. No new data in logs or responses.
- [x] **Rollback** — revert cleanly. No migration, no state change. Breaker keys
      are Redis-resident and short-lived, so old-format keys age out on their own.

## Not in this PR

An audit of the slow routes found ~20 implementation defects behind the latency —
`permissions/me` performing 51 separate authorizations, file search materializing
every file row in the pod (16,050 in one production pod), a per-row bulk update
where create and upsert are already batched, no indexes at all on dynamic
datastore tables, and a `pool_pre_ping` / commit-per-authorization interaction
that puts a flat 2.5–3s floor under everything. Those are being planned
separately, since several need migrations.

One item was raised to me as a security finding and is **not** one: connector
account resolution taking the un-org-scoped branch cannot cross a boundary,
because `auth_config_id` transitively determines the org, membership is verified
first, and the lookup is also bound by `user_id`.
