### PR TITLE
Pick an element in a running app and hand it to the agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ SHELL := /bin/bash
 #   make init          create .env files with local defaults (idempotent)
 #   make dev           start infra + backend + frontend (hot-reload)
 #   make dev-public    same, with an ephemeral public Cloudflare API URL
+#   make dev-sslip     same, on sslip.io hostnames so apps share the API's
+#                      cookie site (embedded apps stay signed in)
 #   make dev RELOAD=1  same, with uvicorn --reload on the backend
 #   make dev OTEL=1 LLM_OTEL=1  same, with local HyperDX + Phoenix dashboards
 #   make stop          stop backend/frontend processes
@@ -16,9 +18,9 @@ SHELL := /bin/bash
 #   make coverage      full coverage report (unit + e2e per component)
 # ──────────────────────────────────────────────────────────────────────────────
 
-.PHONY: help init dev dev-public stop stop-all logs otel-up otel-down otel-tail otel-smoke \
+.PHONY: help init dev dev-public dev-sslip stop stop-all logs otel-up otel-down otel-tail otel-smoke \
         observability-up observability-down observability-open \
-        _prepare-dev _start-public-api-tunnel _ensure-databases _ensure-sandbox-images _wait-backend \
+        _prepare-dev _sync-dev-env _start-public-api-tunnel _ensure-databases _ensure-sandbox-images _wait-backend \
         _ensure-native-connectors _desktop-verify-dist-app _desktop-ensure-sidecars \
         desktop-dev desktop-sidecars desktop-test desktop-test-app desktop-fmt desktop-fmt-fix \
         desktop-lint desktop-guestd desktop-concepts desktop-concepts-check \
@@ -97,11 +99,30 @@ DEV_POSTGRES_PORT     ?= 5432
 DEV_REDIS_PORT        ?= 6379
 DEV_SUPERTOKENS_PORT  ?= 3567
 
-DEV_BACKEND_URL       := http://localhost:$(DEV_BACKEND_PORT)
-DEV_FRONTEND_URL      := http://localhost:$(DEV_FRONTEND_PORT)
+# The hostname the browser reaches this stack on, and the domain apps are
+# served under. They are separate knobs because they answer different
+# questions, but they have to agree on one thing: cookies are scoped by *site*,
+# not by origin, so an app whose site differs from the API's cannot send the
+# session cookie and every embedded app renders signed-out.
+#
+# `localhost` + `apps.lemma.localhost` are two different sites, which is why
+# `make dev-sslip` exists: it puts the whole stack under `sslip.io` (a public
+# DNS service that resolves any name embedding an IP back to it), so the shell,
+# the API, and every app share one site — the way they do in production, where
+# `api.lemma.work` and `<slug>.apps.lemma.work` are both `lemma.work`.
+DEV_HOST              ?= localhost
+DEV_APPS_HOST         ?= apps.lemma.localhost
+# What `make dev-sslip` switches to. sslip.io resolves any name ending in an
+# embedded IP back to that IP, including nested labels — so
+# `<slug>.apps.127-0-0-1.sslip.io` reaches this machine with no /etc/hosts
+# entry and no local DNS. It does need working internet DNS.
+DEV_SSLIP_HOST        ?= 127-0-0-1.sslip.io
+
+DEV_BACKEND_URL       := http://$(DEV_HOST):$(DEV_BACKEND_PORT)
+DEV_FRONTEND_URL      := http://$(DEV_HOST):$(DEV_FRONTEND_PORT)
 DEV_AUTH_FRONTEND_URL := $(DEV_FRONTEND_URL)
-DEV_APP_BASE_DOMAIN   := apps.lemma.localhost:$(DEV_BACKEND_PORT)
-DEV_APPS_DOMAIN_SUFFIX := apps.lemma.localhost
+DEV_APP_BASE_DOMAIN   := $(DEV_APPS_HOST):$(DEV_BACKEND_PORT)
+DEV_APPS_DOMAIN_SUFFIX := $(DEV_APPS_HOST)
 DEV_DATABASE_URL      := postgresql+asyncpg://postgres:postgres@localhost:$(DEV_POSTGRES_PORT)/lemma
 DEV_DATASTORE_DATABASE_URL := postgresql+asyncpg://postgres:postgres@localhost:$(DEV_POSTGRES_PORT)/lemma_datastore
 DEV_REDIS_URL         := redis://localhost:$(DEV_REDIS_PORT)/0
@@ -200,6 +221,11 @@ BACKEND_WORKSPACE_CALLBACK_AUTH_URL ?= $(DEV_SANDBOX_FRONTEND_URL)
 BACKEND_WORKSPACE_CALLBACK_FRONTEND_URL ?= $(DEV_SANDBOX_FRONTEND_URL)
 BACKEND_APP_BASE_DOMAIN         ?= $(DEV_APP_BASE_DOMAIN)
 BACKEND_SESSION_COOKIE_DOMAIN   ?=
+# Empty, and meaningfully so: it tells SuperTokens the previous session cookies
+# were host-only, so a browser still holding cookies from a different DEV_HOST
+# gets them cleared on refresh instead of a 500 that only a manual cookie purge
+# fixes. Switching between `make dev` and `make dev-sslip` is exactly that case.
+BACKEND_SESSION_OLDER_COOKIE_DOMAIN ?=
 BACKEND_SESSION_COOKIE_SECURE   ?= false
 BACKEND_SESSION_COOKIE_SAME_SITE?= lax
 BACKEND_CORS_ORIGINS            ?= ["http://localhost:$(DEV_FRONTEND_PORT)","http://127.0.0.1:$(DEV_FRONTEND_PORT)"]
@@ -240,6 +266,7 @@ BACKEND_DEV_ENV := \
 	ENABLE_SLACK_SOCKET_MODE=$(BACKEND_SLACK_SOCKET_MODE) \
 	APP_BASE_DOMAIN=$(BACKEND_APP_BASE_DOMAIN) \
 	SESSION_COOKIE_DOMAIN=$(BACKEND_SESSION_COOKIE_DOMAIN) \
+	SESSION_OLDER_COOKIE_DOMAIN=$(BACKEND_SESSION_OLDER_COOKIE_DOMAIN) \
 	SESSION_COOKIE_SECURE=$(BACKEND_SESSION_COOKIE_SECURE) \
 	SESSION_COOKIE_SAME_SITE=$(BACKEND_SESSION_COOKIE_SAME_SITE) \
 	CORS_ORIGINS='$(BACKEND_CORS_ORIGINS)' \
@@ -290,6 +317,7 @@ help:
 	@echo "  Dev stack"
 	@echo "    make dev                start infra + backend + frontend"
 	@echo "    make dev-public         start with an ephemeral public API tunnel"
+	@echo "    make dev-sslip          start on sslip.io hostnames (embedded apps stay signed in)"
 	@echo "    make dev RELOAD=1       same, with uvicorn --reload on the backend"
 	@echo "    make stop               stop app and tunnel processes"
 	@echo "    make stop-all           also bring down infra containers"
@@ -559,6 +587,11 @@ dev:
 		}; \
 		wait
 
+dev-sslip:
+	@$(MAKE) --no-print-directory dev \
+		DEV_HOST=$(DEV_SSLIP_HOST) \
+		DEV_APPS_HOST=apps.$(DEV_SSLIP_HOST)
+
 dev-public:
 	@echo "→ Starting Lemma dev stack with a public Cloudflare API URL…"
 	@$(MAKE) --no-print-directory _prepare-dev
@@ -591,9 +624,45 @@ dev-public:
 	}; \
 	wait
 
+# Keys whose values are derived from the host/port knobs at the top of this
+# file. `make dev` injects them as process env, and that is what the running
+# stack uses — but the generated .env files are what everything started
+# *outside* make reads: alembic, pytest, a hand-run uvicorn, the CLI. Left
+# alone they drift, so a `make dev-sslip` session and a `uv run alembic` in the
+# next terminal disagree about which host this stack is on, and a browser can
+# end up holding session cookies for two of them at once.
+#
+# So rewrite exactly those keys on every start. Every other line in the file —
+# API keys, personal overrides — is left untouched.
+_sync-dev-env:
+	@set -e; \
+	upsert() { \
+		file="$$1"; key="$$2"; value="$$3"; \
+		[ -f "$$file" ] || return 0; \
+		if grep -qE "^$$key=" "$$file"; then \
+			awk -v k="$$key" -v v="$$value" \
+				'index($$0, k "=") == 1 { print k "=" v; next } { print }' \
+				"$$file" > "$$file.tmp" && mv "$$file.tmp" "$$file"; \
+		else \
+			printf '%s=%s\n' "$$key" "$$value" >> "$$file"; \
+		fi; \
+	}; \
+	upsert $(BACKEND_DIR)/.env API_URL '$(DEV_BACKEND_URL)'; \
+	upsert $(BACKEND_DIR)/.env FRONTEND_URL '$(DEV_FRONTEND_URL)'; \
+	upsert $(BACKEND_DIR)/.env AUTH_FRONTEND_URL '$(DEV_AUTH_FRONTEND_URL)'; \
+	upsert $(BACKEND_DIR)/.env CLI_API_URL '$(DEV_BACKEND_URL)'; \
+	upsert $(BACKEND_DIR)/.env CLI_AUTH_FRONTEND_URL '$(DEV_AUTH_FRONTEND_URL)'; \
+	upsert $(BACKEND_DIR)/.env APP_BASE_DOMAIN '$(DEV_APP_BASE_DOMAIN)'; \
+	upsert $(BACKEND_DIR)/.env CORS_ORIGINS '$(BACKEND_CORS_ORIGINS)'; \
+	upsert $(FRONTEND_DIR)/.env.local NEXT_PUBLIC_API_URL '$(DEV_BACKEND_URL)'; \
+	upsert $(FRONTEND_DIR)/.env.local NEXT_PUBLIC_SITE_URL '$(DEV_FRONTEND_URL)'; \
+	upsert $(FRONTEND_DIR)/.env.local NEXT_PUBLIC_AUTH_URL '$(DEV_AUTH_FRONTEND_URL)'; \
+	upsert $(FRONTEND_DIR)/.env.local NEXT_PUBLIC_APPS_DOMAIN_SUFFIX '$(DEV_APPS_DOMAIN_SUFFIX)'
+
 _prepare-dev:
 	@$(MAKE) --no-print-directory stop 2>/dev/null || true
 	@$(MAKE) --no-print-directory _ensure-init
+	@$(MAKE) --no-print-directory _sync-dev-env
 	@$(MAKE) --no-print-directory _ensure-sandbox-images
 	@$(MAKE) --no-print-directory _infra-up
 	@$(MAKE) --no-print-directory _wait-infra

--- a/lemma-backend/app/core/app_editor.py
+++ b/lemma-backend/app/core/app_editor.py
@@ -1,0 +1,95 @@
+"""The element picker an app carries so it can be edited from the pod shell.
+
+An app runs on its own subdomain, framed by the pod shell. Cross-origin means
+the shell cannot read the app's DOM, so "click this element and tell the agent
+what to change about it" has to be answered by code running inside the app.
+That code is :mod:`app.core.assets.lemma-app-editor-bridge` (plain browser JS,
+injected verbatim); this module decides who is allowed to drive it and wraps it
+for injection.
+
+The allowlist is the security boundary. The bridge reads the rendered page and
+hands it to whichever window framed it, so without an origin check any site
+could embed a public app and read back whatever the viewer's session renders.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import json
+from functools import lru_cache
+from pathlib import Path
+from urllib.parse import urlparse
+
+from app.core.config import settings
+
+# Sentinel attribute marking the injected <script>, so injection is idempotent
+# for a document that already carries the bridge.
+EDITOR_BRIDGE_SENTINEL = "data-lemma-editor-bridge"
+
+_BRIDGE_PATH = Path(__file__).parent / "assets" / "lemma-app-editor-bridge.js"
+
+
+@lru_cache(maxsize=1)
+def _bridge_source() -> str:
+    # The asset ships with the backend and never changes at runtime, so it is
+    # read once rather than per served entrypoint.
+    return _BRIDGE_PATH.read_text(encoding="utf-8")
+
+
+def _origin_of(url: str | None) -> str | None:
+    if not url:
+        return None
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def editor_origins() -> list[str]:
+    """Origins allowed to drive an app's element picker.
+
+    The CORS allowlist plus the frontend itself. A browser origin this
+    deployment already trusts to make credentialed API calls is, by
+    construction, at least as privileged as one allowed to read a framed app's
+    DOM — so it is the right list, and it covers the desktop app's ``tauri://``
+    origin without a second place to configure. A ``*`` entry is dropped: as a
+    CORS value it permits unauthenticated reads, which is not the same claim as
+    "any embedder may read what this viewer sees".
+    """
+    origins: list[str] = []
+    candidates = [_origin_of(settings.frontend_url), *settings.cors_origins]
+    for candidate in candidates:
+        value = (candidate or "").strip()
+        if not value or value == "*" or value in origins:
+            continue
+        origins.append(value)
+    return origins
+
+
+def editor_bridge_script() -> str:
+    """The bridge as a ``<script>`` element, or ``""`` when nothing may drive it."""
+    origins = editor_origins()
+    if not origins:
+        return ""
+    allowlist = html.escape(json.dumps(origins), quote=True)
+    # `</script` inside the body would close the element early. The asset does
+    # not contain it today; escaping means a future edit cannot break the page.
+    source = _bridge_source().replace("</script", "<\\/script")
+    return (
+        f'<script {EDITOR_BRIDGE_SENTINEL} data-lemma-editor-origins="{allowlist}">'
+        f"{source}</script>"
+    )
+
+
+def editor_bridge_fingerprint() -> str:
+    """Short hash of the bridge and its allowlist, for entrypoint ETags.
+
+    Entrypoints are cached against a token covering everything injected into
+    them. Without this, a viewer holding a cached page would keep running the
+    previous bridge — including its previous idea of who may drive it.
+    """
+    payload = json.dumps(
+        {"origins": editor_origins(), "source": _bridge_source()}, sort_keys=True
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]

--- a/lemma-backend/app/core/assets/lemma-app-editor-bridge.js
+++ b/lemma-backend/app/core/assets/lemma-app-editor-bridge.js
@@ -1,0 +1,392 @@
+/*
+ * Lemma app editor bridge.
+ *
+ * Injected into every served app entrypoint, next to window.__LEMMA_CONFIG__.
+ * An app runs on its own subdomain, so the pod shell that frames it cannot read
+ * its DOM: picking an element to talk to the agent about has to be done by code
+ * running *inside* the app, which is this.
+ *
+ * It is inert until the framing window says hello from an origin on the
+ * allowlist stamped onto this script tag. That matters because the bridge reads
+ * the rendered page and hands it to whoever framed it — without the origin
+ * check, any site could embed a public app and use this to read what the
+ * viewer's session renders.
+ *
+ * Injected verbatim (no build step), so it stays plain browser JS.
+ */
+(() => {
+  const NS = 'lemma-app-editor:';
+  const MESSAGE = {
+    hello: NS + 'hello',
+    ready: NS + 'ready',
+    selectMode: NS + 'select-mode',
+    selection: NS + 'selection',
+  };
+  const MAX_HTML = 1200;
+  const MAX_TEXT = 200;
+  const MAX_CHAIN = 6;
+  const MAX_PATH_DEPTH = 8;
+  const FALLBACK_ACCENT = '#5b6cff';
+  const REPORTED_STYLES = [
+    'display',
+    'position',
+    'width',
+    'height',
+    'padding',
+    'margin',
+    'color',
+    'background-color',
+    'font-size',
+    'font-weight',
+    'line-height',
+    'border-radius',
+    'gap',
+    'flex-direction',
+  ];
+
+  const script = document.currentScript;
+  if (!script || window.parent === window) return;
+
+  let allowedOrigins = [];
+  try {
+    const raw = script.getAttribute('data-lemma-editor-origins');
+    const parsed = raw ? JSON.parse(raw) : [];
+    if (Array.isArray(parsed)) {
+      allowedOrigins = parsed.filter((value) => typeof value === 'string' && value);
+    }
+  } catch (error) {
+    allowedOrigins = [];
+  }
+  if (!allowedOrigins.length) return;
+
+  let hostOrigin = null;
+  let active = false;
+  let hovered = null;
+  let overlay = null;
+  let box = null;
+  let label = null;
+  let previousCursor = '';
+
+  // --- messaging ----------------------------------------------------------
+
+  function post(type, payload) {
+    if (!hostOrigin) return;
+    window.parent.postMessage(Object.assign({ type }, payload), hostOrigin);
+  }
+
+  function appInfo() {
+    const config = window.__LEMMA_CONFIG__ || {};
+    const app = config.app || {};
+    return {
+      name: app.name || null,
+      id: config.appId || null,
+      podId: config.podId || null,
+    };
+  }
+
+  window.addEventListener('message', (event) => {
+    if (event.source !== window.parent) return;
+    if (allowedOrigins.indexOf(event.origin) === -1) return;
+    const data = event.data;
+    if (!data || typeof data !== 'object') return;
+
+    if (data.type === MESSAGE.hello) {
+      hostOrigin = event.origin;
+      post(MESSAGE.ready, { app: appInfo() });
+      return;
+    }
+    // Every other message requires a completed handshake, so a frame that never
+    // introduced itself cannot drive the picker.
+    if (event.origin !== hostOrigin) return;
+    if (data.type === MESSAGE.selectMode) setActive(data.active === true);
+  });
+
+  // --- element resolution -------------------------------------------------
+
+  function elementFrom(node) {
+    let candidate = node;
+    if (candidate && candidate.nodeType === Node.TEXT_NODE) {
+      candidate = candidate.parentElement;
+    }
+    return candidate instanceof Element ? candidate : null;
+  }
+
+  /* The outermost element written by the same component as `element`.
+   *
+   * This is what makes a click land on the component someone can talk about
+   * ("this order row") rather than on whichever nested <div> happened to sit
+   * under the cursor. Elements carry the component that *wrote* them, so
+   * walking up while that name holds steady walks to that component's root.
+   * A component that renders itself recursively defeats it; alt-click selects
+   * the exact element under the cursor for that case. */
+  function componentRoot(element) {
+    const name = element.getAttribute('data-lemma-component');
+    if (!name) return element;
+    let current = element;
+    while (
+      current.parentElement &&
+      current.parentElement.getAttribute('data-lemma-component') === name
+    ) {
+      current = current.parentElement;
+    }
+    return current;
+  }
+
+  function resolveTarget(node, exact) {
+    const element = elementFrom(node);
+    if (!element || element === document.documentElement || element === document.body) {
+      return null;
+    }
+    return exact ? element : componentRoot(element);
+  }
+
+  // --- selection payload --------------------------------------------------
+
+  function parseSourceLocation(value) {
+    if (!value) return null;
+    const match = /^(.*):(\d+):(\d+)$/.exec(value);
+    if (!match) return { file: value, line: null, column: null };
+    return { file: match[1], line: Number(match[2]), column: Number(match[3]) };
+  }
+
+  function componentChain(element) {
+    const chain = [];
+    let current = element;
+    while (current && chain.length < MAX_CHAIN) {
+      const name = current.getAttribute('data-lemma-component');
+      if (name && chain[chain.length - 1] !== name) chain.push(name);
+      current = current.parentElement;
+    }
+    return chain;
+  }
+
+  /* A CSS path to the element. The only handle an app without source stamps
+   * (a single-file HTML app, or a Vite build made before stamping) can offer,
+   * and still the fastest way to find the element in a source file. */
+  function domPath(element) {
+    const parts = [];
+    let current = element;
+    while (current && current !== document.body && parts.length < MAX_PATH_DEPTH) {
+      if (current.id) {
+        parts.unshift('#' + current.id);
+        break;
+      }
+      const tag = current.tagName.toLowerCase();
+      const parent = current.parentElement;
+      if (!parent) {
+        parts.unshift(tag);
+        break;
+      }
+      const siblings = Array.prototype.filter.call(
+        parent.children,
+        (child) => child.tagName === current.tagName,
+      );
+      parts.unshift(
+        siblings.length > 1 ? tag + ':nth-of-type(' + (siblings.indexOf(current) + 1) + ')' : tag,
+      );
+      current = parent;
+    }
+    return parts.join(' > ');
+  }
+
+  function truncate(value, limit) {
+    if (!value) return '';
+    return value.length > limit ? value.slice(0, limit) + '…' : value;
+  }
+
+  function computedStyles(element) {
+    const computed = window.getComputedStyle(element);
+    const styles = {};
+    REPORTED_STYLES.forEach((name) => {
+      const value = computed.getPropertyValue(name);
+      if (value) styles[name] = value.trim();
+    });
+    return styles;
+  }
+
+  function selectionPayload(element) {
+    const rect = element.getBoundingClientRect();
+    return {
+      app: appInfo(),
+      route: window.location.pathname + window.location.search,
+      source: parseSourceLocation(element.getAttribute('data-lemma-loc')),
+      component: element.getAttribute('data-lemma-component') || null,
+      componentChain: componentChain(element),
+      tag: element.tagName.toLowerCase(),
+      domId: element.id || null,
+      className:
+        typeof element.className === 'string' ? truncate(element.className, 300) : null,
+      domPath: domPath(element),
+      text: truncate((element.textContent || '').replace(/\s+/g, ' ').trim(), MAX_TEXT),
+      html: truncate(element.outerHTML || '', MAX_HTML),
+      rect: {
+        x: Math.round(rect.x),
+        y: Math.round(rect.y),
+        width: Math.round(rect.width),
+        height: Math.round(rect.height),
+      },
+      styles: computedStyles(element),
+    };
+  }
+
+  // --- overlay ------------------------------------------------------------
+
+  function setStyles(element, styles) {
+    Object.keys(styles).forEach((name) => {
+      // `important` because the overlay lives in the app's document and must
+      // survive whatever the app's own stylesheet says about bare divs.
+      element.style.setProperty(name, styles[name], 'important');
+    });
+  }
+
+  function accentColor() {
+    const themed = window
+      .getComputedStyle(document.documentElement)
+      .getPropertyValue('--lemma-app-accent')
+      .trim();
+    return themed || FALLBACK_ACCENT;
+  }
+
+  function ensureOverlay() {
+    if (overlay) return;
+    const accent = accentColor();
+
+    overlay = document.createElement('div');
+    setStyles(overlay, {
+      position: 'fixed',
+      top: '0',
+      left: '0',
+      right: '0',
+      bottom: '0',
+      'z-index': '2147483646',
+      'pointer-events': 'none',
+    });
+
+    box = document.createElement('div');
+    setStyles(box, {
+      position: 'fixed',
+      border: '2px solid ' + accent,
+      'border-radius': '3px',
+      background: 'color-mix(in srgb, ' + accent + ' 12%, transparent)',
+      'pointer-events': 'none',
+      display: 'none',
+    });
+
+    label = document.createElement('div');
+    setStyles(label, {
+      position: 'absolute',
+      left: '0',
+      top: '-22px',
+      padding: '2px 6px',
+      'border-radius': '3px',
+      background: accent,
+      color: '#fff',
+      font: '500 11px/1.4 ui-sans-serif, system-ui, sans-serif',
+      'white-space': 'nowrap',
+      'pointer-events': 'none',
+    });
+
+    box.appendChild(label);
+    overlay.appendChild(box);
+    document.documentElement.appendChild(overlay);
+  }
+
+  function labelFor(element) {
+    const component = element.getAttribute('data-lemma-component');
+    const source = parseSourceLocation(element.getAttribute('data-lemma-loc'));
+    const name = component || element.tagName.toLowerCase();
+    if (!source || !source.line) return name;
+    const file = source.file.split('/').pop();
+    return name + ' · ' + file + ':' + source.line;
+  }
+
+  function highlight(element) {
+    hovered = element;
+    if (!element) {
+      if (box) setStyles(box, { display: 'none' });
+      return;
+    }
+    ensureOverlay();
+    const rect = element.getBoundingClientRect();
+    setStyles(box, {
+      display: 'block',
+      left: rect.left + 'px',
+      top: rect.top + 'px',
+      width: rect.width + 'px',
+      height: rect.height + 'px',
+    });
+    // Keep the label on screen when the element is flush against the top.
+    setStyles(label, { top: rect.top < 24 ? '100%' : '-22px' });
+    label.textContent = labelFor(element);
+  }
+
+  // --- select mode --------------------------------------------------------
+
+  function onPointerMove(event) {
+    highlight(resolveTarget(event.target, event.altKey));
+  }
+
+  function onClick(event) {
+    event.preventDefault();
+    event.stopPropagation();
+    const element = resolveTarget(event.target, event.altKey || event.detail > 1);
+    if (!element) return;
+    post(MESSAGE.selection, { selection: selectionPayload(element) });
+    // One pick per activation: the person's next move is to describe the change
+    // in the composer, not to keep clicking. The host toggle follows this.
+    setActive(false);
+    post(MESSAGE.selectMode, { active: false });
+  }
+
+  /* Swallow the rest of the pointer sequence too. Preventing `click` alone
+   * still lets an app that acts on mousedown (drag handles, menus) react to a
+   * pick, which would edit the very state the person is pointing at. */
+  function swallow(event) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  function onKeyDown(event) {
+    if (event.key !== 'Escape') return;
+    event.preventDefault();
+    event.stopPropagation();
+    setActive(false);
+    post(MESSAGE.selectMode, { active: false });
+  }
+
+  function onViewportChange() {
+    if (hovered) highlight(hovered);
+  }
+
+  const CAPTURED_EVENTS = ['mousedown', 'mouseup', 'pointerdown', 'pointerup', 'dblclick'];
+
+  function setActive(next) {
+    if (next === active) return;
+    active = next;
+
+    if (active) {
+      document.addEventListener('pointermove', onPointerMove, true);
+      document.addEventListener('click', onClick, true);
+      document.addEventListener('keydown', onKeyDown, true);
+      CAPTURED_EVENTS.forEach((name) => document.addEventListener(name, swallow, true));
+      window.addEventListener('scroll', onViewportChange, true);
+      window.addEventListener('resize', onViewportChange, true);
+      previousCursor = document.documentElement.style.cursor;
+      document.documentElement.style.setProperty('cursor', 'crosshair', 'important');
+      return;
+    }
+
+    document.removeEventListener('pointermove', onPointerMove, true);
+    document.removeEventListener('click', onClick, true);
+    document.removeEventListener('keydown', onKeyDown, true);
+    CAPTURED_EVENTS.forEach((name) => document.removeEventListener(name, swallow, true));
+    window.removeEventListener('scroll', onViewportChange, true);
+    window.removeEventListener('resize', onViewportChange, true);
+    document.documentElement.style.cursor = previousCursor;
+    highlight(null);
+    if (overlay && overlay.parentNode) overlay.parentNode.removeChild(overlay);
+    overlay = null;
+    box = null;
+    label = null;
+  }
+})();

--- a/lemma-backend/app/core/auth_urls.py
+++ b/lemma-backend/app/core/auth_urls.py
@@ -1,0 +1,56 @@
+"""Where the auth UI lives, as one URL.
+
+The auth site is configured as two halves — an origin (``auth_frontend_url``)
+and the path the UI is mounted at (``auth_website_base_path``) — because
+SuperTokens is initialised with ``website_domain`` and ``website_base_path``
+separately. Consumers *inside* the backend want the origin: CORS, the
+SuperTokens init, the Telegram OIDC issuer.
+
+Every consumer *outside* it wants the two already joined. The browser SDK
+derives sign-in and callback routes from the pathname of the ``authUrl`` it is
+handed, and the CLI opens ``<auth url>/cli/login``. Handed the bare origin they
+build ``/`` and ``/callback`` and ``/cli/login`` — none of which exist, because
+the routes are all under the base path. This module is that join, in one place,
+so each client stops re-deriving it (and the web shell's hand-rolled ``/auth``
+append has something to converge on).
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from app.core.config import settings
+
+
+def apply_auth_base_path(base: str) -> str:
+    """``base`` with the auth UI's base path applied, at most once.
+
+    Idempotent on purpose: a deployment that already points its auth URL at the
+    mounted path is configured correctly, and must not end up at
+    ``/auth/auth``.
+    """
+    trimmed = base.rstrip("/")
+    base_path = settings.auth_website_base_path
+    # "/" means the UI is mounted at the origin — there is nothing to join.
+    if base_path == "/":
+        return trimmed
+    if urlparse(trimmed).path.rstrip("/").endswith(base_path):
+        return trimmed
+    return f"{trimmed}{base_path}"
+
+
+def auth_ui_url() -> str:
+    """The auth UI URL handed to browsers — apps and the web SDK."""
+    return apply_auth_base_path(settings.auth_frontend_url)
+
+
+def cli_auth_ui_url() -> str:
+    """The auth UI URL handed to the CLI and to workspace sandboxes.
+
+    ``cli_auth_frontend_url`` exists so local dev can advertise a different host
+    to the CLI than the browser canonical one; when it is unset the browser URL
+    is the same answer.
+    """
+    return apply_auth_base_path(
+        settings.cli_auth_frontend_url or settings.auth_frontend_url
+    )

--- a/lemma-backend/app/core/config.py
+++ b/lemma-backend/app/core/config.py
@@ -975,6 +975,19 @@ class Settings(BaseSettings):
         default=None,
         description="Override SameSite for auth session cookies",
     )
+    session_older_cookie_domain: Optional[str] = Field(
+        default=None,
+        description=(
+            "Cookie domain the session cookies used to be set on. A browser "
+            "that holds cookies from before a host change sends two of each, "
+            "which SuperTokens rejects on refresh with a 500 that only "
+            "clearing cookies by hand resolves; naming the previous domain "
+            "lets it clear them instead. An EMPTY string is meaningful and "
+            "distinct from unset — it means the old cookies were host-only "
+            "(no Domain attribute), which is the case here. Deliberately not "
+            "blank-to-None normalised for that reason."
+        ),
+    )
 
     @field_validator(
         "session_cookie_domain",

--- a/lemma-backend/app/core/runtime_config.py
+++ b/lemma-backend/app/core/runtime_config.py
@@ -17,6 +17,11 @@ from pathlib import PurePosixPath
 from urllib.parse import urlencode
 from uuid import UUID
 
+from app.core.app_editor import (
+    EDITOR_BRIDGE_SENTINEL,
+    editor_bridge_fingerprint,
+    editor_bridge_script,
+)
 from app.core.auth_urls import auth_ui_url
 from app.core.config import settings
 
@@ -223,13 +228,17 @@ def runtime_config_token(
     app: dict[str, str] | None = None,
     branding: dict[str, str] | None = None,
 ) -> str:
-    """Short, stable hash of the runtime config, for cache busting (ETags)."""
+    """Short, stable hash of everything injected, for cache busting (ETags)."""
     config = build_runtime_config(pod_id, app=app)
     token_payload: object = (
         {"config": config, "branding": branding} if branding else config
     )
     payload = json.dumps(token_payload, sort_keys=True)
-    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+    digest = hashlib.sha256(payload.encode("utf-8"))
+    # The editor bridge is injected into the same document, so a change to it
+    # (or to who may drive it) has to move the ETag too.
+    digest.update(editor_bridge_fingerprint().encode("utf-8"))
+    return digest.hexdigest()[:12]
 
 
 def inject_runtime_config(
@@ -269,6 +278,10 @@ def inject_runtime_config(
         injection += _public_app_social_metadata(app)
     if APP_BRANDING_SENTINEL not in text:
         injection += _public_app_branding_script(branding)
+    # Apps only. A widget is a fragment inside a conversation, with no source
+    # tree of its own to point an edit at, so it carries no picker.
+    if app_id and EDITOR_BRIDGE_SENTINEL not in text:
+        injection += editor_bridge_script()
     if not injection:
         return text.encode("utf-8")
 

--- a/lemma-backend/app/core/runtime_config.py
+++ b/lemma-backend/app/core/runtime_config.py
@@ -17,6 +17,7 @@ from pathlib import PurePosixPath
 from urllib.parse import urlencode
 from uuid import UUID
 
+from app.core.auth_urls import auth_ui_url
 from app.core.config import settings
 
 # Sentinel attribute marking the injected <script>. Idempotency keys off this,
@@ -64,7 +65,7 @@ def build_runtime_config(
     config: dict[str, object] = {
         "podId": str(pod_id),
         "apiUrl": settings.api_url,
-        "authUrl": settings.auth_frontend_url,
+        "authUrl": auth_ui_url(),
     }
     if app_id:
         # Two things at once: the app names itself so its API calls resolve to

--- a/lemma-backend/app/core/tests/unit/test_app_editor.py
+++ b/lemma-backend/app/core/tests/unit/test_app_editor.py
@@ -1,0 +1,96 @@
+"""Unit tests for the app editor bridge and who is allowed to drive it."""
+
+from __future__ import annotations
+
+import json
+import re
+from html import unescape
+from uuid import uuid4
+
+import pytest
+
+from app.core import app_editor
+from app.core.app_editor import (
+    EDITOR_BRIDGE_SENTINEL,
+    editor_bridge_fingerprint,
+    editor_bridge_script,
+    editor_origins,
+)
+from app.core.runtime_config import inject_runtime_config, runtime_config_token
+
+_HTML = b"<html><head><meta></head><body><div id='root'></div></body></html>"
+
+
+def _allowlist_from(script: str) -> list[str]:
+    match = re.search(r'data-lemma-editor-origins="([^"]*)"', script)
+    assert match, "bridge script carries no origin allowlist"
+    return json.loads(unescape(match.group(1)))
+
+
+@pytest.fixture
+def origins(monkeypatch):
+    def _set(frontend_url: str, cors: list[str]):
+        monkeypatch.setattr(app_editor.settings, "frontend_url", frontend_url)
+        monkeypatch.setattr(app_editor.settings, "cors_origins", cors)
+
+    return _set
+
+
+def test_origins_include_frontend_and_cors(origins):
+    origins("https://app.lemma.work/some/path", ["tauri://localhost"])
+    assert editor_origins() == ["https://app.lemma.work", "tauri://localhost"]
+
+
+def test_origins_drop_wildcard_and_duplicates(origins):
+    origins("https://app.lemma.work", ["*", "https://app.lemma.work", "  "])
+    assert editor_origins() == ["https://app.lemma.work"]
+
+
+def test_bridge_is_not_served_when_no_origin_may_drive_it(origins):
+    origins("", ["*"])
+    assert editor_bridge_script() == ""
+
+
+def test_bridge_script_carries_its_allowlist(origins):
+    origins("https://app.lemma.work", ["tauri://localhost"])
+    script = editor_bridge_script()
+    assert _allowlist_from(script) == ["https://app.lemma.work", "tauri://localhost"]
+    assert "lemma-app-editor:" in script
+
+
+def test_bridge_body_cannot_close_the_script_element():
+    # The element is only safe while nothing in the body reads as a closing tag.
+    assert "</script" not in editor_bridge_script().removesuffix("</script>")
+
+
+def test_app_entrypoint_carries_the_bridge():
+    out = inject_runtime_config(
+        _HTML, uuid4(), app={"name": "orders"}, app_id=uuid4()
+    ).decode()
+    assert EDITOR_BRIDGE_SENTINEL in out
+    assert "__LEMMA_CONFIG__" in out
+
+
+def test_widget_document_does_not_carry_the_bridge():
+    # A widget has no source tree of its own to point an edit at.
+    assert EDITOR_BRIDGE_SENTINEL not in inject_runtime_config(_HTML, uuid4()).decode()
+
+
+def test_bridge_injection_is_idempotent():
+    pod_id, app_id = uuid4(), uuid4()
+    once = inject_runtime_config(_HTML, pod_id, app_id=app_id).decode()
+    twice = inject_runtime_config(once, pod_id, app_id=app_id).decode()
+    assert twice.count(EDITOR_BRIDGE_SENTINEL) == 1
+
+
+def test_entrypoint_token_changes_with_the_allowlist(origins):
+    pod_id = uuid4()
+    origins("https://app.lemma.work", [])
+    before = runtime_config_token(pod_id, app={"name": "orders"})
+    origins("https://app.lemma.work", ["https://evil.example"])
+    assert runtime_config_token(pod_id, app={"name": "orders"}) != before
+
+
+def test_fingerprint_is_stable_for_unchanged_input(origins):
+    origins("https://app.lemma.work", [])
+    assert editor_bridge_fingerprint() == editor_bridge_fingerprint()

--- a/lemma-backend/app/core/tests/unit/test_auth_urls.py
+++ b/lemma-backend/app/core/tests/unit/test_auth_urls.py
@@ -1,0 +1,82 @@
+"""Unit tests for the auth UI URL handed to clients.
+
+The bug these exist to prevent: advertising the bare origin. The browser SDK
+derives its routes from the pathname it is given and the CLI appends
+``/cli/login``, so an origin without the base path sends both to routes that do
+not exist.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from app.core import auth_urls
+from app.core.auth_urls import apply_auth_base_path, auth_ui_url, cli_auth_ui_url
+from app.core.runtime_config import build_runtime_config
+
+
+@pytest.fixture
+def auth_settings(monkeypatch):
+    def _set(*, frontend: str, base_path: str = "/auth", cli: str | None = None):
+        monkeypatch.setattr(auth_urls.settings, "auth_frontend_url", frontend)
+        monkeypatch.setattr(auth_urls.settings, "auth_website_base_path", base_path)
+        monkeypatch.setattr(auth_urls.settings, "cli_auth_frontend_url", cli)
+
+    return _set
+
+
+def test_base_path_is_joined_onto_the_origin(auth_settings):
+    auth_settings(frontend="https://lemma.work")
+    assert auth_ui_url() == "https://lemma.work/auth"
+
+
+def test_joining_is_idempotent(auth_settings):
+    # A deployment already pointing at the mounted path is configured correctly
+    # and must not end up at /auth/auth.
+    auth_settings(frontend="https://lemma.work/auth")
+    assert auth_ui_url() == "https://lemma.work/auth"
+
+
+def test_trailing_slash_does_not_double_up(auth_settings):
+    auth_settings(frontend="https://lemma.work/")
+    assert auth_ui_url() == "https://lemma.work/auth"
+
+
+def test_a_root_mounted_ui_is_left_alone(auth_settings):
+    auth_settings(frontend="https://auth.lemma.work", base_path="/")
+    assert auth_ui_url() == "https://auth.lemma.work"
+
+
+def test_a_host_ending_in_auth_is_not_mistaken_for_the_path(auth_settings):
+    # "myauth" ends in "auth" but is not the base path.
+    auth_settings(frontend="https://example.com/myauth")
+    assert auth_ui_url() == "https://example.com/myauth/auth"
+
+
+def test_a_nested_base_path_is_joined_whole(auth_settings):
+    auth_settings(frontend="https://lemma.work", base_path="/accounts/auth")
+    assert auth_ui_url() == "https://lemma.work/accounts/auth"
+
+
+def test_the_cli_url_prefers_its_own_host_and_still_gets_the_path(auth_settings):
+    auth_settings(frontend="https://lemma.work", cli="http://localhost:3710")
+    assert cli_auth_ui_url() == "http://localhost:3710/auth"
+
+
+def test_the_cli_falls_back_to_the_browser_url(auth_settings):
+    auth_settings(frontend="https://lemma.work", cli=None)
+    assert cli_auth_ui_url() == "https://lemma.work/auth"
+
+
+def test_a_served_app_is_handed_the_auth_ui_not_the_origin(auth_settings):
+    auth_settings(frontend="https://lemma.work")
+    config = build_runtime_config(uuid4())
+    # The SDK reads this pathname to build sign-in and callback routes.
+    assert config["authUrl"] == "https://lemma.work/auth"
+
+
+def test_apply_is_usable_on_an_arbitrary_base(auth_settings):
+    auth_settings(frontend="https://lemma.work")
+    assert apply_auth_base_path("https://other.example") == "https://other.example/auth"

--- a/lemma-backend/app/modules/identity/api/controllers/auth_controller.py
+++ b/lemma-backend/app/modules/identity/api/controllers/auth_controller.py
@@ -12,6 +12,7 @@ from supertokens_python.recipe.session.asyncio import (
     get_session,
 )
 
+from app.core.auth_urls import cli_auth_ui_url
 from app.core.config import settings
 from app.core.helpers.identifiers import normalize_mobile_e164
 from app.core.infrastructure.db.session import async_session_maker
@@ -425,7 +426,7 @@ async def verify_token(
 async def cli_auth_info() -> CliAuthInfoResponse:
     return CliAuthInfoResponse(
         api_url=settings.cli_api_url or settings.api_url,
-        auth_frontend_url=settings.cli_auth_frontend_url or settings.auth_frontend_url,
+        auth_frontend_url=cli_auth_ui_url(),
     )
 
 

--- a/lemma-backend/app/modules/identity/infrastructure/supertokens_auth/initialization.py
+++ b/lemma-backend/app/modules/identity/infrastructure/supertokens_auth/initialization.py
@@ -130,6 +130,7 @@ def initialize_supertokens():
         recipe_list=[
             session.init(
                 cookie_domain=settings.session_cookie_domain,
+                older_cookie_domain=settings.session_older_cookie_domain,
                 cookie_secure=settings.session_cookie_secure,
                 cookie_same_site=settings.session_cookie_same_site,
             ),

--- a/lemma-backend/app/modules/identity/tests/unit/test_supertokens_configuration.py
+++ b/lemma-backend/app/modules/identity/tests/unit/test_supertokens_configuration.py
@@ -260,3 +260,23 @@ def test_build_thirdparty_providers_skips_unconfigured_providers():
         settings.microsoft_tenant_id = original_microsoft_tenant_id
 
     assert providers == []
+
+
+def test_older_cookie_domain_keeps_empty_string_distinct_from_unset(monkeypatch):
+    """An empty ``SESSION_OLDER_COOKIE_DOMAIN`` must survive as ``""``.
+
+    SuperTokens reads ``""`` as "the previous cookies were host-only" and
+    ``None`` as "this feature is off". Normalising blank to None — as several
+    neighbouring URL settings do — would silently turn the feature off and
+    bring back the 500 on refresh that it exists to prevent.
+    """
+    monkeypatch.setenv("SESSION_OLDER_COOKIE_DOMAIN", "")
+    assert Settings().session_older_cookie_domain == ""
+
+    monkeypatch.delenv("SESSION_OLDER_COOKIE_DOMAIN", raising=False)
+    assert Settings().session_older_cookie_domain is None
+
+
+def test_older_cookie_domain_accepts_an_explicit_domain(monkeypatch):
+    monkeypatch.setenv("SESSION_OLDER_COOKIE_DOMAIN", ".lemma.work")
+    assert Settings().session_older_cookie_domain == ".lemma.work"

--- a/lemma-backend/app/modules/pod_bundle/infrastructure/app_builder.py
+++ b/lemma-backend/app/modules/pod_bundle/infrastructure/app_builder.py
@@ -38,6 +38,7 @@ from typing import Any, Callable
 from uuid import UUID
 
 from app.core.concurrency.offload import run_blocking
+from app.core.auth_urls import auth_ui_url
 from app.core.config import settings
 from app.core.log.log import get_logger
 from app.modules.pod_bundle.domain.errors import AppBuildFailedError
@@ -148,7 +149,7 @@ class AppSandboxBuilder:
         ``dist/index.html``."""
         env = {
             "VITE_LEMMA_API_URL": settings.api_url,
-            "VITE_LEMMA_AUTH_URL": settings.auth_frontend_url,
+            "VITE_LEMMA_AUTH_URL": auth_ui_url(),
             "VITE_LEMMA_POD_ID": str(pod_id),
         }
         session = await self._service().get_session(

--- a/lemma-backend/app/modules/workspace/services/workspace_sandbox_service.py
+++ b/lemma-backend/app/modules/workspace/services/workspace_sandbox_service.py
@@ -14,6 +14,7 @@ from uuid import UUID, uuid4
 
 from opentelemetry import trace
 
+from app.core.auth_urls import cli_auth_ui_url
 from app.core.config import settings
 from app.core.request_context import create_inherited_task
 from sandbox_runtime.protocol import (
@@ -316,11 +317,9 @@ class WorkspaceSandboxService:
             delegated_tokens_enabled=settings.authz_delegated_tokens_enabled,
         )
         api_url = self._resolve_workspace_api_url()
-        auth_url = (
-            settings.workspace_callback_auth_url
-            or settings.cli_auth_frontend_url
-            or settings.auth_frontend_url
-        )
+        # An explicit workspace override is taken verbatim; otherwise the
+        # sandbox gets the same auth URL the CLI is told to open.
+        auth_url = settings.workspace_callback_auth_url or cli_auth_ui_url()
         host_origin = (
             settings.workspace_callback_frontend_url or settings.frontend_url
         )

--- a/lemma-cli/lemma_cli/cli_app/app_bundle.py
+++ b/lemma-cli/lemma_cli/cli_app/app_bundle.py
@@ -4,7 +4,8 @@ import os
 import shutil
 import subprocess
 import tempfile
-from pathlib import Path
+from io import BytesIO
+from pathlib import Path, PurePosixPath
 from typing import Any
 from zipfile import ZIP_DEFLATED, ZipFile
 
@@ -222,3 +223,56 @@ def deploy_app_bundle(
                 os.unlink(path)
         if temp_dist_dir is not None and temp_dist_dir.exists():
             shutil.rmtree(temp_dist_dir, ignore_errors=True)
+
+
+def _safe_archive_member(name: str, target_dir: Path) -> Path | None:
+    """Where ``name`` may be written under ``target_dir``, or None to skip it.
+
+    Directory entries are skipped (their parents are created for the files that
+    need them). Absolute paths, drive letters, and ``..`` traversal are rejected
+    rather than clamped: an archive that tries to escape is a hostile archive,
+    and silently rewriting its paths would hide that.
+    """
+    if not name or name.endswith("/"):
+        return None
+    candidate = PurePosixPath(name)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        raise ValueError(f"App source archive contains an unsafe path: {name}")
+    destination = (target_dir / Path(*candidate.parts)).resolve()
+    if not destination.is_relative_to(target_dir.resolve()):
+        raise ValueError(f"App source archive contains an unsafe path: {name}")
+    return destination
+
+
+def extract_app_source_archive(
+    archive_bytes: bytes,
+    target_dir: Path,
+    *,
+    overwrite: bool = False,
+) -> list[str]:
+    """Unpack a downloaded app source archive into ``target_dir``.
+
+    Returns the relative paths written, in archive order. Refuses to write into
+    a directory that already holds files unless ``overwrite`` is set, so a pull
+    never silently clobbers work in progress.
+    """
+    target_dir = target_dir.expanduser()
+    if target_dir.exists() and not target_dir.is_dir():
+        raise ValueError(f"App source target is not a directory: {target_dir}")
+    if target_dir.is_dir() and any(target_dir.iterdir()) and not overwrite:
+        raise ValueError(
+            f"{target_dir} is not empty. Re-run with --force to overwrite it."
+        )
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    resolved_target = target_dir.resolve()
+    written: list[str] = []
+    with ZipFile(BytesIO(archive_bytes)) as archive:
+        for name in archive.namelist():
+            destination = _safe_archive_member(name, resolved_target)
+            if destination is None:
+                continue
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(archive.read(name))
+            written.append(destination.relative_to(resolved_target).as_posix())
+    return written

--- a/lemma-cli/lemma_cli/cli_core/assets/app_vite_template/lemma-source-loc.ts
+++ b/lemma-cli/lemma_cli/cli_core/assets/app_vite_template/lemma-source-loc.ts
@@ -1,0 +1,105 @@
+import { relative } from 'node:path'
+
+// Babel plugin: stamp every host element with where it was written.
+//
+// Lemma's app editor lets someone click an element in the running app and hand
+// it to the agent to change. For that to be an *edit* rather than a guess, the
+// click has to resolve to a file and a line — and a production bundle has
+// neither: esbuild mangles component names and React's automatic runtime only
+// records source locations in dev. So the location is written into the markup
+// itself, at build time, where it survives minification:
+//
+//   <div data-lemma-loc="src/OrderRow.tsx:42:5" data-lemma-component="OrderRow">
+//
+// Host elements only. An attribute added to `<OrderRow />` would arrive as a
+// prop that the component is free to drop, so it would describe the call site
+// of something that may never reach the DOM. Host elements *are* the DOM, which
+// is what the picker hit-tests.
+//
+// `data-lemma-component` names the component whose body wrote the element, not
+// the element's own tag. That is what lets the picker snap a click to a
+// component boundary — the nearest ancestor written by a *different* component
+// — instead of selecting whichever nested `<div>` happened to be under the
+// cursor.
+
+const LOCATION_ATTRIBUTE = 'data-lemma-loc'
+const COMPONENT_ATTRIBUTE = 'data-lemma-component'
+
+interface BabelTypes {
+  jsxAttribute: (name: unknown, value: unknown) => unknown
+  jsxIdentifier: (name: string) => unknown
+  stringLiteral: (value: string) => unknown
+}
+
+// Loosely typed on purpose: the template does not depend on @babel/core, and
+// `tsc -b` only covers `src`, so pulling in Babel's AST types would cost the
+// scaffolded app a dependency it otherwise never needs.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+type BabelPath = any
+
+function isHostElement(name: any): boolean {
+  // `<div>` yes, `<OrderRow>` no, `<Foo.Bar>` no — see the note above.
+  return name?.type === 'JSXIdentifier' && /^[a-z]/.test(name.name ?? '')
+}
+
+function hasAttribute(node: any, attributeName: string): boolean {
+  return (node.attributes ?? []).some(
+    (attribute: any) =>
+      attribute.type === 'JSXAttribute' && attribute.name?.name === attributeName,
+  )
+}
+
+/** The nearest enclosing function that reads as a React component. */
+function enclosingComponentName(path: BabelPath): string | null {
+  let current = path.getFunctionParent()
+  while (current) {
+    const node = current.node
+    const candidate =
+      node.id?.name ??
+      (current.parentPath?.isVariableDeclarator()
+        ? current.parentPath.node.id?.name
+        : null) ??
+      (node.type === 'ClassMethod' ? current.parentPath?.parentPath?.node?.id?.name : null)
+    if (typeof candidate === 'string' && /^[A-Z]/.test(candidate)) return candidate
+    current = current.getFunctionParent()
+  }
+  return null
+}
+
+export function lemmaSourceLoc({ types: t }: { types: BabelTypes }) {
+  return {
+    name: 'lemma-source-loc',
+    visitor: {
+      JSXOpeningElement(path: BabelPath, state: any) {
+        const node = path.node
+        if (!isHostElement(node.name)) return
+        if (hasAttribute(node, LOCATION_ATTRIBUTE)) return
+
+        const filename: string | undefined = state.filename
+        const start = node.loc?.start
+        if (!filename || !start) return
+
+        const root: string = state.file?.opts?.root ?? state.cwd ?? process.cwd()
+        // Posix separators so the value reads the same on every OS — the agent
+        // uses it as a repo-relative path, not a local filesystem path.
+        const location = relative(root, filename).split('\\').join('/')
+        // Babel counts columns from 0; editors count from 1.
+        const stamp = `${location}:${start.line}:${start.column + 1}`
+
+        node.attributes.push(
+          t.jsxAttribute(t.jsxIdentifier(LOCATION_ATTRIBUTE), t.stringLiteral(stamp)),
+        )
+
+        const component = enclosingComponentName(path)
+        if (component && !hasAttribute(node, COMPONENT_ATTRIBUTE)) {
+          node.attributes.push(
+            t.jsxAttribute(
+              t.jsxIdentifier(COMPONENT_ATTRIBUTE),
+              t.stringLiteral(component),
+            ),
+          )
+        }
+      },
+    },
+  }
+}

--- a/lemma-cli/lemma_cli/cli_core/assets/app_vite_template/vite.config.ts
+++ b/lemma-cli/lemma_cli/cli_core/assets/app_vite_template/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, loadEnv, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import { execSync } from 'node:child_process'
+import { lemmaSourceLoc } from './lemma-source-loc'
 
 // Dev-only auth: resolve the current Lemma access token from the CLI and seed it
 // into localStorage *before* the app bundle runs, so `npm run dev` is logged in
@@ -46,6 +47,7 @@ function lemmaDevAuth(env: Record<string, string>): Plugin {
 // path is '/' in dev and resolved from VITE_LEMMA_APP_BASE_PATH in prod.
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
+  const sourceLocEnabled = (env.LEMMA_APP_SOURCE_LOC ?? '1') !== '0'
 
   // Optional same-origin dev proxy (opt in with `lemma apps init --proxy`). When
   // LEMMA_DEV_PROXY_TARGET is set, the SDK talks to a same-origin '/api' path and
@@ -66,7 +68,17 @@ export default defineConfig(({ mode }) => {
 
   return {
     base: mode === 'production' ? env.VITE_LEMMA_APP_BASE_PATH || '/' : '/',
-    plugins: [react(), lemmaDevAuth(env)],
+    plugins: [
+      // `data-lemma-loc` / `data-lemma-component` on every host element, so the
+      // Lemma app editor's picker resolves a click to a file and a line instead
+      // of to anonymous minified markup. See ./lemma-source-loc.ts. Set
+      // LEMMA_APP_SOURCE_LOC=0 to ship without the stamps (the picker still
+      // works, but it can only report DOM, not source).
+      react(
+        sourceLocEnabled ? { babel: { plugins: [lemmaSourceLoc] } } : undefined,
+      ),
+      lemmaDevAuth(env),
+    ],
     server,
     resolve: {
       // Force a single copy of React (and friends). When the SDK is linked from a

--- a/lemma-cli/lemma_cli/cli_core/commands/apps.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/apps.py
@@ -33,6 +33,7 @@ from lemma_sdk.config import resolve_auth_url, resolve_base_url, resolve_token
 from ...cli_app.app_bundle import (
     classify_app_source,
     deploy_app_bundle,
+    extract_app_source_archive,
 )
 
 app = typer.Typer(help="App commands.")
@@ -391,6 +392,53 @@ def deploy_app(
         ctx,
         run,
     )
+    if result is not None:
+        emit(state, result)
+
+
+@app.command("pull")
+def pull_app(
+    ctx: typer.Context,
+    app: str = typer.Argument(...),
+    target: Path | None = typer.Argument(
+        None,
+        file_okay=False,
+        dir_okay=True,
+        writable=True,
+        help="Directory to write the source into. Defaults to ./<app>.",
+    ),
+    pod: str | None = typer.Option(None, "--pod"),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Overwrite files in a target directory that is not empty.",
+    ),
+) -> None:
+    """Download a deployed app's source into a local directory.
+
+    The inverse of ``deploy``: ``deploy`` uploads project source alongside the
+    built dist, and this brings that source back so an app can be edited from
+    a machine (or a workspace sandbox) that never held the original checkout.
+    Vite apps arrive without ``node_modules``, so run an install before
+    building.
+    """
+    state = state_from_ctx(ctx)
+    target_dir = target if target is not None else Path(app)
+
+    def run(client, s):  # type: ignore[no-untyped-def]
+        archive = pod_client(client, s, pod).apps.download_source_archive(app)
+        try:
+            written = extract_app_source_archive(archive, target_dir, overwrite=force)
+        except ValueError as error:
+            fail(str(error))
+        return {
+            "app": app,
+            "target": str(target_dir.expanduser().resolve()),
+            "files": len(written),
+        }
+
+    result = run_with_client(ctx, run)
     if result is not None:
         emit(state, result)
 

--- a/lemma-cli/tests/test_commands_apps.py
+++ b/lemma-cli/tests/test_commands_apps.py
@@ -203,3 +203,109 @@ def test_apps_open_never_puts_the_token_in_argv(monkeypatch):
     # It still reaches the browser -- over stdin, where the process table
     # cannot see it.
     assert any(secret in call["input"] for call in calls)
+
+
+def _source_zip(entries: dict[str, str]) -> bytes:
+    import io
+    from zipfile import ZIP_DEFLATED, ZipFile
+
+    buffer = io.BytesIO()
+    with ZipFile(buffer, "w", compression=ZIP_DEFLATED) as archive:
+        for name, content in entries.items():
+            archive.writestr(name, content)
+    return buffer.getvalue()
+
+
+def _patch_pull(monkeypatch, archive: bytes):
+    captured = {}
+
+    class FakeApps:
+        def download_source_archive(self, name):
+            captured["downloaded"] = name
+            return archive
+
+    class FakePod:
+        def __init__(self):
+            self.apps = FakeApps()
+
+    state = SimpleNamespace(
+        config={"_runtime": {"pod": "pod-1"}, "defaults": {"org_id": "org-1"}},
+        output="json",
+        full=False,
+    )
+    monkeypatch.setattr(apps, "pod_client", lambda client, s, pod=None: FakePod())
+    monkeypatch.setattr(apps, "run_with_client", lambda ctx, fn: fn(object(), state))
+    return captured
+
+
+def test_apps_pull_writes_source_tree(monkeypatch, tmp_path):
+    archive = _source_zip(
+        {
+            "package.json": '{"name":"my-app"}',
+            "src/main.tsx": "export {}\n",
+        }
+    )
+    captured = _patch_pull(monkeypatch, archive)
+    target = tmp_path / "my-app"
+
+    result = runner.invoke(
+        app, ["--json", "--pod", "pod-1", "apps", "pull", "my-app", str(target)]
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert captured["downloaded"] == "my-app"
+    assert (target / "package.json").read_text() == '{"name":"my-app"}'
+    assert (target / "src" / "main.tsx").read_text() == "export {}\n"
+    payload = json.loads(result.stdout)
+    assert payload["files"] == 2
+
+
+def test_apps_pull_refuses_non_empty_target_without_force(monkeypatch, tmp_path):
+    _patch_pull(monkeypatch, _source_zip({"index.html": "<!doctype html>"}))
+    target = tmp_path / "my-app"
+    target.mkdir()
+    (target / "keep.txt").write_text("mine")
+
+    result = runner.invoke(
+        app, ["--pod", "pod-1", "apps", "pull", "my-app", str(target)]
+    )
+
+    assert result.exit_code != 0
+    assert (target / "keep.txt").read_text() == "mine"
+    assert not (target / "index.html").exists()
+
+
+def test_apps_pull_force_overwrites_non_empty_target(monkeypatch, tmp_path):
+    _patch_pull(monkeypatch, _source_zip({"index.html": "<!doctype html>"}))
+    target = tmp_path / "my-app"
+    target.mkdir()
+    (target / "index.html").write_text("stale")
+
+    result = runner.invoke(
+        app, ["--json", "--pod", "pod-1", "apps", "pull", "my-app", str(target), "--force"]
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert (target / "index.html").read_text() == "<!doctype html>"
+
+
+def test_apps_pull_rejects_path_traversal(monkeypatch, tmp_path):
+    _patch_pull(monkeypatch, _source_zip({"../escaped.txt": "nope"}))
+    target = tmp_path / "my-app"
+
+    result = runner.invoke(
+        app, ["--pod", "pod-1", "apps", "pull", "my-app", str(target)]
+    )
+
+    assert result.exit_code != 0
+    assert not (tmp_path / "escaped.txt").exists()
+
+
+def test_apps_pull_defaults_target_to_app_name(monkeypatch, tmp_path):
+    _patch_pull(monkeypatch, _source_zip({"index.html": "<!doctype html>"}))
+    monkeypatch.chdir(tmp_path)
+
+    result = runner.invoke(app, ["--json", "--pod", "pod-1", "apps", "pull", "my-app"])
+
+    assert result.exit_code == 0, result.stdout
+    assert (tmp_path / "my-app" / "index.html").exists()

--- a/lemma-frontend/components/ai/ai-assistant-context.tsx
+++ b/lemma-frontend/components/ai/ai-assistant-context.tsx
@@ -20,6 +20,10 @@ import {
     type DisplayResourceRequest,
 } from '@/lib/assistant/display-resource';
 import { buildConversationPresentationHref } from '@/lib/assistant/conversation-presentation';
+import {
+    ASSISTANT_PREFILL_EVENT,
+    parseAssistantPrefillDetail,
+} from '@/lib/assistant/prefill';
 import { resolveAssistantControllerGates } from '@/lib/assistant/controller-gates';
 import {
     projectConversationMetadata,
@@ -71,6 +75,12 @@ interface AIAssistantContextType {
     // the way from pod home into the conversation it creates.
     pendingProject: ProjectSelection | null;
     setPendingProject: (project: ProjectSelection | null) => void;
+    // Text waiting to be dropped into the next composer to mount. It lives here
+    // for the same reason `pendingProject` does — the composer is unmounted
+    // whenever the assistant is closed, and the things that hand it a starting
+    // message (an app's element picker, a resource view) fire while it is.
+    pendingDraft: string | null;
+    setPendingDraft: (draft: string | null) => void;
     isOpenedConversationRunning: boolean;
     isActiveConversationRunning: boolean;
     openConversation: (conversationId: string) => void;
@@ -192,6 +202,7 @@ export function AIAssistantProvider({
         pendingProjectRef.current = project;
         setPendingProjectState(project);
     }, []);
+    const [pendingDraft, setPendingDraft] = useState<string | null>(null);
     const isOpenRef = useRef(isOpen);
     const seenAutoNavigationToolCallIds = useRef<Set<string>>(new Set());
     const allowAutoNavigationRef = useRef(false);
@@ -550,6 +561,24 @@ export function AIAssistantProvider({
         controllerRef.current.clearPendingFiles();
     }, []);
 
+    // Something elsewhere in the pod wants the assistant opened with a message
+    // already written. The listener lives here, on the provider, because the
+    // provider is mounted for the whole pod while the composer only exists once
+    // the panel is open — a listener inside the panel cannot hear the event that
+    // is supposed to open it.
+    useEffect(() => {
+        const onPrefill = (event: Event) => {
+            const detail = parseAssistantPrefillDetail((event as CustomEvent<unknown>).detail);
+            if (!detail) return;
+            if (detail.forceNewConversation) clearMessages();
+            setPendingDraft(detail.content);
+            openAssistant();
+        };
+
+        window.addEventListener(ASSISTANT_PREFILL_EVENT, onPrefill);
+        return () => window.removeEventListener(ASSISTANT_PREFILL_EVENT, onPrefill);
+    }, [clearMessages, openAssistant]);
+
     const openConversation = useCallback((conversationId: string) => {
         setHasActivatedController(true);
         controllerRef.current.openConversation(conversationId);
@@ -646,6 +675,8 @@ export function AIAssistantProvider({
         setConversationModel: controller.setConversationModel as (model: ConversationModel | null, runtime?: AgentRuntimeConfig | null) => Promise<void>,
         pendingProject,
         setPendingProject,
+        pendingDraft,
+        setPendingDraft,
         isOpenedConversationRunning: controller.isOpenedConversationRunning,
         isActiveConversationRunning: controller.isOpenedConversationRunning,
         openConversation,
@@ -683,6 +714,8 @@ export function AIAssistantProvider({
         closeConversation,
         pendingProject,
         setPendingProject,
+        pendingDraft,
+        setPendingDraft,
         controller.openedConversationId,
         controller.availableModels,
         controller.canRetryFailedMessage,

--- a/lemma-frontend/components/ai/pod-assistant.tsx
+++ b/lemma-frontend/components/ai/pod-assistant.tsx
@@ -36,7 +36,6 @@ import { cn } from "@/lib/utils";
 import { getConversationStatusView, type ConversationStatusView } from "@/lib/utils/conversations";
 import { useAIAssistant } from "./ai-assistant-context";
 
-const ASSISTANT_PREFILL_EVENT = "lemma-assistant-prefill-draft";
 const DEFAULT_DATASTORE_NAME = "default";
 
 function ConversationStatusPill({ statusView }: { statusView: ConversationStatusView }) {
@@ -67,11 +66,6 @@ function ConversationStatusPill({ statusView }: { statusView: ConversationStatus
   );
 }
 
-interface AssistantPrefillDetail {
-  content: string;
-  forceNewConversation?: boolean;
-}
-
 interface PodAssistantEmbeddedProps {
   title?: string;
   subtitle?: string;
@@ -91,23 +85,6 @@ interface PodAssistantEmbeddedProps {
   onDraftChange?: (value: string) => void;
 }
 
-function parseAssistantPrefillDetail(
-  value: unknown,
-): AssistantPrefillDetail | null {
-  if (!value || typeof value !== "object") return null;
-  const detail = value as Partial<AssistantPrefillDetail>;
-  if (
-    typeof detail.content !== "string" ||
-    detail.content.trim().length === 0
-  ) {
-    return null;
-  }
-
-  return {
-    content: detail.content.trim(),
-    forceNewConversation: detail.forceNewConversation === true,
-  };
-}
 
 function getFileMentionPath(value: unknown): string {
   if (!value || typeof value !== "object" || Array.isArray(value)) return "";
@@ -172,28 +149,19 @@ function buildControllerView(
   };
 }
 
+/** Drain any draft the provider parked while this composer was unmounted.
+ *
+ * The panel only exists while the assistant is open, so it cannot be the thing
+ * that hears "open with this text" — by then it is too late. The provider takes
+ * the event and holds the text; this consumes it on the way in. */
 function useAssistantPrefillDraft(setDraft: (value: string) => void) {
-  const { clearMessages, openAssistant } = useAIAssistant();
+  const { pendingDraft, setPendingDraft } = useAIAssistant();
 
   useEffect(() => {
-    const handlePrefillEvent = (event: Event) => {
-      const customEvent = event as CustomEvent<unknown>;
-      const detail = parseAssistantPrefillDetail(customEvent.detail);
-      if (!detail) return;
-
-      if (detail.forceNewConversation) {
-        clearMessages();
-      }
-
-      setDraft(detail.content);
-      openAssistant();
-    };
-
-    window.addEventListener(ASSISTANT_PREFILL_EVENT, handlePrefillEvent);
-    return () => {
-      window.removeEventListener(ASSISTANT_PREFILL_EVENT, handlePrefillEvent);
-    };
-  }, [clearMessages, openAssistant, setDraft]);
+    if (pendingDraft === null) return;
+    setDraft(pendingDraft);
+    setPendingDraft(null);
+  }, [pendingDraft, setDraft, setPendingDraft]);
 }
 
 function PodAssistantSurface({

--- a/lemma-frontend/components/app/app-frame-host.tsx
+++ b/lemma-frontend/components/app/app-frame-host.tsx
@@ -63,22 +63,28 @@ export function AppFrameHost({
 
     return (
         <div aria-hidden={!visible} className={cn('absolute inset-0 z-20', visible ? 'block' : 'hidden')}>
-            {livePages.map((page) => (
-                <div
-                    key={page.slug}
-                    className={cn('absolute inset-0', page.slug === activeSlug ? 'block' : 'hidden')}
-                >
-                    <AppFrame
-                        podId={podId}
-                        appId={page.id}
-                        appName={page.title}
-                        title={page.title}
-                        url={page.url as string}
-                        visibility={page.visibility}
-                        canShare={resourceAllows(page, 'app.update', canUpdateApp)}
-                    />
-                </div>
-            ))}
+            {livePages.map((page) => {
+                // One permission answers both: changing how the app is shared and
+                // changing what it renders are the same right over the same app.
+                const canUpdate = resourceAllows(page, 'app.update', canUpdateApp);
+                return (
+                    <div
+                        key={page.slug}
+                        className={cn('absolute inset-0', page.slug === activeSlug ? 'block' : 'hidden')}
+                    >
+                        <AppFrame
+                            podId={podId}
+                            appId={page.id}
+                            appName={page.title}
+                            title={page.title}
+                            url={page.url as string}
+                            visibility={page.visibility}
+                            canShare={canUpdate}
+                            canEdit={canUpdate}
+                        />
+                    </div>
+                );
+            })}
 
             {loading ? (
                 <div className="absolute inset-0 flex items-center justify-center">

--- a/lemma-frontend/components/app/app-launch.tsx
+++ b/lemma-frontend/components/app/app-launch.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useTheme } from 'next-themes';
-import { Copy, ExternalLink, RefreshCw, Share2 } from '@/components/ui/icons';
+import { Copy, CursorClick, ExternalLink, RefreshCw, Share2 } from '@/components/ui/icons';
 import { toast } from 'sonner';
 
 import { ResourceHeader } from '@/components/pod/resource-layout';
@@ -17,6 +17,7 @@ import { useProfile } from '@/lib/hooks/use-user';
 import { trackAppOpened } from '@/lib/analytics/onboarding';
 import { resolveWidgetTheme } from '@/lib/assistant/widget-theme';
 import { buildResourceShareUrl } from '@/lib/assistant/conversation-presentation';
+import { useAppEditor } from '@/components/app/use-app-editor';
 
 interface AppFrameProps {
     podId: string;
@@ -26,6 +27,8 @@ interface AppFrameProps {
     url: string;
     visibility?: string | null;
     canShare?: boolean;
+    /** Whether the viewer may change this app — the picker edits its source. */
+    canEdit?: boolean;
     /**
      * What draws around the frame. `bar` claims the shell's context bar, for a
      * pane the app owns. `none` draws the frame alone, for a pane that already
@@ -43,6 +46,7 @@ export function AppFrame({
     url,
     visibility,
     canShare = false,
+    canEdit = false,
     chrome = 'bar',
 }: AppFrameProps) {
     const queryClient = useQueryClient();
@@ -52,6 +56,13 @@ export function AppFrame({
     const [frameKey, setFrameKey] = useState(0);
     const [frameLoaded, setFrameLoaded] = useState(false);
     const [frameFailed, setFrameFailed] = useState(false);
+    const editor = useAppEditor({
+        iframeRef,
+        url,
+        appName: appName || title,
+        enabled: canEdit,
+        frameLoaded,
+    });
 
     const postAppTheme = useCallback(() => {
         const iframe = iframeRef.current;
@@ -206,6 +217,33 @@ export function AppFrame({
                                 </a>
                             </Button>
                         </section>
+                    </div>
+                ) : null}
+
+                {editor.ready ? (
+                    <div className="absolute right-3 top-3 z-30">
+                        <TooltipProvider>
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <Button
+                                        type="button"
+                                        variant={editor.selecting ? 'primary' : 'secondary'}
+                                        size="sm"
+                                        className="h-8 gap-1.5 rounded-full px-3 text-xs shadow-[var(--shadow-sm)]"
+                                        onClick={editor.toggleSelecting}
+                                        aria-pressed={editor.selecting}
+                                    >
+                                        <CursorClick className="h-3.5 w-3.5" />
+                                        {editor.selecting ? 'Pick an element' : 'Edit'}
+                                    </Button>
+                                </TooltipTrigger>
+                                <TooltipContent side="left">
+                                    {editor.selecting
+                                        ? 'Click an element in the app, or press Escape'
+                                        : 'Select an element to edit with the assistant'}
+                                </TooltipContent>
+                            </Tooltip>
+                        </TooltipProvider>
                     </div>
                 ) : null}
 

--- a/lemma-frontend/components/app/use-app-editor.ts
+++ b/lemma-frontend/components/app/use-app-editor.ts
@@ -1,0 +1,150 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
+
+import {
+    APP_EDITOR_MESSAGE,
+    buildAppEditorHelloMessage,
+    buildAppEditorSelectModeMessage,
+    describeAppEditorSelection,
+    buildAppEditorPrefill,
+    parseAppEditorMessage,
+} from '@/lib/app/app-editor';
+import { requestAssistantPrefill } from '@/lib/assistant/prefill';
+
+/**
+ * Drives the element picker inside a running app frame.
+ *
+ * The app answers `hello` only if it carries the injected bridge, so `ready` is
+ * what the toggle waits on rather than an assumption that every app can be
+ * picked from. Picking one element opens the assistant with the element already
+ * described; the sentence about what to change is still the person's to write.
+ *
+ * Readiness is tracked as *which load* answered rather than as a boolean that
+ * something has to remember to clear. A reload replaces the document and the
+ * bridge inside it, so a stale yes would leave a toggle that talks to a window
+ * no longer listening.
+ */
+export function useAppEditor({
+    iframeRef,
+    url,
+    appName,
+    enabled,
+    frameLoaded,
+}: {
+    iframeRef: React.RefObject<HTMLIFrameElement | null>;
+    url: string;
+    appName: string;
+    enabled: boolean;
+    frameLoaded: boolean;
+}) {
+    const [readyLoadKey, setReadyLoadKey] = useState<string | null>(null);
+    const [selectRequested, setSelectRequested] = useState(false);
+    const selectRequestedRef = useRef(false);
+
+    const loadKey = useMemo(
+        () => `${url}#${frameLoaded ? 'loaded' : 'pending'}`,
+        [frameLoaded, url],
+    );
+
+    const appOrigin = useMemo(() => {
+        if (typeof window === 'undefined') return null;
+        try {
+            return new URL(url, window.location.href).origin;
+        } catch {
+            return null;
+        }
+    }, [url]);
+
+    const post = useCallback(
+        (message: object) => {
+            const frame = iframeRef.current;
+            if (!frame?.contentWindow || !appOrigin) return;
+            frame.contentWindow.postMessage(message, appOrigin);
+        },
+        [appOrigin, iframeRef],
+    );
+
+    const ready = enabled && frameLoaded && readyLoadKey === loadKey;
+    const selecting = ready && selectRequested;
+
+    /** Follow the app's own view of select mode, without echoing it back. */
+    const trackSelectMode = useCallback((active: boolean) => {
+        selectRequestedRef.current = active;
+        setSelectRequested(active);
+    }, []);
+
+    const requestSelectMode = useCallback(
+        (active: boolean) => {
+            trackSelectMode(active);
+            post(buildAppEditorSelectModeMessage(active));
+        },
+        [post, trackSelectMode],
+    );
+
+    useEffect(() => {
+        if (!enabled || !frameLoaded) return;
+        post(buildAppEditorHelloMessage());
+    }, [enabled, frameLoaded, loadKey, post]);
+
+    useEffect(() => {
+        if (!enabled || !appOrigin) return;
+
+        const onMessage = (event: MessageEvent) => {
+            // Both checks matter: the origin alone would accept any frame served
+            // from the app's host, and the window alone would accept whatever
+            // that window later navigated to.
+            if (event.origin !== appOrigin) return;
+            if (event.source !== iframeRef.current?.contentWindow) return;
+
+            const message = parseAppEditorMessage(event.data);
+            if (!message) return;
+
+            if (message.type === APP_EDITOR_MESSAGE.ready) {
+                setReadyLoadKey(loadKey);
+                // A fresh document is not in select mode, whatever the last one was.
+                trackSelectMode(false);
+                return;
+            }
+            if (message.type === APP_EDITOR_MESSAGE.selectMode) {
+                // The app leaves select mode itself on Escape and after a pick,
+                // so the toggle follows the app rather than the reverse.
+                trackSelectMode(message.active);
+                return;
+            }
+            if (message.type === APP_EDITOR_MESSAGE.selection) {
+                trackSelectMode(false);
+                requestAssistantPrefill({
+                    content: buildAppEditorPrefill(message.selection, appName),
+                });
+                toast.success(`Selected ${describeAppEditorSelection(message.selection)}`);
+            }
+        };
+
+        window.addEventListener('message', onMessage);
+        return () => window.removeEventListener('message', onMessage);
+    }, [appName, appOrigin, enabled, iframeRef, loadKey, trackSelectMode]);
+
+    // The app cancels on Escape too, but only while it holds focus — and after
+    // the toggle is clicked, focus is still on the toggle. Without this, the one
+    // way out of select mode would be to pick something.
+    useEffect(() => {
+        if (!selecting) return;
+
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key !== 'Escape') return;
+            event.preventDefault();
+            requestSelectMode(false);
+        };
+
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, [requestSelectMode, selecting]);
+
+    const toggleSelecting = useCallback(() => {
+        requestSelectMode(!selectRequestedRef.current);
+    }, [requestSelectMode]);
+
+    return { ready, selecting, toggleSelecting };
+}

--- a/lemma-frontend/components/ui/icons.ts
+++ b/lemma-frontend/components/ui/icons.ts
@@ -36,6 +36,7 @@ export {
     Code,
     Copy,
     Cpu,
+    CursorClick,
     Database,
     Download,
     Eye,

--- a/lemma-frontend/lib/app/__tests__/app-editor.test.ts
+++ b/lemma-frontend/lib/app/__tests__/app-editor.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    APP_EDITOR_MESSAGE,
+    buildAppEditorPrefill,
+    describeAppEditorSelection,
+    parseAppEditorMessage,
+    type AppEditorSelection,
+} from '../app-editor';
+
+const selection: AppEditorSelection = {
+    app: { name: 'orders', id: 'app-1', podId: 'pod-1' },
+    route: '/orders/42',
+    source: { file: 'src/components/OrderRow.tsx', line: 42, column: 5 },
+    component: 'OrderRow',
+    componentChain: ['OrderRow', 'OrdersTable', 'OrdersPage'],
+    tag: 'div',
+    domId: null,
+    className: 'order-row',
+    domPath: 'main > div:nth-of-type(2) > div',
+    text: 'Order #1042 · Shipped',
+    html: '<div class="order-row">Order #1042</div>',
+    rect: { x: 10, y: 20, width: 300, height: 48 },
+    styles: { display: 'flex', 'font-size': '13px', 'z-index': '2' },
+};
+
+function selectionMessage(overrides: Record<string, unknown> = {}) {
+    return {
+        type: APP_EDITOR_MESSAGE.selection,
+        selection: { ...selection, ...overrides },
+    };
+}
+
+describe('parseAppEditorMessage', () => {
+    it('parses a selection into the typed shape', () => {
+        const message = parseAppEditorMessage(selectionMessage());
+
+        expect(message).toEqual({ type: APP_EDITOR_MESSAGE.selection, selection });
+    });
+
+    it('rejects anything that is not one of the four message types', () => {
+        expect(parseAppEditorMessage(null)).toBeNull();
+        expect(parseAppEditorMessage('lemma-app-editor:selection')).toBeNull();
+        expect(parseAppEditorMessage({ type: 'lemma-app-theme' })).toBeNull();
+        expect(parseAppEditorMessage([selectionMessage()])).toBeNull();
+    });
+
+    it('rejects a selection with no element in it', () => {
+        // A payload without a tag names nothing the agent could go and change.
+        expect(parseAppEditorMessage(selectionMessage({ tag: null }))).toBeNull();
+        expect(parseAppEditorMessage({ type: APP_EDITOR_MESSAGE.selection })).toBeNull();
+    });
+
+    it('drops fields of the wrong type instead of trusting the frame', () => {
+        const message = parseAppEditorMessage(
+            selectionMessage({
+                route: 42,
+                componentChain: ['OrderRow', 7, null],
+                styles: { display: 'flex', padding: 12 },
+                rect: { x: 'left', y: 20, width: 300, height: 48 },
+                source: { file: 'src/App.tsx', line: 'twelve', column: 3 },
+            }),
+        );
+
+        expect(message).not.toBeNull();
+        const parsed = (message as { selection: AppEditorSelection }).selection;
+        expect(parsed.route).toBe('');
+        expect(parsed.componentChain).toEqual(['OrderRow']);
+        expect(parsed.styles).toEqual({ display: 'flex' });
+        expect(parsed.rect).toEqual({ x: 0, y: 20, width: 300, height: 48 });
+        expect(parsed.source).toEqual({ file: 'src/App.tsx', line: null, column: 3 });
+    });
+
+    it('reads a source location with no file as no source at all', () => {
+        const message = parseAppEditorMessage(selectionMessage({ source: { line: 3 } }));
+
+        expect((message as { selection: AppEditorSelection }).selection.source).toBeNull();
+    });
+
+    it('parses the select-mode echo the app sends on Escape', () => {
+        expect(parseAppEditorMessage({ type: APP_EDITOR_MESSAGE.selectMode })).toEqual({
+            type: APP_EDITOR_MESSAGE.selectMode,
+            active: false,
+        });
+        expect(
+            parseAppEditorMessage({ type: APP_EDITOR_MESSAGE.selectMode, active: true }),
+        ).toEqual({ type: APP_EDITOR_MESSAGE.selectMode, active: true });
+    });
+});
+
+describe('describeAppEditorSelection', () => {
+    it('names the component and where it is written', () => {
+        expect(describeAppEditorSelection(selection)).toBe(
+            'OrderRow — src/components/OrderRow.tsx:42',
+        );
+    });
+
+    it('falls back to the tag when the app carries no source stamps', () => {
+        expect(
+            describeAppEditorSelection({ ...selection, component: null, source: null }),
+        ).toBe('<div>');
+    });
+});
+
+describe('buildAppEditorPrefill', () => {
+    it('opens with the facts and leaves the request to the person', () => {
+        const prefill = buildAppEditorPrefill(selection, 'orders');
+
+        expect(prefill).toContain('Editing the "orders" app');
+        expect(prefill).toContain('- Source: src/components/OrderRow.tsx:42:5');
+        expect(prefill).toContain('- Component: OrderRow');
+        expect(prefill).toContain('- Inside: OrdersTable → OrdersPage');
+        expect(prefill).toContain('- Route: /orders/42');
+        expect(prefill).toContain('- Text: Order #1042 · Shipped');
+        expect(prefill).toContain('```html');
+        // Ends on a blank line, so typing continues below the block.
+        expect(prefill.endsWith('\n\n')).toBe(true);
+    });
+
+    it('reports only styles worth arguing about', () => {
+        const prefill = buildAppEditorPrefill(selection, 'orders');
+
+        expect(prefill).toContain('display: flex; font-size: 13px');
+        expect(prefill).not.toContain('z-index');
+    });
+
+    it('leans on the DOM path when there is no source location', () => {
+        const prefill = buildAppEditorPrefill(
+            { ...selection, source: null, component: null, componentChain: [] },
+            'orders',
+        );
+
+        expect(prefill).not.toContain('- Source:');
+        expect(prefill).toContain('- DOM path: main > div:nth-of-type(2) > div');
+    });
+});

--- a/lemma-frontend/lib/app/app-editor.ts
+++ b/lemma-frontend/lib/app/app-editor.ts
@@ -1,0 +1,205 @@
+/**
+ * Host half of the app element picker.
+ *
+ * An app runs on its own subdomain, so the shell cannot read its DOM. The
+ * picker lives inside the app (the bridge the backend injects into every app
+ * entrypoint) and this is the contract the shell speaks to it: say hello, turn
+ * select mode on, receive the element someone picked.
+ *
+ * Everything arriving over `postMessage` is untrusted until it has passed both
+ * checks a caller must make — that it came from the app frame's own window, and
+ * from the app's own origin — and then `parseAppEditorMessage`, which is the
+ * only thing that turns it into a typed value.
+ */
+
+export const APP_EDITOR_MESSAGE = {
+    hello: 'lemma-app-editor:hello',
+    ready: 'lemma-app-editor:ready',
+    selectMode: 'lemma-app-editor:select-mode',
+    selection: 'lemma-app-editor:selection',
+} as const;
+
+export interface AppEditorSourceLocation {
+    file: string;
+    line: number | null;
+    column: number | null;
+}
+
+export interface AppEditorSelection {
+    app: { name: string | null; id: string | null; podId: string | null };
+    route: string;
+    source: AppEditorSourceLocation | null;
+    component: string | null;
+    componentChain: string[];
+    tag: string;
+    domId: string | null;
+    className: string | null;
+    domPath: string;
+    text: string;
+    html: string;
+    rect: { x: number; y: number; width: number; height: number };
+    styles: Record<string, string>;
+}
+
+export type AppEditorMessage =
+    | { type: typeof APP_EDITOR_MESSAGE.ready }
+    | { type: typeof APP_EDITOR_MESSAGE.selectMode; active: boolean }
+    | { type: typeof APP_EDITOR_MESSAGE.selection; selection: AppEditorSelection };
+
+export function buildAppEditorHelloMessage() {
+    return { type: APP_EDITOR_MESSAGE.hello } as const;
+}
+
+export function buildAppEditorSelectModeMessage(active: boolean) {
+    return { type: APP_EDITOR_MESSAGE.selectMode, active } as const;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+    return value as Record<string, unknown>;
+}
+
+function asString(value: unknown, fallback = ''): string {
+    return typeof value === 'string' ? value : fallback;
+}
+
+function asNullableString(value: unknown): string | null {
+    return typeof value === 'string' && value ? value : null;
+}
+
+function asNumber(value: unknown): number {
+    return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function parseSource(value: unknown): AppEditorSourceLocation | null {
+    const record = asRecord(value);
+    const file = record ? asNullableString(record.file) : null;
+    if (!file) return null;
+    return {
+        file,
+        line: typeof record?.line === 'number' ? record.line : null,
+        column: typeof record?.column === 'number' ? record.column : null,
+    };
+}
+
+function parseStringMap(value: unknown): Record<string, string> {
+    const record = asRecord(value);
+    if (!record) return {};
+    const parsed: Record<string, string> = {};
+    Object.entries(record).forEach(([key, entry]) => {
+        if (typeof entry === 'string') parsed[key] = entry;
+    });
+    return parsed;
+}
+
+function parseSelection(value: unknown): AppEditorSelection | null {
+    const record = asRecord(value);
+    if (!record) return null;
+    const tag = asNullableString(record.tag);
+    // Without a tag there is no element to talk about, so there is no selection.
+    if (!tag) return null;
+
+    const app = asRecord(record.app) ?? {};
+    const rect = asRecord(record.rect) ?? {};
+    const chain = Array.isArray(record.componentChain)
+        ? record.componentChain.filter((entry): entry is string => typeof entry === 'string')
+        : [];
+
+    return {
+        app: {
+            name: asNullableString(app.name),
+            id: asNullableString(app.id),
+            podId: asNullableString(app.podId),
+        },
+        route: asString(record.route),
+        source: parseSource(record.source),
+        component: asNullableString(record.component),
+        componentChain: chain,
+        tag,
+        domId: asNullableString(record.domId),
+        className: asNullableString(record.className),
+        domPath: asString(record.domPath),
+        text: asString(record.text),
+        html: asString(record.html),
+        rect: {
+            x: asNumber(rect.x),
+            y: asNumber(rect.y),
+            width: asNumber(rect.width),
+            height: asNumber(rect.height),
+        },
+        styles: parseStringMap(record.styles),
+    };
+}
+
+export function parseAppEditorMessage(value: unknown): AppEditorMessage | null {
+    const record = asRecord(value);
+    if (!record) return null;
+
+    if (record.type === APP_EDITOR_MESSAGE.ready) {
+        return { type: APP_EDITOR_MESSAGE.ready };
+    }
+    if (record.type === APP_EDITOR_MESSAGE.selectMode) {
+        return { type: APP_EDITOR_MESSAGE.selectMode, active: record.active === true };
+    }
+    if (record.type === APP_EDITOR_MESSAGE.selection) {
+        const selection = parseSelection(record.selection);
+        return selection ? { type: APP_EDITOR_MESSAGE.selection, selection } : null;
+    }
+    return null;
+}
+
+/** How the selection reads in the composer and to the agent. */
+export function describeAppEditorSelection(selection: AppEditorSelection): string {
+    const component = selection.component ?? `<${selection.tag}>`;
+    if (!selection.source) return component;
+    const { file, line } = selection.source;
+    return line ? `${component} — ${file}:${line}` : `${component} — ${file}`;
+}
+
+function styleSummary(styles: Record<string, string>): string {
+    // Enough to argue about spacing and colour without pasting a whole
+    // computed-style dump into the conversation.
+    const wanted = ['display', 'font-size', 'font-weight', 'color', 'background-color', 'padding'];
+    const parts = wanted
+        .filter((name) => styles[name])
+        .map((name) => `${name}: ${styles[name]}`);
+    return parts.join('; ');
+}
+
+/**
+ * The message the composer opens with once someone has picked an element.
+ *
+ * A block of facts, then a blank line for the person to type into. The agent
+ * needs the file and line to edit the right thing; the DOM path is what it
+ * falls back to for an app with no source stamps, where the markup itself is
+ * the source.
+ */
+export function buildAppEditorPrefill(
+    selection: AppEditorSelection,
+    appName: string,
+): string {
+    const lines = [`Editing the "${appName}" app — I selected this element:`, ''];
+
+    if (selection.source) {
+        const { file, line, column } = selection.source;
+        const position = line ? `:${line}${column ? `:${column}` : ''}` : '';
+        lines.push(`- Source: ${file}${position}`);
+    }
+    if (selection.component) lines.push(`- Component: ${selection.component}`);
+    if (selection.componentChain.length > 1) {
+        lines.push(`- Inside: ${selection.componentChain.slice(1).join(' → ')}`);
+    }
+    if (selection.route) lines.push(`- Route: ${selection.route}`);
+    if (selection.domPath) lines.push(`- DOM path: ${selection.domPath}`);
+    if (selection.text) lines.push(`- Text: ${selection.text}`);
+
+    const styles = styleSummary(selection.styles);
+    if (styles) lines.push(`- Styles: ${styles}`);
+
+    if (selection.html) {
+        lines.push('', '```html', selection.html, '```');
+    }
+
+    lines.push('', '');
+    return lines.join('\n');
+}

--- a/lemma-frontend/lib/assistant/prefill.test.ts
+++ b/lemma-frontend/lib/assistant/prefill.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseAssistantPrefillDetail } from './prefill';
+
+describe('parseAssistantPrefillDetail', () => {
+    it('keeps a real message and trims it', () => {
+        expect(parseAssistantPrefillDetail({ content: '  make this denser  ' })).toEqual({
+            content: 'make this denser',
+            forceNewConversation: false,
+        });
+    });
+
+    it('opts into a new conversation only when asked explicitly', () => {
+        expect(
+            parseAssistantPrefillDetail({ content: 'hi', forceNewConversation: true }),
+        ).toEqual({ content: 'hi', forceNewConversation: true });
+        expect(
+            parseAssistantPrefillDetail({ content: 'hi', forceNewConversation: 'yes' }),
+        ).toEqual({ content: 'hi', forceNewConversation: false });
+    });
+
+    it('rejects anything that would open the assistant with nothing to say', () => {
+        expect(parseAssistantPrefillDetail(null)).toBeNull();
+        expect(parseAssistantPrefillDetail('make this denser')).toBeNull();
+        expect(parseAssistantPrefillDetail({})).toBeNull();
+        expect(parseAssistantPrefillDetail({ content: '   ' })).toBeNull();
+        expect(parseAssistantPrefillDetail({ content: 42 })).toBeNull();
+    });
+});

--- a/lemma-frontend/lib/assistant/prefill.ts
+++ b/lemma-frontend/lib/assistant/prefill.ts
@@ -1,0 +1,37 @@
+/**
+ * Opening the assistant with something already written in the composer.
+ *
+ * A window event rather than a prop or a context value: the things that want to
+ * hand the assistant a starting message — an app frame, a resource view — sit
+ * anywhere in the tree, and the assistant that receives it is mounted once, in
+ * the pod shell, above the router. The event is the seam between them.
+ *
+ * It fills the draft; it never sends. What to ask for is still the person's
+ * sentence to write.
+ */
+
+export const ASSISTANT_PREFILL_EVENT = 'lemma-assistant-prefill-draft';
+
+export interface AssistantPrefillDetail {
+    content: string;
+    forceNewConversation?: boolean;
+}
+
+export function requestAssistantPrefill(detail: AssistantPrefillDetail): void {
+    if (typeof window === 'undefined') return;
+    window.dispatchEvent(new CustomEvent(ASSISTANT_PREFILL_EVENT, { detail }));
+}
+
+export function parseAssistantPrefillDetail(
+    value: unknown,
+): AssistantPrefillDetail | null {
+    if (!value || typeof value !== 'object') return null;
+    const detail = value as Partial<AssistantPrefillDetail>;
+    if (typeof detail.content !== 'string' || detail.content.trim().length === 0) {
+        return null;
+    }
+    return {
+        content: detail.content.trim(),
+        forceNewConversation: detail.forceNewConversation === true,
+    };
+}

--- a/lemma-frontend/styles/features/assistant-overrides.css
+++ b/lemma-frontend/styles/features/assistant-overrides.css
@@ -181,11 +181,16 @@
 }
 
 .pod-assistant-sidebar-surface .lemma-assistant-header {
-  height: 3.5rem;
-  min-height: 3.5rem;
+  /* One 48px header band across the shell: the workspace tab bar, the resource
+     context bar, and the sidebar nav header are each `h-12`, and the docked
+     assistant sits beside them, so its header has to land on the same rail or
+     the dividers step. Pinned rather than derived — without a height this
+     header is padding plus whichever control inside it is tallest, so turning
+     on the new-conversation button (size-9) or dropping the header actions
+     would move the divider on its own. */
+  height: 3rem;
+  min-height: 3rem;
   align-items: center;
-  /* Match the shell topbar + nav header border so the 56px header band reads as
-     one continuous strip across all three regions. */
   border-bottom-color: color-mix(in srgb, var(--border-subtle) 32%, transparent);
   background: var(--pod-main-bg);
   padding: 0 var(--space-4);

--- a/lemma-skills/lemma-builder/references/apps.md
+++ b/lemma-skills/lemma-builder/references/apps.md
@@ -108,6 +108,36 @@ panel · action row), **workflow inbox** (assigned forms + run context + agent
 output), **document review** (doc queue · preview + extracted data · validation
 form), **team ops** (records by owner/status/SLA · members · linked runs).
 
+## Editing what someone pointed at
+
+Someone viewing an app in the pod can switch on the element picker and click a piece
+of the interface. That arrives in the conversation as a block naming what they picked:
+
+```
+Editing the "support-app" app — I selected this element:
+
+- Source: src/components/TicketRow.tsx:42:5
+- Component: TicketRow
+- Inside: TicketList → QueuePage
+- Route: /queue
+- DOM path: #root > main > div > div:nth-of-type(3)
+- Text: SEV-2 · Payments API · 4h
+```
+
+Treat the source line as the answer to *where*, not as the whole request — read the
+file before changing it, and change the component, not the one rendered instance.
+A row clicked inside a `.map()` reports the single source site that renders every
+row: styling it changes all of them, which is usually what was meant. When only that
+one row should change, the fix is in the data or the condition, not in the markup.
+
+`- Source:` is absent for a single-file HTML app, and for a Vite build made before
+source stamping. Then the DOM path and the markup are the handle: find that element
+in `index.html` (HTML apps are their own source) or search the components for the
+class names and text in the block.
+
+The loop from there is the ordinary one — `lemma apps pull` if you don't have the
+source, edit, `lemma apps deploy`, then reload the app to see it.
+
 ## Scaffold, develop, deploy (Vite)
 
 ```bash
@@ -140,6 +170,18 @@ lemma apps open support-app          # open the DEPLOYED app in the agent browse
   `lemma-typescript` checkout / `--sdk-path` is present). Start every new app with `init` —
   don't hand-write `package.json` or copy an old app's stale SDK pin.
 - `deploy` builds with the project env, zips `dist/` + source, uploads, serves.
+- **Every host element carries where it was written.** The template's Vite config
+  stamps `data-lemma-loc="src/File.tsx:12:4"` and `data-lemma-component="Name"` onto
+  each JSX host element (`<div>`, `<span>`, …; components are skipped — an attribute
+  on `<TicketRow />` would be a prop, not markup). That is what makes the element
+  picker resolve a click to a file and a line in a minified build. It survives
+  `vite build` by design; set `LEMMA_APP_SOURCE_LOC=0` to build without it, at the
+  cost of the picker only being able to report DOM.
+- `pull` is the inverse: `lemma apps pull <app> [dir]` downloads that uploaded source
+  into `./<app>` (or `dir`), so an app can be edited from a machine or sandbox that
+  never held the original checkout. It refuses a non-empty directory unless you pass
+  `--force`, and Vite apps arrive without `node_modules` — install before building.
+  **Start here when asked to change an existing app you have no source for.**
 - **Auth/testing — one bearer.** The dev server's dev-only plugin resolves the
   current token via `lemma auth print-token` and seeds `localStorage["lemma_token"]`
   before the app boots, so opening the dev URL in **any** browser (or the agent


### PR DESCRIPTION
## What changes

Switch on **Edit** in a pod app, click any element, and the assistant opens
with that element already described — component, source file and line, route,
DOM path, text, and the styles worth arguing about. You type what to change;
it never sends on your behalf.

Four other things came out of getting that working end to end, each its own
commit:

- **`lemma apps pull`** — brings a deployed app's source back, so an app can be
  changed from a machine or sandbox that never held the original checkout.
- **Auth URL fix** — apps, the CLI, bundled apps and workspace sandboxes were
  handed the auth *origin* without its base path, so sign-in, callback and
  `cli/login` all resolved to routes that do not exist.
- **`make dev-sslip`** — puts the dev stack on one cookie site so embedded apps
  stay signed in, plus two follow-ons: the generated `.env` files no longer
  drift from the running host, and a stale-cookie 500 on session refresh now
  self-heals.
- **Assistant header alignment** — the docked header sat 8px below the shell
  bars it lines up against.

## Why

"Change this bit of the app" meant describing the bit in prose and hoping the
agent found it. The picker gives it a real anchor instead.

Two constraints shaped the design. An app runs on its own subdomain, so the
shell cannot read its DOM — the picker has to run *inside* the app, and is
injected next to `window.__LEMMA_CONFIG__` at serve time so every deployed app
gets it with no rebuild. And a production bundle has no source locations —
esbuild mangles component names, React's automatic runtime only records them in
dev — so the template's Vite config stamps `data-lemma-loc` /
`data-lemma-component` onto host elements at build time, where they survive
minification. Apps without the stamps degrade to DOM context rather than
breaking.

The auth and dev-stack commits are pre-existing bugs found while testing this,
not part of the feature. They are separated so they can be reviewed — or
reverted — on their own.

## How to verify

```bash
# Backend: unit suite + architecture/settings gates
cd lemma-backend && uv run pytest -q -m "not e2e" && \
  uv run python scripts/check_architecture.py && \
  uv run python scripts/check_settings_attrs.py
# 5297 passed, 51 skipped · ratchet passed (12 inherited, 0 cycles) · settings passed

# CLI
cd lemma-cli && uv run pytest -m "not e2e" -q          # 604 passed

# Frontend
cd lemma-frontend && npx vitest run && npm run design:audit:ci && \
  npx tsc --noEmit --skipLibCheck && npx eslint
# 898 passed · design audit productStrict=0 · typecheck and lint clean

# Dev-stack config
python3 -m unittest tests.test_dev_workflow            # 7 passed
```

Manually, against a local stack: built a stamped Vite app, injected the real
bridge, and served it cross-origin. An embedder off the allowlist got no bridge
at all; on the allowlist, hovering a `<span>` highlighted its whole `OrderRow`
and labelled it `main.tsx:9`, the pick returned `src/main.tsx:9:5` with a DOM
path distinguishing row 1 from row 2, alt-click returned the exact span at line
10, and the app's own click/mousedown handlers fired **zero** times during a
pick and normally again afterwards.

Backend e2e is not included above — it needs Docker services this machine could
not start.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **API surface** — no route or schema changed; `apps pull` uses the
      existing `app.source.archive.get` endpoint, so no spec or SDK regeneration
- [x] **Security** — the bridge hands the rendered page to whoever frames it, so
      it stays inert until a window on an origin allowlist completes a
      handshake; without that, any site could embed a public app and read back
      what the viewer's session renders. The allowlist is the frontend origin
      plus `cors_origins` (a `*` entry is dropped), and it is folded into the
      entrypoint ETag so a changed allowlist cannot be served stale. Archive
      extraction rejects absolute and traversing paths. No new secret in a log,
      response, or payload.

## Compatibility and rollback notes

No migrations. Every commit reverts cleanly and independently.

Two behavioral notes for reviewers:

- `SESSION_OLDER_COOKIE_DOMAIN` treats an **empty string as meaningful** and
  distinct from unset — it means the previous cookies were host-only. Several
  neighbouring URL settings are blank-to-None normalised by a shared validator;
  adding this field to that list would silently disable the feature and bring
  the refresh 500 back. There is a test pinning that.
- Source stamping is on by default for newly scaffolded Vite apps and adds two
  data attributes per host element. `LEMMA_APP_SOURCE_LOC=0` builds without it,
  at the cost of the picker reporting DOM instead of a file and line.
