### PR TITLE
Stop three xdist workers starving the async workers the tests wait on

### DIFF
--- a/.github/e2e-shards.json
+++ b/.github/e2e-shards.json
@@ -29,7 +29,7 @@
     {
       "name": "datastore",
       "args": "app/modules app/core --ignore=app/modules/agent/tests/e2e --ignore=app/modules/agent_surfaces/tests/e2e --ignore=app/modules/connectors/tests/e2e --ignore=app/modules/function/tests/e2e --ignore=app/modules/identity/tests/e2e --ignore=app/modules/pod/tests/e2e --ignore=app/modules/pod_bundle/tests/e2e --ignore=app/modules/workspace/tests/e2e",
-      "workers": 3,
+      "workers": 2,
       "markers": "e2e and not slow and not workspace and not provider and not local_cli and not indexing and not protected",
       "needs_sandbox_images": false,
       "catch_all": true,
@@ -39,7 +39,7 @@
     {
       "name": "pod",
       "args": "app/modules/connectors/tests/e2e app/modules/pod/tests/e2e app/modules/pod_bundle/tests/e2e",
-      "workers": 3,
+      "workers": 2,
       "markers": "e2e and not slow and not workspace and not provider and not local_cli and not indexing and not protected",
       "needs_sandbox_images": false,
       "catch_all": false,
@@ -49,7 +49,7 @@
     {
       "name": "surfaces",
       "args": "app/modules/agent_surfaces/tests/e2e app/modules/identity/tests/e2e",
-      "workers": 3,
+      "workers": 2,
       "markers": "e2e and not slow and not workspace and not provider and not local_cli and not indexing and not protected",
       "needs_sandbox_images": false,
       "catch_all": false,

--- a/scripts/e2e_durations.py
+++ b/scripts/e2e_durations.py
@@ -41,12 +41,20 @@ DEFAULT_BUDGET_SECONDS = 45.0
 NOTABLE_SECONDS = 15.0
 
 
-def _cases(paths: list[Path]) -> list[tuple[float, str, str]]:
+def _cases(paths: list[Path], *, passing_only: bool = False) -> list[tuple[float, str, str]]:
     cases: list[tuple[float, str, str]] = []
     for path in paths:
         if not path.exists():
             continue
         for case in ET.parse(path).getroot().iter("testcase"):
+            # A failed test's duration is not a measurement of anything. A test
+            # that blows a 90-second condition wait reports 92s and would trip
+            # the budget, so one real failure became two red steps and the
+            # second one pointed at the wrong problem.
+            if passing_only and any(
+                child.tag in ("failure", "error") for child in case
+            ):
+                continue
             cases.append((
                 float(case.get("time") or 0),
                 case.get("classname", ""),
@@ -108,10 +116,13 @@ def main() -> int:
     parser.add_argument("--top", type=int, default=15)
     args = parser.parse_args()
 
-    cases = _cases(args.junit)
+    cases = _cases(args.junit, passing_only=args.check)
     if not cases:
-        print(f"no testcases found in {[str(p) for p in args.junit]}", file=sys.stderr)
-        return 1
+        # In --check this is the correct answer for a shard whose every test
+        # failed: the run is already red for a better reason.
+        print(f"no passing testcases found in {[str(p) for p in args.junit]}",
+              file=sys.stderr)
+        return 0 if args.check else 1
     return (check(cases, args.budget_seconds) if args.check
             else summarize(cases, args.top))
 

--- a/scripts/plan_e2e_shards.py
+++ b/scripts/plan_e2e_shards.py
@@ -89,7 +89,20 @@ PINNED = [
 # wall-clock, which is the floor for the whole workflow, while staying well
 # inside the free plan's twenty-concurrent-job budget.
 PACKED_SHARDS = 3
-PACKED_WORKERS = 3
+# Two, not three. Three was generalised from the one shard ever measured at it
+# -- the old `pod` shard, 94 tests of pure API work -- and it does not hold for
+# a packed bin. Each xdist worker runs its own SuperTokens container and its
+# own streaq worker subprocess, so three of them on a four-vCPU runner starve
+# the async workers the tests are waiting on. It shows up as a *condition*
+# wait timing out with a generous budget rather than as a slow assert:
+# test_apply_destructive_requires_confirmation blew a 90-second wait for a
+# bundle import, intermittently -- green on one run, red on the next with the
+# same shard contents.
+#
+# This costs no wall-clock. The `sandbox` shard runs serially at ~550s and is
+# the floor for the whole workflow; a packed bin at two workers lands near
+# 420s, still comfortably underneath it.
+PACKED_WORKERS = 2
 
 # The catch-all shard collects these roots and ignores every directory that was
 # explicitly assigned, so a new module's e2e tests land somewhere by default


### PR DESCRIPTION
## What changes

The packed backend e2e shards drop from three xdist workers to two, and the PR-lane duration gate stops judging tests that failed.

## Why

Both are fallout from #431, found on #432.

**The worker count.** #431 packed the non-serial shards at `-n 3`. That number was generalised from the one shard ever measured at it — the old `pod` shard, 94 tests of pure API work — and it does not survive a packed bin. Each xdist worker runs its own SuperTokens container *and* its own streaq worker subprocess, so three of them on a four-vCPU runner leave nothing for the background work the tests are blocked on.

It surfaces as a **condition wait timing out with a generous budget**, not as a slow assert, which is what makes it easy to misread as a product bug. On #432:

```
FAILED test_import_apply_e2e::test_apply_destructive_requires_confirmation (92.6s)
  Timed out waiting for pod … bundle import … to reach {'AWAITING_CONFIRMATION'}
```

That helper allows **90 seconds** and still blew it. And it is intermittent, not deterministic — the identical shard contents went green on #431's own run (`pod`, 309s) and red on the very next PR.

Two workers is what these modules ran at before #431 (`pod_bundle` lived in the old `rest` shard at `-n 2`), and **it costs no wall-clock**: the `sandbox` shard runs serially at ~550s and is the floor for the whole workflow, while a packed bin at two workers lands near 420s — still underneath it. The three-worker setting bought nothing and paid in flakes.

**The duration gate.** #432 went red twice for one problem. A test that blows a 90-second wait reports 92 seconds, so the new 45s budget flagged it too — and told the author to mark a *broken* test `@pytest.mark.slow`, which is the wrong advice about the wrong thing. A failed test's duration measures nothing, so `--check` now looks only at tests that passed.

## How to verify

```bash
python3 scripts/plan_e2e_shards.py --verify
uv run --no-project --with pyyaml python scripts/check_ci_aggregators.py
cd lemma-backend && uv run pytest app/core/tests/unit/test_e2e_workflow_contract.py \
  app/core/tests/unit/test_ci_configuration_contract.py -q
```

For the gate fix specifically, run it against #432's real JUnit artifact rather than a fixture:

```bash
gh run download 32473662227 -n backend-e2e-pod-coverage -D /tmp/pr432
python3 scripts/e2e_durations.py /tmp/pr432/coverage-backend/junit-e2e-pod.xml --check
```

What that printed:

| | Result |
|---|---|
| `plan_e2e_shards.py --verify` | 15 e2e directories, each in exactly one of 5 shards |
| `check_ci_aggregators.py` | Aggregator and timeout checks passed (15 workflows) |
| CI-contract unit tests | 15 passed |
| Gate vs #432's artifact, **before** this fix | `::error:: … took 92.6s, over the 45s PR-lane budget` |
| Gate vs #432's artifact, **after** | `e2e duration budget: 233 tests, none over 45s` |
| Gate vs a genuinely slow **passing** test (pre-split Kreuzberg JUnit) | still `::error:: … took 129.7s`, exit 1 |

That last row is the one that matters: the gate got narrower, not weaker.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

Workflow and tooling only — no migrations, no API surface, no SDK regeneration. A plain revert restores `-n 3`, which re-introduces the flake.

Worth noting what this does *not* claim: two workers is what these modules demonstrably ran at for months, not a number I have independently proven safe under load. If the same shape of timeout reappears at `-n 2`, the next step is to stop guessing at worker counts and give the packed shards a runner with more than four cores, or split the bin further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
