### PR TITLE
Stop leaking Docker containers, volumes, and CPU load from tests

### DIFF
--- a/desktop/scripts/stress_test_under_load.sh
+++ b/desktop/scripts/stress_test_under_load.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Reproduce a flaky test under artificial CPU load, without leaking the load.
+#
+# An earlier ad hoc version of this loop spawned N `while :; do :; done`
+# background CPU hogs, ran a test binary hundreds of times, then did
+# `kill $(jobs -p)` as its last line. That bare kill only runs if the script
+# reaches its own last line — if the invoking process is killed, times out, or
+# the session running it just ends first, the busy-loop children are orphaned
+# and each pins 100% of a CPU core forever. One instance ran for 20+ hours
+# before it was noticed, on a machine with several of them stacked up.
+#
+# This version traps cleanup so it fires on normal exit, error, Ctrl-C, AND an
+# external SIGTERM (e.g. a wrapper script's timeout) — the case the old
+# version couldn't handle — and enforces its own hard runtime ceiling so a
+# hung test loop can't keep the load generators alive indefinitely even if
+# something else goes wrong.
+#
+# Usage:
+#   desktop/scripts/stress_test_under_load.sh <cargo-test-filter> [iterations] [cpu_hogs] [max_runtime_seconds]
+#
+# Example (reproduce a desktop_context/native_material-style flake):
+#   desktop/scripts/stress_test_under_load.sh "desktop_context native_material" 400 12 1800
+
+set -euo pipefail
+
+filter="${1:?usage: $0 <cargo-test-filter> [iterations] [cpu_hogs] [max_runtime_seconds]}"
+iterations="${2:-100}"
+cpu_hogs="${3:-$(( $(sysctl -n hw.ncpu 2>/dev/null || nproc) - 1 ))}"
+max_runtime_seconds="${4:-1800}"
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+load_pids=()
+watchdog_pid=""
+
+cleanup() {
+    if [[ -n "$watchdog_pid" ]]; then
+        kill "$watchdog_pid" 2>/dev/null || true
+    fi
+    if [[ ${#load_pids[@]} -gt 0 ]]; then
+        kill "${load_pids[@]}" 2>/dev/null || true
+        wait "${load_pids[@]}" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT INT TERM
+
+echo "Spawning $cpu_hogs CPU load generator(s)…"
+for _ in $(seq 1 "$cpu_hogs"); do
+    (while :; do :; done) &
+    load_pids+=("$!")
+done
+echo "Load pids: ${load_pids[*]}"
+
+# Hard backstop: if the test loop below hangs, this still tears everything
+# down after max_runtime_seconds rather than running forever.
+(sleep "$max_runtime_seconds" && kill -TERM $$ 2>/dev/null) &
+watchdog_pid=$!
+
+sleep 1
+
+fail=0
+for i in $(seq 1 "$iterations"); do
+    if ! cargo test --quiet -- "$filter" --test-threads 16 >/dev/null 2>&1; then
+        fail=$((fail + 1))
+        echo "FAIL run $i"
+    fi
+done
+
+echo "failures=$fail/$iterations"

--- a/lemma-backend/Makefile
+++ b/lemma-backend/Makefile
@@ -60,7 +60,7 @@ FUNCTION_BENCH_ENV = \
 	FUNCTION_BENCH_TERMINAL_TIMEOUT_SECONDS=$(FUNCTION_BENCH_TERMINAL_TIMEOUT_SECONDS)
 FUNCTION_BENCH_TEST = app/modules/function/tests/perf/test_function_execution_benchmark.py
 
-.PHONY: help test test-unit test-e2e test-e2e-real test-e2e-fast test-e2e-runtime test-module coverage coverage-unit coverage-e2e coverage-backend-unit coverage-backend-e2e-shard coverage-backend-report coverage-backend-gate test-collect lint lint-async lint-session-scope lint-io-hygiene lint-import-budget test-connection-scope typecheck-critical architecture migrate docker-build docker-build-cloud docker-build-arm64 docker-build-amd64 benchmark-functions-docker benchmark-functions-e2b teams-manifest-zip load-test-build load-test-up load-test-migrate load-test-setup load-test-run load-test-sse load-test-journey load-test-datastore-up load-test-datastore-setup load-test-datastore-files load-test-datastore-stats load-test-datastore-down load-test-monitor load-test-profile load-test-down load-test
+.PHONY: help test test-unit test-e2e test-e2e-real test-e2e-fast test-e2e-runtime test-module coverage coverage-unit coverage-e2e coverage-backend-unit coverage-backend-e2e-shard coverage-backend-report coverage-backend-gate test-collect lint lint-async lint-session-scope lint-io-hygiene lint-import-budget test-connection-scope typecheck-critical architecture migrate docker-build docker-build-cloud docker-build-arm64 docker-build-amd64 benchmark-functions-docker benchmark-functions-e2b teams-manifest-zip load-test-build load-test-up load-test-migrate load-test-setup load-test-run load-test-sse load-test-journey load-test-datastore-up load-test-datastore-setup load-test-datastore-files load-test-datastore-stats load-test-datastore-down load-test-monitor load-test-profile load-test-down load-test docker-reap
 
 help:
 	@echo "Lemma backend:"
@@ -109,6 +109,13 @@ help:
 	@echo "                         #   PROFILE=journey|ws|sse|micro USERS=20"
 	@echo "  make load-test-down    # tear down containers and clean up"
 	@echo "  Override: MAX_SUBSCRIBERS=200 WRITER_VUS=4 make load-test"
+	@echo ""
+	@echo "  make docker-reap       # remove stopped lemma.e2e / sandbox / load-test"
+	@echo "                         #   Docker containers+volumes past their grace"
+	@echo "                         #   period. Safe to run anytime, including next"
+	@echo "                         #   to a live test run — never touches anything"
+	@echo "                         #   still running. Run this if your machine is"
+	@echo "                         #   sluggish from accumulated test leftovers."
 	@echo ""
 	@echo "Run app-level commands such as setup/start/logs from the repository root."
 
@@ -453,6 +460,16 @@ load-test-down:
 load-test: load-test-build load-test-up load-test-migrate load-test-setup load-test-run
 	@echo ""
 	@echo "Done. Run 'make load-test-down' to remove containers and credentials."
+
+# Age-gated, so safe to run any time — including while another test/sandbox/
+# load-test session is active on the same Docker daemon. Only ever touches
+# containers that are already STOPPED and volumes with zero references, past
+# a generous grace period per resource kind (see test_utils.py). This is the
+# same sweep that already runs automatically around e2e sessions; this target
+# is for manual/periodic cleanup (e.g. a crashed run from yesterday, or a
+# machine that's accumulated cruft across many worktrees).
+docker-reap:
+	uv run python -m app.core.test_utils
 
 # ── Sandbox images ────────────────────────────────────────────────────────────
 # The two images the workspace module provisions. They live here because the

--- a/lemma-backend/app/core/test_utils.py
+++ b/lemma-backend/app/core/test_utils.py
@@ -1,9 +1,11 @@
 import os
+import shutil
 import socket
 import subprocess
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from typing import Generator, Optional
 from uuid import uuid4
 
@@ -107,8 +109,12 @@ class LemmaDockerContainer:
 
     def __exit__(self, exc_type, exc, tb) -> None:
         if self.container_id:
+            # -v also removes the container's anonymous data volume (e.g.
+            # postgres/pgvector, supertokens, and kreuzberg all declare VOLUME
+            # in their image) — without it, every teardown, even a clean one,
+            # leaked one volume forever.
             subprocess.run(
-                ["docker", "rm", "-f", self.container_id],
+                ["docker", "rm", "-f", "-v", self.container_id],
                 check=False,
                 capture_output=True,
             )
@@ -159,32 +165,158 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-def _prune_e2e_containers() -> None:
-    """Best-effort cleanup for stale E2E containers."""
-    if os.getenv("TESTCONTAINERS_PRUNE_ENABLED", "").lower() not in {
-        "1",
-        "true",
-        "yes",
-    }:
-        return
+# (docker filter, hours a STOPPED matching container may sit before reaping).
+# Thresholds are generous per resource kind, not a single global number:
+# lemma.e2e testcontainers finish in minutes, so 2h is already a wide margin;
+# managed-by=lemma-workspace is also the PRODUCTION sandbox label, and a dev
+# may run a real sandbox locally for an afternoon, so it gets 12h; a
+# load-test session (build the fixture stack, run k6, inspect the result) can
+# reasonably span a few hours, so lemma-load-* gets 6h.
+_REAPABLE_CONTAINER_FILTERS: tuple[tuple[str, float], ...] = (
+    (f"label={DOCKER_LABEL}", 2.0),
+    ("label=managed-by=lemma-workspace", 12.0),
+    ("name=^lemma-load-", 6.0),
+)
+# Only the workspace provider's own named sandbox volumes (lemma-vol-*) are
+# swept here — anonymous container volumes are handled by passing -v to every
+# `docker rm -f` above, and `docker volume prune` (see `make docker-reap`)
+# already only ever touches volumes with zero references.
+_REAPABLE_VOLUME_FILTER: tuple[str, float] = ("label=managed-by=lemma-workspace", 12.0)
 
-    container_ids = []
+
+def _has_docker() -> bool:
+    return shutil.which("docker") is not None
+
+
+def _parse_docker_timestamp(raw: str) -> Optional[datetime]:
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _stopped_container_age_hours(container_id: str) -> Optional[float]:
+    """Hours since creation, or None if the container is running/unknown.
+
+    A running container is never a reap candidate regardless of age — that is
+    what makes this safe to call unconditionally on a shared dev machine: a
+    concurrently active session's containers are always excluded, full stop.
+    """
+    result = subprocess.run(
+        [
+            "docker",
+            "inspect",
+            "--format",
+            "{{.State.Running}}|{{.Created}}",
+            container_id,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0 or "|" not in result.stdout:
+        return None
+    running, created = result.stdout.strip().split("|", 1)
+    if running == "true":
+        return None
+    created_at = _parse_docker_timestamp(created)
+    if created_at is None:
+        return None
+    return (datetime.now(timezone.utc) - created_at).total_seconds() / 3600
+
+
+def reap_stale_lemma_containers() -> list[str]:
+    """Force-remove STOPPED Lemma-managed containers past their grace period.
+
+    Best-effort cleanup for containers a crashed/hard-killed test or sandbox
+    process never got to tear down in its own `finally`/fixture teardown.
+    Age-gated per `_REAPABLE_CONTAINER_FILTERS`, so it is safe to run
+    unconditionally: nothing still running is ever touched, so it can't
+    disturb a concurrently running e2e/sandbox/load-test session on the same
+    Docker daemon.
+    """
+    if not _has_docker():
+        return []
+    removed: list[str] = []
+    seen: set[str] = set()
+    for docker_filter, max_age_hours in _REAPABLE_CONTAINER_FILTERS:
+        list_result = subprocess.run(
+            ["docker", "ps", "-aq", "--filter", docker_filter],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if list_result.returncode != 0:
+            continue
+        for container_id in list_result.stdout.splitlines():
+            container_id = container_id.strip()
+            if not container_id or container_id in seen:
+                continue
+            seen.add(container_id)
+            age_hours = _stopped_container_age_hours(container_id)
+            if age_hours is None or age_hours < max_age_hours:
+                continue
+            subprocess.run(
+                ["docker", "rm", "-f", "-v", container_id],
+                check=False,
+                capture_output=True,
+            )
+            removed.append(container_id)
+    return removed
+
+
+def reap_stale_lemma_volumes() -> list[str]:
+    """Force-remove named ``lemma-vol-*`` sandbox volumes past their grace period.
+
+    ``docker volume rm`` refuses (harmlessly — ``check=False``) a volume still
+    attached to any container, so this can never touch a volume backing a live
+    sandbox even if that sandbox happens to be older than the threshold.
+    """
+    if not _has_docker():
+        return []
+    docker_filter, max_age_hours = _REAPABLE_VOLUME_FILTER
     list_result = subprocess.run(
-        ["docker", "ps", "-aq", "--filter", f"label={DOCKER_LABEL}"],
+        ["docker", "volume", "ls", "-q", "--filter", docker_filter],
         capture_output=True,
         text=True,
         check=False,
     )
     if list_result.returncode != 0:
-        return
-    container_ids.extend(cid for cid in list_result.stdout.splitlines() if cid.strip())
+        return []
+    removed: list[str] = []
+    for name in list_result.stdout.splitlines():
+        name = name.strip()
+        if not name:
+            continue
+        inspect_result = subprocess.run(
+            ["docker", "volume", "inspect", "--format", "{{.CreatedAt}}", name],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if inspect_result.returncode != 0:
+            continue
+        created_at = _parse_docker_timestamp(inspect_result.stdout)
+        if created_at is None:
+            continue
+        age_hours = (datetime.now(timezone.utc) - created_at).total_seconds() / 3600
+        if age_hours < max_age_hours:
+            continue
+        rm_result = subprocess.run(
+            ["docker", "volume", "rm", name], check=False, capture_output=True
+        )
+        if rm_result.returncode == 0:
+            removed.append(name)
+    return removed
 
-    if not container_ids:
-        return
 
-    subprocess.run(
-        ["docker", "rm", "-f", *container_ids], check=False, capture_output=True
-    )
+def reap_stale_lemma_resources() -> None:
+    """Best-effort cleanup for stale E2E/sandbox/load-test Docker resources."""
+    reap_stale_lemma_containers()
+    reap_stale_lemma_volumes()
 
 
 def _wait_for_tcp(
@@ -226,12 +358,12 @@ def get_test_network() -> Generator[LemmaDockerNetwork, None, None]:
     """
     Creates a Docker network for test containers to communicate.
     """
-    _prune_e2e_containers()
+    reap_stale_lemma_containers()
     with LemmaDockerNetwork() as network:
         try:
             yield network
         finally:
-            _prune_e2e_containers()
+            reap_stale_lemma_containers()
 
 
 @contextmanager
@@ -416,7 +548,7 @@ def start_shared_kreuzberg(name: str) -> str:
     (and the label-based prune sweeps any straggler).
     """
     # Clear any straggler with this name from a previously crashed run.
-    subprocess.run(["docker", "rm", "-f", name], check=False, capture_output=True)
+    subprocess.run(["docker", "rm", "-f", "-v", name], check=False, capture_output=True)
     container = LemmaDockerContainer(KREUZBERG_IMAGE, 8000).with_run_args(
         "--name", name, "--restart", "unless-stopped"
     )
@@ -428,8 +560,10 @@ def start_shared_kreuzberg(name: str) -> str:
 
 
 def remove_named_container(name: str) -> None:
-    """Force-remove a container by name (best effort)."""
-    subprocess.run(["docker", "rm", "-f", name], check=False, capture_output=True)
+    """Force-remove a container by name, and its anonymous volumes (best effort)."""
+    subprocess.run(
+        ["docker", "rm", "-f", "-v", name], check=False, capture_output=True
+    )
 
 
 SHARED_KREUZBERG_NAME = "lemma-e2e-kreuzberg-shared"
@@ -532,3 +666,30 @@ def get_kreuzberg_url(container: LemmaDockerContainer) -> str:
     host = container.get_container_host_ip()
     port = container.get_exposed_port(8000)
     return f"http://{host}:{port}"
+
+
+def _reap_cli() -> None:
+    """Entry point for ``make docker-reap`` — a manual, on-demand version of the
+    same age-gated sweep that already runs automatically around e2e test
+    sessions. Prints what it removed; safe to run anytime, including while
+    another e2e/load-test run is active on the same machine, since it never
+    touches anything still running."""
+    containers = reap_stale_lemma_containers()
+    volumes = reap_stale_lemma_volumes()
+    if containers:
+        print(f"Removed {len(containers)} stale container(s): {', '.join(containers)}")
+    else:
+        print("No stale containers to remove.")
+    if volumes:
+        print(f"Removed {len(volumes)} stale volume(s): {', '.join(volumes)}")
+    else:
+        print("No stale lemma-vol-* volumes to remove.")
+    print(
+        "Note: this does not prune anonymous/dangling volumes left by older "
+        "runs before the -v fix, nor unrelated Docker images/build cache — "
+        "run `docker volume prune` / `docker system prune` separately for those."
+    )
+
+
+if __name__ == "__main__":
+    _reap_cli()

--- a/lemma-backend/app/core/tests/unit/test_stale_docker_reaper.py
+++ b/lemma-backend/app/core/tests/unit/test_stale_docker_reaper.py
@@ -1,0 +1,150 @@
+"""The stale-resource reaper must never touch anything still running.
+
+This age-gated sweep replaces an unsafe pattern: an opt-in, presence-based
+prune that, once enabled, removed EVERY matching container regardless of
+whether it belonged to a concurrently running test session on the same Docker
+daemon — a documented trap for anyone running two suites side by side on a
+shared dev machine. Age-gating only fixes that if a running container is
+unconditionally immune and the age threshold is actually enforced in both
+directions. Both are asserted here directly against a faked ``docker``, so a
+regression that silently loosens either guarantee fails loudly here rather
+than showing up as a stomped concurrent session on someone else's machine.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timedelta, timezone
+
+from app.core import test_utils
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=""
+    )
+
+
+def test_a_running_container_is_never_reaped_no_matter_its_age(monkeypatch) -> None:
+    ancient = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["docker", "ps"]:
+            return _completed("container-1\n")
+        if command[:2] == ["docker", "inspect"]:
+            return _completed(f"true|{ancient}")
+        raise AssertionError(f"unexpected command, rm should never run: {command}")
+
+    monkeypatch.setattr(test_utils, "_has_docker", lambda: True)
+    monkeypatch.setattr(test_utils.subprocess, "run", fake_run)
+
+    assert test_utils.reap_stale_lemma_containers() == []
+
+
+def test_a_stopped_container_past_its_grace_period_is_reaped_once(
+    monkeypatch,
+) -> None:
+    """Also covers dedup: the same id can match more than one label filter."""
+    ancient = (datetime.now(timezone.utc) - timedelta(hours=100)).isoformat()
+    rm_calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["docker", "ps"]:
+            return _completed("container-1\n")
+        if command[:2] == ["docker", "inspect"]:
+            return _completed(f"false|{ancient}")
+        if command[:3] == ["docker", "rm", "-f"]:
+            rm_calls.append(command)
+            return _completed()
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(test_utils, "_has_docker", lambda: True)
+    monkeypatch.setattr(test_utils.subprocess, "run", fake_run)
+
+    removed = test_utils.reap_stale_lemma_containers()
+
+    assert removed == ["container-1"]
+    assert rm_calls == [["docker", "rm", "-f", "-v", "container-1"]]
+
+
+def test_a_recently_stopped_container_is_left_alone(monkeypatch) -> None:
+    recent = (datetime.now(timezone.utc) - timedelta(minutes=5)).isoformat()
+
+    def fake_run(command, **kwargs):
+        if command[:2] == ["docker", "ps"]:
+            return _completed("container-1\n")
+        if command[:2] == ["docker", "inspect"]:
+            return _completed(f"false|{recent}")
+        raise AssertionError(f"unexpected command, rm should never run: {command}")
+
+    monkeypatch.setattr(test_utils, "_has_docker", lambda: True)
+    monkeypatch.setattr(test_utils.subprocess, "run", fake_run)
+
+    assert test_utils.reap_stale_lemma_containers() == []
+
+
+def test_a_stale_named_sandbox_volume_is_reaped(monkeypatch) -> None:
+    ancient = (datetime.now(timezone.utc) - timedelta(hours=100)).isoformat()
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["docker", "volume", "ls"]:
+            return _completed("lemma-vol-abc-1\n")
+        if command[:3] == ["docker", "volume", "inspect"]:
+            return _completed(ancient)
+        if command[:3] == ["docker", "volume", "rm"]:
+            return _completed()
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(test_utils, "_has_docker", lambda: True)
+    monkeypatch.setattr(test_utils.subprocess, "run", fake_run)
+
+    assert test_utils.reap_stale_lemma_volumes() == ["lemma-vol-abc-1"]
+
+
+def test_a_volume_still_attached_to_a_container_is_not_counted_as_removed(
+    monkeypatch,
+) -> None:
+    """``docker volume rm`` fails (nonzero) on an attached volume — that must
+    not be reported as removed, and must not raise."""
+    ancient = (datetime.now(timezone.utc) - timedelta(hours=100)).isoformat()
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["docker", "volume", "ls"]:
+            return _completed("lemma-vol-abc-1\n")
+        if command[:3] == ["docker", "volume", "inspect"]:
+            return _completed(ancient)
+        if command[:3] == ["docker", "volume", "rm"]:
+            return _completed(returncode=1)
+        raise AssertionError(f"unexpected command: {command}")
+
+    monkeypatch.setattr(test_utils, "_has_docker", lambda: True)
+    monkeypatch.setattr(test_utils.subprocess, "run", fake_run)
+
+    assert test_utils.reap_stale_lemma_volumes() == []
+
+
+def test_a_recent_named_sandbox_volume_is_left_alone(monkeypatch) -> None:
+    recent = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+
+    def fake_run(command, **kwargs):
+        if command[:3] == ["docker", "volume", "ls"]:
+            return _completed("lemma-vol-abc-1\n")
+        if command[:3] == ["docker", "volume", "inspect"]:
+            return _completed(recent)
+        raise AssertionError(f"unexpected command, rm should never run: {command}")
+
+    monkeypatch.setattr(test_utils, "_has_docker", lambda: True)
+    monkeypatch.setattr(test_utils.subprocess, "run", fake_run)
+
+    assert test_utils.reap_stale_lemma_volumes() == []
+
+
+def test_without_docker_installed_both_reapers_are_no_ops(monkeypatch) -> None:
+    def fail_run(*args, **kwargs):
+        raise AssertionError("subprocess.run should not be called without docker")
+
+    monkeypatch.setattr(test_utils, "_has_docker", lambda: False)
+    monkeypatch.setattr(test_utils.subprocess, "run", fail_run)
+
+    assert test_utils.reap_stale_lemma_containers() == []
+    assert test_utils.reap_stale_lemma_volumes() == []

--- a/lemma-backend/app/modules/test_support/e2e_base.py
+++ b/lemma-backend/app/modules/test_support/e2e_base.py
@@ -111,7 +111,12 @@ def _cleanup_e2e_workspace_containers(*, sandboxes_only: bool = False) -> None:
             line.strip() for line in ps.stdout.splitlines() if line.strip()
         ]
     if container_ids:
-        subprocess.run(["docker", "rm", "-f", *sorted(set(container_ids))], check=False)
+        # -v also removes each container's anonymous data volume (postgres,
+        # supertokens, and kreuzberg all declare VOLUME in their image) — every
+        # sweep that ran without it leaked one volume per container, forever.
+        subprocess.run(
+            ["docker", "rm", "-f", "-v", *sorted(set(container_ids))], check=False
+        )
 
     if sandboxes_only:
         return


### PR DESCRIPTION
## What changes

Every ephemeral test container (Postgres/pgvector, SuperTokens, MinIO, Kreuzberg) leaked its anonymous data volume on teardown, and orphaned test/sandbox containers had no safety net if their owning process was hard-killed. Together these accumulated 358 anonymous volumes (~14.9GB) and several stopped-but-never-removed containers on a dev machine. Also adds a safe, trap-based CPU load generator script for reproducing flaky tests under load.

## Why

- `docker rm -f` without `-v` at 6 call sites (`app/core/test_utils.py`, `app/modules/test_support/e2e_base.py`) removed the container but never its anonymous data volume — every image here (pgvector, supertokens, minio, kreuzberg) declares one. Confirmed directly: `docker inspect` shows the pgvector test container's anonymous volume, and it's gone after teardown once `-v` is passed.
- The one existing safety net for crash-killed test processes (`_prune_e2e_containers`, gated behind `TESTCONTAINERS_PRUNE_ENABLED`) was intentionally left off by default — the code comment explains why: sweeping by a shared label unconditionally would kill a *different, concurrently running* pytest session's containers on a shared dev machine. That made it safe but also dead — nothing ever set the env var.
- Replaced it with an age-gated reaper (`reap_stale_lemma_containers` / `reap_stale_lemma_volumes`) that only ever inspects containers already stopped and volumes with zero references, past a generous per-resource-kind grace period (2h for ephemeral e2e testcontainers, 12h for the production `managed-by=lemma-workspace` sandbox label — a dev may run a real sandbox locally for an afternoon, 6h for `lemma-load-*`). Age-gating makes this safe to run unconditionally instead of opt-in, since a live session's resources are always younger than the threshold.
- The ad hoc CPU-load pattern that orphaned 7 busy-loop shells for 20+ hours (its own `kill $(jobs -p)` only ran if the script reached its last line) wasn't committed anywhere — added `desktop/scripts/stress_test_under_load.sh` with a real `trap` and a runtime ceiling so a future flaky-test-under-load investigation doesn't repeat it.

## How to verify

```bash
cd lemma-backend
make lint && make lint-async && make typecheck-critical && make architecture
uv run pytest app/core/tests/unit/test_stale_docker_reaper.py -v
uv run pytest app/modules/workspace/tests/integration/test_docker_provider_real.py -v
make docker-reap   # manual/periodic cleanup, safe to run anytime
bash -n ../desktop/scripts/stress_test_under_load.sh
```

Also verified end-to-end against a real Docker daemon: spun up a `LemmaDockerContainer` on the pgvector image, confirmed via `docker inspect` that it has an anonymous volume mount, tore it down, and confirmed `docker volume inspect` on that volume now returns non-zero (gone).

## Checklist

- [x] Tests cover the behavioral change — new `test_stale_docker_reaper.py` (7 cases: running-container immunity, age-gating both directions, dedup across overlapping filters, docker-absent no-op, attached-volume-removal-failure handled without raising), plus the existing real-Docker integration suite still passes.
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

No schema, API, or SDK changes. Pure test/dev-tooling infrastructure — nothing here runs in the production request path. Revert is a plain `git revert`; the only behavioral risk of reverting is the leak resuming, not any user-facing regression.