### PR TITLE
Read the caption a photo came with, and stop tagging whichever message arrived last

### DIFF
--- a/lemma-backend/app/core/file_types.py
+++ b/lemma-backend/app/core/file_types.py
@@ -104,6 +104,30 @@ EXTENSION_MIME_MAP = {
 }
 
 
+def extension_for_mime(mime_type: str | None) -> str | None:
+    """The file extension a MIME type should be saved under, or None.
+
+    The reverse of :func:`get_content_type`, and it exists because a name is the
+    only thing the datastore has to type a file by: a WhatsApp photo arrives
+    with a mime type and no filename at all, and stored as bare ``image`` it
+    comes back out as ``application/octet-stream`` -- unviewable, unindexable,
+    and indistinguishable from a blob.
+    """
+    normalized = str(mime_type or "").split(";")[0].strip().lower()
+    # "octet-stream" is the absence of a type, not a type. Naming a file
+    # ``photo.bin`` from it would be worse than leaving it bare: it looks
+    # decided.
+    if not normalized or normalized.endswith("/octet-stream"):
+        return None
+    guessed = mimetypes.guess_extension(normalized)
+    if guessed:
+        return guessed
+    for extension, mapped in EXTENSION_MIME_MAP.items():
+        if mapped == normalized:
+            return extension
+    return None
+
+
 def get_content_type(path: str) -> str:
     extension = os.path.splitext(path)[1].lower()
     return (

--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -147,6 +147,7 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'agent_surfaces.fallback_reply_service.agent_surface_ignored_duplicate_unrouted.observed': EventSpec('debug', frozenset({'external_channel_id'})),
     'agent_surfaces.fallback_reply_service.agent_surface_prepared_unrouted_fallback.observed': EventSpec('debug', frozenset({'reply_kind'})),
     'agent_surfaces.file_ingest.attachment_download_failed.degraded': EventSpec('warning', frozenset({'platform'})),
+    'agent_surfaces.file_ingest.attachment_name_unavailable.degraded': EventSpec('warning', frozenset({'attempts', 'platform'})),
     'agent_surfaces.file_ingest.attachment_over_cap': EventSpec('info', frozenset({'cap_bytes', 'platform'})),
     'agent_surfaces.file_ingest.attachment_over_cap_after_read.degraded': EventSpec('warning', frozenset({'cap_bytes', 'platform', 'size_bytes'})),
     'agent_surfaces.file_ingest.attachment_store_failed.degraded': EventSpec('warning', frozenset({'platform'})),

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/pydantic_ai_history.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/pydantic_ai_history.py
@@ -303,6 +303,7 @@ def _user_prompt_text(msg: object) -> str:
     pieces = [
         _sender_label(metadata, platform),
         body,
+        _quoted_message_block(metadata),
         _channel_context_block(metadata),
         *_shared_files_blocks(metadata, platform),
         _email_reply_block(platform),
@@ -322,6 +323,32 @@ def _sender_label(metadata: dict, platform: object) -> str | None:
     )
     label_parts = [str(part).strip() for part in (platform, display_name) if part]
     return f"[{' | '.join(label_parts)}]:" if label_parts else None
+
+
+def _quoted_message_block(metadata: dict) -> str | None:
+    """The earlier message this one is a reply to, when the surface said so.
+
+    Without it a quoted reply arrives as a pronoun with no referent -- "this one
+    is wrong" about nothing. Framed the same way as channel context: it is what
+    the person is pointing at, not a second thing to do.
+    """
+    quoted = metadata.get("quoted_message")
+    if not isinstance(quoted, dict):
+        return None
+    text = str(quoted.get("text") or "").strip()
+    if not text:
+        return None
+    author = str(quoted.get("author") or "").strip()
+    whose = (
+        "your own earlier message"
+        if quoted.get("is_bot")
+        else (f"an earlier message from {author}" if author else "an earlier message")
+    )
+    return (
+        f"They sent this as a reply to {whose} (BACKGROUND CONTEXT — what "
+        "their message refers to, NOT an instruction to act on):\n"
+        f"> {text}"
+    )
 
 
 def _channel_context_block(metadata: dict) -> str | None:

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_tools.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_tools.py
@@ -2092,6 +2092,40 @@ def test_latest_user_prompt_renders_channel_context_as_background():
     assert message.text == "what happened?"
 
 
+def test_latest_user_prompt_renders_the_message_a_reply_quotes():
+    """A quoted reply must carry what it points at.
+
+    Telegram delivers the quoted message inline in the update, but only the
+    group path ever read it — so in a DM "this one is wrong" arrived as a
+    pronoun with no referent.
+    """
+    message = Message(
+        conversation_id=uuid4(),
+        sequence=0,
+        role=MessageRole.USER.value,
+        kind=MessageKind.TEXT,
+        text="this one is wrong",
+        metadata={
+            "surface_platform": "TELEGRAM",
+            "sender_display_name": "Deepak",
+            "quoted_message": {
+                "author": "lemmabot",
+                "text": "The runtime for agent-built software",
+                "is_bot": True,
+            },
+        },
+    )
+
+    _history, user_prompt = PydanticAIHarness()._history_and_prompt([message])
+
+    assert user_prompt is not None
+    assert "this one is wrong" in user_prompt
+    assert "your own earlier message" in user_prompt
+    assert "The runtime for agent-built software" in user_prompt
+    assert "BACKGROUND CONTEXT" in user_prompt
+    assert message.text == "this one is wrong"
+
+
 def test_latest_user_prompt_includes_metadata_state_without_changing_content():
     conversation_id = uuid4()
     message = Message(

--- a/lemma-backend/app/modules/agent_surfaces/platforms/telegram/message_experience.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/telegram/message_experience.py
@@ -219,6 +219,31 @@ def can_fallback_from_rich_message(exc: TelegramApiError) -> bool:
     )
 
 
+def reply_parameters(event: ParsedInboundSurfaceEvent) -> dict[str, Any] | None:
+    """What an outbound should quote, or ``None`` to quote nothing.
+
+    Groups and forum topics only, never a one-to-one DM. The event an outbound
+    is built from is the conversation link's *last* inbound, not the message
+    this run is answering -- so in a DM the quote pointed at whatever the person
+    happened to say most recently, which is how every reply ended up tagging an
+    unrelated message. In a DM it disambiguates nothing anyway: two of us, one
+    thread.
+
+    The id is coerced to an int because that is what the Bot API takes, and
+    because a non-numeric one -- a debounced burst's synthetic ``batch:5-6``,
+    say -- would fail the entire send rather than just the quoting.
+    """
+    if event.is_dm:
+        return None
+    try:
+        message_id = int(event.reply_target.get("message_id") or 0)
+    except TypeError, ValueError:
+        return None
+    if message_id <= 0:
+        return None
+    return {"message_id": message_id, "allow_sending_without_reply": True}
+
+
 def _message_thread_id(event: ParsedInboundSurfaceEvent) -> int | None:
     raw = event.reply_target.get("message_thread_id")
     if raw in (None, "", "0", 0):

--- a/lemma-backend/app/modules/agent_surfaces/platforms/telegram/parser.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/telegram/parser.py
@@ -66,16 +66,67 @@ def _batch(payload: dict[str, Any], message: dict[str, Any]) -> list[Any]:
     return [message]
 
 
-def _batch_message_id(message: dict[str, Any], batch: list[Any]) -> str:
-    """One id for the whole batch, or the single message's own id."""
-    ids = [
+def _batch_message_ids(batch: list[Any]) -> list[str]:
+    """Every real Telegram message id in the batch, in arrival order."""
+    return [
         str(item.get("message_id"))
         for item in batch
         if isinstance(item, dict) and item.get("message_id") is not None
     ]
+
+
+def _batch_message_id(message: dict[str, Any], batch: list[Any]) -> str:
+    """One id for the whole batch, or the single message's own id.
+
+    Synthetic for a batch (``batch:41-43``) because its job is identity --
+    dedup and the conversation link -- and no single Telegram id names the
+    burst. It is not a message id and must never be sent back to Telegram as
+    one; :func:`_reply_to_message_id` is what a reply points at.
+    """
+    ids = _batch_message_ids(batch)
     if len(ids) > 1:
         return f"batch:{ids[0]}-{ids[-1]}"
     return str(message.get("message_id", ""))
+
+
+def _reply_to_message_id(message: dict[str, Any], batch: list[Any]) -> str:
+    """The message a reply should quote: the last one of the burst.
+
+    Telegram's ``reply_parameters.message_id`` takes an integer id of a real
+    message. Handing it the synthetic batch id sent a 400 for every debounced
+    burst, so the reply to two photos sent a second apart failed outright.
+    """
+    ids = _batch_message_ids(batch)
+    if ids:
+        return ids[-1]
+    return str(message.get("message_id", ""))
+
+
+# A quoted message is context, not a document: enough to know what is being
+# pointed at, and not so much that a long quote crowds out the actual request.
+_QUOTED_TEXT_LIMIT = 1000
+
+
+def _quoted_message(message: dict[str, Any]) -> dict[str, Any] | None:
+    """The message this one is a reply to, or None when it replies to nothing.
+
+    Telegram delivers the quoted message inline in the update, so this costs
+    nothing -- and without it a reply reads as a bare "what about this one?"
+    with the "this" missing. The group path had it via ``fetch_thread_context``;
+    a DM never called that, which is where replying to an earlier message
+    silently lost its subject.
+    """
+    reply = payload_section(message, "reply_to_message")
+    text = str(reply.get("text") or reply.get("caption") or "").strip()
+    if not text:
+        return None
+    from_user = payload_section(reply, "from")
+    author = str(from_user.get("username") or from_user.get("first_name") or "").strip()
+    return {
+        "author": author or None,
+        "text": text[:_QUOTED_TEXT_LIMIT],
+        "is_bot": bool(from_user.get("is_bot")),
+    }
 
 
 def _media_group_ids(batch: list[Any]) -> list[str]:
@@ -148,7 +199,7 @@ class TelegramMessageParser:
             should_start_conversation=True,
             reply_target={
                 "chat_id": chat_id,
-                "message_id": message_id,
+                "message_id": _reply_to_message_id(message, batch),
                 # Forum-topic id so replies land in the same topic; empty for
                 # ordinary chats.
                 "message_thread_id": payload_text(message, "message_thread_id"),
@@ -159,6 +210,7 @@ class TelegramMessageParser:
                 "is_topic_message": bool(message.get("is_topic_message")),
                 "message_thread_id": payload_text(message, "message_thread_id"),
                 "is_thread_reply": is_reply_to_bot,
+                "quoted_message": _quoted_message(message),
                 "sender_username": sender.username,
                 "contact_shared": contact["contact_shared"],
                 "contact_shared_by_sender": contact["contact_shared_by_sender"],

--- a/lemma-backend/app/modules/agent_surfaces/platforms/telegram/service.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/telegram/service.py
@@ -39,6 +39,7 @@ from app.modules.agent_surfaces.platforms.telegram.client import (
 from app.modules.agent_surfaces.platforms.telegram.message_experience import (
     acknowledge_interaction as acknowledge_telegram_interaction,
     end_progress as end_telegram_progress,
+    reply_parameters as telegram_reply_parameters,
     send_chunk,
     stream_progress as stream_telegram_progress,
 )
@@ -153,7 +154,7 @@ class TelegramPlatformService:
         """
         chat_id = event.reply_target.get("chat_id") or event.external_channel_id
         thread_id = self._message_thread_id(event)
-        reply_to = event.reply_target.get("message_id")
+        reply_parameters = telegram_reply_parameters(event)
         reply_markup = (metadata or {}).get("reply_markup")
         retry_action = (metadata or {}).get("retry_action") is True
         if retry_action and not isinstance(reply_markup, dict):
@@ -176,11 +177,8 @@ class TelegramPlatformService:
             if thread_id is not None:
                 payload["message_thread_id"] = thread_id
             # Thread the reply / attach a keyboard only on the first chunk.
-            if index == 0 and reply_to:
-                payload["reply_parameters"] = {
-                    "message_id": reply_to,
-                    "allow_sending_without_reply": True,
-                }
+            if index == 0 and reply_parameters is not None:
+                payload["reply_parameters"] = reply_parameters
             if index == 0 and isinstance(reply_markup, dict):
                 payload["reply_markup"] = reply_markup
             await self._send_chunk(payload, raw_chunk)
@@ -321,15 +319,15 @@ class TelegramPlatformService:
     ) -> None:
         del metadata
         chat_id = event.reply_target.get("chat_id") or event.external_channel_id
-        reply_to = event.reply_target.get("message_id")
+        reply_parameters = telegram_reply_parameters(event)
 
         payload: dict[str, Any] = {
             "chat_id": chat_id,
             "text": _telegram_display_resource_text(render_plan),
             "parse_mode": "HTML",
         }
-        if reply_to:
-            payload["reply_to_message_id"] = reply_to
+        if reply_parameters is not None:
+            payload["reply_parameters"] = reply_parameters
         thread_id = self._message_thread_id(event)
         if thread_id is not None:
             payload["message_thread_id"] = thread_id

--- a/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/parser.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/parser.py
@@ -152,9 +152,13 @@ class WhatsAppMessageParser:
     def _message_body(self, msg: dict[str, Any]) -> tuple[str, list[dict[str, Any]]]:
         """The readable text of a message, and any attachment, by type.
 
-        WhatsApp puts the readable part somewhere different for each type, and a
-        media message's caption is optional -- hence the fall back to the type
-        name, so the agent at least knows something arrived.
+        WhatsApp puts the readable part somewhere different for each type. A
+        media message's caption lives on the *media* object -- ``image.caption``,
+        never ``text.body``, which a media message does not have at all -- and
+        reading the wrong one is why a photo sent with a question arrived at the
+        agent as the bare word "image" with the question dropped. The type name
+        stays as the fallback for media genuinely sent without a caption, so the
+        agent at least knows something arrived.
         """
         msg_type = msg.get("type", "text")
         if msg_type == "text":
@@ -162,7 +166,9 @@ class WhatsAppMessageParser:
         if msg_type == "interactive":
             return self._interactive_title(payload_section(msg, "interactive")), []
         attachment = self._parse_attachment(msg, msg_type)
-        caption = payload_section(msg, "text").get("body", "") or msg_type
+        caption = (
+            str(payload_section(msg, msg_type).get("caption") or "").strip() or msg_type
+        )
         return caption, ([attachment] if attachment else [])
 
     def _interactive_title(self, interactive: dict[str, Any]) -> str:
@@ -173,6 +179,13 @@ class WhatsAppMessageParser:
         return str(interactive)
 
     def _parse_attachment(self, msg: dict, msg_type: str) -> dict[str, Any] | None:
+        """One inbound media object, as an attachment the ingest step can save.
+
+        ``filename`` is sent for documents and for nothing else, so an image or
+        a voice note has only its mime type to be named by. Ingest completes the
+        name from the mime type of the bytes it actually downloads; the type name
+        alone is what the prompt block falls back to when the file is not saved.
+        """
         media_data = msg.get(msg_type)
         if not isinstance(media_data, dict):
             return None

--- a/lemma-backend/app/modules/agent_surfaces/services/surface_file_ingest_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/surface_file_ingest_service.py
@@ -37,7 +37,11 @@ from app.modules.agent_surfaces.platforms.attachment_limits import (
     INBOUND_VOICE_TRANSCRIBE_BYTE_CAP,
 )
 from app.composition.surface_datastore import build_file_service
-from app.modules.datastore.contracts import normalize_datastore_name
+from app.core.file_types import extension_for_mime
+from app.modules.datastore.contracts import (
+    DatastoreConflictError,
+    normalize_datastore_name,
+)
 
 logger = get_logger(__name__)
 
@@ -81,14 +85,47 @@ def _attachments_from_parsed(parsed: ParsedInboundSurfaceEvent) -> list[dict[str
     return [item for item in raw if isinstance(item, dict)]
 
 
-def _safe_file_name(name: str | None) -> str:
-    """Reduce an attachment name to a single valid datastore segment."""
+def _safe_file_name(name: str | None, mime: str | None = None) -> str:
+    """Reduce an attachment name to a single valid datastore segment.
+
+    The extension is part of the name's job here. A chat surface is free to send
+    a file with no filename -- WhatsApp names a photo nothing at all, Telegram
+    calls every one of them ``photo`` -- and the datastore types a file by its
+    name alone. Saved bare, the photo comes back as ``application/octet-stream``:
+    ``view_image`` refuses it, indexing skips it, and the agent is left holding a
+    path to something it cannot open. So when the name carries no suffix and the
+    download told us what the bytes are, say so in the name.
+    """
     candidate = Path(str(name or "").strip().replace("\\", "/")).name.strip()
     candidate = candidate.replace("/", "_").strip() or "attachment"
+    if not Path(candidate).suffix:
+        candidate += extension_for_mime(mime) or ""
     try:
         return normalize_datastore_name(candidate)
     except Exception:
         return "attachment"
+
+
+# How many names to try before giving up on one attachment. A person sending a
+# handful of photos in a row is ordinary; a hundred identically-named ones is
+# not worth a hundred round trips.
+_NAME_ATTEMPTS = 25
+
+
+def _numbered(name: str, attempt: int) -> str:
+    """``image.jpg`` -> ``image-2.jpg`` for the second one, and so on.
+
+    Chat surfaces name nothing: every WhatsApp photo is ``image``, every
+    Telegram one is ``photo``. The datastore refuses a duplicate path, so
+    without this the *second* photo anyone ever sent was dropped -- logged as a
+    warning nobody was reading, with the agent told only about the first.
+    """
+    if attempt == 0:
+        return name
+    stem, dot, extension = name.rpartition(".")
+    if not dot:
+        return f"{name}-{attempt + 1}"
+    return f"{stem}-{attempt + 1}.{extension}"
 
 
 class SurfaceFileIngestService:
@@ -280,31 +317,50 @@ class SurfaceFileIngestService:
             return None
 
         content_type = attachment.get("content_type")
+        file_name = _safe_file_name(name, mime)
 
-        async def _persist(file_service: Any) -> IngestedAttachment | None:
-            entity = await file_service.create_file(
-                pod_id=pod_id,
-                name=_safe_file_name(name),
-                file_content=content,
-                ctx=ctx,
-                directory_path=directory,
-                search_enabled=True,
-            )
-            result = IngestedAttachment(
-                path=entity.path,
-                name=entity.name,
-                mime=mime,
-                content_type=str(content_type) if content_type else None,
-            )
-            # Carry audio bytes for in-ingress transcription when small enough;
-            # larger audio is still saved (the agent can `listen` to it) but not
-            # transcribed.
-            if result.is_audio and len(content) <= INBOUND_VOICE_TRANSCRIBE_BYTE_CAP:
-                result.audio_bytes = content
-            return result
+        def _persist_as(candidate: str):
+            async def _persist(file_service: Any) -> IngestedAttachment | None:
+                entity = await file_service.create_file(
+                    pod_id=pod_id,
+                    name=candidate,
+                    file_content=content,
+                    ctx=ctx,
+                    directory_path=directory,
+                    search_enabled=True,
+                )
+                result = IngestedAttachment(
+                    path=entity.path,
+                    name=entity.name,
+                    mime=mime,
+                    content_type=str(content_type) if content_type else None,
+                )
+                # Carry audio bytes for in-ingress transcription when small
+                # enough; larger audio is still saved (the agent can `listen` to
+                # it) but not transcribed.
+                if (
+                    result.is_audio
+                    and len(content) <= INBOUND_VOICE_TRANSCRIBE_BYTE_CAP
+                ):
+                    result.audio_bytes = content
+                return result
+
+            return _persist
 
         try:
-            return await store(_persist)
+            for attempt in range(_NAME_ATTEMPTS):
+                try:
+                    return await store(_persist_as(_numbered(file_name, attempt)))
+                except DatastoreConflictError:
+                    # That name is taken -- by an earlier photo from this same
+                    # person, almost always. Try the next one.
+                    continue
+            logger.warning(
+                "agent_surfaces.file_ingest.attachment_name_unavailable.degraded",
+                platform=platform,
+                attempts=_NAME_ATTEMPTS,
+            )
+            return None
         except Exception:
             logger.warning(
                 "agent_surfaces.file_ingest.attachment_store_failed.degraded",

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_platform_contracts_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_platform_contracts_e2e.py
@@ -77,17 +77,19 @@ def _teams_event(fake_teams) -> ParsedInboundSurfaceEvent:
     )
 
 
-def _telegram_event() -> ParsedInboundSurfaceEvent:
+def _telegram_event(*, is_dm: bool = True) -> ParsedInboundSurfaceEvent:
     return ParsedInboundSurfaceEvent(
         platform="TELEGRAM",
-        conversation_type=ConversationType.EXTERNAL_DM,
+        conversation_type=(
+            ConversationType.EXTERNAL_DM if is_dm else ConversationType.EXTERNAL_GROUP
+        ),
         external_channel_id="424242",
         external_thread_id="424242",
         external_message_id="111",
         sender_external_user_id="424242",
         sender_display_name="Contract User",
         message_text="hello",
-        is_dm=True,
+        is_dm=is_dm,
         mentioned_agent=True,
         reply_target={"chat_id": "424242", "message_id": 111},
     )
@@ -245,12 +247,35 @@ async def test_telegram_final_answer_contract_and_retry(fake_telegram, message_s
     assert payload["_method"] == "POST"
     assert payload["_path"] == "/bottelegram-contract-token/sendMessage"
     assert payload["chat_id"] == "424242"
+    # A DM quotes nothing: the event an outbound is built from is the link's
+    # last inbound, not the message being answered, so a quote here would tag
+    # whatever arrived most recently.
+    assert "reply_parameters" not in payload
+    assert payload["parse_mode"] == "MarkdownV2"
+    assert "Contract" in payload["text"]
+
+
+async def test_telegram_quotes_the_inbound_message_in_a_group(
+    fake_telegram, message_store
+):
+    service = TelegramPlatformService(
+        {
+            "bot_token": "telegram-contract-token",
+            "api_base_url": f"{fake_telegram.api_base}/bot",
+        }
+    )
+
+    await service.send_message(
+        event=_telegram_event(is_dm=False),
+        message="Contract reply",
+    )
+
+    messages = await wait_for_messages(message_store, "TELEGRAM", min_count=1)
+    payload = messages[-1]
     assert payload["reply_parameters"] == {
         "message_id": 111,
         "allow_sending_without_reply": True,
     }
-    assert payload["parse_mode"] == "MarkdownV2"
-    assert "Contract" in payload["text"]
 
 
 async def test_whatsapp_final_answer_contract(fake_whatsapp, message_store):

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_platform_new_adapters.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_platform_new_adapters.py
@@ -91,6 +91,57 @@ def test_whatsapp_parse_text_message():
     assert event.external_message_id == "wamid-test-001"
 
 
+def _whatsapp_image_payload(image: dict) -> dict:
+    payload = _whatsapp_text_payload()
+    message = payload["entry"][0]["changes"][0]["value"]["messages"][0]
+    message.pop("text")
+    message["type"] = "image"
+    message["image"] = image
+    return payload
+
+
+def test_whatsapp_image_caption_is_the_message_text():
+    """A photo sent with a question must arrive as the question.
+
+    WhatsApp puts a media caption on the media object, never on ``text.body``
+    (a media message has no ``text`` at all) — reading the wrong one delivered
+    the bare word "image" and dropped what the person actually asked.
+    """
+    parser = WhatsAppMessageParser()
+    event = parser.parse(
+        _whatsapp_image_payload(
+            {
+                "id": "media-001",
+                "mime_type": "image/jpeg",
+                "caption": "Bro the bold text feels weird here",
+            }
+        )
+    )
+
+    assert event is not None
+    assert event.message_text == "Bro the bold text feels weird here"
+    assert event.metadata["attachments"] == [
+        {
+            "id": "media-001",
+            "name": "image",
+            "content_type": "image",
+            "mime_type": "image/jpeg",
+            "size": None,
+            "download_url": None,
+        }
+    ]
+
+
+def test_whatsapp_image_without_a_caption_still_says_something_arrived():
+    parser = WhatsAppMessageParser()
+    event = parser.parse(
+        _whatsapp_image_payload({"id": "media-002", "mime_type": "image/png"})
+    )
+
+    assert event is not None
+    assert event.message_text == "image"
+
+
 def test_whatsapp_parse_empty_entry():
     parser = WhatsAppMessageParser()
     assert parser.parse({}) is None

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_surface_file_ingest_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_surface_file_ingest_service.py
@@ -12,8 +12,10 @@ from app.modules.agent_surfaces.platforms.attachment_limits import (
 )
 from app.modules.agent_surfaces.services.surface_file_ingest_service import (
     SurfaceFileIngestService,
+    _numbered,
     _safe_file_name,
 )
+from app.modules.datastore.contracts import DatastoreConflictError
 
 
 def _event(attachments: list[dict]) -> ParsedInboundSurfaceEvent:
@@ -46,8 +48,11 @@ class _FakeAdapter:
 
 
 class _FakeFileService:
+    """Stands in for the datastore, including its refusal of a duplicate path."""
+
     def __init__(self):
         self.created: list[dict] = []
+        self.taken: set[str] = set()
 
     async def create_file(
         self,
@@ -60,6 +65,10 @@ class _FakeFileService:
         search_enabled=True,
         **kwargs,
     ):
+        path = f"{directory_path}/{name}"
+        if path in self.taken:
+            raise DatastoreConflictError(f"A file or folder already exists at '{path}'")
+        self.taken.add(path)
         self.created.append(
             {
                 "pod_id": pod_id,
@@ -68,7 +77,7 @@ class _FakeFileService:
                 "directory_path": directory_path,
             }
         )
-        return SimpleNamespace(path=f"{directory_path}/{name}", name=name)
+        return SimpleNamespace(path=path, name=name)
 
 
 def _direct_store(file_service):
@@ -224,6 +233,83 @@ def test_safe_file_name_strips_paths_and_falls_back():
     assert _safe_file_name("a/b/c.txt") == "c.txt"
     assert _safe_file_name("") == "attachment"
     assert _safe_file_name(None) == "attachment"
+
+
+def test_safe_file_name_completes_a_nameless_photo_from_its_mime_type():
+    """A chat photo arrives with no filename; the datastore types by name only.
+
+    Saved as bare ``image``/``photo`` the file comes back as
+    ``application/octet-stream``: ``view_image`` refuses it and indexing skips
+    it, so the agent holds a path to something it cannot open.
+    """
+    assert _safe_file_name("image", "image/jpeg") == "image.jpg"
+    assert _safe_file_name("photo", "image/png") == "photo.png"
+    assert _safe_file_name("voice", "audio/ogg; codecs=opus") == "voice.ogg"
+    # An extension the sender supplied is left exactly as it is.
+    assert _safe_file_name("report.pdf", "application/pdf") == "report.pdf"
+    # "octet-stream" is the absence of a type; inventing ".bin" would look decided.
+    assert _safe_file_name("image", "application/octet-stream") == "image"
+    assert _safe_file_name("image", None) == "image"
+
+
+def test_numbered_puts_the_counter_before_the_extension():
+    assert _numbered("image.jpg", 0) == "image.jpg"
+    assert _numbered("image.jpg", 1) == "image-2.jpg"
+    assert _numbered("report.tar.gz", 2) == "report.tar-3.gz"
+    assert _numbered("attachment", 1) == "attachment-2"
+
+
+async def test_a_second_photo_with_the_same_name_is_still_saved():
+    """Every WhatsApp photo is called "image"; every Telegram one, "photo".
+
+    The datastore refuses a duplicate path, so the second one anyone ever sent
+    used to be dropped — logged as a warning, and the agent told only about the
+    first.
+    """
+    service = _service()
+    adapter = _FakeAdapter(
+        results={
+            "p1": (b"one", "photo", "image/png"),
+            "p2": (b"two", "photo", "image/png"),
+        }
+    )
+    file_service = _FakeFileService()
+    attachments = [{"file_id": "p1"}, {"file_id": "p2"}]
+
+    saved = await service._ingest_all(
+        adapter=adapter,
+        pod_id=uuid4(),
+        platform="TELEGRAM",
+        parsed=_event(attachments),
+        credentials={},
+        store=_direct_store(file_service),
+        ctx=SimpleNamespace(),
+        attachments=attachments,
+    )
+
+    assert [item.path for item in saved] == [
+        "/me/telegram/photo.png",
+        "/me/telegram/photo-2.png",
+    ]
+
+
+async def test_a_nameless_photo_is_stored_under_a_typed_name():
+    service = _service()
+    adapter = _FakeAdapter(results={"p1": (b"\x89PNG", "photo", "image/png")})
+    file_service = _FakeFileService()
+
+    saved = await service._ingest_all(
+        adapter=adapter,
+        pod_id=uuid4(),
+        platform="TELEGRAM",
+        parsed=_event([{"file_id": "p1"}]),
+        credentials={},
+        store=_direct_store(file_service),
+        ctx=SimpleNamespace(),
+        attachments=[{"file_id": "p1"}],
+    )
+
+    assert [item.path for item in saved] == ["/me/telegram/photo.png"]
 
 
 async def test_no_transaction_is_open_while_an_attachment_downloads():

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_telegram_safe_render.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_telegram_safe_render.py
@@ -94,10 +94,19 @@ def _service(recorder: _RecordingClient) -> TelegramPlatformService:
     return service
 
 
-def _event(text: str = "hi", *, message_id: int = 5, thread_id: int | None = None):
+def _event(
+    text: str = "hi",
+    *,
+    message_id: int = 5,
+    thread_id: int | None = None,
+    chat_type: str | None = None,
+):
     message: dict = {
         "message_id": message_id,
-        "chat": {"id": 123, "type": "supergroup" if thread_id else "private"},
+        "chat": {
+            "id": 123,
+            "type": chat_type or ("supergroup" if thread_id else "private"),
+        },
         "from": {"id": 1, "first_name": "U"},
         "text": text,
     }
@@ -113,7 +122,7 @@ async def test_send_message_uses_rich_markdown_and_reply_parameters():
     recorder = _RecordingClient()
     service = _service(recorder)
 
-    await service.send_message(_event(), "Use **bold** here.")
+    await service.send_message(_event(chat_type="supergroup"), "Use **bold** here.")
 
     assert len(recorder.calls) == 1
     method, payload = recorder.calls[0]
@@ -121,10 +130,57 @@ async def test_send_message_uses_rich_markdown_and_reply_parameters():
     assert payload["rich_message"]["markdown"] == "Use **bold** here."
     assert payload["chat_id"] == "123"
     assert payload["reply_parameters"] == {
-        "message_id": "5",
+        "message_id": 5,
         "allow_sending_without_reply": True,
     }
     assert "message_thread_id" not in payload
+
+
+async def test_send_message_does_not_quote_in_a_dm():
+    """A DM reply quotes nothing.
+
+    The event an outbound is built from is the link's *last* inbound, not the
+    message being answered — so a quote here points at whatever arrived most
+    recently. There is one thread and two people; nothing to disambiguate.
+    """
+    recorder = _RecordingClient()
+    service = _service(recorder)
+
+    await service.send_message(_event(), "answering you")
+
+    _, payload = recorder.calls[0]
+    assert "reply_parameters" not in payload
+
+
+async def test_send_message_never_quotes_a_synthetic_batch_id():
+    """A debounced burst has no single Telegram message id.
+
+    ``external_message_id`` is ``batch:5-6`` for identity; sending that back as
+    ``reply_parameters.message_id`` is a 400 that fails the whole reply, so the
+    reply points at the last real message of the burst instead.
+    """
+    first = {
+        "message_id": 5,
+        "chat": {"id": 123, "type": "supergroup"},
+        "from": {"id": 1, "first_name": "U"},
+        "text": "first",
+    }
+    second = {**first, "message_id": 6, "text": "second"}
+    parsed = TelegramMessageParser().parse(
+        {"message": first, "_lemma_batch_messages": [first, second]}
+    )
+    assert parsed is not None
+    assert parsed.external_message_id == "batch:5-6"
+
+    recorder = _RecordingClient()
+    service = _service(recorder)
+    await service.send_message(parsed, "on it")
+
+    _, payload = recorder.calls[0]
+    assert payload["reply_parameters"] == {
+        "message_id": 6,
+        "allow_sending_without_reply": True,
+    }
 
 
 async def test_send_message_falls_back_to_plain_text_on_parse_error():
@@ -153,7 +209,7 @@ async def test_send_message_chunks_long_text_under_limit():
     recorder = _RecordingClient()
     service = _service(recorder)
 
-    await service.send_message(_event(), "x" * 9000)
+    await service.send_message(_event(chat_type="supergroup"), "x" * 9000)
 
     assert len(recorder.calls) >= 3
     assert all(
@@ -196,6 +252,53 @@ async def test_send_message_retry_button_stores_only_the_action():
             [{"text": "Try again", "callback_data": "retry-token"}],
         ]
     }
+
+
+def test_parser_carries_the_message_a_reply_quotes():
+    """Telegram ships the quoted message inline; the parser must keep it.
+
+    Without it a DM reply reaches the agent as "what about this one?" with the
+    "this" missing — the group path had it via ``fetch_thread_context``, and a
+    DM never called that.
+    """
+    parsed = TelegramMessageParser().parse(
+        {
+            "message": {
+                "message_id": 9,
+                "chat": {"id": 123, "type": "private"},
+                "from": {"id": 1, "first_name": "Deepak"},
+                "text": "this one is wrong",
+                "reply_to_message": {
+                    "message_id": 7,
+                    "from": {"id": 2, "is_bot": True, "username": "lemmabot"},
+                    "text": "The runtime for agent-built software",
+                },
+            }
+        }
+    )
+
+    assert parsed is not None
+    assert parsed.metadata["quoted_message"] == {
+        "author": "lemmabot",
+        "text": "The runtime for agent-built software",
+        "is_bot": True,
+    }
+
+
+def test_parser_leaves_quoted_message_unset_when_nothing_was_quoted():
+    parsed = TelegramMessageParser().parse(
+        {
+            "message": {
+                "message_id": 9,
+                "chat": {"id": 123, "type": "private"},
+                "from": {"id": 1, "first_name": "Deepak"},
+                "text": "hello",
+            }
+        }
+    )
+
+    assert parsed is not None
+    assert parsed.metadata["quoted_message"] is None
 
 
 def test_parser_combines_burst_text_and_album_attachments():


### PR DESCRIPTION
## What changes

A photo sent on WhatsApp with a caption now reaches the agent as the caption,
and as a file it can actually open. Telegram stops quoting a message on every
reply — which, in a DM, could only ever be the wrong one.

Six defects, in two clusters.

**A photo sent with a question (WhatsApp, and half of it Telegram)**

1. The caption was read from `text.body`. A media message has no `text` object
   at all; WhatsApp puts the caption on the media object (`image.caption`). So
   every captioned photo arrived as the bare word `"image"` and the question was
   dropped.
2. The saved file was untyped, so the agent could not look at it. WhatsApp sends
   `filename` only for documents, so a photo was stored as bare
   `/me/whatsapp/image` — and the datastore types a file by its name alone, so
   it came back `application/octet-stream`: `view_image` refuses it and indexing
   skips it. Ingest now completes a nameless attachment's name from the mime
   type of the bytes it downloaded. Telegram had the same bug, where every photo
   is called `photo`.
3. The second photo anyone ever sent was silently dropped: same name, the
   datastore refuses a duplicate path, and the conflict was swallowed by the
   per-attachment catch. It now retries as `image-2.jpg`.

**Replying (Telegram)**

4. Every outbound quoted the inbound message, and could only ever quote the
   *last* one: an outbound is rebuilt from the conversation link's `last_event`,
   not the message the run is answering. So a reply tagged whatever had arrived
   most recently. It now quotes only in groups and forum topics, where the reply
   would otherwise float unaddressed; a DM has one thread and two people, and
   nothing to disambiguate.
5. A debounced burst broke replies outright. Two messages within 2s batch into
   one event whose id is the synthetic `batch:41-43`, and that string was being
   sent as `reply_parameters.message_id` — a 400 that fails the whole reply. The
   reply now points at the last real message of the burst, coerced to an int.
6. Replying *to* a message told the agent nothing about what was being pointed
   at. Telegram ships the quoted message inline in the update, but only the
   group path read it (`fetch_thread_context`), so in a DM "this one is wrong"
   arrived as a pronoun with no referent. It now travels in metadata and gets
   its own prompt block, framed as background context rather than an instruction.

## Why

Reported from a real WhatsApp thread: a screenshot sent with a question reached
the agent as `image`, with no question and nothing viewable at the other end.
The reply complaint came with it — on Telegram the bot "always seems to tag the
last message."

## Not in this change

WhatsApp's own quoted replies stay unresolved. The Cloud API webhook carries
only `context: {from, id}` for a reply — never the quoted text — and the message
ids of the agent's outbound sends are discarded (`send_message` returns `None`
on every adapter), so there is nothing to resolve the id against. Fixing it
means persisting outbound ids across every platform adapter, which is its own
change.

## How to verify

```bash
cd lemma-backend && uv run pytest \
  app/modules/agent_surfaces/tests/unit \
  app/modules/agent/tests/unit -q
make quality
```

Unit tests: `1983 passed, 29 skipped`. The one failure,
`test_telegram_manager_service.py::test_redis_store_enforces_atomic_state_and_claims`,
needs a local Redis and fails identically on a stashed tree.

`make quality`: `✓ quality gates pass` (ruff, format, async-safety,
session-scope, I/O hygiene, import budget, typecheck-critical, architecture
ratchet, log event catalog, OpenAPI freshness, scenario traceability).

The reported message, end to end:

```bash
cd lemma-backend && uv run python -c "
from app.modules.agent_surfaces.platforms.whatsapp.parser import WhatsAppMessageParser
from app.modules.agent_surfaces.services.surface_file_ingest_service import _safe_file_name
p = {'entry':[{'id':'waba','changes':[{'value':{'metadata':{'phone_number_id':'pn1'},'contacts':[{'wa_id':'155','profile':{'name':'D'}}],'messages':[{'from':'155','id':'wamid.A','type':'image','image':{'id':'m1','mime_type':'image/jpeg','caption':'Bro the bold text feels wierd'}}]}}]}]}
e = WhatsAppMessageParser().parse(p); a = e.metadata['attachments'][0]
print(e.message_text); print('/me/whatsapp/' + _safe_file_name(a['name'], a['mime_type']))
"
```

prints `Bro the bold text feels wierd` and `/me/whatsapp/image.jpg` — previously
`image` and `/me/whatsapp/image`.

Not run locally: the two e2e contract tests I updated
(`test_platform_contracts_e2e.py`) need Docker, which is not available on this
machine. CI covers them.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

No migration, no API surface change, no new secret. One user-visible behavior
change beyond the bug fixes: **Telegram no longer quotes the user's message when
replying in a DM.** Group and forum-topic replies still quote. Plain revert if
that reads wrong.

`send_display_resource` also moves from the deprecated `reply_to_message_id` to
`reply_parameters`, which is the same wire behavior on a current Bot API.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
