### PR TITLE
Say something on WhatsApp while the agent works, and stop guessing at its markdown

### DIFF
--- a/lemma-backend/app/modules/agent_surfaces/platforms/platform_capabilities.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/platform_capabilities.py
@@ -15,11 +15,36 @@ Byte caps are reused from :mod:`attachment_limits` rather than duplicated.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 
 from app.modules.agent_surfaces.platforms.attachment_limits import (
     attachment_cap,
     inline_cap,
 )
+
+
+class ProgressStyle(StrEnum):
+    """How a platform can show that a long run is still going.
+
+    The three sets the progress observer used to hand-maintain — who streams
+    tokens, who edits a live message, who gets nothing — were three answers to
+    one question, and they drifted: WhatsApp was in none of them and its comment
+    claimed an inbound reaction covered it, which no adapter ever sent. One field
+    on the platform, and the observer reads it.
+    """
+
+    #: A real streaming API: tokens append to a message that is closed *with*
+    #: the final answer, so the steps and the answer are one message (Slack).
+    STREAM = "stream"
+    #: One live message, edited in place as the work proceeds, replaced or
+    #: cleared at the end (Telegram, Teams).
+    EDIT = "edit"
+    #: No edit API at all. Progress can only be a *new* message, so it has to be
+    #: rare and worth the interruption — a plan, or a single "still going"
+    #: (WhatsApp).
+    POST = "post"
+    #: One composed reply and nothing before it (email).
+    NONE = "none"
 
 
 @dataclass(frozen=True)
@@ -53,12 +78,10 @@ class PlatformCapabilities:
     # Email genuinely can — it is the only reason an unreachable colleague still
     # gets told anything.
     can_cold_open: bool = False
-    # Can a live progress stream be closed *with* the final answer, so the
-    # agent's steps and the answer they produced are one message? True only
-    # where the platform has a real streaming API (Slack's chat.startStream /
-    # appendStream / stopStream). Everywhere else progress is a separate
-    # message that gets cleared before the answer is sent.
-    finishes_stream_with_answer: bool = False
+    # How this platform can show that a long run is still going. See
+    # ``ProgressStyle`` — the observer branches on this instead of on three
+    # hand-maintained platform sets.
+    progress_style: ProgressStyle = ProgressStyle.NONE
     # Hours after the person's last inbound message during which free-form
     # replies are allowed. WhatsApp's 24h customer-service rule is real: past it
     # a send is refused unless it is a pre-approved template. None means no
@@ -78,6 +101,21 @@ class PlatformCapabilities:
     # address off one key *is* the design, so applying the identity rule here
     # let the first mailbox in an organization block every one after it.
     system_credential_is_identity: bool = True
+
+    @property
+    def finishes_stream_with_answer(self) -> bool:
+        """Can a live stream be closed *with* the answer, as one message?
+
+        Only a real streaming API can (Slack's chat.startStream / appendStream /
+        stopStream). Everywhere else progress is a separate message that is
+        cleared before the answer is sent.
+        """
+        return self.progress_style is ProgressStyle.STREAM
+
+    @property
+    def shows_live_progress(self) -> bool:
+        """Does anything at all get shown between the question and the answer?"""
+        return self.progress_style is not ProgressStyle.NONE
 
     @property
     def attachment_byte_cap(self) -> int:
@@ -134,7 +172,7 @@ PLATFORM_CAPABILITIES: dict[str, PlatformCapabilities] = {
         markdown_mode="mrkdwn",
         formatting_style=_SLACK_FORMATTING,
         soft_char_limit=3000,
-        finishes_stream_with_answer=True,
+        progress_style=ProgressStyle.STREAM,
     ),
     "TEAMS": PlatformCapabilities(
         platform="TEAMS",
@@ -146,6 +184,7 @@ PLATFORM_CAPABILITIES: dict[str, PlatformCapabilities] = {
         markdown_mode="limited_markdown",
         formatting_style=_TEAMS_FORMATTING,
         soft_char_limit=4000,
+        progress_style=ProgressStyle.EDIT,
     ),
     "WHATSAPP": PlatformCapabilities(
         platform="WHATSAPP",
@@ -159,6 +198,10 @@ PLATFORM_CAPABILITIES: dict[str, PlatformCapabilities] = {
         markdown_mode="whatsapp",
         formatting_style=_WHATSAPP_FORMATTING,
         soft_char_limit=1500,
+        # No message-edit API, so a progress update can only be a new message
+        # in the person's chat. Rationed hard by the observer: a plan when the
+        # agent has one, otherwise a single "still going" on a long run.
+        progress_style=ProgressStyle.POST,
         # Meta closes free-form messaging 24h after the person's last message.
         # A notification past that window needs an approved template, which we
         # do not have, so delivery falls through to the next channel.
@@ -177,6 +220,7 @@ PLATFORM_CAPABILITIES: dict[str, PlatformCapabilities] = {
         markdown_mode="markdownv2_converted",
         formatting_style=_TELEGRAM_FORMATTING,
         soft_char_limit=3500,
+        progress_style=ProgressStyle.EDIT,
     ),
     "GMAIL": PlatformCapabilities(
         platform="GMAIL",
@@ -313,6 +357,26 @@ def platform_agent_guidance(platform: str | None) -> str:
             "audio. Do NOT also call display_resource for it."
         )
         lines.append("\n".join(delivery))
+
+        if caps.shows_live_progress:
+            # The plan is the only thing the person can see while a long run is
+            # still going, and on a surface with no edit API it is the only thing
+            # worth interrupting them with. An agent that skips `write_todos`
+            # leaves them watching silence.
+            waiting = (
+                "a live checklist that updates in place"
+                if caps.progress_style is not ProgressStyle.POST
+                else "a short progress message, sent sparingly"
+            )
+            lines.append(
+                "## Work that takes a while\n"
+                "For anything multi-step, call `write_todos` with your plan before "
+                "you start and check items off as you finish them. Lemma shows "
+                f"that checklist to the person as {waiting} — it is the only thing "
+                "they can see while they wait, so a run without one looks to them "
+                "like nothing is happening. Do not narrate progress as chat "
+                "messages; the checklist is how progress is delivered here."
+            )
 
     # Formatting + sizing.
     lines.append(

--- a/lemma-backend/app/modules/agent_surfaces/platforms/platform_capabilities.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/platform_capabilities.py
@@ -28,8 +28,7 @@ class ProgressStyle(StrEnum):
 
     The three sets the progress observer used to hand-maintain — who streams
     tokens, who edits a live message, who gets nothing — were three answers to
-    one question, and they drifted: WhatsApp was in none of them and its comment
-    claimed an inbound reaction covered it, which no adapter ever sent. One field
+    one question, kept in three places that had to be updated together. One field
     on the platform, and the observer reads it.
     """
 

--- a/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/adapter.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/adapter.py
@@ -92,6 +92,26 @@ class WhatsAppSurfaceAdapter(BaseSurfaceAdapter):
     ) -> ParsedSurfaceInteraction | None:
         return self._parser.parse_interaction(payload, headers)
 
+    async def stream_progress(
+        self,
+        *,
+        credentials: dict[str, Any],
+        event: ParsedInboundSurfaceEvent,
+        progress_text: str,
+        progress_handle: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any] | None:
+        """Post a progress update as a new message.
+
+        Returns ``None`` deliberately: a handle is a reference to a live message
+        that later edits and the end-of-run cleanup act on, and WhatsApp has no
+        such message. Each update stands on its own and there is nothing to
+        clear afterwards.
+        """
+        del progress_handle, metadata
+        await WhatsAppPlatformService(credentials).stream_progress(event, progress_text)
+        return None
+
     async def add_processing_indicator(
         self,
         *,

--- a/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/parser.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/parser.py
@@ -15,7 +15,7 @@ from app.modules.agent_surfaces.domain.entities import (
     ParsedInboundSurfaceEvent,
     ParsedSurfaceInteraction,
 )
-from app.modules.agent_surfaces.platforms.whatsapp.service import (
+from app.modules.agent_surfaces.platforms.whatsapp.payloads import (
     WHATSAPP_APPROVAL_HEADER,
     WHATSAPP_INTERACTION_SEP,
 )

--- a/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/payloads.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/payloads.py
@@ -1,0 +1,252 @@
+"""Building the JSON bodies WhatsApp's Cloud API expects.
+
+Pure construction: what an outbound message, an interactive reply-button block,
+a list picker, a CTA-URL card and a media caption look like on the wire, and how
+each of them is kept inside Meta's length limits. Split from
+:mod:`service` — which owns credentials, HTTP and the API calls — because it is
+the half with no I/O in it and the half worth reading on its own.
+
+Every string that reaches these builders is model-authored, so every one of them
+goes through :mod:`text_format` on the way in. That is not decoration: the agent
+writes Markdown, WhatsApp renders a different and much smaller syntax, and an
+untranslated string arrives on the phone as literal asterisks. Truncation runs
+*after* translation and is followed by a re-balance, because a cut can land in
+the middle of a pair and leave the marker this module exists to prevent.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.modules.agent_surfaces.domain.models import (
+    SurfaceApprovalRenderPlan,
+    SurfaceDisplayRenderPlan,
+    SurfaceQuestion,
+)
+from app.modules.agent_surfaces.platforms.rendering import chunk_text
+from app.modules.agent_surfaces.platforms.whatsapp.text_format import (
+    balance_whatsapp_delimiters,
+    to_plain_text,
+    to_whatsapp_text,
+)
+
+# Meta's hard ceiling on a text message body.
+WHATSAPP_TEXT_LIMIT = 4096
+
+
+# Separator for encoding ask_user routing into a WhatsApp button/list ``id``
+# (``callback_id~header~value``). The callback id itself uses ``|``, so ``~``
+# unambiguously splits the three parts. WhatsApp allows ids up to 256 chars.
+WHATSAPP_INTERACTION_SEP = "~"
+
+# Sentinel used in place of a question ``header`` to mark an approval button
+# reply (``callback_id~__approval__~<decision>``). The parser routes this to an
+# approval decision instead of an ask_user answer.
+WHATSAPP_APPROVAL_HEADER = "__approval__"
+
+
+def build_whatsapp_interactive(
+    callback_id: str, question: SurfaceQuestion
+) -> dict[str, Any] | None:
+    """Build a WhatsApp interactive payload for one question, or ``None`` if it
+    can't be expressed natively (id over 256 chars, more than 10 options, or a
+    header containing the reserved separator)."""
+    # The reply id packs ``callback_id~header~value`` and is decoded with a
+    # 2-split, so the value may contain ``~`` but the header must not — otherwise
+    # the split misassigns and the answer is mis-keyed. Fall back to text when a
+    # header contains the separator (rare; header is model-authored).
+    if WHATSAPP_INTERACTION_SEP in (question.header or ""):
+        return None
+    rows: list[tuple[str, str]] = []
+    for option in question.options:
+        button_id = (
+            f"{callback_id}{WHATSAPP_INTERACTION_SEP}{question.header}"
+            f"{WHATSAPP_INTERACTION_SEP}{option.label}"
+        )
+        if len(button_id.encode("utf-8")) > 256:
+            return None
+        rows.append((button_id, option.label))
+    # The question is model-authored, so it arrives as Markdown like every other
+    # outbound string and needs the same translation the message body gets.
+    body = {"text": to_whatsapp_text(question.question or "")[:1024] or "Please choose"}
+    if 1 <= len(rows) <= 3:
+        return {
+            "type": "button",
+            "body": body,
+            "action": {
+                "buttons": [
+                    {"type": "reply", "reply": {"id": rid, "title": title[:20]}}
+                    for rid, title in rows
+                ]
+            },
+        }
+    if 4 <= len(rows) <= 10:
+        return {
+            "type": "list",
+            "body": body,
+            "action": {
+                "button": "Choose",
+                "sections": [
+                    {"rows": [{"id": rid, "title": title[:24]} for rid, title in rows]}
+                ],
+            },
+        }
+    return None
+
+
+def build_whatsapp_approval_interactive(
+    plan: SurfaceApprovalRenderPlan,
+) -> dict[str, Any] | None:
+    """Build a WhatsApp reply-button payload for an approval prompt, or ``None``
+    if it can't be expressed natively (more than 3 buttons, or an id over 256
+    chars). Each button id packs ``callback_id~__approval__~<decision>``."""
+    buttons: list[dict[str, Any]] = []
+    for button in plan.buttons:
+        button_id = (
+            f"{plan.callback_id}{WHATSAPP_INTERACTION_SEP}{WHATSAPP_APPROVAL_HEADER}"
+            f"{WHATSAPP_INTERACTION_SEP}{button.decision}"
+        )
+        if len(button_id.encode("utf-8")) > 256:
+            return None
+        buttons.append(
+            {"type": "reply", "reply": {"id": button_id, "title": button.label[:20]}}
+        )
+    if not 1 <= len(buttons) <= 3:
+        return None
+    # The title is wrapped in bold here, so its own markers are stripped first —
+    # a ``*`` inside it would close the wrapper early and leave the rest literal.
+    body_parts = [f"*{to_plain_text(plan.title)}*"]
+    if plan.reason:
+        body_parts.append(to_whatsapp_text(plan.reason))
+    if plan.action_summary:
+        body_parts.append(f"Action: {to_whatsapp_text(plan.action_summary)}")
+    body_text = balance_whatsapp_delimiters(
+        "\n\n".join(part for part in body_parts if part.strip())[:1024]
+    ).strip()
+    body_text = body_text or "Approval needed"
+    return {
+        "type": "button",
+        "body": {"text": body_text},
+        "action": {"buttons": buttons},
+    }
+
+
+def resolve_whatsapp_send_type(*, delivery_mode: str, mime_type: str) -> str:
+    requested = str(delivery_mode or "auto").lower()
+    if requested != "auto":
+        return requested
+    if mime_type.startswith("image/"):
+        return "image"
+    if mime_type.startswith("audio/"):
+        return "audio"
+    if mime_type.startswith("video/"):
+        return "video"
+    return "document"
+
+
+def whatsapp_message_bodies(message: str) -> list[str]:
+    """Translate the agent's answer, then split it into sendable messages.
+
+    A long answer used to be sent as one oversized body that Meta rejects
+    outright — the person got nothing rather than a truncated something. Split on
+    paragraph, then line, then word boundaries, and each piece is re-balanced
+    because the split itself can cut a ``*bold*`` pair in half.
+    """
+    body = to_whatsapp_text(message)
+    if not body:
+        return []
+    return [
+        balanced
+        for balanced in (
+            balance_whatsapp_delimiters(chunk)
+            for chunk in chunk_text(body, limit=WHATSAPP_TEXT_LIMIT)
+        )
+        if balanced.strip()
+    ]
+
+
+def whatsapp_cta_url_payload(
+    *,
+    recipient_wa_id: str,
+    render_plan: SurfaceDisplayRenderPlan,
+) -> dict[str, Any]:
+    action = render_plan.primary_action
+    body = balance_whatsapp_delimiters(
+        truncate_whatsapp_text(
+            to_whatsapp_text(
+                whatsapp_display_resource_text(render_plan, include_action=False)
+            ),
+            1024,
+        )
+    )
+    return {
+        "messaging_product": "whatsapp",
+        "recipient_type": "individual",
+        "to": recipient_wa_id,
+        "type": "interactive",
+        "interactive": {
+            "type": "cta_url",
+            "body": {"text": body},
+            "action": {
+                "name": "cta_url",
+                "parameters": {
+                    "display_text": truncate_whatsapp_button_text(
+                        action.label if action else "Open"
+                    ),
+                    "url": action.url if action else "",
+                },
+            },
+        },
+    }
+
+
+def whatsapp_text_payload(
+    *,
+    recipient_wa_id: str,
+    body: str,
+    preview_url: bool,
+) -> dict[str, Any]:
+    return {
+        "messaging_product": "whatsapp",
+        "recipient_type": "individual",
+        "to": recipient_wa_id,
+        "type": "text",
+        "text": {
+            # Balanced *after* truncating: a 4096-character slice can land in the
+            # middle of a ``*bold*`` pair, which is the broken marker
+            # ``to_whatsapp_text`` exists to prevent.
+            "body": balance_whatsapp_delimiters(
+                truncate_whatsapp_text(to_whatsapp_text(body), WHATSAPP_TEXT_LIMIT)
+            ),
+            "preview_url": preview_url,
+        },
+    }
+
+
+def whatsapp_display_resource_text(
+    render_plan: SurfaceDisplayRenderPlan,
+    *,
+    include_action: bool = True,
+) -> str:
+    parts = [f"*{render_plan.title}*"]
+    if render_plan.summary:
+        parts.append(render_plan.summary)
+    parts.extend(render_plan.detail_lines[:5])
+    action = render_plan.primary_action
+    if include_action and action is not None:
+        parts.append(f"{action.label}: {action.url}")
+    return "\n\n".join(parts)
+
+
+def truncate_whatsapp_button_text(value: str) -> str:
+    text = " ".join(str(value or "").split()) or "Open"
+    return text if len(text) <= 20 else text[:19].rstrip() + "..."
+
+
+def truncate_whatsapp_text(value: str, max_length: int) -> str:
+    text = str(value or "").strip()
+    return text if len(text) <= max_length else text[: max_length - 1].rstrip() + "..."
+
+
+def filename_from_url(url: str) -> str:
+    return str(url or "").rstrip("/").split("/")[-1].strip()

--- a/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/service.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/service.py
@@ -11,7 +11,6 @@ from app.modules.agent_surfaces.domain.entities import ParsedInboundSurfaceEvent
 from app.modules.agent_surfaces.domain.models import (
     SurfaceApprovalRenderPlan,
     SurfaceDisplayRenderPlan,
-    SurfaceQuestion,
     SurfaceQuestionRenderPlan,
     SurfaceSenderProfile,
 )
@@ -28,102 +27,22 @@ from app.modules.agent_surfaces.platforms.whatsapp.models import (
     WhatsAppCurrentContactResult,
     WhatsAppFileAttachment,
 )
+from app.modules.agent_surfaces.platforms.whatsapp.payloads import (
+    build_whatsapp_approval_interactive,
+    build_whatsapp_interactive,
+    filename_from_url,
+    resolve_whatsapp_send_type,
+    whatsapp_cta_url_payload,
+    whatsapp_display_resource_text,
+    whatsapp_message_bodies,
+    whatsapp_text_payload,
+)
 from app.modules.agent_surfaces.platforms.whatsapp.text_format import (
     to_plain_text,
     to_whatsapp_text,
 )
 
 logger = get_logger(__name__)
-
-# Separator for encoding ask_user routing into a WhatsApp button/list ``id``
-# (``callback_id~header~value``). The callback id itself uses ``|``, so ``~``
-# unambiguously splits the three parts. WhatsApp allows ids up to 256 chars.
-WHATSAPP_INTERACTION_SEP = "~"
-
-# Sentinel used in place of a question ``header`` to mark an approval button
-# reply (``callback_id~__approval__~<decision>``). The parser routes this to an
-# approval decision instead of an ask_user answer.
-WHATSAPP_APPROVAL_HEADER = "__approval__"
-
-
-def _build_whatsapp_interactive(
-    callback_id: str, question: SurfaceQuestion
-) -> dict[str, Any] | None:
-    """Build a WhatsApp interactive payload for one question, or ``None`` if it
-    can't be expressed natively (id over 256 chars, more than 10 options, or a
-    header containing the reserved separator)."""
-    # The reply id packs ``callback_id~header~value`` and is decoded with a
-    # 2-split, so the value may contain ``~`` but the header must not — otherwise
-    # the split misassigns and the answer is mis-keyed. Fall back to text when a
-    # header contains the separator (rare; header is model-authored).
-    if WHATSAPP_INTERACTION_SEP in (question.header or ""):
-        return None
-    rows: list[tuple[str, str]] = []
-    for option in question.options:
-        button_id = (
-            f"{callback_id}{WHATSAPP_INTERACTION_SEP}{question.header}"
-            f"{WHATSAPP_INTERACTION_SEP}{option.label}"
-        )
-        if len(button_id.encode("utf-8")) > 256:
-            return None
-        rows.append((button_id, option.label))
-    body = {"text": (question.question or "").strip()[:1024] or "Please choose"}
-    if 1 <= len(rows) <= 3:
-        return {
-            "type": "button",
-            "body": body,
-            "action": {
-                "buttons": [
-                    {"type": "reply", "reply": {"id": rid, "title": title[:20]}}
-                    for rid, title in rows
-                ]
-            },
-        }
-    if 4 <= len(rows) <= 10:
-        return {
-            "type": "list",
-            "body": body,
-            "action": {
-                "button": "Choose",
-                "sections": [
-                    {"rows": [{"id": rid, "title": title[:24]} for rid, title in rows]}
-                ],
-            },
-        }
-    return None
-
-
-def _build_whatsapp_approval_interactive(
-    plan: SurfaceApprovalRenderPlan,
-) -> dict[str, Any] | None:
-    """Build a WhatsApp reply-button payload for an approval prompt, or ``None``
-    if it can't be expressed natively (more than 3 buttons, or an id over 256
-    chars). Each button id packs ``callback_id~__approval__~<decision>``."""
-    buttons: list[dict[str, Any]] = []
-    for button in plan.buttons:
-        button_id = (
-            f"{plan.callback_id}{WHATSAPP_INTERACTION_SEP}{WHATSAPP_APPROVAL_HEADER}"
-            f"{WHATSAPP_INTERACTION_SEP}{button.decision}"
-        )
-        if len(button_id.encode("utf-8")) > 256:
-            return None
-        buttons.append(
-            {"type": "reply", "reply": {"id": button_id, "title": button.label[:20]}}
-        )
-    if not 1 <= len(buttons) <= 3:
-        return None
-    body_parts = [f"*{plan.title}*"]
-    if plan.reason:
-        body_parts.append(plan.reason)
-    if plan.action_summary:
-        body_parts.append(f"Action: {plan.action_summary}")
-    body_text = "\n\n".join(body_parts).strip()[:1024] or "Approval needed"
-    return {
-        "type": "button",
-        "body": {"text": body_text},
-        "action": {"buttons": buttons},
-    }
-
 
 _WHATSAPP_API_BASE = "https://graph.facebook.com/v21.0"
 
@@ -189,14 +108,47 @@ class WhatsAppPlatformService:
             )
             return
 
+        for body in whatsapp_message_bodies(message):
+            await self._client.send_message_payload(
+                phone_number_id=phone_number_id,
+                payload={
+                    "messaging_product": "whatsapp",
+                    "to": sender_wa_id,
+                    "type": "text",
+                    "text": {"body": body},
+                },
+            )
+
+    async def stream_progress(
+        self,
+        event: ParsedInboundSurfaceEvent,
+        progress_text: str,
+    ) -> None:
+        """Post a progress update as its own message.
+
+        WhatsApp has no message-edit API, so unlike Telegram or Teams there is no
+        live message to rewrite — an update can only be a new message in the
+        person's chat. The observer is what keeps that from becoming spam: it
+        rations these to a moved plan or one "still going" per run. This end just
+        sends what it is given, best-effort, so a failed update cannot touch the
+        run.
+        """
+        phone_number_id = (
+            event.reply_target.get("phone_number_id") or self._phone_number_id
+        )
+        sender_wa_id = event.reply_target.get("sender_wa_id") or event.sender_phone
+        if not sender_wa_id or not phone_number_id or not self._access_token:
+            return
+        body = to_whatsapp_text(progress_text)
+        if not body:
+            return
         await self._client.send_message_payload(
             phone_number_id=phone_number_id,
-            payload={
-                "messaging_product": "whatsapp",
-                "to": sender_wa_id,
-                "type": "text",
-                "text": {"body": to_whatsapp_text(message)},
-            },
+            payload=whatsapp_text_payload(
+                recipient_wa_id=sender_wa_id,
+                body=body,
+                preview_url=False,
+            ),
         )
 
     async def send_questions(
@@ -231,7 +183,7 @@ class WhatsAppPlatformService:
             return False
         interactives = []
         for question in question_plan.questions:
-            interactive = _build_whatsapp_interactive(
+            interactive = build_whatsapp_interactive(
                 question_plan.callback_id, question
             )
             if interactive is None:
@@ -264,7 +216,7 @@ class WhatsAppPlatformService:
         sender_wa_id = event.reply_target.get("sender_wa_id") or event.sender_phone
         if not sender_wa_id or not phone_number_id or not self._access_token:
             return False
-        interactive = _build_whatsapp_approval_interactive(approval_plan)
+        interactive = build_whatsapp_approval_interactive(approval_plan)
         if interactive is None:
             return False
         await self._client.send_interactive(
@@ -295,9 +247,9 @@ class WhatsAppPlatformService:
         if action is None:
             await self._client.send_message_payload(
                 phone_number_id=phone_number_id,
-                payload=_whatsapp_text_payload(
+                payload=whatsapp_text_payload(
                     recipient_wa_id=sender_wa_id,
-                    body=_whatsapp_display_resource_text(render_plan),
+                    body=whatsapp_display_resource_text(render_plan),
                     preview_url=False,
                 ),
             )
@@ -306,7 +258,7 @@ class WhatsAppPlatformService:
         try:
             await self._client.send_message_payload(
                 phone_number_id=phone_number_id,
-                payload=_whatsapp_cta_url_payload(
+                payload=whatsapp_cta_url_payload(
                     recipient_wa_id=sender_wa_id,
                     render_plan=render_plan,
                 ),
@@ -317,9 +269,9 @@ class WhatsAppPlatformService:
             )
             await self._client.send_message_payload(
                 phone_number_id=phone_number_id,
-                payload=_whatsapp_text_payload(
+                payload=whatsapp_text_payload(
                     recipient_wa_id=sender_wa_id,
-                    body=_whatsapp_display_resource_text(render_plan),
+                    body=whatsapp_display_resource_text(render_plan),
                     preview_url=True,
                 ),
             )
@@ -336,9 +288,12 @@ class WhatsAppPlatformService:
         shows for ~25s or until the next message is sent, so a single call at run
         start is enough (WhatsApp has no message-edit API for per-step progress).
         Best-effort: an indicator failure never affects the run. When the inbound
-        message id is missing we fall back to the legacy 💬 reaction.
+        message id is missing we fall back to the legacy 💬 reaction — but only
+        on the opening call. The bubble expires after ~25s so the observer
+        refreshes it on a timer, and a reaction re-posted on every tick would be
+        an API call every twenty seconds to say something already said.
         """
-        del metadata
+        is_refresh = bool((metadata or {}).get("is_refresh"))
         phone_number_id = (
             event.reply_target.get("phone_number_id") or self._phone_number_id
         )
@@ -363,7 +318,7 @@ class WhatsAppPlatformService:
 
         # Fallback: no inbound id (or read/typing rejected) — post a reaction so
         # the user still sees the agent acknowledged the message.
-        if not sender_wa_id or not message_id:
+        if is_refresh or not sender_wa_id or not message_id:
             return
         try:
             await self._client.react(
@@ -397,7 +352,7 @@ class WhatsAppPlatformService:
             return None
         file_name = (
             str(attachment.get("name") or "").strip()
-            or _filename_from_url(download_url)
+            or filename_from_url(download_url)
             or "whatsapp_file"
         )
         content = await self._client.download_media(download_url)
@@ -430,7 +385,7 @@ class WhatsAppPlatformService:
         recipient_wa_id = event.reply_target.get("sender_wa_id") or event.sender_phone
         if not self._access_token or not phone_number_id or not recipient_wa_id:
             return False
-        send_type = _resolve_whatsapp_send_type(
+        send_type = resolve_whatsapp_send_type(
             delivery_mode="auto", mime_type=mime_type
         )
         try:
@@ -534,94 +489,3 @@ class WhatsAppPlatformService:
             if candidate:
                 return candidate
         return None
-
-
-def _resolve_whatsapp_send_type(*, delivery_mode: str, mime_type: str) -> str:
-    requested = str(delivery_mode or "auto").lower()
-    if requested != "auto":
-        return requested
-    if mime_type.startswith("image/"):
-        return "image"
-    if mime_type.startswith("audio/"):
-        return "audio"
-    if mime_type.startswith("video/"):
-        return "video"
-    return "document"
-
-
-def _whatsapp_cta_url_payload(
-    *,
-    recipient_wa_id: str,
-    render_plan: SurfaceDisplayRenderPlan,
-) -> dict[str, Any]:
-    action = render_plan.primary_action
-    body = _truncate_whatsapp_text(
-        _whatsapp_display_resource_text(render_plan, include_action=False),
-        1024,
-    )
-    return {
-        "messaging_product": "whatsapp",
-        "recipient_type": "individual",
-        "to": recipient_wa_id,
-        "type": "interactive",
-        "interactive": {
-            "type": "cta_url",
-            "body": {"text": body},
-            "action": {
-                "name": "cta_url",
-                "parameters": {
-                    "display_text": _truncate_whatsapp_button_text(
-                        action.label if action else "Open"
-                    ),
-                    "url": action.url if action else "",
-                },
-            },
-        },
-    }
-
-
-def _whatsapp_text_payload(
-    *,
-    recipient_wa_id: str,
-    body: str,
-    preview_url: bool,
-) -> dict[str, Any]:
-    return {
-        "messaging_product": "whatsapp",
-        "recipient_type": "individual",
-        "to": recipient_wa_id,
-        "type": "text",
-        "text": {
-            "body": _truncate_whatsapp_text(to_whatsapp_text(body), 4096),
-            "preview_url": preview_url,
-        },
-    }
-
-
-def _whatsapp_display_resource_text(
-    render_plan: SurfaceDisplayRenderPlan,
-    *,
-    include_action: bool = True,
-) -> str:
-    parts = [f"*{render_plan.title}*"]
-    if render_plan.summary:
-        parts.append(render_plan.summary)
-    parts.extend(render_plan.detail_lines[:5])
-    action = render_plan.primary_action
-    if include_action and action is not None:
-        parts.append(f"{action.label}: {action.url}")
-    return "\n\n".join(parts)
-
-
-def _truncate_whatsapp_button_text(value: str) -> str:
-    text = " ".join(str(value or "").split()) or "Open"
-    return text if len(text) <= 20 else text[:19].rstrip() + "..."
-
-
-def _truncate_whatsapp_text(value: str, max_length: int) -> str:
-    text = str(value or "").strip()
-    return text if len(text) <= max_length else text[: max_length - 1].rstrip() + "..."
-
-
-def _filename_from_url(url: str) -> str:
-    return str(url or "").rstrip("/").split("/")[-1].strip()

--- a/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/service.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/service.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from pydantic_ai.tools import RunContext
 
+from app.core.log.log import get_logger
 from app.modules.agent.contracts import ConversationContext
 from app.modules.agent_surfaces.domain.entities import ParsedInboundSurfaceEvent
 from app.modules.agent_surfaces.domain.models import (
@@ -27,7 +28,10 @@ from app.modules.agent_surfaces.platforms.whatsapp.models import (
     WhatsAppCurrentContactResult,
     WhatsAppFileAttachment,
 )
-from app.core.log.log import get_logger
+from app.modules.agent_surfaces.platforms.whatsapp.text_format import (
+    to_plain_text,
+    to_whatsapp_text,
+)
 
 logger = get_logger(__name__)
 
@@ -191,7 +195,7 @@ class WhatsAppPlatformService:
                 "messaging_product": "whatsapp",
                 "to": sender_wa_id,
                 "type": "text",
-                "text": {"body": message},
+                "text": {"body": to_whatsapp_text(message)},
             },
         )
 
@@ -453,7 +457,7 @@ class WhatsAppPlatformService:
             media_id=media_id,
             send_type=send_type,
             file_name=file_name,
-            caption=caption,
+            caption=to_plain_text(caption) if caption else None,
         )
         return bool(message_id)
 
@@ -588,7 +592,7 @@ def _whatsapp_text_payload(
         "to": recipient_wa_id,
         "type": "text",
         "text": {
-            "body": _truncate_whatsapp_text(body, 4096),
+            "body": _truncate_whatsapp_text(to_whatsapp_text(body), 4096),
             "preview_url": preview_url,
         },
     }

--- a/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/text_format.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/text_format.py
@@ -1,0 +1,136 @@
+"""Translate and sanitize free-form text for WhatsApp delivery.
+
+WhatsApp renders a small native subset — ``*bold*``, ``_italic_``,
+``~strike~``, ````` ``` ````` for monospace — and nothing else. The agents
+that author outbound messages write normal Markdown, and when any of it leaks
+through we get the symptom this fixes: literal ``*asterisks*`` on the phone
+instead of bold. Two things make WhatsApp show markers verbatim:
+
+* Markdown with no WhatsApp mapping (``**bold**``, ``# heading``,
+  ``[t](url)``, `` `code` ``) is passed through as-is, so it renders literally.
+* WhatsApp drops *all* native formatting in a message the moment its
+  delimiters unbalance — a stray ``*``, a bare ``*`` used as a bullet, an odd
+  trailing marker. One stray ``*`` and every ``*bold*`` in that message renders
+  literally.
+
+``to_whatsapp_text`` converts the Markdown that maps onto WhatsApp's subset,
+leaves syntax WhatsApp already understands untouched, and reduces everything
+else to plain text so no raw marker leaks. ``to_plain_text`` is the aggressive
+variant for media captions, where WhatsApp never applies formatting at all —
+there markers are removed entirely so the caption reads clean.
+"""
+
+from __future__ import annotations
+
+import re
+
+# 1..6 heading prefix at the start of a line: ``# Heading`` -> ``Heading``.
+_HEADING_PATTERN = re.compile(r"(?m)^[ \t]{0,3}#{1,6}[ \t]+(.*)$")
+
+# Markdown strong: ``**bold**`` -> ``*bold*``.
+_STRONG_PATTERN = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
+
+# Markdown inline code: `` `code` `` -> ``` ``code`` ``` (WhatsApp monospace).
+_INLINE_CODE_PATTERN = re.compile(r"(?<!`)`([^`\n]+)`(?!`)")
+
+# Markdown link: ``[label](url)`` -> bare ``url`` (WhatsApp guidance: paste the
+# bare URL).
+_LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)\s]+)\)")
+
+# A lone ``*`` on its own line — a bare bullet, not formatting. Dropping it
+# keeps the message's delimiters balanced so it cannot nuke nearby bold.
+_BARE_ASTERISK_BULLET_PATTERN = re.compile(r"(?m)^[ \t]*\*[ \t]*$")
+
+# Stray delimiters hugging whitespace and/or a line edge (no text both sides).
+# These are the unbalanced markers that kill the rest of the message's
+# formatting; we only drop a delimiter that is adjacent to whitespace or the
+# start/end of a line, never one that touches text on both sides.
+_STRAY_OPEN_PATTERN = re.compile(r"(?:^|(?<=\s))[*_~](?=\s)")
+_STRAY_CLOSE_PATTERN = re.compile(r"(?<=\s)[*_~](?:$|(?=\s))")
+
+
+def to_whatsapp_text(text: str) -> str:
+    """Map Markdown onto WhatsApp's subset and balance its delimiters.
+
+    Text the author already wrote in WhatsApp syntax (``*bold*``, ``_italic_``,
+    ``~strike~``, ``` ``` ```code``` ``) is preserved byte-for-byte. Markdown
+    with a mapping is translated; Markdown with no mapping (headings, links,
+    code fences) is reduced to plain text.
+    """
+    if not text:
+        return text
+
+    result = text
+
+    # Headings have no WhatsApp equivalent — strip the prefix, keep the words.
+    result = _HEADING_PATTERN.sub(lambda m: m.group(1), result)
+
+    # Links: emit the bare URL, matching the platform's WhatsApp guidance.
+    result = _LINK_PATTERN.sub(lambda m: m.group(2), result)
+
+    # Paired code fences: keep the code, drop the fence lines. A single
+    # triple-backtick monospace span (WhatsApp native) is left untouched.
+    result = _strip_fenced_code_blocks(result)
+
+    # Markdown strong -> WhatsApp bold.
+    result = _STRONG_PATTERN.sub(r"*\1*", result)
+
+    # Markdown inline code -> WhatsApp monospace (triple backticks).
+    result = _INLINE_CODE_PATTERN.sub(lambda m: "```" + m.group(1) + "```", result)
+
+    # A bare ``*`` bullet is not bold — drop it so it stays balanced.
+    result = _BARE_ASTERISK_BULLET_PATTERN.sub("", result)
+
+    # Drop stray delimiters hugging whitespace (fixpoint: early drops can expose
+    # new edges).
+    for _ in range(4):
+        before = result
+        result = _STRAY_OPEN_PATTERN.sub("", result)
+        result = _STRAY_CLOSE_PATTERN.sub("", result)
+        if result == before:
+            break
+
+    return result.strip()
+
+
+def to_plain_text(text: str) -> str:
+    """Strip every formatting marker to plain text (for media captions).
+
+    WhatsApp never renders Markdown in captions, so a caption carrying
+    ``*emphasis*``, ``**bold**`` or ``` ```code``` `` would show the literal
+    markers. This removes them and collapses the text to clean lines.
+    """
+    if not text:
+        return text
+
+    result = _HEADING_PATTERN.sub(lambda m: m.group(1), text)
+    result = _LINK_PATTERN.sub(lambda m: m.group(2), result)
+    result = _strip_fenced_code_blocks(result)
+    # Remove any run of formatting delimiters (backticks, asterisks, tilde).
+    # Underscores are common in identifiers, so a ``_`` pair is only removed when
+    # it does not touch word characters on either side (a genuine italic marker).
+    result = re.sub(r"`{1,3}|\*{1,2}|~{1,2}", "", result)
+    # Underscores are common in identifiers, so a ``_`` pair is only treated as
+    # an italic marker when it wraps a word: ``_word_`` -> ``word``. A word-
+    # internal ``_`` (``a_b``, ``var_name``) is an identifier, not formatting,
+    # and is kept.
+    result = re.sub(r"(?<!\w)_([^\s_]+)_(?!\w)", r"\1", result)
+    # A stray single ``_`` not touching a word on either side is dropped.
+    result = re.sub(r"(?<!\w)_(?!\w)", "", result)
+    # Collapse leftover whitespace and blank lines.
+    result = re.sub(r"[ \t]*\n[ \t]*\n+", "\n", result)
+    result = re.sub(r" {2,}", " ", result)
+    return result.strip()
+
+
+def _strip_fenced_code_blocks(text: str) -> str:
+    """Remove *paired* backtick/tilde code fences, keeping the code lines.
+
+    Only a real block (an opening fence line, content, a closing fence line) is
+    touched; a single-line triple-backtick monospace span is WhatsApp-native and
+    deliberately left alone so ``to_whatsapp_text`` cannot mangle it.
+    """
+    fenced = re.compile(r"(?ms)^[ \t]*`{3,}[^\n]*\n(?P<body>.*?)\n^[ \t]*`{3,}[^\n]*$")
+    result = fenced.sub(lambda m: m.group("body"), text)
+    tilde = re.compile(r"(?ms)^[ \t]*~{3,}[^\n]*\n(?P<body>.*?)\n^[ \t]*~{3,}[^\n]*$")
+    return tilde.sub(lambda m: m.group("body"), result)

--- a/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/text_format.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/text_format.py
@@ -1,52 +1,101 @@
 """Translate and sanitize free-form text for WhatsApp delivery.
 
 WhatsApp renders a small native subset — ``*bold*``, ``_italic_``,
-``~strike~``, ````` ``` ````` for monospace — and nothing else. The agents
-that author outbound messages write normal Markdown, and when any of it leaks
-through we get the symptom this fixes: literal ``*asterisks*`` on the phone
-instead of bold. Two things make WhatsApp show markers verbatim:
+``~strike~``, ````` ``` ````` for monospace, ``- `` bullets, ``> `` quotes —
+and nothing else. The agents that author outbound messages write normal
+Markdown, and when any of it leaks through we get the symptom this fixes:
+literal ``*asterisks*`` on the phone instead of bold. Two things make WhatsApp
+show markers verbatim:
 
 * Markdown with no WhatsApp mapping (``**bold**``, ``# heading``,
   ``[t](url)``, `` `code` ``) is passed through as-is, so it renders literally.
-* WhatsApp drops *all* native formatting in a message the moment its
-  delimiters unbalance — a stray ``*``, a bare ``*`` used as a bullet, an odd
-  trailing marker. One stray ``*`` and every ``*bold*`` in that message renders
-  literally.
+* A delimiter that never finds a partner (``*bold`` with no closing marker)
+  renders as a literal character in the middle of a sentence.
 
 ``to_whatsapp_text`` converts the Markdown that maps onto WhatsApp's subset,
 leaves syntax WhatsApp already understands untouched, and reduces everything
 else to plain text so no raw marker leaks. ``to_plain_text`` is the aggressive
 variant for media captions, where WhatsApp never applies formatting at all —
 there markers are removed entirely so the caption reads clean.
+
+Both share one rule about stray delimiters, and it is deliberately narrower
+than "delete anything suspicious". A delimiter is only removed when it is
+*unpaired and hugging text on exactly one side* — the shape of a genuinely
+broken marker. A delimiter with whitespace on both sides is something the
+author typed as a character (``2 * 3 = 6``, ``approx ~5 items``), and deleting
+it silently rewrites the message; one with text on both sides is an identifier
+(``var_name``). Both survive.
 """
 
 from __future__ import annotations
 
 import re
 
-# 1..6 heading prefix at the start of a line: ``# Heading`` -> ``Heading``.
-_HEADING_PATTERN = re.compile(r"(?m)^[ \t]{0,3}#{1,6}[ \t]+(.*)$")
+_DELIMITERS = ("*", "_", "~")
 
-# Markdown strong: ``**bold**`` -> ``*bold*``.
-_STRONG_PATTERN = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
+# 1..6 heading prefix at the start of a line: ``# Heading`` -> ``*Heading*``.
+# WhatsApp has no headings, but it has bold, and a heading reduced to bare prose
+# loses the structure the author was signalling.
+_HEADING_PATTERN = re.compile(
+    r"(?m)^[ \t]{0,3}#{1,6}[ \t]+(?P<text>.+?)[ \t]*#*[ \t]*$"
+)
+
+# Markdown strong: ``**bold**`` / ``__bold__`` -> ``*bold*``. Deliberately not
+# DOTALL: WhatsApp's bold does not span a newline, so a match that crossed one
+# would emit a pair the platform renders as two literal asterisks.
+_STRONG_STAR_PATTERN = re.compile(r"\*\*(?P<text>[^\n*]+?)\*\*")
+_STRONG_UNDERSCORE_PATTERN = re.compile(r"__(?P<text>[^\n_]+?)__")
 
 # Markdown inline code: `` `code` `` -> ``` ``code`` ``` (WhatsApp monospace).
 _INLINE_CODE_PATTERN = re.compile(r"(?<!`)`([^`\n]+)`(?!`)")
 
+# Markdown image: ``![alt](url)`` -> the URL. Matched before links so the
+# leading ``!`` goes with it instead of being left stranded.
+_IMAGE_PATTERN = re.compile(r"!\[(?P<alt>[^\]]*)\]\((?P<url>[^)\s]+)\)")
+
 # Markdown link: ``[label](url)`` -> bare ``url`` (WhatsApp guidance: paste the
-# bare URL).
+# bare URL, which the client auto-links).
 _LINK_PATTERN = re.compile(r"\[([^\]]*)\]\(([^)\s]+)\)")
 
-# A lone ``*`` on its own line — a bare bullet, not formatting. Dropping it
-# keeps the message's delimiters balanced so it cannot nuke nearby bold.
-_BARE_ASTERISK_BULLET_PATTERN = re.compile(r"(?m)^[ \t]*\*[ \t]*$")
+# A thematic break (``---``, ``***``, ``___``) has no WhatsApp equivalent, and
+# the asterisk/underscore forms are stray delimiters if left in place.
+_THEMATIC_BREAK_PATTERN = re.compile(
+    r"(?m)^[ \t]{0,3}(?:(?:\*[ \t]*){3,}|(?:_[ \t]*){3,}|(?:-[ \t]*){3,})$"
+)
 
-# Stray delimiters hugging whitespace and/or a line edge (no text both sides).
-# These are the unbalanced markers that kill the rest of the message's
-# formatting; we only drop a delimiter that is adjacent to whitespace or the
-# start/end of a line, never one that touches text on both sides.
-_STRAY_OPEN_PATTERN = re.compile(r"(?:^|(?<=\s))[*_~](?=\s)")
-_STRAY_CLOSE_PATTERN = re.compile(r"(?<=\s)[*_~](?:$|(?=\s))")
+# List bullets written with ``*`` or ``+``. WhatsApp renders ``- `` as a native
+# bullet, so the marker is translated rather than deleted — dropping it flattens
+# a list into an unmarked run of lines.
+_STAR_BULLET_PATTERN = re.compile(r"(?m)^(?P<indent>[ \t]*)[*+][ \t]+(?=\S)")
+
+# A lone ``*``/``+``/``-`` on its own line — an empty bullet, not formatting.
+_EMPTY_BULLET_PATTERN = re.compile(r"(?m)^[ \t]*[*+-][ \t]*$")
+
+# A markdown table separator row (``|---|:--:|``) is pure layout scaffolding.
+_TABLE_SEPARATOR_PATTERN = re.compile(
+    r"(?m)^[ \t]*\|?[ \t]*:?-{2,}:?[ \t]*(?:\|[ \t]*:?-{2,}:?[ \t]*)+\|?[ \t]*$"
+)
+
+# A markdown table row. WhatsApp has no tables and a pipe grid on a phone is
+# unreadable, so cells are joined into one line.
+_TABLE_ROW_PATTERN = re.compile(r"(?m)^[ \t]*\|(?P<cells>.+)\|[ \t]*$")
+
+# Markdown strong that survived translation because it spans a newline.
+_LEFTOVER_STRONG_RUN_PATTERN = re.compile(r"\*{2,}")
+_BLANK_RUN_PATTERN = re.compile(r"\n{3,}")
+
+# Code fences are stashed under a placeholder while the rest is rewritten. The
+# NUL terminator cannot occur in a WhatsApp message body, so nothing an author
+# writes can collide with it.
+_FENCE_PLACEHOLDER = "\x00lemma-fence-"
+_FENCE_PLACEHOLDER_PATTERN = re.compile(r"\x00lemma-fence-(?P<index>\d+)\x00")
+
+_FENCED_BACKTICK_PATTERN = re.compile(
+    r"(?ms)^[ \t]*`{3,}[^\n]*\n(?P<body>.*?)\n^[ \t]*`{3,}[ \t]*$"
+)
+_FENCED_TILDE_PATTERN = re.compile(
+    r"(?ms)^[ \t]*~{3,}[^\n]*\n(?P<body>.*?)\n^[ \t]*~{3,}[ \t]*$"
+)
 
 
 def to_whatsapp_text(text: str) -> str:
@@ -55,42 +104,66 @@ def to_whatsapp_text(text: str) -> str:
     Text the author already wrote in WhatsApp syntax (``*bold*``, ``_italic_``,
     ``~strike~``, ``` ``` ```code``` ``) is preserved byte-for-byte. Markdown
     with a mapping is translated; Markdown with no mapping (headings, links,
-    code fences) is reduced to plain text.
+    tables) is reduced to the nearest thing WhatsApp can show.
     """
     if not text:
         return text
 
-    result = text
+    result = text.replace("\r\n", "\n").replace("\r", "\n")
 
-    # Headings have no WhatsApp equivalent — strip the prefix, keep the words.
-    result = _HEADING_PATTERN.sub(lambda m: m.group(1), result)
+    # Fenced code blocks come out first and go back in last. Everything between
+    # is a Markdown rewrite, and a code block is the one place where ``**``,
+    # ``# ``, and ``|`` are literal characters the author wants delivered
+    # verbatim — rewriting them would corrupt the code being shown.
+    result, blocks = _extract_code_fences(result)
 
-    # Links: emit the bare URL, matching the platform's WhatsApp guidance.
+    # Images before links: the pattern for a link also matches the ``[alt](url)``
+    # tail of an image, which would leave a stranded ``!``.
+    result = _IMAGE_PATTERN.sub(lambda m: m.group("url"), result)
     result = _LINK_PATTERN.sub(lambda m: m.group(2), result)
 
-    # Paired code fences: keep the code, drop the fence lines. A single
-    # triple-backtick monospace span (WhatsApp native) is left untouched.
-    result = _strip_fenced_code_blocks(result)
+    result = _THEMATIC_BREAK_PATTERN.sub("", result)
+    result = _flatten_tables(result)
+
+    # Headings have no WhatsApp equivalent; bold is the closest thing it has.
+    result = _HEADING_PATTERN.sub(lambda m: f"*{m.group('text')}*", result)
 
     # Markdown strong -> WhatsApp bold.
-    result = _STRONG_PATTERN.sub(r"*\1*", result)
+    result = _STRONG_STAR_PATTERN.sub(lambda m: f"*{m.group('text')}*", result)
+    result = _STRONG_UNDERSCORE_PATTERN.sub(lambda m: f"*{m.group('text')}*", result)
+    # Any ``**`` left over spans a newline, which WhatsApp's bold cannot. Collapsed
+    # to a single marker so the balancing pass below can judge it; left as a run it
+    # would sail past that pass and land on the phone as literal asterisks.
+    result = _LEFTOVER_STRONG_RUN_PATTERN.sub("*", result)
 
     # Markdown inline code -> WhatsApp monospace (triple backticks).
     result = _INLINE_CODE_PATTERN.sub(lambda m: "```" + m.group(1) + "```", result)
 
-    # A bare ``*`` bullet is not bold — drop it so it stays balanced.
-    result = _BARE_ASTERISK_BULLET_PATTERN.sub("", result)
+    # ``* item`` / ``+ item`` -> ``- item``, which WhatsApp bullets natively.
+    result = _STAR_BULLET_PATTERN.sub(lambda m: f"{m.group('indent')}- ", result)
+    result = _EMPTY_BULLET_PATTERN.sub("", result)
 
-    # Drop stray delimiters hugging whitespace (fixpoint: early drops can expose
-    # new edges).
-    for _ in range(4):
-        before = result
-        result = _STRAY_OPEN_PATTERN.sub("", result)
-        result = _STRAY_CLOSE_PATTERN.sub("", result)
-        if result == before:
-            break
-
+    result = balance_whatsapp_delimiters(result)
+    result = _restore_code_fences(result, blocks)
+    # Dropped rules and empty bullets leave runs of blank lines behind.
+    result = _BLANK_RUN_PATTERN.sub("\n\n", result)
     return result.strip()
+
+
+def balance_whatsapp_delimiters(text: str) -> str:
+    """Drop delimiters that can never pair, leaving literal characters alone.
+
+    Exposed because truncation happens *after* translation — slicing a message
+    at 4096 characters can cut a ``*bold*`` pair in half, which is exactly the
+    broken marker this module exists to prevent. Re-run it on anything that was
+    cut.
+    """
+    if not text:
+        return text
+    lines = text.split("\n")
+    for delimiter in _DELIMITERS:
+        lines = [_drop_unpaired(line, delimiter) for line in lines]
+    return "\n".join(lines)
 
 
 def to_plain_text(text: str) -> str:
@@ -98,39 +171,157 @@ def to_plain_text(text: str) -> str:
 
     WhatsApp never renders Markdown in captions, so a caption carrying
     ``*emphasis*``, ``**bold**`` or ``` ```code``` `` would show the literal
-    markers. This removes them and collapses the text to clean lines.
+    markers. Paired markers are removed; a character the author typed as itself
+    (``2 * 3``, ``approx ~5``, ``var_name``) is kept.
     """
     if not text:
         return text
 
-    result = _HEADING_PATTERN.sub(lambda m: m.group(1), text)
-    result = _LINK_PATTERN.sub(lambda m: m.group(2), result)
-    result = _strip_fenced_code_blocks(result)
-    # Remove any run of formatting delimiters (backticks, asterisks, tilde).
-    # Underscores are common in identifiers, so a ``_`` pair is only removed when
-    # it does not touch word characters on either side (a genuine italic marker).
-    result = re.sub(r"`{1,3}|\*{1,2}|~{1,2}", "", result)
-    # Underscores are common in identifiers, so a ``_`` pair is only treated as
-    # an italic marker when it wraps a word: ``_word_`` -> ``word``. A word-
-    # internal ``_`` (``a_b``, ``var_name``) is an identifier, not formatting,
-    # and is kept.
-    result = re.sub(r"(?<!\w)_([^\s_]+)_(?!\w)", r"\1", result)
-    # A stray single ``_`` not touching a word on either side is dropped.
-    result = re.sub(r"(?<!\w)_(?!\w)", "", result)
+    result = to_whatsapp_text(text)
+    result = re.sub(r"`{3}", "", result)
+    for delimiter in _DELIMITERS:
+        result = "\n".join(_drop_paired(line, delimiter) for line in result.split("\n"))
     # Collapse leftover whitespace and blank lines.
     result = re.sub(r"[ \t]*\n[ \t]*\n+", "\n", result)
     result = re.sub(r" {2,}", " ", result)
     return result.strip()
 
 
-def _strip_fenced_code_blocks(text: str) -> str:
-    """Remove *paired* backtick/tilde code fences, keeping the code lines.
+def _extract_code_fences(text: str) -> tuple[str, list[str]]:
+    """Replace paired fences with placeholders; return the text and the blocks.
 
-    Only a real block (an opening fence line, content, a closing fence line) is
-    touched; a single-line triple-backtick monospace span is WhatsApp-native and
-    deliberately left alone so ``to_whatsapp_text`` cannot mangle it.
+    The block that comes back is WhatsApp monospace — the fence is kept, because
+    WhatsApp does render a multi-line ``` block and code reduced to bare prose is
+    indistinguishable from the sentence above it. Only the ``py`` / ``bash`` info
+    string is dropped, since WhatsApp would print it as the block's first line.
     """
-    fenced = re.compile(r"(?ms)^[ \t]*`{3,}[^\n]*\n(?P<body>.*?)\n^[ \t]*`{3,}[^\n]*$")
-    result = fenced.sub(lambda m: m.group("body"), text)
-    tilde = re.compile(r"(?ms)^[ \t]*~{3,}[^\n]*\n(?P<body>.*?)\n^[ \t]*~{3,}[^\n]*$")
-    return tilde.sub(lambda m: m.group("body"), result)
+    blocks: list[str] = []
+
+    def _stash(match: re.Match[str]) -> str:
+        blocks.append("```\n" + match.group("body") + "\n```")
+        return f"{_FENCE_PLACEHOLDER}{len(blocks) - 1}\x00"
+
+    result = _FENCED_BACKTICK_PATTERN.sub(_stash, text)
+    result = _FENCED_TILDE_PATTERN.sub(_stash, result)
+    return result, blocks
+
+
+def _restore_code_fences(text: str, blocks: list[str]) -> str:
+    if not blocks:
+        return text
+    return _FENCE_PLACEHOLDER_PATTERN.sub(lambda m: blocks[int(m.group("index"))], text)
+
+
+def _flatten_tables(text: str) -> str:
+    """Turn a Markdown table into one line per row, ``a — b — c``.
+
+    A pipe grid on a phone wraps into nonsense and the ``|---|`` rule row is
+    pure scaffolding. Neither carries meaning WhatsApp can show, so the cells
+    become a readable line instead.
+    """
+    result = _TABLE_SEPARATOR_PATTERN.sub("", text)
+
+    def _row(match: re.Match[str]) -> str:
+        cells = [cell.strip() for cell in match.group("cells").split("|")]
+        return " — ".join(cell for cell in cells if cell)
+
+    return _TABLE_ROW_PATTERN.sub(_row, result)
+
+
+def _flanking(line: str, index: int) -> tuple[bool, bool]:
+    """Whether the delimiter at ``index`` can open and/or close a span.
+
+    WhatsApp will not open a span whose first character is whitespace, nor close
+    one whose last character is whitespace, so a marker's role is decided by its
+    neighbours (a line edge counts as whitespace):
+
+    * whitespace before, text after -> it can only open;
+    * text before, whitespace after -> it can only close;
+    * text on both sides -> part of a word (``var_name``, a URL path), not a
+      marker at all;
+    * whitespace on both sides -> a character the author typed (``2 * 3``).
+
+    The last two cases return ``(False, False)``: neither pairs, and neither is
+    ever removed.
+    """
+    left = line[index - 1] if index > 0 else " "
+    right = line[index + 1] if index + 1 < len(line) else " "
+    left_is_space = left.isspace()
+    right_is_space = right.isspace()
+    if left_is_space == right_is_space:
+        return False, False
+    return right_is_space is False, left_is_space is False
+
+
+def _delimiter_positions(line: str, delimiter: str) -> list[int]:
+    """Single occurrences of ``delimiter``, skipping runs (``**``, ``~~``).
+
+    A run is either already-translated syntax or something the author repeated
+    on purpose; pairing individual characters out of it would corrupt it.
+    """
+    positions: list[int] = []
+    index = 0
+    length = len(line)
+    while index < length:
+        if line[index] != delimiter:
+            index += 1
+            continue
+        run_end = index
+        while run_end < length and line[run_end] == delimiter:
+            run_end += 1
+        if run_end - index == 1:
+            positions.append(index)
+        index = run_end
+    return positions
+
+
+def _pair(line: str, delimiter: str) -> tuple[set[int], set[int]]:
+    """Greedily pair markers on one line; return ``(paired, unpaired)``.
+
+    Only markers that flank text on exactly one side take part — the rest are
+    literal characters and appear in neither set, so neither pass touches them.
+    """
+    paired: set[int] = set()
+    unpaired: set[int] = set()
+    open_index: int | None = None
+    for index in _delimiter_positions(line, delimiter):
+        can_open, can_close = _flanking(line, index)
+        if open_index is None:
+            if can_open:
+                open_index = index
+            elif can_close:
+                unpaired.add(index)
+            continue
+        if can_close:
+            paired.add(open_index)
+            paired.add(index)
+            open_index = None
+        else:
+            # A second opener with no close between them: the first one is the
+            # broken marker, and this one may still find a partner.
+            unpaired.add(open_index)
+            open_index = index
+    if open_index is not None:
+        unpaired.add(open_index)
+    return paired, unpaired
+
+
+def _drop_unpaired(line: str, delimiter: str) -> str:
+    """Remove markers that flank text but never found a partner.
+
+    That one-sided shape is what a broken marker looks like — ``*bold`` with no
+    close, or a pair cut in half by truncation. Everything ``_pair`` declined to
+    classify is a character the author typed, and stays.
+    """
+    _, unpaired = _pair(line, delimiter)
+    if not unpaired:
+        return line
+    return "".join(char for i, char in enumerate(line) if i not in unpaired)
+
+
+def _drop_paired(line: str, delimiter: str) -> str:
+    """Remove only the delimiters that form a real pair (caption stripping)."""
+    paired, _ = _pair(line, delimiter)
+    if not paired:
+        return line
+    return "".join(char for i, char in enumerate(line) if i not in paired)

--- a/lemma-backend/app/modules/agent_surfaces/services/progress_display.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/progress_display.py
@@ -124,10 +124,11 @@ class ProgressDisplayMixin:
     async def _maybe_post_progress(self, conversation_id, activity: str | None) -> None:
         """Send a standing-alone progress message, sparingly.
 
-        Before this, a long run on WhatsApp was silence: no typing indicator
-        exists there, no adapter ever sent the reaction the registry claimed
-        covered it, and the next thing the person saw was the answer — minutes
-        later, with no way to tell a slow run from a dropped one.
+        Before this, a long run on WhatsApp was silence. The inbound path marks
+        the message read and shows a typing bubble when it picks the message up,
+        but that bubble expires after ~25s; past it the next thing the person saw
+        was the answer, minutes later, with no way to tell a slow run from a
+        dropped one.
 
         What gets through is the plan, and only when it has actually moved. A run
         with no plan gets a single "still going" once it is long enough to look

--- a/lemma-backend/app/modules/agent_surfaces/services/progress_display.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/progress_display.py
@@ -1,0 +1,176 @@
+"""Showing a run in flight, in whatever way the surface can manage.
+
+Split out of :mod:`progress_observer` because the observer owns a run's
+lifecycle — what is buffered, what is the answer, when it is delivered — while
+this owns the separate question of what the person watching sees before that
+answer arrives. The two used to be tangled, and the seam between them was three
+hand-maintained sets of platform names.
+
+There is one branch here, on the platform's :class:`ProgressStyle`, and it is
+the whole design:
+
+``STREAM``
+    A real streaming API. The answer is written into a live message and that
+    same message is closed with it, so steps and answer are one thing. Slack.
+``EDIT``
+    One live message, rewritten as the work moves. Cheap — an edit costs no new
+    notification — so it can be refreshed freely. Telegram, Teams.
+``POST``
+    No edit API at all. An update can only be a *new* message in someone's chat,
+    which costs their attention and, on WhatsApp, sits inside a metered 24-hour
+    window. So updates are rationed rather than throttled: the plan when it has
+    actually moved, and one "still going" for a long run that has none.
+``NONE``
+    Nothing before the reply, by design. Email.
+"""
+
+from __future__ import annotations
+
+import time
+
+from app.modules.agent.contracts import AgentEvent
+from app.modules.agent_surfaces.platforms.platform_capabilities import (
+    PLATFORM_CAPABILITIES,
+    ProgressStyle,
+)
+from app.modules.agent_surfaces.services.progress_events import (
+    _progress_text_from_event,
+)
+from app.modules.agent_surfaces.services.progress_plan import render_plan
+
+# How often a live, edited progress message may be rewritten. Slack never comes
+# through here: it streams the answer token by token, and a step chunk appended
+# into that same stream lands *inside* the sentence being written, splitting it
+# mid-word. Its streamed text is its own progress indicator.
+_MIN_TEXT_PROGRESS_INTERVAL_SECONDS = 2.0
+
+# The plan is the one update that gets through a ``POST`` platform immediately:
+# an agent only writes one for real multi-step work, and "here are the five
+# things I am about to do" is the most useful thing the person can be told at the
+# start of a long run. Everything after it waits its turn.
+_POST_PROGRESS_MIN_INTERVAL_SECONDS = 45.0
+_POST_PROGRESS_MAX_PER_RUN = 5
+# With no plan there is nothing substantive to report, so a long run gets one
+# acknowledgement that it is still alive and nothing more.
+_POST_HEARTBEAT_DELAY_SECONDS = 60.0
+_POST_HEARTBEAT_TEXT = (
+    "Still working on this — it is a longer one. "
+    "I will send the answer as soon as I have it."
+)
+
+
+class ProgressDisplayMixin:
+    """The "what does the person see while they wait" half of the observer."""
+
+    async def _maybe_send_text_progress(
+        self,
+        event: AgentEvent,
+        platform: str | None,
+        conversation_id,
+    ) -> None:
+        """Show what the run is doing, in whatever way this platform can.
+
+        Telegram/Teams rewrite one live message; WhatsApp has no edit API and can
+        only post a new one, so it is rationed instead of throttled. Slack does
+        not come through here at all — its streamed answer is its own progress
+        indicator. Email shows nothing before the reply, by design.
+        """
+        capabilities = PLATFORM_CAPABILITIES.get(platform or "")
+        if capabilities is None:
+            return
+        activity = _progress_text_from_event(event)
+        if capabilities.progress_style is ProgressStyle.EDIT:
+            await self._edit_live_progress(conversation_id, activity)
+        elif capabilities.progress_style is ProgressStyle.POST:
+            await self._maybe_post_progress(conversation_id, activity)
+
+    async def _edit_live_progress(self, conversation_id, activity: str | None) -> None:
+        """Rewrite the one live message: the plan, then what is happening now.
+
+        A plan that has moved is always worth an edit — that is the update the
+        person is waiting on — so it bypasses the activity throttle, which exists
+        only to stop a fast tool loop rewriting the message every few hundred
+        milliseconds.
+        """
+        plan_changed = self._plan is not None and (
+            self._plan.signature != self._shown_plan_signature
+        )
+        now = time.monotonic()
+        if not plan_changed:
+            if not activity:
+                return
+            if (
+                activity == self._last_text_progress
+                or now - self._last_text_progress_at
+                < _MIN_TEXT_PROGRESS_INTERVAL_SECONDS
+            ):
+                return
+        body = self._live_progress_body(activity)
+        if not body:
+            return
+        self._last_text_progress = activity
+        self._last_text_progress_at = now
+        if self._plan is not None:
+            self._shown_plan_signature = self._plan.signature
+        await self._stream_progress(conversation_id, body)
+
+    def _live_progress_body(self, activity: str | None) -> str:
+        """The checklist over the current step, for a message that gets edited."""
+        plan_text = render_plan(self._plan) if self._plan is not None else ""
+        if plan_text and activity:
+            return f"{plan_text}\n\n{activity}"
+        return plan_text or (activity or "")
+
+    async def _maybe_post_progress(self, conversation_id, activity: str | None) -> None:
+        """Send a standing-alone progress message, sparingly.
+
+        Before this, a long run on WhatsApp was silence: no typing indicator
+        exists there, no adapter ever sent the reaction the registry claimed
+        covered it, and the next thing the person saw was the answer — minutes
+        later, with no way to tell a slow run from a dropped one.
+
+        What gets through is the plan, and only when it has actually moved. A run
+        with no plan gets a single "still going" once it is long enough to look
+        broken. Both are capped per run, because every one of these is a message
+        in someone's chat.
+        """
+        del activity
+        now = time.monotonic()
+        if self._posted_updates >= _POST_PROGRESS_MAX_PER_RUN:
+            return
+        plan = self._plan
+        if plan is not None and plan.signature != self._shown_plan_signature:
+            first_update = self._posted_updates == 0
+            if (
+                not first_update
+                and now - self._last_post_at < _POST_PROGRESS_MIN_INTERVAL_SECONDS
+            ):
+                return
+            self._shown_plan_signature = plan.signature
+            await self._post_progress(conversation_id, render_plan(plan), now)
+            return
+        if (
+            plan is None
+            and not self._heartbeat_posted
+            and now - self._run_started_at >= _POST_HEARTBEAT_DELAY_SECONDS
+        ):
+            self._heartbeat_posted = True
+            await self._post_progress(conversation_id, _POST_HEARTBEAT_TEXT, now)
+
+    async def _post_progress(self, conversation_id, body: str, now: float) -> None:
+        if not body:
+            return
+        self._posted_updates += 1
+        self._last_post_at = now
+        await self._stream_progress(conversation_id, body)
+
+    async def _stream_progress(self, conversation_id, progress_text: str) -> None:
+        async with self.uow_factory() as uow:
+            service = self.service_factory(uow)
+            handle = await service.send_progress_update_for_conversation(
+                conversation_id=conversation_id,
+                progress_text=progress_text,
+                progress_handle=self._progress_handle,
+            )
+        if handle is not None:
+            self._progress_handle = handle

--- a/lemma-backend/app/modules/agent_surfaces/services/progress_observer.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/progress_observer.py
@@ -55,10 +55,12 @@ logger = get_logger(__name__)
 _TYPING_REFRESH_INTERVAL_SECONDS = {
     SurfacePlatform.TELEGRAM.value: 4.0,
     SurfacePlatform.TEAMS.value: 10.0,
-    # WhatsApp couples mark-as-read and the typing bubble into one call, and the
-    # bubble expires after ~25s. Refreshed inside that window it is the cheapest
-    # honest "still working" the platform has — it costs no conversation message
-    # and no attention, unlike the posted updates that back it up.
+    # WhatsApp couples mark-as-read and the typing bubble into one call, which
+    # the ingress path already makes once when it picks the message up. The
+    # bubble expires after ~25s, so on anything longer than a quick answer it
+    # went dark and stayed dark — dead in exactly the runs where it was the only
+    # sign of life. Refreshed inside that window it costs no conversation
+    # message and no attention, unlike the posted updates that back it up.
     SurfacePlatform.WHATSAPP.value: 20.0,
 }
 _MAX_TYPING_REFRESH_SECONDS = 15 * 60.0
@@ -166,25 +168,18 @@ class SurfaceAgentRunProgressObserver(
         if platform is None:
             return
         capabilities = PLATFORM_CAPABILITIES.get(platform or "")
-        if capabilities is None or not capabilities.shows_live_progress:
-            # Email: one composed reply and nothing before it.
-            return
-        if capabilities.finishes_stream_with_answer:
+        if capabilities is not None and capabilities.finishes_stream_with_answer:
             # Open the stream up front. Slack shows a live indicator on an open
             # stream, which is the only "working on it" signal a *channel* gets
             # — setStatus is assistant-DM only, and waiting for the first token
             # leaves a tool-heavy run looking dead. An empty stream is disposed
-            # of by end_progress if no answer ever arrives. That open stream *is*
-            # the acknowledgement, so nothing else is sent here.
+            # of by end_progress if no answer ever arrives.
             await self._open_stream(conversation)
-            return
-        # Acknowledge first, refresh second. These were behind one guard keyed on
-        # the refresh interval, so a platform absent from the refresh table never
-        # got the opening acknowledgement either — which is how WhatsApp came to
-        # have a read-receipt-and-typing call that nothing ever invoked.
-        sent = await self._send_indicator(conversation_id=conversation.id)
         interval = _TYPING_REFRESH_INTERVAL_SECONDS.get(platform)
-        if not sent or interval is None:
+        if interval is None:
+            return
+        sent = await self._send_indicator(conversation_id=conversation.id)
+        if not sent:
             return
         self._typing_task = create_inherited_task(
             self._refresh_typing_loop(

--- a/lemma-backend/app/modules/agent_surfaces/services/progress_observer.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/progress_observer.py
@@ -30,6 +30,13 @@ from app.modules.agent_surfaces.platforms.rendering import (
 from app.modules.agent_surfaces.services.ingress_service import (
     AgentSurfaceIngressService,
 )
+from app.modules.agent_surfaces.services.progress_display import (
+    ProgressDisplayMixin,
+)
+from app.modules.agent_surfaces.services.progress_plan import (
+    SurfacePlan,
+    plan_from_event,
+)
 from app.modules.agent_surfaces.services.token_stream import TokenStreamMixin
 from app.modules.agent_surfaces.services.progress_events import (
     _assistant_text_from_event,
@@ -39,7 +46,6 @@ from app.modules.agent_surfaces.services.progress_events import (
     _is_final_answer_event,
     _is_tool_activity_event,
     _join_text,
-    _progress_text_from_event,
     _safe_run_error_text,
     _surface_platform,
 )
@@ -49,22 +55,13 @@ logger = get_logger(__name__)
 _TYPING_REFRESH_INTERVAL_SECONDS = {
     SurfacePlatform.TELEGRAM.value: 4.0,
     SurfacePlatform.TEAMS.value: 10.0,
+    # WhatsApp couples mark-as-read and the typing bubble into one call, and the
+    # bubble expires after ~25s. Refreshed inside that window it is the cheapest
+    # honest "still working" the platform has — it costs no conversation message
+    # and no attention, unlike the posted updates that back it up.
+    SurfacePlatform.WHATSAPP.value: 20.0,
 }
 _MAX_TYPING_REFRESH_SECONDS = 15 * 60.0
-# Slack/Telegram/Teams render progress as a live, edited message (streaming):
-# Slack via chat.update, Telegram via editMessageText, Teams via PUT activity.
-# WhatsApp has no message-edit API, so it gets no per-step progress (the inbound
-# reaction indicator signals work) and email gets a single composed reply.
-_TEXT_PROGRESS_PLATFORMS: set[str] = set()
-# Slack is deliberately absent: it streams the answer token by token, and a
-# step chunk appended into that same stream lands *inside* the sentence being
-# written — splitting it mid-word. The streamed text is the progress indicator,
-# so a separate step timeline is both redundant and destructive.
-_STREAM_PROGRESS_PLATFORMS = {
-    SurfacePlatform.TELEGRAM.value,
-    SurfacePlatform.TEAMS.value,
-}
-_MIN_TEXT_PROGRESS_INTERVAL_SECONDS = 2.0
 # Email recipients should get one composed reply, not a stream of chat
 # messages. Agents reply via the platform reply tools; the observer only
 # falls back to emailing the final assistant text if no reply was sent.
@@ -79,17 +76,26 @@ _EMAIL_PLATFORMS = {
 }
 
 
-class SurfaceAgentRunProgressObserver(ProgressWaitingMixin, TokenStreamMixin):
+class SurfaceAgentRunProgressObserver(
+    ProgressWaitingMixin, ProgressDisplayMixin, TokenStreamMixin
+):
     """Reflect agent run progress through platform-native surface indicators.
 
     A surface conversation should receive exactly one content message per run:
     the agent's final answer. The agent's intermediate narration, reasoning
     (``ThinkingContent``) and tool activity (``ToolCallContent`` /
     ``ToolReturnContent``) must never be delivered as chat messages — they only
-    drive progress indicators (typing for Telegram/Teams, a status string for
-    Slack). To achieve this the observer buffers assistant text during the run
-    and delivers the final answer once on ``on_run_finished``, resetting the
-    buffer whenever a tool runs so only the post-final-tool text survives.
+    drive progress indicators. To achieve this the observer buffers assistant
+    text during the run and delivers the final answer once on
+    ``on_run_finished``, resetting the buffer whenever a tool runs so only the
+    post-final-tool text survives.
+
+    What "progress indicator" means is the platform's ``ProgressStyle``: Slack
+    streams the answer as it is written, Telegram and Teams keep one live message
+    and rewrite it, WhatsApp can only post a new message and so is rationed to a
+    plan that has moved, and email shows nothing before the reply. The one thing
+    they share is what they show — the agent's ``write_todos`` checklist, which
+    is the only account of a long run the person ever gets.
     """
 
     def __init__(
@@ -138,6 +144,16 @@ class SurfaceAgentRunProgressObserver(ProgressWaitingMixin, TokenStreamMixin):
         # written. See ``_deliver_final_answer``.
         self._answer_was_all_reasoning = False
         self._rendered_waiting_tool_calls: set[tuple[str, str]] = set()
+        # The agent's checklist, as of the last ``write_todos`` return, plus the
+        # snapshot that was last actually shown. Kept apart so a plan rewritten
+        # with the same contents does not spend an update.
+        self._plan: SurfacePlan | None = None
+        self._shown_plan_signature: tuple[tuple[str, bool], ...] | None = None
+        # Rationing for platforms that can only post a *new* message.
+        self._run_started_at = time.monotonic()
+        self._posted_updates = 0
+        self._last_post_at = 0.0
+        self._heartbeat_posted = False
 
     async def on_run_started(
         self,
@@ -145,22 +161,30 @@ class SurfaceAgentRunProgressObserver(ProgressWaitingMixin, TokenStreamMixin):
         ctx: ConversationContext,
     ) -> None:
         del ctx
+        self._run_started_at = time.monotonic()
         platform = _surface_platform(conversation)
         if platform is None:
             return
         capabilities = PLATFORM_CAPABILITIES.get(platform or "")
-        if capabilities is not None and capabilities.finishes_stream_with_answer:
+        if capabilities is None or not capabilities.shows_live_progress:
+            # Email: one composed reply and nothing before it.
+            return
+        if capabilities.finishes_stream_with_answer:
             # Open the stream up front. Slack shows a live indicator on an open
             # stream, which is the only "working on it" signal a *channel* gets
             # — setStatus is assistant-DM only, and waiting for the first token
             # leaves a tool-heavy run looking dead. An empty stream is disposed
-            # of by end_progress if no answer ever arrives.
+            # of by end_progress if no answer ever arrives. That open stream *is*
+            # the acknowledgement, so nothing else is sent here.
             await self._open_stream(conversation)
-        interval = _TYPING_REFRESH_INTERVAL_SECONDS.get(platform)
-        if interval is None:
             return
+        # Acknowledge first, refresh second. These were behind one guard keyed on
+        # the refresh interval, so a platform absent from the refresh table never
+        # got the opening acknowledgement either — which is how WhatsApp came to
+        # have a read-receipt-and-typing call that nothing ever invoked.
         sent = await self._send_indicator(conversation_id=conversation.id)
-        if not sent:
+        interval = _TYPING_REFRESH_INTERVAL_SECONDS.get(platform)
+        if not sent or interval is None:
             return
         self._typing_task = create_inherited_task(
             self._refresh_typing_loop(
@@ -227,52 +251,11 @@ class SurfaceAgentRunProgressObserver(ProgressWaitingMixin, TokenStreamMixin):
             self._reset_text_on_next = True
             if _email_reply_tool_called(event):
                 self._email_reply_tool_called = True
+            plan = plan_from_event(event)
+            if plan is not None:
+                self._plan = plan
 
         await self._maybe_send_text_progress(event, platform, conversation.id)
-
-    async def _maybe_send_text_progress(
-        self,
-        event: AgentEvent,
-        platform: str | None,
-        conversation_id,
-    ) -> None:
-        """Reflect thinking/tool activity as a status string where supported.
-
-        Telegram/Teams show a typing indicator (refreshed by the loop started in
-        on_run_started); Slack is the only platform that renders a status text.
-        """
-        streams = platform in _STREAM_PROGRESS_PLATFORMS
-        if platform not in _TEXT_PROGRESS_PLATFORMS and not streams:
-            return
-        progress_text = _progress_text_from_event(event)
-        if not progress_text:
-            return
-        now = time.monotonic()
-        if (
-            progress_text == self._last_text_progress
-            or now - self._last_text_progress_at < _MIN_TEXT_PROGRESS_INTERVAL_SECONDS
-        ):
-            return
-        self._last_text_progress = progress_text
-        self._last_text_progress_at = now
-        if streams:
-            await self._stream_progress(conversation_id, progress_text)
-        else:
-            await self._send_indicator(
-                conversation_id=conversation_id,
-                metadata={"progress_text": progress_text},
-            )
-
-    async def _stream_progress(self, conversation_id, progress_text: str) -> None:
-        async with self.uow_factory() as uow:
-            service = self.service_factory(uow)
-            handle = await service.send_progress_update_for_conversation(
-                conversation_id=conversation_id,
-                progress_text=progress_text,
-                progress_handle=self._progress_handle,
-            )
-        if handle is not None:
-            self._progress_handle = handle
 
     async def _finish_stream_with_answer(self, conversation: Conversation) -> bool:
         """Close a live stream with the final answer, so they are one message.
@@ -447,7 +430,16 @@ class SurfaceAgentRunProgressObserver(ProgressWaitingMixin, TokenStreamMixin):
         try:
             while time.monotonic() - started_at < _MAX_TYPING_REFRESH_SECONDS:
                 await asyncio.sleep(interval)
-                sent = await self._send_indicator(conversation_id=conversation_id)
+                # Flagged as a refresh so an adapter can tell a keep-alive from
+                # the opening acknowledgement. WhatsApp needs the distinction:
+                # its acknowledgement falls back to posting a reaction when the
+                # read/typing call is refused, and a fallback that fires on every
+                # tick would be an API call every twenty seconds for the whole
+                # run.
+                sent = await self._send_indicator(
+                    conversation_id=conversation_id,
+                    metadata={"is_refresh": True},
+                )
                 if not sent:
                     return
         except asyncio.CancelledError:

--- a/lemma-backend/app/modules/agent_surfaces/services/progress_plan.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/progress_plan.py
@@ -1,0 +1,195 @@
+"""The agent's plan, read off a ``write_todos`` call and drawn for a surface.
+
+The plan already exists — ``write_todos`` keeps a checklist in conversation
+metadata and the agent ticks items off as it goes — but on a surface it was
+invisible. Every tool call reduces to one status string, so a plan of five steps
+reached the person as ``Using write_todos``: the single most informative thing
+the agent produces, rendered as the least informative line it could be.
+
+That matters most exactly where it was worst. On a long WhatsApp or Telegram run
+the person has no other window into what is happening, so "which of the five
+steps are done" is the whole answer to "is this still working". Here the
+checklist is parsed back out of the tool's own return value and drawn as a
+checklist.
+
+The drawing is deliberately emoji and plain text — no Markdown. It renders
+identically on WhatsApp, Telegram and Teams, and it cannot unbalance a delimiter
+or need per-platform escaping on the way out.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+
+from app.modules.agent.contracts import (
+    AgentEvent,
+    AgentEventType,
+    MessageDraft,
+    MessageKind,
+)
+
+#: The planning tool from ``app.modules.agent.capabilities.todo``.
+TODO_TOOL_NAME = "write_todos"
+
+# ``write_todos`` returns its list already rendered as markdown checklist lines
+# ("- [x] Fetch the Q3 report"), which is what we parse back.
+_RENDERED_TODO_RE = re.compile(r"^\s*(?:[-*]\s+)?\[(?P<mark>[ xX*])\]\s*(?P<text>.+)$")
+
+_DONE_MARK = "✅"
+_ACTIVE_MARK = "⏳"
+_PENDING_MARK = "⬜"
+
+# A plan is a progress update, not the answer. Long ones are summarised rather
+# than pasted whole so the update stays glanceable on a phone.
+_MAX_RENDERED_ITEMS = 8
+_MAX_ITEM_CHARS = 80
+
+
+@dataclass(frozen=True)
+class PlanItem:
+    text: str
+    done: bool
+
+
+@dataclass(frozen=True)
+class SurfacePlan:
+    """A snapshot of the agent's checklist at one moment in a run."""
+
+    items: tuple[PlanItem, ...]
+
+    @property
+    def total(self) -> int:
+        return len(self.items)
+
+    @property
+    def done_count(self) -> int:
+        return sum(1 for item in self.items if item.done)
+
+    @property
+    def signature(self) -> tuple[tuple[str, bool], ...]:
+        """What must change before the plan is worth sending again.
+
+        Compared rather than the rendered text so a re-send is driven by the
+        plan actually moving, not by wording or by the same snapshot being
+        written twice.
+        """
+        return tuple((item.text, item.done) for item in self.items)
+
+
+def plan_from_event(event: AgentEvent) -> SurfacePlan | None:
+    """Read the current plan out of a ``write_todos`` tool return.
+
+    The *return* is used rather than the call arguments because the tool merges
+    a single check-off line into the stored list before answering: the arguments
+    can be one line ("- [x] step three"), while the return is always the whole
+    list. Rendering the arguments would show a one-item plan every time an item
+    was ticked off.
+    """
+    if event.type != AgentEventType.MESSAGE:
+        return None
+    data = event.data
+    if not isinstance(data, MessageDraft):
+        return None
+    if data.kind is not MessageKind.TOOL_RETURN or data.tool_name != TODO_TOOL_NAME:
+        return None
+    lines = _rendered_lines(data.tool_result)
+    if lines is None:
+        return None
+    items = tuple(
+        PlanItem(text=parsed[0], done=parsed[1])
+        for parsed in (_parse_rendered_line(line) for line in lines)
+        if parsed is not None
+    )
+    # An empty list is a real state ("the plan was cleared"), but there is
+    # nothing to show for it, and sending a blank update is worse than sending
+    # none.
+    return SurfacePlan(items=items) if items else None
+
+
+def render_plan(plan: SurfacePlan) -> str:
+    """Draw the plan as a checklist, in plain text with emoji marks.
+
+    No Markdown: this string is delivered by every platform's progress path, and
+    an unbalanced ``*`` or an unescaped ``.`` behaves differently on each of
+    them. Emoji marks read the same everywhere.
+    """
+    if not plan.items:
+        return ""
+    lines = [_headline(plan)]
+    lines.extend(_body_lines(plan))
+    return "\n".join(lines)
+
+
+def _headline(plan: SurfacePlan) -> str:
+    if plan.done_count >= plan.total:
+        return f"All {plan.total} steps done — writing up the answer now."
+    return f"Working on it — {plan.done_count} of {plan.total} steps done."
+
+
+def _body_lines(plan: SurfacePlan) -> list[str]:
+    """The checklist, trimmed to what is worth reading on a phone.
+
+    A long plan collapses its finished history to a count: the person already
+    saw those tick off, and the useful part of a fifteen-step plan is where it
+    is now and what is left.
+    """
+    active_seen = False
+    rendered: list[str] = []
+    for item in plan.items:
+        if item.done:
+            mark = _DONE_MARK
+        elif not active_seen:
+            mark = _ACTIVE_MARK
+            active_seen = True
+        else:
+            mark = _PENDING_MARK
+        rendered.append(f"{mark} {_clip(item.text)}")
+
+    if len(rendered) <= _MAX_RENDERED_ITEMS:
+        return rendered
+    keep_from = len(rendered) - _MAX_RENDERED_ITEMS
+    hidden = [item for item in plan.items[:keep_from]]
+    summary = f"{_DONE_MARK} {len(hidden)} earlier steps"
+    if any(not item.done for item in hidden):
+        summary = f"…{len(hidden)} earlier steps"
+    return [summary, *rendered[keep_from:]]
+
+
+def _clip(text: str) -> str:
+    collapsed = " ".join(text.split())
+    if len(collapsed) <= _MAX_ITEM_CHARS:
+        return collapsed
+    return collapsed[: _MAX_ITEM_CHARS - 1].rstrip() + "…"
+
+
+def _rendered_lines(tool_result: object) -> list[str] | None:
+    """Pull the ``todos`` list out of a tool return, dict or JSON string.
+
+    Harnesses differ on whether a tool return arrives decoded: the in-process
+    one hands over the dict the tool built, while a remote harness relaying over
+    MCP can deliver the same payload as a JSON string.
+    """
+    result = tool_result
+    if isinstance(result, str):
+        try:
+            result = json.loads(result)
+        except ValueError:
+            return None
+    if not isinstance(result, dict):
+        return None
+    todos = result.get("todos")
+    if not isinstance(todos, list):
+        return None
+    return [line for line in todos if isinstance(line, str)]
+
+
+def _parse_rendered_line(line: str) -> tuple[str, bool] | None:
+    match = _RENDERED_TODO_RE.match(line)
+    if match is None:
+        return None
+    text = match.group("text").strip()
+    if not text:
+        return None
+    return text, match.group("mark") in ("x", "X", "*")

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_progress_streaming_matrix_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_progress_streaming_matrix_e2e.py
@@ -1,7 +1,6 @@
 """Progress-streaming tool-coverage matrix: tool-call activity renders as a
 live, edited message on Slack (chat.update), Telegram (editMessageText), and
-Teams (PUT activity) — the three platforms in
-``progress_observer._STREAM_PROGRESS_PLATFORMS``.
+Teams (PUT activity).
 
 Each scripted tool call carries a ``comment`` (nested under ``request``, since
 every platform tool takes a single ``request: Model`` parameter and no such
@@ -10,13 +9,16 @@ progress observer reads that comment straight off the persisted (pre-tool-
 execution) event to drive the live status text, independent of whatever the
 wrapped tool itself returns.
 
-N/A cells (see ``_STREAM_PROGRESS_PLATFORMS``/``_TEXT_PROGRESS_PLATFORMS`` in
-``progress_observer.py``):
-- **WhatsApp has no message-edit API** — it gets no per-step progress at all
-  (only the inbound reaction/typing indicator signals work is happening).
-- **Email gets one composed reply, never a stream** — Gmail/Outlook/Resend
-  recipients would find a live-editing inbox message bizarre; the observer
-  intentionally skips streaming there regardless of platform capability.
+Which platforms belong here is decided by ``ProgressStyle`` on the platform
+capability (see ``progress_display.py``), and the cells this file does not cover
+are the styles that are not an edited message:
+
+- **WhatsApp** (``POST``) has no message-edit API, so it cannot appear in a
+  matrix about edits. It is not silent — it posts the agent's plan as its own
+  message, rationed — but that path is driven by plan changes rather than by
+  per-tool comments, and is covered in ``tests/unit/test_progress_observer.py``.
+- **Email** (``NONE``) gets one composed reply, never a stream — Gmail/Outlook/
+  Resend recipients would find a live-editing inbox message bizarre.
 """
 
 from __future__ import annotations
@@ -65,12 +67,12 @@ async def test_progress_streams_via_chat_update_on_slack(
 ):
     """Slack opens one native stream, appends the answer, and closes it."""
     from app.core.config import settings as app_settings
-    from app.modules.agent_surfaces.services import progress_observer as _po
+    from app.modules.agent_surfaces.services import progress_display as _pd
 
     monkeypatch.setattr(app_settings, "api_url", "https://api.example.test")
     monkeypatch.setattr(surface_settings, "slack_signing_secret", "slack-secret")
     # Disable the inter-update throttle so both progress comments stream.
-    monkeypatch.setattr(_po, "_MIN_TEXT_PROGRESS_INTERVAL_SECONDS", 0.0)
+    monkeypatch.setattr(_pd, "_MIN_TEXT_PROGRESS_INTERVAL_SECONDS", 0.0)
     pod_id = test_pod["id"]
     account = await _ensure_connector_account(
         db_session,
@@ -126,9 +128,9 @@ async def test_progress_streams_via_edit_message_on_telegram(
 ):
     """Tool activity streams as an edited Telegram message (editMessageText);
     the placeholder is cleared before the final answer is sent as a new one."""
-    from app.modules.agent_surfaces.services import progress_observer as _po
+    from app.modules.agent_surfaces.services import progress_display as _pd
 
-    monkeypatch.setattr(_po, "_MIN_TEXT_PROGRESS_INTERVAL_SECONDS", 0.0)
+    monkeypatch.setattr(_pd, "_MIN_TEXT_PROGRESS_INTERVAL_SECONDS", 0.0)
     monkeypatch.setattr(surface_settings, "telegram_bot_token", "native-telegram")
     monkeypatch.setattr(surface_settings, "telegram_webhook_secret", "native-secret")
     monkeypatch.setattr(surface_settings, "enable_telegram_polling_mode", True)
@@ -182,9 +184,9 @@ async def test_progress_streams_via_put_activity_on_teams(
     is a new activity POST."""
     from app.core.config import settings as app_settings
     from app.modules.agent_surfaces.platforms.teams.adapter import TeamsSurfaceAdapter
-    from app.modules.agent_surfaces.services import progress_observer as _po
+    from app.modules.agent_surfaces.services import progress_display as _pd
 
-    monkeypatch.setattr(_po, "_MIN_TEXT_PROGRESS_INTERVAL_SECONDS", 0.0)
+    monkeypatch.setattr(_pd, "_MIN_TEXT_PROGRESS_INTERVAL_SECONDS", 0.0)
 
     async def _fake_bot_token(self, tenant_id: str) -> str | None:
         del self, tenant_id

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_native_approvals.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_native_approvals.py
@@ -120,15 +120,15 @@ def test_teams_approval_card_and_parse_round_trip():
 
 
 def test_whatsapp_approval_buttons_and_parse_round_trip():
-    from app.modules.agent_surfaces.platforms.whatsapp.service import (
-        _build_whatsapp_approval_interactive,
+    from app.modules.agent_surfaces.platforms.whatsapp.payloads import (
+        build_whatsapp_approval_interactive,
     )
     from app.modules.agent_surfaces.platforms.whatsapp.parser import (
         WhatsAppMessageParser,
     )
 
     plan = _plan()
-    interactive = _build_whatsapp_approval_interactive(plan)
+    interactive = build_whatsapp_approval_interactive(plan)
     assert interactive["type"] == "button"
     button = interactive["action"]["buttons"][0]
     reply_id = button["reply"]["id"]

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_native_questions.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_native_questions.py
@@ -522,8 +522,8 @@ async def test_whatsapp_parse_inbound_interaction_ignores_non_lemma_id():
 def test_whatsapp_interactive_rejects_header_with_separator():
     """A header containing '~' would corrupt the packed reply id → fall back to
     text (return None) rather than mis-key the answer."""
-    from app.modules.agent_surfaces.platforms.whatsapp.service import (
-        _build_whatsapp_interactive,
+    from app.modules.agent_surfaces.platforms.whatsapp.payloads import (
+        build_whatsapp_interactive,
     )
 
     question = SurfaceQuestion(
@@ -531,7 +531,7 @@ def test_whatsapp_interactive_rejects_header_with_separator():
         header="time~zone",  # contains the reserved separator
         options=[SurfaceQuestionOption(label="US"), SurfaceQuestionOption(label="CA")],
     )
-    assert _build_whatsapp_interactive("conv|tool", question) is None
+    assert build_whatsapp_interactive("conv|tool", question) is None
 
 
 def test_whatsapp_parse_interaction_preserves_value_with_separator():

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_progress_observer.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_progress_observer.py
@@ -11,7 +11,7 @@ from app.modules.agent.domain.value_objects import (
     AgentEventType,
     MessageDraft,
 )
-from app.modules.agent_surfaces.services import progress_observer
+from app.modules.agent_surfaces.services import progress_display, progress_observer
 from app.modules.agent_surfaces.services.progress_observer import (
     SurfaceAgentRunProgressObserver,
 )
@@ -416,10 +416,13 @@ async def test_progress_observer_refreshes_telegram_typing_in_process(monkeypatc
     await asyncio.sleep(0.03)
     await observer.on_run_finished(conversation, SimpleNamespace())
 
-    assert service.calls
+    # The opening acknowledgement, then keep-alive ticks flagged as refreshes so
+    # an adapter can tell them apart from it.
+    assert service.calls[0] == {"conversation_id": conversation.id, "metadata": None}
+    assert len(service.calls) > 1
     assert service.calls[-1] == {
         "conversation_id": conversation.id,
-        "metadata": None,
+        "metadata": {"is_refresh": True},
     }
 
 
@@ -1005,4 +1008,184 @@ async def test_non_streaming_platforms_do_not_open_a_stream_at_run_start():
 
     await observer.on_run_started(conversation, SimpleNamespace())
 
+    assert service.streamed == []
+
+
+def _plan_return(*lines: str) -> AgentEvent:
+    """A ``write_todos`` tool return carrying the whole checklist."""
+    return AgentEvent(
+        type=AgentEventType.MESSAGE,
+        data=MessageDraft.of_tool_return(
+            tool_name="write_todos",
+            tool_call_id="todo-1",
+            tool_result={"success": True, "todos": list(lines)},
+        ),
+    )
+
+
+def _conversation(platform: str) -> SimpleNamespace:
+    return SimpleNamespace(id=uuid4(), metadata={"surface_platform": platform})
+
+
+async def test_the_plan_is_drawn_as_a_checklist_not_as_using_write_todos():
+    """The most informative tool call used to render as the least informative line.
+
+    Every tool call collapses to one status string, so a five-step plan reached
+    the person as ``Using write_todos``.
+    """
+    service = _SurfaceService()
+    observer = _observer(service)
+    conversation = _conversation("TELEGRAM")
+
+    await observer.on_event(
+        _plan_return("- [x] Pull the Q3 numbers", "- [ ] Draft the summary"),
+        conversation,
+        SimpleNamespace(),
+    )
+
+    body = service.progress[-1]["progress_text"]
+    assert "write_todos" not in body
+    assert "Working on it — 1 of 2 steps done." in body
+    assert "✅ Pull the Q3 numbers" in body
+    assert "⏳ Draft the summary" in body
+
+
+async def test_a_plan_that_has_not_moved_does_not_spend_an_update():
+    service = _SurfaceService()
+    observer = _observer(service)
+    conversation = _conversation("TELEGRAM")
+    plan = _plan_return("- [ ] Only step")
+
+    await observer.on_event(plan, conversation, SimpleNamespace())
+    await observer.on_event(plan, conversation, SimpleNamespace())
+
+    assert len(service.progress) == 1
+
+
+async def test_whatsapp_posts_the_plan_it_previously_showed_nothing_for():
+    """WhatsApp has no edit API, so a long run used to be pure silence."""
+    service = _SurfaceService()
+    observer = _observer(service)
+    conversation = _conversation("WHATSAPP")
+
+    await observer.on_event(
+        _plan_return("- [ ] Reconcile the ledger", "- [ ] Write it up"),
+        conversation,
+        SimpleNamespace(),
+    )
+
+    assert len(service.progress) == 1
+    assert "0 of 2 steps done" in service.progress[0]["progress_text"]
+
+
+async def test_whatsapp_rations_updates_after_the_first_plan():
+    """Every WhatsApp update is a message in someone's chat, so they are capped.
+
+    The first plan goes straight through — it is what the person most wants at
+    the start of a long run — and the next one waits out the interval.
+    """
+    service = _SurfaceService()
+    observer = _observer(service)
+    conversation = _conversation("WHATSAPP")
+
+    await observer.on_event(
+        _plan_return("- [ ] One", "- [ ] Two"), conversation, SimpleNamespace()
+    )
+    await observer.on_event(
+        _plan_return("- [x] One", "- [ ] Two"), conversation, SimpleNamespace()
+    )
+
+    assert len(service.progress) == 1
+
+    observer._last_post_at -= progress_display._POST_PROGRESS_MIN_INTERVAL_SECONDS + 1
+    await observer.on_event(
+        _plan_return("- [x] One", "- [x] Two"), conversation, SimpleNamespace()
+    )
+
+    assert len(service.progress) == 2
+    assert "All 2 steps done" in service.progress[1]["progress_text"]
+
+
+async def test_whatsapp_says_something_on_a_long_run_with_no_plan():
+    service = _SurfaceService()
+    observer = _observer(service)
+    conversation = _conversation("WHATSAPP")
+    activity = AgentEvent(
+        type=AgentEventType.MESSAGE,
+        data=MessageDraft.of_tool_call(
+            tool_name="run_query",
+            tool_call_id="tool-9",
+            tool_args={"request": {"comment": "Scanning the ledger"}},
+        ),
+    )
+
+    await observer.on_event(activity, conversation, SimpleNamespace())
+    assert service.progress == []
+
+    observer._run_started_at -= progress_display._POST_HEARTBEAT_DELAY_SECONDS + 1
+    await observer.on_event(activity, conversation, SimpleNamespace())
+
+    assert len(service.progress) == 1
+    assert "Still working on this" in service.progress[0]["progress_text"]
+
+    # One acknowledgement, not a drip feed.
+    observer._run_started_at -= 600
+    await observer.on_event(activity, conversation, SimpleNamespace())
+    assert len(service.progress) == 1
+
+
+async def test_whatsapp_is_acknowledged_when_the_run_starts():
+    """The read-receipt-and-typing call existed but nothing ever invoked it.
+
+    It sat behind the same guard as the typing-refresh loop, and WhatsApp is not
+    in the refresh table.
+    """
+    service = _SurfaceService()
+    observer = _observer(service)
+    conversation = _conversation("WHATSAPP")
+
+    await observer.on_run_started(conversation, SimpleNamespace())
+    task = observer._typing_task
+    if task is not None:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert service.calls == [{"conversation_id": conversation.id, "metadata": None}]
+
+
+async def test_email_still_shows_nothing_before_the_reply():
+    service = _SurfaceService()
+    observer = _observer(service)
+    conversation = _conversation("RESEND")
+
+    await observer.on_event(
+        _plan_return("- [ ] Draft it"), conversation, SimpleNamespace()
+    )
+
+    assert service.progress == []
+    assert service.messages == []
+
+
+async def test_slack_is_acknowledged_by_its_open_stream_and_nothing_else():
+    """The open stream is Slack's indicator; a second call would double up."""
+    service = _SurfaceService()
+    observer = _observer(service)
+    conversation = _conversation("SLACK")
+
+    await observer.on_run_started(conversation, SimpleNamespace())
+
+    assert service.streamed == [
+        {"conversation_id": conversation.id, "progress_handle": None, "text": ""}
+    ]
+    assert service.calls == []
+
+
+async def test_email_is_not_acknowledged_at_all():
+    service = _SurfaceService()
+    observer = _observer(service)
+
+    await observer.on_run_started(_conversation("GMAIL"), SimpleNamespace())
+
+    assert service.calls == []
     assert service.streamed == []

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_progress_observer.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_progress_observer.py
@@ -1134,11 +1134,11 @@ async def test_whatsapp_says_something_on_a_long_run_with_no_plan():
     assert len(service.progress) == 1
 
 
-async def test_whatsapp_is_acknowledged_when_the_run_starts():
-    """The read-receipt-and-typing call existed but nothing ever invoked it.
+async def test_whatsapp_keeps_its_typing_bubble_alive():
+    """The bubble the inbound path lights up expires after ~25s.
 
-    It sat behind the same guard as the typing-refresh loop, and WhatsApp is not
-    in the refresh table.
+    Nothing refreshed it, so on a long run it went dark early — dead in exactly
+    the runs where it was the only sign of life.
     """
     service = _SurfaceService()
     observer = _observer(service)
@@ -1168,7 +1168,7 @@ async def test_email_still_shows_nothing_before_the_reply():
 
 
 async def test_slack_is_acknowledged_by_its_open_stream_and_nothing_else():
-    """The open stream is Slack's indicator; a second call would double up."""
+    """The open stream is Slack's indicator — the observer adds nothing to it."""
     service = _SurfaceService()
     observer = _observer(service)
     conversation = _conversation("SLACK")
@@ -1181,7 +1181,7 @@ async def test_slack_is_acknowledged_by_its_open_stream_and_nothing_else():
     assert service.calls == []
 
 
-async def test_email_is_not_acknowledged_at_all():
+async def test_email_gets_no_indicator_from_the_observer():
     service = _SurfaceService()
     observer = _observer(service)
 

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_progress_plan.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_progress_plan.py
@@ -1,0 +1,101 @@
+"""Reading the agent's checklist back off a ``write_todos`` return."""
+
+from __future__ import annotations
+
+import json
+
+from app.modules.agent.domain.value_objects import (
+    AgentEvent,
+    AgentEventType,
+    MessageDraft,
+)
+from app.modules.agent_surfaces.services.progress_plan import (
+    plan_from_event,
+    render_plan,
+)
+
+
+def _return(result: object, *, tool_name: str = "write_todos") -> AgentEvent:
+    return AgentEvent(
+        type=AgentEventType.MESSAGE,
+        data=MessageDraft.of_tool_return(
+            tool_name=tool_name,
+            tool_call_id="todo-1",
+            tool_result=result,
+        ),
+    )
+
+
+def test_the_return_is_read_not_the_arguments():
+    """A check-off call carries one line; only the return carries the plan.
+
+    ``write_todos`` merges a single line into the stored list before answering,
+    so rendering the arguments would show a one-item plan every time an item was
+    ticked off.
+    """
+    call = AgentEvent(
+        type=AgentEventType.MESSAGE,
+        data=MessageDraft.of_tool_call(
+            tool_name="write_todos",
+            tool_call_id="todo-1",
+            tool_args={"request": {"todos": ["- [x] Step two"]}},
+        ),
+    )
+    assert plan_from_event(call) is None
+
+    plan = plan_from_event(_return({"todos": ["- [x] Step one", "- [ ] Step two"]}))
+    assert plan is not None
+    assert plan.total == 2
+    assert plan.done_count == 1
+
+
+def test_a_json_encoded_return_is_understood():
+    # A remote harness relaying over MCP can deliver the same payload as a string.
+    plan = plan_from_event(_return(json.dumps({"todos": ["- [ ] Only step"]})))
+    assert plan is not None
+    assert plan.total == 1
+
+
+def test_another_tool_is_not_a_plan():
+    assert (
+        plan_from_event(_return({"todos": ["- [ ] x"]}, tool_name="run_query")) is None
+    )
+
+
+def test_an_empty_list_produces_no_update():
+    # A cleared plan is a real state, but a blank update is worse than none.
+    assert plan_from_event(_return({"todos": []})) is None
+
+
+def test_the_next_step_is_marked_apart_from_the_ones_after_it():
+    plan = plan_from_event(
+        _return({"todos": ["- [x] Done", "- [ ] Now", "- [ ] Later"]})
+    )
+    assert plan is not None
+    body = render_plan(plan)
+    assert body.splitlines() == [
+        "Working on it — 1 of 3 steps done.",
+        "✅ Done",
+        "⏳ Now",
+        "⬜ Later",
+    ]
+
+
+def test_a_long_plan_collapses_the_history_it_already_showed():
+    todos = [f"- [x] Step {n}" for n in range(1, 11)] + ["- [ ] Step 11"]
+    plan = plan_from_event(_return({"todos": todos}))
+    assert plan is not None
+    lines = render_plan(plan).splitlines()
+
+    assert lines[0] == "Working on it — 10 of 11 steps done."
+    assert lines[1] == "✅ 3 earlier steps"
+    assert len(lines) == 10
+    assert lines[-1] == "⏳ Step 11"
+
+
+def test_the_rendering_carries_no_markdown():
+    # This string is delivered by every platform's progress path; a stray marker
+    # behaves differently on each of them.
+    plan = plan_from_event(_return({"todos": ["- [ ] Ship **it**"]}))
+    assert plan is not None
+    assert render_plan(plan) == "Working on it — 0 of 1 steps done.\n⏳ Ship **it**"

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_whatsapp_client.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_whatsapp_client.py
@@ -170,3 +170,114 @@ async def test_add_processing_indicator_noop_without_message_id(monkeypatch):
     # No inbound message id → nothing to mark read / react to; must not raise.
     await service.add_processing_indicator(_inbound_event(message_id=None))
     assert calls == []
+
+
+# --- outbound message bodies ----------------------------------------------
+
+
+def _service() -> WhatsAppPlatformService:
+    return WhatsAppPlatformService(
+        {
+            "access_token": "t",
+            "phone_number_id": "phone-1",
+            "api_base_url": "http://x/v21.0",
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_long_answer_is_split_rather_than_dropped(monkeypatch):
+    """4096 is Meta's hard ceiling, and an oversized body is rejected outright.
+
+    The person got nothing at all, which is worse than the truncation the other
+    send path did.
+    """
+    service = _service()
+    bodies: list[str] = []
+
+    async def _capture(*, phone_number_id, payload):
+        bodies.append(payload["text"]["body"])
+        return "wamid.out"
+
+    monkeypatch.setattr(service._client, "send_message_payload", _capture)
+
+    paragraph = "word " * 400  # ~2000 characters
+    await service.send_message(
+        _inbound_event(message_id="wamid.in-1"), "\n\n".join([paragraph] * 4)
+    )
+
+    assert len(bodies) > 1
+    assert all(len(body) <= 4096 for body in bodies)
+    assert "".join(bodies).count("word") == 1600
+
+
+@pytest.mark.asyncio
+async def test_a_split_never_leaves_half_a_bold_pair(monkeypatch):
+    service = _service()
+    bodies: list[str] = []
+
+    async def _capture(*, phone_number_id, payload):
+        bodies.append(payload["text"]["body"])
+        return "wamid.out"
+
+    monkeypatch.setattr(service._client, "send_message_payload", _capture)
+
+    filler = "word " * 900  # pushes the bold run over the boundary
+    await service.send_message(
+        _inbound_event(message_id="wamid.in-1"), f"{filler}\n\n**Conclusion** here"
+    )
+
+    for body in bodies:
+        assert body.count("*") % 2 == 0
+
+
+@pytest.mark.asyncio
+async def test_progress_is_posted_as_its_own_message(monkeypatch):
+    """WhatsApp cannot edit a message, so an update can only be a new one."""
+    service = _service()
+    payloads: list[dict] = []
+
+    async def _capture(*, phone_number_id, payload):
+        payloads.append(payload)
+        return "wamid.progress"
+
+    monkeypatch.setattr(service._client, "send_message_payload", _capture)
+
+    await service.stream_progress(
+        _inbound_event(message_id="wamid.in-1"),
+        "Working on it — 1 of 2 steps done.\n✅ Pull the numbers",
+    )
+
+    assert len(payloads) == 1
+    assert payloads[0]["type"] == "text"
+    assert payloads[0]["text"]["preview_url"] is False
+    assert "✅ Pull the numbers" in payloads[0]["text"]["body"]
+
+
+@pytest.mark.asyncio
+async def test_a_typing_refresh_does_not_re_post_the_reaction(monkeypatch):
+    """The bubble is refreshed on a timer; the acknowledgement is sent once.
+
+    Without the distinction, a rejected read/typing call would drop into the
+    reaction fallback on every tick — an API call every twenty seconds saying
+    something already said.
+    """
+    service = _service()
+    calls: list[dict] = []
+
+    async def _refuse(*, phone_number_id, message_id):
+        raise RuntimeError("read receipts unavailable")
+
+    async def _capture_reaction(**kwargs):
+        calls.append(kwargs)
+        return "wamid.reaction"
+
+    monkeypatch.setattr(service._client, "mark_read_and_typing", _refuse)
+    monkeypatch.setattr(service._client, "react", _capture_reaction)
+
+    event = _inbound_event(message_id="wamid.in-1")
+    await service.add_processing_indicator(event)
+    assert len(calls) == 1
+
+    await service.add_processing_indicator(event, {"is_refresh": True})
+    assert len(calls) == 1

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_whatsapp_text_format.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_whatsapp_text_format.py
@@ -6,6 +6,7 @@ WhatsApp drop all native formatting in a message.
 """
 
 from app.modules.agent_surfaces.platforms.whatsapp.text_format import (
+    balance_whatsapp_delimiters,
     to_plain_text,
     to_whatsapp_text,
 )
@@ -30,17 +31,28 @@ def test_markdown_link_reduces_to_bare_url():
     )
 
 
-def test_heading_prefix_is_stripped():
-    assert to_whatsapp_text("# Eyebrow") == "Eyebrow"
-    assert to_whatsapp_text("## Secondary") == "Secondary"
+def test_heading_becomes_bold():
+    # WhatsApp has no headings, and a heading flattened to bare prose loses the
+    # structure the author meant. Bold is the closest thing the platform has.
+    assert to_whatsapp_text("# Eyebrow") == "*Eyebrow*"
+    assert to_whatsapp_text("## Secondary") == "*Secondary*"
 
 
 def test_inline_code_maps_to_whatsapp_monospace():
     assert to_whatsapp_text("run `lemma --help`") == "run ```lemma --help```"
 
 
-def test_fenced_code_block_drops_fences_keeps_body():
-    assert to_whatsapp_text("```py\nx = 1\n```") == "x = 1"
+def test_fenced_code_block_keeps_the_fence_and_drops_the_language_tag():
+    # WhatsApp renders a multi-line ``` block as monospace. Dropping the fence
+    # would leave a shell transcript indistinguishable from the prose above it;
+    # keeping the ``py`` tag would print it as the block's first line.
+    assert to_whatsapp_text("```py\nx = 1\n```") == "```\nx = 1\n```"
+
+
+def test_markdown_inside_a_code_block_is_delivered_verbatim():
+    # Inside a fence, ``**`` and ``|`` are the code, not formatting.
+    raw = "See:\n```py\nx = a**b\n| a | b |\n```"
+    assert to_whatsapp_text(raw) == "See:\n```\nx = a**b\n| a | b |\n```"
 
 
 def test_existing_whatsapp_monospace_is_not_mangled():
@@ -55,9 +67,51 @@ def test_bare_asterisk_bullet_is_dropped_and_does_not_kill_bold():
     assert "\n*\n" not in result
 
 
-def test_stray_delimiter_hugging_space_is_dropped():
-    assert to_whatsapp_text("* bold") == "bold"
-    assert to_whatsapp_text("a * ").strip() == "a"
+def test_star_bullets_become_native_whatsapp_bullets():
+    # Deleting the marker flattens a list into an unmarked run of lines; WhatsApp
+    # bullets ``- `` natively, so the bullet is translated, not dropped.
+    assert to_whatsapp_text("* first\n* second") == "- first\n- second"
+    assert to_whatsapp_text("+ first") == "- first"
+
+
+def test_unpaired_marker_hugging_text_on_one_side_is_dropped():
+    # ``*bold`` never finds a partner, so the marker would land as a literal
+    # asterisk mid-sentence.
+    assert to_whatsapp_text("this is *bold") == "this is bold"
+    assert to_whatsapp_text("**line one\nline two**") == "line one\nline two"
+
+
+def test_a_character_the_author_typed_is_not_deleted():
+    # The old rule deleted any delimiter hugging whitespace, which silently
+    # rewrote arithmetic and identifiers.
+    assert to_whatsapp_text("2 * 3 = 6") == "2 * 3 = 6"
+    assert to_whatsapp_text("a ~ b") == "a ~ b"
+    assert to_whatsapp_text("call var_name twice") == "call var_name twice"
+
+
+def test_image_does_not_leave_a_stranded_bang():
+    assert to_whatsapp_text("![alt](https://x.test/a.png)") == "https://x.test/a.png"
+
+
+def test_table_is_flattened_into_readable_lines():
+    assert to_whatsapp_text("| a | b |\n|---|---|\n| 1 | 2 |") == "a — b\n\n1 — 2"
+
+
+def test_underscore_strong_maps_to_whatsapp_bold():
+    assert to_whatsapp_text("__Agents__") == "*Agents*"
+
+
+def test_translation_is_idempotent():
+    # Several call sites format then truncate then re-balance; running the
+    # translation twice must not keep eating the message.
+    once = to_whatsapp_text("# Title\n\n**bold** and `code`\n* one\n* two")
+    assert to_whatsapp_text(once) == once
+
+
+def test_balancing_repairs_a_pair_cut_in_half_by_truncation():
+    # Truncation happens after translation, so a 4096-character slice can cut a
+    # ``*bold*`` pair in half — the exact broken marker this module prevents.
+    assert balance_whatsapp_delimiters("intro *bol") == "intro bol"
 
 
 def test_empty_and_whitespace_input_are_safe():
@@ -67,6 +121,7 @@ def test_empty_and_whitespace_input_are_safe():
 
 def test_plain_text_strips_markers_for_captions():
     assert to_plain_text("**Live** *hero*") == "Live hero"
+    assert to_plain_text("2 * 3 = 6") == "2 * 3 = 6"
     assert to_plain_text("[x](https://lemma.world)") == "https://lemma.world"
     assert to_plain_text("# Heading text") == "Heading text"
 

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_whatsapp_text_format.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_whatsapp_text_format.py
@@ -1,0 +1,83 @@
+"""Deterministic guards for WhatsApp outbound text translation/sanitization.
+
+These cover the bug where Markdown leaks into WhatsApp messages and renders as
+literal ``*asterisks*`` instead of bold, and where a stray delimiter makes
+WhatsApp drop all native formatting in a message.
+"""
+
+from app.modules.agent_surfaces.platforms.whatsapp.text_format import (
+    to_plain_text,
+    to_whatsapp_text,
+)
+
+
+def test_native_whatsapp_syntax_is_preserved_untouched():
+    # Text already in WhatsApp's own subset must pass through byte-for-byte.
+    assert to_whatsapp_text("*Live hero (lemma.world)*") == "*Live hero (lemma.world)*"
+    assert to_whatsapp_text("_italic_") == "_italic_"
+    assert to_whatsapp_text("~strike~") == "~strike~"
+    assert to_whatsapp_text("*Agents, Apps, People*") == "*Agents, Apps, People*"
+
+
+def test_markdown_strong_maps_to_whatsapp_bold():
+    assert to_whatsapp_text("**Agents, Apps, People**") == "*Agents, Apps, People*"
+    assert to_whatsapp_text("see **bold** here") == "see *bold* here"
+
+
+def test_markdown_link_reduces_to_bare_url():
+    assert to_whatsapp_text("read [the homepage](https://lemma.world)") == (
+        "read https://lemma.world"
+    )
+
+
+def test_heading_prefix_is_stripped():
+    assert to_whatsapp_text("# Eyebrow") == "Eyebrow"
+    assert to_whatsapp_text("## Secondary") == "Secondary"
+
+
+def test_inline_code_maps_to_whatsapp_monospace():
+    assert to_whatsapp_text("run `lemma --help`") == "run ```lemma --help```"
+
+
+def test_fenced_code_block_drops_fences_keeps_body():
+    assert to_whatsapp_text("```py\nx = 1\n```") == "x = 1"
+
+
+def test_existing_whatsapp_monospace_is_not_mangled():
+    assert to_whatsapp_text("```if x:```") == "```if x:```"
+
+
+def test_bare_asterisk_bullet_is_dropped_and_does_not_kill_bold():
+    raw = "list:\n*\n*Agents, Apps, People*\nend"
+    result = to_whatsapp_text(raw)
+    assert "*Agents, Apps, People*" in result
+    # The bare bullet line no longer sits between the two *bold* markers.
+    assert "\n*\n" not in result
+
+
+def test_stray_delimiter_hugging_space_is_dropped():
+    assert to_whatsapp_text("* bold") == "bold"
+    assert to_whatsapp_text("a * ").strip() == "a"
+
+
+def test_empty_and_whitespace_input_are_safe():
+    assert to_whatsapp_text("") == ""
+    assert to_whatsapp_text("   ") == ""
+
+
+def test_plain_text_strips_markers_for_captions():
+    assert to_plain_text("**Live** *hero*") == "Live hero"
+    assert to_plain_text("[x](https://lemma.world)") == "https://lemma.world"
+    assert to_plain_text("# Heading text") == "Heading text"
+
+
+def test_plain_text_keeps_underscores_inside_identifiers():
+    # word-internal underscores (var names) are not italic markers.
+    assert to_plain_text("a_b and _italic_") == "a_b and italic"
+
+
+def test_message_uses_to_whatsapp_backport_preserves_bullets():
+    raw = "• *Agents, Apps, People*\n• *triad as H1*"
+    result = to_whatsapp_text(raw)
+    assert "• *Agents, Apps, People*" in result
+    assert "• *triad as H1*" in result


### PR DESCRIPTION
## What

Two halves of the same complaint: on a surface without streaming, a long run is
silence and then an answer, and whatever answer does arrive has the agent's
Markdown in it.

### Progress on surfaces that cannot stream

Progress is now one field on the platform — `ProgressStyle` — replacing three
hand-maintained sets in the progress observer: three answers to one question,
kept in three places that had to be updated together.

| Style | Platforms | What the person sees |
|---|---|---|
| `STREAM` | Slack | the answer as it is written, closed in the same message |
| `EDIT` | Telegram, Teams | one live message, rewritten in place |
| `POST` | WhatsApp | a new message, rationed — no edit API exists |
| `NONE` | Gmail, Outlook, Resend | nothing before the reply, by design |

`finishes_stream_with_answer` becomes a property derived from it, so the two
cannot disagree.

### The plan, handled natively

`write_todos` already keeps a checklist and the agent already ticks it off, but
on a surface it reduced to one status string: the most informative thing the
agent produces, rendered as `Using write_todos`. The tool's return is now parsed
back into a checklist and drawn with emoji marks — no Markdown, so it needs no
per-platform escaping and cannot unbalance a delimiter:

```
Working on it — 1 of 3 steps done.
✅ Pull the Q3 numbers
⏳ Reconcile the ledger
⬜ Draft the summary
```

On `EDIT` platforms it fills the live message with the current step beneath it.
On WhatsApp it is posted: the first plan immediately, then at least 45s apart,
five per run at most. A run with no plan gets a single "still working" after 60s
and nothing else. Tool-level activity lines stay off WhatsApp entirely — an edit
is free, a message is not.

Agents are told in the platform prompt that this checklist is the only thing the
person can see while they wait, so they write one.

### Two things WhatsApp was missing outright

- The read-receipt-and-typing bubble that `start_agent_chat` lights up when it
  picks the message up expires after ~25s, and nothing renewed it — so it went
  dark early in exactly the long runs where it was the only sign of life. It is
  now refreshed inside that window, flagged `is_refresh` so the reaction fallback
  fires once rather than on every tick.
- A long answer was handed to Meta as one oversized body and rejected outright —
  the person got nothing, which is worse than the truncation the other send path
  did. Split at 4096 on paragraph, line, then word boundaries.

### The formatter, extended

Beyond the original fix (Markdown leaking as literal `*asterisks*`):

| Was | Now |
|---|---|
| `* one` / `* two` lost the marker — list flattened to unmarked lines | `- one` / `- two`, which WhatsApp bullets natively |
| `2 * 3 = 6` → `2  3 = 6`, `approx ~5` → `approx 5` | preserved |
| code fence deleted; Markdown *inside* a block rewritten | fence kept (WhatsApp renders it), info string dropped, body verbatim |
| truncation ran after translation and could cut `*bold*` in half | re-balanced after every cut |
| `![alt](url)` → `!url`; `__bold__` untranslated; `**a\nb**` emitted bold across a newline | all handled |

The delimiter rule caused two of those. It removed anything hugging whitespace;
it now removes only a marker that **flanks text on exactly one side and never
found a partner**. Whitespace both sides is a character the author typed;
text both sides is `var_name`.

Three send paths the original fix had not reached now go through it too:
`send_questions` bodies, `send_approval` reason/summary, and the `cta_url` card.

### Files split

Two files crossed the 600-line architecture ratchet, so they are split along
seams that already existed:

- `whatsapp/payloads.py` — payload construction, no I/O, out of `service.py`
- `services/progress_display.py` — what the watcher sees, out of the observer's
  run lifecycle (joining `ProgressWaitingMixin` / `TokenStreamMixin`)

## Testing

```
make quality
```
passes, including the architecture ratchet (both files back under the limit),
the logging event catalog, OpenAPI freshness and scenario traceability.

```
uv run pytest $(find app -type d -name unit -path '*/tests/*')
```
5118 passed, 30 skipped, 1 failed. The failure is
`test_redis_store_enforces_atomic_state_and_claims`, which needs Redis and fails
identically on a clean checkout of `main`.

New coverage:

- `test_progress_plan.py` — the return is read, not the arguments (a check-off
  call carries one line); a JSON-encoded return from a remote harness; a long
  plan collapsing its history; the rendering carrying no Markdown.
- `test_progress_observer.py` — the plan drawn as a checklist rather than
  `Using write_todos`; a plan that has not moved not spending an update;
  WhatsApp posting, then rationing; the heartbeat firing once; WhatsApp
  acknowledged at run start; Slack acknowledged by its open stream and nothing
  else; email untouched.
- `test_whatsapp_client.py` — a long answer split rather than dropped; a split
  never leaving half a bold pair; progress posted as its own message; a typing
  refresh not re-posting the reaction.
- `test_whatsapp_text_format.py` — bullets, fences, Markdown inside a fence,
  characters the author typed, images, tables, idempotency, and a pair repaired
  after truncation.

Backend e2e needs Docker for Postgres and could not be run locally; CI covers
it. It caught one thing a local run could not: `test_progress_streaming_matrix_e2e`
patches `_MIN_TEXT_PROGRESS_INTERVAL_SECONDS`, which moved to `progress_display`
along with the code that reads it. Fixed in 969e831e.
