### PR TITLE
Keep the nightly channel to the three most recent builds

### DIFF
--- a/.github/workflows/release-local-images.yml
+++ b/.github/workflows/release-local-images.yml
@@ -1081,6 +1081,65 @@ jobs:
             echo "[Download the DMG](${url})"
           } >> "${GITHUB_STEP_SUMMARY}"
 
+      # The nightly channel is a rolling window, not an archive. Every shared
+      # build used to leave its prerelease behind for good: by 0.7.0 twelve had
+      # accumulated, so most of the releases page was throwaway builds and the
+      # newest real release had been pushed fifth from the top. Nothing reads a
+      # nightly tag except the DMG built in the same run, and its own notes say
+      # there is no upgrade path, so keeping them all bought nothing.
+      #
+      # Pruning here rather than beside the release's creation is deliberate.
+      # By this point the new nightly is complete -- runtime assets and a
+      # notarized, stapled DMG -- so the window never closes over older builds
+      # in favour of one that turned out to be unusable.
+      - name: Prune superseded nightly prereleases
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KEEP: "3"
+        run: |
+          # No -e: this is housekeeping running after the DMG is already
+          # published. A GitHub API hiccup here must not report the nightly as
+          # failed, so failures warn and the step still succeeds.
+          set -uo pipefail
+          # `if !` rather than a bare assignment: with pipefail a failed
+          # listing yields an empty string, which is indistinguishable from
+          # "there is nothing to prune" -- and reporting a broken API as a tidy
+          # release page is how this quietly stops working.
+          if ! stale="$(
+            gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+              --jq '.[]
+                    | select(.prerelease and (.tag_name | startswith("desktop-nightly-")))
+                    | [.created_at, .tag_name]
+                    | @tsv' \
+              | sort -r \
+              | tail -n "+$((KEEP + 1))" \
+              | cut -f2
+          )"; then
+            echo "::warning title=Could not list nightly prereleases::Nothing was pruned."
+            exit 0
+          fi
+          if [[ -z "${stale}" ]]; then
+            echo "Nothing to prune: ${KEEP} or fewer nightly prereleases exist."
+            exit 0
+          fi
+          while read -r tag; do
+            [[ -n "${tag}" ]] || continue
+            # Re-checked rather than trusted, because the next line deletes a
+            # release *and its tag*. A version tag reaching this loop would
+            # destroy a real release, so a surprise here stops the step instead
+            # of proceeding on the assumption that the filter above held.
+            if [[ "${tag}" != desktop-nightly-* ]]; then
+              echo "::error title=Refusing to delete a non-nightly release::${tag}"
+              exit 1
+            fi
+            if gh release delete "${tag}" --cleanup-tag --yes; then
+              echo "Pruned ${tag}"
+            else
+              echo "::warning title=Could not prune a nightly prerelease::${tag}"
+            fi
+          done <<< "${stale}"
+
       - name: Remove temporary signing keychain
         if: always() && steps.apple-signing.outcome == 'success'
         run: security delete-keychain "${{ steps.apple-signing.outputs.keychain-path }}"

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -229,6 +229,16 @@ signed with Developer ID, notarized and stapled — and attaches it there. The
 download link is printed to the job summary. Prereleases never become "Latest",
 so the version-tag release channel is untouched.
 
+The nightly channel is a **rolling window of the three most recent builds**, not
+an archive. Once a run has published a complete nightly — runtime assets and a
+notarized DMG — it deletes the older nightly prereleases and their tags. Without
+that they accumulated one per shared build, and by 0.7.0 there were twelve of
+them sitting above the newest real release on the releases page. So a nightly
+DMG is good for about three more shared builds: download it, install the runtime,
+and re-share when you need a newer one. Version tags are never touched — the
+prune re-checks the `desktop-nightly-` prefix immediately before deleting,
+because `--cleanup-tag` removes the tag along with the release.
+
 It has to be the online DMG. Apple's notary service unpacks `host-runtime.zip`
 and rejects everything inside: a bundled CPython and `node_modules` are not
 Developer ID signed and never will be. So a self-contained DMG cannot be

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -317,6 +317,11 @@ digest-verified runtime archives to a prerelease tagged
 `desktop-nightly-<short-sha>`, then attaches a signed, notarized online DMG
 built against them — installable by anyone, with no version tag cut.
 
+Only the three most recent nightly prereleases are kept; each successful shared
+build deletes the ones before them. Install the runtime from a nightly DMG while
+it is current, because once its prerelease is pruned the first-launch download
+has nothing to fetch.
+
 This is not a public offline installer. It exercises the same first-launch
 installer using trusted application resources, while infrastructure and
 sandbox OCI images still require network access. CI rejects:

--- a/lemma-backend/app/core/tests/unit/test_ci_configuration_contract.py
+++ b/lemma-backend/app/core/tests/unit/test_ci_configuration_contract.py
@@ -58,3 +58,153 @@ def test_expensive_security_jobs_are_change_scoped() -> None:
     assert "if: needs.changes.outputs.javascript == 'true'" in workflow
     assert "if: needs.changes.outputs.python_dependencies == 'true'" in workflow
     assert "if: needs.changes.outputs.backend_image == 'true'" in workflow
+
+
+def _nightly_prune_step() -> dict:
+    """The shipped prune step, read out of the workflow rather than retyped.
+
+    A test that restates the script proves only that two copies agree. These
+    run the text that will actually execute in CI.
+    """
+    import yaml
+
+    workflow = yaml.safe_load(_read(".github/workflows/release-local-images.yml"))
+    steps = workflow["jobs"]["share-desktop-dmg"]["steps"]
+    return next(s for s in steps if s["name"] == "Prune superseded nightly prereleases")
+
+
+def _run_prune(tmp_path, releases: list[str], *, keep: str = "3") -> tuple[int, str]:
+    """Run the step with a stubbed `gh`, so no delete can escape the test."""
+    import os
+    import subprocess
+
+    listing = "".join(f'printf "%s\\n" "{line}"\n' for line in releases)
+    stub = tmp_path / "gh"
+    stub.write_text(
+        "#!/bin/bash\n"
+        'if [[ "$1" == "api" ]]; then\n'
+        f"{listing}"
+        "  exit 0\n"
+        "fi\n"
+        'if [[ "$1" == "release" && "$2" == "delete" ]]; then\n'
+        '  echo "DELETED $3"\n'
+        "  exit 0\n"
+        "fi\n"
+        "exit 1\n"
+    )
+    stub.chmod(0o755)
+    script = tmp_path / "prune.sh"
+    script.write_text(_nightly_prune_step()["run"])
+    completed = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PATH": f"{tmp_path}:{os.environ['PATH']}",
+            "GITHUB_REPOSITORY": "lemma-work/lemma-platform",
+            "GH_TOKEN": "stub",
+            "KEEP": keep,
+        },
+    )
+    return completed.returncode, completed.stdout + completed.stderr
+
+
+def test_nightly_prune_keeps_a_rolling_window_of_the_newest_builds(tmp_path) -> None:
+    """Twelve nightly prereleases had buried v0.7.0 fifth from the top.
+
+    Ordering is by creation time and the newest are kept, so the release this
+    run just published is always inside the window and stays installable.
+    """
+    returncode, output = _run_prune(
+        tmp_path,
+        [
+            "2026-08-14T15:07:47Z\tdesktop-nightly-oldest00",
+            "2026-08-18T05:36:33Z\tdesktop-nightly-newest00",
+            "2026-08-17T09:39:47Z\tdesktop-nightly-fourth00",
+            "2026-08-18T05:34:01Z\tdesktop-nightly-second00",
+            "2026-08-17T19:13:00Z\tdesktop-nightly-third000",
+        ],
+    )
+
+    assert returncode == 0, output
+    deleted = {
+        line.split()[1] for line in output.splitlines() if line.startswith("DELETED ")
+    }
+    assert deleted == {"desktop-nightly-fourth00", "desktop-nightly-oldest00"}
+
+
+def test_nightly_prune_refuses_to_delete_anything_that_is_not_a_nightly(
+    tmp_path,
+) -> None:
+    """The guard, not the filter, is what stands between a bug and a lost release.
+
+    `gh release delete --cleanup-tag` destroys the release *and* its tag, so a
+    version tag reaching that loop is unrecoverable. This feeds one straight
+    past the API filter and asserts the loop stops rather than trusting it.
+    """
+    returncode, output = _run_prune(
+        tmp_path,
+        [
+            "2026-08-18T05:36:33Z\tdesktop-nightly-newest00",
+            "2026-08-18T05:34:01Z\tdesktop-nightly-second00",
+            "2026-08-17T19:13:00Z\tdesktop-nightly-third000",
+            "2026-08-15T13:18:34Z\tv0.7.0",
+            "2026-08-14T15:07:47Z\tdesktop-nightly-oldest00",
+        ],
+    )
+
+    assert returncode != 0
+    assert "Refusing to delete a non-nightly release::v0.7.0" in output
+    # It must stop *before* deleting, not merely complain on the way past.
+    assert "DELETED" not in output
+
+
+def test_nightly_prune_survives_a_listing_failure_without_claiming_success(
+    tmp_path,
+) -> None:
+    """Housekeeping runs after the DMG is published, so it must not fail the build.
+
+    But an unreadable listing must not read as a tidy release page either --
+    that is how a prune quietly stops running and the page fills up again.
+    """
+    import os
+    import subprocess
+
+    stub = tmp_path / "gh"
+    stub.write_text(
+        '#!/bin/bash\nif [[ "$1" == "api" ]]; then exit 1; fi\necho "DELETED $3"\n'
+    )
+    stub.chmod(0o755)
+    script = tmp_path / "prune.sh"
+    script.write_text(_nightly_prune_step()["run"])
+
+    completed = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "PATH": f"{tmp_path}:{os.environ['PATH']}",
+            "GITHUB_REPOSITORY": "lemma-work/lemma-platform",
+            "GH_TOKEN": "stub",
+            "KEEP": "3",
+        },
+    )
+
+    assert completed.returncode == 0
+    assert "Could not list nightly prereleases" in completed.stdout
+    assert "DELETED" not in completed.stdout
+
+
+def test_nightly_prune_asks_the_api_only_for_nightly_prereleases() -> None:
+    """Both halves of the filter matter, and neither is implied by the other.
+
+    Dropping `.prerelease` would sweep in any future `desktop-nightly-` release
+    that was promoted; dropping the prefix would sweep in every prerelease.
+    """
+    run = _nightly_prune_step()["run"]
+
+    assert 'select(.prerelease and (.tag_name | startswith("desktop-nightly-")))' in run
+    # Deleting the tag is the point -- an orphaned tag is still clutter.
+    assert "--cleanup-tag" in run


### PR DESCRIPTION
## What changes

Nightly Desktop prereleases become a **rolling window of the three most recent
builds** instead of a permanent archive. After a shared build has published a
complete nightly — runtime assets and a notarized, stapled DMG — it deletes the
older `desktop-nightly-*` prereleases and their tags.

## Why

Every `share=true` run left a prerelease behind for good. Twelve had accumulated
by 0.7.0:

```
12 of 21 releases were desktop-nightly-*   →   v0.7.0 sat fifth from the top
```

**A release is genuinely required for the runtime, so "stop publishing one" was
not on the table.** The manifest embeds
`https://github.com/<repo>/releases/download/<tag>/...` URLs that the app fetches
anonymously at first launch. Workflow artifacts need an authenticated API call
and arrive zipped; a draft release has no public download URL and no git tag, so
`gh release download <tag>` in the Windows job would not resolve either. What was
optional was keeping every one of them forever.

Nothing reads a nightly tag except the DMG built in the same run, and the nightly
notes already say there is no upgrade path — so the archive bought nothing.

## Trade-off, stated plainly

A nightly DMG is good for about three more shared builds. Once its prerelease is
pruned, first-launch runtime download 404s. Both docs now say so. Per-SHA tags
were kept rather than collapsing to one rolling `desktop-nightly` tag precisely
because of this: a rolling tag would replace assets under a DMG's baked-in
digests and break the *previous* build immediately, rather than after three.

## How to verify

The prune step was extracted from the workflow and run against the live
repository with `gh release delete` stubbed — read-only, nothing deleted:

```bash
# 9 of 12 nightlies selected, 3 newest kept, no v* release touched
WOULD-DELETE desktop-nightly-6c19231b ... desktop-nightly-3e2233e4
```

The tests run that same shipped text with `gh` stubbed, so they cannot drift from
what CI executes. Each was checked against a mutant:

| mutation | caught by |
|---|---|
| guard removed | `test_nightly_prune_refuses_to_delete_anything_that_is_not_a_nightly` |
| `sort -r` → `sort` | `test_nightly_prune_keeps_a_rolling_window_of_the_newest_builds` |
| listing failure swallowed | `test_nightly_prune_survives_a_listing_failure_without_claiming_success` |
| `.prerelease` dropped from the filter | `test_nightly_prune_asks_the_api_only_for_nightly_prereleases` |

```bash
make quality   # ✓ quality gates pass
cd lemma-backend && uv run pytest app/core/tests/unit/test_ci_configuration_contract.py -q   # 8 passed
```

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

`gh release delete --cleanup-tag` removes the release **and** its tag, so the
loop re-checks the `desktop-nightly-` prefix immediately before deleting rather
than trusting the API filter that produced the list — a version tag reaching that
point fails the step instead of proceeding. Everything else is housekeeping
running after the DMG is already published, so a failed listing or delete warns
and the nightly still reports success.

Reverting is a plain revert; it only stops future pruning. Already-deleted
nightlies do not come back, which is the intended effect.

The **currently running** build (`32119869914`, on `f3e6907c`) predates this
change and will not prune. The existing 12-nightly backlog needs a one-time
cleanup, or it clears itself over the next few shared builds.