### PR TITLE
Stop flashing the landing page at a visitor who is already signed in

### DIFF
--- a/lemma-frontend/app/home/page.tsx
+++ b/lemma-frontend/app/home/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { RootPageSwitch } from '@/components/root/root-page-switch';
+import { hasSessionCookie } from '@/lib/auth/server-session';
 
 export const metadata: Metadata = {
     title: 'Home | Lemma',
@@ -10,6 +11,10 @@ export const metadata: Metadata = {
     },
 };
 
-export default function HomeRoutePage() {
-    return <RootPageSwitch mode="home" />;
+export default async function HomeRoutePage() {
+    // Same reason as the root page: this route is `noindex`, so the marketing
+    // page has nothing to earn here — it is only ever the placeholder someone
+    // signed out would land on, and never what a signed-in visitor should read
+    // for the length of a `/users/me` round trip.
+    return <RootPageSwitch mode="home" hasSessionCookie={await hasSessionCookie()} />;
 }

--- a/lemma-frontend/app/page.tsx
+++ b/lemma-frontend/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { RootPageSwitch } from '@/components/root/root-page-switch';
 import { JsonLd } from '@/components/seo/json-ld';
+import { hasSessionCookie } from '@/lib/auth/server-session';
 import { SITE_DESCRIPTION, SITE_TITLE } from '@/lib/seo/site-copy';
 import {
     organizationSchema,
@@ -41,7 +42,13 @@ export const metadata: Metadata = {
     },
 };
 
-export default function HomePage() {
+export default async function HomePage() {
+    // Read before anything renders, so a signed-in visitor is never served a
+    // page of marketing to look at while the auth check flies. See
+    // `hasSessionCookie` — a hint about which placeholder to paint, not a
+    // claim about who they are.
+    const arrivedWithSession = await hasSessionCookie();
+
     return (
         <>
             {/*
@@ -52,7 +59,7 @@ export default function HomePage() {
               to read.
             */}
             <JsonLd schema={[organizationSchema(), webSiteSchema(), softwareApplicationSchema()]} />
-            <RootPageSwitch />
+            <RootPageSwitch hasSessionCookie={arrivedWithSession} />
         </>
     );
 }

--- a/lemma-frontend/components/root/root-page-switch.tsx
+++ b/lemma-frontend/components/root/root-page-switch.tsx
@@ -25,7 +25,18 @@ const AccountOnboarding = dynamic(
 
 type RootPageMode = 'redirect' | 'home';
 
-export function RootPageSwitch({ mode = 'redirect' }: { mode?: RootPageMode }) {
+export function RootPageSwitch({
+    mode = 'redirect',
+    hasSessionCookie = false,
+}: {
+    mode?: RootPageMode;
+    /**
+     * Did this request arrive holding a session cookie? Read on the server by
+     * `hasSessionCookie()`, and a hint about which placeholder to paint — never
+     * a claim that the visitor is signed in. See the branch below.
+     */
+    hasSessionCookie?: boolean;
+}) {
     const { isAuthenticated, isLoading } = useLemmaAuth();
 
     // A local installation is not selling anything. The marketing page never
@@ -36,8 +47,19 @@ export function RootPageSwitch({ mode = 'redirect' }: { mode?: RootPageMode }) {
     // is still in flight. The auth check is a network round trip, which makes
     // this both the server render and what a crawler with no JavaScript sees:
     // real marketing copy, never a blank loading shell.
-    if (!isLocalDeployment() && (isLoading || !isAuthenticated)) {
-        return <LandingPage />;
+    //
+    // Unless the request carried a session cookie. Rendering the pitch during
+    // that round trip means someone who is already signed in watches a page of
+    // marketing load and then throw itself away — a second of the wrong app,
+    // on every visit to the root. The cookie is the one thing the server knows
+    // about them before the check resolves, and it is enough to paint the
+    // loader instead. A crawler carries no cookies, so the SSR'd marketing page
+    // it reads is unchanged, and so is the first paint for a real signed-out
+    // visitor. If the cookie turns out to be stale the check says so and the
+    // landing page renders a moment later, which is the same place a visitor
+    // with no cookie at all lands.
+    if (!isLocalDeployment() && !isAuthenticated) {
+        return isLoading && hasSessionCookie ? <PageLoader /> : <LandingPage />;
     }
 
     if (isLoading) {

--- a/lemma-frontend/lib/auth/server-session.ts
+++ b/lemma-frontend/lib/auth/server-session.ts
@@ -1,0 +1,28 @@
+import "server-only";
+import { cookies } from "next/headers";
+import { sessionCookiePresent } from "./session-cookie";
+
+/**
+ * `sessionCookiePresent`, over the incoming request.
+ *
+ * Answered on the server, before anything renders, so the root page can pick
+ * between the marketing page and the app shell in the *first* HTML rather than
+ * after a `/users/me` round trip has resolved on the client. What the answer
+ * does and does not mean is documented on `sessionCookiePresent` — it is a hint
+ * about which placeholder to paint, not a claim about who is asking.
+ *
+ * Calling this opts the route into dynamic rendering, which is not a cost so
+ * much as the point: a response that depends on a cookie must not be built once
+ * and handed to everyone. Next marks such a response `private` for the same
+ * reason, so nothing in front can serve one visitor's shell to another.
+ *
+ * When the session cookie is scoped to the API's own host rather than shared
+ * across the parent domain, the frontend server never sees it and this is
+ * always false. That is a return to the previous behaviour rather than a new
+ * failure: the marketing page renders while the auth check flies, as it did
+ * before this existed.
+ */
+export async function hasSessionCookie(): Promise<boolean> {
+    const store = await cookies();
+    return sessionCookiePresent((name) => store.get(name)?.value);
+}

--- a/lemma-frontend/lib/auth/session-cookie.test.ts
+++ b/lemma-frontend/lib/auth/session-cookie.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { sessionCookiePresent } from "./session-cookie";
+
+const source = (path: string) =>
+    readFileSync(new URL(`../../${path}`, import.meta.url), "utf8");
+
+const cookieJar =
+    (...names: string[]) =>
+    (name: string) =>
+        names.includes(name) ? "a-value" : undefined;
+
+/**
+ * A signed-in visitor must not be shown the marketing page.
+ *
+ * The root page renders one of two placeholders while the client's `/users/me`
+ * check is in flight. Getting that choice wrong is not a subtle bug: it is a
+ * full second of the pitch, on every visit to the root, for people who already
+ * bought it. The session cookie is the only thing the server knows about them
+ * that early, so this is the whole of the decision.
+ */
+describe("the session hint", () => {
+    it("reads a session from either cookie SuperTokens sets", () => {
+        // Either alone is enough. They are set together, so requiring both
+        // would turn a partial expiry back into the flash this prevents.
+        expect(sessionCookiePresent(cookieJar("sFrontToken"))).toBe(true);
+        expect(sessionCookiePresent(cookieJar("st-access-token"))).toBe(true);
+        expect(
+            sessionCookiePresent(cookieJar("sFrontToken", "st-access-token")),
+        ).toBe(true);
+    });
+
+    it("reads no session from a request that carries none", () => {
+        // The crawler case, and the signed-out visitor's case. Both must still
+        // get real marketing copy in the server-rendered HTML — that is what
+        // #444 fixed, and this must not undo it.
+        expect(sessionCookiePresent(cookieJar())).toBe(false);
+        expect(sessionCookiePresent(cookieJar("st-refresh-token"))).toBe(false);
+    });
+
+    it("treats an empty cookie as no cookie", () => {
+        // A cleared cookie is often an empty one rather than an absent one —
+        // `clearFrontendSessionState` expires them by writing `name=`.
+        expect(sessionCookiePresent(() => "")).toBe(false);
+    });
+});
+
+/**
+ * The hint is worthless unless it reaches the switch.
+ *
+ * A source contract rather than a render test for the same reason as the rest
+ * of this suite: the failure it guards is a wiring mistake that typechecks
+ * perfectly — `hasSessionCookie` defaults to false, so a call site that forgets
+ * to pass it compiles, ships, and flashes the landing page exactly as before.
+ */
+describe("both root call sites read the hint on the server", () => {
+    it.each(["app/page.tsx", "app/home/page.tsx"])("wires %s", (path) => {
+        const pageSource = source(path);
+
+        expect(pageSource).toContain("hasSessionCookie");
+        expect(pageSource).toContain("@/lib/auth/server-session");
+        expect(pageSource).toMatch(/<RootPageSwitch[^>]*hasSessionCookie=\{/);
+    });
+});

--- a/lemma-frontend/lib/auth/session-cookie.ts
+++ b/lemma-frontend/lib/auth/session-cookie.ts
@@ -1,0 +1,40 @@
+/**
+ * Does a request arrive holding a session?
+ *
+ * Deliberately free of `server-only` and `next/headers`, which the binding in
+ * `server-session.ts` supplies. Both of those refuse to load outside a server
+ * component — including under the unit suite, which is node-only — so keeping
+ * the decision here is what lets it be asserted on at all.
+ *
+ * This is a hint, never an authorization. Nothing here validates a token; the
+ * server has no way to and does not need to. The only thing it decides is which
+ * of two placeholders the root page paints while the real auth check runs, and
+ * both branches converge on the same verified answer a moment later. A forged
+ * cookie buys a stranger a loading spinner.
+ */
+
+/**
+ * The cookies SuperTokens sets for a session, in `tokenTransferMethod:
+ * "cookie"` mode (see `ensureCookieSessionSupport` in the SDK).
+ *
+ * `sFrontToken` is the one the frontend itself reads — it is what makes
+ * `doesSessionExist()` answer true, and what `clearFrontendSessionState` in
+ * `browser-session.ts` clears to end a session locally. `st-access-token` is
+ * HttpOnly and unreadable from the browser, but a server sees every cookie the
+ * browser sends, so it works just as well here and outlives any future change
+ * to how the frontend stores its half.
+ */
+export const SESSION_HINT_COOKIES = ["sFrontToken", "st-access-token"] as const;
+
+/**
+ * True when the request carries either session cookie.
+ *
+ * Either alone counts. They are set together, so requiring both would turn a
+ * partial expiry into a marketing page flashed at someone who is signed in —
+ * exactly the thing this exists to stop.
+ */
+export function sessionCookiePresent(
+    readCookie: (name: string) => string | undefined,
+): boolean {
+    return SESSION_HINT_COOKIES.some((name) => Boolean(readCookie(name)));
+}

--- a/lemma-frontend/lib/desktop/local-deployment.test.ts
+++ b/lemma-frontend/lib/desktop/local-deployment.test.ts
@@ -23,7 +23,7 @@ describe("local deployments never serve the landing page", () => {
 
         expect(switchSource.match(/<LandingPage \/>/g) ?? []).toHaveLength(1);
         expect(switchSource).toMatch(
-            /if \(!isLocalDeployment\(\) && \(isLoading \|\| !isAuthenticated\)\) \{\s*return <LandingPage \/>;/,
+            /if \(!isLocalDeployment\(\) && !isAuthenticated\) \{\s*return isLoading && hasSessionCookie \? <PageLoader \/> : <LandingPage \/>;/,
         );
     });
 


### PR DESCRIPTION
## What changes

Opening the app no longer shows the marketing page for a second before the real app appears. The root page now decides which placeholder to paint **before** it sends any HTML, based on whether the request carried a session cookie: a signed-in visitor gets the loader, a signed-out visitor and a crawler still get the full landing page.

`/home` had the same flash and is `noindex`, so it gets the same treatment.

## Why

#444 made the root page render the pitch while the auth check is in flight, deliberately and for a good reason — the page previously server-rendered a spinner, so a crawler with no JavaScript read a loading shell instead of the product's own copy. That fixed the site's agent-readiness score.

The cost landed on everyone already signed in. `isLoading` covers a `/users/me` round trip, so every visit to the root painted a full page of marketing, downloaded its chunk, and threw it away.

```
- if (!isLocalDeployment() && (isLoading || !isAuthenticated)) {
-     return <LandingPage />;
+ if (!isLocalDeployment() && !isAuthenticated) {
+     return isLoading && hasSessionCookie ? <PageLoader /> : <LandingPage />;
  }
```

The session cookie is the one thing the server knows about the visitor that early, and it separates the two cases cleanly: a crawler and a signed-out visitor carry none.

**It is a hint, never an authorization.** Nothing validates the token — the server has no way to and does not need to. The only thing it decides is which of two placeholders to paint while the real check runs, and both branches converge on the same verified answer a moment later. A forged cookie buys a stranger a spinner. A stale one buys the loader, then the landing page, which is where a visitor with no cookie lands anyway.

## How to verify

```bash
cd lemma-frontend && npm run build && npx next start -p 3999 &

# Signed out / crawler: full marketing copy in the server-rendered HTML
curl -s http://127.0.0.1:3999/ | grep -c "The software you need"

# Signed in: the loader, no marketing markup
curl -s -H 'Cookie: sFrontToken=x' http://127.0.0.1:3999/ | grep -c "The software you need"

# #444's markdown negotiation still works
curl -s -H 'Accept: text/markdown' http://127.0.0.1:3999/ | head -3

# Next marks the cookie-dependent response private on its own
curl -sI http://127.0.0.1:3999/ | grep -i cache-control
```

Printed:

| Request | Rendered body |
|---|---|
| No cookie | Full landing page — nav, hero, headline, CTA (99 KB) |
| `sFrontToken` present | Empty — the loader (24 KB) |

- `Accept: text/markdown` still returns `# Lemma …` as `text/markdown; charset=utf-8`.
- `Cache-Control: private, no-cache, no-store, max-age=0, must-revalidate`.
- Build output confirms `ƒ /` and `ƒ /home` (server-rendered on demand).

Stale-cookie fallback checked in a real browser against `npm run dev` with the API down: the loader paints, `checkAuth` resolves to unauthenticated, the landing page renders. No dead end — every failure path in `performAuthCheck`, including the network `catch`, calls `applyUnauthenticatedState()`.

Gates:

```bash
cd lemma-frontend && npm run check && npm test && npm run bundle:budget:ci
```

`check` (design audit, lint, typecheck, edu-anchors) passes; **1046 tests across 97 files** pass; `Bundle budget OK — shared JS 111.5 KB brotli`.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload. The cookie is read but never validated, forwarded, or logged; it gates nothing but a choice of placeholder, and authorization is unchanged (still `/users/me` on the client, still enforced at the API).
- [x] **Rollback** — revert the commit. No migration, no API change, no persisted state.

## Compatibility and rollback notes

**`/` and `/home` are now server-rendered on demand** rather than prerendered at build time. That is inherent to the fix — a response that depends on a cookie must not be built once and handed to everyone — and it is why Next marks the response `private`. I checked the Dockerfile, compose files, and nginx config: there is no CDN in front of the frontend today, and the page does no data fetching, so the cost is negligible. **If a CDN is ever put in front of `lemma.work`, `/` will need `Vary: Cookie`**, and it would be worth revisiting anonymous caching via a proxy rewrite instead.

**The fix depends on `session_cookie_domain` being set** in the deployed backend config, so the session cookie is shared across the parent domain rather than scoped to the API's own host. If it is unset in production, the frontend server never sees the cookie and the hint is always false — the flash persists exactly as before. That is a graceful no-op rather than a new failure, but it is worth confirming against the deployed config before assuming this is fixed in prod.

### Note for the reviewer

The decision is split across two files on purpose. `lib/auth/session-cookie.ts` holds the pure predicate with no framework imports; `lib/auth/server-session.ts` holds the `server-only` + `next/headers` binding. `server-only` refuses to load under the unit suite, which is node-only, so the split is what lets the decision be tested at all — the same shape as `clearFrontendSessionState` in `browser-session.ts`.

### Unrelated drift spotted

`lemma-frontend/public/openapi.json` is stale on `main` — the `sync-openapi-spec` prebuild regenerates it with an unrelated `OrganizationSlugAvailabilityResponse` change. I reverted it to keep this diff focused; it should land on its own.
