### PR TITLE
Close the app round trip: export and import agree, and every deploy keeps its source

### DIFF
--- a/docs/product/journeys/packaging-and-reuse.md
+++ b/docs/product/journeys/packaging-and-reuse.md
@@ -171,6 +171,9 @@ their credentials do not travel with it.
 
 - When a person with pod access downloads an app's source or build, the system
   shall give them the exact archive that was uploaded.
+- The system shall keep an app's source for every app it deploys, including one
+  promoted from something an agent produced, so what a person gets back is what
+  the app was authored from and not only its built output.
 - If a person without pod access requests either, then the system shall refuse.
 
 **Contracts:** `app.source.archive.get`, `app.dist.archive.get`

--- a/lemma-backend/app/modules/apps/services/app_service.py
+++ b/lemma-backend/app/modules/apps/services/app_service.py
@@ -188,6 +188,7 @@ class AppService:
         The widget and the app share one source artifact at two lifecycle stages:
         the stored fragment is preserved, wrapped as a standalone document (no
         embed bridge or conversation padding), and deployed as the app's bundle.
+        A no-build app's html is its own source, so it is stored as both archives.
         """
         for issue in lint_app_html(artifact.content):
             logger.debug(
@@ -206,14 +207,13 @@ class AppService:
         app = await self.create_app_with_context(
             AppEntity(**entity_data), user_id, ctx=ctx
         )
+        bundle = await run_blocking(self._single_index_html_zip, document)
         return await self.upload_bundle(
             pod_id,
             app.name,
             user_id,
-            source_archive_bytes=None,
-            dist_archive_bytes=await run_blocking(
-                self._single_index_html_zip, document
-            ),
+            source_archive_bytes=bundle,
+            dist_archive_bytes=bundle,
             ctx=ctx,
         )
 

--- a/lemma-backend/app/modules/apps/tests/unit/test_app_from_widget.py
+++ b/lemma-backend/app/modules/apps/tests/unit/test_app_from_widget.py
@@ -106,7 +106,10 @@ async def test_service_uploads_single_standalone_index():
 
     assert result is created
     _, kwargs = svc.upload_bundle.call_args
-    assert kwargs["source_archive_bytes"] is None
+    # A no-build app's html IS its source. Storing only the dist left the app
+    # with no source archive, so exporting the pod wrote an opaque dist.zip
+    # instead of the html the author edits and re-imports.
+    assert kwargs["source_archive_bytes"] == kwargs["dist_archive_bytes"]
     with ZipFile(io.BytesIO(kwargs["dist_archive_bytes"])) as z:
         names = z.namelist()
         index = z.read("index.html").decode()

--- a/lemma-backend/app/modules/pod_bundle/infrastructure/app_builder.py
+++ b/lemma-backend/app/modules/pod_bundle/infrastructure/app_builder.py
@@ -101,6 +101,19 @@ def zip_dir(source_dir: Path, *, exclude_build_dirs: bool = True) -> bytes:
     return buffer.getvalue()
 
 
+def zip_html_file(html_file: Path) -> bytes:
+    """Zip a single-file app's ``html.html`` as ``index.html``.
+
+    The CLI's bundle format lets a no-build app be one editable file. Without
+    this the server-side importer saw neither a ``source/`` directory nor a
+    ``dist.zip`` and failed a bundle the CLI imports happily.
+    """
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("index.html", html_file.read_text(encoding="utf-8"))
+    return buffer.getvalue()
+
+
 def slug_candidates(preferred: str | None, *, pod_id: UUID, app_name: str) -> list[str]:
     """Deterministic ordered slug candidates: the preferred/normalized base first,
     then a stable ``(pod_id, app_name)`` hash suffix. Deterministic — never random
@@ -352,9 +365,11 @@ class AppStepRunner:
         user_id: UUID,
     ) -> tuple[bytes | None, bytes]:
         """Produce ``(source_bytes, dist_bytes)`` for upload. A Vite source is built
-        in a sandbox; a static source is deployed as-is; a bundle carrying only a
-        prebuilt ``dist.zip`` (widget/no-source app) is uploaded with no source."""
+        in a sandbox; a static source or a single ``html.html`` is deployed as-is;
+        a bundle carrying only a prebuilt ``dist.zip`` (widget/no-source app) is
+        uploaded with no source."""
         source_dir = resource_dir / "source"
+        html_file = resource_dir / "html.html"
         dist_zip = resource_dir / "dist.zip"
 
         if source_dir.is_dir():
@@ -371,12 +386,18 @@ class AppStepRunner:
                 dist_bytes = source_bytes
             return source_bytes, dist_bytes
 
+        if html_file.is_file():
+            # A single-file app's html IS its source; there is no build step
+            # making one tree from another, so the same archive is both.
+            bundle = await run_blocking(zip_html_file, html_file, limiter="cpu_bound")
+            return bundle, bundle
+
         if dist_zip.is_file():
             dist_bytes = await run_blocking(dist_zip.read_bytes, limiter="cpu_bound")
             return None, dist_bytes
 
         raise AppBuildFailedError(
-            f"App '{name}' bundle has neither a source/ directory nor a dist.zip."
+            f"App '{name}' bundle has no source/ directory, html.html, or dist.zip."
         )
 
     # --- phase 3 ---------------------------------------------------------

--- a/lemma-backend/app/modules/pod_bundle/infrastructure/exporter.py
+++ b/lemma-backend/app/modules/pod_bundle/infrastructure/exporter.py
@@ -630,8 +630,8 @@ class BundleExporter:
     ) -> None:
         """Bundle an app's code: its source (extracted to ``source/``), or — for a
         widget/no-source app — its built ``dist.zip``. Best-effort and byte-budgeted:
-        an app with neither archive, or one over budget, exports metadata-only.
-        Mirrors the CLI's ``_download_app_assets`` for format parity."""
+        an app with neither archive, or one over budget, exports metadata-only. A
+        one-file app lands as ``source/index.html``; the CLI writes ``html.html``."""
         from app.modules.apps.contracts import AppNotFoundError
 
         # Prefer source (rebuildable in the target pod); the exported vite dist is

--- a/lemma-backend/app/modules/pod_bundle/tests/unit/test_app_builder.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/unit/test_app_builder.py
@@ -184,6 +184,24 @@ async def test_artifacts_vite_builds_in_sandbox(tmp_path):
     assert sandbox.call == {"app_slug": "app-x", "pod_id": _POD}
 
 
+async def test_artifacts_single_html_file_is_its_own_source(tmp_path):
+    """`html.html` is the CLI bundle format's one-file no-build app. The server
+    importer used to see no source/ and no dist.zip and fail a bundle the CLI
+    imports happily."""
+    resource = tmp_path / "apps" / "page"
+    resource.mkdir(parents=True)
+    (resource / "html.html").write_text("<h1>hi</h1>")
+
+    source_bytes, dist_bytes = await _runner(_ExplodingSandbox())._artifacts(
+        resource, "page", app_slug="page", pod_id=_POD, user_id=uuid4()
+    )
+
+    assert source_bytes == dist_bytes
+    with zipfile.ZipFile(io.BytesIO(dist_bytes)) as zf:
+        assert zf.namelist() == ["index.html"]
+        assert zf.read("index.html").decode() == "<h1>hi</h1>"
+
+
 async def test_artifacts_dist_zip_fallback_when_no_source(tmp_path):
     resource = tmp_path / "apps" / "widget"
     resource.mkdir(parents=True)

--- a/lemma-cli/lemma_cli/cli_app/app_bundle.py
+++ b/lemma-cli/lemma_cli/cli_app/app_bundle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import os
 import shutil
 import subprocess
@@ -160,6 +161,72 @@ def _materialize_static_dist(source: Path, tier: str) -> Path:
         target.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(path, target)
     return dist_dir
+
+
+def _extract_archive(archive_bytes: bytes, target_dir: Path) -> list[str]:
+    """Unpack an app archive into ``target_dir``, refusing to escape it."""
+    target_dir.mkdir(parents=True, exist_ok=True)
+    written: list[str] = []
+    with ZipFile(io.BytesIO(archive_bytes)) as archive:
+        for member in archive.infolist():
+            if member.is_dir():
+                continue
+            destination = target_dir / member.filename
+            if not destination.resolve().is_relative_to(target_dir.resolve()):
+                raise ValueError(f"Unsafe path in app archive: {member.filename}")
+            written.append(member.filename)
+        archive.extractall(target_dir)
+    return sorted(written)
+
+
+def pull_app_bundle(
+    client: Any,
+    *,
+    pod_id: str,
+    app_name: str,
+    target_dir: Path,
+    dist: bool = False,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Download a deployed app into ``target_dir``, ready to edit and redeploy.
+
+    The source archive is what comes back by default: for a Vite app that is the
+    project, and for a no-build app it is the single ``index.html``. Either is a
+    valid ``lemma apps deploy`` source, so pull → edit → deploy is a closed loop.
+    ``dist`` asks for the built output instead, which is what an app deployed
+    before its source was stored has.
+    """
+    if target_dir.exists() and any(target_dir.iterdir()) and not force:
+        raise ValueError(
+            f"Directory is not empty: {target_dir}. Pass --force to overwrite it."
+        )
+
+    pod_sdk = client.pod(pod_id)
+    kind = "dist" if dist else "source"
+    if dist:
+        archive_bytes = pod_sdk.apps.download_dist_archive(app_name)
+    else:
+        archive_bytes = pod_sdk.apps.download_source_archive(app_name)
+        if not archive_bytes:
+            # An app deployed before its source was stored has only a dist. Say
+            # so rather than writing an empty directory: what lands is built
+            # output, which redeploys but is not what the author edits.
+            archive_bytes = pod_sdk.apps.download_dist_archive(app_name)
+            kind = "dist"
+
+    if not archive_bytes:
+        raise ValueError(f"App has no {kind} archive to pull: {app_name}")
+
+    if force and target_dir.exists():
+        shutil.rmtree(target_dir)
+    files = _extract_archive(archive_bytes, target_dir)
+    return {
+        "app": app_name,
+        "pod_id": pod_id,
+        "directory": str(target_dir),
+        "archive": kind,
+        "files": files,
+    }
 
 
 def deploy_app_bundle(

--- a/lemma-cli/lemma_cli/cli_app/pod_bundle.py
+++ b/lemma-cli/lemma_cli/cli_app/pod_bundle.py
@@ -135,7 +135,7 @@ from lemma_sdk.openapi_client.models.workflow_update_request import (
 from ..cli_core.io import list_items, to_plain
 from ..cli_core.payload import build_request
 from ..cli_core.state import err_console as console
-from .app_bundle import deploy_app_bundle
+from .app_bundle import classify_app_source, deploy_app_bundle
 from .enums import SURFACE_PLATFORMS
 from lemma_pod_bundle.limits import (
     MAX_APP_BYTES,
@@ -695,6 +695,25 @@ def _extract_large_text(
     return next_payload
 
 
+def _collapse_single_file_app_source(resource_dir: Path) -> None:
+    """Rewrite a one-file `source/index.html` app back to `html.html`.
+
+    A no-build app uploads the same archive as source and dist, so its source
+    comes back as a lone `index.html`. `html.html` is the form the author wrote
+    and the form the docs describe, and it survives a re-export unchanged — a
+    round trip should hand back the file you edit, not a directory pretending
+    to be a project.
+    """
+    source_dir = resource_dir / "source"
+    files = [path for path in source_dir.rglob("*") if path.is_file()]
+    if len(files) != 1 or files[0].name != "index.html":
+        return
+    (resource_dir / "html.html").write_text(
+        files[0].read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    shutil.rmtree(source_dir)
+
+
 def _download_app_assets(
     client: Lemma,
     pod_id: str,
@@ -723,6 +742,7 @@ def _download_app_assets(
                         f"Unsafe path in app source archive for {app_name}: {member.filename}"
                     )
             archive.extractall(source_dir)
+        _collapse_single_file_app_source(resource_dir)
         return
 
     try:
@@ -1528,11 +1548,17 @@ def _build_import_plan(
     for resource_dir in app_dirs:
         app_name = resource_dir.name
         try:
-            if (resource_dir / "source").exists():
-                _build_app_bundle(
-                    resource_dir,
-                    stream_output=False,
-                )
+            source_subdir = resource_dir / "source"
+            if source_subdir.exists():
+                # Classify exactly as the deploy path does. Only a Vite project
+                # gets built here (a dry run should catch a broken build); a
+                # no-build source is uploaded as-is, so demanding a package.json
+                # rejected the very bundles export writes.
+                if classify_app_source(source_subdir) == "vite":
+                    _build_app_bundle(
+                        resource_dir,
+                        stream_output=False,
+                    )
         except ValueError as exc:
             issues.append(
                 BundleValidationIssue(path=str(resource_dir), message=str(exc))

--- a/lemma-cli/lemma_cli/cli_core/commands/apps.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/apps.py
@@ -33,6 +33,7 @@ from lemma_sdk.config import resolve_auth_url, resolve_base_url, resolve_token
 from ...cli_app.app_bundle import (
     classify_app_source,
     deploy_app_bundle,
+    pull_app_bundle,
 )
 
 app = typer.Typer(help="App commands.")
@@ -397,6 +398,68 @@ def deploy_app(
     )
     if result is not None:
         emit(state, result)
+
+
+@app.command("pull")
+def pull_app(
+    ctx: typer.Context,
+    app: str = typer.Argument(...),
+    directory: Path | None = typer.Argument(
+        None,
+        file_okay=False,
+        dir_okay=True,
+        help="Where to write the app. Defaults to ./<app>.",
+    ),
+    pod: str | None = typer.Option(None, "--pod"),
+    dist: bool = typer.Option(
+        False,
+        "--dist",
+        help="Pull the built output instead of the source.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        "-f",
+        help="Overwrite the target directory if it is not empty.",
+    ),
+) -> None:
+    """Download a deployed app's source to edit locally.
+
+    What lands is a valid deploy source: a Vite project keeps its files, and a
+    no-build app arrives as a single index.html. Edit it, then
+    `lemma apps deploy <app> <directory>` to push it back.
+    """
+    state = state_from_ctx(ctx)
+    # Resolve for the filesystem, but echo back what was typed: an absolute temp
+    # path in the "next step" line is unreadable and not what anyone retypes.
+    written_to = directory or Path(app)
+    target = written_to.resolve()
+
+    def run(client, s):  # type: ignore[no-untyped-def]
+        from .pods import resolve_pod_id
+
+        return pull_app_bundle(
+            client,
+            pod_id=resolve_pod_id(client, s, pod),
+            app_name=app,
+            target_dir=target,
+            dist=dist,
+            force=force,
+        )
+
+    result = run_with_client(ctx, run)
+    if result is None:
+        return
+    if result.get("archive") == "dist" and not dist:
+        console.print(
+            f"[yellow]Warning:[/yellow] {app} has no stored source — pulled its "
+            "built output instead. Redeploying it works, but it is not the code "
+            "you wrote."
+        )
+    emit(state, result)
+    console.print(
+        f"Next: edit {written_to}, then `lemma apps deploy {app} {written_to}`"
+    )
 
 
 @app.command("init")

--- a/lemma-cli/tests/test_commands_apps.py
+++ b/lemma-cli/tests/test_commands_apps.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import io
 import json
 from types import SimpleNamespace
+from zipfile import ZIP_DEFLATED, ZipFile
 
 from typer.testing import CliRunner
 
@@ -225,3 +227,86 @@ def test_apps_open_never_puts_the_token_in_argv(monkeypatch):
     # It still reaches the browser -- over stdin, where the process table
     # cannot see it.
     assert any(secret in call["input"] for call in calls)
+
+
+_POD_UUID = "01a02962-89c2-72be-a2d8-9c6966f24104"
+
+
+def _zip_bytes(files: dict[str, str]) -> bytes:
+    buffer = io.BytesIO()
+    with ZipFile(buffer, "w", compression=ZIP_DEFLATED) as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+    return buffer.getvalue()
+
+
+def _pull_client(*, source: bytes, dist: bytes):
+    class FakeApps:
+        def download_source_archive(self, name):
+            return source
+
+        def download_dist_archive(self, name):
+            return dist
+
+    class FakeClient:
+        def pod(self, pod_id):
+            return SimpleNamespace(apps=FakeApps())
+
+    return FakeClient()
+
+
+def test_apps_pull_writes_the_source_tree(monkeypatch, tmp_path):
+    client = _pull_client(
+        source=_zip_bytes({"package.json": "{}", "src/main.ts": "run()"}),
+        dist=_zip_bytes({"index.html": "<html>built</html>"}),
+    )
+    _patch(monkeypatch, client)
+    target = tmp_path / "my-app"
+
+    result = runner.invoke(
+        app, ["apps", "pull", "my-app", str(target), "--pod", _POD_UUID]
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert (target / "package.json").read_text() == "{}"
+    assert (target / "src" / "main.ts").read_text() == "run()"
+
+
+def test_apps_pull_falls_back_to_dist_and_says_so(monkeypatch, tmp_path):
+    """An app deployed before its source was stored has only built output.
+    Writing it silently would look like the code the author wrote."""
+    client = _pull_client(source=b"", dist=_zip_bytes({"index.html": "<h1>hi</h1>"}))
+    _patch(monkeypatch, client)
+    target = tmp_path / "my-app"
+
+    result = runner.invoke(
+        app, ["apps", "pull", "my-app", str(target), "--pod", _POD_UUID]
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert (target / "index.html").read_text() == "<h1>hi</h1>"
+    assert "no stored source" in result.stdout
+
+
+def test_apps_pull_refuses_to_clobber_a_non_empty_directory(monkeypatch, tmp_path):
+    client = _pull_client(source=_zip_bytes({"index.html": "<h1>new</h1>"}), dist=b"")
+    _patch(monkeypatch, client)
+    target = tmp_path / "my-app"
+    target.mkdir()
+    (target / "notes.md").write_text("mine")
+
+    result = runner.invoke(
+        app, ["apps", "pull", "my-app", str(target), "--pod", _POD_UUID]
+    )
+
+    assert result.exit_code != 0
+    assert (target / "notes.md").read_text() == "mine"
+
+    forced = runner.invoke(
+        app,
+        ["apps", "pull", "my-app", str(target), "--pod", _POD_UUID, "--force"],
+    )
+
+    assert forced.exit_code == 0, forced.stdout
+    assert not (target / "notes.md").exists()
+    assert (target / "index.html").read_text() == "<h1>new</h1>"

--- a/lemma-cli/tests/test_pod_bundle.py
+++ b/lemma-cli/tests/test_pod_bundle.py
@@ -3345,3 +3345,119 @@ def test_import_pod_bundle_uploads_a_no_build_app_as_source_and_dist(tmp_path: P
     assert upload["dist_archive"] == app_dir / "dist.zip"
     # The regression: this key used to be absent entirely.
     assert upload["source_archive"] == upload["dist_archive"]
+
+
+def test_download_app_assets_writes_html_html_for_a_single_file_app(tmp_path: Path):
+    """A no-build app comes back as the one file the author edits.
+
+    A single-`index.html` source archive IS an `html.html` app: writing it to
+    `source/index.html` is the form the round trip used to produce and the
+    importer used to reject.
+    """
+    resource_dir = tmp_path / "apps" / "support_app"
+    resource_dir.mkdir(parents=True)
+
+    source_zip = BytesIO()
+    with ZipFile(source_zip, "w", compression=ZIP_DEFLATED) as archive:
+        archive.writestr("index.html", "<h1>hello</h1>")
+
+    client = FakeClient(
+        apps=SimpleNamespace(
+            download_source_archive=lambda pod_id, app_name: source_zip.getvalue(),
+            download_dist_archive=lambda pod_id, app_name: b"pretend-dist",
+        )
+    )
+
+    from lemma_cli.cli_app.pod_bundle import _ByteBudget, _download_app_assets
+
+    _download_app_assets(
+        client,
+        "pod_123",
+        "support_app",
+        resource_dir,
+        app_budget=_ByteBudget(per_item=10_000_000, total=20_000_000, warnings=[]),
+    )
+
+    assert (resource_dir / "html.html").read_text(encoding="utf-8") == "<h1>hello</h1>"
+    assert not (resource_dir / "source").exists()
+    assert not (resource_dir / "dist.zip").exists()
+
+
+def test_import_pod_bundle_accepts_a_no_build_app_source_dir(tmp_path: Path):
+    """`source/index.html` with no `package.json` is the documented no-build
+    form, and the deploy path already accepts it. Validation used to demand a
+    `package.json` there, so an exported bundle could not be re-imported."""
+    (tmp_path / "pod.json").write_text(
+        json.dumps({"name": "demo", "format_version": 1}), encoding="utf-8"
+    )
+    app_dir = tmp_path / "apps" / "support_app"
+    source_dir = app_dir / "source"
+    source_dir.mkdir(parents=True)
+    (source_dir / "index.html").write_text("<h1>hello</h1>", encoding="utf-8")
+    (app_dir / "support_app.json").write_text(
+        json.dumps({"name": "support_app", "description": "app"}),
+        encoding="utf-8",
+    )
+
+    client = _bare_pod_client()
+
+    result = import_pod_bundle(
+        client, pod_id="pod_123", source_dir=tmp_path, dry_run=True
+    )
+
+    assert result["errors"] == []
+    assert result["ok"] is True
+    assert result["summary"]["apps"] == ["created:support_app"]
+
+
+def test_exported_no_build_app_re_imports(tmp_path: Path):
+    """The round trip, end to end: export a no-build HTML app, then plan an
+    import of exactly what export wrote.
+
+    Export used to write `source/index.html` and the importer used to demand
+    `source/package.json` there, so no exported bundle carrying an HTML app
+    could ever be re-imported.
+    """
+    source_zip = BytesIO()
+    with ZipFile(source_zip, "w", compression=ZIP_DEFLATED) as archive:
+        archive.writestr("index.html", "<h1>hello</h1>")
+
+    exporter = FakeClient(
+        pods=SimpleNamespace(get=lambda pod_id: {"id": pod_id, "name": "demo-pod"}),
+        apps=SimpleNamespace(
+            list=lambda pod_id, limit=1000: {"items": [{"name": "support_app"}]},
+            get=lambda pod_id, app_name: {
+                "name": app_name,
+                "description": "app",
+                "public_slug": "support-app",
+            },
+            download_source_archive=lambda pod_id, app_name: source_zip.getvalue(),
+            download_dist_archive=lambda pod_id, app_name: b"",
+        ),
+    )
+
+    export_pod_bundle(
+        exporter,
+        pod_id="pod_123",
+        output_dir=tmp_path,
+        exclude={
+            "tables",
+            "functions",
+            "agents",
+            "workflows",
+            "schedules",
+            "surfaces",
+            "files",
+        },
+    )
+
+    bundle_root = tmp_path / "demo-pod"
+    assert (bundle_root / "apps" / "support_app" / "html.html").exists()
+
+    result = import_pod_bundle(
+        _bare_pod_client(), pod_id="pod_456", source_dir=bundle_root, dry_run=True
+    )
+
+    assert result["errors"] == []
+    assert result["ok"] is True
+    assert result["summary"]["apps"] == ["created:support_app"]

--- a/lemma-skills/lemma-builder/references/apps.md
+++ b/lemma-skills/lemma-builder/references/apps.md
@@ -45,6 +45,7 @@ a server-side `DATASTORE` schedule, which reacts by *doing work* (`schedules-and
 | Author | one `index.html`, vanilla/CDN JS | React + `lemma-sdk` + native blocks |
 | SDK | load `lemma-client.js` from `window.__LEMMA_CONFIG__.apiUrl` (see snippet) → `window.LemmaClient`; pod context from the same injected config | `import { LemmaClient } from "lemma-sdk"`, `import.meta.env.VITE_LEMMA_*`, `AuthGuard` |
 | Deploy | `lemma apps init ./d --html` → edit → `lemma apps deploy d ./d/index.html` — no build, no env | `lemma apps init` → `npm run dev` → `lemma apps deploy` (builds) |
+| Fetch back | `lemma apps pull <app> ./d` — writes `index.html` | `lemma apps pull <app> ./d` — writes the project |
 
 **Default to HTML for a single page** (the host injects pod context and the SDK
 loads from it — nothing to build); reach for **Vite** when the app genuinely needs
@@ -58,7 +59,14 @@ document without embed-only padding or height messaging — see the `lemma-widge
 lemma apps init ./board --html --title "Board"   # one polished, pod-aware index.html
 # edit ./board/index.html
 lemma apps deploy board ./board/index.html        # no build, no env — uploaded as-is
+lemma apps pull board ./board --force             # fetch back what is deployed
 ```
+
+`pull` is the other half of `deploy`: it writes the deployed app's **source** into a
+directory that `deploy` accepts unchanged, so pull → edit → deploy closes the loop from
+any machine. A Vite app arrives as its project; a no-build app arrives as one
+`index.html`. `--dist` pulls built output instead, which is all an app deployed before
+its source was stored has (`pull` falls back to it and says so).
 
 ```html
 <!-- Load the SDK from the API origin in the injected window.__LEMMA_CONFIG__,

--- a/lemma-skills/lemma-builder/references/cli-and-bundles.md
+++ b/lemma-skills/lemma-builder/references/cli-and-bundles.md
@@ -44,7 +44,8 @@ my-pod/
   schedules/<name>/<name>.json
   surfaces/<platform>/<platform>.json   # e.g. surfaces/slack/slack.json
   apps/<name>/<name>.json
-  apps/<name>/source/            # Vite app project (built on import/deploy)
+  apps/<name>/source/            # Vite app project (built on import/deploy), OR a
+                                 #   no-build site (index.html, no package.json)
   apps/<name>/html.html          # OR a single no-build HTML app (uploaded as-is)
   files/<folder>/.folder.json     # folder metadata (file bytes travel with --with-files)
   payloads/                        # local test fixtures, not imported as pod resources
@@ -218,6 +219,10 @@ So a surface bundle looks like this, not like a literal uuid:
 - Import **does not create the pod** — create/select it first.
 - **No in-place column mutation.** Changing a column's type fails; imports only add/remove columns. Treat type changes as a migration (new column, backfill, drop old).
 - **Function schemas follow the code** — `input_schema`/`output_schema`/`config_schema` are re-extracted from the Pydantic models on every code-bearing create *or* update, import included. Edit the models and re-import.
+- **Export round-trips.** Every deploy stores the app's source, so `pods export`
+  writes back the form you authored: a Vite project comes back as `source/`, and a
+  single-file app comes back as `html.html` — re-importable as-is. An app deployed
+  before its source was stored has only built output, and exports as `dist.zip`.
 - **File bytes and table rows travel only on request.** `pods export --with-files --with-data` (or `--data-table <t>` for specific tables) writes them into the bundle; `pods import --with-files --with-data` applies them. Without those flags you get structure only, and you upload bytes with `lemma files upload` after import.
 - **Connectors are not bundle resources.** Auth configs, accounts, and connect state are org runtime state — script their setup (`lemma connectors ...`) in the pod README.
 - **Grants are name-based and portable.** `resource_name` is the table name (`tickets`), the stored folder path (a shared `/knowledge` or personal `/me/...` — there is **no** `/pod` prefix), or the connector id (`gmail`). Importing into a different pod resolves names against the target pod, so grants port cleanly as long as the named resources exist there (they do, when they're part of the same bundle). The **one exception is a pinned `connector_account` grant**, whose `resource_name` is an account id: export turns it into a `${…}` variable, and an import that doesn't supply it drops the grant with a warning (the workload falls back to the invoking user's own account). See `authorization-model.md` §4b.
@@ -297,7 +302,8 @@ lemma surfaces list|get|upsert|enable|disable|setup|channels|available-channels|
 lemma feedback --category cli|skill|platform|docs|other --subject … --issue-encountered … --expected-behavior … --actual-behavior …
 
 # apps
-lemma apps list|get|init|create|update|deploy|delete
+lemma apps list|get|init|create|update|deploy|pull|delete
+lemma apps pull <app> [./dir] [--dist] [--force]   # download the deployed source to edit
 ```
 
 ## Verify


### PR DESCRIPTION
## What changes

An exported pod bundle carrying a no-build HTML app can be re-imported again. It could not before: export wrote `apps/<name>/source/index.html`, and import validation demanded `source/package.json` there — so a bundle the CLI had just written failed with `App source is missing package.json`. That gate runs on a real import too, not only `--dry-run`, so the bundle was unusable, not merely unplannable.

Also here: `lemma apps pull` fetches a deployed app's source back for editing, and every deploy path now stores that source.

## Why

The two ends were inverted, and neither matched the documentation:

| | `source/index.html`, no `package.json` | `html.html` |
|---|---|---|
| CLI import validation | **rejected** | accepted |
| CLI deploy (`classify_app_source`) | accepted | accepted |
| Server-side importer (`classify_source_dir`) | accepted | **rejected** |

`references/cli-and-bundles.md` already described both forms as valid, so the docs were right and the code disagreed with itself. Three fixes make them agree:

- Import validation classifies exactly as the deploy path does, and builds only the Vite tier (a broken Vite build still fails a dry run; a no-build source is no longer asked to have a package.json).
- Export writes a one-file app back as `html.html` — the round trip returns the file the author edits, not a directory pretending to be a project. Stable across re-exports.
- The server-side importer accepts `html.html`, closing the other half of the inversion for the share → import path.

Separately, `create_app_from_widget` uploaded a dist with `source_archive_bytes=None`, so every app promoted from an agent's widget had built output only and exported as an opaque `dist.zip`. It now stores the same archive as both, matching what the no-build path already did everywhere else. That was the last source-less upload in the repo, so the guarantee now holds end to end and is recorded as a promise under PS-PACK-032.

`lemma apps pull <app> [./dir] [--dist] [--force]` writes the deployed source into a directory `deploy` accepts unchanged, so pull → edit → deploy closes from any machine. A Vite app arrives as its project, a no-build app as one `index.html`. With no stored source it falls back to the dist and says so, rather than quietly handing back something that is not the author's code.

## How to verify

```bash
cd lemma-cli && uv run pytest tests/ --ignore=tests/e2e -q
cd lemma-backend && uv run pytest app/modules/apps/tests/unit app/modules/pod_bundle/tests/unit -q
make architecture
```

`609 passed` (CLI), `354 passed` (backend units), `Architecture ratchet passed`. Six new tests, including `test_exported_no_build_app_re_imports`, which exports a bundle and then plans an import of exactly what export wrote — it fails on the old code with the reported error.

Backend e2e was **not** run: Docker is unavailable in this worktree, so those suites error in setup. `make lint` fails identically before and after this change (the TypeScript SDK's `node_modules` is not installed here); the Python halves pass.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **API surface** — unchanged. `apps pull` uses the existing `app.source.archive.get` / `app.dist.archive.get` endpoints, so no spec or SDK regeneration.
- [x] **Compatibility** — no breaking change. Every bundle that imported before still imports; the two previously rejected forms now import as well.
- [x] **Security** — archive extraction validates every member stays under the target directory before extracting, the same guard the exporter already used.
- [x] **Rollback** — plain revert, no migration and no persisted format change.

## Compatibility and rollback notes

Apps deployed before this lands still have no stored source; they export as `dist.zip` and `apps pull` falls back to their built output with a warning. Redeploying such an app stores its source and it round-trips from then on. Nothing needs backfilling.

One deliberate omission: the server-side exporter still writes `source/index.html` where the CLI writes `html.html`. Both forms import cleanly on both ends now, so nothing is broken — but `exporter.py` is 941 lines against the ratchet's cap, and growing it for cosmetic parity is the wrong trade. Its docstring no longer claims a parity it does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)