### PR TITLE
Send a downloaded file in one response, not one message per newline

### DIFF
--- a/lemma-backend/app/modules/datastore/api/file_download_response.py
+++ b/lemma-backend/app/modules/datastore/api/file_download_response.py
@@ -1,14 +1,27 @@
-"""Cache-correct HTTP responses for datastore originals and child artifacts."""
+"""Cache-correct HTTP responses for datastore originals and child artifacts.
+
+Both builders receive a body that is *already* fully in memory. That matters
+for how it is sent: ``StreamingResponse(BytesIO(content))`` looks like it
+streams, but iterating a ``BytesIO`` yields one **line** at a time — it splits
+on ``\n`` — so a binary body is emitted as one ASGI message per newline byte
+it happens to contain. Measured against dev, throughput was a flat ~3,750
+chunks/second regardless of chunk size, which made download time a function of
+how many ``0x0A`` bytes a file contained rather than how large it was: a 2.1MB
+PDF with 51,571 newlines took 13.8 seconds while a 6.4MB one with 28,778 took
+7.6. Reading the same objects straight from storage took 40 milliseconds.
+
+A body held in memory is sent as one response. It is also the more honest
+answer to the client, which now gets a ``Content-Length`` instead of a chunked
+transfer of unknown size.
+"""
 
 from __future__ import annotations
 
 import hashlib
 import unicodedata
-from io import BytesIO
 from urllib.parse import quote
 
 from fastapi import Response, status
-from fastapi.responses import StreamingResponse
 
 from app.modules.datastore.services.files.http_cache import (
     file_cache_headers,
@@ -51,8 +64,8 @@ def build_original_download_response(file_entity, download) -> Response:
     cache_headers["Content-Disposition"] = build_content_disposition(
         "inline" if inline else "attachment", file_entity.name
     )
-    return StreamingResponse(
-        BytesIO(content), media_type=content_type, headers=cache_headers
+    return Response(
+        content=content, media_type=content_type, headers=cache_headers
     )
 
 
@@ -78,6 +91,6 @@ def build_child_download_response(
         "inline" if inline else "attachment",
         artifact_name.rsplit("/", 1)[-1],
     )
-    return StreamingResponse(
-        BytesIO(content), media_type=content_type, headers=cache_headers
+    return Response(
+        content=content, media_type=content_type, headers=cache_headers
     )

--- a/lemma-backend/app/modules/datastore/tests/unit/test_download_response_chunking.py
+++ b/lemma-backend/app/modules/datastore/tests/unit/test_download_response_chunking.py
@@ -1,0 +1,128 @@
+"""A download already in memory must go out as one response, not one per newline.
+
+``StreamingResponse(BytesIO(content))`` reads as harmless and is not. Iterating
+a ``BytesIO`` yields one **line** at a time, so a binary body becomes one ASGI
+``http.response.body`` message per ``0x0A`` byte it happens to contain. Against
+dev that ran at a flat ~3,750 chunks/second whatever the chunk size, which made
+download latency a function of a file's newline count rather than its size — a
+2.1MB PDF containing 51,571 newlines took 13.8 seconds, while a 6.4MB PDF with
+28,778 took 7.6. Reading the same objects out of storage took 40ms.
+
+Counted in ASGI messages rather than timed, deliberately. The defect is a
+message per newline; wall clock is how it was noticed, not what it is, and a
+timing assertion on CI hardware would be both flakier and less specific.
+"""
+
+from __future__ import annotations
+
+import anyio
+import pytest
+
+from app.modules.datastore.api.file_download_response import (
+    build_child_download_response,
+    build_original_download_response,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _Entity:
+    """The fields the original-download builder reads."""
+
+    def __init__(self, name: str, content_type: str, sha: str | None) -> None:
+        self.name = name
+        self.content_type = content_type
+        self.content_sha256 = sha
+
+
+class _Download:
+    def __init__(self, content: bytes) -> None:
+        self.content = content
+        self.not_modified = False
+
+
+def _pdf_like(newlines: int) -> bytes:
+    """A binary body with a known number of newline bytes, like a real PDF."""
+    return b"%PDF-1.4\n" + b"".join(b"x" * 64 + b"\n" for _ in range(newlines - 1))
+
+
+async def _body_messages(response) -> list[bytes]:
+    """Drive the response through ASGI and collect its body messages.
+
+    ``receive`` reports the request body once and then blocks, which is what a
+    real server does: the disconnect message only arrives if the client
+    actually goes away. Both of the obvious shortcuts break the measurement in
+    opposite directions -- returning ``http.request`` forever livelocks
+    ``StreamingResponse``'s disconnect watcher, and returning
+    ``http.disconnect`` straight away makes it abandon the stream before
+    sending anything, so the pre-fix behaviour reads as zero messages instead
+    of one per line. Starlette cancels the watcher once the body is done, so
+    blocking here terminates normally.
+    """
+    sent: list[dict] = []
+    delivered = False
+
+    async def receive():
+        nonlocal delivered
+        if not delivered:
+            delivered = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+        await anyio.sleep_forever()
+
+    async def send(message):
+        sent.append(message)
+
+    await response({"type": "http", "method": "GET", "headers": []}, receive, send)
+    return [m["body"] for m in sent if m["type"] == "http.response.body" and m.get("body")]
+
+
+@pytest.mark.parametrize("newlines", [1, 500, 20_000])
+async def test_an_original_download_is_one_body_message(newlines: int) -> None:
+    content = _pdf_like(newlines)
+    response = build_original_download_response(
+        _Entity("paper.pdf", "application/pdf", "abc123"), _Download(content)
+    )
+
+    bodies = await _body_messages(response)
+
+    assert len(bodies) == 1, (
+        f"a {len(content)}-byte body containing {newlines} newlines was sent as "
+        f"{len(bodies)} ASGI messages; it is being iterated per line, which "
+        "makes download time scale with newline count rather than size"
+    )
+    assert b"".join(bodies) == content, "the body was altered in transit"
+
+
+async def test_a_child_artifact_download_is_one_body_message() -> None:
+    """The derived-artifact path had the same shape and the same fix."""
+    content = _pdf_like(20_000)
+    response = build_child_download_response(
+        request_if_none_match=None,
+        artifact_name="document.md",
+        content=content,
+        content_type="text/markdown",
+    )
+
+    bodies = await _body_messages(response)
+
+    assert len(bodies) == 1, (
+        f"a child artifact was sent as {len(bodies)} ASGI messages"
+    )
+    assert b"".join(bodies) == content
+
+
+async def test_the_client_is_told_how_many_bytes_to_expect() -> None:
+    """Content-Length is the other thing the streaming form gave up.
+
+    Without it the transfer is chunked and of unknown size, so a client cannot
+    show progress or size-check before reading.
+    """
+    content = _pdf_like(1_000)
+    response = build_original_download_response(
+        _Entity("paper.pdf", "application/pdf", "abc123"), _Download(content)
+    )
+
+    assert response.headers.get("content-length") == str(len(content)), (
+        f"content-length is {response.headers.get('content-length')!r} for a "
+        f"{len(content)}-byte body"
+    )


### PR DESCRIPTION
## What changes

Datastore file downloads — both the original and the derived-artifact path —
send the body as **one response** instead of one ASGI message per newline byte.

## Why

Production reports `GET /pods/{pod_id}/datastore/files/download` at p50 6.2s,
max 9.4s, all HTTP 200. It is neither the transfer nor the storage.

Measured **inside the cluster**, so no client network is involved:

| file | size | endpoint | object-storage read |
|---|---|---|---|
| `few_shot_learners.pdf` | 6.45 MB | **7.6s** | 0.06s |
| `attention_is_all_you_need.pdf` | 2.11 MB | **13.8s** | 0.04s |
| `seq2seq.pdf` | 0.42 MB | **1.5s** | 0.03s |

The 2MB file is slower than the 6MB one, and reading the same objects straight
out of storage takes **40 milliseconds**. So the cost is neither size nor I/O.

`StreamingResponse(BytesIO(content))` looks like streaming and is not.
**Iterating a `BytesIO` yields one line at a time** — it splits on `\n` — so a
binary body is emitted as one `http.response.body` message per `0x0A` byte it
happens to contain, each a threadpool hop because the iterator is synchronous.
Download time is therefore a function of a file's newline count:

| file | newline bytes | endpoint | implied chunks/s |
|---|---|---|---|
| attention | 51,571 | 13.77s | 3,745 |
| few_shot | 28,778 | 7.57s | 3,802 |
| seq2seq | 5,402 | 1.47s | 3,675 |

A flat ~3,750 chunks/second across all three — pure per-message overhead.

## How

Nothing was being streamed in the first place. Both builders are handed a body
that is *already fully in memory* (`content = download.content`), so there was
never a memory ceiling to hold and never a first byte to send early. A plain
`Response` sends it in one go — and gives the client a `Content-Length` instead
of a chunked transfer of unknown size.

## How to verify

```bash
cd lemma-backend && uv run pytest app/modules/datastore/tests/unit/test_download_response_chunking.py -q
```
`5 passed`

Reverting the fix turns it red with the defect stated exactly:

> `a 32444-byte body containing 500 newlines was sent as 500 ASGI messages`

```bash
cd lemma-backend && uv run pytest app/modules/datastore/tests/e2e/test_files_e2e.py app/modules/datastore/tests/e2e/test_signed_url_e2e.py app/modules/datastore/tests/e2e/test_user_markdown_e2e.py -q
```
`20 passed`

```bash
cd lemma-backend && uv run pytest -m "not e2e" -q && make quality
```
`5013 passed, 53 skipped` / `✓ quality gates pass`

## Checklist

- [x] Tests cover the behavioral change — verified to fail on the old code
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Compatibility** — same bytes, same status, same cache headers. Clients
      additionally get `Content-Length`. `304` handling is untouched.
- [x] **Security** — no change to authorization or path resolution.
- [x] **Rollback** — reverts cleanly. No migration, no state.

## Notes

**The test counts ASGI messages, not milliseconds.** The defect is a message
per newline; wall clock is how it was noticed, not what it is, and a timing
assertion on CI hardware would be flakier and less specific.

**Two harness mistakes are documented in the test**, because both made the
pre-fix behaviour unmeasurable and neither is obvious:

- a `receive` that keeps returning `http.request` **livelocks**
  `StreamingResponse`'s disconnect watcher, so the old code looks like it hangs;
- one that returns `http.disconnect` immediately makes it **abandon** the
  stream, so the old code looks like it sends *zero* messages and the assertion
  blames the wrong thing.

Blocking after the first message is what a real server does, and it is what
makes the failure read `500 newlines was sent as 500 ASGI messages`.

**Not in scope, measured and reported separately:** file search (~2.0s in dev)
is 81% embedding + reranker network calls to Fireworks and is not a database
problem; connector execute (p50 2.5s, all HTTP 200) is third-party time inside
its documented 1–45s contract; and the `unmatched` 81s outlier is undiagnosable
in production only because prod runs a build predating the path-logging fix
already on `main`.
