### PR TITLE
Wait on Agent Host — ask, approve, and sleep — instead of talking the agent out of it

### DIFF
--- a/desktop/agent-host/src/mcp_bridge.rs
+++ b/desktop/agent-host/src/mcp_bridge.rs
@@ -22,6 +22,24 @@ const MAX_MCP_ATTEMPTS: u32 = 4;
 const MCP_RETRY_MIN: std::time::Duration = std::time::Duration::from_millis(400);
 const MCP_RETRY_MAX: std::time::Duration = std::time::Duration::from_secs(8);
 
+/// Key Lemma sets on a tool result when it is waiting for a person rather than
+/// answering. `ask_user` and `request_approval` return it on an Agent Host run:
+/// they cannot end the agent's turn from inside a tool call, so the wait
+/// happens here instead.
+const PARKED_KEY: &str = "parked_tool_call_id";
+
+/// How long a parked tool response is held open.
+///
+/// The same half hour the host already gives a native ACP permission request,
+/// because it is the same act from the person's side: they are being asked
+/// something and the agent is waiting. Matching it keeps one answer to "how
+/// long will this sit there" rather than two.
+const PARK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+/// Gap between polls while parked. Slow on purpose: a person is deciding, and
+/// nothing about answering sooner depends on asking more often.
+const PARK_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
+
 pub async fn run_bridge(paths: &HostPaths, target_id: Uuid, run_id: Uuid) -> anyhow::Result<()> {
     // The run's MCP configuration was delivered inline with the start command
     // and journaled durably before dispatch, so the bridge is fully local.
@@ -153,6 +171,11 @@ pub async fn run_bridge(paths: &HostPaths, target_id: Uuid, run_id: Uuid) -> any
         let Some(frames) = frames else {
             continue;
         };
+        // Lemma may have answered "waiting for the person" instead of with a
+        // result. Hold the tool response open until the decision lands, so the
+        // model sits inside its turn exactly as it does for one of its own
+        // native permission requests.
+        let frames = resolve_parked_frames(&http, &endpoint, frames).await;
         for frame in frames {
             stdout.write_all(frame.as_bytes()).await?;
             stdout.write_all(b"\n").await?;
@@ -173,6 +196,114 @@ pub async fn run_bridge(paths: &HostPaths, target_id: Uuid, run_id: Uuid) -> any
         let _ = http.delete(&endpoint.url).headers(headers).send().await;
     }
     Ok(())
+}
+
+/// Wait out any frame that came back parked, and answer with the decision.
+///
+/// A frame is parked when Lemma could not answer yet because it is waiting for
+/// a person -- `ask_user` and `request_approval` on an Agent Host run. Those
+/// tools cannot end the agent's turn from inside a tool call, so the waiting is
+/// done here, and the agent is simply handed the person's answer as that call's
+/// result. From the model's side nothing unusual happened: one tool took a
+/// while.
+async fn resolve_parked_frames(
+    http: &reqwest::Client,
+    endpoint: &ResolvedEndpoint,
+    frames: Vec<String>,
+) -> Vec<String> {
+    let mut resolved = Vec::with_capacity(frames.len());
+    for frame in frames {
+        resolved.push(match parked_tool_call_id(&frame) {
+            Some(tool_call_id) => match await_decision(http, endpoint, &tool_call_id).await {
+                Some(answer) => frame_with_result(&frame, answer).unwrap_or(frame),
+                // Timed out, or the poll never succeeded. The unchanged frame
+                // still says it is waiting, which is true and leaves the model
+                // able to say so rather than stalling on a promise nobody kept.
+                None => frame,
+            },
+            None => frame,
+        });
+    }
+    resolved
+}
+
+/// The parked id on a `tools/call` result, if this frame carries one.
+fn parked_tool_call_id(frame: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(frame).ok()?;
+    value
+        .pointer("/result/structuredContent")?
+        .get(PARKED_KEY)?
+        .as_str()
+        .filter(|id| !id.is_empty())
+        .map(str::to_owned)
+}
+
+/// Poll Lemma until the person decides, or the park times out.
+async fn await_decision(
+    http: &reqwest::Client,
+    endpoint: &ResolvedEndpoint,
+    tool_call_id: &str,
+) -> Option<Value> {
+    let url = interactions_url(&endpoint.url, tool_call_id)?;
+    let authorization = normalize_authorization(&endpoint.authorization).ok()?;
+    let deadline = tokio::time::Instant::now() + PARK_TIMEOUT;
+    tracing::info!(
+        tool_call_id,
+        "waiting for the user to answer a parked tool call"
+    );
+    while tokio::time::Instant::now() < deadline {
+        match http
+            .get(&url)
+            .header(AUTHORIZATION, authorization)
+            .header("x-lemma-agent-run-id", endpoint.run_id.to_string())
+            .send()
+            .await
+        {
+            // 204 is "not decided yet", which is the expected answer for most
+            // of the wait; anything else non-2xx is transient and treated the
+            // same way, because giving up would strand the agent.
+            Ok(response) if response.status() == reqwest::StatusCode::OK => {
+                return response.json::<Value>().await.ok();
+            }
+            Ok(_) => {}
+            Err(error) => {
+                tracing::debug!(%error, "polling a parked tool call failed; retrying");
+            }
+        }
+        tokio::time::sleep(PARK_POLL_INTERVAL).await;
+    }
+    tracing::warn!(tool_call_id, "a parked tool call was never answered");
+    None
+}
+
+/// `.../conversations/{id}/mcp` -> `.../conversations/{id}/interactions/{id}`.
+fn interactions_url(mcp_url: &str, tool_call_id: &str) -> Option<String> {
+    let base = mcp_url.trim_end_matches('/').strip_suffix("/mcp")?;
+    Some(format!("{base}/interactions/{tool_call_id}"))
+}
+
+/// Put the decision where the parked placeholder was, in both places a client
+/// reads a tool result: the structured content and the text beside it.
+fn frame_with_result(frame: &str, answer: Value) -> Option<String> {
+    let mut value: Value = serde_json::from_str(frame).ok()?;
+    let text = serde_json::to_string(&answer).ok()?;
+    let result = value.get_mut("result")?;
+    result
+        .as_object_mut()?
+        .insert("structuredContent".to_owned(), answer);
+    if let Some(content) = result.pointer_mut("/content")
+        && let Some(entries) = content.as_array_mut()
+    {
+        for entry in entries.iter_mut() {
+            if entry.get("type").and_then(Value::as_str) == Some("text")
+                && let Some(object) = entry.as_object_mut()
+            {
+                object.insert("text".to_owned(), Value::String(text.clone()));
+                break;
+            }
+        }
+    }
+    serde_json::to_string(&value).ok()
 }
 
 struct ResolvedEndpoint {
@@ -409,5 +540,80 @@ mod tests {
         let result =
             endpoint_from_mcp(Uuid::new_v4(), &json!({"url": "https://lemma.example/mcp"}));
         assert!(result.is_err());
+    }
+}
+
+#[cfg(test)]
+mod parked_tests {
+    use super::*;
+
+    fn parked_frame(id: &str) -> String {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "result": {
+                "content": [{"type": "text", "text": "{\"parked_tool_call_id\":\"x\"}"}],
+                "structuredContent": {"success": true, PARKED_KEY: id},
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn a_parked_result_is_recognised_and_an_ordinary_one_is_not() {
+        assert_eq!(
+            parked_tool_call_id(&parked_frame("call-42")).as_deref(),
+            Some("call-42")
+        );
+
+        let ordinary = serde_json::json!({
+            "jsonrpc": "2.0", "id": 7,
+            "result": {"structuredContent": {"success": true, "rows": []}}
+        })
+        .to_string();
+        assert!(parked_tool_call_id(&ordinary).is_none());
+
+        // An empty id would send the poller at a URL that can never resolve.
+        assert!(parked_tool_call_id(&parked_frame("")).is_none());
+    }
+
+    #[test]
+    fn the_decision_replaces_the_placeholder_everywhere_a_client_reads_it() {
+        // Clients read either the structured content or the text beside it, so
+        // leaving one of them saying "parked" would show the model a decision
+        // and a contradiction at the same time.
+        let answer = serde_json::json!({"success": true, "answers": {"Pick": "Blue"}});
+        let resolved = frame_with_result(&parked_frame("call-42"), answer).expect("rewritten");
+        let value: Value = serde_json::from_str(&resolved).unwrap();
+
+        assert!(parked_tool_call_id(&resolved).is_none());
+        assert_eq!(
+            value.pointer("/result/structuredContent/answers/Pick"),
+            Some(&Value::String("Blue".to_owned()))
+        );
+        let text = value
+            .pointer("/result/content/0/text")
+            .and_then(Value::as_str)
+            .expect("text content");
+        assert!(text.contains("Blue"), "{text}");
+        // The envelope has to survive: a client matches the response to its
+        // request by id.
+        assert_eq!(value.get("id"), Some(&Value::from(7)));
+    }
+
+    #[test]
+    fn the_poll_url_is_the_mcp_url_with_the_interaction_on_it() {
+        assert_eq!(
+            interactions_url(
+                "https://api.lemma.work/agent-runtime/conversations/abc/mcp",
+                "call-42"
+            )
+            .as_deref(),
+            Some("https://api.lemma.work/agent-runtime/conversations/abc/interactions/call-42")
+        );
+        // Trailing slash is how the endpoint is sometimes written.
+        assert!(interactions_url("https://x/conversations/abc/mcp/", "c").is_some());
+        // Anything that is not the MCP endpoint must not be guessed at.
+        assert!(interactions_url("https://x/conversations/abc", "c").is_none());
     }
 }

--- a/desktop/agent-host/tests/lemma_mcp_e2e.rs
+++ b/desktop/agent-host/tests/lemma_mcp_e2e.rs
@@ -614,3 +614,85 @@ async fn a_refreshed_credential_reaches_the_bridge_without_restarting_the_run() 
 
     host.shutdown().await;
 }
+
+/// Parking, driven through the real bridge subprocess.
+///
+/// `ask_user` and `request_approval` on an Agent Host run cannot end the
+/// agent's turn from inside a tool call, so they answer "waiting for the
+/// person" and the bridge does the waiting. This drives that: the stand-in
+/// answers parked, holds the decision back for two polls, and the agent must
+/// see one ordinary tool result carrying the person's actual answer.
+///
+/// Deliberately at this level rather than over the helper functions alone.
+/// Those were unit-tested first, and deleting the call that wires them into the
+/// bridge loop failed nothing -- the agent would have received the raw parked
+/// placeholder and had no idea a person was ever asked.
+#[tokio::test]
+async fn the_bridge_waits_for_a_person_and_answers_with_their_decision() {
+    let endpoint = LemmaMcpEndpoint::start(McpTransport::StatelessJson).await;
+    let directory = TempDir::new().unwrap();
+    let paths = HostPaths::under(directory.path());
+    paths.ensure().unwrap();
+    let target_id = Uuid::new_v4();
+    let run_id = Uuid::new_v4();
+    journal_run(&paths, target_id, run_id, endpoint.run_configuration());
+
+    let mut bridge = BridgeProcess::spawn(directory.path(), target_id, run_id);
+    bridge
+        .request(
+            "initialize",
+            json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "bridge-e2e", "version": "1.0.0"},
+            }),
+        )
+        .await;
+    bridge.notify("notifications/initialized").await;
+    let called = bridge
+        .request(
+            "tools/call",
+            json!({"name": support::PARK_TOOL, "arguments": {}}),
+        )
+        .await;
+    let output = bridge.finish().await;
+
+    assert!(
+        output.status.success(),
+        "bridge exited with {:?}: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // The agent sees the decision, not the placeholder.
+    assert_eq!(
+        called["result"]["structuredContent"]["answers"]["Pick one"], "Blue",
+        "the person's answer never reached the agent: {called}"
+    );
+    assert!(
+        called["result"]["structuredContent"]
+            .get("parked_tool_call_id")
+            .is_none(),
+        "the parked placeholder was left in the result the agent reads"
+    );
+    // The text beside it has to agree, or a client reading either one sees a
+    // decision and a contradiction at the same time.
+    let text = called["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(
+        text.contains("Blue"),
+        "text content still says parked: {text}"
+    );
+    // And it genuinely waited rather than asking once and getting lucky.
+    assert!(
+        endpoint.interaction_polls() > 2,
+        "the bridge did not keep asking: {} poll(s)",
+        endpoint.interaction_polls()
+    );
+    // The parked call is answered under the durable id Lemma handed back, which
+    // is the id the person's approval card resolves through.
+    assert_eq!(
+        called["result"]["structuredContent"]["decided_for"],
+        support::PARK_CALL_ID
+    );
+}

--- a/desktop/agent-host/tests/real_harness_e2e.rs
+++ b/desktop/agent-host/tests/real_harness_e2e.rs
@@ -1128,3 +1128,56 @@ async fn a_real_agent_answers_from_history_carried_in_the_prompt() {
         println!("{agent}: answered from prompt-carried history");
     }
 }
+
+/// Parking, with a real commercial agent on the other end.
+///
+/// The hermetic suite proves the bridge waits and rewrites the frame. Only a
+/// real provider can prove the part that matters to a person: that an agent
+/// handed a parked tool result *stays in its turn* while someone decides, and
+/// then uses their answer — rather than treating the slow tool as a failure,
+/// giving up, or answering from its own head.
+///
+/// The stand-in withholds the decision for two polls, so the agent genuinely
+/// waits rather than being handed an answer that happened to be ready.
+#[tokio::test]
+#[ignore = "requires authenticated local agents and spends real provider quota"]
+async fn a_real_agent_waits_inside_its_turn_for_a_parked_tool() {
+    for agent in configured_agents() {
+        let endpoint = support::LemmaMcpEndpoint::start(support::McpTransport::StatelessJson).await;
+        let (_directory, control) = paired_real_run(
+            &agent,
+            concat!(
+                "Call the Lemma MCP tool named lemma_park with no arguments. ",
+                "It may take a while to answer; wait for it. Do not use any ",
+                "other tool and do not write files. When it returns, reply ",
+                "with exactly the value it gives for the key 'Pick one'."
+            ),
+            endpoint.run_configuration(),
+            support::PermissionAnswer::AllowOnce,
+            Duration::from_secs(300),
+        )
+        .await;
+
+        let call = endpoint
+            .requests()
+            .into_iter()
+            .find(|record| record.method == "tools/call")
+            .unwrap_or_else(|| panic!("{agent} never called the parked tool"));
+        assert_eq!(call.params["name"], support::PARK_TOOL);
+        // The bridge really held the response open rather than handing the
+        // placeholder straight to the agent.
+        assert!(
+            endpoint.interaction_polls() > 2,
+            "{agent}'s bridge did not wait: {} poll(s)",
+            endpoint.interaction_polls()
+        );
+        // And the agent used the person's answer, which it could only have
+        // received as that tool's return.
+        assert!(
+            control.assistant_text().contains("Blue"),
+            "{agent} did not use the parked answer: {:?}",
+            control.assistant_text()
+        );
+        println!("{agent}: LEMMA_REAL_PARKED_TOOL_OK");
+    }
+}

--- a/desktop/agent-host/tests/real_harness_e2e.rs
+++ b/desktop/agent-host/tests/real_harness_e2e.rs
@@ -1181,3 +1181,72 @@ async fn a_real_agent_waits_inside_its_turn_for_a_parked_tool() {
         println!("{agent}: LEMMA_REAL_PARKED_TOOL_OK");
     }
 }
+
+/// Waking up, with a real agent on the other end.
+///
+/// A woken run adds no user message, so Lemma prompts it with the return it
+/// synthesized for the `snooze` call it resolved — rendered exactly as
+/// `remote_payload._render_history` writes it. The hermetic tests prove that
+/// return is chosen and rendered. Only a real provider can prove the part that
+/// decides whether the feature works: that an agent resuming its own session
+/// reads a tool result arriving as a fresh prompt as *its own call returning*,
+/// and carries on with what it was doing — rather than treating it as a new
+/// request, apologising for a tool it does not remember calling, or starting
+/// the task over.
+///
+/// The subject is the tell, and it appears only in the first turn. An answer
+/// that names it came from the resumed session; the wake prompt says nothing
+/// about what the agent was waiting for.
+#[tokio::test]
+#[ignore = "requires authenticated local agents and spends real provider quota"]
+async fn a_real_agent_wakes_and_carries_on_where_it_slept() {
+    let paths = HostPaths::under(agent_host_data_directory());
+    let manifest = AdapterManifest::builtin()
+        .unwrap()
+        .with_cache_root(paths.adapters.clone());
+
+    for agent in configured_agents() {
+        let conversation_id = Uuid::new_v4();
+        let workspace = conversation_workspace(&paths, &agent, conversation_id);
+        let (session_id, _) = one_turn(
+            &manifest,
+            &workspace,
+            &agent,
+            conversation_id,
+            "You are waiting for the Fenwick deployment to finish. It is not \
+             ready yet, so you called the snooze tool to sleep. Reply with \
+             only: sleeping.",
+            None,
+        )
+        .await;
+
+        // Exactly the shape `_render_history` produces for the return the wake
+        // writes, prompted into the session the agent slept in. Deliberately
+        // says nothing about the subject: everything the agent knows about what
+        // it was doing has to come from the session it is resuming.
+        let (resumed_session_id, answer) = one_turn(
+            &manifest,
+            &workspace,
+            &agent,
+            conversation_id,
+            "TOOL:\nTool result snooze(lemma-mcp-1):\n{\n  \"success\": true,\n  \
+             \"woke_because\": \"TIMER\",\n  \"slept_seconds\": 600,\n  \
+             \"note_to_self\": \"name what you were waiting for, in one \
+             sentence\",\n  \"message\": \"Your time elapsed. That is all this \
+             means - check whatever you were waiting for before acting as \
+             though it happened.\"\n}",
+            Some(session_id.clone()),
+        )
+        .await;
+
+        assert_eq!(
+            resumed_session_id, session_id,
+            "{agent} woke in a different session than the one it slept in"
+        );
+        assert!(
+            answer.to_lowercase().contains("fenwick"),
+            "{agent} did not carry on from where it slept; it answered {answer:?}"
+        );
+        println!("{agent}: LEMMA_REAL_WAKE_OK -> {answer:?}");
+    }
+}

--- a/desktop/agent-host/tests/support/mod.rs
+++ b/desktop/agent-host/tests/support/mod.rs
@@ -432,6 +432,15 @@ async fn mcp_post(
                     "required": ["text"],
                 },
                 "_meta": {"lemma_tool_name": "echo"},
+            }, {
+                // The parking tool has to be *offered*, not merely answered: an
+                // agent cannot call a tool it was never shown, which is exactly
+                // how the first real-provider run of this failed.
+                "name": PARK_TOOL,
+                "description":
+                    "Ask the user a question and wait for their answer.",
+                "inputSchema": {"type": "object", "properties": {}},
+                "_meta": {"lemma_tool_name": "ask_user"},
             }]},
         }),
         "tools/call" => {

--- a/desktop/agent-host/tests/support/mod.rs
+++ b/desktop/agent-host/tests/support/mod.rs
@@ -168,6 +168,7 @@ pub struct LemmaMcpEndpoint {
     transport: McpTransport,
     accepted: Arc<Mutex<Vec<String>>>,
     scripted: Arc<Mutex<Vec<ScriptedFailure>>>,
+    polls: Arc<Mutex<u32>>,
 }
 
 /// A failure to serve instead of the next real answer.
@@ -197,8 +198,34 @@ pub enum McpTransport {
     ServerSentEvents,
 }
 
+/// The tool that parks, and the durable id it parks under.
+pub const PARK_TOOL: &str = "lemma_park";
+pub const PARK_CALL_ID: &str = "parked-call-1";
+const PARKED_POLLS_BEFORE_DECISION: u32 = 2;
+
+async fn interaction_poll(
+    axum::extract::State(state): axum::extract::State<McpState>,
+    axum::extract::Path((_conversation_id, tool_call_id)): axum::extract::Path<(String, String)>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    let mut polls = state.polls.lock().unwrap();
+    *polls += 1;
+    let answered = *polls > PARKED_POLLS_BEFORE_DECISION;
+    drop(polls);
+    if !answered {
+        return axum::http::StatusCode::NO_CONTENT.into_response();
+    }
+    axum::Json(json!({
+        "success": true,
+        "answers": {"Pick one": "Blue"},
+        "decided_for": tool_call_id,
+    }))
+    .into_response()
+}
+
 #[derive(Clone)]
 struct McpState {
+    polls: Arc<Mutex<u32>>,
     requests: Arc<Mutex<Vec<McpRequestRecord>>>,
     deletes: Arc<Mutex<Vec<Option<String>>>>,
     transport: McpTransport,
@@ -210,6 +237,11 @@ struct McpState {
 }
 
 impl LemmaMcpEndpoint {
+    /// How many times the bridge asked whether the parked call was decided.
+    pub fn interaction_polls(&self) -> u32 {
+        *self.polls.lock().unwrap()
+    }
+
     /// # Panics
     /// If the listener cannot bind.
     pub async fn start(transport: McpTransport) -> Self {
@@ -217,7 +249,9 @@ impl LemmaMcpEndpoint {
         let deletes = Arc::new(Mutex::new(Vec::new()));
         let accepted = Arc::new(Mutex::new(vec![format!("Bearer {MCP_BEARER}")]));
         let scripted = Arc::new(Mutex::new(Vec::new()));
+        let polls = Arc::new(Mutex::new(0u32));
         let state = McpState {
+            polls: Arc::clone(&polls),
             requests: Arc::clone(&requests),
             deletes: Arc::clone(&deletes),
             transport,
@@ -228,6 +262,14 @@ impl LemmaMcpEndpoint {
             .route(
                 "/agent-runtime/conversations/{conversation_id}/mcp",
                 post(mcp_post).delete(mcp_delete),
+            )
+            // What Lemma answers a bridge that is holding a parked tool
+            // response open: 204 while the person is still deciding, then the
+            // decision. Two 204s first, so the test proves the bridge actually
+            // waits rather than happening to ask once after the answer landed.
+            .route(
+                "/agent-runtime/conversations/{conversation_id}/interactions/{tool_call_id}",
+                axum::routing::get(interaction_poll),
             )
             .with_state(state);
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -244,6 +286,7 @@ impl LemmaMcpEndpoint {
             transport,
             accepted,
             scripted,
+            polls,
         }
     }
 
@@ -400,7 +443,20 @@ async fn mcp_post(
                 .pointer("/params/arguments/text")
                 .and_then(Value::as_str)
                 .unwrap_or_default();
-            if name == ECHO_TOOL {
+            if name == PARK_TOOL {
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "content": [{"type": "text", "text": "{\"parked\":true}"}],
+                        "structuredContent": {
+                            "success": true,
+                            "parked_tool_call_id": PARK_CALL_ID,
+                        },
+                        "isError": false,
+                    },
+                })
+            } else if name == ECHO_TOOL {
                 json!({
                     "jsonrpc": "2.0",
                     "id": id,

--- a/lemma-backend/agent_tool_schemas.json
+++ b/lemma-backend/agent_tool_schemas.json
@@ -3245,10 +3245,6 @@
           ],
           "default": null,
           "description": "Whatever you passed in note_to_self."
-        },
-        "interaction_fallback": {
-          "default": false,
-          "type": "boolean"
         }
       },
       "title": "SnoozeResponse",

--- a/lemma-backend/agent_tool_schemas.json
+++ b/lemma-backend/agent_tool_schemas.json
@@ -116,6 +116,18 @@
           "default": false,
           "description": "True when a remote harness runtime could not pause and the model must ask the question conversationally instead.",
           "type": "boolean"
+        },
+        "parked_tool_call_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Set when the answer is not ready yet and the caller must wait for it. The Agent Host MCP bridge holds the tool response open and polls this id until the person decides, so the model sits inside its turn exactly as it does for its own native approvals."
         }
       },
       "title": "AskUserResponse",
@@ -2849,6 +2861,18 @@
           "default": false,
           "description": "True when a remote harness runtime could not pause and the model must ask for confirmation conversationally instead.",
           "type": "boolean"
+        },
+        "parked_tool_call_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Set when the decision is not in yet and the caller must wait for it. The Agent Host MCP bridge holds the tool response open and polls this id until the person decides, so the model sits inside its turn exactly as it does for its own native approvals."
         }
       },
       "title": "RequestApprovalResponse",

--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -69,6 +69,7 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'agent.infrastructure.agent_host_event_intake.stream_resynced': EventSpec('warning', frozenset({'agent_run_id', 'from_sequence'})),
     'agent.infrastructure.agent_host_event_stream.delete_failed': EventSpec('debug', frozenset({'agent_run_id'})),
     'agent.infrastructure.agent_host_event_stream.entry_dropped': EventSpec('warning', frozenset({'agent_run_id'})),
+    'agent.mcp_pausing_calls.recorded': EventSpec('debug', frozenset({'conversation_id', 'tool_name'})),
     'agent.mock_model.mock_llm_structured_output_required.diagnostic': EventSpec('debug', frozenset()),
     'agent.module.system_lemma_models_will_be.observed': EventSpec('debug', frozenset()),
     'agent.pod_mcp_service.pod_mcp_tool_r_returning.diagnostic': EventSpec('debug', frozenset()),

--- a/lemma-backend/app/mcp_server.py
+++ b/lemma-backend/app/mcp_server.py
@@ -8,7 +8,7 @@ import mcp.types
 from fastmcp import FastMCP
 from fastmcp.server.auth import AccessToken, AuthProvider
 from fastmcp.server.dependencies import get_http_headers
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, Response
 from starlette.types import Receive, Scope, Send
 
 from app.modules.agent.infrastructure.mcp import LEMMA_MCP_SERVER_NAME
@@ -19,6 +19,14 @@ from app.modules.agent.services.pod_mcp_service import pod_mcp_service
 
 _CONVERSATION_MCP_PATH = re.compile(
     r"^(?:/agent-runtime/conversations)?/(?P<conversation_id>[0-9a-fA-F-]{36})/mcp/?$"
+)
+# Polled by the host's MCP bridge while it holds a parked tool response open.
+# Deliberately not an MCP tool: the model must not see it, and must not be able
+# to call it -- waiting is the bridge's job, and a tool the model could poll
+# would invite it to spin instead of sitting still.
+_CONVERSATION_INTERACTION_PATH = re.compile(
+    r"^(?:/agent-runtime/conversations)?/(?P<conversation_id>[0-9a-fA-F-]{36})"
+    r"/interactions/(?P<tool_call_id>[A-Za-z0-9_.:-]{1,200})/?$"
 )
 _POD_MCP_PATH = re.compile(
     r"^(?:/agent-runtime/pods)?/(?P<pod_id>[0-9a-fA-F-]{36})/mcp/?$"
@@ -131,6 +139,10 @@ class ConversationMCPASGIApp:
             return
 
         path = str(scope.get("path") or "")
+        parked = _CONVERSATION_INTERACTION_PATH.match(path)
+        if parked is not None:
+            await _serve_parked_interaction(parked, scope, receive, send)
+            return
         match = _CONVERSATION_MCP_PATH.match(path)
         if match is None:
             response = JSONResponse({"error": "not_found"}, status_code=404)
@@ -149,6 +161,51 @@ class ConversationMCPASGIApp:
         scope["raw_path"] = b"/mcp"
         scope["headers"] = headers
         await self._mcp_app(scope, receive, send)
+
+
+async def _serve_parked_interaction(
+    match: "re.Match[str]",
+    scope: Scope,
+    receive: Receive,
+    send: Send,
+) -> None:
+    """Answer "has this interaction been decided yet?" for the waiting bridge.
+
+    Authorized by the same conversation token every MCP call on this mount
+    carries, and scoped to that conversation, so a token cannot read an
+    interaction belonging to someone else's conversation.
+
+    204 rather than 404 while pending: "not decided yet" is a normal, expected
+    answer that the bridge polls on, and 404 is what an unknown route returns.
+    """
+    conversation_id = UUID(match.group("conversation_id"))
+    tool_call_id = match.group("tool_call_id")
+    token = ""
+    for name, value in scope.get("headers") or []:
+        if name == b"authorization":
+            scheme, _, raw = value.decode("latin-1").partition(" ")
+            if scheme.lower() == "bearer":
+                token = raw
+            break
+    if not token or not await conversation_mcp_service.authorize(
+        conversation_id=conversation_id, token=token
+    ):
+        response = JSONResponse({"error": "unauthorized"}, status_code=401)
+        await response(scope, receive, send)
+        return
+
+    answer = await conversation_mcp_service.parked_tool_return(
+        conversation_id=conversation_id,
+        tool_call_id=tool_call_id,
+    )
+    if answer is None:
+        # `Response`, not `JSONResponse(None)`: a 204 carries no body, and
+        # serializing `null` into one makes uvicorn raise "Response content
+        # longer than Content-Length" behind an otherwise correct 204.
+        response: Response = Response(status_code=204)
+    else:
+        response = JSONResponse(answer, status_code=200)
+    await response(scope, receive, send)
 
 
 def get_agent_mcp_app() -> ConversationMCPASGIApp:

--- a/lemma-backend/app/modules/agent/domain/pausing_tools.py
+++ b/lemma-backend/app/modules/agent/domain/pausing_tools.py
@@ -14,6 +14,8 @@ interrupted tool and report it to the model as failed.
 
 from __future__ import annotations
 
-PAUSING_TOOL_NAMES = ("ask_user", "request_approval", "snooze")
+SNOOZE_TOOL_NAME = "snooze"
 
-__all__ = ["PAUSING_TOOL_NAMES"]
+PAUSING_TOOL_NAMES = ("ask_user", "request_approval", SNOOZE_TOOL_NAME)
+
+__all__ = ["PAUSING_TOOL_NAMES", "SNOOZE_TOOL_NAME"]

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host.py
@@ -64,6 +64,8 @@ from app.modules.agent.infrastructure.harnesses.agent_host_run_config import (
     _agent_host_run_config,
     _resolve_pod_cwd,
 )
+from app.modules.agent.domain.pausing_tools import SNOOZE_TOOL_NAME
+from app.modules.agent.services.run_suspension import run_suspended_on
 from app.modules.agent.infrastructure.harnesses.agent_host_run_window import (
     CREDENTIAL_DEADLINE_MESSAGE,
     DEFAULT_AGENT_HOST_EVENT_TIMEOUT_SECONDS,
@@ -95,7 +97,6 @@ DEFAULT_STREAM_BLOCK_MS = 1_000
 # it only matters for acceptance, expiry, and recovery.
 DEFAULT_LEASE_CHECK_SECONDS = 5.0
 DEFAULT_TERMINAL_EVENT_GRACE_SECONDS = 5.0
-
 
 
 class RemoteHarness:
@@ -140,7 +141,9 @@ class RemoteHarness:
         try:
             run_config = _agent_host_run_config(options)
         except (KeyError, TypeError, ValueError) as exc:
-            yield error_event(agent_run_id, f"Invalid Agent Host runtime profile: {exc}")
+            yield error_event(
+                agent_run_id, f"Invalid Agent Host runtime profile: {exc}"
+            )
             return
 
         try:
@@ -264,9 +267,7 @@ class RemoteHarness:
             lease_check_due_at = now + self.lease_check_seconds
 
             wall_clock = self._now()
-            if credential_refresh_due(
-                expires_at=credential_expires_at, now=wall_clock
-            ):
+            if credential_refresh_due(expires_at=credential_expires_at, now=wall_clock):
                 refreshed = await refresh_credential(
                     uow_factory=self.uow_factory,
                     agent_run_id=agent_run_id,
@@ -277,9 +278,7 @@ class RemoteHarness:
                 )
                 if refreshed is not None:
                     credential_expires_at = refreshed
-            if credential_exhausted(
-                expires_at=credential_expires_at, now=wall_clock
-            ):
+            if credential_exhausted(expires_at=credential_expires_at, now=wall_clock):
                 # Every refresh failed. Ending the run here is what keeps this
                 # from becoming a run whose tools silently 401 for the rest of
                 # its life without anything being reported to anyone.
@@ -308,8 +307,8 @@ class RemoteHarness:
                 # this is the only chance to pick up a final answer the tool
                 # recorded before the stream went quiet.
                 await adopt_recorded_final_answer(
-                self.uow_factory, normalizer, agent_run_id=agent_run_id
-            )
+                    self.uow_factory, normalizer, agent_run_id=agent_run_id
+                )
                 for event in normalizer.finish_without_terminal(
                     state=outcome.terminal_state
                 ):
@@ -408,7 +407,59 @@ class RemoteHarness:
                 self.uow_factory, normalizer, agent_run_id=agent_run_id
             )
         events.extend(normalizer.normalize(envelope, payload_override=payload_override))
+        if entry.type == AgentHostEventType.TERMINAL.value:
+            events = await self._as_suspension(
+                events, agent_run_id=agent_run_id, conversation=conversation
+            )
         return events
+
+    async def _as_suspension(
+        self,
+        events: list[AgentEvent],
+        *,
+        agent_run_id: UUID,
+        conversation: Conversation,
+    ) -> list[AgentEvent]:
+        """Re-read a turn that ended as one that was suspended, if it was.
+
+        ``snooze`` on a remote harness cannot end the turn from inside its own
+        tool call, so Lemma asks the host to stop it. The host has no idea why
+        and reports what it saw: ``CANCELLED`` when the stop arrived first,
+        ``SUCCEEDED`` when the agent finished talking before it did. Neither is
+        what happened. The durable wait row is, and it says the agent is asleep
+        — which is ``WAITING``, exactly as the in-process harness reports the
+        same tool.
+
+        Failures are left alone. A run that hit its context ceiling or lost its
+        host really did fail, and a wait row does not make that untrue; the
+        timer still wakes the conversation either way.
+        """
+        if not any(
+            event.type in {AgentEventType.COMPLETED, AgentEventType.STOPPED}
+            for event in events
+        ):
+            return events
+        async with self.uow_factory() as uow:
+            wait = await run_suspended_on(uow, agent_run_id=agent_run_id)
+        if wait is None:
+            return events
+        return [
+            AgentEvent(
+                type=AgentEventType.WAITING,
+                # The shape the in-process pause yields, so that everything
+                # downstream of a paused turn reads one event, not two.
+                data={
+                    "tool_call_id": wait.tool_call_id,
+                    "kind": SNOOZE_TOOL_NAME,
+                    "conversation_id": str(conversation.id),
+                },
+                agent_run_id=agent_run_id,
+                sequence=event.sequence,
+            )
+            if event.type in {AgentEventType.COMPLETED, AgentEventType.STOPPED}
+            else event
+            for event in events
+        ]
 
     async def _cancel_if_requested(
         self,

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_dispatch.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_dispatch.py
@@ -17,7 +17,7 @@ from app.core.infrastructure.db.uow_factory import UnitOfWorkFactory
 from app.core.log.log import get_logger
 from app.modules.agent.domain.agent_host import NEW_SESSION_ONLY, AgentHostRunSpec
 from app.modules.agent.domain.context import AgentContext
-from app.modules.agent.domain.entities import Agent, Conversation, Message
+from app.modules.agent.domain.entities import Agent, AgentRun, Conversation, Message
 from app.modules.agent.domain.prompts import load_agent_host_runtime_prompt
 from app.modules.agent.domain.value_objects import HarnessOptions
 from app.modules.agent.infrastructure.agent_host_channels import poke_host
@@ -27,6 +27,7 @@ from app.modules.agent.infrastructure.agent_host_dispatch_repository import (
 from app.modules.agent.infrastructure.agent_host_repository import (
     AgentHostRepository,
 )
+from app.modules.agent.infrastructure.repositories import ConversationRepository
 from app.modules.agent.infrastructure import agent_host_session_memory
 from app.modules.agent.infrastructure.agent_host_repository_common import (
     AgentHostRepositoryError,
@@ -55,9 +56,9 @@ logger = get_logger(__name__)
 
 
 async def refresh_credential(
-*,
-uow_factory: UnitOfWorkFactory,
-agent_run_id: UUID,
+    *,
+    uow_factory: UnitOfWorkFactory,
+    agent_run_id: UUID,
     ctx: AgentContext,
     options: HarnessOptions,
     agent: Agent,
@@ -89,9 +90,7 @@ agent_run_id: UUID,
         if encrypted is None:
             raise RuntimeError("could not encrypt the refreshed MCP configuration")
         async with uow_factory() as uow:
-            command = await AgentHostDispatchRepository(
-                uow
-            ).enqueue_credential_refresh(
+            command = await AgentHostDispatchRepository(uow).enqueue_credential_refresh(
                 run_id=agent_run_id,
                 encrypted_mcp_payload=encrypted,
             )
@@ -110,11 +109,18 @@ agent_run_id: UUID,
     return token_expires_at(mcp)
 
 
+def _resumed_tool_call_id(run: AgentRun | None) -> str | None:
+    """Which paused tool call this run was started to answer, if any."""
+    metadata = (run.metadata if run is not None else None) or {}
+    value = metadata.get("resumed_tool_call_id")
+    return value if isinstance(value, str) and value else None
+
+
 async def enqueue_run(
-*,
-uow_factory: UnitOfWorkFactory,
-event_timeout_seconds: float,
-agent: Agent,
+    *,
+    uow_factory: UnitOfWorkFactory,
+    event_timeout_seconds: float,
+    agent: Agent,
     conversation: Conversation,
     messages: Sequence[Message],
     ctx: AgentContext,
@@ -141,6 +147,10 @@ agent: Agent,
         host_id = harness.host_id
         harness_key = harness.harness_key
         config_revision = harness.config_revision
+        # Set only on a run started to answer a pausing tool call. Read from
+        # the run rather than passed in, because the run row is where the
+        # resume recorded it and a second copy could only ever disagree.
+        run = await ConversationRepository(uow).get_agent_run(agent_run_id)
 
     payload = run_start_payload(
         agent=agent,
@@ -150,6 +160,7 @@ agent: Agent,
         agent_run_id=agent_run_id,
         runtime_instructions=load_agent_host_runtime_prompt(),
         carries_history=resume_session_id is None,
+        resumed_tool_call_id=_resumed_tool_call_id(run),
     )
     prompt = _json_object(payload.get("prompt"))
     mcp = await mcp_payload(

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_events.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host_events.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass
 from uuid import UUID
 
 from app.modules.agent.domain.agent_host import AgentHostEventType, AgentHostRunState
+from app.modules.agent.domain.pausing_tools import PAUSING_TOOL_NAMES
 from app.modules.agent.domain.agent_host_permissions import (
     permission_approval_events,
     permission_approval_tool_call_id,
@@ -238,6 +239,13 @@ class AgentHostEventNormalizer:
         if announced is None:
             return []
         draft, sequence = announced
+        if draft.tool_name in PAUSING_TOOL_NAMES:
+            # Already on the record, under an id that can be answered. Lemma
+            # writes these itself when the MCP call arrives, because the id the
+            # harness reports here is one no approval endpoint, timer or resume
+            # can address. Keeping both would ask the person the same question
+            # twice, once on a card nothing resolves. See ``mcp_pausing_calls``.
+            return self._drain_tokens()
         return [
             *self._drain_tokens(),
             AgentEvent(
@@ -386,6 +394,12 @@ class AgentHostEventNormalizer:
                 "success": False,
                 "error": str(payload.get("error") or status.lower()),
             }
+        if tool_name in PAUSING_TOOL_NAMES:
+            # The other half of the drop above: with no call on the record under
+            # this id, a return under it pairs with nothing. What the model was
+            # actually told — a park's answer, a snooze's "you are asleep" — is
+            # written against the id Lemma owns, by whatever resolved it.
+            return [*opening, *self._drain_tokens()]
         return [
             *opening,
             *self._drain_tokens(),

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/remote_payload.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/remote_payload.py
@@ -45,12 +45,14 @@ def run_start_payload(
     agent_run_id: UUID,
     runtime_instructions: str,
     carries_history: bool,
+    resumed_tool_call_id: str | None = None,
 ) -> JsonObject:
     """Everything one dispatched run needs, and nothing it does not.
 
     ``carries_history`` is set when the run is not even going to try to resume a
-    provider session, so the prompt has to bring the conversation with it. See
-    :func:`_turn_messages`.
+    provider session, so the prompt has to bring the conversation with it, and
+    ``resumed_tool_call_id`` names the pausing call this run exists to answer.
+    See :func:`_turn_messages`.
 
     Deliberately does not carry ``runtime_credentials``. They were assembled
     here and then dropped by the only caller, on the one code path whose
@@ -63,7 +65,11 @@ def run_start_payload(
         "prompt": _prompt_payload(
             agent=agent,
             conversation=conversation,
-            messages=_turn_messages(messages, carries_history=carries_history),
+            messages=_turn_messages(
+                messages,
+                carries_history=carries_history,
+                resumed_tool_call_id=resumed_tool_call_id,
+            ),
             ctx=ctx,
             runtime_instructions=runtime_instructions,
         ),
@@ -160,7 +166,7 @@ def _token_expiry_iso(token: str) -> str | None:
     try:
         decoded = base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4))
         claims = json.loads(decoded)
-    except (binascii.Error, ValueError, UnicodeDecodeError):
+    except binascii.Error, ValueError, UnicodeDecodeError:
         return None
     expiry = claims.get("exp") if isinstance(claims, dict) else None
     if not isinstance(expiry, (int, float)) or isinstance(expiry, bool):
@@ -245,6 +251,7 @@ def _turn_messages(
     messages: Sequence[Message],
     *,
     carries_history: bool,
+    resumed_tool_call_id: str | None = None,
 ) -> list[Message]:
     """The messages this prompt has to carry.
 
@@ -253,7 +260,15 @@ def _turn_messages(
     on every turn — so the rest is already on the other side and resending it
     would only duplicate the conversation in its context.
 
-    The exception is a run that is not going to try: a harness that never
+    A run that resumes a pause is the same rule with a different answer. Waking
+    from a ``snooze`` adds no user message, so "the latest user message" is the
+    request that started the task — and re-sending that to an agent whose
+    session already contains it does not read as "carry on", it reads as the
+    person asking again, so the agent does the work twice. What the session has
+    genuinely not seen is the return Lemma synthesized for the call it paused
+    on, which is exactly what resuming has to deliver.
+
+    The other exception is a run that is not going to try: a harness that never
     advertised ``loadSession`` has no session to resume, ever. Sending one lone
     message there leaves the agent answering a follow-up it has never seen the
     start of. This costs nothing in the usual case, because a resumable harness
@@ -263,13 +278,19 @@ def _turn_messages(
     ordered = sorted(messages, key=lambda item: item.sequence)
     if carries_history:
         return ordered
+    if resumed_tool_call_id is not None:
+        resumed = [
+            message
+            for message in ordered
+            if message.kind == MessageKind.TOOL_RETURN
+            and message.tool_call_id == resumed_tool_call_id
+        ]
+        if resumed:
+            return resumed
     for message in reversed(ordered):
         if message.role == MessageRole.USER:
             return [message]
     return ordered[-1:]
-
-
-
 
 
 def _runtime_profile_value(options: HarnessOptions, key: str) -> object | None:

--- a/lemma-backend/app/modules/agent/infrastructure/wait_repository.py
+++ b/lemma-backend/app/modules/agent/infrastructure/wait_repository.py
@@ -70,6 +70,25 @@ class AgentConversationWaitRepository:
         model = (await self.session.execute(stmt)).scalars().first()
         return model.to_entity() if model else None
 
+    async def find_active_for_run(
+        self, agent_run_id: UUID
+    ) -> AgentConversationWaitEntity | None:
+        """The wait that this run suspended on, if it suspended on one.
+
+        Asked by the remote harness of a run that just ended, to tell a turn
+        that stopped because the agent went to sleep from one that stopped
+        because it was over. Keyed on the run rather than the conversation
+        because that is the question being asked, even though the partial
+        unique index means the two can only ever disagree by naming a wait
+        some *other* run of the same conversation is holding.
+        """
+        stmt = select(AgentConversationWaitModel).where(
+            AgentConversationWaitModel.agent_run_id == agent_run_id,
+            AgentConversationWaitModel.status == AgentWaitStatus.ACTIVE.value,
+        )
+        model = (await self.session.execute(stmt)).scalars().first()
+        return model.to_entity() if model else None
+
     async def find_active_for_conversation(
         self, conversation_id: UUID
     ) -> AgentConversationWaitEntity | None:

--- a/lemma-backend/app/modules/agent/prompts/agent_host_runtime.md
+++ b/lemma-backend/app/modules/agent/prompts/agent_host_runtime.md
@@ -7,22 +7,27 @@ Your workspace is a sandbox Lemma runs for this conversation, and the `lemma_*` 
 
 Pod files are a third place, separate from both: a shared store where a human leaves you inputs, documents and project material, and where you publish finished work. Read from it when you need what someone left you; write to it when you have something to hand back. It is not scratch space — the workspace is.
 
-# Pausing is not available here
-This runtime cannot suspend a turn and resume it later, so `ask_user`,
-`request_approval` and `snooze` do not run: each returns
-`interaction_fallback: true` with the behaviour to use instead. Other guidance
-describes workflows built on them — waiting for a colleague's reply, asking the
-user to choose, treating a 403 as a cue to request approval. Read those as
-describing what a pausing runtime does, and substitute prose here:
+# Waiting for someone
+You can wait. What you cannot do is wait *inside* a tool call: `ask_user`,
+`request_approval` and `snooze` return `interaction_fallback: true` here,
+because they pause by ending the run and resuming in a new one, and a tool
+running over MCP cannot end your turn from the inside.
 
-- Need an answer or a choice: ask in your reply and end your turn. You will see
-  the response when the person answers.
+So do it from the outside, which is the same shape: say what you need, then end
+the turn with `final_answer` and `status: "WAITING"`. The conversation waits,
+and the person's reply starts a fresh run that carries on with their answer.
+Nothing is lost and nobody has to poll.
+
+- Need an answer or a choice: ask it plainly, then end the turn WAITING.
 - Need permission, or about to do something destructive: say exactly what you
-  intend and why, and let the person confirm or run it themselves.
-- Waiting on someone: say what you are waiting for and end the turn. Nothing
-  resumes you, so do everything you can first.
+  intend and why, then end the turn WAITING rather than proceeding.
+- Waiting on a colleague: `message_user` sends -- only the waiting half is
+  unavailable -- so send, then end the turn WAITING and pick their reply up next
+  run.
 
-`message_user` itself works — it sends. Only the waiting half is unavailable.
+Approvals for your *own* native tools are unaffected: those are handled by your
+harness and reach the person as a normal Lemma approval, and your run is held
+open while they decide.
 
 # Native image generation
 When running as Codex and the user asks to generate or edit an image, use Codex's built-in `$imagegen` capability. Do not substitute Pillow, SVG, canvas, Python, shell scripts, or an external image CLI unless the user explicitly requests that implementation. Copy each final generated image into the `.lemma-artifacts` directory in the provider scratch workspace. Agent Host publishes files from that directory into the conversation's pod files; do not call the Lemma CLI to upload a private host path.

--- a/lemma-backend/app/modules/agent/prompts/agent_host_runtime.md
+++ b/lemma-backend/app/modules/agent/prompts/agent_host_runtime.md
@@ -7,27 +7,28 @@ Your workspace is a sandbox Lemma runs for this conversation, and the `lemma_*` 
 
 Pod files are a third place, separate from both: a shared store where a human leaves you inputs, documents and project material, and where you publish finished work. Read from it when you need what someone left you; write to it when you have something to hand back. It is not scratch space — the workspace is.
 
-# Waiting for someone
-You can wait. What you cannot do is wait *inside* a tool call: `ask_user`,
-`request_approval` and `snooze` return `interaction_fallback: true` here,
-because they pause by ending the run and resuming in a new one, and a tool
-running over MCP cannot end your turn from the inside.
+# Waiting
+You can wait, and the tools for it work here. There are two shapes, and the
+difference is only whether your turn stays open.
 
-So do it from the outside, which is the same shape: say what you need, then end
-the turn with `final_answer` and `status: "WAITING"`. The conversation waits,
-and the person's reply starts a fresh run that carries on with their answer.
-Nothing is lost and nobody has to poll.
+`ask_user` and `request_approval` keep you in this turn. The call does not
+return until the person answers -- however long that takes -- and then it
+returns their actual answer, exactly like an approval for one of your own
+native tools. So use them: they render as a real interaction card, with your
+choices and buttons, on whichever surface the person is already using. Asking
+the same thing in prose gets you a paragraph they have to answer in words.
 
-- Need an answer or a choice: ask it plainly, then end the turn WAITING.
-- Need permission, or about to do something destructive: say exactly what you
-  intend and why, then end the turn WAITING rather than proceeding.
-- Waiting on a colleague: `message_user` sends -- only the waiting half is
-  unavailable -- so send, then end the turn WAITING and pick their reply up next
-  run.
+`snooze` ends this turn on purpose. Use it for a wait with no person at the
+other end -- a build to check back on, a colleague you reached with
+`message_user` who will reply in their own time. Your turn stops where the call
+is, you wake later in this same conversation, and you are told how long you
+slept. Two things to get right before you call it: your sandbox does not
+survive, so write anything you need to the pod first; and waking proves only
+that the time elapsed, so check the thing you were waiting for.
 
-Approvals for your *own* native tools are unaffected: those are handled by your
-harness and reach the person as a normal Lemma approval, and your run is held
-open while they decide.
+Do not use `snooze` to wait on the person you are talking to. Ask them with
+`ask_user` and stay in your turn, or end the turn and let their reply start the
+next one.
 
 # Native image generation
 When running as Codex and the user asks to generate or edit an image, use Codex's built-in `$imagegen` capability. Do not substitute Pillow, SVG, canvas, Python, shell scripts, or an external image CLI unless the user explicitly requests that implementation. Copy each final generated image into the `.lemma-artifacts` directory in the provider scratch workspace. Agent Host publishes files from that directory into the conversation's pod files; do not call the Lemma CLI to upload a private host path.

--- a/lemma-backend/app/modules/agent/services/conversation_mcp_service.py
+++ b/lemma-backend/app/modules/agent/services/conversation_mcp_service.py
@@ -40,6 +40,11 @@ from app.modules.agent.infrastructure.repositories import (
     AgentRuntimeProfileRepository,
     ConversationRepository,
 )
+from app.modules.agent.services.mcp_pausing_calls import (
+    close_pausing_tool_call,
+    is_pausing_tool,
+    record_pausing_tool_call,
+)
 from app.modules.agent.services.workspace_location import (
     ensure_recorded_location,
     pod_cwd_from_workspace_cwd,
@@ -174,6 +179,19 @@ class ConversationMCPService:
             agent_run_id=agent_run_id,
         )
         tool_name = normalize_local_mcp_tool_name(name)
+        # A tool that outlives its own return needs an id the record is
+        # addressed by, and MCP supplies none. See ``mcp_pausing_calls``.
+        tool_call_id = (
+            await record_pausing_tool_call(
+                self.uow_factory,
+                conversation_id=conversation_id,
+                agent_run_id=agent_run_id,
+                tool_name=tool_name,
+                arguments=arguments,
+            )
+            if is_pausing_tool(tool_name)
+            else None
+        )
         try:
             result = await self.dispatcher.call_tool(
                 agent=agent,
@@ -182,6 +200,7 @@ class ConversationMCPService:
                 name=tool_name,
                 arguments=arguments,
                 agent_run_id=agent_run_id,
+                tool_call_id=tool_call_id,
                 # Must match list_tools, or we advertise a tool we then reject
                 # as unknown.
                 include_final_answer=True,
@@ -197,8 +216,44 @@ class ConversationMCPService:
                 "agent.conversation_mcp_service.conversation_mcp_tool_r_returning.diagnostic",
                 exc_info=True,
             )
-            return self._mcp_error_result(tool_name, exc)
+            error = self._mcp_error_result(tool_name, exc)
+            await self._close_if_it_did_not_wait(
+                tool_call_id=tool_call_id,
+                conversation_id=conversation_id,
+                agent_run_id=agent_run_id,
+                tool_name=tool_name,
+                result=error.structuredContent,
+            )
+            return error
+        await self._close_if_it_did_not_wait(
+            tool_call_id=tool_call_id,
+            conversation_id=conversation_id,
+            agent_run_id=agent_run_id,
+            tool_name=tool_name,
+            result=result,
+        )
         return self._mcp_result(result)
+
+    async def _close_if_it_did_not_wait(
+        self,
+        *,
+        tool_call_id: str | None,
+        conversation_id: UUID,
+        agent_run_id: UUID | None,
+        tool_name: str,
+        result: object,
+    ) -> None:
+        """Finish a recorded pausing call that answered instead of waiting."""
+        if tool_call_id is None:
+            return
+        await close_pausing_tool_call(
+            self.uow_factory,
+            conversation_id=conversation_id,
+            agent_run_id=agent_run_id,
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+            result=result,
+        )
 
     async def _load_agent_context(
         self,

--- a/lemma-backend/app/modules/agent/services/conversation_mcp_service.py
+++ b/lemma-backend/app/modules/agent/services/conversation_mcp_service.py
@@ -82,6 +82,34 @@ class ConversationMCPService:
             )
         return conversation is not None and conversation.user_id == token_user_id
 
+    async def parked_tool_return(
+        self,
+        *,
+        conversation_id: UUID,
+        tool_call_id: str,
+    ) -> JsonObject | None:
+        """The answer to a parked interaction, or ``None`` while it is pending.
+
+        The host's MCP bridge polls this after `ask_user` or `request_approval`
+        hands it a parked id, and hands the result back as that tool's return so
+        the model never leaves its turn.
+
+        Nothing new is stored to make this work. Deciding an interaction already
+        writes a synthesized tool RETURN under the same durable id -- that is how
+        the in-process resume replays the answer, and how re-running an approved
+        tool is prevented -- so the pending/decided question is just "has that
+        return been written yet".
+        """
+        async with self.uow_factory() as uow:
+            message = await ConversationRepository(uow).get_tool_return(
+                conversation_id=conversation_id,
+                tool_call_id=tool_call_id,
+            )
+        if message is None:
+            return None
+        result = getattr(message, "tool_result", None)
+        return result if isinstance(result, dict) else {"result": to_json_value(result)}
+
     async def list_tools(
         self,
         *,

--- a/lemma-backend/app/modules/agent/services/conversation_service.py
+++ b/lemma-backend/app/modules/agent/services/conversation_service.py
@@ -315,9 +315,7 @@ class ConversationService(PauseResumeMixin):
         latest = conversation.agent_runs[-1] if conversation.agent_runs else None
         if latest is None or latest.status != AgentRunStatus.FAILED:
             return False
-        return await self.conversation_repository.run_has_only_user_messages(
-            latest.id
-        )
+        return await self.conversation_repository.run_has_only_user_messages(latest.id)
 
     async def update_conversation(
         self,
@@ -701,6 +699,9 @@ class ConversationService(PauseResumeMixin):
             # duplicate host run for the same turn.
             return
 
+        if await self.resume_would_duplicate_a_live_turn(paused_run_id):
+            return
+
         await self.start_resume_run_if_ready(
             conversation=conversation,
             paused_run_id=paused_run_id,
@@ -896,9 +897,7 @@ class ConversationService(PauseResumeMixin):
         )
         async with uow_factory() as uow:
             profile_service = AgentRuntimeProfileService(
-                AgentRuntimeProfileRepository(
-                    uow, encryption=get_secret_cipher()
-                )
+                AgentRuntimeProfileRepository(uow, encryption=get_secret_cipher())
             )
             resolved = await profile_service.resolve(
                 runtime=selected_runtime,
@@ -1130,9 +1129,7 @@ class ConversationService(PauseResumeMixin):
                     "tool_call_id": message.tool_call_id,
                     "kind": message.tool_name,
                     "tool_args": (
-                        message.tool_args
-                        if isinstance(message.tool_args, dict)
-                        else {}
+                        message.tool_args if isinstance(message.tool_args, dict) else {}
                     ),
                     "agent_run_id": message.agent_run_id,
                 }
@@ -1202,9 +1199,7 @@ class ConversationService(PauseResumeMixin):
             selected_agent_runtime = (
                 conversation.agent_runtime
                 or agent.agent_runtime
-                or await self._default_agent_runtime_for_pod(
-                    pod_id=conversation.pod_id
-                )
+                or await self._default_agent_runtime_for_pod(pod_id=conversation.pod_id)
             )
             await self._assert_usage_preflight_allowed(
                 organization_id=conversation.organization_id,

--- a/lemma-backend/app/modules/agent/services/mcp_pausing_calls.py
+++ b/lemma-backend/app/modules/agent/services/mcp_pausing_calls.py
@@ -1,0 +1,177 @@
+"""Putting an MCP-served interaction on the durable record before it runs.
+
+A pausing tool — ``ask_user``, ``request_approval``, ``snooze`` — outlives its
+own return. The person answers minutes later, on a different surface, through
+``/approvals/{tool_call_id}/decision``; the timer fires hours later and the
+resume is written under the same id. All of that is addressed by the id of the
+tool call, which for an in-process run is the model's own and is handed to the
+tool by pydantic-ai.
+
+Nothing supplies one over MCP. ``tools/call`` carries a name and arguments; the
+JSON-RPC request id dies with the response. So the tool ran with
+``ctx.tool_call_id`` set to ``None``, and every one of those tools has a guard
+that turns that into an error — an agent asking a question got back "requires a
+durable tool call id" instead of the question reaching anybody.
+
+The harness does eventually report the call, with an id of its own, and that
+looked like the answer: wait for it and use it. It is a race that cannot be
+won. The adapter announces a call and invokes it in the same breath, so which of
+the two arrives at Lemma first — the announcement, over the run's event stream
+and a normalizer that deliberately *holds* calls whose arguments are still
+streaming, or the tool call itself, over HTTP — is not something either side
+decides.
+
+So Lemma records the call, exactly as it does for an in-process run, and the
+harness's later duplicate is dropped (see ``agent_host_events``). Ownership
+follows the interaction: the record has to exist for the card to render and the
+decision to land somewhere, and Lemma is the only side that knows that.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+from app.core.infrastructure.db.uow_factory import UnitOfWorkFactory
+from app.core.log.log import get_logger
+from app.modules.agent.domain.pausing_tools import PAUSING_TOOL_NAMES
+from app.modules.agent.domain.value_objects import (
+    JsonObject,
+    MessageDraft,
+    to_json_value,
+)
+from app.modules.agent.infrastructure.repositories import ConversationRepository
+from app.modules.agent.infrastructure.wait_repository import (
+    AgentConversationWaitRepository,
+)
+from app.modules.agent.services.realtime import (
+    message_payload,
+    publish_conversation_event,
+)
+from app.modules.agent.services.serialization import message_to_payload
+
+logger = get_logger(__name__)
+
+# Prefixed so the record says where the id came from. Nothing parses it — the
+# point is that anyone reading a conversation, or a support log, can tell a call
+# Lemma recorded on a harness's behalf from one the harness reported itself.
+_ID_PREFIX = "lemma-mcp"
+
+
+def is_pausing_tool(tool_name: str) -> bool:
+    return tool_name in PAUSING_TOOL_NAMES
+
+
+async def record_pausing_tool_call(
+    uow_factory: UnitOfWorkFactory,
+    *,
+    conversation_id: UUID,
+    agent_run_id: UUID | None,
+    tool_name: str,
+    arguments: JsonObject | None,
+) -> str | None:
+    """Record the call and return the id it is addressed by.
+
+    ``None`` when there is no run to attach it to, which is the one case where
+    an interaction genuinely has nowhere to live; the tool then reports that
+    rather than pausing on a call nobody can answer.
+    """
+    if agent_run_id is None:
+        return None
+    tool_call_id = f"{_ID_PREFIX}-{uuid4().hex}"
+    async with uow_factory() as uow:
+        saved = await ConversationRepository(uow).append_message(
+            conversation_id=conversation_id,
+            agent_run_id=agent_run_id,
+            draft=MessageDraft.of_tool_call(
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+                tool_args=dict(arguments or {}),
+            ),
+        )
+        await uow.commit()
+    # The card the person answers is rendered from this event, so a live
+    # conversation shows the question at the moment it is asked rather than
+    # whenever the next poll happens to run.
+    await publish_conversation_event(
+        conversation_id,
+        message_payload(agent_run_id, message_to_payload(saved)),
+    )
+    logger.debug(
+        "agent.mcp_pausing_calls.recorded",
+        conversation_id=str(conversation_id),
+        tool_name=tool_name,
+    )
+    return tool_call_id
+
+
+async def close_pausing_tool_call(
+    uow_factory: UnitOfWorkFactory,
+    *,
+    conversation_id: UUID,
+    agent_run_id: UUID | None,
+    tool_call_id: str,
+    tool_name: str,
+    result: object,
+) -> None:
+    """Write the return for a pausing call that turned out not to pause.
+
+    Most calls to these tools do wait, and this does nothing for those: the
+    return is written later, by whoever resolves them. But a pausing tool can
+    also answer straight away — a snooze under the minimum, a request the model
+    was already granted, an argument that would not validate — and those calls
+    are finished the moment they return.
+
+    Leaving one open is not cosmetic. ``start_resume_run_if_ready`` refuses to
+    start a resume while any pausing call in the run is still outstanding, on
+    the grounds that resuming would orphan it. So a rejected ``snooze(5)``
+    early in a turn would sit there, and the *next* snooze — the real one, with
+    a timer counting down — would wake to a resume that declines to start. The
+    agent sleeps forever, and nothing anywhere reports a failure.
+    """
+    if await _still_waiting(
+        uow_factory,
+        agent_run_id=agent_run_id,
+        tool_call_id=tool_call_id,
+        result=result,
+    ):
+        return
+    async with uow_factory() as uow:
+        saved = await ConversationRepository(uow).append_message(
+            conversation_id=conversation_id,
+            agent_run_id=agent_run_id,
+            draft=MessageDraft.of_tool_return(
+                tool_call_id=tool_call_id,
+                tool_name=tool_name,
+                tool_result=to_json_value(result),
+            ),
+        )
+        await uow.commit()
+    await publish_conversation_event(
+        conversation_id,
+        message_payload(agent_run_id, message_to_payload(saved)),
+    )
+
+
+async def _still_waiting(
+    uow_factory: UnitOfWorkFactory,
+    *,
+    agent_run_id: UUID | None,
+    tool_call_id: str,
+    result: object,
+) -> bool:
+    """Whether this call is genuinely outstanding, asked two ways.
+
+    ``parked_tool_call_id`` is how ``ask_user`` and ``request_approval`` say a
+    person is being waited on. ``snooze`` says it by leaving an ACTIVE wait row,
+    which is also the thing that will eventually wake the conversation — so
+    reading the row rather than the response means the two cannot disagree.
+    """
+    if getattr(result, "parked_tool_call_id", None):
+        return True
+    if agent_run_id is None:
+        return False
+    async with uow_factory() as uow:
+        wait = await AgentConversationWaitRepository(uow).find_active_for_run(
+            agent_run_id
+        )
+    return wait is not None and wait.tool_call_id == tool_call_id

--- a/lemma-backend/app/modules/agent/services/pause_resume.py
+++ b/lemma-backend/app/modules/agent/services/pause_resume.py
@@ -22,7 +22,11 @@ from app.modules.agent.domain.events import AgentRunStartedEvent
 from app.modules.agent.domain.pausing_tools import (
     PAUSING_TOOL_NAMES as _PAUSING_TOOL_NAMES_DOMAIN,
 )
-from app.modules.agent.domain.value_objects import MessageDraft, MessageKind
+from app.modules.agent.domain.value_objects import (
+    AgentRunStatus,
+    MessageDraft,
+    MessageKind,
+)
 from app.modules.agent.services.realtime import (
     message_payload,
     publish_conversation_event,
@@ -82,6 +86,24 @@ class PauseResumeMixin:
                 message_payload(paused_run_id, message_to_payload(saved_return)),
             )
         return True
+
+    async def resume_would_duplicate_a_live_turn(self, paused_run_id: UUID) -> bool:
+        """Is the "paused" run actually still running?
+
+        A remote harness's `ask_user` / `request_approval` parks rather than
+        pausing: the run keeps running while the host's MCP bridge holds the
+        tool response open, and the synthesized return appended by the
+        resolution is exactly what that bridge is polling for. The turn carries
+        on the moment it reads it, so resuming would put two runs on one turn.
+
+        Keyed on the run still running rather than on a marker in the call's
+        arguments, unlike the ACP permission path: those arguments come from the
+        model, not from Lemma, so there is nothing of ours to read back. It is
+        also the honest condition -- a run still running is precisely what makes
+        a resume wrong.
+        """
+        run = await self.conversation_repository.get_agent_run(paused_run_id)
+        return run is not None and run.status == AgentRunStatus.RUNNING
 
     async def start_resume_run_if_ready(
         self,
@@ -183,4 +205,3 @@ class PauseResumeMixin:
             and message.tool_call_id is not None
             and message.tool_call_id not in resolved
         ]
-

--- a/lemma-backend/app/modules/agent/services/run_suspension.py
+++ b/lemma-backend/app/modules/agent/services/run_suspension.py
@@ -1,0 +1,64 @@
+"""How a remote harness's turn ends when a tool puts the agent to sleep.
+
+The in-process harness suspends from the inside: ``snooze`` raises
+``AgentInputRequired``, the run loop catches it, and the turn is over. A remote
+harness owns its own session and runs the tool over MCP, so nothing raised
+inside that tool call can end its turn — the agent simply carries on with the
+result. Lemma has to ask it to stop.
+
+The ask is the ordinary ``CANCEL_RUN``, which every host already implements. It
+is *what Lemma asked for* that differs, not what the host does, so nothing here
+touches the protocol. The two halves live together because they are one
+statement made twice: :func:`suspend_remote_run` says "stop, this run is going
+to wait", and :func:`run_suspended_on` is how the harness reads that back when
+the run's terminal state arrives and it has to decide whether a stopped turn
+means STOPPED or WAITING.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
+from app.modules.agent.domain.wait import AgentConversationWaitEntity
+from app.modules.agent.infrastructure.agent_host_dispatch_repository import (
+    AgentHostDispatchRepository,
+)
+from app.modules.agent.infrastructure.wait_repository import (
+    AgentConversationWaitRepository,
+)
+
+
+async def suspend_remote_run(
+    uow: SqlAlchemyUnitOfWork,
+    *,
+    agent_run_id: UUID,
+) -> UUID | None:
+    """Ask the host to end this turn. Returns the host to poke, if any.
+
+    ``None`` covers every case where there is nothing to stop — a run with no
+    host lease, one already terminal, one whose cancel is already on its way.
+    All of them are fine: the wait row is what wakes the conversation, and it is
+    written whether or not this lands. What is *not* fine is skipping this and
+    trusting the model to end its own turn, because a turn still running when
+    the timer fires makes the wake a no-op and the agent never wakes at all.
+    """
+    command = await AgentHostDispatchRepository(uow).enqueue_cancel(run_id=agent_run_id)
+    return command.host_id if command is not None else None
+
+
+async def run_suspended_on(
+    uow: SqlAlchemyUnitOfWork,
+    *,
+    agent_run_id: UUID,
+) -> AgentConversationWaitEntity | None:
+    """The wait this run stopped for, if it stopped for one.
+
+    Read at the end of a remote run to tell a turn that finished from one that
+    was suspended mid-thought. Deliberately keyed on the durable wait row rather
+    than on the terminal state the host reported: the host says ``CANCELLED``
+    when it stopped the turn and ``SUCCEEDED`` when the agent got there first,
+    and which of those happens is a race between a poke and a model deciding to
+    stop talking. Neither answers the question being asked.
+    """
+    return await AgentConversationWaitRepository(uow).find_active_for_run(agent_run_id)

--- a/lemma-backend/app/modules/agent/services/snooze_wake_service.py
+++ b/lemma-backend/app/modules/agent/services/snooze_wake_service.py
@@ -15,6 +15,7 @@ from app.core.authorization.current import reset_current_context, set_current_co
 from app.core.authorization.factory import create_authorization_data_service
 from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
 from app.core.log.log import get_logger
+from app.modules.agent.domain.pausing_tools import SNOOZE_TOOL_NAME
 from app.modules.agent.domain.wait import (
     AgentConversationWaitEntity,
     AgentWaitWakeReason,
@@ -29,8 +30,6 @@ from app.modules.agent.tools.snooze.models import (
 )
 
 logger = get_logger(__name__)
-
-SNOOZE_TOOL_NAME = "snooze"
 
 
 class SnoozeWakeService:

--- a/lemma-backend/app/modules/agent/tests/e2e/test_agent_host_seam_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_agent_host_seam_e2e.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+from types import SimpleNamespace
 from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid7
 
@@ -45,10 +46,27 @@ from app.modules.agent.infrastructure.harnesses.agent_host import (
     RemoteHarness,
     _AgentHostRunConfig,
 )
+from app.modules.agent.infrastructure.harnesses.agent_host_dispatch import (
+    _resumed_tool_call_id,
+)
 from app.modules.agent.infrastructure.harnesses.agent_host_run_window import (
     DispatchedRun,
 )
+from app.modules.agent.domain.pausing_tools import SNOOZE_TOOL_NAME
+from app.modules.agent.domain.value_objects import AgentRunStatus
+from app.modules.agent.infrastructure.models import AgentRunModel
 from app.modules.agent.infrastructure.runtime_models import AgentHostCommandModel
+from app.modules.agent.infrastructure.repositories import ConversationRepository
+from app.modules.agent.infrastructure.wait_repository import (
+    AgentConversationWaitRepository,
+)
+from app.modules.agent.services.mcp_pausing_calls import (
+    close_pausing_tool_call,
+    record_pausing_tool_call,
+)
+from app.modules.agent.services.snooze_wake_service import SnoozeWakeService
+from app.modules.agent.tools.snooze.models import SnoozeRequest
+from app.modules.agent.tools.snooze.pydantic_adapter import snooze
 from app.modules.agent.tests.e2e.agent_host_helpers import (
     conversation_with_a_leased_run,
     paired_machine,
@@ -242,7 +260,9 @@ async def test_the_stream_carries_a_permission_request_without_ending_the_run(
         batch=AgentHostEventBatch(
             events=[
                 at(1, AgentHostEventType.AGENT_MESSAGE_CHUNK, {"text": "One moment. "}),
-                at(2, AgentHostEventType.AGENT_MESSAGE_UPSERT, {"text": "One moment. "}),
+                at(
+                    2, AgentHostEventType.AGENT_MESSAGE_UPSERT, {"text": "One moment. "}
+                ),
                 at(
                     3,
                     AgentHostEventType.PERMISSION_REQUEST,
@@ -546,3 +566,258 @@ async def _await_refresh_command(db_session, run_id: UUID, *, timeout: float = 2
         await db_session.rollback()
         await asyncio.sleep(0.1)
     return None
+
+
+@pytest.mark.asyncio
+async def test_a_snoozing_agent_ends_its_turn_waiting_and_wakes_where_it_left_off(
+    db_session, scenario
+):
+    """The whole sleep, on the real seam: tool, turn, wake.
+
+    `snooze` is the one tool an agent uses to say "not now, later". In-process it
+    raises and the run loop catches it. A remote harness cannot be interrupted
+    from inside its own MCP tool call, so this is the path where every step is
+    different: Lemma has to end the turn, read a stopped run as a sleeping one,
+    and start the woken run itself.
+
+    The failure this guards is silent in every piece and only visible whole — a
+    turn that never stops leaves a run active, and the wake finds one and does
+    nothing, so the agent sleeps forever and the conversation looks busy.
+    """
+    await scenario.create_org_with_pod(name_prefix="Snooze")
+    pod_id = scenario.pod_id
+    conversation_id, run_id, host_id = await _seed_run(db_session, scenario, pod_id)
+    await db_session.commit()
+
+    ctx = BaseAgentContext(
+        user_id=UUID(scenario.owner_user["id"]),
+        pod_id=pod_id,
+        conversation_id=conversation_id,
+        agent_run_id=run_id,
+        # False for every Agent Host run: nothing here catches a raised pause.
+        supports_pause_signal=False,
+    )
+    tool_call_id = await record_pausing_tool_call(
+        lambda: SqlAlchemyUnitOfWork(db_session),
+        conversation_id=conversation_id,
+        agent_run_id=run_id,
+        tool_name=SNOOZE_TOOL_NAME,
+        arguments={"reason": "waiting for the nightly build", "seconds": 600},
+    )
+    await db_session.commit()
+
+    answer = await snooze(
+        SimpleNamespace(deps=ctx, tool_call_id=tool_call_id),
+        SnoozeRequest(
+            reason="waiting for the nightly build",
+            seconds=600,
+            note_to_self="check whether it went green",
+        ),
+    )
+    assert answer.success is True
+
+    # The host was really told to stop, on the real lease.
+    commands = (
+        (
+            await db_session.execute(
+                select(AgentHostCommandModel).where(
+                    AgentHostCommandModel.run_id == run_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert [command.kind for command in commands] == [
+        AgentHostCommandKind.CANCEL_RUN.value
+    ]
+
+    # ... and the host stops, reporting what it saw. Which is not what happened.
+    repository = AgentHostDispatchRepository(SqlAlchemyUnitOfWork(db_session))
+    ack = await repository.append_events(
+        host_id=host_id,
+        batch=AgentHostEventBatch(
+            events=[
+                AgentHostEvent(
+                    run_id=run_id,
+                    lease_epoch=1,
+                    sequence=1,
+                    type=AgentHostEventType.TERMINAL.value,
+                    payload={
+                        "state": AgentHostRunState.CANCELLED.value,
+                        "stop_reason": "cancelled",
+                    },
+                    occurred_at=datetime.now(timezone.utc),
+                )
+            ]
+        ),
+    )
+    assert ack.acked_through == 1
+
+    events = await _drive(
+        RemoteHarness(lambda: SqlAlchemyUnitOfWork(db_session)),
+        run_id=run_id,
+        agent=_agent(pod_id),
+        conversation=_conversation(conversation_id, pod_id),
+        ctx=ctx,
+    )
+    # Not STOPPED, which reads as "the user pressed Stop" and leaves the
+    # conversation looking finished while a timer counts down to wake it.
+    assert events[-1].type is AgentEventType.WAITING
+    assert events[-1].data["tool_call_id"] == tool_call_id
+
+    # The run has to be over before the timer fires, or the wake sees a live run
+    # and quietly declines to start a second one.
+    await ConversationRepository(SqlAlchemyUnitOfWork(db_session)).finish_agent_run(
+        agent_run_id=run_id, status=AgentRunStatus.COMPLETED
+    )
+    await db_session.commit()
+
+    uow = SqlAlchemyUnitOfWork(db_session)
+    waits = AgentConversationWaitRepository(uow)
+    wait = await waits.find_active_for_run(run_id)
+    assert wait is not None and wait.tool_call_id == tool_call_id
+
+    woke = await SnoozeWakeService(uow).wake(wait=wait)
+    await db_session.commit()
+    assert woke is True
+
+    runs = (
+        (
+            await db_session.execute(
+                select(AgentRunModel)
+                .where(AgentRunModel.conversation_id == conversation_id)
+                .order_by(AgentRunModel.created_at)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(runs) == 2, "the timer did not start the run that carries on"
+    assert runs[-1].run_metadata["source"] == "snooze_resume"
+    # Named so the dispatch can prompt the woken agent with what it woke to,
+    # rather than re-sending a request its provider session already holds.
+    assert runs[-1].run_metadata["resumed_tool_call_id"] == tool_call_id
+    assert _resumed_tool_call_id(runs[-1].to_entity()) == tool_call_id
+
+    messages, _ = await ConversationRepository(uow).list_messages(
+        conversation_id=conversation_id, limit=50
+    )
+    returned = [
+        message
+        for message in messages
+        if message.kind is MessageKind.TOOL_RETURN
+        and message.tool_call_id == tool_call_id
+    ]
+    assert len(returned) == 1, "the wake wrote no return, or wrote two"
+    assert returned[0].tool_result["woke_because"] == "TIMER"
+    assert returned[0].tool_result["note_to_self"] == "check whether it went green"
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_snooze_does_not_strand_the_one_that_follows(
+    db_session, scenario
+):
+    """A pausing call that answers at once must not stay open.
+
+    `snooze(5)` is rejected on purpose — waking replays the conversation, so a
+    poll loop costs more than it saves. But the call is on the record by then,
+    and `start_resume_run_if_ready` refuses to resume a run while any pausing
+    call in it is outstanding. So the rejected one would sit there and the real
+    snooze after it would wake to a resume that quietly declines to start: an
+    agent asleep forever, with nothing reporting a failure anywhere.
+    """
+    await scenario.create_org_with_pod(name_prefix="Snooze")
+    pod_id = scenario.pod_id
+    conversation_id, run_id, _ = await _seed_run(db_session, scenario, pod_id)
+    await db_session.commit()
+
+    uow_factory = lambda: SqlAlchemyUnitOfWork(db_session)  # noqa: E731
+    ctx = BaseAgentContext(
+        user_id=UUID(scenario.owner_user["id"]),
+        pod_id=pod_id,
+        conversation_id=conversation_id,
+        agent_run_id=run_id,
+        supports_pause_signal=False,
+    )
+
+    rejected_id = await record_pausing_tool_call(
+        uow_factory,
+        conversation_id=conversation_id,
+        agent_run_id=run_id,
+        tool_name=SNOOZE_TOOL_NAME,
+        arguments={"reason": "polling", "seconds": 5},
+    )
+    refusal = await snooze(
+        SimpleNamespace(deps=ctx, tool_call_id=rejected_id),
+        SnoozeRequest(reason="polling", seconds=5),
+    )
+    assert refusal.success is False
+    await close_pausing_tool_call(
+        uow_factory,
+        conversation_id=conversation_id,
+        agent_run_id=run_id,
+        tool_call_id=rejected_id,
+        tool_name=SNOOZE_TOOL_NAME,
+        result=refusal,
+    )
+    await db_session.commit()
+
+    real_id = await record_pausing_tool_call(
+        uow_factory,
+        conversation_id=conversation_id,
+        agent_run_id=run_id,
+        tool_name=SNOOZE_TOOL_NAME,
+        arguments={"reason": "the nightly build", "seconds": 600},
+    )
+    slept = await snooze(
+        SimpleNamespace(deps=ctx, tool_call_id=real_id),
+        SnoozeRequest(reason="the nightly build", seconds=600),
+    )
+    assert slept.success is True
+    await close_pausing_tool_call(
+        uow_factory,
+        conversation_id=conversation_id,
+        agent_run_id=run_id,
+        tool_call_id=real_id,
+        tool_name=SNOOZE_TOOL_NAME,
+        result=slept,
+    )
+    await ConversationRepository(uow_factory()).finish_agent_run(
+        agent_run_id=run_id, status=AgentRunStatus.COMPLETED
+    )
+    await db_session.commit()
+
+    uow = uow_factory()
+    wait = await AgentConversationWaitRepository(uow).find_active_for_run(run_id)
+    assert wait is not None and wait.tool_call_id == real_id
+    assert await SnoozeWakeService(uow).wake(wait=wait) is True
+    await db_session.commit()
+
+    runs = (
+        (
+            await db_session.execute(
+                select(AgentRunModel).where(
+                    AgentRunModel.conversation_id == conversation_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(runs) == 2, "the rejected snooze held the real one's wake shut"
+
+    # And closing the rejected one did not also close the real one: the return
+    # under the sleeping call has to be the wake, not the acknowledgement the
+    # model already read. `append_pause_tool_return` is idempotent, so a return
+    # written early is the wake never being written at all.
+    messages, _ = await ConversationRepository(uow).list_messages(
+        conversation_id=conversation_id, limit=50
+    )
+    returns = {
+        message.tool_call_id: message.tool_result
+        for message in messages
+        if message.kind is MessageKind.TOOL_RETURN
+    }
+    assert returns[real_id]["woke_because"] == "TIMER"
+    assert returns[rejected_id]["success"] is False

--- a/lemma-backend/app/modules/agent/tests/e2e/test_mcp_client_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_mcp_client_e2e.py
@@ -17,7 +17,7 @@ tests confirm a real client completes the handshake and calls tools.
 
 from __future__ import annotations
 
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import httpx
 import pytest
@@ -111,7 +111,9 @@ async def test_pod_mcp_client_lists_and_calls_tools(
             {"table_name": table},
         )
         assert listed.is_error is False, listed.content
-        titles = [record.get("title") for record in listed.structured_content["records"]]
+        titles = [
+            record.get("title") for record in listed.structured_content["records"]
+        ]
         assert "from-mcp" in titles, listed.structured_content
 
 
@@ -241,3 +243,69 @@ async def test_mcp_endpoint_is_stateless(
         body = list_tools.json()
         names = {tool["name"] for tool in body["result"]["tools"]}
         assert "lemma_pod_get_records" in names, body
+
+
+@pytest.mark.asyncio
+async def test_the_bridge_can_poll_a_parked_interaction_until_it_is_decided(
+    authenticated_client,
+    fixed_test_org,
+    fixed_test_user,
+    backend_server,
+    db_session,
+):
+    """What the host's MCP bridge does while it holds a tool response open.
+
+    `ask_user` and `request_approval` hand a remote harness a parked tool call id
+    instead of prose. This is the other end of that: the bridge polls the id and
+    gets 204 until a person decides, then the answer -- which it returns as the
+    tool's own result, so the model waits inside its turn exactly as it does for
+    a native ACP permission.
+
+    Nothing is stored to make this work. Deciding an interaction already writes a
+    synthesized tool RETURN under the same durable id, so "decided" is simply
+    "that return exists".
+    """
+    pod_id = await _create_pod(authenticated_client, fixed_test_org)
+    created = await authenticated_client.post(
+        f"/pods/{pod_id}/conversations", json={"title": "parked"}
+    )
+    assert created.status_code == status.HTTP_201_CREATED, created.text
+    conversation_id = created.json()["id"]
+
+    base = backend_server["host_base_url"].rstrip("/")
+    tool_call_id = f"parked-{uuid4().hex[:8]}"
+    url = f"{base}/agent-runtime/conversations/{conversation_id}/interactions/{tool_call_id}"
+    headers = {"Authorization": f"Bearer {fixed_test_user['token']}"}
+
+    async with httpx.AsyncClient() as client:
+        pending = await client.get(url, headers=headers)
+        # 204, not 404: "not decided yet" is the normal answer the bridge polls
+        # on, and 404 is what an unknown route says.
+        assert pending.status_code == status.HTTP_204_NO_CONTENT, pending.text
+
+        # A token that is not this conversation's must not be able to read it.
+        anonymous = await client.get(url, headers={"Authorization": "Bearer nope"})
+        assert anonymous.status_code == status.HTTP_401_UNAUTHORIZED, anonymous.text
+
+    # The person decides. This is the same write the approvals endpoint makes.
+    from app.modules.agent.domain.value_objects import MessageKind, MessageRole
+    from app.modules.agent.infrastructure.models import MessageModel
+
+    db_session.add(
+        MessageModel(
+            conversation_id=UUID(conversation_id),
+            role=MessageRole.TOOL.value,
+            kind=MessageKind.TOOL_RETURN.value,
+            tool_call_id=tool_call_id,
+            tool_name="ask_user",
+            tool_result={"success": True, "answers": {"Pick one": "Blue"}},
+            sequence=1,
+        )
+    )
+    await db_session.commit()
+
+    async with httpx.AsyncClient() as client:
+        decided = await client.get(url, headers=headers)
+
+    assert decided.status_code == status.HTTP_200_OK, decided.text
+    assert decided.json()["answers"] == {"Pick one": "Blue"}

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_host_harness_lifecycle.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_host_harness_lifecycle.py
@@ -16,8 +16,12 @@ from uuid import uuid7
 
 import pytest
 
+from app.modules.agent.domain.agent_host import AgentHostEventType
 from app.modules.agent.domain.value_objects import AgentEvent, AgentEventType
-from app.modules.agent.infrastructure.agent_host_event_stream import StreamBatch
+from app.modules.agent.infrastructure.agent_host_event_stream import (
+    StreamBatch,
+    StreamedEvent,
+)
 from app.modules.agent.infrastructure.harnesses import agent_host
 from app.modules.agent.infrastructure.harnesses.agent_host import RemoteHarness
 from app.modules.agent.infrastructure.harnesses.agent_host_run_window import (
@@ -55,8 +59,39 @@ def _options():
     )
 
 
-def _harness(stream: _RecordingStream, **kwargs) -> RemoteHarness:
-    return RemoteHarness(uow_factory=None, event_stream=stream, **kwargs)
+def _sleeping_since(*, tool_call_id: str):
+    """Stand in for the wait row a snoozing run leaves behind."""
+
+    async def _lookup(uow, *, agent_run_id):
+        del uow, agent_run_id
+        return SimpleNamespace(tool_call_id=tool_call_id)
+
+    return _lookup
+
+
+def _awake():
+    async def _lookup(uow, *, agent_run_id):
+        del uow, agent_run_id
+        return None
+
+    return _lookup
+
+
+def _uow_factory():
+    """A unit of work that opens and closes and touches nothing."""
+
+    class _Uow:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    return _Uow()
+
+
+def _harness(stream, *, uow_factory=None, **kwargs) -> RemoteHarness:
+    return RemoteHarness(uow_factory=uow_factory, event_stream=stream, **kwargs)
 
 
 def _stub_dispatch(harness: RemoteHarness, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -167,3 +202,113 @@ class TestStreamDeletion:
 
         assert [event.type for event in events] == [AgentEventType.ERROR]
         assert stream.deleted == []
+
+
+class _TerminalStream:
+    """A stream that reports one finished run and nothing else."""
+
+    def __init__(self, state: str) -> None:
+        self.state = state
+        self.deleted: list = []
+        self.sent = False
+
+    async def read(self, *, run_id, after_id="0-0", block_ms=1000):
+        if self.sent:
+            return StreamBatch([], cursor=after_id)
+        self.sent = True
+        return StreamBatch(
+            [
+                StreamedEvent(
+                    stream_id="1-0",
+                    sequence=1,
+                    type=AgentHostEventType.TERMINAL.value,
+                    object_id=None,
+                    payload={"state": self.state},
+                )
+            ],
+            cursor="1-0",
+        )
+
+    async def delete(self, *, run_id) -> None:
+        self.deleted.append(run_id)
+
+
+class TestATurnEndedForASleepingAgent:
+    """A remote `snooze` ends its turn from the outside, so the state lies.
+
+    Lemma asks the host to stop, and the host reports what it saw — CANCELLED
+    when the stop landed first, SUCCEEDED when the agent finished talking before
+    it did, and which one wins is a race between a poke and a model. Taken
+    literally, the first says the user pressed Stop and the second says the turn
+    is over; both leave the conversation looking finished while a timer is still
+    counting down to wake it. What actually happened is on the wait row.
+    """
+
+    @pytest.mark.parametrize("state", ["CANCELLED", "SUCCEEDED"])
+    async def test_either_ending_is_reported_as_waiting(
+        self, state: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        agent_run_id = uuid7()
+        stream = _TerminalStream(state)
+        harness = _harness(
+            stream,
+            uow_factory=_uow_factory,
+            event_timeout_seconds=30.0,
+            stream_block_ms=1,
+        )
+        _stub_dispatch(harness, monkeypatch)
+        monkeypatch.setattr(
+            agent_host,
+            "run_suspended_on",
+            _sleeping_since(tool_call_id="lemma-mcp-1"),
+        )
+
+        events = [event async for event in await _drive(harness, agent_run_id)]
+
+        assert events[-1].type is AgentEventType.WAITING
+        # The shape the in-process pause yields, so one reader serves both.
+        assert events[-1].data["tool_call_id"] == "lemma-mcp-1"
+        assert events[-1].data["kind"] == "snooze"
+
+    async def test_a_turn_that_simply_ended_is_untouched(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        agent_run_id = uuid7()
+        stream = _TerminalStream("SUCCEEDED")
+        harness = _harness(
+            stream,
+            uow_factory=_uow_factory,
+            event_timeout_seconds=30.0,
+            stream_block_ms=1,
+        )
+        _stub_dispatch(harness, monkeypatch)
+        monkeypatch.setattr(agent_host, "run_suspended_on", _awake())
+
+        events = [event async for event in await _drive(harness, agent_run_id)]
+
+        assert events[-1].type is AgentEventType.COMPLETED
+
+    async def test_a_failure_is_still_a_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A run that hit its context ceiling really did fail, wait row or not.
+
+        Reporting it as WAITING would hide the error behind a conversation that
+        looks like it is patiently sleeping. The timer still wakes it either way.
+        """
+        agent_run_id = uuid7()
+        stream = _TerminalStream("FAILED")
+        harness = _harness(
+            stream,
+            uow_factory=_uow_factory,
+            event_timeout_seconds=30.0,
+            stream_block_ms=1,
+        )
+        _stub_dispatch(harness, monkeypatch)
+        monkeypatch.setattr(
+            agent_host, "run_suspended_on", _sleeping_since(tool_call_id="x")
+        )
+
+        events = [event async for event in await _drive(harness, agent_run_id)]
+
+        assert events[-1].type is AgentEventType.ERROR

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_host_normalizer.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_host_normalizer.py
@@ -351,6 +351,49 @@ class TestToolCalls:
         assert duplicate == []
         assert len(_messages(closed)) == 1
 
+    def test_a_pausing_tool_is_left_to_lemma_to_record(self) -> None:
+        """The harness's copy of `ask_user` never reaches the conversation.
+
+        Lemma records these itself, when the MCP call arrives, because only an
+        id Lemma minted can be answered: the approval endpoint, the snooze
+        timer and the resume all address a call by its id, and the one the
+        harness reports here belongs to a namespace none of them can reach.
+        Emitting both put two identical questions in the conversation, one of
+        them on a card whose buttons resolved nothing.
+        """
+        n = _normalizer()
+        opened = n.normalize(
+            _event(
+                1,
+                AgentHostEventType.TOOL_CALL_UPSERT,
+                {"name": "ask_user", "rawInput": {"question": "Which one?"}},
+                object_id="host-call-1",
+            )
+        )
+        closed = n.normalize(
+            _event(
+                2,
+                AgentHostEventType.TOOL_CALL_UPDATE,
+                {"status": "COMPLETED", "result": {"answer": "the blue one"}},
+                object_id="host-call-1",
+            )
+        )
+        assert _messages(opened) == []
+        assert _messages(closed) == []
+
+    def test_an_ordinary_tool_is_still_recorded_from_the_harness(self) -> None:
+        """The suppression is by tool, not a general silencing of the lane."""
+        n = _normalizer()
+        opened = n.normalize(
+            _event(
+                1,
+                AgentHostEventType.TOOL_CALL_UPSERT,
+                {"name": "exec_command", "rawInput": {"command": "ls"}},
+                object_id="host-call-2",
+            )
+        )
+        assert len(_messages(opened)) == 1
+
     def test_a_streamed_call_keeps_the_arguments_that_arrive_after_it(self) -> None:
         """The sequence a streaming adapter really sends, in order.
 

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_host_permission_approvals.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_host_permission_approvals.py
@@ -35,7 +35,11 @@ from app.modules.agent.services.approval_reconciliation import (
 from app.modules.agent.services.conversation_service import ConversationService
 
 _PAYLOAD = {
-    "toolCall": {"toolCallId": "call-9", "title": "Run rm -rf build", "kind": "execute"},
+    "toolCall": {
+        "toolCallId": "call-9",
+        "title": "Run rm -rf build",
+        "kind": "execute",
+    },
     "message": "The local agent asked for permission to use a native tool.",
     "options": [
         {"optionId": "reject", "kind": "reject_once", "name": "No"},
@@ -105,7 +109,12 @@ class TestDecisionMapping:
         """Adapters differ on `allow_once` vs `allowOnce`; guessing wrong would
         silently fall through to "first allowed option"."""
         request = _request(
-            {"options": [{"optionId": "x", "kind": "rejectOnce"}, {"optionId": "y", "kind": "allowOnce"}]}
+            {
+                "options": [
+                    {"optionId": "x", "kind": "rejectOnce"},
+                    {"optionId": "y", "kind": "allowOnce"},
+                ]
+            }
         )
 
         assert request.option_for(AgentRunApprovalDecision.APPROVE_ONCE) == "y"
@@ -346,7 +355,9 @@ def _patch_agent_host(
     monkeypatch.setitem(sys.modules, channels.__name__, channels)
     monkeypatch.setitem(sys.modules, dispatch.__name__, dispatch)
     monkeypatch.setattr(
-        approval_reconciliation, "SessionUnitOfWorkFactory", lambda _maker: _FakeUowFactory()
+        approval_reconciliation,
+        "SessionUnitOfWorkFactory",
+        lambda _maker: _FakeUowFactory(),
     )
 
 
@@ -387,6 +398,11 @@ class _ConversationRepository:
         )
         self.appended.append(message)
         return message
+
+    async def get_agent_run(self, _run_id):
+        # None unless a test says otherwise: a run that paused in-process has
+        # already finished, so "no run here" is the ordinary case.
+        return getattr(self, "paused_run", None)
 
     async def lock_conversation(self, _conversation_id) -> None:
         return None
@@ -470,9 +486,7 @@ class TestResolutionRouting:
         )
 
         assert resolution.status == "resolved"
-        assert dispatched == [
-            ("call-9", run_id, AgentRunApprovalDecision.APPROVE_ONCE)
-        ]
+        assert dispatched == [("call-9", run_id, AgentRunApprovalDecision.APPROVE_ONCE)]
         assert repository.created_runs == 0
 
     @pytest.mark.asyncio
@@ -562,10 +576,60 @@ async def test_a_session_approval_is_recorded_before_the_tool_runs() -> None:
     # path that commits first.
     uow.after_commit(_record)
 
-    await uow.commit()          # execute_approved_tool_as_user commits here …
-    order.append("tool-ran")    # … and only then executes.
+    await uow.commit()  # execute_approved_tool_as_user commits here …
+    order.append("tool-ran")  # … and only then executes.
 
     assert order == ["approval-recorded", "tool-ran"], (
         "the session approval landed after the tool ran; an APPROVE_FOR_SESSION "
         "call will be denied by the grant the user just gave"
     )
+
+
+class TestAParkedInteractionDoesNotResume:
+    """A decision for a turn that is still in flight must not start a second one.
+
+    A remote harness's `ask_user` / `request_approval` parks: the run keeps
+    running while the host's MCP bridge holds the tool response open, and the
+    synthesized return appended by the resolution is exactly what that bridge is
+    polling for. The turn carries on the moment it reads it, so dispatching a
+    resume run here would put two runs on the same turn.
+
+    Keyed on the run still running rather than on a marker in the call's
+    arguments, unlike the ACP permission above: those arguments come from the
+    model, not from Lemma, so there is nothing of ours to read back. "Still
+    running" is also the honest condition — it is what makes a resume wrong.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_live_run_is_left_to_finish_its_own_turn(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from app.modules.agent.domain.value_objects import AgentRunStatus
+
+        service, repository, run_id = TestResolutionRouting()._service(monkeypatch, [])
+        # An ordinary request_approval — no ACP marker, so only the run's own
+        # state can tell this apart from an in-process pause.
+        repository.call.tool_args = {"tool_name": "exec_command", "args": {}}
+        repository.paused_run = SimpleNamespace(
+            id=run_id, status=AgentRunStatus.RUNNING
+        )
+        conversation = SimpleNamespace(
+            id=repository.call.conversation_id, agent_id=None, pod_id=uuid4()
+        )
+
+        await service.resolve_user_approval_internal(
+            conversation=conversation,
+            approval_id=repository.call.tool_call_id,
+            user_id=uuid4(),
+            pod_id=conversation.pod_id,
+            # Denied rather than approved: an approval would run the wrapped
+            # tool as the user, which is a different mechanism entirely. The
+            # resume guard is the same either way, and a denial reaches it
+            # without dragging runtime resolution into a unit test.
+            decision=AgentRunApprovalDecision.DENY,
+        )
+
+        assert repository.created_runs == 0, "a duplicate run was dispatched"
+        # The answer still has to be written, because it is the thing the parked
+        # bridge is waiting to read.
+        assert any(m.kind == MessageKind.TOOL_RETURN for m in repository.appended)

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_host_prompt_payload.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_host_prompt_payload.py
@@ -83,15 +83,35 @@ def _ctx() -> BaseAgentContext:
     )
 
 
-def _user_prompt(*, carries_history: bool) -> str:
+def _woke_up(sequence: int, tool_call_id: str) -> Message:
+    """The return the wake synthesizes for the snooze it resolved."""
+    return Message(
+        id=uuid7(),
+        conversation_id=CONVERSATION_ID,
+        sequence=sequence,
+        role=MessageRole.TOOL,
+        kind=MessageKind.TOOL_RETURN,
+        tool_name="snooze",
+        tool_call_id=tool_call_id,
+        tool_result={"woke_because": "TIMER", "note_to_self": "check the build"},
+    )
+
+
+def _user_prompt(
+    *,
+    carries_history: bool,
+    messages: list[Message] | None = None,
+    resumed_tool_call_id: str | None = None,
+) -> str:
     payload = run_start_payload(
         agent=_agent(),
         conversation=_conversation(),
-        messages=_transcript(),
+        messages=_transcript() if messages is None else messages,
         ctx=_ctx(),
         agent_run_id=uuid7(),
         runtime_instructions="",
         carries_history=carries_history,
+        resumed_tool_call_id=resumed_tool_call_id,
     )
     return str(payload["prompt"]["user_prompt"])
 
@@ -115,6 +135,45 @@ class TestHistory:
         assert "Which night?" in prompt
         assert "Friday." in prompt
         assert prompt.index("Book me a table") < prompt.index("Friday.")
+
+
+class TestWakingUp:
+    """What a run started by a timer says to an agent that already remembers.
+
+    A woken run adds no user message, so "the latest user message" is the
+    request that started the task — and the provider session already contains
+    it, along with everything the agent did about it. Sending it again does not
+    read as "carry on", it reads as the person asking a second time, and the
+    agent starts the work over.
+    """
+
+    async def test_the_woken_run_is_told_it_woke(self):
+        prompt = _user_prompt(
+            carries_history=False,
+            messages=[*_transcript(), _woke_up(4, "lemma-mcp-1")],
+            resumed_tool_call_id="lemma-mcp-1",
+        )
+
+        assert "TIMER" in prompt
+        assert "check the build" in prompt
+        assert "Friday." not in prompt
+
+    async def test_an_ordinary_turn_still_sends_the_latest_message(self):
+        prompt = _user_prompt(carries_history=False, resumed_tool_call_id=None)
+
+        assert "Friday." in prompt
+
+    async def test_a_resume_whose_return_is_gone_falls_back(self):
+        """History is trimmed by size, so the message may not have survived.
+
+        Re-sending the last user message is a poor prompt but a live one; a run
+        dispatched with no prompt at all is an agent asked to do nothing.
+        """
+        prompt = _user_prompt(
+            carries_history=False, resumed_tool_call_id="lemma-mcp-missing"
+        )
+
+        assert "Friday." in prompt
 
 
 class TestCredentials:

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_tools.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_tools.py
@@ -605,16 +605,29 @@ async def test_request_approval_auto_execute_failure_reports_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_interaction_tools_guide_instead_of_pausing_on_remote_harness():
-    """On remote/MCP runs (no pause signal) the tools never raise or block; they
-    return guidance so the model falls back to a conversational ask."""
+async def test_interaction_tools_park_instead_of_refusing_on_a_remote_harness():
+    """A remote harness waits for the person; it does not fall back to prose.
+
+    These tools never raise here -- raising is caught only by the in-process run
+    loop, and a tool served over MCP cannot end its caller's turn from inside a
+    tool call. So they return a parked id instead, and the host's MCP bridge
+    holds the response open until the decision lands, exactly as it already does
+    for the harness's own native ACP permission requests.
+
+    They used to return guidance telling the model to ask in prose. That lost
+    the interaction card: the choices, the recommended option and the native
+    buttons on Slack/Teams/Telegram all collapsed into a paragraph.
+    """
     ask = await ask_user(
         _ask_ctx(supports_pause_signal=False),  # type: ignore[arg-type]
         _one_question(),
     )
-    assert ask.success is False
-    assert ask.interaction_fallback is True
-    assert "continue this conversation" in (ask.message or "")
+    assert ask.success is True
+    assert ask.interaction_fallback is False
+    assert ask.parked_tool_call_id, ask
+    # The id the bridge polls has to be the durable tool call id the card
+    # resolves through, or the answer would be waited for in the wrong place.
+    assert ask.parked_tool_call_id == "question-call"
 
     approval = await request_approval(
         _approval_ctx("approval-remote", supports_pause_signal=False),  # type: ignore[arg-type]
@@ -622,9 +635,9 @@ async def test_interaction_tools_guide_instead_of_pausing_on_remote_harness():
         args={"cmd": "ls"},
         title="List files?",
     )
-    assert approval.success is False
-    assert approval.interaction_fallback is True
-    assert "can't run a tool with the user's approval" in (approval.message or "")
+    assert approval.success is True
+    assert approval.interaction_fallback is False
+    assert approval.parked_tool_call_id == "approval-remote"
 
 
 @pytest.mark.asyncio

--- a/lemma-backend/app/modules/agent/tests/unit/test_conversation_mcp_service.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_conversation_mcp_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from uuid import uuid4
 
 import pytest
@@ -8,6 +10,7 @@ from pydantic_ai.tools import RunContext
 from pydantic_ai.toolsets import FunctionToolset
 
 from app.modules.agent.domain.entities import Agent, Conversation
+from app.modules.agent.domain.value_objects import AgentToolset
 from app.modules.agent.services.conversation_mcp_service import ConversationMCPService
 from app.modules.agent.tools.context import BaseAgentContext
 
@@ -146,7 +149,157 @@ async def test_conversation_mcp_exposes_todo_tools_when_agent_has_todo(monkeypat
     )
 
     service = ConversationMCPService()
-    names = {tool.name for tool in await service.list_tools(conversation_id=conversation_id)}
+    names = {
+        tool.name for tool in await service.list_tools(conversation_id=conversation_id)
+    }
     assert "lemma_write_todos" in names
     # The todo surface is a single merge-by-text tool now (no status updater).
     assert "lemma_update_todo_status" not in names
+
+
+@pytest.mark.asyncio
+async def test_a_pausing_tool_reaches_a_person_over_mcp(monkeypatch):
+    """End to end through the real `ask_user`, on the real MCP route.
+
+    Every pausing tool addresses itself by ``ctx.tool_call_id``: it is the id an
+    approval card is answered through, the id a decision is recorded against,
+    and the id a snooze's wake writes its return under. Nothing on the MCP wire
+    supplies one — ``tools/call`` carries a name and arguments, and the
+    JSON-RPC id dies with the response — so it arrived as ``None``, and each of
+    those tools has a guard that turns ``None`` into an error. An Agent Host
+    agent asking a question got back "requires a durable tool call id" and the
+    question reached nobody.
+    """
+    recorded: list[dict] = []
+    user_id, pod_id, conversation_id = uuid4(), uuid4(), uuid4()
+    agent_run_id = uuid4()
+    agent = Agent(
+        pod_id=pod_id,
+        user_id=user_id,
+        name="A",
+        instruction="ask me",
+        toolsets=[AgentToolset.USER_INTERACTION],
+    )
+    conversation = Conversation(
+        id=conversation_id, user_id=user_id, pod_id=pod_id, title="t"
+    )
+    # supports_pause_signal is False, as it is for every Agent Host run: this is
+    # the branch that cannot raise its way out of a turn.
+    ctx = BaseAgentContext(
+        user_id=user_id,
+        pod_id=pod_id,
+        conversation_id=conversation_id,
+        agent_run_id=agent_run_id,
+    )
+
+    async def fake_load_agent_context(self, *, conversation_id, agent_run_id):
+        del self, conversation_id, agent_run_id
+        return agent, conversation, ctx
+
+    async def fake_record(uow_factory, **kwargs):
+        del uow_factory
+        recorded.append(kwargs)
+        return "lemma-mcp-deadbeef"
+
+    async def fake_callable_toolsets(self, *, agent, allow_subagents=True):
+        del self, agent, allow_subagents
+        return []
+
+    monkeypatch.setattr(
+        ConversationMCPService, "_load_agent_context", fake_load_agent_context
+    )
+    monkeypatch.setattr(
+        "app.modules.agent.services.conversation_mcp_service.record_pausing_tool_call",
+        fake_record,
+    )
+    monkeypatch.setattr(
+        "app.modules.agent.tools.callable_tool_factory."
+        "AgentCallableToolFactory.build_toolsets",
+        fake_callable_toolsets,
+    )
+
+    result = await ConversationMCPService().call_tool(
+        conversation_id=conversation_id,
+        name="lemma_ask_user",
+        # Flat, because that is the schema the tool advertises: pydantic-ai
+        # unwraps a single request model, so this is the shape a real agent
+        # sends -- and the shape the approval card parses back out of what
+        # gets recorded.
+        arguments={
+            "questions": [
+                {
+                    "question": "Which one?",
+                    "header": "Pick",
+                    "options": [
+                        {"label": "Blue", "description": "the blue one"},
+                        {"label": "Red", "description": "the red one"},
+                    ],
+                }
+            ]
+        },
+        agent_run_id=agent_run_id,
+    )
+
+    answer = json.loads(result.content[0].text)
+    assert answer["parked_tool_call_id"] == "lemma-mcp-deadbeef", answer
+    # Recorded before the tool ran, against the run that made the call, with the
+    # arguments the card is rendered from.
+    assert recorded[0]["tool_name"] == "ask_user"
+    assert recorded[0]["agent_run_id"] == agent_run_id
+    asked = recorded[0]["arguments"]["questions"][0]
+    assert asked["question"] == "Which one?"
+    assert asked["header"] == "Pick"
+
+
+@pytest.mark.asyncio
+async def test_an_ordinary_tool_is_not_put_on_the_record_first(monkeypatch):
+    """Only a call that outlives its own return needs one; the rest would be noise."""
+    recorded: list[dict] = []
+    user_id, pod_id, conversation_id = uuid4(), uuid4(), uuid4()
+    agent = Agent(
+        pod_id=pod_id,
+        user_id=user_id,
+        name="A",
+        instruction="i",
+        toolsets=[AgentToolset.USER_INTERACTION],
+    )
+    conversation = Conversation(
+        id=conversation_id, user_id=user_id, pod_id=pod_id, title="t"
+    )
+    ctx = BaseAgentContext(
+        user_id=user_id, pod_id=pod_id, conversation_id=conversation_id
+    )
+
+    async def fake_load_agent_context(self, *, conversation_id, agent_run_id):
+        del self, conversation_id, agent_run_id
+        return agent, conversation, ctx
+
+    async def fake_record(uow_factory, **kwargs):
+        del uow_factory
+        recorded.append(kwargs)
+        return "lemma-mcp-deadbeef"
+
+    async def fake_callable_toolsets(self, *, agent, allow_subagents=True):
+        del self, agent, allow_subagents
+        return []
+
+    monkeypatch.setattr(
+        ConversationMCPService, "_load_agent_context", fake_load_agent_context
+    )
+    monkeypatch.setattr(
+        "app.modules.agent.services.conversation_mcp_service.record_pausing_tool_call",
+        fake_record,
+    )
+    monkeypatch.setattr(
+        "app.modules.agent.tools.callable_tool_factory."
+        "AgentCallableToolFactory.build_toolsets",
+        fake_callable_toolsets,
+    )
+
+    await ConversationMCPService().call_tool(
+        conversation_id=conversation_id,
+        name="lemma_display_resource",
+        arguments={"request": {"type": "TEXT"}},
+        agent_run_id=uuid4(),
+    )
+    assert recorded == []

--- a/lemma-backend/app/modules/agent/tests/unit/test_polling_idiom_guidance.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_polling_idiom_guidance.py
@@ -73,28 +73,27 @@ def test_an_omitted_chars_still_polls_rather_than_writing_stdin():
     assert "if chars:" in source
 
 
-def test_the_agent_host_prompt_says_pausing_is_unavailable():
-    """The fallbacks degrade well; nothing told the agent they existed.
+def test_the_agent_host_prompt_teaches_both_ways_of_waiting():
+    """All three pausing tools work here now, and they do not work alike.
 
-    `ask_user`, `request_approval` and `snooze` all return
-    `interaction_fallback: true` under Agent Host, because the runtime cannot
-    suspend a turn. Meanwhile the base guidance builds whole workflows on them
-    -- the message_user/snooze/check_messages sequence for reaching a person,
-    "a 403 is your cue to request_approval", "ask_user pauses and resumes with
-    their answer". An agent discovered the mismatch only by calling and failing.
+    They used to return `interaction_fallback: true` and the prompt said so.
+    Then `ask_user`/`request_approval` learned to hold their MCP response open
+    while a person decides, and `snooze` learned to end the turn and be woken --
+    two different contracts, neither of them a fallback. A prompt still
+    describing the old refusal is worse than one saying nothing: an agent that
+    believes asking is unavailable will not ask.
     """
     from app.modules.agent.domain.prompts import load_agent_host_runtime_prompt
 
     prompt = load_agent_host_runtime_prompt()
 
     for tool in ("ask_user", "request_approval", "snooze"):
-        assert tool in prompt, f"{tool} is inert here and goes unmentioned"
-    # And names the mechanism that *does* work, not merely that they fail.
-    # Falling back to prose loses the rendered interaction card, so the
-    # replacement has to be the real waiting contract: end the turn with
-    # `final_answer` at status WAITING and let the reply start a fresh run.
-    assert "final_answer" in prompt
-    assert "WAITING" in prompt
-    # This runtime pauses -- it holds an ACP permission open for half an hour --
-    # so the guidance must not claim it cannot.
+        assert tool in prompt, f"{tool} works here and goes unmentioned"
+    # Nothing may still describe them as refusing, or as unable to pause. Both
+    # sentences were true once and are now the opposite of the behaviour.
+    assert "interaction_fallback" not in prompt
     assert "cannot suspend a turn" not in prompt
+    # The two contracts are different in the one way that changes what the agent
+    # should do, so the prompt has to distinguish them.
+    assert "keep you in this turn" in prompt
+    assert "ends this turn" in prompt

--- a/lemma-backend/app/modules/agent/tests/unit/test_polling_idiom_guidance.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_polling_idiom_guidance.py
@@ -89,5 +89,12 @@ def test_the_agent_host_prompt_says_pausing_is_unavailable():
 
     for tool in ("ask_user", "request_approval", "snooze"):
         assert tool in prompt, f"{tool} is inert here and goes unmentioned"
-    # And says what to do instead, not merely that they fail.
-    assert "end your turn" in prompt
+    # And names the mechanism that *does* work, not merely that they fail.
+    # Falling back to prose loses the rendered interaction card, so the
+    # replacement has to be the real waiting contract: end the turn with
+    # `final_answer` at status WAITING and let the reply start a fresh run.
+    assert "final_answer" in prompt
+    assert "WAITING" in prompt
+    # This runtime pauses -- it holds an ACP permission open for half an hour --
+    # so the guidance must not claim it cannot.
+    assert "cannot suspend a turn" not in prompt

--- a/lemma-backend/app/modules/agent/tests/unit/test_snooze.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_snooze.py
@@ -89,18 +89,6 @@ def test_seconds_is_required():
 
 
 @pytest.mark.asyncio
-async def test_snooze_falls_back_when_the_runtime_cannot_pause():
-    """Remote harnesses own their session; guide the model instead of hanging."""
-    response = await snooze(
-        _ctx(supports_pause_signal=False),
-        SnoozeRequest(reason="waiting", seconds=600),
-    )
-    assert response.success is False
-    assert response.interaction_fallback is True
-    assert "end your turn" in (response.message or "")
-
-
-@pytest.mark.asyncio
 async def test_snooze_refuses_a_pointless_short_sleep():
     """Rejected, not clamped — a 5s ask means the model misread the tool."""
     response = await snooze(
@@ -180,12 +168,26 @@ def suspend_harness(monkeypatch):
         async def commit(self):
             pass
 
+    suspended: list = []
+    poked: list = []
+
+    async def _fake_suspend_remote_run(uow, *, agent_run_id):
+        suspended.append(agent_run_id)
+        return "host-1"
+
+    async def _fake_poke_host(host_id):
+        poked.append(host_id)
+
     monkeypatch.setattr(adapter, "schedule_snooze_wake", _fake_schedule_snooze_wake)
     monkeypatch.setattr(adapter, "AgentConversationWaitRepository", _FakeRepo)
     monkeypatch.setattr(
         adapter, "SessionUnitOfWorkFactory", lambda maker: lambda: _FakeUow()
     )
-    return SimpleNamespace(scheduled=scheduled, created=created)
+    monkeypatch.setattr(adapter, "suspend_remote_run", _fake_suspend_remote_run)
+    monkeypatch.setattr(adapter, "poke_host", _fake_poke_host)
+    return SimpleNamespace(
+        scheduled=scheduled, created=created, suspended=suspended, poked=poked
+    )
 
 
 @pytest.mark.asyncio
@@ -214,6 +216,44 @@ async def test_snooze_schedules_a_timer_and_pauses_the_run(suspend_harness):
     assert wait.status is AgentWaitStatus.ACTIVE
     assert wait.tool_call_id == "tc-1"
     assert wait.spec["note_to_self"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_remote_harness_sleeps_too_and_is_told_to_stop(suspend_harness):
+    """The same wait, ended a different way.
+
+    A remote harness cannot catch a pause raised inside its own MCP tool call,
+    so Lemma asks the host to end the turn. What it must *not* do is what it
+    used to: refuse the sleep and tell the model to give up, which left the one
+    tool for "check back on this in an hour" unavailable to every agent running
+    on somebody's own machine.
+    """
+    ctx = _ctx(supports_pause_signal=False)
+    response = await snooze(ctx, SnoozeRequest(reason="waiting", seconds=600))
+
+    # Armed exactly as it is in-process: same timer, same ACTIVE row, same id.
+    (job,) = suspend_harness.scheduled
+    (wait,) = suspend_harness.created
+    assert str(job["timer_id"]) == wait.external_ref
+    assert wait.status is AgentWaitStatus.ACTIVE
+    assert wait.tool_call_id == "tc-1"
+
+    # The turn is ended by Lemma, not left to the model to end politely.
+    assert suspend_harness.suspended == [ctx.deps.agent_run_id]
+    assert suspend_harness.poked == ["host-1"]
+
+    assert response.success is True
+    assert "Your turn ends here" in (response.message or "")
+
+
+@pytest.mark.asyncio
+async def test_the_in_process_harness_is_never_asked_to_cancel_itself(
+    suspend_harness,
+):
+    """It raises, which the run loop catches; a cancel would race that."""
+    with pytest.raises(AgentInputRequired):
+        await snooze(_ctx(), SnoozeRequest(reason="waiting", seconds=600))
+    assert suspend_harness.suspended == []
 
 
 @pytest.mark.asyncio

--- a/lemma-backend/app/modules/agent/tools/dispatcher.py
+++ b/lemma-backend/app/modules/agent/tools/dispatcher.py
@@ -97,6 +97,7 @@ class AgentToolDispatcher:
         toolsets: list[object] | None = None,
         agent_run_id: UUID | None = None,
         include_final_answer: bool = False,
+        tool_call_id: str | None = None,
     ) -> object:
         async with AsyncExitStack() as exit_stack:
             prepared = await self._prepare(
@@ -111,7 +112,7 @@ class AgentToolDispatcher:
             tool = prepared.get(name)
             if tool is None:
                 raise UnknownToolError(name)
-            tool_ctx = self._tool_call_context(tool, agent_run_id)
+            tool_ctx = self._tool_call_context(tool, agent_run_id, tool_call_id)
             validated = await self._validate_arguments(
                 tool=tool,
                 arguments=arguments or {},
@@ -182,7 +183,19 @@ class AgentToolDispatcher:
         self,
         tool: PreparedTool,
         agent_run_id: UUID | None,
+        tool_call_id: str | None = None,
     ) -> RunContext[Any]:
+        """The context one tool call runs under.
+
+        ``tool_call_id`` is what a tool addresses itself by on the durable
+        record — the id an approval card is resolved through, a widget's
+        content is stored under, and a paused call's return is written to. The
+        in-process run loop fills it in from the model's own tool call. There is
+        no equivalent over MCP: the wire format carries a JSON-RPC request id
+        and nothing that survives the response, so a caller that needs the call
+        to outlive its own return has to put it on the record and pass the id
+        in here.
+        """
         max_retries = tool.tool.max_retries
         if max_retries is None:
             max_retries = _DEFAULT_TOOL_MAX_RETRIES
@@ -191,6 +204,7 @@ class AgentToolDispatcher:
             usage=RunUsage(tool_calls=1),
             retries={tool.name: 0},
             tool_name=tool.name,
+            tool_call_id=tool_call_id,
             retry=0,
             max_retries=max_retries,
             run_id=str(agent_run_id) if agent_run_id is not None else None,

--- a/lemma-backend/app/modules/agent/tools/snooze/models.py
+++ b/lemma-backend/app/modules/agent/tools/snooze/models.py
@@ -57,9 +57,6 @@ class SnoozeResponse(BaseToolResponse):
     note_to_self: str | None = Field(
         default=None, description="Whatever you passed in note_to_self."
     )
-    # Set when a runtime cannot pause. Mirrors ask_user's contract so the model
-    # gets guidance instead of a dead end.
-    interaction_fallback: bool = False
 
 
 # The two messages the model can wake to. TIMER leans on what it does *not* say:

--- a/lemma-backend/app/modules/agent/tools/snooze/pydantic_adapter.py
+++ b/lemma-backend/app/modules/agent/tools/snooze/pydantic_adapter.py
@@ -1,10 +1,15 @@
 """Snooze toolset: let an agent suspend its own turn and wake later.
 
-Reuses the pause `ask_user` and `request_approval` already have — raise
-``AgentInputRequired``, the harness ends the run cleanly, the conversation goes
-WAITING, and resolving the pending tool call starts a fresh run that replays the
-synthesized return from history. The only new thing here is *who resolves it*: a
-scheduler timer rather than a person.
+Reuses the pause `ask_user` and `request_approval` already have — the run ends
+cleanly, the conversation goes WAITING, and resolving the pending tool call
+starts a fresh run that replays the synthesized return from history. The only
+new thing here is *who resolves it*: a scheduler timer rather than a person.
+
+Ending the run is the one step that is not the same everywhere. The in-process
+harness suspends from the inside, by catching ``AgentInputRequired``. A remote
+harness owns its own session, so nothing raised inside an MCP tool call reaches
+it — there, Lemma asks the host to stop the turn instead. Everything before that
+point, and everything after it, is identical; see ``services/run_suspension``.
 """
 
 from __future__ import annotations
@@ -18,10 +23,13 @@ from app.composition.agent_snooze_scheduler import schedule_snooze_wake
 from app.core.infrastructure.db.session import async_session_maker
 from app.core.infrastructure.db.uow_factory import SessionUnitOfWorkFactory
 from app.core.log.log import get_logger
+from app.modules.agent.domain.pausing_tools import SNOOZE_TOOL_NAME
 from app.modules.agent.domain.wait import AgentConversationWaitEntity, AgentWaitType
+from app.modules.agent.infrastructure.agent_host_channels import poke_host
 from app.modules.agent.infrastructure.wait_repository import (
     AgentConversationWaitRepository,
 )
+from app.modules.agent.services.run_suspension import suspend_remote_run
 from app.modules.agent.tools.context import BaseAgentContext
 from app.modules.agent.tools.snooze.models import (
     MAX_SNOOZE_SECONDS,
@@ -32,8 +40,6 @@ from app.modules.agent.tools.snooze.models import (
 from app.modules.agent.tools.tool_errors import AgentInputRequired
 
 logger = get_logger(__name__)
-
-SNOOZE_TOOL_NAME = "snooze"
 
 
 async def snooze(
@@ -69,19 +75,6 @@ async def snooze(
     if deps.pod_id is None:
         return SnoozeResponse(
             success=False, error="snooze is only available inside a pod."
-        )
-    if not getattr(deps, "supports_pause_signal", False):
-        # Remote harnesses (Codex / Claude Code / OpenCode) run tools over MCP and
-        # own their session, so the run cannot pause mid tool-call. Same contract
-        # as ask_user: tell the model rather than hanging.
-        return SnoozeResponse(
-            success=False,
-            interaction_fallback=True,
-            message=(
-                "This runtime can't suspend a turn. Do what you can now and end "
-                "your turn, telling the user what you're waiting for and asking "
-                "them to prompt you again when it happens."
-            ),
         )
     if not ctx.tool_call_id:
         return SnoozeResponse(
@@ -125,9 +118,19 @@ async def snooze(
             "started_at": now.isoformat(),
         },
     )
+    suspends_itself = bool(getattr(deps, "supports_pause_signal", False))
     async with SessionUnitOfWorkFactory(async_session_maker)() as uow:
         await AgentConversationWaitRepository(uow).create(wait)
+        # One transaction, because a run asked to stop with no wait row to wake
+        # it is an agent that goes to sleep forever.
+        host_to_poke = (
+            None
+            if suspends_itself
+            else await suspend_remote_run(uow, agent_run_id=deps.agent_run_id)
+        )
         await uow.commit()
+    if host_to_poke is not None:
+        await poke_host(host_to_poke)
 
     logger.debug(
         "agent.snooze.suspended",
@@ -135,9 +138,24 @@ async def snooze(
         wait_type=wait.wait_type.value,
     )
 
-    # Ends the run cleanly (conversation -> WAITING). The wake path synthesizes
-    # this call's return and starts a fresh run that replays it.
-    raise AgentInputRequired(ctx.tool_call_id, SNOOZE_TOOL_NAME)
+    if suspends_itself:
+        # Ends the run cleanly (conversation -> WAITING). The wake path
+        # synthesizes this call's return and starts a fresh run that replays it.
+        raise AgentInputRequired(ctx.tool_call_id, SNOOZE_TOOL_NAME)
+
+    # A remote harness reads this and then stops, mid-sentence if that is where
+    # the cancel catches it. Written for a model that may get no further turn to
+    # act on it: it says the sleep is already arranged, so there is nothing left
+    # to do and nothing to confirm.
+    return SnoozeResponse(
+        success=True,
+        note_to_self=request.note_to_self,
+        message=(
+            f"Asleep for {seconds}s. Your turn ends here — stop now, and do not "
+            "call another tool. You wake in this same conversation with a fresh "
+            "prompt telling you the time elapsed."
+        ),
+    )
 
 
 snooze_toolset = FunctionToolset[BaseAgentContext](tools=[snooze])

--- a/lemma-backend/app/modules/agent/tools/user_interaction/models.py
+++ b/lemma-backend/app/modules/agent/tools/user_interaction/models.py
@@ -205,6 +205,15 @@ class RequestApprovalResponse(BaseToolResponse):
             "for confirmation conversationally instead."
         ),
     )
+    parked_tool_call_id: str | None = Field(
+        default=None,
+        description=(
+            "Set when the decision is not in yet and the caller must wait for "
+            "it. The Agent Host MCP bridge holds the tool response open and "
+            "polls this id until the person decides, so the model sits inside "
+            "its turn exactly as it does for its own native approvals."
+        ),
+    )
 
 
 class AskUserOption(BaseModel):
@@ -251,5 +260,14 @@ class AskUserResponse(BaseToolResponse):
             "True when a remote harness runtime could not pause and the model must "
             "ask "
             "the question conversationally instead."
+        ),
+    )
+    parked_tool_call_id: str | None = Field(
+        default=None,
+        description=(
+            "Set when the answer is not ready yet and the caller must wait for "
+            "it. The Agent Host MCP bridge holds the tool response open and "
+            "polls this id until the person decides, so the model sits inside "
+            "its turn exactly as it does for its own native approvals."
         ),
     )

--- a/lemma-backend/app/modules/agent/tools/user_interaction/pydantic_adapter.py
+++ b/lemma-backend/app/modules/agent/tools/user_interaction/pydantic_adapter.py
@@ -200,15 +200,23 @@ async def request_approval(
         # Remote harnesses (Codex/Claude-Code/OpenCode) run tools over MCP and own
         # their session, so the run can't pause mid tool-call. Guide the model to
         # the conversational fallback instead of hanging or aborting the run.
+        # Parked rather than refused -- see the note on `ask_user` below. The
+        # decision reaches this call through the same approvals endpoint every
+        # other surface already resolves, and the bridge waits for it.
+        if not ctx.tool_call_id:
+            return RequestApprovalResponse(
+                success=False,
+                error="request_approval requires a durable tool call id.",
+            )
+        auto_approved = await _run_if_exact_match_already_approved(
+            deps=deps, tool_name=tool_name, args=args
+        )
+        if auto_approved is not None:
+            return auto_approved
         return RequestApprovalResponse(
-            success=False,
-            interaction_fallback=True,
-            message=(
-                "This runtime can't run a tool with the user's approval mid-turn. "
-                f"Explain what you need to do ({tool_name}) and why it needs their "
-                "authority, ask the user to confirm or run it themselves, and "
-                "continue once they reply."
-            ),
+            success=True,
+            parked_tool_call_id=ctx.tool_call_id,
+            message=f"Waiting for the user's decision on {tool_name}.",
         )
     # Email surfaces are non-interactive — they can't pause for an approve/deny
     # reply, and pausing would strand the run in WAITING with nothing delivered.
@@ -347,14 +355,25 @@ async def ask_user(
         # Remote harnesses (Codex/Claude-Code/OpenCode) run tools over MCP and own
         # their session, so the run can't pause mid tool-call to collect answers.
         # Guide the model to ask conversationally instead of hanging/aborting.
+        # Parked, not refused. A remote harness reaches this tool over MCP and
+        # cannot end its own turn from inside a tool call -- but it does not
+        # need to. Its bridge holds the MCP response open and waits, which is
+        # exactly what the host already does for its own native ACP permission
+        # requests, so the model sits inside its turn and the person answers on
+        # whichever surface they are already using.
+        #
+        # Falling back to prose was worse than it looked: the questions stopped
+        # rendering as an interaction card, so the choices, the recommended
+        # option and the native buttons on Slack/Teams/Telegram all became a
+        # paragraph the person had to read and answer in their own words.
+        if not ctx.tool_call_id:
+            return AskUserResponse(
+                success=False, error="ask_user requires a durable tool call id."
+            )
         return AskUserResponse(
-            success=False,
-            interaction_fallback=True,
-            message=(
-                "This runtime can't pause to collect a multiple-choice answer. Ask "
-                "the user your question(s) directly in your reply and end your turn; "
-                "their next message will continue this conversation with the answer."
-            ),
+            success=True,
+            parked_tool_call_id=ctx.tool_call_id,
+            message="Waiting for the user's answer.",
         )
     # Email surfaces are non-interactive — they can't pause for an answer, and
     # pausing would strand the run in WAITING with nothing delivered. Fail fast so


### PR DESCRIPTION
## What changes

Every way a Lemma agent waits now works on Agent Host, the same way it works on
the in-process agent.

| tool | before | now |
|---|---|---|
| `ask_user` | prose: "ask in your reply instead" | the model **stays in its turn** while the person decides, and gets their actual answer as the tool's return |
| `request_approval` | prose: "ask them to confirm or run it themselves" | same — a real approval card, resolved through the same endpoint as everywhere else |
| `snooze` | prose: "ask them to prompt you again" | the turn **ends**, a timer wakes it, and the agent carries on where it slept |

They all returned `interaction_fallback: true` before, with prose telling the
model to give up and describe what it wanted.

## Why the fallback was worse than it looked

`ask_user` and `request_approval` **render as interaction cards** — the choices,
the recommended option, native buttons on Slack/Teams/Telegram. Prose collapses
that into a paragraph a person has to answer in their own words.

`snooze` has no substitute at all. It is the only way an agent comes back later,
and `messaging.md` teaches a three-step sequence for reaching a colleague whose
middle step is exactly this. On Agent Host that sequence could not be followed.

And the stated reason was wrong. The prompt said *"This runtime cannot suspend a
turn and resume it later."* The host already holds an ACP permission request open
for **30 minutes** while a person decides. What a tool served over MCP genuinely
cannot do is end its caller's turn from *inside* a tool call —
`AgentInputRequired` is caught by the in-process run loop and nothing else. So
each tool moves the waiting to somewhere it can happen.

## Two shapes, because they are two different acts

**A person is right there** → the bridge waits.

```
Claude → host's mcp-bridge → Lemma: lemma_request_approval
                                      ↓ records the call (this is the card)
                                      ← {parked_tool_call_id}
         bridge holds the MCP response open, polling
                                      ← decision (answered on web/Slack/Teams)
Claude ← the person's answer, as the tool's return
```

**Nobody is there** → the run ends and a timer restarts it. Holding a bridge open
for a 24-hour sleep would be wrong; a suspended run costs nothing.

```
Claude → lemma_snooze          Lemma: arms the timer, writes the wait row,
                                      and queues CANCEL_RUN for the host
       ← "asleep, your turn ends here"
         host stops the turn  Lemma: reads the wait row → run WAITING
         ...
         timer fires          Lemma: synthesizes the return, starts a fresh run
Claude ← woken in its own provider session, prompted with what it woke to
```

## The bug underneath all of it

`ctx.tool_call_id` is **`None` for every tool served over MCP**. `tools/call`
carries a name and arguments; the JSON-RPC id dies with the response. Each of
these tools guards on that id and turns `None` into an error — so the parking in
the first four commits *never engaged in production*. An agent asking a question
got back `"ask_user requires a durable tool call id"`.

Its real-agent test passed because the stand-in on the other end always supplied
an id. Correct about the bridge; silent about the half that feeds it.

Using the harness's own id is not available: the adapter announces a call and
invokes it in the same breath, so whether the announcement (over the run's event
stream, through a normalizer that deliberately *holds* calls whose arguments are
still streaming) or the tool call (over HTTP) reaches Lemma first is not something
either side decides. And no approval endpoint, timer or resume can address the
harness's namespace anyway.

So Lemma records the call itself, exactly as it does in-process, and the
harness's duplicate is dropped — otherwise the same question appears twice, once
on a card whose buttons resolve nothing.

## What a woken agent is told

A resumed run sends only the latest user message, because the provider session
holds the rest. A woken run has no latest user message — nobody typed anything, a
timer fired — so that resolved to **the request that started the task**, and an
agent whose session already contains it does not read a second copy as "carry
on". It reads it as the person asking again, and does the work twice.

It now carries the one thing the session has not seen: the synthesized snooze
return.

## Verification

Every fix mutation-checked — revert it, confirm a test fails, restore.

**Two mutations earned their keep.** Deleting the line that wires the parked-frame
helpers into the bridge loop failed *nothing* (fixed: the E2E drives the real
`mcp-bridge` subprocess). And leaving a rejected `snooze(5)` open on the record
silently holds shut the wake of the *real* snooze after it — an agent asleep
forever, with nothing reporting a failure anywhere.

**Real Claude Code, not asserted:**

- `claude-code: LEMMA_REAL_PARKED_TOOL_OK` — called the tool, waited through two
  withheld polls, used the answer.
- `claude-code: LEMMA_REAL_WAKE_OK` — woke in its own session, named what it had
  been waiting for (a subject the wake prompt never mentions), and declined to
  assume it had happened: *"Timer elapsed only — I still need to check whether
  the Fenwick deployment actually finished."*

```bash
cd lemma-backend && uv run pytest -m "not e2e" -q                  # 5047 passed
uv run pytest app/modules/agent/tests/e2e/test_agent_host_seam_e2e.py -q
cd ../desktop && cargo test -p lemma-agent-host                    # workspace green
cd .. && make quality                                              # ✓
```

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

**No protocol change.** Snooze ends the turn with the ordinary `CANCEL_RUN` that
every deployed host already implements; only the *reason* is new, and the reason
is Lemma's to know. The host reports `CANCELLED` or `SUCCEEDED` depending on
whether the stop or the model got there first — a race — so neither is read
literally. The durable wait row is what actually happened.

A genuine failure stays a failure: a wait row does not make a context ceiling
untrue, and the timer still wakes the conversation either way.

The await route is deliberately **not** an MCP tool: the model must not see it or
call it. Waiting is the bridge's job, and a pollable tool would invite the model
to spin instead of sitting still.

`SnoozeResponse.interaction_fallback` is removed — it meant "set when a runtime
cannot pause", and none does.

Plain revert; nothing is stateful.
