### PR TITLE
Close the resource stage with a cross, not a sidebar toggle

### DIFF
--- a/lemma-frontend/components/pod/conversation-presentation-stage.tsx
+++ b/lemma-frontend/components/pod/conversation-presentation-stage.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { Maximize2, PanelRightClose } from '@/components/ui/icons';
+import { ArrowUpRight, X } from '@/components/ui/icons';
 import { useEffect, useRef, type ReactNode } from 'react';
 
 import { useApp } from '@/components/app/app-context';
@@ -48,7 +48,7 @@ function presentationTitle(resourceHref: string): string {
 
 /**
  * The app itself, in the pane — no workspace around it. The stage's own header
- * already names the app and holds the close and full-view controls, so the frame
+ * already names the app and holds the close and open-in-tab controls, so the frame
  * draws without the context bar it would otherwise claim from the conversation.
  */
 function StageAppBody({
@@ -165,10 +165,10 @@ export function ConversationPresentationStage({
                         size="icon"
                         onClick={onClose}
                         className="lemma-shell-icon-button custom-focus-ring h-8 w-8 shrink-0"
-                        aria-label="Back to conversation"
-                        title="Back to conversation"
+                        aria-label="Close"
+                        title="Close"
                     >
-                        <PanelRightClose className="h-4 w-4" strokeWidth={1.8} />
+                        <X className="h-4 w-4" strokeWidth={1.8} />
                     </Button>
                     <div className="min-w-0 flex-1 truncate text-sm font-medium text-[var(--text-primary)]">
                         {title}
@@ -179,8 +179,8 @@ export function ConversationPresentationStage({
                         size="icon"
                         className="lemma-shell-icon-button custom-focus-ring h-8 w-8 shrink-0"
                     >
-                        <Link href={standaloneHref} aria-label="Open full view" title="Open full view">
-                            <Maximize2 className="h-4 w-4" strokeWidth={1.8} />
+                        <Link href={standaloneHref} aria-label="Open in new tab" title="Open in new tab">
+                            <ArrowUpRight className="h-4 w-4" strokeWidth={1.8} />
                         </Link>
                     </Button>
                 </header>


### PR DESCRIPTION
## What changes

The pane that opens when an agent presents a file, table, widget or app gets two honest icons. Close is now a cross (`X`, labelled "Close") instead of a sidebar-toggle glyph, and full view is `ArrowUpRight` labelled "Open in new tab" instead of the expand arrows.

## Why

Both glyphs promised something the buttons don't do.

The close button used `PanelRightClose`, which resolves to Phosphor's `SidebarSimple` in [`icons.ts`](https://github.com/lemma-work/lemma-platform/blob/main/lemma-frontend/components/ui/icons.ts). A sidebar glyph reads as a mode toggle — a panel that stays put and comes back. This pane doesn't stay: `closePresentedResource` drops the URL param and the conversation reflows to full width. Its label said a third thing, "Back to conversation".

The expand button was the sharper problem. `Maximize2` already means "open the side stage" one layer up, on the inline widget card's own menu (`inline-widget.tsx`) — and the stage header used that same glyph for a link to the resource's pod route, which is the entry *directly above it* in that same menu, named "Open in new tab" and drawn with `ArrowUpRight`. One glyph, two destinations, two clicks apart.

So the fix is to speak the vocabulary the product already has, per the rule stated at the top of `icons.ts`: one UI concept resolves to one glyph everywhere.

- Close is `X` — the pairing the workspace tab strip and the other dismissible surfaces in the shell already use.
- Full view is `ArrowUpRight` / "Open in new tab", matching the card menu word for word, so the same action reached from either place has the same name and the same mark.
- Deliberately *not* `ExternalLink`/`ArrowSquareOut`: that one is spoken for as "leave the app for a browser tab" in `pod-workspace-tabs.tsx`. This link stays in the app — the tab strip is derived from the URL, so the conversation survives as its own tab.

## How to verify

Display copy and glyphs only; no behavior, props, or routes change. Lint and typecheck on the touched file:

```bash
cd lemma-frontend && npx eslint components/pod/conversation-presentation-stage.tsx && npx tsc --noEmit -p tsconfig.json
```

ESLint is clean. `tsc` reports no error in this file; the four it does print are pre-existing on `main` and unrelated (missing `posthog-js`, a `ScheduleDetailResponse` field, an SDK config key).

I did not exercise this in a browser: reaching the pane needs a live pod with a presented resource, which is disproportionate setup for a three-line icon swap. A reviewer with a pod running can confirm by having an agent `display_resource` anything and looking at the pane header.

## Checklist

- [x] Lint and typecheck pass locally on the touched file

No tests: there is no behavioral change to cover, and nothing asserts on these two glyphs. No migrations, no API surface, no new CSS (so the design-audit baseline is untouched).

## Compatibility and rollback notes

Nothing to note — a single component's icons and labels, revertable on its own.