### PR TITLE
Let something else authenticate the standing cast

### DIFF
--- a/tests/scenarios/harness/provision.py
+++ b/tests/scenarios/harness/provision.py
@@ -16,15 +16,38 @@ reports that it had nothing to do.
 the `scn` mark, so it can only ever touch things a run made — and puts the
 cast's roles back to what this module says they should be. For when a run dies
 partway through and leaves somebody promoted.
+
+## Deployments this process cannot register the cast on by itself
+
+Signing up is not always possible from here. A deployment can put a
+proof-of-work challenge in front of it, or require a verification email to be
+read back before anything else works — gates this module has no business
+knowing how to get past, because publishing how would be indistinguishable
+from documenting how to defeat them in bulk.
+
+`--authenticate-with path/to/module.py:function` replaces *only* the "get the
+cast signed in" half with an external one. Everything after that — building
+the organizations, the pods, the memberships — is unchanged and still runs
+here, because none of that is gated by anything the replacement needed to get
+past. The function receives the `World` and must return every `tenant.CAST`
+label mapped to a signed-in `Person` (`Person.api.authenticate(token)` and
+`Person.user_id` set — the same state `signs_up`/`signs_in` leave behind).
+What it does to get there is its own business: `IdentitySteps.signs_up`,
+`.requests_email_verification` and the rest all accept `**kwargs`, reaching
+the raw request, for exactly this — an external caller can attach whatever a
+particular deployment demands without this module ever needing to know what
+that was.
 """
 
 from __future__ import annotations
 
 import argparse
 import asyncio
+import importlib.util
 import os
 import sys
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
+from pathlib import Path
 from typing import Any
 
 from harness import environment, tenant
@@ -34,6 +57,11 @@ from harness.world import Person, World
 JSON = dict[str, Any]
 
 BASE_URL_SETTING = "SCENARIOS_BASE_URL"
+AUTHENTICATE_WITH_SETTING = "SCENARIOS_AUTHENTICATE_WITH"
+
+#: What an --authenticate-with function must return: every tenant.CAST label
+#: mapped to a Person already in the state signs_up/signs_in leave one in.
+Authenticator = Callable[[World], Awaitable[dict[str, Person]]]
 
 
 class Ledger:
@@ -67,24 +95,36 @@ def owner_of(company: tenant.Company) -> tenant.Colleague:
     raise AssertionError(f"{company.name} has no owner declared in harness/tenant.py")
 
 
-async def provision(base_url: str, *, reset: bool = False) -> str:
+async def provision(
+    base_url: str, *, reset: bool = False, authenticate: Authenticator | None = None
+) -> str:
     target = environment.describe(base_url)
     environment.confirm_writable(target)
     ledger = Ledger()
 
     world = World(base_url=base_url)
     try:
-        people = {
-            colleague.label: world.arriving(colleague.label, colleague.email)
-            for colleague in tenant.CAST
-        }
-
-        for colleague in tenant.CAST:
-            person = people[colleague.label]
-            if await person.arrives():
-                ledger.did(f"registered {colleague.full_name} <{colleague.email}>")
-            else:
-                ledger.already(f"{colleague.full_name} already has an account")
+        if authenticate is not None:
+            people = await authenticate(world)
+            missing = {colleague.label for colleague in tenant.CAST} - set(people)
+            if missing:
+                raise AssertionError(
+                    f"--authenticate-with did not return {sorted(missing)}; it "
+                    f"must authenticate every label in harness/tenant.py's CAST"
+                )
+            for colleague in tenant.CAST:
+                ledger.already(f"{colleague.full_name} authenticated externally")
+        else:
+            people = {
+                colleague.label: world.arriving(colleague.label, colleague.email)
+                for colleague in tenant.CAST
+            }
+            for colleague in tenant.CAST:
+                person = people[colleague.label]
+                if await person.arrives():
+                    ledger.did(f"registered {colleague.full_name} <{colleague.email}>")
+                else:
+                    ledger.already(f"{colleague.full_name} already has an account")
 
         companies: dict[str, JSON] = {}
         for company in tenant.COMPANIES:
@@ -391,6 +431,32 @@ async def _clear_run_pods(
             ledger.did(f"removed leftover pod {name!r}")
 
 
+def _load_authenticator(spec: str) -> Authenticator:
+    """``spec`` is ``path/to/module.py:function_name``.
+
+    A file path rather than an importable module name: the replacement is, by
+    its nature, likely to live somewhere this suite's own package layout does
+    not reach — a private repo entirely, in the case this was written for.
+    """
+    path_str, sep, func_name = spec.partition(":")
+    if not sep or not func_name:
+        raise SystemExit(
+            f"--authenticate-with wants 'path/to/module.py:function_name', got {spec!r}"
+        )
+    path = Path(path_str)
+    if not path.is_file():
+        raise SystemExit(f"--authenticate-with: no such file {path}")
+    spec_obj = importlib.util.spec_from_file_location(f"_authenticator_{path.stem}", path)
+    if spec_obj is None or spec_obj.loader is None:
+        raise SystemExit(f"--authenticate-with: could not load {path}")
+    module = importlib.util.module_from_spec(spec_obj)
+    spec_obj.loader.exec_module(module)
+    try:
+        return getattr(module, func_name)
+    except AttributeError:
+        raise SystemExit(f"--authenticate-with: {path} has no {func_name!r}") from None
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument(
@@ -403,6 +469,16 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="also clear what runs left behind and put the cast's roles back",
     )
+    parser.add_argument(
+        "--authenticate-with",
+        default=os.getenv(AUTHENTICATE_WITH_SETTING, ""),
+        help=(
+            "path/to/module.py:function — get the cast signed in some other "
+            f"way, for a deployment this process cannot register on by "
+            f"itself (or {AUTHENTICATE_WITH_SETTING}). See this module's own "
+            f"docstring."
+        ),
+    )
     arguments = parser.parse_args(argv)
     if not arguments.base_url:
         parser.error(
@@ -410,8 +486,17 @@ def main(argv: list[str] | None = None) -> int:
             f"There is no default on purpose: this script registers accounts "
             f"and creates organizations, and an organization cannot be deleted."
         )
+    authenticate = (
+        _load_authenticator(arguments.authenticate_with)
+        if arguments.authenticate_with
+        else None
+    )
     try:
-        print(asyncio.run(provision(arguments.base_url, reset=arguments.reset)))
+        print(
+            asyncio.run(
+                provision(arguments.base_url, reset=arguments.reset, authenticate=authenticate)
+            )
+        )
     except (environment.Unreachable, AssertionError) as stopped:
         print(f"provisioning stopped: {stopped}", file=sys.stderr)
         return 1

--- a/tests/scenarios/harness/steps/identity.py
+++ b/tests/scenarios/harness/steps/identity.py
@@ -58,11 +58,18 @@ class IdentitySteps:
 
     # --- account ---------------------------------------------------------
 
-    async def signs_up(self) -> JSON:
-        """Register, which also signs the person in — there is no second step."""
-        return await self._enters(SIGNUP_PATH, doing="sign up")
+    async def signs_up(self, **kwargs: Any) -> JSON:
+        """Register, which also signs the person in — there is no second step.
 
-    async def signs_in(self) -> JSON:
+        ``**kwargs`` reaches the raw request untouched (``headers=``, most
+        often) — this method has no opinion on what a deployment wants in
+        front of signup, only on what signing up means once it is let
+        through. A deployment that wants more than a password is a caller's
+        problem to solve, not this suite's to know how.
+        """
+        return await self._enters(SIGNUP_PATH, doing="sign up", **kwargs)
+
+    async def signs_in(self, **kwargs: Any) -> JSON:
         """Come back to an account that already exists.
 
         This is what a standing cast does at the start of every run, and it is
@@ -70,9 +77,9 @@ class IdentitySteps:
         not: signing in passes none of the gates a real deployment keeps in
         front of registration.
         """
-        return await self._enters(SIGNIN_PATH, doing="sign in")
+        return await self._enters(SIGNIN_PATH, doing="sign in", **kwargs)
 
-    async def arrives(self) -> bool:
+    async def arrives(self, **kwargs: Any) -> bool:
         """Register if this address is new, sign in if it is not. New?
 
         What provisioning uses, and the order it tries them in is the point.
@@ -82,7 +89,9 @@ class IdentitySteps:
         block outright. Registering first costs one request either way and never
         fails on a person who is simply already here.
         """
-        response = await self.api.call("POST", SIGNUP_PATH, json=self._credentials())
+        response = await self.api.call(
+            "POST", SIGNUP_PATH, json=self._credentials(), **kwargs
+        )
         payload = response.json() if response.content else {}
         if response.status_code == 200 and payload.get("status") == "OK":
             self._admitted(response, payload, doing="sign up")
@@ -104,10 +113,12 @@ class IdentitySteps:
             ]
         }
 
-    async def _enters(self, path: str, *, doing: str) -> JSON:
+    async def _enters(self, path: str, *, doing: str, **kwargs: Any) -> JSON:
         # Deliberately `call` rather than `expect`: the access token comes back
         # as a response *header*, so the decoded body alone is not enough.
-        response = await self.api.call("POST", path, json=self._credentials())
+        response = await self.api.call(
+            "POST", path, json=self._credentials(), **kwargs
+        )
         if response.status_code != 200:
             raise AssertionError(
                 f"{self.label} could not {doing}: {response.status_code}\n"
@@ -135,6 +146,30 @@ class IdentitySteps:
         # ageing out mid-run is the driver's problem rather than a scenario's.
         self.api.renews_with(self.signs_in)
         self.user_id = payload["user"]["id"]
+
+    async def is_email_verified(self) -> bool:
+        return bool((await self.api.get("/st/auth/user/email/verify")).get("isVerified"))
+
+    async def requests_email_verification(self, **kwargs: Any) -> None:
+        """Ask the deployment to send this person a verification email.
+
+        ``**kwargs`` reaches the raw request, same as ``signs_up`` — a
+        deployment that gates this the way it gates signup is a caller's
+        problem to solve, not this method's to know how.
+        """
+        await self.api.post("/st/auth/user/email/verify/token", **kwargs)
+
+    async def verifies_email(self, token: str) -> None:
+        """Consume a verification token — the one a person gets by clicking
+        the email's link, obtained however the caller obtained it."""
+        payload = await self.api.post(
+            "/st/auth/user/email/verify", json={"method": "token", "token": token}
+        )
+        if payload.get("status") != "OK":
+            raise AssertionError(
+                f"{self.label} could not verify their email: "
+                f"{payload.get('status')!r} — {payload}"
+            )
 
     async def profile(self) -> JSON:
         return await self.api.get("/users/me")


### PR DESCRIPTION
## Summary

Some deployments put a proof-of-work challenge in front of signup, or refuse every authenticated request from an unverified account until a real verification email is read back (dev sets both `AUTH_ALTCHA_ENABLED` and `AUTH_EMAIL_VERIFICATION_REQUIRED`). `harness/provision.py` has no business knowing how to get past either — publishing that would be indistinguishable from documenting how to defeat them in bulk — but it still needs the cast signed in before it can build organizations, pods and memberships.

## Change

- **`provision(base_url, *, reset=False, authenticate=None)`** — a hook. When given, `authenticate(world)` replaces only "get the cast signed in"; everything after that (companies, pods, memberships) is unchanged public code.
- **`--authenticate-with path/to/module.py:function`** (or `SCENARIOS_AUTHENTICATE_WITH`) on the CLI, loading an external Python file by path via `importlib` — deliberately a file path rather than an importable module, since a replacement like this is likely to live somewhere this repo's own layout doesn't reach.
- **`signs_up`, `arrives`, `signs_in`, `requests_email_verification`** now accept `**kwargs` reaching the raw request (`headers=`, most often) — the generic mechanism that lets an external `authenticate()` attach whatever a particular deployment demands, without this module ever needing to know what that was.
- **`is_email_verified`, `requests_email_verification`, `verifies_email`** — three new `IdentitySteps`, the same shape as `signs_up`/`signs_in`: plain product actions, no opinion on what gates a deployment puts in front of them.

## Test plan

- [x] `journeys/test_harness_contract.py` (guards): 80 passed
- [x] End to end against a real deployment gating both altcha and email verification: an external `authenticate()` (held privately, not part of this repo — it solves the deployment's own proof-of-work and reads the verification email back from that deployment's own mail) got all five accounts registered and verified, then **this unmodified code** built both organizations, all five standing pods and every membership — 14 changes on the first run, `nothing to do — the tenant already matches harness/tenant.py` on the second.
- [ ] `make scenarios` locally, unaffected by default (`authenticate=None` is exactly the prior code path) — will confirm before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)