### PR TITLE
Install the local runtime when switching to Local, not only when relaunching

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1006,15 +1006,32 @@ fn enriched_path() -> String {
 
 fn ensure_locald(app: &AppHandle) -> Result<(), String> {
     let shell: State<Shell> = app.state();
-    if shell.locald_writer.lock().unwrap().is_some() {
-        return Ok(());
-    }
-    // Deliberately before the connect guard, under a lock of its own. This can
-    // take minutes on a first run, and holding `locald_connect` across it turned
+    // The runtime comes first, and before the "already connected" check rather
+    // than after it.
+    //
+    // Both modes run this same daemon: hosted brings it up through
+    // `ensure_locald_without_host_pack` so the Agent Host has a supervisor, and
+    // only local needs the runtime artifacts. So by the time someone switches
+    // hosted -> local, the writer is already `Some` -- and this returned `Ok`
+    // having installed nothing at all. `start` then reached a daemon with no
+    // private runtime and came back "private runtime is not ready for host
+    // processes", the splash sat on "Lemma is starting", and the only cure was
+    // relaunching the app, because a fresh process is the one thing that makes
+    // the writer `None` again and lets this run properly.
+    //
+    // Cheap when there is nothing to do: an installed runtime is self-contained
+    // and is recognised from its own recorded identity, without consulting an
+    // artifact host.
+    //
+    // Still before the connect guard, under a lock of its own. This can take
+    // minutes on a first run, and holding `locald_connect` across it turned
     // every unrelated caller into a hang of the same length.
     {
         let _install_guard = shell.runtime_install.lock().unwrap();
         ensure_runtime_artifacts(app)?;
+    }
+    if shell.locald_writer.lock().unwrap().is_some() {
+        return Ok(());
     }
 
     let _connect_guard = shell.locald_connect.lock().unwrap();


### PR DESCRIPTION
## What changes

Switching a **running** app from Lemma Cloud to Local left it stuck on "Lemma is starting" forever, with a follow-up error saying Lemma was still finishing another operation. Quitting and reopening fixed it — which is the tell.

`ensure_locald` returned early when the daemon was already connected, **before** the step that installs the local runtime:

```rust
fn ensure_locald(app: &AppHandle) -> Result<(), String> {
    if shell.locald_writer.lock().unwrap().is_some() {
        return Ok(());                       // <-- installed nothing
    }
    { let _guard = ...; ensure_runtime_artifacts(app)?; }   // never reached
```

Both modes run the same daemon. Hosted brings it up through `ensure_locald_without_host_pack` so the Agent Host has a supervisor — the comment on that split already says *"only the local one needs the runtime artifacts."* So on a hosted→local switch `locald_writer` is already `Some`, and the 502 MB runtime was never fetched.

`start` then reached a daemon with no private runtime. The runtime step now runs **before** that check.

## Why the restart "fixed" it

A fresh process is the one thing that makes `locald_writer` `None` again — the only path that reached the install. That is why it worked on relaunch and only on relaunch, and why nothing was downloading in between: nothing had asked it to.

## Evidence

From the reporting install's own logs, not reasoning:

**`launch.log`** — three separate process starts; the install began only on the one that started in local mode:
```
11:28:56  process start, mode=undecided
11:32:13  process start, mode=hosted
11:40:12  process start, mode=local     <- install begins 6s later
```

**`install.log`** — one and only one `Preparing local runtime`, at `11:40:18`. Nothing during the switch at ~11:33.

**`locald.log`** — last line:
```
backend environment unavailable: private runtime is not ready for host processes
```

**Agent Host status at 11:32:31** confirms the daemon was already connected while in hosted mode, which is the precondition for the early return.

The "still finishing another operation" message is secondary: a retry hitting the single-flight guard after the failed start.

## How to verify

```bash
cd desktop
cargo fmt --all --check && cargo clippy --workspace --locked --all-targets -- -D warnings && cargo test --workspace --locked
```

Clean; 132 desktop-crate tests pass.

Manually: from a running app in Cloud mode with no local runtime installed, switch to Local from the tray. Before, the splash sat on "Lemma is starting" and `install.log` stayed silent until a relaunch. After, the runtime download starts immediately.

## Checklist

- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Rollback** — plain revert; a one-block move with no state or format change.

## Compatibility and rollback notes

`ensure_runtime_artifacts` now runs on every `ensure_locald` call rather than only on the not-yet-connected path. It is cheap when there is nothing to do: an installed runtime is self-contained and is recognised from its own recorded identity **without consulting an artifact host**, so this adds no network call and keeps offline launches working. It stays before the connect guard and under its own lock, for the reason already recorded there — a first run takes minutes, and holding `locald_connect` across it turns every unrelated caller into a hang of the same length.

## Related, not fixed here

`active_operation_id` is an in-memory single-flight lock with no timeout and nothing that clears it on a mode change. It is not the cause here, but it is why a failed operation presents as "Lemma is still finishing another operation" until the app is relaunched, rather than as the actual error. Worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)