### PR TITLE
Tell pydantic-ai which conversation the run belongs to

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -172,8 +172,20 @@ shows up in Phoenix.
 
 One agent run is one trace, rooted at the `agent.run` span. A conversation is
 many runs, so a conversation is many traces — and what joins them back together
-in Phoenix is the OpenInference `session.id` attribute, which
-`agent_run_telemetry_context` sets to the conversation id. Our own
+in Phoenix is the OpenInference `session.id` attribute.
+
+**Two things write that attribute, and they have to agree.** On the model spans
+it comes from the OpenInference instrumentation, which derives it from
+pydantic-ai's `gen_ai.conversation.id` and overwrites whatever was on the span at
+start — so the harness passes our conversation id into
+`Agent.iter(conversation_id=...)` to make that value ours. Left unset,
+pydantic-ai takes it from the most recent conversation id on `message_history`,
+and we rebuild history from the database every run, so there is never one to
+inherit and it mints a fresh UUID7 per run. On the root `agent.run` span it comes
+from `agent_run_telemetry_context`, because that span lives on the general
+provider and never sees that instrumentation. Phoenix binds a trace to a session
+from whichever of the trace's spans it happens to insert first, so both writers
+naming the same id is what makes the binding deterministic rather than a race. Our own
 `lemma.conversation_id` rides along beside it for the general pipeline, but it
 is a filter, not a grouping key: Phoenix's Sessions view reads `session.id` and
 nothing else. `user.id` is set the same way, from the same context, and the

--- a/lemma-backend/app/core/observability/telemetry.py
+++ b/lemma-backend/app/core/observability/telemetry.py
@@ -169,9 +169,17 @@ def agent_run_telemetry_context(
         # A conversation is many runs, and each run is its own trace. Phoenix
         # joins those traces back into one session by exactly one attribute --
         # `session.id`, the OpenInference name -- and by nothing else. Our own
-        # `lemma.conversation_id` is filterable but not groupable, so without
-        # this line the Sessions view is empty and every turn of a conversation
-        # is an unrelated trace.
+        # `lemma.conversation_id` is filterable but not groupable.
+        #
+        # This is the SECOND of two writers, and they must agree. The model spans
+        # get their `session.id` from the OpenInference instrumentation, which
+        # derives it from pydantic-ai's `gen_ai.conversation.id` and overwrites
+        # whatever was set at span start -- so the harness passes our
+        # conversation id into `Agent.iter(conversation_id=...)` to make that
+        # value ours. This line covers the root `agent.run` span, which is on the
+        # general provider and never sees that instrumentation. Phoenix binds a
+        # trace to a session from whichever of its spans it inserts first, so the
+        # two writers agreeing is what makes the binding deterministic.
         SpanAttributes.SESSION_ID: str(conversation_id),
     }
     optional_attributes = {

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/pydantic_ai.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/pydantic_ai.py
@@ -351,7 +351,7 @@ class PydanticAIHarness:
             # GracefulToolset turns ordinary execution errors into tool responses,
             # so this is the rare "model kept sending invalid arguments" case.
             logger.debug(
-                'agent.pydantic_ai.agent_run_ended_after_repeated.diagnostic',
+                "agent.pydantic_ai.agent_run_ended_after_repeated.diagnostic",
                 exc_info=True,
             )
             yield AgentEvent(
@@ -390,7 +390,9 @@ class PydanticAIHarness:
             )
             return
         except Exception as exc:
-            logger.error("agent.pydantic_ai.pydanticai_harness_type.failed", exc_info=True)
+            logger.error(
+                "agent.pydantic_ai.pydanticai_harness_type.failed", exc_info=True
+            )
             yield AgentEvent(
                 type=AgentEventType.ERROR,
                 data=_user_facing_error_message(exc),
@@ -492,6 +494,16 @@ class PydanticAIHarness:
                 ),
                 "deps": ctx,
                 "usage_limits": options.usage_limits,
+                # Our conversation id, not pydantic-ai's. Left unset, pydantic-ai
+                # takes the most recent conversation id off `message_history` --
+                # and we rebuild history from the database every run, so there is
+                # never one to inherit and it mints a fresh UUID7 per run instead.
+                # That id becomes `gen_ai.conversation.id`, which the
+                # OpenInference instrumentation maps onto `session.id`, which is
+                # the only thing Phoenix groups a session by. So every turn
+                # became its own single-trace session: 648 traces, 648 sessions,
+                # exactly one-to-one, on the deployment where this was found.
+                "conversation_id": str(conversation.id),
             }
             if resume_history is not None or user_prompt is None:
                 return pydantic_agent.iter(**iter_kwargs)
@@ -520,153 +532,150 @@ class PydanticAIHarness:
                 # usage off the run that just failed.
                 state["run"] = run
                 async for node in run:
-                        if PydanticAIAgent.is_model_request_node(node):
-                            # Snapshot BEFORE streaming, because after a
-                            # mid-stream failure `all_messages()` has grown a
-                            # truncated ModelResponse plus an empty
-                            # ModelRequest: resuming from that makes the model
-                            # continue an answer whose first half we threw away.
-                            #
-                            # `node.request` must be appended explicitly. It is
-                            # the request about to be sent (for a post-tool node,
-                            # the one carrying the ToolReturnParts) and it does
-                            # not enter `all_messages()` until the request
-                            # actually happens. Without it the resume history
-                            # ends on a ModelResponse whose tool calls have no
-                            # results, and pydantic-ai — correctly — executes
-                            # those tools again. That is how a retry would
-                            # double-charge a card.
-                            snapshot = list(run.all_messages())
-                            pending = getattr(node, "request", None)
-                            if pending is not None and (
-                                not snapshot or snapshot[-1] is not pending
-                            ):
-                                snapshot.append(pending)
-                            state["resume_from"] = snapshot
-                            # A model response is persisted all-or-nothing. Parts
-                            # that finish before the stream dies are NOT in
-                            # `run.all_messages()` (pydantic-ai appends the
-                            # ModelResponse only once the node completes), so
-                            # writing them as they arrive would duplicate them on
-                            # resume. Tokens still stream live; only the durable
-                            # write waits for the node to finish.
-                            buffered: list[AgentEvent] = []
-                            async for event in self._stream_model_request(
-                                node,
-                                run,
-                                agent_run_id=agent_run_id,
-                                malformed_tool_call_ids=malformed_tool_call_ids,
-                                should_stop=should_stop,
-                            ):
-                                if event.type is AgentEventType.MESSAGE:
-                                    buffered.append(event)
-                                    continue
-                                if event.type in {
-                                    AgentEventType.ERROR,
-                                    AgentEventType.STOPPED,
-                                }:
-                                    # A stop is a real ending, not a lost response:
-                                    # flush what the model already produced before
-                                    # the terminal event so the user keeps it.
-                                    for held in buffered:
-                                        await queue.put(("event", held))
-                                    await queue.put(("event", event))
-                                    return
+                    if PydanticAIAgent.is_model_request_node(node):
+                        # Snapshot BEFORE streaming, because after a
+                        # mid-stream failure `all_messages()` has grown a
+                        # truncated ModelResponse plus an empty
+                        # ModelRequest: resuming from that makes the model
+                        # continue an answer whose first half we threw away.
+                        #
+                        # `node.request` must be appended explicitly. It is
+                        # the request about to be sent (for a post-tool node,
+                        # the one carrying the ToolReturnParts) and it does
+                        # not enter `all_messages()` until the request
+                        # actually happens. Without it the resume history
+                        # ends on a ModelResponse whose tool calls have no
+                        # results, and pydantic-ai — correctly — executes
+                        # those tools again. That is how a retry would
+                        # double-charge a card.
+                        snapshot = list(run.all_messages())
+                        pending = getattr(node, "request", None)
+                        if pending is not None and (
+                            not snapshot or snapshot[-1] is not pending
+                        ):
+                            snapshot.append(pending)
+                        state["resume_from"] = snapshot
+                        # A model response is persisted all-or-nothing. Parts
+                        # that finish before the stream dies are NOT in
+                        # `run.all_messages()` (pydantic-ai appends the
+                        # ModelResponse only once the node completes), so
+                        # writing them as they arrive would duplicate them on
+                        # resume. Tokens still stream live; only the durable
+                        # write waits for the node to finish.
+                        buffered: list[AgentEvent] = []
+                        async for event in self._stream_model_request(
+                            node,
+                            run,
+                            agent_run_id=agent_run_id,
+                            malformed_tool_call_ids=malformed_tool_call_ids,
+                            should_stop=should_stop,
+                        ):
+                            if event.type is AgentEventType.MESSAGE:
+                                buffered.append(event)
+                                continue
+                            if event.type in {
+                                AgentEventType.ERROR,
+                                AgentEventType.STOPPED,
+                            }:
+                                # A stop is a real ending, not a lost response:
+                                # flush what the model already produced before
+                                # the terminal event so the user keeps it.
+                                for held in buffered:
+                                    await queue.put(("event", held))
                                 await queue.put(("event", event))
-                            for held in buffered:
-                                await queue.put(("event", held))
-                        elif PydanticAIAgent.is_call_tools_node(node):
-                            async for event in self._stream_tool_calls(
-                                node,
-                                run,
-                                conversation_id=ctx.conversation_id,
-                                agent_run_id=agent_run_id,
-                                malformed_tool_call_ids=malformed_tool_call_ids,
-                                emitted_tool_response_ids=emitted_tool_response_ids,
-                                should_stop=should_stop,
-                            ):
-                                await queue.put(("event", event))
-                                if event.type in {
-                                    AgentEventType.ERROR,
-                                    AgentEventType.STOPPED,
-                                }:
-                                    return
-                        elif PydanticAIAgent.is_end_node(node):
-                            if node.data.tool_call_id:
-                                if (
-                                    node.data.tool_call_id
-                                    not in emitted_tool_response_ids
-                                ):
-                                    await queue.put(
-                                        (
-                                            "event",
-                                            AgentEvent(
-                                                type=AgentEventType.MESSAGE,
-                                                data=MessageDraft.of_tool_return(
-                                                    tool_name=node.data.tool_name
-                                                    or "unknown_tool",
-                                                    tool_call_id=node.data.tool_call_id,
-                                                    tool_result=to_json_value(
-                                                        node.data.output
-                                                    ),
-                                                    metadata={
-                                                        "tool_name": node.data.tool_name
-                                                        or "unknown_tool"
-                                                    },
+                                return
+                            await queue.put(("event", event))
+                        for held in buffered:
+                            await queue.put(("event", held))
+                    elif PydanticAIAgent.is_call_tools_node(node):
+                        async for event in self._stream_tool_calls(
+                            node,
+                            run,
+                            conversation_id=ctx.conversation_id,
+                            agent_run_id=agent_run_id,
+                            malformed_tool_call_ids=malformed_tool_call_ids,
+                            emitted_tool_response_ids=emitted_tool_response_ids,
+                            should_stop=should_stop,
+                        ):
+                            await queue.put(("event", event))
+                            if event.type in {
+                                AgentEventType.ERROR,
+                                AgentEventType.STOPPED,
+                            }:
+                                return
+                    elif PydanticAIAgent.is_end_node(node):
+                        if node.data.tool_call_id:
+                            if node.data.tool_call_id not in emitted_tool_response_ids:
+                                await queue.put(
+                                    (
+                                        "event",
+                                        AgentEvent(
+                                            type=AgentEventType.MESSAGE,
+                                            data=MessageDraft.of_tool_return(
+                                                tool_name=node.data.tool_name
+                                                or "unknown_tool",
+                                                tool_call_id=node.data.tool_call_id,
+                                                tool_result=to_json_value(
+                                                    node.data.output
                                                 ),
-                                                agent_run_id=agent_run_id,
+                                                metadata={
+                                                    "tool_name": node.data.tool_name
+                                                    or "unknown_tool"
+                                                },
                                             ),
-                                        )
+                                            agent_run_id=agent_run_id,
+                                        ),
                                     )
-                                    if await self._should_stop(should_stop):
-                                        await queue.put(
-                                            ("event", self._stopped_event(agent_run_id))
-                                        )
-                                        return
-                                final_message = self._final_output_message(
-                                    output=node.data.output,
-                                    tool_name=node.data.tool_name,
-                                    tool_call_id=node.data.tool_call_id,
                                 )
-                                if final_message is not None:
+                                if await self._should_stop(should_stop):
                                     await queue.put(
-                                        (
-                                            "event",
-                                            AgentEvent(
-                                                type=AgentEventType.MESSAGE,
-                                                data=final_message,
-                                                agent_run_id=agent_run_id,
-                                            ),
-                                        )
+                                        ("event", self._stopped_event(agent_run_id))
                                     )
-                                    if await self._should_stop(should_stop):
-                                        await queue.put(
-                                            ("event", self._stopped_event(agent_run_id))
-                                        )
-                                        return
+                                    return
+                            final_message = self._final_output_message(
+                                output=node.data.output,
+                                tool_name=node.data.tool_name,
+                                tool_call_id=node.data.tool_call_id,
+                            )
+                            if final_message is not None:
+                                await queue.put(
+                                    (
+                                        "event",
+                                        AgentEvent(
+                                            type=AgentEventType.MESSAGE,
+                                            data=final_message,
+                                            agent_run_id=agent_run_id,
+                                        ),
+                                    )
+                                )
+                                if await self._should_stop(should_stop):
+                                    await queue.put(
+                                        ("event", self._stopped_event(agent_run_id))
+                                    )
+                                    return
 
-                            elif options.output_type is not None:
-                                final_message = self._final_output_message(
-                                    output=node.data.output,
-                                    tool_name=None,
-                                    tool_call_id=None,
-                                )
-                                if final_message is not None:
-                                    await queue.put(
-                                        (
-                                            "event",
-                                            AgentEvent(
-                                                type=AgentEventType.MESSAGE,
-                                                data=final_message,
-                                                agent_run_id=agent_run_id,
-                                            ),
-                                        )
+                        elif options.output_type is not None:
+                            final_message = self._final_output_message(
+                                output=node.data.output,
+                                tool_name=None,
+                                tool_call_id=None,
+                            )
+                            if final_message is not None:
+                                await queue.put(
+                                    (
+                                        "event",
+                                        AgentEvent(
+                                            type=AgentEventType.MESSAGE,
+                                            data=final_message,
+                                            agent_run_id=agent_run_id,
+                                        ),
                                     )
-                                    if await self._should_stop(should_stop):
-                                        await queue.put(
-                                            ("event", self._stopped_event(agent_run_id))
-                                        )
-                                        return
+                                )
+                                if await self._should_stop(should_stop):
+                                    await queue.put(
+                                        ("event", self._stopped_event(agent_run_id))
+                                    )
+                                    return
 
                 # Tokens burned by abandoned attempts are still billed by the
                 # provider, so they are carried forward rather than forgotten.
@@ -827,7 +836,7 @@ class PydanticAIHarness:
                 if tool_args is None:
                     malformed_tool_call_ids.add(part.tool_call_id)
                     logger.debug(
-                        'agent.pydantic_ai.skipping_malformed_tool_call_persistence.diagnostic',
+                        "agent.pydantic_ai.skipping_malformed_tool_call_persistence.diagnostic",
                         tool_call_id=part.tool_call_id,
                     )
                     return None
@@ -1094,7 +1103,7 @@ class PydanticAIHarness:
                     result_part = event.part
                     if result_part.tool_call_id in malformed_tool_call_ids:
                         logger.debug(
-                            'agent.pydantic_ai.skipping_tool_result_malformed_call.diagnostic',
+                            "agent.pydantic_ai.skipping_tool_result_malformed_call.diagnostic",
                             tool_call_id=result_part.tool_call_id,
                         )
                         continue

--- a/lemma-backend/app/modules/agent/tests/unit/test_pydantic_ai_harness_tracing.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_pydantic_ai_harness_tracing.py
@@ -1,0 +1,118 @@
+"""The run must tell pydantic-ai which conversation it belongs to.
+
+Phoenix groups traces into a session by `session.id` and by nothing else, and on
+the model spans that value does not come from us: the OpenInference
+instrumentation derives it from pydantic-ai's `gen_ai.conversation.id`. Left
+unset, pydantic-ai takes that id from the most recent conversation id on
+`message_history` -- and we rebuild history from the database on every run, so
+there is never one to inherit and it mints a fresh UUID7 per run.
+
+The result was one session per turn. On the deployment where this was found:
+648 traces, 648 sessions, one-to-one, with no way to see a conversation whole.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from uuid import uuid4
+
+import pytest
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+
+from app.modules.agent.domain.context import AgentContext
+from app.modules.agent.domain.entities import Agent, Conversation
+from app.modules.agent.domain.value_objects import HarnessOptions
+from app.modules.agent.infrastructure.harnesses import pydantic_ai as harness_module
+from app.modules.agent.infrastructure.harnesses.pydantic_ai import PydanticAIHarness
+
+pytestmark = pytest.mark.unit
+
+
+async def _answer(messages, info: AgentInfo) -> AsyncIterator[str]:
+    del messages, info
+    yield "done"
+
+
+async def _run_capturing_iter_kwargs(conversation: Conversation):
+    """Run the harness, returning the kwargs it handed to `Agent.iter`.
+
+    Its own patch context, not the test's: a caller runs this more than once, and
+    patches that outlive a call stack onto each other -- the second run's wrapper
+    closes over the first run's wrapper, so both calls end up writing into both
+    dicts and two different conversations read as one.
+    """
+    captured: dict[str, object] = {}
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(
+            harness_module,
+            "_runtime_profile_model",
+            lambda options: FunctionModel(stream_function=_answer),
+        )
+        original_iter = harness_module.PydanticAIAgent.iter
+
+        def _capturing_iter(self, *args, **kwargs):
+            captured.update(kwargs)
+            return original_iter(self, *args, **kwargs)
+
+        monkeypatch.setattr(harness_module.PydanticAIAgent, "iter", _capturing_iter)
+        await _drain(conversation)
+    return captured
+
+
+async def _drain(conversation: Conversation) -> None:
+    async for _ in PydanticAIHarness()._execute(
+        agent=Agent(
+            pod_id=conversation.pod_id,
+            user_id=conversation.user_id,
+            name="assistant",
+            instruction="",
+        ),
+        conversation=conversation,
+        messages=[],
+        ctx=AgentContext(
+            user_id=conversation.user_id,
+            pod_id=conversation.pod_id,
+            conversation_id=conversation.id,
+        ),
+        options=HarnessOptions(
+            model_name="test-model",
+            history_summarization_enabled=False,
+        ),
+        agent_run_id=uuid4(),
+        malformed_tool_call_ids=set(),
+        emitted_tool_response_ids=set(),
+        should_stop=None,
+    ):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_the_run_is_tagged_with_our_conversation_id() -> None:
+    conversation = Conversation(pod_id=uuid4(), user_id=uuid4())
+
+    captured = await _run_capturing_iter_kwargs(conversation)
+
+    assert captured["conversation_id"] == str(conversation.id)
+
+
+@pytest.mark.asyncio
+async def test_two_runs_of_one_conversation_share_the_id() -> None:
+    """The point of the whole exercise: turns of one conversation group together."""
+    conversation = Conversation(pod_id=uuid4(), user_id=uuid4())
+
+    first = await _run_capturing_iter_kwargs(conversation)
+    second = await _run_capturing_iter_kwargs(conversation)
+
+    assert first["conversation_id"] == second["conversation_id"] == str(conversation.id)
+
+
+@pytest.mark.asyncio
+async def test_separate_conversations_do_not_collide() -> None:
+    one = await _run_capturing_iter_kwargs(
+        Conversation(pod_id=uuid4(), user_id=uuid4())
+    )
+    two = await _run_capturing_iter_kwargs(
+        Conversation(pod_id=uuid4(), user_id=uuid4())
+    )
+
+    assert one["conversation_id"] != two["conversation_id"]


### PR DESCRIPTION
Follow-up to [#428](https://github.com/lemma-work/lemma-platform/pull/428), which fixed half of this. Found while verifying the merged change against the live dev Phoenix.

## What #428 missed

It set `session.id` on the root `agent.run` span. But on the **model** spans that attribute doesn't come from us at all — `openinference-instrumentation-pydantic-ai` derives it from pydantic-ai's `gen_ai.conversation.id`:

```python
# openinference/instrumentation/pydantic_ai/semantic_conventions.py:317
yield SpanAttributes.SESSION_ID, gen_ai_attrs[GenAIConversationID.CONVERSATION_ID]
```

and its processor merges its own attributes **over** the span's at `on_end`:

```python
span._attributes = {**span.attributes, **openinference_attributes}
```

So anything `AgentRunSpanEnricher` writes at `on_start` loses on those spans.

## And pydantic-ai's conversation id was never ours

Unset, pydantic-ai takes it from "the most recent `conversation_id` on `message_history`, or a fresh UUID7." The harness rebuilds history from the database every run, so there is never one to inherit — a fresh UUID7 per run, every run.

That is measurable on dev right now:

```
traces   = 648
sessions = 648      -- one-to-one
```

Every turn its own single-trace session. Which is exactly the "can't track at conversation level" symptom, still true after #428.

## The fix

Pass `conversation_id=str(conversation.id)` into `Agent.iter`. Both writers then name the same value, which matters beyond tidiness: Phoenix binds a trace to a session from whichever of the trace's spans it inserts **first**, and the root span ends **last** — so disagreeing writers are a race the root usually loses.

`run_id` still distinguishes individual runs, so nothing that relied on per-run identity changes.

## Testing

`test_pydantic_ai_harness_tracing.py` — the run is tagged with our conversation id; two runs of one conversation share it; separate conversations don't collide.

```
uv run pytest app/modules/agent/tests/unit app/core/tests/unit -m "not e2e"   # 1572 passed
```

Existing sessions in Phoenix keep their old per-run ids — this changes new traces only, and there's no backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)