### PR TITLE
Clear the launch URL when the message goes out, not when the answer lands

### DIFF
--- a/lemma-frontend/app/pod/[id]/conversations/[conversationId]/page.tsx
+++ b/lemma-frontend/app/pod/[id]/conversations/[conversationId]/page.tsx
@@ -25,7 +25,7 @@ import { useAgentRuntimes } from '@/lib/hooks/use-agent-runtime';
 import { useAgent, useAgents } from '@/lib/hooks/use-agents';
 import { usePod } from '@/lib/hooks/use-pods';
 import { usePodAccess } from '@/lib/hooks/use-pod-access';
-import { parseConversationMetadataParam } from '@/lib/pods/composer-launch';
+import { parseConversationMetadataParam, stripAssistantLaunchParams } from '@/lib/pods/composer-launch';
 import { withSettingsReturnPath } from '@/lib/navigation/settings-return';
 import type { AgentRuntimeConfig } from '@/lib/types';
 
@@ -227,6 +227,12 @@ export default function PodConversationPage({
         if (handledAssistantMessageRef.current === key) return;
         handledAssistantMessageRef.current = key;
 
+        // Before the send, not after it. The params are spent the moment the
+        // message is dispatched, and waiting for the answer would leave a URL
+        // that replays the whole send on reload for as long as the turn runs.
+        const nextQuery = stripAssistantLaunchParams(searchParams);
+        router.replace(`/pod/${podId}/conversations/new${nextQuery ? `?${nextQuery}` : ''}`);
+
         void (async () => {
             closeAssistant({ suppressUrlRestore: false });
             clearMessages();
@@ -243,12 +249,6 @@ export default function PodConversationPage({
                         : 'onboarding_start',
                 },
             });
-            const nextParams = new URLSearchParams(searchParams.toString());
-            nextParams.delete('assistantMessage');
-            nextParams.delete('conversationInstructions');
-            nextParams.delete('conversationMetadata');
-            const nextQuery = nextParams.toString();
-            router.replace(`/pod/${podId}/conversations/new${nextQuery ? `?${nextQuery}` : ''}`);
         })();
     }, [assistantMessage, clearMessages, closeAssistant, conversationInstructions, conversationMetadata, isNewConversation, isReady, newConversationScopeKey, podId, router, searchParams, sendMessage]);
 

--- a/lemma-frontend/app/pod/[id]/layout.tsx
+++ b/lemma-frontend/app/pod/[id]/layout.tsx
@@ -26,7 +26,7 @@ import { getLemmaClient } from "@/lib/sdk/lemma-client";
 import { usePod } from "@/lib/hooks/use-pods";
 import { usePodContext } from "@/lib/hooks/use-pod-context";
 import { usePodAccess } from "@/lib/hooks/use-pod-access";
-import { parseConversationMetadataParam } from "@/lib/pods/composer-launch";
+import { parseConversationMetadataParam, stripAssistantLaunchParams } from "@/lib/pods/composer-launch";
 import { clearLastOpenedPodId, writeLastOpenedPodId } from "@/lib/pods/last-opened-pod";
 import { getWorkspaceTabAfterClose, getWorkspaceTabHref } from "@/lib/pods/workspace-tabs";
 import {
@@ -460,31 +460,26 @@ function PodShell({
         if (handledAssistantMessageRef.current === key) return;
         handledAssistantMessageRef.current = key;
 
-        const nextParams = new URLSearchParams(searchParams.toString());
-        nextParams.delete("assistantMessage");
-        const nextQuery = nextParams.toString();
-
         if (isPodHome) {
-            const conversationParams = new URLSearchParams(nextParams.toString());
-            conversationParams.set("assistantMessage", assistantMessage);
-            router.replace(`/pod/${pod.id}/conversations/new?${conversationParams.toString()}`);
+            router.replace(`/pod/${pod.id}/conversations/new?${searchParams.toString()}`);
             return;
         }
 
+        // Cleared as the send goes out. Clearing it after the turn instead
+        // pinned the launch URL on screen for the length of the answer, and
+        // then replaced whatever route the reader had moved on to.
+        const nextQuery = stripAssistantLaunchParams(searchParams);
+        router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname);
+
         void (async () => {
-            if (isConversationRoute) {
-                closeAssistant();
-            } else {
-                openAssistant();
-            }
+            openAssistant();
             await sendMessage(assistantMessage, {
                 forceNewConversation: true,
                 instructions: conversationInstructions || undefined,
                 conversationMetadata: parsedConversationMetadata,
             });
-            router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname);
         })();
-    }, [assistantMessage, closeAssistant, conversationInstructions, conversationMetadata, isConversationRoute, isPodHome, isReady, openAssistant, parsedConversationMetadata, pathname, pod.id, router, searchParams, sendMessage]);
+    }, [assistantMessage, conversationInstructions, conversationMetadata, isConversationRoute, isPodHome, isReady, openAssistant, parsedConversationMetadata, pathname, pod.id, router, searchParams, sendMessage]);
 
     useEffect(() => {
         if (isPodHome && isAssistantOpen) {

--- a/lemma-frontend/lib/pods/composer-launch.test.ts
+++ b/lemma-frontend/lib/pods/composer-launch.test.ts
@@ -4,6 +4,7 @@ import {
     buildComposerLaunchHref,
     parseConversationMetadataParam,
     readComposerLaunch,
+    stripAssistantLaunchParams,
     stripComposerLaunchParams,
 } from './composer-launch';
 
@@ -48,6 +49,25 @@ describe('composer launch', () => {
         expect(stripComposerLaunchParams(params)).toBe('tab=build');
         // The source must not be mutated — the effect still reads it afterward.
         expect(params.get('composerDraft')).toBe('hello');
+    });
+
+    it('strips a send-on-arrival launch without taking the route scope with it', () => {
+        const params = new URLSearchParams(
+            'agent=support&assistantMessage=Hi&conversationInstructions=framing&conversationMetadata=%7B%7D',
+        );
+
+        // `agent=` is what the route runs as, not part of the launch: dropping
+        // it would hand the message to the pod default instead.
+        expect(stripAssistantLaunchParams(params)).toBe('agent=support');
+        expect(params.get('assistantMessage')).toBe('Hi');
+    });
+
+    it('leaves a composer launch alone, and the reverse', () => {
+        const composer = new URLSearchParams('composerDraft=hello');
+        const assistant = new URLSearchParams('assistantMessage=Hi');
+
+        expect(stripAssistantLaunchParams(composer)).toBe('composerDraft=hello');
+        expect(stripComposerLaunchParams(assistant)).toBe('assistantMessage=Hi');
     });
 
     it('drops metadata it cannot trust rather than failing the navigation', () => {

--- a/lemma-frontend/lib/pods/composer-launch.ts
+++ b/lemma-frontend/lib/pods/composer-launch.ts
@@ -24,6 +24,18 @@ export const COMPOSER_LAUNCH_PARAMS = [
   CONVERSATION_METADATA_PARAM,
 ] as const;
 
+export const ASSISTANT_MESSAGE_PARAM = "assistantMessage";
+
+/**
+ * The loud version's params. `assistantMessage` sends on arrival and the other
+ * two are the framing that rides with it; all three are spent by that one send.
+ */
+export const ASSISTANT_LAUNCH_PARAMS = [
+  ASSISTANT_MESSAGE_PARAM,
+  CONVERSATION_INSTRUCTIONS_PARAM,
+  CONVERSATION_METADATA_PARAM,
+] as const;
+
 export interface ComposerLaunch {
   /** An unfinished sentence for the user to complete. Never sent on its own. */
   draft: string;
@@ -86,13 +98,31 @@ export function readComposerLaunch(
   };
 }
 
+function withoutParams(
+  params: URLSearchParams,
+  remove: readonly string[],
+): string {
+  const next = new URLSearchParams(params.toString());
+  for (const param of remove) next.delete(param);
+  return next.toString();
+}
+
 /**
  * The same URL with the launch params removed, for the `router.replace` that
  * follows seeding. Without it a refresh re-seeds a draft the user already
  * cleared, and a second conversation inherits the first one's framing.
  */
 export function stripComposerLaunchParams(params: URLSearchParams): string {
-  const next = new URLSearchParams(params.toString());
-  for (const param of COMPOSER_LAUNCH_PARAMS) next.delete(param);
-  return next.toString();
+  return withoutParams(params, COMPOSER_LAUNCH_PARAMS);
+}
+
+/**
+ * The same for a send-on-arrival launch, and it must run when the message is
+ * dispatched rather than when the answer lands. A turn is minutes long: held
+ * that whole time, the launch URL is still on screen for a reload to replay,
+ * and the replace that finally clears it arrives wherever the reader has since
+ * navigated to.
+ */
+export function stripAssistantLaunchParams(params: URLSearchParams): string {
+  return withoutParams(params, ASSISTANT_LAUNCH_PARAMS);
 }


### PR DESCRIPTION
## What changes

Starting a conversation from a link that carries its first message (`?assistantMessage=`) now clears that param as the message goes out, instead of after the whole answer has streamed. The URL settles on the real conversation while the agent is still writing, so a reload mid-answer lands on the live conversation.

## Why

The `router.replace` that cleared the launch params sat after `await sendMessage(...)`, and that await resolves only once the SSE turn is fully consumed. The launch URL therefore stayed in the address bar for the entire length of the answer — the screenshot that started this was `/conversations/new?assistantMessage=…` still sitting there mid-stream.

Three consequences, none cosmetic:

- **A reload mid-answer re-sent the message.** The param was still there and `handledAssistantMessageRef` is per-mount, so the refresh fired `forceNewConversation: true` again — a second conversation with the same first message.
- **The URL could not reach the conversation it was showing.** The effect that swaps `/conversations/new` for the real conversation id is gated on `if (assistantMessage) return;`, so it was blocked for the whole turn.
- **The late replace hard-codes `/conversations/new`.** Navigating away during the answer got yanked back when it finally landed.

The quiet composer launch (`?composerDraft=`) already clears its params at dispatch, in `app/pod/[id]/page.tsx`. This puts the loud one on the same timing and gives both one shared strip helper.

The layout path also now drops `conversationInstructions` and `conversationMetadata`, which it had been leaving in the URL.

## Reviewer note

The `new` → `{conversationId}` swap now happens as soon as the conversation is created rather than at turn end. That is the intended behavior change — it is what makes a mid-answer reload resume instead of replay. The streaming transcript is unaffected: the assistant controller lives in the layout provider, not the page, and `isRouteConversationSelected` is already true at that moment, so the route change shows no skeleton and triggers no refetch (`openConversation` is skipped when the ids match).

Also removed a dead `isConversationRoute` branch inside the layout effect — the effect returns early on that condition a few lines above, so the `closeAssistant()` arm could never run.

## How to verify

```bash
cd lemma-frontend && npm test && npx tsc --noEmit && npm run lint
```

Prints `Test Files 81 passed (81)` / `Tests 801 passed (801)`, and tsc and eslint are both silent. Three of those tests are new, covering `stripAssistantLaunchParams` — that it leaves `?agent=` alone (dropping it would hand the message to the pod default instead of the chosen agent), that it does not mutate its input, and that the composer and assistant strips do not touch each other's params.

Not verified in a browser: port 3710 is a dev server on another checkout, and exercising this end to end means burning a live agent turn.

The backend quality gates (`make quality`, architecture ratchet, OpenAPI freshness) do not apply — this is frontend-only, no API surface, no migration.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

Nothing to note. Four frontend source files, no schema or API surface; a plain revert restores the previous behavior.
