### PR TITLE
Stop the desktop tests killing each other's processes, and AppKit killing the run

### DIFF
--- a/desktop/locald/src/host_process.rs
+++ b/desktop/locald/src/host_process.rs
@@ -2073,7 +2073,36 @@ mod tests {
     #[cfg(unix)]
     use crate::port_reservation::PortReservation;
     use std::net::{Ipv4Addr, TcpListener};
-    use tempfile::tempdir;
+    use tempfile::{tempdir, TempDir};
+
+    /// The log directory to hand a manager under test: a directory *inside*
+    /// `root`, never `root` itself.
+    ///
+    /// A manager takes its installation state root — `installation.id` and the
+    /// process ledger — from the log directory's *parent*, because in
+    /// production it is handed `<state root>/logs`. Passing `root.path()` here
+    /// therefore made the parent the system temporary directory, so every
+    /// manager in every test, and in every test binary running at the same
+    /// time, shared one `$TMPDIR/processes.json` under one installation id.
+    ///
+    /// That is a live weapon: constructing a manager runs
+    /// `reclaim_verified_processes`, which SIGTERMs any pid in the ledger that
+    /// still matches its recorded executable and start time. With the ledger
+    /// shared, one test's `HostProcessManager::new` killed the `/bin/sleep`
+    /// services another test had spawned seconds earlier — which is exactly
+    /// how `opens_restart_circuit_after_crash_budget_is_exhausted` came to
+    /// fail on a loaded runner with its frontend dead 50ms after it started,
+    /// and why it never failed on an idle machine, where the tests do not
+    /// overlap. One directory deeper gives every manager its own installation,
+    /// which is what the reclaim was written to assume.
+    fn log_dir_in(root: &TempDir) -> PathBuf {
+        root.path().join("logs")
+    }
+
+    /// A manager whose installation state stays inside `root`.
+    fn manager_in(root: &TempDir, value: HostPackManifest) -> Arc<HostProcessManager> {
+        HostProcessManager::new(value, log_dir_in(root)).unwrap()
+    }
 
     fn manifest(services: Vec<HostProcessSpec>) -> HostPackManifest {
         HostPackManifest {
@@ -2282,8 +2311,7 @@ mod tests {
             stabilization_seconds: 0,
         });
         let root = tempdir().unwrap();
-        let manager =
-            HostProcessManager::new(manifest(vec![frontend, backend]), root.path().into()).unwrap();
+        let manager = manager_in(&root, manifest(vec![frontend, backend]));
 
         assert_eq!(manager.application_ports(), Some((3711, 8711)));
         assert_eq!(loopback_http_port("https://127.0.0.1:3711/"), None);
@@ -2325,14 +2353,13 @@ mod tests {
     #[test]
     fn operator_secrets_are_ephemeral_and_backend_scoped() {
         let root = tempdir().unwrap();
-        let manager = HostProcessManager::new(
+        let manager = manager_in(
+            &root,
             manifest(vec![
                 service("frontend", &["backend"]),
                 service("backend", &[]),
             ]),
-            root.path().into(),
-        )
-        .unwrap();
+        );
         manager.set_backend_environment(HashMap::from([(
             "LEMMA_OPENAI_API_KEY".into(),
             "vault-secret".into(),
@@ -2355,14 +2382,13 @@ mod tests {
     #[test]
     fn dependency_failure_clears_readiness_and_surfaces_the_cause() {
         let root = tempdir().unwrap();
-        let manager = HostProcessManager::new(
+        let manager = manager_in(
+            &root,
             manifest(vec![
                 service("frontend", &["backend"]),
                 service("backend", &[]),
             ]),
-            root.path().into(),
-        )
-        .unwrap();
+        );
         manager.desired_running.store(true, Ordering::Release);
         manager.health_ready.store(true, Ordering::Release);
 
@@ -2392,7 +2418,7 @@ mod tests {
             service("backend", &[]),
         ]);
         value.setup[0].command = vec!["/usr/bin/env".into()];
-        let manager = HostProcessManager::new(value, root.path().into()).unwrap();
+        let manager = manager_in(&root, value);
         manager.set_backend_environment(HashMap::from([(
             "DATABASE_URL".into(),
             "postgresql://private-guest/lemma".into(),
@@ -2400,7 +2426,7 @@ mod tests {
 
         manager.run_setups().unwrap();
 
-        let log = std::fs::read_to_string(root.path().join("migrations.log")).unwrap();
+        let log = std::fs::read_to_string(log_dir_in(&root).join("migrations.log")).unwrap();
         assert!(log.contains("DATABASE_URL=postgresql://private-guest/lemma"));
     }
 
@@ -2421,7 +2447,7 @@ mod tests {
         value.setup[0].command = vec!["/bin/sh".into(), "-c".into(), "exit 9".into()];
         value.setup[0].max_attempts = 1;
         value.setup[0].optional = true;
-        let manager = HostProcessManager::new(value, root.path().to_path_buf()).unwrap();
+        let manager = manager_in(&root, value);
 
         manager
             .run_setups()
@@ -2439,7 +2465,7 @@ mod tests {
         value.setup[0].command = vec!["/bin/sh".into(), "-c".into(), "exit 9".into()];
         value.setup[0].max_attempts = 1;
         value.setup[0].optional = false;
-        let manager = HostProcessManager::new(value, root.path().to_path_buf()).unwrap();
+        let manager = manager_in(&root, value);
 
         assert!(manager.run_setups().is_err());
     }
@@ -2461,11 +2487,11 @@ mod tests {
             marker.to_string_lossy().into_owned(),
         ];
         value.setup[0].max_attempts = 2;
-        let manager = HostProcessManager::new(value, root.path().into()).unwrap();
+        let manager = manager_in(&root, value);
 
         manager.run_setups().unwrap();
 
-        let log = std::fs::read_to_string(root.path().join("migrations.log")).unwrap();
+        let log = std::fs::read_to_string(log_dir_in(&root).join("migrations.log")).unwrap();
         assert!(log.contains("setup attempt 1 exited"));
         assert!(marker.is_file());
     }
@@ -2500,7 +2526,7 @@ mod tests {
         ]);
         value.setup[0].command = vec!["/usr/bin/true".into()];
         value.setup[0].timeout_seconds = 5;
-        let manager = HostProcessManager::new(value, root.path().into()).unwrap();
+        let manager = manager_in(&root, value);
         manager.set_backend_environment(HashMap::from([(
             "DATABASE_URL".into(),
             format!("postgresql://postgres:secret@{address}/lemma"),
@@ -2554,7 +2580,7 @@ mod tests {
         let root = tempdir().unwrap();
         let mut value = manifest(vec![frontend, backend]);
         value.setup[0].command = vec!["/usr/bin/true".into()];
-        let manager = HostProcessManager::new(value, root.path().into()).unwrap();
+        let manager = manager_in(&root, value);
 
         manager.start_all().unwrap();
         assert!(manager.status().iter().all(|process| process.running));
@@ -2659,7 +2685,7 @@ mod tests {
         let root = tempdir().unwrap();
         let mut value = manifest(vec![frontend, backend]);
         value.setup[0].command = vec!["/usr/bin/true".into()];
-        let manager = HostProcessManager::new(value, root.path().into()).unwrap();
+        let manager = manager_in(&root, value);
 
         let started = Instant::now();
         let error = manager.start_all().unwrap_err().to_string();
@@ -2695,7 +2721,7 @@ mod tests {
         let root = tempdir().unwrap();
         let mut value = manifest(vec![frontend, backend]);
         value.setup[0].command = vec!["/usr/bin/true".into()];
-        let manager = HostProcessManager::new(value, root.path().into()).unwrap();
+        let manager = manager_in(&root, value);
         // The production path mints the generation before starting, and every
         // health spec is rewritten to expect it.
         *body.lock().unwrap() = manager.prepare_runtime_generation().unwrap();
@@ -2739,7 +2765,7 @@ mod tests {
         let root = tempdir().unwrap();
         let mut value = manifest(vec![frontend, backend]);
         value.setup[0].command = vec!["/usr/bin/true".into()];
-        let manager = HostProcessManager::new(value, root.path().into()).unwrap();
+        let manager = manager_in(&root, value);
         manager.start_all().unwrap();
         assert!(manager.backend_restart_available());
         manager.mark_dependency_unavailable("private runtime is cold".into());
@@ -2858,7 +2884,7 @@ mod tests {
         let root = tempdir().unwrap();
         let mut value = manifest(vec![frontend, backend]);
         value.setup[0].command = vec!["/usr/bin/true".into()];
-        let manager = HostProcessManager::new(value, root.path().into()).unwrap();
+        let manager = manager_in(&root, value);
 
         manager.start_all().unwrap();
         // Both, before anything is crashed. The frontend depends on the backend

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -3930,24 +3930,62 @@ fn handle_deep_link(app: &AppHandle, url: &tauri::Url) {
     }
 }
 
+/// The last accent AppKit was asked for, and the only answer anything off the
+/// main thread is allowed to see.
+#[cfg(target_os = "macos")]
+static REMEMBERED_ACCENT: Mutex<Option<(u8, u8, u8)>> = Mutex::new(None);
+
 /// The user's System Settings accent, as sRGB bytes.
 ///
 /// `controlAccentColor` is a catalog colour with no component accessors of its
 /// own — it has to be resolved into a real colour space before it can be read,
 /// which is what the `colorUsingColorSpace` hop is for. Returns `None` if that
 /// resolution fails, and callers fall back to systemBlue, the macOS default.
+///
+/// The main-thread gate is not a formality. AppKit is main-thread-only, and
+/// this is reached from threads that are not it: `open_local_settings` builds
+/// the control webview from a spawned thread on purpose, and the Rust test
+/// harness runs every test on a spawned thread of a process that never
+/// created an NSApplication at all. Two of those test threads landing in
+/// AppKit's first-use initialization at once is what killed the whole
+/// `lemma-desktop` test binary with SIGSEGV partway through a CI run — no
+/// assertion failed, the process simply died, and the two tests that call
+/// `desktop_context_script` were the only two that never reported a result.
+///
+/// So the read happens on the main thread and its answer is remembered.
+/// Everyone else gets the remembered answer — which the main window's setup
+/// has already stored by the time any worker can ask — or `None` before the
+/// first read, which is the same fallback a machine that cannot answer gets.
 #[cfg(target_os = "macos")]
 fn macos_accent_rgb() -> Option<(u8, u8, u8)> {
+    use objc2::MainThreadMarker;
     use objc2_app_kit::{NSColor, NSColorSpace};
 
+    fn remembered() -> Option<(u8, u8, u8)> {
+        *REMEMBERED_ACCENT
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    if MainThreadMarker::new().is_none() {
+        return remembered();
+    }
     let accent = NSColor::controlAccentColor();
-    let srgb = accent.colorUsingColorSpace(&NSColorSpace::sRGBColorSpace())?;
+    let Some(srgb) = accent.colorUsingColorSpace(&NSColorSpace::sRGBColorSpace()) else {
+        // A failed resolution says nothing about the accent that was read
+        // before it, so the remembered one stands rather than being cleared.
+        return remembered();
+    };
     let to_byte = |v: f64| (v.clamp(0.0, 1.0) * 255.0).round() as u8;
-    Some((
+    let rgb = (
         to_byte(srgb.redComponent()),
         to_byte(srgb.greenComponent()),
         to_byte(srgb.blueComponent()),
-    ))
+    );
+    *REMEMBERED_ACCENT
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(rgb);
+    Some(rgb)
 }
 
 #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
## What changes

Fixes the two flakes in the **Desktop workspace** CI job. Both look like bad luck; neither is.

I surveyed every run of that job in the last ~120 CI runs and classified all 13 failures first, because the raw failure rate is misleading:

| Signature | Count | Verdict |
|---|---|---|
| `host_process.rs:2891` | **5** | Flake — fixed here |
| `cargo fmt` (`Diff in /`) | 4 | Not a flake; someone forgot `cargo fmt` |
| agent-host tests, 2026-08-15 only | 2 | Real bugs from that day's work; no recurrence |
| SIGSEGV | 1 | Flake — fixed here |

So the job is ~19% flaky, not the ~41% the failure count suggests — and one flake accounts for five of the six.

### 1. Every manager under test shared one process ledger, in `$TMPDIR`

`HostProcessManager` takes its installation state root from the log directory's **parent** ([host_process.rs:299-303](desktop/locald/src/host_process.rs#L299)), because production hands it `<state root>/logs` ([daemon.rs:78](desktop/locald/src/daemon.rs#L78)). Every test handed it the `TempDir` itself — so the parent was the *system temp directory*, and all 13 managers, across every test and every concurrently running test binary, shared one `$TMPDIR/processes.json` under one installation id. Both files were confirmed physically present there.

That is a live weapon. Constructing a manager runs `reclaim_verified_processes`, which SIGTERMs any pid in the ledger still matching its recorded executable and start time. Every test's services are `/bin/sleep 30`, so entries matched trivially — and the pids belonged to a *different test*.

The losing interleaving, captured with an instrumented build:

```
1786995633285  spawned frontend pid=48615 in=48444
1786995633295  frontend_pid=48615 in=48444
1786995633336  tvp SIGTERM pid=48615 from=48444     <- another test's reclaim
PROBE frontend down: pid_was=48615 last_exit=Some("signal: 15 (SIGTERM) after 56 ms")
```

Nothing had reaped it yet, so `wait_for_running` still returned the pid and the test proceeded — to fail 300 ms later on `assert!(process_status(&manager, "frontend").running)`.

This is **not** a health-poll race and **not** a tight timeout: the CI failures completed in ~0.3s, nowhere near the 30s `sleep`. The `wait_for_*` helpers were already correct; adding another would have hidden a real kill.

Two neighbours had the same cause and are fixed by the same change: `backend_config_restart_keeps_the_frontend_process_running` and `services_boot_alongside_each_other_rather_than_one_after_another` (the latter reproduced as `backend failed health gate: process exited with signal: 15 (SIGTERM) after 37 ms`).

Dates to `f96fd7c0` (#323), which introduced the ledger, the reclaim, and this test together.

### 2. A segfault — which is also a production bug

`macos_accent_rgb` reads `NSColor::controlAccentColor`. AppKit is main-thread-only, and this was reached from threads that are not it. The test harness runs every test on a spawned thread in a process that never created an `NSApplication`; two landing in AppKit's first-use initialization at once killed the whole `lemma-desktop` binary with SIGSEGV mid-run.

The log proves it rather than merely suggesting it. libtest runs alphabetically. Of 78 tests, 73 reported; the five missing are indices 43, 54, 76, 77, 78. Indices 76-78 are the tail. But **43 and 54 started long before and never completed while 32 later tests finished around them** — and those two are exactly the ones reaching `desktop_context_script`.

The same call runs in the shipping app: `create_control_child` ([main.rs:2377](desktop/src/main.rs#L2377)) is invoked from a deliberately spawned worker — Tauri deadlocks on Windows if a child webview is built from a synchronous handler — so **opening Local settings read AppKit off the main thread on every launch**.

The read is now gated on `MainThreadMarker` and its answer remembered. The main window's `setup` primes it on the main thread, and Local settings cannot be opened before that window exists, so the worker gets the real accent rather than a fallback. A failed colour-space resolution keeps the previous value instead of clearing it.

**No sibling instances:** this `NSColor` call was the only AppKit/objc2 call site in the whole desktop workspace. The `window-vibrancy` calls sit inside the Tauri `setup` hook and are unreachable from any test.

## How to verify

Gates:

```bash
cd desktop
cargo fmt --all --check
cargo clippy --workspace --locked --all-targets -- -D warnings
cargo test --workspace --locked
```

All clean. The flake fix was then verified **both directions** — the fix stashed and unstashed, six concurrent test binaries at `--test-threads 8`:

```
WITHOUT FIX: 10/30 concurrent runs FAILED  (2 hit the exact CI line 2891)
WITH FIX:     0/30 concurrent runs FAILED
```

Isolated (`--exact`, 200 runs) it never failed either way — it only fails when tests overlap, which is why an idle machine never shows it and CI does.

**The SIGSEGV did not reproduce locally**: 300 full-binary runs, 400 runs of the two tests under CPU load, and 500 runs of a purpose-built 32-thread barrier probe were all clean on an unloaded 16-core machine. That diagnosis rests on the run-order analysis above plus the code, not on a local repro. After the fix, 400/400 clean at `--test-threads 16`, and `--test-threads 1` (where libtest does use the main thread) passes too.

## Checklist

- [x] Tests cover the behavioral change — the fix *is* to the test harness for #1; #2's production path is covered by the existing two tests that reach it, which now exercise the non-main-thread branch
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Rollback** — plain revert. No migrations, no API surface, no persisted format change.

## Compatibility and rollback notes

Change #1 is confined to `mod tests`. Change #2 alters production behaviour on macOS only: the accent is read once on the main thread and cached, where it was previously read on each call from whichever thread asked. A caller that runs before the main window exists now gets `None` and the systemBlue fallback — the same fallback a machine that cannot resolve the colour space already got.

## Deliberately not fixed

- `managed_runtime::tests::tcp_forwarder_relays_bytes_and_releases_its_port` panicked once under six-way parallel stress — port contention between concurrent test binaries, which CI does not do. Never recurred, never seen in CI.
- The two agent-host failures from 2026-08-15 — different root cause (that test uses a private tempdir cache, so it is not the shared-state pattern), no recurrence.
- `start_identity` granularity: `ps -o lstart` is second-resolution, so ledger identity is pid + executable + same-second start. With the ledger now correctly private per installation this is contained, but it stays a weak discriminator if a stale ledger ever meets pid reuse. Changing the production reclaim's identity scheme is well outside these two failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)