### PR TITLE
Put the transcript's cards back in chronological order, and give a voice note somewhere to play

### DIFF
--- a/lemma-frontend/components/lemma/assistant/assistant-experience.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-experience.tsx
@@ -33,6 +33,7 @@ import { cn } from "@/lib/utils";
 import { DEFAULT_RESPONDER_NAME } from "@/lib/utils/agents";
 import { LEM_SEED } from "@/lib/identity/seeded-identity";
 import { ResourceIdentity } from "@/components/shared/resource-identity";
+import { Button } from "@/components/ui/button";
 import type {
   AssistantRenderableMessage,
 } from "lemma-sdk/react";
@@ -566,15 +567,17 @@ export function AssistantExperienceView({
   const composerStatus = (
     <>
       {interactionPending ? (
-        <button
+        <Button
           type="button"
+          variant="link"
+          size="xs"
           onClick={scrollToPendingInteraction}
-          className="focus-ring -mx-1 rounded-md px-1 py-0.5 text-left text-xs text-[var(--action-primary)] hover:underline"
+          className="h-auto px-0 text-xs font-normal"
         >
           {pendingInteractionIsAsk
             ? "Answer the question to continue"
             : "Approve or reject to continue"}
-        </button>
+        </Button>
       ) : null}
       {showComposerStatus && runStatusModel ? (
         <LiveRunStatusLine status={runStatusModel} />

--- a/lemma-frontend/components/lemma/assistant/assistant-experience.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-experience.tsx
@@ -21,12 +21,13 @@ import type {
 import {
   buildDisplayMessageRows,
   findPendingUserApprovalInvocation,
+  isAskUserToolName,
   latestPlanSummary,
   latestUserIndex,
 } from "lemma-sdk";
 // Rows → turns: the conversation-shaped model (ask, work pill, speech,
 // artifacts, interaction cards) the transcript renders.
-import { buildChatTurns } from "@/lib/assistant/turns";
+import { buildChatTurns, interactionAnchorId } from "@/lib/assistant/turns";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { DEFAULT_RESPONDER_NAME } from "@/lib/utils/agents";
@@ -344,6 +345,19 @@ export function AssistantExperienceView({
   // the composer stays put — but answering is the card's job, so the composer
   // refuses to send until the interaction resolves.
   const interactionPending = !!activePendingApprovalInvocation;
+  // A blocked composer has to be able to point at what is blocking it. The card
+  // is the only way to answer and the input refuses to send until it resolves,
+  // so if the reader has scrolled away from it — or a tall card below it pushed
+  // it off screen — the conversation has no visible way forward.
+  const pendingInteractionCallId = activePendingApprovalInvocation?.toolCallId ?? null;
+  const pendingInteractionIsAsk = !!activePendingApprovalInvocation
+    && isAskUserToolName(activePendingApprovalInvocation.toolName);
+  const scrollToPendingInteraction = useCallback(() => {
+    if (!pendingInteractionCallId) return;
+    document
+      .getElementById(interactionAnchorId(pendingInteractionCallId))
+      ?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }, [pendingInteractionCallId]);
 
   const canLoadOlder = hasOlderMessages && !isLoadingMessages && !isLoadingOlderMessages;
   const loadOlder = useCallback(() => {
@@ -548,9 +562,20 @@ export function AssistantExperienceView({
     : failedFileCount > 0
       ? `${pluralize(failedFileCount, "file")} failed to upload`
       : null;
-  const hasComposerStatus = showComposerStatus || !!uploadStatusLabel;
+  const hasComposerStatus = showComposerStatus || !!uploadStatusLabel || interactionPending;
   const composerStatus = (
     <>
+      {interactionPending ? (
+        <button
+          type="button"
+          onClick={scrollToPendingInteraction}
+          className="focus-ring -mx-1 rounded-md px-1 py-0.5 text-left text-xs text-[var(--action-primary)] hover:underline"
+        >
+          {pendingInteractionIsAsk
+            ? "Answer the question to continue"
+            : "Approve or reject to continue"}
+        </button>
+      ) : null}
       {showComposerStatus && runStatusModel ? (
         <LiveRunStatusLine status={runStatusModel} />
       ) : null}

--- a/lemma-frontend/components/lemma/assistant/assistant-turn.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-turn.tsx
@@ -9,8 +9,11 @@
 //     thought, each tool row still drilling into its full details
 //   - speech is speech: narration beats and short answers are left bubbles;
 //     a long or structured answer is a doc card with real heading hierarchy
-//   - deliverables arrive as artifact cards (video/images play inline)
+//   - deliverables arrive as artifact cards (video/images/audio play inline)
 //   - ask_user and request_approval are in-chat cards where the run paused
+//
+// Beats, cards and questions all come out of `turn.items` in the order they
+// happened — a card never jumps ahead of the question that follows it.
 //
 // Everything here is fed by the pure turn model in lib/assistant/turns.ts.
 
@@ -40,6 +43,7 @@ import {
   answerIsDocument,
   chatTurnFingerprint,
   completedTurnStatusLabel,
+  interactionAnchorId,
   type ChatArtifact,
   type ChatTurn,
   type TraceEntry,
@@ -424,9 +428,9 @@ function FileArtifactCard({ artifact, onOpen }: { artifact: ChatArtifact; onOpen
     : <div className={className}>{body}</div>;
 }
 
-/** Video and image artifacts fetch a short-lived file URL and play inline,
- * the way a messenger renders media. Anything that fails degrades to the
- * plain file card. */
+/** Video, image and audio artifacts fetch a short-lived file URL and play
+ * inline, the way a messenger renders media. Anything that fails degrades to
+ * the plain file card. */
 function MediaArtifactCard({ artifact, podId, onOpen }: { artifact: ChatArtifact; podId: string | null; onOpen?: () => void }) {
   const urlQuery = useQuery({
     queryKey: ["chat-artifact-url", podId, artifact.path],
@@ -447,6 +451,25 @@ function MediaArtifactCard({ artifact, podId, onOpen }: { artifact: ChatArtifact
   ) : artifact.href ? (
     <Link href={artifact.href} className="lchat-file-go">Open</Link>
   ) : null;
+  // Audio has no frame to fill: it is a player strip, not a stage, so it keeps
+  // the card's own background instead of the video stock.
+  if (artifact.kind === "audio") {
+    return (
+      <div className="lchat-media">
+        <div className="lchat-audio">
+          {!urlQuery.data
+            ? <InlineLoader size="xs" />
+            : <audio className="lchat-audio-player" controls preload="metadata" src={urlQuery.data} />}
+        </div>
+        <div className="lchat-media-meta">
+          <span className="lchat-file-n">{artifact.name}</span>
+          {meta ? <span className="lchat-file-m">{meta}</span> : null}
+          {openControl}
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="lchat-media">
       <div className={artifact.kind === "video" ? "lchat-media-stage lchat-media-stage-video" : "lchat-media-stage"}>
@@ -579,10 +602,43 @@ export const AssistantTurnView = memo(function AssistantTurnView({
           return <div key={item.id} className="lchat-notice">{item.text}</div>;
         }
 
+        if (item.kind === "artifact") {
+          const artifact = item.artifact;
+          // Open beside the conversation in the presentation stage — the
+          // same handler the display_resource cards have always used.
+          const openInStage = onNavigateResource ? () => onNavigateResource("display_resource", artifact.toolCallId ?? artifact.key, {
+            request: { type: "FILE", path: artifact.path, loadingMessages: [] },
+            conversationId: activeConversationId,
+          }) : undefined;
+          return (
+            <div key={item.id} className="lchat-atts">
+              {artifact.kind === "file"
+                ? <FileArtifactCard artifact={artifact} onOpen={openInStage} />
+                : <MediaArtifactCard artifact={artifact} podId={podId} onOpen={openInStage} />}
+            </div>
+          );
+        }
+
+        if (item.kind === "resource") {
+          return (
+            <div key={item.id} className="lchat-resources">
+              <DisplayResourceCards
+                cards={[item.card]}
+                activeConversationId={activeConversationId}
+                onNavigateResource={onNavigateResource}
+              />
+            </div>
+          );
+        }
+
         if (item.kind === "interaction") {
           const isAsk = isAskUserToolName(item.invocation.toolName);
           return (
-            <div key={item.id} className="lchat-interaction">
+            <div
+              key={item.id}
+              className="lchat-interaction"
+              id={interactionAnchorId(item.invocation.toolCallId)}
+            >
               {isAsk ? (
                 <AskUserCard
                   invocation={item.invocation}
@@ -619,32 +675,6 @@ export const AssistantTurnView = memo(function AssistantTurnView({
           </div>
         );
       })}
-
-      {turn.artifacts.length > 0 ? (
-        <div className="lchat-atts">
-          {turn.artifacts.map((artifact) => {
-            // Open beside the conversation in the presentation stage — the
-            // same handler the display_resource cards have always used.
-            const openInStage = onNavigateResource ? () => onNavigateResource("display_resource", artifact.toolCallId ?? artifact.key, {
-              request: { type: "FILE", path: artifact.path, loadingMessages: [] },
-              conversationId: activeConversationId,
-            }) : undefined;
-            return artifact.kind === "file"
-              ? <FileArtifactCard key={artifact.key} artifact={artifact} onOpen={openInStage} />
-              : <MediaArtifactCard key={artifact.key} artifact={artifact} podId={podId} onOpen={openInStage} />;
-          })}
-        </div>
-      ) : null}
-
-      {turn.resources.length > 0 ? (
-        <div className="lchat-resources">
-          <DisplayResourceCards
-            cards={turn.resources}
-            activeConversationId={activeConversationId}
-            onNavigateResource={onNavigateResource}
-          />
-        </div>
-      ) : null}
 
       {turn.isLive ? statusPill : null}
 

--- a/lemma-frontend/lib/assistant/__tests__/turns.test.ts
+++ b/lemma-frontend/lib/assistant/__tests__/turns.test.ts
@@ -261,6 +261,71 @@ describe("buildChatTurns", () => {
     expect(turns[0].resources[0].request.type).toBe("TABLE");
   });
 
+  it("cards render where they happened, so a question never sits above the card it asks about", () => {
+    const turns = turnsFor([
+      userMessage("show me the orders and pick one"),
+      toolCall("display_resource", "call-1", 10, { type: "TABLE", name: "orders" }, { success: true }),
+      toolCall("ask_user", "call-2", 20, { questions: [{ header: "Row", question: "Which one?" }] }),
+    ]);
+
+    expect(turns[0].items.map((item) => item.kind)).toEqual(["resource", "interaction"]);
+    expect(turns[0].hasPendingInteraction).toBe(true);
+  });
+
+  it("a written file's card moves to the beat that presented it", () => {
+    const turns = turnsFor([
+      userMessage("make it, say something, then show it"),
+      toolCall("pod_write_file", "call-1", 10, { path: "/me/intro.mp4" }, { success: true, path: "/me/intro.mp4", size_bytes: 4_200_000 }),
+      assistantText("Rendered it — have a look.", 20, { is_intermediate_assistant_message: true }),
+      toolCall("display_resource", "call-2", 30, { type: "FILE", path: "/me/intro.mp4" }, { success: true }),
+    ]);
+
+    expect(turns[0].items.map((item) => item.kind)).toEqual(["text", "artifact"]);
+    expect(turns[0].artifacts).toHaveLength(1);
+  });
+
+  it("a card between beats does not break the closing answer's document card", () => {
+    const long = `# Report\n\n${"Body text that runs on. ".repeat(40)}`;
+    const turns = turnsFor([
+      userMessage("write it up"),
+      toolCall("display_resource", "call-1", 10, { type: "TABLE", name: "orders" }, { success: true }),
+      assistantText(long, 20),
+    ]);
+
+    const answer = turns[0].items.find((item) => item.kind === "text");
+    expect(answer).toMatchObject({ kind: "text", documentEligible: true });
+  });
+
+  it("say is the reply: the voice note cards as audio and never lands in the trace", () => {
+    const turns = turnsFor([
+      userMessage("read that back to me"),
+      toolCall("say", "call-1", 10, { text: "Here you go." }, { success: true, audio_file_path: "/me/speech/019f2c.mp3" }),
+    ]);
+
+    expect(turns[0].artifacts).toHaveLength(1);
+    expect(turns[0].artifacts[0]).toMatchObject({
+      path: "/me/speech/019f2c.mp3",
+      kind: "audio",
+      ext: "MP3",
+      name: "Voice note",
+    });
+    expect(turns[0].items.map((item) => item.kind)).toEqual(["artifact"]);
+    expect(turns[0].trace).toHaveLength(0);
+    expect(turns[0].toolCount).toBe(0);
+  });
+
+  it("a failed say has nothing to play, so it stays work in the trace", () => {
+    const turns = turnsFor([
+      userMessage("read that back to me"),
+      toolCall("say", "call-1", 10, { text: "Here you go." }, { success: false, error: "Speech synthesis failed." }),
+      assistantText("Voice is down — here it is as text.", 20),
+    ]);
+
+    expect(turns[0].artifacts).toHaveLength(0);
+    expect(turns[0].toolCount).toBe(1);
+    expect(turns[0].failedCount).toBe(1);
+  });
+
   it("ask_user becomes an in-chat interaction card, pending until answered", () => {
     const pending = turnsFor([
       userMessage("deploy it"),

--- a/lemma-frontend/lib/assistant/turns.ts
+++ b/lemma-frontend/lib/assistant/turns.ts
@@ -12,10 +12,18 @@
 //     answer all render as bubbles/cards — they are never demoted to a trace
 //   - tool work and genuine thinking collect into one collapsible trace, which
 //     the UI renders as a single left-aligned status pill ("Worked for 9m 14s")
-//   - files the run produced (presented via display_resource, or written with a
-//     deliverable extension) become artifact cards; other display_resource calls
-//     become resource cards
+//   - files the run produced (presented via display_resource, written with a
+//     deliverable extension, or spoken with `say`) become artifact cards; other
+//     display_resource calls become resource cards
 //   - ask_user / request_approval calls become in-chat interaction cards
+//
+// Everything a turn shows is ONE list, in the order it happened. Cards used to
+// be collected into buckets rendered after the speech, which put a question the
+// run is blocked on *above* the widget it asked about — and, since the composer
+// disables itself while an interaction is pending, a reader scrolled to the
+// bottom could see a dead input box telling them to answer a card that was off
+// the top of the screen. Chronology fixes that by construction: the run is
+// paused at the ask, so nothing can come after it.
 //
 // Pure and framework-free so the grouping rules are unit-testable without
 // rendering anything.
@@ -27,6 +35,7 @@ import {
   isRenderableUserInteractionInvocation,
   messageTextContent,
   messageTimeMs,
+  normalizeAgentToolName,
   normalizeAssistantDisplayText,
   userApprovalResolvedDecision,
   type AssistantMessagePart,
@@ -68,7 +77,17 @@ export type ChatTurnItem =
     streaming: boolean;
   }
   | { kind: "notice"; id: string; text: string }
-  | { kind: "interaction"; id: string; invocation: AssistantToolInvocation; message: AssistantRenderableMessage };
+  | { kind: "interaction"; id: string; invocation: AssistantToolInvocation; message: AssistantRenderableMessage }
+  /** A deliverable, carded where the run produced or presented it. */
+  | { kind: "artifact"; id: string; artifact: ChatArtifact }
+  /** A non-file display_resource, carded where the run presented it. */
+  | { kind: "resource"; id: string; card: ChatResourceCard };
+
+/** DOM id of an interaction card, so a blocked composer can scroll to the
+ *  question blocking it. A string, not a lookup: this module stays pure. */
+export function interactionAnchorId(toolCallId: string): string {
+  return `lchat-interaction-${toolCallId}`;
+}
 
 export interface ChatArtifact {
   /** Dedupe key — the pod path. */
@@ -79,7 +98,7 @@ export interface ChatArtifact {
   name: string;
   /** Uppercase extension badge label ("PDF"). */
   ext: string;
-  kind: "video" | "image" | "file";
+  kind: "video" | "image" | "audio" | "file";
   sizeBytes?: number;
   /** In-app href to the file in the pod's files view. */
   href: string | null;
@@ -118,16 +137,25 @@ const FILE_WRITE_TOOLS = new Set(["pod_write_file", "create_file"]);
 
 const VIDEO_EXTENSIONS = new Set(["mp4", "webm", "mov", "m4v"]);
 const IMAGE_EXTENSIONS = new Set(["png", "jpg", "jpeg", "gif", "webp", "svg"]);
+const AUDIO_EXTENSIONS = new Set(["mp3", "wav", "ogg", "opus", "m4a", "aac", "flac"]);
 
 // A written file only earns a card when it looks like a deliverable. Build
 // scripts and scratch output stay in the trace — otherwise a run that wrote
 // twelve files to produce two would end with fourteen cards.
 const DELIVERABLE_EXTENSIONS = new Set([
-  "pdf", "pptx", "docx", "xlsx", "csv", "tsv", "md", "html", "epub",
-  "mp3", "wav", "ogg", "flac", "zip",
+  "pdf", "pptx", "docx", "xlsx", "csv", "tsv", "md", "html", "epub", "zip",
   ...VIDEO_EXTENSIONS,
   ...IMAGE_EXTENSIONS,
+  ...AUDIO_EXTENSIONS,
 ]);
+
+/** `say` — the speech toolset's synthesis half. Its own tool description tells
+ *  the agent the audio IS the reply and not to present it with
+ *  display_resource afterwards, so nothing else will ever card it. */
+function isSpeechSayToolName(toolName: unknown): boolean {
+  if (typeof toolName !== "string") return false;
+  return normalizeAgentToolName(toolName).toLowerCase().replace(/[.:]/g, "_") === "say";
+}
 
 // A long or structured answer reads as a document; a short one as a chat
 // bubble. The rule is a pure function of the text, so a streaming answer and
@@ -171,6 +199,13 @@ function humanizeFileName(fileName: string): string {
 
 function normalizeName(toolName: string): string {
   return toolName.trim().toLowerCase();
+}
+
+/** Item id of a path's artifact card. Keyed by path, not by tool call, because
+ *  the write and the presentation of one file share a card — and a stable id
+ *  is what lets that card move to the presentation without remounting. */
+function artifactItemId(path: string): string {
+  return `artifact:${path}`;
 }
 
 /**
@@ -318,7 +353,17 @@ export function buildChatTurns({
 
   const addArtifact = (
     turn: MutableTurn,
-    artifact: { path: string; href: string | null; sizeBytes?: number; toolCallId: string },
+    artifact: {
+      path: string;
+      href: string | null;
+      sizeBytes?: number;
+      toolCallId: string;
+      /** A call that SHOWED the file (display_resource, `say`) rather than one
+       *  that wrote it — which is where the merged card belongs. */
+      presented?: boolean;
+      /** Overrides the humanized file name; a voice note is not "019f2c…". */
+      name?: string;
+    },
   ) => {
     const fileName = fileNameFromPath(artifact.path);
     const ext = extensionOf(fileName);
@@ -329,21 +374,35 @@ export function buildChatTurns({
       existing.href = existing.href ?? artifact.href;
       existing.sizeBytes = existing.sizeBytes ?? artifact.sizeBytes;
       existing.toolCallId = artifact.toolCallId;
+      if (artifact.name) existing.name = artifact.name;
+      // One card, anchored at the beat the reader saw it: a write that is later
+      // presented moves down to the presentation, not the other way round.
+      if (artifact.presented) {
+        const at = turn.items.findIndex((item) => item.id === artifactItemId(artifact.path));
+        if (at >= 0 && at !== turn.items.length - 1) turn.items.push(...turn.items.splice(at, 1));
+      }
       return;
     }
     const entry: ChatArtifact = {
       key: artifact.path,
       path: artifact.path,
       fileName,
-      name: humanizeFileName(fileName),
+      name: artifact.name ?? humanizeFileName(fileName),
       ext: ext ? ext.toUpperCase() : "FILE",
-      kind: VIDEO_EXTENSIONS.has(ext) ? "video" : IMAGE_EXTENSIONS.has(ext) ? "image" : "file",
+      kind: VIDEO_EXTENSIONS.has(ext)
+        ? "video"
+        : IMAGE_EXTENSIONS.has(ext)
+          ? "image"
+          : AUDIO_EXTENSIONS.has(ext)
+            ? "audio"
+            : "file",
       sizeBytes: artifact.sizeBytes,
       href: artifact.href,
       toolCallId: artifact.toolCallId,
     };
     turn.artifactByPath.set(artifact.path, entry);
     turn.artifacts.push(entry);
+    turn.items.push({ kind: "artifact", id: artifactItemId(artifact.path), artifact: entry });
   };
 
   const fileHref = (toolCallId: string, path: string): string | null => {
@@ -393,13 +452,44 @@ export function buildChatTurns({
             })
             : null;
           if (displayResource.request.type === "FILE" && displayResource.request.path) {
-            addArtifact(turn, { path: displayResource.request.path, href, toolCallId: displayResource.toolCallId });
+            addArtifact(turn, {
+              path: displayResource.request.path,
+              href,
+              toolCallId: displayResource.toolCallId,
+              presented: true,
+            });
           } else {
-            turn.resources.push({ toolCallId: displayResource.toolCallId, request: displayResource.request, href });
+            const card: ChatResourceCard = {
+              toolCallId: displayResource.toolCallId,
+              request: displayResource.request,
+              href,
+            };
+            turn.resources.push(card);
+            turn.items.push({ kind: "resource", id: `resource:${card.toolCallId}`, card });
           }
         }
       }
       return;
+    }
+
+    // A voice note is speech, not machinery. `say` synthesizes audio, saves it
+    // to the pod and — on a chat surface — delivers it natively; on web nothing
+    // delivers it, so without this the whole reply was a row in a collapsed
+    // trace. A synthesis that failed or is still running has nothing to play
+    // and stays work.
+    if (isSpeechSayToolName(invocation.toolName) && invocation.state === "result") {
+      const result = record(invocation.result);
+      const path = typeof result.audio_file_path === "string" ? result.audio_file_path.trim() : "";
+      if (result.success !== false && path) {
+        addArtifact(turn, {
+          path,
+          href: fileHref(invocation.toolCallId, path),
+          toolCallId: invocation.toolCallId,
+          presented: true,
+          name: "Voice note",
+        });
+        return;
+      }
     }
 
     // Questions and approvals are conversation, not machinery: they render as
@@ -563,6 +653,14 @@ export function buildChatTurns({
     let index = turn.items.length - 1;
     while (index >= 0) {
       const item = turn.items[index];
+      // A card is how the answer is *shown*; it does not interrupt the closing
+      // run of answer text it sits beside. (Before the cards joined the item
+      // stream they could not fall between two beats at all, so skipping them
+      // is what keeps this rule reading the same text it always did.)
+      if (item.kind === "artifact" || item.kind === "resource") {
+        index -= 1;
+        continue;
+      }
       if (item.kind !== "text" || !item.answer) break;
       item.documentEligible = true;
       index -= 1;
@@ -658,6 +756,13 @@ export function chatTurnFingerprint(turn: ChatTurn): string {
     }
     if (item.kind === "interaction") {
       return `${item.id}:i:${item.invocation.state}`;
+    }
+    if (item.kind === "artifact") {
+      // href and size arrive on the merge, not the first sighting.
+      return `${item.id}:a:${item.artifact.href ?? ""}:${item.artifact.sizeBytes ?? ""}`;
+    }
+    if (item.kind === "resource") {
+      return `${item.id}:r:${item.card.href ?? ""}`;
     }
     return `${item.id}:n:${item.text}`;
   }).join(",");

--- a/lemma-frontend/styles/features/assistant-chat.css
+++ b/lemma-frontend/styles/features/assistant-chat.css
@@ -527,6 +527,19 @@ a.lchat-file:hover .lchat-file-go {
     max-height: 60vh;
 }
 
+/* Audio is a strip, not a stage: no frame to fill, so no video stock behind
+   it. The player sizes itself; the card only gives it room. */
+.lchat-audio {
+    display: grid;
+    min-height: 3.25rem;
+    padding: var(--space-2-5) var(--space-3) 0;
+    place-items: center;
+}
+
+.lchat-audio-player {
+    width: 100%;
+}
+
 .lchat-media-loading {
     display: grid;
     aspect-ratio: 16 / 9;
@@ -615,6 +628,14 @@ a.lchat-file:hover .lchat-file-go {
     align-self: flex-start;
     width: min(32rem, 100%);
     margin-top: var(--space-1-5);
+}
+
+/* Each card is its own block now (they render where they happened, not in one
+   bucket at the end), so consecutive cards would pay the full leading twice.
+   The turn's own gap plus this is the gap they had inside the old bucket. */
+.lchat-atts + .lchat-atts,
+.lchat-resources + .lchat-resources {
+    margin-top: var(--space-1);
 }
 
 /* --- arrival motion -------------------------------------------------------------


### PR DESCRIPTION
## What changes

In a pod conversation, resource and artifact cards now render **where they
happened** instead of being collected into two buckets appended after the
speech. The visible effect: a question the run is blocked on no longer sits
*above* the widget it is asking about, and a pending `ask_user` can no longer be
pushed off the top of the screen by a tall card below it. While an interaction
is pending the composer also carries a line that scrolls the blocking card into
view.

Separately, the `say` tool finally renders on web: a voice note is now an audio
card with an inline player, not a row in a collapsed trace.

## Why

The transcript rendered a turn in fixed positional order — speech, then every
artifact, then every resource — which is not the order things happened. The
common shape "present the widget, then ask about it" came out inverted.

That was worse than a layout nit. The composer **disables itself** while an
interaction is pending (`interactionPending`, placeholder "Respond above to
continue"). Combine that with an inline widget rendered at a share of the
viewport and a transcript pinned to the bottom, and the reader gets a big
widget, a dead input box, and instructions to answer a card that is scrolled
off the top. Nothing on screen is actionable. Chat surfaces degrade gracefully
here — each `display_resource` and each `ask_user` is its own message, sent when
it happens — so the web transcript was the only place that re-sorted them.

`say` had no web rendering at all. It synthesizes audio, saves it to the pod,
and delivers a native voice note on chat surfaces; on web nothing delivers it,
and the tool's own description tells the agent *not* to present it with
`display_resource` afterwards — so the entire reply was one row inside a
collapsed trace.

### Notes for a reviewer

- **Chronology fixes the blocking case by construction.** The run is *paused* at
  an ask, so nothing can render after it — a pending question is now last in the
  turn, always. The composer affordance is belt and braces for a reader who has
  scrolled away.
- **The merge case now has a defined position.** A file that is written and
  later presented is still one card; the presentation *moves* it down to the
  beat the reader was shown it. The item id is keyed by path, not tool call, so
  the move does not remount the card.
- **One rule needed adjusting.** `documentEligible` walks backwards from the last
  item looking for the closing run of answer text; a trailing card would have
  stopped that walk cold and killed the doc card on any answer followed by a
  `display_resource`. Cards are skipped in that walk, which reproduces exactly
  what the bucketed layout did implicitly.
- **`turn.artifacts` / `turn.resources` are kept** as derived summaries; only the
  render reads from `items`.
- **A failed or in-flight `say` stays work** in the trace — there is nothing to
  play. `listen` is unchanged: it is comprehension, and its contract says never
  to echo the transcript.

## How to verify

```bash
cd lemma-frontend
npm run typecheck
npx eslint lib/assistant/turns.ts components/lemma/assistant/assistant-turn.tsx components/lemma/assistant/assistant-experience.tsx
npx vitest run
```

`typecheck` and `eslint` print nothing. `vitest run` reports **96 files, 1046
tests passed** — including five new cases in
`lib/assistant/__tests__/turns.test.ts`:

- cards render where they happened, so a question never sits above the card it
  asks about
- a written file's card moves to the beat that presented it
- a card between beats does not break the closing answer's document card
- `say` is the reply: the voice note cards as audio and never lands in the trace
- a failed `say` has nothing to play, so it stays work in the trace

**Not verified in a running browser.** Docker was not available in this
environment, so the full stack (postgres/redis/supertokens + backend) never came
up, and a real `say` call needs a Deepgram key. The render layer is a mechanical
move of the existing card components into the item loop; the behavioral change
is in the pure turn model and is covered by the tests above. Worth a manual look
at three things before merge: a turn with two consecutive cards (the spacing
rule that replaces the old shared flex gap), the audio card in both themes, and
the composer's "Answer the question to continue" line.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

Frontend-only: no migrations, no API surface change, no SDK regeneration, no new
secrets or authorization boundaries touched. The architecture ratchet is a
backend gate and is unaffected.

## Compatibility and rollback notes

Nothing to note — this is a presentation change behind no flag, and reverting
the commit restores the previous layout exactly. No persisted data or wire
format changes shape.
