### PR TITLE
Stop two deployments deleting each other's sandboxes, and run the tests that would have caught it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,26 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      # This lane runs `-m "not e2e"`, which includes the integration tests, and
+      # those skip themselves when no database answers. Without this service 57
+      # of them did -- the whole workspace integration suite: the sandbox state
+      # machine, the repository, and every one of the sweeper's decisions about
+      # what it may destroy. They passed locally and were absent here, which is
+      # how a sweep that deleted live user workspaces reached production with 24
+      # tests written about it.
+      postgres:
+        image: pgvector/pgvector:0.8.3-pg15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: lemma
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d lemma"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v5
@@ -152,6 +172,7 @@ jobs:
         run: make coverage-backend-unit
         env:
           REDIS_URL: redis://localhost:6379
+          TEST_DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/lemma
       - name: Add backend coverage to job summary
         if: always()
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,12 +34,21 @@ name: Backend E2E
 # regenerating it, which only a workflow_run event carries. Don't remove
 # workflow_run from `on:` for that reason; backend-e2e just no longer needs it.
 #
-# Required check: all 8 "lemma-backend e2e (<shard>)" shard checks are
-# required status checks on main's protect-main ruleset, alongside
-# lemma-backend unit — a green e2e is a hard merge requirement. Deliberately
-# not aggregate-coverage (below), which also enforces the separately-tracked
-# coverage floors some modules are still below; making that one required
-# too would block every PR today for an unrelated reason.
+# Required checks: main's protect-main ruleset requires "lemma-backend unit"
+# plus seven of the "lemma-backend e2e (<shard>)" checks — surfaces, agent,
+# function, pod, datastore, connectors, rest. A green e2e is a hard merge
+# requirement for those.
+#
+# `workspace` is NOT among them, and that is not deliberate. The shard exists
+# and runs; nothing blocks a merge on it. So the workspace module's own real
+# Docker contract — a user's files surviving a release, the orphan sweep
+# leaving a live workspace alone — can go red without anyone being stopped.
+# Adding "lemma-backend e2e (workspace)" to the ruleset is a repository
+# settings change, not a change to this file.
+#
+# Deliberately not aggregate-coverage (below), which also enforces the
+# separately-tracked coverage floors some modules are still below; making that
+# one required too would block every PR today for an unrelated reason.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/sandbox-e2b-conformance.yml
+++ b/.github/workflows/sandbox-e2b-conformance.yml
@@ -57,6 +57,11 @@ jobs:
             echo "Missing required E2B configuration:$missing" >&2
             exit 1
           fi
+      # Named explicitly rather than by directory, so a suite is only run
+      # because someone chose to run it against a real, billed account. The
+      # cost of that choice is that a new suite is invisible until it is added:
+      # `test_e2b_lifecycle_real.py` and `test_e2b_function_liveness_real.py`
+      # existed for months, nineteen tests between them, and ran nowhere.
       - name: Real E2B provider contract
         timeout-minutes: 30
         env:
@@ -68,6 +73,9 @@ jobs:
         run: >-
           uv run python -m pytest
           app/modules/workspace/tests/integration/test_e2b_provider_real.py
+          app/modules/workspace/tests/integration/test_e2b_lifecycle_real.py
+          app/modules/workspace/tests/integration/test_e2b_function_liveness_real.py
+          app/modules/workspace/tests/integration/test_e2b_cross_namespace_isolation_real.py
           sandbox_runtime/tests/test_e2b_templates.py
           sandbox_runtime/tests/test_e2b_template_build_config.py
           -m ""

--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -648,8 +648,9 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'workflow.step.suspended': EventSpec('debug', frozenset({'node_id', 'run_id', 'wait_type'})),
     'workspace.e2b.profile_drift_tolerated': EventSpec('info', frozenset({'sandbox_id'})),
     'workspace.e2b.template_drift_replacing': EventSpec('info', frozenset({'configured', 'kind', 'recorded', 'sandbox_id'})),
-    'workspace.local_sandbox_client.adopted_sandbox_not_serving': EventSpec('warning', frozenset({'error_type', 'sandbox_id'})),
+    'workspace.local_sandbox_client.adopted_sandbox_not_serving': EventSpec('warning', frozenset({'error_type', 'kind', 'sandbox_id'})),
     'workspace.mime_type.unknown': EventSpec('debug', frozenset()),
+    'workspace.provider_factory.metadata_namespace_derived': EventSpec('info', frozenset({'environment', 'namespace'})),
     'workspace.sandbox_service.ensure_retrying': EventSpec('info', frozenset({'attempt', 'sandbox_id'})),
     'workspace.sandbox_service.provisioning_claim_expired': EventSpec('info', frozenset({'sandbox_id'})),
     'workspace.sandbox_service.workspace_storage_recreated': EventSpec('info', frozenset({'sandbox_id'})),
@@ -662,4 +663,5 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'workspace.sandbox_sweeper.orphan_reclaimed': EventSpec('info', frozenset({'reason', 'sandbox_id'})),
     'workspace.sandbox_sweeper.reclaimed_orphaned_objects.observed': EventSpec('info', frozenset({'reclaimed_count'})),
     'workspace.sandbox_sweeper.released_idle_sandboxes.observed': EventSpec('info', frozenset({'released_count'})),
+    'workspace.sandbox_sweeper.unattributed_objects': EventSpec('info', frozenset({'count', 'sample'})),
 }

--- a/lemma-backend/app/modules/function/tests/perf/conftest.py
+++ b/lemma-backend/app/modules/function/tests/perf/conftest.py
@@ -441,7 +441,9 @@ async def function_benchmark_runtime(
             "add_host_gateway": workspace_settings.add_host_gateway,
             "host_alias": workspace_settings.host_alias,
             "runtime_credential_key": workspace_settings.runtime_credential_key,
+            "e2b_metadata_namespace": workspace_settings.e2b_metadata_namespace,
         }
+        original_namespace_env = os.environ.get("E2B_METADATA_NAMESPACE")
         runtime: FunctionBenchmarkRuntime | None = None
         benchmark_error: BaseException | None = None
         try:
@@ -455,6 +457,30 @@ async def function_benchmark_runtime(
             # through the environment before the interpreter starts; a bare
             # pytest run, which is how CI invokes the suite, does not.
             workspace_settings.runtime_credential_key = _RUNTIME_CREDENTIAL_KEY
+            if provider == "e2b":
+                # Never the namespace anything real is using. This benchmark
+                # provisions in-process against a throwaway database, so every
+                # sandbox in the account that is not its own looks to the orphan
+                # sweep like something identifiable as ours with no row -- which
+                # is how one deployment came to delete another's workspaces.
+                # A per-run value makes this run's sandboxes invisible to
+                # everyone else's sweep, and everyone else's invisible to it.
+                #
+                # `E2E_SANDBOX_MODE`'s runtime fixture has generated one of
+                # these for a while; this suite reached the same provider
+                # without it, and so ran under the bare production namespace.
+                benchmark_namespace = (
+                    os.getenv("E2B_METADATA_NAMESPACE")
+                    or f"lemma-fn-bench-{uuid4().hex[:12]}"
+                )
+                workspace_settings.e2b_metadata_namespace = benchmark_namespace
+                # Into the environment as well, because the worker that runs
+                # JOB functions is a separate process. It builds its own
+                # provider from env, so a namespace set only on this process's
+                # settings leaves the worker looking for the sandbox under a
+                # different one -- which is every JOB case failing while every
+                # API case passes.
+                os.environ["E2B_METADATA_NAMESPACE"] = benchmark_namespace
             if provider == "docker":
                 # The benchmark images are content-addressed tags, not digests,
                 # and the sandboxes have to reach this process to fetch their
@@ -561,6 +587,10 @@ async def function_benchmark_runtime(
                 setattr(settings, name, value)
             for name, value in original_workspace.items():
                 setattr(workspace_settings, name, value)
+            if original_namespace_env is None:
+                os.environ.pop("E2B_METADATA_NAMESPACE", None)
+            else:
+                os.environ["E2B_METADATA_NAMESPACE"] = original_namespace_env
 
 
 @asynccontextmanager

--- a/lemma-backend/app/modules/function/tests/perf/test_function_execution_benchmark.py
+++ b/lemma-backend/app/modules/function/tests/perf/test_function_execution_benchmark.py
@@ -27,6 +27,13 @@ pytestmark = [
 _DEFAULT_PLATFORM_OVERHEAD_P95_SECONDS = 2.0
 _DEFAULT_WARM_NOOP_P95_SECONDS = 2.0
 _DEFAULT_COLD_NOOP_SECONDS = 8.0
+# Resuming a paused function sandbox restores a memory snapshot, so it should
+# land far closer to warm than to a fresh build. Budgeted separately from
+# `_DEFAULT_REBUILT_NOOP_SECONDS` precisely so the two can be compared: if
+# resume is not meaningfully cheaper than rebuild, pausing is buying nothing and
+# the provider should kill instead (`E2BSandboxProvider._lifecycle`).
+_DEFAULT_RESUMED_NOOP_SECONDS = 8.0
+_DEFAULT_REBUILT_NOOP_SECONDS = 20.0
 
 
 def _positive_int(name: str, default: int) -> int:
@@ -43,7 +50,9 @@ def _positive_float(name: str, default: float) -> float:
     return value
 
 
-def _latency_budgets(provider: str) -> tuple[LatencyBudget, ...]:
+def _latency_budgets(
+    provider: str, *, lifecycle_measured: bool
+) -> tuple[LatencyBudget, ...]:
     del provider
     budgets: list[LatencyBudget] = []
     for case in (
@@ -84,6 +93,22 @@ def _latency_budgets(provider: str) -> tuple[LatencyBudget, ...]:
                     if case == "api_noop"
                     else None
                 ),
+                resumed_terminal_seconds=(
+                    _positive_float(
+                        f"{prefix}_RESUMED_TERMINAL_SECONDS",
+                        _DEFAULT_RESUMED_NOOP_SECONDS,
+                    )
+                    if case == "api_noop" and lifecycle_measured
+                    else None
+                ),
+                rebuilt_terminal_seconds=(
+                    _positive_float(
+                        f"{prefix}_REBUILT_TERMINAL_SECONDS",
+                        _DEFAULT_REBUILT_NOOP_SECONDS,
+                    )
+                    if case == "api_noop" and lifecycle_measured
+                    else None
+                ),
             )
         )
     return tuple(budgets)
@@ -103,6 +128,53 @@ def _report_path(provider: str) -> Path:
     )
 
 
+def _lifecycle_comparison(report) -> dict[str, object]:
+    """The four numbers that decide the function sandbox's lifecycle policy.
+
+    A function invocation is latency-sensitive on every path, not just the warm
+    one, so the interesting comparison is not any single figure but the spread:
+
+    * `warm` -- the sandbox was already running.
+    * `cold` -- its very first invocation.
+    * `resumed` -- it had been paused, and this call woke it. On the function
+      profile that pause keeps memory, so this restores a snapshot rather than
+      re-running the image command.
+    * `rebuilt` -- it had been destroyed, and this call had to build a new one.
+
+    `resumed_vs_rebuilt_seconds` is the one to read. Pausing only earns its
+    place if resume is faster than a fresh build by more than the pause itself
+    costs -- E2B prices a memory snapshot at roughly four seconds per GiB, and
+    the function profile has two. If that number goes to zero or negative,
+    keeping memory is buying nothing and the provider should kill on timeout
+    instead of pausing.
+    """
+    by_phase = {sample.phase: sample for sample in report.lifecycle}
+    cold = next(
+        (sample for sample in report.cold if sample.case == "api_noop"), None
+    )
+    warm = next(
+        (case for case in report.cases if case.case == "api_noop"), None
+    )
+    resumed = by_phase.get("resumed")
+    rebuilt = by_phase.get("rebuilt")
+    comparison: dict[str, object] = {
+        "warm_p95_seconds": warm.terminal.p95_seconds if warm else None,
+        "cold_seconds": cold.terminal_seconds if cold else None,
+        "resumed_seconds": resumed.terminal_seconds if resumed else None,
+        "rebuilt_seconds": rebuilt.terminal_seconds if rebuilt else None,
+        "pause_seconds": resumed.disturb_seconds if resumed else None,
+        "kill_seconds": rebuilt.disturb_seconds if rebuilt else None,
+    }
+    if resumed is not None and rebuilt is not None:
+        comparison["resumed_vs_rebuilt_seconds"] = (
+            rebuilt.terminal_seconds - resumed.terminal_seconds
+        )
+        comparison["pause_is_worth_taking"] = (
+            rebuilt.terminal_seconds - resumed.terminal_seconds
+        ) > (resumed.disturb_seconds or 0.0)
+    return comparison
+
+
 @pytest.mark.asyncio
 async def test_function_execution_quality_benchmark(
     authenticated_client,
@@ -118,8 +190,68 @@ async def test_function_execution_quality_benchmark(
             (WorkloadKind.FUNCTION, pod_id),
         )
     )
+    # The two lifecycle hooks. They exist here rather than in the harness
+    # because only the test process can reach the sandbox control plane -- the
+    # harness speaks public HTTP APIs, and no public route releases or destroys
+    # a sandbox. Each opens its own client: the benchmark runs for minutes
+    # between calls, and holding one open across that adds a connection whose
+    # only purpose is to be idle.
+    async def _drop_cached_endpoint() -> None:
+        """Forget the direct runtime lease, the way `quarantine` does.
+
+        Not optional, and not bookkeeping. `RouteResolver.quarantine` invalidates
+        the cached endpoint *before* destroying the sandbox, and skipping that
+        half does not measure a rebuild -- it measures dispatch to an endpoint
+        that no longer exists. Left out, the rebuilt sample came back
+        `InvocationOutcomeUnconfirmed` rather than a latency, because the cache
+        happily served the dead sandbox's URL for the rest of its TTL.
+
+        The cache is a process-local singleton and the benchmark's API server
+        runs in this process, so this reaches the same instance the dispatch
+        path reads.
+        """
+        from app.modules.function.api.dependencies import (
+            _function_runtime_endpoint_cache,
+        )
+        from app.modules.function.application.function_runtime_endpoint_cache import (
+            FunctionRuntimeEndpointKey,
+        )
+        from app.modules.workspace.providers.profiles import profile_for
+        from app.modules.workspace.domain.sandbox import SandboxKind
+
+        await _function_runtime_endpoint_cache.invalidate(
+            FunctionRuntimeEndpointKey(
+                pod_id=pod_id,
+                profile_digest=profile_for(SandboxKind.FUNCTION).digest,
+            )
+        )
+
+    async def _release_function_sandbox() -> None:
+        from app.modules.workspace.services.sandbox_composition import (
+            build_local_client,
+        )
+
+        await _drop_cached_endpoint()
+        async with build_local_client() as client:
+            await client.release_sandbox(WorkloadKind.FUNCTION, pod_id)
+
+    async def _destroy_function_sandbox() -> None:
+        from app.modules.workspace.services.sandbox_composition import (
+            build_local_client,
+        )
+
+        await _drop_cached_endpoint()
+        async with build_local_client() as client:
+            await client.destroy_sandbox(WorkloadKind.FUNCTION, pod_id)
+
+    lifecycle_measured = os.getenv(
+        "FUNCTION_BENCH_LIFECYCLE", "1"
+    ).strip().lower() not in {"0", "false", "no"}
+
     config = BenchmarkConfig(
         provider=provider,
+        release_sandbox=_release_function_sandbox if lifecycle_measured else None,
+        destroy_sandbox=_destroy_function_sandbox if lifecycle_measured else None,
         concurrency=_positive_int("FUNCTION_BENCH_CONCURRENCY", 5),
         invocations=_positive_int("FUNCTION_BENCH_INVOCATIONS", 5),
         batch_rows=_positive_int("FUNCTION_BENCH_BATCH_ROWS", 1_000),
@@ -131,7 +263,9 @@ async def test_function_execution_quality_benchmark(
             os.getenv("FUNCTION_BENCH_TERMINAL_TIMEOUT_SECONDS", "240")
         ),
         pool_fill_hold_ms=_positive_int("FUNCTION_BENCH_POOL_FILL_HOLD_MS", 750),
-        latency_budgets=_latency_budgets(provider),
+        latency_budgets=_latency_budgets(
+            provider, lifecycle_measured=lifecycle_measured
+        ),
     )
     report = await FunctionExecutionBenchmark(
         authenticated_client,
@@ -165,6 +299,7 @@ async def test_function_execution_quality_benchmark(
                     }
                     for case in report.cases
                 ],
+                "lifecycle": _lifecycle_comparison(report),
                 "errors": report.errors,
             },
             indent=2,

--- a/lemma-backend/app/modules/workspace/config.py
+++ b/lemma-backend/app/modules/workspace/config.py
@@ -7,9 +7,6 @@ module's own -- `WORKSPACE_*`, plus `FUNCTION_*` for the function runtime and
 
 from typing import Literal, Optional
 
-from app.modules.workspace.providers.e2b_common import (
-    DEFAULT_METADATA_NAMESPACE,
-)
 from pydantic import AliasChoices, Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -172,20 +169,26 @@ class WorkspaceSettings(BaseSettings):
         validation_alias=AliasChoices("E2B_DOMAIN"),
         description="E2B API domain override",
     )
-    e2b_metadata_namespace: str = Field(
-        default=DEFAULT_METADATA_NAMESPACE,
+    e2b_metadata_namespace: Optional[str] = Field(
+        default=None,
         validation_alias=AliasChoices("E2B_METADATA_NAMESPACE"),
         description=(
             "Namespace for every metadata key the E2B provider writes and "
             "queries. A provider is blind to sandboxes labelled by another "
-            "namespace, which is what makes it safe to point a test at an "
-            "account that also holds real workspaces.\n\n"
-            "This is a safety boundary, not a preference. The orphan sweep "
-            "destroys any provider object it can identify as ours but cannot "
-            "find a sandbox row for, and a test runs against a throwaway "
-            "database in which no production sandbox has a row -- so sharing "
-            "this value with production means a test sweep deletes live "
-            "workspaces. Override it for anything that is not production."
+            "namespace, which is what makes it safe to point one deployment at "
+            "an account that also holds another's workspaces.\n\n"
+            "This is a safety boundary, not a preference, and it deliberately "
+            "has no shared default. The orphan sweep destroys any provider "
+            "object it can identify as ours but cannot find a sandbox row for, "
+            "and another deployment's sandboxes have no row here -- so sharing "
+            "this value across deployments means each one deletes the other's "
+            "live workspaces. It did: dev and prod held separate API keys for "
+            "one E2B team, both fell back to the same default, and each "
+            "destroyed the other's sandboxes every five minutes.\n\n"
+            "Unset, it is derived from ENVIRONMENT by "
+            "``provider_factory.resolve_metadata_namespace``, which refuses to "
+            "derive one for `local` or `testing` because every developer and "
+            "every CI run would share it."
         ),
     )
 

--- a/lemma-backend/app/modules/workspace/providers/e2b.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b.py
@@ -50,7 +50,6 @@ from app.modules.workspace.providers.base import (
     ProviderStorageKind,
 )
 from app.modules.workspace.providers.e2b_common import (
-    DEFAULT_METADATA_NAMESPACE,
     ensure_serving,
     meta_epoch,
     meta_profile_digest,
@@ -74,15 +73,17 @@ class E2BProviderConfig:
     api_key: str
     workspace_template: str
     function_template: str
+    # Namespaces every metadata key this provider writes and queries, making a
+    # provider blind to sandboxes labelled by another namespace. Required, not
+    # defaulted: a shared default is what let two deployments on one E2B team
+    # read each other's sandboxes as unowned orphans and destroy them. See
+    # `provider_factory.resolve_metadata_namespace`.
+    metadata_namespace: str
     # How long E2B keeps a sandbox alive without contact. The service touches
     # activity on use, so this is a backstop against leaking compute when the
     # backend dies, not the primary idle policy.
     sandbox_timeout_seconds: int = 60 * 30
     domain: str | None = None
-    # Namespaces every metadata key this provider writes and queries. Changing
-    # it makes a provider blind to sandboxes labelled by another namespace,
-    # which is exactly what a conformance run against a shared account needs.
-    metadata_namespace: str = DEFAULT_METADATA_NAMESPACE
 
 
 class E2BSandboxProvider(E2BOpsMixin):
@@ -401,7 +402,7 @@ class E2BSandboxProvider(E2BOpsMixin):
         keep_memory = kind is SandboxKind.FUNCTION
         sandbox = await self._connect(instance.provider_id)
         with sdk_errors():
-            await sandbox.beta_pause(keep_memory=keep_memory, **self._api())
+            await sandbox.pause(keep_memory=keep_memory, **self._api())
 
     async def destroy(self, name: str, *, deadline_at: datetime) -> None:
         """Kill a sandbox, addressed either by container name or by E2B id.
@@ -593,7 +594,3 @@ class E2BSandboxProvider(E2BOpsMixin):
                 timeout=self._config.sandbox_timeout_seconds,
                 **self._api(),
             )
-
-
-
-

--- a/lemma-backend/app/modules/workspace/services/local_sandbox_client.py
+++ b/lemma-backend/app/modules/workspace/services/local_sandbox_client.py
@@ -444,6 +444,14 @@ class LocalSandboxClient(LocalSandboxFilesMixin):
         Replaced once, not retried: the same dead sandbox would fail the same way
         forever, and a function sandbox holds no files, so rebuilding it costs a
         cold start and nothing else.
+
+        That last clause is why the recovery branches on kind. It is only true
+        of a function sandbox. A workspace owns the user's disk -- on a
+        SANDBOX_NATIVE provider the sandbox *is* the disk -- so the same
+        recovery would answer a twenty-second readiness failure by deleting
+        everything the user had. `kind` was already computed here and simply
+        never consulted, which left that one call away from happening the first
+        time any caller asked a workspace to verify.
         """
         deadline = deadline_at or datetime.now(timezone.utc) + timedelta(seconds=30)
         kind = (
@@ -462,8 +470,16 @@ class LocalSandboxClient(LocalSandboxFilesMixin):
                 "workspace.local_sandbox_client.adopted_sandbox_not_serving",
                 sandbox_id=str(sandbox_id),
                 error_type=type(exc).__name__,
+                kind=kind.value,
             )
         self._service.forget(sandbox_id)
+        if kind is not SandboxKind.FUNCTION:
+            # Re-ensure without destroying. Forgetting the handle is enough to
+            # send the next ensure back to the provider, which resumes a paused
+            # sandbox or provisions a replacement if it has genuinely gone --
+            # and if it is merely slow to answer, the disk is still there when
+            # it does.
+            return await self._service.ensure(sandbox_id)
         await self._service.destroy(sandbox_id)
         await self._ensure_row(sandbox_id, workload_kind)
         return await self._service.ensure(sandbox_id)

--- a/lemma-backend/app/modules/workspace/services/provider_factory.py
+++ b/lemma-backend/app/modules/workspace/services/provider_factory.py
@@ -8,7 +8,17 @@ the ones a given deployment will never install.
 
 from __future__ import annotations
 
+from app.core.log.log import get_logger
 from app.modules.workspace.config import workspace_settings
+
+logger = get_logger(__name__)
+
+# Environments whose name is shared by many deployments at once. Every
+# developer's machine reports `local`, and every CI run reports `testing`, so a
+# namespace derived from either would be identical across all of them -- which
+# is the same collision the derivation exists to prevent, just between
+# colleagues instead of between dev and prod. These must say who they are.
+_AMBIGUOUS_ENVIRONMENTS = frozenset({"local", "testing"})
 
 def build_provider(name: str | None = None):
     """Construct the configured sandbox provider.
@@ -99,10 +109,66 @@ def _build_e2b_provider():
             workspace_template=workspace_settings.e2b_workspace_template,
             function_template=workspace_settings.e2b_function_template,
             domain=workspace_settings.e2b_domain,
-            # Carried explicitly. The provider defaults this, and defaulting it
-            # here too is what let a test run share production's namespace --
-            # which the orphan sweep reads as "these are mine and have no row",
-            # against a database where nothing does.
-            metadata_namespace=workspace_settings.e2b_metadata_namespace,
+            metadata_namespace=resolve_metadata_namespace(),
         )
     )
+
+
+def resolve_metadata_namespace(
+    configured: str | None = None, environment: str | None = None
+) -> str:
+    """Which metadata namespace this deployment writes and queries E2B under.
+
+    This is the boundary that decides whether two deployments can see each
+    other's sandboxes, and it used to have a shared default. Both `lemma-dev`
+    and `lemma-prod` held their own `E2B_API_KEY`, but the two keys resolved to
+    one E2B team, and neither set a namespace -- so each backend enumerated the
+    other's sandboxes, found no row for them in its own database, and destroyed
+    them as orphans. One user's workspace was wiped five times inside a single
+    twenty-minute conversation, each kill landing seconds after the other
+    environment rebuilt it.
+
+    So there is no shared default any more. An explicit `E2B_METADATA_NAMESPACE`
+    always wins; otherwise the namespace is derived from `ENVIRONMENT`, which
+    already distinguishes the deployments that collided.
+
+    `local` and `testing` are refused rather than derived. Deriving would give
+    every developer's machine and every CI run the same namespace, which
+    rebuilds the same collision at a smaller scale -- and those are precisely
+    the deployments that pair a throwaway database with a real E2B account, the
+    combination that turns a sweep into a deletion. A warning would not do:
+    warnings in local development are not read, and the cost of missing one is
+    somebody else's work.
+    """
+
+    from app.core.config import settings
+
+    explicit = (
+        configured
+        if configured is not None
+        else workspace_settings.e2b_metadata_namespace
+    )
+    if explicit:
+        return explicit
+
+    resolved_environment = environment or settings.environment
+    if resolved_environment in _AMBIGUOUS_ENVIRONMENTS:
+        raise RuntimeError(
+            "E2B_METADATA_NAMESPACE must be set explicitly when ENVIRONMENT is "
+            f"{resolved_environment!r}. It is the only thing keeping this "
+            "deployment from seeing sandboxes that belong to another one: the "
+            "orphan sweep destroys any sandbox it can identify as this "
+            "platform's but cannot find a row for, and on E2B destroying a "
+            f"sandbox destroys the user's files. Every {resolved_environment} "
+            "deployment reports the same environment name, so a derived value "
+            "would not tell them apart. Pick something unique, for example "
+            f"'lemma-{resolved_environment}-<your-name>'."
+        )
+
+    namespace = f"lemma-{resolved_environment}"
+    logger.info(
+        "workspace.provider_factory.metadata_namespace_derived",
+        namespace=namespace,
+        environment=resolved_environment,
+    )
+    return namespace

--- a/lemma-backend/app/modules/workspace/services/sandbox_sweeper.py
+++ b/lemma-backend/app/modules/workspace/services/sandbox_sweeper.py
@@ -21,7 +21,10 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 
 from app.core.log.log import get_logger
-from app.modules.workspace.domain.sandbox import SandboxDesiredState
+from app.modules.workspace.domain.sandbox import (
+    SandboxDesiredState,
+    SandboxInstanceState,
+)
 from app.modules.workspace.infrastructure.sandbox_repository import SandboxRepository
 from app.modules.workspace.process_output import TERMINAL_PROCESS_STATES
 from app.modules.workspace.providers.base import (
@@ -34,6 +37,11 @@ from app.modules.workspace.providers.base import (
 from sandbox_runtime.errors import SandboxError
 
 logger = get_logger(__name__)
+
+# How many unattributed provider ids to name in the aggregated report. Enough to
+# identify which environment they belong to, few enough that the line stays
+# readable when an account holds hundreds.
+_UNATTRIBUTED_SAMPLE = 10
 
 
 class SandboxSweeper:
@@ -146,21 +154,23 @@ class SandboxSweeper:
         return any(not _has_stopped(p) for p in processes)
 
     async def reclaim_orphans(self, *, dry_run: bool = False) -> tuple[str, ...]:
-        """Destroy provider objects no live sandbox row accounts for.
+        """Destroy provider objects this environment created and no longer wants.
 
-        An object is orphaned when it belongs to a sandbox that no longer
-        exists or is deleted, or when it is behind the sandbox's current epoch.
-        Anything this module cannot identify is left strictly alone -- a sweep
-        that guesses would delete somebody else's containers.
+        Reclaimable means *this database* asked for the object to be gone -- see
+        `_reclaim_reason`. An object this database has never heard of is not
+        reclaimable at any confidence, and that is the distinction this method
+        exists to hold.
         """
         deadline_at = datetime.now(timezone.utc) + timedelta(seconds=60)
         objects = await self._provider.list_objects(deadline_at=deadline_at)
 
         reclaimed: list[str] = []
+        unattributed: list[str] = []
         for obj in objects:
             if obj.sandbox_id is None:
-                # Not identifiable as ours. Leaving a stray object running is
-                # recoverable; deleting a stranger's container is not.
+                # Not identifiable as ours at all. Leaving a stray object
+                # running is recoverable; deleting a stranger's container is
+                # not.
                 continue
 
             async with self._uow_factory() as uow:
@@ -173,23 +183,39 @@ class SandboxSweeper:
                 )
 
             if sandbox is None:
-                reason = "no sandbox row"
-            elif sandbox.desired_state is SandboxDesiredState.DELETED:
-                reason = "sandbox deleted"
-            elif obj.legacy:
-                # A pre-cutover object carries no epoch, so it cannot be judged
-                # by one. While both provisioning paths exist it may still be
-                # the *only* container serving this sandbox, and destroying it
-                # would kill a live workspace. It is only reclaimable once this
-                # module has provisioned a replacement.
-                if instance is None:
-                    continue
-                reason = "superseded by the current provisioning path"
-            elif self._epoch_is_a_fence and obj.epoch is not None and (
-                obj.epoch < sandbox.epoch
-            ):
-                reason = f"epoch {obj.epoch} is behind {sandbox.epoch}"
-            else:
+                # Identifiable, but not ours -- and this is the branch that must
+                # never destroy.
+                #
+                # A sandbox this environment created always has a row. Nothing
+                # hard-deletes one (`SandboxService.destroy` sets
+                # `desired_state=DELETED` and keeps it), and `begin_instance`
+                # commits the row *before* the provider is asked to create
+                # anything, so even a create whose response was lost leaves a
+                # row behind. "No row" therefore cannot mean "ours and
+                # forgotten". It can only mean another database's: a second
+                # environment sharing this provider account, a developer's local
+                # backend, or a database restored from before the object existed.
+                #
+                # Destroying on it is an unfalsifiable negative that resolves
+                # towards deleting a stranger's live workspace, and on a
+                # SANDBOX_NATIVE provider that is the user's disk. It is what
+                # happened: dev and prod held two API keys for one E2B team,
+                # both defaulted to the same metadata namespace, and each
+                # environment's sweep destroyed the other's sandboxes every five
+                # minutes -- five times inside one twenty-minute conversation,
+                # each kill seconds after the other side rebuilt it.
+                #
+                # The namespace is the boundary that stops the two seeing each
+                # other at all, and it is derived rather than shared now
+                # (`provider_factory.resolve_metadata_namespace`). This is the
+                # second line: a namespace can be misconfigured again, and a
+                # report costs money while a destroy costs work nobody can get
+                # back.
+                unattributed.append(obj.provider_id)
+                continue
+
+            reason = self._reclaim_reason(obj, sandbox, instance)
+            if reason is None:
                 continue
 
             if dry_run:
@@ -227,7 +253,63 @@ class SandboxSweeper:
                 sandbox_id=str(obj.sandbox_id),
                 reason=reason,
             )
+
+        if unattributed:
+            # One line per sweep, not one per object. A shared provider account
+            # can hold hundreds of these, and a per-object log would bury the
+            # signal the report exists to raise: a rising count means another
+            # environment has started writing into this account.
+            logger.info(
+                "workspace.sandbox_sweeper.unattributed_objects",
+                count=len(unattributed),
+                # Joined, not a tuple: the log pipeline drops any value that is
+                # not a scalar, so a tuple arrives as `dropped_fields` and the
+                # sample that makes the count actionable is lost.
+                sample=",".join(sorted(unattributed)[:_UNATTRIBUTED_SAMPLE]),
+            )
         return tuple(reclaimed)
+
+    def _reclaim_reason(self, obj, sandbox, instance) -> str | None:
+        """Why this object may be destroyed, or None to leave it alone.
+
+        Split from the loop so the loop is about *doing* a reclaim and this is
+        about *deciding* one -- and so neither trips the complexity ratchet,
+        which the two together did.
+
+        Note what is absent: "there is no row". That never reaches here, because
+        it is not a reason at any confidence. See the caller.
+        """
+        if sandbox.desired_state is SandboxDesiredState.DELETED:
+            if instance is not None and (
+                instance.state is SandboxInstanceState.CREATING
+            ):
+                # A provision is in flight against a row that still reads
+                # DELETED. `destroy` sets DELETED, and the `_provision` that
+                # follows only sets it back to PRESENT at the very end -- so
+                # between `begin_instance` and that write, a live create looks
+                # exactly like an abandoned sandbox. Destroying here kills the
+                # sandbox the caller is waiting on.
+                #
+                # CREATING is the whole window and not merely most of it:
+                # `mark_instance_ready` and `set_desired_state(PRESENT)` commit
+                # in one unit of work, so READY is never observable while the
+                # row still says DELETED.
+                return None
+            return "sandbox deleted"
+        if obj.legacy:
+            # A pre-cutover object carries no epoch, so it cannot be judged by
+            # one. While both provisioning paths exist it may still be the
+            # *only* container serving this sandbox, and destroying it would
+            # kill a live workspace. It is only reclaimable once this module has
+            # provisioned a replacement.
+            if instance is None:
+                return None
+            return "superseded by the current provisioning path"
+        if self._epoch_is_a_fence and obj.epoch is not None and (
+            obj.epoch < sandbox.epoch
+        ):
+            return f"epoch {obj.epoch} is behind {sandbox.epoch}"
+        return None
 
     async def _still_present(self, obj, *, deadline_at: datetime) -> bool:
         """Whether the provider can still see *this* object after the destroy.

--- a/lemma-backend/app/modules/workspace/testing/fake_e2b.py
+++ b/lemma-backend/app/modules/workspace/testing/fake_e2b.py
@@ -322,7 +322,7 @@ class FakeE2B:
                 world.sandboxes.pop(self.sandbox_id, None)
                 return True
 
-            async def beta_pause(self, keep_memory=True, **_kwargs):
+            async def pause(self, keep_memory=True, **_kwargs):
                 # Recorded because the default is the bug: a workspace pause
                 # that keeps memory restores whatever was running into the
                 # next conversation.
@@ -330,6 +330,14 @@ class FakeE2B:
                 world.paused.append(self.sandbox_id)
                 world.sandboxes[self.sandbox_id].state = "paused"
                 return True
+
+            async def beta_pause(self, keep_memory=True, **_kwargs):
+                # Kept because the real SDK still carries it, deprecated, and a
+                # double that drops a method the provider might call would
+                # certify a call that no longer exists. It delegates rather
+                # than duplicating, so the two can never disagree about what a
+                # pause records.
+                return await self.pause(keep_memory=keep_memory, **_kwargs)
 
             def get_host(self, port):
                 return f"{port}-{self.sandbox_id}.e2b.test"

--- a/lemma-backend/app/modules/workspace/tests/e2e/test_sandbox_end_to_end.py
+++ b/lemma-backend/app/modules/workspace/tests/e2e/test_sandbox_end_to_end.py
@@ -4,6 +4,14 @@ This is the test that decides whether the cutover is safe. Everything else
 verifies a piece; this verifies that an agent tool call issued through the
 unchanged session reaches a real sandbox and comes back with the right answer,
 and that a user's files survive the sandbox being stopped and resumed.
+
+It lives in the e2e lane because that is the only lane where it runs. As an
+`integration` test it took its image from `WORKSPACE_IMAGE`, which no CI job
+sets, and its database from a local postgres the unit lane did not have -- so
+all eight of these skipped themselves on every run, including the one that
+proves a user's files survive a release. The e2e workspace shard already builds
+a content-addressed workspace image and stands up postgres, so both of those
+questions already have answers here.
 """
 
 from __future__ import annotations
@@ -15,6 +23,7 @@ from uuid import uuid4
 import pytest
 import pytest_asyncio
 
+from app.core.infrastructure.db.uow_factory import SessionUnitOfWorkFactory
 from app.modules.workspace.config import workspace_settings
 from app.modules.workspace.sandbox_session import SandboxWorkspaceSession
 from app.modules.workspace.domain.sandbox import SandboxKind, SandboxOwnerKind
@@ -27,20 +36,32 @@ from app.modules.workspace.providers.docker_engine import DockerEngineClient
 from app.modules.workspace.services.local_sandbox_client import LocalSandboxClient
 from app.modules.workspace.services.sandbox_service import SandboxService
 
-pytestmark = [pytest.mark.integration, pytest.mark.workspace, pytest.mark.asyncio]
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.workspace,
+    pytest.mark.asyncio,
+    pytest.mark.timeout(600),
+]
 
 _SOCKET = os.getenv("WORKSPACE_DOCKER_SOCKET_PATH", "/var/run/docker.sock")
-_IMAGE = os.getenv("WORKSPACE_IMAGE", "")
 
 
 @pytest_asyncio.fixture
-async def sandbox_stack(sandbox_uow_factory, monkeypatch) -> AsyncIterator[tuple]:
-    if not _IMAGE:
-        pytest.skip("set WORKSPACE_IMAGE to run the end-to-end sandbox test")
+async def sandbox_stack(
+    workspace_image, db_manager, monkeypatch
+) -> AsyncIterator[tuple]:
+    """The real Docker stack, on the image this lane already builds.
+
+    The image comes from the `workspace_image` fixture rather than an
+    environment variable. `WORKSPACE_IMAGE` was the gate that made this whole
+    file a no-op in CI: it is set nowhere, so every test here skipped rather
+    than failing, and nothing said so.
+    """
     if not os.path.exists(_SOCKET):
         pytest.skip(f"no docker socket at {_SOCKET}")
 
-    monkeypatch.setattr(workspace_settings, "workspace_image", _IMAGE)
+    sandbox_uow_factory = SessionUnitOfWorkFactory(db_manager.session_factory)
+    monkeypatch.setattr(workspace_settings, "workspace_image", workspace_image)
 
     engine = DockerEngineClient(socket_path=_SOCKET)
     provider = DockerSandboxProvider(
@@ -159,6 +180,13 @@ async def test_an_operation_against_a_replaced_sandbox_does_not_hit_the_new_one(
     first = await service.ensure(sandbox.id)
 
     await provider.destroy(first.provider_id, deadline_at=_far_future())
+    # Losing the container behind the service's back is exactly what `forget`
+    # is for. `ensure` answers from a five-second handle cache, so without this
+    # the second call returns the handle to the container just destroyed and no
+    # new epoch is ever minted -- which is what this assertion caught the first
+    # time it ran. Production reaches `forget` on `ProviderGone`; a test that
+    # destroys through the provider has to say so itself.
+    service.forget(sandbox.id)
     second = await service.ensure(sandbox.id)
 
     assert second.epoch > first.epoch

--- a/lemma-backend/app/modules/workspace/tests/e2e/test_workspace_durability_e2e.py
+++ b/lemma-backend/app/modules/workspace/tests/e2e/test_workspace_durability_e2e.py
@@ -1,0 +1,219 @@
+"""The workspace's durability contract, against a real sandbox, in the gated lane.
+
+Two invariants live here, and both were previously tested only where the test
+could not run.
+
+*Files survive a release.* Releasing stops compute and keeps the disk -- that is
+the whole reason the idle sweep is allowed to run at all. It was covered by
+`integration/test_sandbox_end_to_end.py`, which skips unless `WORKSPACE_IMAGE`
+is set, and nothing in CI sets it. Those eight tests have never run in CI.
+
+*The orphan sweep does not destroy a live workspace.* Covered by 24 integration
+tests against a fake provider, none of which ran in CI either: that lane had no
+database, so every one of them skipped itself. The sweep destroyed live user
+workspaces in production for days while its own suite was green and absent.
+
+So these are here, in the workspace e2e shard, which runs on every pull request
+against a real Docker sandbox.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import status
+
+from app.core.infrastructure.db.uow_factory import SessionUnitOfWorkFactory
+from app.modules.agent.tools.context import BaseAgentContext
+from app.modules.agent.tools.workspace_cli.models import ExecCommandRequest
+from app.modules.agent.tools.workspace_cli.workspace_cli import exec_command_internal
+from app.modules.test_support.e2e.waiters import eventually
+from app.modules.workspace.infrastructure.sandbox_repository import SandboxRepository
+from app.modules.workspace.services.sandbox_sweeper import SandboxSweeper
+
+pytestmark = [pytest.mark.e2e, pytest.mark.workspace, pytest.mark.timeout(600)]
+
+
+async def _context(authenticated_client, fixed_test_org, fixed_test_user):
+    response = await authenticated_client.post(
+        "/pods",
+        json={
+            "name": f"Durability Pod {uuid4().hex[:8]}",
+            "type": "ASSISTANT",
+            "organization_id": fixed_test_org["id"],
+        },
+    )
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+    pod = response.json()
+    ctx = BaseAgentContext(
+        user_id=UUID(fixed_test_user["id"]),
+        org_id=UUID(fixed_test_org["id"]),
+        pod_id=UUID(pod["id"]),
+        conversation_id=uuid4(),
+        agent_name="workspace_durability_e2e",
+        workload_type="agent",
+    )
+
+    async def warmup():
+        return await exec_command_internal(
+            ctx, ExecCommandRequest(cmd="true", timeout_seconds=180)
+        )
+
+    await eventually(
+        label="real workspace sandbox warmup",
+        probe=warmup,
+        done=lambda result: result.success,
+        timeout_seconds=300,
+        interval_seconds=2.0,
+    )
+    return ctx
+
+
+async def _run(ctx, command: str):
+    result = await exec_command_internal(
+        ctx, ExecCommandRequest(cmd=command, timeout_seconds=180)
+    )
+    assert result.success, getattr(result, "error", result)
+    return result
+
+
+def _sandbox_service():
+    from app.modules.workspace.services.sandbox_composition import get_sandbox_service
+
+    return get_sandbox_service()
+
+
+async def test_a_workspace_keeps_its_files_across_a_release_and_resume(
+    local_sandbox_server,
+    backend_server,
+    configure_workspace_api_url,
+    authenticated_client,
+    fixed_test_org,
+    fixed_test_user,
+) -> None:
+    """Releasing stops compute and keeps the disk. Everything else assumes it.
+
+    The idle sweep releases a workspace after a few minutes of quiet, so this
+    runs constantly in production. If it ever stopped being true, every user
+    would lose their files a few minutes after they stopped typing.
+    """
+    del local_sandbox_server, backend_server, configure_workspace_api_url
+    ctx = await _context(authenticated_client, fixed_test_org, fixed_test_user)
+    user_id = UUID(fixed_test_user["id"])
+
+    await _run(ctx, "mkdir -p /workspace/keep && echo durable > /workspace/keep/file")
+
+    service = _sandbox_service()
+    before = await service.get(user_id)
+    assert before is not None
+    await service.release(user_id)
+
+    read_back = await _run(ctx, "cat /workspace/keep/file")
+    assert "durable" in (read_back.stdout or ""), read_back
+
+    after = await service.get(user_id)
+    assert after is not None
+    # The generation is the signal an agent reads as "your files are gone". A
+    # release must never move it -- that is the difference between a resume and
+    # a replacement, and the agent has no other way to tell them apart.
+    assert after.storage_generation == before.storage_generation
+
+
+async def test_the_orphan_sweep_leaves_a_live_workspace_and_its_files_alone(
+    local_sandbox_server,
+    backend_server,
+    configure_workspace_api_url,
+    authenticated_client,
+    fixed_test_org,
+    fixed_test_user,
+    db_manager,
+) -> None:
+    """The regression that cost users their work, held against a real sandbox.
+
+    Two sweeps, because they fail differently. The first runs against this
+    database, where the workspace has a row: it must recognise the row and leave
+    the object alone. The second runs against a database where the row has been
+    hidden, which is exactly what one deployment's workspace looks like to
+    another's sweep -- and is the case the old rule read as "ours and forgotten"
+    before destroying it.
+    """
+    del local_sandbox_server, backend_server, configure_workspace_api_url
+    ctx = await _context(authenticated_client, fixed_test_org, fixed_test_user)
+    user_id = UUID(fixed_test_user["id"])
+
+    await _run(ctx, "echo swept-but-alive > /workspace/sentinel")
+
+    service = _sandbox_service()
+    uow_factory = SessionUnitOfWorkFactory(db_manager.session_factory)
+    sweeper = SandboxSweeper(service=service, uow_factory=uow_factory)
+
+    before = await service.get(user_id)
+    assert before is not None
+
+    assert await sweeper.reclaim_orphans() == ()
+
+    survived = await _run(ctx, "cat /workspace/sentinel")
+    assert "swept-but-alive" in (survived.stdout or ""), survived
+    after = await service.get(user_id)
+    assert after is not None
+    assert after.storage_generation == before.storage_generation
+
+    # Now the cross-database case. Marking the row DELETED would be a different
+    # test -- that object really is reclaimable. What has to be proved is the
+    # *unknown* object, so the sweep is pointed at a repository that reports no
+    # row for anything, the way another deployment's database would.
+    class _BlindRepository(SandboxRepository):
+        async def get(self, sandbox_id):  # type: ignore[override]
+            return None
+
+    import app.modules.workspace.services.sandbox_sweeper as sweeper_module
+
+    original = sweeper_module.SandboxRepository
+    sweeper_module.SandboxRepository = _BlindRepository  # type: ignore[assignment]
+    try:
+        assert await sweeper.reclaim_orphans() == ()
+    finally:
+        sweeper_module.SandboxRepository = original  # type: ignore[assignment]
+
+    still_there = await _run(ctx, "cat /workspace/sentinel")
+    assert "swept-but-alive" in (still_there.stdout or ""), still_there
+
+
+async def test_a_deleted_workspace_is_still_reclaimed(
+    local_sandbox_server,
+    backend_server,
+    configure_workspace_api_url,
+    authenticated_client,
+    fixed_test_org,
+    fixed_test_user,
+    db_manager,
+) -> None:
+    """The sweep has to stay useful, not merely safe.
+
+    A sweep that never destroys anything would pass the test above and leak
+    every container the control plane has finished with, which is what the
+    orphan sweep exists to stop.
+    """
+    del local_sandbox_server, backend_server, configure_workspace_api_url
+    ctx = await _context(authenticated_client, fixed_test_org, fixed_test_user)
+    user_id = UUID(fixed_test_user["id"])
+    await _run(ctx, "true")
+
+    service = _sandbox_service()
+    uow_factory = SessionUnitOfWorkFactory(db_manager.session_factory)
+    sweeper = SandboxSweeper(service=service, uow_factory=uow_factory)
+
+    from app.modules.workspace.domain.sandbox import SandboxDesiredState
+
+    async with uow_factory() as uow:
+        repository = SandboxRepository(uow)
+        await repository.set_desired_state(user_id, SandboxDesiredState.DELETED)
+        await uow.commit()
+
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=120)
+    reclaimed: tuple[str, ...] = ()
+    while datetime.now(timezone.utc) < deadline and not reclaimed:
+        reclaimed = await sweeper.reclaim_orphans()
+    assert reclaimed, "a sandbox this database asked to be rid of was not reclaimed"

--- a/lemma-backend/app/modules/workspace/tests/integration/test_e2b_cross_namespace_isolation_real.py
+++ b/lemma-backend/app/modules/workspace/tests/integration/test_e2b_cross_namespace_isolation_real.py
@@ -1,0 +1,221 @@
+"""The two things that kept a user's workspace, held against the real service.
+
+Both come from one production incident. `lemma-dev` and `lemma-prod` each held
+their own `E2B_API_KEY`, but the two keys resolved to a single E2B team, and
+neither deployment set a metadata namespace -- so each backend enumerated the
+other's sandboxes, found no row for them in its own database, and destroyed them
+as orphans. One user's workspace was wiped five times inside a twenty-minute
+conversation, each kill landing seconds after the other environment rebuilt it.
+
+Two independent properties had to fail together for that to happen, so both are
+checked here, against the real service, because both are about what E2B actually
+returns:
+
+* a provider must not *see* sandboxes labelled by another namespace, which is
+  what stops the question being asked at all; and
+* a sweep must not destroy a sandbox it cannot attribute to a row, which is what
+  stops the wrong answer being fatal when the first property is misconfigured.
+
+The unit and integration suites cover the sweep's decision table against a fake.
+What they cannot cover is whether E2B's metadata query really is blind across
+namespaces, and whether a sandbox this sweep declines to touch really does
+survive -- so those are the assertions here.
+
+Safety: everything runs under its own per-run namespace, so no query can match a
+production sandbox. Only sandboxes this file created are ever killed.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+from datetime import datetime, timedelta, timezone
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+
+from app.modules.workspace.domain.sandbox import SandboxKind
+from app.modules.workspace.providers import naming
+from sandbox_runtime.protocol import ByteRange
+
+from app.modules.workspace.providers.base import ProviderCreateSpec
+from app.modules.workspace.providers.e2b import E2BProviderConfig, E2BSandboxProvider
+from app.modules.workspace.testing.fake_output_buffer import InMemoryOutputBuffer
+
+pytestmark = [pytest.mark.integration, pytest.mark.provider, pytest.mark.asyncio]
+
+_KEY = os.getenv("E2B_API_KEY", "")
+_TEMPLATE = os.getenv("E2B_WORKSPACE_TEMPLATE", "")
+# Two namespaces standing in for two deployments sharing one E2B team. Per-run
+# on purpose: a fixed pair would collide between concurrent runs, which is the
+# very failure this file is about.
+_RUN = uuid4().hex[:8]
+_NAMESPACE_A = f"lemma-xns-a-{_RUN}"
+_NAMESPACE_B = f"lemma-xns-b-{_RUN}"
+
+
+def _deadline(seconds: int = 120) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(seconds=seconds)
+
+
+def _build_provider(namespace: str) -> E2BSandboxProvider:
+    return E2BSandboxProvider(
+        E2BProviderConfig(
+            api_key=_KEY,
+            workspace_template=_TEMPLATE,
+            function_template=_TEMPLATE,
+            sandbox_timeout_seconds=300,
+            metadata_namespace=namespace,
+        ),
+        output=InMemoryOutputBuffer(),
+    )
+
+
+def _spec(sandbox_id: UUID, *, epoch: int = 1) -> ProviderCreateSpec:
+    return ProviderCreateSpec(
+        sandbox_id=sandbox_id,
+        kind=SandboxKind.WORKSPACE,
+        epoch=epoch,
+        name=naming.container_name(sandbox_id, SandboxKind.WORKSPACE, epoch),
+        image="",
+        profile_name="workspace",
+        profile_digest="sha256:" + "a" * 64,
+        deadline_at=_deadline(),
+    )
+
+
+@pytest_asyncio.fixture
+async def deployment_a() -> AsyncIterator[E2BSandboxProvider]:
+    """One deployment's provider, plus the cleanup that owns what it made."""
+    if not _KEY or not _TEMPLATE:
+        pytest.skip(
+            "set E2B_API_KEY and E2B_WORKSPACE_TEMPLATE to run cross-namespace tests"
+        )
+    instance = _build_provider(_NAMESPACE_A)
+    created: list[str] = []
+    instance._created = created  # type: ignore[attr-defined]
+    try:
+        yield instance
+    finally:
+        for provider_id in created:
+            try:
+                sandbox = await instance._connect(provider_id)
+                await sandbox.kill(**instance._api())
+            except Exception:
+                continue
+
+
+@pytest_asyncio.fixture
+def deployment_b() -> E2BSandboxProvider:
+    """The other deployment, sharing the account and nothing else."""
+    if not _KEY or not _TEMPLATE:
+        pytest.skip(
+            "set E2B_API_KEY and E2B_WORKSPACE_TEMPLATE to run cross-namespace tests"
+        )
+    return _build_provider(_NAMESPACE_B)
+
+
+async def _create(provider: E2BSandboxProvider, sandbox_id: UUID):
+    instance = await provider.create(_spec(sandbox_id))
+    provider._created.append(instance.provider_id)  # type: ignore[attr-defined]
+    return instance
+
+
+async def test_a_sandbox_is_invisible_to_another_namespace(
+    deployment_a: E2BSandboxProvider, deployment_b: E2BSandboxProvider
+) -> None:
+    """The boundary itself, measured rather than assumed.
+
+    Every safety argument in this module rests on E2B's metadata query being
+    exact: the sandbox id is stored under a namespaced key, so a provider asking
+    under a different namespace must get nothing back. Asserting it against the
+    real service is the only way to know the key really is part of the query and
+    not, say, matched loosely.
+    """
+    sandbox_id = uuid4()
+    created = await _create(deployment_a, sandbox_id)
+
+    assert await deployment_a._find_any(sandbox_id) is not None
+    assert await deployment_b._find_any(sandbox_id) is None
+
+    # And the sweep sees it the same way, which is the call that matters.
+    seen_by_b = await deployment_b.list_objects(deadline_at=_deadline())
+    assert created.provider_id not in {obj.provider_id for obj in seen_by_b}
+
+
+async def test_a_sweep_does_not_destroy_a_sandbox_it_cannot_attribute(
+    deployment_a: E2BSandboxProvider, sandbox_uow_factory
+) -> None:
+    """The second line of defence, exercised where it actually has to hold.
+
+    A sandbox whose id has no row is precisely what one deployment's sandbox
+    looks like to another's database. The old rule read that as "ours and
+    forgotten" and destroyed it; there is no row here either, and the sandbox
+    has to still be running afterwards.
+    """
+    from app.modules.workspace.services.sandbox_service import SandboxService
+    from app.modules.workspace.services.sandbox_sweeper import SandboxSweeper
+
+    sandbox_id = uuid4()
+    created = await _create(deployment_a, sandbox_id)
+
+    service = SandboxService(provider=deployment_a, uow_factory=sandbox_uow_factory)
+    sweeper = SandboxSweeper(service=service, uow_factory=sandbox_uow_factory)
+
+    reclaimed = await sweeper.reclaim_orphans()
+
+    assert created.provider_id not in reclaimed
+    still_there = await deployment_a._find_any(sandbox_id)
+    assert still_there is not None, "the sweep destroyed a sandbox it did not own"
+    assert still_there.provider_id == created.provider_id
+
+
+async def test_a_pause_and_resume_keeps_the_files_and_the_sandbox(
+    deployment_a: E2BSandboxProvider,
+) -> None:
+    """What the incident cost, stated as the property that has to survive.
+
+    Not a duplicate of the lifecycle suite's pause test: that one proves pause
+    keeps files. This one adds the identity claim the sweep depends on -- the
+    resumed sandbox is the *same* E2B sandbox, so nothing along the way decided
+    to replace it, and the storage generation therefore has no reason to move.
+    """
+    sandbox_id = uuid4()
+    created = await _create(deployment_a, sandbox_id)
+    await deployment_a.wait_ready(
+        created, kind=SandboxKind.WORKSPACE, deadline_at=_deadline()
+    )
+
+    sentinel = "/workspace/cross-namespace-sentinel.txt"
+
+    async def payload():
+        yield b"survived"
+
+    await deployment_a.write_file(
+        created,
+        path=sentinel,
+        data=payload(),
+        expected_sha256=None,
+        deadline_at=_deadline(),
+    )
+    await deployment_a.release(
+        created, kind=SandboxKind.WORKSPACE, deadline_at=_deadline()
+    )
+
+    resumed = await deployment_a._find_any(sandbox_id)
+    assert resumed is not None
+    assert resumed.provider_id == created.provider_id, (
+        "a resume that changes the sandbox id has replaced the disk"
+    )
+
+    chunks = [
+        chunk
+        async for chunk in deployment_a.open_file(
+            resumed,
+            path=sentinel,
+            byte_range=ByteRange(offset=0, length=None),
+            deadline_at=_deadline(),
+        )
+    ]
+    assert b"".join(chunks) == b"survived"

--- a/lemma-backend/app/modules/workspace/tests/integration/test_local_sandbox_client_verify.py
+++ b/lemma-backend/app/modules/workspace/tests/integration/test_local_sandbox_client_verify.py
@@ -1,0 +1,114 @@
+"""What a failed readiness probe is allowed to cost.
+
+`ensure_sandbox(verify_ready=True)` exists because adoption is not proof: on a
+VM the process inside can die without the provider's answer changing, and a
+function sandbox in exactly that state served 502 to every dispatch for 100
+minutes. The recovery is to replace the sandbox once.
+
+That recovery is only safe for a function sandbox, and the reason is written in
+its own docstring -- "a function sandbox holds no files". A workspace owns the
+user's disk, and on a SANDBOX_NATIVE provider the sandbox *is* the disk, so the
+same recovery answers a twenty-second probe failure by deleting everything the
+user had. `kind` was computed at that call site and never consulted, so the two
+cases shared one recovery and only the caller list kept the workspace case from
+happening.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.modules.workspace.domain.sandbox import SandboxKind, SandboxOwnerKind
+from app.modules.workspace.providers.base import ProviderNotReady
+from app.modules.workspace.services.local_sandbox_client import LocalSandboxClient
+from app.modules.workspace.services.sandbox_service import SandboxService
+from app.modules.workspace.tests.integration.test_sandbox_service import FakeProvider
+from sandbox_runtime.protocol import WorkloadKind
+
+pytestmark = [pytest.mark.integration, pytest.mark.asyncio]
+
+
+@pytest.fixture
+def provider() -> FakeProvider:
+    return FakeProvider()
+
+
+@pytest.fixture
+def client(provider: FakeProvider, sandbox_uow_factory) -> LocalSandboxClient:
+    SandboxService._inflight.clear()
+    SandboxService._recent.clear()
+    service = SandboxService(provider=provider, uow_factory=sandbox_uow_factory)
+    return LocalSandboxClient(service=service)
+
+
+def _refuse_readiness_once(provider: FakeProvider, *, on_call: int) -> None:
+    """Fail exactly one readiness probe, the way a transiently wedged one does.
+
+    Exactly one, not "every call from here on". A permanently unready provider
+    sends `_ensure_once` into its five-minute retry budget, so the test would
+    spend 300 seconds proving something about the retry loop instead of one
+    second proving something about the recovery.
+
+    Call 1 is the provision inside the first `ensure`; call 2 is the verify
+    probe, which is the one under test.
+    """
+    original = provider.wait_ready
+    calls = {"n": 0}
+
+    async def flaky(instance, *, kind, deadline_at):
+        calls["n"] += 1
+        if calls["n"] == on_call:
+            raise ProviderNotReady("runtime is not answering")
+        return await original(instance, kind=kind, deadline_at=deadline_at)
+
+    provider.wait_ready = flaky  # type: ignore[method-assign]
+
+
+async def _workspace_row(client: LocalSandboxClient) -> UUID:
+    """A workspace row, which `_ensure_row` does not create.
+
+    Only a function runtime is resolved on first use; workspace rows are
+    backfilled per user, so a test addressing one has to put it there itself.
+    """
+    user_id = uuid4()
+    sandbox = await client._service.resolve(
+        kind=SandboxKind.WORKSPACE,
+        owner_kind=SandboxOwnerKind.USER,
+        owner_id=user_id,
+    )
+    return sandbox.id
+
+
+async def test_a_workspace_that_fails_its_probe_keeps_its_disk(
+    client: LocalSandboxClient, provider: FakeProvider
+) -> None:
+    """The one that mattered: a probe failure must not delete the user's files."""
+    logical_id = await _workspace_row(client)
+    _refuse_readiness_once(provider, on_call=2)
+
+    await client.ensure_sandbox(
+        WorkloadKind.WORKSPACE, logical_id, verify_ready=True
+    )
+
+    assert provider.destroyed == [], (
+        "a readiness failure destroyed a workspace, and on E2B that is the disk"
+    )
+
+
+async def test_a_function_that_fails_its_probe_is_still_replaced(
+    client: LocalSandboxClient, provider: FakeProvider
+) -> None:
+    """The recovery has to stay, or the 502-for-100-minutes failure comes back.
+
+    A function sandbox refetches its artifact from the gateway, so replacing it
+    costs a cold start and nothing else.
+    """
+    _refuse_readiness_once(provider, on_call=2)
+
+    await client.ensure_sandbox(
+        WorkloadKind.FUNCTION, uuid4(), verify_ready=True
+    )
+
+    assert provider.destroyed != [], "a wedged function sandbox must be replaced"

--- a/lemma-backend/app/modules/workspace/tests/integration/test_sandbox_sweeper.py
+++ b/lemma-backend/app/modules/workspace/tests/integration/test_sandbox_sweeper.py
@@ -81,6 +81,27 @@ async def _workspace(service: SandboxService):
     )
 
 
+async def _reclaimable(
+    service: SandboxService, provider: SweepableProvider
+) -> ProviderObject:
+    """A provider object the sweep is genuinely allowed to destroy.
+
+    Which now means one this database asked to be rid of. Tests about *how* the
+    sweep destroys -- dry runs, failure isolation, confirming the destroy landed
+    -- used to reach for an id with no row at all, because that was the easiest
+    reclaimable thing to make. It is no longer reclaimable at any confidence
+    (see `test_a_container_with_no_row_is_reported_not_reclaimed`), so they
+    build a deleted sandbox instead and keep testing what they were about.
+    """
+    sandbox = await _workspace(service)
+    handle = await service.ensure(sandbox.id)
+    await service.destroy(sandbox.id)
+    provider.destroyed.clear()
+    return _object(
+        name=handle.provider_id, sandbox_id=sandbox.id, epoch=handle.epoch
+    )
+
+
 async def test_unidentifiable_containers_are_left_alone(
     sweeper: SandboxSweeper, provider: SweepableProvider
 ) -> None:
@@ -92,19 +113,110 @@ async def test_unidentifiable_containers_are_left_alone(
     assert provider.destroyed == []
 
 
-async def test_a_container_with_no_row_is_reclaimed(
-    sweeper: SandboxSweeper, provider: SweepableProvider
+async def test_a_container_with_no_row_is_reported_not_reclaimed(
+    sweeper: SandboxSweeper, provider: SweepableProvider, caplog
 ) -> None:
-    """This is the one that costs money: compute the control plane forgot."""
+    """The rule this replaces read "no row" as "ours and forgotten", and it cost
+    a user their files five times inside one conversation.
+
+    A sandbox this environment created always has a row: nothing hard-deletes
+    one -- `destroy` sets `desired_state=DELETED` and keeps it -- and
+    `begin_instance` commits before the provider is asked to create anything.
+    So "no row" can only mean the object belongs to another database, which is
+    what `lemma-dev` and `lemma-prod` were to each other while two API keys
+    resolved to one E2B team.
+
+    Reporting it costs money. Destroying it costs work nobody can get back, so
+    this is the direction the uncertainty has to resolve.
+    """
     orphan = uuid4()
     provider.objects = [
         _object(name=f"lemma-ws-{orphan.hex}-1", sandbox_id=orphan, epoch=1)
     ]
 
+    with caplog.at_level("INFO"):
+        reclaimed = await sweeper.reclaim_orphans()
+
+    assert reclaimed == ()
+    assert provider.destroyed == []
+    assert "workspace.sandbox_sweeper.unattributed_objects" in caplog.text
+
+
+async def test_unattributed_objects_are_reported_once_per_sweep(
+    sweeper: SandboxSweeper, provider: SweepableProvider, caplog
+) -> None:
+    """A shared account can hold hundreds. One line per object would bury the
+    signal the report exists to raise."""
+    orphans = [uuid4() for _ in range(4)]
+    provider.objects = [
+        _object(name=f"lemma-ws-{orphan.hex}-1", sandbox_id=orphan, epoch=1)
+        for orphan in orphans
+    ]
+
+    with caplog.at_level("INFO"):
+        await sweeper.reclaim_orphans()
+
+    reports = [
+        record
+        for record in caplog.records
+        if "unattributed_objects" in record.getMessage()
+    ]
+    assert len(reports) == 1
+    assert provider.destroyed == []
+
+
+async def test_a_deleted_row_still_being_provisioned_is_not_reclaimed(
+    sweeper: SandboxSweeper, provider: SweepableProvider, service: SandboxService,
+    sandbox_uow_factory,
+) -> None:
+    """`destroy` sets DELETED and only the `_provision` after it sets PRESENT.
+
+    Between the two the row reads DELETED while a live create is in flight, and
+    a sweep landing there destroys the sandbox the caller is waiting on. CREATING
+    is the whole window: `mark_instance_ready` and `set_desired_state(PRESENT)`
+    commit together, so READY is never visible while the row still says DELETED.
+    """
+    sandbox = await _workspace(service)
+    handle = await service.ensure(sandbox.id)
+    async with sandbox_uow_factory() as uow:
+        repository = SandboxRepository(uow)
+        await repository.set_desired_state(sandbox.id, SandboxDesiredState.DELETED)
+        instance = await repository.current_instance(sandbox.id)
+        await repository.begin_instance(
+            sandbox_id=sandbox.id,
+            provider=instance.provider,
+            provider_id=instance.provider_id,
+            provider_volume_id=None,
+            epoch=instance.epoch + 1,
+        )
+        await repository.bump_epoch(sandbox.id)
+        await uow.commit()
+    provider.objects = [
+        _object(name=handle.provider_id, sandbox_id=sandbox.id, epoch=handle.epoch)
+    ]
+
+    assert await sweeper.reclaim_orphans() == ()
+    assert provider.destroyed == []
+
+
+async def test_a_deleted_row_with_no_provision_in_flight_is_reclaimed(
+    sweeper: SandboxSweeper, provider: SweepableProvider, service: SandboxService,
+    sandbox_uow_factory,
+) -> None:
+    """The sweep has to stay useful, not merely safe: a sandbox this database
+    genuinely asked to be rid of is still reclaimed."""
+    sandbox = await _workspace(service)
+    handle = await service.ensure(sandbox.id)
+    await service.destroy(sandbox.id)
+    provider.destroyed.clear()
+    provider.objects = [
+        _object(name=handle.provider_id, sandbox_id=sandbox.id, epoch=handle.epoch)
+    ]
+
     reclaimed = await sweeper.reclaim_orphans()
 
-    assert reclaimed == (f"lemma-ws-{orphan.hex}-1",)
-    assert provider.destroyed == [f"lemma-ws-{orphan.hex}-1"]
+    assert reclaimed == (handle.provider_id,)
+    assert provider.destroyed == [handle.provider_id]
 
 
 async def test_the_current_container_is_never_reclaimed(
@@ -184,26 +296,23 @@ async def test_a_legacy_container_is_reclaimed_once_superseded(
 
 
 async def test_a_dry_run_reports_without_destroying(
-    sweeper: SandboxSweeper, provider: SweepableProvider
+    sweeper: SandboxSweeper, provider: SweepableProvider, service: SandboxService
 ) -> None:
-    orphan = uuid4()
-    provider.objects = [
-        _object(name=f"lemma-ws-{orphan.hex}-1", sandbox_id=orphan, epoch=1)
-    ]
+    target = await _reclaimable(service, provider)
+    provider.objects = [target]
 
     reclaimed = await sweeper.reclaim_orphans(dry_run=True)
 
-    assert reclaimed == (f"lemma-ws-{orphan.hex}-1",)
+    assert reclaimed == (target.name,)
     assert provider.destroyed == []
 
 
 async def test_one_failure_does_not_stop_the_sweep(
-    sweeper: SandboxSweeper, provider: SweepableProvider
+    sweeper: SandboxSweeper, provider: SweepableProvider, service: SandboxService
 ) -> None:
-    first, second = uuid4(), uuid4()
     provider.objects = [
-        _object(name=f"lemma-ws-{first.hex}-1", sandbox_id=first, epoch=1),
-        _object(name=f"lemma-ws-{second.hex}-1", sandbox_id=second, epoch=1),
+        await _reclaimable(service, provider),
+        await _reclaimable(service, provider),
     ]
     original = provider.destroy
     calls: list[str] = []
@@ -292,7 +401,7 @@ async def test_a_sandbox_that_cannot_be_probed_is_left_alone(
 
 
 async def test_an_object_the_provider_cannot_reap_is_not_reported_as_reclaimed(
-    sweeper: SandboxSweeper, provider: SweepableProvider
+    sweeper: SandboxSweeper, provider: SweepableProvider, service: SandboxService
 ) -> None:
     """A destroy that returns is not a destroy that happened.
 
@@ -302,9 +411,9 @@ async def test_an_object_the_provider_cannot_reap_is_not_reported_as_reclaimed(
     count never moved. Silence about that is worse than the leak: the sweep
     looks like it is working.
     """
-    orphan = uuid4()
-    name = f"lemma-ws-{orphan.hex}-1"
-    provider.objects = [_object(name=name, sandbox_id=orphan, epoch=1)]
+    target = await _reclaimable(service, provider)
+    name = target.name
+    provider.objects = [target]
     # Accepts the call, keeps the object -- what killing a paused sandbox does.
     provider.containers[name] = ProviderInstance(
         provider_id=name, name=name, running=False
@@ -323,12 +432,12 @@ async def test_an_object_the_provider_cannot_reap_is_not_reported_as_reclaimed(
 
 
 async def test_a_destroy_that_works_is_still_reported(
-    sweeper: SandboxSweeper, provider: SweepableProvider
+    sweeper: SandboxSweeper, provider: SweepableProvider, service: SandboxService
 ) -> None:
     """The confirmation must not turn every real reclaim into a warning."""
-    orphan = uuid4()
-    name = f"lemma-ws-{orphan.hex}-1"
-    provider.objects = [_object(name=name, sandbox_id=orphan, epoch=1)]
+    target = await _reclaimable(service, provider)
+    name = target.name
+    provider.objects = [target]
     provider.containers[name] = ProviderInstance(
         provider_id=name, name=name, running=True
     )

--- a/lemma-backend/app/modules/workspace/tests/unit/test_e2b_namespace_isolation.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_e2b_namespace_isolation.py
@@ -6,7 +6,12 @@ owns a throwaway database in which no real workspace has a row. Share the
 namespace with a live account and the sweep deletes live workspaces.
 
 The provider has always supported the isolation; the factory did not pass it, so
-every deployment and every test ran as ``lemma`` regardless.
+every deployment and every test ran as ``lemma`` regardless. Then the factory
+passed it and the *default* was still shared, which is how `lemma-dev` and
+`lemma-prod` -- two API keys resolving to one E2B team -- ended up destroying
+each other's sandboxes every five minutes. So there is no shared default now:
+the namespace is derived from ENVIRONMENT, and refused outright for the two
+environment names that many deployments answer to at once.
 """
 
 from __future__ import annotations
@@ -17,6 +22,9 @@ from app.modules.workspace.config import workspace_settings
 from app.modules.workspace.providers.e2b_common import (
     DEFAULT_METADATA_NAMESPACE,
     meta_sandbox_id,
+)
+from app.modules.workspace.services.provider_factory import (
+    resolve_metadata_namespace,
 )
 
 
@@ -33,9 +41,58 @@ def test_the_factory_carries_the_configured_namespace(monkeypatch) -> None:
     assert provider._config.metadata_namespace == "lemma-e2e-abc"
 
 
-def test_the_shipped_default_is_the_production_namespace() -> None:
-    """Production keeps the bare name; everything else must opt out of it."""
-    assert workspace_settings.e2b_metadata_namespace == DEFAULT_METADATA_NAMESPACE
+def test_nothing_ships_with_a_shared_default() -> None:
+    """The default was the bug, so there is no longer one to fall back to."""
+    assert workspace_settings.e2b_metadata_namespace is None
+
+
+@pytest.mark.parametrize(
+    ("environment", "expected"),
+    [("development", "lemma-development"), ("production", "lemma-production")],
+)
+def test_a_deployed_environment_derives_its_own_namespace(
+    environment: str, expected: str
+) -> None:
+    """`ENVIRONMENT` already tells the deployments apart, so use it.
+
+    This is what makes the fix need no configuration change: `lemma-dev` reports
+    `development` and `lemma-prod` reports `production`, so deriving from it
+    separates the two the moment it deploys.
+    """
+    assert (
+        resolve_metadata_namespace(configured=None, environment=environment) == expected
+    )
+
+
+@pytest.mark.parametrize("environment", ["local", "testing"])
+def test_a_shared_environment_name_is_refused_rather_than_derived(
+    environment: str,
+) -> None:
+    """Deriving here would rebuild the same collision between colleagues.
+
+    Every developer's machine reports `local` and every CI run reports
+    `testing`, so a derived value would be identical across all of them -- and
+    those are exactly the deployments that pair a throwaway database with a real
+    E2B account, which is the combination that turns the orphan sweep into a
+    deletion.
+    """
+    with pytest.raises(RuntimeError) as raised:
+        resolve_metadata_namespace(configured=None, environment=environment)
+
+    message = str(raised.value)
+    # The message has to name the hazard, not just the missing variable. Someone
+    # hitting this at startup needs to know why it is not merely a nuisance.
+    assert "E2B_METADATA_NAMESPACE" in message
+    assert "destroys the user's files" in message
+
+
+@pytest.mark.parametrize("environment", ["local", "testing", "production"])
+def test_an_explicit_namespace_always_wins(environment: str) -> None:
+    """Including where derivation would refuse: stating one is the way out."""
+    assert (
+        resolve_metadata_namespace(configured="lemma-mine", environment=environment)
+        == "lemma-mine"
+    )
 
 
 def test_namespaces_do_not_collide_on_the_metadata_key() -> None:

--- a/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
@@ -29,6 +29,7 @@ from app.modules.workspace.providers.e2b import (
     E2BSandboxProvider,
 )
 from app.modules.workspace.providers.e2b_common import (
+    DEFAULT_METADATA_NAMESPACE,
     META_EPOCH,
     META_PROFILE_DIGEST,
     META_SANDBOX_ID,
@@ -61,6 +62,11 @@ def provider(world: FakeE2B, monkeypatch) -> E2BSandboxProvider:
             api_key="test-key",
             workspace_template="lemma-workspace",
             function_template="lemma-function",
+            # Stated, because the config no longer supplies one. The META_*
+            # constants this module asserts against are built from this same
+            # value, so the pair has to be named together or the assertions
+            # would be checking the fixture against itself.
+            metadata_namespace=DEFAULT_METADATA_NAMESPACE,
         )
     )
     # Only the SDK is substituted. The query type comes through the SDK itself,

--- a/lemma-backend/load_tests/function_execution.py
+++ b/lemma-backend/load_tests/function_execution.py
@@ -11,10 +11,11 @@ persistence.
 from __future__ import annotations
 
 import asyncio
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC, datetime
 from enum import StrEnum
 import json
+from collections.abc import Awaitable, Callable
 import math
 from pathlib import Path
 import statistics
@@ -43,6 +44,22 @@ class BenchmarkPhase(StrEnum):
     COLD = "cold"
     POOL_FILL = "pool_fill"
     STEADY = "steady"
+    # The two states a real pod spends most of its life entering, and the two
+    # the benchmark could not previously price. STEADY measures a sandbox that
+    # is already running; nobody's first call of the morning is that call.
+    #
+    # RESUMED: the sandbox was released and its next invocation woke it. This is
+    # the routine one -- the idle sweep releases after
+    # `WORKSPACE_IDLE_RELEASE_SECONDS`, so this is what a user pays after any
+    # gap longer than that.
+    #
+    # REBUILT: the sandbox was destroyed and its next invocation had to make a
+    # new one. This should be rare, and the gap between it and RESUMED is what
+    # a lifecycle bug costs. It was not rare: two deployments sharing an E2B
+    # team destroyed each other's sandboxes every five minutes, so every
+    # invocation was paying REBUILT while the dashboards showed STEADY.
+    RESUMED = "resumed"
+    REBUILT = "rebuilt"
 
 
 @dataclass(frozen=True, slots=True)
@@ -96,6 +113,8 @@ class LatencyBudget:
     submit_p95_seconds: float | None = None
     platform_overhead_p95_seconds: float | None = None
     cold_terminal_seconds: float | None = None
+    resumed_terminal_seconds: float | None = None
+    rebuilt_terminal_seconds: float | None = None
 
     def __post_init__(self) -> None:
         if not self.case:
@@ -105,6 +124,8 @@ class LatencyBudget:
             self.submit_p95_seconds,
             self.platform_overhead_p95_seconds,
             self.cold_terminal_seconds,
+            self.resumed_terminal_seconds,
+            self.rebuilt_terminal_seconds,
         )
         if not any(value is not None for value in configured):
             raise ValueError("latency budget must configure at least one limit")
@@ -126,6 +147,17 @@ class BenchmarkConfig:
     pool_fill_hold_ms: int = 750
     cleanup: bool = True
     latency_budgets: tuple[LatencyBudget, ...] = ()
+    # Supplied by the caller because only it can reach the sandbox control
+    # plane: the harness speaks public HTTP APIs, and there is no public route
+    # that releases or destroys a sandbox. Left unset, the lifecycle phases are
+    # skipped and the report simply carries no RESUMED/REBUILT samples.
+    release_sandbox: Callable[[], Awaitable[None]] | None = None
+    destroy_sandbox: Callable[[], Awaitable[None]] | None = None
+    # Which case pays for the lifecycle measurement. `api_noop` by default: it
+    # issues no SDK call, so its terminal time is the platform path and nothing
+    # else, and it writes no rows -- which keeps sink-row verification exact
+    # without teaching it about these extra invocations.
+    lifecycle_case: str = "api_noop"
 
     def __post_init__(self) -> None:
         if not self.provider:
@@ -166,6 +198,13 @@ class InvocationSample:
     platform_overhead_seconds: float | None
     output_data: dict[str, Any] | None
     error: str | None
+    # Only set on lifecycle samples: how long the release or destroy that
+    # preceded this invocation took. It is not part of anyone's latency, but it
+    # is what decides the policy -- E2B documents a pause at roughly four
+    # seconds per GiB of RAM, so a memory-preserving pause of a 2 GiB function
+    # sandbox spends real time that a kill does not. Pausing is only worth it
+    # if `resumed` beats `rebuilt` by more than the pause costs to take.
+    disturb_seconds: float | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -207,6 +246,7 @@ class BenchmarkReport:
     resources: dict[str, Any]
     cold: tuple[InvocationSample, ...]
     pool_fill: tuple[InvocationSample, ...]
+    lifecycle: tuple[InvocationSample, ...]
     cases: tuple[CaseSummary, ...]
     samples: tuple[InvocationSample, ...]
     verified_sink_rows: dict[str, int]
@@ -286,11 +326,18 @@ def evaluate_latency_budgets(
     budgets: tuple[LatencyBudget, ...],
     *,
     cold: tuple[InvocationSample, ...] | list[InvocationSample] = (),
+    lifecycle: tuple[InvocationSample, ...] | list[InvocationSample] = (),
 ) -> tuple[str, ...]:
     """Return stable quality-gate failures for a benchmark report."""
 
     summaries = {summary.case: summary for summary in cases}
     cold_by_case = {sample.case: sample for sample in cold}
+    # Keyed by phase as well as case: one case contributes both a RESUMED and a
+    # REBUILT sample, and collapsing them onto the case would let whichever
+    # arrived last answer for both.
+    lifecycle_by_phase = {
+        (sample.phase, sample.case): sample for sample in lifecycle
+    }
     failures: list[str] = []
     for budget in budgets:
         summary = summaries.get(budget.case)
@@ -337,7 +384,43 @@ def evaluate_latency_budgets(
                     f"{cold_sample.terminal_seconds:.3f}s exceeds "
                     f"{budget.cold_terminal_seconds:.3f}s"
                 )
+        for phase, limit in (
+            (BenchmarkPhase.RESUMED, budget.resumed_terminal_seconds),
+            (BenchmarkPhase.REBUILT, budget.rebuilt_terminal_seconds),
+        ):
+            if limit is None:
+                continue
+            sample = lifecycle_by_phase.get((phase, budget.case))
+            if sample is None:
+                # Absent rather than slow: the hooks were not supplied, so the
+                # phase never ran. Saying so beats a budget that silently
+                # passes because nothing measured it.
+                failures.append(f"{budget.case} {phase.value} has no sample")
+            elif sample.terminal_seconds > limit:
+                failures.append(
+                    f"{budget.case} {phase.value} terminal "
+                    f"{sample.terminal_seconds:.3f}s exceeds {limit:.3f}s"
+                )
     return tuple(failures)
+
+
+def _serializable_config(config: BenchmarkConfig) -> dict[str, Any]:
+    """The config as recorded in the report, minus the parts that are code.
+
+    `release_sandbox` and `destroy_sandbox` are callables the caller injects,
+    and `asdict` carries them straight into a structure the report then tries
+    to serialise as JSON. What a reader needs is whether the lifecycle phases
+    ran at all, which is a boolean.
+    """
+    payload = {
+        key: value
+        for key, value in asdict(config).items()
+        if key not in {"release_sandbox", "destroy_sandbox"}
+    }
+    payload["lifecycle_phases_enabled"] = (
+        config.release_sandbox is not None or config.destroy_sandbox is not None
+    )
+    return payload
 
 
 def write_report(report: BenchmarkReport, path: Path) -> None:
@@ -468,6 +551,7 @@ class FunctionExecutionBenchmark:
         errors: list[str] = []
         cold: list[InvocationSample] = []
         pool_fill: list[InvocationSample] = []
+        lifecycle: list[InvocationSample] = []
         samples: list[InvocationSample] = []
         summaries: list[CaseSummary] = []
         verified_sink_rows: dict[str, int] = {}
@@ -507,6 +591,8 @@ class FunctionExecutionBenchmark:
                     )
                 )
 
+            lifecycle.extend(await self._run_lifecycle(cases, resources))
+
             verified_sink_rows = await self._verify_sink_rows(resources)
             executions_per_case = (
                 1 + self._config.concurrency + self._config.invocations
@@ -522,7 +608,7 @@ class FunctionExecutionBenchmark:
                     "sink row verification failed: "
                     f"expected {expected_sink_rows}, found {verified_sink_rows}"
                 )
-            for sample in (*cold, *pool_fill, *samples):
+            for sample in (*cold, *pool_fill, *lifecycle, *samples):
                 if sample.status != "COMPLETED":
                     errors.append(
                         f"{sample.case}[{sample.index}] {sample.status}: "
@@ -533,6 +619,7 @@ class FunctionExecutionBenchmark:
                     summaries,
                     self._config.latency_budgets,
                     cold=cold,
+                    lifecycle=lifecycle,
                 )
             )
         finally:
@@ -548,15 +635,55 @@ class FunctionExecutionBenchmark:
             provider=self._config.provider,
             started_at=started.isoformat(),
             finished_at=datetime.now(UTC).isoformat(),
-            config=asdict(self._config),
+            config=_serializable_config(self._config),
             resources=asdict(resources),
             cold=tuple(cold),
             pool_fill=tuple(pool_fill),
+            lifecycle=tuple(lifecycle),
             cases=tuple(summaries),
             samples=tuple(samples),
             verified_sink_rows=verified_sink_rows,
             errors=tuple(errors),
         )
+
+    async def _run_lifecycle(
+        self,
+        cases: tuple[BenchmarkCase, ...],
+        resources: BenchmarkResources,
+    ) -> list[InvocationSample]:
+        """Price the two states STEADY cannot see: resumed, and rebuilt.
+
+        Both are measured on one case and one invocation each, because what is
+        being measured is a step change, not a distribution: resuming a paused
+        sandbox and building a new one differ by seconds, and a single sample
+        separates them unambiguously. Spending the benchmark's time on repeats
+        here would buy precision nobody needs and slow every run.
+
+        Order matters. Release first, because releasing a sandbox that has just
+        been destroyed measures nothing; and the resumed invocation leaves a
+        running sandbox behind, which is exactly the state destroy needs.
+        """
+        case = next(
+            (item for item in cases if item.name == self._config.lifecycle_case),
+            None,
+        )
+        if case is None:
+            return []
+
+        samples: list[InvocationSample] = []
+        function_name = resources.functions[case.name]
+        for phase, disturb in (
+            (BenchmarkPhase.RESUMED, self._config.release_sandbox),
+            (BenchmarkPhase.REBUILT, self._config.destroy_sandbox),
+        ):
+            if disturb is None:
+                continue
+            disturb_started = time.perf_counter()
+            await disturb()
+            disturb_seconds = time.perf_counter() - disturb_started
+            sample = await self._invoke(case, function_name, 0, phase=phase)
+            samples.append(replace(sample, disturb_seconds=disturb_seconds))
+        return samples
 
     async def provision(self) -> BenchmarkResources:
         suffix = uuid4().hex[:10]


### PR DESCRIPTION
## What changes

The orphan sweep no longer destroys a sandbox it cannot attribute to a row in its own database. Two deployments sharing one E2B team were destroying each other's workspaces every five minutes — and on E2B the sandbox *is* the disk, so each of those was a user's files. One workspace was wiped five times inside a single twenty-minute conversation, each kill landing seconds after the other environment rebuilt it.

Alongside that, `E2B_METADATA_NAMESPACE` is now derived from `ENVIRONMENT` instead of falling back to a shared default, so two deployments cannot see each other's sandboxes in the first place. **No deployment config change is needed** — the two environments already report different `ENVIRONMENT` values.

Operator-visible: a new `workspace.sandbox_sweeper.unattributed_objects` line, once per sweep, counting objects in the provider account that belong to some other database. A non-zero count is expected on a shared account; a *rising* one means another deployment has started writing into it. `workspace.sandbox_sweeper.orphan_reclaimed` should become rare, and `workspace.sandbox_service.workspace_storage_recreated` should go to ~zero — both are worth alerting on.

Also here, because they are what let this ship unnoticed: fifty-seven workspace tests that silently skipped in CI now run, and so do twenty-seven more that ran nowhere at all.

## Why

`reclaim_orphans` treated "no sandbox row" as a reason to destroy. That is an unfalsifiable negative. A sandbox this environment created **always** has a row:

- nothing hard-deletes one — `SandboxService.destroy` sets `desired_state='deleted'` and keeps it; and
- `begin_instance` commits the row *before* the provider is asked to create anything, so even a create whose response was lost leaves a row behind.

So "no row" cannot mean "ours and forgotten". It can only mean another database's: a second environment on the same provider account, a developer's local backend, or a database restored from before the object existed. Resolving that towards deletion costs work nobody can get back; resolving it towards a report costs money. The report is the right default, and the namespace is the boundary that should have stopped the question being asked at all.

Three smaller fixes travel with it:

- The `desired_state='deleted'` arm could destroy a sandbox that had just been re-provisioned. `destroy` sets `deleted` and only the following `_provision` sets it back to `present`, so a sweep landing in that window killed the sandbox the caller was waiting on. `creating` is the whole window — `mark_instance_ready` and `set_desired_state(present)` commit together.
- `LocalSandboxClient._verified` answered a readiness-probe failure by destroying the sandbox. It computed `kind` and then never branched on it; the safety argument in its own docstring ("a function sandbox holds no files") only holds for functions. Only the current caller list kept a twenty-second probe failure from deleting a user's disk.
- `beta_pause` → `pause`; the pinned SDK marks the former deprecated.

### Why the tests did not catch it

The sweeper had twenty-four tests. None of them ran in CI.

| Suite | Tests | Why it never ran |
|---|---:|---|
| workspace integration (sweeper, service, repository) | 57 | the unit lane runs `-m "not e2e"`, which includes integration tests, but the job had no Postgres — they `pytest.skip` themselves |
| `test_sandbox_end_to_end.py` | 8 | gated on `WORKSPACE_IMAGE`, which no CI job sets |
| `test_e2b_lifecycle_real.py`, `test_e2b_function_liveness_real.py` | 19 | the conformance workflow names files explicitly and never listed them |

All of them now run: Postgres added to `backend-unit`, the end-to-end file moved into the e2e workspace shard that already builds a workspace image, and the two real-E2B suites added to the conformance workflow. One of the eight relocated tests was already failing when it finally ran — it raced the five-second handle-reuse window, which was added after the test stopped running.

New coverage, each verified to fail against the old code:

- `test_e2b_cross_namespace_isolation_real.py` — against real E2B, reproduces the incident exactly: a sandbox whose id has no row survives a sweep. Fails on `main`.
- `test_workspace_durability_e2e.py` — against a real Docker sandbox in the gated lane: files survive a release with `storage_generation` unmoved; a sweep spares a live workspace and its files, including when the row is hidden the way another deployment's database would hide it; a genuinely deleted workspace is still reclaimed, so the sweep stays useful and not merely safe.
- `test_local_sandbox_client_verify.py` — a workspace keeps its disk through a probe failure; a function is still replaced.
- `test_a_container_with_no_row_is_reclaimed` encoded the bug and is inverted.

### Function latency, measured

The benchmark could price a warm call and a first call, but not the two states a pod actually spends its life entering. It now measures `resumed` (paused, then woken) and `rebuilt` (destroyed, then rebuilt), and records what the pause itself cost. Against real E2B:

| tier | terminal | disturb |
|---|---:|---:|
| warm p95 | 0.497s | — |
| cold | 0.409s | — |
| resumed | 3.419s | 1.064s |
| rebuilt | 5.837s | 0.999s |

Resume beats a fresh build by 2.42s while the pause costs 1.06s, so keeping memory on the function profile earns its place — it had never been measured. The report carries `pause_is_worth_taking`; if that flips, `E2BSandboxProvider._lifecycle` should kill on timeout rather than pause.

The new startup guard immediately caught a real case: the benchmark harness was configuring E2B with **no** metadata namespace, i.e. running under the production one against a throwaway database. Its JOB cases were also failing because the worker is a separate process that reads the namespace from the environment; both are fixed.

## How to verify

```bash
make quality
```

```bash
cd lemma-backend && make coverage-backend-unit
```

`5285 passed, 0 failed`. Fifty-seven of those are workspace integration tests that skipped before this change — reproduce the old behaviour by pointing the database at a dead port:

```bash
cd lemma-backend && DATABASE_URL="postgresql+asyncpg://postgres:postgres@127.0.0.1:1/lemma" uv run pytest app/modules/workspace -m "not e2e" -q
```

`246 passed, 109 skipped` against `303 passed, 52 skipped` with a database up.

The workspace e2e shard, as CI runs it — 4 tests before this change, 15 now:

```bash
cd lemma-backend && E2E_REAL=1 uv run pytest app/modules/workspace/tests/e2e -m "e2e and not slow and not provider and not local_cli and not indexing and not protected" -q
```

The real-E2B suites, as the conformance workflow now runs them (needs `E2B_API_KEY` and both template ids; `33 passed in 4m15s`, zero sandboxes left behind):

```bash
cd lemma-backend && uv run pytest app/modules/workspace/tests/integration/test_e2b_provider_real.py app/modules/workspace/tests/integration/test_e2b_lifecycle_real.py app/modules/workspace/tests/integration/test_e2b_function_liveness_real.py app/modules/workspace/tests/integration/test_e2b_cross_namespace_isolation_real.py -m "" -q
```

The latency table above:

```bash
cd lemma-backend && make benchmark-functions-e2b FUNCTION_BENCH_INVOCATIONS=5 FUNCTION_BENCH_CONCURRENCY=3 FUNCTION_BENCH_BATCH_ROWS=100 FUNCTION_BENCH_TUNNEL=ngrok
```

Diff coverage is 97% (one uncovered line: the deprecated `beta_pause` shim in the E2B double, which nothing calls any more — which is the point).

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload. The new `unattributed_objects` line carries a count and provider-assigned sandbox ids, no user data.
- [x] **Rollback** — see below

## Compatibility and rollback notes

No migration and no API change.

**One breaking configuration change.** `E2B_METADATA_NAMESPACE` no longer has a default. A deployment running `WORKSPACE_PROVIDER=e2b` with `ENVIRONMENT` set to `local` or `testing` will now **refuse to start** until the variable is set; `development` and `production` derive `lemma-<environment>` and need no change. This is deliberate: those two environment names are shared by every developer machine and every CI run, and they are exactly the deployments that pair a throwaway database with a real provider account.

Because the namespace is part of the metadata *key* and E2B metadata is immutable after create, sandboxes made under the old namespace become invisible to both adoption and the sweep after deploy. They are not destroyed — they leak, and need one deliberate operator pass. The cost is near zero right now: the account currently holds no live workspace sandboxes on the current scheme, because they were being destroyed.

**Rollback** is a plain revert. It restores the deletion, so prefer forward-fixing. The sweep's behaviour can also be narrowed without a revert — the reporting branch is a single `continue`.

### Not in this change

Deployment config lives in a separate repository and is untouched here. Three things belong there, none required for this fix to work:

- Optionally pin `E2B_METADATA_NAMESPACE` explicitly per environment, so a future `ENVIRONMENT` edit cannot silently re-merge two deployments.
- `WORKSPACE_IDLE_RELEASE_SECONDS` is `180` in both environments, five times more aggressive than the `900` default and against the documented five-minute policy. Releasing is filesystem-only, so it kills python sessions, PTYs and the browser under a run that is merely between tool calls.
- Two deployments share one E2B team. Separate teams would give a real billing and blast-radius boundary, at the cost of rebuilding both templates in the new team.

Two further items in this repository, deliberately left out to keep this focused:

- **`lemma-backend e2e (workspace)` is not a required status check.** The ruleset requires `lemma-backend unit` plus seven of the eight e2e shards; workspace is the one omitted. `e2e.yml`'s header claimed all eight were required, which was wrong and is corrected here — but adding the check to `protect-main` is a repository settings change. Until it lands, the tests added here can go red without blocking a merge.
- **Template drift still wipes the fleet.** `E2BSandboxProvider.create` kills a sandbox whose recorded template differs from config, and both environments pin `template:build_id`, so every template promotion destroys every workspace disk on next ensure. An unstamped sandbox counts as stale too. This contradicts the sandbox fabric design's §6 ("nothing is replaced") and wants copy-then-swap with a snapshot first — `create_snapshot()` in the pinned SDK is persistent and survives sandbox deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
