### PR TITLE
Send Phoenix the root of an agent run, and the session it belongs to

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -168,6 +168,32 @@ The LLM pipeline defaults to independent deterministic 1% sampling. Configure
 `make dev LLM_OTEL=1` sets `always_on` sampling instead, so every local call
 shows up in Phoenix.
 
+### A conversation is a session, not a trace
+
+One agent run is one trace, rooted at the `agent.run` span. A conversation is
+many runs, so a conversation is many traces — and what joins them back together
+in Phoenix is the OpenInference `session.id` attribute, which
+`agent_run_telemetry_context` sets to the conversation id. Our own
+`lemma.conversation_id` rides along beside it for the general pipeline, but it
+is a filter, not a grouping key: Phoenix's Sessions view reads `session.id` and
+nothing else. `user.id` is set the same way, from the same context, and the
+`lemma.*` fields are restated as a JSON `metadata` blob so they are filterable
+as an object rather than as a dozen loose attributes.
+
+The root `agent.run` span is created on the **general** tracer, because the SQL
+and HTTP work beneath it belongs in the infrastructure pipeline, while the model
+spans below it are created on the LLM tracer. Two providers, one trace id — so
+the root has to be copied across, or Phoenix receives children whose parent it
+was never sent and shows every run as a headless fragment with no session, no
+input and no output. `_build_llm_fanout_processor` is that copy, and it forwards
+only spans that already carry an OpenInference kind: fanning out everything is
+what once filled Phoenix with `db.operation` noise.
+
+The consequence for sampling: **the general ratio must not be lower than the LLM
+ratio.** Set it lower and the root is sampled away while its children are kept,
+which is the headless-fragment failure by another route. Both are `1.0` wherever
+Phoenix is enabled today.
+
 ## The dashboard
 
 `make observability-up` provisions "Lemma API Overview" in HyperDX

--- a/lemma-backend/app/core/observability/telemetry.py
+++ b/lemma-backend/app/core/observability/telemetry.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Mapping, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 import hashlib
+import json
 import logging
 import os
 from pathlib import Path
@@ -165,6 +166,13 @@ def agent_run_telemetry_context(
     attributes = {
         "lemma.conversation_id": str(conversation_id),
         "lemma.agent_run_id": str(agent_run_id),
+        # A conversation is many runs, and each run is its own trace. Phoenix
+        # joins those traces back into one session by exactly one attribute --
+        # `session.id`, the OpenInference name -- and by nothing else. Our own
+        # `lemma.conversation_id` is filterable but not groupable, so without
+        # this line the Sessions view is empty and every turn of a conversation
+        # is an unrelated trace.
+        SpanAttributes.SESSION_ID: str(conversation_id),
     }
     optional_attributes = {
         "lemma.agent_id": agent_id,
@@ -174,16 +182,81 @@ def agent_run_telemetry_context(
         "lemma.agent_name": agent_name,
         "lemma.harness_kind": harness_kind,
         "lemma.model_name": model_name,
+        # Same story one level down: "show me this person's sessions" is a
+        # first-class Phoenix filter keyed on `user.id`.
+        SpanAttributes.USER_ID: user_id,
     }
     for key, value in optional_attributes.items():
         if value is not None:
             attributes[key] = str(value)
+    # Everything else the run knows, in the one attribute Phoenix renders as a
+    # filterable object rather than as an opaque string. Built from the same
+    # values so the two can't disagree, and JSON because that is the encoding
+    # Phoenix parses -- a bare dict is dropped by the OTel attribute types.
+    metadata = {
+        key.removeprefix("lemma."): value
+        for key, value in attributes.items()
+        if key.startswith("lemma.")
+    }
+    attributes[SpanAttributes.METADATA] = json.dumps(metadata, separators=(",", ":"))
 
     token = _agent_run_context.set(attributes)
     try:
         yield attributes
     finally:
         _agent_run_context.reset(token)
+
+
+# Phoenix renders these in full, so the cap is about what a span is allowed to
+# weigh on the wire rather than about what is readable. A run's transcript can
+# be megabytes; the OTLP batch it would ride in is not the place to find that
+# out.
+_MAX_SPAN_CONTENT_CHARS = 8_192
+
+
+def record_span_input(span: Any, value: Any) -> None:
+    """Record what went in, in the attribute a trace UI reads as the input."""
+    _record_span_content(
+        span,
+        value,
+        value_key=SpanAttributes.INPUT_VALUE,
+        mime_key=SpanAttributes.INPUT_MIME_TYPE,
+    )
+
+
+def record_span_output(span: Any, value: Any) -> None:
+    """Record what came out, in the attribute a trace UI reads as the output."""
+    _record_span_content(
+        span,
+        value,
+        value_key=SpanAttributes.OUTPUT_VALUE,
+        mime_key=SpanAttributes.OUTPUT_MIME_TYPE,
+    )
+
+
+def _record_span_content(
+    span: Any,
+    value: Any,
+    *,
+    value_key: str,
+    mime_key: str,
+) -> None:
+    if value is None:
+        return
+    if isinstance(value, str):
+        rendered, mime_type = value, "text/plain"
+    else:
+        try:
+            rendered, mime_type = (
+                json.dumps(value, default=str, separators=(",", ":")),
+                "application/json",
+            )
+        except TypeError, ValueError:
+            rendered, mime_type = str(value), "text/plain"
+    if not rendered:
+        return
+    span.set_attribute(value_key, rendered[:_MAX_SPAN_CONTENT_CHARS])
+    span.set_attribute(mime_key, mime_type)
 
 
 def _get_settings():
@@ -470,8 +543,59 @@ def _setup_tracing(service_name: str) -> TracerProvider | None:
             )
         )
     )
+    llm_fanout = _build_llm_fanout_processor()
+    if llm_fanout is not None:
+        provider.add_span_processor(llm_fanout)
     trace.set_tracer_provider(provider)
     return provider
+
+
+def _build_llm_fanout_processor() -> SpanProcessor | None:
+    """Send this provider's OpenInference spans to the LLM backend as well.
+
+    The agent run's root span -- the AGENT-kind `agent.run` that carries the
+    conversation, the session id and the run's input and output -- is created on
+    the *general* tracer, because everything below it (SQL, HTTP, the run phase
+    spans) belongs in the infrastructure pipeline. The model spans underneath it
+    are created on the LLM tracer instead, which is a separate provider with a
+    separate exporter.
+
+    Nothing joined those two halves. The pipelines share a trace id, because
+    context propagation is provider-independent, so Phoenix received the model
+    spans with a `parent_span_id` pointing at a span it was never sent: every
+    agent run arrived as a headless fragment, with no AGENT root, no session,
+    and no input or output to show in a session list. The claim that "the
+    OpenInference pipeline already carries the whole AGENT -> LLM -> TOOL
+    hierarchy" was true of every level except the top one.
+
+    This is the join, and it is deliberately a filter and not a fan-out of
+    everything: only spans that already carry an OpenInference kind cross over,
+    which today is the one root span per run. Fanning out the rest is what
+    filled Phoenix with `db.operation` noise the last time this was tried.
+    Unsanitized, like the LLM pipeline it feeds -- prompts and outputs are the
+    point of that backend, and the general exporter's allowlist would strip
+    exactly the attributes being sent.
+
+    One thing to keep true: the two pipelines sample independently
+    (`OTEL_TRACES_SAMPLER_ARG` here, `LLM_OTEL_TRACES_SAMPLER_ARG` there). Set
+    the general ratio below the LLM one and the root is dropped while its
+    children are kept, which is the headless-fragment failure again. Both are
+    1.0 wherever this backend is enabled.
+    """
+    settings = _get_settings()
+    endpoint = settings.llm_otel_exporter_otlp_endpoint
+    if not settings.llm_otel_enabled or not endpoint:
+        return None
+    return BatchSpanProcessor(
+        FilteringSpanExporter(
+            _build_span_exporter(
+                endpoint,
+                protocol=settings.llm_otel_exporter_otlp_protocol,
+                headers=_llm_otlp_headers(),
+            ),
+            _is_llm_span,
+        )
+    )
 
 
 def _setup_llm_tracing(service_name: str) -> TracerProvider | None:

--- a/lemma-backend/app/core/tests/unit/test_telemetry_helpers.py
+++ b/lemma-backend/app/core/tests/unit/test_telemetry_helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+import json
 
 import pytest
 from opentelemetry.sdk.trace import ReadableSpan
@@ -30,7 +31,9 @@ class _Exporter(SpanExporter):
 
 def test_filtering_exporter_filters_and_flushes():
     delegate = _Exporter(flush=False)
-    exporter = telemetry.FilteringSpanExporter(delegate, lambda span: span.name == "keep")
+    exporter = telemetry.FilteringSpanExporter(
+        delegate, lambda span: span.name == "keep"
+    )
     keep = SimpleNamespace(name="keep")
     drop = SimpleNamespace(name="drop")
 
@@ -55,7 +58,10 @@ def test_filtering_exporter_without_flush_method_succeeds():
 
 
 def test_agent_run_context_enriches_spans_and_restores_previous_context():
-    span = SimpleNamespace(attributes={}, set_attribute=lambda key, value: span.attributes.update({key: value}))
+    span = SimpleNamespace(
+        attributes={},
+        set_attribute=lambda key, value: span.attributes.update({key: value}),
+    )
     enricher = telemetry.AgentRunSpanEnricher()
 
     assert telemetry._agent_run_context.get() == {}
@@ -168,3 +174,140 @@ def test_llm_span_detection_uses_openinference_kind():
     drop = SimpleNamespace(attributes={})
     assert telemetry._is_llm_span(keep)
     assert not telemetry._is_llm_span(drop)
+
+
+def test_agent_run_context_carries_openinference_session_and_user():
+    """Phoenix groups a conversation's traces on `session.id` and nothing else."""
+    with telemetry.agent_run_telemetry_context(
+        conversation_id="conversation-1",
+        agent_run_id="run-1",
+        user_id="user-1",
+        pod_id="pod-1",
+        agent_name="assistant",
+    ) as attributes:
+        assert attributes[telemetry.SpanAttributes.SESSION_ID] == "conversation-1"
+        assert attributes[telemetry.SpanAttributes.USER_ID] == "user-1"
+        metadata = json.loads(attributes[telemetry.SpanAttributes.METADATA])
+
+    # The metadata blob restates the lemma.* fields, unprefixed, and carries
+    # nothing else -- it is built from them, so the two cannot disagree.
+    assert metadata == {
+        "conversation_id": "conversation-1",
+        "agent_run_id": "run-1",
+        "pod_id": "pod-1",
+        "user_id": "user-1",
+        "agent_name": "assistant",
+    }
+
+
+def test_agent_run_context_omits_user_id_when_absent():
+    with telemetry.agent_run_telemetry_context(
+        conversation_id="conversation-1",
+        agent_run_id="run-1",
+    ) as attributes:
+        assert telemetry.SpanAttributes.USER_ID not in attributes
+        assert attributes[telemetry.SpanAttributes.SESSION_ID] == "conversation-1"
+
+
+def test_llm_fanout_processor_is_built_only_when_the_llm_backend_is_on(monkeypatch):
+    settings = SimpleNamespace(
+        llm_otel_enabled=False,
+        llm_otel_exporter_otlp_endpoint="http://phoenix:4317",
+        llm_otel_exporter_otlp_protocol="grpc",
+        llm_otel_exporter_otlp_headers=None,
+    )
+    monkeypatch.setattr(telemetry, "_get_settings", lambda: settings)
+    assert telemetry._build_llm_fanout_processor() is None
+
+    settings.llm_otel_enabled = True
+    settings.llm_otel_exporter_otlp_endpoint = None
+    assert telemetry._build_llm_fanout_processor() is None
+
+    settings.llm_otel_exporter_otlp_endpoint = "http://phoenix:4317"
+    processor = telemetry._build_llm_fanout_processor()
+    assert processor is not None
+    processor.shutdown()
+
+
+def test_llm_fanout_forwards_only_openinference_spans(monkeypatch):
+    """The root AGENT span crosses to the LLM backend; the SQL beside it does not."""
+    delegate = _Exporter()
+    monkeypatch.setattr(
+        telemetry,
+        "_get_settings",
+        lambda: SimpleNamespace(
+            llm_otel_enabled=True,
+            llm_otel_exporter_otlp_endpoint="http://phoenix:4317",
+            llm_otel_exporter_otlp_protocol="grpc",
+            llm_otel_exporter_otlp_headers=None,
+        ),
+    )
+    monkeypatch.setattr(
+        telemetry,
+        "_build_span_exporter",
+        lambda endpoint, *, protocol, headers=None: delegate,
+    )
+    processor = telemetry._build_llm_fanout_processor()
+    assert processor is not None
+
+    agent_span = SimpleNamespace(
+        name="agent.run",
+        attributes={telemetry.SpanAttributes.OPENINFERENCE_SPAN_KIND: "AGENT"},
+    )
+    sql_span = SimpleNamespace(name="SELECT", attributes={})
+    # Straight at the exporter the processor was built around: batching is the
+    # SDK's business, the filter is ours.
+    processor.span_exporter.export([agent_span, sql_span])
+
+    assert [span.name for batch in delegate.exported for span in batch] == ["agent.run"]
+    processor.shutdown()
+
+
+def test_record_span_input_and_output_encode_and_truncate():
+    span = SimpleNamespace(
+        attributes={},
+        set_attribute=lambda key, value: span.attributes.update({key: value}),
+    )
+
+    telemetry.record_span_input(span, "what is the status of order 42?")
+    telemetry.record_span_output(span, {"status": "shipped"})
+
+    assert span.attributes[telemetry.SpanAttributes.INPUT_VALUE] == (
+        "what is the status of order 42?"
+    )
+    assert span.attributes[telemetry.SpanAttributes.INPUT_MIME_TYPE] == "text/plain"
+    assert span.attributes[telemetry.SpanAttributes.OUTPUT_VALUE] == (
+        '{"status":"shipped"}'
+    )
+    assert (
+        span.attributes[telemetry.SpanAttributes.OUTPUT_MIME_TYPE] == "application/json"
+    )
+
+    telemetry.record_span_input(span, "x" * 20_000)
+    assert (
+        len(span.attributes[telemetry.SpanAttributes.INPUT_VALUE])
+        == telemetry._MAX_SPAN_CONTENT_CHARS
+    )
+
+
+def test_record_span_content_skips_nothing_worth_recording():
+    span = SimpleNamespace(
+        attributes={},
+        set_attribute=lambda key, value: span.attributes.update({key: value}),
+    )
+    telemetry.record_span_input(span, None)
+    telemetry.record_span_output(span, "")
+    assert span.attributes == {}
+
+
+def test_record_span_output_encodes_values_json_cannot_hold_natively():
+    span = SimpleNamespace(
+        attributes={},
+        set_attribute=lambda key, value: span.attributes.update({key: value}),
+    )
+
+    telemetry.record_span_output(span, {"key": {1, 2}})
+    assert span.attributes[telemetry.SpanAttributes.OUTPUT_MIME_TYPE] == (
+        "application/json"
+    )
+    assert "1" in span.attributes[telemetry.SpanAttributes.OUTPUT_VALUE]

--- a/lemma-backend/app/modules/agent/services/agent_runner_service.py
+++ b/lemma-backend/app/modules/agent/services/agent_runner_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from contextlib import suppress
 import asyncio
 import time
@@ -17,7 +18,11 @@ from opentelemetry import trace
 from app.core.config import settings
 from app.core.infrastructure.db.uow_factory import UnitOfWorkFactory
 from app.core.log.log import get_logger
-from app.core.observability.telemetry import agent_run_telemetry_context
+from app.core.observability.telemetry import (
+    agent_run_telemetry_context,
+    record_span_input,
+    record_span_output,
+)
 from app.modules.agent.config import agent_settings
 from app.modules.agent.domain.vision import resolve_vision_mode
 from app.modules.agent.infrastructure.transport_errors import (
@@ -43,6 +48,8 @@ from app.modules.agent.domain.value_objects import (
     HarnessOptions,
     JsonObject,
     JsonValue,
+    MessageKind,
+    MessageRole,
 )
 from app.modules.agent.domain.runtime_profiles import (
     RuntimeModelCapability,
@@ -165,6 +172,25 @@ def _rejected_run_error_message(data: object) -> str:
         if isinstance(detail, str) and detail.strip():
             return detail.strip()
     return "The Agent Host rejected this run before dispatch. Try again."
+
+
+def _run_input_text(messages: Sequence[Message]) -> str | None:
+    """The prompt this run is answering: the last thing the user said.
+
+    The harness is handed the whole selected history, but a trace's input is the
+    turn, not the transcript -- the earlier turns are already their own traces in
+    the same session. Tool returns and thinking blocks are skipped for the same
+    reason: they are rows in the run, not the thing that started it.
+    """
+    for message in reversed(messages):
+        if message.role != MessageRole.USER.value:
+            continue
+        if message.kind is not MessageKind.TEXT:
+            continue
+        text = (message.text or "").strip()
+        if text:
+            return text
+    return None
 
 
 def _profile_model_settings(
@@ -425,6 +451,11 @@ class AgentRunnerService:
                         "gen_ai.request.model",
                         resolved_runtime.model_name_for_harness,
                     )
+                    # What a trace UI shows as the run's input and output. Without
+                    # them a session reads as a column of timestamps: the turns are
+                    # grouped correctly and every row is blank, so finding the run
+                    # you want means opening each one.
+                    record_span_input(span, _run_input_text(messages))
                     if observer is not None:
                         try:
                             await observer.on_run_started(conversation, ctx)
@@ -507,6 +538,10 @@ class AgentRunnerService:
                                 if should_stop:
                                     terminal_event_seen = True
                     finally:
+                        # In `finally`, because a run that failed or was
+                        # cancelled part-way is the one worth reading, and it
+                        # still has whatever the model produced before it went.
+                        record_span_output(span, output_data)
                         if observer is not None and observer_started:
                             try:
                                 await observer.on_run_finished(conversation, ctx)

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_runner_service.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_runner_service.py
@@ -1,19 +1,27 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 
-from app.modules.agent.domain.value_objects import AgentRunStatus, ConversationStatus
+from app.modules.agent.domain.entities import Message
+from app.modules.agent.domain.value_objects import (
+    AgentRunStatus,
+    ConversationStatus,
+    MessageKind,
+    MessageRole,
+)
 from app.modules.agent.infrastructure.harnesses.registry import HarnessRegistry
 from app.modules.agent.services import agent_runner_service as runner_module
 from app.modules.agent.services.agent_runner_service import (
     AgentRunnerService,
     _finalize_safely,
     _rejected_run_error_message,
+    _run_input_text,
 )
 from app.modules.test_support.fakes import FakeUnitOfWork
 
@@ -30,7 +38,9 @@ def test_rejected_run_error_message_uses_the_harness_supplied_detail():
 
 def test_rejected_run_error_message_falls_back_for_malformed_data():
     assert _rejected_run_error_message("not-a-dict") == _GENERIC_REJECTION
-    assert _rejected_run_error_message({"reason": "something_else"}) == _GENERIC_REJECTION
+    assert (
+        _rejected_run_error_message({"reason": "something_else"}) == _GENERIC_REJECTION
+    )
     assert _rejected_run_error_message({"detail": "   "}) == _GENERIC_REJECTION
 
 
@@ -197,4 +207,48 @@ async def test_execute_does_not_re_raise_cancelled_error(monkeypatch) -> None:
         user_id=UUID("00000000-0000-0000-0000-000000000021"),
         pod_id=UUID("00000000-0000-0000-0000-000000000022"),
         agent_name="test-agent",
+    )
+
+
+def _message(role: str, kind: MessageKind, text: str | None) -> Message:
+    return Message(
+        id=uuid4(),
+        created_at=datetime.now(UTC),
+        conversation_id=uuid4(),
+        sequence=0,
+        agent_run_id=None,
+        role=role,
+        kind=kind,
+        text=text,
+    )
+
+
+def test_run_input_text_is_the_turn_that_started_the_run():
+    """The span's input is this turn, not the transcript it was handed."""
+    messages = [
+        _message(MessageRole.USER.value, MessageKind.TEXT, "the previous turn"),
+        _message(MessageRole.ASSISTANT.value, MessageKind.TEXT, "an earlier answer"),
+        _message(MessageRole.USER.value, MessageKind.TEXT, "what changed?"),
+        _message(MessageRole.TOOL.value, MessageKind.TOOL_RETURN, "tool output"),
+    ]
+    assert _run_input_text(messages) == "what changed?"
+
+
+def test_run_input_text_skips_non_textual_and_blank_user_messages():
+    assert _run_input_text([]) is None
+    assert (
+        _run_input_text(
+            [_message(MessageRole.ASSISTANT.value, MessageKind.TEXT, "only the agent")]
+        )
+        is None
+    )
+    assert (
+        _run_input_text(
+            [
+                _message(MessageRole.USER.value, MessageKind.TEXT, "the real prompt"),
+                _message(MessageRole.USER.value, MessageKind.TEXT, "   "),
+                _message(MessageRole.USER.value, MessageKind.THINKING, "not a prompt"),
+            ]
+        )
+        == "the real prompt"
     )


### PR DESCRIPTION
Phoenix showed agent runs as headless fragments — no AGENT root, no session grouping, nothing to read in a session list. Both causes are in our wiring.

## The root span never arrived

`agent.run` is created on the **general** tracer, because the SQL, HTTP and run-phase spans beneath it belong in the Cloud Trace pipeline. The model spans below it are created on the **LLM** tracer — a separate provider with a separate exporter. Nothing joined the two.

The pipelines share a trace id, because context propagation is provider-independent, so Phoenix received children carrying a `parent_span_id` pointing at a span it was never sent. The comment in `gappy-infra` that justified removing the collector fan-out ("the application's OpenInference pipeline already carries the whole AGENT → LLM → TOOL hierarchy") was true of every level except the top one.

`_build_llm_fanout_processor` is the join: a second processor on the general provider that forwards only spans already carrying an OpenInference kind — today, the one root span per run. Everything else still stays out, because fanning out the rest is what once filled Phoenix with 8,591 traces of `db.operation`.

## A conversation was never a session

Each run is its own trace. Phoenix joins traces into a session on `session.id` and on nothing else; `lemma.conversation_id` is filterable but not groupable, so the Sessions view was empty and every turn read as an unrelated trace.

`agent_run_telemetry_context` now sets, from the values it already had:

- `session.id` — the conversation id
- `user.id`
- `metadata` — a JSON restatement of the `lemma.*` fields, so they filter as an object

And `agent.run` carries `input.value` (the turn that started the run — the last user text message, not the whole transcript the harness was handed) and `output.value`, recorded in `finally` so a failed or cancelled run still shows what it produced.

## Blast radius

None of these attributes reach Cloud Trace: `span_sanitizer`'s allowlist is default-deny and none of them are on it. The fan-out is gated on `LLM_OTEL_ENABLED`, which is `false` in production.

One constraint this creates: the two pipelines sample independently, and the general ratio must not be **lower** than the LLM ratio, or the root is sampled away while its children are kept. Both are `1.0` wherever Phoenix is enabled. Documented in `docs/observability.md` and in the processor's docstring.

## Testing

`app/core/tests/unit/test_telemetry_helpers.py` — session/user/metadata attributes, the fan-out's build conditions and its filter, and the input/output encoding and truncation. `app/modules/agent/tests/unit/test_agent_runner_service.py` — that the recorded input is the turn, not the transcript.

```
uv run pytest app/core/tests/unit app/modules/agent/tests/unit -m "not e2e"   # 1569 passed
make lint-import-budget architecture typecheck-critical                        # clean
```

Pairs with [gappyai/gappy-infra#273](https://github.com/gappyai/gappy-infra/pull/273), which upgrades the Phoenix that receives this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)