### PR TITLE
Make workspace readiness a smoke command, not a port that never answers

### DIFF
--- a/lemma-backend/app/modules/workspace/providers/e2b.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b.py
@@ -51,7 +51,7 @@ from app.modules.workspace.providers.base import (
 )
 from app.modules.workspace.providers.e2b_common import (
     DEFAULT_METADATA_NAMESPACE,
-    ensure_runtime_serving,
+    ensure_serving,
     meta_epoch,
     meta_profile_digest,
     meta_sandbox_id,
@@ -359,16 +359,15 @@ class E2BSandboxProvider(E2BOpsMixin):
         kind: SandboxKind,
         deadline_at: datetime,
     ) -> None:
-        """Ready means the runtime answers, not merely that the VM exists.
+        """Ready means the thing this kind's operations depend on answers.
 
         `is_running()` alone passed a sandbox whose runtime had died, because a
-        VM outlives its process. See `ensure_runtime_serving`.
+        VM outlives its process. See `ensure_serving`.
         """
         sandbox = await self._connect(instance.provider_id)
-        await ensure_runtime_serving(
-            sandbox,
-            instance.provider_id,
-            runtime_port=profile_for(kind).runtime_port,
+        await ensure_serving(
+            sandbox, instance.provider_id,
+            kind=kind, runtime_port=profile_for(kind).runtime_port,
         )
 
     async def release(

--- a/lemma-backend/app/modules/workspace/providers/e2b_common.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b_common.py
@@ -13,6 +13,7 @@ from sandbox_runtime.errors import (
     SandboxPathNotFound,
     SandboxUnavailable,
 )
+from app.modules.workspace.domain.sandbox import SandboxKind
 from app.modules.workspace.providers.base import (
     ProviderFailed,
     ProviderGone,
@@ -207,6 +208,100 @@ async def ensure_runtime_serving(
             f"e2b sandbox {provider_id} is running but its runtime answered "
             f"{status}; the process inside has died"
         )
+
+
+async def ensure_serving(
+    sandbox,
+    provider_id: str,
+    *,
+    kind: SandboxKind,
+    runtime_port: int,
+    budget_seconds: float = 20.0,
+) -> None:
+    """Raise unless the thing this kind's operations depend on answers.
+
+    A function sandbox's operations go through its runtime HTTP server, and a
+    VM outlives the process it was started for -- the port probe is what
+    catches that. A workspace starts no such server: the edge answers 502 for
+    its profile port forever, so its readiness is one command through the
+    sandbox agent instead. Splitting by kind is what `sandbox-protocol.md`
+    §8 specifies.
+    """
+    if kind is SandboxKind.FUNCTION:
+        await ensure_runtime_serving(
+            sandbox,
+            provider_id,
+            runtime_port=runtime_port,
+            budget_seconds=budget_seconds,
+        )
+    else:
+        await ensure_agent_serving(
+            sandbox, provider_id, budget_seconds=budget_seconds
+        )
+
+
+async def ensure_agent_serving(
+    sandbox,
+    provider_id: str,
+    *,
+    budget_seconds: float = 20.0,
+) -> None:
+    """Raise unless this sandbox's agent answers a trivial command.
+
+    A workspace has no runtime HTTP server for the port probe to ask: the
+    template starts no listener on the profile port, and E2B's edge answers
+    502 for an unlistened port forever. So the probe that catches a dead
+    *function* runtime failed a healthy *workspace* every single time --
+    verified against the real service, where a fresh workspace's port
+    answered 502 for 45 straight seconds while its agent replied in half
+    a second. Every fresh workspace's first ensure was rejected, and the
+    retry only passed because adoption skips the probe. What a workspace's
+    operations actually need is the sandbox agent (envd), which every
+    command and filesystem call goes through, and the honest check that it
+    is serving is one command run through it -- `sandbox-protocol.md` §8:
+    "E2B workspace: exact sandbox connected plus one native
+    command/filesystem smoke operation".
+    """
+    with sdk_errors():
+        if not await sandbox.is_running():
+            raise ProviderFailed(f"e2b sandbox {provider_id} is not running")
+
+    # Substitutable like `runtime_status`: a fake sandbox runs no commands,
+    # and a unit test still has to be able to say whether the agent answered.
+    substitute = getattr(sandbox, "smoke_command", None)
+    runner = substitute if substitute is not None else lambda: _run_true(sandbox)
+    if not await _poll_agent(runner, budget_seconds):
+        raise ProviderFailed(
+            f"e2b sandbox {provider_id} is running but its agent never "
+            f"answered a command within {budget_seconds}s"
+        )
+
+
+async def _run_true(sandbox) -> bool:
+    """One trivial command through the sandbox agent: did it answer?"""
+    try:
+        with sdk_errors():
+            result = await sandbox.commands.run("true")
+    except (ProviderGone, SandboxUnavailable):
+        # Not up yet: the agent can lag the VM by a moment after a create or
+        # a resume, and the budget decides how long "a moment" is allowed to
+        # be. A definitive refusal still escapes.
+        return False
+    return getattr(result, "exit_code", None) == 0
+
+
+async def _poll_agent(runner, budget_seconds: float) -> bool:
+    """True when the smoke command answers inside the budget."""
+    import asyncio
+    import time
+
+    deadline = time.monotonic() + budget_seconds
+    while True:
+        if await runner():
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        await asyncio.sleep(0.25)
 
 
 async def _poll_runtime(url: str, budget_seconds: float) -> int | None:

--- a/lemma-backend/app/modules/workspace/testing/fake_e2b.py
+++ b/lemma-backend/app/modules/workspace/testing/fake_e2b.py
@@ -95,6 +95,11 @@ class FakeE2B:
     #: port listening -- and 502 is the sandbox whose runtime process has died
     #: while the VM keeps running, which is the state readiness must now catch.
     runtime_status: int = 404
+    #: Whether the sandbox agent answers a command. Workspace readiness is a
+    #: smoke command through the agent -- there is no runtime port to probe --
+    #: so a workspace whose agent is down is modelled here, not with
+    #: `runtime_status`.
+    agent_answers: bool = True
     # The lifetime each started process was given, in the order they started.
     # Recorded because E2B kills a command at this value and defaults it to 60s,
     # so "the provider passed no timeout" is indistinguishable from "the
@@ -165,6 +170,8 @@ class FakeE2B:
                 timeout=None,
                 **_kwargs,
             ):
+                if not world.agent_answers:
+                    raise FakeE2BError("the sandbox agent is not answering")
                 world.commands.append(cmd)
                 world.process_timeouts.append(timeout)
                 if on_stdout is not None:

--- a/lemma-backend/app/modules/workspace/tests/integration/test_e2b_provider_real.py
+++ b/lemma-backend/app/modules/workspace/tests/integration/test_e2b_provider_real.py
@@ -255,6 +255,104 @@ async def test_creating_twice_really_yields_one_sandbox(
     assert first.provider_id == second.provider_id
 
 
+async def test_a_first_contact_herd_all_get_served(
+    provider: E2BSandboxProvider,
+) -> None:
+    """Parallel first tool calls on a cold sandbox must not fail.
+
+    This is the 2026-08-20 incident's shape: an agent's first turn fires
+    several tool calls at once, each one ensures the sandbox, and the cold
+    provision used to fail readiness while E2B was still coming up -- so the
+    first call died and only the retry passed. One sandbox is created here
+    and then readied and used by a herd, the way the service's singleflight
+    hands one provisioning to every waiting caller.
+    """
+    import asyncio
+
+    sandbox_id = uuid4()
+    instance = await _create(provider, sandbox_id)
+
+    async def tool_call(marker: bytes) -> bytes:
+        await provider.wait_ready(
+            instance, kind=SandboxKind.WORKSPACE, deadline_at=_deadline()
+        )
+
+        async def payload():
+            yield marker
+
+        path = f"/workspace/herd-{marker.decode()}.txt"
+        await provider.write_file(
+            instance, path=path, data=payload(),
+            expected_sha256=None, deadline_at=_deadline(),
+        )
+        chunks = [
+            chunk
+            async for chunk in provider.open_file(
+                instance, path=path,
+                byte_range=ByteRange(offset=0, length=None),
+                deadline_at=_deadline(),
+            )
+        ]
+        return b"".join(chunks)
+
+    markers = [f"call{i}".encode() for i in range(8)]
+    results = await asyncio.gather(*(tool_call(marker) for marker in markers))
+
+    assert results == markers
+    # The herd shared one sandbox -- nobody got a second one underneath it.
+    found = await provider.inspect(
+        naming.container_name(sandbox_id, SandboxKind.WORKSPACE, 1),
+        deadline_at=_deadline(),
+    )
+    assert found is not None and found.provider_id == instance.provider_id
+
+
+async def test_files_survive_a_pause_and_a_herd_after_resume(
+    provider: E2BSandboxProvider,
+) -> None:
+    """Pause, resume, and the disk is the same disk -- under parallel load.
+
+    The disk-continuity promise: a paused workspace keeps its filesystem,
+    resumes as the same sandbox, and the tool calls waiting on that resume
+    all see the files that were written before it.
+    """
+    import asyncio
+
+    sandbox_id = uuid4()
+    first = await _create(provider, sandbox_id)
+
+    async def payload():
+        yield b"written-before-the-pause"
+
+    await provider.write_file(
+        first, path="/workspace/before.txt", data=payload(),
+        expected_sha256=None, deadline_at=_deadline(),
+    )
+    await provider.release(first, kind=SandboxKind.WORKSPACE, deadline_at=_deadline())
+
+    resumed = await provider.create(_spec(provider, sandbox_id, epoch=2))
+    assert resumed.provider_id == first.provider_id
+    assert resumed.storage_adopted is True
+
+    async def read_back() -> bytes:
+        await provider.wait_ready(
+            resumed, kind=SandboxKind.WORKSPACE, deadline_at=_deadline()
+        )
+        chunks = [
+            chunk
+            async for chunk in provider.open_file(
+                resumed, path="/workspace/before.txt",
+                byte_range=ByteRange(offset=0, length=None),
+                deadline_at=_deadline(),
+            )
+        ]
+        return b"".join(chunks)
+
+    results = await asyncio.gather(*(read_back() for _ in range(8)))
+
+    assert results == [b"written-before-the-pause"] * 8
+
+
 async def test_real_storage_kind_is_sandbox_native(
     provider: E2BSandboxProvider,
 ) -> None:

--- a/lemma-backend/app/modules/workspace/tests/unit/test_e2b_common.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_e2b_common.py
@@ -158,3 +158,59 @@ async def test_a_stopped_vm_is_not_polled_at_all(scripted_httpx) -> None:
             _Sandbox(running=False), "i12345", runtime_port=8080,
             budget_seconds=0.3,
         )
+
+
+# ---------------------------------------------------------------------------
+# Workspace readiness: one command through the sandbox agent
+# ---------------------------------------------------------------------------
+
+
+class _AgentSandbox(_Sandbox):
+    """A sandbox whose agent answers from a script of booleans.
+
+    Each entry is one smoke-command attempt: True answers, False does not.
+    Exhausting the script repeats its last entry.
+    """
+
+    def __init__(self, script: list[bool], *, running: bool = True) -> None:
+        super().__init__(running=running)
+        self._script = script
+        self.attempts = 0
+
+    async def smoke_command(self) -> bool:
+        entry = self._script[min(self.attempts, len(self._script) - 1)]
+        self.attempts += 1
+        return entry
+
+
+async def test_a_workspace_is_ready_once_its_agent_answers() -> None:
+    """The agent can lag the VM after a create or resume; readiness waits."""
+    from app.modules.workspace.providers.e2b_common import ensure_agent_serving
+
+    sandbox = _AgentSandbox([False, False, True])
+
+    await ensure_agent_serving(sandbox, "i12345", budget_seconds=5.0)
+
+    assert sandbox.attempts == 3
+
+
+async def test_a_workspace_whose_agent_stays_down_is_not_ready() -> None:
+    from app.modules.workspace.providers.e2b_common import ensure_agent_serving
+
+    sandbox = _AgentSandbox([False])
+
+    with pytest.raises(ProviderFailed) as failure:
+        await ensure_agent_serving(sandbox, "i12345", budget_seconds=0.5)
+
+    assert "never answered a command" in str(failure.value)
+
+
+async def test_a_stopped_workspace_vm_is_not_polled() -> None:
+    from sandbox_runtime.errors import SandboxUnavailable
+
+    from app.modules.workspace.providers.e2b_common import ensure_agent_serving
+
+    with pytest.raises(SandboxUnavailable):
+        await ensure_agent_serving(
+            _AgentSandbox([True], running=False), "i12345", budget_seconds=0.5
+        )

--- a/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
@@ -1021,3 +1021,33 @@ async def test_a_serving_sandbox_is_ready(
     await provider.wait_ready(
         instance, kind=SandboxKind.FUNCTION, deadline_at=_deadline()
     )
+
+
+async def test_a_workspace_is_ready_when_its_agent_answers(
+    provider: E2BSandboxProvider, world: FakeE2B
+) -> None:
+    """Workspace readiness is a command through the agent, not a port probe.
+
+    The workspace template starts no listener on the profile port, so E2B's
+    edge answers 502 for it forever -- the port probe that catches a dead
+    function runtime failed every healthy workspace's first ensure.
+    """
+    instance = await provider.create(_spec(uuid4()))
+
+    await provider.wait_ready(
+        instance, kind=SandboxKind.WORKSPACE, deadline_at=_deadline()
+    )
+
+    assert "true" in world.commands
+
+
+async def test_a_workspace_whose_agent_died_is_not_ready(
+    provider: E2BSandboxProvider, world: FakeE2B
+) -> None:
+    instance = await provider.create(_spec(uuid4()))
+    world.agent_answers = False
+
+    with pytest.raises(ProviderFailed):
+        await provider.wait_ready(
+            instance, kind=SandboxKind.WORKSPACE, deadline_at=_deadline()
+        )


### PR DESCRIPTION
## What changes

Fresh E2B workspaces stop failing their first ensure. `wait_ready` no longer probes the workspace's profile port over HTTP — a port the workspace template never listens on, so E2B's edge answers 502 for it *forever* — and instead proves readiness with one trivial command through the sandbox agent (envd), which is what every workspace operation actually goes through. Function sandboxes keep the runtime port probe unchanged.

## Why

Follow-up to #416. That PR made the probe poll through *transient* edge-lag 502s — but running the real-E2B conformance suites against a live account showed the workspace 502 is not transient: a fresh workspace's port 8080 answered 502 for 45 straight seconds while its agent replied in 0.5s. So every fresh workspace's first ensure was rejected (`SandboxRejected … runtime answered 502`), the first tool call of the agent run died, and the retry only passed because adoption skips the probe. That is exactly the user-facing incident: "first tool call of workspace CLI is failing for our agents".

`sandbox-protocol.md` §8 already specifies the split ("E2B workspace: exact sandbox connected plus one native command/filesystem smoke operation") — the code had diverged from it. `ensure_serving` now branches by kind; the agent smoke command is polled through the moments envd lags the VM after create/resume.

## How to verify

Real execution against a throwaway E2B account (templates built with `sandbox-images/templates/e2b/build_templates.py`, zero sandboxes left behind):

```bash
cd lemma-backend
uv run --extra e2b pytest app/modules/workspace/tests/integration/test_e2b_provider_real.py -q
# 11 passed — incl. two new herd tests:
#   test_a_first_contact_herd_all_get_served        (8 parallel first tool calls on a cold sandbox)
#   test_files_survive_a_pause_and_a_herd_after_resume  (disk continuity across pause/resume)
uv run --extra e2b pytest app/modules/workspace/tests/integration/test_e2b_lifecycle_real.py -q
# 13 passed — pause keeps files, pause carries no processes, created-to-pause-on-timeout
uv run --extra e2b pytest app/modules/workspace/tests/integration/test_e2b_function_liveness_real.py -q
# 6 passed — dead runtime still refused, replacement restores service
```

Unit + gates:

```bash
uv run pytest app/modules/workspace/tests/unit/ -q   # 236 passed
make lint && make lint-async && make typecheck-critical && make architecture
cd .. && make quality                                # ✓ quality gates pass
```

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload; authorization checked at the boundary
- [x] **Rollback** — the plan if this has to be reverted after deploy

## Compatibility and rollback notes

No API, schema, or migration changes; provider-internal readiness behavior only. Rollback is a plain revert, after which fresh workspace provisions would again fail their first ensure (the pre-#416 behavior modulo the polling fix). Function-sandbox readiness is deliberately untouched; the 2026-08-16 P0 regression tests still pass unchanged.
