### PR TITLE
Land a new account in a pod that is already talking

### DIFF
--- a/lemma-backend/agent_tool_schemas.json
+++ b/lemma-backend/agent_tool_schemas.json
@@ -2,7 +2,7 @@
   {
     "tool_name": "ask_user",
     "toolset": "USER_INTERACTION",
-    "description": "Ask the user one or more multiple-choice questions and wait for their answers.\n\nUse it for a decision you genuinely cannot infer. Each question carries 2-4\nconcrete options; mark the one you recommend. The run pauses, and answers come\nback in `answers` keyed by each question's `header`.\n\nPrefer this over a prose question whenever the answer is a choice among known\noptions. For free-form input, ask in prose and end your turn. Only ask when it\nchanges what you do next \u2014 otherwise take the obvious default and proceed.",
+    "description": "Ask the user one or more multiple-choice questions and wait for their answers.\n\nUse it for a decision you genuinely cannot infer. Each question carries 2-4\nconcrete options; mark the one you recommend. The run pauses, and answers come\nback in `answers` keyed by each question's `header`.\n\nPrefer this over a prose question whenever the answer is a choice among known\noptions. For free-form input, ask in prose and end your turn. Only ask when it\nchanges what you do next \u2014 otherwise take the obvious default and proceed.\n\n`content` optionally replaces the choice chips with your own inline HTML, for\na question worth showing rather than listing. It does not change the answer\nshape: the widget posts back the same headers and option labels, anything\nelse is rejected, and a client that cannot render it shows the chips. So fill\n`questions` properly either way.",
     "input_schema": {
       "$defs": {
         "AskUserOption": {
@@ -66,6 +66,26 @@
           "items": {
             "$ref": "#/$defs/AskUserQuestion"
           },
+          "type": "array"
+        },
+        "content": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional inline HTML/SVG rendered in place of the default choice chips. No DOCTYPE/<html>/<head>/<body>; same contract as a WIDGET, so load the `lemma-widget` skill before writing one. The widget answers the questions above rather than replacing them: it posts back the same headers and option labels, and anything else is rejected. Always fill `questions` -- a client that cannot render the widget falls back to the chips, and the answer shape is identical either way."
+        },
+        "loading_messages": {
+          "description": "Messages shown while `content` renders.",
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 4,
           "type": "array"
         }
       },

--- a/lemma-backend/app/core/html_document.py
+++ b/lemma-backend/app/core/html_document.py
@@ -37,10 +37,14 @@ _HEIGHT_BRIDGE = """
           "--lemma-widget-chart-5"
         ];
         var post = function () {
+          // No floor here. `min-height` used to sit on html/body, which made the
+          // document always as tall as the frame the host had already sized —
+          // so this measured the host's own guess and a short widget could
+          // never shrink below it. The host clamps the low end; this reports
+          // what the content actually is.
           var h = Math.max(
             document.documentElement.scrollHeight || 0,
-            document.body ? document.body.scrollHeight : 0,
-            240
+            document.body ? document.body.scrollHeight : 0
           );
           parent.postMessage({ type: "lemma-widget-height", height: h }, "*");
         };
@@ -78,7 +82,7 @@ _RESET_STYLES = """
 # blends into the conversation surface. A standalone (promoted) app gets none of
 # this — it owns the full page.
 _EMBED_STYLES = """
-      html, body { min-height: 100%; background: transparent; }
+      html, body { background: transparent; }
       body { padding: 16px; }"""
 
 

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_tools.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_tools.py
@@ -2028,3 +2028,40 @@ def test_unparseable_tool_arguments_are_reported_rather_than_vanishing():
     assert len(return_parts) == 1
     assert return_parts[0].content["success"] is False
     assert "could not be parsed" in return_parts[0].content["error"]
+
+
+@pytest.mark.asyncio
+async def test_ask_user_with_widget_content_still_pauses():
+    """A widget only changes how the question is drawn, never the pause contract:
+    the answer still comes back through the same resume path."""
+    request = _one_question()
+    request.content = "<div id='pick'>Pick one</div>"
+
+    with pytest.raises(AgentInputRequired) as excinfo:
+        await ask_user(_ask_ctx(), request)  # type: ignore[arg-type]
+
+    assert excinfo.value.kind == "ask_user"
+
+
+@pytest.mark.asyncio
+async def test_ask_user_rejects_loading_messages_without_content():
+    request = _one_question()
+    request.loading_messages = ["Drawing the options"]
+
+    result = await ask_user(_ask_ctx(), request)  # type: ignore[arg-type]
+
+    assert result.success is False
+    assert "only valid together with content" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_ask_user_rejects_full_document_content_without_pausing():
+    """Widget content goes through the same fragment rules as display_resource,
+    and a rejection must not strand the run in WAITING."""
+    request = _one_question()
+    request.content = "<!DOCTYPE html><html><body><p>Pick</p></body></html>"
+
+    result = await ask_user(_ask_ctx(), request)  # type: ignore[arg-type]
+
+    assert result.success is False
+    assert "Invalid content" in (result.error or "")

--- a/lemma-backend/app/modules/agent/tools/user_interaction/models.py
+++ b/lemma-backend/app/modules/agent/tools/user_interaction/models.py
@@ -242,6 +242,36 @@ class AskUserRequest(BaseModel):
             "added for the user, so do not add one yourself."
         )
     )
+    content: str | None = Field(
+        default=None,
+        description=(
+            "Optional inline HTML/SVG rendered in place of the default choice "
+            "chips. No DOCTYPE/<html>/<head>/<body>; same contract as a WIDGET, "
+            "so load the `lemma-widget` skill before writing one. The widget "
+            "answers the questions above rather than replacing them: it posts "
+            "back the same headers and option labels, and anything else is "
+            "rejected. Always fill `questions` -- a client that cannot render "
+            "the widget falls back to the chips, and the answer shape is "
+            "identical either way."
+        ),
+    )
+    loading_messages: list[str] = Field(
+        default_factory=list,
+        max_length=4,
+        description="Messages shown while `content` renders.",
+    )
+
+
+def validate_ask_user_payload(request: "AskUserRequest") -> str | None:
+    """Semantic checks the pydantic model cannot express.
+
+    Returned as a string so ``ask_user`` can answer ``success=false`` with a
+    readable reason, the same way ``display_resource`` does, instead of raising
+    a validation error the model has to guess at.
+    """
+    if request.loading_messages and not (request.content and request.content.strip()):
+        return "loading_messages is only valid together with content."
+    return None
 
 
 class AskUserResponse(BaseToolResponse):

--- a/lemma-backend/app/modules/agent/tools/user_interaction/pydantic_adapter.py
+++ b/lemma-backend/app/modules/agent/tools/user_interaction/pydantic_adapter.py
@@ -15,6 +15,7 @@ from app.modules.agent.tools.user_interaction.models import (
     DisplayResourceResponse,
     DisplayResourceType,
     RequestApprovalResponse,
+    validate_ask_user_payload,
     validate_display_payload,
 )
 from app.core.widget_html_validation import validate_widget_html
@@ -332,6 +333,12 @@ async def ask_user(
     Prefer this over a prose question whenever the answer is a choice among known
     options. For free-form input, ask in prose and end your turn. Only ask when it
     changes what you do next — otherwise take the obvious default and proceed.
+
+    `content` optionally replaces the choice chips with your own inline HTML, for
+    a question worth showing rather than listing. It does not change the answer
+    shape: the widget posts back the same headers and option labels, anything
+    else is rejected, and a client that cannot render it shows the chips. So fill
+    `questions` properly either way.
     """
     if not request.questions:
         return AskUserResponse(
@@ -344,6 +351,18 @@ async def ask_user(
                 error=(
                     f"Question {question.header!r} must have between 2 and 4 options."
                 ),
+            )
+
+    payload_error = validate_ask_user_payload(request)
+    if payload_error is not None:
+        return AskUserResponse(success=False, error=payload_error)
+
+    if request.content and request.content.strip():
+        widget_errors = validate_widget_html(request.content)
+        if widget_errors:
+            return AskUserResponse(
+                success=False,
+                error="Invalid content: " + " ".join(widget_errors),
             )
 
     deps = ctx.deps

--- a/lemma-backend/app/modules/identity/api/controllers/organization_controller.py
+++ b/lemma-backend/app/modules/identity/api/controllers/organization_controller.py
@@ -68,6 +68,7 @@ async def create_organization(
     organization = await org_service.create_organization(
         entity=entity,
         owner_user_id=user.id,
+        resolve_name_conflicts=data.resolve_name_conflicts,
     )
     await _sync_org_role_assignment(
         uow,

--- a/lemma-backend/app/modules/identity/api/schemas/organization_schemas.py
+++ b/lemma-backend/app/modules/identity/api/schemas/organization_schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import EmailStr, field_validator
+from pydantic import EmailStr, Field, field_validator
 
 from app.core.api.schemas import BaseSchema
 from app.modules.identity.domain.email import normalize_identity_email
@@ -21,6 +21,15 @@ class OrganizationCreateRequest(BaseSchema):
     slug: str | None = None
     email_domain: str | None = None
     join_policy: OrganizationJoinPolicy = OrganizationJoinPolicy.INVITE_ONLY
+    resolve_name_conflicts: bool = Field(
+        default=False,
+        description=(
+            "Take the next free name instead of conflicting. For a name the "
+            "user did not choose -- onboarding's derived first workspace -- "
+            "where a 409 is a dead end for someone who never typed a name. "
+            "Leave false for a name they typed, so a clash is reported."
+        ),
+    )
 
 
 class OrganizationUpdateRequest(BaseSchema):

--- a/lemma-backend/app/modules/identity/domain/organization_identity.py
+++ b/lemma-backend/app/modules/identity/domain/organization_identity.py
@@ -1,0 +1,108 @@
+"""What identity an organization may claim: its name, its slug, its domain.
+
+Organization names are globally unique. Onboarding used to walk that ladder from
+the browser — up to twenty sequential creates on the critical path of a signup,
+with the workspace renaming itself under the user while they watched — because a
+derived name has no one to arbitrate a collision. This does the walk in one call
+instead.
+
+Kept out of ``organization_service`` deliberately: that file is already over the
+architecture ratchet's size limit, and both of these are the kind of rule worth
+testing without a whole service behind them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+from uuid import UUID, uuid4
+
+from app.modules.identity.domain.email_domains import work_domain_from_email
+from app.modules.identity.domain.errors import (
+    IdentityValidationError,
+    OrganizationConflictError,
+)
+from app.modules.identity.domain.organization_entities import (
+    OrganizationJoinPolicy,
+)
+
+from app.modules.identity.domain.organization_slugs import (
+    normalize_organization_slug,
+)
+
+# How many readable names to try before falling back to one that cannot collide.
+# Small on purpose: past a handful, "Acme 7" is no better a name than a suffixed
+# one, and each rung costs a query.
+READABLE_ATTEMPTS = 5
+
+# Suffixed candidates are 24 bits of hex against a namespace of one organization.
+# Bounded anyway, because an unbounded loop in a signup path is a hang.
+SUFFIXED_ATTEMPTS = 5
+
+IsFree = Callable[[str, str], Awaitable[bool]]
+
+
+class NoAvailableOrganizationName(Exception):
+    """Every candidate was taken. Astronomically unlikely; not silently ignored."""
+
+
+async def resolve_available_identity(
+    base_name: str,
+    *,
+    is_free: IsFree,
+) -> tuple[str, str]:
+    """A ``(name, slug)`` pair no organization holds yet.
+
+    ``is_free`` answers for one candidate pair; the caller owns the lookup so
+    this stays independent of how organizations are stored.
+    """
+    for attempt in range(READABLE_ATTEMPTS):
+        candidate = base_name if attempt == 0 else f"{base_name} {attempt + 1}"
+        slug = normalize_organization_slug("", candidate)
+        if await is_free(candidate, slug):
+            return candidate, slug
+
+    for _ in range(SUFFIXED_ATTEMPTS):
+        candidate = f"{base_name} {uuid4().hex[:6]}"
+        slug = normalize_organization_slug("", candidate)
+        if await is_free(candidate, slug):
+            return candidate, slug
+
+    raise NoAvailableOrganizationName(base_name)
+
+
+async def resolve_email_domain_for_policy(
+    *,
+    owner_email: str,
+    join_policy: OrganizationJoinPolicy,
+    provided_domain: str | None,
+    exclude_org_id: UUID | None,
+    get_email_domain_org: Callable[[str], Awaitable[Any]],
+) -> str | None:
+    """Resolve the domain an org claims, enforcing per-domain uniqueness.
+
+    Only ``EMAIL_DOMAIN`` orgs claim a domain (everyone else stores NULL, so
+    same-domain users can still create their own orgs). Attempting to claim a
+    domain already held by another ``EMAIL_DOMAIN`` org raises a conflict.
+    """
+    if join_policy != OrganizationJoinPolicy.EMAIL_DOMAIN:
+        return None
+
+    owner_domain = work_domain_from_email(owner_email)
+    if owner_domain is None:
+        raise IdentityValidationError(
+            "The EMAIL_DOMAIN join policy requires a work email domain"
+        )
+    if provided_domain:
+        normalized = provided_domain.strip().lower()
+        if normalized != owner_domain:
+            raise IdentityValidationError(
+                "Organization email domain must match the owner's email domain"
+            )
+
+    existing_domain = await get_email_domain_org(owner_domain)
+    if existing_domain and existing_domain.id != exclude_org_id:
+        raise OrganizationConflictError(
+            "This email domain is already taken by another organization"
+        )
+    return owner_domain

--- a/lemma-backend/app/modules/identity/infrastructure/supertokens_auth/override_thirdparty.py
+++ b/lemma-backend/app/modules/identity/infrastructure/supertokens_auth/override_thirdparty.py
@@ -16,6 +16,9 @@ from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
 from app.core.infrastructure.events.message_bus import get_message_bus
 from app.modules.identity.domain.email import normalize_identity_email
 from app.modules.identity.domain.user_entities import UserEntity
+from app.modules.identity.infrastructure.supertokens_auth.provider_profile import (
+    names_from_provider,
+)
 from app.modules.identity.infrastructure.organization_repositories import (
     OrganizationRepository,
 )
@@ -102,10 +105,19 @@ def override_thirdparty_functions(
                             uow, message_bus=message_bus
                         ),
                     )
+                    # The provider just told us who this is. Storing it here is
+                    # what lets the first screen after signup be the product
+                    # rather than a form asking for a name we were handed.
+                    first_name, last_name = names_from_provider(
+                        raw_user_info_from_provider.from_id_token_payload,
+                        raw_user_info_from_provider.from_user_info_api,
+                    )
                     await user_service.create_user(
                         UserEntity(
                             id=UUID(result.user.id),
                             email=normalize_identity_email(result.user.emails[0]),
+                            first_name=first_name,
+                            last_name=last_name,
                             is_verified=is_verified,
                             email_verified_at=(
                                 datetime.now(timezone.utc) if is_verified else None

--- a/lemma-backend/app/modules/identity/infrastructure/supertokens_auth/provider_profile.py
+++ b/lemma-backend/app/modules/identity/infrastructure/supertokens_auth/provider_profile.py
@@ -1,0 +1,69 @@
+"""Names an identity provider already told us, so signup stops asking for them.
+
+Google, Microsoft and the other OIDC providers send the person's name in the
+sign-in payload. Until this module existed it was dropped on the floor and the
+first screen after signup asked for a name the provider had just supplied --
+the single mandatory question on an otherwise automatic path.
+
+Kept pure and separate from the sign-in override so the shapes can be tested
+without standing up SuperTokens.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Long enough for any real name, short enough that a hostile provider payload
+# cannot use the column as storage.
+MAX_NAME_LENGTH = 128
+
+
+def _clean(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = " ".join(value.split())
+    if not cleaned:
+        return None
+    return cleaned[:MAX_NAME_LENGTH]
+
+
+def split_full_name(full_name: str) -> tuple[str | None, str | None]:
+    """First word is the given name, the rest is the family name.
+
+    Wrong for some naming conventions, and deliberately so: the alternative is
+    asking, and the point of this module is to stop asking. The user can correct
+    it in their profile, which no amount of guessing here would beat.
+    """
+    parts = full_name.split()
+    if not parts:
+        return None, None
+    if len(parts) == 1:
+        return _clean(parts[0]), None
+    return _clean(parts[0]), _clean(" ".join(parts[1:]))
+
+
+def names_from_provider(
+    from_id_token_payload: dict[str, Any] | None,
+    from_user_info_api: dict[str, Any] | None,
+) -> tuple[str | None, str | None]:
+    """``(first_name, last_name)`` from an OIDC payload, or ``(None, None)``.
+
+    The id-token payload is preferred over the userinfo response because it is
+    the signed one. Structured claims beat the display name: ``given_name`` and
+    ``family_name`` are what the provider actually knows, while ``name`` is a
+    formatted string we would have to guess our way back out of.
+    """
+    for source in (from_id_token_payload, from_user_info_api):
+        if not isinstance(source, dict):
+            continue
+
+        first = _clean(source.get("given_name"))
+        last = _clean(source.get("family_name"))
+        if first or last:
+            return first, last
+
+        full_name = _clean(source.get("name"))
+        if full_name:
+            return split_full_name(full_name)
+
+    return None, None

--- a/lemma-backend/app/modules/identity/services/organization_service.py
+++ b/lemma-backend/app/modules/identity/services/organization_service.py
@@ -15,6 +15,11 @@ from app.modules.identity.domain.errors import (
     OrganizationNotFoundError,
     UserNotFoundError,
 )
+from app.modules.identity.domain.organization_identity import (
+    NoAvailableOrganizationName,
+    resolve_available_identity,
+    resolve_email_domain_for_policy,
+)
 from app.modules.identity.domain.organization_slugs import normalize_organization_slug
 from app.modules.identity.domain.organization_entities import (
     OrganizationEntity,
@@ -98,71 +103,64 @@ class OrganizationService:
 
         return member
 
-    async def _resolve_email_domain_for_policy(
-        self,
-        *,
-        owner: UserEntity,
-        join_policy: OrganizationJoinPolicy,
-        provided_domain: str | None,
-        exclude_org_id: UUID | None = None,
-    ) -> str | None:
-        """Resolve the domain an org claims, enforcing per-domain uniqueness.
-
-        Only ``EMAIL_DOMAIN`` orgs claim a domain (everyone else stores NULL, so
-        same-domain users can still create their own orgs). Attempting to claim a
-        domain already held by another ``EMAIL_DOMAIN`` org raises a conflict.
-        """
-        if join_policy != OrganizationJoinPolicy.EMAIL_DOMAIN:
-            return None
-
-        owner_domain = work_domain_from_email(str(owner.email))
-        if owner_domain is None:
-            raise IdentityValidationError(
-                "The EMAIL_DOMAIN join policy requires a work email domain"
-            )
-        if provided_domain:
-            normalized = provided_domain.strip().lower()
-            if normalized != owner_domain:
-                raise IdentityValidationError(
-                    "Organization email domain must match the owner's email domain"
-                )
-
-        existing_domain = await self.organization_repository.get_email_domain_org(
-            owner_domain
-        )
-        if existing_domain and existing_domain.id != exclude_org_id:
-            raise OrganizationConflictError(
-                "This email domain is already taken by another organization"
-            )
-        return owner_domain
+    async def _identity_is_free(self, name: str, slug: str) -> bool:
+        if await self.organization_repository.get_by_name(name):
+            return False
+        return await self.organization_repository.get_by_slug(slug) is None
 
     async def create_organization(
-        self, entity: OrganizationEntity, owner_user_id: UUID
+        self,
+        entity: OrganizationEntity,
+        owner_user_id: UUID,
+        *,
+        resolve_name_conflicts: bool = False,
     ) -> OrganizationEntity:
+        """Create an organization owned by ``owner_user_id``.
+
+        ``resolve_name_conflicts`` is for a name the user did not choose -- the
+        one onboarding derives for a first workspace. There, a 409 is a dead end
+        for someone who never typed a name, so the server picks the next free
+        one instead. A name the user *did* type still conflicts loudly: silently
+        creating "Acme 2" for someone who asked for "Acme" would be worse than
+        telling them.
+        """
         owner = await self.user_repository.get(owner_user_id)
         if not owner:
             raise UserNotFoundError()
 
-        existing_name = await self.organization_repository.get_by_name(entity.name)
-        if existing_name:
-            raise OrganizationConflictError(
-                "Organization with this name already exists",
-                code=OrganizationConflictError.NAME_TAKEN,
-            )
+        if resolve_name_conflicts:
+            try:
+                entity.name, entity.slug = await resolve_available_identity(
+                    entity.name, is_free=self._identity_is_free
+                )
+            except NoAvailableOrganizationName as exc:
+                raise OrganizationConflictError(
+                    "Could not find an available organization name",
+                    code=OrganizationConflictError.NAME_TAKEN,
+                ) from exc
+        else:
+            existing_name = await self.organization_repository.get_by_name(entity.name)
+            if existing_name:
+                raise OrganizationConflictError(
+                    "Organization with this name already exists",
+                    code=OrganizationConflictError.NAME_TAKEN,
+                )
 
-        entity.slug = normalize_organization_slug(entity.slug, entity.name)
+            entity.slug = normalize_organization_slug(entity.slug, entity.name)
 
-        existing_slug = await self.organization_repository.get_by_slug(entity.slug)
-        if existing_slug:
-            raise OrganizationConflictError(
-                "Organization slug already exists",
-                code=OrganizationConflictError.SLUG_TAKEN,
-            )
+            existing_slug = await self.organization_repository.get_by_slug(entity.slug)
+            if existing_slug:
+                raise OrganizationConflictError(
+                    "Organization slug already exists",
+                    code=OrganizationConflictError.SLUG_TAKEN,
+                )
 
-        entity.email_domain = await self._resolve_email_domain_for_policy(
-            owner=owner,
+        entity.email_domain = await resolve_email_domain_for_policy(
+            owner_email=str(owner.email),
             join_policy=entity.join_policy,
             provided_domain=entity.email_domain,
+            exclude_org_id=None,
+            get_email_domain_org=self.organization_repository.get_email_domain_org,
         )
 
         organization = await self.organization_repository.create(entity)
@@ -212,11 +210,12 @@ class OrganizationService:
         provided_domain = (
             email_domain if email_domain is not None else organization.email_domain
         )
-        organization.email_domain = await self._resolve_email_domain_for_policy(
-            owner=requester,
+        organization.email_domain = await resolve_email_domain_for_policy(
+            owner_email=str(requester.email),
             join_policy=new_policy,
             provided_domain=provided_domain,
             exclude_org_id=org_id,
+            get_email_domain_org=self.organization_repository.get_email_domain_org,
         )
         organization.join_policy = new_policy
 

--- a/lemma-backend/app/modules/identity/tests/unit/test_organization_service.py
+++ b/lemma-backend/app/modules/identity/tests/unit/test_organization_service.py
@@ -1156,3 +1156,115 @@ async def test_accept_invitation_without_pod_id_does_not_call_pod_port(
 
     pod_membership_port_mock.get_pod_organization_id.assert_not_awaited()
     pod_membership_port_mock.add_member_to_pod.assert_not_awaited()
+
+
+# --- automatic first-organization naming ------------------------------------
+#
+# A name onboarding derived, not one the user typed. A 409 there is a dead end
+# for someone who never chose anything, so the server walks the ladder itself
+# rather than sending the browser round it twenty times.
+
+
+@pytest.mark.asyncio
+async def test_resolving_names_keeps_the_first_choice_when_it_is_free(
+    organization_service: OrganizationService,
+    organization_repository_mock: AsyncMock,
+):
+    organization_repository_mock.get_by_name.return_value = None
+    organization_repository_mock.get_by_slug.return_value = None
+    organization_repository_mock.create.side_effect = lambda entity: entity
+
+    organization = await organization_service.create_organization(
+        OrganizationEntity(name="Acme", slug=""),
+        owner_user_id=uuid4(),
+        resolve_name_conflicts=True,
+    )
+
+    assert organization.name == "Acme"
+    assert organization.slug == "acme"
+
+
+@pytest.mark.asyncio
+async def test_resolving_names_steps_past_a_taken_name(
+    organization_service: OrganizationService,
+    organization_repository_mock: AsyncMock,
+):
+    taken = {"Acme"}
+    organization_repository_mock.get_by_name.side_effect = (
+        lambda name: OrganizationEntity(name=name, slug="x") if name in taken else None
+    )
+    organization_repository_mock.get_by_slug.return_value = None
+    organization_repository_mock.create.side_effect = lambda entity: entity
+
+    organization = await organization_service.create_organization(
+        OrganizationEntity(name="Acme", slug=""),
+        owner_user_id=uuid4(),
+        resolve_name_conflicts=True,
+    )
+
+    assert organization.name == "Acme 2"
+    assert organization.slug == "acme-2"
+
+
+@pytest.mark.asyncio
+async def test_resolving_names_steps_past_a_taken_slug_too(
+    organization_service: OrganizationService,
+    organization_repository_mock: AsyncMock,
+):
+    """A free name whose slug is taken is not a free identity."""
+    organization_repository_mock.get_by_name.return_value = None
+    organization_repository_mock.get_by_slug.side_effect = (
+        lambda slug: OrganizationEntity(name="Other", slug=slug)
+        if slug == "acme"
+        else None
+    )
+    organization_repository_mock.create.side_effect = lambda entity: entity
+
+    organization = await organization_service.create_organization(
+        OrganizationEntity(name="Acme", slug=""),
+        owner_user_id=uuid4(),
+        resolve_name_conflicts=True,
+    )
+
+    assert organization.name == "Acme 2"
+
+
+@pytest.mark.asyncio
+async def test_resolving_names_falls_back_to_a_suffix_it_cannot_lose(
+    organization_service: OrganizationService,
+    organization_repository_mock: AsyncMock,
+):
+    """Every readable rung taken must still not fail a signup."""
+    readable = {"Acme"} | {f"Acme {n}" for n in range(2, 12)}
+    organization_repository_mock.get_by_name.side_effect = (
+        lambda name: OrganizationEntity(name=name, slug="x") if name in readable else None
+    )
+    organization_repository_mock.get_by_slug.return_value = None
+    organization_repository_mock.create.side_effect = lambda entity: entity
+
+    organization = await organization_service.create_organization(
+        OrganizationEntity(name="Acme", slug=""),
+        owner_user_id=uuid4(),
+        resolve_name_conflicts=True,
+    )
+
+    assert organization.name.startswith("Acme ")
+    assert organization.name not in readable
+
+
+@pytest.mark.asyncio
+async def test_a_typed_name_still_conflicts_loudly(
+    organization_service: OrganizationService,
+    organization_repository_mock: AsyncMock,
+):
+    """Silently creating "Acme 2" for someone who asked for "Acme" would be
+    worse than telling them, so the default is unchanged."""
+    organization_repository_mock.get_by_name.return_value = OrganizationEntity(
+        name="Acme", slug="acme"
+    )
+
+    with pytest.raises(OrganizationConflictError):
+        await organization_service.create_organization(
+            OrganizationEntity(name="Acme", slug="acme"),
+            owner_user_id=uuid4(),
+        )

--- a/lemma-backend/app/modules/identity/tests/unit/test_provider_profile.py
+++ b/lemma-backend/app/modules/identity/tests/unit/test_provider_profile.py
@@ -1,0 +1,69 @@
+"""The names an OIDC provider hands us, and the ones it does not."""
+
+from app.modules.identity.infrastructure.supertokens_auth.provider_profile import (
+    MAX_NAME_LENGTH,
+    names_from_provider,
+    split_full_name,
+)
+
+
+def test_prefers_structured_claims_over_the_display_name():
+    first, last = names_from_provider(
+        {"given_name": "Ada", "family_name": "Lovelace", "name": "Countess Ada"},
+        None,
+    )
+    assert (first, last) == ("Ada", "Lovelace")
+
+
+def test_falls_back_to_splitting_the_display_name():
+    assert names_from_provider({"name": "Ada Lovelace"}, None) == ("Ada", "Lovelace")
+
+
+def test_keeps_a_multi_word_family_name_whole():
+    assert split_full_name("Ada van der Lovelace") == ("Ada", "van der Lovelace")
+
+
+def test_a_single_word_name_has_no_family_name():
+    assert names_from_provider({"name": "Prince"}, None) == ("Prince", None)
+
+
+def test_prefers_the_signed_id_token_over_the_userinfo_response():
+    first, last = names_from_provider(
+        {"given_name": "Ada", "family_name": "Lovelace"},
+        {"given_name": "Someone", "family_name": "Else"},
+    )
+    assert (first, last) == ("Ada", "Lovelace")
+
+
+def test_falls_through_to_userinfo_when_the_id_token_carries_no_name():
+    first, last = names_from_provider(
+        {"email": "ada@example.com"},
+        {"given_name": "Ada", "family_name": "Lovelace"},
+    )
+    assert (first, last) == ("Ada", "Lovelace")
+
+
+def test_a_given_name_alone_is_enough_to_stop_asking():
+    assert names_from_provider({"given_name": "Ada"}, None) == ("Ada", None)
+
+
+def test_returns_nothing_when_the_provider_said_nothing():
+    assert names_from_provider(None, None) == (None, None)
+    assert names_from_provider({}, {}) == (None, None)
+    assert names_from_provider({"name": "   "}, None) == (None, None)
+
+
+def test_ignores_non_string_claims_rather_than_coercing_them():
+    assert names_from_provider({"given_name": 42, "family_name": ["x"]}, None) == (
+        None,
+        None,
+    )
+
+
+def test_collapses_whitespace_and_bounds_length():
+    first, last = names_from_provider({"given_name": "  Ada\n\tGrace  "}, None)
+    assert first == "Ada Grace"
+
+    long_first, _ = names_from_provider({"given_name": "A" * 500}, None)
+    assert long_first is not None
+    assert len(long_first) == MAX_NAME_LENGTH

--- a/lemma-cli/lemma_cli/cli_core/commands/surfaces.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/surfaces.py
@@ -306,3 +306,78 @@ def setup_status(
     )
     if result is not None:
         emit(state, result)
+
+
+@app.command("telegram-setup")
+def start_telegram_setup(
+    ctx: typer.Context,
+    pod: str | None = typer.Option(None, "--pod"),
+    name: str | None = typer.Option(
+        None, "--name", help="Pod-unique surface name. Defaults to telegram."
+    ),
+    default_agent_name: str | None = typer.Option(
+        None,
+        "--agent",
+        "--agent-name",
+        help="Agent that answers. Omit to answer as the pod assistant.",
+    ),
+    enabled: bool | None = typer.Option(None, "--enabled/--disabled"),
+    data: str | None = typer.Option(None, "--data", "-d", help="Raw JSON payload."),
+    file: Path | None = typer.Option(
+        None,
+        "--file",
+        "-f",
+        exists=True,
+        dir_okay=False,
+        readable=True,
+    ),
+) -> None:
+    """Start a managed Telegram bot setup and print the link that creates the bot.
+
+    The bot is made inside Telegram: open the returned ``launch_url`` (or show it
+    as a QR), name the bot there, and it binds to this pod on its own -- there is
+    no token to copy back. The surface does not exist until that finishes, so
+    poll ``telegram-setup-status SETUP_ID`` until ``bot_username`` is set.
+
+    Omitting ``--agent`` answers as the pod assistant, which is what lets a brand
+    new pod take Telegram messages before any agent has been created.
+    """
+    state = state_from_ctx(ctx)
+    payload: dict[str, Any] = read_json(data, file, required=False) or {}
+    if name is not None:
+        payload["name"] = name
+    if default_agent_name is not None:
+        payload["default_agent_name"] = default_agent_name
+    if enabled is not None:
+        payload["is_enabled"] = enabled
+    result = run_with_client(
+        ctx,
+        lambda client, s: pod_client(
+            client, s, pod
+        ).surfaces.start_telegram_bot_setup(payload),
+    )
+    if result is not None:
+        emit(state, result)
+
+
+@app.command("telegram-setup-status")
+def telegram_setup_status(
+    ctx: typer.Context,
+    setup_id: str = typer.Argument(..., help="Setup id from `telegram-setup`."),
+    pod: str | None = typer.Option(None, "--pod"),
+) -> None:
+    """Show where a managed Telegram bot setup has got to.
+
+    ``status`` moves while the person is in Telegram; ``bot_username`` and
+    ``surface_id`` are only set once the bot exists and is bound to this pod.
+    ``error`` is set when the setup failed rather than merely being unfinished.
+    """
+    state = state_from_ctx(ctx)
+    result = run_with_client(
+        ctx,
+        lambda client, s: pod_client(client, s, pod).surfaces.get_telegram_bot_setup(
+            setup_id
+        ),
+    )
+    if result is not None:
+        emit(state, result)

--- a/lemma-cli/tests/test_commands_connectors_surfaces.py
+++ b/lemma-cli/tests/test_commands_connectors_surfaces.py
@@ -126,3 +126,113 @@ def test_surfaces_list_json_output(monkeypatch):
     payload = json.loads(result.stdout)
     assert "items" in payload
     assert payload["items"][0]["platform"] == "SLACK"
+
+
+# ---------------------------------------------------------------------------
+# Managed Telegram bot setup
+# ---------------------------------------------------------------------------
+
+def _make_telegram_setup_client_and_captured():
+    captured = {}
+
+    class FakeSurfaces:
+        def start_telegram_bot_setup(self, payload):
+            captured["start_payload"] = payload
+            return {
+                "setup_id": "setup-1",
+                "status": "AWAITING_BOT",
+                "launch_url": "https://t.me/LemmaManagerBot?start=setup-1",
+                "manager_bot_username": "LemmaManagerBot",
+                "expires_at": "2026-08-18T10:00:00Z",
+            }
+
+        def get_telegram_bot_setup(self, setup_id):
+            captured["status_setup_id"] = setup_id
+            return {
+                "setup_id": setup_id,
+                "status": "COMPLETED",
+                "launch_url": "https://t.me/LemmaManagerBot?start=setup-1",
+                "manager_bot_username": "LemmaManagerBot",
+                "expires_at": "2026-08-18T10:00:00Z",
+                "bot_username": "acme_ops_bot",
+            }
+
+    class FakePod:
+        def __init__(self):
+            self.surfaces = FakeSurfaces()
+
+    class FakeClient:
+        def pod(self, pod_id):
+            captured["pod_id"] = pod_id
+            return FakePod()
+
+    return FakeClient(), captured
+
+
+def test_telegram_setup_starts_and_returns_launch_url(monkeypatch):
+    client, captured = _make_telegram_setup_client_and_captured()
+    _patch_surfaces(monkeypatch, client, output="json")
+
+    result = runner.invoke(
+        app, ["--json", "--pod", "pod-1", "surfaces", "telegram-setup"]
+    )
+
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    assert payload["launch_url"].startswith("https://t.me/")
+    assert payload["setup_id"] == "setup-1"
+
+
+def test_telegram_setup_defaults_to_the_pod_assistant(monkeypatch):
+    """No --agent means no `default_agent_name`, which is what binds the surface
+    to the pod assistant instead of requiring an agent to exist first."""
+    client, captured = _make_telegram_setup_client_and_captured()
+    _patch_surfaces(monkeypatch, client, output="json")
+
+    result = runner.invoke(
+        app, ["--json", "--pod", "pod-1", "surfaces", "telegram-setup"]
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert "default_agent_name" not in captured["start_payload"]
+
+
+def test_telegram_setup_forwards_agent_and_name(monkeypatch):
+    client, captured = _make_telegram_setup_client_and_captured()
+    _patch_surfaces(monkeypatch, client, output="json")
+
+    result = runner.invoke(
+        app,
+        [
+            "--json",
+            "--pod",
+            "pod-1",
+            "surfaces",
+            "telegram-setup",
+            "--agent",
+            "ops",
+            "--name",
+            "telegram-ops",
+            "--disabled",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert captured["start_payload"]["default_agent_name"] == "ops"
+    assert captured["start_payload"]["name"] == "telegram-ops"
+    assert captured["start_payload"]["is_enabled"] is False
+
+
+def test_telegram_setup_status_dispatches_setup_id(monkeypatch):
+    client, captured = _make_telegram_setup_client_and_captured()
+    _patch_surfaces(monkeypatch, client, output="json")
+
+    result = runner.invoke(
+        app,
+        ["--json", "--pod", "pod-1", "surfaces", "telegram-setup-status", "setup-1"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert captured["status_setup_id"] == "setup-1"
+    payload = json.loads(result.stdout)
+    assert payload["bot_username"] == "acme_ops_bot"

--- a/lemma-frontend/components/app/app-launch.tsx
+++ b/lemma-frontend/components/app/app-launch.tsx
@@ -13,6 +13,8 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { getLemmaClient } from '@/lib/sdk/lemma-client';
 import { appIndexQueryKey } from '@/lib/hooks/use-app';
 import { buildAppThemeMessage } from '@/lib/app/app-theme';
+import { useProfile } from '@/lib/hooks/use-user';
+import { trackAppOpened } from '@/lib/analytics/onboarding';
 import { resolveWidgetTheme } from '@/lib/assistant/widget-theme';
 import { buildResourceShareUrl } from '@/lib/assistant/conversation-presentation';
 
@@ -44,6 +46,7 @@ export function AppFrame({
     chrome = 'bar',
 }: AppFrameProps) {
     const queryClient = useQueryClient();
+    const { data: profile } = useProfile();
     const { resolvedTheme } = useTheme();
     const iframeRef = useRef<HTMLIFrameElement | null>(null);
     const [frameKey, setFrameKey] = useState(0);
@@ -218,6 +221,11 @@ export function AppFrame({
                     onLoad={() => {
                         setFrameLoaded(true);
                         setFrameFailed(false);
+                        // A rendered app frame is the pod doing work for its
+                        // owner -- the second activation transition. Deduped to
+                        // once per browser, so this stays activation rather than
+                        // becoming an app-usage counter.
+                        trackAppOpened(profile?.created_at ?? null);
                         postAppTheme();
                     }}
                     onError={() => {

--- a/lemma-frontend/components/lemma/assistant/assistant-approval-cards.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-approval-cards.tsx
@@ -5,8 +5,9 @@
 // panel, and the inline call). Consumed by the tool-details panel and the rollup.
 
 import { useCallback, useMemo, useState } from "react";
+import { usePathname } from "next/navigation";
 import { isAskUserToolName, userApprovalResolvedDecision } from "lemma-sdk";
-import { Check, CheckCircle2, MessageCircleQuestion, ShieldAlert, XCircle } from "@/components/ui/icons";
+import { Check, CheckCircle2, ChevronDown, ChevronUp, MessageCircleQuestion, ShieldAlert, XCircle } from "@/components/ui/icons";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -18,6 +19,8 @@ import {
   stringifyAssistantError,
   summarizeToolPayload,
 } from "./assistant-format";
+import { InlineWidget } from "./inline-widget";
+import { podIdFromPathname } from "@/lib/pods/pod-id-from-pathname";
 import type { AssistantToolInvocation } from "lemma-sdk/react";
 import type {
   ToolCardArgs,
@@ -391,6 +394,68 @@ export function parseAskUserQuestions(args: ToolCardArgs): AskUserQuestionDef[] 
     .filter((question) => question.header && question.options.length > 0);
 }
 
+/** The inline widget an ask_user may carry in place of its choice chips. */
+export function parseAskUserWidget(args: ToolCardArgs): {
+  content: string | null;
+  loadingMessages: string[];
+} {
+  const record = args as Record<string, unknown>;
+  const content = asString(record.content) || null;
+  const raw = record.loading_messages;
+  const loadingMessages = Array.isArray(raw)
+    ? raw.map((entry) => asString(entry) || "").filter(Boolean).slice(0, 4)
+    : [];
+  return { content: content && content.trim() ? content : null, loadingMessages };
+}
+
+// A person typing into the chips' "Other" box is bounded by patience; a widget
+// is not, so free text gets an explicit ceiling rather than an implicit one.
+const ASK_USER_MAX_FREE_TEXT = 4000;
+
+/**
+ * Turn a widget's posted message into answers ask_user already accepts, or null.
+ *
+ * The widget renders model-authored HTML inside an iframe, so what it posts is
+ * data, not instruction. An answer counts only when it names a question that was
+ * declared and, where possible, an option that was declared with it. Free text
+ * survives because the chip UI offers the same thing through "Other" -- capped
+ * here, since nothing else bounds it. Every question must be answered, matching
+ * what the chips require before they enable submit.
+ */
+export function coerceWidgetAnswers(
+  questions: AskUserQuestionDef[],
+  raw: Record<string, unknown>,
+): Record<string, string | string[]> | null {
+  if (questions.length === 0) return null;
+  const answers: Record<string, string | string[]> = {};
+
+  for (const question of questions) {
+    const value = raw[question.header];
+    const labels = question.options.map((option) => option.label);
+
+    if (question.multiSelect) {
+      if (!Array.isArray(value)) return null;
+      const picked = value
+        .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+        .filter(Boolean)
+        .map((entry) => (labels.includes(entry) ? entry : entry.slice(0, ASK_USER_MAX_FREE_TEXT)))
+        .slice(0, labels.length + 1);
+      if (picked.length === 0) return null;
+      answers[question.header] = picked;
+      continue;
+    }
+
+    if (typeof value !== "string") return null;
+    const picked = value.trim();
+    if (!picked) return null;
+    answers[question.header] = labels.includes(picked)
+      ? picked
+      : picked.slice(0, ASK_USER_MAX_FREE_TEXT);
+  }
+
+  return answers;
+}
+
 function askUserAnswers(resultData: ToolCardResult): Record<string, unknown> | null {
   const answers = asRecord(resultData).answers;
   return answers && typeof answers === "object" ? (answers as Record<string, unknown>) : null;
@@ -401,10 +466,13 @@ function AskUserQuestionsForm({
   invocation,
   onResolveUserApproval,
   variant,
+  conversationId,
 }: {
   invocation: AssistantToolInvocation;
   onResolveUserApproval?: (approvalId: string, decision: UserApprovalDecision, response?: Record<string, unknown> | null) => Promise<void>;
   variant: "card" | "composer";
+  /** Needed to mint the widget's embed URL; without it the chips are shown. */
+  conversationId?: string | null;
 }) {
   const questions = useMemo(() => parseAskUserQuestions(invocation.args), [invocation.args]);
   // Single-select keeps one label (or ASK_USER_OTHER); multi-select keeps a set.
@@ -460,6 +528,32 @@ function AskUserQuestionsForm({
     }
   }, [answerFor, invocation.toolCallId, onResolveUserApproval, pending, questions]);
 
+  // A widget answers the same questions through the same resume path; only the
+  // drawing changes. Rendering it needs a pod and a conversation to mint the
+  // embed URL from, so anywhere those are missing falls back to the chips --
+  // which is also the fallback for a client that cannot iframe at all.
+  const widget = useMemo(() => parseAskUserWidget(invocation.args), [invocation.args]);
+  const pathname = usePathname();
+  const podId = podIdFromPathname(pathname);
+  const showWidget = Boolean(widget.content && podId && conversationId);
+
+  const submitWidgetAnswers = useCallback(async (raw: Record<string, unknown>) => {
+    if (!onResolveUserApproval || pending !== null) return;
+    const answers = coerceWidgetAnswers(questions, raw);
+    if (!answers) {
+      setError("That answer did not match the question, so nothing was sent.");
+      return;
+    }
+    setPending("submit");
+    setError(null);
+    try {
+      await onResolveUserApproval(invocation.toolCallId, "APPROVE_ONCE", { answers });
+    } catch (submitError) {
+      setError(stringifyAssistantError(submitError) || "Could not submit your answer.");
+      setPending(null);
+    }
+  }, [invocation.toolCallId, onResolveUserApproval, pending, questions]);
+
   const toggleMulti = useCallback((header: string, value: string) => {
     setMultiChoice((prev) => {
       const next = new Set(prev[header] ?? []);
@@ -472,6 +566,38 @@ function AskUserQuestionsForm({
   const optionPad = variant === "composer" ? "px-3 py-2" : "px-2.5 py-1.5";
 
   if (!current) return null;
+
+  if (showWidget && podId && widget.content) {
+    return (
+      <div className="flex flex-col gap-3">
+        <InlineWidget
+          podId={podId}
+          conversationId={conversationId ?? null}
+          toolCallId={invocation.toolCallId}
+          title={current.header || "Question"}
+          loadingMessages={widget.loadingMessages}
+          variant="inline"
+          onAnswer={(answers) => { void submitWidgetAnswers(answers); }}
+        />
+        {error ? <p className="text-xs text-[var(--state-error)]">{error}</p> : null}
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="quiet"
+            size="sm"
+            onClick={() => { void submit("DENY", "dismiss"); }}
+            disabled={!onResolveUserApproval || pending !== null}
+            className="h-9 px-3 text-sm text-[var(--text-secondary)]"
+          >
+            {pending === "dismiss" ? "Dismissing..." : "Dismiss"}
+          </Button>
+          {pending === "submit" ? (
+            <span className="text-xs text-[var(--text-tertiary)]">Submitting...</span>
+          ) : null}
+        </div>
+      </div>
+    );
+  }
 
   const selectedMulti = multiChoice[current.header] ?? new Set<string>();
   const otherSelected = current.multiSelect
@@ -652,9 +778,11 @@ export function askUserInlineTitle(args: ToolCardArgs): string {
 export function AskUserCard({
   invocation,
   onResolveUserApproval,
+  conversationId,
 }: {
   invocation: AssistantToolInvocation;
   onResolveUserApproval?: (approvalId: string, decision: UserApprovalDecision, response?: Record<string, unknown> | null) => Promise<void>;
+  conversationId?: string | null;
 }) {
   const resultData = (invocation.result || {}) as ToolCardResult;
   const isResolved = invocation.state === "result" || askUserAnswers(resultData) !== null;
@@ -680,6 +808,7 @@ export function AskUserCard({
                 invocation={invocation}
                 onResolveUserApproval={onResolveUserApproval}
                 variant="card"
+                conversationId={conversationId}
               />
             )}
           </div>
@@ -692,17 +821,62 @@ export function AskUserCard({
 export function ComposerAskUserPanel({
   invocation,
   onResolveUserApproval,
+  conversationId,
 }: {
   invocation: AssistantToolInvocation;
   onResolveUserApproval?: (approvalId: string, decision: UserApprovalDecision, response?: Record<string, unknown> | null) => Promise<void>;
+  conversationId?: string | null;
 }) {
+  // A question with four richly-described options is tall, and this panel sits
+  // over the thread — so it can cover the very answer someone needs in order to
+  // choose. Collapsing is not dismissing: the run stays paused and the question
+  // stays unanswered, which is why this is a separate control from Dismiss.
+  const [collapsed, setCollapsed] = useState(false);
+  const title = askUserInlineTitle(invocation.args);
+
   return (
     <div className="lemma-assistant-user-approval-card border border-[color:color-mix(in_srgb,var(--row-border)_86%,transparent)] bg-[color:color-mix(in_srgb,var(--surface-1)_96%,transparent)] p-4 shadow-[var(--shadow-sm)]">
-      <AskUserQuestionsForm
-        invocation={invocation}
-        onResolveUserApproval={onResolveUserApproval}
-        variant="composer"
-      />
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <MessageCircleQuestion className="size-4 shrink-0 text-[var(--text-secondary)]" />
+          <span className="truncate text-sm text-[var(--text-primary)]">
+            {collapsed ? title : "The assistant has a question"}
+          </span>
+        </div>
+        <Button
+          type="button"
+          variant="quiet"
+          size="sm"
+          onClick={() => setCollapsed((current) => !current)}
+          className="-mr-1 -mt-1 h-7 shrink-0 gap-1 px-2 text-xs text-[var(--text-secondary)]"
+          aria-expanded={!collapsed}
+        >
+          {collapsed ? (
+            <>
+              Answer
+              <ChevronUp className="size-3.5" />
+            </>
+          ) : (
+            <>
+              Hide
+              <ChevronDown className="size-3.5" />
+            </>
+          )}
+        </Button>
+      </div>
+
+      {collapsed ? null : (
+        // Bounded even when open: the options list scrolls inside the panel
+        // rather than pushing the conversation off the screen.
+        <div className="mt-3 max-h-[min(52vh,26rem)] overflow-y-auto pr-1">
+          <AskUserQuestionsForm
+            invocation={invocation}
+            onResolveUserApproval={onResolveUserApproval}
+            variant="composer"
+            conversationId={conversationId}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/lemma-frontend/components/lemma/assistant/assistant-tool-details.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-tool-details.tsx
@@ -172,6 +172,7 @@ export function ToolDetailsPanel({
           <AskUserCard
             invocation={interactionInvocation}
             onResolveUserApproval={onResolveUserApproval}
+            conversationId={activeConversationId}
           />
         ) : (
           <UserApprovalCard

--- a/lemma-frontend/components/lemma/assistant/inline-widget.tsx
+++ b/lemma-frontend/components/lemma/assistant/inline-widget.tsx
@@ -92,6 +92,15 @@ export interface InlineWidgetProps {
      */
     podTabHref?: string | null;
     onExpand?: () => void;
+    /**
+     * Answers posted up by an interactive widget (an `ask_user` rendered as one).
+     *
+     * The widget is model-authored HTML, so this is an untrusted message: the
+     * caller is responsible for accepting only answers that name a question and
+     * option it declared. Absent this prop the widget stays display-only, which
+     * is what a `display_resource` widget is.
+     */
+    onAnswer?: (answers: Record<string, unknown>) => void;
 }
 
 /**
@@ -129,10 +138,11 @@ export function InlineWidget({
     maxHeight,
     podTabHref,
     onExpand,
+    onAnswer,
 }: InlineWidgetProps) {
     const { resolvedTheme } = useTheme();
     const iframeRef = useRef<HTMLIFrameElement | null>(null);
-    const [reportedHeight, setReportedHeight] = useState(variant === "full" ? 520 : 320);
+    const [reportedHeight, setReportedHeight] = useState(variant === "full" ? 520 : 180);
     const [heightReported, setHeightReported] = useState(false);
     const [loadedIframeSrc, setLoadedIframeSrc] = useState<string | null>(null);
     const [loadingProgress, setLoadingProgress] = useState({ key: "", index: 0 });
@@ -191,22 +201,41 @@ export function InlineWidget({
         return () => window.clearInterval(intervalId);
     }, [loading, loadingKey, normalizedLoadingMessages.length]);
 
+    // Held in a ref so the listener below subscribes once: `onAnswer` is a fresh
+    // closure on most renders, and re-subscribing on each one would drop a
+    // message posted mid-render.
+    const onAnswerRef = useRef(onAnswer);
+    useEffect(() => {
+        onAnswerRef.current = onAnswer;
+    }, [onAnswer]);
+
     useEffect(() => {
         const handleMessage = (event: MessageEvent) => {
             if (!iframeRef.current || event.source !== iframeRef.current.contentWindow) return;
             const data = event.data && typeof event.data === "object" ? event.data as Record<string, unknown> : {};
+            if (data.type === "lemma-widget-answer") {
+                // Height is cosmetic; an answer resolves a paused agent run, so
+                // it is checked against the frame's own origin as well as its
+                // window before it is passed on. The receiver still validates
+                // the payload -- the widget's HTML is model-authored.
+                if (!iframeSrc || event.origin !== new URL(iframeSrc).origin) return;
+                const answers = data.answers;
+                if (!answers || typeof answers !== "object" || Array.isArray(answers)) return;
+                onAnswerRef.current?.(answers as Record<string, unknown>);
+                return;
+            }
             if (data.type !== "lemma-widget-height") return;
             const nextHeight = typeof data.height === "number" ? data.height : Number(data.height);
             if (!Number.isFinite(nextHeight)) return;
-            setReportedHeight(Math.max(120, Math.min(2400, Math.round(nextHeight))));
+            setReportedHeight(Math.max(64, Math.min(2400, Math.round(nextHeight))));
             setHeightReported(true);
         };
         window.addEventListener("message", handleMessage);
         return () => window.removeEventListener("message", handleMessage);
-    }, []);
+    }, [iframeSrc]);
 
     const isInline = variant === "inline";
-    const fullHeight = !heightReported ? 360 : reportedHeight;
+    const fullHeight = !heightReported ? (isInline ? 180 : 360) : reportedHeight;
     const overflows = isInline && heightReported && reportedHeight > resolvedMaxHeight;
     const renderedHeight = isInline ? Math.min(fullHeight, resolvedMaxHeight) : fullHeight;
 

--- a/lemma-frontend/components/onboarding/account-onboarding-helpers.ts
+++ b/lemma-frontend/components/onboarding/account-onboarding-helpers.ts
@@ -695,6 +695,45 @@ export function organizationNameCandidate({
   return generatedOrganizationName(email, attempt - COMPANY_NAME_ATTEMPTS);
 }
 
+// The server accepts letters, numbers, spaces, hyphens and underscores in a pod
+// name and nothing else (`normalize_pod_name`), because pods are addressable by
+// name from the CLI. A name derived from a person routinely breaks that —
+// apostrophes in "O'Brien", accents in "José" — so it is folded to the allowed
+// set here rather than discovered as a rejected create.
+const POD_NAME_DISALLOWED = /[^A-Za-z0-9 _-]/g;
+const COMBINING_MARKS = /[\u0300-\u036f]/g;
+
+function podNameSafe(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(COMBINING_MARKS, "")
+    .replace(POD_NAME_DISALLOWED, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * What to call the pod an account is given on arrival.
+ *
+ * "Personal Pod" is nobody's workspace; a name with the person in it is theirs
+ * from the first screen. The possessive form this wanted ("Ada's Pod") is not
+ * available: the apostrophe is exactly what the server rejects. Falls back to
+ * the generic name when nothing usable survives.
+ */
+export function firstPodName(
+  profile?: {
+    email?: string | null;
+    first_name?: string | null;
+    last_name?: string | null;
+    full_name?: string | null;
+  } | null,
+) {
+  const { firstName } = splitName(inferFullName(profile));
+  const safe = podNameSafe(firstName || "");
+  if (!safe) return "Personal Pod";
+  return `${safe} Pod`;
+}
+
 export function podNameForAudience(audience: Audience, teamName = "") {
   if (audience === "personal") return "Personal Pod";
 

--- a/lemma-frontend/components/onboarding/account-onboarding-steps.tsx
+++ b/lemma-frontend/components/onboarding/account-onboarding-steps.tsx
@@ -25,6 +25,10 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
+  trackMemberJoined,
+  trackPodReady,
+} from "@/lib/analytics/onboarding";
+import {
   type Organization,
   type OrganizationInvitation,
 } from "@/lib/types";
@@ -129,8 +133,14 @@ const PROVIDER_PRESETS: ProviderPreset[] = [
 
 export function InvitationsStep({
   invitations,
+  signupAt,
+  ownerEmail,
 }: {
   invitations: OrganizationInvitation[];
+  /** Profile `created_at`, so activation can be reported against signup. */
+  signupAt?: string | null;
+  /** Whose skip this is. Without it the flag would mute the next account too. */
+  ownerEmail?: string | null;
 }) {
   const router = useRouter();
   const firstInvitation = invitations[0];
@@ -143,7 +153,11 @@ export function InvitationsStep({
     hasSubmittedRef.current = true;
     acceptInvitation(firstInvitation.id, {
       onSuccess: (response) => {
-        markOnboardingSkippedFirstPod();
+        markOnboardingSkippedFirstPod(ownerEmail);
+        // The invited teammate is the pod's second member: this is the only
+        // place the client witnesses a pod actually becoming shared.
+        trackMemberJoined(signupAt);
+        trackPodReady("invite", signupAt);
         const destination =
           response.redirect_uri || firstInvitation.redirect_uri || "/";
 
@@ -159,7 +173,7 @@ export function InvitationsStep({
         router.replace(`/invitations/${firstInvitation.id}/accept`);
       },
     });
-  }, [acceptInvitation, firstInvitation, router]);
+  }, [acceptInvitation, firstInvitation, ownerEmail, router, signupAt]);
 
   return (
     <SetupShell>

--- a/lemma-frontend/components/onboarding/account-onboarding.tsx
+++ b/lemma-frontend/components/onboarding/account-onboarding.tsx
@@ -2,7 +2,6 @@
 
 import {
   useEffect,
-  useMemo,
   useRef,
   useState,
   useSyncExternalStore,
@@ -20,10 +19,15 @@ import {
   subscribeToLastOpenedPodId,
 } from "@/lib/pods/last-opened-pod";
 import {
+  hasSkippedFirstPod as skipBelongsToOwner,
   readOnboardingSkippedFirstPod,
   subscribeToOnboardingSkippedFirstPod,
 } from "@/lib/pods/onboarding-skip";
 import { buildComposerLaunchHref } from "@/lib/pods/composer-launch";
+import {
+  trackOnboardingStep,
+  trackPodReady,
+} from "@/lib/analytics/onboarding";
 import {
   clearOnboardingDraft,
   findDraftBasePod,
@@ -37,7 +41,6 @@ import {
   useCreateOrganization,
   useJoinSuggestedOrganization,
   useMyOrganizationInvitations,
-  useOrganizationNameAvailability,
   useSuggestedOrganizations,
 } from "@/lib/hooks/use-organizations";
 import { useAccessiblePods, type AccessiblePod } from "@/lib/hooks/use-pods";
@@ -55,7 +58,6 @@ import {
 } from "@/lib/types";
 import {
   normalizeEmailDomain,
-  slugifyOrganizationName,
   workDomainFromEmail,
 } from "@/lib/utils/organization-slugs";
 import {
@@ -66,8 +68,6 @@ import { SetupChrome, SetupShell } from "./account-onboarding-chrome";
 import {
   hasUsableProfileName,
   inferFullName,
-  isRetriableOrganizationNameConflict,
-  MAX_ORGANIZATION_NAME_ATTEMPTS,
   nextTeamSetupStep,
   normalizeOnboardingStep,
   organizationNameCandidate,
@@ -96,6 +96,7 @@ import {
 } from "./account-onboarding-steps";
 import { LocalIntelligenceStep, LocalSharingStep } from "./local-setup-steps";
 import { isLocalDeployment } from "@/lib/config";
+import { useFirstPodProvisioning } from "./use-first-pod-provisioning";
 import { readLocalAiStatus } from "@/lib/desktop/local-capabilities";
 
 /** What onboarding needs of a pod, whether it created it or restored it. */
@@ -129,12 +130,16 @@ export function AccountOnboarding({
     () => null,
   );
   const hasLastOpenedPod = requireFirstPod && Boolean(lastOpenedPodId);
-  const skippedFirstPod = useSyncExternalStore(
+  const skippedFirstPodOwner = useSyncExternalStore(
     subscribeToOnboardingSkippedFirstPod,
     readOnboardingSkippedFirstPod,
     () => null,
   );
-  const hasSkippedFirstPod = requireFirstPod && Boolean(skippedFirstPod);
+  // Only this account's own skip counts. An unowned flag left by whoever used
+  // this browser last used to switch first-pod provisioning off for everyone
+  // after them, which is exactly how a new account landed on an empty home.
+  const hasSkippedFirstPod =
+    requireFirstPod && skipBelongsToOwner(skippedFirstPodOwner, profile?.email);
   const storedOnboardingDraft = useSyncExternalStore(
     subscribeToOnboardingDraft,
     readOnboardingDraft,
@@ -167,12 +172,45 @@ export function AccountOnboarding({
     !isLoadingPods &&
     pendingInvitations.length === 0 &&
     shouldResumeOnboarding(onboardingDraft, pods.length);
+  // A pending invitation wins outright. It used to lose to the identity step,
+  // which put a name question and a screen in front of the one arrival that was
+  // already perfect: the invite carries a destination, so an invited teammate
+  // can go straight to the pod -- and to the app -- they were invited to.
+  const needsInvitations = pendingInvitations.length > 0;
   const needsIdentityStep =
-    needsProfile ||
-    (!onboardingDraft && (needsOrganization || needsFirstPod));
-  const needsInvitations =
-    !needsIdentityStep && pendingInvitations.length > 0;
+    !needsInvitations &&
+    (needsProfile || (!onboardingDraft && (needsOrganization || needsFirstPod)));
   const [setupActive, setSetupActive] = useState(false);
+
+  // Hosted accounts with nothing yet are provisioned rather than interviewed.
+  // A local installation is excluded: it still owes the user a model before a
+  // pod means anything, which is what its own steps are for. A draft means a
+  // half-finished run of the old flow, which stays with the old flow.
+  const isLocal = isLocalDeployment();
+  const canAutoProvision =
+    !isLocal &&
+    !setupActive &&
+    !needsInvitations &&
+    !onboardingDraft &&
+    !isLoadingProfile &&
+    !isLoadingOrganizations &&
+    !isLoadingInvitations &&
+    Boolean(profile) &&
+    (needsOrganization || needsFirstPod);
+  const autoSuggestedOrganizations = useSuggestedOrganizations({
+    enabled: canAutoProvision && organizations.length === 0,
+  });
+  // Resolved before provisioning starts, because creating an organization for
+  // someone whose colleague already claimed the domain is the one mistake here
+  // that a rename cannot undo.
+  const suggestionsSettled =
+    organizations.length > 0 || !autoSuggestedOrganizations.isLoading;
+  const provisioning = useFirstPodProvisioning({
+    enabled: canAutoProvision && suggestionsSettled,
+    profile,
+    organizations,
+    suggestedOrganization: autoSuggestedOrganizations.data?.items?.[0] ?? null,
+  });
   const nextSetupStep = resolveOnboardingStartStep(
     onboardingDraft?.step,
     needsIdentityStep,
@@ -204,8 +242,30 @@ export function AccountOnboarding({
     );
   }
 
+  // `navigated` keeps this held after `canAutoProvision` goes false: the pod now
+  // exists, so the conditions that justified provisioning have stopped being
+  // true, and falling through here renders the redirect that overwrites the
+  // composer launch with a bare pod URL.
+  if ((canAutoProvision || provisioning === "navigated") && provisioning !== "failed") {
+    return preflightFallback ?? (
+      <SetupShell>
+        <WaitingScreen
+          title="Setting up your workspace"
+          description="This takes a moment. You will land straight in your pod."
+          className="w-full max-w-xl"
+        />
+      </SetupShell>
+    );
+  }
+
   if (needsInvitations) {
-    return <InvitationsStep invitations={pendingInvitations} />;
+    return (
+      <InvitationsStep
+        invitations={pendingInvitations}
+        signupAt={profile?.created_at ?? null}
+        ownerEmail={profile?.email ?? null}
+      />
+    );
   }
 
   if (needsProfile || needsOrganization || needsFirstPod || setupActive) {
@@ -254,6 +314,7 @@ function SetupAssistant({
     first_name?: string | null;
     last_name?: string | null;
     full_name?: string | null;
+    created_at?: string | null;
   } | null;
   organizations: Organization[];
   // The navigation listing, not a full pod record: this only ever reads `id`
@@ -298,6 +359,12 @@ function SetupAssistant({
     isLocal,
   );
   const [step, setStep] = useState<SetupStep>(normalizedInitialStep);
+  const signupAt = profile?.created_at ?? null;
+  // Every step renders at "/", so this is the only thing that can tell the
+  // funnel's stages apart -- a pageview cannot.
+  useEffect(() => {
+    trackOnboardingStep(step);
+  }, [step]);
   const [createdOrganization, setCreatedOrganization] =
     useState<Organization | null>(null);
   // Either a pod just created here (a full record) or one restored from the
@@ -315,7 +382,6 @@ function SetupAssistant({
   );
   const [identityName, setIdentityName] = useState(initialIdentityName);
   const [identityCompletedLocally, setIdentityCompletedLocally] = useState(false);
-  const [organizationNameAttempt, setOrganizationNameAttempt] = useState(0);
   const [workspaceName, setWorkspaceName] = useState(
     initialDraft?.workspaceName ||
       organizationNameCandidate({ email, workDomain: normalizedWorkDomain }),
@@ -338,52 +404,7 @@ function SetupAssistant({
       organizations.length === 0,
   });
   const suggestedOrganization = suggestedOrganizations.data?.items?.[0] || null;
-  const slug = useMemo(
-    () => slugifyOrganizationName(workspaceName),
-    [workspaceName],
-  );
-  const nameAvailability = useOrganizationNameAvailability(
-    { slug, name: workspaceName },
-    {
-      enabled:
-        (step === "identity" || step === "workspace") &&
-        !suggestedOrganization &&
-        organizations.length === 0 &&
-        slug.length > 2,
-    },
-  );
   const activeOrganization = createdOrganization || initialOrganization;
-
-  // Keep the name we show on the identity step to one that is still free. This
-  // is for honest copy only — the create itself re-walks the ladder against the
-  // server, which is the authority.
-  useEffect(() => {
-    if (
-      step !== "identity" ||
-      suggestedOrganization ||
-      nameAvailability.available !== false ||
-      organizationNameAttempt >= MAX_ORGANIZATION_NAME_ATTEMPTS
-    ) {
-      return;
-    }
-
-    const nextAttempt = organizationNameAttempt + 1;
-    setOrganizationNameAttempt(nextAttempt);
-    setWorkspaceName(
-      organizationNameCandidate({
-        email,
-        workDomain: normalizedWorkDomain,
-        attempt: nextAttempt,
-      }),
-    );
-  }, [
-    email,
-    nameAvailability.available,
-    normalizedWorkDomain,
-    organizationNameAttempt,
-    step,
-    suggestedOrganization,
-  ]);
 
   useEffect(() => {
     if (
@@ -432,36 +453,28 @@ function SetupAssistant({
    * the race. So the ladder is walked here too, against the only authority
    * there is, and setup survives a collision instead of dead-ending on it.
    */
+  /**
+   * The workspace nobody asked for, created without asking.
+   *
+   * This used to walk a twenty-rung name ladder from the browser -- one
+   * sequential create per rung, on the critical path of a signup, for a name
+   * the user never typed. The server resolves its own collision now, so this is
+   * one call that cannot fail on a name.
+   */
   const createFirstOrganization = async (): Promise<Organization> => {
     const useDomainJoin = Boolean(normalizedWorkDomain);
-    let lastError: unknown = null;
 
-    for (
-      let attempt = organizationNameAttempt;
-      attempt < organizationNameAttempt + MAX_ORGANIZATION_NAME_ATTEMPTS;
-      attempt += 1
-    ) {
-      try {
-        return await createOrganization.mutateAsync({
-          name: organizationNameCandidate({
-            email,
-            workDomain: normalizedWorkDomain,
-            attempt,
-          }),
-          join_policy: useDomainJoin
-            ? OrganizationJoinPolicy.EMAIL_DOMAIN
-            : OrganizationJoinPolicy.INVITE_ONLY,
-          email_domain: useDomainJoin ? normalizedWorkDomain : null,
-        });
-      } catch (error) {
-        if (!isRetriableOrganizationNameConflict(error)) throw error;
-        lastError = error;
-      }
-    }
-
-    throw lastError instanceof Error
-      ? lastError
-      : new Error("Could not find an available organization name");
+    return createOrganization.mutateAsync({
+      name: organizationNameCandidate({
+        email,
+        workDomain: normalizedWorkDomain,
+      }),
+      join_policy: useDomainJoin
+        ? OrganizationJoinPolicy.EMAIL_DOMAIN
+        : OrganizationJoinPolicy.INVITE_ONLY,
+      email_domain: useDomainJoin ? normalizedWorkDomain : null,
+      resolve_name_conflicts: true,
+    });
   };
 
   const handleIdentitySubmit = async (event: React.FormEvent) => {
@@ -897,6 +910,7 @@ function SetupAssistant({
 
     if (path === "templates") {
       clearOnboardingDraft();
+      trackPodReady("new_org", signupAt);
       router.push(`/pod/${pod.id}/recipes`);
       return true;
     }
@@ -914,10 +928,12 @@ function SetupAssistant({
     // Nothing to say on their behalf. The pod's own home already asks the
     // question better than a form could.
     if (!launch) {
+      trackPodReady("new_org", signupAt);
       router.push(`/pod/${pod.id}`);
       return true;
     }
 
+    trackPodReady("new_org", signupAt);
     router.push(
       buildComposerLaunchHref(pod.id, {
         draft: launch.stem,
@@ -985,14 +1001,7 @@ function SetupAssistant({
                 ? "join"
                 : "create"
           }
-          isResolvingWorkspace={
-            suggestedOrganizations.isLoading ||
-            (!activeOrganization &&
-              !suggestedOrganization &&
-              (nameAvailability.isLoading ||
-                nameAvailability.isFetching ||
-                nameAvailability.available === false))
-          }
+          isResolvingWorkspace={suggestedOrganizations.isLoading}
           isSaving={
             updateProfile.isPending ||
             joinSuggestedOrganization.isPending ||
@@ -1034,7 +1043,6 @@ function SetupAssistant({
           domain={workDomain || null}
           suggestedOrganization={suggestedOrganization}
           workspaceName={workspaceName}
-          slugAvailable={nameAvailability.available}
           allowDomainJoin={allowDomainJoin}
           isJoining={joinSuggestedOrganization.isPending}
           isCreating={createOrganization.isPending || isCreatingPod}

--- a/lemma-frontend/components/onboarding/use-first-pod-provisioning.ts
+++ b/lemma-frontend/components/onboarding/use-first-pod-provisioning.ts
@@ -1,0 +1,185 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { getLemmaClient } from "@/lib/sdk/lemma-client";
+import {
+  useCreateOrganization,
+  useJoinSuggestedOrganization,
+} from "@/lib/hooks/use-organizations";
+import { useUpdateProfile } from "@/lib/hooks/use-user";
+import { trackPodReady, type OnboardingEntryKind } from "@/lib/analytics/onboarding";
+import { buildNewPodConversationHref } from "@/lib/pods/new-pod-conversation";
+import { OrganizationJoinPolicy, type Organization } from "@/lib/types";
+import { normalizeEmailDomain, workDomainFromEmail } from "@/lib/utils/organization-slugs";
+
+import {
+  firstPodName,
+  hasUsableProfileName,
+  inferFullName,
+  organizationNameCandidate,
+  splitName,
+} from "./account-onboarding-helpers";
+
+/**
+ * Only failure is state.
+ *
+ * "Working" is not: `enabled` already says provisioning should be running, so a
+ * second flag tracking the same fact would be a synchronous setState in an
+ * effect body and one more thing to keep in step. The caller needs exactly one
+ * answer from here — whether to stop waiting and show the old flow instead.
+ */
+export type ProvisioningState = "running" | "navigated" | "failed";
+
+/**
+ * Give a new account a workspace without asking it anything.
+ *
+ * Every question the old flow asked here had an answer already: the provider
+ * sent the name, the email says which company, and the pod is theirs by
+ * definition. So this runs while the pod shell is already on screen rather than
+ * in front of it, and the naming choices it makes are all renameable from
+ * inside — which is what makes it safe to make them silently.
+ *
+ * Not transactional, because the client cannot be. The failure it actually has
+ * to survive is an organization created and a pod not: on the next load there
+ * are organizations and no pods, and this runs again and creates just the pod.
+ */
+export function useFirstPodProvisioning({
+  enabled,
+  profile,
+  organizations,
+  suggestedOrganization,
+}: {
+  enabled: boolean;
+  profile?: {
+    email?: string | null;
+    first_name?: string | null;
+    last_name?: string | null;
+    full_name?: string | null;
+    created_at?: string | null;
+  } | null;
+  organizations: Organization[];
+  suggestedOrganization: Organization | null;
+}): ProvisioningState {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const updateProfile = useUpdateProfile();
+  const createOrganization = useCreateOrganization();
+  const joinSuggestedOrganization = useJoinSuggestedOrganization();
+  const [failed, setFailed] = useState(false);
+  // Set before the navigation, not after. Creating the pod invalidates the pods
+  // query, which re-renders the caller with `needsFirstPod` already false — and
+  // the child it then renders is the root redirect, which navigates to the bare
+  // pod URL and takes the composer launch with it.
+  const [navigated, setNavigated] = useState(false);
+  // Provisioning must happen once per mount even though its inputs change
+  // underneath it — creating the organization is itself one of those changes.
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled || startedRef.current) return;
+    startedRef.current = true;
+
+    void (async () => {
+      try {
+        const email = profile?.email || "";
+
+        // The name is derived, never asked. A provider that sent one has
+        // already populated the profile; this covers the rest from the address,
+        // and the profile page is where anyone who dislikes it fixes it.
+        if (!hasUsableProfileName(profile)) {
+          const parsed = splitName(inferFullName(profile));
+          if (parsed.firstName) {
+            await updateProfile.mutateAsync({
+              first_name: parsed.firstName,
+              last_name: parsed.lastName || null,
+            });
+          }
+        }
+
+        const workDomain = normalizeEmailDomain(workDomainFromEmail(email));
+        let entryKind: OnboardingEntryKind = "new_org";
+        let organization = organizations[0] || null;
+
+        if (!organization && suggestedOrganization) {
+          // A colleague already claimed this domain. Joining them beats
+          // fragmenting the company across two workspaces.
+          organization = await joinSuggestedOrganization.mutateAsync(
+            suggestedOrganization.id,
+          );
+          entryKind = "domain_join";
+        } else if (!organization) {
+          organization = await createOrganization.mutateAsync({
+            name: organizationNameCandidate({ email, workDomain }),
+            join_policy: workDomain
+              ? OrganizationJoinPolicy.EMAIL_DOMAIN
+              : OrganizationJoinPolicy.INVITE_ONLY,
+            email_domain: workDomain || null,
+            resolve_name_conflicts: true,
+          });
+        }
+
+        if (!organization) {
+          setFailed(true);
+          return;
+        }
+
+        // Joining an existing organization still earns a pod of your own:
+        // otherwise you land in a workspace where everything belongs to someone
+        // else, which is a worse first screen than an empty one. `create_pod`
+        // asks only for organization membership, so a domain-joined member may
+        // do this — there is no extra permission to clear.
+        const pod = await getLemmaClient().pods.create({
+          name: firstPodName(profile),
+          description:
+            "A private workspace for apps, surface agents, knowledge, and operating loops.",
+          organization_id: organization.id,
+        });
+
+        setNavigated(true);
+        trackPodReady(entryKind, profile?.created_at ?? null);
+        // Into the conversation, not onto pod home: nobody answered a question
+        // to get here, so the launcher there has nothing to offer them yet.
+        router.replace(
+          buildNewPodConversationHref({
+            podId: pod.id,
+            podName: pod.name,
+            workDomain,
+            isFirstPod: true,
+          }),
+        );
+        // After the navigation is queued: refreshing the listing first is what
+        // hands the race to the redirect this is trying to beat.
+        queryClient.invalidateQueries({ queryKey: ["pods"] });
+      } catch (error) {
+        // Say what went wrong. An earlier version swallowed this and quietly
+        // redirected, which turned a rejected pod name into "the pod just did
+        // not appear" — invisible from the UI and from the logs alike. The
+        // wizard behind this is still the way out; it is not a reason to be
+        // silent about why we are falling back to it.
+        toast.error(
+          error instanceof Error && error.message
+            ? `Could not finish setting up your workspace: ${error.message}`
+            : "Could not finish setting up your workspace.",
+        );
+        setFailed(true);
+      }
+    })();
+  }, [
+    createOrganization,
+    enabled,
+    joinSuggestedOrganization,
+    organizations,
+    profile,
+    queryClient,
+    router,
+    suggestedOrganization,
+    updateProfile,
+  ]);
+
+  if (failed) return "failed";
+  return navigated ? "navigated" : "running";
+}

--- a/lemma-frontend/components/pod/create-pod-screen.tsx
+++ b/lemma-frontend/components/pod/create-pod-screen.tsx
@@ -17,7 +17,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ArrowRight, Boxes } from "@/components/ui/icons";
-import { buildComposerLaunchHref } from "@/lib/pods/composer-launch";
+import { buildNewPodConversationHref } from "@/lib/pods/new-pod-conversation";
 import { normalizeRemixSource, remixSourceLabel } from "@/lib/remix/app-remix";
 import { getLemmaClient } from "@/lib/sdk/lemma-client";
 
@@ -68,7 +68,7 @@ export function CreatePodScreen({ remixSource: rawRemixSource }: { remixSource: 
    */
   const createAndGo = async (
     action: PendingAction,
-    destination: (podId: string) => string,
+    destination: (podId: string, podName: string) => string,
     fallbackName = DEFAULT_POD_NAME,
   ) => {
     if (pending) return;
@@ -84,7 +84,7 @@ export function CreatePodScreen({ remixSource: rawRemixSource }: { remixSource: 
         organization_id: currentOrg.id,
       });
       queryClient.invalidateQueries({ queryKey: ["pods"] });
-      router.push(destination(pod.id));
+      router.push(destination(pod.id, pod.name));
     } catch (error) {
       toast.error(
         error instanceof Error && error.message
@@ -99,10 +99,16 @@ export function CreatePodScreen({ remixSource: rawRemixSource }: { remixSource: 
     const launch = startPathComposerLaunch(path);
     void createAndGo(
       path,
-      (podId) =>
-        buildComposerLaunchHref(podId, {
-          draft: launch.stem,
-          instructions: remixSource
+      // Same landing as naming a pod and pressing create. Picking a starting
+      // point is a *stronger* statement of intent, so it must not end up
+      // somewhere less started than saying nothing did.
+      (podId, podName) =>
+        buildNewPodConversationHref({
+          podId,
+          podName,
+          isFirstPod: false,
+          openingMessage: launch.stem,
+          extraInstructions: remixSource
             ? [
                 launch.instructions,
                 `Use ${remixSource} as the reference experience. Inspect it before building, preserve the interaction mechanics that matter, and make the result Lemma-native rather than a visual copy.`,
@@ -148,7 +154,9 @@ export function CreatePodScreen({ remixSource: rawRemixSource }: { remixSource: 
             className="mt-7"
             onSubmit={(event) => {
               event.preventDefault();
-              void createAndGo("create", (podId) => `/pod/${podId}`);
+              void createAndGo("create", (podId, podName) =>
+                buildNewPodConversationHref({ podId, podName, isFirstPod: false }),
+              );
             }}
           >
             <Label

--- a/lemma-frontend/components/root/root-page-switch.tsx
+++ b/lemma-frontend/components/root/root-page-switch.tsx
@@ -41,7 +41,10 @@ export function RootPageSwitch({ mode = 'redirect' }: { mode?: RootPageMode }) {
     }
 
     return (
-        <AccountOnboarding preflightFallback={<PageLoader />}>
+        <AccountOnboarding
+            preflightFallback={<PageLoader />}
+            requireFirstPod={mode !== 'home'}
+        >
             {mode === 'home' ? <DashboardHomePage /> : <AuthenticatedRootRedirect />}
         </AccountOnboarding>
     );
@@ -88,7 +91,14 @@ function AuthenticatedRootRedirect() {
         const firstPod = podsData?.items?.[0];
         if (firstPod) {
             router.replace(`/pod/${firstPod.id}`);
+            return;
         }
+
+        // No pod this account can open. Someone who joined an organization as a
+        // plain member has exactly this shape — they can read the org and
+        // nothing in it — and this used to return the loader forever, which is
+        // a dead end wearing a spinner. Home can at least say where they are.
+        router.replace('/home');
     }, [isLoading, podsData?.items, router, shouldFetchPods]);
 
     return <PageLoader />;

--- a/lemma-frontend/components/surfaces/surface-modal.tsx
+++ b/lemma-frontend/components/surfaces/surface-modal.tsx
@@ -37,6 +37,8 @@ import {
 import { useAssistants } from '@/lib/hooks/use-assistants';
 import { useAccounts, useAuthConfigs } from '@/lib/hooks/use-connectors';
 import { usePod } from '@/lib/hooks/use-pods';
+import { useProfile } from '@/lib/hooks/use-user';
+import { trackSurfaceConnected } from '@/lib/analytics/onboarding';
 import {
     useAvailableSurfaces,
     useCreatePodSurface,
@@ -118,6 +120,7 @@ export function SurfaceModal({
     const definition = getSurfaceDefinition(target?.platform);
 
     const { data: pod } = usePod(podId);
+    const { data: profile } = useProfile();
     const { data: surfaces = [] } = usePodSurfaces(target ? podId : undefined);
     const { data: catalog } = useAvailableSurfaces(podId, Boolean(target));
     const { data: assistantsData } = useAssistants(target ? podId : '');
@@ -300,8 +303,11 @@ export function SurfaceModal({
                 ? `@${managedSetup.bot_username} is connected`
                 : 'Your Telegram bot is connected',
         );
+        if (definition) {
+            trackSurfaceConnected(definition.platform, profile?.created_at ?? null);
+        }
         setStep('live');
-    }, [managedSetup, podId, queryClient]);
+    }, [definition, managedSetup, podId, profile?.created_at, queryClient]);
 
     const patchDraft = useCallback(
         (patch: Partial<ConfigureDraft>) => setDraft((current) => ({ ...current, ...patch })),
@@ -399,6 +405,7 @@ export function SurfaceModal({
             })) as AssistantSurface;
 
             setCreatedSurface(created);
+            trackSurfaceConnected(definition.platform, profile?.created_at ?? null);
             // A surface Lemma can't wire up itself isn't reachable yet, so the
             // proof state would be a lie — go straight to what's left to do.
             // The setup read resolves against the surface we just created.

--- a/lemma-frontend/lib/analytics/catalog.test.ts
+++ b/lemma-frontend/lib/analytics/catalog.test.ts
@@ -83,7 +83,17 @@ describe("declared events are emitted or named as gaps", () => {
         // `client.error` is raised by app/global-error.tsx, the root error
         // boundary — the only place that can see an error which escaped
         // everything below it.
-        const emitted = ["share_link.viewed", "import.started", "client.error"];
+        const emitted = [
+            "share_link.viewed",
+            "import.started",
+            "client.error",
+            // lib/analytics/onboarding.ts is the only emitter of these five.
+            "onboarding.step_viewed",
+            "onboarding.pod_ready",
+            "activation.surface_connected",
+            "activation.app_opened",
+            "activation.member_joined",
+        ];
         const accounted = new Set([...emitted, ...KNOWN_UNEMITTED]);
         const unaccounted = Object.keys(CLIENT_CATALOG).filter((n) => !accounted.has(n as never));
         expect(unaccounted).toEqual([]);

--- a/lemma-frontend/lib/analytics/catalog.ts
+++ b/lemma-frontend/lib/analytics/catalog.ts
@@ -38,6 +38,32 @@ export const CLIENT_CATALOG = {
     /** A client-side error. `error_class` is a constructor name, never a message
      *  — messages carry user content. */
     "client.error": { properties: ["error_class"] },
+
+    // --- onboarding -------------------------------------------------------
+    //
+    // Onboarding renders every step at "/", so pageviews cannot tell them
+    // apart and the funnel was previously unmeasurable end to end. `step` is
+    // the bounded SetupStep union, never free text.
+    /** One onboarding step shown. */
+    "onboarding.step_viewed": { properties: ["step"] },
+    /** The user is inside a pod: the end of onboarding, however they got there.
+     *  `entry_kind` says which of the three routes they took. */
+    "onboarding.pod_ready": { properties: ["entry_kind", "elapsed_bucket"] },
+
+    // --- activation -------------------------------------------------------
+    //
+    // The three transitions that each permanently widen what the product can
+    // do, and the thing worth optimising rather than step completion. Elapsed
+    // time is bucketed rather than exact: a duration is not an id, an enum or a
+    // boolean, and the funnel only ever reads it in bands anyway.
+    /** A chat surface went live. The pod can be *reached* only once its owner
+     *  has messaged the bot — a backend fact — so this is the nearest thing the
+     *  client can honestly witness, and is named for what it measures. */
+    "activation.surface_connected": { properties: ["platform", "elapsed_bucket"] },
+    /** The pod does work for its owner: an app page opened. */
+    "activation.app_opened": { properties: ["elapsed_bucket"] },
+    /** The pod is shared: an invited teammate accepted and landed inside it. */
+    "activation.member_joined": { properties: ["elapsed_bucket"] },
 } as const satisfies Record<string, ClientAnalyticEvent>;
 
 export type WebAnalyticEvent = keyof typeof CLIENT_CATALOG;

--- a/lemma-frontend/lib/analytics/onboarding.test.ts
+++ b/lemma-frontend/lib/analytics/onboarding.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { elapsedBucket } from "./onboarding";
+
+describe("elapsedBucket", () => {
+    const now = new Date("2026-08-18T12:00:00.000Z");
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(now);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    const at = (minutesAgo: number) =>
+        new Date(now.getTime() - minutesAgo * 60_000).toISOString();
+
+    it("bands elapsed time since signup", () => {
+        expect(elapsedBucket(at(0.5))).toBe("under_1m");
+        expect(elapsedBucket(at(3))).toBe("1_5m");
+        expect(elapsedBucket(at(10))).toBe("5_15m");
+        expect(elapsedBucket(at(40))).toBe("15_60m");
+        expect(elapsedBucket(at(120))).toBe("over_1h");
+    });
+
+    it("puts the boundaries in the later band", () => {
+        expect(elapsedBucket(at(1))).toBe("1_5m");
+        expect(elapsedBucket(at(5))).toBe("5_15m");
+        expect(elapsedBucket(at(15))).toBe("15_60m");
+        expect(elapsedBucket(at(60))).toBe("over_1h");
+    });
+
+    it("reports unknown rather than guessing", () => {
+        expect(elapsedBucket(null)).toBe("unknown");
+        expect(elapsedBucket(undefined)).toBe("unknown");
+        expect(elapsedBucket("not a date")).toBe("unknown");
+    });
+
+    it("refuses a signup in the future, which would flatter the funnel", () => {
+        expect(elapsedBucket(at(-30))).toBe("unknown");
+    });
+});

--- a/lemma-frontend/lib/analytics/onboarding.ts
+++ b/lemma-frontend/lib/analytics/onboarding.ts
@@ -1,0 +1,106 @@
+/**
+ * Onboarding and activation emitters.
+ *
+ * Two reasons this is a module rather than `captureEvent` calls scattered at the
+ * call sites. Elapsed-since-signup is bucketed in exactly one place, so two call
+ * sites cannot disagree about what "fast" means. And the transitions below are
+ * once-per-account facts: firing `activation.app_opened` on every app page view
+ * would turn an activation metric into a usage metric, which is the failure mode
+ * that makes an activation dashboard quietly useless.
+ */
+
+import { captureEvent } from "./client";
+
+/**
+ * How long after signup something happened, in bands.
+ *
+ * Bucketed rather than exact because the catalog admits ids, bounded enums and
+ * booleans — and because the only question anyone asks of this number is which
+ * band it lands in.
+ */
+export type ElapsedBucket =
+    | "under_1m"
+    | "1_5m"
+    | "5_15m"
+    | "15_60m"
+    | "over_1h"
+    | "unknown";
+
+/** How this account arrived at its first pod. */
+export type OnboardingEntryKind = "invite" | "domain_join" | "new_org";
+
+export function elapsedBucket(signupAt?: string | null): ElapsedBucket {
+    if (!signupAt) return "unknown";
+    const started = Date.parse(signupAt);
+    if (!Number.isFinite(started)) return "unknown";
+
+    const minutes = (Date.now() - started) / 60_000;
+    // A clock skewed backwards would otherwise report "under_1m" and quietly
+    // flatter every funnel it touches.
+    if (minutes < 0) return "unknown";
+    if (minutes < 1) return "under_1m";
+    if (minutes < 5) return "1_5m";
+    if (minutes < 15) return "5_15m";
+    if (minutes < 60) return "15_60m";
+    return "over_1h";
+}
+
+export function trackOnboardingStep(step: string): void {
+    captureEvent("onboarding.step_viewed", { step });
+}
+
+export function trackPodReady(
+    entryKind: OnboardingEntryKind,
+    signupAt?: string | null,
+): void {
+    if (!markOnce("pod_ready")) return;
+    captureEvent("onboarding.pod_ready", {
+        entry_kind: entryKind,
+        elapsed_bucket: elapsedBucket(signupAt),
+    });
+}
+
+export function trackSurfaceConnected(
+    platform: string,
+    signupAt?: string | null,
+): void {
+    if (!markOnce(`surface_connected:${platform}`)) return;
+    captureEvent("activation.surface_connected", {
+        platform,
+        elapsed_bucket: elapsedBucket(signupAt),
+    });
+}
+
+export function trackAppOpened(signupAt?: string | null): void {
+    if (!markOnce("app_opened")) return;
+    captureEvent("activation.app_opened", { elapsed_bucket: elapsedBucket(signupAt) });
+}
+
+export function trackMemberJoined(signupAt?: string | null): void {
+    if (!markOnce("member_joined")) return;
+    captureEvent("activation.member_joined", { elapsed_bucket: elapsedBucket(signupAt) });
+}
+
+const ONCE_KEY_PREFIX = "lemma:activation:";
+
+/**
+ * True the first time this browser reports a given transition.
+ *
+ * Deliberately localStorage and not memory: these fire on page load paths, so an
+ * in-memory guard would let a refresh re-report the same first-ever moment. It is
+ * a best-effort de-dup — a second browser reports again — which is why the real
+ * answer still lives in the warehouse, keyed by person.
+ */
+function markOnce(key: string): boolean {
+    if (typeof window === "undefined") return false;
+    const storageKey = `${ONCE_KEY_PREFIX}${key}`;
+    try {
+        if (window.localStorage.getItem(storageKey)) return false;
+        window.localStorage.setItem(storageKey, "1");
+        return true;
+    } catch {
+        // Private mode, or storage disabled. Reporting twice is a better failure
+        // than reporting never.
+        return true;
+    }
+}

--- a/lemma-frontend/lib/assistant/__tests__/ask-user-widget.test.ts
+++ b/lemma-frontend/lib/assistant/__tests__/ask-user-widget.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+    coerceWidgetAnswers,
+    parseAskUserQuestions,
+    parseAskUserWidget,
+} from '@/components/lemma/assistant/assistant-approval-cards';
+
+const QUESTIONS = parseAskUserQuestions({
+    questions: [
+        {
+            question: 'Where should approvals go?',
+            header: 'Approvals',
+            options: [{ label: 'To me' }, { label: 'Whoever is on duty' }],
+        },
+    ],
+} as never);
+
+const MULTI = parseAskUserQuestions({
+    questions: [
+        {
+            question: 'Which channels?',
+            header: 'Channels',
+            multi_select: true,
+            options: [{ label: 'Telegram' }, { label: 'Slack' }, { label: 'Email' }],
+        },
+    ],
+} as never);
+
+describe('parseAskUserWidget', () => {
+    it('reads inline content and caps loading messages', () => {
+        const widget = parseAskUserWidget({
+            content: '<div>pick</div>',
+            loading_messages: ['a', 'b', 'c', 'd', 'e'],
+        } as never);
+
+        expect(widget.content).toBe('<div>pick</div>');
+        expect(widget.loadingMessages).toHaveLength(4);
+    });
+
+    it('treats blank content as absent, so the chips are shown instead', () => {
+        expect(parseAskUserWidget({ content: '   ' } as never).content).toBeNull();
+        expect(parseAskUserWidget({} as never).content).toBeNull();
+    });
+});
+
+describe('coerceWidgetAnswers', () => {
+    it('accepts a declared option label', () => {
+        expect(coerceWidgetAnswers(QUESTIONS, { Approvals: 'To me' })).toEqual({
+            Approvals: 'To me',
+        });
+    });
+
+    it('rejects an answer for a question that was never asked', () => {
+        expect(coerceWidgetAnswers(QUESTIONS, { SomethingElse: 'To me' })).toBeNull();
+    });
+
+    it('ignores extra keys the widget invented', () => {
+        expect(
+            coerceWidgetAnswers(QUESTIONS, { Approvals: 'To me', Injected: 'ignore me' }),
+        ).toEqual({ Approvals: 'To me' });
+    });
+
+    it('rejects non-string answers rather than coercing them', () => {
+        expect(coerceWidgetAnswers(QUESTIONS, { Approvals: { evil: true } })).toBeNull();
+        expect(coerceWidgetAnswers(QUESTIONS, { Approvals: 42 })).toBeNull();
+        expect(coerceWidgetAnswers(QUESTIONS, { Approvals: '  ' })).toBeNull();
+    });
+
+    it('keeps free text, because the chips allow it through "Other"', () => {
+        expect(coerceWidgetAnswers(QUESTIONS, { Approvals: 'my ops rota' })).toEqual({
+            Approvals: 'my ops rota',
+        });
+    });
+
+    it('caps free text, which nothing else bounds in a widget', () => {
+        const answers = coerceWidgetAnswers(QUESTIONS, { Approvals: 'x'.repeat(10_000) });
+        expect((answers?.Approvals as string).length).toBe(4000);
+    });
+
+    it('requires every question to be answered, matching the chips', () => {
+        const two = parseAskUserQuestions({
+            questions: [
+                { question: 'A?', header: 'A', options: [{ label: 'yes' }, { label: 'no' }] },
+                { question: 'B?', header: 'B', options: [{ label: 'yes' }, { label: 'no' }] },
+            ],
+        } as never);
+
+        expect(coerceWidgetAnswers(two, { A: 'yes' })).toBeNull();
+        expect(coerceWidgetAnswers(two, { A: 'yes', B: 'no' })).toEqual({ A: 'yes', B: 'no' });
+    });
+
+    it('takes a list only for a multi-select question', () => {
+        expect(coerceWidgetAnswers(MULTI, { Channels: ['Telegram', 'Slack'] })).toEqual({
+            Channels: ['Telegram', 'Slack'],
+        });
+        expect(coerceWidgetAnswers(MULTI, { Channels: 'Telegram' })).toBeNull();
+        expect(coerceWidgetAnswers(QUESTIONS, { Approvals: ['To me'] })).toBeNull();
+    });
+
+    it('drops empty entries and refuses an all-empty list', () => {
+        expect(coerceWidgetAnswers(MULTI, { Channels: ['Telegram', '', '  '] })).toEqual({
+            Channels: ['Telegram'],
+        });
+        expect(coerceWidgetAnswers(MULTI, { Channels: [] })).toBeNull();
+    });
+
+    it('returns null when there are no questions to answer', () => {
+        expect(coerceWidgetAnswers([], { Anything: 'x' })).toBeNull();
+    });
+});

--- a/lemma-frontend/lib/hooks/use-organizations.ts
+++ b/lemma-frontend/lib/hooks/use-organizations.ts
@@ -82,8 +82,14 @@ export const useOrganizationNameAvailability = (
 export const useCreateOrganization = () => {
     const queryClient = useQueryClient();
     return useMutation({
-        mutationFn: (data: { name: string; join_policy?: OrganizationJoinPolicy; email_domain?: string | null }) =>
-            getLemmaClient().organizations.create(data) as Promise<Organization>,
+        mutationFn: (data: {
+            name: string;
+            join_policy?: OrganizationJoinPolicy;
+            email_domain?: string | null;
+            /** Take the next free name rather than conflicting. For a derived
+             *  name the user never typed; leave unset for one they did. */
+            resolve_name_conflicts?: boolean;
+        }) => getLemmaClient().organizations.create(data) as Promise<Organization>,
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['organizations'] });
             queryClient.invalidateQueries({ queryKey: ['organizations', 'suggested'] });

--- a/lemma-frontend/lib/pods/new-pod-conversation.test.ts
+++ b/lemma-frontend/lib/pods/new-pod-conversation.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    NEW_POD_OPENING_MESSAGE,
+    buildNewPodInstructions,
+    buildNewPodConversationHref,
+} from './new-pod-conversation';
+
+function launchFrom(href: string) {
+    const [path, query] = href.split('?');
+    const params = new URLSearchParams(query);
+    return {
+        path,
+        message: params.get('assistantMessage'),
+        instructions: params.get('conversationInstructions'),
+        metadata: JSON.parse(params.get('conversationMetadata') ?? '{}'),
+    };
+}
+
+const firstRun = (podName = 'Ada Pod', workDomain?: string) =>
+    buildNewPodInstructions({ podName, workDomain, isFirstPod: true });
+
+const laterPod = (podName = 'GTM Pod') =>
+    buildNewPodInstructions({ podName, isFirstPod: false });
+
+describe('every new pod', () => {
+    it('forbids creating a second pod, which is what an agent does otherwise', () => {
+        // Both variants say it; only the first-run script says it mid-sentence.
+        for (const instructions of [firstRun(), laterPod()]) {
+            expect(instructions?.toLowerCase()).toContain('do not create another pod');
+        }
+    });
+
+    it('opens a conversation rather than pod home, which is a launcher', () => {
+        const { path, message, metadata } = launchFrom(
+            buildNewPodConversationHref({
+                podId: 'pod-1',
+                podName: 'GTM Pod',
+                isFirstPod: false,
+            }),
+        );
+
+        expect(path).toBe('/pod/pod-1/conversations/new');
+        expect(message).toBe(NEW_POD_OPENING_MESSAGE);
+        expect(metadata).toMatchObject({ source: 'create_pod', first_run: false });
+    });
+
+    it('keeps the opening message trivial, because instructions carry the work', () => {
+        expect(NEW_POD_OPENING_MESSAGE.length).toBeLessThan(12);
+    });
+
+    it('treats a typed name as the clearest statement of intent available', () => {
+        expect(laterPod('GTM Pod')).toContain('They named it "GTM Pod"');
+    });
+
+    it('reads nothing into a name the user never chose', () => {
+        expect(laterPod('Untitled pod')).not.toContain('They named it');
+        // A first pod is named for the person, never by them: "Kapeed Pod" is
+        // an identity, not a brief.
+        expect(firstRun('Kapeed Pod')).not.toContain('They named it');
+        expect(firstRun('Personal Pod')).not.toContain('They named it');
+    });
+
+    it('escapes a pod id that would otherwise break the URL', () => {
+        const { path } = launchFrom(
+            buildNewPodConversationHref({
+                podId: 'a/b c',
+                podName: 'X Pod',
+                isFirstPod: false,
+            }),
+        );
+
+        expect(path).toBe('/pod/a%2Fb%20c/conversations/new');
+    });
+});
+
+describe('the first ten minutes are paced, in order', () => {
+    it('runs Telegram, then the app, then the invite', () => {
+        const instructions = firstRun();
+        const telegram = instructions.indexOf('ONE — put this pod on their phone');
+        const build = instructions.indexOf('TWO — build them something real');
+        const share = instructions.indexOf('THREE — make it theirs together');
+
+        expect(telegram).toBeGreaterThan(-1);
+        expect(build).toBeGreaterThan(telegram);
+        expect(share).toBeGreaterThan(build);
+    });
+
+    it('names the commands and skills the Telegram step actually needs', () => {
+        const instructions = firstRun();
+
+        expect(instructions).toContain('lemma surfaces telegram-setup');
+        expect(instructions).toContain('telegram-setup-status');
+        expect(instructions).toContain('lemma-builder');
+        expect(instructions).toContain('lemma-widget');
+    });
+
+    it('binds the bot to the pod assistant, so no agent has to exist first', () => {
+        expect(firstRun()).toContain('Pass no `--agent`');
+    });
+
+    it('says why messaging the bot once matters, not just that it exists', () => {
+        // The handshake: a chat bot cannot open a conversation, so the pod can
+        // only reach out after it has been reached.
+        expect(firstRun()).toContain('message *them*');
+    });
+
+    it('does not send it inspecting an empty pod', () => {
+        const instructions = firstRun();
+
+        expect(instructions).toContain('The pod is empty');
+        expect(instructions).toContain('Do not inspect it');
+        expect(instructions).not.toContain('inspect what is already there first');
+    });
+
+    it('gates the invite on something existing worth sharing', () => {
+        expect(firstRun()).toContain('worth showing, and not before');
+    });
+
+    it('stops after the QR instead of stacking the next question onto it', () => {
+        // The failure this exists for: one turn carrying the QR, the research
+        // and four app options at once, which reads as a wall, not a
+        // conversation.
+        const instructions = firstRun();
+
+        expect(instructions).toContain('Never stack two things in a turn');
+        expect(instructions).toContain('End your turn with nothing else in it');
+        expect(instructions).toContain('do not report it yet');
+    });
+
+    it('points the background research at their work domain', () => {
+        expect(firstRun('Ada Pod', 'linkedin.com')).toContain('linkedin.com');
+        expect(firstRun('Ada Pod')).not.toContain('start the background research there');
+    });
+
+    it('asks for widgets over prose, since that is the demonstration', () => {
+        expect(firstRun()).toContain('prefer a widget over a paragraph');
+    });
+});
+
+describe('a later pod gets the same conversation, minus the welcome', () => {
+    // The regression this exists for: the later-pod branch was three terse
+    // lines ending in "start building", so a second pod got no pacing, no
+    // widgets, no Telegram — just tables nobody asked for.
+    it('skips the product introduction but keeps everything else', () => {
+        const instructions = laterPod();
+
+        expect(instructions).not.toContain('first conversation this person has ever had');
+        expect(instructions).toContain('already use Lemma');
+    });
+
+    it.each([
+        ['the pacing rule', 'Never stack two things in a turn'],
+        ['propose-before-build', 'Propose before you build'],
+        ['the Telegram step', 'lemma surfaces telegram-setup'],
+        ['the widget guidance', 'prefer a widget over a paragraph'],
+        ['the invite step', 'THREE — make it theirs together'],
+    ])('still carries %s', (_label, phrase) => {
+        expect(laterPod()).toContain(phrase);
+    });
+
+    it('never tells it to start building unasked', () => {
+        for (const instructions of [firstRun(), laterPod()]) {
+            expect(instructions).not.toContain('and start building');
+            expect(instructions).toContain('wait for them to agree');
+        }
+    });
+});
+
+describe('a stated intent replaces the placeholder greeting', () => {
+    it('sends what the user picked instead of "Hi"', () => {
+        const { message } = launchFrom(
+            buildNewPodConversationHref({
+                podId: 'pod-1',
+                podName: 'Telegram Pod',
+                isFirstPod: false,
+                openingMessage: 'Build a Telegram agent that ',
+            }),
+        );
+
+        expect(message).toBe('Build a Telegram agent that');
+    });
+
+    it('keeps the new-pod framing underneath the start path brief', () => {
+        const { instructions } = launchFrom(
+            buildNewPodConversationHref({
+                podId: 'pod-1',
+                podName: 'Telegram Pod',
+                isFirstPod: false,
+                extraInstructions: 'Wire the Telegram surface.',
+            }),
+        );
+
+        expect(instructions?.toLowerCase()).toContain('do not create another pod');
+        expect(instructions).toContain('Wire the Telegram surface.');
+    });
+
+    it('falls back to the greeting when nothing was stated', () => {
+        const { message } = launchFrom(
+            buildNewPodConversationHref({
+                podId: 'pod-1',
+                podName: 'X Pod',
+                isFirstPod: false,
+                openingMessage: '   ',
+            }),
+        );
+
+        expect(message).toBe(NEW_POD_OPENING_MESSAGE);
+    });
+
+    it('lets a caller add origin metadata without losing the defaults', () => {
+        const { metadata } = launchFrom(
+            buildNewPodConversationHref({
+                podId: 'pod-1',
+                podName: 'X Pod',
+                isFirstPod: false,
+                metadata: { start_path: 'telegram' },
+            }),
+        );
+
+        expect(metadata).toMatchObject({ pod_id: 'pod-1', start_path: 'telegram' });
+    });
+});

--- a/lemma-frontend/lib/pods/new-pod-conversation.ts
+++ b/lemma-frontend/lib/pods/new-pod-conversation.ts
@@ -1,0 +1,153 @@
+import {
+    CONVERSATION_INSTRUCTIONS_PARAM,
+    CONVERSATION_METADATA_PARAM,
+} from "@/lib/pods/composer-launch";
+
+/**
+ * The conversation a newly created pod opens in.
+ *
+ * A new pod's home is a launcher — a grid of starters and three ways to
+ * describe something — which is a menu of decisions for someone who has just
+ * said what they want by creating the pod at all. So a new pod lands in a
+ * conversation with the assistant already working instead, and everything it
+ * should do lives in `instructions`. Changing the experience is editing prose,
+ * not rebuilding a screen, which is the only version of this that scales.
+ *
+ * The greeting is sent as the user because that is the only way to start a turn
+ * here, and it is deliberately trivial: `instructions` carries the substance.
+ */
+export const NEW_POD_OPENING_MESSAGE = "Hi";
+
+/** A name that says nothing about intent, so nothing should be read into it. */
+const PLACEHOLDER_POD_NAMES = new Set(["untitled pod", "personal pod"]);
+
+function namedWithIntent(podName: string): boolean {
+    return !PLACEHOLDER_POD_NAMES.has(podName.trim().toLowerCase());
+}
+
+/**
+ * How to behave in a pod that was just made, whoever made it.
+ *
+ * Shared on purpose. These rules used to live only in the first-run branch, so
+ * a second pod got three terse lines ending in "start building" — and the
+ * assistant did exactly that: no conversation, no question, just tables nobody
+ * asked for. Anything about *how to talk to someone* belongs here; only the
+ * welcome differs between a first pod and a fifth.
+ */
+const CONVERSATION_RULES = [
+    "Have a conversation. Do one thing, then stop and let them answer. Never stack two things in a turn — do not show something and ask about the next thing in the same breath, and never leave two things waiting on them at once. A turn that ends with one clear thing to do is the point; a turn that ends with three is the thing to avoid.",
+    "Propose before you build. They have said almost nothing, so anything you make now is a guess — say what you would build and why, in a sentence or two, and wait for them to agree or redirect you. Do not create tables, apps, agents or workflows before they have said yes to something. Handing someone a schema they never asked for is not momentum; it is a mess they now have to clean up.",
+    "The pod is empty. Do not inspect it, do not go looking for existing resources, and do not create another pod: you are already inside theirs.",
+    "Use widgets generously. `display_resource` with type WIDGET renders live HTML inline in this conversation, and it is the best demonstration of this platform there is — a QR code, a set of choices, a status panel, a preview of what you are building. Load the `lemma-widget` skill before your first one, and prefer a widget over a paragraph every time.",
+].join("\n\n");
+
+/**
+ * Three things worth reaching, and the order that makes each one land.
+ *
+ * Guidance, not a checklist. A pod gets its own Telegram surface, so this is as
+ * true of someone's fifth pod as their first — what changes is how much
+ * explaining it needs, not whether it is offered at all.
+ */
+const THREE_MOMENTS = [
+    "There are three things worth reaching here, in this order, each making the next worth more. Take them one at a time and let each finish before starting the next. Do not describe the plan up front and do not present them as steps to get through.",
+    "ONE — put this pod on their phone. Connect this pod's assistant to Telegram. Load the `lemma-builder` skill for how surfaces work, then run `lemma surfaces telegram-setup` in the workspace. Pass no `--agent`: the bot then answers as the pod's own assistant, which needs no agent to exist first. It returns a `launch_url` — render that as a QR code in a widget, tell them to scan it and say hello to the bot, and say why it matters: a chat bot cannot open a conversation, so once they have messaged it even once, this pod can message *them*, unprompted, from then on. That is what makes it a colleague rather than a website they visit.",
+    "Then stop. End your turn with nothing else in it — no questions, no options, no preview of what comes next. They are on their phone now and cannot answer you anyway. Wait for them to come back and say something, anything. While you wait you may quietly look into what they are likely to need, but do not report it yet.",
+    "When they come back, check whether the bot actually came up with `lemma surfaces telegram-setup-status <setup_id>` before you say it worked, and say so briefly either way. If it never completed, offer the link again rather than letting it quietly go missing.",
+    "TWO — build them something real. Only now bring up building. Offer a small set of concrete things you could build, as a widget of choices rather than a paragraph of suggestions. When they pick one, build it properly: real tables, believable sample data, an agent doing the work behind it. It should be alive the moment it opens, not a shell they have to fill in. Keep narrating in short turns as you go.",
+    "THREE — make it theirs together. Once something exists that is worth showing, and not before, ask whether a teammate should have it. An invitation lands that person directly in the app you just built, able to use it and its agents immediately.",
+    "Throughout: short turns, plain language, no walls of text. Ask at most one question at a time, and only when you truly cannot proceed without the answer. Never make them configure something before they have seen something work.",
+].join("\n\n");
+
+/** Only for someone who has never seen Lemma before. */
+const FIRST_RUN_WELCOME =
+    "You are opening the first conversation this person has ever had in Lemma. Their pod was created for them automatically and named after them: they have chosen nothing, configured nothing, and told you nothing. They have said only hello. Open with one warm, genuine line that welcomes them — confident and personal, never corporate — then get on with it.";
+
+/** For someone who already uses Lemma and has just made another pod. */
+const RETURNING_WELCOME =
+    "They already use Lemma and have just made themselves another pod, so skip any introduction to the product and keep the opening to a single short line. Everything below still applies: this pod is as empty as their first one was, and they have told you no more about it than its name.";
+
+export function buildNewPodInstructions({
+    podName,
+    workDomain,
+    isFirstPod,
+}: {
+    podName: string;
+    /** The company behind their address, when it is a work one. */
+    workDomain?: string | null;
+    /** Their first pod ever, rather than another one in a workspace they know. */
+    isFirstPod: boolean;
+}): string {
+    const parts: string[] = [
+        isFirstPod ? FIRST_RUN_WELCOME : RETURNING_WELCOME,
+        CONVERSATION_RULES,
+        THREE_MOMENTS,
+        `This pod is called ${podName}.`,
+    ];
+
+    // Only a name the user typed says anything. A first pod is named for the
+    // person by `firstPodName`, so "Kapeed Pod" is not a brief — telling the
+    // assistant to build something fitting it would send it after a name.
+    if (!isFirstPod && namedWithIntent(podName)) {
+        parts.push(
+            `They named it "${podName}" before it contained anything, so it is the closest thing to a brief you have — let it shape what you propose, but still ask before you build.`,
+        );
+    }
+
+    if (workDomain) {
+        parts.push(
+            `Their work email is at ${workDomain} — a reasonable place to start working out what they are likely to need.`,
+        );
+    }
+
+    return parts.join("\n\n");
+}
+
+/** Pod home is a launcher; a pod that was just created belongs in a conversation. */
+export function buildNewPodConversationHref({
+    podId,
+    podName,
+    workDomain,
+    isFirstPod,
+    openingMessage,
+    extraInstructions,
+    metadata,
+}: {
+    podId: string;
+    podName: string;
+    workDomain?: string | null;
+    isFirstPod: boolean;
+    /**
+     * What opens the conversation, when the user has already said it.
+     *
+     * Someone who picked a starting point has stated an intent, and sending it
+     * beats "Hi" — the greeting only exists because a pod created from nothing
+     * has nothing better to send.
+     */
+    openingMessage?: string;
+    /** What that starting point asks for, on top of the new-pod framing. */
+    extraInstructions?: string;
+    /** Merged over the defaults, for callers that know more about the origin. */
+    metadata?: Record<string, unknown>;
+}): string {
+    const instructions = [
+        buildNewPodInstructions({ podName, workDomain, isFirstPod }),
+        extraInstructions,
+    ]
+        .filter(Boolean)
+        .join("\n\n");
+
+    const params = new URLSearchParams();
+    params.set("assistantMessage", openingMessage?.trim() || NEW_POD_OPENING_MESSAGE);
+    params.set(CONVERSATION_INSTRUCTIONS_PARAM, instructions);
+    params.set(
+        CONVERSATION_METADATA_PARAM,
+        JSON.stringify({
+            source: isFirstPod ? "onboarding" : "create_pod",
+            first_run: isFirstPod,
+            pod_id: podId,
+            ...metadata,
+        }),
+    );
+
+    return `/pod/${encodeURIComponent(podId)}/conversations/new?${params.toString()}`;
+}

--- a/lemma-frontend/lib/pods/onboarding-skip.test.ts
+++ b/lemma-frontend/lib/pods/onboarding-skip.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasSkippedFirstPod, normalizeSkipOwner } from './onboarding-skip';
+
+describe('hasSkippedFirstPod', () => {
+    it('counts a skip recorded by this account', () => {
+        expect(hasSkippedFirstPod('ada@example.com', 'ada@example.com')).toBe(true);
+    });
+
+    it('ignores case and padding on both sides', () => {
+        expect(hasSkippedFirstPod('ada@example.com', '  Ada@Example.com ')).toBe(true);
+    });
+
+    it('ignores a skip recorded by a different account', () => {
+        // The bug this exists for: one browser, several accounts, and a flag
+        // that muted first-pod provisioning for everyone after the first.
+        expect(hasSkippedFirstPod('someone-else@example.com', 'ada@example.com')).toBe(
+            false,
+        );
+    });
+
+    it('heals the legacy unowned "1" instead of trusting it', () => {
+        expect(hasSkippedFirstPod('1', 'ada@example.com')).toBe(false);
+    });
+
+    it('is false when there is no flag or no signed-in address', () => {
+        expect(hasSkippedFirstPod(null, 'ada@example.com')).toBe(false);
+        expect(hasSkippedFirstPod('ada@example.com', null)).toBe(false);
+        expect(hasSkippedFirstPod('ada@example.com', '   ')).toBe(false);
+        expect(hasSkippedFirstPod(null, null)).toBe(false);
+    });
+});
+
+describe('normalizeSkipOwner', () => {
+    it('normalizes an address, and treats blank as absent', () => {
+        expect(normalizeSkipOwner('  Ada@Example.com ')).toBe('ada@example.com');
+        expect(normalizeSkipOwner('')).toBeNull();
+        expect(normalizeSkipOwner('   ')).toBeNull();
+        expect(normalizeSkipOwner(null)).toBeNull();
+    });
+});

--- a/lemma-frontend/lib/pods/onboarding-skip.ts
+++ b/lemma-frontend/lib/pods/onboarding-skip.ts
@@ -1,5 +1,25 @@
 export const ONBOARDING_SKIPPED_FIRST_POD_KEY = 'lemma:onboarding-skipped-first-pod';
+const ONBOARDING_SKIPPED_FIRST_POD_EVENT = 'lemma:onboarding-skipped-first-pod-change';
 
+/**
+ * Who skipped their first pod, not merely that somebody did.
+ *
+ * This used to store `"1"`. Browser storage is per browser and this app signs a
+ * different person in whenever it is asked to, so a flag with no owner said
+ * "this account already has somewhere to be" about every account that came
+ * after — silently switching off first-pod provisioning for all of them, with
+ * no expiry and no way to notice. It cost an afternoon.
+ *
+ * Storing the owner's email *as the value* makes the old `"1"` heal itself: it
+ * matches nobody's address, so it reads as "not this account" and provisioning
+ * runs again.
+ */
+export function normalizeSkipOwner(email?: string | null): string | null {
+    const normalized = email?.trim().toLowerCase();
+    return normalized || null;
+}
+
+/** The address that skipped, or null. Compare it against the signed-in user. */
 export function readOnboardingSkippedFirstPod(): string | null {
     if (typeof window === 'undefined') return null;
 
@@ -10,21 +30,39 @@ export function readOnboardingSkippedFirstPod(): string | null {
     }
 }
 
+/** True only when *this* account is the one that skipped. */
+export function hasSkippedFirstPod(
+    stored: string | null,
+    ownerEmail?: string | null,
+): boolean {
+    const owner = normalizeSkipOwner(ownerEmail);
+    return Boolean(owner) && stored === owner;
+}
+
 export function subscribeToOnboardingSkippedFirstPod(callback: () => void) {
     if (typeof window === 'undefined') return () => undefined;
 
     window.addEventListener('storage', callback);
-    return () => window.removeEventListener('storage', callback);
+    window.addEventListener(ONBOARDING_SKIPPED_FIRST_POD_EVENT, callback);
+    return () => {
+        window.removeEventListener('storage', callback);
+        window.removeEventListener(ONBOARDING_SKIPPED_FIRST_POD_EVENT, callback);
+    };
 }
 
-export function markOnboardingSkippedFirstPod() {
+export function markOnboardingSkippedFirstPod(ownerEmail?: string | null) {
     if (typeof window === 'undefined') return;
 
+    const owner = normalizeSkipOwner(ownerEmail);
+    // Nobody to attribute it to means nobody it can be read back for. Writing an
+    // unowned flag is what caused the original bug.
+    if (!owner) return;
+
     try {
-        window.localStorage.setItem(ONBOARDING_SKIPPED_FIRST_POD_KEY, '1');
-        window.dispatchEvent(new StorageEvent('storage', { key: ONBOARDING_SKIPPED_FIRST_POD_KEY }));
+        window.localStorage.setItem(ONBOARDING_SKIPPED_FIRST_POD_KEY, owner);
+        window.dispatchEvent(new Event(ONBOARDING_SKIPPED_FIRST_POD_EVENT));
     } catch {
-        // localStorage can be unavailable in private or restricted browser contexts.
+        // localStorage can be unavailable in private or restricted contexts.
     }
 }
 
@@ -33,8 +71,8 @@ export function clearOnboardingSkippedFirstPod() {
 
     try {
         window.localStorage.removeItem(ONBOARDING_SKIPPED_FIRST_POD_KEY);
-        window.dispatchEvent(new StorageEvent('storage', { key: ONBOARDING_SKIPPED_FIRST_POD_KEY }));
+        window.dispatchEvent(new Event(ONBOARDING_SKIPPED_FIRST_POD_EVENT));
     } catch {
-        // localStorage can be unavailable in private or restricted browser contexts.
+        // localStorage can be unavailable in private or restricted contexts.
     }
 }

--- a/lemma-frontend/lib/pods/onboarding-steps.test.ts
+++ b/lemma-frontend/lib/pods/onboarding-steps.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   codingAgentStarterPrompt,
+  firstPodName,
   generatedOrganizationName,
   hasUsableProfileName,
   isRetriableOrganizationNameConflict,
@@ -238,5 +239,56 @@ describe("onboarding step paths", () => {
     expect(launch.instructions).toContain(
       "Codex, Claude Code, or OpenCode",
     );
+  });
+});
+
+describe("firstPodName", () => {
+  // The server's own rule, copied from `normalize_pod_name`. Every name this
+  // builds is checked against it: a name the server rejects fails the create,
+  // which is invisible from here and cost two rounds of debugging once already.
+  const SERVER_POD_NAME_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9 _-]*[A-Za-z0-9])?$/;
+
+  it("puts the person in the name of the pod they are given", () => {
+    expect(firstPodName({ first_name: "Kapeed", last_name: "Verma" })).toBe(
+      "Kapeed Pod",
+    );
+    expect(firstPodName({ full_name: "Ada Lovelace" })).toBe("Ada Pod");
+  });
+
+  it("derives a name from the address when the provider sent none", () => {
+    expect(firstPodName({ email: "ada.lovelace@example.com" })).toBe("Ada Pod");
+  });
+
+  it("drops an apostrophe rather than sending a name the server refuses", () => {
+    expect(firstPodName({ full_name: "Siobhan O'Brien" })).toBe("Siobhan Pod");
+    expect(firstPodName({ first_name: "O'Brien" })).toBe("OBrien Pod");
+  });
+
+  it("folds accents instead of stripping the letters under them", () => {
+    expect(firstPodName({ first_name: "José" })).toBe("Jose Pod");
+    expect(firstPodName({ first_name: "Ångström" })).toBe("Angstrom Pod");
+  });
+
+  it("falls back to the generic name when nothing usable survives", () => {
+    expect(firstPodName(null)).toBe("Personal Pod");
+    expect(firstPodName({ email: "" })).toBe("Personal Pod");
+    expect(firstPodName({ first_name: "陳" })).toBe("Personal Pod");
+  });
+
+  it("only ever builds a name the server will accept", () => {
+    const profiles = [
+      { first_name: "Kapeed", last_name: "Verma" },
+      { full_name: "Siobhan O'Brien" },
+      { first_name: "José" },
+      { first_name: "Ångström" },
+      { email: "ada.lovelace@example.com" },
+      { email: "x_y-z@example.com" },
+      { first_name: "陳" },
+      null,
+    ];
+
+    for (const profile of profiles) {
+      expect(firstPodName(profile)).toMatch(SERVER_POD_NAME_PATTERN);
+    }
   });
 });

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -13,4 +13,4 @@ SDK and the server it is talking to.
 from __future__ import annotations
 
 API_VERSION = "0.7.0"
-SPEC_SHA256 = "e526404fead289be5285d1a7f72c1c6cc2165d30d8f5363c8cd9b852549ad0e2"
+SPEC_SHA256 = "59ea84dfc20c5e95d9f121b93e8d5949f7b22de9887877fd2eda38e7154d9148"

--- a/lemma-python/lemma_sdk/openapi_client/models/organization_create_request.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/organization_create_request.py
@@ -20,12 +20,16 @@ class OrganizationCreateRequest:
         name (str):
         email_domain (None | str | Unset):
         join_policy (OrganizationJoinPolicy | Unset): Who may self-join an organization, ordered from closed to open.
+        resolve_name_conflicts (bool | Unset): Take the next free name instead of conflicting. For a name the user did
+            not choose -- onboarding's derived first workspace -- where a 409 is a dead end for someone who never typed a
+            name. Leave false for a name they typed, so a clash is reported. Default: False.
         slug (None | str | Unset):
     """
 
     name: str
     email_domain: None | str | Unset = UNSET
     join_policy: OrganizationJoinPolicy | Unset = UNSET
+    resolve_name_conflicts: bool | Unset = False
     slug: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -41,6 +45,8 @@ class OrganizationCreateRequest:
         join_policy: str | Unset = UNSET
         if not isinstance(self.join_policy, Unset):
             join_policy = self.join_policy.value
+
+        resolve_name_conflicts = self.resolve_name_conflicts
 
         slug: None | str | Unset
         if isinstance(self.slug, Unset):
@@ -59,6 +65,8 @@ class OrganizationCreateRequest:
             field_dict["email_domain"] = email_domain
         if join_policy is not UNSET:
             field_dict["join_policy"] = join_policy
+        if resolve_name_conflicts is not UNSET:
+            field_dict["resolve_name_conflicts"] = resolve_name_conflicts
         if slug is not UNSET:
             field_dict["slug"] = slug
 
@@ -85,6 +93,8 @@ class OrganizationCreateRequest:
         else:
             join_policy = OrganizationJoinPolicy(_join_policy)
 
+        resolve_name_conflicts = d.pop("resolve_name_conflicts", UNSET)
+
         def _parse_slug(data: object) -> None | str | Unset:
             if data is None:
                 return data
@@ -98,6 +108,7 @@ class OrganizationCreateRequest:
             name=name,
             email_domain=email_domain,
             join_policy=join_policy,
+            resolve_name_conflicts=resolve_name_conflicts,
             slug=slug,
         )
 

--- a/lemma-python/lemma_sdk/openapi_spec.json
+++ b/lemma-python/lemma_sdk/openapi_spec.json
@@ -9570,6 +9570,12 @@
             "title": "Name",
             "type": "string"
           },
+          "resolve_name_conflicts": {
+            "default": false,
+            "description": "Take the next free name instead of conflicting. For a name the user did not choose -- onboarding's derived first workspace -- where a 409 is a dead end for someone who never typed a name. Leave false for a name they typed, so a clash is reported.",
+            "title": "Resolve Name Conflicts",
+            "type": "boolean"
+          },
           "slug": {
             "anyOf": [
               {

--- a/lemma-typescript/src/openapi_client/models/OrganizationCreateRequest.ts
+++ b/lemma-typescript/src/openapi_client/models/OrganizationCreateRequest.ts
@@ -10,5 +10,9 @@ export type OrganizationCreateRequest = {
     email_domain?: (string | null);
     join_policy?: OrganizationJoinPolicy;
     name: string;
+    /**
+     * Take the next free name instead of conflicting. For a name the user did not choose -- onboarding's derived first workspace -- where a 409 is a dead end for someone who never typed a name. Leave false for a name they typed, so a clash is reported.
+     */
+    resolve_name_conflicts?: boolean;
     slug?: (string | null);
 };


### PR DESCRIPTION
Signing up meant a preflight spinner, a name form, and a seven-way choice of what to build — before seeing anything. None of those questions had an answer we didn't already have: the identity provider sends the name, the pod is theirs by definition, and the choice was a worse copy of the launcher that already lives inside the pod.

A hosted account with nothing yet is now provisioned rather than interviewed, and lands mid-conversation with the assistant already working.

## What changed

**`Let an agent set up a Telegram bot without a token to paste`** — the managed setup (BotFather link, nothing copied back) existed only as a frontend mutation, so an agent in a pod could reach `upsert`/`enable`/`setup` but not the path that actually produces a working bot. Adds `surfaces telegram-setup` and `telegram-setup-status`. Omitting `--agent` binds the surface to the pod assistant, which is what lets a brand new pod take messages before any agent exists.

**`Let a question be drawn rather than listed, and let a widget be its own height`** — `ask_user` takes optional `content`: the same inline HTML a WIDGET takes, rendered in place of the choice chips. The pause/resume path is untouched, and a client that can't render it still shows the chips. The serve path needed no changes at all — `WidgetAssetService` reads inline content by `(conversation_id, tool_call_id)` and never filtered by tool name.

What a widget posts back is untrusted (it is model-authored HTML), so answers are taken only when they name a declared question and, where possible, a declared option. A `sendPrompt`-style channel would have let generated markup put arbitrary words in the user's mouth.

Sizing: `min-height: 100%` on the embed styles made the document always as tall as the frame the host had already sized, so the height bridge measured the host's own guess and reported it back — a short widget could never shrink.

**`Keep the name the provider sent, and stop a derived org name failing a signup`** — `sign_in_up` dropped `raw_user_info_from_provider`, so the next screen asked for a name Google had just supplied. And because org names are globally unique, onboarding walked a twenty-rung ladder from the browser, one sequential create per rung, for a name nobody typed. `create_organization` now takes `resolve_name_conflicts` and resolves server-side in one call. A name the user *did* type still conflicts loudly.

**`Give onboarding a funnel, and name the three moments worth measuring`** — `captureEvent` had three call sites in the app and none in onboarding, and every step renders at `/`, so pageviews couldn't separate them either. Five catalogued events, with the three activation transitions deduped once-per-browser so activation doesn't decay into a usage counter.

**`Land a new account in a pod that is already talking`** — the provisioning path, the invite-ordering fix, the account-scoped skip flag, and the first-run conversation.

## Two things worth a reviewer's attention

**`organization_service.py` shrank.** It was already over the architecture ratchet's 600-line limit at a 672 baseline, and the new rules grew it. Rather than let it grow, the naming ladder *and* the pre-existing email-domain policy moved to `domain/organization_identity.py` — they answer the same question, what identity may this organization claim. The file is now 669.

**The first run is prose, not UI.** Everything the assistant should do on a new pod lives in `new-pod-conversation.ts` as instructions. Tuning the experience is an edit to a string — no deploy, no screen to rebuild. The rules are shared between a first pod and a fifth; only the welcome differs. An earlier cut gave later pods three terse lines ending in "start building", and the assistant did exactly that: no conversation, no question, just tables nobody asked for. "Propose before you build" is now explicit, as is one thing per turn.

## Fixed along the way

- A pending invitation lost to the identity step, so an invited teammate was asked their name before being let into the pod they were invited to.
- `onboarding-skipped-first-pod` stored `"1"` with no owner. Browser storage is per browser and this app signs in whoever it's asked to, so one account accepting an invitation switched off first-pod provisioning for every account after it, with no expiry. It stores the owner's address now, which also heals the old value.
- The root redirect returned a loader forever when an account had no openable pod — a dead end with a spinner on it.
- Derived pod names could contain apostrophes and accents, which `normalize_pod_name` rejects. A test now asserts every generated name matches the server's own pattern.

## Verified

`make test-unit` (5072), `make architecture`, `make lint`, `make lint-async`, `make typecheck-critical` · frontend `npm run check` + 855 tests · CLI 599 unit + `make lint`. CLI e2e needs a provisioned backend and was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)