### PR TITLE
Put Python and the shell in one directory, and make a plan get ticked off

### DIFF
--- a/lemma-backend/app/modules/agent/capabilities/todo.py
+++ b/lemma-backend/app/modules/agent/capabilities/todo.py
@@ -19,6 +19,7 @@ plan rather than extending completed history.
 
 from __future__ import annotations
 
+import difflib
 import re
 from uuid import UUID
 
@@ -202,6 +203,73 @@ def _normalize_stored(stored: list[JsonObject]) -> list[JsonObject]:
     return todos
 
 
+
+def _close_open_match(content: str, todos: list[JsonObject]) -> JsonObject | None:
+    """The open task a reworded check-off almost certainly meant.
+
+    Exact text is how a single line finds its task, and a model that finishes
+    "Fetch the Q3 report" and reports "- [x] Fetch Q3 report" used to *add* a
+    second, completed item -- leaving the planned one open forever while the
+    list quietly grew. Matched conservatively: only when one open task is close
+    enough that nothing else competes, so "add a task I forgot" still adds.
+    """
+    open_by_key = {_norm(str(item["content"])): item for item in todos if not item.get("done")}
+    if not open_by_key:
+        return None
+    matches = difflib.get_close_matches(
+        _norm(content), list(open_by_key), n=2, cutoff=0.85
+    )
+    if len(matches) != 1:
+        return None
+    return open_by_key[matches[0]]
+
+
+def _merge_todos(
+    parsed: list[tuple[str, bool]], todos: list[JsonObject]
+) -> list[JsonObject]:
+    """Upsert parsed lines into the stored list, in place."""
+    index = {_norm(str(item["content"])): item for item in todos}
+    single_check_off = len(parsed) == 1 and parsed[0][1]
+    for content, done in parsed:
+        existing = index.get(_norm(content))
+        if existing is None and single_check_off:
+            existing = _close_open_match(content, todos)
+        if existing is not None:
+            existing["done"] = done
+            continue
+        entry: JsonObject = {"content": content, "done": done}
+        todos.append(entry)
+        index[_norm(content)] = entry
+    return todos
+
+
+def _todo_result(todos: list[JsonObject]) -> JsonObject:
+    """The list, plus the one instruction that keeps it honest.
+
+    The usage prompt says to check items off as they finish, and it is many tool
+    calls away by the time one does. This rides back on every call, so the next
+    step is stated where the model is actually looking.
+    """
+    result: JsonObject = {"success": True, "todos": [_render(item) for item in todos]}
+    open_items = [item for item in todos if not item.get("done")]
+    if not todos:
+        return result
+    if not open_items:
+        result["reminder"] = (
+            "Every item is checked off. Report what you produced rather than "
+            "extending a finished plan."
+        )
+        return result
+    next_item = str(open_items[0].get("content", ""))
+    result["next"] = next_item
+    result["reminder"] = (
+        f"{len(todos) - len(open_items)} of {len(todos)} done. Next: {next_item}. "
+        f'Call write_todos(["- [x] {next_item}"]) the moment it is finished and '
+        "before starting the one after it -- not in a batch at the end."
+    )
+    return result
+
+
 class TodoCapability(AbstractCapability[object]):
     """The todo tool plus its usage instructions."""
 
@@ -259,10 +327,7 @@ def build_todo_toolset(
 
         if not parsed:
             # Nothing real to merge: return the current list rather than wiping it.
-            result: JsonObject = {
-                "success": True,
-                "todos": [_render(t) for t in todos],
-            }
+            result = _todo_result(todos)
             if not todos:
                 result["note"] = (
                     "No tasks provided. Only use write_todos for real, multi-step "
@@ -276,18 +341,9 @@ def build_todo_toolset(
         if len(parsed) > 1:
             todos = []
 
-        index = {_norm(t["content"]): t for t in todos}
-        for content, done in parsed:
-            existing = index.get(_norm(content))
-            if existing is not None:
-                existing["done"] = done
-            else:
-                entry = {"content": content, "done": done}
-                todos.append(entry)
-                index[_norm(content)] = entry
-
+        todos = _merge_todos(parsed, todos)
         await store.write(todos)
-        return {"success": True, "todos": [_render(t) for t in todos]}
+        return _todo_result(todos)
 
     return FunctionToolset[BaseAgentContext](tools=[write_todos], id=TODO_TOOLSET_ID)
 

--- a/lemma-backend/app/modules/agent/domain/prompts.py
+++ b/lemma-backend/app/modules/agent/domain/prompts.py
@@ -183,6 +183,14 @@ def build_agent_instructions(
             )
         )
 
+    # The task list the conversation already has, if any. Without this a run
+    # starts blind: the list lives in conversation metadata, and the tool return
+    # that last showed it is an old message that history trimming can drop. An
+    # agent that cannot see its own plan cannot tick anything off it, which is
+    # exactly how a checklist written in turn one stays unchecked forever.
+    # Appended unconditionally; the join below drops it when it is empty.
+    sections.append(_task_list_section(conversation, enabled=enabled))
+
     if agent.instruction.strip():
         sections.append("# Agent Instructions\n" + agent.instruction.strip())
     if conversation.instructions and conversation.instructions.strip():
@@ -211,13 +219,77 @@ def _workspace_cwd(ctx: AgentContext, conversation: Conversation) -> str:
         return str(cwd)
     get_cwd = getattr(ctx, "get_workspace_cwd", None)
     if callable(get_cwd):
-        try:
-            value = get_cwd()
-        except Exception:  # pragma: no cover - defensive
-            value = None
+        # Not guarded. The only implementation reads a field and formats a
+        # string, and swallowing a failure here would put a directory in the
+        # prompt that the tools do not use -- which is the precise bug this
+        # resolution exists to prevent, made silent.
+        value = get_cwd()
         if value:
             return str(value)
     return f"/workspace/conversations/{conversation.id}"
+
+
+
+def _stored_todos(conversation: Conversation) -> list[tuple[str, bool]]:
+    """The conversation's task list as ``(content, done)``, oldest first."""
+    metadata = conversation.metadata if isinstance(conversation.metadata, dict) else {}
+    raw = metadata.get("todos")
+    if not isinstance(raw, list):
+        return []
+    items: list[tuple[str, bool]] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        content = str(entry.get("content") or "").strip()
+        if content:
+            # `status == "completed"` is the pre-simplification shape; rows in
+            # that form are still in metadata on older conversations.
+            items.append(
+                (content, bool(entry.get("done")) or entry.get("status") == "completed")
+            )
+    return items
+
+
+def _task_list_section(
+    conversation: Conversation, *, enabled: set[AgentToolset]
+) -> str:
+    """Show the run its own task list, and say what finishing an item requires.
+
+    Empty for an agent without the todo toolset, and for a conversation that has
+    never planned anything: an agent with no list should decide whether the work
+    needs one, not be nagged about a checklist that does not exist.
+    """
+    if AgentToolset.TODO not in enabled:
+        return ""
+    items = _stored_todos(conversation)
+    if not items:
+        return ""
+    rendered = "\n".join(
+        f"- [{'x' if done else ' '}] {content}" for content, done in items
+    )
+    done_count = sum(1 for _, done in items if done)
+    if done_count == len(items):
+        return (
+            "# Task list\n"
+            "Every item on this conversation's list is finished:\n\n"
+            f"{rendered}\n\n"
+            "That plan is history. If this message needs multi-step work, call "
+            "`write_todos` with the new plan and it replaces the old one."
+        )
+    first_open = next(content for content, done in items if not done)
+    return (
+        "# Task list\n"
+        "This conversation already has a task list. Lemma stores it, the person "
+        f"can see it, and right now it reads ({done_count} of {len(items)} "
+        "done):\n\n"
+        f"{rendered}\n\n"
+        f"Pick up at the first unchecked item — **{first_open}** — unless this "
+        "message sends you somewhere else. The moment you finish an item, call "
+        "`write_todos` with that one line checked "
+        f"(`[\"- [x] {first_open}\"]`) and only then start the next. A finished "
+        "item still showing unchecked is not a cosmetic problem: it is what the "
+        "person is reading to know where you are."
+    )
 
 
 def _workspace_repo(ctx: AgentContext):

--- a/lemma-backend/app/modules/agent/prompts/todo.md
+++ b/lemma-backend/app/modules/agent/prompts/todo.md
@@ -2,4 +2,12 @@
 
 `write_todos` tracks multi-step work. Use it when a task takes several distinct steps — multi-source research, a multi-file change, a build-then-verify flow. Skip it for single-step requests, and never call it just to announce you're starting.
 
-It takes markdown checklist lines: `["- [ ] Fetch the Q3 report", "- [ ] Summarize findings"]`. Call it once with your real tasks, then again with a line checked off (`["- [x] Fetch the Q3 report"]`) as you finish each. Lines match existing tasks by exact text, so send just the line you're flipping; sending several lines replaces the whole list. Every task needs concrete imperative text. The tool returns the full updated list.
+It takes markdown checklist lines: `["- [ ] Fetch the Q3 report", "- [ ] Summarize findings"]`. Every task needs concrete imperative text. Sending several lines replaces the whole list; sending one line matches an existing task by its text and flips just that one. The tool returns the full updated list.
+
+Writing the plan is the easy half. The half that matters:
+
+- **Check an item off the moment it is done, before you start the next one.** `["- [x] Fetch the Q3 report"]` — one line, the task's own words. Not at the end of the run, not in a batch, not "once I'm sure".
+- **Reuse the exact text you planned with.** That is how the tool finds the task. Reworded lines are matched when they're close, but they don't have to be guessed at if you copy the line back.
+- **The list is not a note to yourself.** Lemma stores it and the person watching this conversation reads it to know where you are. An item you finished an hour ago that still shows unchecked tells them you are stuck on it.
+
+If the plan turns out to be wrong, send the new plan as a full set of lines rather than patching around it.

--- a/lemma-backend/app/modules/agent/tests/e2e/test_agent_hermetic_journeys_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_agent_hermetic_journeys_e2e.py
@@ -1138,25 +1138,50 @@ async def test_the_shell_and_python_share_the_conversations_one_directory(
     )
     assert events[-1]["type"] == "completed", events
 
-    messages = await authenticated_client.get(
-        f"/pods/{pod_id}/conversations/{conversation_id}/messages"
-    )
-    assert messages.status_code == status.HTTP_200_OK, messages.text
-    returns = {
-        item["tool_call_id"]: item["tool_result"]
-        for item in messages.json()["items"]
-        if item["kind"] == "TOOL_RETURN"
-    }
+    async def _returns_by_id() -> dict[str, list[dict]]:
+        messages = await authenticated_client.get(
+            f"/pods/{pod_id}/conversations/{conversation_id}/messages"
+        )
+        assert messages.status_code == status.HTTP_200_OK, messages.text
+        grouped: dict[str, list[dict]] = {}
+        for item in messages.json()["items"]:
+            if item["kind"] == "TOOL_RETURN":
+                grouped.setdefault(item["tool_call_id"], []).append(
+                    item["tool_result"]
+                )
+        return grouped
 
-    shell_cwd = (returns["shell-pwd-1"]["stdout"] or "").strip()
-    python_cwd = (returns["python-cwd-1"]["stdout"] or "").strip()
+    returns = await _returns_by_id()
+
+    shell_cwd = (returns["shell-pwd-1"][0]["stdout"] or "").strip()
+    python_cwd = (returns["python-cwd-1"][0]["stdout"] or "").strip()
     assert shell_cwd == recorded_cwd, returns["shell-pwd-1"]
     assert python_cwd == recorded_cwd, returns["python-cwd-1"]
 
-    assert returns["python-write-1"]["success"] is True, returns["python-write-1"]
-    assert "python-was-here" in str(returns["shell-read-1"]), returns["shell-read-1"]
-    assert returns["shell-write-1"]["success"] is True, returns["shell-write-1"]
-    assert "shell-was-here" in str(returns["python-read-1"]), returns["python-read-1"]
+    assert returns["python-write-1"][0]["success"] is True, returns["python-write-1"]
+    assert "python-was-here" in str(returns["shell-read-1"][0]), returns["shell-read-1"]
+    assert returns["shell-write-1"][0]["success"] is True, returns["shell-write-1"]
+    assert "shell-was-here" in str(returns["python-read-1"][0]), returns["python-read-1"]
+
+    # A second turn in the same conversation, because the directory is a
+    # property of the conversation rather than of a run. Anything that
+    # recomputed it per run -- a default, a fresh slug, a fallback -- would move
+    # house here and leave the first turn's files behind, which is the failure
+    # the recorded cwd exists to prevent.
+    second = await _send_message(
+        authenticated_client,
+        pod_id,
+        conversation_id,
+        "Where are you working now?",
+    )
+    assert second[-1]["type"] == "completed", second
+
+    returns = await _returns_by_id()
+    assert len(returns["shell-pwd-1"]) == 2, returns["shell-pwd-1"]
+    assert (returns["shell-pwd-1"][1]["stdout"] or "").strip() == recorded_cwd
+    assert (returns["python-cwd-1"][1]["stdout"] or "").strip() == recorded_cwd
+    # And the previous turn's files are still under it, read by relative name.
+    assert "shell-was-here" in str(returns["python-read-1"][1])
 
 
 @pytest.mark.asyncio

--- a/lemma-backend/app/modules/agent/tests/e2e/test_agent_hermetic_journeys_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_agent_hermetic_journeys_e2e.py
@@ -1014,6 +1014,265 @@ async def test_scripted_todo_and_workspace_tools_stream_and_persist_real_results
 
 
 @pytest.mark.asyncio
+@pytest.mark.fast_workspace
+@pytest.mark.timeout(300)
+async def test_the_shell_and_python_share_the_conversations_one_directory(
+    authenticated_client,
+    fixed_test_org,
+    e2e_settings,
+    worker,
+    configure_workspace_api_url,
+):
+    """One conversation is one directory, whichever tool the agent reaches for.
+
+    The conversation's metadata is the single source of truth for where it
+    works. `exec_command` honoured it and `execute_python` did not: on a
+    provider with no resident interpreter the cwd was only ever passed when the
+    session was created, and the E2B provider dropped it there and started each
+    execution wherever the sandbox image defaults to. The agent saw `pwd` and
+    `os.getcwd()` disagree, and a file one tool wrote by relative path was
+    invisible to the other -- which reads, from inside the run, as work
+    vanishing.
+
+    So this asserts the two facts that make the directory real: both tools
+    report the path metadata records, and each one can read what the other
+    wrote by relative name.
+    """
+    del worker, configure_workspace_api_url
+    runtime = await _create_runtime_profile(
+        authenticated_client,
+        fixed_test_org,
+        e2e_settings,
+    )
+    pod = await _create_pod(authenticated_client, fixed_test_org)
+    pod_id = pod["id"]
+    agent_name = f"cwd_{uuid4().hex[:8]}"
+    agent = await authenticated_client.post(
+        f"/pods/{pod_id}/agents",
+        json={
+            "name": agent_name,
+            "instruction": "Report the working directory.",
+            "agent_runtime": {
+                "profile_id": runtime["id"],
+                "model_name": "mock-safe-model",
+            },
+            "toolsets": ["WORKSPACE_CLI"],
+        },
+    )
+    assert agent.status_code == status.HTTP_201_CREATED, agent.text
+
+    script = [
+        script_tool_call(
+            "exec_command",
+            {"cmd": "pwd", "comment": "Where the shell is"},
+            tool_call_id="shell-pwd-1",
+        ),
+        script_tool_call(
+            "execute_python",
+            {
+                "code": "import os\nprint(os.getcwd())",
+                "comment": "Where the interpreter is",
+            },
+            tool_call_id="python-cwd-1",
+        ),
+        script_tool_call(
+            "execute_python",
+            {
+                # Relative on purpose: an absolute path would pass even with the
+                # interpreter sitting in the wrong directory, which is exactly
+                # the bug this is here to catch.
+                "code": (
+                    "from pathlib import Path\n"
+                    "Path('python-wrote.txt').write_text('python-was-here')"
+                ),
+                "comment": "Write a file by relative name",
+            },
+            tool_call_id="python-write-1",
+        ),
+        script_tool_call(
+            "exec_command",
+            {"cmd": "cat python-wrote.txt", "comment": "Read what Python wrote"},
+            tool_call_id="shell-read-1",
+        ),
+        script_tool_call(
+            "exec_command",
+            {
+                "cmd": "printf 'shell-was-here' > shell-wrote.txt",
+                "comment": "Write a file by relative name",
+            },
+            tool_call_id="shell-write-1",
+        ),
+        script_tool_call(
+            "execute_python",
+            {
+                "code": (
+                    "from pathlib import Path\n"
+                    "print(Path('shell-wrote.txt').read_text())"
+                ),
+                "comment": "Read what the shell wrote",
+            },
+            tool_call_id="python-read-1",
+        ),
+        script_text("Working directory confirmed."),
+    ]
+    conversation = await authenticated_client.post(
+        f"/pods/{pod_id}/conversations",
+        json={
+            "agent_name": agent_name,
+            "title": "Working directory",
+            "metadata": {"mock_llm_script": script},
+        },
+    )
+    assert conversation.status_code == status.HTTP_201_CREATED, conversation.text
+    conversation_id = conversation.json()["id"]
+    # Creation stamps the directory; everything below must agree with it rather
+    # than with any path recomputed on the side.
+    recorded_cwd = conversation.json()["metadata"]["cwd"]
+    assert recorded_cwd.startswith("/workspace/"), conversation.json()["metadata"]
+
+    events = await _send_message(
+        authenticated_client,
+        pod_id,
+        conversation_id,
+        "Say where you are working.",
+    )
+    assert events[-1]["type"] == "completed", events
+
+    messages = await authenticated_client.get(
+        f"/pods/{pod_id}/conversations/{conversation_id}/messages"
+    )
+    assert messages.status_code == status.HTTP_200_OK, messages.text
+    returns = {
+        item["tool_call_id"]: item["tool_result"]
+        for item in messages.json()["items"]
+        if item["kind"] == "TOOL_RETURN"
+    }
+
+    shell_cwd = (returns["shell-pwd-1"]["stdout"] or "").strip()
+    python_cwd = (returns["python-cwd-1"]["stdout"] or "").strip()
+    assert shell_cwd == recorded_cwd, returns["shell-pwd-1"]
+    assert python_cwd == recorded_cwd, returns["python-cwd-1"]
+
+    assert returns["python-write-1"]["success"] is True, returns["python-write-1"]
+    assert "python-was-here" in str(returns["shell-read-1"]), returns["shell-read-1"]
+    assert returns["shell-write-1"]["success"] is True, returns["shell-write-1"]
+    assert "shell-was-here" in str(returns["python-read-1"]), returns["python-read-1"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.fast_workspace
+@pytest.mark.timeout(300)
+async def test_a_project_conversation_is_checked_out_before_python_runs(
+    authenticated_client,
+    fixed_test_org,
+    e2e_settings,
+    worker,
+    configure_workspace_api_url,
+):
+    """Picking a project is picking a directory -- for both tools, not one.
+
+    A conversation started against a repo resolves its cwd to
+    `/workspace/repos/{owner}/{repo}`, and `get_session` creates that directory
+    whether or not anything was ever cloned into it. Only `exec_command` ran the
+    checkout, so an agent whose first tool call was `execute_python` opened its
+    project, found an empty folder, and was told nothing about why.
+
+    The repo here cannot exist, so the clone fails for a stable reason and the
+    assertion is on the part that matters: the agent is *told*, on the Python
+    result, rather than left to infer something from an empty directory.
+    """
+    del worker, configure_workspace_api_url
+    runtime = await _create_runtime_profile(
+        authenticated_client,
+        fixed_test_org,
+        e2e_settings,
+    )
+    pod = await _create_pod(authenticated_client, fixed_test_org)
+    pod_id = pod["id"]
+    agent_name = f"project_{uuid4().hex[:8]}"
+    agent = await authenticated_client.post(
+        f"/pods/{pod_id}/agents",
+        json={
+            "name": agent_name,
+            "instruction": "Work in the project.",
+            "agent_runtime": {
+                "profile_id": runtime["id"],
+                "model_name": "mock-safe-model",
+            },
+            "toolsets": ["WORKSPACE_CLI"],
+        },
+    )
+    assert agent.status_code == status.HTTP_201_CREATED, agent.text
+
+    owner = "lemma-work"
+    repo = f"no-such-repo-{uuid4().hex[:12]}"
+    script = [
+        # Python first, deliberately: this is the order that used to skip the
+        # checkout entirely.
+        script_tool_call(
+            "execute_python",
+            {
+                "code": "import os\nprint(os.getcwd())",
+                "comment": "Open the project with Python",
+            },
+            tool_call_id="python-first-1",
+        ),
+        script_tool_call(
+            "exec_command",
+            {"cmd": "pwd", "comment": "And the shell, for comparison"},
+            tool_call_id="shell-after-1",
+        ),
+        script_text("Project directory reported."),
+    ]
+    conversation = await authenticated_client.post(
+        f"/pods/{pod_id}/conversations",
+        json={
+            "agent_name": agent_name,
+            "title": "On a project",
+            "metadata": {
+                "mock_llm_script": script,
+                "repo": {"owner": owner, "repo": repo},
+            },
+        },
+    )
+    assert conversation.status_code == status.HTTP_201_CREATED, conversation.text
+    conversation_id = conversation.json()["id"]
+    # The repo derives the directory: one source of truth, not two to keep in
+    # step.
+    recorded_cwd = conversation.json()["metadata"]["cwd"]
+    assert recorded_cwd == f"/workspace/repos/{owner}/{repo}", conversation.json()
+
+    events = await _send_message(
+        authenticated_client,
+        pod_id,
+        conversation_id,
+        "Start work on the project.",
+    )
+    assert events[-1]["type"] == "completed", events
+
+    messages = await authenticated_client.get(
+        f"/pods/{pod_id}/conversations/{conversation_id}/messages"
+    )
+    assert messages.status_code == status.HTTP_200_OK, messages.text
+    returns = {
+        item["tool_call_id"]: item["tool_result"]
+        for item in messages.json()["items"]
+        if item["kind"] == "TOOL_RETURN"
+    }
+
+    python_stdout = returns["python-first-1"]["stdout"] or ""
+    # Said, not left to be inferred -- and said on the Python result, which is
+    # where this conversation's first tool call actually was.
+    assert "[workspace notice]" in python_stdout, returns["python-first-1"]
+    assert f"{owner}/{repo}" in python_stdout, returns["python-first-1"]
+    # And still the conversation's own directory, the one the shell reports.
+    assert recorded_cwd in python_stdout, returns["python-first-1"]
+    assert (returns["shell-after-1"]["stdout"] or "").strip().endswith(
+        recorded_cwd
+    ), returns["shell-after-1"]
+
+
+@pytest.mark.asyncio
 async def test_scripted_write_todos_normalizes_malformed_and_duplicate_checkbox_input(
     authenticated_client,
     fixed_test_org,
@@ -1120,6 +1379,117 @@ async def test_scripted_write_todos_normalizes_malformed_and_duplicate_checkbox_
     assert persisted.json()["metadata"]["todos"] == [
         {"content": "Draft the proposal", "done": False},
         {"content": "Send the invoice", "done": True},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_a_plan_is_ticked_off_and_the_tool_says_what_is_next(
+    authenticated_client,
+    fixed_test_org,
+    e2e_settings,
+    worker,
+):
+    """The half of the task list that was never happening, end to end.
+
+    Agents wrote the plan and then left it: every item unchecked for the rest of
+    the conversation, which is what the person watching reads as "still on step
+    one". Two things had to change for that, and both are asserted here -- the
+    tool result now names the next item and when to flip it, and a check-off in
+    slightly different words lands on the planned task instead of appending a
+    near-duplicate beside it.
+    """
+    del worker  # session fixture keeps the production streaq worker alive
+    runtime = await _create_runtime_profile(
+        authenticated_client,
+        fixed_test_org,
+        e2e_settings,
+    )
+    pod = await _create_pod(authenticated_client, fixed_test_org)
+    pod_id = pod["id"]
+    agent_name = f"todo_flow_{uuid4().hex[:8]}"
+    agent = await authenticated_client.post(
+        f"/pods/{pod_id}/agents",
+        json={
+            "name": agent_name,
+            "instruction": "Plan, then work the plan.",
+            "agent_runtime": {
+                "profile_id": runtime["id"],
+                "model_name": "mock-safe-model",
+            },
+            "toolsets": ["TODO"],
+        },
+    )
+    assert agent.status_code == status.HTTP_201_CREATED, agent.text
+
+    script = [
+        script_tool_call(
+            "write_todos",
+            {"todos": ["- [ ] Fetch the Q3 report", "- [ ] Summarize findings"]},
+            tool_call_id="todo-plan-1",
+        ),
+        script_tool_call(
+            "write_todos",
+            # Reworded on purpose: "the" dropped, which is exactly how a model
+            # restates its own task, and exactly what used to append a second
+            # completed item while the planned one stayed open.
+            {"todos": ["- [x] Fetch Q3 report"]},
+            tool_call_id="todo-flip-1",
+        ),
+        script_text("First step done."),
+    ]
+    conversation = await authenticated_client.post(
+        f"/pods/{pod_id}/conversations",
+        json={
+            "agent_name": agent_name,
+            "title": "Working the plan",
+            "metadata": {"mock_llm_script": script},
+        },
+    )
+    assert conversation.status_code == status.HTTP_201_CREATED, conversation.text
+    conversation_id = conversation.json()["id"]
+
+    events = await _send_message(
+        authenticated_client,
+        pod_id,
+        conversation_id,
+        "Research Q3 and summarize it.",
+    )
+    assert events[-1]["type"] == "completed", events
+
+    messages = await authenticated_client.get(
+        f"/pods/{pod_id}/conversations/{conversation_id}/messages"
+    )
+    assert messages.status_code == status.HTTP_200_OK, messages.text
+    returns = {
+        item["tool_call_id"]: item["tool_result"]
+        for item in messages.json()["items"]
+        if item["kind"] == "TOOL_RETURN"
+    }
+
+    plan = returns["todo-plan-1"]
+    assert plan["next"] == "Fetch the Q3 report"
+    assert "0 of 2 done" in plan["reminder"]
+    # The literal call to make next, so flipping it is copying rather than
+    # remembering.
+    assert '- [x] Fetch the Q3 report' in plan["reminder"]
+
+    flip = returns["todo-flip-1"]
+    assert flip["todos"] == [
+        "- [x] Fetch the Q3 report",
+        "- [ ] Summarize findings",
+    ]
+    assert flip["next"] == "Summarize findings"
+    assert "1 of 2 done" in flip["reminder"]
+
+    persisted = await authenticated_client.get(
+        f"/pods/{pod_id}/conversations/{conversation_id}"
+    )
+    assert persisted.status_code == status.HTTP_200_OK, persisted.text
+    # Stored under the wording the person already saw, with one item done --
+    # not two tasks that mean the same thing.
+    assert persisted.json()["metadata"]["todos"] == [
+        {"content": "Fetch the Q3 report", "done": True},
+        {"content": "Summarize findings", "done": False},
     ]
 
 

--- a/lemma-backend/app/modules/agent/tests/e2e/test_workspace_tools_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_workspace_tools_e2e.py
@@ -304,6 +304,317 @@ async def test_agent_uses_lemma_cli_through_selected_workspace_provider(
     assert fixed_test_user["email"] in assistant_text, assistant_text
 
 
+@pytest.mark.slow
+@pytest.mark.provider
+@pytest.mark.real_llm
+@pytest.mark.real_sandbox
+@pytest.mark.skipif(
+    not e2e_real_llm(),
+    reason="set E2E_LLM_MODE=real to run the live two-tool directory acceptance test",
+)
+@pytest.mark.skipif(not system_lemma_available(), reason=SYSTEM_LEMMA_SKIP_REASON)
+async def test_a_real_agent_finds_with_the_shell_what_it_wrote_with_python(
+    authenticated_client,
+    fixed_test_org,
+    fixed_test_user,
+    configure_workspace_api_url,
+    db_manager,
+    e2e_settings,
+):
+    """The failure as a person actually hits it, with a real model driving.
+
+    `execute_python` ran in the sandbox image's default directory while
+    `exec_command` ran in the conversation's own, so a relative path meant two
+    different files and an agent watched its own work disappear between tools.
+    The scripted journeys pin the contract; this pins the experience -- nobody
+    tells this agent a directory, it just uses both tools the way a model does.
+
+    Deliberately no absolute paths in the prompt: an absolute path passes even
+    with the interpreter sitting in the wrong place, which is the whole bug.
+    """
+    del db_manager
+    await workspace_runtime.close_workspace_tool_runtimes()
+    provider = configure_workspace_api_url["provider"]
+
+    pod_response = await authenticated_client.post(
+        "/pods",
+        json={
+            "name": f"Two Tool Directory Pod {uuid4().hex[:8]}",
+            "type": "ASSISTANT",
+            "organization_id": fixed_test_org["id"],
+        },
+    )
+    assert pod_response.status_code == status.HTTP_201_CREATED, pod_response.text
+    pod = pod_response.json()
+
+    create_agent = await authenticated_client.post(
+        f"/pods/{pod['id']}/agents",
+        json={
+            "name": f"Two Tool Directory Agent {uuid4().hex[:8]}",
+            "instruction": (
+                "You do small workspace tasks with the tools you are given. "
+                "Use execute_python for Python and exec_command for shell "
+                "commands. Never answer from memory -- run the tools."
+            ),
+            "toolsets": ["WORKSPACE_CLI"],
+            "agent_runtime": {
+                "profile_id": "system:lemma",
+                "model_name": _ACCEPTANCE_MODEL,
+            },
+        },
+    )
+    assert create_agent.status_code == status.HTTP_201_CREATED, create_agent.text
+    agent = create_agent.json()
+
+    create_conversation = await authenticated_client.post(
+        f"/pods/{pod['id']}/conversations",
+        json={
+            "agent_name": agent["name"],
+            "title": f"{provider} two-tool directory acceptance",
+            "type": "CHAT",
+        },
+    )
+    assert create_conversation.status_code == status.HTTP_201_CREATED, (
+        create_conversation.text
+    )
+    conversation = create_conversation.json()
+    conversation_id = conversation["id"]
+    recorded_cwd = conversation["metadata"]["cwd"]
+
+    async with production_worker_process(
+        e2e_settings,
+        log_prefix=f"sandbox_{provider}_two_tool_directory",
+    ) as acceptance_worker:
+        events = await _post_sse(
+            authenticated_client,
+            f"/pods/{pod['id']}/conversations/{conversation_id}/messages",
+            {
+                "content": (
+                    "Use execute_python to write the text TWO_TOOL_PROOF into a "
+                    "file called handoff.txt, using that relative filename and "
+                    "no directory. Then use exec_command to `cat handoff.txt`, "
+                    "also with no directory. Reply with what cat printed."
+                )
+            },
+        )
+        if any(event.get("type") == "error" for event in events):
+            pytest.fail(
+                "Two-tool directory acceptance run failed.\nWorker log:\n"
+                + acceptance_worker.read_log_tail()
+            )
+    _assert_completed_without_error(events)
+
+    messages = await authenticated_client.get(
+        f"/pods/{pod['id']}/conversations/{conversation_id}/messages"
+    )
+    assert messages.status_code == status.HTTP_200_OK, messages.text
+    items = messages.json()["items"]
+
+    def _returns(tool_name: str) -> list[dict]:
+        return [
+            item
+            for item in items
+            if item["kind"] == "TOOL_RETURN" and item["tool_name"] == tool_name
+        ]
+
+    python_returns = _returns("execute_python")
+    shell_returns = _returns("exec_command")
+    assert python_returns, items
+    assert shell_returns, items
+
+    # The handoff itself: the shell found, by relative name, the file Python
+    # wrote by relative name. This is the assertion that fails when the two
+    # tools are in different directories, and it fails for the reason the
+    # person experiences rather than on an internal detail.
+    shell_output = json.dumps(
+        [item.get("tool_result") for item in shell_returns], sort_keys=True
+    )
+    assert "TWO_TOOL_PROOF" in shell_output, shell_output
+    assert "No such file" not in shell_output, shell_output
+
+    assistant_text = " ".join(
+        item.get("text") or ""
+        for item in items
+        if item["role"] == "assistant" and item["kind"] == "TEXT"
+    )
+    assert "TWO_TOOL_PROOF" in assistant_text, assistant_text
+
+    # And the file is in the conversation's own directory, so the handoff
+    # worked because both tools were there -- not because they happened to
+    # share the image's default.
+    probe = await exec_command_internal(
+        BaseAgentContext(
+            user_id=UUID(fixed_test_user["id"]),
+            org_id=UUID(fixed_test_org["id"]),
+            pod_id=UUID(pod["id"]),
+            conversation_id=UUID(conversation_id),
+            agent_name="two_tool_directory_probe",
+            workspace_cwd=recorded_cwd,
+        ),
+        ExecCommandRequest(
+            cmd=f"cat {shlex.quote(recorded_cwd)}/handoff.txt", timeout_seconds=30
+        ),
+    )
+    assert probe.success is True, probe
+    assert "TWO_TOOL_PROOF" in (probe.stdout or ""), probe
+
+
+@pytest.mark.slow
+@pytest.mark.provider
+@pytest.mark.real_llm
+@pytest.mark.real_sandbox
+@pytest.mark.skipif(
+    not e2e_real_llm(),
+    reason="set E2E_LLM_MODE=real to run the live task-list acceptance test",
+)
+@pytest.mark.skipif(not system_lemma_available(), reason=SYSTEM_LEMMA_SKIP_REASON)
+async def test_a_real_agent_picks_up_its_plan_in_a_later_turn_and_finishes_it(
+    authenticated_client,
+    fixed_test_org,
+    configure_workspace_api_url,
+    db_manager,
+    e2e_settings,
+):
+    """A live agent working a plan across two turns, end to end.
+
+    Read this for what it is: a guard, not a proof. The reported failure -- a
+    checklist written at the start of a session and never updated again -- did
+    not reproduce here against the pre-fix code (3/3 passed on the acceptance
+    model, 2/3 on the weaker default, and that one failure was the model never
+    calling `write_todos` at all rather than never updating it). The mechanism
+    the prompt section addresses needs a conversation long enough for
+    summarization to bite: it keeps the last 40 messages, and past that the
+    `write_todos` return carrying the list is simply gone from history. Getting
+    there costs ~70k tokens of conversation, which no e2e should spend, so the
+    section is pinned at unit level instead.
+
+    What this does hold: the whole loop works with a real model across a turn
+    boundary, and the outcome the person sees is right -- the stored list ends
+    ticked off, holding the tasks that were planned rather than a re-plan or
+    paraphrases beside them.
+    """
+    del db_manager
+    await workspace_runtime.close_workspace_tool_runtimes()
+    provider = configure_workspace_api_url["provider"]
+
+    pod_response = await authenticated_client.post(
+        "/pods",
+        json={
+            "name": f"Task List Pod {uuid4().hex[:8]}",
+            "type": "ASSISTANT",
+            "organization_id": fixed_test_org["id"],
+        },
+    )
+    assert pod_response.status_code == status.HTTP_201_CREATED, pod_response.text
+    pod = pod_response.json()
+
+    create_agent = await authenticated_client.post(
+        f"/pods/{pod['id']}/agents",
+        json={
+            "name": f"Task List Agent {uuid4().hex[:8]}",
+            "instruction": (
+                "You do multi-step workspace tasks. Track work that takes "
+                "several steps with write_todos, and keep the list current as "
+                "you go. Do the work with the workspace tools -- never answer "
+                "from memory."
+            ),
+            "toolsets": ["WORKSPACE_CLI", "TODO"],
+            "agent_runtime": {
+                "profile_id": "system:lemma",
+                "model_name": _ACCEPTANCE_MODEL,
+            },
+        },
+    )
+    assert create_agent.status_code == status.HTTP_201_CREATED, create_agent.text
+    agent = create_agent.json()
+
+    create_conversation = await authenticated_client.post(
+        f"/pods/{pod['id']}/conversations",
+        json={
+            "agent_name": agent["name"],
+            "title": f"{provider} task list acceptance",
+            "type": "CHAT",
+        },
+    )
+    assert create_conversation.status_code == status.HTTP_201_CREATED, (
+        create_conversation.text
+    )
+    conversation_id = create_conversation.json()["id"]
+    messages_url = f"/pods/{pod['id']}/conversations/{conversation_id}/messages"
+
+    async with production_worker_process(
+        e2e_settings,
+        log_prefix=f"sandbox_{provider}_task_list",
+    ) as acceptance_worker:
+        first = await _post_sse(
+            authenticated_client,
+            messages_url,
+            {
+                "content": (
+                    "Four steps in the workspace, please: (1) write ALPHA into "
+                    "alpha.txt, (2) write the number of characters in alpha.txt "
+                    "into beta.txt, (3) join both files into gamma.txt, (4) "
+                    "print gamma.txt. Plan all four before you start, then do "
+                    "only the first two and stop -- I will tell you when to "
+                    "carry on."
+                )
+            },
+        )
+        if any(event.get("type") == "error" for event in first):
+            pytest.fail(
+                "Task list acceptance run failed.\nWorker log:\n"
+                + acceptance_worker.read_log_tail()
+            )
+        _assert_completed_without_error(first)
+
+        second = await _post_sse(
+            authenticated_client,
+            messages_url,
+            {"content": "Carry on with the rest of the plan."},
+        )
+        if any(event.get("type") == "error" for event in second):
+            pytest.fail(
+                "Task list continuation run failed.\nWorker log:\n"
+                + acceptance_worker.read_log_tail()
+            )
+        _assert_completed_without_error(second)
+
+    messages = await authenticated_client.get(messages_url)
+    assert messages.status_code == status.HTTP_200_OK, messages.text
+    items = messages.json()["items"]
+
+    todo_calls = [
+        item
+        for item in items
+        if item["kind"] == "TOOL_CALL" and item["tool_name"] == "write_todos"
+    ]
+    # More than once is the whole point: writing the plan was never the part
+    # that failed.
+    assert len(todo_calls) >= 2, [item.get("tool_args") for item in todo_calls]
+
+    persisted = await authenticated_client.get(
+        f"/pods/{pod['id']}/conversations/{conversation_id}"
+    )
+    assert persisted.status_code == status.HTTP_200_OK, persisted.text
+    stored = persisted.json()["metadata"]["todos"]
+    assert stored, persisted.json()["metadata"]
+    assert all(item["done"] for item in stored), stored
+
+    # The list the person reads is the plan, not the plan plus paraphrases of
+    # it: a check-off in different words used to append beside the task it
+    # meant. Compare against what the agent actually planned first.
+    planned = (todo_calls[0].get("tool_args") or {}).get("todos") or []
+    assert len(stored) <= max(len(planned), 1) + 1, (planned, stored)
+
+    # And the work itself really happened.
+    assistant_text = " ".join(
+        item.get("text") or ""
+        for item in items
+        if item["role"] == "assistant" and item["kind"] == "TEXT"
+    )
+    assert "ALPHA" in assistant_text.upper(), assistant_text
+
+
 async def test_agent_workspace_cli_tools_execute_through_a_real_sandbox(
     authenticated_client,
     fixed_test_org,

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_tools.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_tools.py
@@ -859,6 +859,123 @@ def test_workspace_agent_prompt_states_working_directory():
     assert "uv venv" in prompt
 
 
+def test_a_run_is_shown_the_task_list_it_is_supposed_to_be_ticking_off():
+    """A plan written in turn one has to still be visible in turn five.
+
+    The list lives in conversation metadata; the only place a later run could
+    have seen it was the `write_todos` tool return, an old message that history
+    trimming eventually drops. An agent that cannot see its own checklist cannot
+    check anything off it -- which is how a plan gets written once and never
+    updated again.
+
+    Both harnesses get this: the section is added outside the
+    `include_toolset_prompts` guard, like the working-directory one.
+    """
+    conversation = Conversation(
+        pod_id=uuid4(),
+        user_id=uuid4(),
+        agent_id=uuid4(),
+        metadata={
+            "todos": [
+                {"content": "Fetch the Q3 report", "done": True},
+                {"content": "Summarize findings", "done": False},
+            ]
+        },
+    )
+    agent = Agent(
+        pod_id=conversation.pod_id,
+        user_id=conversation.user_id,
+        name="researcher",
+        instruction="Do the task.",
+        toolsets=[AgentToolset.TODO],
+    )
+
+    for include_fragments in (True, False):
+        prompt = build_agent_instructions(
+            agent=agent,
+            conversation=conversation,
+            ctx=SimpleNamespace(surface_platform=None),
+            include_toolset_prompts=include_fragments,
+        )
+        assert "# Task list" in prompt
+        assert "- [x] Fetch the Q3 report" in prompt
+        assert "- [ ] Summarize findings" in prompt
+        assert "1 of 2 done" in prompt
+        # Named, so picking up mid-plan needs no inference.
+        assert "Summarize findings**" in prompt
+
+
+def test_a_conversation_that_never_planned_is_not_nagged_about_a_task_list():
+    """An agent with no list should decide whether the work needs one."""
+    conversation = Conversation(pod_id=uuid4(), user_id=uuid4(), agent_id=uuid4())
+    agent = Agent(
+        pod_id=conversation.pod_id,
+        user_id=conversation.user_id,
+        name="researcher",
+        instruction="Do the task.",
+        toolsets=[AgentToolset.TODO],
+    )
+
+    prompt = build_agent_instructions(
+        agent=agent,
+        conversation=conversation,
+        ctx=SimpleNamespace(surface_platform=None),
+    )
+
+    assert "This conversation already has a task list" not in prompt
+
+
+def test_an_agent_without_the_todo_toolset_is_never_shown_a_task_list():
+    """A list it cannot edit is noise: there is no `write_todos` on this run."""
+    conversation = Conversation(
+        pod_id=uuid4(),
+        user_id=uuid4(),
+        agent_id=uuid4(),
+        metadata={"todos": [{"content": "Fetch the Q3 report", "done": False}]},
+    )
+    agent = Agent(
+        pod_id=conversation.pod_id,
+        user_id=conversation.user_id,
+        name="builder",
+        instruction="Do the task.",
+        toolsets=[AgentToolset.WORKSPACE_CLI],
+    )
+
+    prompt = build_agent_instructions(
+        agent=agent,
+        conversation=conversation,
+        ctx=SimpleNamespace(workspace_cwd="/workspace/c/x/y", surface_platform=None),
+    )
+
+    assert "# Task list" not in prompt
+
+
+def test_a_finished_plan_is_shown_as_history_rather_than_as_work():
+    """All-done is not "nothing to do": the next request replaces the plan."""
+    conversation = Conversation(
+        pod_id=uuid4(),
+        user_id=uuid4(),
+        agent_id=uuid4(),
+        metadata={"todos": [{"content": "Ship it", "done": True}]},
+    )
+    agent = Agent(
+        pod_id=conversation.pod_id,
+        user_id=conversation.user_id,
+        name="researcher",
+        instruction="Do the task.",
+        toolsets=[AgentToolset.TODO],
+    )
+
+    prompt = build_agent_instructions(
+        agent=agent,
+        conversation=conversation,
+        ctx=SimpleNamespace(surface_platform=None),
+    )
+
+    assert "Every item on this conversation's list is finished" in prompt
+    assert "replaces the old one" in prompt
+
+
 def test_project_agent_prompt_describes_the_checkout_not_the_scratchpad():
     """On a repo, the scratchpad orientation is not just unhelpful but wrong:
     there is no sibling `/workspace/c/<date>/<slug>` holding earlier work, and

--- a/lemma-backend/app/modules/agent/tests/unit/test_capabilities.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_capabilities.py
@@ -369,6 +369,127 @@ async def test_write_todos_merges_lines_and_flips_status(monkeypatch):
     ]
 
 
+@pytest.mark.anyio
+async def test_write_todos_says_what_to_do_next_on_every_call(monkeypatch):
+    """The usage prompt is many tool calls away by the time an item finishes.
+
+    Writing a plan is the half models do reliably; checking items off is the
+    half they drop, and the instruction to do it lived only in the system
+    prompt. It rides back on the tool result now, where the model is already
+    looking, naming the next item and when to flip it.
+    """
+    from pydantic_ai.tools import RunContext
+    from pydantic_ai.usage import RunUsage
+
+    from app.modules.agent.capabilities import todo_storage as storage_mod
+    from app.modules.agent.capabilities.todo import build_todo_capability
+    from app.modules.agent.tools.context import BaseAgentContext
+
+    store: dict = {}
+    monkeypatch.setattr(
+        storage_mod, "ConversationRepository", lambda _uow: _FakeRepo(store)
+    )
+    capability = build_todo_capability(
+        uow_factory=lambda: _FakeUoW(), conversation_id=uuid4()
+    )
+    toolset = capability.get_toolset()
+    run_ctx = RunContext(
+        deps=BaseAgentContext(
+            user_id=uuid4(), pod_id=uuid4(), conversation_id=uuid4()
+        ),
+        model=None,  # type: ignore[arg-type]
+        usage=RunUsage(),
+        prompt=None,
+    )
+
+    async def call(args: dict):
+        prepared = await toolset.for_run(run_ctx)
+        async with prepared:
+            tools = await prepared.get_tools(run_ctx)
+            tool = tools["write_todos"]
+            validated = tool.args_validator.validate_python(
+                args, context=run_ctx.validation_context
+            )
+            return await prepared.call_tool("write_todos", validated, run_ctx, tool)
+
+    planned = await call({"todos": ["- [ ] Fetch the Q3 report", "- [ ] Summarize"]})
+    assert planned["next"] == "Fetch the Q3 report"
+    assert "0 of 2 done" in planned["reminder"]
+    # The exact call to make, in the task's own words, so flipping it is copying.
+    assert '- [x] Fetch the Q3 report' in planned["reminder"]
+
+    flipped = await call({"todos": ["- [x] Fetch the Q3 report"]})
+    assert flipped["todos"] == ["- [x] Fetch the Q3 report", "- [ ] Summarize"]
+    assert flipped["next"] == "Summarize"
+    assert "1 of 2 done" in flipped["reminder"]
+
+    finished = await call({"todos": ["- [x] Summarize"]})
+    assert "next" not in finished
+    assert "Every item is checked off" in finished["reminder"]
+
+
+@pytest.mark.anyio
+async def test_a_reworded_check_off_flips_the_task_instead_of_adding_one(monkeypatch):
+    """Text is how a single line finds its task, and models paraphrase.
+
+    "- [x] Fetch Q3 report" against a planned "Fetch the Q3 report" used to
+    append a second, completed item: the planned one stayed open forever and
+    the list grew a near-duplicate. Adding a genuinely new task must still add.
+    """
+    from pydantic_ai.tools import RunContext
+    from pydantic_ai.usage import RunUsage
+
+    from app.modules.agent.capabilities import todo_storage as storage_mod
+    from app.modules.agent.capabilities.todo import build_todo_capability
+    from app.modules.agent.tools.context import BaseAgentContext
+
+    store: dict = {}
+    monkeypatch.setattr(
+        storage_mod, "ConversationRepository", lambda _uow: _FakeRepo(store)
+    )
+    capability = build_todo_capability(
+        uow_factory=lambda: _FakeUoW(), conversation_id=uuid4()
+    )
+    toolset = capability.get_toolset()
+    run_ctx = RunContext(
+        deps=BaseAgentContext(
+            user_id=uuid4(), pod_id=uuid4(), conversation_id=uuid4()
+        ),
+        model=None,  # type: ignore[arg-type]
+        usage=RunUsage(),
+        prompt=None,
+    )
+
+    async def call(args: dict):
+        prepared = await toolset.for_run(run_ctx)
+        async with prepared:
+            tools = await prepared.get_tools(run_ctx)
+            tool = tools["write_todos"]
+            validated = tool.args_validator.validate_python(
+                args, context=run_ctx.validation_context
+            )
+            return await prepared.call_tool("write_todos", validated, run_ctx, tool)
+
+    await call({"todos": ["- [ ] Fetch the Q3 report", "- [ ] Summarize findings"]})
+
+    reworded = await call({"todos": ["- [x] Fetch Q3 report"]})
+
+    # Flipped in place, and stored under the wording the person already saw.
+    assert reworded["todos"] == [
+        "- [x] Fetch the Q3 report",
+        "- [ ] Summarize findings",
+    ]
+
+    # An unrelated new task is still an addition, not a mangled match.
+    added = await call({"todos": ["- [ ] Email the board"]})
+    assert added["todos"][-1] == "- [ ] Email the board"
+
+    # An unchecked line that resembles an open task is left alone too: only a
+    # check-off is treated as "I meant the one already on the list".
+    restated = await call({"todos": ["- [ ] Summarise findings"]})
+    assert "- [ ] Summarise findings" in restated["todos"]
+
+
 def test_normalize_stored_todos_recovers_observed_corrupt_history():
     from app.modules.agent.capabilities.todo import _normalize_stored
 

--- a/lemma-backend/app/modules/agent/tests/unit/test_capabilities.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_capabilities.py
@@ -254,7 +254,7 @@ async def test_write_todos_merges_lines_and_flips_status(monkeypatch):
     )
 
     capability = build_todo_capability(
-        uow_factory=lambda: _FakeUoW(), conversation_id=uuid4()
+        uow_factory=_FakeUoW, conversation_id=uuid4()
     )
     toolset = capability.get_toolset()
     run_ctx = RunContext(
@@ -390,7 +390,7 @@ async def test_write_todos_says_what_to_do_next_on_every_call(monkeypatch):
         storage_mod, "ConversationRepository", lambda _uow: _FakeRepo(store)
     )
     capability = build_todo_capability(
-        uow_factory=lambda: _FakeUoW(), conversation_id=uuid4()
+        uow_factory=_FakeUoW, conversation_id=uuid4()
     )
     toolset = capability.get_toolset()
     run_ctx = RunContext(
@@ -448,7 +448,7 @@ async def test_a_reworded_check_off_flips_the_task_instead_of_adding_one(monkeyp
         storage_mod, "ConversationRepository", lambda _uow: _FakeRepo(store)
     )
     capability = build_todo_capability(
-        uow_factory=lambda: _FakeUoW(), conversation_id=uuid4()
+        uow_factory=_FakeUoW, conversation_id=uuid4()
     )
     toolset = capability.get_toolset()
     run_ctx = RunContext(
@@ -544,7 +544,7 @@ async def test_write_todos_guards_empty_and_blank_calls(monkeypatch):
         storage_mod, "ConversationRepository", lambda _uow: _FakeRepo(store)
     )
     capability = build_todo_capability(
-        uow_factory=lambda: _FakeUoW(), conversation_id=uuid4()
+        uow_factory=_FakeUoW, conversation_id=uuid4()
     )
     toolset = capability.get_toolset()
     run_ctx = RunContext(
@@ -732,7 +732,7 @@ async def test_pod_default_visible_toolset_is_slim(monkeypatch):
         conversation=SimpleNamespace(id=deps.conversation_id, metadata={}),
     )
     capabilities = await build_lemma_harness_tooling(
-        uow_factory=lambda: _FakeUoW(),
+        uow_factory=_FakeUoW,
         agent=SimpleNamespace(toolsets=list(POD_DEFAULT_AGENT_TOOLSETS)),
         ctx=deps,
         full_toolsets=full_toolsets,
@@ -807,7 +807,7 @@ async def test_pod_default_speech_capability_carries_its_prompt(monkeypatch):
         conversation=SimpleNamespace(id=deps.conversation_id, metadata={}),
     )
     capabilities = await build_lemma_harness_tooling(
-        uow_factory=lambda: _FakeUoW(),
+        uow_factory=_FakeUoW,
         agent=SimpleNamespace(toolsets=list(POD_DEFAULT_AGENT_TOOLSETS)),
         ctx=deps,
         full_toolsets=full_toolsets,
@@ -860,7 +860,7 @@ async def test_pod_default_gains_view_image_toolset_when_vision_supported():
         if supports_vision:
             toolsets = [*full_toolsets, view_image_toolset]
         return await build_lemma_harness_tooling(
-            uow_factory=lambda: _FakeUoW(),
+            uow_factory=_FakeUoW,
             agent=SimpleNamespace(toolsets=list(POD_DEFAULT_AGENT_TOOLSETS)),
             ctx=deps,
             full_toolsets=toolsets,
@@ -936,7 +936,7 @@ async def test_pod_default_messaging_is_deferred_but_keeps_its_contract(monkeypa
         conversation=SimpleNamespace(id=deps.conversation_id, metadata={}),
     )
     capabilities = await build_lemma_harness_tooling(
-        uow_factory=lambda: _FakeUoW(),
+        uow_factory=_FakeUoW,
         agent=SimpleNamespace(toolsets=list(POD_DEFAULT_AGENT_TOOLSETS)),
         ctx=deps,
         full_toolsets=full_toolsets,
@@ -1022,7 +1022,7 @@ async def test_a_user_created_agent_keeps_messaging_visible(monkeypatch):
     )
     full_toolsets = list(resolve_agent_toolsets(agent_entity.toolsets))
     capabilities = await build_lemma_harness_tooling(
-        uow_factory=lambda: _FakeUoW(),
+        uow_factory=_FakeUoW,
         agent=agent_entity,
         ctx=deps,
         full_toolsets=full_toolsets,

--- a/lemma-backend/app/modules/agent/tests/unit/test_github_credential_bridge.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_github_credential_bridge.py
@@ -8,6 +8,7 @@ import pytest
 from app.modules.agent.services.workspace_location import ProjectRepo
 from app.modules.agent.tools.context import BaseAgentContext
 from app.modules.agent.tools.workspace_cli import github_credential_bridge as bridge
+from app.modules.agent.tools.workspace_cli import github_project
 from app.modules.agent.tools.workspace_cli import workspace_cli
 from app.modules.agent.tools.workspace_cli.models import ExecCommandRequest
 from app.modules.connectors.domain.errors import (
@@ -271,7 +272,7 @@ async def test_exec_command_internal_invokes_bridge_only_for_git_like_commands(
         del ctx, workspace_session
         calls.append("called")
 
-    monkeypatch.setattr(workspace_cli, "ensure_github_credentials", _fake_ensure)
+    monkeypatch.setattr(github_project, "ensure_github_credentials", _fake_ensure)
 
     await workspace_cli.exec_command_internal(_context(), ExecCommandRequest(cmd="pwd"))
     assert calls == []
@@ -295,7 +296,9 @@ async def test_exec_command_internal_runs_command_even_if_bridge_raises(
         del ctx, workspace_session
         raise RuntimeError("redis is down")
 
-    monkeypatch.setattr(workspace_cli, "ensure_github_credentials", _broken_bridge)
+    # Patched where it is now called from: the shared preparation step both
+    # workspace tools go through.
+    monkeypatch.setattr(github_project, "ensure_github_credentials", _broken_bridge)
 
     result = await workspace_cli.exec_command_internal(
         _context(), ExecCommandRequest(cmd="git push")

--- a/lemma-backend/app/modules/agent/tests/unit/test_github_project.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_github_project.py
@@ -7,7 +7,11 @@ import pytest
 from app.modules.agent.services.workspace_location import ProjectRepo
 from app.modules.agent.tools.context import BaseAgentContext
 from app.modules.agent.tools.workspace_cli import github_project, workspace_cli
-from app.modules.agent.tools.workspace_cli.models import ExecCommandRequest
+from app.modules.agent.tools.workspace_cli.models import (
+    ExecCommandRequest,
+    ExecutePythonRequest,
+)
+from app.modules.agent.tools.workspace_entities import PythonExecutionResult
 
 
 class _FakeRedis:
@@ -180,6 +184,16 @@ class _RecordingWorkspaceSession:
             "process_id": None,
         }
 
+    async def execute_code(self, code, timeout_seconds=60):
+        del code, timeout_seconds
+        return PythonExecutionResult(
+            success=True,
+            stdout="the code ran",
+            stderr="",
+            result=None,
+            error_in_exec=None,
+        )
+
 
 class _RecordingRuntime:
     def __init__(self, session):
@@ -201,11 +215,30 @@ def _patch_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+# Both workspace tools run in the conversation's one directory, so both have to
+# find the same thing in it. These are parametrized over the two rather than
+# written for the shell alone, which is how `execute_python` came to be the one
+# tool that opened a project and found an empty folder.
+_TOOLS = ("exec_command", "execute_python")
+
+
+async def _run_tool(name: str, ctx):
+    if name == "exec_command":
+        return await workspace_cli.exec_command_internal(
+            ctx, ExecCommandRequest(cmd="pwd")
+        )
+    return await workspace_cli.execute_python_internal(
+        ctx, ExecutePythonRequest(code="print(1)")
+    )
+
+
 @pytest.mark.asyncio
-async def test_a_project_conversation_checks_out_before_any_command(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize("tool", _TOOLS)
+async def test_a_project_conversation_checks_out_before_any_tool_call(
+    tool: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Not just git-looking ones: the project has to be on disk before `ls`."""
+    """Not just git-looking commands, and not just the shell: the project has to
+    be on disk before `ls`, and before the first line of Python."""
 
     _patch_runtime(monkeypatch)
     calls: list[str] = []
@@ -219,39 +252,42 @@ async def test_a_project_conversation_checks_out_before_any_command(
         calls.append("checkout")
         return None
 
-    monkeypatch.setattr(workspace_cli, "ensure_github_credentials", _creds)
-    monkeypatch.setattr(workspace_cli, "ensure_project_checkout", _checkout)
+    monkeypatch.setattr(github_project, "ensure_github_credentials", _creds)
+    monkeypatch.setattr(github_project, "ensure_project_checkout", _checkout)
 
-    await workspace_cli.exec_command_internal(
-        _context(_REPO), ExecCommandRequest(cmd="pwd")
-    )
+    await _run_tool(tool, _context(_REPO))
 
     # Credentials first: a private repo cannot be cloned without them.
     assert calls == ["credentials", "checkout"]
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("tool", _TOOLS)
 async def test_a_scratchpad_conversation_is_untouched_by_the_project_step(
-    monkeypatch: pytest.MonkeyPatch,
+    tool: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _patch_runtime(monkeypatch)
 
     async def _fail(ctx, session):
         raise AssertionError("no project, nothing to check out")
 
-    monkeypatch.setattr(workspace_cli, "ensure_project_checkout", _fail)
+    monkeypatch.setattr(github_project, "ensure_project_checkout", _fail)
 
-    result = await workspace_cli.exec_command_internal(
-        _context(None), ExecCommandRequest(cmd="pwd")
-    )
+    result = await _run_tool(tool, _context(None))
 
     assert result.success is True
 
 
 @pytest.mark.asyncio
-async def test_a_failed_checkout_reaches_the_agent_without_failing_the_command(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize(
+    "tool, ran", [("exec_command", "the command ran"), ("execute_python", "the code ran")]
+)
+async def test_a_failed_checkout_reaches_the_agent_without_failing_the_work(
+    tool: str, ran: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """The notice is the whole point: an empty directory with no explanation is
+    what the agent is left to guess at, whichever tool it reached for."""
+
     _patch_runtime(monkeypatch)
 
     async def _creds(ctx, session):
@@ -261,15 +297,33 @@ async def test_a_failed_checkout_reaches_the_agent_without_failing_the_command(
         del ctx, session
         return "[workspace notice] acme/web could not be cloned"
 
-    monkeypatch.setattr(workspace_cli, "ensure_github_credentials", _creds)
-    monkeypatch.setattr(workspace_cli, "ensure_project_checkout", _checkout)
+    monkeypatch.setattr(github_project, "ensure_github_credentials", _creds)
+    monkeypatch.setattr(github_project, "ensure_project_checkout", _checkout)
 
-    result = await workspace_cli.exec_command_internal(
-        _context(_REPO), ExecCommandRequest(cmd="ls")
-    )
+    result = await _run_tool(tool, _context(_REPO))
 
     assert result.success is True
     assert result.stdout is not None
     assert result.stdout.startswith("[workspace notice] acme/web could not be cloned")
-    # The command's own output is still there, under the notice.
-    assert "the command ran" in result.stdout
+    # The tool's own output is still there, under the notice.
+    assert ran in result.stdout
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool", _TOOLS)
+async def test_a_broken_bridge_never_blocks_the_work_itself(
+    tool: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Redis or DB hiccup must not turn into a failed tool call: the work runs
+    uncredentialed and fails with git's own error, exactly as with no bridge."""
+
+    _patch_runtime(monkeypatch)
+
+    async def _broken(ctx, session):
+        raise RuntimeError("redis is down")
+
+    monkeypatch.setattr(github_project, "ensure_github_credentials", _broken)
+
+    result = await _run_tool(tool, _context(_REPO))
+
+    assert result.success is True

--- a/lemma-backend/app/modules/agent/tools/workspace_cli/github_project.py
+++ b/lemma-backend/app/modules/agent/tools/workspace_cli/github_project.py
@@ -19,6 +19,10 @@ Two rules shape what this does and does not do:
 
 Like the credential bridge next door, the work is marker-guarded in Redis so a
 session running twenty commands pays for this once.
+
+``prepare_project_directory`` at the bottom is the entry point both workspace
+tools use, so the shell and the interpreter cannot drift into disagreeing about
+what is in the directory they share.
 """
 
 from __future__ import annotations
@@ -28,7 +32,11 @@ import shlex
 from app.core.config import settings
 from app.core.infrastructure.redis.client import get_redis
 from app.core.log.log import get_logger
+from app.modules.agent.services.run_phase_spans import run_phase
 from app.modules.agent.tools.context import BaseAgentContext
+from app.modules.agent.tools.workspace_cli.github_credential_bridge import (
+    ensure_github_credentials,
+)
 
 logger = get_logger(__name__)
 
@@ -102,3 +110,36 @@ async def ensure_project_checkout(
         f"{repo.cwd}, so this directory is empty for a reason. "
         f"{detail}".strip()
     )
+
+
+async def prepare_project_directory(
+    ctx: BaseAgentContext,
+    workspace_session,
+    *,
+    wanted: bool,
+) -> str | None:
+    """Put the conversation's project on disk before either tool looks for it.
+
+    Shared by the shell and the interpreter deliberately. The two run in the
+    same directory, so they have to find the same thing in it: only
+    `exec_command` used to clone, and an agent whose first call was
+    `execute_python` opened a project and found an empty folder with nothing
+    said about why. Returns a notice to show once, or None.
+
+    A broken bridge (DB/Redis hiccup, a sandbox write failure) is logged and
+    swallowed rather than blocking the work: the command or the code runs
+    uncredentialed and fails with git's own native error, exactly as it would
+    with no bridge at all.
+    """
+    if not wanted:
+        return None
+    try:
+        with run_phase("tool.workspace.credentials"):
+            await ensure_github_credentials(ctx, workspace_session)
+            return await ensure_project_checkout(ctx, workspace_session)
+    except Exception:
+        logger.debug(
+            "agent.workspace_cli.github_credential_bridge_failed.diagnostic",
+            exc_info=True,
+        )
+        return None

--- a/lemma-backend/app/modules/agent/tools/workspace_cli/workspace_cli.py
+++ b/lemma-backend/app/modules/agent/tools/workspace_cli/workspace_cli.py
@@ -31,11 +31,10 @@ from app.modules.agent.tools.workspace_cli.models import (
     WriteStdinRequest,
 )
 from app.modules.agent.tools.workspace_cli.github_credential_bridge import (
-    ensure_github_credentials,
     looks_like_git_command,
 )
 from app.modules.agent.tools.workspace_cli.github_project import (
-    ensure_project_checkout,
+    prepare_project_directory,
 )
 from app.modules.agent.tools.workspace_cli.helper import (
     CHARACTER_LIMIT_STDOUT,
@@ -275,28 +274,17 @@ async def exec_command_internal(
                 session_id=runtime_context.default_shell_session_id,
                 close_on_exit=False,
             )
-        project_notice: str | None = None
         async with workspace_session:
             # A repo-backed conversation needs credentials for every command,
             # not just git-looking ones: the clone that puts the project on disk
             # has to happen before whatever the agent actually asked for, even
             # when that is `ls`.
-            if ctx.workspace_repo is not None or looks_like_git_command(request.cmd):
-                try:
-                    with run_phase("tool.workspace.credentials"):
-                        await ensure_github_credentials(ctx, workspace_session)
-                        project_notice = await ensure_project_checkout(
-                            ctx, workspace_session
-                        )
-                except Exception:
-                    # A broken credential bridge (DB/Redis hiccup, sandbox
-                    # write failure) should not block the command itself --
-                    # it just runs without credentials and fails with git's
-                    # own native auth error, same as with no bridge at all.
-                    logger.debug(
-                        "agent.workspace_cli.github_credential_bridge_failed.diagnostic",
-                        exc_info=True,
-                    )
+            project_notice = await prepare_project_directory(
+                ctx,
+                workspace_session,
+                wanted=ctx.workspace_repo is not None
+                or looks_like_git_command(request.cmd),
+            )
             if request.tty:
                 effective_yield_time_ms = request.yield_time_ms
                 effective_timeout = _DEFAULT_EXEC_TIMEOUT_S
@@ -484,12 +472,16 @@ async def execute_python_internal(ctx: BaseAgentContext, request: ExecutePythonR
             close_on_exit=False,
         )
         async with workspace_session:
+            project_notice = await prepare_project_directory(
+                ctx, workspace_session, wanted=ctx.workspace_repo is not None
+            )
             result = await workspace_session.execute_code(
                 request.code, request.timeout_seconds
             )
         trimmed = trim_python_result(result)
         if workspace_session.workspace_recreated:
             trimmed.stdout = _with_recreation_notice(trimmed.stdout, recreated=True)
+        trimmed.stdout = _with_notice(trimmed.stdout, notice=project_notice)
         return trimmed
     except Exception as exc:
         return _python_workspace_tool_failure(exc, operation="execute_python")

--- a/lemma-backend/app/modules/workspace/providers/e2b_ops.py
+++ b/lemma-backend/app/modules/workspace/providers/e2b_ops.py
@@ -455,6 +455,12 @@ class E2BOpsMixin:
         E2B has no resident-interpreter concept to reserve, so there is nothing
         to allocate ahead of time and pretending otherwise would mean tracking
         state with no backing.
+
+        The request's ``cwd`` is deliberately not remembered here either. It
+        arrives again on every ``execute_python`` through the session reference,
+        which is the only form of it that survives this backend running in more
+        than one process -- remembering it in this one would work until the next
+        call landed on another worker.
         """
         return None
 
@@ -480,6 +486,14 @@ class E2BOpsMixin:
         code is split with `ast` and the last node evaluated separately when it
         is an expression. Without this, `x = 6 * 7` followed by `x` returns
         nothing and an agent cannot see what it computed.
+
+        *A working directory* -- the interpreter starts in the session's `cwd`,
+        the very same one `start_process` gives a shell command. A fresh process
+        per call means there is no shell to inherit it from, and without this it
+        started in whatever directory the image defaults to: `execute_python`
+        reported `/workspace` while `exec_command` reported the conversation's
+        own directory, so a file one tool wrote by relative path was invisible
+        to the other.
         """
         sandbox = await self._connect(instance.provider_id)
         state_path = f"/tmp/lemma-python-{session.session_id}.pkl"
@@ -499,6 +513,7 @@ class E2BOpsMixin:
             )
             outcome = await sandbox.commands.run(
                 f"python3 {runner_path}",
+                cwd=session.cwd,
                 envs={item.name: item.value for item in request.environment},
                 # `None` here meant unbounded, so `execute_python`'s
                 # `timeout_seconds` bounded only how long the backend waited --

--- a/lemma-backend/app/modules/workspace/sandbox_session.py
+++ b/lemma-backend/app/modules/workspace/sandbox_session.py
@@ -126,6 +126,8 @@ class SandboxWorkspaceSession:
                 lambda: self.client.execute_python(
                     self.logical_id,
                     self.python_session_id,
+                    # Every call: E2B has no interpreter to hold this.
+                    cwd=self._cwd,
                     operation_id=operation_id,
                     code=code,
                     environment=self._environment,

--- a/lemma-backend/app/modules/workspace/services/local_sandbox_files.py
+++ b/lemma-backend/app/modules/workspace/services/local_sandbox_files.py
@@ -28,9 +28,20 @@ from sandbox_runtime.protocol import (
 
 @dataclass(frozen=True, slots=True)
 class LocalPythonSessionRef:
-    """Only the session id travels; the runtime keys sessions by it."""
+    """The session id and the directory it runs in.
+
+    The id alone was enough for the runtime-backed providers, which spawn the
+    interpreter once at ``create_python_session`` and never need to be told
+    again. It is not enough for E2B, which has no resident interpreter: every
+    execution is a fresh ``python3``, so the cwd has to arrive with the
+    execution or that process starts wherever the sandbox image happens to put
+    it. It used to, and `execute_python` ran in `/workspace` while
+    `exec_command` ran in the conversation's directory -- one tool could not see
+    the other's files.
+    """
 
     session_id: UUID
+    cwd: str
 
 
 class LocalSandboxFilesMixin:
@@ -186,23 +197,27 @@ class LocalSandboxFilesMixin:
                 deadline_at=deadline_at,
             ),
         )
-        return LocalPythonSessionRef(session_id=session_id)
+        return LocalPythonSessionRef(session_id=session_id, cwd=cwd)
 
     async def execute_python(
         self,
         logical_id: UUID,
         session_id: UUID,
         *,
+        cwd: str,
         operation_id: UUID,
         code: str,
         environment: tuple[EnvironmentVariable, ...] = (),
         output_limit_bytes: int = 1024 * 1024,
         deadline_at: datetime,
     ) -> PythonResult:
+        # `cwd` is required rather than defaulted: a default here is a silent
+        # answer to the one question this call must not guess at, and the
+        # caller -- the session -- already holds the conversation's directory.
         _, instance = await self._instance(logical_id)
         return await self._provider.execute_python(
             instance,
-            LocalPythonSessionRef(session_id=session_id),
+            LocalPythonSessionRef(session_id=session_id, cwd=cwd),
             ExecutePythonRequest(
                 operation_id=operation_id,
                 code=code,
@@ -230,7 +245,7 @@ class LocalSandboxFilesMixin:
             return
 
     async def restart_python_session(
-        self, logical_id: UUID, session_id: UUID, *, deadline_at: datetime
+        self, logical_id: UUID, session_id: UUID, *, cwd: str, deadline_at: datetime
     ) -> LocalPythonSessionRef:
         # Deleting is enough: the next execute recreates the session lazily
         # from its deterministic id, so there is no separate restart path to
@@ -238,4 +253,4 @@ class LocalSandboxFilesMixin:
         await self.delete_python_session(
             logical_id, session_id, deadline_at=deadline_at
         )
-        return LocalPythonSessionRef(session_id=session_id)
+        return LocalPythonSessionRef(session_id=session_id, cwd=cwd)

--- a/lemma-backend/app/modules/workspace/testing/fake_e2b.py
+++ b/lemma-backend/app/modules/workspace/testing/fake_e2b.py
@@ -90,6 +90,14 @@ class FakeE2B:
     paused: list[str] = field(default_factory=list)
     files: dict[str, bytes] = field(default_factory=dict)
     commands: list[str] = field(default_factory=list)
+    # The directory each command was started in, in the order they started.
+    # Recorded because E2B answers a `cwd=None` by starting the process in the
+    # image's own default -- a real directory, so the command succeeds and a
+    # fake that dropped the argument could not tell "the provider said where"
+    # from "the provider said nothing". It said nothing for `execute_python`,
+    # and that is precisely how the interpreter ended up in `/workspace` while
+    # the shell was in the conversation's directory.
+    command_cwds: list[str | None] = field(default_factory=list)
     pause_kept_memory: list[bool] = field(default_factory=list)
     #: What the runtime port answers. 404 is a healthy runtime -- route absent,
     #: port listening -- and 502 is the sandbox whose runtime process has died
@@ -173,6 +181,7 @@ class FakeE2B:
                 if not world.agent_answers:
                     raise FakeE2BError("the sandbox agent is not answering")
                 world.commands.append(cmd)
+                world.command_cwds.append(cwd)
                 world.process_timeouts.append(timeout)
                 if on_stdout is not None:
                     await on_stdout(f"ran: {cmd}")
@@ -242,6 +251,7 @@ class FakeE2B:
                 **_kwargs,
             ):
                 world._next += 1
+                world.command_cwds.append(cwd)
                 world.process_timeouts.append(timeout)
                 if on_data is not None:
                     await on_data(b"$ ")

--- a/lemma-backend/app/modules/workspace/tests/integration/test_e2b_provider_real.py
+++ b/lemma-backend/app/modules/workspace/tests/integration/test_e2b_provider_real.py
@@ -427,12 +427,92 @@ async def test_real_python_keeps_state_across_executions(
     assert "42" in second.stdout, (second.stdout, second.stderr)
 
 
-def _session_ref(session_id):
-    """Build the SDK-neutral session reference the provider only reads an id from."""
-    from dataclasses import dataclass
+def _session_ref(session_id, *, cwd: str = "/workspace"):
+    """The reference production hands the provider, not a stand-in for it.
 
-    @dataclass(frozen=True)
-    class _Ref:
-        session_id: object
+    It used to be a local dataclass carrying only `session_id` -- which is
+    exactly what the provider read, and exactly why nobody noticed the cwd it
+    also carries was going nowhere.
+    """
+    from app.modules.workspace.services.local_sandbox_files import (
+        LocalPythonSessionRef,
+    )
 
-    return _Ref(session_id=session_id)
+    return LocalPythonSessionRef(session_id=session_id, cwd=cwd)
+
+
+async def test_real_python_runs_where_the_shell_runs(
+    provider: E2BSandboxProvider,
+) -> None:
+    """The interpreter and the shell must be in the same directory, for real.
+
+    E2B starts a fresh `python3` per execution, so it can only be in the
+    session's directory if that directory is passed on the execution itself.
+    It was not, and `execute_python` reported `/workspace` while the shell
+    reported the conversation's own directory -- so a relative path meant two
+    different files. The cross-read below is the assertion that matters: it
+    fails for the reason an agent actually experiences.
+    """
+    from sandbox_runtime.protocol import ExecutePythonRequest
+
+    instance = await _create(provider, uuid4())
+    await provider.wait_ready(
+        instance, kind=SandboxKind.WORKSPACE, deadline_at=_deadline()
+    )
+    cwd = f"/workspace/c/conformance-{uuid4().hex[:8]}"
+    await provider.create_directory(instance, path=cwd, deadline_at=_deadline())
+    session = _session_ref(uuid4(), cwd=cwd)
+
+    reported = await provider.execute_python(
+        instance,
+        session,
+        ExecutePythonRequest(
+            operation_id=uuid4(),
+            code="import os\nprint(os.getcwd())",
+            environment=(),
+            output_limit_bytes=64 * 1024,
+            deadline_at=_deadline(),
+        ),
+    )
+    assert cwd in reported.stdout, (reported.stdout, reported.stderr)
+
+    wrote = await provider.execute_python(
+        instance,
+        session,
+        ExecutePythonRequest(
+            operation_id=uuid4(),
+            code=(
+                "from pathlib import Path\n"
+                "Path('python-wrote.txt').write_text('python-was-here')"
+            ),
+            environment=(),
+            output_limit_bytes=64 * 1024,
+            deadline_at=_deadline(),
+        ),
+    )
+    assert wrote.state is not None, wrote
+
+    process_id = await provider.start_process(
+        instance,
+        StartProcessRequest(
+            operation_id=uuid4(),
+            shell_command="cat python-wrote.txt",
+            argv=None,
+            cwd=cwd,
+            environment=(),
+            tty=None,
+            output_limit_bytes=64 * 1024,
+            deadline_at=_deadline(),
+            initial_input=None,
+        ),
+        deadline_at=_deadline(),
+    )
+    snapshot = await provider.read_process_output(
+        instance,
+        process_id=process_id,
+        after_sequence=0,
+        wait_seconds=10,
+        deadline_at=_deadline(),
+    )
+    output = b"".join(chunk.data for chunk in snapshot.chunks)
+    assert b"python-was-here" in output, output

--- a/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_e2b_provider.py
@@ -1057,3 +1057,67 @@ async def test_a_workspace_whose_agent_died_is_not_ready(
         await provider.wait_ready(
             instance, kind=SandboxKind.WORKSPACE, deadline_at=_deadline()
         )
+
+
+
+async def test_python_and_the_shell_are_given_the_same_directory(
+    provider: E2BSandboxProvider, world: FakeE2B, monkeypatch
+) -> None:
+    """One conversation, one directory -- whichever tool the agent reaches for.
+
+    `start_process` was told the conversation's cwd and `execute_python` was
+    told nothing, so the interpreter started in whatever the image defaults to.
+    The two tools reported different answers for `pwd`, and a file written by
+    relative path in one was invisible to the other: the exact failure an agent
+    reads as "my files disappeared".
+    """
+    from app.modules.workspace.testing.fake_output_buffer import InMemoryOutputBuffer
+    from app.modules.workspace.services.local_sandbox_files import (
+        LocalPythonSessionRef,
+    )
+    from sandbox_runtime.protocol import ExecutePythonRequest
+
+    buffer = InMemoryOutputBuffer()
+    monkeypatch.setattr(provider, "_output", buffer)
+    monkeypatch.setattr(provider, "_remember_pid", buffer.remember_pid)
+    monkeypatch.setattr(provider, "_recall_pid", buffer.recall_pid)
+
+    cwd = "/workspace/c/2026-08-21/0d8y15k6"
+    instance = await provider.create(_spec(uuid4()))
+    world.command_cwds.clear()
+
+    await provider.start_process(
+        instance,
+        StartProcessRequest(
+            operation_id=uuid4(),
+            shell_command="pwd",
+            argv=None,
+            cwd=cwd,
+            environment=(),
+            tty=None,
+            output_limit_bytes=1024,
+            deadline_at=_deadline(),
+            initial_input=None,
+        ),
+        deadline_at=_deadline(),
+    )
+    await provider.execute_python(
+        instance,
+        # The reference production actually hands this provider, not a
+        # stand-in shaped to whatever the assertion needs.
+        LocalPythonSessionRef(session_id=uuid4(), cwd=cwd),
+        ExecutePythonRequest(
+            operation_id=uuid4(),
+            code="import os\nprint(os.getcwd())",
+            environment=(),
+            output_limit_bytes=64 * 1024,
+            deadline_at=_deadline(),
+        ),
+    )
+
+    # The interpreter is run by a shell command of its own, so every command
+    # this provider started -- the shell's and the runner's alike -- must name
+    # the one directory. Writing the file and the runner does not count: those
+    # go to absolute paths under /tmp.
+    assert world.command_cwds, "no command reached the sandbox"
+    assert set(world.command_cwds) == {cwd}, world.command_cwds

--- a/lemma-backend/app/modules/workspace/tests/unit/test_sandbox_session.py
+++ b/lemma-backend/app/modules/workspace/tests/unit/test_sandbox_session.py
@@ -359,6 +359,36 @@ async def test_relative_initial_cwd_is_canonicalized_under_workspace() -> None:
 
 
 @pytest.mark.asyncio
+async def test_every_execution_carries_the_directory_the_shell_uses() -> None:
+    """The session holds one cwd, and both surfaces are told it every time.
+
+    Creating the session with a cwd is not enough. A provider without a
+    resident interpreter (E2B) starts a fresh process per execution, so it can
+    only learn the directory from the execution itself -- and it was never
+    given one, which is how `execute_python` ran in `/workspace` while
+    `exec_command` ran in the conversation's own directory.
+    """
+    client = _CanonicalClient()
+    session = SandboxWorkspaceSession(
+        client=client,  # type: ignore[arg-type]
+        sandbox_id=uuid4(),
+        session_id="conversation-1",
+        initial_cwd="/workspace/c/2026-08-21/0d8y15k6",
+    )
+
+    await session.exec_command(cmd="pwd")
+    await session.execute_code("import os; os.getcwd()")
+    # A second execution: the create round trip is skipped once the interpreter
+    # is known to exist, so anything carried only on create would be lost here.
+    await session.execute_code("import os; os.getcwd()")
+
+    shell_cwd = client.started[0]["cwd"]
+    assert shell_cwd == "/workspace/c/2026-08-21/0d8y15k6"
+    assert [call["cwd"] for call in client.python_executes] == [shell_cwd, shell_cwd]
+    assert client.python_creates[0]["cwd"] == shell_cwd
+
+
+@pytest.mark.asyncio
 async def test_workspace_paths_cannot_escape_runtime_roots() -> None:
     client = _CanonicalClient()
     session = _session(client)


### PR DESCRIPTION
## What changes

An agent's shell and its interpreter now run in the same directory. `execute_python` reported `/workspace` while `exec_command` reported the conversation's own directory, so a file written by relative path in one tool was invisible to the other — which reads, from inside a run, as work vanishing.

Two adjacent fixes ride along:

- A repo-backed conversation is checked out before **either** tool touches it, not just before a shell command. An agent whose first call was `execute_python` used to open its project and find an empty folder with nothing said about why.
- Task lists actually get ticked off. Agents wrote a plan at the start of a conversation and left every item unchecked for the rest of it.

## Why

**The directory.** Conversation metadata is the single source of truth for where a conversation works, and the resolution chain around it is sound — `resolve_workspace_location` reads `metadata.cwd` (or derives it from `metadata.repo`), `ensure_recorded_location` writes it down for legacy rows, and all three context-construction sites set `workspace_cwd` from it. The break was one call site below all of that: the E2B provider ran the Python runner with no `cwd`, while `start_process` two hundred lines above passed one.

The structural reason it could happen is worth more than the one-liner: the session reference handed to providers carried only `session_id`. The cwd was passed once, at `create_python_session` — and E2B's `ensure_python_session` is a deliberate no-op, because E2B has no resident interpreter to reserve. On that provider the conversation's directory had no route to the execution at all. The Docker and lemma_local providers were fine only because their runtime spawns a long-lived worker with `cwd=` at creation, which is also why CI never went red.

**The checkout.** Same asymmetry, second half: `ensure_github_credentials` + `ensure_project_checkout` ran from `exec_command_internal` only.

**The task list.** Three independent causes, all of them enough on their own:

1. A run could not see its own list. It lives in conversation metadata; the only place a later run could read it was the `write_todos` tool return — an old message that history trimming eventually drops.
2. Nothing re-stated the rule at the moment of use. "Check items off as you go" sat in the system prompt, dozens of tool calls away by the time an item finished.
3. A reworded check-off appended a near-duplicate. `- [x] Fetch Q3 report` against a planned `Fetch the Q3 report` added a second, *completed* item while the planned one stayed open forever.

## How to verify

```bash
cd lemma-backend && uv run pytest app/modules/agent/tests/unit app/modules/workspace/tests/unit -q
```

```bash
cd lemma-backend && uv run pytest app/modules/agent/tests/e2e/test_agent_hermetic_journeys_e2e.py -q -k "one_directory or checked_out_before_python or ticked_off"
```

```bash
make quality
```

1275 unit tests pass; the three e2e journeys pass against the real Docker sandbox; quality gates are green.

New coverage, each verified to fail with its fix reverted:

- `test_python_and_the_shell_are_given_the_same_directory` (unit, E2B provider) — the fake now *records* `cwd` instead of swallowing it, which is why nothing caught this before.
- `test_every_execution_carries_the_directory_the_shell_uses` (unit, session) — including the second execution, where the create round-trip is skipped.
- `test_real_python_runs_where_the_shell_runs` (integration, real E2B) — and `_session_ref` builds the real `LocalPythonSessionRef` rather than a stand-in shaped to whatever the assertion needed.
- `test_the_shell_and_python_share_the_conversations_one_directory` (e2e, agent shard) — both tools report `metadata["cwd"]`, then cross-read a relative file each way.
- `test_a_project_conversation_is_checked_out_before_python_runs` (e2e) — Python first, on a repo-backed conversation.
- The three tool-level checkout tests are parametrized over both tools now. Writing them per-tool is how Python came to be the odd one out.
- `test_a_plan_is_ticked_off_and_the_tool_says_what_is_next` (e2e) plus unit tests for the reminder, the reworded check-off, and the prompt section.

### Notes for the reviewer

**The architecture ratchet was paid for, not bumped.** Sharing the checkout step adds a function carrying the existing broad catch, which grows `agent:count` 65 → 66 even though the handler total is unchanged. That is offset by removing the `except Exception:  # pragma: no cover - defensive` in `prompts._workspace_cwd`, which wrapped a call that reads a field and formats a string — and where swallowing a failure would put a directory in the prompt that the tools do not use, i.e. the silent form of the bug this PR fixes. Both counts stay flat.

**One thing I could not rule out on the task-list half.** If the behaviour was observed on Agent Host, Claude Code and Codex have their own native plan tool (`update_plan`, which the frontend already renders) and the model may track internally after one `write_todos` call. Nothing here reaches that path.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload
- [x] **Rollback** — revert is safe and self-contained; no migration, no stored-state change. Existing E2B Python sessions keep their pickled namespace (the state path is unchanged), and todo metadata rows are read with the same shape they were written in.

---

## Verification with a real model

Everything below ran locally against the real provider (`E2E_LLM_MODE=real`, `system:lemma` on Fireworks) and the real Docker sandbox, with a production worker subprocess.

Two live-agent acceptance tests were added — no scripted model, the agent chooses its own tools:

- `test_a_real_agent_finds_with_the_shell_what_it_wrote_with_python` — the prompt names no directory at all, only relative filenames. An absolute path would pass even with the interpreter in the wrong place, which is the entire bug.
- `test_a_real_agent_picks_up_its_plan_in_a_later_turn_and_finishes_it` — plans four steps, is stopped after two, and is told to carry on in a second turn.

### Which tests actually discriminate

Each fix was re-run against the pre-fix sources to check the test fails without it. Six do:

| Fix | Test | Fails pre-fix |
|---|---|---|
| cwd on every execute call | `test_every_execution_carries_the_directory_the_shell_uses` | yes |
| E2B runs Python in the session cwd | `test_python_and_the_shell_are_given_the_same_directory` | yes |
| checkout before Python too | `test_a_project_conversation_checks_out_before_any_tool_call[execute_python]` | yes |
| next-step reminder on the tool result | `test_write_todos_says_what_to_do_next_on_every_call` | yes |
| reworded check-off flips instead of appending | `test_a_reworded_check_off_flips_the_task_instead_of_adding_one` | yes |
| task list in the run's prompt | `test_a_run_is_shown_the_task_list_it_is_supposed_to_be_ticking_off` | yes |

### What did not reproduce, stated plainly

The **behavioural** half of the task-list problem did not reproduce against the pre-fix code:

- acceptance model (`minimax-m3`), single turn: 3/3 passed **pre-fix**
- acceptance model, two turns: 3/3 passed **pre-fix**
- weaker configured default (`deepseek-v4-flash-0731`), two turns: 2/3 passed pre-fix — and the one failure was the model never calling `write_todos` at all, which is a different problem from never updating it. 3/3 post-fix.

So the live task-list test is a guard, not a proof, and its docstring says so.

The mechanism the prompt section addresses is consistent with the report ("written at the start of a session, never updated") but is not reachable from a short e2e: summarization keeps the last 40 messages, and past that the `write_todos` return carrying the list is gone from history — so the run has no way to see its own plan. Getting a conversation there costs ~70k tokens, which no e2e should spend, so that one is pinned at unit level instead.

### The E2B path specifically

Still unverified against E2B itself, and this is the provider the bug was reported on. `E2B_WORKSPACE_TEMPLATE` and `E2B_FUNCTION_TEMPLATE` are not in either checkout's `.env` (only `E2B_API_KEY`), so both the provider conformance test and the E2B e2e mode skip. The local runs above use Docker, whose runtime spawns a long-lived worker with `cwd=` at creation and never had the bug. What covers the E2B line today is the unit test against a fake that now records `cwd` instead of swallowing it, plus `test_real_python_runs_where_the_shell_runs`, which is ready to run the moment those template ids are available.
