### PR TITLE
Ask for the GitHub account we actually publish with

### DIFF
--- a/lemma-frontend/components/bundle/import-dialog.tsx
+++ b/lemma-frontend/components/bundle/import-dialog.tsx
@@ -29,6 +29,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { showResourceErrorToast } from '@/components/shared/resource-feedback';
 import { BundleProgressBar } from '@/components/bundle/bundle-progress';
 import { AccountVariableField } from '@/components/bundle/account-variable-field';
+import { KIND } from '@/components/connectors/connector-utils';
 import { ShareSheet } from '@/components/bundle/share-sheet';
 import { getLemmaClient } from '@/lib/sdk/lemma-client';
 import { usePod } from '@/lib/hooks/use-pods';
@@ -813,11 +814,13 @@ export function ImportDialog({
                                             placeholder="github.com/owner/repo"
                                         />
                                     </div>
+                                    {/* Native `http` kind, as in the share sheet: importing reads
+                                        the repository through the same connector that publishes it. */}
                                     <AccountVariableField
                                         organizationId={organizationId}
                                         podId={targetPodId}
                                         connectorId="github"
-                                        connectorKind="composio"
+                                        connectorKind={KIND.HTTP}
                                         label="GitHub account"
                                         description="Optional for public repositories; required for private repositories and higher rate limits."
                                         value={githubAccountId}

--- a/lemma-frontend/components/bundle/share-sheet.tsx
+++ b/lemma-frontend/components/bundle/share-sheet.tsx
@@ -20,6 +20,7 @@ import { Switch, SwitchThumb, SwitchTrack } from '@/components/ui/switch';
 import { showResourceErrorToast } from '@/components/shared/resource-feedback';
 import { BundleProgressBar } from '@/components/bundle/bundle-progress';
 import { AccountVariableField } from '@/components/bundle/account-variable-field';
+import { KIND } from '@/components/connectors/connector-utils';
 import { SocialCardPanel } from '@/components/share/social-card-panel';
 import {
     getPublish,
@@ -462,11 +463,16 @@ export function ShareSheet({ podId, podName, open, onOpenChange, canPublish = tr
                                         placeholder="my-pod"
                                     />
                                 </div>
+                                {/* GitHub is Lemma's own `http`-kind connector, not a Composio
+                                    toolkit: publishing runs its native git-data operations, and a
+                                    workspace agent needs the account's real OAuth token. Retired
+                                    Composio installs are disabled rather than deleted, so pinning
+                                    the kind is what keeps their accounts out of this picker. */}
                                 <AccountVariableField
                                     organizationId={pod?.organization_id}
                                     podId={podId}
                                     connectorId="github"
-                                    connectorKind="composio"
+                                    connectorKind={KIND.HTTP}
                                     label="GitHub account"
                                     description="The connected account that owns and publishes the repository."
                                     required


### PR DESCRIPTION
## What changes

The share sheet offers the GitHub account you already connected, instead of
showing "Connect GitHub" to everyone forever. Publishing a pod to GitHub is
reachable from the sheet again, and private-repo import works from the
GitHub-URL path.

## Why

[#322](https://github.com/lemma-work/lemma-platform/pull/322) moved GitHub off
Composio onto Lemma's own `http`-kind connector — a workspace agent's `git`/`gh`
need the account's real OAuth token, which a broker never hands over. Both
bundle account pickers were left pinned to `connectorKind="composio"`.

That one stale prop drives three things in `AccountVariableField`, and all three
failed together:

1. the accounts filter dropped the connected account, whose `kind` now reads
   `http` (it comes from the auth config, `AccountResponseSchema.kind`);
2. the auth-config filter dropped its install, so `resolveAuthConfigId` found
   nothing active;
3. `getKindSpec(connector, 'composio')` returned `null`, because the retirement
   pass strips the Composio spec out of the connector's `kinds`.

With no capability resolved, `isOAuth` and `canCredential` were both false, so
**Connect GitHub** did not start OAuth at all — it fell through to the last
resort and opened the connectors page in a new tab. No account could be
selected, so `disabled={!repoName.trim() || !githubAccountId}` kept **Publish to
GitHub** permanently disabled. The import dialog carried the same stale kind,
where it is less visible (public repos need no account) but breaks private-repo
import.

The kind stays pinned rather than dropped. The retirement pass *disables* rather
than deletes old Composio installs, precisely so nobody is silently
disconnected — an unfiltered picker would therefore offer accounts whose
operations no longer exist. And `getPrimaryKindSpec` is Composio-first by
design, which is the wrong default here. `connector-utils` already knew about
this migration (`isOAuthOverHttp` says so in as many words); only the two bundle
pickers were left behind.

## How to verify

From `lemma-frontend`:

```bash
npm run check && npm test
```

Printed: eslint clean, `tsc --noEmit` clean, `Design audit passed
productStrict=0 informational=67 protectedAssistant=1`, `check-edu-anchors: 9
anchors verified.`, and `Test Files 85 passed (85) / Tests 860 passed (860)`.

Not verified against a live deployment: confirming the picker lists a real
account needs an org with a GitHub account connected through the native
connector, which I could not stand up here. The reasoning above is read off the
catalog (`lemma_apps_config.json` has GitHub at `"kind": "http"`) and the
retirement pass in `import_connector_catalog.py`, so that end is worth a
reviewer's eyes on a real org.

## Checklist

- [ ] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

No test: the repo has no component-render harness — every test under
`components/` covers a pure helper, and the filtering here lives inside
`AccountVariableField`. A test of the predicate would not have caught this
anyway; the predicate was always correct, its argument was stale. Typecheck
covers the constant swap.

## Compatibility and rollback notes

Frontend-only, two prop values. Nothing to migrate; revert the commit to roll
back.
