### PR TITLE
Stop asking people to enable what a grant already said

### DIFF
--- a/docs/product/coverage.md
+++ b/docs/product/coverage.md
@@ -18,7 +18,7 @@ only a promise marked `covered` with no test is.
 | `withdrawn` | 0 |
 | **total** | **161** |
 
-Scenario tests declaring a promise: 345.
+Scenario tests declaring a promise: 347.
 
 ## Contract coverage
 
@@ -36,7 +36,7 @@ the module suites may cover it — but it is untested *as product*.
 | Scenario | Status | Proven by |
 | --- | --- | --- |
 | `PS-AGENT-001` A person creates an agent and gives it a job | `covered` | `test_an_agent_can_be_changed`, `test_an_agent_is_created`, `test_a_duplicate_agent_name_is_refused` |
-| `PS-AGENT-002` An agent gets only the access it was granted | `covered` | `test_an_agents_reach_can_be_set`, `test_an_agents_grants_are_readable`, `test_an_agent_uses_github_only_when_granted`, `test_an_agent_cannot_call_an_ungranted_connector` |
+| `PS-AGENT-002` An agent gets only the access it was granted | `covered` | `test_an_agents_reach_can_be_set`, `test_a_data_grant_brings_its_own_tools`, `test_the_universal_abilities_need_no_declaring`, `test_an_agents_grants_are_readable`, `test_an_agent_uses_github_only_when_granted`, `test_an_agent_cannot_call_an_ungranted_connector` |
 | `PS-AGENT-003` A pod has an agent without anyone creating one | `covered` | `test_a_pod_can_be_asked_without_building_an_agent`, `test_deleting_an_agent_keeps_the_default` |
 | `PS-AGENT-005` A person gives an agent a memory | `covered` | `test_memory_comes_with_the_access_it_needs`, `test_memory_access_is_not_handed_out_unasked`, `test_memory_access_leaves_with_the_capability` |
 | `PS-AGENT-004` A person chooses which model an agent uses | `covered` | `test_runtime_profiles_are_listable`, `test_an_outsider_cannot_see_profiles`, `test_an_organization_can_add_a_provider`, `test_a_provider_key_is_never_returned`, `test_a_provider_can_be_archived_and_restored`, `test_an_outsider_cannot_add_a_provider` |

--- a/docs/product/journeys/agents-and-conversations.md
+++ b/docs/product/journeys/agents-and-conversations.md
@@ -43,6 +43,14 @@ it happens.
   access than that person has, even where the agent's own grants allow more.
 - When a person changes an agent's grants, the system shall apply the change to
   the next run and not to one already in flight.
+- When a person grants an agent pod data or a connected app, the system shall
+  give it the tools to use that grant without asking them to enable anything
+  else — a capability the grant already implies is not a second decision.
+- The system shall not let that inference widen access: tools it turns on are
+  still scoped by the grant that turned them on, and a grant on one kind of
+  resource shall not imply tools for another.
+- The system shall give every agent the ability to ask a person a question and
+  to request approval, whatever else it was or was not granted.
 
 **Contracts:** `agent.permissions.get`, `agent.permissions.replace`
 

--- a/lemma-backend/app/modules/agent/domain/context.py
+++ b/lemma-backend/app/modules/agent/domain/context.py
@@ -31,6 +31,11 @@ class AgentContext(BaseModel):
     # `memory_is_active`, which the run-context builder resolves once here so
     # the capability assembler and the brief builder cannot disagree about it.
     memory_enabled: bool = False
+    # This agent's grant summary, loaded once for the run. Toolset selection
+    # derives POD and CONNECTORS from it, and the tool assembler reuses it
+    # rather than reading the same rows a second time. Typed loosely here to
+    # keep this domain model free of a tools-layer import.
+    grant_summary: object | None = None
     # Rendered runtime brief (pod/user/granted resources) appended to the system
     # prompt. Built once per run by the runner; harness-neutral so it just rides
     # along on the context.

--- a/lemma-backend/app/modules/agent/services/agent_runner_service.py
+++ b/lemma-backend/app/modules/agent/services/agent_runner_service.py
@@ -244,6 +244,9 @@ class AgentRunnerService:
                 agent=agent,
                 conversation=conversation,
                 vision_mode=ctx.vision_mode,
+                # Already read while building the context; the assembler would
+                # otherwise load the same grants again on every run.
+                grants=getattr(ctx, "grant_summary", None),
             )
             # Remote harnesses (Codex/Claude-Code) reach every tool through the MCP
             # server, so they keep the full toolset list. The in-process LEMMA

--- a/lemma-backend/app/modules/agent/services/run_context_builder.py
+++ b/lemma-backend/app/modules/agent/services/run_context_builder.py
@@ -33,6 +33,7 @@ from app.modules.agent.services.workspace_location import (
     resolve_workspace_location,
 )
 from app.modules.agent.tools.context import ConversationContext
+from app.modules.agent.tools.tool_assembler import load_agent_grant_summary
 from app.modules.agent.tools.toolset_selection import resolve_toolset_names
 from app.modules.agent.services.vision_service import vision_delegate_available
 
@@ -74,9 +75,12 @@ async def build_run_context(
         }
     pod_cwd = pod_cwd_from_workspace_cwd(workspace_location.cwd)
     # Resolved from the run's *effective* toolsets, not the agent's configured
-    # ones, so the sub-agent withholding and the pod-default set are both
-    # accounted for -- the same list `RunToolAssembler` builds tools from.
-    run_toolsets, _ = resolve_toolset_names(agent, conversation)
+    # ones, so the always-on set, the grant-derived ones and the sub-agent
+    # withholding are all accounted for -- the same list `RunToolAssembler`
+    # builds tools from. The summary is carried on the context so the assembler
+    # can reuse it instead of reading the same grants again.
+    grant_summary = await load_agent_grant_summary(uow_factory, agent=agent)
+    run_toolsets, _ = resolve_toolset_names(agent, conversation, grants=grant_summary)
     ctx = ConversationContext(
         user_id=user_id,
         org_id=conversation.organization_id,
@@ -103,6 +107,7 @@ async def build_run_context(
         supports_pause_signal=(resolved_runtime.harness_kind == HarnessKind.LEMMA),
         is_pod_default_agent=(agent.id == POD_ASSISTANT_AGENT_ID),
         memory_enabled=memory_is_active(run_toolsets),
+        grant_summary=grant_summary,
         **surface_context,
     )
     with suppress(Exception):

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_tools.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_tools.py
@@ -8,6 +8,7 @@ import pytest
 import app.modules.agent.tools.user_interaction.pydantic_adapter as user_interaction_adapter
 from app.modules.agent.domain.entities import Agent, AgentRun, Conversation, Message
 from app.modules.agent.domain.prompts import build_agent_instructions
+from app.modules.agent.tools.toolset_selection import AgentGrantSummary
 from app.modules.agent.domain.value_objects import (
     AgentRuntimeConfig,
     AgentToolset,
@@ -141,16 +142,20 @@ async def test_default_pod_agent_gets_fixed_default_toolsets():
 
 
 @pytest.mark.asyncio
-async def test_user_created_agent_gets_only_its_selected_toolsets():
-    # A user-created agent must get EXACTLY the toolsets it was created with —
-    # the pod defaults (workspace CLI, skills, …) are NOT forced onto it.
+async def test_a_user_created_agent_gets_no_declarable_toolset_it_did_not_choose():
+    """The declared half stays exactly what the author picked.
+
+    Universal abilities are added on top (see the next test), but nothing from
+    the *declarable* set is ever implied — an agent that was not given a sandbox
+    shell or the ability to spawn sub-agents does not quietly acquire one.
+    """
     runner = AgentRunnerService(uow_factory=object(), harness_registry=object())
     agent = Agent(
         pod_id=uuid4(),
         user_id=uuid4(),
         name="reporter",
         instruction="Summarize records.",
-        toolsets=[AgentToolset.POD, AgentToolset.WEB_SEARCH],
+        toolsets=[AgentToolset.WEB_SEARCH],
     )
     conversation = Conversation(
         pod_id=agent.pod_id,
@@ -163,26 +168,61 @@ async def test_user_created_agent_gets_only_its_selected_toolsets():
         conversation=conversation,
     )
 
-    assert pod_toolset in toolsets
     assert web_search_toolset in toolsets
-    # Nothing from the pod defaults is implicitly added — including SUBAGENTS,
-    # which is opt-in for user-created agents.
     assert workspace_cli_toolset not in toolsets
-    assert user_interaction_toolset not in toolsets
     assert subagents_toolset not in toolsets
+    # POD is derived from a grant, and this agent holds none.
+    assert pod_toolset not in toolsets
 
 
 @pytest.mark.asyncio
-async def test_todo_toolset_gated_by_agent_definition(monkeypatch):
+async def test_every_agent_can_reach_a_person_whatever_it_was_given():
+    """`request_approval` is the seam where a human gets to say no.
+
+    It rides in USER_INTERACTION, which is why that toolset is universal rather
+    than a switch: withholding it never made an agent safer, it only removed the
+    place a person could intervene.
+    """
+    runner = AgentRunnerService(uow_factory=object(), harness_registry=object())
+    agent = Agent(
+        pod_id=uuid4(),
+        user_id=uuid4(),
+        name="narrow",
+        instruction="Answer questions.",
+        toolsets=[],
+    )
+    conversation = Conversation(
+        pod_id=agent.pod_id, user_id=agent.user_id, agent_id=agent.id
+    )
+
+    toolsets = await runner.tool_assembler.assemble(
+        agent=agent, conversation=conversation
+    )
+
+    assert user_interaction_toolset in toolsets
+
+
+@pytest.mark.asyncio
+async def test_todo_reaches_an_agent_that_never_declared_it(monkeypatch):
     # RunToolAssembler feeds BOTH the in-process harness and the remote MCP path,
-    # so a user-created agent gets the todo tools only when its toolsets include
-    # TODO — never implicitly.
+    # and a task list is conversation-scoped scratch with no access implication —
+    # so it is universal rather than a switch. The prompt still says nothing when
+    # the conversation has never planned anything.
     from app.modules.agent.tools import callable_tool_factory as ctf
 
-    async def _no_dynamic(self, *, agent, allow_subagents):  # noqa: ANN001
+    async def _no_dynamic(self, *, agent, allow_subagents, grants=None):  # noqa: ANN001
         return []
 
     monkeypatch.setattr(ctf.AgentCallableToolFactory, "build_toolsets", _no_dynamic)
+
+    # Toolset selection now reads the agent's grants (POD and CONNECTORS are
+    # derived from them), so the assembler opens a unit of work even when the
+    # dynamic tools above are stubbed out. Return an empty summary rather than a
+    # database.
+    async def _no_grants(self, *, pod_id, agent_id):  # noqa: ANN001
+        return AgentGrantSummary()
+
+    monkeypatch.setattr(ctf.AgentCallableToolFactory, "load_grant_summary", _no_grants)
 
     runner = AgentRunnerService(uow_factory=lambda: None, harness_registry=object())
 
@@ -201,7 +241,7 @@ async def test_todo_toolset_gated_by_agent_definition(monkeypatch):
         user_id=without_todo.user_id,
         agent_id=without_todo.id,
     )
-    assert not _has_todo(
+    assert _has_todo(
         await runner.tool_assembler.assemble(agent=without_todo, conversation=conv)
     )
 

--- a/lemma-backend/app/modules/agent/tests/unit/test_conversation_mcp_service.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_conversation_mcp_service.py
@@ -13,10 +13,16 @@ from app.modules.agent.domain.entities import Agent, Conversation
 from app.modules.agent.domain.value_objects import AgentToolset
 from app.modules.agent.services.conversation_mcp_service import ConversationMCPService
 from app.modules.agent.tools.context import BaseAgentContext
+from app.modules.agent.tools.toolset_selection import AgentGrantSummary
 
 
 class _SurfaceToolRequest(BaseModel):
     path: str
+
+
+async def _no_grant_summary(self, *, pod_id, agent_id):
+    del self, pod_id, agent_id
+    return AgentGrantSummary()
 
 
 @pytest.mark.asyncio
@@ -69,18 +75,26 @@ async def test_conversation_mcp_includes_surface_toolsets(monkeypatch):
         del self, conversation
         return [FunctionToolset[BaseAgentContext](tools=[telegram_send_file])]
 
-    async def fake_callable_toolsets(self, *, agent, allow_subagents=True):
+    async def fake_callable_toolsets(self, *, agent, allow_subagents=True, grants=None):
         # Unit test: must not touch the real database. The production
         # implementation runs a SQL query whenever the agent has an id (always
         # true, ids are auto-generated), which made this test depend on a live
         # Postgres and on loop-bound engine state shared across the session.
-        del self, agent, allow_subagents
+        del self, agent, allow_subagents, grants
         return []
 
     monkeypatch.setattr(
         ConversationMCPService,
         "_load_agent_context",
         fake_load_agent_context,
+    )
+    # Toolset selection derives POD/CONNECTORS from grants, so the assembler
+    # reads them before building any tool. Same reason as the stub above:
+    # this is a unit test and must not reach Postgres.
+    monkeypatch.setattr(
+        "app.modules.agent.tools.callable_tool_factory."
+        "AgentCallableToolFactory.load_grant_summary",
+        _no_grant_summary,
     )
     monkeypatch.setattr(
         "app.modules.agent.tools.callable_tool_factory."
@@ -135,12 +149,20 @@ async def test_conversation_mcp_exposes_todo_tools_when_agent_has_todo(monkeypat
         del self, conversation_id, agent_run_id
         return agent, conversation, ctx
 
-    async def fake_callable_toolsets(self, *, agent, allow_subagents=True):
-        del self, agent, allow_subagents
+    async def fake_callable_toolsets(self, *, agent, allow_subagents=True, grants=None):
+        del self, agent, allow_subagents, grants
         return []
 
     monkeypatch.setattr(
         ConversationMCPService, "_load_agent_context", fake_load_agent_context
+    )
+    # Toolset selection derives POD/CONNECTORS from grants, so the assembler
+    # reads them before building any tool. Same reason as the stub above:
+    # this is a unit test and must not reach Postgres.
+    monkeypatch.setattr(
+        "app.modules.agent.tools.callable_tool_factory."
+        "AgentCallableToolFactory.load_grant_summary",
+        _no_grant_summary,
     )
     monkeypatch.setattr(
         "app.modules.agent.tools.callable_tool_factory."
@@ -201,8 +223,8 @@ async def test_a_pausing_tool_reaches_a_person_over_mcp(monkeypatch):
         recorded.append(kwargs)
         return "lemma-mcp-deadbeef"
 
-    async def fake_callable_toolsets(self, *, agent, allow_subagents=True):
-        del self, agent, allow_subagents
+    async def fake_callable_toolsets(self, *, agent, allow_subagents=True, grants=None):
+        del self, agent, allow_subagents, grants
         return []
 
     monkeypatch.setattr(
@@ -211,6 +233,14 @@ async def test_a_pausing_tool_reaches_a_person_over_mcp(monkeypatch):
     monkeypatch.setattr(
         "app.modules.agent.services.conversation_mcp_service.record_pausing_tool_call",
         fake_record,
+    )
+    # Toolset selection derives POD/CONNECTORS from grants, so the assembler
+    # reads them before building any tool. Same reason as the stub above:
+    # this is a unit test and must not reach Postgres.
+    monkeypatch.setattr(
+        "app.modules.agent.tools.callable_tool_factory."
+        "AgentCallableToolFactory.load_grant_summary",
+        _no_grant_summary,
     )
     monkeypatch.setattr(
         "app.modules.agent.tools.callable_tool_factory."
@@ -279,8 +309,8 @@ async def test_an_ordinary_tool_is_not_put_on_the_record_first(monkeypatch):
         recorded.append(kwargs)
         return "lemma-mcp-deadbeef"
 
-    async def fake_callable_toolsets(self, *, agent, allow_subagents=True):
-        del self, agent, allow_subagents
+    async def fake_callable_toolsets(self, *, agent, allow_subagents=True, grants=None):
+        del self, agent, allow_subagents, grants
         return []
 
     monkeypatch.setattr(
@@ -289,6 +319,14 @@ async def test_an_ordinary_tool_is_not_put_on_the_record_first(monkeypatch):
     monkeypatch.setattr(
         "app.modules.agent.services.conversation_mcp_service.record_pausing_tool_call",
         fake_record,
+    )
+    # Toolset selection derives POD/CONNECTORS from grants, so the assembler
+    # reads them before building any tool. Same reason as the stub above:
+    # this is a unit test and must not reach Postgres.
+    monkeypatch.setattr(
+        "app.modules.agent.tools.callable_tool_factory."
+        "AgentCallableToolFactory.load_grant_summary",
+        _no_grant_summary,
     )
     monkeypatch.setattr(
         "app.modules.agent.tools.callable_tool_factory."

--- a/lemma-backend/app/modules/agent/tests/unit/test_toolset_selection.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_toolset_selection.py
@@ -1,0 +1,178 @@
+"""The three sources an agent's toolsets come from, and the order they combine in.
+
+These rules used to be one implication and one subtraction. They are now the
+difference between a person answering five questions in the agent editor and
+answering twelve, so they are worth pinning down away from a database.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from app.core.authorization.context import ResourceType
+from app.modules.agent.domain.value_objects import AgentToolset
+from app.modules.agent.tools.toolset_selection import (
+    ALWAYS_ON_TOOLSETS,
+    DECLARABLE_TOOLSETS,
+    AgentGrantSummary,
+    derived_toolsets,
+    resolve_toolsets,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _agent(*toolsets: AgentToolset):
+    return SimpleNamespace(
+        id=uuid4(), pod_id=uuid4(), user_id=uuid4(), name="a", toolsets=list(toolsets)
+    )
+
+
+def _conversation(*, is_sub_agent: bool = False):
+    metadata = {"is_sub_agent": True} if is_sub_agent else {}
+    return SimpleNamespace(id=uuid4(), metadata=metadata)
+
+
+def _grants(*resource_types: ResourceType) -> AgentGrantSummary:
+    return AgentGrantSummary.from_grants(
+        [(resource_type.value, uuid4()) for resource_type in resource_types]
+    )
+
+
+def test_the_declarable_and_always_on_sets_never_overlap():
+    """A toolset is either a person's decision or it is not. Both would mean the
+    editor shows a switch that changes nothing."""
+    assert not set(DECLARABLE_TOOLSETS) & set(ALWAYS_ON_TOOLSETS)
+
+
+def test_the_derived_ones_are_in_neither_set():
+    """POD and CONNECTORS come from a grant. Listing them as declarable would put
+    the same permission behind two controls, which is what this replaced."""
+    for toolset in (AgentToolset.POD, AgentToolset.CONNECTORS):
+        assert toolset not in DECLARABLE_TOOLSETS
+        assert toolset not in ALWAYS_ON_TOOLSETS
+
+
+def test_view_image_is_never_declarable():
+    """It is appended at run time from the model's own vision capability and is
+    never persisted, so offering it as a switch would be offering a no-op."""
+    assert AgentToolset.VIEW_IMAGE not in DECLARABLE_TOOLSETS
+    assert AgentToolset.VIEW_IMAGE not in ALWAYS_ON_TOOLSETS
+
+
+def test_every_agent_gets_the_always_on_set():
+    resolved = resolve_toolsets(_agent(), _conversation())
+
+    assert set(ALWAYS_ON_TOOLSETS) <= set(resolved.names)
+
+
+def test_a_declarable_toolset_is_never_implied():
+    resolved = resolve_toolsets(_agent(AgentToolset.WEB_SEARCH), _conversation())
+
+    assert AgentToolset.WEB_SEARCH in resolved.names
+    for toolset in DECLARABLE_TOOLSETS:
+        if toolset is not AgentToolset.WEB_SEARCH:
+            assert toolset not in resolved.names
+
+
+@pytest.mark.parametrize(
+    "resource_type",
+    [
+        ResourceType.FOLDER,
+        ResourceType.DOCUMENT,
+        ResourceType.DATASTORE_TABLE,
+        ResourceType.DATASTORE_RECORD,
+    ],
+)
+def test_any_data_grant_implies_pod_access(resource_type):
+    """Granting a folder and then ticking 'pod data' asked the same question
+    twice, and forgetting the second half failed silently."""
+    resolved = resolve_toolsets(
+        _agent(), _conversation(), grants=_grants(resource_type)
+    )
+
+    assert AgentToolset.POD in resolved.names
+    assert AgentToolset.POD in resolved.derived
+
+
+@pytest.mark.parametrize(
+    "resource_type",
+    [
+        ResourceType.CONNECTOR,
+        ResourceType.CONNECTOR_ACCOUNT,
+        ResourceType.CONNECTOR_AUTH_CONFIG,
+    ],
+)
+def test_any_connector_grant_implies_the_connector_tools(resource_type):
+    """The toolset never granted anything on its own — reaching an app always
+    needed the per-app grant as well."""
+    resolved = resolve_toolsets(
+        _agent(), _conversation(), grants=_grants(resource_type)
+    )
+
+    assert AgentToolset.CONNECTORS in resolved.names
+
+
+def test_a_function_grant_alone_implies_neither():
+    """Being allowed to run a function says nothing about reading pod data or
+    reaching a connected app."""
+    resolved = resolve_toolsets(
+        _agent(), _conversation(), grants=_grants(ResourceType.FUNCTION)
+    )
+
+    assert AgentToolset.POD not in resolved.names
+    assert AgentToolset.CONNECTORS not in resolved.names
+
+
+def test_no_grants_derives_nothing():
+    assert derived_toolsets(None) == frozenset()
+    assert derived_toolsets(AgentGrantSummary()) == frozenset()
+
+
+def test_a_sub_agent_loses_the_withheld_ones_even_though_they_are_always_on():
+    """The subtraction has to run last.
+
+    MESSAGING and SNOOZE are universal now, so an ordering that added them after
+    the sub-agent filter would hand a child run the two toolsets it is
+    specifically withheld from.
+    """
+    resolved = resolve_toolsets(_agent(), _conversation(is_sub_agent=True))
+
+    assert AgentToolset.MESSAGING not in resolved.names
+    assert AgentToolset.SNOOZE not in resolved.names
+    assert AgentToolset.SUBAGENTS not in resolved.names
+    # The rest of the always-on set survives.
+    assert AgentToolset.USER_INTERACTION in resolved.names
+    assert AgentToolset.TODO in resolved.names
+    assert resolved.allow_subagents is False
+
+
+def test_a_stale_declared_toolset_is_harmless():
+    """Nothing migrates existing rows, so agents still carry POD and CONNECTORS
+    from before they were derived. The effective set is a union, so a stale entry
+    simply stops mattering — it must not duplicate or raise."""
+    resolved = resolve_toolsets(
+        _agent(AgentToolset.POD, AgentToolset.CONNECTORS),
+        _conversation(),
+        grants=_grants(ResourceType.FOLDER),
+    )
+
+    assert resolved.names.count(AgentToolset.POD) == 1
+    assert resolved.names.count(AgentToolset.CONNECTORS) == 1
+
+
+def test_an_unknown_name_on_an_old_row_is_skipped():
+    resolved = resolve_toolsets(_agent("RETIRED_TOOLSET"), _conversation())
+
+    assert set(ALWAYS_ON_TOOLSETS) <= set(resolved.names)
+
+
+def test_the_pod_default_assistant_still_gets_its_fixed_set():
+    """A run with no agent is Lem, which has no grants of its own — it runs with
+    the user's permissions and takes its toolsets from the default set."""
+    from app.modules.agent.tools.registry import POD_DEFAULT_AGENT_TOOLSETS
+
+    resolved = resolve_toolsets(None, _conversation())
+
+    assert set(POD_DEFAULT_AGENT_TOOLSETS) <= set(resolved.names)

--- a/lemma-backend/app/modules/agent/tools/callable_tool_factory.py
+++ b/lemma-backend/app/modules/agent/tools/callable_tool_factory.py
@@ -28,6 +28,7 @@ from app.modules.agent.infrastructure.repositories import (
     AgentRepository,
 )
 from app.modules.agent.tools.context import BaseAgentContext
+from app.modules.agent.tools.toolset_selection import AgentGrantSummary
 from app.modules.function.contracts import (
     FunctionEntity,
     FunctionRunEntity,
@@ -132,7 +133,13 @@ class AgentCallableToolFactory:
         *,
         agent: Agent,
         allow_subagents: bool = True,
+        grants: AgentGrantSummary | None = None,
     ) -> list[FunctionToolset[BaseAgentContext]]:
+        """``function_<name>`` / ``agent_<name>`` tools for this agent's grants.
+
+        ``grants`` is the summary the caller already loaded for toolset
+        selection; passing it through spares a second read of the same rows.
+        """
         if agent.pod_id is None or agent.id is None:
             return []
 
@@ -140,11 +147,11 @@ class AgentCallableToolFactory:
         async with self.uow_factory() as uow:
             function_repo = create_function_repository(uow)
             agent_repo = AgentRepository(uow)
-            function_ids, agent_ids = await self._load_callable_resource_ids(
-                uow,
-                pod_id=agent.pod_id,
-                agent_id=agent.id,
-            )
+            if grants is None:
+                grants = await self._load_grant_summary(
+                    uow, pod_id=agent.pod_id, agent_id=agent.id
+                )
+            function_ids, agent_ids = grants.function_ids, grants.agent_ids
 
             for function_id in function_ids:
                 function = await function_repo.get(function_id)
@@ -175,38 +182,65 @@ class AgentCallableToolFactory:
         # conversations.
         return [FunctionToolset[BaseAgentContext](tools=tools)]
 
-    async def _load_callable_resource_ids(
+    async def load_grant_summary(
+        self, *, pod_id: UUID, agent_id: UUID
+    ) -> AgentGrantSummary:
+        """Everything one agent's grants decide, in one query.
+
+        Two consumers need this and they used to be able to disagree: the
+        callable tools below, and the toolset selection that now derives POD and
+        CONNECTORS from a grant rather than a second switch. Reading the table
+        once and handing the same answer to both is what keeps a tool from being
+        listed by one path and refused by the other.
+
+        Not filtered by permission id, unlike the callable-tool query it
+        replaces: "does this agent hold *any* grant on a folder" is a different
+        question from "may it execute this function", and a read-only grant
+        still means the agent should be able to reach pod data.
+        """
+        async with self.uow_factory() as uow:
+            return await self._load_grant_summary(uow, pod_id=pod_id, agent_id=agent_id)
+
+    async def _load_grant_summary(
         self,
         uow,
         *,
         pod_id: UUID,
         agent_id: UUID,
-    ) -> tuple[list[UUID], list[UUID]]:
+    ) -> AgentGrantSummary:
         from sqlalchemy import select
 
         stmt = select(
             ResourcePermissionGrantModel.resource_type,
             ResourcePermissionGrantModel.resource_id,
+            ResourcePermissionGrantModel.permission_id,
         ).where(
             ResourcePermissionGrantModel.pod_id == pod_id,
             ResourcePermissionGrantModel.grantee_type == "AGENT",
             ResourcePermissionGrantModel.grantee_id == agent_id,
-            ResourcePermissionGrantModel.permission_id.in_(
-                [Permissions.FUNCTION_EXECUTE, Permissions.AGENT_EXECUTE]
-            ),
         )
         rows = list((await uow.session.execute(stmt)).all())
-        function_ids = [
+        callable_rows = [
+            (resource_type, resource_id)
+            for resource_type, resource_id, permission_id in rows
+            if permission_id
+            in (Permissions.FUNCTION_EXECUTE, Permissions.AGENT_EXECUTE)
+        ]
+        function_ids = tuple(
             resource_id
-            for resource_type, resource_id in rows
+            for resource_type, resource_id in callable_rows
             if resource_type == "function"
-        ]
-        agent_ids = [
+        )
+        agent_ids = tuple(
             resource_id
-            for resource_type, resource_id in rows
+            for resource_type, resource_id in callable_rows
             if resource_type == "agent" and resource_id != agent_id
-        ]
-        return function_ids, agent_ids
+        )
+        return AgentGrantSummary.from_grants(
+            [(resource_type, resource_id) for resource_type, resource_id, _ in rows],
+            function_ids=function_ids,
+            agent_ids=agent_ids,
+        )
 
     def _build_function_tool(
         self, function: FunctionEntity, *, parent_agent: Agent

--- a/lemma-backend/app/modules/agent/tools/tool_assembler.py
+++ b/lemma-backend/app/modules/agent/tools/tool_assembler.py
@@ -12,11 +12,30 @@ from app.modules.agent.domain.entities import Agent, Conversation
 from app.modules.agent.domain.value_objects import AgentToolset
 from app.modules.agent.domain.vision import AgentVisionMode
 from app.modules.agent.tools.callable_tool_factory import AgentCallableToolFactory
-from app.modules.agent.tools.toolset_selection import resolve_toolset_names
+from app.modules.agent.tools.toolset_selection import (
+    AgentGrantSummary,
+    resolve_toolset_names,
+)
 from app.modules.agent.tools.registry import (
     resolve_agent_toolsets,
 )
 from app.modules.agent.services.run_phase_spans import run_phase
+
+
+async def load_agent_grant_summary(
+    uow_factory: UnitOfWorkFactory, *, agent: Agent
+) -> AgentGrantSummary:
+    """This agent's grant summary, or an empty one where it cannot have grants.
+
+    The pod default assistant is the empty case and not an error: it has no
+    ``Agent`` row of its own, runs with the user's permissions, and takes its
+    toolsets from the fixed default set rather than from anything granted to it.
+    """
+    if agent.pod_id is None or agent.id is None:
+        return AgentGrantSummary()
+    return await AgentCallableToolFactory(uow_factory).load_grant_summary(
+        pod_id=agent.pod_id, agent_id=agent.id
+    )
 
 
 class RunToolAssembler:
@@ -32,13 +51,23 @@ class RunToolAssembler:
         conversation: Conversation | None,
         include_final_answer: bool = False,
         vision_mode: AgentVisionMode | None = None,
+        grants: AgentGrantSummary | None = None,
     ) -> list[object]:
+        """Every tool this (agent, conversation) can reach.
+
+        ``grants`` lets a caller that already loaded the agent's grant summary
+        (the runner does, to build its context brief) hand it over instead of
+        paying for the same query twice. Callers without one -- the MCP server
+        and the approval executor -- leave it unset and it is loaded here, so
+        every path still resolves the same toolsets.
+        """
         with run_phase("tool_assembly") as span:
             toolsets = await self._assemble(
                 agent=agent,
                 conversation=conversation,
                 include_final_answer=include_final_answer,
                 vision_mode=vision_mode,
+                grants=grants,
             )
             span.set_attribute("lemma.toolsets", len(toolsets))
             return toolsets
@@ -81,8 +110,13 @@ class RunToolAssembler:
         conversation: Conversation | None,
         include_final_answer: bool,
         vision_mode: AgentVisionMode | None = None,
+        grants: AgentGrantSummary | None = None,
     ) -> list[object]:
-        toolset_names, allow_subagents = resolve_toolset_names(agent, conversation)
+        if grants is None and agent is not None and callable(self.uow_factory):
+            grants = await load_agent_grant_summary(self.uow_factory, agent=agent)
+        toolset_names, allow_subagents = resolve_toolset_names(
+            agent, conversation, grants=grants
+        )
         toolsets: list[object] = list(resolve_agent_toolsets(toolset_names))
         # TODO is conversation-scoped (its list lives in conversation metadata), so
         # it isn't a static singleton in the registry — build it per conversation
@@ -107,6 +141,7 @@ class RunToolAssembler:
                 await AgentCallableToolFactory(self.uow_factory).build_toolsets(
                     agent=agent,
                     allow_subagents=allow_subagents,
+                    grants=grants,
                 )
             )
         if (

--- a/lemma-backend/app/modules/agent/tools/toolset_selection.py
+++ b/lemma-backend/app/modules/agent/tools/toolset_selection.py
@@ -1,28 +1,106 @@
 """Which toolsets a run is entitled to, before any of them are built.
 
-Two rules decide this and both are easy to lose in the middle of assembly, so
-they live here where they can be read and tested without a database:
+An agent's toolsets come from three places, and only one of them is a person's
+decision:
 
-* **`USER_INTERACTION` implies `SKILLS`.** `display_resource` can only author
-  WIDGET content after reading the built-in `lemma-widget` skill, so an agent
-  granted one without the other would be given a tool it cannot use correctly.
-  This grants skill *reading* only -- no pod, shell, network or resource access
-  rides along with it.
-* **Depth is one.** A run that is itself a spawned sub-agent gets neither the
-  sub-agent controls nor the `agent_<name>` spawn tools, so a sub-agent cannot
-  spawn its own.
+* **Declared** — what the author chose, persisted on ``Agent.toolsets`` and
+  shown in the agent editor. Reserved for abilities where the answer is a
+  judgement rather than a fact: a sandbox shell, the open web, delegating to
+  other agents, voice, memory.
+* **Always on** — abilities every agent should simply have. Asking a person a
+  question and requesting approval are the two that matter most: withholding
+  ``request_approval`` does not make an agent safer, it removes the seam where a
+  human gets to say no.
+* **Derived** — implied by a grant the author already made. Granting a folder
+  and then separately ticking "pod data" asks the same question twice, and the
+  failure mode is silent: the agent cannot see the folder you just gave it.
 
-The depth rule reads `is_sub_agent`, stamped by `SubAgentService.spawn`, and
-deliberately not `parent_id`: a conversation can have a parent -- pinned under a
-project, say -- without being a sub-agent, and those keep their spawning
+The rules below all live here, rather than in the assembler, because three
+callers must agree on the answer exactly — the runner, the conversation/pod MCP
+server, and the approval executor. A tool that one of them believes in and
+another does not is a tool that lists and then fails to dispatch.
+
+Derivation reads grants, but this module stays synchronous and pure: the caller
+loads an ``AgentGrantSummary`` (one query, shared with the callable-tool factory
+that was already making it) and passes it in. That keeps every rule here
+testable without a database.
+
+**Depth is one.** A run that is itself a spawned sub-agent gets neither the
+sub-agent controls nor the ``agent_<name>`` spawn tools, so a sub-agent cannot
+spawn its own. That subtraction happens last, after the always-on set, or
+sub-agents would be handed back the very toolsets they are withheld from.
+
+The depth rule reads ``is_sub_agent``, stamped by ``SubAgentService.spawn``, and
+deliberately not ``parent_id``: a conversation can have a parent -- pinned under
+a project, say -- without being a sub-agent, and those keep their spawning
 ability.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+
+from app.core.authorization.context import ResourceType
 from app.modules.agent.domain.entities import Agent, Conversation
 from app.modules.agent.domain.value_objects import AgentToolset
 from app.modules.agent.tools.registry import POD_DEFAULT_AGENT_TOOLSETS
+
+# What the agent editor offers and ``Agent.toolsets`` is expected to hold. Each
+# one is a real decision with a cost or a blast radius behind it; everything
+# else an agent can do is either universal or already answered by a grant.
+DECLARABLE_TOOLSETS: tuple[AgentToolset, ...] = (
+    AgentToolset.WORKSPACE_CLI,
+    AgentToolset.WEB_SEARCH,
+    AgentToolset.SUBAGENTS,
+    AgentToolset.SPEECH,
+    AgentToolset.MEMORY,
+)
+
+# Given to every agent. None of these reaches pod data, the internet, or a
+# sandbox; each is either a way to involve a person or conversation-scoped
+# scratch.
+#
+# SKILLS was already implied by USER_INTERACTION (display_resource cannot author
+# WIDGET content without reading the built-in lemma-widget skill), and with
+# USER_INTERACTION universal the implication was universal too -- so it is
+# stated here rather than derived from a toolset that is now always present.
+#
+# MESSAGING and SNOOZE are one capability in practice: `message_user` does not
+# block, so an agent given the first without the second can send and then has no
+# way to be around when the reply lands. Messaging is fenced to pod members by
+# `resolve_pod_recipient`, which joins through PodMember and returns None for
+# anyone outside the pod -- so "reach a colleague" cannot become "reach a
+# stranger", and the capability is the pod's own membership list.
+ALWAYS_ON_TOOLSETS: tuple[AgentToolset, ...] = (
+    AgentToolset.USER_INTERACTION,
+    AgentToolset.SKILLS,
+    AgentToolset.SNOOZE,
+    AgentToolset.MESSAGING,
+    AgentToolset.TODO,
+)
+
+# Resource types whose grant implies the agent should be able to reach pod data
+# at all. Files and tables are the same toolset (`POD`), and the grant is what
+# actually scopes it -- the toolset only decides whether the tools are offered.
+_POD_DATA_RESOURCES = frozenset(
+    {
+        ResourceType.FOLDER,
+        ResourceType.DOCUMENT,
+        ResourceType.DATASTORE_TABLE,
+        ResourceType.DATASTORE_RECORD,
+    }
+)
+
+# Likewise for connected apps. The connector toolset never granted anything on
+# its own -- reaching an app has always needed a per-app grant as well -- so
+# requiring both was asking for the same permission twice.
+_CONNECTOR_RESOURCES = frozenset(
+    {
+        ResourceType.CONNECTOR,
+        ResourceType.CONNECTOR_ACCOUNT,
+        ResourceType.CONNECTOR_AUTH_CONFIG,
+    }
+)
 
 # Withheld from a sub-agent, each for its own reason:
 #
@@ -37,6 +115,60 @@ _SUB_AGENT_WITHHELD = frozenset(
 )
 
 
+@dataclass(frozen=True, slots=True)
+class AgentGrantSummary:
+    """What one agent has been granted, in the shape toolset selection needs.
+
+    Loaded once per run from a single query and shared with
+    ``AgentCallableToolFactory``, which was already reading the same table for
+    its ``function_<name>`` and ``agent_<name>`` tools.
+
+    An empty summary is the honest default for a caller that has no agent to
+    look up (the pod default assistant has no grants of its own -- it runs with
+    the user's permissions and gets its toolsets from the fixed default set).
+    """
+
+    function_ids: tuple[str, ...] = ()
+    agent_ids: tuple[str, ...] = ()
+    has_pod_data: bool = False
+    has_connectors: bool = False
+
+    @classmethod
+    def from_grants(
+        cls,
+        rows: list[tuple[str, object]],
+        *,
+        function_ids: tuple[str, ...] = (),
+        agent_ids: tuple[str, ...] = (),
+    ) -> "AgentGrantSummary":
+        """Build from ``(resource_type, resource_id)`` rows of one agent's grants."""
+        resource_types = {str(resource_type) for resource_type, _ in rows}
+        return cls(
+            function_ids=function_ids,
+            agent_ids=agent_ids,
+            has_pod_data=bool(
+                resource_types & {member.value for member in _POD_DATA_RESOURCES}
+            ),
+            has_connectors=bool(
+                resource_types & {member.value for member in _CONNECTOR_RESOURCES}
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedToolsets:
+    """The effective toolsets for one run, and why each one is there.
+
+    The breakdown is not decoration: the agent editor shows a person only what
+    they chose, while support questions ("why can this agent read that folder?")
+    are answered by the derived half.
+    """
+
+    names: list[AgentToolset] = field(default_factory=list)
+    allow_subagents: bool = True
+    derived: frozenset[AgentToolset] = frozenset()
+
+
 def is_sub_agent_run(conversation: Conversation | None) -> bool:
     """Whether this conversation was spawned as somebody else's sub-agent."""
     if conversation is None:
@@ -45,19 +177,62 @@ def is_sub_agent_run(conversation: Conversation | None) -> bool:
     return bool(metadata.get("is_sub_agent"))
 
 
-def resolve_toolset_names(
-    agent: Agent | None, conversation: Conversation | None
-) -> tuple[list[AgentToolset], bool]:
+def derived_toolsets(grants: AgentGrantSummary | None) -> frozenset[AgentToolset]:
+    """Toolsets a grant already implies, so nobody has to tick them twice."""
+    if grants is None:
+        return frozenset()
+    derived: set[AgentToolset] = set()
+    if grants.has_pod_data:
+        derived.add(AgentToolset.POD)
+    if grants.has_connectors:
+        derived.add(AgentToolset.CONNECTORS)
+    return frozenset(derived)
+
+
+def resolve_toolsets(
+    agent: Agent | None,
+    conversation: Conversation | None,
+    *,
+    grants: AgentGrantSummary | None = None,
+) -> ResolvedToolsets:
     """The toolsets this run may have, and whether it may spawn sub-agents.
 
     The pod default assistant -- a run with no specific agent -- gets the fixed
-    default set. A user-created agent gets what it was configured with, plus the
-    narrow runtime dependencies needed to use those correctly.
+    default set. A user-created agent gets what it was configured with, plus
+    everything universal, plus whatever its grants imply.
+
+    Order matters at the end: the sub-agent subtraction runs last, so a child
+    run does not receive MESSAGING and SNOOZE back through the always-on set.
     """
-    names = list(agent.toolsets if agent is not None else POD_DEFAULT_AGENT_TOOLSETS)
-    if AgentToolset.USER_INTERACTION in names and AgentToolset.SKILLS not in names:
-        names.append(AgentToolset.SKILLS)
+    declared = list(agent.toolsets if agent is not None else POD_DEFAULT_AGENT_TOOLSETS)
+    implied = derived_toolsets(grants)
+
+    names: list[AgentToolset] = []
+    seen: set[AgentToolset] = set()
+    for name in (*declared, *ALWAYS_ON_TOOLSETS, *sorted(implied, key=str)):
+        try:
+            toolset = AgentToolset(name)
+        except ValueError:  # pragma: no cover - a stale name on an old row
+            continue
+        if toolset in seen:
+            continue
+        seen.add(toolset)
+        names.append(toolset)
+
     allow_subagents = not is_sub_agent_run(conversation)
     if not allow_subagents:
         names = [name for name in names if name not in _SUB_AGENT_WITHHELD]
-    return names, allow_subagents
+    return ResolvedToolsets(
+        names=names, allow_subagents=allow_subagents, derived=implied
+    )
+
+
+def resolve_toolset_names(
+    agent: Agent | None,
+    conversation: Conversation | None,
+    *,
+    grants: AgentGrantSummary | None = None,
+) -> tuple[list[AgentToolset], bool]:
+    """``(names, allow_subagents)`` -- the tuple most callers actually want."""
+    resolved = resolve_toolsets(agent, conversation, grants=grants)
+    return resolved.names, resolved.allow_subagents

--- a/lemma-frontend/components/agents/agent-access-dialog.tsx
+++ b/lemma-frontend/components/agents/agent-access-dialog.tsx
@@ -81,6 +81,11 @@ const CATEGORIES: AccessCategory[] = [
 /**
  * Toolsets, said in terms of what the agent gains. The enum name is an
  * implementation detail — `WORKSPACE_CLI` told nobody anything.
+ *
+ * Deliberately wider than `TOOL_ORDER`: only the declarable ones render as
+ * rows, but an agent created before pod access became derived still *holds*
+ * `POD`, and `toolSetLabel` is what names it wherever it is shown. Drop an entry
+ * and that becomes a title-cased enum name in front of a user.
  */
 const TOOL_COPY: Record<string, { label: string; description: string; icon: LemmaIcon }> = {
     WORKSPACE_CLI: {
@@ -153,35 +158,41 @@ const TOOL_COPY: Record<string, { label: string; description: string; icon: Lemm
     },
 };
 
-/** Ordered so the abilities most agents want are decided first. */
+/**
+ * The only toolsets a person decides. Everything else an agent can do is either
+ * universal or already answered by a grant, and the server resolves it:
+ *
+ *   always on  — ask a person, skills, sleep/resume, message people, task list
+ *   derived    — pod data (any folder or table grant), connected apps (any
+ *                connector grant)
+ *   runtime    — vision, from the model's own capability
+ *
+ * Kept in step with `DECLARABLE_TOOLSETS` in
+ * `lemma-backend/app/modules/agent/tools/toolset_selection.py`. Nothing checks
+ * that for you: showing a switch the server ignores, or hiding one it honours,
+ * both fail silently.
+ *
+ * Ordered so the abilities most agents want are decided first.
+ */
 const TOOL_ORDER: string[] = [
     'WORKSPACE_CLI',
-    'POD',
     'WEB_SEARCH',
-    'SKILLS',
-    'USER_INTERACTION',
     'SUBAGENTS',
     'MEMORY',
-    'TODO',
     'SPEECH',
-    'SNOOZE',
-    'MESSAGING',
-    'VIEW_IMAGE',
-    'CONNECTORS',
 ];
 
 const EACH_PERSON_ACCOUNT = '__each_person__';
 
 /**
- * Memory keeps its facts in pod files, and carries no tools of its own to read
- * or write them with — so on an agent that has neither the workspace shell nor
- * pod data it is a switch that does nothing. Say so on the row rather than
- * letting someone turn it on and wonder why the agent never remembers.
+ * Memory keeps its facts in pod files and carries no tools of its own to read or
+ * write them with. Pod access is no longer a switch — it comes from granting a
+ * folder or a table — so the two ways to make memory work are the workspace
+ * shell or any data grant. Say so on the row rather than letting someone turn it
+ * on and wonder why the agent never remembers.
  */
-const MEMORY_FILE_TOOLS: string[] = ['WORKSPACE_CLI', 'POD'];
-
-function memoryNeedsAFileTool(tool: string, selected: readonly string[]) {
-    return tool === 'MEMORY' && !MEMORY_FILE_TOOLS.some((entry) => selected.includes(entry));
+function memoryNeedsAFileTool(tool: string, selected: readonly string[], grantedData: boolean) {
+    return tool === 'MEMORY' && !selected.includes('WORKSPACE_CLI') && !grantedData;
 }
 
 function toolCopy(tool: string) {
@@ -518,6 +529,13 @@ export function AgentAccessDialog({
                     <section className="agent-access-pane" aria-label={activeCategory.label}>
                         <header className="agent-access-pane-header">
                             <p className="agent-access-pane-blurb">{activeCategory.blurb}</p>
+                            {category === 'tools' ? (
+                                <p className="agent-access-pane-blurb">
+                                    Every agent can already ask you a question, request approval, keep a task
+                                    list, message people in this pod, and pause and resume. Reaching pod data
+                                    and connected apps comes from granting them, not from a switch here.
+                                </p>
+                            ) : null}
                             {isSearchable ? (
                                 <div className="agent-access-search">
                                     <Search className="agent-access-search-icon h-4 w-4" />
@@ -538,14 +556,15 @@ export function AgentAccessDialog({
                                 <div className="agent-access-list">
                                     {TOOL_ORDER
                                         .filter((tool) => Object.values(ToolSet).includes(tool as ToolSet))
-                                        .concat(
-                                            Object.values(ToolSet).filter((tool) => !TOOL_ORDER.includes(tool)),
-                                        )
                                         .filter((tool) => matches(query, toolCopy(tool).label, toolCopy(tool).description))
                                         .map((tool) => {
                                             const copy = toolCopy(tool);
                                             const Icon = copy.icon;
-                                            const unmet = memoryNeedsAFileTool(tool, selectedTools);
+                                            const unmet = memoryNeedsAFileTool(
+                                                tool,
+                                                selectedTools,
+                                                selectedFolders.length > 0 || selectedTables.length > 0,
+                                            );
 
                                             return (
                                                 <AccessRow
@@ -555,7 +574,7 @@ export function AgentAccessDialog({
                                                     title={copy.label}
                                                     description={
                                                         unmet
-                                                            ? `${copy.description} Add Workspace or Pod data — without one of them it has no way to read or write its files.`
+                                                            ? `${copy.description} Add Workspace, or grant it a folder or table — without one of those it has no way to read or write its files.`
                                                             : copy.description
                                                     }
                                                     onToggle={() => toggleTool(tool as ToolSet)}

--- a/lemma-skills/lemma-builder/references/agents.md
+++ b/lemma-skills/lemma-builder/references/agents.md
@@ -81,26 +81,43 @@ Optional fields: `input_schema` (typed input when other systems invoke the agent
 
 ## Toolsets
 
-Grant only the toolsets the job needs:
+Only five are a decision. Set those on the agent; the rest arrive on their own.
+
+- **Declared** — `WORKSPACE_CLI`, `WEB_SEARCH`, `SUBAGENTS`, `SPEECH`, `MEMORY`.
+  Put these in `tool_sets`. Grant only what the job needs.
+- **Always on** — `USER_INTERACTION`, `SKILLS`, `SNOOZE`, `MESSAGING`, `TODO`.
+  Every agent has them; listing them changes nothing.
+- **Derived** — `POD` follows any folder or table grant, `CONNECTORS` follows any
+  connector grant. Grant the resource and the tools appear. Do **not** also list
+  the toolset: it was the same permission asked twice, and forgetting the second
+  half failed silently.
+- **Runtime** — `VIEW_IMAGE` comes from the model's own vision capability and is
+  never stored on an agent.
+
+A stale `POD` or `CONNECTORS` in an older agent's `tool_sets` is harmless — the
+effective set is the union — but do not write new ones.
 
 | Toolset | Enables |
 | --- | --- |
-| `POD` | read/query pod tables and records, read/search pod files, and mint file URLs (in-app member link or a public hit-capped share link) — grant-checked against the agent's own grants |
-| `WORKSPACE_CLI` | a sandbox shell with the `lemma` CLI — the most powerful and broadest toolset. Includes `view_image` (vision-gated: silently withheld if the active model has no vision capability) |
-| `SKILLS` | loading skills available in the workspace; also added automatically at runtime when `USER_INTERACTION` is configured so widget-capable agents can load `lemma-widget` |
-| `WEB_SEARCH` | web search |
-| `USER_INTERACTION` | ask multiple-choice questions (`ask_user`), show resources/files/tables/widgets (`display_resource`), and gate sensitive actions behind approval (`request_approval`) — behaviors & schemas in `agent-tools.md` |
-| `SPEECH` | speak replies and transcribe voice notes (`say` / `listen`) — see `agent-tools.md` |
-| `SUBAGENTS` | async sub-agent orchestration — spawn/await/list child conversations, including another instance of itself (see *Agents & Functions as Tools*) |
-| `CONNECTORS` | call third-party APIs through the org's connector installs, without a sandbox. **Deferred**: an org with a couple of MCP servers can expose thousands of operations, so these tools are not in the prompt prefix — the agent finds them with `search_tools` first. Then `search_connector_operations` (leave `auth_config` unset to search **every** install — each hit names the one to run it against) and `run_connector_operation`; `describe_connector_operation` only if you want the full input schema up front, `list_connectors` only to see what is installed. Needs a `connector:<name>:use` grant per app — the toolset alone grants nothing |
-| `TODO` | a task list (`write_todos`) for planning multi-step work — conversation-scoped scratch for the agent, not pod state. Skip it for single-step requests |
-| `MEMORY` | durable facts kept between conversations, in ordinary pod files: `/memory` for what the whole pod should know, `/me` for what is true of one person only. `AGENTS.md` in each scope is read into every run automatically, so it must stay a short index of pointers — it is capped, and the overflow is truncated with a marker. Carries **no tools of its own**: pair it with `WORKSPACE_CLI` or `POD`, or the agent is told to remember things it has no way to write. Granting it also grants `folder.write` on `/memory`, and removing it takes that back |
-| `SNOOZE` | suspend the current turn and resume it later after a delay (`snooze`), capped at 24h. Opt-in: waking replays the whole conversation, so grant it only to agents whose work genuinely has a gap in the middle |
-| `MESSAGING` | look up who is in the pod, and reach a *member who is not in this conversation* on whichever surface they last used — or by email, cold, if they have never messaged the bot — with a copy always landing in their Lemma inbox (`message_user` / `check_messages` / `list_pod_members`). Opt-in, and a real capability to hand out: it also exposes the member list, and the recipient sees the pod's bot and extends it the trust they extend to Lemma, so every message names both the agent and the human whose authority the run carries. It does **not** pause the run — the reply is handled by the recipient's own agent, under their permissions, guided by the `background_instruction`. Pair it with `SNOOZE` for any agent that needs the answer in the same run, since nothing wakes it otherwise. Holding the toolset **is** the grant — there is no second surface-level switch to find. Reaching the person the run belongs to needs nothing at all: the run already carries their delegated authority |
+| `POD` | **Derived — any folder or table grant.**  read/query pod tables and records, read/search pod files, and mint file URLs (in-app member link or a public hit-capped share link) — grant-checked against the agent's own grants |
+| `WORKSPACE_CLI` | **Declared.**  a sandbox shell with the `lemma` CLI — the most powerful and broadest toolset. Includes `view_image` (vision-gated: silently withheld if the active model has no vision capability) |
+| `SKILLS` | **Always on.**  loading skills available in the workspace; also added automatically at runtime when `USER_INTERACTION` is configured so widget-capable agents can load `lemma-widget` |
+| `WEB_SEARCH` | **Declared.**  web search |
+| `USER_INTERACTION` | **Always on.**  ask multiple-choice questions (`ask_user`), show resources/files/tables/widgets (`display_resource`), and gate sensitive actions behind approval (`request_approval`) — behaviors & schemas in `agent-tools.md` |
+| `SPEECH` | **Declared.**  speak replies and transcribe voice notes (`say` / `listen`) — see `agent-tools.md` |
+| `SUBAGENTS` | **Declared.**  async sub-agent orchestration — spawn/await/list child conversations, including another instance of itself (see *Agents & Functions as Tools*) |
+| `CONNECTORS` | **Derived — any connector grant.**  call third-party APIs through the org's connector installs, without a sandbox. **Deferred**: an org with a couple of MCP servers can expose thousands of operations, so these tools are not in the prompt prefix — the agent finds them with `search_tools` first. Then `search_connector_operations` (leave `auth_config` unset to search **every** install — each hit names the one to run it against) and `run_connector_operation`; `describe_connector_operation` only if you want the full input schema up front, `list_connectors` only to see what is installed. Needs a `connector:<name>:use` grant per app — the toolset alone grants nothing |
+| `TODO` | **Always on.**  a task list (`write_todos`) for planning multi-step work — conversation-scoped scratch for the agent, not pod state. Skip it for single-step requests |
+| `MEMORY` | **Declared.**  durable facts kept between conversations, in ordinary pod files: `/memory` for what the whole pod should know, `/me` for what is true of one person only. `AGENTS.md` in each scope is read into every run automatically, so it must stay a short index of pointers — it is capped, and the overflow is truncated with a marker. Carries **no tools of its own**: pair it with `WORKSPACE_CLI` or `POD`, or the agent is told to remember things it has no way to write. Granting it also grants `folder.write` on `/memory`, and removing it takes that back |
+| `SNOOZE` | **Always on.**  suspend the current turn and resume it later after a delay (`snooze`), capped at 24h. Opt-in: waking replays the whole conversation, so grant it only to agents whose work genuinely has a gap in the middle |
+| `MESSAGING` | **Always on.**  look up who is in the pod, and reach a *member who is not in this conversation* on whichever surface they last used — or by email, cold, if they have never messaged the bot — with a copy always landing in their Lemma inbox (`message_user` / `check_messages` / `list_pod_members`). Opt-in, and a real capability to hand out: it also exposes the member list, and the recipient sees the pod's bot and extends it the trust they extend to Lemma, so every message names both the agent and the human whose authority the run carries. It does **not** pause the run — the reply is handled by the recipient's own agent, under their permissions, guided by the `background_instruction`. Pair it with `SNOOZE` for any agent that needs the answer in the same run, since nothing wakes it otherwise. Holding the toolset **is** the grant — there is no second surface-level switch to find. Reaching the person the run belongs to needs nothing at all: the run already carries their delegated authority |
 
-For pod files and data, prefer `POD` (typed, grant-checked table/record/file tools).
-`WORKSPACE_CLI` is the escape hatch when the agent needs a real shell. There is no
-separate file-system toolset — file access is part of `POD`, gated by folder grants.
+For pod files and data you grant the folder or table and `POD` follows — typed,
+grant-checked table/record/file tools. `WORKSPACE_CLI` is the escape hatch when
+the agent needs a real shell, and it is a declared choice because a shell is
+broader than anything a grant describes. There is no separate file-system
+toolset: file access is part of `POD`, scoped by the folder grants that produced
+it.
 
 ## Using files (search-first → read markdown → page → view image)
 

--- a/tests/scenarios/journeys/agents_and_conversations/test_agent_lifecycle.py
+++ b/tests/scenarios/journeys/agents_and_conversations/test_agent_lifecycle.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from harness import capability, covers, journey, proves, scenario
+from harness.steps.agent import answers, attempts
 from harness.steps.datastore import column
 
 pytestmark = [journey("Agents and conversations"), capability("Define an agent")]
@@ -183,3 +184,93 @@ class TestModelProfiles:
         )
 
         assert response.status_code >= 400, response.status_code
+
+
+@scenario("Granting a table is enough — the agent needs no second switch for it")
+@proves("PS-AGENT-002")
+@covers("agent.permissions.replace", "agent.conversation.create")
+async def test_a_data_grant_brings_its_own_tools(pod):
+    """This agent declares no toolsets at all.
+
+    Pod access used to be two decisions: grant the table, then separately enable
+    the pod tools. Forgetting the second failed silently — the agent could not
+    see the table it had just been given. A tool no toolset exposes fails the
+    run, so this passing is the derivation working.
+    """
+    alice, the_pod = pod
+    agent = await alice.creates_an_agent(in_pod=the_pod, toolsets=[])
+    table = await alice.creates_a_table(in_pod=the_pod, columns=[column("title")])
+    await alice.replaces_agent_grants(
+        agent["name"],
+        grants=[
+            {
+                "resource_type": "datastore_table",
+                "resource_name": table["name"],
+                "permission_ids": ["datastore.table.read", "datastore.record.read"],
+            }
+        ],
+        in_pod=the_pod,
+    )
+
+    conversation = await alice.starts_a_conversation(
+        in_pod=the_pod,
+        with_agent=agent["name"],
+        saying="What is in the table?",
+        where_the_agent=[
+            attempts("pod_get_records", table_name=table["name"]),
+            answers("Nothing yet."),
+        ],
+    )
+    await alice.waits_for_the_run_to_settle(conversation=conversation, in_pod=the_pod)
+
+    # The call and its return are two messages; only the return carries the
+    # result, which is the half that says whether the tool actually ran.
+    messages = await alice.messages_in(conversation, in_pod=the_pod)
+    returned = next(
+        (
+            message["tool_result"]
+            for message in messages
+            if message.get("tool_name") == "pod_get_records"
+            and isinstance(message.get("tool_result"), dict)
+        ),
+        None,
+    )
+    assert returned is not None, (
+        f"the agent never got the pod tools its grant implies: {messages}"
+    )
+    assert returned.get("success") is True, returned
+
+
+@scenario("An agent that declares nothing can still plan its work")
+@proves("PS-AGENT-002")
+@covers("agent.conversation.create")
+async def test_the_universal_abilities_need_no_declaring(pod):
+    """A task list is conversation-scoped scratch with no access implication.
+
+    It is one of the abilities every agent simply has now, along with asking a
+    person a question and requesting approval — the seam where a human gets to
+    say no, which was never made safer by being optional.
+    """
+    alice, the_pod = pod
+    agent = await alice.creates_an_agent(in_pod=the_pod, toolsets=[])
+
+    conversation = await alice.starts_a_conversation(
+        in_pod=the_pod,
+        with_agent=agent["name"],
+        saying="Plan something.",
+        where_the_agent=[
+            attempts("write_todos", todos=["- [ ] Work out what to do"]),
+            answers("Planned."),
+        ],
+    )
+    await alice.waits_for_the_run_to_settle(conversation=conversation, in_pod=the_pod)
+
+    planned = next(
+        (
+            message
+            for message in await alice.messages_in(conversation, in_pod=the_pod)
+            if message.get("tool_name") == "write_todos"
+        ),
+        None,
+    )
+    assert planned is not None, "an agent that declared nothing could not plan"


### PR DESCRIPTION
Stacked on #459 — review that first, or use the compare against
`lemma/agent-memory-capability` to see only this change.

## What changes

The agent editor drops from **twelve switches to five**. What a person decides:

| | |
|---|---|
| **Declared** | Workspace · Web search · Delegation · Memory · Speech |
| **Always on** | Ask a person · Skills · Sleep and resume · Message people · Task list |
| **Derived** | Pod data ← any folder or table grant · Connected apps ← any connector grant |
| **Runtime** | Vision, from the model's own capability |

Granting a folder is now enough — the agent gets the tools to use it. Nothing
migrates: the effective set is a union, so a `POD` or `CONNECTORS` still stored
on an older agent simply stops mattering.

## Why

Twelve switches were not twelve decisions.

**Two of them asked the same question a grant had already answered**, and got it
wrong in the dangerous direction: grant an agent a folder, forget to also tick
"Pod data", and it silently cannot see the folder you just gave it. Connectors
was the clearer case — the builder skill already said the quiet part: *"Needs a
`connector:<name>:use` grant per app — **the toolset alone grants nothing**."*
The switch gated tool *visibility* while the grant gated tool *use*. The
frontend copy apologised for it in place: *"This is the ability, not the list…
both are required to act in one."*

**One was actively harmful as a switch.** `USER_INTERACTION` holds
`request_approval`. Withholding it never made an agent safer — it removed the
seam where a person gets to say no.

**One was already a lie.** `VIEW_IMAGE` is marked in the enum as *"Reserved:
never persisted on Agent.toolsets"* and is appended at run time from the model's
vision capability. The editor showed a "Vision" row for it anyway. That toggle
did nothing in either position.

### Notes on the shape

**Messaging cannot leave the pod.** `resolve_pod_recipient` joins through
`PodMember`, so an email address that is not a member's resolves to `None` and
the tool refuses with *"No member of this pod matches"*. "Cold" in the docs
means *a pod member who has never written to the bot* — chat platforms cannot
open a thread, email can. That is what made it safe to make universal.

**Messaging and Sleep go together.** `message_user` does not block, so an agent
with the first and not the second can send and then has no way to be around when
the reply lands.

**The sub-agent subtraction runs last.** Messaging and Sleep are universal now,
so an ordering that added them after the filter would hand a child run the two
toolsets it is specifically withheld from. There is a test whose only job is to
pin that ordering.

**Derivation reads grants, but the rules stayed synchronous.** Making
`resolve_toolset_names` async would have touched the three callers that must
agree exactly — the runner, the MCP server, the approval executor — and a tool
one of them believes in and another does not is a tool that lists and then fails
to dispatch. Instead the caller loads an `AgentGrantSummary` and passes it in,
so every rule stays pure and testable without a database. That summary is **one
query, shared** with `AgentCallableToolFactory`, which was already reading the
same rows for its `function_`/`agent_` tools, and it rides on the run context so
the assembler does not read them a second time. No extra round trip on any path.

**The frontend `.concat()` is gone.** The dialog used to render any toolset
missing from `TOOL_ORDER` as a raw enum name with an empty description — so a
forgotten toolset shipped *looking broken* rather than being absent. It now
renders the declarable list and nothing else. `TOOL_COPY` deliberately stays
wider, because an older agent still *holds* `POD` and something has to name it.

## How to verify

```bash
make quality
```

```bash
cd lemma-backend && uv run pytest -m "not e2e" -q
```

```bash
make test-backend-e2e
```

```bash
cd tests/scenarios && uv run pytest journeys/agents_and_conversations -q
```

```bash
cd lemma-frontend && npm test && npm run lint
```

The two scenarios worth reading are in `test_agent_lifecycle.py`. Both create an
agent with **no toolsets at all**: one grants it a table and has it read the
table, the other has it plan its work. A tool no toolset exposes fails the run,
so those passing is the derivation and the always-on set actually working —
end to end, through the real API, not against a stub.

`test_toolset_selection.py` covers the rules themselves: the sets never overlap,
a declarable toolset is never implied, each data and connector resource type
implies its toolset, a function grant implies neither, a stale declared entry
does not duplicate, and a sub-agent still loses what it is withheld.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Compatibility** — see below

Not applicable: no migrations, no API surface change (the `AgentToolset` enum is
unchanged; only which of its members the editor offers).

## Compatibility and rollback notes

**API.** Unchanged. `Agent.toolsets` still accepts every enum member, and
declaring a now-derived one is accepted and harmless rather than rejected —
older clients and existing pod bundles keep working untouched.

**Behaviour.** Every agent gains the always-on set. For most that is strictly
more capable; the one to know about is `MESSAGING`, which every agent now has,
fenced to pod members. Agents that previously declared `POD` or `CONNECTORS`
without holding a matching grant keep them, because declared ∪ derived — the
switch stops being *required*, it does not start being *revoked*.

**Rollback.** Revert the commit. Nothing is written or migrated, so agents
return to their stored `tool_sets` exactly as they are today. Agents created
during the window with an empty `tool_sets` and only grants would lose their
derived pod access on revert and need the toolset ticked — worth knowing before
reverting after a long soak.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
