### PR TITLE
Offer to make a Slack app where you first need one, and stop hiding it once connected

### DIFF
--- a/lemma-frontend/components/connectors/advanced-config.tsx
+++ b/lemma-frontend/components/connectors/advanced-config.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Check, Copy, ExternalLink } from '@/components/ui/icons';
+import { Check, Copy } from '@/components/ui/icons';
 import { Button } from '@/components/ui/button';
 import { config } from '@/lib/config';
-import { useSlackManifest } from '@/lib/hooks/use-pod-surfaces';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -12,6 +11,7 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { buildSchemaFormPayload, buildSchemaFormValues } from 'lemma-sdk';
 import { toast } from 'sonner';
 import type { Connector } from '@/lib/types';
+import { CreateSlackAppButton } from './create-slack-app-button';
 import { SchemaFields } from './schema-fields';
 import {
     getAppLabel,
@@ -81,54 +81,6 @@ function OAuthRedirectField() {
             <p className="text-xs leading-5 text-[var(--text-tertiary)]">
                 It’s where you land after signing in. Without it, signing in fails on the
                 other side — not here. It has to start with https.
-            </p>
-        </div>
-    );
-}
-
-/**
- * Slack hands you an app pre-built from a manifest, so nothing below has to be
- * copied by hand — not the callback URL, not the event URL, not the scopes.
- *
- * What a manifest cannot carry is credentials: Slack has no API that gives a
- * third party another app's client id, client secret or signing secret. They
- * exist only on the app's own Basic Information page. So the floor is one
- * click and three pastes, and this button removes everything above that floor.
- */
-function CreateSlackAppButton() {
-    const { data: manifest, isLoading, isError } = useSlackManifest();
-
-    if (isLoading) {
-        return (
-            <p className="flex items-center gap-2 text-xs text-[var(--text-tertiary)]">
-                <StepLoader size="xs" /> Getting things ready…
-            </p>
-        );
-    }
-    if (isError || !manifest) {
-        return (
-            <p className="text-xs leading-5 text-[var(--text-secondary)]">
-                Make your app at api.slack.com, then paste its details below. We can’t set
-                it up for you here — Slack needs a web address it can reach, and this copy
-                of Lemma doesn’t have one yet.
-            </p>
-        );
-    }
-
-    const href = `https://api.slack.com/apps?new_app=1&manifest_json=${encodeURIComponent(
-        JSON.stringify(manifest),
-    )}`;
-
-    return (
-        <div className="grid gap-1">
-            <Button asChild size="sm" variant="secondary" className="w-fit">
-                <a href={href} target="_blank" rel="noreferrer">
-                    Make your Slack app <ExternalLink className="ml-1.5 h-3.5 w-3.5" />
-                </a>
-            </Button>
-            <p className="text-xs leading-5 text-[var(--text-tertiary)]">
-                Opens Slack with everything already filled in. Create the app, add it to
-                your workspace, then copy the three values Slack shows you.
             </p>
         </div>
     );

--- a/lemma-frontend/components/connectors/connector-card.tsx
+++ b/lemma-frontend/components/connectors/connector-card.tsx
@@ -60,7 +60,13 @@ export function ConnectorRow({
                 ) : null}
             </div>
 
-            {hasAdvanced && !isConnected ? (
+            {/* Not gated on `isConnected`. Advanced is where an org brings its
+                own app, and having connected once is no reason to be done: a
+                workspace may run a second Slack app, or replace the one whose
+                credentials it is holding. Hiding this after the first connect
+                made "make your own bot" a thing you could only ever reach
+                before you had anything working. */}
+            {hasAdvanced ? (
                 <Button
                     variant="quiet"
                     size="sm"

--- a/lemma-frontend/components/connectors/create-slack-app-button.tsx
+++ b/lemma-frontend/components/connectors/create-slack-app-button.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { ExternalLink } from '@/components/ui/icons';
+
+import { StepLoader } from '@/components/brand/loader';
+import { Button } from '@/components/ui/button';
+import { useSlackManifest } from '@/lib/hooks/use-pod-surfaces';
+
+/**
+ * Slack hands you an app pre-built from a manifest, so nothing below has to be
+ * copied by hand — not the callback URL, not the event URL, not the scopes.
+ *
+ * What a manifest cannot carry is credentials: Slack has no API that gives a
+ * third party another app's client id, client secret or signing secret. They
+ * exist only on the app's own Basic Information page. So the floor is one
+ * click and three pastes, and this button removes everything above that floor.
+ *
+ * Lives on its own rather than inside the credential form it used to sit in:
+ * making the app is what *produces* those credentials, so it is a peer of the
+ * form, not a field in it — and it is the same offer wherever someone first
+ * runs out of Slack accounts to pick, which is the surface modal as often as
+ * the connector list. Nothing here is scoped to a pod, an org or an account,
+ * so rendering it twice is not two of anything: the manifest describes the
+ * deployment, and an org may run as many Slack apps as it likes.
+ */
+export function CreateSlackAppButton({ label = 'Make your Slack app' }: { label?: string }) {
+    const { data: manifest, isLoading, isError } = useSlackManifest();
+
+    if (isLoading) {
+        return (
+            <p className="flex items-center gap-2 text-xs text-[var(--text-tertiary)]">
+                <StepLoader size="xs" /> Getting things ready…
+            </p>
+        );
+    }
+    if (isError || !manifest) {
+        return (
+            <p className="text-xs leading-5 text-[var(--text-secondary)]">
+                Make your app at api.slack.com, then paste its details below. We can’t set
+                it up for you here — Slack needs a web address it can reach, and this copy
+                of Lemma doesn’t have one yet.
+            </p>
+        );
+    }
+
+    const href = `https://api.slack.com/apps?new_app=1&manifest_json=${encodeURIComponent(
+        JSON.stringify(manifest),
+    )}`;
+
+    return (
+        <div className="grid gap-1">
+            <Button asChild size="sm" variant="secondary" className="w-fit">
+                <a href={href} target="_blank" rel="noreferrer">
+                    {label} <ExternalLink className="ml-1.5 h-3.5 w-3.5" />
+                </a>
+            </Button>
+            <p className="text-xs leading-5 text-[var(--text-tertiary)]">
+                Opens Slack with everything already filled in. Create the app, add it to
+                your workspace, then copy the three values Slack shows you.
+            </p>
+        </div>
+    );
+}

--- a/lemma-frontend/components/surfaces/surface-connect-step.tsx
+++ b/lemma-frontend/components/surfaces/surface-connect-step.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { ExternalLink } from '@/components/ui/icons';
 
+import { CreateSlackAppButton } from '@/components/connectors/create-slack-app-button';
 import { SchemaFields } from '@/components/connectors/schema-fields';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -127,15 +128,25 @@ export function SurfaceConnectStep({
                         Signing in to {definition.label} happens once for the whole organization.
                         Do that first, then come back here.
                     </p>
-                    {definition.platform === 'SLACK' ? (
-                        <p className="mt-2 text-xs leading-5 text-[var(--text-tertiary)]">
-                            Want Lemma to show up under your own name in Slack? You can set
-                            that up there too.
-                        </p>
-                    ) : null}
                     <Button asChild className="mt-3" size="sm" variant="secondary">
                         <Link href={`/pod/${podId}/connectors`}>Open connectors</Link>
                     </Button>
+                    {/* Running your own Slack app is a second route to the same
+                        place, not a footnote on this one — and it starts here,
+                        because making the app is what produces the credentials
+                        connectors then asks for. Burying it behind the link
+                        above meant nobody found it: it sat inside the custom
+                        credential form, on a row action that hid itself once
+                        Slack was connected. */}
+                    {definition.platform === 'SLACK' ? (
+                        <div className="mt-4 border-t border-[var(--border-subtle)] pt-3">
+                            <p className="mb-2 text-xs leading-5 text-[var(--text-secondary)]">
+                                Or run Lemma under your own name in Slack — your workspace,
+                                your app, your bot’s name and icon.
+                            </p>
+                            <CreateSlackAppButton />
+                        </div>
+                    ) : null}
                 </div>
             )}
         </div>


### PR DESCRIPTION
Running your own Slack app has shipped since #303. Nobody could find it.

The button that builds the app from a manifest sat four steps deep — Connectors → hover the Slack row until a quiet action fades in → **Advanced** → **Use my own** — and only then rendered, *inside* the credential form. That nesting is backwards: making the app is what **produces** the client id and secret that form asks for, so it belongs beside the form, not in it.

Worse, the row action that was the only way in hid itself the moment Slack was connected (`hasAdvanced && !isConnected`) — the door closed exactly when an org would go looking for it.

## What changes

- **New `create-slack-app-button.tsx`** — the button lifted out of the credential form so it can live in more than one place.
- **`surface-connect-step.tsx`** — it now renders in the surface modal, at the moment you run out of Slack accounts to pick from. That state previously answered with a line of prose pointing vaguely at Connectors ("You can set that up there too") — a footnote to a route nobody was going to walk. It's now a visible second route.
- **`connector-card.tsx`** — dropped the `!isConnected` gate.
- **`advanced-config.tsx`** — imports the shared button; inline copy and two now-unused imports removed.

## On running more than one app

The gate made "bring your own app" read as a one-shot. The data model stopped believing that a while ago — `auth_config.py` replaced the old unique `(organization_id, connector_id)` index with one-default-per-connector, so that "many installs are now legal". An org may run a second Slack app, or replace the one whose credentials it holds. Nothing about the manifest is scoped to a pod, an org or an account: it describes the deployment, so rendering the button in two places is not two of anything.

## Verification

`tsc --noEmit` and `eslint` clean on top of this base. The manifest endpoint was exercised directly — 28 bot scopes, event/interactivity/redirect URLs substituted from `API_URL`, ~2.4KB of JSON, well inside what the link can carry.

Not driven through a signed-in browser: the local dev server had no session.

## Found while verifying, deliberately not fixed here

With a non-public `API_URL`, `build_slack_app_manifest()` skips URL substitution and serves the committed manifest unchanged — which hardcodes `https://api.lemma.work/surfaces/webhooks/slack`. The OAuth redirect still gets the local value, so a self-hosted deployment hands out an app whose events point at a **different deployment**, with no error:

```
API_URL=http://localhost:8711
  → event url: https://api.lemma.work/surfaces/webhooks/slack
  → redirect : http://localhost:8711/connectors/connect-requests/oauth/callback
```

Separate fix — it's a backend correctness bug, not a UI placement one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)