### PR TITLE
Stop timing four guestd tests against a one-second bus

### DIFF
--- a/desktop/local-runtime/guestd/src/lib.rs
+++ b/desktop/local-runtime/guestd/src/lib.rs
@@ -2675,6 +2675,27 @@ mod tests {
         }
     }
 
+    /// A ceiling on a test that hangs, not part of what any test asserts.
+    ///
+    /// These budgets were all one second, which reads as harmless — the work
+    /// they bound takes milliseconds. But they are *wall-clock* deadlines, and
+    /// the suite runs its tests in parallel on a shared CI runner, so a 250ms
+    /// retry sleep or a `printf` can miss a one-second bus. Four tests failed
+    /// at random against deadlines none of them were about; under contention
+    /// one of them was measured taking over seven seconds.
+    ///
+    /// Nothing is slower for it. Each of these tests is driven by a fake that
+    /// answers immediately or a script that exits, so the budget is only ever
+    /// reached when something is already broken.
+    const UNHURRIED_TEST_TIMEOUT_SECS: u64 = 30;
+
+    /// How long the stand-in engine sleeps when a test needs it not to finish.
+    ///
+    /// The timeout test proves the kill landed by returning long before this
+    /// elapses, so its assertion is written against this rather than against a
+    /// second constant that could drift away from it.
+    const FORKING_ENGINE_SLEEP_SECS: u64 = 30;
+
     fn output(success: bool, stdout: &str) -> Output {
         Output {
             status: std::process::ExitStatus::from_raw(if success { 0 } else { 1 }),
@@ -2777,7 +2798,10 @@ mod tests {
         .unwrap();
 
         let value = service
-            .wait_engine_output(&["exec".into(), "lemma-core-postgres".into()], 1)
+            .wait_engine_output(
+                &["exec".into(), "lemma-core-postgres".into()],
+                UNHURRIED_TEST_TIMEOUT_SECS,
+            )
             .unwrap();
 
         assert_eq!(value, "1");
@@ -2805,7 +2829,9 @@ mod tests {
         )
         .unwrap();
 
-        service.ensure_database("lemma_datastore", 1).unwrap();
+        service
+            .ensure_database("lemma_datastore", UNHURRIED_TEST_TIMEOUT_SECS)
+            .unwrap();
 
         let commands = service.engine.commands.lock().unwrap();
         assert_eq!(commands.len(), 3);
@@ -3411,7 +3437,11 @@ mod tests {
         let executable = root.path().join("forking-engine");
         let capture_root = root.path().join("captures");
         fs::create_dir(&capture_root).unwrap();
-        fs::write(&executable, "#!/bin/sh\nsleep 30\n").unwrap();
+        fs::write(
+            &executable,
+            format!("#!/bin/sh\nsleep {FORKING_ENGINE_SLEEP_SECS}\n"),
+        )
+        .unwrap();
         fs::set_permissions(&executable, fs::Permissions::from_mode(0o700)).unwrap();
         let started = Instant::now();
 
@@ -3419,8 +3449,19 @@ mod tests {
             run_bounded_engine_command(&executable, &capture_root, &[], Duration::from_millis(100))
                 .unwrap_err();
 
-        assert!(error.contains("timed out"));
-        assert!(started.elapsed() < Duration::from_secs(2));
+        // Carries the error: the one CI failure this test has produced was this
+        // assertion printing nothing about what it actually got, and it was
+        // neither of the two conditions reproducible under load.
+        assert!(error.contains("timed out"), "{error}");
+        // Well short of the sleep, so returning at all means the kill landed
+        // rather than the script running itself out. Half of it, rather than a
+        // fixed two seconds: the elapsed time also covers spawning, polling and
+        // reaping on a machine running the rest of the suite beside it.
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(FORKING_ENGINE_SLEEP_SECS / 2),
+            "the engine outlived its timeout by {elapsed:?}"
+        );
     }
 
     #[test]
@@ -3432,9 +3473,13 @@ mod tests {
         fs::write(&executable, "#!/bin/sh\nprintf '%s' \"$TMPDIR\"\n").unwrap();
         fs::set_permissions(&executable, fs::Permissions::from_mode(0o700)).unwrap();
 
-        let output =
-            run_bounded_engine_command(&executable, &capture_root, &[], Duration::from_secs(1))
-                .unwrap();
+        let output = run_bounded_engine_command(
+            &executable,
+            &capture_root,
+            &[],
+            Duration::from_secs(UNHURRIED_TEST_TIMEOUT_SECS),
+        )
+        .unwrap();
 
         assert!(output.status.success());
         assert_eq!(


### PR DESCRIPTION
## What changes

Four tests in `lemma-guestd` stop being timed against a one-second wall clock.
Nothing about the daemon changes — this is entirely inside `mod tests`.

## Why

`engine_timeout_kills_the_entire_process_group` failed the **Guest daemon
(Linux)** job on an unrelated PR (#405, run 32169148940). It is not alone: under
load the same module fails in four places, and all four are the same defect.

Each bounds its work with a wall-clock deadline of one second, which reads as
harmless because the work takes milliseconds. But the suite runs its tests in
parallel on a shared runner, so what the deadline actually measures is how much
of the second was left after everything else on the box had its turn. A 250 ms
retry sleep misses it; a `printf` misses it; the two-second bound on a killed
process missed it **by five seconds**.

None of the four assertions is *about* elapsed time:

| test | what it proves | what it was timing |
|---|---|---|
| `database_command_retries_through_postgres_initialization_restart` | a transient engine failure is retried and the retry's answer used | the retry loop's budget |
| `database_provisioning_accepts_an_ambiguous_committed_create` | an ambiguous `createdb` is accepted once a follow-up check confirms it | the retry loop's budget |
| `engine_capture_and_child_tmpdir_use_explicit_writable_storage` | the child's `TMPDIR` lands on writable storage | how fast `printf` runs |
| `engine_timeout_kills_the_entire_process_group` | a hung engine is killed with its whole process group | how fast spawn + poll + reap runs |

So the budgets that are not assertions become one named constant, generous
enough that scheduling cannot exhaust it. The one bound that *is* an assertion
is now written against the sleep it is proving did not end the run, rather than
a number that can drift away from it.

Nothing runs slower. Each of these tests is driven by a fake that answers
immediately or a script that exits, so the budget is only ever reached when
something is already broken.

## The CI failure is not one of the four

Worth being explicit: the assertion CI hit was `error.contains("timed out")`,
and that one **never fired** in any of the 60 loaded runs below. 16,000
write-then-exec cycles on Linux also produced no spawn failure that would
explain it.

Rather than guess at a cause, that assertion now carries the error it got. It
printed nothing at all before, which is why one CI failure produced no
information. The next occurrence will say what happened.

## How to verify

Reproduced first, then fixed — the crate's tests built for Linux and run 60
times on one CPU against sixteen spinning loads.

**Before:** 157 failures across the four assertions, the killed-process bound
measured at **7.1 s** against its two-second limit.

**After:** 0 / 60, under double that load (two containers were competing).

```bash
# Build the test binary for Linux against the real workspace.
docker run --rm -v "$PWD/desktop:/src:ro" -v /tmp/guestd:/out -w /src \
  -e CARGO_TARGET_DIR=/out/target -e CARGO_HOME=/out/cargo \
  rust:1-slim-bookworm cargo test -p lemma-guestd --locked --no-run

# Run it repeatedly on one CPU with sixteen spinners beside it.
docker run --rm --cpus 1 -v /tmp/guestd:/out -w /out rust:1-slim-bookworm bash -c '
  BIN=$(ls /out/target/debug/deps/lemma_guestd-* | grep -v "\.d$" | head -1)
  fails=0
  for i in $(seq 1 60); do
    for j in $(seq 1 16); do (while :; do :; done) & done
    LOAD=$(jobs -p)
    "$BIN" --test-threads 32 >/dev/null 2>&1 || fails=$((fails+1))
    kill $LOAD 2>/dev/null; wait 2>/dev/null
  done
  echo "FAILURES: $fails / 60"'
```

```bash
cd desktop && cargo test -p lemma-guestd --locked   # 27 passed
cargo fmt --all -- --check                          # clean
make desktop-lint                                   # ✓ clippy clean
```

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

## Rollback

Plain revert. Test-only; no runtime behaviour is touched.
