### PR TITLE
Only ask which pod answers you when two surfaces really share one address

### DIFF
--- a/lemma-backend/app/modules/agent_surfaces/api/controllers/user_surfaces_controller.py
+++ b/lemma-backend/app/modules/agent_surfaces/api/controllers/user_surfaces_controller.py
@@ -12,7 +12,7 @@ from fastapi import APIRouter
 
 from app.core.api.dependencies import CurrentUser
 from app.modules.agent_surfaces.api.dependencies import UserSurfacesServiceDep
-from app.modules.agent_surfaces.api.schemas import (
+from app.modules.agent_surfaces.api.user_surface_schemas import (
     SetDefaultSurfaceRequest,
     UserSurfaceItem,
     UserSurfacePlatformGroup,
@@ -38,6 +38,7 @@ def _to_response(groups: list[UserSurfaceGroup]) -> UserSurfacesResponse:
                         platform=surface.surface_type,
                         agent_id=surface.agent_id,
                         is_default=surface.id == group.default_surface_id,
+                        shares_address=surface.id in group.contended,
                     )
                     for surface in group.surfaces
                 ],
@@ -57,7 +58,8 @@ async def list_my_surfaces(
     service: UserSurfacesServiceDep,
 ) -> UserSurfacesResponse:
     """Every surface across the current user's pods, grouped by platform, with
-    the chosen default and a ``conflict`` flag when more than one could answer."""
+    the chosen default and a ``conflict`` flag when two of them answer at the
+    same address."""
     groups = await service.list_user_surfaces(user.id)
     return _to_response(groups)
 

--- a/lemma-backend/app/modules/agent_surfaces/api/schemas.py
+++ b/lemma-backend/app/modules/agent_surfaces/api/schemas.py
@@ -351,38 +351,6 @@ class AgentSurfaceListResponse(BaseModel):
     next_page_token: str | None = None
 
 
-class UserSurfaceItem(BaseModel):
-    """One of the current user's surfaces (across any pod they belong to)."""
-
-    id: UUID
-    name: str
-    pod_id: UUID
-    platform: SurfacePlatform
-    agent_id: UUID | None = None
-    is_default: bool = False
-
-
-class UserSurfacePlatformGroup(BaseModel):
-    """All of a user's surfaces for one platform. ``conflict`` is true when more
-    than one surface could answer them (they should pick a ``default``)."""
-
-    platform: SurfacePlatform
-    conflict: bool = False
-    default_surface_id: UUID | None = None
-    surfaces: list[UserSurfaceItem]
-
-
-class UserSurfacesResponse(BaseModel):
-    groups: list[UserSurfacePlatformGroup]
-
-
-class SetDefaultSurfaceRequest(BaseModel):
-    """Pick which surface answers this user for ``platform`` when several could."""
-
-    platform: SurfacePlatform
-    surface_id: UUID
-
-
 class SurfaceSendRequest(BaseModel):
     """Send a proactive message to a pod member on this surface."""
 

--- a/lemma-backend/app/modules/agent_surfaces/api/user_surface_schemas.py
+++ b/lemma-backend/app/modules/agent_surfaces/api/user_surface_schemas.py
@@ -1,0 +1,51 @@
+"""Wire shapes for the user-scoped ``/surfaces/me`` routes.
+
+Kept beside the pod-scoped schemas rather than inside them: these answer for a
+person across every pod they belong to, which is a different question from what
+one pod has configured.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from app.modules.agent_surfaces.domain.entities import SurfacePlatform
+
+
+class UserSurfaceItem(BaseModel):
+    """One of the current user's surfaces (across any pod they belong to)."""
+
+    id: UUID
+    name: str
+    pod_id: UUID
+    platform: SurfacePlatform
+    agent_id: UUID | None = None
+    is_default: bool = False
+    # True when another surface in this list answers at the same address (the
+    # deployment's shared bot/number). Only these are a choice; a pod's own bot
+    # has its own handle, so a message to it can only arrive there.
+    shares_address: bool = False
+
+
+class UserSurfacePlatformGroup(BaseModel):
+    """All of a user's surfaces for one platform. ``conflict`` is true when two
+    of them answer at the same address, so the user has to say which pod hears
+    them (the ``shares_address`` surfaces are the ones to choose between)."""
+
+    platform: SurfacePlatform
+    conflict: bool = False
+    default_surface_id: UUID | None = None
+    surfaces: list[UserSurfaceItem]
+
+
+class UserSurfacesResponse(BaseModel):
+    groups: list[UserSurfacePlatformGroup]
+
+
+class SetDefaultSurfaceRequest(BaseModel):
+    """Pick which surface answers this user for ``platform`` when several could."""
+
+    platform: SurfacePlatform
+    surface_id: UUID

--- a/lemma-backend/app/modules/agent_surfaces/services/surface_address.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/surface_address.py
@@ -1,0 +1,82 @@
+"""Which of a user's surfaces answer at the *same* address.
+
+Two surfaces only compete for a sender when a message to one of them could
+land on either — that is, when both answer at the same inbound identity. That
+happens on the deployment's shared bot/number, and it is the whole point of
+it: one Telegram bot, one WhatsApp number, one Slack app, fronting pods in
+several organizations, so a DM has to pick which pod hears it.
+
+A bot a pod brought itself is the opposite case. Telegram delivers by token and
+a token belongs to one surface across every org (``ensure_unique_telegram_account``);
+a connected mailbox has its own address. Messaging that bot is already
+unambiguous, so there is no choice to offer and asking for one only suggests
+the message might go somewhere else.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from uuid import UUID
+
+from app.modules.agent_surfaces.domain.entities import (
+    AgentSurfaceEntity,
+    SurfaceCredentialMode,
+    SurfacePlatform,
+)
+from app.modules.agent_surfaces.platforms.platform_capabilities import (
+    get_platform_capabilities,
+)
+
+
+def _tenant_scope(surface: AgentSurfaceEntity) -> str:
+    """The workspace/tenant an inbound event has to match (``matches_tenant``).
+
+    One Microsoft bot app or Slack app serves many tenants, and an event only
+    ever reaches the surfaces installed in the tenant it came from — so the
+    shared credential is one address *per tenant*, not one overall.
+    """
+    if surface.surface_type is SurfacePlatform.TEAMS:
+        return surface.external_tenant_id or ""
+    if surface.surface_type is SurfacePlatform.SLACK:
+        return surface.external_workspace_id or ""
+    return ""
+
+
+def inbound_address_key(surface: AgentSurfaceEntity) -> str:
+    """An opaque key equal for two surfaces exactly when they share an address.
+
+    The deployment's system credential is one identity per platform (see
+    ``system_credential_is_identity``), so every surface riding it shares a key,
+    narrowed by the workspace/tenant inbound events are matched against.
+    Everything else is keyed on the identity it actually owns — its mailbox
+    address, its connected account, its resolved handle — and falls back to the
+    surface's own id, which can never collide, when none of those is known yet.
+    """
+    platform = surface.surface_type.value
+    capabilities = get_platform_capabilities(platform)
+    if (
+        surface.account_id is None
+        and surface.credential_mode is SurfaceCredentialMode.SYSTEM
+        and (capabilities is None or capabilities.system_credential_is_identity)
+    ):
+        return f"system:{platform}:{_tenant_scope(surface)}"
+    if surface.surface_identity_email:
+        return f"email:{surface.surface_identity_email.strip().lower()}"
+    if surface.account_id is not None:
+        return f"account:{platform}:{surface.account_id}"
+    if surface.surface_identity_username:
+        return f"handle:{platform}:{surface.surface_identity_username.strip().lower()}"
+    return f"surface:{surface.id}"
+
+
+def contended_surface_ids(surfaces: Iterable[AgentSurfaceEntity]) -> set[UUID]:
+    """The ids of surfaces that share their address with another in ``surfaces``.
+
+    Only these are a choice for the user; the rest each own their address.
+    """
+    by_address: dict[str, list[UUID]] = {}
+    for surface in surfaces:
+        by_address.setdefault(inbound_address_key(surface), []).append(surface.id)
+    return {
+        surface_id for ids in by_address.values() if len(ids) > 1 for surface_id in ids
+    }

--- a/lemma-backend/app/modules/agent_surfaces/services/user_surfaces_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/user_surfaces_service.py
@@ -15,19 +15,32 @@ from app.modules.agent_surfaces.domain.ports import (
     SurfaceInstallationRepositoryPort,
     SurfacePodMembershipPort,
 )
+from app.modules.agent_surfaces.services.surface_address import (
+    contended_surface_ids,
+)
 from app.modules.identity.contracts import UserPreferences, UserRepositoryPort
 
 
 @dataclass(frozen=True)
 class UserSurfaceGroup:
     """All of a user's surfaces for one platform, across every pod they belong
-    to, with the platform's default (if set) and whether the choice is
-    ambiguous (more than one surface → a conflict the user should resolve)."""
+    to, with the platform's default (if set) and which of them the user actually
+    has to choose between.
+
+    ``contended`` holds the surfaces sharing one address — the deployment's
+    shared bot/number fronting several pods. More than one surface on a platform
+    is not by itself ambiguous: a pod's own bot has its own handle, and a message
+    to it can only ever arrive there."""
 
     platform: SurfacePlatform
     surfaces: list[AgentSurfaceEntity]
     default_surface_id: UUID | None
-    conflict: bool
+    contended: set[UUID]
+
+    @property
+    def conflict(self) -> bool:
+        """Whether the user has a routing choice to make on this platform."""
+        return bool(self.contended)
 
 
 class UserSurfacesService:
@@ -35,7 +48,8 @@ class UserSurfacesService:
 
     Powers ``GET /surfaces/me`` and ``PUT /surfaces/me/default`` so a user
     reachable via a shared system bot/number in several orgs can see every
-    surface that would answer them and pick a default when they conflict.
+    surface that would answer them and pick a default when they share one
+    address (see ``surface_address``).
     """
 
     def __init__(
@@ -79,7 +93,7 @@ class UserSurfacesService:
                     platform=platform,
                     surfaces=surfaces,
                     default_surface_id=preferences.default_surface_for(platform.value),
-                    conflict=len(surfaces) > 1,
+                    contended=contended_surface_ids(surfaces),
                 )
             )
         groups.sort(key=lambda g: g.platform.value)

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_surface_me_api_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_surface_me_api_e2e.py
@@ -49,6 +49,8 @@ async def test_surfaces_me_lists_and_sets_default(
     assert any(
         s["id"] == surface["id"] and s["is_default"] is False for s in tg["surfaces"]
     )
+    # Nothing else answers at this address, so there is nothing to choose.
+    assert all(s["shares_address"] is False for s in tg["surfaces"])
 
     # 2. Set the default.
     put = await authenticated_client.put(

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_surface_address.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_surface_address.py
@@ -1,0 +1,94 @@
+"""Which surfaces share an inbound address — the only ones a user must choose between."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from app.modules.agent_surfaces.domain.entities import (
+    AgentSurfaceEntity,
+    SurfaceConfig,
+    SurfaceCredentialMode,
+    SurfacePlatform,
+)
+from app.modules.agent_surfaces.services.surface_address import (
+    contended_surface_ids,
+    inbound_address_key,
+)
+
+
+def _surface(platform=SurfacePlatform.TELEGRAM, **overrides) -> AgentSurfaceEntity:
+    return AgentSurfaceEntity(
+        id=uuid4(),
+        pod_id=uuid4(),
+        name=platform.value.lower(),
+        surface_type=platform,
+        config=SurfaceConfig(),
+        **overrides,
+    )
+
+
+def test_shared_system_bot_is_one_address_across_pods():
+    first = _surface()
+    second = _surface()
+
+    assert inbound_address_key(first) == inbound_address_key(second)
+    assert contended_surface_ids([first, second]) == {first.id, second.id}
+
+
+def test_own_bot_has_its_own_address():
+    """A Telegram token answers for exactly one surface, so it can never contend."""
+    own = _surface(account_id=uuid4(), credential_mode=SurfaceCredentialMode.CUSTOM)
+    shared = _surface()
+
+    assert inbound_address_key(own) != inbound_address_key(shared)
+    assert contended_surface_ids([own, shared]) == set()
+
+
+def test_same_handle_on_two_surfaces_still_contends():
+    """Whatever produced it, one @handle answering twice is a real choice."""
+    handle = "@lemma_bot"
+    first = _surface(
+        credential_mode=SurfaceCredentialMode.CUSTOM, surface_identity_username=handle
+    )
+    second = _surface(
+        credential_mode=SurfaceCredentialMode.CUSTOM, surface_identity_username=handle
+    )
+
+    assert contended_surface_ids([first, second]) == {first.id, second.id}
+
+
+def test_one_slack_app_is_one_address_per_workspace():
+    """Inbound is matched against the workspace, so only same-workspace surfaces
+    can take each other's messages."""
+    here = _surface(SurfacePlatform.SLACK, external_workspace_id="T_ACME")
+    also_here = _surface(SurfacePlatform.SLACK, external_workspace_id="T_ACME")
+    elsewhere = _surface(SurfacePlatform.SLACK, external_workspace_id="T_OTHER")
+
+    assert contended_surface_ids([here, also_here, elsewhere]) == {
+        here.id,
+        also_here.id,
+    }
+
+
+def test_resend_mailboxes_share_a_key_but_not_an_address():
+    """One API key, a catch-all domain, a unique address per surface."""
+    first = _surface(
+        SurfacePlatform.RESEND, surface_identity_email="one@pods.lemma.run"
+    )
+    second = _surface(
+        SurfacePlatform.RESEND, surface_identity_email="two@pods.lemma.run"
+    )
+
+    assert contended_surface_ids([first, second]) == set()
+
+
+def test_unidentified_surfaces_fall_back_to_their_own_id():
+    """Nothing known yet is not evidence of a shared address."""
+    first = _surface(
+        SurfacePlatform.GMAIL, credential_mode=SurfaceCredentialMode.CUSTOM
+    )
+    second = _surface(
+        SurfacePlatform.GMAIL, credential_mode=SurfaceCredentialMode.CUSTOM
+    )
+
+    assert contended_surface_ids([first, second]) == set()

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_user_surfaces_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_user_surfaces_service.py
@@ -12,6 +12,7 @@ import pytest
 from app.modules.agent_surfaces.domain.entities import (
     AgentSurfaceEntity,
     SurfaceConfig,
+    SurfaceCredentialMode,
     SurfacePlatform,
 )
 from app.modules.agent_surfaces.domain.errors import (
@@ -27,6 +28,7 @@ pytestmark = pytest.mark.asyncio
 
 
 def _surface(pod_id, platform=SurfacePlatform.WHATSAPP, *, created_offset=0):
+    """A surface on the deployment's shared bot/number (the default)."""
     return AgentSurfaceEntity(
         id=uuid4(),
         pod_id=pod_id,
@@ -37,6 +39,14 @@ def _surface(pod_id, platform=SurfacePlatform.WHATSAPP, *, created_offset=0):
             second=created_offset
         ),
     )
+
+
+def _own_bot_surface(pod_id, platform=SurfacePlatform.TELEGRAM, *, created_offset=0):
+    """A surface on a bot the pod brought itself — its own handle, its own address."""
+    surface = _surface(pod_id, platform, created_offset=created_offset)
+    surface.account_id = uuid4()
+    surface.credential_mode = SurfaceCredentialMode.CUSTOM
+    return surface
 
 
 def _service(*, pod_ids, surfaces_by_pod, preferences=None, get_surface=None):
@@ -88,6 +98,48 @@ async def test_list_groups_by_platform_and_flags_conflict():
     tg = by_platform[SurfacePlatform.TELEGRAM]
     assert tg.conflict is False
     assert tg.default_surface_id is None
+
+
+async def test_own_bot_surfaces_never_conflict():
+    """Connecting your own Telegram bot in eleven pods is eleven addresses.
+
+    Each bot answers on its own token, so a message can only ever land on the
+    bot it was sent to — asking which pod should hear it invents a choice and
+    implies the message might go somewhere else."""
+    pods = [uuid4() for _ in range(3)]
+    surfaces = {
+        pod: [_own_bot_surface(pod, created_offset=index)]
+        for index, pod in enumerate(pods)
+    }
+    service, _ = _service(
+        pod_ids=pods, surfaces_by_pod=surfaces, preferences=UserPreferences()
+    )
+
+    groups = await service.list_user_surfaces(uuid4())
+    telegram = next(g for g in groups if g.platform is SurfacePlatform.TELEGRAM)
+
+    assert len(telegram.surfaces) == 3
+    assert telegram.contended == set()
+    assert telegram.conflict is False
+
+
+async def test_conflict_covers_only_the_shared_bot_surfaces():
+    """A mix: the shared bot in two pods, plus a pod running its own bot."""
+    shared_a, shared_b, own = uuid4(), uuid4(), uuid4()
+    tg_a = _surface(shared_a, SurfacePlatform.TELEGRAM, created_offset=1)
+    tg_b = _surface(shared_b, SurfacePlatform.TELEGRAM, created_offset=2)
+    tg_own = _own_bot_surface(own, created_offset=3)
+    service, _ = _service(
+        pod_ids=[shared_a, shared_b, own],
+        surfaces_by_pod={shared_a: [tg_a], shared_b: [tg_b], own: [tg_own]},
+        preferences=UserPreferences(),
+    )
+
+    groups = await service.list_user_surfaces(uuid4())
+    telegram = next(g for g in groups if g.platform is SurfacePlatform.TELEGRAM)
+
+    assert telegram.conflict is True
+    assert telegram.contended == {tg_a.id, tg_b.id}
 
 
 async def test_set_default_writes_preference_for_in_pod_surface():

--- a/lemma-backend/architecture-baseline.json
+++ b/lemma-backend/architecture-baseline.json
@@ -83,7 +83,7 @@
   "module_cycles": [],
   "oversized_files": {
     "app/modules/agent_surfaces/api/controllers/surface_controller.py": 627,
-    "app/modules/agent_surfaces/api/schemas.py": 610,
+    "app/modules/agent_surfaces/api/schemas.py": 578,
     "app/modules/agent_surfaces/platforms/whatsapp/service.py": 623,
     "app/modules/apps/services/app_service.py": 628,
     "app/modules/connectors/services/connector_operation_service.py": 665,

--- a/lemma-frontend/components/settings/user-surfaces-panel.tsx
+++ b/lemma-frontend/components/settings/user-surfaces-panel.tsx
@@ -22,10 +22,11 @@ const PLATFORM_LABEL: Record<string, string> = {
 const platformLabel = (platform: string) => PLATFORM_LABEL[platform] ?? platform;
 
 /**
- * User-scoped surface routing. When the same person is reachable through more
- * than one surface on a platform (e.g. a shared bot spanning orgs), only one
- * can answer — this panel surfaces those conflicts and lets the user pick which
- * surface wins.
+ * User-scoped surface routing. When two surfaces answer at the *same* address —
+ * Lemma's shared bot or number fronting pods in several orgs — only one of them
+ * can take a message, so this panel raises that choice. Surfaces on their own
+ * address (a pod's own bot, its own mailbox) are listed but never asked about:
+ * a message sent to one of those can only ever arrive there.
  */
 export function UserSurfacesPanel() {
     const { data, isLoading } = useUserSurfaces();
@@ -70,7 +71,9 @@ export function UserSurfacesPanel() {
         <div className="grid gap-4">
             {groups.map((group) => {
                 const surfaces = group.surfaces ?? [];
-                const hasConflict = Boolean(group.conflict) && surfaces.length > 1;
+                const sharing = surfaces.filter((surface) => surface.shares_address);
+                const own = surfaces.filter((surface) => !surface.shares_address);
+                const hasConflict = sharing.length > 1;
 
                 return (
                     <div
@@ -84,17 +87,13 @@ export function UserSurfacesPanel() {
                             ) : null}
                         </div>
 
-                        {surfaces.length <= 1 ? (
-                            <p className="text-xs leading-5 text-[var(--text-secondary)]">
-                                Answers you from {podLabel(surfaces[0]?.pod_id ?? '')}.
-                            </p>
-                        ) : (
+                        {hasConflict ? (
                             <>
                                 <p className="text-xs leading-5 text-[var(--text-secondary)]">
-                                    You’re reachable from several {platformLabel(group.platform)} surfaces — choose the one that should answer you.
+                                    These pods share one {platformLabel(group.platform)} address — choose the one that should answer you.
                                 </p>
                                 <div className="grid gap-1.5">
-                                    {surfaces.map((surface) => {
+                                    {sharing.map((surface) => {
                                         const isDefault =
                                             surface.is_default || group.default_surface_id === surface.id;
                                         const isSaving = isPending && variables?.surface_id === surface.id;
@@ -127,7 +126,17 @@ export function UserSurfacesPanel() {
                                     })}
                                 </div>
                             </>
-                        )}
+                        ) : null}
+
+                        {own.length ? (
+                            <p className="text-xs leading-5 text-[var(--text-secondary)]">
+                                {own.length === 1
+                                    ? `Answers you from ${podLabel(own[0].pod_id)}.`
+                                    : `${own.length} pods answer you, each at its own address: ${own
+                                          .map((surface) => podLabel(surface.pod_id))
+                                          .join(', ')}.`}
+                            </p>
+                        ) : null}
                     </div>
                 );
             })}

--- a/lemma-frontend/components/surfaces/surface-live-step.tsx
+++ b/lemma-frontend/components/surfaces/surface-live-step.tsx
@@ -86,9 +86,10 @@ export function SurfaceLiveStep({
     );
 }
 
-/** Only renders when the same shared identity really could answer this person in
- * more than one pod — otherwise there is no choice to make and no reason to
- * raise the idea. */
+/** Only renders when the address just shown really could answer this person in
+ * more than one pod — Lemma's shared bot or number, fronting pods in several
+ * orgs. A bot the pod brought itself has its own handle, so a message to it can
+ * only land there; raising the question anyway suggests it might not. */
 function ReachableElsewhereNotice({ surface }: { surface: AssistantSurface }) {
     const platform = String(surface.platform || '').toUpperCase();
     const { data: userSurfaces, isLoading } = useUserSurfaces(Boolean(platform));
@@ -98,19 +99,23 @@ function ReachableElsewhereNotice({ surface }: { surface: AssistantSurface }) {
     const group = userSurfaces?.groups?.find(
         (candidate) => String(candidate.platform).toUpperCase() === platform,
     );
-    if (isLoading || !group?.conflict) return null;
+    // `shares_address` marks the surfaces answering at one address; the rest own
+    // theirs. The choice is only this surface's to make when it is one of them.
+    const sharing = (group?.surfaces ?? []).filter((candidate) => candidate.shares_address);
+    if (isLoading || sharing.length < 2) return null;
+    if (!sharing.some((candidate) => candidate.id === surface.id)) return null;
 
     const podNames = new Map((podsData?.items ?? []).map((pod) => [pod.id, pod.name]));
-    const selectedId = group.default_surface_id ?? surface.id;
+    const selectedId = group?.default_surface_id ?? surface.id;
 
     return (
         <div className="surface-panel-muted grid gap-2.5 p-3">
             <p className="flex items-start gap-2 text-xs leading-5 text-[var(--text-secondary)]">
                 <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                You’re in {group.surfaces.length} pods reachable this way. Your messages go to:
+                You’re in {sharing.length} pods reachable at this address. Your messages go to:
             </p>
             <div className="grid gap-1">
-                {group.surfaces.map((candidate) => {
+                {sharing.map((candidate) => {
                     const checked = candidate.id === selectedId;
                     return (
                         <button

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -13,4 +13,4 @@ SDK and the server it is talking to.
 from __future__ import annotations
 
 API_VERSION = "0.7.0"
-SPEC_SHA256 = "7c540d2fb5b7377c89bfd9929a05e0050d7e96d1ada28a2b3b7c860947a2873d"
+SPEC_SHA256 = "8e0e16e2dccf06af44a241c44c3e5b1720376fb5983ea9bf528ad29f4ae866c3"

--- a/lemma-python/lemma_sdk/openapi_client/api/agent_surfaces_me/agent_surface_list_mine.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/agent_surfaces_me/agent_surface_list_mine.py
@@ -51,7 +51,8 @@ def sync_detailed(
     """List My Surfaces
 
      Every surface across the current user's pods, grouped by platform, with
-    the chosen default and a ``conflict`` flag when more than one could answer.
+    the chosen default and a ``conflict`` flag when two of them answer at the
+    same address.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -77,7 +78,8 @@ def sync(
     """List My Surfaces
 
      Every surface across the current user's pods, grouped by platform, with
-    the chosen default and a ``conflict`` flag when more than one could answer.
+    the chosen default and a ``conflict`` flag when two of them answer at the
+    same address.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -99,7 +101,8 @@ async def asyncio_detailed(
     """List My Surfaces
 
      Every surface across the current user's pods, grouped by platform, with
-    the chosen default and a ``conflict`` flag when more than one could answer.
+    the chosen default and a ``conflict`` flag when two of them answer at the
+    same address.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -123,7 +126,8 @@ async def asyncio(
     """List My Surfaces
 
      Every surface across the current user's pods, grouped by platform, with
-    the chosen default and a ``conflict`` flag when more than one could answer.
+    the chosen default and a ``conflict`` flag when two of them answer at the
+    same address.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.

--- a/lemma-python/lemma_sdk/openapi_client/models/user_surface_item.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/user_surface_item.py
@@ -24,6 +24,7 @@ class UserSurfaceItem:
         pod_id (UUID):
         agent_id (None | Unset | UUID):
         is_default (bool | Unset):  Default: False.
+        shares_address (bool | Unset):  Default: False.
     """
 
     id: UUID
@@ -32,6 +33,7 @@ class UserSurfaceItem:
     pod_id: UUID
     agent_id: None | Unset | UUID = UNSET
     is_default: bool | Unset = False
+    shares_address: bool | Unset = False
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -53,6 +55,8 @@ class UserSurfaceItem:
 
         is_default = self.is_default
 
+        shares_address = self.shares_address
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
@@ -67,6 +71,8 @@ class UserSurfaceItem:
             field_dict["agent_id"] = agent_id
         if is_default is not UNSET:
             field_dict["is_default"] = is_default
+        if shares_address is not UNSET:
+            field_dict["shares_address"] = shares_address
 
         return field_dict
 
@@ -100,6 +106,8 @@ class UserSurfaceItem:
 
         is_default = d.pop("is_default", UNSET)
 
+        shares_address = d.pop("shares_address", UNSET)
+
         user_surface_item = cls(
             id=id,
             name=name,
@@ -107,6 +115,7 @@ class UserSurfaceItem:
             pod_id=pod_id,
             agent_id=agent_id,
             is_default=is_default,
+            shares_address=shares_address,
         )
 
         user_surface_item.additional_properties = d

--- a/lemma-python/lemma_sdk/openapi_client/models/user_surface_platform_group.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/user_surface_platform_group.py
@@ -19,8 +19,9 @@ T = TypeVar("T", bound="UserSurfacePlatformGroup")
 
 @_attrs_define
 class UserSurfacePlatformGroup:
-    """All of a user's surfaces for one platform. ``conflict`` is true when more
-    than one surface could answer them (they should pick a ``default``).
+    """All of a user's surfaces for one platform. ``conflict`` is true when two
+    of them answer at the same address, so the user has to say which pod hears
+    them (the ``shares_address`` surfaces are the ones to choose between).
 
         Attributes:
             platform (SurfacePlatform):

--- a/lemma-python/lemma_sdk/openapi_spec.json
+++ b/lemma-python/lemma_sdk/openapi_spec.json
@@ -15748,6 +15748,11 @@
             "format": "uuid",
             "title": "Pod Id",
             "type": "string"
+          },
+          "shares_address": {
+            "default": false,
+            "title": "Shares Address",
+            "type": "boolean"
           }
         },
         "required": [
@@ -15760,7 +15765,7 @@
         "type": "object"
       },
       "UserSurfacePlatformGroup": {
-        "description": "All of a user's surfaces for one platform. ``conflict`` is true when more\nthan one surface could answer them (they should pick a ``default``).",
+        "description": "All of a user's surfaces for one platform. ``conflict`` is true when two\nof them answer at the same address, so the user has to say which pod hears\nthem (the ``shares_address`` surfaces are the ones to choose between).",
         "properties": {
           "conflict": {
             "default": false,
@@ -32113,7 +32118,7 @@
     },
     "/surfaces/me": {
       "get": {
-        "description": "Every surface across the current user's pods, grouped by platform, with\nthe chosen default and a ``conflict`` flag when more than one could answer.",
+        "description": "Every surface across the current user's pods, grouped by platform, with\nthe chosen default and a ``conflict`` flag when two of them answer at the\nsame address.",
         "operationId": "agent.surface.list_mine",
         "responses": {
           "200": {

--- a/lemma-typescript/public/lemma-client.js
+++ b/lemma-typescript/public/lemma-client.js
@@ -15248,7 +15248,8 @@ var LemmaClient = (() => {
     /**
      * List My Surfaces
      * Every surface across the current user's pods, grouped by platform, with
-     * the chosen default and a ``conflict`` flag when more than one could answer.
+     * the chosen default and a ``conflict`` flag when two of them answer at the
+     * same address.
      * @returns UserSurfacesResponse Successful Response
      * @throws ApiError
      */

--- a/lemma-typescript/src/openapi_client/models/UserSurfaceItem.ts
+++ b/lemma-typescript/src/openapi_client/models/UserSurfaceItem.ts
@@ -13,4 +13,5 @@ export type UserSurfaceItem = {
     name: string;
     platform: SurfacePlatform;
     pod_id: string;
+    shares_address?: boolean;
 };

--- a/lemma-typescript/src/openapi_client/models/UserSurfacePlatformGroup.ts
+++ b/lemma-typescript/src/openapi_client/models/UserSurfacePlatformGroup.ts
@@ -5,8 +5,9 @@
 import type { SurfacePlatform } from './SurfacePlatform.js';
 import type { UserSurfaceItem } from './UserSurfaceItem.js';
 /**
- * All of a user's surfaces for one platform. ``conflict`` is true when more
- * than one surface could answer them (they should pick a ``default``).
+ * All of a user's surfaces for one platform. ``conflict`` is true when two
+ * of them answer at the same address, so the user has to say which pod hears
+ * them (the ``shares_address`` surfaces are the ones to choose between).
  */
 export type UserSurfacePlatformGroup = {
     conflict?: boolean;

--- a/lemma-typescript/src/openapi_client/services/AgentSurfacesMeService.ts
+++ b/lemma-typescript/src/openapi_client/services/AgentSurfacesMeService.ts
@@ -11,7 +11,8 @@ export class AgentSurfacesMeService {
     /**
      * List My Surfaces
      * Every surface across the current user's pods, grouped by platform, with
-     * the chosen default and a ``conflict`` flag when more than one could answer.
+     * the chosen default and a ``conflict`` flag when two of them answer at the
+     * same address.
      * @returns UserSurfacesResponse Successful Response
      * @throws ApiError
      */


### PR DESCRIPTION
## What changes

Connecting your own Telegram bot no longer asks which of your pods should
answer you. That question now appears only when two surfaces really do answer
at the same address — Lemma's shared bot or number fronting pods in several
orgs — and the picker lists only those pods, not every pod you belong to.

The same correction applies everywhere else it was wrong: Gmail and Outlook
mailboxes no longer conflict with each other, Resend addresses no longer
conflict (one unique address per surface off one shared key is the design), and
a Slack app is treated as one address *per workspace* rather than one overall.

## Why

`GET /surfaces/me` flagged a conflict on `len(surfaces) > 1` — any two surfaces
on a platform, whatever address they answer at. But a bot a pod brings itself is
stored with its own connector account and `CUSTOM` credentials, and a Telegram
token answers for exactly one surface across every org
(`ensure_unique_telegram_account`), so a DM to `@that_bot` can only ever reach
the pod that connected it.

Routing already knew this. A platform-wide webhook is narrowed to
system-credential surfaces before the sender is disambiguated
(`_system_bot_surfaces`), and a native receiver scopes updates to the surfaces
its own bot serves. Only the listing endpoint disagreed.

It was also a trap, not just noise: choosing a custom-bot pod saved a default
that the next shared-bot event treated as stale and silently cleared.

`surface_address.inbound_address_key` now gives each surface the address it
actually answers at — the shared system credential when that credential is an
identity (`system_credential_is_identity`), narrowed by the Slack workspace or
Teams tenant inbound is matched against; otherwise the mailbox, connected
account, or resolved handle it owns. Two surfaces contend only when those keys
are equal.

## How to verify

```bash
cd lemma-backend && uv run pytest app/modules/agent_surfaces/tests/unit -q
```

841 passed. The one failure in that suite, `test_redis_store_enforces_atomic_state_and_claims`,
needs a local Redis and fails the same way on a clean tree.

```bash
cd lemma-backend && uv run ruff check app/modules/agent_surfaces && cd .. && make architecture
```

`All checks passed!` / `Architecture ratchet passed (12 inherited import violations, 0 inherited cycles).`

```bash
cd lemma-frontend && npx tsc --noEmit --pretty false --skipLibCheck && npx eslint components/settings/user-surfaces-panel.tsx components/surfaces/surface-live-step.tsx
```

Clean, no output.

The `/surfaces/me` E2E gained a `shares_address` assertion but could not be run
locally — Docker was unavailable for the Postgres container, so CI is the first
run of it.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **API surface** — OpenAPI spec regenerated from the code, both SDKs
      regenerated from that spec, all committed here. The spec diff is only this
      change (one new field plus two docstrings).
- [x] **Compatibility** — additive only. `shares_address` defaults to `false`,
      and `conflict` keeps its name and type on the wire; an older client that
      ignores the new field sees a `conflict` flag that is now correct rather
      than over-eager.
- [x] **Security** — no new secret anywhere. The address key is derived from
      columns already on the surface row and never contains a credential; a bot
      token is never read or exposed by it.
- [x] **Rollback** — plain revert, no state to unwind.

## Compatibility and rollback notes

No migration, and nothing in the persistence layer is touched. `shares_address`
is computed per request from existing columns (`credential_mode`, `account_id`,
`external_workspace_id`, `external_tenant_id`, `surface_identity_email`,
`surface_identity_username`) and never stored.

One data note: a default a user had already saved pointing at an own-bot surface
stays in `users.preferences` and is no longer offered in the UI. It was already
inert — routing treated it as stale and cleared it on the next shared-bot event
— so no backfill is needed.

Reverting restores the old over-eager prompt; nothing else changes.

## Note for reviewers

`api/schemas.py` was already over the 600-line architecture ratchet at 610, so
adding a field to it failed `make architecture`. The four `/surfaces/me` schemas
(imported by one controller only) moved to `api/user_surface_schemas.py`,
following the `agent/api/agent_host_schemas.py` precedent. That file is 578 now,
and `architecture-baseline.json` ratchets down to match rather than keeping the
old allowance.
