### PR TITLE
Retry the GRANT that loses a catalog race, instead of losing the grant

### DIFF
--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -402,6 +402,7 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'datastore.projection.delete_derived_child_artifacts_s.diagnostic': EventSpec('debug', frozenset()),
     'datastore.projection.delete_file_s_s.diagnostic': EventSpec('debug', frozenset()),
     'datastore.projection.remove_indexed_chunks_s_s.diagnostic': EventSpec('debug', frozenset()),
+    'datastore.query_role.grant.contended': EventSpec('debug', frozenset({'attempt', 'schema_name', 'table_name'})),
     'datastore.query_role.grant.degraded': EventSpec('warning', frozenset({'schema_name', 'table_name'})),
     'datastore.reader.load_child_manifest_s.diagnostic': EventSpec('debug', frozenset()),
     'datastore.record.bulk_update.propagated': EventSpec('debug', frozenset()),

--- a/lemma-backend/app/modules/datastore/infrastructure/query_role.py
+++ b/lemma-backend/app/modules/datastore/infrastructure/query_role.py
@@ -10,15 +10,56 @@ its first table.
 Every grant here is best-effort and never raises: a deployment whose app role
 cannot create or grant roles must still be able to create pods and tables.
 Queries fail closed, and ``backfill_grants`` repairs whatever was missed.
+
+The commonest way to lose a grant, though, is not privilege but contention.
+``GRANT`` writes a catalog row, and two sessions granting on the same schema at
+once — two API processes, or two test workers — leave one of them holding a
+transient error instead of the grant it asked for. Those are retried here
+rather than degraded, because "best-effort" was never meant to mean "gives up
+the first time two pods are created at the same moment".
 """
 
+import asyncio
+import random
+
 from sqlalchemy import text
+from sqlalchemy.exc import DBAPIError
 
 from app.core.log.log import get_logger
 from app.modules.datastore.config import datastore_settings
 from app.modules.datastore.infrastructure.sql_identifiers import sanitize_identifier
 
 logger = get_logger(__name__)
+
+# Bounded: a conflict that survives four attempts is not contention any more,
+# and the caller's degraded path is a better answer than a longer wait.
+_GRANT_ATTEMPTS = 4
+_GRANT_BACKOFF_SECONDS = 0.05
+
+# 40001 serialization_failure, 40P01 deadlock_detected — the two codes
+# PostgreSQL documents as "retry the transaction".
+_TRANSIENT_SQLSTATES = frozenset({"40001", "40P01"})
+
+# `tuple concurrently updated` is raised by a bare elog() deep in the catalog
+# update path, so it arrives as XX000 (internal_error) — a code it shares with
+# every other unclassified server fault. Unlike the codes above it can only be
+# recognised by its message, which is exact enough to be safe and is the reason
+# this list exists at all.
+_TRANSIENT_MESSAGES = ("tuple concurrently updated", "tuple concurrently deleted")
+
+
+def _is_transient_conflict(exc: BaseException) -> bool:
+    """Whether PostgreSQL refused the statement over contention, not privilege.
+
+    Read through ``orig`` first: SQLAlchemy wraps the driver error, and the
+    SQLSTATE is the only identification that does not depend on message text.
+    """
+    orig = getattr(exc, "orig", None)
+    sqlstate = getattr(orig, "sqlstate", None) or getattr(exc, "sqlstate", None)
+    if sqlstate in _TRANSIENT_SQLSTATES:
+        return True
+    message = str(exc)
+    return any(fragment in message for fragment in _TRANSIENT_MESSAGES)
 
 
 class QueryRoleGrants:
@@ -75,18 +116,57 @@ class QueryRoleGrants:
                 await conn.execute(text(f'GRANT "{role}" TO CURRENT_USER'))
         self._role_ready = True
 
+    async def _retrying(
+        self,
+        run,
+        schema_name: str | None = None,
+        table_name: str | None = None,
+    ) -> None:
+        """Run ``run`` again while PostgreSQL is only losing a catalog race.
+
+        ``ensure_role`` guards its own concurrency in SQL, with ``EXCEPTION
+        WHEN duplicate_object``. A ``GRANT`` has no such clause available: the
+        conflict surfaces as an aborted transaction, so the equivalent guard
+        has to be issuing the statement again. Each attempt opens a fresh
+        transaction — the failed one is already rolled back, and every
+        statement under this role is idempotent, so a repeat is a no-op once
+        the racing session has committed.
+
+        Backoff is jittered so that workers that collided once do not line up
+        to collide again on the same schedule.
+        """
+        for attempt in range(1, _GRANT_ATTEMPTS + 1):
+            try:
+                await run()
+                return
+            except DBAPIError as exc:
+                if attempt == _GRANT_ATTEMPTS or not _is_transient_conflict(exc):
+                    raise
+                logger.debug(
+                    "datastore.query_role.grant.contended",
+                    attempt=attempt,
+                    schema_name=schema_name,
+                    table_name=table_name,
+                )
+            delay = _GRANT_BACKOFF_SECONDS * 2 ** (attempt - 1)
+            await asyncio.sleep(delay + random.uniform(0, delay / 2))
+
     async def try_grant(self, schema_name: str, table_name: str | None = None) -> None:
         """Best-effort read access to one schema, and optionally one table.
 
         Runs in its own transaction so a failure cannot roll back the schema or
-        table it follows.
+        table it follows, and retries a transient conflict before degrading —
+        losing this grant to a momentary catalog race would be indistinguishable
+        from never having had the privilege, and only one of those is worth a
+        warning.
 
         Logged at warning, not debug: a pod that silently loses this grant
         answers every ``query.execute`` with "permission denied for schema",
         and nothing else in the system says why.
         """
         role = self._role()
-        try:
+
+        async def grant() -> None:
             await self.ensure_role()
             async with self._engine.begin() as conn:
                 await conn.execute(
@@ -99,6 +179,9 @@ class QueryRoleGrants:
                             f'TO "{role}"'
                         )
                     )
+
+        try:
+            await self._retrying(grant, schema_name=schema_name, table_name=table_name)
         except Exception:  # noqa: BLE001
             logger.warning(
                 "datastore.query_role.grant.degraded",
@@ -113,18 +196,27 @@ class QueryRoleGrants:
         Idempotent; covers pods whose schemas/tables were created before the
         role mechanism existed. Safe to run at every startup, but it is the
         repair path — schemas and tables grant on creation.
+
+        Retried on the same conflicts as ``try_grant``, and with more at stake:
+        this is one transaction over *every* pod schema, so a single grant
+        losing a race to a pod being created alongside it discards the repair
+        for all the others too, until the next restart.
         """
-        await self.ensure_role()
         role = self._role()
-        async with self._engine.begin() as conn:
-            await conn.execute(
-                text(
-                    "DO $$ DECLARE s text; BEGIN "
-                    "FOR s IN SELECT nspname FROM pg_namespace "
-                    "WHERE nspname LIKE 'pod\\_%' LOOP "
-                    f"EXECUTE format('GRANT USAGE ON SCHEMA %I TO \"{role}\"', s); "
-                    "EXECUTE format("
-                    f"'GRANT SELECT ON ALL TABLES IN SCHEMA %I TO \"{role}\"', s); "
-                    "END LOOP; END $$"
+
+        async def backfill() -> None:
+            await self.ensure_role()
+            async with self._engine.begin() as conn:
+                await conn.execute(
+                    text(
+                        "DO $$ DECLARE s text; BEGIN "
+                        "FOR s IN SELECT nspname FROM pg_namespace "
+                        "WHERE nspname LIKE 'pod\\_%' LOOP "
+                        f"EXECUTE format('GRANT USAGE ON SCHEMA %I TO \"{role}\"', s); "
+                        "EXECUTE format("
+                        f"'GRANT SELECT ON ALL TABLES IN SCHEMA %I TO \"{role}\"', s); "
+                        "END LOOP; END $$"
+                    )
                 )
-            )
+
+        await self._retrying(backfill)

--- a/lemma-backend/app/modules/datastore/tests/unit/test_query_role.py
+++ b/lemma-backend/app/modules/datastore/tests/unit/test_query_role.py
@@ -1,19 +1,29 @@
-"""The query role must be establishable without the power to create roles.
+"""The query role must survive both a weak app role and a contended catalog.
 
 An app role that is only a *member* of an already-provisioned query role is the
 least privilege this mechanism can run on, and it is what a managed Postgres
 deployment tends to hand out. These tests pin that case: every privileged
 statement is probed before it is issued, so the common no-op costs two catalog
 lookups instead of an ``insufficient_privilege`` error.
+
+The second half pins the other way a grant goes missing. ``GRANT`` updates a
+catalog row, and two sessions granting on the same schema at once leave one of
+them with a transient error instead of the grant. That one is retried; a
+genuine refusal still degrades on the first answer.
 """
 
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
 import pytest
+from sqlalchemy.exc import DBAPIError
 
 from app.modules.datastore.config import datastore_settings
-from app.modules.datastore.infrastructure.query_role import QueryRoleGrants
+from app.modules.datastore.infrastructure import query_role as query_role_module
+from app.modules.datastore.infrastructure.query_role import (
+    QueryRoleGrants,
+    _is_transient_conflict,
+)
 
 ROLE = datastore_settings.datastore_query_role
 
@@ -33,10 +43,22 @@ class _Connection:
     statement outright rather than reporting the object as a duplicate.
     """
 
-    def __init__(self, *, role_exists: bool, is_member: bool, forbid: tuple = ()):
+    def __init__(
+        self,
+        *,
+        role_exists: bool,
+        is_member: bool,
+        forbid: tuple = (),
+        fail: object = None,
+        fail_on: str = "GRANT",
+        fail_times: int = 0,
+    ):
         self.role_exists = role_exists
         self.is_member = is_member
         self.forbid = forbid
+        self.fail = fail
+        self.fail_on = fail_on
+        self.fail_times = fail_times
         self.statements: list[str] = []
 
     async def execute(self, statement, params=None):
@@ -49,6 +71,9 @@ class _Connection:
                     "DETAIL: Only roles with the CREATEROLE attribute may "
                     "create roles."
                 )
+        if self.fail is not None and self.fail_times and self.fail_on in sql:
+            self.fail_times -= 1
+            raise self.fail()
         if "pg_roles" in sql:
             return _Result(1 if self.role_exists else None)
         if "pg_has_role" in sql:
@@ -66,6 +91,52 @@ def _grants(connection: _Connection) -> QueryRoleGrants:
 
 def _issued(connection: _Connection, fragment: str) -> bool:
     return any(fragment in statement for statement in connection.statements)
+
+
+def _times_issued(connection: _Connection, fragment: str) -> int:
+    return sum(fragment in statement for statement in connection.statements)
+
+
+class _Conflict(DBAPIError):
+    """A ``GRANT`` that lost a catalog race, shaped the way asyncpg reports it.
+
+    `tuple concurrently updated` carries no SQLSTATE of its own — PostgreSQL
+    raises it from a bare ``elog`` — so it reaches us as an internal error whose
+    message is the only thing that identifies it.
+    """
+
+    def __init__(self):
+        super().__init__(
+            'GRANT USAGE ON SCHEMA "pod_abc"',
+            {},
+            Exception("tuple concurrently updated"),
+        )
+
+
+class _Deadlock(DBAPIError):
+    """40P01, reported through ``orig.sqlstate`` rather than the message."""
+
+    def __init__(self):
+        super().__init__('GRANT USAGE ON SCHEMA "pod_abc"', {}, Exception("deadlock"))
+        self.orig = type("_Orig", (), {"sqlstate": "40P01"})()
+
+
+class _Refusal(DBAPIError):
+    """A permanent answer: no retry can turn this one into a grant."""
+
+    def __init__(self):
+        super().__init__(
+            'GRANT USAGE ON SCHEMA "pod_abc"',
+            {},
+            Exception("permission denied for schema pod_abc"),
+        )
+        self.orig = type("_Orig", (), {"sqlstate": "42501"})()
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff(monkeypatch):
+    """The retry is bounded by attempts, not by wall clock; don't pay for it."""
+    monkeypatch.setattr(query_role_module, "_GRANT_BACKOFF_SECONDS", 0.0)
 
 
 @pytest.mark.asyncio
@@ -165,3 +236,123 @@ async def test_the_catalog_is_probed_once_per_process() -> None:
     await grants.ensure_role()
 
     assert sum("pg_roles" in s for s in connection.statements) == 1
+
+
+class TestTransientConflictDetection:
+    """A retry that fires on the wrong error hides a real misconfiguration."""
+
+    def test_a_lost_catalog_race_is_recognised(self) -> None:
+        assert _is_transient_conflict(_Conflict()) is True
+
+    def test_a_deadlock_is_recognised_by_sqlstate(self) -> None:
+        assert _is_transient_conflict(_Deadlock()) is True
+
+    def test_a_denied_grant_is_not_transient(self) -> None:
+        assert _is_transient_conflict(_Refusal()) is False
+
+    def test_an_error_with_no_driver_detail_is_not_transient(self) -> None:
+        assert _is_transient_conflict(PermissionError("permission denied")) is False
+
+
+@pytest.mark.asyncio
+async def test_a_grant_that_lost_a_catalog_race_is_retried() -> None:
+    """The regression: two workers granting at once, and one grant vanishes.
+
+    ``try_grant`` swallowed the conflict and logged a warning, so the role never
+    received USAGE and the pod answered every ``query.execute`` with "permission
+    denied for table <x>" — somewhere else entirely, and much later.
+    """
+    connection = _Connection(
+        role_exists=True,
+        is_member=True,
+        fail=_Conflict,
+        fail_on="GRANT USAGE",
+        fail_times=1,
+    )
+
+    await _grants(connection).try_grant("pod_abc", "widgets")
+
+    assert (
+        _times_issued(connection, f'GRANT USAGE ON SCHEMA "pod_abc" TO "{ROLE}"') == 2
+    )
+    assert _issued(connection, f'GRANT SELECT ON "pod_abc"."widgets" TO "{ROLE}"')
+
+
+@pytest.mark.asyncio
+async def test_a_deadlocked_grant_is_retried() -> None:
+    connection = _Connection(
+        role_exists=True,
+        is_member=True,
+        fail=_Deadlock,
+        fail_on="GRANT USAGE",
+        fail_times=2,
+    )
+
+    await _grants(connection).try_grant("pod_abc")
+
+    assert _times_issued(connection, "GRANT USAGE ON SCHEMA") == 3
+
+
+@pytest.mark.asyncio
+async def test_a_denied_grant_degrades_without_retrying() -> None:
+    """Waiting out a privilege the app role does not have helps nobody."""
+    connection = _Connection(
+        role_exists=True,
+        is_member=True,
+        fail=_Refusal,
+        fail_on="GRANT USAGE",
+        fail_times=99,
+    )
+
+    await _grants(connection).try_grant("pod_abc")
+
+    assert _times_issued(connection, "GRANT USAGE ON SCHEMA") == 1
+
+
+@pytest.mark.asyncio
+async def test_an_unending_conflict_still_degrades_rather_than_retrying_forever() -> (
+    None
+):
+    """Bounded. A pod creation must not block on a catalog that stays contended."""
+    connection = _Connection(
+        role_exists=True,
+        is_member=True,
+        fail=_Conflict,
+        fail_on="GRANT USAGE",
+        fail_times=99,
+    )
+
+    await _grants(connection).try_grant("pod_abc")
+
+    assert _times_issued(connection, "GRANT USAGE ON SCHEMA") == 4
+
+
+@pytest.mark.asyncio
+async def test_backfill_retries_a_lost_catalog_race() -> None:
+    """One transaction covers every pod schema, so one lost race loses them all."""
+    connection = _Connection(
+        role_exists=True,
+        is_member=True,
+        fail=_Conflict,
+        fail_on="FOR s IN SELECT nspname",
+        fail_times=1,
+    )
+
+    await _grants(connection).backfill_grants()
+
+    assert _times_issued(connection, "FOR s IN SELECT nspname FROM pg_namespace") == 2
+
+
+@pytest.mark.asyncio
+async def test_backfill_still_surfaces_a_conflict_it_cannot_clear() -> None:
+    """Startup logs this one; swallowing it here would leave nothing to log."""
+    connection = _Connection(
+        role_exists=True,
+        is_member=True,
+        fail=_Conflict,
+        fail_on="FOR s IN SELECT nspname",
+        fail_times=99,
+    )
+
+    with pytest.raises(DBAPIError):
+        await _grants(connection).backfill_grants()


### PR DESCRIPTION
## What changes

A `GRANT` that loses a Postgres catalog race is now retried instead of silently
degrading. The query role gets its `USAGE` grant even when two processes
provision pods at the same moment, so ad-hoc `query.execute` stops intermittently
answering `permission denied for table <x>`.

## Why

`GRANT USAGE ON SCHEMA` writes a catalog row. Two sessions granting on the same
schema at once — two API processes, or two pytest-xdist workers — leave one of
them holding `tuple concurrently updated` instead of the grant it asked for.

`try_grant` caught that with the rest of its `except Exception`, logged
`datastore.query_role.grant.degraded`, and moved on. The role never received
`USAGE`, and the pod said so much later and somewhere else, as `permission
denied for table <x>` from whichever test happened to query next. The method's
own docstring already anticipated exactly this ("a pod that silently loses this
grant answers every `query.execute` with 'permission denied for schema', and
nothing else in the system says why") — it just had no retry.

That is the flake in the `lemma-backend e2e (datastore)` shard. On #465 (run
32636234840) attempt 1 failed
`test_rls_table_behaves_like_personal_rows_for_each_user`, attempt 2 failed a
*different* test, `test_sql_query_joins_rls_and_shared_tables_scoped_per_user`,
and attempt 3 passed — a different test each time with the same underlying
error, which is a race rather than a logic bug. #465 touches zero datastore
files; it was only the branch that surfaced this.

## How it works

`_retrying` re-issues the work in a fresh transaction on a transient conflict:
four attempts, 50ms doubling with jitter, then the existing degraded path
unchanged. `ensure_role` already guards the same concurrency for `CREATE ROLE`
with `EXCEPTION WHEN duplicate_object`; a `GRANT` has no such clause available,
so the equivalent guard has to be issuing the statement again. Each attempt
opens a new transaction — the failed one is already rolled back, and every
statement here is idempotent, so a repeat is a no-op once the racing session has
committed.

Three things worth a reviewer's attention:

- **`tuple concurrently updated` is matched by message, deliberately.** Postgres
  raises it from a bare `elog`, so it arrives as `XX000` — a code it shares with
  every other unclassified server fault, which makes the message the only
  discriminator. The other two (`40001` serialization_failure, `40P01`
  deadlock_detected) are read from SQLSTATE through `.orig`, matching the
  existing `_is_deadlock` precedent in `agent_host_controller.py`.
- **A denied grant is still answered on the first attempt.** Waiting out a
  privilege the app role does not have helps nobody, and the retry must not turn
  a real misconfiguration into a slow one. There is a test for this.
- **`backfill_grants` has the same race, with higher stakes.** It is one
  transaction over *every* pod schema, so a single grant losing a race to a pod
  being created alongside it discards the repair for all the others until the
  next restart. It takes the same treatment and still re-raises to the startup
  logger when it cannot clear.

The datastore module's broad-catch count is unchanged at one — the retry catches
`DBAPIError`, and the existing `except Exception` degraded path is untouched.

## How to verify

```bash
cd lemma-backend && uv run pytest app/modules/datastore/tests/unit -q
```

- Datastore unit suite plus the logging contract: `532 passed, 2 warnings in 14.77s`.
- `make quality` from the repo root: `✓ quality gates pass` — including
  `Architecture ratchet passed (12 inherited import violations, 0 inherited cycles)`.
- The six new tests are real regressions, not tautologies: forcing
  `_GRANT_ATTEMPTS = 1` (the pre-fix behaviour) fails exactly the four retry
  tests and no others.

**The e2e shard did not run locally.** Docker is unavailable on this machine
(`failed to connect to the docker API at unix:///…/docker.sock`), so
`test_records_e2e.py` errors at fixture setup — an infrastructure error, not a
result. The race itself is therefore unreproduced locally; the unit tests pin
the retry mechanism, and CI's parallel shard is what will actually exercise the
collision.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload. The one
      new event, `datastore.query_role.grant.contended` (debug), carries
      `attempt`, `schema_name`, `table_name`, and was added to the catalog by
      `generate_logging_event_catalogs.py`, not by hand.
- [x] **Rollback** — revert the commit. No migration, no API surface, no
      persisted state; the fallback path this sits in front of is byte-for-byte
      the old behaviour.

## Compatibility and rollback notes

Nothing to note. No schema, API, or SDK change — the SQL issued is unchanged,
only how often it is issued.
