### PR TITLE
Poll through E2B edge-lag 502s in the runtime readiness probe

### DIFF
--- a/lemma-backend/app/modules/workspace/providers/e2b_common.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b_common.py
@@ -158,7 +158,7 @@ async def ensure_runtime_serving(
     provider_id: str,
     *,
     runtime_port: int,
-    budget_seconds: float = 6.0,
+    budget_seconds: float = 20.0,
 ) -> None:
     """Raise unless the runtime inside this sandbox is answering.
 
@@ -172,11 +172,15 @@ async def ensure_runtime_serving(
 
     So any HTTP answer at all means the runtime is there -- 404 included, and
     deliberately, because the probe must not depend on an authenticated route.
-    502 and a transport failure mean it is not.
+    A 502 that *persists* means it is not.
 
-    Polled rather than probed once, because readiness is allowed to wait: a
-    resumed sandbox needs a moment before E2B's edge routes to it. The budget is
-    short because this also runs on the warm path, and it only elapses when the
+    The same 502 is also the normal shape of the first moments after a create
+    or a resume: E2B's edge answers before it has routed to the sandbox. That
+    is why the probe polls through 5xx rather than taking the first answer as
+    final -- treating the first 502 as definitive failed the whole provision
+    during ordinary edge lag, and with it the first tool call of every run
+    that landed on a cold sandbox (2026-08-20). Only callers off the warm path
+    reach here, so the budget can be generous; it only elapses when the
     runtime is *not* answering -- a healthy one replies well inside it.
     """
     with sdk_errors():
@@ -206,18 +210,31 @@ async def ensure_runtime_serving(
 
 
 async def _poll_runtime(url: str, budget_seconds: float) -> int | None:
-    """The runtime's status, or None if it never answered inside the budget."""
+    """The runtime's status, or None if it never answered inside the budget.
+
+    Both failure shapes are polled through, because both are transient on a
+    sandbox that is still coming up: a transport error is the edge not yet
+    listening for this host at all, and a 5xx is the edge listening but not
+    yet routed to the sandbox. Only an answer below 500 ends the wait early --
+    it is the one outcome that cannot mean "not up yet". A budget that expires
+    on 5xx answers returns the last one, so the failure still says *what* the
+    runtime answered rather than merely that it did not.
+    """
     import asyncio
     import time
 
     import httpx
 
     deadline = time.monotonic() + budget_seconds
+    status: int | None = None
     async with httpx.AsyncClient(timeout=budget_seconds) as client:
         while True:
             try:
-                return (await client.get(url)).status_code
+                status = (await client.get(url)).status_code
+                if status < 500:
+                    return status
             except httpx.HTTPError:
-                if time.monotonic() >= deadline:
-                    return None
-                await asyncio.sleep(0.1)
+                pass
+            if time.monotonic() >= deadline:
+                return status
+            await asyncio.sleep(0.1)

--- a/lemma-backend/app/modules/workspace/tests/unit/test_e2b_common.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_e2b_common.py
@@ -1,0 +1,160 @@
+"""The runtime-readiness probe's polling contract.
+
+`ensure_runtime_serving` exists because a VM outlives the process inside it,
+so readiness is an HTTP answer, not `is_running()`. But the answer the probe
+gets first is not always the answer that is true: E2B's edge answers 502 both
+for a runtime that has died and for a sandbox it has not routed to yet, and
+the seconds after a create or a resume are the second kind. Taking the first
+502 as final failed the whole provision during ordinary edge lag -- and with
+it the first tool call of every run that landed on a cold sandbox.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.modules.workspace.providers.base import ProviderFailed
+from app.modules.workspace.providers.e2b_common import (
+    _poll_runtime,
+    ensure_runtime_serving,
+)
+
+
+class _ScriptedHttpx:
+    """An `httpx.AsyncClient` stand-in answering from a script.
+
+    Entries are status codes, or ``None`` for a transport failure. Exhausting
+    the script repeats its last entry, so "never stops failing" does not need
+    an infinite list.
+    """
+
+    def __init__(self, script: list):
+        self._script = script
+        self.calls = 0
+
+    async def __aenter__(self) -> "_ScriptedHttpx":
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+    async def get(self, url: str):
+        entry = self._script[min(self.calls, len(self._script) - 1)]
+        self.calls += 1
+        if entry is None:
+            raise httpx.ConnectError("edge not listening yet")
+        return httpx.Response(status_code=entry)
+
+
+@pytest.fixture
+def scripted_httpx(monkeypatch: pytest.MonkeyPatch):
+    """Install the scripted client and hand the test its instance."""
+
+    instances: list[_ScriptedHttpx] = []
+
+    def factory(script: list) -> _ScriptedHttpx:
+        instance = _ScriptedHttpx(script)
+        instances.append(instance)
+        return instance
+
+    def construct(*_args, **_kwargs) -> _ScriptedHttpx:
+        assert instances, "the test must script its answers before polling"
+        return instances[-1]
+
+    monkeypatch.setattr(httpx, "AsyncClient", construct)
+    return factory
+
+
+class _Sandbox:
+    """Just enough of the SDK sandbox for the probe."""
+
+    def __init__(self, *, running: bool = True) -> None:
+        self._running = running
+
+    async def is_running(self) -> bool:
+        return self._running
+
+    def get_host(self, port: int) -> str:
+        return f"{port}-i12345.e2b.dev"
+
+
+async def test_a_transient_502_is_polled_through(scripted_httpx) -> None:
+    """Edge lag after a create or resume answers 502 first, 404 once routed.
+
+    This is the 2026-08-20 first-tool-call failure: the probe took the first
+    502 as final, so a healthy sandbox still being routed to was declared
+    dead and the provision was rejected.
+    """
+    client = scripted_httpx([502, 502, 404])
+
+    status = await _poll_runtime("https://8080-i12345.e2b.dev/health", 5.0)
+
+    assert status == 404
+    assert client.calls == 3
+
+
+async def test_a_persistent_502_still_fails_with_the_status(scripted_httpx) -> None:
+    """The P0 the probe exists for: a runtime that never comes back.
+
+    Polling must not turn that into silence -- the failure keeps the status,
+    because "answered 502" and "answered nothing" are different diagnoses.
+    """
+    scripted_httpx([502])
+
+    status = await _poll_runtime("https://8080-i12345.e2b.dev/health", 0.3)
+
+    assert status == 502
+
+
+async def test_a_port_that_never_answers_returns_none(scripted_httpx) -> None:
+    scripted_httpx([None])
+
+    status = await _poll_runtime("https://8080-i12345.e2b.dev/health", 0.3)
+
+    assert status is None
+
+
+async def test_a_healthy_runtime_is_answered_immediately(scripted_httpx) -> None:
+    """The budget is only spent on sandboxes that are not serving; a healthy
+    one must not pay for it."""
+    client = scripted_httpx([404])
+
+    status = await _poll_runtime("https://8080-i12345.e2b.dev/health", 5.0)
+
+    assert status == 404
+    assert client.calls == 1
+
+
+async def test_ensure_waits_out_edge_lag_after_a_resume(scripted_httpx) -> None:
+    scripted_httpx([502, 502, 404])
+
+    await ensure_runtime_serving(_Sandbox(), "i12345", runtime_port=8080)
+
+
+async def test_ensure_reports_the_status_of_a_dead_runtime(scripted_httpx) -> None:
+    scripted_httpx([502])
+
+    with pytest.raises(ProviderFailed) as failure:
+        await ensure_runtime_serving(
+            _Sandbox(), "i12345", runtime_port=8080, budget_seconds=0.3
+        )
+
+    assert "502" in str(failure.value)
+
+
+async def test_a_stopped_vm_is_not_polled_at_all(scripted_httpx) -> None:
+    """A VM that is not running fails before any HTTP is attempted.
+
+    Raised inside `sdk_errors`, the failure is classified like any SDK call's:
+    an unrecognised shape reads as transient, so this surfaces as
+    `SandboxUnavailable` -- retryable, which is the right reading of a VM that
+    may simply still be starting.
+    """
+    from sandbox_runtime.errors import SandboxUnavailable
+
+    with pytest.raises(SandboxUnavailable):
+        await ensure_runtime_serving(
+            _Sandbox(running=False), "i12345", runtime_port=8080,
+            budget_seconds=0.3,
+        )


### PR DESCRIPTION
## What changes

The first tool call of an agent run that lands on a cold E2B workspace no longer dies with `SandboxRejected: e2b sandbox … is running but its runtime answered 502`. The runtime readiness probe now waits out E2B's edge-routing lag instead of taking the first 502 as final.

## Why

`ensure_runtime_serving` exists to catch a VM whose runtime process has died (the 2026-08-16 P0: healthy answers 404, dead answers 502). But the same 502 is also the normal shape of the first moments after a create or a resume, while E2B's edge has not routed to the sandbox yet. `_poll_runtime` polled through transport errors only, so the first edge-lag 502 ended the probe → `ProviderFailed` → non-retryable `SandboxRejected` → the run's first tool call failed. A manual retry adopted the same (healthy) sandbox and went through clean, which is exactly what the incident report showed.

Evidence (Cloud Logging, 7 days): 9 occurrences of this exact signature across dev and prod, every one on the first ensure of a cold sandbox, e.g. dev worker 2026-08-20T08:20:42Z (`agent.web_fetch.session_failed.degraded`, sandbox `iev3lqkhqlp2qnmkra9gd`).

The probe now polls through 5xx as well as transport failures; only an answer below 500 ends the wait early. A budget that expires on persistent 5xx still returns the last status, so a genuinely dead runtime fails with the same "answered 502" diagnosis as before (existing P0 regression test preserved). Budget 6s → 20s: the probe only runs on cold paths (create/resume), never the warm path, and a healthy runtime replies well inside it.

## How to verify

```bash
cd lemma-backend
uv run pytest app/modules/workspace/tests/unit/test_e2b_common.py -q
# 7 passed
uv run pytest app/modules/workspace/tests/unit/ -q
# 231 passed
make test-unit    # 5175 passed, 109 skipped
make lint         # All checks passed!
make lint-async   # All checks passed!
make typecheck-critical   # 0 errors
make architecture # ratchet passed
cd .. && make quality     # ✓ quality gates pass
```

Also exercised the live dev deployment (`api.asur.work` = `lemma-gateway-dev`) end-to-end with `lemma agents run curator …`: workspace ensure + directory creation + conversation completed clean.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload; authorization checked at the boundary
- [x] **Rollback** — the plan if this has to be reverted after deploy

## Compatibility and rollback notes

No API, schema, or migration changes; provider-internal probe behavior only. Rollback is a plain revert. The one behavioral trade: a sandbox whose runtime is *genuinely* dead now takes 20s (was 6s) to fail readiness — once per dead sandbox, off the warm path.

Follow-ups found during the investigation, deliberately not in this PR: paused-orphan reclamation logs `orphan_reclaimed` for the same ids every cycle without them disappearing (kill is ineffective on paused E2B sandboxes), and workspace sandboxes created before the `on_timeout: pause` fix (#380) still carry kill-on-timeout lifecycle, which is what wiped a dev workspace's disk twice at exact 30-minute intervals this morning.
