### PR TITLE
Get provisioning past AUTH_EMAIL_VERIFICATION_REQUIRED for real

### DIFF
--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -238,6 +238,17 @@ is why a run leaves no new organizations behind, which matters because the
 product has no way to delete one. A stack the suite boots itself is the
 exception: it starts empty, so the tenant is built in it on first use.
 
+If the target enforces `AUTH_EMAIL_VERIFICATION_REQUIRED`, signing up is not
+enough on its own — every authenticated request from an unverified account is
+refused regardless of session. There is no gate to sign around here the way
+the others are avoided, so provisioning gets past it the way a person does:
+set `SCENARIOS_RESEND_API_KEY` to a Resend key that can read mail sent to
+`SCENARIOS_TENANT_DOMAIN`, and `make scenarios-provision` receives each
+colleague's real verification email and uses the real token in it. Unset,
+this step is skipped entirely — harmless anywhere that does not require it,
+loud (`provisioning stopped: ...`) anywhere that does. See
+[`harness/inbox.py`](harness/inbox.py).
+
 ## The two lanes
 
 `make scenarios` is the fast lane: everything runs against containers the stack

--- a/tests/scenarios/harness/inbox.py
+++ b/tests/scenarios/harness/inbox.py
@@ -1,0 +1,129 @@
+"""Reading a real inbox back, for the one thing provisioning cannot sign around.
+
+Every other gate a real deployment keeps in front of registration is something
+the standing cast avoids by signing in rather than up (see `tenant.py`). Email
+verification is not avoidable that way — the token only ever exists inside the
+email the deployment actually sent, so the only honest way through the gate is
+to receive that email and use the token in it, the way a person would.
+
+This reads Resend's inbound API rather than running a webhook receiver: a
+one-shot provisioning script has no server for Resend to call, and polling a
+handful of times is simpler than standing one up for five emails, once.
+
+Configured the same way `credentials.py` configures the live lane — a setting
+this run either has or does not, never a secret with a default:
+
+    SCENARIOS_RESEND_API_KEY   a Resend key with read access to the inbound
+                                domain the standing cast's addresses resolve to
+                                (see tenant.py's SCENARIOS_TENANT_DOMAIN)
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from datetime import datetime
+
+import httpx
+
+API_KEY_SETTING = "SCENARIOS_RESEND_API_KEY"
+
+#: The link in the email points at the frontend: .../auth/verify-email?token=…
+#: A person clicks it; this reads the same query parameter out of the message
+#: instead, since the token is all `verifies_email` needs.
+_TOKEN_IN_LINK = re.compile(r"[?&]token=([^&\"'\s<]+)")
+
+#: How long to wait for one email, and how often to ask. A deployment sending
+#: through a real provider takes a few seconds, not milliseconds — polling
+#: faster than that would only spend more of Resend's own rate limit for no
+#: extra timeliness.
+_TIMEOUT_SECONDS = 90.0
+_POLL_INTERVAL_SECONDS = 3.0
+
+
+class InboxUnavailable(AssertionError):
+    """Reading the inbox is not possible or did not produce the email."""
+
+
+def configured() -> bool:
+    return bool(os.getenv(API_KEY_SETTING, "").strip())
+
+
+def _client() -> httpx.Client:
+    key = os.getenv(API_KEY_SETTING, "").strip()
+    if not key:
+        raise InboxUnavailable(
+            f"{API_KEY_SETTING} is not set. This deployment requires email "
+            f"verification (AUTH_EMAIL_VERIFICATION_REQUIRED=true) and "
+            f"provisioning cannot get past it without reading the standing "
+            f"cast's real inbox — set {API_KEY_SETTING} to a Resend key that "
+            f"can read mail sent to the standing cast's domain."
+        )
+    return httpx.Client(
+        base_url="https://api.resend.com",
+        headers={"Authorization": f"Bearer {key}"},
+        timeout=30.0,
+    )
+
+
+def wait_for_verification_link(to: str, *, since: float) -> str:
+    """The verification token from the newest email to ``to`` sent after ``since``.
+
+    ``since`` is a ``time.time()`` taken before the email was requested — not
+    optional, because Resend keeps 30 days of received mail and the standing
+    cast's addresses have almost certainly been sent to before. Reading a stale
+    token off an old email would fail confusingly, much later, on the actual
+    verify call, instead of here where the cause is obvious.
+    """
+    with _client() as client:
+        deadline = time.monotonic() + _TIMEOUT_SECONDS
+        while True:
+            response = client.get("/emails/receiving", params={"limit": 20})
+            response.raise_for_status()
+            candidates = [
+                item
+                for item in response.json().get("data", [])
+                if to in item.get("to", []) and _after(item.get("created_at"), since)
+            ]
+            if candidates:
+                newest = max(candidates, key=lambda item: item.get("created_at", ""))
+                return _token_from(client, newest["id"], to=to)
+            if time.monotonic() >= deadline:
+                raise InboxUnavailable(
+                    f"no verification email reached {to} within "
+                    f"{_TIMEOUT_SECONDS:.0f}s. Confirm {API_KEY_SETTING} reads "
+                    f"the domain {to.rsplit('@', 1)[-1]!r} resolves to, and "
+                    f"that its MX record actually points at Resend."
+                )
+            time.sleep(_POLL_INTERVAL_SECONDS)
+
+
+def _after(created_at: str | None, since: float) -> bool:
+    if not created_at:
+        return False
+    try:
+        # A 5s allowance for clock skew between here and Resend — not for
+        # correctness of "after", but so a request timed right at the second
+        # boundary is never the one email this rejects for being 200ms early.
+        parsed = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+        return parsed.timestamp() >= since - 5
+    except ValueError:
+        return True  # an unparsable timestamp should not hide a real email
+
+
+def _token_from(client: httpx.Client, email_id: str, *, to: str) -> str:
+    response = client.get(f"/emails/receiving/{email_id}")
+    response.raise_for_status()
+    full = response.json()
+    haystacks = (full.get("html") or "", full.get("text") or "")
+    for haystack in haystacks:
+        match = _TOKEN_IN_LINK.search(haystack)
+        if match:
+            return match.group(1)
+    raise InboxUnavailable(
+        f"an email reached {to} (subject {full.get('subject')!r}) but no "
+        f"verification link was in it. Either the template changed — update "
+        f"_TOKEN_IN_LINK in harness/inbox.py — or this was not the "
+        f"verification email at all."
+    )

--- a/tests/scenarios/harness/provision.py
+++ b/tests/scenarios/harness/provision.py
@@ -24,10 +24,11 @@ import argparse
 import asyncio
 import os
 import sys
+import time
 from collections.abc import Callable
 from typing import Any
 
-from harness import environment, tenant
+from harness import environment, inbox, tenant
 from harness.run import current, made_by_a_run
 from harness.world import Person, World
 
@@ -86,6 +87,19 @@ async def provision(base_url: str, *, reset: bool = False) -> str:
             else:
                 ledger.already(f"{colleague.full_name} already has an account")
 
+        # Gated on whether *this run* was given a way to read the inbox, not on
+        # what the target says it needs — production deliberately withholds
+        # `email_verification_required` along with the rest of its security
+        # posture (see health_capabilities in lemma-backend/app/app.py), so
+        # asking the target would skip verification there by default, which is
+        # exactly backwards: production is the one place getting this wrong is
+        # expensive. Configuring SCENARIOS_RESEND_API_KEY is the operator
+        # saying "this target needs it and here is how" — the same shape
+        # `credentials.py` already uses for everything else this suite reads.
+        if inbox.configured():
+            for colleague in tenant.CAST:
+                await _verify(people[colleague.label], colleague, ledger)
+
         companies: dict[str, JSON] = {}
         for company in tenant.COMPANIES:
             owner = people[owner_of(company).label]
@@ -124,6 +138,28 @@ async def provision(base_url: str, *, reset: bool = False) -> str:
         )
     finally:
         await world.aclose()
+
+
+async def _verify(person: Person, colleague: tenant.Colleague, ledger: Ledger) -> None:
+    """Get past AUTH_EMAIL_VERIFICATION_REQUIRED the way a person actually does.
+
+    Every other gate the standing cast avoids by signing in instead of up (see
+    tenant.py's module docstring). This one cannot be avoided that way: a
+    deployment enforcing it refuses every authenticated request from an
+    unverified account regardless of session, so a signed-in Priya is still
+    turned away the moment `_company` asks for her organizations. The only
+    honest way through is the one a person uses — receive the real email,
+    read the real token out of it, and consume it — which is what this does,
+    via `harness/inbox.py`.
+    """
+    if await person.is_email_verified():
+        ledger.already(f"{colleague.full_name}'s email is verified")
+        return
+    since = time.time()
+    await person.requests_email_verification()
+    token = inbox.wait_for_verification_link(colleague.email, since=since)
+    await person.verifies_email(token)
+    ledger.did(f"verified {colleague.full_name}'s email")
 
 
 async def _company(owner: Person, company: tenant.Company, ledger: Ledger) -> JSON:

--- a/tests/scenarios/harness/steps/identity.py
+++ b/tests/scenarios/harness/steps/identity.py
@@ -136,6 +136,24 @@ class IdentitySteps:
         self.api.renews_with(self.signs_in)
         self.user_id = payload["user"]["id"]
 
+    async def is_email_verified(self) -> bool:
+        return bool((await self.api.get("/st/auth/user/email/verify")).get("isVerified"))
+
+    async def requests_email_verification(self) -> None:
+        await self.api.post("/st/auth/user/email/verify/token")
+
+    async def verifies_email(self, token: str) -> None:
+        """Consume a verification token — the one a person gets by clicking the
+        email's link, extracted instead of clicked. See harness/inbox.py."""
+        payload = await self.api.post(
+            "/st/auth/user/email/verify", json={"method": "token", "token": token}
+        )
+        if payload.get("status") != "OK":
+            raise AssertionError(
+                f"{self.label} could not verify their email: "
+                f"{payload.get('status')!r} — {payload}"
+            )
+
     async def profile(self) -> JSON:
         return await self.api.get("/users/me")
 


### PR DESCRIPTION
## Summary

#457 built the standing tenant and had it sign in rather than up specifically so the suite could run against a deployment with registration gates on — but one of those gates cannot be signed around. A deployment enforcing `AUTH_EMAIL_VERIFICATION_REQUIRED` refuses **every** authenticated request from an unverified account regardless of session (`lemma-backend/app/core/security.py`), so a freshly-registered Priya was still turned away the moment `provision()` asked for her organizations. Confirmed against `api.asur.work`, which sets this true — `make scenarios-provision` failed there before this change.

## Change

- **`harness/inbox.py`** (new) — reads a real verification email back from Resend's inbound API (`GET /emails/receiving`, `GET /emails/receiving/{id}`), no webhook receiver: a one-shot provisioning script has nothing for Resend to call, and polling a handful of times for five emails, once, is simpler than standing one up. Extracts the token from the link's `?token=` query param (confirmed against the exact link shape `lemma-backend/app/core/tests/test_transactional_email.py` already asserts on).
- **`harness/steps/identity.py`** — three new steps mirroring the existing `signs_up`/`signs_in` shape: `is_email_verified`, `requests_email_verification`, `verifies_email`.
- **`harness/provision.py`** — new `_verify` helper, called per colleague right after the `arrives()` loop and before anything touches `/organizations`. Skips anyone already verified (idempotent, matching the file's own promise).
- **`README.md`** — documents `SCENARIOS_RESEND_API_KEY` next to the existing `SCENARIOS_TENANT_DOMAIN` note.

## Why gated on `SCENARIOS_RESEND_API_KEY`, not on what the target reports

Production deliberately withholds `email_verification_required` along with the rest of its security posture (`health_capabilities` in `lemma-backend/app/app.py`: "the honest answer to a stranger asking 'are your gates on?' is that it is none of their business"). Gating on the target's own answer would silently skip verification exactly where getting it wrong is most expensive. Configuring the key is the operator saying "this target needs it and here is how" — the same shape `credentials.py` already uses for everything else this suite reads from outside itself. Unset, this is a no-op everywhere it was before — no behavior change for the local or live lanes.

## Test plan

- [x] `make scenarios` locally (this path is inert without the env var, so local behavior is unchanged): **379 passed, 1 failed** — the same pre-existing worker-contention flake #457 already documented (`test_an_unknown_sender_is_told_how_to_get_access`), unrelated to this change.
- [ ] `make scenarios-provision TARGET=https://api.asur.work` against dev, once dev's app carries #457's `/health/capabilities` (a separate app release, in progress) — will update this PR with the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)