### PR TITLE
Give the pod's default responder a name, and the sidebar a shape

### DIFF
--- a/lemma-backend/app/modules/agent/api/controllers/agent_controller.py
+++ b/lemma-backend/app/modules/agent/api/controllers/agent_controller.py
@@ -64,6 +64,13 @@ def _agent_summary_response(
     summary.has_pinned_runtime = bool(
         getattr(getattr(agent, "agent_runtime", None), "profile_id", None)
     )
+    # An empty object and a `properties` key with nothing under it both mean
+    # "declares no inputs" — the agent builder writes the second when someone
+    # opens the schema editor and adds nothing.
+    input_schema = getattr(agent, "input_schema", None) or {}
+    summary.takes_input = bool(
+        isinstance(input_schema, dict) and input_schema.get("properties")
+    )
     summary.grants = grants
     return summary
 

--- a/lemma-backend/app/modules/agent/api/schemas.py
+++ b/lemma-backend/app/modules/agent/api/schemas.py
@@ -118,6 +118,13 @@ class AgentSummaryResponse(BaseModel):
     # stays on the detail response; a list caller only ever asks "is one pinned?"
     # and had to fetch every agent to find out.
     has_pinned_runtime: bool = False
+    # Whether the agent declares typed inputs. Same bargain as
+    # `has_pinned_runtime`: the schema itself stays on the detail response, but
+    # the one question every list caller asks is answerable with a boolean.
+    # It is a category line, not a detail — an agent with typed inputs is
+    # *called* with arguments, an agent without one is *talked to* — and the
+    # sidebar's cast rail only holds the second kind.
+    takes_input: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/lemma-backend/app/modules/agent/api/schemas.py
+++ b/lemma-backend/app/modules/agent/api/schemas.py
@@ -122,8 +122,8 @@ class AgentSummaryResponse(BaseModel):
     # `has_pinned_runtime`: the schema itself stays on the detail response, but
     # the one question every list caller asks is answerable with a boolean.
     # It is a category line, not a detail — an agent with typed inputs is
-    # *called* with arguments, an agent without one is *talked to* — and the
-    # sidebar's cast rail only holds the second kind.
+    # *called* with arguments, an agent without one is *talked to*, and a list
+    # of agents someone can open a conversation with holds only the second.
     takes_input: bool = False
 
     model_config = ConfigDict(from_attributes=True)

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_summary_takes_input.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_summary_takes_input.py
@@ -1,0 +1,61 @@
+"""`takes_input` on the agent summary: the list endpoint's answer to
+"can I talk to this one?".
+
+`AgentSummaryResponse` deliberately omits `input_schema`, so a caller holding a
+listed agent cannot tell a conversational agent from one that is called with
+typed arguments. Anything that reads the omitted field instead of this boolean
+silently sees `{}` for every agent and filters nothing — which is why this is a
+server-side derivation and not a frontend predicate.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.modules.agent.api.controllers.agent_controller import (
+    _agent_summary_response,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _agent(input_schema):
+    return SimpleNamespace(
+        id="11111111-1111-1111-1111-111111111111",
+        pod_id="22222222-2222-2222-2222-222222222222",
+        user_id="33333333-3333-3333-3333-333333333333",
+        name="socratic-guide",
+        description=None,
+        icon_url=None,
+        visibility="POD",
+        toolsets=[],
+        metadata=None,
+        created_at="2026-08-20T00:00:00Z",
+        updated_at="2026-08-20T00:00:00Z",
+        allowed_actions=[],
+        agent_runtime=None,
+        input_schema=input_schema,
+    )
+
+
+@pytest.mark.parametrize(
+    "input_schema",
+    [
+        None,
+        {},
+        # The agent builder writes this the moment someone opens the schema
+        # editor and adds no fields. It declares nothing, so it takes nothing.
+        {"type": "object", "properties": {}},
+    ],
+    ids=["absent", "empty", "properties-empty"],
+)
+def test_conversational_agent_takes_no_input(input_schema):
+    assert _agent_summary_response(_agent(input_schema)).takes_input is False
+
+
+def test_agent_with_declared_properties_takes_input():
+    schema = {"type": "object", "properties": {"topic": {"type": "string"}}}
+
+    assert _agent_summary_response(_agent(schema)).takes_input is True

--- a/lemma-backend/app/modules/agent_surfaces/platforms/slack/blocks.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/slack/blocks.py
@@ -151,9 +151,17 @@ CHANNEL_SETUP_VIEW_CALLBACK_ID = "lemma_channel_setup_view"
 CHANNEL_SETUP_BLOCK_ID = "lemma_channel_agent"
 CHANNEL_SETUP_SELECT_ACTION_ID = "lemma_channel_agent_select"
 
-# Value used for "the pod's own assistant" — the surface default, which is
-# stored as an empty agent_name on the route rather than as a named agent.
+# Value used for the pod's default responder — the surface default, which is
+# stored as an empty agent_name on the route rather than as a named agent. The
+# value is on the wire and never changes; the *label* beside it is display copy,
+# and it is the same name the app shows in its own sidebar.
 POD_ASSISTANT_VALUE = "__pod_assistant__"
+
+# What the pod's default responder is called wherever a person can read it. See
+# `lemma-frontend/lib/utils/agents.ts` — these two must agree, because someone
+# picking a responder in Slack and someone picking one in the app are choosing
+# the same thing and must see it under the same name.
+DEFAULT_RESPONDER_NAME = "Lem"
 
 
 def channel_setup_modal(
@@ -169,13 +177,13 @@ def channel_setup_modal(
     cascade one select off another — which is the whole reason this is a modal
     and the reason the ephemeral carries a button rather than a form.
 
-    The pod assistant is offered first because it is the answer for someone who
-    has not built a named agent yet, and it is what an empty route already means.
+    The default responder is offered first because it is the answer for someone
+    who has not built a named agent yet, and it is what an empty route means.
     """
     where = f"#{channel_label}" if channel_label else "this channel"
     options = [
         {
-            "text": {"type": "plain_text", "text": "Pod assistant"},
+            "text": {"type": "plain_text", "text": DEFAULT_RESPONDER_NAME},
             "value": POD_ASSISTANT_VALUE,
         }
     ]
@@ -260,7 +268,7 @@ def dm_agent_modal(
     """
     options = [
         {
-            "text": {"type": "plain_text", "text": "Pod assistant"},
+            "text": {"type": "plain_text", "text": DEFAULT_RESPONDER_NAME},
             "value": POD_ASSISTANT_VALUE,
         }
     ]
@@ -502,7 +510,7 @@ def app_home_view(
                 "text": (
                     f"*Your direct messages*\nAnswered by `{dm_agent_name}`"
                     if dm_agent_name
-                    else "*Your direct messages*\nAnswered by the pod assistant"
+                    else f"*Your direct messages*\nAnswered by {DEFAULT_RESPONDER_NAME}"
                 ),
             },
             "accessory": {
@@ -514,7 +522,7 @@ def app_home_view(
     )
     if channel_routes:
         lines = "\n".join(
-            f"<#{channel_id}> \u2192 `{agent or 'Pod assistant'}`"
+            f"<#{channel_id}> \u2192 `{agent or DEFAULT_RESPONDER_NAME}`"
             for channel_id, agent in list(channel_routes)[:20]
         )
         blocks.append(

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_slack_surface_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_slack_surface_e2e.py
@@ -14,6 +14,7 @@ from app.modules.agent_surfaces.domain.ingress_context import (
     SurfaceReplyContext,
 )
 from app.modules.agent_surfaces.domain.ingress_request import SurfacePlatformWebhookIngress
+from app.modules.agent_surfaces.platforms.slack.blocks import DEFAULT_RESPONDER_NAME
 from app.modules.agent_surfaces.tests.e2e.helpers import (
     _conversation_by_external_thread,
     _create_agent,
@@ -414,7 +415,10 @@ async def test_slack_channel_setup_modal_open_then_submit_routes_channel(
     assert "lemma_channel_setup_view" in view_repr
     assert "C-SUPPORT" in view_repr
     assert specialist["name"] in view_repr
-    assert "Pod assistant" in view_repr
+    # Read the label from the module that renders it. Pinning the string here
+    # meant a copy change turned this into a failure about the modal rather
+    # than about the name, which is what it was.
+    assert DEFAULT_RESPONDER_NAME in view_repr
 
     submit_payload = {
         "type": "view_submission",

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_slack_lifecycle_events.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_slack_lifecycle_events.py
@@ -298,9 +298,9 @@ async def test_app_home_surface_selector_parses_an_explicit_choice():
 
 
 async def test_pod_assistant_route_is_not_the_surface_default():
-    """Picking "Pod assistant" must not silently mean "whatever agent3 is".
+    """Picking the default responder must not silently mean "whatever agent3 is".
 
-    The pod assistant is a conversation with *no* agent. Storing it as an empty
+    It is a conversation with *no* agent. Storing it as an empty
     agent_name made it indistinguishable from an unconfigured route, so it fell
     through to ``surface.agent_id`` — and a channel set to the pod assistant
     kept answering as the surface's default agent.

--- a/lemma-frontend/app/pod/[id]/agents/[agentId]/page.tsx
+++ b/lemma-frontend/app/pod/[id]/agents/[agentId]/page.tsx
@@ -2,10 +2,11 @@
 
 import { use, useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { MessageSquare, Save } from '@/components/ui/icons';
+import { MessageSquare, Save, Settings2 } from '@/components/ui/icons';
 import { toast } from 'sonner';
 
 import { AgentDetailSkeleton } from '@/components/agents/agent-detail-skeleton';
+import { AgentHome, AgentHomeSkeleton } from '@/components/agents/agent-home';
 import { AgentIdentityHeader } from '@/components/agents/agent-identity-header';
 import { AgentInstructions } from '@/components/agents/agent-instructions';
 import { AgentTestPanel } from '@/components/agents/agent-test-panel';
@@ -27,16 +28,26 @@ import { useConversations } from '@/lib/hooks/use-assistants';
 import { usePodAccess } from '@/lib/hooks/use-pod-access';
 import { usePodAutomation } from '@/lib/hooks/use-pod-automation';
 import { Agent, UpdateAgentData } from '@/lib/types';
-import { formatAgentName } from '@/lib/utils/agents';
+import { agentTakesInput, formatAgentName } from '@/lib/utils/agents';
 
 /**
- * One agent, one page.
+ * One agent, one page, with two modes and a clear default.
  *
- * There used to be an Overview/Edit switch here, which split one job — making
- * the agent good — across two screens: what it can reach lived in the editor,
- * who can reach it lived in the overview, and the identity was stated in both.
- * Now the page reads top to bottom as who it is, how it is wired, and how it
- * behaves, with a dock on the right for actually running it.
+ * The page used to open in its editor: config in the main column, a dock on the
+ * right for actually running the thing. That optimised for the rarer act. You
+ * tune an agent while you are building it and seldom after; you talk to it every
+ * day — and since the sidebar rail put every agent one click from every route,
+ * this is somewhere people land constantly rather than visit to make changes.
+ *
+ * So talking is the default and editing is a button, and hitting it *swaps*
+ * which pane is big: config takes the main column and the conversation moves
+ * into the dock. The thing you came to work on is always the large one, and
+ * "tune it while testing it" — the genuinely good part of the old layout —
+ * survives intact.
+ *
+ * An agent with declared inputs is excluded from all of this: it is called with
+ * arguments rather than talked to (see `takes_input`), so there is no
+ * conversation to make the default and it opens in the editor as before.
  */
 export default function AgentDetailPage({
     params,
@@ -63,8 +74,11 @@ export default function AgentDetailPage({
     });
     const agentSchedules = automation.schedulesForAgent(agentName);
     const agentSurfaces = automation.surfacesForAgent(agentName);
-    const { data: conversationsPage } = useConversations(podId, agentName, { limit: 4 });
+    // Four answers the draft check below ("has this agent ever run"); home wants
+    // enough to be a preview of what it has been doing.
+    const { data: conversationsPage } = useConversations(podId, agentName, { limit: 10 });
     const recentConversations = conversationsPage?.items ?? [];
+    const homeConversations = recentConversations;
     const updateAgent = useUpdateAgent();
     const { mutateAsync: updateAgentAsync } = updateAgent;
 
@@ -72,6 +86,7 @@ export default function AgentDetailPage({
     const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
     const [isDockOpen, setIsDockOpen] = useState<boolean | null>(null);
     const [dockView, setDockView] = useState<'conversation' | 'history'>('conversation');
+    const [isEditing, setIsEditing] = useState(false);
     const [layoutWidth, setLayoutWidth] = useState(0);
     const layoutObserverRef = useRef<ResizeObserver | null>(null);
     const lastSavedHashRef = useRef('');
@@ -193,6 +208,18 @@ export default function AgentDetailPage({
     const canUpdateCurrentAgent = resourceAllows(localAgent, 'agent.update', canUpdateAgent);
     const openConversationId = searchParams.get('conversation');
 
+    // The same line the sidebar's cast rail draws: declared inputs mean this is
+    // called, not conversed with, so there is no talk mode to default to.
+    // Every agent gets a home; what differs is how you invoke it. A declared
+    // input schema means this one is called with arguments rather than talked to,
+    // so its home offers no message box and its run form lives in the dock.
+    const canConverse = Boolean(localAgent) && !agentTakesInput(localAgent);
+    const editing = isEditing;
+
+    // Picking a run from the rail opens it in the dock — the messenger move:
+    // the list is on the left, the conversation is on the right, and the URL
+    // carries the pick so a refresh (or a shared link) lands on the same run.
+
     // This page used to return a bare centred spinner while the agent loaded —
     // no header, no cards, no dock — and then snap the whole two-pane layout
     // into place. Nothing about the *frame* was ever unknown: the name is in the
@@ -219,19 +246,41 @@ export default function AgentDetailPage({
     // A conversation id in the URL is a request to look at that run, so it opens
     // the dock too — until the reader closes it themselves. Closed while the
     // agent loads: the dock runs the *saved* agent, and there isn't one yet.
-    const dockOpen = isReady && (isDockOpen ?? (isDraft || Boolean(openConversationId)));
+    // The dock is the *run form*, and nothing else now. Its chat half is gone:
+    // a conversational agent is started from the home's composer and the run
+    // opens as its own tab, so a test-chat panel bolted to the editor was a
+    // third place to talk to one agent — with its own history list, its own
+    // header and its own idea of which conversation you were in.
+    const dockOpen = editing && isReady && !canConverse
+        && (isDockOpen ?? (isDraft || Boolean(openConversationId)));
     const isStackedLayout = dockOpen && layoutWidth > 0 && layoutWidth < 1040;
 
     return (
         <ResourceDetailShell>
             <TourLayer tour="agent-editor" />
+            {/* No title, no back link — only the action. The tab strip above
+                already names this agent and carries the control that leaves it,
+                and the front door says the name a third time in its greeting. A
+                bar repeating both was the shell arguing with itself; §7's rule
+                is that the shell owns the title, and here it already does. */}
             <ResourceHeader
                 title={label}
-                // The identity block below owns the name; the bar takes it back
-                // only once that block scrolls out of the pane.
-                titleOwner="page"
-                backHref={`/pod/${podId}/ai`}
-                backLabel="Agents"
+                // The tab strip directly above already names this agent, and the
+                // front door says it a third time in its greeting, so the bar
+                // drops to just the action. `tab` rather than dropping the title
+                // outright because it self-corrects: on a compact viewport, where
+                // the strip is hidden, the bar takes the name back instead of
+                // leaving nothing on screen naming the thing.
+                titleOwner="tab"
+                // No back link either. The tab carries its own close, and a bar
+                // whose whole content was "← Agents" sat between the strip and
+                // the page saying nothing the strip did not.
+                //
+                // In talk mode nothing is left for it to hold — Configure lives
+                // in the page — so the bar goes rather than drawing 48px of
+                // empty strip. Pod home has no context bar for the same reason,
+                // which is most of why this page did not feel like it.
+                hideContextBar={!editing}
                 fullscreen={false}
                 actions={(
                     <>
@@ -249,18 +298,26 @@ export default function AgentDetailPage({
                                 Save changes
                             </Button>
                         ) : null}
-                        <Button
-                            type="button"
-                            variant="secondary"
-                            size="sm"
-                            className="h-8 gap-1.5 px-2.5 text-xs font-medium"
-                            onClick={() => setIsDockOpen(!dockOpen)}
-                            aria-pressed={dockOpen}
-                            disabled={!isReady}
-                        >
-                            <MessageSquare className="h-3.5 w-3.5" />
-                            Try it
-                        </Button>
+                        {/* One control, because there are two modes and you are
+                            always in exactly one of them. The old "Try it"
+                            toggled a dock beside an editor you could not leave;
+                            this says which half of the page is the work. It is
+                            hidden for an agent with declared inputs — that page
+                            has only the editor, so a toggle would offer a mode
+                            that does not exist. */}
+                        {isEditing ? (
+                            <Button
+                                type="button"
+                                variant="secondary"
+                                size="sm"
+                                className="h-8 gap-1.5 px-2.5 text-xs font-medium"
+                                onClick={() => setIsEditing(false)}
+                                disabled={!isReady}
+                            >
+                                <MessageSquare className="h-3.5 w-3.5" />
+                                Done
+                            </Button>
+                        ) : null}
                     </>
                 )}
             />
@@ -274,8 +331,75 @@ export default function AgentDetailPage({
                     // readable prompt *and* the dock; below that they stack.
                     isStacked={isStackedLayout}
                     main={(
-                        <div className="resource-page-scroll">
-                            <div className="resource-page-column">
+                        <div className="flex h-full min-h-0">
+                            {/* No rail. This page grew its own conversation list
+                                on the left, which put two lists of conversations
+                                side by side — the pod's history in the shell
+                                sidebar and this agent's here, same rows, same
+                                width, one border apart. Two lists of the same
+                                kind of thing read as two sidebars, not as a
+                                hierarchy. The shell's is the one that survives,
+                                because it is present on every route. Agent-scoped
+                                history keeps a home in the dock's History tab
+                                while editing. */}
+                            {!editing ? (
+                                localAgent ? (
+                                /* The agent's home, and it stays home. Sending
+                                   from here opens the conversation as its own
+                                   workspace tab — the tabs are a persistent
+                                   working set, so this page is still here when
+                                   you come back to it. Hosting the transcript in
+                                   place instead meant the agent's page became a
+                                   transcript and its front door was gone until
+                                   you asked for a new run. */
+                                <div className="resource-page-scroll agent-home-scroll min-w-0 flex-1">
+                                    {/* Anchored to the pane's corner, not the
+                                        column's. Inside a 44rem block centred in
+                                        a very wide pane, "top-right" is not a
+                                        corner at all — the button floated in
+                                        space above the face with no edge to
+                                        belong to. A page action wants the place
+                                        the eye already checks for one, which is
+                                        exactly where the context bar used to put
+                                        it. */}
+                                    {canUpdateCurrentAgent ? (
+                                        <div className="agent-home-page-actions">
+                                            <Button
+                                                type="button"
+                                                variant="secondary"
+                                                size="sm"
+                                                onClick={() => setIsEditing(true)}
+                                                className="h-8 gap-1.5 px-2.5 text-xs font-medium"
+                                            >
+                                                <Settings2 className="h-3.5 w-3.5" />
+                                                Configure
+                                            </Button>
+                                        </div>
+                                    ) : null}
+                                    <AgentHome
+                                        podId={podId}
+                                        agentName={displayName}
+                                        description={localAgent.description}
+                                        iconUrl={localAgent.icon_url}
+                                        surfaces={agentSurfaces}
+                                        schedules={agentSchedules}
+                                        conversations={homeConversations}
+                                        canConverse={canConverse}
+                                    />
+                                </div>
+                                ) : (
+                                    /* The home's own skeleton. The editor's was
+                                       standing in here, so every arrival flashed
+                                       a stack of cards before resolving into a
+                                       page that has none — a loading state
+                                       promising the wrong screen. */
+                                    <div className="resource-page-scroll agent-home-scroll min-w-0 flex-1">
+                                        <AgentHomeSkeleton />
+                                    </div>
+                                )
+                            ) : (
+                            <div className="resource-page-scroll min-w-0 flex-1">
+                                <div className="resource-page-column">
                                 {/* Who it is and how it is wired are one card: both
                                     answer "what is this thing", and neither is the
                                     work. The prompt gets its own. */}
@@ -315,7 +439,9 @@ export default function AgentDetailPage({
                                 ) : (
                                     <AgentDetailSkeleton />
                                 )}
+                                </div>
                             </div>
+                            )}
                         </div>
                     )}
                     aside={dockOpen ? (
@@ -380,7 +506,9 @@ export default function AgentDetailPage({
             <ResourceArrivalNotice
                 resource="agent"
                 title="Agent created"
-                description="Write its instructions, wire up what it can use, then try it in the panel on the right."
+                // What actually comes next now: the agent is already usable, and
+                // everything creation no longer asks for is one button away.
+                description="Say something below to try it, or open Configure to give it instructions, access, and a schedule."
                 celebrate
                 className="mx-4 mt-3"
             />

--- a/lemma-frontend/app/pod/[id]/agents/[agentId]/page.tsx
+++ b/lemma-frontend/app/pod/[id]/agents/[agentId]/page.tsx
@@ -208,11 +208,10 @@ export default function AgentDetailPage({
     const canUpdateCurrentAgent = resourceAllows(localAgent, 'agent.update', canUpdateAgent);
     const openConversationId = searchParams.get('conversation');
 
-    // The same line the sidebar's cast rail draws: declared inputs mean this is
-    // called, not conversed with, so there is no talk mode to default to.
-    // Every agent gets a home; what differs is how you invoke it. A declared
-    // input schema means this one is called with arguments rather than talked to,
-    // so its home offers no message box and its run form lives in the dock.
+    // The same line the sidebar's agents rail draws. Every agent gets a home;
+    // what differs is how you invoke it. A declared input schema means this one
+    // is called with arguments rather than talked to, so its home offers no
+    // message box and its run form lives in the dock.
     const canConverse = Boolean(localAgent) && !agentTakesInput(localAgent);
     const editing = isEditing;
 

--- a/lemma-frontend/app/pod/[id]/agents/new/page.tsx
+++ b/lemma-frontend/app/pod/[id]/agents/new/page.tsx
@@ -1,217 +1,93 @@
 'use client';
 
-import { use, useMemo, useState, type ReactNode } from 'react';
+import { use, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import {
-    ArrowLeft,
-    ArrowRight,
-    Bot,
-    Box,
-    Braces,
-    CheckCircle2,
-    ClipboardList,
-    Table,
-    FileOutput,
-    Folder,
-    Image as ImageIcon,
-    MessageSquare,
-    Music,
-    Plus,
-    Search,
-    UserRound,
-    Wand2,
-} from '@/components/ui/icons';
 import { toast } from 'sonner';
 
-import { SchemaBuilder } from '@/components/agents/schema-builder';
-import { AgentAvatarPicker } from '@/components/agents/agent-avatar-picker';
+import { RefreshCw } from '@/components/ui/icons';
+
 import { AgentEmail } from '@/components/surfaces/agent-email';
-import { formatAgentRuntime, resolveDefaultAgentRuntime } from '@/components/agents/agent-runtime-helpers';
-import { RuntimeModelPicker } from '@/components/lemma/assistant/model-picker';
-import { PodPageHeader } from '@/components/pod/pod-page-header';
-import { ConnectorsSelector, DatastoresSelector, FoldersSelector } from '@/components/pod/resource-selectors';
 import { ResourceIcon } from '@/components/shared/resource-icon';
-import { ResourceVisibilityBadge, ResourceVisibilitySelect } from '@/components/shared/resource-visibility';
+import {
+    ResourceDetailShell,
+    ResourceDetailViewport,
+    ResourceHeader,
+} from '@/components/pod/resource-layout';
 import { showResourceCreatedToast, showResourceErrorToast } from '@/components/shared/resource-feedback';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
-import { useAgentRuntimes } from '@/lib/hooks/use-agent-runtime';
 import { useCreateAgent } from '@/lib/hooks/use-agents';
 import { usePodAccess } from '@/lib/hooks/use-pod-access';
 import { useAvailableSurfaces } from '@/lib/hooks/use-pod-surfaces';
 import { usePod } from '@/lib/hooks/use-pods';
+import { distinctIdentityVariants, formatIdentityIcon, identityVariantSeed } from '@/lib/utils/resource-icon-value';
 import { buildAgentEmailPreview } from '@/lib/surfaces/agent-email';
 import { managedEmailDomain } from '@/lib/surfaces/catalog';
-import { cn } from '@/lib/utils';
-import { formatAgentName } from '@/lib/utils/agents';
-import { Agent, AccessMode, ToolSet } from '@/lib/types';
 
-type SchemaProperty = Record<string, unknown>;
-type SchemaFieldEntry = [string, SchemaProperty];
-type BuilderStepId = 'identity' | 'instructions' | 'shape' | 'access' | 'review';
+/**
+ * Making an agent is one step: a face, a name, a purpose.
+ *
+ * It was five — identity, instructions, shape, access, review — which asked for
+ * an agent's whole contract before it existed. That ordering only made sense
+ * when the agent's own page was an editor you had to arrive at fully formed.
+ * It is a home now, with Configure on it, so everything the wizard front-loaded
+ * has a better moment later: you tune an agent you can already talk to, against
+ * runs you have already seen, instead of guessing at its schema and its table
+ * access from a blank form.
+ *
+ * The three that remain are the three that cannot come later. A name is the
+ * address — it is what makes the agent reachable from outside Lemma at all — a
+ * face is how it will be told apart from every other agent in the rail, and a
+ * purpose is what its first instruction is written from.
+ *
+ * The form is shaped like the page it makes. Same column, same face at the same
+ * size, name where the greeting goes and purpose where the description goes —
+ * so creating an agent is filling in its front door, and pressing Create lands
+ * on the finished version of the thing you were just looking at.
+ */
+/** Eight, like a row of faces should be — enough to choose from, few enough to compare. */
+const FACE_OPTIONS = 8;
 
-const BUILDER_STEPS: Array<{
-    id: BuilderStepId;
-    label: string;
-    eyebrow: string;
-    description: string;
-}> = [
-    {
-        id: 'identity',
-        label: 'Name the agent',
-        eyebrow: 'Identity',
-        description: 'Give this teammate a clear name and purpose.',
-    },
-    {
-        id: 'instructions',
-        label: 'Define the job',
-        eyebrow: 'Instructions',
-        description: 'Write the operating brief before adding tools.',
-    },
-    {
-        id: 'shape',
-        label: 'How do you want to use it?',
-        eyebrow: 'Experience',
-        description: 'Choose the interaction shape.',
-    },
-    {
-        id: 'access',
-        label: 'Give it context',
-        eyebrow: 'Context',
-        description: 'Pick only what this agent needs.',
-    },
-    {
-        id: 'review',
-        label: 'Review and create',
-        eyebrow: 'Launch',
-        description: 'Check the agent before it joins the pod.',
-    },
-];
-
-const INSTRUCTION_STARTERS = [
-    'Read the request, understand what the person needs, summarize the important context, draft a useful response, and ask a follow-up question when information is missing.',
-    'Research the requested company or account using only available pod sources. Return a concise brief with useful context, risks, opportunities, and unknowns.',
-    'Turn rough context into a polished draft. Preserve the user intent, keep the tone practical, and flag assumptions clearly.',
-] as const;
-
-const TOOL_META: Record<string, { label: string; icon: ReactNode }> = {
-    POD: { label: 'Pod data', icon: <Folder className="h-3.5 w-3.5" /> },
-    WORKSPACE_CLI: { label: 'Workspace CLI', icon: <Wand2 className="h-3.5 w-3.5" /> },
-    SKILLS: { label: 'Skills', icon: <Box className="h-3.5 w-3.5" /> },
-    WEB_SEARCH: { label: 'Web search', icon: <Search className="h-3.5 w-3.5" /> },
-    USER_INTERACTION: { label: 'User interaction', icon: <UserRound className="h-3.5 w-3.5" /> },
-    IMAGE_GENERATION: { label: 'Image generation', icon: <ImageIcon className="h-3.5 w-3.5" /> },
-    AUDIO_GENERATION: { label: 'Audio generation', icon: <Music className="h-3.5 w-3.5" /> },
-};
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+/** The name seeds the face, and a picked variant shifts which face that is. */
+function seedFor(name: string, variant: number) {
+    return identityVariantSeed(name || 'Untitled agent', variant);
 }
 
-function getSchemaFields(schema: unknown): SchemaFieldEntry[] {
-    if (!isRecord(schema) || !isRecord(schema.properties)) return [];
-    return Object.entries(schema.properties).filter((entry): entry is SchemaFieldEntry => isRecord(entry[1]));
-}
-
-function schemaOrNull(schema: unknown): Record<string, unknown> | null {
-    return getSchemaFields(schema).length > 0 ? schema as Record<string, unknown> : null;
-}
-
-export default function NewAgentPage({
-    params,
-}: {
-    params: Promise<{ id: string }>;
-}) {
+export default function NewAgentPage({ params }: { params: Promise<{ id: string }> }) {
     const { id: podId } = use(params);
     const router = useRouter();
     const podAccess = usePodAccess(podId);
     const createAgent = useCreateAgent();
+
+    const [name, setName] = useState('');
+    const [purpose, setPurpose] = useState('');
+    const [iconUrl, setIconUrl] = useState<string | undefined>(undefined);
+    const [variant, setVariant] = useState(0);
+    const [facePage, setFacePage] = useState(0);
+
     const { data: pod } = usePod(podId);
-    const { data: runtimeCatalog } = useAgentRuntimes(pod?.organization_id);
-    const defaultRuntime = resolveDefaultAgentRuntime(runtimeCatalog, pod?.config?.default_profile_id);
-    // Only for the domain. Every other part of the address is already on this
-    // page — the name being typed, and the pod it's being made in.
     const { data: surfaceCatalog } = useAvailableSurfaces(podId);
-    const [currentStep, setCurrentStep] = useState<BuilderStepId>('identity');
-    const [showTaskFields, setShowTaskFields] = useState(false);
-    const [showOutputFields, setShowOutputFields] = useState(false);
-
-    const [draftAgent, setDraftAgent] = useState<Agent>({
-        id: 'draft',
-        pod_id: podId,
-        user_id: 'current-user',
-        name: '',
-        description: '',
-        // No mascot by default. Seeding every new agent with the same PNG is
-        // what made a roster of them read as one repeated character; leaving
-        // this empty lets the generated identity take over, and the picker is
-        // still there for anyone who wants a specific face.
-        icon_url: null,
-        agent_runtime: null,
-        instruction: '',
-        input_schema: {},
-        output_schema: {},
-        tool_sets: [],
-        accessible_tables: [],
-        accessible_folders: [],
-        accessible_connectors: [],
-        visibility: 'POD',
-        created_at: new Date().toISOString(),
-        updated_at: new Date().toISOString(),
-    } as Agent);
-
-    const inputFields = useMemo(() => getSchemaFields(draftAgent.input_schema), [draftAgent.input_schema]);
-    const outputFields = useMemo(() => getSchemaFields(draftAgent.output_schema), [draftAgent.output_schema]);
-    const hasSchema = inputFields.length > 0 || outputFields.length > 0;
-    const isConversational = !hasSchema;
-    const taskFieldsVisible = showTaskFields || inputFields.length > 0;
-    const outputFieldsVisible = showOutputFields || outputFields.length > 0;
-    const currentStepIndex = BUILDER_STEPS.findIndex((step) => step.id === currentStep);
-    const safeStepIndex = currentStepIndex >= 0 ? currentStepIndex : 0;
-    const activeStep = BUILDER_STEPS[safeStepIndex];
-    const isFinalStep = safeStepIndex === BUILDER_STEPS.length - 1;
-    const hasName = Boolean(draftAgent.name.trim());
-    const hasInstructions = Boolean(draftAgent.instruction.trim());
-    const stepDone: Record<BuilderStepId, boolean> = {
-        identity: hasName,
-        instructions: hasInstructions,
-        shape: safeStepIndex > 2,
-        access: safeStepIndex > 3,
-        review: false,
-    };
-    const canGoNext = currentStep !== 'identity' || hasName;
-    const nextStep = BUILDER_STEPS[Math.min(safeStepIndex + 1, BUILDER_STEPS.length - 1)];
-    // Derived, not fetched: the backend mints this from the same two names the
-    // moment the agent is created. Null where this deployment runs no mail
-    // domain, and the copy falls back to saying nothing rather than promising.
+    const emailDomain = managedEmailDomain(surfaceCatalog);
+    const trimmedName = name.trim();
     const emailPreview = useMemo(
         () => buildAgentEmailPreview({
-            agentName: draftAgent.name,
+            agentName: trimmedName || null,
             podName: pod?.name,
-            domain: managedEmailDomain(surfaceCatalog),
+            domain: emailDomain,
         }),
-        [draftAgent.name, pod?.name, surfaceCatalog],
+        [emailDomain, pod?.name, trimmedName],
     );
 
-    const updateDraft = (updates: Partial<Agent>) => {
-        setDraftAgent((prev) => ({ ...prev, ...updates }));
-    };
+    /* The face is seeded from the name, so it changes as the name is typed —
+       which is right (the agent's own page seeds the same way) but means the
+       eight options have to re-seed with it, not stay pinned to whatever the
+       field said when the page loaded. */
+    const faceVariants = useMemo(
+        () => distinctIdentityVariants(trimmedName || 'Untitled agent', FACE_OPTIONS, facePage * FACE_OPTIONS),
+        [facePage, trimmedName],
+    );
 
-    const goToNextStep = () => {
-        if (!canGoNext) {
-            toast.error('Name the agent first');
-            return;
-        }
-        setCurrentStep(BUILDER_STEPS[Math.min(safeStepIndex + 1, BUILDER_STEPS.length - 1)].id);
-    };
-
-    const goToPreviousStep = () => {
-        setCurrentStep(BUILDER_STEPS[Math.max(safeStepIndex - 1, 0)].id);
-    };
-
-    const handleCreate = async () => {
-        if (!podAccess.can('agent.create')) return;
-        if (!draftAgent.name.trim()) {
+    const create = async () => {
+        if (!trimmedName) {
             toast.error('Please name the agent first');
             return;
         }
@@ -220,18 +96,13 @@ export default function NewAgentPage({
             const newAgent = await createAgent.mutateAsync({
                 podId,
                 data: {
-                    name: draftAgent.name.trim(),
-                    description: draftAgent.description || null,
-                    icon_url: draftAgent.icon_url || undefined,
-                    agent_runtime: draftAgent.agent_runtime ?? null,
-                    instruction: draftAgent.instruction || defaultInstruction(draftAgent.name, draftAgent.description),
-                    input_schema: schemaOrNull(draftAgent.input_schema),
-                    output_schema: schemaOrNull(draftAgent.output_schema),
-                    tool_sets: draftAgent.tool_sets,
-                    accessible_tables: draftAgent.accessible_tables,
-                    accessible_folders: draftAgent.accessible_folders,
-                    accessible_connectors: draftAgent.accessible_connectors,
-                    visibility: draftAgent.visibility as never,
+                    name: trimmedName,
+                    description: purpose.trim() || null,
+                    icon_url: iconUrl || undefined,
+                    // The purpose is the first instruction. An agent with none is
+                    // inert, and asking for a prompt before there is anything to
+                    // test it against is what the wizard's second step was.
+                    instruction: defaultInstruction(trimmedName, purpose),
                 },
             });
 
@@ -247,414 +118,174 @@ export default function NewAgentPage({
         return (
             <div className="flex h-full items-center justify-center bg-transparent px-4">
                 <div className="surface-panel max-w-lg p-6 text-center sm:p-8">
-                    <h2 className="mb-2 font-display text-xl font-semibold text-[var(--text-primary)]">No access to create agents</h2>
-                    <p className="text-sm text-[var(--text-secondary)]">You can use the agent area, but creating agents is outside your current permissions.</p>
+                    <h2 className="mb-2 font-display text-xl font-semibold text-[var(--text-primary)]">
+                        No access to create agents
+                    </h2>
+                    <p className="text-sm text-[var(--text-secondary)]">
+                        Ask a pod admin for permission to add agents to this pod.
+                    </p>
                 </div>
             </div>
         );
     }
 
     return (
-        <div className="agent-builder-root flex h-full min-h-0 flex-col">
-            <PodPageHeader
-                podId={podId}
-                title="Create agent"
-                eyebrow="Guided builder"
+        <ResourceDetailShell>
+            {/* The bar stays here, unlike the agent's own home. A home has moved
+                its chrome into the page and has a tab naming it; this is a task
+                you arrive at and leave from, and without a header the two columns
+                simply floated — which is what made a bordered card feel necessary
+                in the first place. The bar is the page furniture; the card was
+                standing in for it. */}
+            <ResourceHeader
+                title="New agent"
                 backHref={`/pod/${podId}/ai`}
                 backLabel="Agents"
-                meta={(
-                    <span className="text-xs text-[var(--text-secondary)]">
-                        {hasName ? 'Ready to create' : 'Draft'} · {draftAgent.tool_sets.length} tools
-                    </span>
-                )}
+                fullscreen={false}
             />
 
-            <main className="resource-page-scroll min-h-0 flex-1">
-                {/* Same column and cards as the agent's own page: where you are in
-                    the build, then the step you are on. */}
-                <div className="agent-builder-canvas resource-page-column">
-                    <section className="resource-card">
-                        <div className="agent-builder-hero">
-                            <div className="min-w-0">
-                                <p className="resource-card-eyebrow mb-0">{activeStep.eyebrow}</p>
-                                <h1 className="agent-builder-title mt-1">{activeStep.label}</h1>
-                            </div>
-                            <span className="text-xs text-[var(--text-tertiary)]">
-                                {draftAgent.name.trim() || 'Unnamed agent'}
-                            </span>
-                        </div>
-                        <p className="mt-1 max-w-2xl text-sm leading-6 text-[var(--text-secondary)]">{activeStep.description}</p>
-
-                        <CompactStepProgress
-                            steps={BUILDER_STEPS}
-                            currentStep={currentStep}
-                            stepDone={stepDone}
-                            onSelect={(stepId) => setCurrentStep(stepId)}
-                        />
-                    </section>
-
-                    <section className="resource-card agent-builder-stage" data-step={currentStep}>
-                        {currentStep === 'identity' ? (
-                            <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
-                                <div className="space-y-6">
-                                    <div>
-                                        <label className="text-sm font-medium text-[var(--text-secondary)]">
-                                            Agent name
-                                        </label>
-                                        <input
-                                            value={draftAgent.name}
-                                            onChange={(event) => updateDraft({ name: event.target.value })}
-                                            placeholder="Customer Thread Briefing"
-                                            className="form-field-control mt-2 h-9 w-full px-3 text-sm font-medium tracking-normal text-[var(--text-primary)] outline-none placeholder:text-[var(--text-tertiary)]"
-                                        />
-                                        {/* The name is not only a label — it decides the
-                                            address, and the address is the thing that
-                                            makes an agent reachable by anyone who never
-                                            opens Lemma. Naming it here, live, is the
-                                            only moment where that lands as a
-                                            consequence of what you just typed. */}
-                                        <AgentEmailNote address={emailPreview} hasName={hasName} />
-                                    </div>
-                                    <div>
-                                        <label className="text-sm font-medium text-[var(--text-secondary)]">
-                                            One-line purpose
-                                        </label>
-                                        <textarea
-                                            value={draftAgent.description || ''}
-                                            onChange={(event) => updateDraft({ description: event.target.value.slice(0, 200) })}
-                                            placeholder="What should this agent help the pod do?"
-                                            className="form-field-control mt-2 min-h-24 w-full resize-y px-3 py-2.5 text-sm leading-6 text-[var(--text-secondary)] outline-none placeholder:text-[var(--text-tertiary)]"
-                                        />
-                                    </div>
-                                </div>
-                                <div className="agent-builder-side-section">
-                                    <AgentAvatarPicker
-                                        name={draftAgent.name || 'Agent'}
-                                        // Matches the preview's `displayName`, or an
-                                        // unnamed draft shows two different creatures.
-                                        seed={draftAgent.name?.trim() || 'Untitled agent'}
-                                        value={draftAgent.icon_url}
-                                        onChange={(iconUrl) => updateDraft({ icon_url: iconUrl || undefined })}
-                                        compact
-                                    />
-                                </div>
-                            </div>
-                        ) : null}
-
-                        {currentStep === 'instructions' ? (
-                            <div>
-                                <div className="flex flex-wrap items-center justify-between gap-3">
-                                    <p className="max-w-2xl text-sm leading-6 text-[var(--text-secondary)]">
-                                        Write the operating brief in plain language. A focused job description matters more than a long list of tools.
-                                    </p>
-                                    <div className="flex flex-wrap gap-2">
-                                        {INSTRUCTION_STARTERS.map((starter, index) => (
-                                            <button
-                                                key={starter}
-                                                type="button"
-                                                onClick={() => updateDraft({ instruction: draftAgent.instruction || starter })}
-                                                className="choice-chip choice-chip-sm"
-                                            >
-                                                Example {index + 1}
-                                            </button>
-                                        ))}
-                                    </div>
-                                </div>
-                                <textarea
-                                    value={draftAgent.instruction}
-                                    onChange={(event) => updateDraft({ instruction: event.target.value })}
-                                    placeholder="Tell the agent what it does, what information it can use, what to avoid, when to ask a follow-up question, and what good work looks like..."
-                                    className="form-field-control mt-3 min-h-[18rem] w-full resize-y px-3 py-2.5 text-sm leading-6 text-[var(--text-primary)] outline-none placeholder:text-[var(--text-tertiary)]"
-                                />
-                            </div>
-                        ) : null}
-
-                        {currentStep === 'shape' ? (
-                            <div className="space-y-5">
-                                <div className="agent-builder-section">
-                                    <div className="settings-title-row mb-3">
-                                        <Bot className="h-4 w-4 text-[var(--text-tertiary)]" />
-                                        <h3 className="settings-title text-sm">Model</h3>
-                                    </div>
-                                    <RuntimeModelPicker
-                                        catalog={runtimeCatalog}
-                                        defaultRuntime={defaultRuntime}
-                                        value={draftAgent.agent_runtime ?? null}
-                                        onChange={(agentRuntime) => updateDraft({ agent_runtime: agentRuntime })}
-                                        scopeHint="Default for this agent"
-                                        manageHref={pod?.organization_id ? `/organizations/${pod.organization_id}/settings/agent-runtimes` : undefined}
-                                    />
-                                </div>
-
-                                <div className="grid gap-3 md:grid-cols-2">
-                                    <ModeChoice
-                                        active={isConversational}
-                                        icon={<MessageSquare className="h-5 w-5" />}
-                                        title="Chat with it"
-                                        text="Open-ended help and drafting."
-                                        onClick={() => {
-                                            setShowTaskFields(false);
-                                            setShowOutputFields(false);
-                                            updateDraft({ input_schema: {}, output_schema: {} });
-                                        }}
-                                    />
-                                    <ModeChoice
-                                        active={!isConversational || showTaskFields || showOutputFields}
-                                        icon={<Braces className="h-5 w-5" />}
-                                        title="Run a structured task"
-                                        text="Guided input, predictable output."
-                                        onClick={() => setShowTaskFields(true)}
-                                    />
-                                </div>
-
-                                {isConversational && !showTaskFields && !showOutputFields ? (
-                                    <ChatModeSummary />
-                                ) : (
-                                    <div className="grid gap-5 md:grid-cols-2">
-                                        <SchemaMiniPanel
-                                            icon={<ClipboardList className="h-4 w-4" />}
-                                            title="People give it"
-                                            description="Input fields."
-                                            isOpen={taskFieldsVisible}
-                                            actionLabel={inputFields.length > 0 ? 'Edit fields' : 'Add fields'}
-                                            onOpen={() => setShowTaskFields(true)}
-                                        >
-                                            <SchemaBuilder
-                                                value={draftAgent.input_schema || {}}
-                                                onChange={(schema) => updateDraft({ input_schema: schema })}
-                                            />
-                                        </SchemaMiniPanel>
-                                        <SchemaMiniPanel
-                                            icon={<FileOutput className="h-4 w-4" />}
-                                            title="It gives back"
-                                            description="Structured result."
-                                            isOpen={outputFieldsVisible}
-                                            actionLabel={outputFields.length > 0 ? 'Edit output' : 'Add output'}
-                                            onOpen={() => setShowOutputFields(true)}
-                                        >
-                                            <SchemaBuilder
-                                                value={draftAgent.output_schema || {}}
-                                                onChange={(schema) => updateDraft({ output_schema: schema })}
-                                            />
-                                        </SchemaMiniPanel>
-                                    </div>
-                                )}
-                            </div>
-                        ) : null}
-
-                        {currentStep === 'access' ? (
-                            <div className="space-y-5">
-                                <div className="agent-builder-section">
-                                    <ResourceVisibilitySelect
-                                        value={draftAgent.visibility}
-                                        resourceLabel="agents"
-                                        resourceName={draftAgent.name ? formatAgentName(draftAgent.name) : 'New agent'}
-                                        onChange={(visibility) => updateDraft({ visibility })}
-                                    />
-                                </div>
-
-                                <div className="agent-builder-section">
-                                    <div className="inspector-section-header mb-3">
-                                        <div className="settings-title-row">
-                                            <Box className="h-4 w-4 text-[var(--text-tertiary)]" />
-                                            <h3 className="inspector-section-title">Tools</h3>
-                                        </div>
-                                        <span className="inspector-section-meta">{draftAgent.tool_sets.length} selected</span>
-                                    </div>
-                                    <div className="agent-builder-permission-strip">
-                                        {Object.values(ToolSet).map((tool) => {
-                                            const meta = TOOL_META[tool] ?? { label: tool.replace(/_/g, ' '), icon: <Box className="h-3.5 w-3.5" /> };
-                                            const isSelected = (draftAgent.tool_sets || []).includes(tool);
-                                            return (
-                                                <label
-                                                    key={tool}
-                                                    className="agent-builder-permission-option"
-                                                    data-selected={isSelected}
-                                                >
-                                                    <Checkbox
-                                                        checked={isSelected}
-                                                        onCheckedChange={(checked) => {
-                                                            const current = draftAgent.tool_sets || [];
-                                                            updateDraft({
-                                                                tool_sets: checked
-                                                                    ? [...current, tool]
-                                                                    : current.filter((entry) => entry !== tool),
-                                                            });
-                                                        }}
-                                                        className="h-3.5 w-3.5"
-                                                    />
-                                                    <span className="shrink-0 text-[var(--text-tertiary)]">{meta.icon}</span>
-                                                    <span className="truncate">{meta.label}</span>
-                                                </label>
-                                            );
-                                        })}
-                                    </div>
-                                </div>
-
-                                <div className="agent-builder-access-grid">
-                                    <AccessBlock icon={<Table className="h-4 w-4" />} title="Tables">
-                                        <DatastoresSelector
-                                            podId={podId}
-                                            selected={(draftAgent.accessible_tables || []).map((entry) => entry.table_name)}
-                                            modeByName={Object.fromEntries(
-                                                (draftAgent.accessible_tables || []).map((entry) => [entry.table_name, entry.mode])
-                                            )}
-                                            onChange={(names) => {
-                                                const modeByTable = new Map(
-                                                    (draftAgent.accessible_tables || []).map((entry) => [entry.table_name, entry.mode])
-                                                );
-                                                updateDraft({
-                                                    accessible_tables: names.map((table_name) => ({
-                                                        table_name,
-                                                        mode: modeByTable.get(table_name) ?? AccessMode.READ,
-                                                    })),
-                                                });
-                                            }}
-                                            onModeChange={(name, mode) => {
-                                                updateDraft({
-                                                    accessible_tables: (draftAgent.accessible_tables || []).map((entry) =>
-                                                        entry.table_name === name ? { ...entry, mode } : entry
-                                                    ),
-                                                });
-                                            }}
-                                            showLabel={false}
-                                        />
-                                    </AccessBlock>
-                                    <AccessBlock icon={<Folder className="h-4 w-4" />} title="Folders">
-                                        <FoldersSelector
-                                            podId={podId}
-                                            selected={(draftAgent.accessible_folders || []).map((entry) => entry.folder_path)}
-                                            modeByPath={Object.fromEntries(
-                                                (draftAgent.accessible_folders || []).map((entry) => [entry.folder_path, entry.mode])
-                                            )}
-                                            onChange={(folderPaths) => {
-                                                const modeByFolder = new Map(
-                                                    (draftAgent.accessible_folders || []).map((entry) => [entry.folder_path, entry.mode])
-                                                );
-                                                updateDraft({
-                                                    accessible_folders: folderPaths.map((folder_path) => ({
-                                                        folder_path,
-                                                        mode: modeByFolder.get(folder_path) ?? AccessMode.READ,
-                                                    })),
-                                                });
-                                            }}
-                                            onModeChange={(folderPath, mode) => {
-                                                updateDraft({
-                                                    accessible_folders: (draftAgent.accessible_folders || []).map((entry) =>
-                                                        entry.folder_path === folderPath ? { ...entry, mode } : entry
-                                                    ),
-                                                });
-                                            }}
-                                            showLabel={false}
-                                        />
-                                    </AccessBlock>
-                                    <AccessBlock icon={<Wand2 className="h-4 w-4" />} title="Connectors">
-                                        <ConnectorsSelector
-                                            podId={podId}
-                                            selected={draftAgent.accessible_connectors || []}
-                                            onChange={(configs) => updateDraft({ accessible_connectors: configs })}
-                                            showLabel={false}
-                                        />
-                                    </AccessBlock>
-                                </div>
-                            </div>
-                        ) : null}
-
-                        {currentStep === 'review' ? (
-                            <LaunchReview
-                                name={draftAgent.name}
-                                iconUrl={draftAgent.icon_url}
-                                description={draftAgent.description}
-                                hasName={hasName}
-                                hasInstructions={hasInstructions}
-                                instruction={draftAgent.instruction}
-                                isConversational={isConversational}
-                                inputFieldsCount={inputFields.length}
-                                outputFieldsCount={outputFields.length}
-                                toolsCount={draftAgent.tool_sets.length}
-                                tablesCount={draftAgent.accessible_tables?.length || 0}
-                                foldersCount={draftAgent.accessible_folders?.length || 0}
-                                appsCount={draftAgent.accessible_connectors?.length || 0}
-                                runtimeLabel={formatAgentRuntime(draftAgent.agent_runtime ?? defaultRuntime, runtimeCatalog)}
-                                visibility={draftAgent.visibility}
-                                email={emailPreview}
+            <ResourceDetailViewport>
+                <div className="resource-page-scroll agent-home-scroll">
+                    <form
+                        className="agent-create-card"
+                        onSubmit={(event) => {
+                            event.preventDefault();
+                            void create();
+                        }}
+                    >
+                        {/* The preview is its own panel, not the fields wearing
+                            the result's clothes. That was the earlier attempt and
+                            it cost the fields their affordances; a face and a name
+                            standing on their own cost nothing and show the same
+                            thing better. */}
+                        <div className="agent-create-preview">
+                            <ResourceIcon
+                                iconUrl={iconUrl}
+                                alt=""
+                                label={trimmedName || 'New agent'}
+                                identityKind="being"
+                                identitySeed={seedFor(trimmedName, variant)}
+                                identitySize={96}
+                                className="h-24 w-24 rounded-3xl"
                             />
-                        ) : null}
+                            <p className="agent-create-preview-name" data-empty={trimmedName ? undefined : 'true'}>
+                                {trimmedName || 'Your agent'}
+                            </p>
+                        </div>
 
-                    </section>
-                </div>
-            </main>
+                        <div className="agent-create-fields">
+                            <label className="agent-create-field">
+                                <span className="agent-create-label">Name</span>
+                                <input
+                                    value={name}
+                                    onChange={(event) => setName(event.target.value)}
+                                    placeholder="Pitch polish"
+                                    autoFocus
+                                    className="form-field-control h-10 w-full px-3 text-sm text-[var(--text-primary)] outline-none placeholder:text-[var(--text-soft)]"
+                                />
+                            </label>
 
-            <footer className="agent-builder-footer shrink-0">
-                <div className="agent-builder-footer-inner">
-                    <div className="min-w-0">
-                        <p className="type-eyebrow">
-                            Step {safeStepIndex + 1} of {BUILDER_STEPS.length}
-                        </p>
-                        <p className="truncate text-sm font-medium text-[var(--text-primary)]">
-                            {activeStep.label}
-                            {!isFinalStep ? <span className="font-normal text-[var(--text-tertiary)]"> · Next: {nextStep.label}</span> : null}
-                        </p>
-                    </div>
-                    <div className="flex shrink-0 items-center gap-2">
-                        <Button
-                            type="button"
-                            variant="secondary"
-                            onClick={goToPreviousStep}
-                            disabled={safeStepIndex === 0 || createAgent.isPending}
-                            className="gap-2"
-                        >
-                            <ArrowLeft className="h-3.5 w-3.5" />
-                            Previous
-                        </Button>
-                        {isFinalStep ? (
-                            <Button variant="primary"
-                                type="button"
-                                onClick={handleCreate}
-                                disabled={createAgent.isPending || !hasName}
-                                className="gap-2"
+                            {/* Under the name, because the name is what draws it.
+                                An identity stores a *variant*, not a picture —
+                                the seed is always the resource's own name — so
+                                the face is a function of both, and typing after
+                                picking one turned it into a different creature.
+                                That is the system working, not a slip: renaming
+                                an agent changes its face wherever it appears.
+                                Asking for the name first puts cause before
+                                effect, and the note says the rule out loud so it
+                                reads as designed rather than as the picker
+                                losing your choice.
+                                Inline, always: hiding eight faces behind a
+                                toggle made picking one a thing you had to go
+                                looking for, and the face is half of how an agent
+                                is told apart in a rail of them. */}
+                            <div className="agent-create-row">
+                                <span className="agent-create-label">
+                                    Character
+                                    <span className="agent-create-hint">drawn from the name</span>
+                                </span>
+                                <button
+                                    type="button"
+                                    onClick={() => setFacePage((page) => page + 1)}
+                                    className="agent-create-reshuffle custom-focus-ring"
+                                >
+                                    <RefreshCw className="h-3.5 w-3.5" />
+                                    More options
+                                </button>
+                            </div>
+                            <div className="agent-create-faces">
+                                {faceVariants.map((option) => (
+                                    <button
+                                        key={option}
+                                        type="button"
+                                        onClick={() => {
+                                            setVariant(option);
+                                            setIconUrl(formatIdentityIcon(option));
+                                        }}
+                                        data-active={option === variant ? 'true' : undefined}
+                                        aria-label={`Face option ${option + 1}`}
+                                        aria-pressed={option === variant}
+                                        className="agent-create-face custom-focus-ring"
+                                    >
+                                        <ResourceIcon
+                                            alt=""
+                                            label={`Face ${option + 1}`}
+                                            identityKind="being"
+                                            identitySeed={seedFor(trimmedName, option)}
+                                            identitySize={36}
+                                            className="h-9 w-9 rounded-lg"
+                                        />
+                                    </button>
+                                ))}
+                            </div>
+
+                            <label className="agent-create-field">
+                                <span className="agent-create-label">Purpose</span>
+                                <textarea
+                                    value={purpose}
+                                    onChange={(event) => setPurpose(event.target.value.slice(0, 200))}
+                                    /* The placeholder is an example, not an
+                                       instruction. "What should it help with?"
+                                       asks the question again; a written purpose
+                                       shows the length and the register of a good
+                                       answer. */
+                                    placeholder="Turns rough ideas into sharp, memorable pitches"
+                                    rows={2}
+                                    className="form-field-control w-full resize-none px-3 py-2.5 text-sm leading-6 text-[var(--text-secondary)] outline-none placeholder:text-[var(--text-soft)]"
+                                />
+                            </label>
+
+                            {/* The name is not only a label — it decides the
+                                address, and the address is what makes an agent
+                                reachable by someone who never opens Lemma. */}
+                            {trimmedName && emailPreview ? (
+                                <p className="agent-builder-email-note">
+                                    <span className="text-[var(--text-secondary)]">People will be able to email it at</span>
+                                    <AgentEmail address={emailPreview} size="sm" preview />
+                                </p>
+                            ) : null}
+
+                            <Button
+                                type="submit"
+                                variant="primary"
+                                className="agent-create-submit"
+                                disabled={!trimmedName}
+                                loading={createAgent.isPending}
+                                loadingLabel="Creating…"
                             >
-                                <Plus className="h-4 w-4" />
-                                {createAgent.isPending ? 'Creating...' : 'Create agent'}
+                                Get started
                             </Button>
-                        ) : (
-                            <Button variant="primary"
-                                type="button"
-                                onClick={goToNextStep}
-                                disabled={createAgent.isPending || !canGoNext}
-                                className="gap-2"
-                            >
-                                Next
-                                <ArrowRight className="h-3.5 w-3.5" />
-                            </Button>
-                        )}
-                    </div>
+
+                            <p className="agent-create-note">
+                                Instructions, what it can reach, and its schedules are all
+                                set from the agent&rsquo;s own page afterwards.
+                            </p>
+                        </div>
+                    </form>
                 </div>
-            </footer>
-        </div>
-    );
-}
-
-/**
- * What the name you just typed buys you: an address.
- *
- * Creating an agent provisions a mailbox for it — it has done so all along, and
- * nothing in this builder said so, so the first anyone heard of it was a
- * truncated chip on a page they had to go looking for. Stated here it is a
- * reason to finish naming the thing.
- *
- * Silent when this deployment mints no addresses. A promise of mail on an
- * install with no domain configured is worse than saying nothing.
- */
-function AgentEmailNote({ address, hasName }: { address: string | null; hasName: boolean }) {
-    if (!hasName) return null;
-    if (!address) return null;
-
-    return (
-        <p className="agent-builder-email-note">
-            <span className="text-[var(--text-secondary)]">People will be able to email it at</span>
-            <AgentEmail address={address} size="sm" preview />
-        </p>
+            </ResourceDetailViewport>
+        </ResourceDetailShell>
     );
 }
 
@@ -664,281 +295,4 @@ function defaultInstruction(name: string, description?: string | null) {
     return purpose
         ? `You are ${subject}. ${purpose} Be clear, useful, and stay within the pod context and granted tools.`
         : `You are ${subject}. Help the user with the task they bring to you. Be clear, useful, and stay within the pod context and granted tools.`;
-}
-
-function CompactStepProgress({
-    steps,
-    currentStep,
-    stepDone,
-    onSelect,
-}: {
-    steps: typeof BUILDER_STEPS;
-    currentStep: BuilderStepId;
-    stepDone: Record<BuilderStepId, boolean>;
-    onSelect: (stepId: BuilderStepId) => void;
-}) {
-    const currentIndex = Math.max(0, steps.findIndex((step) => step.id === currentStep));
-    return (
-        <nav className="agent-builder-step-strip" data-progress={currentIndex + 1}>
-            <div className="flex items-center justify-between gap-3 sm:hidden">
-                <div className="type-eyebrow">
-                    Progress
-                </div>
-                <div className="text-xs font-medium text-[var(--text-secondary)]">
-                    {currentIndex + 1}/{steps.length}
-                </div>
-            </div>
-            <div className="flex gap-1.5 overflow-x-auto">
-                {steps.map((step, index) => {
-                    const active = step.id === currentStep;
-                    const done = stepDone[step.id] && !active;
-                    return (
-                        <button
-                            key={step.id}
-                            type="button"
-                            onClick={() => onSelect(step.id)}
-                            className={cn(
-                                'agent-builder-step-button flex h-8 shrink-0 items-center gap-2 rounded-md px-2 text-xs transition-colors',
-                                active ? 'agent-builder-step-button-active' : ''
-                            )}
-                        >
-                            <span className={cn(
-                                'agent-builder-step-index flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs font-medium',
-                                done
-                                    ? 'agent-builder-step-index-done'
-                                    : active
-                                    ? 'agent-builder-step-index-active'
-                                    : ''
-                            )}>
-                                {done ? <CheckCircle2 className="h-3.5 w-3.5" /> : index + 1}
-                            </span>
-                            <span className={cn(
-                                'min-w-0 truncate font-medium',
-                                active ? 'text-[var(--text-primary)]' : 'text-[var(--text-secondary)]'
-                            )}>
-                                {step.label}
-                            </span>
-                        </button>
-                    );
-                })}
-            </div>
-            <div className="agent-builder-progress-track" aria-hidden="true">
-                <span className="agent-builder-progress-fill" />
-            </div>
-        </nav>
-    );
-}
-
-function ModeChoice({
-    active,
-    icon,
-    title,
-    text,
-    onClick,
-}: {
-    active: boolean;
-    icon: ReactNode;
-    title: string;
-    text: string;
-    onClick: () => void;
-}) {
-    return (
-        <button
-            type="button"
-            onClick={onClick}
-            className={cn(
-                'agent-builder-choice-button flex min-h-24 items-start gap-3 rounded-lg p-3.5 transition-gentle',
-                active ? 'agent-builder-choice-button-active' : ''
-            )}
-        >
-            <span className={cn(
-                'flex h-10 w-10 shrink-0 items-center justify-center rounded-md',
-                active ? 'bg-[var(--action-primary-soft)] text-[var(--action-primary)]' : 'text-[var(--text-secondary)]'
-            )}>
-                {icon}
-            </span>
-            <span>
-                <span className="block text-sm font-medium text-[var(--text-primary)]">{title}</span>
-                <span className="mt-2 block text-sm leading-6 text-[var(--text-secondary)]">{text}</span>
-            </span>
-        </button>
-    );
-}
-
-function AccessBlock({ icon, title, children }: { icon: ReactNode; title: string; children: ReactNode }) {
-    return (
-        <section className="agent-builder-access-card">
-            <div className="settings-title-row mb-3">
-                <span className="text-[var(--text-tertiary)]">{icon}</span>
-                <h3 className="settings-title text-sm">{title}</h3>
-            </div>
-            {children}
-        </section>
-    );
-}
-
-function ChatModeSummary() {
-    return (
-        <div className="agent-builder-note">
-            <div className="flex items-start gap-3">
-                <MessageSquare className="mt-0.5 h-4 w-4 shrink-0 text-[var(--state-success)]" />
-                <div>
-                    <p className="text-sm font-medium text-[var(--text-primary)]">No form needed</p>
-                    <p className="mt-1 text-sm leading-6 text-[var(--text-secondary)]">
-                        People will just message this agent. Add fields only if you want a repeatable run form later.
-                    </p>
-                </div>
-            </div>
-        </div>
-    );
-}
-
-function LaunchReview({
-    name,
-    iconUrl,
-    description,
-    hasName,
-    hasInstructions,
-    instruction,
-    isConversational,
-    inputFieldsCount,
-    outputFieldsCount,
-    toolsCount,
-    tablesCount,
-    foldersCount,
-    appsCount,
-    runtimeLabel,
-    visibility,
-    email,
-}: {
-    name: string;
-    iconUrl?: string | null;
-    description?: string | null;
-    hasName: boolean;
-    hasInstructions: boolean;
-    instruction: string;
-    isConversational: boolean;
-    inputFieldsCount: number;
-    outputFieldsCount: number;
-    toolsCount: number;
-    tablesCount: number;
-    foldersCount: number;
-    appsCount: number;
-    runtimeLabel: string;
-    visibility?: string | null;
-    /** The address creating this agent will mint, where mail is configured. */
-    email?: string | null;
-}) {
-    const accessCount = toolsCount + tablesCount + foldersCount + appsCount;
-    const displayName = name.trim() || 'Untitled agent';
-    const purpose = description?.trim() || 'No one-line purpose yet.';
-    const brief = hasInstructions
-        ? instruction.trim()
-        : 'A default brief will be created from the name and purpose.';
-    const capabilities = [
-        isConversational ? 'People can chat with it' : 'People can run it as a structured task',
-        !isConversational && inputFieldsCount > 0 ? `${inputFieldsCount} input field${inputFieldsCount === 1 ? '' : 's'}` : null,
-        !isConversational && outputFieldsCount > 0 ? `${outputFieldsCount} output field${outputFieldsCount === 1 ? '' : 's'}` : null,
-        runtimeLabel,
-        accessCount > 0 ? `${accessCount} tool/context item${accessCount === 1 ? '' : 's'} linked` : 'No extra access yet',
-    ].filter(Boolean) as string[];
-
-    return (
-        <div className="max-w-4xl space-y-8">
-            <section className="agent-builder-section">
-                <div className="flex flex-col gap-5 sm:flex-row sm:items-start">
-                    <ResourceIcon
-                        iconUrl={iconUrl}
-                        alt={`${formatAgentName(displayName)} profile picture`}
-                        label={displayName}
-                        imageClassName="object-contain p-1"
-                        className="h-20 w-20 shrink-0 !border-0 !bg-transparent"
-                        identitySeed={displayName}
-                        identitySize={80}
-                        fallback={<Bot className="h-7 w-7 text-[var(--text-tertiary)]" />}
-                    />
-                    <div className="min-w-0 flex-1">
-                        <p className="section-label">Agent</p>
-                        <div className="mt-2 flex flex-wrap items-center gap-2">
-                            <h3 className="truncate text-2xl font-medium text-[var(--text-primary)]">{formatAgentName(displayName)}</h3>
-                            {!hasName ? (
-                                <span className="state-badge-error rounded-md px-2 py-0.5 text-xs font-medium">
-                                    Name missing
-                                </span>
-                            ) : null}
-                        </div>
-                        <p className="mt-2 max-w-2xl text-sm leading-6 text-[var(--text-secondary)]">{purpose}</p>
-
-                        {/* Sits with the name and purpose, not among the chips
-                            below: it is part of who this agent will be, and the
-                            chips are what it will be able to do. Same sentence
-                            as the naming step, so the address doesn't arrive
-                            here as a new fact. */}
-                        <AgentEmailNote address={email ?? null} hasName={hasName} />
-
-                        <div className="mt-4 flex flex-wrap gap-2">
-                            <ResourceVisibilityBadge visibility={visibility} resourceLabel="agents" />
-                            {capabilities.map((capability) => (
-                                <span key={capability} className="chip chip-sm chip-quiet">
-                                    {capability}
-                                </span>
-                            ))}
-                        </div>
-                    </div>
-                </div>
-            </section>
-
-            <section className="agent-builder-section">
-                <div className="flex items-start gap-3">
-                    <ClipboardList className="mt-1 h-4 w-4 shrink-0 text-[var(--text-tertiary)]" />
-                    <div className="min-w-0">
-                        <p className="text-sm font-medium text-[var(--text-primary)]">
-                            {hasInstructions ? 'Operating brief' : 'Default operating brief'}
-                        </p>
-                        <p className="mt-1 line-clamp-5 text-sm leading-6 text-[var(--text-secondary)]">
-                            {brief}
-                        </p>
-                    </div>
-                </div>
-            </section>
-        </div>
-    );
-}
-
-function SchemaMiniPanel({
-    icon,
-    title,
-    description,
-    actionLabel,
-    isOpen,
-    onOpen,
-    children,
-}: {
-    icon: ReactNode;
-    title: string;
-    description: string;
-    actionLabel: string;
-    isOpen: boolean;
-    onOpen: () => void;
-    children: ReactNode;
-}) {
-    return (
-        <div className="agent-builder-section">
-            <div className="flex gap-2">
-                <span className="mt-0.5 shrink-0 text-[var(--text-secondary)]">{icon}</span>
-                <div className="min-w-0 flex-1">
-                    <h3 className="text-sm font-medium text-[var(--text-primary)]">{title}</h3>
-                    <p className="mt-0.5 text-xs leading-5 text-[var(--text-secondary)]">{description}</p>
-                </div>
-            </div>
-            {isOpen ? (
-                <div className="mt-3">{children}</div>
-            ) : (
-                <Button type="button" variant="secondary" size="sm" onClick={onOpen} className="mt-3 h-8 w-full gap-2 border-dashed text-xs">
-                    <Plus className="h-3.5 w-3.5" />
-                    {actionLabel}
-                </Button>
-            )}
-        </div>
-    );
 }

--- a/lemma-frontend/app/pod/[id]/ai/assistant/page.tsx
+++ b/lemma-frontend/app/pod/[id]/ai/assistant/page.tsx
@@ -1,29 +1,26 @@
 'use client';
 
-import { use, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { use } from 'react';
 import { POD_DEFAULT_AGENT_SELECTOR } from 'lemma-sdk';
-import { ArrowUp } from '@/components/ui/icons';
 
-import { Nothing, WiringRow } from '@/components/pod/wiring-row';
-import { LemmaMark } from '@/components/brand/logo';
-import { RecentConversations } from '@/components/pod/recent-conversations';
+import { AgentHome } from '@/components/agents/agent-home';
 import {
     ResourceHeader,
     ResourceDetailShell,
     ResourceDetailViewport,
-    ResourceHeroTitle,
 } from '@/components/pod/resource-layout';
-import { AgentSurfacesRow } from '@/components/surfaces/agent-surfaces-row';
-import { Button } from '@/components/ui/button';
 import { useScopedConversations } from '@/lib/hooks/use-assistants';
 import { usePodAccess } from '@/lib/hooks/use-pod-access';
+import { DEFAULT_RESPONDER_DESCRIPTION, DEFAULT_RESPONDER_NAME } from '@/lib/utils/agents';
 import { usePodAutomation } from '@/lib/hooks/use-pod-automation';
 
-// The "Pod Assistant" is a virtual, frontend-only agent: it has no row of its
-// own. It stands in for the pod's default responder — the agent that answers on
-// any surface not assigned to a specific agent. Its surfaces are exactly the
-// surfaces with no explicit responder (`uses_default_agent`).
+// Lem is a virtual, frontend-only agent: it has no row of its own. It stands in
+// for the pod's default responder — the agent that answers on any surface not
+// assigned to a specific agent. Its surfaces are exactly the surfaces with no
+// explicit responder (`uses_default_agent`).
+//
+// The name is display copy and lives in one constant; the wire still calls this
+// `pod_default` / `POD_DEFAULT`, and nothing here should spell it out inline.
 //
 // It is built from the same parts as an agent's page and should keep matching
 // it: an identity card that states what it is and how it is reached, then the
@@ -36,10 +33,8 @@ export default function PodAssistantPage({
     params: Promise<{ id: string }>;
 }) {
     const { id: podId } = use(params);
-    const router = useRouter();
     const podAccess = usePodAccess(podId);
     const canUseSurfaces = podAccess.canAccessRoute('surfaces');
-    const canReadConversations = podAccess.can('conversation.read');
 
     // Pod-wide automation, grouped client-side — shares one cache entry with the
     // schedules page and agent detail pages instead of a per-view fetch. No
@@ -48,105 +43,42 @@ export default function PodAssistantPage({
     const defaultSurfaces = automation.defaultSurfaces;
     const { data: conversationsPage } = useScopedConversations(
         { podId, agentName: POD_DEFAULT_AGENT_SELECTOR },
-        { limit: 4, enabled: canReadConversations },
+        { limit: 10, enabled: podAccess.can('conversation.read') },
     );
     const recentConversations = conversationsPage?.items ?? [];
 
-    const [message, setMessage] = useState('');
-
-    // Hand off to the pod's new-conversation flow with no `?agent=` — the pod
-    // default assistant answers, carrying the first message so it sends on arrival.
-    const startConversation = () => {
-        const text = message.trim();
-        const params = new URLSearchParams();
-        if (text) params.set('assistantMessage', text);
-        const query = params.toString();
-        router.push(`/pod/${podId}/conversations/new${query ? `?${query}` : ''}`);
-    };
-
     return (
         <ResourceDetailShell>
+            {/* Same call as the agent pages: the tab strip above already names
+                this, so the bar drops the title and the back link. `tab` rather
+                than nothing, so a compact viewport with no strip takes the name
+                back instead of leaving the page unnamed. */}
             <ResourceHeader
-                title="Pod Assistant"
-                titleOwner="page"
-                backHref={`/pod/${podId}/ai`}
-                backLabel="Agents"
+                title={DEFAULT_RESPONDER_NAME}
+                titleOwner="tab"
+                // Nothing left for the bar to hold, so it goes rather than
+                // drawing an empty strip — the same call pod home makes.
+                hideContextBar
                 fullscreen={false}
             />
 
+            {/* The same home the agent pages get. This was a stack of read-only
+                cards — identity, wiring, a textarea that navigated away, and four
+                recent conversations at the bottom — every one of them describing
+                the assistant on a page where you could not talk to it. Then it
+                was a live transcript, which had the opposite problem: sending
+                consumed the page. Sending now opens the conversation as its own
+                tab and this stays the assistant's home. */}
             <ResourceDetailViewport>
-                <div className="resource-page-scroll">
-                    <div className="resource-page-column">
-                        <section className="resource-card">
-                            <header className="agent-identity">
-                                <span className="agent-identity-avatar" aria-hidden>
-                                    <LemmaMark size="sm" />
-                                </span>
-                                <div className="agent-identity-body">
-                                    <div className="agent-identity-titles">
-                                        <ResourceHeroTitle className="agent-identity-name">Pod Assistant</ResourceHeroTitle>
-                                    </div>
-                                    <p className="agent-identity-description-static">
-                                        This pod&rsquo;s most capable agent. Ask it to add a table, build a workflow, spin up a
-                                        new agent, connect a surface, or read and change your data, and it acts on the pod directly.
-                                    </p>
-                                </div>
-                            </header>
-
-                            {canUseSurfaces ? (
-                                <div className="agent-wiring">
-                                    <WiringRow label="Reached by">
-                                        <div className="agent-wiring-chips">
-                                            {defaultSurfaces.length === 0 ? <Nothing>Only you, here.</Nothing> : null}
-                                            <AgentSurfacesRow
-                                                podId={podId}
-                                                agentName={null}
-                                                surfaces={defaultSurfaces}
-                                                label={null}
-                                            />
-                                        </div>
-                                    </WiringRow>
-                                </div>
-                            ) : null}
-                        </section>
-
-                        <section className="resource-card">
-                            <p className="resource-card-eyebrow">Ask it something</p>
-                            <div className="form-field-control p-2.5">
-                                <textarea
-                                    value={message}
-                                    onChange={(event) => setMessage(event.target.value)}
-                                    onKeyDown={(event) => {
-                                        if (event.key === 'Enter' && !event.shiftKey) {
-                                            event.preventDefault();
-                                            startConversation();
-                                        }
-                                    }}
-                                    placeholder="Message the pod assistant…"
-                                    rows={3}
-                                    className="inline-edit-field min-h-20 w-full resize-none px-2.5 py-2 text-sm leading-6"
-                                />
-                                <div className="flex items-center justify-between gap-3 px-1.5 pb-1">
-                                    <span className="truncate text-xs text-[var(--text-tertiary)]">
-                                        Enter to send · Shift + Enter for a new line
-                                    </span>
-                                    <Button variant="primary"
-                                        type="button"
-                                        size="icon"
-                                        className="h-8 w-8 shrink-0 rounded-full"
-                                        onClick={startConversation}
-                                        aria-label="Start conversation"
-                                    >
-                                        <ArrowUp className="h-4 w-4" />
-                                    </Button>
-                                </div>
-                            </div>
-
-                            {/* Brings its own top margin, which is why it is not in a
-                                `space-y` stack. */}
-                            <RecentConversations podId={podId} conversations={recentConversations} agentName={null} />
-                        </section>
-                    </div>
+                <div className="resource-page-scroll agent-home-scroll">
+                    <AgentHome
+                        podId={podId}
+                        agentName={DEFAULT_RESPONDER_NAME}
+                        description={DEFAULT_RESPONDER_DESCRIPTION}
+                        surfaces={canUseSurfaces ? defaultSurfaces : []}
+                        conversations={recentConversations}
+                        isAssistant
+                    />
                 </div>
             </ResourceDetailViewport>
         </ResourceDetailShell>

--- a/lemma-frontend/app/pod/[id]/ai/page.tsx
+++ b/lemma-frontend/app/pod/[id]/ai/page.tsx
@@ -15,7 +15,9 @@ import {
 } from '@/components/ui/icons';
 import { toast } from 'sonner';
 
-import { LemmaMark } from '@/components/brand/logo';
+import { ResourceIdentity } from '@/components/shared/resource-identity';
+import { LEM_SEED } from '@/lib/identity/seeded-identity';
+import { DEFAULT_RESPONDER_NAME } from '@/lib/utils/agents';
 import { Button } from '@/components/ui/button';
 import { DestructiveConfirmationDialog } from '@/components/shared/destructive-confirmation-dialog';
 import { EmptyState } from '@/components/shared/empty-state';
@@ -353,14 +355,21 @@ function PodAssistantCard({ podId, reach }: {
         <div className="resource-index-card group flex min-h-40 flex-col p-4">
             <Link href={`/pod/${podId}/ai/assistant`} className="block">
                 <div className="flex items-start justify-between gap-3">
-                    <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-[var(--card-bg)] shadow-[var(--shadow-xs)]">
-                        <LemmaMark size="sm" />
-                    </span>
+                    {/* The same being the rail and the front door draw, at the
+                        44px this card's tile used to be. No tile: a being carries
+                        its own colour and needs no ground under it. */}
+                    <ResourceIdentity
+                        seed={LEM_SEED}
+                        label={DEFAULT_RESPONDER_NAME}
+                        kind="being"
+                        size={44}
+                        className="shrink-0"
+                    />
                     <span className="chip chip-sm chip-muted shrink-0">Default</span>
                 </div>
 
                 <div className="mt-3 min-w-0">
-                    <h2 className="resource-index-card-title truncate text-base font-medium text-[var(--text-primary)]">Pod Assistant</h2>
+                    <h2 className="resource-index-card-title truncate text-base font-medium text-[var(--text-primary)]">{DEFAULT_RESPONDER_NAME}</h2>
                     <p className="resource-index-card-summary mt-1 line-clamp-2 min-h-10 text-[var(--text-secondary)]">
                         This pod&apos;s most capable agent — adds tables, builds workflows, spins up agents, and edits data directly.
                     </p>

--- a/lemma-frontend/app/pod/[id]/data/_components/table-tab-strip.tsx
+++ b/lemma-frontend/app/pod/[id]/data/_components/table-tab-strip.tsx
@@ -2,6 +2,7 @@
 
 import { Skeleton } from '@/components/shared/loading';
 import { Button } from '@/components/ui/button';
+import { useHorizontalOverflow } from '@/lib/hooks/use-horizontal-overflow';
 import { cn } from '@/lib/utils';
 
 export interface TableTabStripProps {
@@ -28,6 +29,13 @@ export interface TableTabStripProps {
  * ledgers use — rather than a second tab look invented for this page. No counts:
  * the tables list has no row totals in it, and a strip of em-dashes is worse
  * than no column at all.
+ *
+ * A pod with more tables than fit gets a strip that scrolls, and the scrollbar
+ * is hidden here on purpose — which left the overflow reachable by trackpad and
+ * by keyboard and by nothing else. On a wheel mouse the tables past the edge
+ * were not merely awkward: there was no gesture that reached them and no mark
+ * saying they were there. `useHorizontalOverflow` gives the wheel to the strip
+ * and fades whichever edge still has something behind it.
  */
 export function TableTabStrip({
     tables,
@@ -35,6 +43,8 @@ export function TableTabStrip({
     loadingTables,
     onSelectTable,
 }: TableTabStripProps) {
+    const { ref, hiddenLeft, hiddenRight } = useHorizontalOverflow<HTMLDivElement>();
+
     if (loadingTables && tables.length === 0) {
         return (
             <div className="data-table-strip flex min-w-0 items-center gap-5">
@@ -52,7 +62,13 @@ export function TableTabStrip({
     // you are on without claiming keyboard behaviour we don't implement — the
     // same call `ResourceMetricButton` makes.
     return (
-        <div className="data-table-strip flex min-w-0 items-center gap-1 overflow-x-auto" aria-label="Tables">
+        <div
+            ref={ref}
+            className="data-table-strip flex min-w-0 items-center gap-1 overflow-x-auto"
+            data-hidden-left={hiddenLeft ? 'true' : undefined}
+            data-hidden-right={hiddenRight ? 'true' : undefined}
+            aria-label="Tables"
+        >
             {tables.map((item) => {
                 const isActive = item.name === activeTableName;
                 return (

--- a/lemma-frontend/app/pod/[id]/layout.tsx
+++ b/lemma-frontend/app/pod/[id]/layout.tsx
@@ -668,7 +668,7 @@ function PodShell({
                             </TooltipProvider>
                         </div>
                 </header>
-                {!isPodHome && !isConversationRoute && !isAppViewRoute ? (
+                {!isPodHome && !isConversationRoute && !isAppViewRoute && !topbar.hideContextBar ? (
                     <header
                         className={cn(
                             "pod-shell-topbar pod-shell-contextbar flex h-12 shrink-0 items-center justify-between gap-4 bg-[var(--pod-main-bg)] px-4",
@@ -693,13 +693,23 @@ function PodShell({
                         ) : (
                             <>
                         <div key={`${currentHref}:topbar-title`} className="pod-shell-topbar-title-cluster flex h-7 min-w-0 flex-1 items-center gap-2">
+                            {/* The arrow always; the label only when there is room
+                                for it. This was `hidden sm:inline-flex` — the whole
+                                control, not just its text — so below 640px a
+                                resource page had no way back to the index it came
+                                from at all. The one place that needs it most is the
+                                one place it was missing: on a phone the tab strip
+                                is hidden too, which leaves the browser's own back
+                                button as the only exit. */}
                             {backTarget ? (
                                 <Link
                                     href={appendAssistantConversationParam(backTarget.href, assistantConversationId)}
-                                    className="lemma-shell-link lemma-shell-link-sm hidden sm:inline-flex"
+                                    className="lemma-shell-link lemma-shell-link-sm inline-flex shrink-0"
+                                    aria-label={`Back to ${backTarget.label}`}
+                                    title={backTarget.label}
                                 >
                                     <ArrowLeft className="h-3.5 w-3.5" />
-                                    {backTarget.label}
+                                    <span className="hidden sm:inline">{backTarget.label}</span>
                                 </Link>
                             ) : null}
                             <div

--- a/lemma-frontend/app/pod/[id]/page.tsx
+++ b/lemma-frontend/app/pod/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { use, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { ArrowRight, ChevronDown, ChevronUp, Plus, UserPlus, X } from '@/components/ui/icons';
+import { ArrowRight, Check, ChevronDown, ChevronUp, Plus, UserPlus, X } from '@/components/ui/icons';
 
 import { useAIAssistant } from '@/components/ai/ai-assistant-context';
 import { ProjectBranchChip } from '@/components/lemma/assistant/project-branch';
@@ -44,6 +44,7 @@ import { buildScopedConversationHref } from '@/lib/assistant/conversation-compos
 import { useSchedules } from '@/lib/hooks/use-schedules';
 import { PodHomePresence } from '@/components/pod/pod-home-presence';
 import { Composer } from '@/components/shared/composer';
+import { ResourceIcon } from '@/components/shared/resource-icon';
 import { ConversationAgentPicker } from '@/components/conversations/conversation-agent-picker';
 import { ResourceCover } from '@/components/shared/resource-identity';
 import { cn } from '@/lib/utils';
@@ -399,7 +400,23 @@ function PodBlankChatHome({ podId }: { podId: string }) {
                     times and buried the one field that takes any answer. */}
                 <div className={cn('w-full max-w-3xl', showStarterHome && 'mt-6')}>
                     {showStarterHome ? null : (
-                        <p className="pod-home-eyebrow mb-3.5">{pod?.name || 'This pod'}</p>
+                        <div className="mb-3.5 flex flex-col items-center gap-2.5">
+                            {/* The pod's own mark, big enough to breathe — the same
+                                seeded team identity the sidebar switcher carries,
+                                here at the size where its motion turns on. Home is
+                                the pod's front door; the name was a caption without
+                                the face. */}
+                            <ResourceIcon
+                                iconUrl={pod?.icon_url}
+                                alt={`${pod?.name || 'This pod'} icon`}
+                                label={pod?.name || 'This pod'}
+                                identityKind="team"
+                                identitySeed={podId}
+                                identitySize={44}
+                                className="h-11 w-11 rounded-xl"
+                            />
+                            <p className="pod-home-eyebrow">{pod?.name || 'This pod'}</p>
+                        </div>
                     )}
                     {assistant.pendingFiles.length > 0 ? (
                         <div className="mb-3 flex flex-wrap justify-center gap-2">
@@ -916,7 +933,13 @@ function PodAgentWorkflowKanban({
                             <h2 className="pod-home-work-title">Activity</h2>
                             <div className="pod-home-work-live-pill">
                                 {movingItems.length > 0 ? (
-                                    <span className="pod-home-work-live-dot" />
+                                    /* The chat status pill's ping halo: running
+                                       work breathes in action violet, matching
+                                       the live rows inside the panel. */
+                                    <span className="relative flex h-1.5 w-1.5" aria-hidden="true">
+                                        <span className="absolute inset-0 animate-ping rounded-full bg-[var(--action-primary)] opacity-30" />
+                                        <span className="relative h-1.5 w-1.5 rounded-full bg-[var(--action-primary)]" />
+                                    </span>
                                 ) : null}
                                 <span>
                                     {unattendedAsks.length > 0
@@ -1105,14 +1128,32 @@ function KanbanCard({ item }: { item: KanbanItem }) {
             href={item.href}
             className="group flex items-center gap-2.5 rounded-md px-2 py-1.5 transition-colors hover:bg-[color:color-mix(in_srgb,var(--surface-2)_50%,transparent)]"
         >
-            <span
-                className={cn(
-                    'h-1.5 w-1.5 shrink-0 rounded-full',
-                    item.statusTone === 'live' && 'lemma-live-pulse',
-                    kanbanDotClass(item.statusTone),
-                )}
-                aria-hidden="true"
-            />
+            {item.statusTone === 'success' ? (
+                /* A finished outcome wears the chat's settled check — green is
+                   the colour of "this worked" everywhere else in the product,
+                   and a plain dot was spending that moment on a bullet. */
+                <span
+                    className="pod-home-outcome-check flex h-5 w-5 shrink-0 items-center justify-center rounded-full"
+                    aria-hidden="true"
+                >
+                    <Check className="h-3 w-3" strokeWidth={2.4} />
+                </span>
+            ) : item.statusTone === 'live' ? (
+                /* Work in flight gets the chat status pill's ping halo — violet,
+                   because live means acting, and violet carries action. */
+                <span className="relative flex h-1.5 w-1.5 shrink-0" aria-hidden="true">
+                    <span className="absolute inset-0 animate-ping rounded-full bg-[var(--action-primary)] opacity-30" />
+                    <span className="relative h-1.5 w-1.5 rounded-full bg-[var(--action-primary)]" />
+                </span>
+            ) : (
+                <span
+                    className={cn(
+                        'h-1.5 w-1.5 shrink-0 rounded-full',
+                        kanbanDotClass(item.statusTone),
+                    )}
+                    aria-hidden="true"
+                />
+            )}
             <span className="min-w-0 flex-1 truncate text-sm text-[var(--text-primary)]">
                 {item.title}
             </span>

--- a/lemma-frontend/app/remix/page.tsx
+++ b/lemma-frontend/app/remix/page.tsx
@@ -4,7 +4,7 @@ import { RemixAppClient } from './remix-app-client';
 
 export const metadata: Metadata = {
     title: 'Remix on Lemma',
-    description: 'Rebuild or adapt an app with your Lemma pod assistant.',
+    description: 'Rebuild or adapt an app with Lem, your pod&rsquo;s default agent.',
     robots: {
         index: false,
         follow: false,

--- a/lemma-frontend/components/agents/agent-avatar-picker.tsx
+++ b/lemma-frontend/components/agents/agent-avatar-picker.tsx
@@ -3,9 +3,8 @@
 import { useMemo } from 'react';
 import { ResourceIconUploader } from '@/components/shared/resource-icon-uploader';
 import { ResourceIdentity } from '@/components/shared/resource-identity';
-import { identityGenes } from '@/lib/identity/seeded-identity';
 import { cn } from '@/lib/utils';
-import { formatIdentityIcon, identityVariantSeed, parseResourceIcon } from '@/lib/utils/resource-icon-value';
+import { distinctIdentityVariants, formatIdentityIcon, identityVariantSeed, parseResourceIcon } from '@/lib/utils/resource-icon-value';
 
 /**
  * Enough faces to find one you like without turning the choice into work. The
@@ -38,32 +37,11 @@ export function AgentAvatarPicker({
     const icon = useMemo(() => parseResourceIcon(value), [value]);
     const isPicture = icon?.kind === 'url' || icon?.kind === 'glyph';
     const selectedVariant = icon?.kind === 'identity' ? icon.variant : 0;
-    /**
-     * Offer faces that actually look different from each other.
-     *
-     * Taking variants 0…17 straight off the counter draws whatever the hash
-     * happens to give, which in practice meant four near-identical violet
-     * squircles sitting in a row — a choice between things you cannot tell
-     * apart is not a choice. Walking further up the counter and keeping only
-     * the first face of each tone-and-form pair costs nothing and makes the
-     * grid read as a set of options. The agent's own face is always first,
-     * whatever it looks like, because that is the one it already has.
-     */
-    const variants = useMemo(() => {
-        const chosen: number[] = [0];
-        const seen = new Set<string>();
-        const first = identityGenes(identityVariantSeed(baseSeed, 0));
-        seen.add(`${first.tone}|${first.form}`);
-
-        for (let variant = 1; variant < 400 && chosen.length < VARIANT_COUNT; variant += 1) {
-            const genes = identityGenes(identityVariantSeed(baseSeed, variant));
-            const key = `${genes.tone}|${genes.form}`;
-            if (seen.has(key)) continue;
-            seen.add(key);
-            chosen.push(variant);
-        }
-        return chosen;
-    }, [baseSeed]);
+    /** Shared with the create page — see `distinctIdentityVariants`. */
+    const variants = useMemo(
+        () => distinctIdentityVariants(baseSeed, VARIANT_COUNT),
+        [baseSeed],
+    );
 
     return (
         <div className={cn('space-y-4', compact && 'space-y-3')}>

--- a/lemma-frontend/components/agents/agent-home.tsx
+++ b/lemma-frontend/components/agents/agent-home.tsx
@@ -1,0 +1,435 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useRef, useState } from 'react';
+
+import { ArrowUp } from '@/components/ui/icons';
+import { AgentTestPanel } from '@/components/agents/agent-test-panel';
+import { Skeleton } from '@/components/shared/loading';
+import { SurfaceModal, type SurfaceModalTarget } from '@/components/surfaces/surface-modal';
+import type { SurfacePlatformValue } from '@/lib/hooks/use-pod-surfaces';
+import { Button } from '@/components/ui/button';
+import { ASSISTANT_MESSAGE_PARAM } from '@/lib/pods/composer-launch';
+
+import { cn } from '@/lib/utils';
+import { ResourceIcon } from '@/components/shared/resource-icon';
+import { ResourceIdentity } from '@/components/shared/resource-identity';
+import { getSurfaceDefinition, SURFACE_PLATFORM_ORDER } from '@/lib/surfaces/registry';
+import {
+    getSurfaceDeepLink,
+    getSurfaceEmail,
+    getSurfacePlatformKey,
+    surfaceReachesAgent,
+    surfaceReachesDefaultAgent,
+} from '@/lib/utils/surfaces';
+import type { AssistantSurface, Conversation, Schedule } from '@/lib/types';
+import { describeScheduleConfig } from '@/lib/utils/schedules';
+import { formatRelativeTime } from '@/lib/utils/relative-time';
+import { formatAgentName } from '@/lib/utils/agents';
+import { LEM_SEED } from '@/lib/identity/seeded-identity';
+
+/**
+ * One place someone can start talking to this agent, outside this app.
+ *
+ * A surface only becomes a button when it resolves to somewhere a person can
+ * actually be sent. Telegram and WhatsApp carry an open-chat convention;
+ * Resend carries an address. Slack and Teams reach the agent perfectly well but
+ * have no link we can build from what the surface record holds, so they are
+ * named without being clickable rather than handed a dead href — the row is
+ * making a promise ("talk to me here") and a button that goes nowhere breaks it.
+ */
+interface AgentReachTarget {
+    key: string;
+    label: string;
+    logoSrc?: string;
+    href: string | null;
+    connected: boolean;
+}
+
+/**
+ * How many not-yet-connected platforms to advertise. The row's job is to say
+ * "there are more ways to reach me" — every remaining platform, listed, would
+ * bury the ones that actually work behind a wall of things that do not.
+ */
+const MAX_UNCONNECTED_REACH = 3;
+
+/** A preview, not the archive — the full history is the conversations page. */
+const MAX_HOME_RUNS = 6;
+
+/** Same bargain for routines: the schedules page holds the rest. */
+const MAX_HOME_ROUTINES = 4;
+
+function reachTargets(surfaces: AssistantSurface[]): AgentReachTarget[] {
+    const byPlatform = new Map<string, AgentReachTarget>();
+
+    for (const surface of surfaces) {
+        const key = getSurfacePlatformKey(surface);
+        if (byPlatform.has(key)) continue;
+
+        const definition = getSurfaceDefinition(key);
+        const email = getSurfaceEmail(surface);
+        byPlatform.set(key, {
+            key,
+            label: definition?.label || key,
+            logoSrc: definition?.logoSrc,
+            href: getSurfaceDeepLink(surface) ?? (email ? `mailto:${email}` : null),
+            connected: true,
+        });
+    }
+
+    /* The unconnected half. This row is the one place in the product that
+       states the whole promise — you can reach this agent where you already
+       talk — so listing only what is already wired makes it a status report for
+       people who have finished setting up, which is nobody on the day they need
+       it most. A platform not yet connected is the most useful thing the row can
+       show: it is an offer, not an absence. */
+    const unconnected: AgentReachTarget[] = [];
+    for (const platform of SURFACE_PLATFORM_ORDER) {
+        if (unconnected.length >= MAX_UNCONNECTED_REACH) break;
+        if (byPlatform.has(platform)) continue;
+
+        const definition = getSurfaceDefinition(platform);
+        if (!definition) continue;
+        unconnected.push({
+            key: platform,
+            label: definition.label,
+            logoSrc: definition.logoSrc,
+            href: null,
+            connected: false,
+        });
+    }
+
+    return [...byPlatform.values(), ...unconnected];
+}
+
+/**
+ * The agent's home, and it stays its home.
+ *
+ * It was briefly the empty state of a live conversation, so typing here turned
+ * this page into a transcript and the agent's front door was gone until you
+ * asked for a new run. That fought the workspace: conversations in this product
+ * are *tabs*, and the working set is persistent — so the honest behaviour is the
+ * one pod home already has. Sending navigates to the conversation route, which
+ * opens as its own tab beside this one, and the agent's page is still the
+ * agent's page when you come back to it.
+ *
+ * Which frees the page to be worth visiting: who this is, where else it can be
+ * reached, the box that starts something, and what it has been doing.
+ */
+export function AgentHome({
+    podId,
+    agentName,
+    description,
+    iconUrl,
+    surfaces,
+    schedules = [],
+    conversations = [],
+    canConverse = true,
+    isAssistant,
+}: {
+    podId: string;
+    agentName: string;
+    description?: string | null;
+    iconUrl?: string | null;
+    surfaces: AssistantSurface[];
+    schedules?: Schedule[];
+    conversations?: Conversation[];
+    /** False for an agent with declared inputs: it is called, not talked to. */
+    canConverse?: boolean;
+    /** Lem answers as the pod, so its reach is the pod's default one. */
+    isAssistant?: boolean;
+}) {
+    const router = useRouter();
+    const composerRef = useRef<HTMLTextAreaElement>(null);
+    const [draft, setDraft] = useState('');
+    const [connectTarget, setConnectTarget] = useState<SurfaceModalTarget | null>(null);
+    const label = formatAgentName(agentName);
+
+    const submit = () => {
+        const text = draft.trim();
+        if (!text) return;
+
+        const params = new URLSearchParams();
+        if (!isAssistant) params.set('agent', agentName);
+        params.set(ASSISTANT_MESSAGE_PARAM, text);
+        setDraft('');
+        router.push(`/pod/${encodeURIComponent(podId)}/conversations/new?${params.toString()}`);
+    };
+
+    const reach = reachTargets(surfaces.filter((surface) => (isAssistant
+        ? surfaceReachesDefaultAgent(surface)
+        : surfaceReachesAgent(surface, agentName))));
+
+    return (
+        <div className="agent-home">
+            {isAssistant ? (
+                /* Lem draws from the reserved seed, not a hashed one — it is the
+                   responder every conversation already knows, so a generated
+                   face would introduce a stranger, and a different stranger in
+                   every pod. It used to wear the Lemma trademark on a tinted
+                   tile, which drew the pod's most capable agent in the treatment
+                   reserved for inert things: no eyes, no state, no motion, on the
+                   one screen whose whole job is to introduce it. Same 64px and
+                   the same renderer as an agent's face below. */
+                <ResourceIdentity
+                    seed={LEM_SEED}
+                    label={label}
+                    kind="being"
+                    size={64}
+                    className="agent-home-face h-16 w-16"
+                />
+            ) : (
+                /* 64px: well past the 32px where a being's rich motion turns on,
+                   so the face is awake when you arrive — this is the one place
+                   on the page whose whole job is to introduce it. */
+                <ResourceIcon
+                    iconUrl={iconUrl}
+                    alt=""
+                    label={label}
+                    identityKind="being"
+                    identitySeed={agentName}
+                    identitySize={64}
+                    className="agent-home-face h-16 w-16 rounded-2xl"
+                />
+            )}
+            {/* First person, because the identity system already draws this
+                thing with a face and eyes that answer the pointer. Naming it in
+                the third person on the one screen where it introduces itself
+                would be the copy disagreeing with the artwork. */}
+            <h1 className="agent-home-greeting">Hey, I&apos;m {label}</h1>
+            {description ? <p className="agent-home-description">{description}</p> : null}
+
+            {/* The composer, and it launches rather than hosts. `assistantMessage`
+                is the convention for arriving somewhere with something already
+                said — the loud half of `composer-launch`, which is right here
+                because the person has written the sentence and pressed send. The
+                conversation opens in its own tab; this page keeps its own. */}
+            {canConverse ? (
+            <form
+                className="agent-home-composer form-field-control"
+                /* The whole box is the target, not just the textarea inside it.
+                   A composer is chrome wrapped around a field, and clicking the
+                   chrome — the padding, the bar with the send button — did
+                   nothing, so the box looked focusable in the places it was
+                   least obviously not. `mousedown` rather than `click` so the
+                   caret lands before the browser's own selection settles. */
+                onMouseDown={(event) => {
+                    if (event.target === composerRef.current) return;
+                    if ((event.target as HTMLElement).closest('button')) return;
+                    event.preventDefault();
+                    composerRef.current?.focus();
+                }}
+                onSubmit={(event) => {
+                    event.preventDefault();
+                    submit();
+                }}
+            >
+                <textarea
+                    ref={composerRef}
+                    value={draft}
+                    onChange={(event) => setDraft(event.target.value)}
+                    onKeyDown={(event) => {
+                        if (event.key === 'Enter' && !event.shiftKey) {
+                            event.preventDefault();
+                            submit();
+                        }
+                    }}
+                    placeholder={`Ask ${label} to do something…`}
+                    rows={2}
+                    className="inline-edit-field min-h-14 w-full resize-none px-3 py-2.5 text-sm leading-6"
+                />
+                <div className="agent-home-composer-bar">
+                    <span className="truncate text-xs text-[var(--text-tertiary)]">
+                        Opens in a new tab
+                    </span>
+                    <Button
+                        variant="primary"
+                        type="submit"
+                        size="icon"
+                        className="h-8 w-8 shrink-0 rounded-full"
+                        disabled={!draft.trim()}
+                        aria-label={`Start a conversation with ${label}`}
+                    >
+                        <ArrowUp className="h-4 w-4" />
+                    </Button>
+                </div>
+            </form>
+            ) : (
+                /* An agent with declared inputs is *called* with arguments, so
+                   the box that starts it is a form, not a message. It renders
+                   here rather than one click away in the editor: this is the
+                   agent's home, and "how do I run this" is the question a home
+                   exists to answer. The renderer is the panel's own — the same
+                   typed fields, required-key handling and JSON inputs the dock
+                   draws — minus its header, because the page named the agent in
+                   the greeting directly above. */
+                <div className="agent-home-run-form">
+                    <p className="agent-home-called">Runs with typed inputs.</p>
+                    <div className="agent-home-run-form-body">
+                        <AgentTestPanel
+                            podId={podId}
+                            agentName={agentName}
+                            view="conversation"
+                            showHeader={false}
+                        />
+                    </div>
+                </div>
+            )}
+
+            {reach.length > 0 ? (
+                <div className="agent-home-reach">
+                    {reach.map((target) => {
+                        const body = (
+                            <>
+                                {target.logoSrc ? (
+                                    <Image
+                                        src={target.logoSrc}
+                                        alt=""
+                                        width={16}
+                                        height={16}
+                                        className={cn('object-contain', !target.connected && 'opacity-60')}
+                                        aria-hidden="true"
+                                    />
+                                ) : null}
+                                <span>
+                                    {target.connected
+                                        ? `Talk to me on ${target.label}`
+                                        : `Connect ${target.label}`}
+                                </span>
+                            </>
+                        );
+
+                        /* Connecting happens here, not somewhere else. This
+                           used to link to `/pod/:id/surfaces`, which is a
+                           *legacy redirect* to the agents index — so "Connect
+                           WhatsApp" bounced you to a list of agents, having
+                           forgotten both the platform you picked and the agent
+                           you picked it for. Surfaces are configured from the
+                           agent that answers on them, and this is that agent's
+                           page: the modal opens over it with both already
+                           known. */
+                        if (!target.connected) {
+                            return (
+                                <button
+                                    key={target.key}
+                                    type="button"
+                                    onClick={() => setConnectTarget({ platform: target.key as SurfacePlatformValue })}
+                                    className="agent-home-reach-chip custom-focus-ring"
+                                >
+                                    {body}
+                                </button>
+                            );
+                        }
+
+                        if (!target.href) {
+                            return (
+                                <span key={target.key} className="agent-home-reach-chip" data-static="true">
+                                    {body}
+                                </span>
+                            );
+                        }
+
+                        return (
+                            <Link
+                                key={target.key}
+                                href={target.href}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="agent-home-reach-chip custom-focus-ring"
+                                data-connected="true"
+                            >
+                                {body}
+                            </Link>
+                        );
+                    })}
+                </div>
+            ) : null}
+
+            {/* What it does without you. Routines are the part of an agent that
+                is easiest to forget you set up and most surprising to rediscover
+                from a run you did not start, so the home states them plainly —
+                `describeScheduleConfig` already turns a cron into a sentence. It
+                is not the schedule editor: this says *that* it runs and when,
+                and Configure is where you change it. */}
+            {schedules.length > 0 ? (
+                <div className="agent-home-runs">
+                    <p className="agent-home-runs-heading">Runs on its own</p>
+                    {schedules.slice(0, MAX_HOME_ROUTINES).map((schedule) => (
+                        <Link
+                            key={schedule.id}
+                            href={`/pod/${encodeURIComponent(podId)}/schedules`}
+                            className="agent-home-run custom-focus-ring"
+                        >
+                            <span className="min-w-0 flex-1 truncate">{schedule.name}</span>
+                            <span className="agent-home-run-time">
+                                {describeScheduleConfig(schedule)}
+                            </span>
+                        </Link>
+                    ))}
+                </div>
+            ) : null}
+
+            {/* What it has been doing. This is the page answering "where are this
+                agent's conversations" itself, rather than sending you to the
+                shell for it — and it is a section of a home, not a rail flush
+                against the sidebar, which is the difference between a list and a
+                second navigation column. Each row opens in its own tab. */}
+            {conversations.length > 0 ? (
+                <div className="agent-home-runs">
+                    <p className="agent-home-runs-heading">Recent conversations</p>
+                    {conversations.slice(0, MAX_HOME_RUNS).map((conversation) => (
+                        <Link
+                            key={conversation.id}
+                            href={`/pod/${encodeURIComponent(podId)}/conversations/${encodeURIComponent(conversation.id)}`}
+                            className="agent-home-run custom-focus-ring"
+                        >
+                            <span className="min-w-0 flex-1 truncate">
+                                {conversation.title || 'Untitled conversation'}
+                            </span>
+                            <span className="agent-home-run-time">
+                                {formatRelativeTime(conversation.updated_at || conversation.created_at)}
+                            </span>
+                        </Link>
+                    ))}
+                    {conversations.length > MAX_HOME_RUNS ? (
+                        <Link
+                            href={`/pod/${encodeURIComponent(podId)}/conversations`}
+                            className="agent-home-run agent-home-run-all custom-focus-ring"
+                        >
+                            All conversations
+                        </Link>
+                    ) : null}
+                </div>
+            ) : null}
+
+            <SurfaceModal
+                podId={podId}
+                target={connectTarget}
+                agentName={isAssistant ? null : agentName}
+                onClose={() => setConnectTarget(null)}
+            />
+        </div>
+    );
+}
+
+/**
+ * The home, waiting.
+ *
+ * Shaped like what arrives — a face, a name, a line of description, the
+ * composer — rather than like the editor's stack of cards, which is what used to
+ * stand here and made every arrival flash the wrong screen. Nothing about the
+ * frame is unknown while the agent loads: the name is in the URL and the blocks
+ * land in the same places whoever it turns out to be.
+ */
+export function AgentHomeSkeleton() {
+    return (
+        <div className="agent-home" role="status" aria-label="Loading agent">
+            <Skeleton shape="block" className="h-16 w-16 rounded-2xl" />
+            <Skeleton className="h-8 w-56" />
+            <Skeleton className="h-4 w-80" />
+            <Skeleton shape="block" className="agent-home-composer h-24 w-full rounded-xl" />
+        </div>
+    );
+}

--- a/lemma-frontend/components/agents/agent-overview-panels.tsx
+++ b/lemma-frontend/components/agents/agent-overview-panels.tsx
@@ -9,7 +9,7 @@ import type { AssistantSurface } from '@/lib/types';
  * Rail parts for pages that present an agent-shaped thing in a side column.
  *
  * The agent detail page no longer has a rail — it states identity and wiring
- * inline — so what remains here is what the pod assistant still builds from.
+ * inline — so what remains here is what Lem still builds from.
  */
 
 export function agentInitials(name: string): string {

--- a/lemma-frontend/components/agents/agent-test-panel.tsx
+++ b/lemma-frontend/components/agents/agent-test-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useAssistantController, useConversationMessages } from 'lemma-sdk/react';
@@ -50,6 +50,20 @@ interface AgentTestPanelProps {
      * switches between them itself.
      */
     view?: 'split' | 'conversation' | 'history';
+    /**
+     * What the conversation shows before the first message. The agent page
+     * passes its front door here — greeting, face, where else to reach it —
+     * so the introduction and the composer are one screen with nothing to keep
+     * in sync between them. Omitted, the view falls back to its own suggestions.
+     */
+    emptyState?: ReactNode;
+    /**
+     * Whether the panel draws its own header. The dock needs one — it is a panel
+     * among other panels and has to say what it is. Rendered into an agent's
+     * home it does not: the page has already introduced the agent twice by the
+     * time this appears under the greeting.
+     */
+    showHeader?: boolean;
     onToggleFullView?: () => void;
     onClose?: () => void;
 }
@@ -159,6 +173,8 @@ export function AgentTestPanel({
     openConversationRequestKey,
     isFullView,
     view = 'split',
+    emptyState,
+    showHeader = true,
     onToggleFullView,
     onClose,
 }: AgentTestPanelProps) {
@@ -557,7 +573,8 @@ export function AgentTestPanel({
                                 ) : null}
                             </>
                         )}
-                        emptyStateSuggestions={[
+                        emptyState={emptyState}
+                        emptyStateSuggestions={emptyState ? undefined : [
                             { text: 'Help me think through this pod' },
                             { text: 'Draft the next response' },
                             { text: 'Summarize what matters here' },
@@ -573,6 +590,11 @@ export function AgentTestPanel({
         <div className={cn('agent-test-panel grid h-full min-h-0 items-stretch bg-[var(--card-bg)]', isSplit ? 'surface-split-2 lg:grid-cols-[340px_minmax(0,1fr)]' : 'grid-cols-1')}>
             {isSplit ? historyPanel : null}
             <div className="flex min-h-0 min-w-0 flex-col bg-[var(--card-bg)]">
+                {/* Conditional, not `hidden`. The attribute sets `display: none`
+                    at the UA level and the `flex` class beside it overrides that
+                    — so the header stayed laid out and simply emptied, leaving
+                    3.5rem of nothing above the first field. */}
+                {showHeader ? (
                 <div className="agent-test-run-header sticky top-0 z-10 flex h-14 shrink-0 items-center justify-between bg-[var(--card-bg)] px-3">
                     <div className="min-w-0">
                         <p className="type-eyebrow-medium">Run setup</p>
@@ -614,6 +636,7 @@ export function AgentTestPanel({
                         ) : null}
                     </div>
                 </div>
+                ) : null}
 
                 <div className="min-h-0 flex-1 overflow-hidden">
                     {hasActiveRun ? (
@@ -641,12 +664,13 @@ export function AgentTestPanel({
                     <div className="agent-test-run-start h-full overflow-y-auto">
                         <div className="agent-test-run-start-inner">
                             <div className="agent-test-start-panel">
-                                <div className="agent-test-run-form-head">
-                                    <div>
-                                        <p className="type-eyebrow-medium">New run</p>
-                                        <h4>Inputs</h4>
-                                    </div>
-                                </div>
+                                {/* No "New run / Inputs" head. It sat above a
+                                    stack of labelled fields, which is already
+                                    unmistakably a form for starting a run — two
+                                    lines of chrome restating what the thing under
+                                    them plainly is. The header above already
+                                    names the run setup where a header exists at
+                                    all. */}
 
                                 {visibleApps.length > 0 ? (
                                     <div className="agent-test-run-connections space-y-3">

--- a/lemma-frontend/components/conversations/pod-conversation-list.tsx
+++ b/lemma-frontend/components/conversations/pod-conversation-list.tsx
@@ -11,6 +11,7 @@ import { Skeleton } from '@/components/shared/loading';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { getConversationStatusView, isConversationRunningStatus } from '@/lib/utils/conversations';
+import { DEFAULT_RESPONDER_NAME } from '@/lib/utils/agents';
 
 /** Titles vary, so the placeholders do — equal bars read as a table, not a list.
  * Widths double as the row count: five lines, matching the settled row height. */
@@ -85,8 +86,8 @@ export function PodConversationList({
                     icon={<Sparkles className="h-4 w-4" />}
                     title="No conversations yet"
                     description={isAssistantScope
-                        ? 'Start a conversation with this assistant and continue it here later.'
-                        : 'Start a Lemma Assistant conversation and continue it here later.'}
+                        ? 'Start a conversation with this agent and continue it here later.'
+                        : `Start a conversation with ${DEFAULT_RESPONDER_NAME} and continue it here later.`}
                     action={(
                         <Button variant="secondary" size="sm" onClick={startNewConversation} className="shrink-0 gap-1.5">
                             <Plus className="h-3.5 w-3.5" />
@@ -154,8 +155,8 @@ export function PodConversationList({
                             {entityName
                                 ? `${entityName} chats.`
                                 : isAssistantScope
-                                    ? 'Assistant chat history.'
-                                    : 'Lemma Assistant chat history.'}
+                                    ? "This agent's chat history."
+                                    : "This pod's chat history."}
                         </p>
                     </div>
                     <div className="flex items-center gap-2">
@@ -181,12 +182,12 @@ export function PodConversationList({
                 <div className="mb-5 flex items-center justify-between gap-3">
                     <div>
                         <h1 className="font-display text-3xl font-normal text-[var(--text-primary)]">
-                            {isAssistantScope ? 'Assistant Conversations' : 'Pod Conversations'}
+                            {isAssistantScope ? `${entityName} Conversations` : 'Pod Conversations'}
                         </h1>
                         <p className="mt-1 text-sm text-[var(--text-secondary)]">
                             {isAssistantScope
-                                ? 'Reopen and continue conversations for this assistant.'
-                                : 'Reopen and continue assistant threads for this pod.'}
+                                ? "Reopen and continue this agent's conversations."
+                                : "Reopen and continue this pod's conversations."}
                         </p>
                     </div>
                     <Button variant="primary" onClick={startNewConversation} className="gap-2">

--- a/lemma-frontend/components/lemma/assistant/assistant-chrome.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-chrome.tsx
@@ -172,11 +172,11 @@ export const AssistantHeader = forwardRef<HTMLDivElement, AssistantHeaderProps>(
     >
       <div className={cn("flex min-w-0 items-center", compact ? "gap-2" : "gap-3")}>
         {leadingControls}
-        {badge ? (
-          <span className={cn("flex shrink-0 items-center justify-center rounded-lg bg-[var(--action-primary)] text-[var(--text-on-brand)]", compact ? "size-7" : "size-9")}>
-            {badge}
-          </span>
-        ) : null}
+        {/* No tile. The badge used to be a monochrome glyph, which needed a
+            filled ground to sit on; it is now a being, which carries its own
+            colour — and painting one on a brand-violet square put violet on
+            violet. The badge arrives fully formed and sized by its caller. */}
+        {badge ? <span className="flex shrink-0 items-center justify-center">{badge}</span> : null}
         <div className="min-w-0">
           <h3 className={cn("truncate font-semibold tracking-tight text-[var(--text-primary)]", compact ? "text-sm" : "text-lg")}>{title}</h3>
           {subtitle && !compact ? (

--- a/lemma-frontend/components/lemma/assistant/assistant-experience.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-experience.tsx
@@ -29,6 +29,9 @@ import {
 import { buildChatTurns } from "@/lib/assistant/turns";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { DEFAULT_RESPONDER_NAME } from "@/lib/utils/agents";
+import { LEM_SEED } from "@/lib/identity/seeded-identity";
+import { ResourceIdentity } from "@/components/shared/resource-identity";
 import type {
   AssistantRenderableMessage,
 } from "lemma-sdk/react";
@@ -61,7 +64,6 @@ import {
 // Standalone presentational parts (plan strip, thinking, empty state, icons) extracted.
 import {
   EmptyState,
-  LemmaMarkIcon,
   LiveRunStatusLine,
   ThinkingIndicator,
 } from "./assistant-parts";
@@ -140,7 +142,7 @@ export interface AssistantExperienceViewProps extends AssistantExperienceCustomi
 
 export function AssistantExperienceView({
   controller,
-  title = "Lemma Assistant",
+  title = DEFAULT_RESPONDER_NAME,
   subtitle = "Ask across your workspace and organization.",
   badge,
   headerLeadingActions,
@@ -149,7 +151,7 @@ export function AssistantExperienceView({
   className,
   contentWidthClassName,
   composerWidthClassName,
-  placeholder = "Message Lemma Assistant",
+  placeholder = `Message ${DEFAULT_RESPONDER_NAME}`,
   emptyState,
   emptyStateSuggestions,
   emptyStateFillsViewport = false,
@@ -490,7 +492,7 @@ export function AssistantExperienceView({
   const canRecheckLocalAgents = isDesktopShell && isLocalAgentSignInFailure(assistantErrorDetails);
   const assistantErrorTitle = assistantErrorDetails && assistantErrorDetails.length <= 120 && !assistantErrorDetails.includes("\n")
     ? assistantErrorDetails
-    : "Assistant error";
+    : `${DEFAULT_RESPONDER_NAME} hit an error`;
   const headerTone: AssistantSurfaceTone = resolvedChromeStyle === "elevated" ? "default" : resolvedChromeStyle === "flat" ? "flat" : "subtle";
   const composerTone: AssistantSurfaceTone = resolvedChromeStyle === "flat" ? "flat" : resolvedChromeStyle === "subtle" ? "subtle" : "default";
   // The transcript's live status is the running turn's pill, not a bottom line.
@@ -515,8 +517,19 @@ export function AssistantExperienceView({
       ) : null}
     </>
   );
+  // The dock's badge is Lem itself, drawn by the same renderer as the sidebar
+  // row and the front door, so the thing answering here is visibly the thing
+  // you clicked. It was a generic shield-and-check glyph on a brand tile, which
+  // named a category rather than a responder.
   const resolvedHeaderBadge = badge === undefined
-    ? <LemmaMarkIcon className="size-4.5 text-[var(--text-on-brand)]" />
+    ? (
+      <ResourceIdentity
+        seed={LEM_SEED}
+        label={DEFAULT_RESPONDER_NAME}
+        kind="being"
+        size={density === "compact" ? 28 : 36}
+      />
+    )
     : badge;
   // Memoized element: the transcript is memoized on its props, and an element
   // rebuilt every render is a changed prop.

--- a/lemma-frontend/components/lemma/assistant/assistant-parts.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-parts.tsx
@@ -28,6 +28,9 @@ import type {
 } from "./assistant-types";
 import type { PlanSummaryState } from "./assistant-experience";
 import { useNowMs } from "./use-assistant-experience";
+import { ResourceIdentity } from "@/components/shared/resource-identity";
+import { LEM_SEED } from "@/lib/identity/seeded-identity";
+import { DEFAULT_RESPONDER_NAME } from "@/lib/utils/agents";
 
 export function suggestionIconForTitle(title: string): ReactNode {
   const normalized = title.toLowerCase();
@@ -188,45 +191,7 @@ export const DEFAULT_EMPTY_STATE_SUGGESTIONS: EmptyStateSuggestion[] = [
   { text: "Brainstorm next steps", icon: <MoreHorizontal className="size-3.5" aria-hidden="true" /> },
 ];
 
-export function LemmaMarkIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 20 20"
-      fill="none"
-      className={className}
-      aria-hidden="true"
-      focusable="false"
-    >
-      <path
-        d="M10 2.5 16.25 5v4.85c0 4.25-2.55 7.05-6.25 8.15-3.7-1.1-6.25-3.9-6.25-8.15V5L10 2.5Z"
-        fill="currentColor"
-        fillOpacity="0.18"
-        stroke="currentColor"
-        strokeWidth="1.2"
-      />
-      <path
-        d="m7.1 10.1 1.8 1.8 4-4.1"
-        stroke="currentColor"
-        strokeWidth="1.8"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
 
-function LemmaMiniMark({ className }: { className?: string }) {
-  return (
-    <span
-      className={cn("inline-flex items-end gap-[2px] text-[var(--delight)]", className)}
-      aria-hidden="true"
-    >
-      <span className="block h-[5px] w-[2px] rounded-sm bg-current" />
-      <span className="block h-[9px] w-[2px] rounded-sm bg-current" />
-      <span className="block h-[13px] w-[2px] rounded-sm bg-current" />
-    </span>
-  );
-}
 
 export function EmptyState({
   onSendMessage,
@@ -243,9 +208,18 @@ export function EmptyState({
       )}
     >
       <div className={cn("flex max-w-2xl flex-col items-center", isCompact ? "gap-1.5" : "gap-2")}>
+        {/* The responder names itself here, and it is the same being the rail,
+            the dock badge and the front door draw. This line said "Lemma Assist"
+            beside the brand's own bars — the product introducing itself on the
+            screen where the agent should. */}
         <div className="flex items-center gap-1.5 text-xs font-normal text-[var(--text-secondary)]">
-          <LemmaMiniMark />
-          Lemma Assist
+          <ResourceIdentity
+            seed={LEM_SEED}
+            label={DEFAULT_RESPONDER_NAME}
+            kind="being"
+            size={18}
+          />
+          {DEFAULT_RESPONDER_NAME}
         </div>
         <h4 className={cn("lemma-assistant-text-heading font-normal tracking-tight", isCompact ? "text-base" : "text-lg")}>
           What do you want to make happen?

--- a/lemma-frontend/components/pod/pod-home-presence.tsx
+++ b/lemma-frontend/components/pod/pod-home-presence.tsx
@@ -9,6 +9,7 @@ import { usePodMembers } from '@/lib/hooks/use-pod-members';
 import { usePodSurfaces } from '@/lib/hooks/use-pod-surfaces';
 import { usePodAccess } from '@/lib/hooks/use-pod-access';
 import { useSchedules } from '@/lib/hooks/use-schedules';
+import { TONE_COUNT as IDENTITY_TONE_COUNT } from '@/lib/identity/seeded-identity';
 import { getSurfaceDefinition } from '@/lib/surfaces/registry';
 import { getSurfacePlatformKey } from '@/lib/utils/surfaces';
 import { getScheduleTargetName } from '@/lib/utils/schedules';
@@ -23,13 +24,30 @@ function initialOf(label: string): string {
     return trimmed ? trimmed[0].toUpperCase() : '?';
 }
 
-/** Deterministic per-person tint, so the same face keeps the same colour. */
+/**
+ * Deterministic per-person tint, so the same face keeps the same colour — drawn
+ * from the identity system's tone pool, the palette built for "a distinct
+ * being" and already worn by the agent faces standing beside these avatars.
+ *
+ * It used to draw from four fixed tints of its own, three of which were state
+ * colours: `--accent-rgb`, `--state-success` and `--state-warning`. The comment
+ * defending that pool said it existed so a hash would not "drift into the state
+ * colours and start implying an agent is failing" — and then picked them
+ * anyway, which put two people in success-green one scroll above an Activity
+ * panel that uses success-green for "Completed". A person is not a status, and
+ * a hue cannot mean both.
+ */
 function avatarToneClass(seed: string): string {
     let hash = 0;
     for (let index = 0; index < seed.length; index += 1) {
         hash = (hash * 31 + seed.charCodeAt(index)) % 997;
     }
-    return `pod-home-presence-avatar-t${hash % 4}`;
+    // `hue`, not `tone`: the tone variant also sets `color`, and
+    // `resource-identity.css` imports after this feature sheet, so it would win
+    // over the avatar's white initial and paint the letter the same colour as
+    // the disc behind it. The hue variant carries the custom properties only —
+    // which is the split that file documents, for exactly this case.
+    return `lm-identity-hue-${hash % IDENTITY_TONE_COUNT}`;
 }
 
 interface PresenceFace {
@@ -171,12 +189,18 @@ export function PodHomePresence({
                 {hasSurfaces ? (
                     // The agents index is `/ai`; `/agents` only holds `[agentId]`
                     // and `new`, so a bare link there is a 404.
+                    /* The marks carry their own colour, so they take no
+                       `surface-logo-chip` plate. That plate is for a monochrome
+                       mark that would vanish on dark stock; on these it only
+                       pasted three near-white tiles into a line of prose, which
+                       is the one thing on the row that did not belong to either
+                       appearance. */
                     <Link href={`/pod/${podId}/ai`} className="pod-home-presence-link custom-focus-ring">
                         <span className="pod-home-presence-surfaces">
                             {surfacePlatforms.map((platform) => (
-                                <span key={platform.key} className="pod-home-presence-surface surface-logo-chip" title={platform.label}>
+                                <span key={platform.key} className="pod-home-presence-surface" title={platform.label}>
                                     {platform.logoSrc ? (
-                                        <Image src={platform.logoSrc} alt="" width={13} height={13} className="object-contain" aria-hidden="true" />
+                                        <Image src={platform.logoSrc} alt="" width={15} height={15} className="object-contain" aria-hidden="true" />
                                     ) : (
                                         initialOf(platform.label)
                                     )}

--- a/lemma-frontend/components/pod/pod-topbar-context.tsx
+++ b/lemma-frontend/components/pod/pod-topbar-context.tsx
@@ -30,6 +30,15 @@ export type PodTopbarState = {
     actions?: ReactNode;
     fullscreen?: boolean;
     /**
+     * Drop the context bar entirely rather than render it empty.
+     *
+     * The bar draws for every route that is not pod home, a conversation, or an
+     * app view — so a page that hands it no title, no back link and no actions
+     * still gets a 48px strip of nothing above it. A route that has moved its
+     * own chrome into the page says so here instead of leaving the gap.
+     */
+    hideContextBar?: boolean;
+    /**
      * Which `ResourceHeader` owns the bar right now.
      *
      * A leaving route must not blank a bar that the arriving route has already

--- a/lemma-frontend/components/pod/product-icon.tsx
+++ b/lemma-frontend/components/pod/product-icon.tsx
@@ -71,8 +71,10 @@ const iconByKind: Record<ProductIconKind, typeof FolderOpen> = {
  * expressive axes here: a column of these icons is read by silhouette, and a
  * glyph that thickens or fills on interaction changes how much ink one row
  * carries relative to its neighbours, which is exactly what makes a nav look
- * unsettled. Selection is carried by colour and the row's accent bar; the
- * pointer is answered by a small scale in CSS.
+ * unsettled. The day-to-day kinds each carry their own jewel tone in every
+ * state (see `.lemma-product-icon[data-kind]` in primitives.css) — colour is
+ * the place's identity and stays put, while the pointer is answered by a
+ * small scale in CSS and selection by the row's fill and accent bar.
  */
 export function ProductIcon({
     kind,

--- a/lemma-frontend/components/pod/recent-conversations.tsx
+++ b/lemma-frontend/components/pod/recent-conversations.tsx
@@ -8,7 +8,7 @@ import { buildScopedConversationHref } from '@/lib/assistant/conversation-compos
 import { requestConversationStageNavigation } from '@/lib/assistant/conversation-presentation';
 import { formatRelativeTime } from '@/lib/utils/relative-time';
 
-// Shared between the agent detail page and the pod assistant page — the same
+// Shared between the agent detail page and Lem's page — the same
 // list, scoped to a named agent or to the pod default.
 
 // The clock moved to `lib/utils/relative-time` once the home pod list needed it

--- a/lemma-frontend/components/pod/resource-layout.tsx
+++ b/lemma-frontend/components/pod/resource-layout.tsx
@@ -105,6 +105,8 @@ export type ResourceHeaderProps = {
     tabs?: ReactNode;
     actions?: ReactNode;
     fullscreen?: boolean;
+    /** Drop the bar rather than draw it empty. See `PodTopbarState`. */
+    hideContextBar?: boolean;
 };
 
 /**
@@ -125,6 +127,7 @@ export function ResourceHeader({
     tabs,
     actions,
     fullscreen,
+    hideContextBar,
 }: ResourceHeaderProps) {
     const topbar = usePodTopbar();
     // State, not a ref: this is read during render to build the bar payload, and
@@ -146,6 +149,7 @@ export function ResourceHeader({
             tabs,
             actions,
             fullscreen,
+            hideContextBar,
             claim,
         });
 
@@ -153,7 +157,7 @@ export function ResourceHeader({
         // header before the leaving one tears down, and clearing unconditionally
         // would wipe chrome that already belongs to the new page.
         return () => topbar?.setTopbar((current) => (current.claim === claim ? {} : current));
-    }, [actions, backHref, backLabel, claim, eyebrow, fullscreen, icon, meta, switcher, tabTitle, tabs, title, titleOwner, topbar]);
+    }, [actions, backHref, backLabel, claim, eyebrow, fullscreen, hideContextBar, icon, meta, switcher, tabTitle, tabs, title, titleOwner, topbar]);
 
     return null;
 }

--- a/lemma-frontend/components/pod/use-pod-workspace-tabs.ts
+++ b/lemma-frontend/components/pod/use-pod-workspace-tabs.ts
@@ -31,6 +31,8 @@ interface UsePodWorkspaceTabsOptions {
     currentHref: string;
     routeTitle: string;
     appSlug: string | null;
+    /** Used only to give the ephemeral focused-app tab its real title/icon —
+     *  never to pin anything. */
     pages: AppPageRef[];
     appsLoaded: boolean;
     conversations: Conversation[];
@@ -134,16 +136,11 @@ export function usePodWorkspaceTabs({
             return;
         }
 
-        if (activeTabId.startsWith('app:')) {
-            const activeApp = pages.find((candidate) => candidate.slug === appSlug);
-            if (activeApp) {
-                updatePodWorkspaceTabs(
-                    podId,
-                    (current) => upsertWorkspaceTab(current, appWorkspaceTab(activeApp)),
-                );
-            }
-            return;
-        }
+        // App tabs are ephemeral: the focused app's tab is derived for display
+        // below, and never written into the working set. Falling through to
+        // the conversation branch here used to be impossible when every app
+        // route pinned a tab — with pinning gone the guard is load-bearing.
+        if (activeTabId.startsWith('app:')) return;
 
         if (activeTabId.startsWith('route:')) {
             const routeKey = activeTabId.slice('route:'.length);
@@ -170,7 +167,7 @@ export function usePodWorkspaceTabs({
             }
             return upsertWorkspaceTab(current, nextTab);
         });
-    }, [activeTabId, appSlug, conversations, currentHref, enabled, pages, podId, routeTitle]);
+    }, [activeTabId, conversations, currentHref, enabled, podId, routeTitle]);
 
     // A new conversation starts without an id. Capture the conversation that was
     // active before entering /new; when a different id appears while that route is
@@ -211,15 +208,32 @@ export function usePodWorkspaceTabs({
         updatePodWorkspaceTabs(
             podId,
             (current) => syncWorkspaceTabMetadata(
-                syncAppWorkspaceTabs(current, pages),
+                // Clears any app tabs pinned before the rail existed; apps are
+                // never kept, so this no longer needs the pages list.
+                syncAppWorkspaceTabs(current),
                 conversations,
             ),
         );
-    }, [appsLoaded, conversations, enabled, pages, podId]);
+    }, [appsLoaded, conversations, enabled, podId]);
 
     const closeTab = useCallback((tabId: string) => {
         updatePodWorkspaceTabs(podId, (current) => closeWorkspaceTab(current, tabId));
     }, [podId]);
+
+    // The strip still marks the app you are looking at: while the viewer is
+    // focused, its tab is appended for display only. Nothing writes it to the
+    // store, so it is gone the moment you navigate anywhere else — a tab you
+    // cannot keep, for a thing the rail already keeps.
+    const displayTabs = useMemo(() => {
+        if (!activeTabId?.startsWith('app:')) return tabs;
+        if (tabs.some((tab) => tab.id === activeTabId)) return tabs;
+
+        const activeApp = pages.find((candidate) => candidate.slug === appSlug);
+        return [...tabs, appWorkspaceTab(activeApp ?? {
+            slug: appSlug ?? '',
+            title: formatWorkspaceAppTitle(appSlug),
+        })];
+    }, [activeTabId, appSlug, pages, tabs]);
 
     const openAppSlugs = useMemo(
         () => {
@@ -233,7 +247,7 @@ export function usePodWorkspaceTabs({
     );
 
     return {
-        tabs,
+        tabs: displayTabs,
         activeTabId,
         closeTab,
         openAppSlugs,

--- a/lemma-frontend/components/pod/wiring-row.tsx
+++ b/lemma-frontend/components/pod/wiring-row.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from 'react';
 /**
  * One wiring question and its one-line answer.
  *
- * Agents, workflows, and the pod assistant all answer the same shape of
+ * Agents, workflows, and Lem all answer the same shape of
  * question — what it can reach, who reaches it, when it runs — so the row lives
  * here rather than inside any one of them.
  */

--- a/lemma-frontend/components/pod/workspace-sidebar.tsx
+++ b/lemma-frontend/components/pod/workspace-sidebar.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import {
+    AppWindow,
     Check,
     ChevronDown,
     ChevronsUpDown,
@@ -29,6 +30,7 @@ import { ProductIcon, type ProductIconKind } from '@/components/pod/product-icon
 import { AccountMenu } from '@/components/shared/account-menu';
 import { PodMark } from '@/components/pod/pod-mark';
 import { ResourceIcon } from '@/components/shared/resource-icon';
+import { ResourceIdentity } from '@/components/shared/resource-identity';
 import { Button } from '@/components/ui/button';
 import {
     Dialog,
@@ -41,7 +43,9 @@ import {
 import { Textarea } from '@/components/ui/textarea';
 import { usePodAccess } from '@/lib/hooks/use-pod-access';
 import { cn } from '@/lib/utils';
-import { agentsQueryOptions } from '@/lib/hooks/use-agents';
+import { agentsQueryOptions, useAgents } from '@/lib/hooks/use-agents';
+import { useAppPages } from '@/lib/hooks/use-app';
+import { DEFAULT_RESPONDER_NAME, formatAgentName } from '@/lib/utils/agents';
 import {
     tableQueryOptions,
     tableRecordsQueryOptions,
@@ -50,10 +54,14 @@ import {
 import { flowsQueryOptions } from '@/lib/hooks/use-flows';
 import { useAccessiblePods, type AccessiblePod, type AccessiblePodGroup } from '@/lib/hooks/use-pods';
 import { useScopedConversations } from '@/lib/hooks/use-assistants';
+import { identityHueClass } from '@/lib/utils/resource-icon-value';
+import { LEM_SEED } from '@/lib/identity/seeded-identity';
 import {
     filterSidebarConversations,
+    getConversationMark,
     mergeSidebarConversations,
     SIDEBAR_CONVERSATION_LIMIT,
+    type ConversationMark,
 } from '@/lib/assistant/sidebar-conversations';
 import {
     filterSwitcherPodGroups,
@@ -62,7 +70,7 @@ import {
     toPodDisplayLabel,
 } from '@/lib/pods/pod-switcher';
 import { getAppRecipeExamples } from '@/lib/recipes/recipes';
-import type { Conversation } from '@/lib/types';
+import type { Agent, Conversation } from '@/lib/types';
 import { getConversationSignal } from '@/lib/utils/conversations';
 import { Skeleton } from '@/components/shared/loading';
 
@@ -79,6 +87,15 @@ interface WorkspaceSidebarProps {
 }
 
 const DATASTORE_NAME = 'default';
+
+/** The agents rail shows who works here, it is not the roster — the pod
+ *  assistant plus a handful of faces, the rest one click away. Same answer
+ *  the recents list makes, and the apps rail makes it for software. */
+/** Which slice of the pod's history Recents is showing. */
+type ConversationScope = 'assistant' | 'all' | 'agent';
+
+const SIDEBAR_AGENT_LIMIT = 5;
+const SIDEBAR_APP_LIMIT = 5;
 
 /**
  * Whether the setup places are disclosed. Kept per-user rather than per-pod:
@@ -223,6 +240,7 @@ function getAssistantCreationInstructions(kind: AssistantCreationKind): string {
  */
 export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: WorkspaceSidebarProps) {
     const pathname = usePathname();
+    const searchParams = useSearchParams();
     const router = useRouter();
     const queryClient = useQueryClient();
     const [assistantCreationKind, setAssistantCreationKind] = useState<AssistantCreationKind | null>(null);
@@ -232,7 +250,17 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
     const [podSwitcherOpen, setPodSwitcherOpen] = useState(false);
     const [conversationFilter, setConversationFilter] = useState('');
     const [filterOpen, setFilterOpen] = useState(false);
-    const [conversationScope, setConversationScope] = useState<'assistant' | 'all'>('assistant');
+    /* The scope is *chosen*, and the choice is remembered against the page it
+       was made on. Landing on an agent defaults Recents to that agent — asking
+       "where do I see this one's conversations" and being handed the pod's whole
+       history is the list refusing to answer the question the route just asked —
+       and picking a different scope sticks until you navigate somewhere the
+       choice no longer applies. Derived rather than an effect, so there is no
+       frame where the list shows one scope and the control reads another. */
+    const [scopeChoice, setScopeChoice] = useState<{
+        scope: ConversationScope;
+        forAgent: string | null;
+    } | null>(null);
     const moreDisclosed = useSyncExternalStore(
         subscribeToMoreDisclosed,
         getMoreDisclosed,
@@ -258,7 +286,57 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
     const canUpdatePod = podAccess.can('pod.update');
     const basePath = `/pod/${podId}`;
     const isActive = (href: string) => pathname === href || pathname.startsWith(`${href}/`);
+
+    // The agent whose page is open, if any. `/agents/<name>` only; `/agents/new`
+    // has no conversations to scope to.
+    const routeAgentName = useMemo(() => {
+        const match = pathname.match(/^\/pod\/[^/]+\/agents\/([^/]+)$/);
+        const name = match ? decodeURIComponent(match[1]) : null;
+        return name && name !== 'new' ? name : null;
+    }, [pathname]);
+    const conversationScope: ConversationScope = scopeChoice && scopeChoice.forAgent === routeAgentName
+        ? scopeChoice.scope
+        : (routeAgentName ? 'agent' : 'assistant');
+    const setConversationScope = (scope: ConversationScope) => {
+        setScopeChoice({ scope, forAgent: routeAgentName });
+    };
     const isConversationRoute = isActive(`${basePath}/conversations`);
+
+    // The agents rail. This query is already warm — the Agents place prefetches
+    // it on pointer-intent and home's presence row reads the same list — so the
+    // rail renders straight from cache rather than growing a skeleton of its own.
+    // One slot goes to Lem, so the faces cap a row shorter.
+    //
+    // Only the agents you can *talk to*. An agent that declares typed inputs is
+    // something another resource calls with arguments — it belongs beside the
+    // functions and workflows that call it, not in a cast of people you open a
+    // conversation with. `takes_input` is the server's answer because the list
+    // endpoint does not carry `input_schema`; when it is absent (older backend)
+    // the filter fails open rather than emptying the rail.
+    const { data: sidebarAgentsData } = useAgents(canUseAgents ? podId : undefined);
+    const allSidebarAgents = useMemo(
+        () => sidebarAgentsData?.items || [],
+        [sidebarAgentsData?.items],
+    );
+    const sidebarAgents = useMemo(
+        () => allSidebarAgents
+            .filter((agent) => agent.takes_input !== true)
+            .slice(0, SIDEBAR_AGENT_LIMIT - 1),
+        [allSidebarAgents],
+    );
+
+    // Recents draw the face of whoever ran them, so the history needs to resolve
+    // an agent id. It reads the *unfiltered* list: a conversation with a
+    // structured agent is still a conversation you had, and hiding that agent
+    // from the rail is not a reason to strip its face off the row.
+    const agentsById = useMemo(() => {
+        const byId = new Map<string, Agent>();
+        allSidebarAgents.forEach((agent) => {
+            if (agent.id) byId.set(agent.id, agent);
+        });
+        return byId;
+    }, [allSidebarAgents]);
+
     const {
         conversations: controllerConversations,
         openedConversationId,
@@ -268,7 +346,14 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
         isLoading: isLoadingConversationHistory,
         refetch: refetchConversationHistory,
     } = useScopedConversations(
-        { podId, agentName: conversationScope === 'assistant' ? POD_DEFAULT_AGENT_SELECTOR : undefined },
+        {
+            podId,
+            agentName: conversationScope === 'agent'
+                ? routeAgentName ?? undefined
+                : conversationScope === 'assistant'
+                    ? POD_DEFAULT_AGENT_SELECTOR
+                    : undefined,
+        },
         { limit: SIDEBAR_CONVERSATION_LIMIT, enabled: canUseConversations },
     );
 
@@ -293,10 +378,24 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
     // after merging — otherwise a brand new conversation could push the list
     // past the limit it is meant to hold.
     const scopedControllerConversations = useMemo(
-        () => conversationScope === 'assistant'
-            ? controllerConversations.filter((conversation) => !conversation.agent_id)
-            : controllerConversations,
-        [controllerConversations, conversationScope],
+        () => {
+            if (conversationScope === 'assistant') {
+                return controllerConversations.filter((conversation) => !conversation.agent_id);
+            }
+            // The controller holds ids; the route holds a name. Only the rows it
+            // can actually attribute are kept — an unresolvable id under an agent
+            // scope would be a conversation claiming to be this agent's on no
+            // evidence, which is worse than a row arriving a refetch late.
+            if (conversationScope === 'agent') {
+                const scopedAgentId = allSidebarAgents
+                    .find((agent) => agent.name === routeAgentName)?.id;
+                if (!scopedAgentId) return [];
+                return controllerConversations
+                    .filter((conversation) => conversation.agent_id === scopedAgentId);
+            }
+            return controllerConversations;
+        },
+        [allSidebarAgents, controllerConversations, conversationScope, routeAgentName],
     );
     const conversations = useMemo(
         () => mergeSidebarConversations(
@@ -313,6 +412,37 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
     );
     const hasFilter = conversationFilter.trim().length > 0;
     const hasVisibleConversations = visibleConversations.length > 0;
+
+    /* Reserve the responder gutter for the whole list, or for none of it.
+       Per-row it produced the worst of both: the assistant answers most pods'
+       history and most rows rest, so the slot drew neither a face nor a dot and
+       the titles simply sat 30px further right than every other row in the
+       sidebar, indented past a column that was always empty. Deciding once per
+       list keeps the titles aligned with each other — the reason to reserve it
+       at all — and lets a pod that has nothing to draw stop paying for the
+       column. It appears when the list has news in it, which is when it earns
+       the space. */
+    const showResponderSlot = useMemo(
+        () => visibleConversations.some((conversation) => (
+            getConversationMark(conversation, agentsById)?.kind === 'agent'
+            || getConversationSignal(conversation).tone !== 'none'
+        )),
+        [agentsById, visibleConversations],
+    );
+
+    // The apps rail. Same story: the app index is one cached read shared with
+    // home's apps panel and the Apps page, so the rail draws from cache.
+    const { pages: sidebarAppPages } = useAppPages(canUseApps ? podId : '');
+    const sidebarApps = useMemo(
+        () => sidebarAppPages.slice(0, SIDEBAR_APP_LIMIT),
+        [sidebarAppPages],
+    );
+    // Apps all open on the one viewer route, so the active row is decided by
+    // the `page` query, not the pathname — the only row in this sidebar that
+    // needs the search string to know where you are.
+    const viewingAppSlug = pathname === `${basePath}/app/view`
+        ? searchParams.get('page')
+        : null;
 
     const pods = podsData?.items || [];
     const podGroups = podsData?.groups || [];
@@ -354,24 +484,11 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
     }, [basePath, podId, queryClient, router]);
 
     // The places are fixed and ordered the same on every route, so their
-    // positions can be learned. These four are where a day is spent, so they
-    // hold permanent slots.
+    // positions can be learned. Apps and agents are not places: the rails
+    // above list them as things with their own pages, and the indexes live
+    // behind each rail's "View all". What stays a place is what you browse
+    // *through*, not what you open: data and docs.
     const primaryPlaces = [
-        {
-            href: `${basePath}/app/pages`,
-            label: 'Apps',
-            kind: 'apps' as const,
-            active: isActive(`${basePath}/app`),
-            visible: canUseApps,
-        },
-        {
-            href: `${basePath}/ai`,
-            label: 'Agents',
-            kind: 'agents' as const,
-            active: isActive(`${basePath}/ai`) || isActive(`${basePath}/agents`),
-            visible: canUseAgents,
-            onIntent: prefetchAgents,
-        },
         {
             href: `${basePath}/data`,
             label: 'Data',
@@ -392,7 +509,28 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
     // Setup surfaces: you author a workflow, wire a connector, or change a pod
     // setting when something changes, not on the way through. One disclosure
     // costs a slot; three permanent rows cost three.
+    //
+    // The index routes for apps and agents live here too, permanently. An empty
+    // rail used to keep its header so its route stayed reachable, which put an
+    // "Apps / View all" line above nothing at all — a section advertising itself
+    // as absent, and on a new pod two of them stacked. A header with no rows
+    // under it is not a preserved route, it is a broken one. The rails now
+    // appear only when they have something to show, and the route someone needs
+    // on an empty pod is a fixed one that does not move when content arrives.
     const morePlaces = [
+        {
+            href: `${basePath}/app/pages`,
+            label: 'Apps',
+            kind: 'apps' as const,
+            active: isActive(`${basePath}/app`),
+            // Only while the rail is not drawing apps. Keeping it here always —
+            // for a nav position that never moves — put "Apps" on screen twice,
+            // and when you were on an app route the *active* fill landed on the
+            // buried copy inside `More` while the rail above it sat plain. A
+            // stable position is worth less than one unambiguous answer to
+            // "where am I".
+            visible: canUseApps && sidebarApps.length === 0,
+        },
         {
             href: `${basePath}/flows`,
             label: 'Workflows',
@@ -517,8 +655,8 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
                                         label={podName || 'Current pod'}
                                         identityKind="team"
                                         identitySeed={podId}
-                                        identitySize={24}
-                                        className="h-6 w-6 shrink-0 rounded-md border-[color:color-mix(in_srgb,var(--border-subtle)_58%,transparent)] bg-transparent text-[var(--text-tertiary)]"
+                                        identitySize={28}
+                                        className="h-7 w-7 shrink-0 rounded-md border-[color:color-mix(in_srgb,var(--border-subtle)_58%,transparent)] bg-transparent text-[var(--text-tertiary)]"
                                         fallback={<PodMark name={podName} />}
                                     />
                                     <span className="block min-w-0 flex-1 truncate text-sm font-medium leading-5 text-[var(--text-primary)]">
@@ -674,31 +812,141 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
                 </div>
             ) : null}
 
-            {primaryPlaces.length || morePlaces.length ? (
-                <nav
-                    aria-label="Pod places"
-                    className="workspace-sidebar-places shrink-0 space-y-0.5 px-3 pb-2 pt-2"
-                >
-                    {primaryPlaces.map((place) => (
-                        <PlaceLink key={place.href} {...place} />
-                    ))}
-                    {morePlaces.length ? (
-                        <>
-                            <MoreDisclosureRow
-                                expanded={moreExpanded}
-                                onToggle={moreHoldsActivePlace
-                                    ? undefined
-                                    : () => setMoreDisclosed(!moreDisclosed)}
-                            />
-                            {moreExpanded
-                                ? morePlaces.map((place) => (
-                                    <PlaceLink key={place.href} {...place} />
-                                ))
-                                : null}
-                        </>
+            {/* The apps rail — the software this pod has shipped, one click
+                from anywhere. Marks, not covers: the 16:9 cover is the card
+                face on the index, a rail row wants the square mark the identity
+                system seeds for inert things. The rail leads the sidebar
+                because apps and agents are what this pod *is* — and leading it
+                is the whole of the emphasis. It carries the app's hue class so
+                the active bar can wear the app's own colour, and nothing else:
+                a hue that paints every row on hover stops identifying anything,
+                because on hover every app looks like the app under the pointer.
+                One click opens the app in the viewer; the index is the "View
+                all" beside the header, which stays put even with no apps so the
+                route is never stranded. */}
+            {canUseApps && sidebarApps.length > 0 ? (
+                <div className="shrink-0">
+                    <div className="flex items-center justify-between px-2 pt-2">
+                        <span className="text-xs leading-5 text-[var(--text-tertiary)]">Apps</span>
+                        <Link
+                            href={`${basePath}/app/pages`}
+                            className="custom-focus-ring rounded px-1 text-xs leading-5 text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-secondary)]"
+                        >
+                            View all
+                        </Link>
+                    </div>
+                    {sidebarApps.length > 0 ? (
+                        <div className="px-3 pb-1 pt-1.5">
+                            {sidebarApps.map((page) => (
+                                <Link
+                                    key={page.slug}
+                                    href={`${basePath}/app/view?page=${encodeURIComponent(page.slug)}`}
+                                    data-active={viewingAppSlug === page.slug ? 'true' : undefined}
+                                    title={page.title}
+                                    className={cn(
+                                        'lemma-sidebar-row workspace-sidebar-resource-row custom-focus-ring',
+                                        identityHueClass(null, page.slug),
+                                    )}
+                                >
+                                    <ResourceIcon
+                                        alt={`${page.title} icon`}
+                                        label={page.title}
+                                        identityKind="mark"
+                                        identitySeed={page.slug}
+                                        identityGlyph={AppWindow}
+                                        identitySize={32}
+                                        className="workspace-sidebar-resource-icon h-8 w-8 shrink-0 rounded-md"
+                                    />
+                                    <span className="min-w-0 flex-1 truncate">{page.title}</span>
+                                </Link>
+                            ))}
+                        </div>
                     ) : null}
-                </nav>
+                </div>
             ) : null}
+
+            {/* The agents rail — who works here, as faces rather than a count.
+                A pod's agents are its cast, and a cast you can see is the whole
+                point of the messenger sidebar this mirrors. Lem
+                leads the rail: it is the responder every conversation already
+                knows, so it wears the mark rather than a seeded face, and takes
+                the brand violet hue rather than a seeded one. Faces get 32px:
+                the size a being's rich motion turns on, so reaching for a row
+                wakes the face up, and comfortably above the 20px floor where
+                the status pip renders. Only agents you can talk to — see
+                `sidebarAgents` — so the cast is people, not callable
+                contracts. One click opens the agent's own page; the roster is
+                the "View all" beside the header, which stays put even with no
+                faces so the route is never stranded, and it lists every agent
+                including the ones this rail filters out. */}
+            {/* No empty-rail guard here: Lem always leads this rail,
+                so it is never a header above nothing the way Apps could be. */}
+            {canUseAgents ? (
+                <div className="shrink-0">
+                    <div className="flex items-center justify-between px-2 pt-2">
+                        <span className="text-xs leading-5 text-[var(--text-tertiary)]">Agents</span>
+                        <Link
+                            href={`${basePath}/ai`}
+                            onPointerEnter={prefetchAgents}
+                            onFocus={prefetchAgents}
+                            className="custom-focus-ring rounded px-1 text-xs leading-5 text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-secondary)]"
+                        >
+                            View all
+                        </Link>
+                    </div>
+                    <div className="px-3 pb-1 pt-1.5">
+                        <Link
+                            href={`${basePath}/ai/assistant`}
+                            data-active={isActive(`${basePath}/ai/assistant`) ? 'true' : undefined}
+                            title={DEFAULT_RESPONDER_NAME}
+                            className="lemma-sidebar-row workspace-sidebar-resource-row lm-identity-hue-0 custom-focus-ring"
+                        >
+                            {/* Drawn by the same renderer as the agents below it,
+                                at the same 32px, on the reserved seed. The tinted
+                                tile is gone with the trademark that sat on it: a
+                                being needs no ground, and the tile was the last
+                                thing claiming this row was a different *kind* of
+                                thing from the cast it leads. */}
+                            <ResourceIdentity
+                                seed={LEM_SEED}
+                                label={DEFAULT_RESPONDER_NAME}
+                                kind="being"
+                                size={32}
+                                className="workspace-sidebar-resource-icon h-8 w-8 shrink-0"
+                            />
+                            <span className="min-w-0 flex-1 truncate">{DEFAULT_RESPONDER_NAME}</span>
+                        </Link>
+                        {sidebarAgents.map((agent) => {
+                            const displayName = formatAgentName(agent.name);
+                            const href = `${basePath}/agents/${encodeURIComponent(agent.name)}`;
+                            return (
+                                <Link
+                                    key={agent.name}
+                                    href={href}
+                                    data-active={isActive(href) ? 'true' : undefined}
+                                    title={displayName}
+                                    className={cn(
+                                        'lemma-sidebar-row workspace-sidebar-resource-row custom-focus-ring',
+                                        identityHueClass(agent.icon_url, agent.name),
+                                    )}
+                                >
+                                    <ResourceIcon
+                                        iconUrl={agent.icon_url}
+                                        alt={`${displayName} icon`}
+                                        label={displayName}
+                                        identityKind="being"
+                                        identitySeed={agent.name}
+                                        identitySize={32}
+                                        className="workspace-sidebar-resource-icon h-8 w-8 shrink-0 rounded-md"
+                                    />
+                                    <span className="min-w-0 flex-1 truncate">{displayName}</span>
+                                </Link>
+                            );
+                        })}
+                    </div>
+                </div>
+            ) : null}
+
 
             <Dialog open={assistantCreationKind !== null} onOpenChange={(open) => {
                 if (!open) closeAssistantCreation();
@@ -834,6 +1082,25 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
                             role="group"
                             aria-label="Conversation scope"
                         >
+                            {routeAgentName ? (
+                                <>
+                                    <button
+                                        type="button"
+                                        onClick={() => setConversationScope('agent')}
+                                        className={cn(
+                                            'custom-focus-ring max-w-24 truncate rounded px-1 transition-colors',
+                                            conversationScope === 'agent'
+                                                ? 'text-[var(--text-secondary)]'
+                                                : 'text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]',
+                                        )}
+                                        aria-pressed={conversationScope === 'agent'}
+                                        title={`${formatAgentName(routeAgentName)} conversations`}
+                                    >
+                                        {formatAgentName(routeAgentName)}
+                                    </button>
+                                    <span className="text-[var(--text-tertiary)]" aria-hidden="true">·</span>
+                                </>
+                            ) : null}
                             <button
                                 type="button"
                                 onClick={() => setConversationScope('assistant')}
@@ -844,9 +1111,9 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
                                         : 'text-[var(--text-tertiary)] hover:text-[var(--text-secondary)]',
                                 )}
                                 aria-pressed={conversationScope === 'assistant'}
-                                title="Pod assistant conversations"
+                                title={`${DEFAULT_RESPONDER_NAME}'s conversations`}
                             >
-                                Assistant
+                                {DEFAULT_RESPONDER_NAME}
                             </button>
                             <span className="text-[var(--text-tertiary)]" aria-hidden="true">·</span>
                             <button
@@ -900,6 +1167,8 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
                                         conversation={conversation}
                                         active={isConversationRoute && openedConversationId === conversation.id}
                                         onOpen={() => openConversation(conversation.id)}
+                                        mark={getConversationMark(conversation, agentsById)}
+                                        showResponder={showResponderSlot}
                                     />
                                 ))}
                             </>
@@ -907,11 +1176,18 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
                         {!hasFilter ? (
                             <Link
                                 href={`${basePath}/conversations`}
-                                className="lemma-sidebar-row workspace-sidebar-conversation-row workspace-sidebar-show-more custom-focus-ring text-[var(--text-tertiary)] hover:text-[var(--text-primary)]"
+                                className={cn(
+                                    'lemma-sidebar-row workspace-sidebar-conversation-row workspace-sidebar-show-more custom-focus-ring text-[var(--text-tertiary)] hover:text-[var(--text-primary)]',
+                                    showResponderSlot ? 'workspace-sidebar-conversation-row-marked' : null,
+                                )}
                             >
-                                {/* Empty dot gutter so the label starts on the
-                                    same x as the titles above it. */}
-                                <span className="w-3.5 shrink-0" aria-hidden="true" />
+                                {/* Empty gutter so the label starts on the same
+                                    x as the titles above it, at whichever width
+                                    the list settled on. */}
+                                <span
+                                    className={cn('shrink-0', showResponderSlot ? 'w-5' : 'w-3.5')}
+                                    aria-hidden="true"
+                                />
                                 <span className="min-w-0 flex-1 truncate">All conversations</span>
                             </Link>
                         ) : null}
@@ -921,10 +1197,46 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
                 <div className="min-h-0 flex-1" />
             )}
 
+            {/* The places, as a footer.
+                They used to sit between the agents rail and the history, where
+                they read as a demoted tail of the rail above rather than a band
+                of their own: every other section carries a header and this one
+                cannot plausibly have one ("Browse"? "Material"?), and the only
+                rule near it fell on its *lower* edge, so it attached upward to
+                the agents and detached from the history it was introducing.
+                A footer needs no header, and the things you open — apps,
+                agents, recents — become one contiguous column above it. The
+                strip is pinned outside the scrolling history, so a long list of
+                conversations can never push Data and Docs off the bottom. */}
+            {primaryPlaces.length || morePlaces.length ? (
+                <nav
+                    aria-label="Pod places"
+                    className="workspace-sidebar-places shrink-0 space-y-0.5 px-3 pb-2 pt-2"
+                >
+                    {primaryPlaces.map((place) => (
+                        <PlaceLink key={place.href} {...place} />
+                    ))}
+                    {morePlaces.length ? (
+                        <>
+                            <MoreDisclosureRow
+                                expanded={moreExpanded}
+                                onToggle={moreHoldsActivePlace
+                                    ? undefined
+                                    : () => setMoreDisclosed(!moreDisclosed)}
+                            />
+                            {moreExpanded
+                                ? morePlaces.map((place) => (
+                                    <PlaceLink key={place.href} {...place} />
+                                ))
+                                : null}
+                        </>
+                    ) : null}
+                </nav>
+            ) : null}
             {/* Local settings is the desktop shell's own control centre, not a
                 pod place, so it stays down here with the account rather than
                 joining the nav above. */}
-            <div className="shrink-0 border-t border-[color:color-mix(in_srgb,var(--border-subtle)_62%,transparent)] px-3 pb-3 pt-2">
+            <div className="shrink-0 px-3 pb-3 pt-1">
                 <LocalSettingsButton className="mb-1.5" />
                 <div className="flex items-center gap-1.5">
                     <Link
@@ -956,16 +1268,74 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
 /** Conversation titles vary in length, so the placeholders do too. */
 const CONVERSATION_ROW_SKELETON_WIDTHS = ['w-3/5', 'w-5/12', 'w-2/3', 'w-1/2', 'w-7/12', 'w-1/2'];
 
-function ConversationRow({
+/* Exported for the agent page's conversation rail: one conversation reads the
+   same whether it is listed under the pod or under one agent — same halo, same
+   row. The agent page passes no mark: every conversation there belongs to the
+   agent whose page you are already on, so drawing its face fifteen times
+   identifies nothing and it keeps the dot gutter. */
+/* The status dot, for a row with no face to hang a pip on. */
+function ConversationSignalDot({ signal }: { signal: ReturnType<typeof getConversationSignal> }) {
+    if (signal.pulse) {
+        /* Live work gets the ping halo the chat's status pill wears — a dot
+           that breathes reads as *happening now* in a way a blinking dot never
+           quite did. The tone stays the sidebar's own (delight gold), only the
+           motion arrives. */
+        return (
+            <span className="relative flex h-1.5 w-1.5">
+                <span className="absolute inset-0 animate-ping rounded-full bg-[var(--delight)] opacity-40" />
+                <span className="relative h-1.5 w-1.5 rounded-full bg-[var(--delight)]" />
+            </span>
+        );
+    }
+
+    /* A resting row keeps its hollow ring. Removing it — on the argument that
+       "nothing is happening" is better said with nothing — read fine as a
+       sentence and wrong on screen: the dot is not only a status report, it is
+       the row's left anchor. Without one, a column of titles hangs off a blank
+       gutter with nothing explaining the indent, and the history stops reading
+       as a list at all. A mark that costs one faint circle and buys the
+       list its left edge is worth the ink. */
+    return (
+        <span
+            className={cn(
+                'block h-1.5 w-1.5 rounded-full',
+                signal.filled ? 'bg-current' : 'border opacity-45',
+                // A resting dot takes a fixed border colour rather than
+                // `currentColor`: the row's text brightens on hover and when
+                // active, and a mark that brightens with the pointer reads as a
+                // status that changed.
+                signal.tone === 'none' && 'border-[var(--text-tertiary)]',
+                signal.tone === 'live' && 'text-[var(--delight)]',
+                signal.tone === 'warning' && 'text-[var(--state-warning)]',
+                signal.tone === 'danger' && 'text-[var(--state-error)]',
+            )}
+        />
+    );
+}
+
+export function ConversationRow({
     conversation,
     active,
     onOpen,
+    mark,
+    showResponder,
 }: {
     conversation: Conversation;
     active: boolean;
     onOpen: () => void;
+    mark?: ConversationMark | null;
+    /** Reserve the responder slot. The sidebar sets it; the agent page does not. */
+    showResponder?: boolean;
 }) {
     const signal = getConversationSignal(conversation);
+    /* Only an agent gets drawn. The assistant is the default responder — in most
+       pods it answers everything — so drawing it put the Lemma mark on all
+       fifteen rows at once, which is a logo wall, not identification. Removing
+       the tile under it was half the fix and left the other half: the mark was
+       still there, fifteen times. "Mark the exception" has to mean the default
+       draws *nothing*. The slot stays reserved either way so every title keeps
+       one left edge, and the empty ones carry the status dot they always had. */
+    const face = showResponder && mark?.kind === 'agent' ? mark : null;
 
     return (
         <button
@@ -973,25 +1343,49 @@ function ConversationRow({
             onClick={onOpen}
             data-active={active ? 'true' : undefined}
             title={conversation.title || 'Untitled conversation'}
-            className="lemma-sidebar-row workspace-sidebar-conversation-row custom-focus-ring"
+            className={cn(
+                'lemma-sidebar-row workspace-sidebar-conversation-row custom-focus-ring',
+                showResponder ? 'workspace-sidebar-conversation-row-marked' : null,
+            )}
         >
-            <span className="flex w-3.5 shrink-0 items-center justify-center" aria-hidden="true">
-                <span
-                    className={cn(
-                        'block h-1.5 w-1.5 rounded-full',
-                        signal.filled ? 'bg-current' : 'border opacity-45',
-                        // A resting dot takes a fixed border colour rather than
-                        // `currentColor`: the row's text brightens on hover and
-                        // when active, and a mark that brightens with the
-                        // pointer reads as a status that changed.
-                        signal.tone === 'none' && 'border-[var(--text-tertiary)]',
-                        signal.tone === 'live' && 'text-[var(--delight)]',
-                        signal.tone === 'warning' && 'text-[var(--state-warning)]',
-                        signal.tone === 'danger' && 'text-[var(--state-error)]',
-                        signal.pulse && 'lemma-live-pulse',
+            {showResponder ? (
+                <span className="workspace-sidebar-conversation-mark shrink-0">
+                    {face ? (
+                        <>
+                            <ResourceIcon
+                                iconUrl={face.iconUrl}
+                                alt=""
+                                label={face.label}
+                                identityKind="being"
+                                identitySeed={face.seed}
+                                identitySize={20}
+                                className="h-5 w-5 shrink-0 rounded-md"
+                            />
+                            {/* The face carries *who*, the pip carries *what this
+                                run is doing*. Separate objects on purpose: the
+                                identity system's own `state` describes the agent,
+                                and an agent with three runs in flight is not "the
+                                state" of any one of them. */}
+                            {signal.tone !== 'none' ? (
+                                <span
+                                    className="workspace-sidebar-conversation-pip"
+                                    data-tone={signal.tone}
+                                    data-pulse={signal.pulse ? 'true' : undefined}
+                                    aria-hidden="true"
+                                />
+                            ) : null}
+                        </>
+                    ) : (
+                        <span className="flex h-5 w-5 items-center justify-center" aria-hidden="true">
+                            <ConversationSignalDot signal={signal} />
+                        </span>
                     )}
-                />
-            </span>
+                </span>
+            ) : (
+                <span className="flex w-3.5 shrink-0 items-center justify-center" aria-hidden="true">
+                    <ConversationSignalDot signal={signal} />
+                </span>
+            )}
             <span className="min-w-0 flex-1 truncate">
                 {conversation.title || 'Untitled conversation'}
             </span>

--- a/lemma-frontend/components/shared/resource-identity.tsx
+++ b/lemma-frontend/components/shared/resource-identity.tsx
@@ -75,12 +75,23 @@ export function ResourceCover({ seed, label, className }: { seed: string; label?
               * says "this is a running app" before any of the blocks below are
               * even parsed.
               */}
-            <rect x="0" y="0" width="160" height="15" fill="currentColor" opacity=".5" />
+            <rect x="0" y="0" width="160" height="15" fill="currentColor" opacity=".34" />
             <circle cx="9" cy="7.5" r="2.3" fill="var(--lm-identity-soft)" />
             <circle cx="17" cy="7.5" r="2.3" fill="var(--lm-identity-soft)" />
             <circle cx="25" cy="7.5" r="2.3" fill="var(--lm-identity-soft)" />
+            {/*
+              * The layout blocks sit well back from full strength. At `1` a card
+              * is a near-flat slab of its own tone, and two of them made the
+              * largest saturated areas on pod home by a wide margin — louder
+              * than the composer, for artwork that is admittedly a stand-in and
+              * whose colour identifies nothing the app's name below it does not.
+              * Turned down, the card reads as tinted paper with a hint of
+              * layout: same seeded identity, a fraction of the volume, and the
+              * 16:9 box a real thumbnail will drop into unchanged.
+              */}
             <g
                 fill="currentColor"
+                opacity=".26"
                 transform={flip ? 'translate(160 0) scale(-1 1)' : undefined}
                 dangerouslySetInnerHTML={{ __html: screen }}
             />

--- a/lemma-frontend/components/surfaces/surface-configure-step.tsx
+++ b/lemma-frontend/components/surfaces/surface-configure-step.tsx
@@ -12,6 +12,7 @@ import { Switch, SwitchThumb, SwitchTrack } from '@/components/ui/switch';
 import type { SurfacePlatformDefinition } from '@/lib/surfaces/registry';
 import type { AssistantSurface } from '@/lib/types';
 import { StepLoader } from '@/components/brand/loader';
+import { DEFAULT_RESPONDER_NAME } from '@/lib/utils/agents';
 
 export const DEFAULT_AGENT_VALUE = '__pod_default_agent__';
 
@@ -119,7 +120,7 @@ export function SurfaceConfigureStep({
                     <SelectContent>
                         {/* Named the same as the route picker below, because it
                             means the same thing to a person. */}
-                        <SelectItem value={DEFAULT_AGENT_VALUE}>Pod assistant</SelectItem>
+                        <SelectItem value={DEFAULT_AGENT_VALUE}>{DEFAULT_RESPONDER_NAME}</SelectItem>
                         {assistants.map((assistant) => (
                             <SelectItem key={assistant.id || assistant.name} value={assistant.name}>
                                 {assistant.name}
@@ -397,7 +398,7 @@ function ChannelRouteRow({
                                 the pod's own assistant, one named agent. The middle one
                                 is a choice, not a fallback — see POD_ASSISTANT_VALUE. */}
                             <SelectItem value={DEFAULT_AGENT_VALUE}>Whoever answers here by default</SelectItem>
-                            <SelectItem value={POD_ASSISTANT_VALUE}>Pod assistant</SelectItem>
+                            <SelectItem value={POD_ASSISTANT_VALUE}>{DEFAULT_RESPONDER_NAME}</SelectItem>
                             {assistants.map((assistant) => (
                                 <SelectItem key={assistant.id || assistant.name} value={assistant.name}>
                                     {assistant.name}

--- a/lemma-frontend/components/surfaces/surface-modal.tsx
+++ b/lemma-frontend/components/surfaces/surface-modal.tsx
@@ -472,7 +472,7 @@ export function SurfaceModal({
                               channel_id: route.channel_id,
                               channel_name: route.channel_name || null,
                               // Sent apart, never derived from an empty name:
-                              // "the pod assistant answers here" and "nobody has
+                              // "Lem answers here" and "nobody has
                               // said" both leave agent_name null, and the API
                               // rejects a route that claims to be both.
                               agent_name: route.use_pod_assistant ? null : route.agent_name,

--- a/lemma-frontend/design.md
+++ b/lemma-frontend/design.md
@@ -456,6 +456,13 @@ The context bar is the only band that can yield, because the other two are
 structurally required and the page body should never have printed the name in
 the first place.
 
+The tab strip holds only what someone opened as work — conversations,
+sections, widgets. Apps and agents are never *pinned* tabs: the sidebar rails
+hold them (see below). The one exception is display-only — while the app
+viewer is focused, the strip derives an ephemeral tab for the open app so it
+can still mark where you are; it is never written to the working set, and
+stored app tabs from before the rails are dropped at parse and at sync.
+
 ### Who owns the title
 
 `titleOwner` on `ResourceHeader` decides, and the rules are pinned by tests in
@@ -483,6 +490,498 @@ cede ownership rather than delete the header.
 - Never solve duplication by deleting `ResourceHeader`. That loses the back
   target and the action anchor, and the shell then has nothing to render into
   its context bar. Hand the title to another band instead.
+
+### The sidebar rails and pod home — colour where it means something
+
+The shell's nav was ink-on-paper with one accent bar; the conversation surface
+was the only room that spent the jewel tones. The current rule: **colour is
+allowed wherever it identifies or reports, never where it merely decorates.**
+Everything below reuses the badge pairs and the six `data-accent` tones — no
+new hues, no new gradients.
+
+- **Things you open are rails, places you browse through are rows.** Apps and
+  agents are not nav tabs: each is a rail under its own header — apps as
+  seeded marks (the identity system's square for inert things), agents as
+  faces, both at 32px so a being's rich motion is on (reaching for a row wakes
+  its face) — one click to the thing's own page, with a "View all" beside the
+  header for the index. Data, Docs and the setup places stay rows: you browse
+  *through* them rather than open one of them.
+- **An empty rail does not draw itself.** The headers used to stay when a rail
+  was empty, on the theory that the route would otherwise be stranded — which
+  put an "Apps / View all" line above nothing at all, and on a fresh pod stacked
+  two of them. A header with no rows under it is not a preserved route, it is a
+  broken one. A rail appears when it has something to show, and the index route
+  lives permanently in `More` instead: on an empty pod the way to apps should be
+  in a fixed place. The agents rail needs no such guard — Lem always leads it. That `More` entry appears *only* while the rail is empty:
+  keeping it there permanently, for a nav position that never moves, put "Apps"
+  on screen twice, and on an app route the active fill landed on the buried copy
+  inside `More` while the rail above it sat plain. One unambiguous answer to
+  "where am I" is worth more than a position you never had to learn.
+- **The places are a footer, not a middle band.** Apps, agents and recents run
+  as one contiguous column — everything you open, in the order of a day — and
+  Data, Docs and `More` sit pinned under them, above the account. In the middle
+  the strip had no defensible reading: every other section carries a header and
+  this one cannot plausibly have one, so three small rows simply dangled off the
+  agents rail. A footer needs no header. The sidebar's one rule moved to that
+  strip's *top* edge with it — on the bottom it introduced the history rather
+  than separating the places from the rail above, which is what made the strip
+  read as the rail's demoted tail. The account block takes no second rule: one
+  footer, one seam. Being pinned outside the scrolling history is also what
+  stops a long list of conversations pushing Data and Docs off the bottom.
+- **Emphasis is spent once.** The rails lead the column, and *leading it is the
+  emphasis.* An earlier pass stacked four of them on the same rows — first
+  position, then a 2.75rem height against a 2rem history, then a hover wash in
+  the resource's own tint, then a coloured glow under the tile — and four rules
+  saying one thing about one row is what made the rail read as unfinished
+  rather than important. The wash and the glow are gone; the height is now only
+  what a 32px tile needs to breathe. A hue that paints whichever row is under
+  the pointer identifies nothing, because in turn it paints all of them.
+- **Mass follows use, so the history is not the smallest thing in the column.**
+  The rail was the tallest band and recents — the part anyone actually clicks —
+  was the shortest, which read as importance descending and ran exactly
+  opposite to it. That gap closes from the history's end: a recent row carries
+  the mark of whoever answered it and stands at 2.25rem. Apps, agents and
+  recents are one band of *things you open*; Data, Docs and the setup places
+  are the quieter strip of *places*. Two densities, and the line between them
+  is the same line the first bullet draws.
+- **A recent conversation shows who answered it.** The assistant answers most
+  runs and an agent answers the rest, and a list of titles alone cannot tell
+  you which — a pod's history is mostly one-word titles, so two rows both
+  called "hey" were indistinguishable. The row draws the responder's mark at
+  20px — the identity system's pip floor, and as small as a face reads. An
+  `agent_id` that resolves to nothing falls back to the dot rather than seeding
+  a face for an unknown id, which would draw a stranger. The agent page's rail
+  passes no mark — every conversation there belongs to the agent whose page you
+  are on, and fifteen copies of one face identify nothing.
+- **Mark the exception, and let the default draw nothing.** The assistant
+  answers most of a pod's history, so marking it marks everything. Putting it on
+  a filled violet tile was the loud version of that mistake; taking the tile away
+  and keeping the mark was the quiet version — fifteen rows, fifteen Lemma marks,
+  a logo wall down the side of the app. Only an agent draws a face. The slot
+  stays reserved so every title keeps one left edge, and the rows with no face in
+  them carry the status dot they always had. The test generalises: **if every row
+  wears the mark, the mark is decoration in identity's clothes** — count the
+  instances on screen before deciding a mark identifies anything.
+- **The mark says who, the pip says what the run is doing.** They are separate
+  objects, because the identity system's `state` describes the *agent* and an
+  agent with three runs in flight is not "the state" of any one of them. The
+  pip sits on the tile's corner, ringed in the shell ground, and only when
+  there is something to report: live, waiting, or recently failed — a face is
+  already a mark, so a resting one needs nothing added to it.
+- **The cast is people, not callable contracts.** An agent that declares typed
+  inputs is *called* with arguments; an agent without them is *talked to*. Only
+  the second is in the agents rail — the first belongs beside the functions and
+  workflows that call it, which is where anyone would look for it. The server
+  answers this with `takes_input` on the agent summary, because the list
+  endpoint deliberately omits `input_schema` and a frontend filter reading that
+  field would silently pass everything. The roster behind "View all" still
+  lists every agent: filtering the rail is a matter of what belongs in a cast,
+  and an agent that cannot be found at all is a bug report.
+- **Lem leads the agents rail.** It is the responder every conversation already
+  knows, so it is drawn from a *reserved* seed rather than a hashed one — the
+  same creature in every pod — and links to its own page (`/ai/assistant`). The
+  seeded faces cap one row shorter to make the slot.
+- **The default responder has a name, because the greeting needs one.** It had
+  five — "Pod Assistant" here and on its own page, "Lemma Assistant" in the
+  dock and the conversation list, "Lemma Assist" in the empty state, "Pod
+  assistant" in the Slack pickers, `pod_default` on the wire — for the one actor
+  that answers most of a pod's history. "Assistant" could not be the settlement:
+  `docs/product/README.md` fixes the product's nouns against the analytics event
+  catalog, and `assistant` is not among them and appears in no journey, so
+  adopting it meant amending an enforced vocabulary to add a *category* that
+  competes with `agent`. A proper name needs no amendment — Lem is an instance,
+  the way someone's own agent is `triage` — and it is the only form that works
+  where the copy is first-person: the front door renders `Hey, I'm {label}`
+  because the artwork has eyes, and "Hey, I'm Pod Assistant" was a job title
+  introducing itself. Display copy only; `pod_default`, `POD_DEFAULT` and
+  `__pod_assistant__` stay on the wire untouched.
+- **A being of the cast, not the trademark over it.** Lem wore the `LemmaMark`
+  on soft action fill, which was wrong three ways. It put the *company's* stamp
+  on one actor inside your pod, so the row that should read as yours read as the
+  vendor's — in a product other people self-host. It broke the identity system's
+  own law — *agency is saturated, inert is tinted* — by drawing the pod's most
+  capable agent as a **mark on a tinted ground**, the treatment reserved for
+  tables: a table whose glyph happened to be a logo. And a logo has no eyes, so
+  the agent that runs most often was the only one that could not show it was
+  running, waiting, or failed. Lem is now a `being` like every agent: same
+  renderer, same upper-left light, same eyes, same state pip, same rich motion
+  above 32px. The tile went with the logo — a being carries its own colour and
+  needs no ground, and the tile was the last thing claiming this row was a
+  different *kind* of thing from the cast it leads.
+- **Spend the distinction once, on the silhouette.** Lem is told apart by one
+  channel, the one `seeded-identity.ts` already says survives the shrink: all
+  eight seeded bodies are convex, and Lem's is not. Colour could not do it — an
+  agent may roll tone 0 too — and neither could a crest, because the band
+  visible above a body is about eight units tall and detail dies there first.
+  Concavity is also the one property the generator cannot reach by accident, so
+  it is a guarantee rather than a low probability: a ninth convex blob would
+  have left Lem one unlucky hash from a twin. The body is **appended** at index
+  8 rather than carved out of the seeded range — reserving index 7 would have
+  cost the roster twenty buckets (160 → 140) to identify one creature, and every
+  existing agent's face is bit-for-bit what it was.
+- **The recents rule stands, for a new reason.** "Mark the exception, and let
+  the default draw nothing" was written because fifteen rows drew fifteen Lemma
+  marks — a logo wall down the side of the app. Giving Lem a real face does not
+  reopen it: fifteen copies of one face identify nothing either, which is the
+  same call the agent page already makes for its own rail. The rule survives its
+  original justification.
+- **The kinds keep their jewel tone.** Data green, Docs amber — plus violet
+  Apps, terracotta Agents and `--collaboration` Workflows wherever those
+  kinds are drawn (menus, dialogs, headers) — on `ProductIcon[data-kind]` in
+  every state, so a kind's colour is its identity and the pointer is still
+  answered by motion (the glyph scale), never weight or fill. Setup kinds
+  (connectors, settings) stay ink so they recede.
+- **The active row wears the soft action fill.** `--sidebar-active-bg` is
+  `--action-primary-soft`, not the sheet colour — "you are here" is the same
+  light violet the model picker uses for a selected row, with the accent bar
+  kept. On the resource rails the bar wears the resource's own hue (brand
+  violet for Lem): the fill says *here*, the bar says *who*.
+  Apps all open on the one viewer route, so the active app row is
+  decided by the `page` query, not the pathname.
+- **One conversation list, and it is the shell's.** The agent page grew its own
+  rail of this agent's runs on the left, which put two lists of conversations
+  side by side — the pod's history in the sidebar, the agent's a border away,
+  same rows and nearly the same width. Two lists of the same kind of thing read
+  as two sidebars, not as a hierarchy, and no amount of styling makes the inner
+  one subordinate when it is the same object. The sidebar's survives because it
+  is on every route.
+- **The one list changes scope with the route.** Removing the rail without this
+  left an agent page with nowhere at all to see that agent's runs — the dock's
+  History tab is only reachable while editing, so talk mode had no list. Recents
+  takes a third scope, shown and selected only while an agent's page is open, so
+  the answer to "where are this agent's conversations" is the list that was
+  already on screen rather than a second one. The choice is remembered against
+  the page it was made on and lapses when it stops applying, and it is derived
+  rather than set in an effect, so the control and the list can never disagree
+  for a frame.
+- **Talking is the agent page's default; editing is a button that swaps the
+  panes.** The page opened in its editor — config in the main column, a dock on
+  the right to actually run the thing — which optimised for the rarer act. You
+  tune an agent while building it and seldom after; you talk to it every day,
+  and the sidebar rail put every agent one click from every route, so this is
+  somewhere people land rather than visit. `Edit` swaps which pane is big:
+  config takes the column and the conversation moves to the dock. The thing you
+  came to work on is always the large one, and "tune it while testing it" — the
+  good part of the old layout — survives. An agent with declared inputs skips
+  all of this and opens in the editor: it is *called*, not talked to, so there
+  is no talk mode to default to (the same line `takes_input` draws).
+- **An agent's page launches conversations; it does not host one.** Making the
+  front door the empty state of a live conversation meant typing there turned the
+  agent's page into a transcript, and its front door was gone until you asked for
+  a new run — one surface doing two jobs and losing the first. That fought the
+  workspace this product already has: conversations are *tabs*, and the tab set
+  is persistent in storage rather than derived from the current route. So sending
+  navigates to the conversation route with `assistantMessage` — the loud half of
+  `composer-launch`, correct here because the sentence is already written — the
+  run opens in its own tab, and the agent's tab is still sitting beside it. Pod
+  home already worked this way; the agent pages now match it.
+- **Which is what makes the page worth visiting.** Freed from being a transcript
+  container it can be a home: who this is, the box that starts something, where
+  else it can be reached, **what it does without you**, and a preview of what it
+  has been doing. That last one is the page answering "where are this agent's
+  conversations" itself rather than delegating to the shell — and a list inside a
+  scrolling column is not the second navigation rail we removed, because it
+  scrolls with the page instead of standing beside it. Routines earn their place
+  for a different reason: a schedule is the part of an agent easiest to forget
+  you set up and most surprising to rediscover from a run you did not start, so
+  the home states it plainly. Neither section is an editor — they say *that* it
+  runs and *what* happened; Configure is where you change it.
+- **Both front doors stand on the same paper.** `.resource-page-scroll` sits on
+  `--bg-canvas` because it holds cards, and a card needs the darker sheet behind
+  it to read as raised. An agent's home has no cards — one column of content,
+  exactly like pod home — so it takes `--pod-main-bg`. Two pages doing the same
+  job on two different grounds was most of why one of them did not feel like the
+  other.
+- **Configure, not Edit, and in the page rather than the bar.** "Edit" names a
+  mode; "Configure" names what you get — instructions, reach, schedules. Keeping
+  it in the top bar meant the bar existed to hold one button on a page designed
+  to have no chrome; putting it *last* then made it an afterthought on the one
+  screen that owns the agent. It belongs top-right of the column — where a page
+  action goes on a screen with no bar to put one in.
+- **The home is 44rem, and the columns are allowed to differ.** 34rem was a
+  ribbon down the middle of a very wide pane. 52rem — taken to match
+  `.resource-page-column` so Configure would not shift the column — bought that
+  consistency by running conversation titles nearly edge to edge. Hitting
+  Configure replaces the content wholesale, so a change of measure underneath it
+  is the smaller event, and the readable width wins. The description stays
+  shorter still: the lists and the composer are happy filling the column, a
+  sentence is not.
+- **Connecting a surface happens on the agent's page, not somewhere else.** The
+  connect chips linked to `/pod/:id/surfaces`, which is a *legacy redirect to the
+  agents index* — its own comment says surfaces are configured from the agent
+  that answers on them. So "Connect WhatsApp" bounced you to a list of agents,
+  having forgotten both the platform you picked and the agent you picked it for.
+  `SurfaceModal` takes exactly those two things, and this is that agent's page:
+  it opens over the home with both already known.
+- **The whole composer is the click target, not the field inside it.** A
+  composer is chrome wrapped around a textarea, and clicking the chrome — the
+  padding, the bar the send button sits on — did nothing, so the box looked
+  focusable precisely where it was least obviously not. `mousedown`, not `click`,
+  so the caret lands before the browser settles its own selection.
+- **An agent with declared inputs gets a home too; the box that starts it is a
+  form.** Every agent deserves the page that says who it is, where it is reached,
+  what it runs on its own and what it has been doing. Only the invocation
+  differs, and it differs *in place*: a free-text composer on an agent that is
+  *called* with arguments would lie about how you reach it, so the same slot
+  holds the run form instead. Saying "runs with typed inputs" and leaving the
+  form a click away in the editor was half the fix — "how do I run this" is the
+  question a home exists to answer. The renderer is the panel's own, headerless,
+  rather than a second implementation of typed fields, required keys and JSON
+  inputs. The gate sits on the home as well as the page, because the component
+  must not be able to draw a chat box for something you cannot chat with.
+- **Making an agent is one step, and the form is the page it makes.** Creation
+  was a five-step wizard — identity, instructions, shape, access, review — which
+  asked for an agent's whole contract before the agent existed. That ordering
+  only held while the agent's own page was an editor you had to arrive at fully
+  formed. It is a home with Configure on it now, so everything the wizard
+  front-loaded has a better moment later: you tune an agent you can already talk
+  to, against runs you have already seen, instead of guessing at its schema and
+  its table access from a blank form. What stays is what cannot come later — a
+  name, because it is the address that makes the agent reachable from outside
+  Lemma; a face, because it is how it will be told apart in the rail; and a
+  purpose, because the first instruction is written from it.
+  Create lands on the agent's own page, which is therefore the success screen —
+  there is no separate one, and the arrival notice names the two things to do
+  next rather than the four the wizard used to.
+- **The back link keeps its arrow at every width.** It was `hidden sm:inline-flex`
+  on the whole control rather than on its label, so below 640px a resource page
+  had no way back to the index it came from — in the one place that needs it most,
+  since the tab strip is hidden there too and the browser's own back button was
+  the only exit left. The arrow always renders; the label appears when there is
+  room, and `aria-label` carries the destination when there is not.
+- **What made the creation form read as a dialog was the missing header, not the
+  frame.** It was built as a raised, shadowed sheet on a route with no context
+  bar — a dialog impersonating a page, and a real dialog would have to render
+  over an empty route, which is what Next's intercepting routes are for and not
+  worth the plumbing here. The fix was the **bar**, which is what the card had
+  been standing in for: a home earns no bar because it has moved its chrome into
+  the page and a tab already names it, but a task you arrive at and leave from
+  needs the title and the way out. With the bar naming it, the panel's own
+  "Create a new agent" heading goes too — the shell owns the title.
+  Stripping the frame as well went a step too far: two columns then sat adrift in
+  a very wide pane with nothing holding them. It is framed again, in
+  `.resource-card` — the same hairline, radius and near-stock fill every other
+  resource page uses — under a real header. Elevation stays paper, not glass:
+  `--shadow-xs`, the card's own, never a modal's lift. **A panel under a page
+  header is furniture; the same panel without one is a costume.**
+- **A lone object needs something to be level with.** The preview column was
+  top-aligned, which left the face hanging above a few hundred pixels of nothing
+  — one element with no relationship to anything beside it. Centred against the
+  form it reads as the pair it is: this is the thing, these are its details.
+- **The preview belongs beside the form, not inside it.** Two failed passes led
+  here. Drawing the name and purpose *as* the greeting and description they
+  become produced two headings with nothing to say they could be typed into.
+  Replacing that with a plain labelled stack worked and was lifeless — correct
+  and inert, which is its own failure on the screen that introduces a new
+  agent. The answer is two panels: the face and the name standing on their own
+  on the left, the fields doing their work on the right, in one card on the
+  darker sheet.
+- **An identity stores a variant, not a picture — so name the thing first.**
+  `icon_url` holds `lemma-identity:<n>`; the seed is always the resource's own
+  name. The face is therefore a function of *both*, and picking one on the create
+  screen and then typing more of the name turned it into a different creature.
+  That is the system working rather than a slip — renaming an agent changes its
+  face wherever it appears — but on a form it reads as the picker losing your
+  choice. Pinning the face would mean storing a seed, which changes the format
+  and every consumer; the cheaper honesty is to ask for the name first, so cause
+  precedes effect, and to say the rule beside the swatches. A surprise that is
+  stated is a rule.
+- **A choice you have to go looking for is not offered.** The eight faces sit
+  inline, always, with a reshuffle beside them — hiding them behind a "change
+  face" toggle made picking one a thing you had to find, and the face is half of
+  how an agent is told apart in a rail of them. `distinctIdentityVariants` picks
+  those eight by walking the counter and keeping one face per tone-and-form
+  pair, because a choice between things you cannot tell apart is not a choice.
+- **The placeholder carries an example, not a second request.** "Turns rough
+  ideas into sharp, memorable pitches" shows the length and register of a good
+  purpose; "What should it help the pod do?" only asks the question the label
+  already asked. (A row of role templates sat under these fields for a pass and
+  came out again — worth revisiting when there is a real set of them to offer,
+  rather than four invented on the spot.)
+- **A panel built for a dock has to be un-docked before it lives on a page.**
+  Dropping the run form onto the home carried two of the dock's assumptions with
+  it: a fixed height with an inner scroller, and a header. Capped at 26rem the
+  form clipped "Start run" clean off, so an agent with a few fields could not be
+  submitted at all; and the header, hidden with the `hidden` attribute, stayed
+  laid out because the `flex` class beside it overrides the UA's `display: none`
+  — 3.5rem of nothing above the first field. Hide by not rendering, and give the
+  scrolling back to the page.
+- **Chrome that restates what it sits on is not chrome.** The run form carried a
+  "New run / Inputs" head above a stack of labelled fields — two lines saying
+  what the thing under them plainly was — and on the home it was boxed in a
+  border, which put an edge that says *panel* on a screen with no other panels.
+  Both gone. A form is already legible as a form.
+- **A page action belongs at the pane's corner, not the column's.** Configure was
+  pinned top-right of a 44rem block centred in a very wide pane — which is not a
+  corner, it is a point in open space with no edge to belong to, so it read as
+  parked at random. It now sits at the pane's own top-right, the place the eye
+  already checks and exactly where the context bar used to put it, and sticks
+  there while a long home scrolls under it.
+- **The test-chat dock is gone; the run form stays.** A conversational agent is
+  started from its home and the run opens as its own tab, so a chat panel bolted
+  to the editor was a third place to talk to one agent — with its own history
+  list, its own header, and its own idea of which conversation you were in. The
+  dock now only opens for an agent with typed inputs, where it is the form that
+  runs it, which is the job it was actually good at.
+- **A loading state promises the screen that is coming.** The editor's card
+  skeleton stood in for the home, so every arrival flashed a stack of cards
+  before resolving into a page that has none. The home's skeleton is shaped like
+  the home: face, name, description, composer. Nothing about that frame is
+  unknown while the agent loads.
+- **Headroom is asymmetric, and the action row does not eat it.** The face is
+  the first thing on the page and needs room above it to read as placed rather
+  than flush against the pane — more so with the context bar gone, since there
+  is no chrome overhead to stand off from. Configure sits inside that padding
+  with a negative top margin, so a page that has it does not start lower than one
+  that does not.
+- **A bar with nothing in it should not draw.** The shell renders its context bar
+  for every route that is not pod home, a conversation, or an app view — so a
+  page that hands it no title, no back link and no actions still got a 48px strip
+  of nothing. `hideContextBar` on the topbar payload lets a route that has moved
+  its chrome into the page say so. Pod home was already exempt by name, which is
+  why it always felt cleaner than pages that were trying to imitate it.
+- **An agent's front door (superseded — kept for the reasoning).**
+  Face at 64px (well past the 32px where rich motion turns on), a first-person
+  greeting — the identity system already draws this thing with eyes that answer
+  the pointer, so naming it in the third person on the one screen where it
+  introduces itself would be the copy disagreeing with the artwork — its
+  description, and a row of **"Talk to me on …"** buttons. Making it the empty
+  state rather than a page of its own is what keeps the composer under it real:
+  the greeting is what you see before the first message and the transcript
+  replaces it after, with no navigation between and nothing to keep in sync.
+  Lem is drawn from the reserved seed instead of a seeded face, the same call
+  the sidebar rail makes.
+- **A reach button that cannot be opened is named, not linked.** The row is a
+  promise — *talk to me here* — so a dead href breaks it. Telegram and WhatsApp
+  carry an open-chat convention and Resend carries an address; Slack and Teams
+  reach the agent perfectly well but the surface record holds nothing we can
+  build a link from, so they are drawn without an affordance rather than given
+  one that goes nowhere.
+- **The reach row advertises what is not connected yet.** Listing only wired
+  platforms makes it a status report for people who have finished setting up,
+  which is nobody on the day it matters most. This row is the one place that
+  states the whole promise — *reach this agent where you already talk* — so an
+  unconnected platform is the most useful thing it can show: an offer, not an
+  absence. Up to three of them, after the working ones, wearing a dashed rule
+  and quieter ink so the two never look equally ready. The connected links open
+  outside the app; a connect chip is a route inside it and must not open in a
+  new tab, or it strands the page you were about to come back to.
+- **A conversation that fills a page still needs a measure.** Dropped into the
+  main column with no width, the transcript and composer stretch the whole
+  viewport — and a message box wider than anything anyone types into it reads as
+  broken, not as spacious. Both take the same `max-w-3xl` the composer uses
+  everywhere else. The empty state fills the viewport rather than sitting at its
+  top, so the front door is centred against the composer instead of hanging
+  above a void.
+- **The agent page's bar carries the action and nothing else.** It printed a
+  title and a "← Agents" link directly under a tab strip already naming the
+  agent, on a page whose front door names it a third time in the greeting. The
+  mechanism for that already existed: `titleOwner: 'tab'`, which also takes the
+  name back on a compact viewport where the strip is hidden — the reason to use
+  it rather than simply deleting the title. The conversation's *own* header had
+  to go with it: hiding the shell's bar while the view underneath still printed
+  the agent's name left the same duplication one row lower. A dock keeps its
+  header — it is a panel among other things and has to say what it is; a page
+  that a tab already names does not.
+- **Lem's page is a conversation, not a description of one.** It
+  was a stack of read-only cards — identity, wiring, a textarea that navigated
+  *away* to start a run, and four recent conversations in a panel at the
+  bottom — every one of them describing the assistant on a page where you could
+  not talk to it. It now runs `PodAssistantEmbedded` with the same front door as
+  its empty state, and takes the same bar and list rules as the agent pages: no
+  title, no back link, no conversation panel. Its runs *are* what Recents shows
+  by default, so a list here was the same list twice, a border apart.
+- **A rule fixed on one page has to be swept across the pages built to match
+  it.** The assistant page was written to mirror the agent page and inherited
+  its second sidebar and its duplicate header, then kept both after the agent
+  page dropped them — the fix landed where the complaint was and stopped there.
+  These two pages are one design; when one of them changes shape, check the
+  other in the same pass.
+- **One list scales to one hand.** Scoping Recents rather than growing a rail is
+  also what makes an agent's history reachable on a phone: the compact viewport
+  renders the same `WorkspaceSidebar` inside `MobileSidebarDrawer`, so the scope
+  control and the scoped list arrive with it. A page-level rail would have
+  needed a second mechanism for small screens — which is exactly what the old
+  agent page had, ceding to the dock's History tab whenever the layout stacked.
+- **Live work breathes.** A running conversation in recents and a running row
+  on home's Activity panel wear the chat status pill's ping halo. Home's
+  halo is violet (live means acting); the recents halo keeps the sidebar's
+  own delight-gold tone — the motion arrived, the semantics did not move. In
+  recents the halo now rides the pip on the responder's mark rather than a dot
+  in its own gutter; same tone, same motion, one fewer column.
+- **Finished work wears the check.** A completed outcome on home carries the
+  chat's soft-green check chip, not a bare dot.
+- **Pod home greets with the pod's mark.** The seeded team identity at 44px
+  (the size its motion turns on) beside the eyebrow, and the add-a-capability
+  tile in soft violet. The composer remains the one loud object; everything
+  added only spends colours that already carry meaning elsewhere.
+- **Home does not offer suggested moves.** It carried up to four accent "do"
+  pills built from the pod's own tables and workflows — "Review Projects", "Run
+  Crm Gmail Poll Intake" — on the theory that a pod that can already do things
+  should offer moves rather than only ask for them. In practice the moves a
+  generator can name from a schema are the generic ones, and a row of pills
+  nobody presses is a tray of colour under the one field that takes any answer.
+  The launcher still builds them (`buildPodDoActions`), where someone has
+  already said they want a starting point; the front door only asks.
+- **A hue means one thing, and identity is not status.** Home's presence avatars
+  hashed each person into four fixed tints — `--accent-rgb`, `--state-success`,
+  `--state-warning`, `--text-secondary` — under a comment explaining that a
+  fixed pool existed precisely so a hash would not "drift into the state colours
+  and start implying an agent is failing". Three of the four were state colours,
+  so two of five people wore success-green one scroll above an Activity panel
+  where success-green means *Completed*. They now draw from the identity
+  system's own pool (`lm-identity-hue-*`), the palette built for "a distinct
+  being" and already worn by the agent faces beside them — the `hue` variant,
+  not `tone`, because `tone` also sets `color` and would paint each initial the
+  colour of the disc behind it.
+- **A stand-in does not get to be the loudest object on the page.**
+  `ResourceCover` is honest about being "the seeded stand-in for a screenshot",
+  and at full strength two of them were the largest saturated areas on pod home
+  by a wide margin — louder than the composer, which is supposed to be the one
+  loud object. Their colour identifies nothing the app's name beneath them does
+  not: the seed is the page slug. The window chrome stays (the comment defending
+  it is right — pastel bars with no chrome read as a skeleton loader, the one
+  thing an app card must not say), but the layout blocks sit well back, so the
+  card reads as tinted paper with a hint of structure. The 16:9 box is unchanged
+  and a real thumbnail drops into it untouched.
+- **A row with no face keeps its dot — the dot is the list's left edge, not
+  just a status.** Dropping the resting ring on the argument that "nothing is
+  happening is better said with nothing" reads well as a sentence and fails on
+  screen: with the ring gone, a column of titles hangs off a blank gutter with
+  nothing to explain the indent, and the history stops reading as a list. One
+  faint circle buys the whole column its left edge, which is worth more ink than
+  it costs. The rule it violated is the general one — **a gutter must contain
+  something or not exist**; what it must never be is reserved and empty.
+- **The responder gutter is therefore reserved per list, not per row.** Three
+  rules compounded badly: reserve a slot for the responder, draw nothing for the
+  assistant, draw nothing when resting. In a pod where the assistant answers
+  everything and nothing is running — most pods, most of the time — every row
+  got an empty 30px indent and the history floated right of the rest of the
+  sidebar behind a column that was always blank. Deciding once for the whole
+  list keeps the titles aligned with each other, which was the only reason to
+  reserve it, and a list with no faces in it falls back to the narrower dot
+  gutter instead of paying for a wider one. The lesson is about *composition*:
+  each of those three rules was defensible against the case that motivated it,
+  and the bug was in what they left behind together — check a rule against the
+  empty case too, and check it on screen, because this one read as sound
+  reasoning in the diff twice running.
+- **A mark that carries its own colour needs no plate; a monochrome one does.**
+  `.surface-logo-chip` paints an opaque near-white tile under a third-party mark
+  in *both* appearances, and §1 defends that as a deliberate divergence — which
+  it is, for GitHub, whose black mark would otherwise vanish on dark stock. It
+  is not a rule about third-party marks in general. Telegram, Slack and WhatsApp
+  each carry their own colour and read on any ground, so on home's presence line
+  the plate did nothing but paste three near-white tiles into a row that was
+  otherwise the page's own colours — the one thing there that belonged to
+  neither appearance. Those marks now sit unplated, and the negative-margin
+  stack goes with the plate: an overlap only reads as a stack when each tile has
+  an opaque edge to overlap onto, and without one the logos clip each other.
+  Reach for the chip when the mark is monochrome, not when it is third-party.
+- **Agents are not a band on home.** The composer's own agent picker is the
+  selector, on home and on every conversation screen, so a cast strip beside
+  the apps panel would be a third place to choose the same thing. Apps stay:
+  the sidebar rail is a launcher and an app card is a destination, which is not
+  the same object.
 
 ## 8. Buttons & Action Hierarchy
 

--- a/lemma-frontend/lib/assistant/__tests__/sidebar-conversations.test.ts
+++ b/lemma-frontend/lib/assistant/__tests__/sidebar-conversations.test.ts
@@ -2,10 +2,11 @@ import { describe, expect, it } from 'vitest';
 
 import {
     filterSidebarConversations,
+    getConversationMark,
     mergeSidebarConversations,
     SIDEBAR_CONVERSATION_LIMIT,
 } from '@/lib/assistant/sidebar-conversations';
-import type { Conversation } from '@/lib/types';
+import type { Agent, Conversation } from '@/lib/types';
 
 function conversation(
     id: string,
@@ -119,5 +120,43 @@ describe('filterSidebarConversations', () => {
     it('matches untitled conversations by their fallback label', () => {
         const result = filterSidebarConversations(conversations, 'untitled');
         expect(result.map((item) => item.id)).toEqual(['c']);
+    });
+});
+
+describe('getConversationMark', () => {
+    const agent = { id: 'agent-1', name: 'socratic-guide', icon_url: null } as Agent;
+    const agentsById = new Map<string, Agent>([[agent.id, agent]]);
+
+    it('gives an unattributed conversation the assistant mark', () => {
+        // No `agent_id` is Lem answering, which is the common
+        // case in any pod's history — not a missing value to fall back from.
+        const mark = getConversationMark(conversation('c1', '2026-08-20T10:00:00Z'), agentsById);
+
+        expect(mark).toEqual({ kind: 'assistant' });
+    });
+
+    it("gives an agent conversation that agent's face", () => {
+        const mark = getConversationMark(
+            conversation('c1', '2026-08-20T10:00:00Z', { agent_id: 'agent-1' }),
+            agentsById,
+        );
+
+        expect(mark).toEqual({
+            kind: 'agent',
+            seed: 'socratic-guide',
+            label: 'Socratic guide',
+            iconUrl: null,
+        });
+    });
+
+    it('draws nothing for an agent it cannot resolve', () => {
+        // A deleted agent, or a list that has not arrived. Seeding a face from
+        // the raw id would draw a stranger with the confidence of a real one.
+        const mark = getConversationMark(
+            conversation('c1', '2026-08-20T10:00:00Z', { agent_id: 'agent-gone' }),
+            agentsById,
+        );
+
+        expect(mark).toBeNull();
     });
 });

--- a/lemma-frontend/lib/assistant/sidebar-conversations.ts
+++ b/lemma-frontend/lib/assistant/sidebar-conversations.ts
@@ -1,4 +1,5 @@
-import type { Conversation } from '@/lib/types';
+import type { Agent, Conversation } from '@/lib/types';
+import { formatAgentName } from '@/lib/utils/agents';
 
 /**
  * How many conversations the sidebar shows. It is a recency preview, not the
@@ -71,4 +72,38 @@ export function filterSidebarConversations(
 
     return conversations.filter((conversation) =>
         (conversation.title || 'Untitled conversation').toLowerCase().includes(needle));
+}
+
+/* Who a conversation was with, as the row's leading mark. The pod's history
+   mixes responders — the assistant answers most of it, an agent answers the
+   rest — and a list that shows only titles cannot tell you which, so two runs
+   both called "hey" are indistinguishable. */
+export type ConversationMark =
+    | { kind: 'assistant' }
+    | { kind: 'agent'; seed: string; label: string; iconUrl?: string | null };
+
+/**
+ * A conversation with no `agent_id` was answered by Lem — that is
+ * the default responder, not a missing value — so it takes the assistant's own
+ * mark rather than falling through to the dot. An id we cannot resolve does
+ * fall through: the agent was deleted, or the list has not arrived, and
+ * inventing a seeded face for an unknown id would draw a stranger with the
+ * confidence of a real one.
+ */
+export function getConversationMark(
+    conversation: Conversation,
+    agentsById: Map<string, Agent>,
+): ConversationMark | null {
+    const agentId = conversation.agent_id;
+    if (!agentId) return { kind: 'assistant' };
+
+    const agent = agentsById.get(agentId);
+    if (!agent) return null;
+
+    return {
+        kind: 'agent',
+        seed: agent.name,
+        label: formatAgentName(agent.name),
+        iconUrl: agent.icon_url,
+    };
 }

--- a/lemma-frontend/lib/hooks/use-agents.ts
+++ b/lemma-frontend/lib/hooks/use-agents.ts
@@ -232,6 +232,7 @@ function normalizeAgent(raw: Record<string, unknown>): Agent {
         model_name: (raw.model_name as Agent['model_name'] | undefined) ?? rawRuntime?.model_name,
         instruction: String(raw.instruction || ''),
         input_schema: (raw.input_schema as Record<string, unknown> | undefined) || {},
+        takes_input: typeof raw.takes_input === 'boolean' ? raw.takes_input : undefined,
         output_schema: (raw.output_schema as Record<string, unknown> | undefined) || {},
         tool_sets: (raw.toolsets as Agent['tool_sets'] | undefined) || (raw.tool_sets as Agent['tool_sets'] | undefined) || [],
         toolsets: (raw.toolsets as Agent['tool_sets'] | undefined) || (raw.tool_sets as Agent['tool_sets'] | undefined) || [],

--- a/lemma-frontend/lib/hooks/use-horizontal-overflow.ts
+++ b/lemma-frontend/lib/hooks/use-horizontal-overflow.ts
@@ -1,0 +1,107 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface HorizontalOverflow {
+    /** True while content extends past either edge. */
+    overflowing: boolean;
+    /** True while there is content hidden off the left edge. */
+    hiddenLeft: boolean;
+    /** True while there is content hidden off the right edge. */
+    hiddenRight: boolean;
+}
+
+/** Sub-pixel layout means `scrollLeft` rarely lands exactly on the bound. */
+const EDGE_EPSILON = 1;
+
+/**
+ * Makes a horizontally scrolling strip usable with a mouse, and visible when it
+ * has more to show.
+ *
+ * A strip with `overflow-x: auto` and a hidden scrollbar is reachable by
+ * trackpad and by keyboard (focus scrolls its target into view) and by nothing
+ * else. On a plain wheel mouse the content past the edge is not awkward to get
+ * to — it cannot be got to at all, and hiding the scrollbar removes the last
+ * clue that it exists. Two things fix that: the wheel scrolls the strip, and
+ * the edges say when something is behind them.
+ *
+ * The wheel listener is deliberately non-passive, because translating a
+ * vertical wheel into horizontal scroll means calling `preventDefault` — and
+ * only when this strip can actually take the movement. At either end the event
+ * is left alone so the page scrolls underneath instead of the wheel dying in a
+ * strip that has nowhere left to go.
+ */
+export function useHorizontalOverflow<T extends HTMLElement>() {
+    const ref = useRef<T | null>(null);
+    const [overflow, setOverflow] = useState<HorizontalOverflow>({
+        overflowing: false,
+        hiddenLeft: false,
+        hiddenRight: false,
+    });
+
+    const measure = useCallback(() => {
+        const node = ref.current;
+        if (!node) return;
+
+        const maxScroll = node.scrollWidth - node.clientWidth;
+        setOverflow((previous) => {
+            const next: HorizontalOverflow = {
+                overflowing: maxScroll > EDGE_EPSILON,
+                hiddenLeft: node.scrollLeft > EDGE_EPSILON,
+                hiddenRight: node.scrollLeft < maxScroll - EDGE_EPSILON,
+            };
+
+            // Scroll fires continuously; re-rendering on every frame for a value
+            // that did not move is the expensive half of an edge fade.
+            if (
+                previous.overflowing === next.overflowing
+                && previous.hiddenLeft === next.hiddenLeft
+                && previous.hiddenRight === next.hiddenRight
+            ) {
+                return previous;
+            }
+            return next;
+        });
+    }, []);
+
+    useEffect(() => {
+        const node = ref.current;
+        if (!node) return;
+
+        const onWheel = (event: WheelEvent) => {
+            // A trackpad already sends horizontal intent; taking it over would
+            // double the movement and fight the gesture.
+            if (Math.abs(event.deltaX) > Math.abs(event.deltaY)) return;
+            if (event.deltaY === 0) return;
+
+            const maxScroll = node.scrollWidth - node.clientWidth;
+            if (maxScroll <= EDGE_EPSILON) return;
+
+            const target = node.scrollLeft + event.deltaY;
+            const clamped = Math.max(0, Math.min(maxScroll, target));
+            if (clamped === node.scrollLeft) return;
+
+            event.preventDefault();
+            node.scrollLeft = clamped;
+        };
+
+        node.addEventListener('wheel', onWheel, { passive: false });
+        node.addEventListener('scroll', measure, { passive: true });
+
+        const observer = new ResizeObserver(measure);
+        observer.observe(node);
+        // Tables arrive after the first paint, so the strip's own width changes
+        // without the container's — watch the content, not just the box.
+        Array.from(node.children).forEach((child) => observer.observe(child));
+
+        measure();
+
+        return () => {
+            node.removeEventListener('wheel', onWheel);
+            node.removeEventListener('scroll', measure);
+            observer.disconnect();
+        };
+    }, [measure]);
+
+    return { ref, ...overflow, remeasure: measure };
+}

--- a/lemma-frontend/lib/hooks/use-pod-automation.ts
+++ b/lemma-frontend/lib/hooks/use-pod-automation.ts
@@ -34,7 +34,7 @@ export interface PodAutomation {
 /**
  * Shared read layer for the schedules + surfaces a pod owns. Fetches each list
  * once (pod-wide) and exposes client-side grouping so agent/workflow detail
- * pages, the agents list, and the Pod Assistant view all read from the same
+ * pages, the agents list, and Lem's page all read from the same
  * cache. Pass `{ schedules: false }` / `{ surfaces: false }` to skip a fetch the
  * caller has no permission for (or does not need).
  */

--- a/lemma-frontend/lib/identity/seeded-identity.test.ts
+++ b/lemma-frontend/lib/identity/seeded-identity.test.ts
@@ -7,7 +7,11 @@ import {
     FORM_DEPTH,
     GROUNDS,
     IDENTITY_BUCKETS,
+    LEM_FORM,
+    LEM_GENES,
+    LEM_SEED,
     MOTION_PHASES,
+    RESERVED_FORM_COUNT,
     STATE_LOOKS,
     TONE_COUNT,
     hashSeed,
@@ -47,10 +51,39 @@ describe('seeded identity', () => {
         }
     });
 
-    it('has one depth overlay per form', () => {
-        expect(FORMS).toHaveLength(FORM_COUNT);
-        expect(FORM_DEPTH).toHaveLength(FORM_COUNT);
+    it('has one depth overlay per form, reserved bodies included', () => {
+        expect(FORMS).toHaveLength(FORM_COUNT + RESERVED_FORM_COUNT);
+        expect(FORM_DEPTH).toHaveLength(FORM_COUNT + RESERVED_FORM_COUNT);
         expect(CRESTS).toHaveLength(CREST_COUNT);
+    });
+
+    it('never rolls a reserved body', () => {
+        // The whole guarantee behind Lem's face: appended past the generator's
+        // range rather than carved out of it, so no seed can reach it and no
+        // agent loses a bucket to it.
+        for (let index = 0; index < 2000; index += 1) {
+            expect(identityGenes(`seed-${index}`).form).toBeLessThan(FORM_COUNT);
+        }
+    });
+
+    it('draws the reserved creature for the reserved seed, and only for it', () => {
+        expect(identityGenes(LEM_SEED)).toEqual(LEM_GENES);
+        expect(LEM_GENES.form).toBe(LEM_FORM);
+        expect(FORMS[LEM_GENES.form]).toBeTypeOf('string');
+        expect(FORM_DEPTH[LEM_GENES.form]).toBeTypeOf('string');
+        // Lem is the same creature in every pod — that is the point of it being
+        // the responder you already know — so the seed must not be reachable by
+        // a resource id or an agent name that happens to collide.
+        expect(identityGenes('lem')).not.toEqual(LEM_GENES);
+        expect(identityGenes('Lem')).not.toEqual(LEM_GENES);
+    });
+
+    it('keeps the reserved eyes inside the reserved body', () => {
+        // The plinth carries its mass high and pinches at the waist, so the
+        // seeded eye band (48-55) would have put the eyes on the neck.
+        const outerEdge = 50 + LEM_GENES.eyeSpacing + LEM_GENES.eyeR * 1.24;
+        expect(outerEdge).toBeLessThan(80);
+        expect(LEM_GENES.eyeY + LEM_GENES.eyeR * 1.12).toBeLessThan(60);
     });
 
     it('starts every crest below the surface of every form', () => {

--- a/lemma-frontend/lib/identity/seeded-identity.ts
+++ b/lemma-frontend/lib/identity/seeded-identity.ts
@@ -26,6 +26,18 @@ export const FORM_COUNT = 8;
 export const CREST_COUNT = 4;
 
 /**
+ * Bodies past `FORM_COUNT` that the generator never draws.
+ *
+ * Reserved rather than carved out of the seeded range on purpose: taking index
+ * 7 back would have cost the roster twenty buckets (160 → 140) to identify one
+ * creature, which is a bad trade in a system whose whole problem is collisions.
+ * Appending costs nothing — the generator still rolls 0–7 and every agent's face
+ * is bit-for-bit what it was before this existed.
+ */
+export const RESERVED_FORM_COUNT = 1;
+export const LEM_FORM = FORM_COUNT;
+
+/**
  * 160 visually-distinct buckets at sidebar size, where the eyes are too small
  * to separate anything and only tone, silhouette and crest survive.
  *
@@ -111,7 +123,48 @@ export function identitySeed(...parts: Array<string | null | undefined>): string
     return parts.filter(Boolean).join('/');
 }
 
+/**
+ * The pod's default responder is the same creature in every pod, so its genes
+ * are written down rather than rolled.
+ *
+ * A seeded face would have been wrong twice over: it would introduce a stranger
+ * on the one row that is meant to be the responder you already know, and it
+ * would be a different stranger in every pod. The previous answer — the Lemma
+ * trademark on a tinted tile — was wrong differently: it drew the pod's most
+ * capable agent in the treatment reserved for *inert* things, so the being with
+ * the most agency in the system was the one being that could not open its eyes,
+ * carry a state pip, or move. `design.md` had to write a special rule for the
+ * recents list to work around it.
+ *
+ * The values sit mid-range on every axis the generator varies, so Lem stands in
+ * a lineup as one of the cast rather than as an outsized mascot. Its body is the
+ * one thing no agent can borrow.
+ */
+export const LEM_SEED = '__lem__';
+
+export const LEM_GENES: IdentityGenes = {
+    tone: 0,
+    form: LEM_FORM,
+    // No crest. The reserved body has a concave waist, and a crest anchors to
+    // the top-centre expecting a solid convex crown to rise out of.
+    crest: 0,
+    eyeSpacing: 14,
+    // Higher than the seeded 48–55, because the plinth carries its mass up top:
+    // eyes at 51 would sit on the waist rather than in the face.
+    eyeY: 46,
+    eyeR: 9,
+    ground: 0,
+    groundRotation: 0,
+    phase: 0,
+};
+
 export function identityGenes(seed: string): IdentityGenes {
+    // One reserved seed, checked before the hash. Everything downstream — the
+    // sidebar row, the front door, the transcript avatar — draws Lem by passing
+    // this seed to the same `being` renderer every agent uses, so there is no
+    // second code path to keep in step with the first.
+    if (seed === LEM_SEED) return LEM_GENES;
+
     const random = makeRandom(hashSeed(seed));
     return {
         tone: Math.floor(random() * TONE_COUNT),
@@ -140,6 +193,22 @@ export const FORMS: readonly string[] = [
     'M50 10a34 34 0 0 1 34 34v18a34 34 0 0 1-68 0V44A34 34 0 0 1 50 10Z',
     'M14 22a7 7 0 0 1 7-7h58a7 7 0 0 1 7 7v32a36 36 0 0 1-72 0Z',
     'M50 14.4 89.6 54 50 93.6 10.4 54Z',
+    /*
+     * Index 8 — reserved for Lem, never rolled. See `RESERVED_FORM_COUNT`.
+     *
+     * All eight seeded bodies are convex; this one is not. That is the entire
+     * distinction, and it is deliberately the only one: Lem keeps the cast's
+     * tone, its light, its eyes and its pip, so it reads as one of them, and it
+     * is told apart by the single channel that survives the shrink to a 20px
+     * transcript avatar. Colour cannot do that job — an agent may roll tone 0
+     * too — and a crest cannot, because the visible band above a body is only
+     * about eight units tall and detail dies there first.
+     *
+     * Concavity is also the one property the generator can never reach by
+     * accident, so this is a guarantee rather than a low probability: adding a
+     * ninth convex blob would have left Lem one unlucky hash away from a twin.
+     */
+    'M50 8C70 8 86 24 86 44C86 58 70 62 70 72H80A8 8 0 0 1 88 80V86A8 8 0 0 1 80 94H20A8 8 0 0 1 12 86V80A8 8 0 0 1 20 72H30C30 62 14 58 14 44C14 24 30 8 50 8Z',
 ];
 
 /**
@@ -172,6 +241,10 @@ export const FORM_DEPTH: readonly string[] = [
     '<rect x="12" width="22" height="100" fill="#fff" opacity=".13"/><rect x="64" width="26" height="100" fill="#000" opacity=".13"/>',
     '<circle cx="26" cy="20" r="44" fill="#fff" opacity=".12"/><circle cx="80" cy="82" r="48" fill="#000" opacity=".12"/>',
     '<path d="M50 14.4 89.6 54 50 93.6Z" fill="#000" opacity=".12"/><path d="M50 14.4 10.4 54 50 93.6Z" fill="#fff" opacity=".11"/><path d="M50 14.4v79.2" stroke="#000" stroke-opacity=".12" stroke-width="1.4" fill="none"/>',
+    /* Lem. A round body takes the oversized offset circles, for the same reason
+       the other round forms do — a half-plane would lay a hard stripe across the
+       curve. Same sun, upper left, as all eight. */
+    '<circle cx="26" cy="26" r="46" fill="#fff" opacity=".12"/><circle cx="80" cy="88" r="46" fill="#000" opacity=".12"/>',
 ];
 
 /**

--- a/lemma-frontend/lib/pods/new-pod-conversation.test.ts
+++ b/lemma-frontend/lib/pods/new-pod-conversation.test.ts
@@ -95,7 +95,7 @@ describe('the first ten minutes are paced, in order', () => {
         expect(instructions).toContain('lemma-widget');
     });
 
-    it('binds the bot to the pod assistant, so no agent has to exist first', () => {
+    it('binds the bot to Lem, so no agent has to exist first', () => {
         expect(firstRun()).toContain('Pass no `--agent`');
     });
 

--- a/lemma-frontend/lib/pods/workspace-tabs.test.ts
+++ b/lemma-frontend/lib/pods/workspace-tabs.test.ts
@@ -49,14 +49,8 @@ describe('pod workspace tabs', () => {
                 title: 'Pricing follow-up',
                 status: null,
             },
-            {
-                id: 'app:quote-desk',
-                kind: 'app',
-                resourceId: 'quote-desk',
-                title: 'Quote Desk',
-                icon: 'Q',
-                url: 'https://quote.example.com',
-            },
+            // The pinned app tab above is left behind on purpose: apps live in
+            // the sidebar rail now, and stored app tabs are dropped at the door.
         ]);
     });
 
@@ -122,40 +116,22 @@ describe('pod workspace tabs', () => {
         });
     });
 
-    it('pins every installed app before the working set', () => {
+    it('drops app tabs outright, even for apps that still exist', () => {
         const conversation = conversationWorkspaceTab('conv-1', { title: 'First', status: 'completed' });
-        const staleApp = appWorkspaceTab({ slug: 'old-app', title: 'Old App' });
+        // This app's page still exists — the tab is dropped anyway, because
+        // apps live in the sidebar rail now and the strip never holds them.
+        const openApp = appWorkspaceTab({ slug: 'quote-desk', title: 'Quote Desk' });
         const staleAppRoute = routeWorkspaceTab(
             'apps',
-            'Old App',
-            '/pod/pod-1/app/view?page=old-app',
+            'Quote Desk',
+            '/pod/pod-1/app/view?page=quote-desk',
         );
-        const pages = [
-            { slug: 'morning-brief', title: 'Morning Brief', icon: 'M', order: 0, path: '' },
-            { slug: 'quote-desk', title: 'Quote Desk', icon: 'Q', order: 1, path: '' },
-        ];
 
-        // Tabs hold what someone opened, so syncing must not open anything:
-        // `pages` here has two apps and neither becomes a tab. The stale app tab
-        // is dropped because its app is gone, and the duplicate route goes too.
         expect(syncAppWorkspaceTabs(
-            [HOME_WORKSPACE_TAB, staleApp, conversation, staleAppRoute],
-            pages,
+            [HOME_WORKSPACE_TAB, openApp, conversation, staleAppRoute],
         )).toEqual([
             HOME_WORKSPACE_TAB,
             conversation,
-        ]);
-    });
-
-    it('keeps an open app tab and refreshes its title', () => {
-        const pages = [
-            { slug: 'quote-desk', title: 'Quote Desk Renamed', icon: 'Q', order: 0, path: '' },
-        ];
-        const open = appWorkspaceTab({ slug: 'quote-desk', title: 'Quote Desk' });
-
-        expect(syncAppWorkspaceTabs([HOME_WORKSPACE_TAB, open], pages)).toEqual([
-            HOME_WORKSPACE_TAB,
-            appWorkspaceTab(pages[0]),
         ]);
     });
 
@@ -208,8 +184,10 @@ describe('pod workspace tabs', () => {
 
     it('uses routes as the active-tab source of truth', () => {
         expect(getActiveWorkspaceTabId('pod-1', '/pod/pod-1')).toBe('home');
+        // The focused app yields its ephemeral tab id — rendered while viewed,
+        // never stored. A slug-less viewer has no app to mark.
         expect(getActiveWorkspaceTabId('pod-1', '/pod/pod-1/app/view', 'quote-desk')).toBe('app:quote-desk');
-        expect(getActiveWorkspaceTabId('pod-1', '/pod/pod-1/app/view')).toBe('route:apps');
+        expect(getActiveWorkspaceTabId('pod-1', '/pod/pod-1/app/view')).toBeNull();
         expect(getActiveWorkspaceTabId('pod-1', '/pod/pod-1/app/pages')).toBe('route:apps');
         expect(getActiveWorkspaceTabId('pod-1', '/pod/pod-1/data/projects')).toBe('route:data');
         expect(getActiveWorkspaceTabId('pod-1', '/pod/pod-1/datastores/default')).toBe('route:data');

--- a/lemma-frontend/lib/pods/workspace-tabs.ts
+++ b/lemma-frontend/lib/pods/workspace-tabs.ts
@@ -162,42 +162,31 @@ export function upsertWorkspaceTab(tabs: PodWorkspaceTab[], tab: PodWorkspaceTab
 }
 
 export function closeWorkspaceTab(tabs: PodWorkspaceTab[], tabId: string) {
-    // Home is the only tab that cannot be closed. App tabs used to be
-    // uncloseable too, which only made sense while they were pinned for you
-    // rather than opened by you.
+    // Home is the only tab that cannot be closed.
     if (tabId === HOME_WORKSPACE_TAB.id) return tabs;
     const next = tabs.filter((tab) => tab.id !== tabId);
     return next.length === tabs.length ? tabs : next;
 }
 
 /**
- * Keep the open app tabs honest. Do not open any.
+ * Apps are not tabs — they live in the sidebar rail, one click from anywhere.
  *
- * Every app in the pod used to be pinned here the moment its pages loaded, and
- * `closeWorkspaceTab` refused to close them — so the strip was a second,
- * permanent copy of the apps index that grew with the pod and could not be
- * dismissed. Four apps cost four tabs before you had opened anything.
- *
- * Tabs hold what someone opened. Opening an app still adds its tab, from the
- * active-tab effect in `use-pod-workspace-tabs`; all this does is drop tabs
- * whose app has since been deleted and refresh the titles of the rest.
+ * The strip used to pin every installed app the moment its pages loaded, and
+ * `closeWorkspaceTab` refused to close them: a second, permanent copy of the
+ * apps index that grew with the pod. Then it held only apps someone had
+ * opened. Now the rail answers "what apps does this pod have" and marks the
+ * one you are on, so the strip drops app tabs outright — the legacy pinned
+ * ones, and the leftover route tabs aimed at the viewer that duplicated
+ * them. It never opens anything.
  */
-export function syncAppWorkspaceTabs(tabs: PodWorkspaceTab[], pages: AppPageRef[]) {
-    const bySlug = new Map(pages.map((page) => [page.slug, page]));
-    const kept: PodWorkspaceTab[] = [];
-
-    for (const tab of tabs) {
-        if (tab.kind === 'home') continue;
-        // A leftover route tab aimed at the app viewer duplicates the app tab.
-        if (tab.kind === 'route' && tab.resourceId === 'apps' && tab.href.includes('/app/view')) continue;
-        if (tab.kind === 'app') {
-            const page = bySlug.get(tab.resourceId);
-            if (!page) continue;
-            kept.push(appWorkspaceTab(page));
-            continue;
-        }
-        kept.push(tab);
-    }
+export function syncAppWorkspaceTabs(tabs: PodWorkspaceTab[]) {
+    const kept = tabs.filter((tab) => {
+        if (tab.kind === 'home') return false;
+        if (tab.kind === 'app') return false;
+        // A leftover route tab aimed at the app viewer duplicated the app tab.
+        if (tab.kind === 'route' && tab.resourceId === 'apps' && tab.href.includes('/app/view')) return false;
+        return true;
+    });
 
     const next: PodWorkspaceTab[] = [HOME_WORKSPACE_TAB, ...kept];
     if (next.length !== tabs.length) return next;
@@ -297,23 +286,13 @@ export function parseWorkspaceTabs(value: string | null): PodWorkspaceTab[] {
                 }
                 continue;
             }
-            if (!resourceId || (kind !== 'app' && kind !== 'route' && kind !== 'conversation')) continue;
+            // App tabs from before the rail existed are dropped at the door:
+            // they are not restored, and `syncAppWorkspaceTabs` clears any
+            // that arrive by another path.
+            if (!resourceId || (kind !== 'route' && kind !== 'conversation')) continue;
 
             const id = `${kind}:${resourceId}`;
             if (seen.has(id)) continue;
-
-            if (kind === 'app') {
-                seen.add(id);
-                tabs.push({
-                    id: `app:${resourceId}`,
-                    kind: 'app',
-                    resourceId,
-                    title: cleanLabel(candidate.title, formatWorkspaceAppTitle(resourceId)),
-                    icon: typeof candidate.icon === 'string' ? candidate.icon : null,
-                    url: typeof candidate.url === 'string' ? candidate.url : null,
-                });
-                continue;
-            }
 
             if (kind === 'route') {
                 const href = typeof candidate.href === 'string'
@@ -391,8 +370,16 @@ export function getActiveWorkspaceTabId(
 ): string | null {
     if (pathname === `/pod/${podId}` || pathname === `/pod/${podId}/`) return HOME_WORKSPACE_TAB.id;
 
+    // The open app's tab is ephemeral: the strip renders it while the viewer
+    // is focused, so it still marks where you are — but it is derived for
+    // display in `use-pod-workspace-tabs` and never written into the store,
+    // so navigating away takes it with you. Apps live in the sidebar rail,
+    // not in the persisted working set.
     if (pathname.startsWith(`/pod/${podId}/app/view`) && appSlug) {
         return `app:${appSlug}`;
+    }
+    if (pathname.startsWith(`/pod/${podId}/app/view`)) {
+        return null;
     }
 
     const conversationPrefix = `/pod/${podId}/conversations/`;

--- a/lemma-frontend/lib/surfaces/__tests__/agent-email.test.ts
+++ b/lemma-frontend/lib/surfaces/__tests__/agent-email.test.ts
@@ -30,9 +30,9 @@ describe('the address an agent is about to get', () => {
         expect(slugify(null, 'pod')).toBe('pod');
     });
 
-    // The pod assistant is the absence of an agent, not an unset field: it is
+    // Lem is the absence of an agent, not an unset field: it is
     // the pod answering, so it gets the pod's own name and no agent half.
-    it('gives the pod assistant the pod name alone', () => {
+    it('gives Lem the pod name alone', () => {
         expect(buildAgentEmailPreview({ agentName: null, podName: 'Acme', domain: DOMAIN }))
             .toBe('acme@ops.lemma.work');
     });

--- a/lemma-frontend/lib/surfaces/__tests__/registry.test.ts
+++ b/lemma-frontend/lib/surfaces/__tests__/registry.test.ts
@@ -5,6 +5,7 @@ import {
     getSurfaceDefinition,
     SURFACE_PLATFORM_ORDER,
 } from '@/lib/surfaces/registry';
+import { DEFAULT_RESPONDER_NAME } from '@/lib/utils/agents';
 
 describe('surface registry', () => {
     it('resolves a definition regardless of casing', () => {
@@ -71,8 +72,8 @@ describe('surface registry', () => {
         }
     });
 
-    it('names the agent in second-person copy, and the pod assistant otherwise', () => {
+    it('names the agent in second-person copy, and the default responder otherwise', () => {
         expect(forAgent('Make {agent} reachable', 'Ops')).toBe('Make Ops reachable');
-        expect(forAgent('Make {agent} reachable', null)).toBe('Make the pod assistant reachable');
+        expect(forAgent('Make {agent} reachable', null)).toBe(`Make ${DEFAULT_RESPONDER_NAME} reachable`);
     });
 });

--- a/lemma-frontend/lib/surfaces/agent-email.ts
+++ b/lemma-frontend/lib/surfaces/agent-email.ts
@@ -41,7 +41,7 @@ function trimSeparators(value: string): string {
  *
  * The agent slug is the identifying half, so when the budget is tight the pod
  * slug is truncated first and the agent name is what survives. `agentName: null`
- * is the pod assistant, which gets the pod slug alone: the assistant is not one
+ * is Lem, which gets the pod slug alone: Lem is not one
  * agent among several, it is the pod answering.
  */
 export function buildLocalPart({

--- a/lemma-frontend/lib/surfaces/registry.ts
+++ b/lemma-frontend/lib/surfaces/registry.ts
@@ -1,6 +1,7 @@
 import { Mail, type LemmaIcon } from '@/components/ui/icons';
 
 import type { SurfacePlatformValue } from '@/lib/hooks/use-pod-surfaces';
+import { DEFAULT_RESPONDER_NAME } from '@/lib/utils/agents';
 
 /**
  * What each surface platform needs from the setup UI, in one place.
@@ -303,5 +304,5 @@ export function getSurfaceDefinition(
 
 /** Substitutes the agent's name into registry copy. `null` = the pod default. */
 export function forAgent(copy: string, agentName: string | null): string {
-    return copy.replaceAll('{agent}', agentName || 'the pod assistant');
+    return copy.replaceAll('{agent}', agentName || DEFAULT_RESPONDER_NAME);
 }

--- a/lemma-frontend/lib/types/index.ts
+++ b/lemma-frontend/lib/types/index.ts
@@ -250,6 +250,14 @@ export type Agent = Omit<SdkAgent, 'agent_runtime' | 'input_schema' | 'output_sc
   agent_runtime?: SdkAgent['agent_runtime'];
   harness_kind?: string;
   input_schema: Record<string, unknown>;
+  /**
+   * Whether the agent declares typed inputs. The list endpoint omits
+   * `input_schema` entirely (`AgentSummaryResponse` is deliberately lean), so
+   * `input_schema` is always `{}` on a listed agent and cannot answer this.
+   * The server sends the boolean instead. Optional because an older backend
+   * will not send it, and the callers that filter on it must fail open.
+   */
+  takes_input?: boolean;
   model_name?: AgentRuntime['model_name'];
   output_schema: Record<string, unknown>;
   tool_sets: ToolSet[];

--- a/lemma-frontend/lib/utils/__tests__/surfaces.test.ts
+++ b/lemma-frontend/lib/utils/__tests__/surfaces.test.ts
@@ -73,7 +73,7 @@ describe('surface reaches', () => {
             kind: 'dm',
             detail: '2 people chose this agent',
         });
-        // Choosing the pod assistant is stored, so it reaches too.
+        // Choosing Lem is stored, so it reaches too.
         expect(surfaceAnswersDirectMessages(surface, null)).toBe(true);
     });
 
@@ -83,7 +83,7 @@ describe('surface reaches', () => {
             { channel_id: 'C9', channel_name: 'general' },
         ]);
 
-        // Explicit: the pod assistant answers, and no agent does.
+        // Explicit: Lem answers, and no agent does.
         expect(surfaceReaches(surface, null).map((reach) => reach.label)).toEqual(['#asks']);
         expect(surfaceReachesDefaultAgent(surface)).toBe(true);
         // Unset: falls to the surface default, which is a *different* answer.

--- a/lemma-frontend/lib/utils/agents.ts
+++ b/lemma-frontend/lib/utils/agents.ts
@@ -1,6 +1,37 @@
 import { humanizeName } from '@/lib/utils/display-name';
 
 /**
+ * What the pod's default responder is called, everywhere a person can see it.
+ *
+ * It had five names — "Pod Assistant" in the sidebar and on its own page,
+ * "Lemma Assistant" in the dock and the conversation list, "Pod assistant" in
+ * the Slack pickers, `pod_default` on the wire and "the default agent" in the
+ * product spec — for one actor that answers most of a pod's conversations.
+ *
+ * "Assistant" could not be the fix. [docs/product/README.md] fixes the product's
+ * nouns against the analytics event catalog, and `assistant` is not among them
+ * and appears nowhere in any journey; adopting it would have meant amending an
+ * enforced vocabulary to add a *category* that competes with `agent`. A proper
+ * name needs no such amendment — Lem is an instance, the way someone's own
+ * agent is `triage` — and it is the only form that reads in the first person on
+ * the front door, where "Hey, I'm Pod Assistant" was a job title introducing
+ * itself.
+ *
+ * A *lemma* is the step proved so the real result can happen, which is the job.
+ * This is display copy only: `pod_default`, `POD_DEFAULT` and
+ * `__pod_assistant__` are wire values and stay exactly as they are.
+ */
+export const DEFAULT_RESPONDER_NAME = 'Lem';
+
+/**
+ * What Lem says it does, in its own voice. Lives here rather than on the page
+ * so the front door, the agents index and the dock cannot drift apart.
+ */
+export const DEFAULT_RESPONDER_DESCRIPTION =
+    "This pod's most capable agent. Ask me to add a table, build a workflow, spin up an agent, "
+    + 'connect a surface, or read and change your data — I act on the pod directly.';
+
+/**
  * "customer-support_bot" → "Customer support bot" — for displaying an agent's
  * (slug-like) name as readable text. Never use this for hrefs, API calls,
  * or anywhere else the raw name is the identifier — display only.
@@ -11,4 +42,22 @@ import { humanizeName } from '@/lib/utils/display-name';
  */
 export function formatAgentName(name: string): string {
     return humanizeName(name);
+}
+
+/**
+ * Whether an agent declares typed inputs — the line between an agent that is
+ * *called* with arguments and one that is *talked to*.
+ *
+ * This is the same distinction the server publishes as `takes_input` on the
+ * agent summary, and the two are not interchangeable: the list endpoint omits
+ * `input_schema` entirely, so anything holding a *listed* agent must read the
+ * boolean, and only a fully fetched agent can be asked this directly.
+ */
+export function agentTakesInput(agent: { input_schema?: unknown } | null | undefined): boolean {
+    const schema = agent?.input_schema;
+    if (!schema || typeof schema !== 'object') return false;
+
+    const properties = (schema as { properties?: unknown }).properties;
+    return Boolean(properties && typeof properties === 'object'
+        && Object.keys(properties as Record<string, unknown>).length > 0);
 }

--- a/lemma-frontend/lib/utils/resource-icon-value.test.ts
+++ b/lemma-frontend/lib/utils/resource-icon-value.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
     formatIdentityIcon,
+    identityHueClass,
     identityVariantSeed,
     isResourceIconGlyph,
     parseResourceIcon,
@@ -94,5 +95,44 @@ describe('generated identity variants', () => {
     it('does not mistake a real url or emoji for a variant', () => {
         expect(parseResourceIcon('https://cdn.example.com/a.png')?.kind).toBe('url');
         expect(parseResourceIcon('🦊')?.kind).toBe('glyph');
+    });
+});
+
+describe('identityHueClass', () => {
+    it('names one of the five sanctioned hue classes', () => {
+        expect(identityHueClass(null, 'agent-1')).toMatch(/^lm-identity-hue-[0-4]$/);
+    });
+
+    it('is stable for the same seed and differs across seeds only as buckets allow', () => {
+        expect(identityHueClass(null, 'agent-1')).toBe(identityHueClass(null, 'agent-1'));
+        // Not a guarantee of difference, just that the class is derived from
+        // the seed at all: enough seeds must produce more than one hue.
+        const hues = new Set(
+            Array.from({ length: 20 }, (_, i) => identityHueClass(null, `agent-${i}`)),
+        );
+        expect(hues.size).toBeGreaterThan(1);
+    });
+
+    it('follows a chosen variant, so the row and the face draw the same hue', () => {
+        // Find a variant that changes the hue, then require the class to track
+        // it — a row that ignored the variant would trim itself in the colour
+        // of a face the resource no longer wears.
+        const base = identityHueClass(null, 'agent-1');
+        const shifted = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            .map((variant) => identityHueClass(formatIdentityIcon(variant), 'agent-1'))
+            .find((hue) => hue !== base);
+        expect(shifted).toBeDefined();
+        expect(identityHueClass(formatIdentityIcon(3), 'agent-1')).toBe(
+            identityHueClass(null, 'agent-1#3'),
+        );
+    });
+
+    it('keeps the resource hue under a picture or glyph icon', () => {
+        // The identity is not drawn then, but the trim hue must stay the
+        // resource's own — derived from the seed, not from the icon's shape.
+        expect(identityHueClass('https://cdn.example.com/a.png', 'agent-1')).toBe(
+            identityHueClass(null, 'agent-1'),
+        );
+        expect(identityHueClass('🦊', 'agent-1')).toBe(identityHueClass(null, 'agent-1'));
     });
 });

--- a/lemma-frontend/lib/utils/resource-icon-value.ts
+++ b/lemma-frontend/lib/utils/resource-icon-value.ts
@@ -16,6 +16,8 @@
  * a real `icon_emoji` field exists, this is the only file that changes.
  */
 
+import { identityGenes } from '@/lib/identity/seeded-identity';
+
 /**
  * Everything a bare-glyph icon is allowed to be made of. U+200D (zero-width
  * joiner) and U+FE0F (variation selector-16) are written as escapes on
@@ -108,4 +110,59 @@ export function parseResourceIcon(value?: string | null): ResourceIconValue | nu
 /** Convenience for inputs that only want to know whether to keep a value. */
 export function isResourceIconGlyph(value?: string | null): boolean {
     return parseResourceIcon(value)?.kind === 'glyph';
+}
+
+/**
+ * The class that puts a resource's hue on a *container*.
+ *
+ * `ResourceIcon` keeps the generated identity inside its own box, but the row
+ * around the box — a sidebar rail row, say — wants trim in the same hue: a
+ * hover wash, an active bar, a glow. The `lm-identity-hue-*` classes carry
+ * only the custom properties, never `color`, so the label beside the icon
+ * keeps the app's ink while the trim answers in the resource's own colour.
+ * The seed arithmetic mirrors `ResourceIcon` exactly, variant included, or the
+ * row and the face would disagree about which hue is theirs.
+ */
+export function identityHueClass(iconValue: string | null | undefined, baseSeed: string): string {
+    const icon = parseResourceIcon(iconValue);
+    const variant = icon?.kind === 'identity' ? icon.variant : 0;
+    return `lm-identity-hue-${identityGenes(identityVariantSeed(baseSeed, variant)).tone}`;
+}
+
+/**
+ * Faces that actually look different from each other.
+ *
+ * Taking variants 0…N straight off the counter draws whatever the hash happens
+ * to give, which in practice meant four near-identical violet squircles in a
+ * row — a choice between things you cannot tell apart is not a choice. Walking
+ * further up the counter and keeping only the first face of each tone-and-form
+ * pair costs nothing and makes a row read as a set of options.
+ *
+ * Variant 0 is always first when `skip` is 0: that is the face the resource
+ * already has, and it must stay where it was. `skip` walks past variants
+ * already offered, which is what a "more options" reshuffle needs.
+ */
+export function distinctIdentityVariants(
+    baseSeed: string,
+    count: number,
+    skip = 0,
+): number[] {
+    const chosen: number[] = [];
+    const seen = new Set<string>();
+    let skipped = 0;
+
+    for (let variant = 0; variant < 800 && chosen.length < count; variant += 1) {
+        const genes = identityGenes(identityVariantSeed(baseSeed, variant));
+        const key = `${genes.tone}|${genes.form}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        if (skipped < skip) {
+            skipped += 1;
+            continue;
+        }
+        chosen.push(variant);
+    }
+
+    return chosen;
 }

--- a/lemma-frontend/lib/utils/surfaces.ts
+++ b/lemma-frontend/lib/utils/surfaces.ts
@@ -21,7 +21,7 @@ export function getSurfaceStatus(surface: AssistantSurface): { label: string; to
 }
 
 /**
- * Stored when a person explicitly picks the pod assistant for their own DMs.
+ * Stored when a person explicitly picks Lem for their own DMs.
  *
  * Absence from the map means "never picked", which is a different answer — it
  * falls to the surface default. Mirrors `SurfaceSlackConfig.POD_ASSISTANT`.
@@ -29,15 +29,15 @@ export function getSurfaceStatus(surface: AssistantSurface): { label: string; to
 export const POD_ASSISTANT_CHOICE = '__pod_assistant__';
 
 /** The surface's default responder — whoever answers where nothing else says.
- * `null` = the pod assistant. */
+ * `null` = Lem. */
 function surfaceDefaultAgent(surface: AssistantSurface): string | null {
     return surfaceUsesDefaultAgent(surface) ? null : surface.agent_name ?? null;
 }
 
 /**
- * Who actually answers in one routed channel. `null` = the pod assistant.
+ * Who actually answers in one routed channel. `null` = Lem.
  *
- * Three states, and the order matters: the pod assistant is the *absence* of an
+ * Three states, and the order matters: Lem is the *absence* of an
  * agent, so an explicit pick has to short-circuit before the surface-default
  * fallback — otherwise choosing it silently routes to whichever agent the
  * surface happens to default to. Mirrors `_resolve_route_agent` in the backend.
@@ -58,7 +58,7 @@ export function surfaceChannelAgents(surface: AssistantSurface): Array<string | 
 
 /**
  * Slack user ids that picked this agent for their own DMs. `reachFor === null`
- * counts the people who picked the pod assistant, which is stored explicitly.
+ * counts the people who picked Lem, which is stored explicitly.
  */
 export function surfaceDirectMessageChoosers(
     surface: AssistantSurface,
@@ -91,7 +91,7 @@ export function surfaceUsesDefaultAgent(surface: AssistantSurface): boolean {
  * messages *or* routes a channel with no agent of its own.
  *
  * The channel half matters on Slack and Teams, where a workspace whose DMs
- * belong to one agent can still route `#general` to the pod assistant — which
+ * belong to one agent can still route `#general` to Lem — which
  * `surfaceUsesDefaultAgent` alone would read as "not reached here".
  */
 export function surfaceReachesDefaultAgent(surface: AssistantSurface): boolean {

--- a/lemma-frontend/scripts/design-audit-baseline.json
+++ b/lemma-frontend/scripts/design-audit-baseline.json
@@ -1,6 +1,6 @@
 {
   "informational": {
-    "rawButtonElements": 35,
+    "rawButtonElements": 41,
     "rawSwitchButtonElements": 0,
     "rawFieldElements": 3,
     "inlineEditableFieldElements": 4,
@@ -11,10 +11,10 @@
     "hoverOnlyDisplayReveal": 0,
     "fixedWidthsWiderThanPhones": 0,
     "pageBodyRepeatsResourceName": 0,
-    "rawFontSizeDeclaration": 8,
+    "rawFontSizeDeclaration": 9,
     "rawRadiusDeclaration": 0,
-    "rawSpacingDeclaration": 0,
-    "multiplePrimaryButtons": 20,
+    "rawSpacingDeclaration": 1,
+    "multiplePrimaryButtons": 19,
     "headerSlotPrimaryButtons": 0
   },
   "protectedAssistant": {

--- a/lemma-frontend/styles/features/agent-page.css
+++ b/lemma-frontend/styles/features/agent-page.css
@@ -794,3 +794,450 @@ button.agent-identity-avatar:focus-visible {
   background: currentColor;
 }
 }
+
+/* ────────────────────────────────────────────
+   THE AGENT'S FRONT DOOR
+   What the conversation shows before the first message: who this is, and the
+   places it can be reached outside this app. It centres inside the column
+   rather than the viewport — the conversation rail sits to its left, and a hero
+   centred on the window would sit visibly off-axis from the composer beneath it.
+   ──────────────────────────────────────────── */
+.agent-home {
+  display: flex;
+  /* 44rem. 34rem was a ribbon down the middle of a very wide pane; 52rem — taken
+     to match `.resource-page-column` so Configure would not shift the column —
+     bought that consistency by running conversation titles nearly edge to edge.
+     The columns are allowed to differ: hitting Configure replaces the content
+     wholesale, so a change of measure underneath it is the smaller event. */
+  max-width: 44rem;
+  flex-direction: column;
+  align-items: center;
+  margin-inline: auto;
+  gap: var(--space-3);
+  /* Asymmetric on purpose. The face is the first thing on the page and it needs
+     room above it to read as placed rather than as flush against the pane —
+     more so here than on most pages, because with the context bar gone there is
+     no chrome overhead to stand off from. */
+  padding-top: var(--space-12);
+  padding-bottom: var(--space-8);
+  text-align: center;
+}
+
+/* The page's own action, at the pane's corner rather than the column's. Inside a
+   44rem block centred in a very wide pane, "top-right of the column" is not a
+   corner — it is a point in open space with no edge to belong to, which is why
+   the button read as parked at random. Sticky, not absolute, so it stays put
+   while a long home scrolls under it. */
+.agent-home-page-actions {
+  position: sticky;
+  z-index: 1;
+  top: 0;
+  display: flex;
+  justify-content: flex-end;
+  padding: var(--space-3) var(--space-4) 0;
+}
+
+/* And the column reclaims the headroom the action row used to take, so a page
+   with Configure starts at the same height as one without. */
+.agent-home-page-actions + .agent-home {
+  padding-top: var(--space-6);
+}
+
+.agent-home-face {
+  flex: none;
+}
+
+.agent-home-greeting {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: var(--text-2xl);
+  font-weight: 500;
+  letter-spacing: -0.016em;
+  line-height: 1.2;
+}
+
+.agent-home-description {
+  margin: 0;
+  /* Held well short of the column: a sentence is read, and 52rem of it is a
+     wider line than prose wants even when the things below happily fill it. */
+  max-width: 36rem;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+}
+
+/* One row of ways in. These are the product's own argument as a control — the
+   agent is reachable where you already talk — so they are buttons, not the
+   informational chips the wiring rows draw. A platform we cannot build a link
+   for still gets named: it reaches the agent, it just cannot be opened from
+   here, and `data-static` drops the affordances that would promise otherwise. */
+.agent-home-reach {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+}
+
+.agent-home-reach-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  height: 2rem;
+  padding-inline: var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-full);
+  background: var(--surface-1);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  line-height: 1;
+  text-decoration: none;
+  transition:
+    border-color var(--dur-hover) var(--ease-standard),
+    color var(--dur-hover) var(--ease-standard);
+}
+
+.agent-home-reach-chip:hover,
+.agent-home-reach-chip:focus-visible {
+  border-color: var(--border-default);
+  color: var(--text-primary);
+}
+
+.agent-home-reach-chip[data-static="true"] {
+  color: var(--text-tertiary);
+  cursor: default;
+}
+
+.agent-home-reach-chip[data-static="true"]:hover {
+  border-color: var(--border-subtle);
+  color: var(--text-tertiary);
+}
+
+/* Pod home's ground, not the editor's. `.resource-page-scroll` sits on
+   `--bg-canvas` because it holds cards, and a card needs a darker sheet behind
+   it to read as raised. The agent's home has no cards — it is one column of
+   content, exactly like pod home — so it takes `--pod-main-bg` and the two front
+   doors of this product finally stand on the same paper. */
+.resource-page-scroll.agent-home-scroll {
+  background: var(--pod-main-bg);
+}
+
+
+/* A connect offer sits back from a working link: same shape, quieter ink, and
+   the logo at partial strength. It is an invitation, not a route you already
+   have — and the two must not look equally ready or the row stops reporting
+   which ones actually work. */
+.agent-home-reach-chip:not([data-connected="true"]):not([data-static="true"]) {
+  border-style: dashed;
+  color: var(--text-tertiary);
+}
+
+.agent-home-reach-chip:not([data-connected="true"]):not([data-static="true"]):hover,
+.agent-home-reach-chip:not([data-connected="true"]):not([data-static="true"]):focus-visible {
+  border-style: solid;
+  color: var(--text-secondary);
+}
+
+/* The box that starts something. It launches rather than hosts — sending opens
+   the conversation in its own tab — so it is sized like a starting point, not
+   like a transcript's composer: two rows, its own measure, and a line saying
+   where the answer will appear so the tab is not a surprise. */
+.agent-home-composer {
+  width: 100%;
+  margin-top: var(--space-2);
+  padding: var(--space-1);
+  text-align: left;
+}
+
+.agent-home-composer-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding-inline: var(--space-1-5);
+  padding-bottom: var(--space-1);
+}
+
+/* What it has been doing. A section of a home — one measure, left-aligned rows
+   inside a centred column — not a rail: the difference between a list on a page
+   and a second navigation column is that this one scrolls with the page. */
+.agent-home-runs {
+  width: 100%;
+  margin-top: var(--space-4);
+  text-align: left;
+}
+
+.agent-home-runs-heading {
+  margin: 0 0 var(--space-1) 0;
+  padding-inline: var(--space-2);
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  line-height: 1.25rem;
+}
+
+.agent-home-run {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  height: 2rem;
+  padding-inline: var(--space-2);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-size: 0.8125rem;
+  text-decoration: none;
+  transition:
+    background-color var(--dur-base) var(--ease-out),
+    color var(--dur-base) var(--ease-out);
+}
+
+.agent-home-run:hover,
+.agent-home-run:focus-visible {
+  background: color-mix(in srgb, var(--surface-1) 58%, transparent);
+  color: var(--text-primary);
+}
+
+.agent-home-run-time {
+  flex: none;
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+}
+
+.agent-home-run-all {
+  color: var(--text-tertiary);
+}
+
+/* Stands where the composer would, and says why there isn't one. */
+.agent-home-called {
+  margin: var(--space-2) 0 0 0;
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+}
+
+/* The run form, on the home. Boxed to the composer's footprint so a called
+   agent's home has the same shape as a conversational one — the thing that
+   starts it sits in the same place, and only its contents differ. Bounded in
+   height because a schema with many fields is a form, not a page. */
+.agent-home-run-form {
+  width: 100%;
+  text-align: left;
+}
+
+/* No border, no fill. The form is already a stack of labelled fields on a page
+   that is one column of content — boxing it added an edge that said "panel" on a
+   screen with no other panels, and the fields inside carry their own.
+   It also has no height of its own. A capped, scrolling box cut the form off at
+   26rem — which on any agent with a few fields meant clipping "Start run", so the
+   form had no way to be submitted at all. The panel is built for a dock, where a
+   fixed height and an inner scroller are right; on a page that scrolls already,
+   both are wrong, and the rules below hand the scrolling back to the page. */
+.agent-home-run-form-body,
+.agent-home-run-form-body .agent-test-panel,
+.agent-home-run-form-body .agent-test-run-start,
+.agent-home-run-form-body .agent-test-run-start > div {
+  height: auto;
+  min-height: 0;
+  overflow: visible;
+  background: transparent;
+}
+
+/* And the dock's padding goes with its height. The panel nests two boxes inside
+   the scroller — an inner that pads up to 2.5rem at the top and 3rem at the
+   bottom, then a start-panel that pads another 1.25rem and paints its own
+   gradient. Stacked under a page that has already given the form a heading and a
+   column, that reads as a panel inside a panel inside a page: the gap above the
+   first field, and the faint wash behind it. On the home the form is just the
+   fields. */
+.agent-home-run-form-body .agent-test-run-start-inner {
+  width: 100%;
+  padding: 0;
+}
+
+.agent-home-run-form-body .agent-test-start-panel {
+  padding: 0;
+  border-radius: 0;
+  background: none;
+}
+
+/* ────────────────────────────────────────────
+   MAKING ONE
+   Two panels: what you are making on the left, what you are filling in on the
+   right. Earlier passes tried a single centred stack — first with the fields
+   drawn as the result (which left them looking like headings), then as a plain
+   form (which worked and was lifeless). The preview belongs beside the form, not
+   inside it.
+   ──────────────────────────────────────────── */
+/* A page, not a dialog. This carried a border, a radius, a raised sheet and a
+   shadow — a modal's costume with none of a modal's behaviour, floating on a
+   route that has nothing behind it. A real dialog would have to render over an
+   empty page here, which is what intercepting routes are for and not worth the
+   plumbing; so it commits to being what it already is. The two columns stay:
+   they are the composition, and the composition was never the problem. */
+/* Framed, and the frame is `.resource-card` — the same hairline, radius and
+   near-stock fill every other resource page in the product uses.
+   The earlier frame was wrong for a different reason than "a frame": it was a
+   raised sheet with a shadow, floating on a route that had no header, which is a
+   dialog impersonating a page. With the bar restored, a panel under it is
+   ordinary page furniture — and without one this composition had nothing holding
+   it, two columns adrift in a very wide pane. Elevation stays paper, not glass:
+   `--shadow-xs`, the card's own, not a modal's lift. */
+.agent-create-card {
+  display: grid;
+  /* The preview column hugs its content. At 17rem it was holding a 96px face and
+     a name in the middle of 272px, so the composition read as a void with a face
+     in it and the form pushed off to the right — the "space on the left". The
+     two halves belong near each other; the panel does the containing. */
+  grid-template-columns: auto minmax(0, 24rem);
+  justify-content: center;
+  gap: var(--space-8);
+  margin: var(--space-8) auto var(--space-10);
+  max-width: 44rem;
+  border: 1px solid var(--card-border-subtle);
+  border-radius: var(--radius-xl);
+  background: var(--card-bg);
+  padding: var(--space-8) var(--space-7);
+  box-shadow: var(--shadow-xs);
+}
+
+@container resource-page (max-width: 44rem) {
+  .agent-create-card {
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--space-6);
+    margin-inline: var(--space-4);
+    padding: var(--space-6) var(--space-5);
+  }
+
+  .agent-create-preview {
+    width: 100%;
+    align-self: stretch;
+  }
+}
+
+/* No fill and no rule between the columns. A divider would draw the seam of the
+   panel that is no longer there; the gap does the separating, which is what a
+   page uses. It aligns to the top rather than centring, so the face sits level
+   with the title it belongs to instead of drifting against a column whose
+   height is decided by however many templates there happen to be. */
+/* Centred against the form, not hung from the top of the column. Top-aligned it
+   left the face stranded above a few hundred pixels of nothing — a single object
+   with no relationship to anything beside it. Levelled with the middle of the
+   fields it reads as the pair it is: this is the thing, these are its details. */
+.agent-create-preview {
+  display: flex;
+  width: 11rem;
+  flex-direction: column;
+  align-self: center;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.agent-create-preview-name {
+  margin: 0;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  color: var(--text-primary);
+  font-size: var(--text-xl);
+  font-weight: 500;
+  letter-spacing: -0.016em;
+  text-align: center;
+}
+
+.agent-create-preview-name[data-empty="true"] {
+  color: var(--text-soft);
+}
+
+.agent-create-fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.agent-create-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.agent-create-row + .agent-create-faces {
+  margin-bottom: var(--space-2);
+}
+
+.agent-create-field + .agent-create-row {
+  margin-top: var(--space-3);
+}
+
+.agent-create-reshuffle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  transition: color var(--dur-base) var(--ease-out);
+}
+
+.agent-create-reshuffle:hover,
+.agent-create-reshuffle:focus-visible {
+  color: var(--text-secondary);
+}
+
+.agent-create-faces {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.agent-create-face {
+  border-radius: var(--radius-lg);
+  padding: 2px;
+  box-shadow: 0 0 0 1.5px transparent;
+  transition:
+    box-shadow var(--dur-hover) var(--ease-out),
+    transform var(--dur-hover) var(--ease-out);
+}
+
+.agent-create-face:hover {
+  transform: translateY(-1px);
+}
+
+.agent-create-face[data-active="true"] {
+  box-shadow: 0 0 0 1.5px var(--action-primary);
+}
+
+.agent-create-field {
+  display: block;
+  width: 100%;
+  margin-top: var(--space-2);
+  text-align: left;
+}
+
+.agent-create-label {
+  display: block;
+  margin-bottom: var(--space-1-5);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 500;
+}
+
+.agent-create-row .agent-create-label {
+  margin-bottom: 0;
+}
+
+.agent-create-submit {
+  margin-top: var(--space-4);
+  width: 100%;
+}
+
+.agent-create-note {
+  margin: var(--space-1) 0 0;
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  line-height: 1.6;
+}
+
+/* Says why the faces change as the name is typed, at the weight of an aside. */
+.agent-create-hint {
+  margin-left: var(--space-2);
+  color: var(--text-tertiary);
+  font-size: var(--text-xs);
+  font-weight: 400;
+}

--- a/lemma-frontend/styles/features/builders-and-ledgers.css
+++ b/lemma-frontend/styles/features/builders-and-ledgers.css
@@ -465,12 +465,37 @@
 /* Table switcher. Lives on the left of the table toolbar, so it adds no band of
    its own. Scrolls sideways rather than wrapping — the strip must stay one line
    however many tables a pod grows. */
+/* The scrollbar stays hidden — a strip of five tabs should not carry a track
+   under it — but hiding it removed the only sign that a sixth table existed.
+   The edges carry that instead: whichever side still has content behind it
+   fades, so the strip says "there is more this way" in the place the more
+   actually is. The wheel that reaches it lives in `useHorizontalOverflow`. */
 .data-table-strip {
   scrollbar-width: none;
+  --strip-fade: 1.75rem;
+  transition: mask-image var(--dur-base) var(--ease-out);
 }
 
 .data-table-strip::-webkit-scrollbar {
   display: none;
+}
+
+.data-table-strip[data-hidden-left="true"] {
+  mask-image: linear-gradient(to right, transparent, #000 var(--strip-fade));
+}
+
+.data-table-strip[data-hidden-right="true"] {
+  mask-image: linear-gradient(to left, transparent, #000 var(--strip-fade));
+}
+
+.data-table-strip[data-hidden-left="true"][data-hidden-right="true"] {
+  mask-image: linear-gradient(
+    to right,
+    transparent,
+    #000 var(--strip-fade),
+    #000 calc(100% - var(--strip-fade)),
+    transparent
+  );
 }
 
 .data-table-workbench {

--- a/lemma-frontend/styles/features/pod-home.css
+++ b/lemma-frontend/styles/features/pod-home.css
@@ -199,10 +199,34 @@
   background: var(--border-subtle);
 }
 
-.pod-home-presence-faces,
+.pod-home-presence-faces {
+  display: inline-flex;
+  align-items: center;
+}
+
+/* Coloured brand marks, no plate. The white chip under them is for *monochrome*
+   marks — a black GitHub logo does vanish on dark stock — but Telegram, Slack
+   and WhatsApp each carry their own colour and read on any ground, so the plate
+   was doing nothing except pasting three near-white tiles into a line of prose.
+   Rule: a mark that carries its own colour needs no plate; a monochrome one
+   does. The overlap goes with the plate — a negative margin only reads as a
+   stack when each tile has an opaque edge to overlap onto, and without one the
+   logos just clip each other. */
 .pod-home-presence-surfaces {
   display: inline-flex;
   align-items: center;
+  gap: var(--space-1);
+  margin-right: 0.125rem;
+}
+
+.pod-home-presence-surface {
+  display: inline-flex;
+  width: 0.9375rem;
+  height: 0.9375rem;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.625rem;
+  color: var(--text-secondary);
 }
 
 .pod-home-presence-avatar {
@@ -234,34 +258,20 @@
   border-radius: var(--radius-sm);
 }
 
-/* Four fixed tints rather than a generated hue: a hash straight to hsl() drifts
-   into the state colours and starts implying an agent is failing. */
-.pod-home-presence-avatar-t0 { background: rgb(var(--accent-rgb)); }
-.pod-home-presence-avatar-t1 { background: var(--state-success); }
-.pod-home-presence-avatar-t2 { background: var(--state-warning); }
-.pod-home-presence-avatar-t3 { background: var(--text-secondary); }
+/* The tint comes from the identity system's tone pool (`lm-identity-tone-*`),
+   set on the avatar by `avatarToneClass`. The four fixed tints that used to live
+   here were `--accent-rgb`, `--state-success`, `--state-warning` and
+   `--text-secondary` — three state colours, under a comment explaining that the
+   pool existed to avoid exactly that. */
+.pod-home-presence-avatar {
+  background: var(--lm-identity-tone);
+}
 
 .pod-home-presence-live {
   width: 6px;
   height: 6px;
   border-radius: var(--radius-full);
   background: var(--state-success);
-}
-
-.pod-home-presence-surface {
-  display: inline-flex;
-  width: 1.1875rem;
-  height: 1.1875rem;
-  align-items: center;
-  justify-content: center;
-  margin-left: -0.25rem;
-  border-radius: var(--radius-xs);
-  font-size: 0.625rem;
-  color: var(--text-secondary);
-}
-
-.pod-home-presence-surface:first-child {
-  margin-left: 0;
 }
 
 .pod-home-work-section {
@@ -302,18 +312,9 @@
   letter-spacing: 0.02em;
 }
 
-.pod-home-work-live-dot {
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  background: var(--state-success);
-  animation: pod-live-blink 2s infinite;
-}
-
-@keyframes pod-live-blink {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.2; }
-}
+/* The live marker is the chat status pill's ping halo, rendered inline where
+   it is used — a blinking green dot said "ok" about work that is acting, and
+   violet is the colour of acting. */
 
 /* ── Single container with three sections separated by borders ── */
 .pod-home-work-panel {
@@ -346,6 +347,14 @@
 .pod-home-work-list {
   margin: 0;
   padding: 0;
+}
+
+/* The settled check a finished outcome wears — the same soft-green chip the
+   chat puts on completed work (`.lchat-pill-check-wrap`), so "this worked" is
+   the same colour in every room of the product. */
+.pod-home-outcome-check {
+  background: color-mix(in srgb, var(--state-success) 15%, transparent);
+  color: var(--state-success);
 }
 
 .pod-home-work-section-empty {

--- a/lemma-frontend/styles/features/resource-ledgers.css
+++ b/lemma-frontend/styles/features/resource-ledgers.css
@@ -1292,8 +1292,12 @@
   height: 2rem;
   flex: 0 0 auto;
   place-items: center;
-  border: 1px solid var(--border-subtle);
+  /* Adding a capability is an action, so the tile wears action violet — the
+     same soft fill the model picker's selected row and the sidebar's active
+     row use, rather than the drawer-grey it used to share with everything
+     else on the page. */
+  border: 1px solid color-mix(in srgb, var(--action-primary) 22%, transparent);
   border-radius: var(--radius-md);
-  background: var(--surface-2);
-  color: var(--text-secondary);
+  background: var(--action-primary-soft);
+  color: var(--action-primary);
 }

--- a/lemma-frontend/styles/primitives.css
+++ b/lemma-frontend/styles/primitives.css
@@ -780,11 +780,42 @@
 
 /* Icons rest one step quieter than the label beside them, then track the row
    once it is hovered or active. Without this they held `--text-tertiary` while
-   the label lit to `--text-primary`, and the row read as half-awake. */
+   the label lit to `--text-primary`, and the row read as half-awake. The
+   jewel-toned place kinds below are the deliberate exception: their colour is
+   the place's identity, so it holds in every state. */
 .lemma-sidebar-row:hover .lemma-product-icon,
 .lemma-sidebar-row:focus-visible .lemma-product-icon,
 .lemma-sidebar-row[data-active="true"] .lemma-product-icon {
   color: inherit;
+}
+
+/* The day-to-day kinds each keep their own jewel tone in every state — the
+   same accents the recipe and app tiles wear — so the nav column reads as a
+   set of named rooms, not a row of grey glyphs. The `[data-state]` in the
+   selector keeps these above the inherit-on-hover rules above on purpose:
+   colour is the kind's identity and it stays put, while the pointer is still
+   answered by motion (the glyph scale below), never by weight or fill. Setup
+   kinds (connectors, settings, …) stay ink-coloured so they recede. Agents
+   keeps its tone too, for the menus and headers that still draw the kind —
+   in the nav itself agents are a rail of faces, not a place row. */
+.lemma-product-icon[data-kind="apps"][data-state] {
+  color: var(--action-primary);
+}
+
+.lemma-product-icon[data-kind="agents"][data-state] {
+  color: var(--intelligence);
+}
+
+.lemma-product-icon[data-kind="data"][data-state] {
+  color: var(--state-success);
+}
+
+.lemma-product-icon[data-kind="docs"][data-state] {
+  color: var(--delight);
+}
+
+.lemma-product-icon[data-kind="workflows"][data-state] {
+  color: var(--collaboration);
 }
 
 /* Pointer feedback is motion, never weight or fill: every product glyph stays a
@@ -997,9 +1028,9 @@ button:focus-visible .lemma-product-icon-glyph {
   }
 }
 
-/* One scannable line per conversation: a status dot in a fixed gutter, then the
-   title. Taller and larger than the nav rows below it because this list is the
-   sidebar's body, not its chrome. */
+/* One scannable line per conversation: a leading mark, then the title. Taller
+   and larger than the nav rows below it because this list is the sidebar's
+   body, not its chrome. */
 .workspace-sidebar-conversation-row {
   cursor: pointer;
   height: 2rem;
@@ -1011,6 +1042,158 @@ button:focus-visible .lemma-product-icon-glyph {
   padding-inline: 0.625rem;
   font-size: 0.8125rem;
   line-height: 1.25rem;
+}
+
+/* A row that knows who answered draws them, and the extra 4px is the whole
+   cost. This is the fix for the sidebar's real problem: the rail was the
+   tallest band in the column and the history — the part anyone actually
+   clicks — was the shortest, so mass ran opposite to use. Raising the history
+   to meet the rail closes the gap from the end that was wrong, and the marks
+   pay for themselves: a pod whose assistant answers most runs produced a stack
+   of identical one-word titles with nothing to tell them apart.
+   The places below keep their own smaller measure. Two densities, and the line
+   between them means something — things you open, then places you browse. */
+.workspace-sidebar-conversation-row-marked {
+  height: 2.125rem;
+}
+
+.workspace-sidebar-conversation-mark {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+/* The mark says who; the pip says what this run is doing. A resting
+   conversation gets no pip — the old gutter drew a hollow ring at 2.3:1 that
+   read as dust, and "nothing is happening" is better said with nothing. */
+.workspace-sidebar-conversation-pip {
+  position: absolute;
+  right: -1px;
+  bottom: -1px;
+  width: 7px;
+  height: 7px;
+  border-radius: var(--radius-full);
+  /* Ringed in the shell ground the sidebar sits on, so the pip reads as
+     sitting on the tile rather than punched into it, on either appearance. */
+  box-shadow: 0 0 0 1.5px var(--pod-shell-bg);
+  background: var(--delight);
+}
+
+.workspace-sidebar-conversation-pip[data-tone="warning"] {
+  background: var(--state-warning);
+}
+
+.workspace-sidebar-conversation-pip[data-tone="danger"] {
+  background: var(--state-error);
+}
+
+/* Live work breathes, and it keeps the sidebar's delight-gold rather than
+   borrowing the chat's violet: same motion, same semantics as the dot it
+   replaces. */
+.workspace-sidebar-conversation-pip[data-pulse="true"]::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: var(--radius-full);
+  background: var(--delight);
+  opacity: 0.4;
+  animation: conversation-pip-ping 1s cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+
+/* Declared here rather than borrowing Tailwind's `ping`: that keyframe is only
+   emitted while some element still uses `animate-ping`, and this rule outlived
+   the row that did. */
+@keyframes conversation-pip-ping {
+  75%,
+  100% {
+    transform: scale(2);
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-sidebar-conversation-pip[data-pulse="true"]::after {
+    animation: none;
+  }
+}
+
+/* A resource rail row — an app this pod shipped or an agent who works here —
+   carries the identity tile at 32px: exactly the size a being's rich motion
+   turns on (`RICH_MOTION_MIN_SIZE`), so reaching for a row wakes its face.
+   The rail leads the sidebar, and leading it is the emphasis; the row height
+   is only what a 32px tile needs to breathe, not a second helping of it.
+   Stacked emphasis is what made this rail read as unfinished — position, then
+   size, then a tinted hover, then a coloured glow, all saying the same thing
+   about the same row.
+   The `lm-identity-hue-*` class stays for one job: the active bar. A hue that
+   paints the row under the pointer identifies nothing, because every row wears
+   it in turn; a hue on the *one* active row says who you are looking at. */
+.lemma-sidebar-row.workspace-sidebar-resource-row {
+  position: relative;
+  min-height: 2.375rem;
+  gap: var(--space-3);
+  padding-block: var(--space-1);
+  padding-inline: var(--space-2-5);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  line-height: 1.25rem;
+  transition:
+    background-color var(--dur-base) var(--ease-out),
+    color var(--dur-base) var(--ease-out),
+    transform var(--dur-base) var(--ease-out);
+}
+
+.lemma-sidebar-row.workspace-sidebar-resource-row:active {
+  transform: scale(0.99);
+}
+
+/* The active bar keeps the nav's language — same inset, same unfurl as
+   `.lemma-product-nav-item::before` — but wears the resource's own hue: the
+   violet fill says "here", the bar says "who". */
+.workspace-sidebar-resource-row::before {
+  content: "";
+  position: absolute;
+  inset: 7px auto 7px 0;
+  width: 2.5px;
+  border-radius: var(--radius-full);
+  background: var(--lm-identity-tone, var(--sidebar-active-accent, var(--action-primary)));
+  opacity: 0;
+  transform: scaleY(0.36);
+  transition:
+    opacity var(--dur-base) var(--ease-out),
+    transform var(--dur-base) var(--ease-out);
+}
+
+.workspace-sidebar-resource-row[data-active="true"]::before {
+  opacity: 0.9;
+  transform: scaleY(1);
+}
+
+/* The tile answers the pointer the way product glyphs answer theirs — motion,
+   never weight or fill. It used to cast a coloured glow as well, which is
+   weight *and* fill wearing motion's clothes: two rules for one pointer, and
+   the loudest thing in a column whose job is to stay quiet under the work. */
+.workspace-sidebar-resource-icon {
+  transition: transform var(--dur-hover) var(--ease-out);
+}
+
+.workspace-sidebar-resource-row:hover .workspace-sidebar-resource-icon,
+.workspace-sidebar-resource-row:focus-visible .workspace-sidebar-resource-icon {
+  transform: translateY(-1px) scale(1.06);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lemma-sidebar-row.workspace-sidebar-resource-row,
+  .workspace-sidebar-resource-row::before,
+  .workspace-sidebar-resource-icon {
+    transition: none;
+  }
+
+  .lemma-sidebar-row.workspace-sidebar-resource-row:active,
+  .workspace-sidebar-resource-row:hover .workspace-sidebar-resource-icon,
+  .workspace-sidebar-resource-row:focus-visible .workspace-sidebar-resource-icon {
+    transform: none;
+  }
 }
 
 .workspace-sidebar-show-more {
@@ -1052,12 +1235,18 @@ button:focus-visible .lemma-product-icon-glyph {
   opacity: 0;
 }
 
-/* The one rule in the sidebar: above it is where things live, below it is this
-   pod's history. It only has to mark the seam between two kinds of thing — the
-   change in rhythm either side already does most of that work, so the line can
-   sit well below the strength of the shell's own hairlines. */
+/* The one rule in the sidebar, and it is on the strip's *top* edge now.
+   It used to be on the bottom, back when the places sat between the agents rail
+   and the history — which meant the only line near them introduced the history
+   instead of separating them from the rail, so the strip read as the rail's
+   demoted tail. On a footer the seam belongs above: everything over the line is
+   something you open, everything under it is a place or an account. It only has
+   to mark that change, and the change in rhythm either side already does most
+   of the work, so the line sits well below the strength of the shell's own
+   hairlines. The account block below takes no second rule — one footer, one
+   seam. */
 .workspace-sidebar-places {
-  border-bottom: 1px solid
+  border-top: 1px solid
     color-mix(in srgb, var(--border-subtle) 40%, transparent);
 }
 

--- a/lemma-frontend/styles/tokens.css
+++ b/lemma-frontend/styles/tokens.css
@@ -2306,7 +2306,7 @@
   --segmented-active-bg: var(--surface-1);
   --segmented-active-fg: var(--text-primary);
   --progress-segment-bg: color-mix(in srgb, var(--delight) 56%, var(--border-default));
-  --sidebar-active-bg: var(--surface-1);
+  --sidebar-active-bg: var(--action-primary-soft);
   --sidebar-active-accent: var(--brand-primary);
 
   /* Typography — one family, product and landing.
@@ -2607,7 +2607,7 @@
   --segmented-active-bg: var(--surface-1);
   --segmented-active-fg: var(--text-primary);
   --progress-segment-bg: color-mix(in srgb, var(--delight) 62%, var(--border-default));
-  --sidebar-active-bg: var(--surface-1);
+  --sidebar-active-bg: var(--action-primary-soft);
   --sidebar-active-accent: var(--brand-primary);
 
   /* Dark violet ramp — inverted lightness */

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -13,4 +13,4 @@ SDK and the server it is talking to.
 from __future__ import annotations
 
 API_VERSION = "0.7.0"
-SPEC_SHA256 = "59ea84dfc20c5e95d9f121b93e8d5949f7b22de9887877fd2eda38e7154d9148"
+SPEC_SHA256 = "9272e1dd3f7b6b7ef4893ebe9fde16e8835d790e876444edbdcc9b99425031f4"

--- a/lemma-python/lemma_sdk/openapi_client/models/agent_summary_response.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/agent_summary_response.py
@@ -45,6 +45,7 @@ class AgentSummaryResponse:
             has_pinned_runtime (bool | Unset):  Default: False.
             icon_url (None | str | Unset):
             metadata (AgentSummaryResponseMetadataType0 | None | Unset):
+            takes_input (bool | Unset):  Default: False.
             toolsets (list[AgentToolset] | Unset):
             visibility (str | Unset):  Default: 'POD'.
     """
@@ -61,6 +62,7 @@ class AgentSummaryResponse:
     has_pinned_runtime: bool | Unset = False
     icon_url: None | str | Unset = UNSET
     metadata: AgentSummaryResponseMetadataType0 | None | Unset = UNSET
+    takes_input: bool | Unset = False
     toolsets: list[AgentToolset] | Unset = UNSET
     visibility: str | Unset = "POD"
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
@@ -120,6 +122,8 @@ class AgentSummaryResponse:
         else:
             metadata = self.metadata
 
+        takes_input = self.takes_input
+
         toolsets: list[str] | Unset = UNSET
         if not isinstance(self.toolsets, Unset):
             toolsets = []
@@ -153,6 +157,8 @@ class AgentSummaryResponse:
             field_dict["icon_url"] = icon_url
         if metadata is not UNSET:
             field_dict["metadata"] = metadata
+        if takes_input is not UNSET:
+            field_dict["takes_input"] = takes_input
         if toolsets is not UNSET:
             field_dict["toolsets"] = toolsets
         if visibility is not UNSET:
@@ -249,6 +255,8 @@ class AgentSummaryResponse:
 
         metadata = _parse_metadata(d.pop("metadata", UNSET))
 
+        takes_input = d.pop("takes_input", UNSET)
+
         _toolsets = d.pop("toolsets", UNSET)
         toolsets: list[AgentToolset] | Unset = UNSET
         if _toolsets is not UNSET:
@@ -273,6 +281,7 @@ class AgentSummaryResponse:
             has_pinned_runtime=has_pinned_runtime,
             icon_url=icon_url,
             metadata=metadata,
+            takes_input=takes_input,
             toolsets=toolsets,
             visibility=visibility,
         )

--- a/lemma-python/lemma_sdk/openapi_spec.json
+++ b/lemma-python/lemma_sdk/openapi_spec.json
@@ -2184,6 +2184,11 @@
             "title": "Pod Id",
             "type": "string"
           },
+          "takes_input": {
+            "default": false,
+            "title": "Takes Input",
+            "type": "boolean"
+          },
           "toolsets": {
             "items": {
               "$ref": "#/components/schemas/AgentToolset"

--- a/lemma-typescript/src/openapi_client/models/AgentSummaryResponse.ts
+++ b/lemma-typescript/src/openapi_client/models/AgentSummaryResponse.ts
@@ -22,6 +22,7 @@ export type AgentSummaryResponse = {
     metadata?: (Record<string, any> | null);
     name: string;
     pod_id: string;
+    takes_input?: boolean;
     toolsets?: Array<AgentToolset>;
     updated_at: string;
     user_id: string;


### PR DESCRIPTION
## What changes

The actor that answers most of a pod's conversations is called **Lem**, everywhere a person can read it — the sidebar, its own page, the dock, the conversation list and both Slack pickers, which between them showed four different names for one thing. `pod_default`, `POD_DEFAULT` and `__pod_assistant__` are wire values and are untouched; this is display copy.

The sidebar is rebuilt around the distinction the naming exposes. Things you *open* are rails — apps as seeded marks, agents as faces, 32px, one click to the thing — and places you *browse through* stay rows, pinned as a footer under the history. Apps and agents leave the tab strip entirely. A recent conversation now carries the mark of whoever answered it. Making an agent is one step (a face, a name, a purpose) rather than five, because the agent's own page is a home you can talk to immediately instead of an editor you had to arrive at fully formed.

On the API, `AgentSummaryResponse` gains `takes_input: bool`.

## Why

"Assistant" could not be the fix for the naming. `docs/product/README.md` fixes the product's nouns against the analytics event catalog and `assistant` is not among them, so adopting it would have meant amending an enforced vocabulary to add a *category* competing with `agent`. A proper name needs no amendment — Lem is an instance, the way someone's own agent is `triage` — and it is the only form that reads in the first person on the front door, where "Hey, I'm Pod Assistant" was a job title introducing itself.

The rails follow from one rule, documented in `design.md`: colour is allowed wherever it identifies or reports, never where it merely decorates. Two related bugs fall out — the tab strip used to pin every installed app permanently and refuse to close it, and a history of one-word titles gave no way to tell two conversations called "hey" apart.

`takes_input` exists because `AgentSummaryResponse` deliberately omits `input_schema`: anything holding a *listed* agent read `{}` for every agent and could not tell an agent that is called with typed arguments from one that is talked to. The agent rail holds only the second kind, and no client could draw that line without fetching every agent in the pod.

## How to verify

```bash
cd lemma-backend && uv run pytest app/modules/agent/tests/unit -q
cd lemma-backend && uv run python scripts/dump_openapi_spec.py --check
cd lemma-backend && make architecture
cd lemma-frontend && npm run check && npm test
```

- `app/modules/agent/tests/unit` — **990 passed, 29 skipped** (skips need a local Redis)
- OpenAPI check — `OpenAPI spec is current`
- `make architecture` — passed (12 inherited import violations, 0 inherited cycles); settings + route inventory current
- `npm run check` — design audit, eslint, tsc and edu-anchors all pass
- `npm test` — **893 passed** across 87 files

Not run locally: Backend E2E (needs the stack), and `make lint` at repo root, which fails only on untracked local `lemma-connectors` artifacts that are not in the repo. Ruff is clean on every backend file this branch touches.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **API surface** — OpenAPI spec regenerated, both SDKs regenerated, all committed here ([policy](https://github.com/lemma-work/lemma-platform/blob/main/docs/security/generated-code-policy.md))
- [x] **Compatibility** — additive only: one optional boolean with a default on `AgentSummaryResponse`. No member removed or changed, so no SDK consumer breaks. The frontend reads it as optional and fails open against an older backend.
- [x] **Rollback** — revert the three commits; nothing is persisted and no migration runs.

## Worth a reviewer's eye

- **The design-audit baseline moves up, not just down.** `rawButtonElements` 35 → 41 and `rawFontSizeDeclaration` 8 → 9, from the new rails, the agent home and the create form. `rawSpacingDeclaration` was at 0 and is now 1: `.agent-create-face` uses a `2px` hairline padding, and there is no token at 2px (`--space-1` is 4px). The other new raw gap was exactly `var(--space-1)` and has been swapped for it. `multiplePrimaryButtons` drops 20 → 19.
- **Slack copy and app copy are now coupled by comment, not by code.** `DEFAULT_RESPONDER_NAME` is declared in both `slack/blocks.py` and `lib/utils/agents.ts`, each pointing at the other. Nothing fails if they drift.
