### PR TITLE
Give each server its own session storage, and stop a dead one hammering the next

### DIFF
--- a/desktop/locald/src/host_process.rs
+++ b/desktop/locald/src/host_process.rs
@@ -327,9 +327,18 @@ impl HostProcessManager {
             log_dir,
         });
         let monitor = Arc::clone(&manager);
-        thread::spawn(move || loop {
-            thread::sleep(Duration::from_secs(1));
-            monitor.reconcile_crashes();
+        thread::spawn(move || {
+            let mut next_rotation = Instant::now() + SERVICE_LOG_ROTATE_INTERVAL;
+            loop {
+                thread::sleep(Duration::from_secs(1));
+                monitor.reconcile_crashes();
+                // Separate cadence from the crash check on purpose: this stats
+                // a file per service and nothing here needs it every second.
+                if Instant::now() >= next_rotation {
+                    monitor.rotate_service_logs();
+                    next_rotation = Instant::now() + SERVICE_LOG_ROTATE_INTERVAL;
+                }
+            }
         });
         Ok(manager)
     }
@@ -985,6 +994,31 @@ impl HostProcessManager {
             state.children.remove(&id);
             state.last_exit.insert(id.clone(), exit);
             let _ = self.remove_ledger_entry(&id);
+        }
+    }
+
+    /// Hold each service's log to its ceiling while the service is running.
+    ///
+    /// `process_log` rotates when it opens the file, which is once, at spawn.
+    /// The handle it returns then *is* the child's stdout and stderr for the
+    /// whole life of the process -- so a backend that stays up for days was
+    /// never checked again. One install was found with a 16 MB `backend.log`
+    /// still growing at 8 MB an hour, and the only thing that would ever have
+    /// truncated it was a restart.
+    ///
+    /// Rotating a live log is exactly what `rotate_log` was built for: it
+    /// copies aside and truncates in place rather than renaming, so the writer
+    /// holding the descriptor keeps writing to the same file and simply finds
+    /// it back at zero. That property was already relied on at spawn; nothing
+    /// was calling it afterwards.
+    fn rotate_service_logs(&self) {
+        for id in &self.ordered_ids {
+            let path = self.log_dir.join(format!("{id}.log"));
+            // Best effort, per service. A log that cannot be rotated -- removed
+            // out from under us, or briefly locked on Windows -- must not stop
+            // the others being rotated, and must not take down the supervisor
+            // thread that is also the crash monitor.
+            let _ = rotate_log(&path, SERVICE_LOG_MAX_BYTES);
         }
     }
 
@@ -1819,9 +1853,18 @@ impl Drop for HostProcessManager {
     }
 }
 
+/// Ceiling for one service's log before it is rotated, and therefore half the
+/// most it can occupy: the rotated copy sits beside it at the same size.
+const SERVICE_LOG_MAX_BYTES: u64 = 5 * 1024 * 1024;
+
+/// How often a running service's log is measured. Long enough to be free, short
+/// enough that a service logging hard cannot get far past the ceiling between
+/// checks.
+const SERVICE_LOG_ROTATE_INTERVAL: Duration = Duration::from_secs(30);
+
 fn process_log(log_dir: &Path, id: &str) -> io::Result<File> {
     let path = log_dir.join(format!("{id}.log"));
-    rotate_log(&path, 5 * 1024 * 1024)?;
+    rotate_log(&path, SERVICE_LOG_MAX_BYTES)?;
     let mut options = OpenOptions::new();
     options.create(true).append(true);
     #[cfg(unix)]
@@ -2102,6 +2145,50 @@ mod tests {
     /// A manager whose installation state stays inside `root`.
     fn manager_in(root: &TempDir, value: HostPackManifest) -> Arc<HostProcessManager> {
         HostProcessManager::new(value, log_dir_in(root)).unwrap()
+    }
+
+    /// A running service's log is truncated under the writer that holds it.
+    ///
+    /// This is the property the whole rotation scheme depends on and the reason
+    /// it copies aside instead of renaming: the child owns this descriptor for
+    /// its entire life, so a rename would leave it writing into the rotated
+    /// file and the live one frozen at zero forever. Asserted with a handle
+    /// still open, because that is the only state that ever actually occurs.
+    #[test]
+    fn a_live_service_log_is_rotated_under_the_process_writing_it() {
+        use std::io::Write;
+
+        let root = tempdir().unwrap();
+        let path = root.path().join("backend.log");
+        let mut writer = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .unwrap();
+        writer.write_all(&vec![b'x'; 1024]).unwrap();
+
+        // Under the ceiling: left exactly alone.
+        rotate_log(&path, 4096).unwrap();
+        assert_eq!(path.metadata().unwrap().len(), 1024);
+        assert!(!path.with_extension("previous.log").exists());
+
+        // Over it: copied aside and truncated back to zero.
+        writer.write_all(&vec![b'x'; 4096]).unwrap();
+        rotate_log(&path, 4096).unwrap();
+        assert_eq!(path.metadata().unwrap().len(), 0);
+        assert_eq!(
+            path.with_extension("previous.log")
+                .metadata()
+                .unwrap()
+                .len(),
+            5120
+        );
+
+        // And the writer that never let go keeps appending to the same file,
+        // which is now counting up from zero rather than from 5 KiB.
+        writer.write_all(b"after").unwrap();
+        writer.flush().unwrap();
+        assert_eq!(path.metadata().unwrap().len(), 5);
     }
 
     fn manifest(services: Vec<HostProcessSpec>) -> HostPackManifest {

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -152,6 +152,13 @@ struct Shell {
     /// `ExitRequested`, including the `app.exit` the confirmed path issues
     /// itself; without this the prompt would re-arm and the app could not leave.
     quit_confirmed: AtomicBool,
+    /// Set while the main window is being swapped onto another server's
+    /// storage. Destroying the only window is indistinguishable from closing
+    /// the last one, so without this the swap raises `ExitRequested` -- which
+    /// on an idle app has nothing to warn about and simply lets it exit, and on
+    /// a running one puts a "quit?" prompt in front of a user who asked to
+    /// change servers.
+    swapping_window: AtomicBool,
 }
 
 struct LocaldConnection {
@@ -181,6 +188,7 @@ impl Shell {
             agent_host_status: Mutex::new(None),
             sharing_mode: Mutex::new(None),
             quit_confirmed: AtomicBool::new(false),
+            swapping_window: AtomicBool::new(false),
         }
     }
 }
@@ -2224,6 +2232,17 @@ fn should_preserve_inflight_phase(
 
 fn open_app_window(app: &AppHandle, url: &str) -> Result<(), String> {
     let target = tauri::Url::parse(url).map_err(|error| format!("invalid app URL: {error}"))?;
+    // Rebuilt rather than refused when it is missing. The window is destroyed
+    // and recreated when the user changes servers, so "not available" is now a
+    // state the app can legitimately be in -- and if the recreate failed, this
+    // is the path the tray's Open uses to ask for it again. Refusing here would
+    // leave a running app whose only interface is a tray icon that cannot open
+    // anything, with no way back except quitting.
+    if app.get_webview_window("main").is_none() {
+        let mode = current_mode(app);
+        build_main_window(app, &mode, WebviewUrl::App("index.html".into()), true)
+            .map_err(|error| format!("could not reopen the window: {error}"))?;
+    }
     let window = app
         .get_webview_window("main")
         .ok_or("main window is not available")?;
@@ -3665,22 +3684,304 @@ fn current_mode(app: &AppHandle) -> String {
     ui.mode.clone()
 }
 
+/// Build the one window the app has, against the storage its server owns.
+///
+/// Extracted from `setup` so a server switch can rebuild it. Everything
+/// here has to be re-applied on a rebuild, not just on first launch: the
+/// navigation and download policies, the theme and accent listeners, the
+/// vibrancy material, and the initialization script that carries the
+/// desktop context into every document the window later navigates to.
+fn build_main_window(
+    handle: &AppHandle,
+    mode: &str,
+    initial_url: WebviewUrl,
+    partitioned: bool,
+) -> tauri::Result<tauri::WebviewWindow> {
+    let main_builder = WebviewWindowBuilder::new(handle, "main", initial_url)
+        .title("Lemma")
+        .inner_size(1280.0, 860.0)
+        .min_inner_size(980.0, 680.0)
+        .devtools(true)
+        // Corrected to the real appearance immediately after build.
+        // Light is the safer guess to start from: a white flash reads
+        // as a page loading, a black one reads as a broken app.
+        .background_color(CANVAS_LIGHT)
+        .initialization_script(desktop_context_script(mode))
+        .on_navigation({
+            let handle = handle.clone();
+            move |url| {
+                let (mode, app_base, api_base) = navigation_context(&handle);
+                match navigation_disposition(url, &mode, &app_base, &api_base) {
+                    NavigationDisposition::Allow => true,
+                    NavigationDisposition::OpenExternal => {
+                        open_external(url.as_str());
+                        false
+                    }
+                    NavigationDisposition::Deny => false,
+                }
+            }
+        })
+        .on_new_window({
+            let handle = handle.clone();
+            move |url, _features| {
+                let (mode, app_base, api_base) = navigation_context(&handle);
+                match new_window_disposition(&url, &mode, &app_base, &api_base) {
+                    NewWindowDisposition::NavigateInApp => {
+                        let _ = navigate_app_window(&handle, url.as_str());
+                    }
+                    NewWindowDisposition::OpenExternal => {
+                        open_external(url.as_str());
+                    }
+                    NewWindowDisposition::Deny => {}
+                }
+                NewWindowResponse::Deny
+            }
+        })
+        .on_download({
+            let handle = handle.clone();
+            move |_webview, event| match event {
+                DownloadEvent::Requested { url, .. } => {
+                    let (mode, app_base, api_base) = navigation_context(&handle);
+                    download_disposition(&url, &mode, &app_base, &api_base)
+                }
+                _ => true,
+            }
+        });
+
+    // Native materials. Vibrancy is only ever visible where the web
+    // content declines to paint, so the window has to be transparent
+    // for any of it to show — which also means every surface that
+    // *should* stay opaque has to say so itself. That sweep is not
+    // done, so this stays behind a flag: without it the app composites
+    // exactly as it did before, and with it the [data-desktop-vibrancy]
+    // rules in styles/tokens.css open up the shell rail.
+    #[cfg(target_os = "macos")]
+    let main_builder = if desktop_vibrancy_enabled() {
+        main_builder.transparent(true)
+    } else {
+        main_builder
+    };
+
+    // Which storage this window gets. Set here because it is a
+    // builder-time property: a live webview cannot be moved between
+    // stores, which is why switching servers rebuilds the window
+    // rather than clearing the one store both used to share.
+    #[cfg(target_os = "macos")]
+    let main_builder = if partitioned {
+        main_builder.data_store_identifier(session_partition_id(mode))
+    } else {
+        main_builder
+    };
+    #[cfg(target_os = "windows")]
+    let main_builder = if partitioned {
+        main_builder.data_directory(session_partition_dir(mode))
+    } else {
+        main_builder
+    };
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    let _ = partitioned;
+
+    let main = main_builder.build()?;
+
+    // The builder had to guess an appearance before the window existed.
+    // Now that it does, ask it, and keep asking: a window whose layer
+    // stays light while the page goes dark flashes white on every
+    // navigation, which is the same bug with the colours swapped.
+    if let Ok(theme) = main.theme() {
+        let _ = main.set_background_color(Some(canvas_color(theme)));
+    }
+    main.on_window_event({
+        let window = main.clone();
+        move |event| {
+            if let tauri::WindowEvent::ThemeChanged(theme) = event {
+                let _ = window.set_background_color(Some(canvas_color(*theme)));
+            }
+        }
+    });
+
+    #[cfg(target_os = "macos")]
+    if desktop_vibrancy_enabled() {
+        use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial, NSVisualEffectState};
+
+        // Sidebar is the material AppKit itself uses behind source
+        // lists, which is what the pod shell rail is.
+        // The attribute itself rides in the initialization script, so it
+        // is already set on this document and on every document the
+        // window navigates to afterwards. Only the failure path needs
+        // to say anything here, and it takes the attribute back off so
+        // the page is not styled for a material that is not there.
+        if let Err(error) = apply_vibrancy(
+            &main,
+            NSVisualEffectMaterial::Sidebar,
+            Some(NSVisualEffectState::FollowsWindowActiveState),
+            None,
+        ) {
+            eprintln!("lemma: could not apply window vibrancy: {error}");
+            let _ = main.eval("document.documentElement.removeAttribute('data-desktop-vibrancy')");
+        }
+    }
+
+    // Only relevant when the OS accent is driving the palette. The
+    // accent is read once at launch, so it would otherwise go stale the
+    // moment the user changes it in System Settings; re-reading on focus
+    // catches exactly that — they leave to change it and come back.
+    if desktop_system_accent_enabled() {
+        main.on_window_event({
+            let window = main.clone();
+            move |event| {
+                if matches!(
+                    event,
+                    tauri::WindowEvent::Focused(true) | tauri::WindowEvent::ThemeChanged(_)
+                ) {
+                    let _ = window.eval(format!(
+                        "document.documentElement.style.setProperty('--accent-rgb','{}')",
+                        accent_channel_triple(),
+                    ));
+                }
+            }
+        });
+    }
+
+    main.show()?;
+    main.set_focus()?;
+    if std::env::var("LEMMA_DESKTOP_DEVTOOLS").as_deref() == Ok("1") {
+        main.open_devtools();
+    }
+    Ok(main)
+}
+
 fn set_mode(app: &AppHandle, mode: &str) -> Result<(), String> {
     write_config(|config| {
         config["connectionMode"] = json!(mode);
         config["connectionModePromptRevision"] = json!(CONNECTION_MODE_PROMPT_REVISION);
     })?;
     refresh_menus_for_connection_mode(app);
-    {
+    let changed = {
         let shell: State<Shell> = app.state();
         let mut ui = shell.ui.lock().unwrap();
-        if ui.mode != mode && mode == "local" {
+        let changed = ui.mode != mode;
+        if changed && mode == "local" {
             ui.url.clear();
             ui.api_url.clear();
         }
         ui.mode = mode.to_string();
+        changed
+    };
+    if changed {
+        rebuild_main_window_for_mode(app, mode);
     }
     Ok(())
+}
+
+/// The storage partition a server's session lives in.
+///
+/// Lemma Cloud and a local install are different servers -- different accounts,
+/// different databases, different signing keys -- shown in one window. They are
+/// also different origins (`lemma.work` versus `app.lemma.localhost`), so the
+/// browser's own rules already stop either reading the other's cookies.
+///
+/// What the origin rules do *not* do is bound a session's lifetime to the
+/// server that issued it. `app.lemma.localhost` is a stable hostname reused by
+/// every local installation this machine ever has, and cookies ignore the port,
+/// so a session minted against one local database is still presented to the
+/// next one -- which rejects it, correctly, on every authorized route while
+/// `/auth/session/refresh` keeps answering 200 because the refresh token itself
+/// is genuinely valid. One install was measured writing 8 MB of backend log an
+/// hour in that state, indefinitely.
+///
+/// Giving each server its own store is what makes the two independent rather
+/// than merely non-overlapping. The earlier version of this fix cleared the
+/// single shared store whenever the mode changed, which signed the user out of
+/// the server they were leaving *and* out of the one they were returning to --
+/// and still did not fix the case above, which needs no mode change at all.
+///
+/// The identifiers are constants, not derived: they have to name the same store
+/// on every launch, or a restart would look like a new server and lose the
+/// session it was meant to keep.
+#[cfg(target_os = "macos")]
+fn session_partition_id(mode: &str) -> [u8; 16] {
+    // Arbitrary, fixed, and distinct. Never reuse or reorder these.
+    const HOSTED: [u8; 16] = *b"lemma.cloud.sess";
+    const LOCAL: [u8; 16] = *b"lemma.local.sess";
+    if mode == "hosted" {
+        HOSTED
+    } else {
+        LOCAL
+    }
+}
+
+/// The Windows spelling of the same idea. WebView2 partitions by user-data
+/// folder rather than by identifier, so the two servers get two directories.
+#[cfg(target_os = "windows")]
+fn session_partition_dir(mode: &str) -> PathBuf {
+    let name = if mode == "hosted" { "hosted" } else { "local" };
+    app_support_dir().join("webview").join(name)
+}
+
+/// Clears the swap flag however the rebuild ends, including on an early
+/// return. A flag left set would make the app unquittable.
+struct ExitGuard(AppHandle);
+
+impl Drop for ExitGuard {
+    fn drop(&mut self) {
+        let shell: State<Shell> = self.0.state();
+        shell.swapping_window.store(false, Ordering::Release);
+    }
+}
+
+/// Move the window onto the storage the new server owns.
+///
+/// A webview's store is fixed when it is built, so this closes the window and
+/// builds it again. That is the price of real isolation, and it is paid only on
+/// an actual server change: a restart, a reconnect, or a runtime coming back on
+/// new ports all keep the window they have.
+///
+/// Failure is deliberately not fatal to the switch. The mode has already been
+/// written and the caller is about to navigate; a window that is still on the
+/// previous store shows the right server with the wrong cookie jar, which is
+/// the behaviour that shipped before this existed. Refusing to switch servers
+/// at all would be worse.
+fn rebuild_main_window_for_mode(app: &AppHandle, mode: &str) {
+    let Some(existing) = app.get_webview_window("main") else {
+        // Nothing built yet -- `setup` will create it against the right store.
+        return;
+    };
+    // Held across both halves, and cleared on every path out. `destroy` is
+    // deliberate rather than `close`: the app hides to tray on CloseRequested,
+    // so `close` would leave the old window alive on the old store and no new
+    // one would ever be built.
+    let shell: State<Shell> = app.state();
+    shell.swapping_window.store(true, Ordering::Release);
+    let _reset = ExitGuard(app.clone());
+    if let Err(error) = existing.destroy() {
+        append_install_log(&format!(
+            "[connection-mode] could not close the previous server's window: {error}"
+        ));
+        return;
+    }
+    // Rebuilt on the splash rather than on the destination: `set_mode`'s caller
+    // navigates immediately afterwards, and for local it has to wait for the
+    // daemon first. Starting anywhere else would show one server's page against
+    // the other's storage for as long as that takes.
+    let initial = WebviewUrl::App("index.html".into());
+    if let Err(error) = build_main_window(app, mode, initial.clone(), true) {
+        // Falling back to the shared store, not to nothing. Per-webview storage
+        // is the newer half of this: macOS needs 14 (which the bundle already
+        // requires) and Windows gives each webview its own WebView2 environment,
+        // which is not something this can prove on every machine it will run on.
+        // Losing the partition costs the isolation and restores exactly the
+        // behaviour that shipped before it; losing the window leaves the user
+        // with an app that has no interface at all.
+        append_install_log(&format!(
+            "[connection-mode] partitioned window failed for {mode}, \
+             falling back to shared storage: {error}"
+        ));
+        if let Err(error) = build_main_window(app, mode, initial, false) {
+            append_install_log(&format!(
+                "[connection-mode] could not reopen the window for {mode}: {error}"
+            ));
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -4993,141 +5294,8 @@ fn main() {
                 WebviewUrl::App("index.html".into())
             };
 
-            let main_builder = WebviewWindowBuilder::new(app, "main", initial_url)
-                .title("Lemma")
-                .inner_size(1280.0, 860.0)
-                .min_inner_size(980.0, 680.0)
-                .devtools(true)
-                // Corrected to the real appearance immediately after build.
-                // Light is the safer guess to start from: a white flash reads
-                // as a page loading, a black one reads as a broken app.
-                .background_color(CANVAS_LIGHT)
-                .initialization_script(desktop_context_script(&mode))
-                .on_navigation({
-                    let handle = handle.clone();
-                    move |url| {
-                        let (mode, app_base, api_base) = navigation_context(&handle);
-                        match navigation_disposition(url, &mode, &app_base, &api_base) {
-                            NavigationDisposition::Allow => true,
-                            NavigationDisposition::OpenExternal => {
-                                open_external(url.as_str());
-                                false
-                            }
-                            NavigationDisposition::Deny => false,
-                        }
-                    }
-                })
-                .on_new_window({
-                    let handle = handle.clone();
-                    move |url, _features| {
-                        let (mode, app_base, api_base) = navigation_context(&handle);
-                        match new_window_disposition(&url, &mode, &app_base, &api_base) {
-                            NewWindowDisposition::NavigateInApp => {
-                                let _ = navigate_app_window(&handle, url.as_str());
-                            }
-                            NewWindowDisposition::OpenExternal => {
-                                open_external(url.as_str());
-                            }
-                            NewWindowDisposition::Deny => {}
-                        }
-                        NewWindowResponse::Deny
-                    }
-                })
-                .on_download({
-                    let handle = handle.clone();
-                    move |_webview, event| match event {
-                        DownloadEvent::Requested { url, .. } => {
-                            let (mode, app_base, api_base) = navigation_context(&handle);
-                            download_disposition(&url, &mode, &app_base, &api_base)
-                        }
-                        _ => true,
-                    }
-                });
-
-            // Native materials. Vibrancy is only ever visible where the web
-            // content declines to paint, so the window has to be transparent
-            // for any of it to show — which also means every surface that
-            // *should* stay opaque has to say so itself. That sweep is not
-            // done, so this stays behind a flag: without it the app composites
-            // exactly as it did before, and with it the [data-desktop-vibrancy]
-            // rules in styles/tokens.css open up the shell rail.
-            #[cfg(target_os = "macos")]
-            let main_builder = if desktop_vibrancy_enabled() {
-                main_builder.transparent(true)
-            } else {
-                main_builder
-            };
-
-            let main = main_builder.build()?;
-
-            // The builder had to guess an appearance before the window existed.
-            // Now that it does, ask it, and keep asking: a window whose layer
-            // stays light while the page goes dark flashes white on every
-            // navigation, which is the same bug with the colours swapped.
-            if let Ok(theme) = main.theme() {
-                let _ = main.set_background_color(Some(canvas_color(theme)));
-            }
-            main.on_window_event({
-                let window = main.clone();
-                move |event| {
-                    if let tauri::WindowEvent::ThemeChanged(theme) = event {
-                        let _ = window.set_background_color(Some(canvas_color(*theme)));
-                    }
-                }
-            });
-
-            #[cfg(target_os = "macos")]
-            if desktop_vibrancy_enabled() {
-                use window_vibrancy::{
-                    apply_vibrancy, NSVisualEffectMaterial, NSVisualEffectState,
-                };
-
-                // Sidebar is the material AppKit itself uses behind source
-                // lists, which is what the pod shell rail is.
-                // The attribute itself rides in the initialization script, so it
-                // is already set on this document and on every document the
-                // window navigates to afterwards. Only the failure path needs
-                // to say anything here, and it takes the attribute back off so
-                // the page is not styled for a material that is not there.
-                if let Err(error) = apply_vibrancy(
-                    &main,
-                    NSVisualEffectMaterial::Sidebar,
-                    Some(NSVisualEffectState::FollowsWindowActiveState),
-                    None,
-                ) {
-                    eprintln!("lemma: could not apply window vibrancy: {error}");
-                    let _ = main
-                        .eval("document.documentElement.removeAttribute('data-desktop-vibrancy')");
-                }
-            }
-
-            // Only relevant when the OS accent is driving the palette. The
-            // accent is read once at launch, so it would otherwise go stale the
-            // moment the user changes it in System Settings; re-reading on focus
-            // catches exactly that — they leave to change it and come back.
-            if desktop_system_accent_enabled() {
-                main.on_window_event({
-                    let window = main.clone();
-                    move |event| {
-                        if matches!(
-                            event,
-                            tauri::WindowEvent::Focused(true) | tauri::WindowEvent::ThemeChanged(_)
-                        ) {
-                            let _ = window.eval(format!(
-                                "document.documentElement.style.setProperty('--accent-rgb','{}')",
-                                accent_channel_triple(),
-                            ));
-                        }
-                    }
-                });
-            }
-
-            main.show()?;
-            main.set_focus()?;
+            build_main_window(&handle, &mode, initial_url, true)?;
             launch_trace("window shown");
-            if std::env::var("LEMMA_DESKTOP_DEVTOOLS").as_deref() == Ok("1") {
-                main.open_devtools();
-            }
 
             app.set_menu(build_app_menu(&handle)?)?;
             app.on_menu_event(|app, event| handle_menu_action(app, event.id().as_ref()));
@@ -5290,6 +5458,14 @@ fn main() {
             // to say so about.
             tauri::RunEvent::ExitRequested { api, .. } => {
                 let shell: State<Shell> = app.state();
+                // A server switch closes the window and opens another one. In
+                // between there are no windows, which looks exactly like the
+                // last one closing -- so hold the exit rather than asking about
+                // it or taking it.
+                if shell.swapping_window.load(Ordering::Acquire) {
+                    api.prevent_exit();
+                    return;
+                }
                 if shell.quit_confirmed.load(Ordering::Acquire) {
                     return;
                 }
@@ -5320,6 +5496,28 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use std::fs::File;
+
+    /// Cloud and local must never share a store, and neither may drift between
+    /// launches.
+    ///
+    /// The identifiers are constants precisely so this can be asserted. If one
+    /// were ever derived from something per-run, a restart would look like a
+    /// different server and silently sign the user out of the one they kept.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn each_server_gets_its_own_session_store() {
+        let hosted = super::session_partition_id("hosted");
+        let local = super::session_partition_id("local");
+        assert_ne!(hosted, local);
+        // Stable across calls, which is what makes a session survive a restart.
+        assert_eq!(hosted, super::session_partition_id("hosted"));
+        assert_eq!(local, super::session_partition_id("local"));
+        // Anything that is not the hosted server is the local one. "undecided"
+        // reaches here on a first launch that has not been answered yet, and it
+        // must not land in the cloud store.
+        assert_eq!(local, super::session_partition_id("undecided"));
+        assert_eq!(local, super::session_partition_id(""));
+    }
 
     /// The shell and the daemon must derive the same endpoint name.
     ///

--- a/lemma-frontend/app/providers.tsx
+++ b/lemma-frontend/app/providers.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider, keepPreviousData } from '@tanstack/re
 import { ThemeProvider as NextThemesProvider } from 'next-themes';
 import { useState, type ReactNode } from 'react';
 import { usePathname } from 'next/navigation';
+import { isUnauthorized } from '@/lib/sdk/is-unauthorized';
 import { Toaster } from 'sonner';
 import { OrganizationProvider } from '@/components/dashboard/org-context';
 import { AnalyticsProvider } from '@/components/analytics/analytics-provider';
@@ -32,6 +33,22 @@ export function Providers({ children }: { children: ReactNode }) {
                          * to keep, so they still get the skeleton.
                          */
                         placeholderData: keepPreviousData,
+                        /**
+                         * Never retry a rejection. Retrying assumes the next
+                         * attempt could be authorized, and by this point the
+                         * session layer has already refreshed and retried on
+                         * its own -- so a 401 here means that did not work.
+                         *
+                         * Retrying anyway multiplies it: react-query's default
+                         * is three more attempts, each of which re-enters the
+                         * refresh-and-retry path underneath. One unusable
+                         * session became a sustained ~10 requests a second
+                         * across every query a workspace screen makes, forever,
+                         * because nothing in the stack treated "still 401 after
+                         * a successful refresh" as an answer.
+                         */
+                        retry: (failureCount, error) =>
+                            !isUnauthorized(error) && failureCount < 3,
                     },
                 },
             })

--- a/lemma-frontend/components/auth/portal/auth/supertokens.ts
+++ b/lemma-frontend/components/auth/portal/auth/supertokens.ts
@@ -236,6 +236,25 @@ export function ensureSuperTokensInit(): void {
       Session.init({
         sessionTokenFrontendDomain: authConfig.sessionTokenDomain,
         tokenTransferMethod: "cookie",
+        /**
+         * How many times one request may be refreshed-and-retried before the
+         * session is called unusable. The library default is 10, which is only
+         * ever right when a refresh eventually fixes the 401.
+         *
+         * It does not always. A refresh token can be genuinely valid -- so
+         * `/auth/session/refresh` answers 200 -- while the access token it
+         * mints authorizes nothing, because the database that would recognise
+         * it has been replaced underneath. The client reads the 200 as "fixed",
+         * retries, gets 401, refreshes again. At 10 attempts per request,
+         * across the ~9 queries a workspace screen makes, on a 60s poll, one
+         * install was measured writing 8 MB of backend log an hour,
+         * indefinitely.
+         *
+         * Two is enough to ride out the case this exists for -- an access token
+         * that expired between being read and being sent -- and small enough
+         * that a session which cannot be repaired stops being hammered.
+         */
+        maxRetryAttemptsForSessionRefresh: 2,
       }),
       EmailPassword.init({
         override: {

--- a/lemma-frontend/lib/sdk/is-unauthorized.test.ts
+++ b/lemma-frontend/lib/sdk/is-unauthorized.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { isUnauthorized } from './is-unauthorized';
+
+describe('isUnauthorized', () => {
+    it('recognises the SDK rejection that must not be retried', () => {
+        // The shape ApiError/UnauthorizedError actually carries.
+        expect(isUnauthorized({ name: 'UnauthorizedError', statusCode: 401 })).toBe(true);
+    });
+
+    it('recognises a 401 whose name did not survive the package boundary', () => {
+        // Why the check is structural: a duplicated copy of the SDK in the
+        // module graph gives an error that is a different class with the same
+        // status. Matching on `instanceof` alone would put the storm back.
+        expect(isUnauthorized({ statusCode: 401 })).toBe(true);
+        expect(isUnauthorized({ name: 'UnauthorizedError' })).toBe(true);
+    });
+
+    it('leaves every other rejection retryable', () => {
+        // 403 is an authenticated user meeting a permission denial — not worth
+        // retrying either, but not this, and the SDK draws the line in the same
+        // place. 429 and 5xx are exactly what the retry budget exists for.
+        expect(isUnauthorized({ name: 'ForbiddenError', statusCode: 403 })).toBe(false);
+        expect(isUnauthorized({ name: 'RateLimitError', statusCode: 429 })).toBe(false);
+        expect(isUnauthorized({ name: 'ServerError', statusCode: 503 })).toBe(false);
+        expect(isUnauthorized({ name: 'NetworkError' })).toBe(false);
+    });
+
+    it('does not throw on the things a rejection can also be', () => {
+        expect(isUnauthorized(undefined)).toBe(false);
+        expect(isUnauthorized(null)).toBe(false);
+        expect(isUnauthorized('401')).toBe(false);
+        expect(isUnauthorized(401)).toBe(false);
+        expect(isUnauthorized(new Error('boom'))).toBe(false);
+    });
+
+    it('does not treat a 401 written as a string as a match', () => {
+        // The SDK types statusCode as a number; a string here means the object
+        // came from somewhere else and the assumption behind skipping the retry
+        // does not hold.
+        expect(isUnauthorized({ statusCode: '401' })).toBe(false);
+    });
+});

--- a/lemma-frontend/lib/sdk/is-unauthorized.ts
+++ b/lemma-frontend/lib/sdk/is-unauthorized.ts
@@ -1,0 +1,25 @@
+/**
+ * Is this rejection the server saying "not you"?
+ *
+ * Used to decide whether retrying could possibly help. By the time a rejection
+ * reaches react-query the session layer has already refreshed and retried
+ * underneath, so a 401 here is not a transient blip that another attempt might
+ * catch -- it is the answer. Retrying it re-enters that refresh-and-retry path
+ * and multiplies one unusable session into a sustained request storm.
+ *
+ * Deliberately only 401. A 403 is an authenticated user meeting a permission or
+ * RLS denial, which is equally not worth retrying but is a different thing, and
+ * the SDK draws that line in the same place (`http.ts` marks the session
+ * unauthenticated on 401 alone).
+ *
+ * Structural rather than `instanceof`: the error crosses a package boundary, so
+ * a duplicated copy of the SDK in the module graph would make `instanceof`
+ * quietly false and put the retry storm back.
+ */
+export function isUnauthorized(error: unknown): boolean {
+    if (!error || typeof error !== 'object') {
+        return false;
+    }
+    const candidate = error as { statusCode?: unknown; name?: unknown };
+    return candidate.statusCode === 401 || candidate.name === 'UnauthorizedError';
+}


### PR DESCRIPTION
## What changes

Switching Lemma Desktop between Cloud and a local install could leave the app in a state it never left: **every authorized route answered 401 while `/auth/session/refresh` answered 200**, so the client refreshed, retried, and refreshed again — forever.

Measured on a real install, from its own `backend.log`:

| | |
|---|---|
| refresh POST → 200 | **484** |
| `/pods/{id}/conversations` → 401 | 143 |
| `notifications/unread-count` → 401 | 132 |
| `permissions/me`, `datastore/tables`, `datastore/files`, `agent-runtime/profiles` → 401 | 88 each |
| sustained log growth | **~8 MB/hour, indefinitely** |

```
POST 200  (refresh)  →  GET 401  →  POST 200  →  GET 401 …   ~10/second
```

### The session outlives the server that issued it

Cloud and a local install are different servers — different accounts, databases and signing keys — shown in one window. They are also **different origins** (`lemma.work` vs `app.lemma.localhost`), so the browser's own rules already stop either reading the other's cookies. Cross-contamination was never the problem.

What origin rules do *not* do is bound a session's **lifetime** to the server that issued it. `app.lemma.localhost` is a stable hostname reused by every local installation this machine ever has, and cookies ignore the port — so a session minted against one local database is still presented to the next one, which correctly rejects it. Verified against the affected install: refresh with *no* cookies returns 401, so the client genuinely held a refresh token the server accepted while its access token authorized nothing.

**Each server now gets its own store** — `data_store_identifier` on macOS (needs 14; the bundle already requires 14.0), a user-data directory on Windows. That makes the two independent rather than merely non-overlapping, and **nobody is signed out to achieve it**.

> An earlier revision of this PR cleared the single shared store on every mode change. That was wrong twice over: it signed the user out of *both* servers, and it still did not fix the case above — which needs no mode change at all. Replaced entirely.

### Rebuilding the window, safely

A store is fixed when the webview is built, so switching servers rebuilds `main`. Three things had to hold, each **checked rather than assumed**:

- **Capabilities** resolve by webview label at invoke time (`resolve_access(command, window, webview, origin)`), so a rebuilt `main` inherits the same ones.
- **No cached webview handles** anywhere — everything looks up by label. The `control` child is destroyed with its parent and rebuilt on demand.
- **`destroy`, not `close`** — this app hides to tray on `CloseRequested`, so `close` would have left the old window alive on the old store with no new one ever built.

Destroying the only window also raises `ExitRequested`, which on an idle app has nothing to warn about and **simply lets it exit**, and on a running one puts a "quit?" prompt in front of someone who asked to change servers. A flag held across the swap holds that exit, cleared by an RAII guard on every path out so a failed rebuild cannot leave the app unquittable.

Two more failure paths are closed: if the partitioned window will not build it **falls back to the shared store rather than to no window**, and `open_app_window` **rebuilds a missing window rather than refusing** — otherwise a failure there leaves a running app whose only interface is a tray icon that cannot open anything.

### Two multipliers turned one dead session into a storm

- **The session layer** refreshed-and-retried up to **10 times** per request (library default) — only ever right when a refresh eventually fixes the 401. Now **2**.
- **react-query** retried **3 more**, each re-entering that path underneath. It no longer retries a 401 at all.

Together: ~360 requests per wave → ~9. The predicate is **structural rather than `instanceof`**, because the error crosses a package boundary and a duplicated SDK in the module graph would make the check quietly false and put the storm back.

I checked the SDK's own policy too — `RETRYABLE_STATUS` is `{429, 502, 503, 504}` — so it correctly never retried 401 and is not a third multiplier.

### 3. The log ceiling was never enforced after the first second

The storm above was writing ~8 MB/hour into `backend.log`, which is supposed to be capped at 5 MiB. It wasn't: `process_log` rotates when it **opens** the file — once, at spawn — and the handle it returns *is* the child's stdout and stderr for the whole life of the process. A desktop backend runs for days, so nothing measured it again. The reporting install had a 16 MB `backend.log` still growing, and the only thing that would ever have truncated it was a restart.

The supervisor already ticks every second to reconcile crashes; it now also measures each service's log, on its own slower cadence (this stats a file per service and does not need to run every second).

Rotating a live log is precisely what `rotate_log` was built for — it copies aside and truncates in place rather than renaming, so a writer holding the descriptor keeps writing to the same file and finds it back at zero. That property was already load-bearing at spawn; nothing called it afterwards. The new test asserts it **with a handle still open**, because that is the only state that ever actually occurs.

Worth noting this bound is now real in both directions: 5 MiB live plus a 5 MiB rotated copy per service, rather than unbounded.

## How to verify

```bash
cd desktop && cargo fmt --all --check && cargo clippy --workspace --locked --all-targets -- -D warnings && cargo test --workspace --locked
cd lemma-frontend && npm run check && npm run test
```

All clean: 132 desktop-workspace tests, 799 frontend tests across 81 files, clippy clean, lint + design audit + typecheck + edu-anchors.

`session_partition_id` has its own test asserting the two stores differ, are stable across calls (a restart must not look like a new server), and that anything not `hosted` — including `undecided` on a first launch — lands in the local store rather than the cloud one.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — narrows credential lifetime and scope rather than widening it; the two servers' cookies now live in separate stores instead of one shared jar
- [x] **Rollback** — plain revert. No migrations, no API surface, no persisted format change.

## Compatibility and rollback notes

**Existing sessions do not carry over.** The current shared store is not migrated into either partition, so the first launch after this lands asks for a sign-in on whichever server you open. That is a one-time cost, not a per-switch one — after it, each server keeps its own session indefinitely and switching is free.

`maxRetryAttemptsForSessionRefresh: 2` also applies on the web. A genuinely slow refresh needing more than two attempts would surface as an error rather than eventually succeeding — I do not believe that case exists (the retries are for a token expiring mid-flight, which one refresh resolves), but it is the risk worth naming.

## Known limits

- **The Windows partition is unproven on real hardware.** wry creates a separate WebView2 environment per `data_directory`, which should work, but I could not test it here and Windows Desktop is not yet a shipped target. This is exactly why the fallback to shared storage exists — on Windows the worst case is losing the isolation, not the window.
- **The app still renders as though signed in** while a session is invalid, because the SDK's `markUnauthenticated()` deliberately does not redirect. With this change the app is quiet and recoverable by signing out; putting it on the login screen automatically is a product decision I have not made here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
