### PR TITLE
Hear a voice note once, in whatever language it was spoken, at a bitrate worth listening to

### DIFF
--- a/lemma-backend/agent_tool_schemas.json
+++ b/lemma-backend/agent_tool_schemas.json
@@ -1119,7 +1119,7 @@
   {
     "tool_name": "listen",
     "toolset": "SPEECH",
-    "description": "Transcribe a voice message or audio file to text.\n\n`file_path` may be a pod path (e.g. `/me/telegram/voice.ogg`) or a workspace\npath; common formats are supported directly.\n\nThe transcript is for YOUR understanding \u2014 act on it as if the user had typed\nit. Never echo it back (\"You said: ...\").",
+    "description": "Transcribe an audio file that has NOT already been transcribed.\n\nA voice note the user sent you on a chat surface is transcribed before the\nmessage reaches you \u2014 their words are already in the message, so calling\nthis on it just pays for the same transcript twice. Use it for audio you\nwent and found: a recording in the datastore, a file someone shared as a\nfile, something you downloaded.\n\n`file_path` may be a pod path (e.g. `/me/telegram/voice.ogg`) or a workspace\npath; common formats are supported directly.\n\nThe transcript is for YOUR understanding \u2014 act on it as if the user had typed\nit. Never echo it back (\"You said: ...\").",
     "input_schema": {
       "description": "Transcribe a pod/workspace audio file to text.",
       "properties": {
@@ -1137,7 +1137,7 @@
             }
           ],
           "default": null,
-          "description": "Optional BCP-47 language hint (e.g. 'en'). None = auto-detect."
+          "description": "Optional BCP-47 language code (e.g. 'en', 'hi'). Leave unset \u2014 the default reads mixed-language speech without being told. Set this only when you already know the language and the transcript came back wrong."
         }
       },
       "required": [
@@ -3018,7 +3018,7 @@
   {
     "tool_name": "say",
     "toolset": "SPEECH",
-    "description": "Speak a reply: synthesize audio and deliver it as a voice note.\n\nText is the default modality, so call this only when voice is genuinely\nwanted. Delivery is automatic \u2014 a native voice note on chat surfaces, an\naudio player on web.\n\nThe audio IS your reply. Do not call `display_resource` afterward, and do not\nrestate the same words as text; add a text line only if it says something\ndifferent.",
+    "description": "Speak a reply: synthesize audio and deliver it as a voice note.\n\nText is the default modality, so call this only when voice is genuinely\nwanted. Delivery is automatic \u2014 a native voice note on chat surfaces, an\naudio player on web.\n\nSpeaking anything other than English: pass `language` (the BCP-47 code the\ntext is in) so the voice speaks that language instead of reading it aloud\nin English.\n\nThe audio IS your reply. Do not call `display_resource` afterward, and do not\nrestate the same words as text; add a text line only if it says something\ndifferent.",
     "input_schema": {
       "description": "Generate spoken audio (MP3) from text.",
       "properties": {
@@ -3037,6 +3037,18 @@
           ],
           "default": null,
           "description": "Optional pod datastore path for the generated .mp3 (e.g. /me/speech/reply.mp3). Defaults to a generated /me/speech/<id>.mp3."
+        },
+        "language": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "BCP-47 code for the language `text` is written in (e.g. 'es', 'ja'). Pass it whenever you are not speaking English so the voice speaks that language rather than reading it with an English accent. None = the default voice."
         },
         "voice": {
           "anyOf": [

--- a/lemma-backend/app/modules/agent/config.py
+++ b/lemma-backend/app/modules/agent/config.py
@@ -140,6 +140,32 @@ class AgentSettings(BaseSettings):
         default=None,
         description="Deepgram API key for the speech toolset (listen/say).",
     )
+    speech_stt_language: str = Field(
+        default="multi",
+        description=(
+            "Default language for transcription when the caller names none. "
+            "'multi' uses Nova-3 multilingual code-switching, which reads a "
+            "voice note that mixes languages (Hinglish, Spanglish) word by "
+            "word instead of forcing the whole file into one language. 'auto' "
+            "uses Deepgram's whole-file language detection, which reaches more "
+            "languages but commits to a single one. A BCP-47 code pins it."
+        ),
+    )
+    speech_tts_voice: str = Field(
+        default="aura-2-thalia-en",
+        description=(
+            "Default Aura-2 voice. Used when neither the caller nor the "
+            "spoken language selects one."
+        ),
+    )
+    speech_tts_bitrate: int = Field(
+        default=48000,
+        description=(
+            "Bitrate (bits/sec) for compressed TTS output. Deepgram's own "
+            "default for Opus is 12000, which is what a native voice note is "
+            "encoded at on WhatsApp and Telegram, and it sounds like it."
+        ),
+    )
 
     # Web research
     web_fetch_impersonate_browser: bool = Field(

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/pydantic_ai_history.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/pydantic_ai_history.py
@@ -381,6 +381,26 @@ def _channel_context_block(metadata: dict) -> str | None:
     )
 
 
+def _transcribed_voice_paths(metadata: dict) -> set[str]:
+    """Paths of inbound voice notes whose words are already in the message.
+
+    Ingress transcribes voice notes before the run starts and folds the
+    transcript in as the user's own words. Listing those files again as
+    something to go and read invites the agent to call `listen` on audio that
+    has already been transcribed — the same transcript, billed and waited for
+    twice. A voice note that failed to transcribe is deliberately absent here,
+    because for that one `listen` is the right call.
+    """
+    provenance = metadata.get("voice_transcripts")
+    if not isinstance(provenance, list):
+        return set()
+    return {
+        str(item.get("path"))
+        for item in provenance
+        if isinstance(item, dict) and item.get("path") and not item.get("failed")
+    }
+
+
 def _shared_files_blocks(metadata: dict, platform: object) -> list[str]:
     """What the user attached, either already ingested or still raw.
 
@@ -391,10 +411,25 @@ def _shared_files_blocks(metadata: dict, platform: object) -> list[str]:
     """
     ingested_files = metadata.get("ingested_files")
     if isinstance(ingested_files, list) and ingested_files:
-        saved = "\n".join(f"- {path}" for path in ingested_files if path)
-        return [
-            f"The user shared files; they are saved in the pod datastore at:\n{saved}"
-        ]
+        transcribed = _transcribed_voice_paths(metadata)
+        saved = "\n".join(
+            f"- {path}" for path in ingested_files if path and path not in transcribed
+        )
+        blocks: list[str] = []
+        if saved:
+            blocks.append(
+                "The user shared files; they are saved in the pod datastore "
+                f"at:\n{saved}"
+            )
+        if transcribed:
+            spoken = "\n".join(f"- {path}" for path in sorted(transcribed))
+            blocks.append(
+                "Their message above includes what they said in a voice note. "
+                "It is already transcribed — treat those words as theirs and do "
+                "NOT call `listen`. The audio itself is saved at:\n" + spoken
+            )
+        if blocks:
+            return blocks
     attachments = metadata.get("attachments")
     if not isinstance(attachments, list) or not attachments:
         return []

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_config.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_config.py
@@ -45,6 +45,9 @@ EXPECTED = [
     ("widget_url_expiry_seconds", "WIDGET_URL_EXPIRY_SECONDS", 1800),
     ("speech_provider", "SPEECH_PROVIDER", "auto"),
     ("deepgram_api_key", "DEEPGRAM_API_KEY", None),
+    ("speech_stt_language", "SPEECH_STT_LANGUAGE", "multi"),
+    ("speech_tts_voice", "SPEECH_TTS_VOICE", "aura-2-thalia-en"),
+    ("speech_tts_bitrate", "SPEECH_TTS_BITRATE", 48000),
     ("web_fetch_impersonate_browser", "WEB_FETCH_IMPERSONATE_BROWSER", True),
 ]
 FACTORY_FIELDS = {"local_agent_runtime_config_path"}

--- a/lemma-backend/app/modules/agent/tests/unit/test_shared_files_prompt_block.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_shared_files_prompt_block.py
@@ -1,0 +1,70 @@
+"""What the agent is told about files that arrived with a message.
+
+The load-bearing case is a voice note: ingress already transcribed it into the
+message text, so naming the audio file as something to go and read is an
+invitation to transcribe it a second time.
+"""
+
+from __future__ import annotations
+
+from app.modules.agent.infrastructure.harnesses.pydantic_ai_history import (
+    _shared_files_blocks,
+)
+
+
+def _voice_metadata(*, failed: bool = False) -> dict:
+    return {
+        "ingested_files": ["/me/whatsapp/voice-1.ogg"],
+        "voice_transcripts": [
+            {
+                "path": "/me/whatsapp/voice-1.ogg",
+                "text": "" if failed else "book me a table for two",
+                **({"failed": True} if failed else {"detected_language": "en"}),
+            }
+        ],
+    }
+
+
+def test_transcribed_voice_note_is_not_offered_as_a_file_to_read():
+    blocks = _shared_files_blocks(_voice_metadata(), "WHATSAPP")
+    joined = "\n\n".join(blocks)
+
+    assert "already transcribed" in joined
+    assert "do NOT call `listen`" in joined
+    # The path is still named — the audio stays available — but never under the
+    # "shared files" framing that reads as "go and open this".
+    assert "/me/whatsapp/voice-1.ogg" in joined
+    assert "The user shared files" not in joined
+
+
+def test_failed_transcription_leaves_the_audio_listed_for_listen():
+    blocks = _shared_files_blocks(_voice_metadata(failed=True), "WHATSAPP")
+    joined = "\n\n".join(blocks)
+
+    # Nothing was transcribed, so `listen` is the right call and the file has
+    # to be reachable.
+    assert "The user shared files" in joined
+    assert "/me/whatsapp/voice-1.ogg" in joined
+    assert "do NOT call `listen`" not in joined
+
+
+def test_other_attachments_survive_alongside_a_voice_note():
+    metadata = _voice_metadata()
+    metadata["ingested_files"] = ["/me/whatsapp/voice-1.ogg", "/me/whatsapp/menu.pdf"]
+
+    blocks = _shared_files_blocks(metadata, "WHATSAPP")
+    joined = "\n\n".join(blocks)
+
+    assert "/me/whatsapp/menu.pdf" in joined
+    assert "The user shared files" in joined
+    # The pdf is listed as a shared file; the voice note is not.
+    shared_block = next(b for b in blocks if b.startswith("The user shared files"))
+    assert "voice-1.ogg" not in shared_block
+
+
+def test_plain_files_are_unchanged_without_voice_metadata():
+    blocks = _shared_files_blocks({"ingested_files": ["/me/slack/report.csv"]}, "SLACK")
+    assert blocks == [
+        "The user shared files; they are saved in the pod datastore at:\n"
+        "- /me/slack/report.csv"
+    ]

--- a/lemma-backend/app/modules/agent/tests/unit/test_speech_tools.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_speech_tools.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from uuid import uuid4
 
+import httpx
+
 import app.modules.agent.tools.speech.speech as speech_module
 from app.modules.agent.tools.speech.models import (
     ListenRequest,
@@ -33,8 +35,13 @@ class _StubProvider:
             text=self._transcript, detected_language="en", duration_seconds=2.0
         )
 
-    async def synthesize(self, text, *, voice=None, output_format="mp3"):
-        self.synthesize_args = {"text": text, "voice": voice, "format": output_format}
+    async def synthesize(self, text, *, voice=None, output_format="mp3", language=None):
+        self.synthesize_args = {
+            "text": text,
+            "voice": voice,
+            "format": output_format,
+            "language": language,
+        }
         return self._audio
 
 
@@ -191,3 +198,205 @@ async def test_say_requires_text():
         SimpleNamespace(pod_id=uuid4()), SayRequest(text="   ")
     )
     assert result.success is False
+
+
+# ---- language + audio quality ----------------------------------------------
+
+
+def test_stt_defaults_to_multilingual_not_single_language(monkeypatch):
+    from app.modules.agent.config import agent_settings
+    from app.modules.agent.tools.speech.deepgram_provider import _language_params
+
+    monkeypatch.setattr(agent_settings, "speech_stt_language", "multi")
+    # A voice note that switches languages mid-sentence must not be forced into
+    # one of them, which is what whole-file detection does.
+    assert _language_params(None) == {"language": "multi"}
+    assert _language_params("hi") == {"language": "hi"}
+
+
+def test_stt_auto_setting_uses_whole_file_detection(monkeypatch):
+    from app.modules.agent.config import agent_settings
+    from app.modules.agent.tools.speech.deepgram_provider import _language_params
+
+    monkeypatch.setattr(agent_settings, "speech_stt_language", "auto")
+    assert _language_params(None) == {"detect_language": "true"}
+
+
+def test_detected_language_falls_back_to_word_tags():
+    from app.modules.agent.tools.speech.deepgram_provider import _parse_transcription
+
+    # Multilingual code-switching tags words, not the channel.
+    result = _parse_transcription(
+        {
+            "results": {
+                "channels": [
+                    {
+                        "alternatives": [
+                            {
+                                "transcript": "hola there",
+                                "words": [
+                                    {"word": "hola", "language": "es"},
+                                    {"word": "there", "language": "es"},
+                                    {"word": "amigo", "language": "en"},
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            },
+            "metadata": {"duration": 1.5},
+        }
+    )
+    assert result.text == "hola there"
+    assert result.detected_language == "es"
+    assert result.duration_seconds == 1.5
+
+
+def test_detected_language_prefers_channel_when_present():
+    from app.modules.agent.tools.speech.deepgram_provider import _parse_transcription
+
+    result = _parse_transcription(
+        {
+            "results": {
+                "channels": [
+                    {
+                        "detected_language": "ja",
+                        "alternatives": [{"transcript": "こんにちは"}],
+                    }
+                ]
+            },
+            "metadata": {},
+        }
+    )
+    assert result.detected_language == "ja"
+
+
+def test_opus_bitrate_is_raised_off_deepgrams_12k_default(monkeypatch):
+    from app.modules.agent.config import agent_settings
+    from app.modules.agent.tools.speech.deepgram_provider import _bitrate_for
+
+    monkeypatch.setattr(agent_settings, "speech_tts_bitrate", 48000)
+    # Opus is what every native voice note is encoded as; Deepgram's own
+    # default for it is 12000.
+    assert _bitrate_for("opus") == 48000
+    # mp3 tops out at 48000, so a higher setting clamps rather than 400s.
+    monkeypatch.setattr(agent_settings, "speech_tts_bitrate", 128000)
+    assert _bitrate_for("mp3") == 48000
+    assert _bitrate_for("opus") == 128000
+    # linear16 takes no bitrate at all.
+    assert _bitrate_for("linear16") is None
+
+
+def test_voice_follows_the_language_being_spoken():
+    from app.modules.agent.tools.speech.deepgram_provider import voice_for_language
+
+    assert voice_for_language("es") == "aura-2-celeste-es"
+    assert voice_for_language("ja-JP") == "aura-2-uzume-ja"
+    assert voice_for_language("en-US") == "aura-2-thalia-en"
+    # Deepgram has no Hindi voice — the caller falls back to the default.
+    assert voice_for_language("hi") is None
+    assert voice_for_language(None) is None
+
+
+async def test_say_passes_language_to_the_provider(monkeypatch):
+    stub = _StubProvider()
+    file_service = _FakeFileService()
+    monkeypatch.setattr(speech_module, "get_speech_provider", lambda *a, **k: stub)
+    monkeypatch.setattr(speech_module, "pod_services", _fake_pod_services(file_service))
+
+    await speech_module.say_internal(
+        SimpleNamespace(pod_id=uuid4()), SayRequest(text="Hola", language="es")
+    )
+    assert stub.synthesize_args["language"] == "es"
+
+
+# ---- what actually goes on the wire ----------------------------------------
+
+
+class _RecordingTransport(httpx.AsyncBaseTransport):
+    """An httpx transport that records requests and replays scripted responses."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.requests: list[httpx.Request] = []
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        status, body = self._responses.pop(0)
+        return httpx.Response(status, content=body, request=request)
+
+
+def _patch_transport(monkeypatch, responses):
+    transport = _RecordingTransport(responses)
+    original = httpx.AsyncClient.__init__
+
+    def _init(self, *args, **kwargs):
+        kwargs["transport"] = transport
+        original(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__init__", _init)
+    return transport
+
+
+async def test_synthesize_sends_a_bitrate_for_opus(monkeypatch):
+    from app.modules.agent.config import agent_settings
+
+    monkeypatch.setattr(agent_settings, "speech_tts_bitrate", 48000)
+    transport = _patch_transport(monkeypatch, [(200, b"AUDIO")])
+
+    audio = await DeepgramSpeechProvider(api_key="k").synthesize(
+        "hola", output_format="ogg", language="es"
+    )
+
+    assert audio == b"AUDIO"
+    params = transport.requests[0].url.params
+    # Unset, Deepgram encodes Opus at 12000 — and Opus is what WhatsApp and
+    # Telegram voice notes are.
+    assert params["bit_rate"] == "48000"
+    assert params["encoding"] == "opus"
+    assert params["container"] == "ogg"
+    assert params["model"] == "aura-2-celeste-es"
+
+
+async def test_synthesize_falls_back_when_the_voice_is_rejected(monkeypatch):
+    from app.modules.agent.config import agent_settings
+
+    monkeypatch.setattr(agent_settings, "speech_tts_voice", "aura-2-thalia-en")
+    transport = _patch_transport(
+        monkeypatch, [(400, b"unknown model"), (200, b"AUDIO")]
+    )
+
+    audio = await DeepgramSpeechProvider(api_key="k").synthesize(
+        "ciao", output_format="mp3", language="it"
+    )
+
+    assert audio == b"AUDIO"
+    assert transport.requests[0].url.params["model"] == "aura-2-melia-it"
+    # The reply still goes out, in the default voice.
+    assert transport.requests[1].url.params["model"] == "aura-2-thalia-en"
+
+
+async def test_transcribe_asks_for_multilingual_by_default(monkeypatch):
+    from app.modules.agent.config import agent_settings
+
+    monkeypatch.setattr(agent_settings, "speech_stt_language", "multi")
+    transport = _patch_transport(
+        monkeypatch,
+        [
+            (
+                200,
+                b'{"results": {"channels": [{"alternatives": '
+                b'[{"transcript": "kal meeting hai"}]}]}, "metadata": {}}',
+            )
+        ],
+    )
+
+    result = await DeepgramSpeechProvider(api_key="k").transcribe(
+        b"OGG", mime="audio/ogg"
+    )
+
+    assert result.text == "kal meeting hai"
+    params = transport.requests[0].url.params
+    assert params["model"] == "nova-3"
+    assert params["language"] == "multi"
+    assert "detect_language" not in params

--- a/lemma-backend/app/modules/agent/tools/speech/deepgram_provider.py
+++ b/lemma-backend/app/modules/agent/tools/speech/deepgram_provider.py
@@ -6,6 +6,7 @@ adding the heavier ``deepgram-sdk`` dependency.
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any
 
 import httpx
@@ -24,13 +25,41 @@ _DEFAULT_TTS_MODEL = "aura-2-thalia-en"
 _STT_TIMEOUT = 120.0
 _TTS_TIMEOUT = 60.0
 
-# Deepgram speak `encoding`/container per requested output format.
+# Deepgram speak `encoding`/container per requested output format, plus whether
+# the format takes a `bit_rate`. Deepgram's defaults are 48000 for mp3 but only
+# 12000 for opus — and opus is the format every native voice note uses, so the
+# unset default is the one people hear.
 _TTS_FORMAT_PARAMS: dict[str, dict[str, str]] = {
     "mp3": {"encoding": "mp3"},
     "wav": {"encoding": "linear16", "container": "wav"},
     "ogg": {"encoding": "opus", "container": "ogg"},
     "opus": {"encoding": "opus", "container": "ogg"},
 }
+# Bitrate ranges Deepgram accepts per encoding; linear16 takes none at all.
+_TTS_BITRATE_RANGE: dict[str, tuple[int, int]] = {
+    "mp3": (32000, 48000),
+    "opus": (4000, 650000),
+}
+
+# One Aura-2 voice per language Deepgram actually speaks. A reply in Spanish
+# read by an English voice is the same defect as a wrong transcript, so the
+# language of the text picks the voice. Languages absent here (Hindi among
+# them) have no Aura-2 voice at all and fall back to the default.
+_VOICE_BY_LANGUAGE: dict[str, str] = {
+    "en": "aura-2-thalia-en",
+    "es": "aura-2-celeste-es",
+    "de": "aura-2-elara-de",
+    "fr": "aura-2-agathe-fr",
+    "nl": "aura-2-beatrix-nl",
+    "it": "aura-2-melia-it",
+    "ja": "aura-2-uzume-ja",
+}
+
+
+def voice_for_language(language: str | None) -> str | None:
+    """The Aura-2 voice for a BCP-47 code, or None when Deepgram has none."""
+    base = str(language or "").strip().lower().replace("_", "-").split("-")[0]
+    return _VOICE_BY_LANGUAGE.get(base)
 
 
 class DeepgramSpeechProvider(SpeechProvider):
@@ -54,10 +83,7 @@ class DeepgramSpeechProvider(SpeechProvider):
         if not self._api_key:
             raise RuntimeError("Deepgram API key is not configured.")
         params: dict[str, str] = {"model": _DEFAULT_STT_MODEL, "smart_format": "true"}
-        if language:
-            params["language"] = language
-        else:
-            params["detect_language"] = "true"
+        params.update(_language_params(language))
         async with httpx.AsyncClient(timeout=_STT_TIMEOUT) as client:
             response = await client.post(
                 _LISTEN_URL,
@@ -75,22 +101,103 @@ class DeepgramSpeechProvider(SpeechProvider):
         *,
         voice: str | None = None,
         output_format: str = "mp3",
+        language: str | None = None,
     ) -> bytes:
         if not self._api_key:
             raise RuntimeError("Deepgram API key is not configured.")
-        params: dict[str, str] = {"model": voice or _DEFAULT_TTS_MODEL}
-        params.update(
-            _TTS_FORMAT_PARAMS.get(output_format.lower(), {"encoding": "mp3"})
+        model = (
+            voice
+            or voice_for_language(language)
+            or agent_settings.speech_tts_voice
+            or _DEFAULT_TTS_MODEL
         )
+        params: dict[str, str] = {}
+        format_params = _TTS_FORMAT_PARAMS.get(
+            output_format.lower(), {"encoding": "mp3"}
+        )
+        params.update(format_params)
+        bit_rate = _bitrate_for(format_params["encoding"])
+        if bit_rate is not None:
+            params["bit_rate"] = str(bit_rate)
         async with httpx.AsyncClient(timeout=_TTS_TIMEOUT) as client:
-            response = await client.post(
-                _SPEAK_URL,
-                params=params,
-                headers=self._headers(content_type="application/json"),
-                json={"text": text},
-            )
-            response.raise_for_status()
-            return response.content
+            try:
+                return await self._speak(client, text, params, model)
+            except httpx.HTTPStatusError as exc:
+                # Deepgram retires and renames voices, and a name it no longer
+                # knows is a 400 on the voice alone. Losing the accent is worth
+                # far less than losing the reply, so fall back to the default
+                # voice rather than failing the call.
+                fallback = agent_settings.speech_tts_voice or _DEFAULT_TTS_MODEL
+                if exc.response.status_code != 400 or model == fallback:
+                    raise
+                return await self._speak(client, text, params, fallback)
+
+    async def _speak(
+        self,
+        client: httpx.AsyncClient,
+        text: str,
+        params: dict[str, str],
+        model: str,
+    ) -> bytes:
+        response = await client.post(
+            _SPEAK_URL,
+            params={**params, "model": model},
+            headers=self._headers(content_type="application/json"),
+            json={"text": text},
+        )
+        response.raise_for_status()
+        return response.content
+
+
+def _language_params(language: str | None) -> dict[str, str]:
+    """Deepgram's language knobs for a requested language.
+
+    An explicit code wins. Otherwise the configured default decides between
+    Nova-3 multilingual code-switching (``multi``, the default — one voice note
+    that mixes two languages transcribes as both) and whole-file detection
+    (``auto``, which reaches more languages but picks exactly one).
+    """
+    requested = (
+        str(language or agent_settings.speech_stt_language or "multi").strip().lower()
+    )
+    if requested in {"auto", "detect"}:
+        return {"detect_language": "true"}
+    return {"language": requested or "multi"}
+
+
+def _bitrate_for(encoding: str) -> int | None:
+    """The configured bitrate, clamped to what Deepgram accepts for ``encoding``."""
+    bounds = _TTS_BITRATE_RANGE.get(encoding)
+    if bounds is None:
+        return None
+    low, high = bounds
+    configured = int(agent_settings.speech_tts_bitrate or high)
+    return max(low, min(high, configured))
+
+
+def _detected_language(
+    channel: dict[str, Any], alternative: dict[str, Any]
+) -> str | None:
+    """The language Deepgram heard, however this response reports it.
+
+    Whole-file detection puts one code on the channel. Multilingual
+    code-switching tags each word instead, so the file's language is the one
+    most of its words were in — which is what picks the reply voice.
+    """
+    detected = channel.get("detected_language")
+    if detected:
+        return str(detected)
+    words = alternative.get("words")
+    if not isinstance(words, list):
+        return None
+    tags = Counter(
+        str(word.get("language"))
+        for word in words
+        if isinstance(word, dict) and word.get("language")
+    )
+    if not tags:
+        return None
+    return tags.most_common(1)[0][0]
 
 
 def _parse_transcription(payload: dict[str, Any]) -> TranscriptionResult:
@@ -98,13 +205,13 @@ def _parse_transcription(payload: dict[str, Any]) -> TranscriptionResult:
     channels = results.get("channels") or []
     first = channels[0] if channels else {}
     alternatives = (first or {}).get("alternatives") or []
-    transcript = str((alternatives[0] if alternatives else {}).get("transcript") or "")
-    detected_language = (first or {}).get("detected_language")
+    alternative = alternatives[0] if alternatives else {}
+    transcript = str(alternative.get("transcript") or "")
     metadata = payload.get("metadata") or {}
     duration = metadata.get("duration")
     return TranscriptionResult(
         text=transcript,
-        detected_language=detected_language if detected_language else None,
+        detected_language=_detected_language(first or {}, alternative),
         duration_seconds=float(duration)
         if isinstance(duration, (int, float))
         else None,

--- a/lemma-backend/app/modules/agent/tools/speech/models.py
+++ b/lemma-backend/app/modules/agent/tools/speech/models.py
@@ -14,7 +14,12 @@ class ListenRequest(BaseModel):
     )
     language: str | None = Field(
         default=None,
-        description="Optional BCP-47 language hint (e.g. 'en'). None = auto-detect.",
+        description=(
+            "Optional BCP-47 language code (e.g. 'en', 'hi'). Leave unset — the "
+            "default reads mixed-language speech without being told. Set this "
+            "only when you already know the language and the transcript came "
+            "back wrong."
+        ),
     )
 
 
@@ -36,6 +41,15 @@ class SayRequest(BaseModel):
         description=(
             "Optional pod datastore path for the generated .mp3 (e.g. "
             "/me/speech/reply.mp3). Defaults to a generated /me/speech/<id>.mp3."
+        ),
+    )
+    language: str | None = Field(
+        default=None,
+        description=(
+            "BCP-47 code for the language `text` is written in (e.g. 'es', "
+            "'ja'). Pass it whenever you are not speaking English so the voice "
+            "speaks that language rather than reading it with an English "
+            "accent. None = the default voice."
         ),
     )
     voice: str | None = Field(

--- a/lemma-backend/app/modules/agent/tools/speech/provider.py
+++ b/lemma-backend/app/modules/agent/tools/speech/provider.py
@@ -47,7 +47,13 @@ class SpeechProvider(ABC):
         *,
         voice: str | None = None,
         output_format: str = "mp3",
-    ) -> bytes: ...
+        language: str | None = None,
+    ) -> bytes:
+        """Speak ``text``.
+
+        ``language`` is the language the text is in, so a provider can pick a
+        voice that speaks it; an explicit ``voice`` overrides that.
+        """
 
 
 def _build(name: SpeechProviderName) -> SpeechProvider:

--- a/lemma-backend/app/modules/agent/tools/speech/pydantic_adapter.py
+++ b/lemma-backend/app/modules/agent/tools/speech/pydantic_adapter.py
@@ -19,7 +19,13 @@ logger = get_logger(__name__)
 async def listen(
     ctx: RunContext[BaseAgentContext], request: ListenRequest
 ) -> ListenResponse:
-    """Transcribe a voice message or audio file to text.
+    """Transcribe an audio file that has NOT already been transcribed.
+
+    A voice note the user sent you on a chat surface is transcribed before the
+    message reaches you — their words are already in the message, so calling
+    this on it just pays for the same transcript twice. Use it for audio you
+    went and found: a recording in the datastore, a file someone shared as a
+    file, something you downloaded.
 
     `file_path` may be a pod path (e.g. `/me/telegram/voice.ogg`) or a workspace
     path; common formats are supported directly.
@@ -40,6 +46,10 @@ async def say(ctx: RunContext[BaseAgentContext], request: SayRequest) -> SayResp
     Text is the default modality, so call this only when voice is genuinely
     wanted. Delivery is automatic — a native voice note on chat surfaces, an
     audio player on web.
+
+    Speaking anything other than English: pass `language` (the BCP-47 code the
+    text is in) so the voice speaks that language instead of reading it aloud
+    in English.
 
     The audio IS your reply. Do not call `display_resource` afterward, and do not
     restate the same words as text; add a text line only if it says something

--- a/lemma-backend/app/modules/agent/tools/speech/speech.py
+++ b/lemma-backend/app/modules/agent/tools/speech/speech.py
@@ -129,7 +129,10 @@ async def say_internal(deps: BaseAgentContext, request: SayRequest) -> SayRespon
     try:
         provider = get_speech_provider()
         audio_bytes = await provider.synthesize(
-            text, voice=request.voice, output_format=output_format
+            text,
+            voice=request.voice,
+            output_format=output_format,
+            language=request.language,
         )
     except Exception as exc:
         return SayResponse(success=False, error=f"Speech synthesis failed: {exc}")

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/helpers.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/helpers.py
@@ -533,9 +533,14 @@ async def fake_speech_provider(monkeypatch):
 
     class _FakeSpeechProvider:
         async def synthesize(
-            self, text: str, *, voice: str | None = None, output_format: str = "mp3"
+            self,
+            text: str,
+            *,
+            voice: str | None = None,
+            output_format: str = "mp3",
+            language: str | None = None,
         ) -> bytes:
-            del voice, output_format
+            del voice, output_format, language
             return b"FAKE-AUDIO-" + text.encode("utf-8")[:64]
 
     fake = _FakeSpeechProvider()


### PR DESCRIPTION
## What changes

A voice note sent on WhatsApp or Telegram is now transcribed once instead of
twice, read in whatever language it was actually spoken in, and answered in a
voice note you can stand to listen to.

- **Transcribed once.** Ingress already turns a voice note into the user's
  words before the run starts. The audio file was *also* listed as a pod file to
  go and read, next to a `listen` tool advertised as "Transcribe a voice
  message" — so the agent frequently transcribed it again, paying for and
  waiting on the same transcript twice. Transcribed voice paths now leave the
  shared-files list and get their own line stating the words are already in the
  message and `listen` is not needed. A voice note that *failed* to transcribe
  deliberately stays in the normal list, because for that one `listen` is the
  right call.
- **Whatever language it was spoken in.** Transcription was already
  auto-detecting, but `detect_language` picks one language for the whole file —
  a sentence that switches between two (Hinglish, Spanglish) comes back as
  neither. Nova-3 multilingual (`language=multi`) reads them word by word and is
  the new default.
- **Audible.** Synthesis never sent a `bit_rate`, and Deepgram's default for
  Opus is **12000 bps** — Opus being exactly what `voice_note_format` returns
  for `TELEGRAM` and `WHATSAPP`. Every native voice note on the two surfaces
  where voice matters most shipped at 12 kbps. It is 48000 now, and the Aura-2
  voice follows the language of the text rather than reading Spanish aloud in
  English.

New operator settings, all with working defaults: `SPEECH_STT_LANGUAGE`
(`multi`), `SPEECH_TTS_VOICE` (`aura-2-thalia-en`), `SPEECH_TTS_BITRATE`
(`48000`).

## Why

Three separate defects that compounded into "speech input is incomplete": a
duplicated round-trip on every voice note, a transcript that is wrong whenever
the speaker mixes languages, and 12 kbps audio going back the other way. The
bitrate one is the most expensive and the least visible — it is a Deepgram
default that only bites the compressed format, so mp3 replies on web sounded
fine while every WhatsApp and Telegram voice note did not.

## How to verify

```bash
cd lemma-backend
uv run pytest app/modules/agent/tests/unit/test_speech_tools.py \
              app/modules/agent/tests/unit/test_shared_files_prompt_block.py -q
uv run pytest app/modules/agent/tests/unit app/modules/agent_surfaces/tests/unit -q
make lint
make architecture
```

The speech and prompt-block suites are 22 passed. The full unit sweep is
`1 failed, 2000 passed, 29 skipped` — the failure is
`test_telegram_manager_service.py::test_redis_store_enforces_atomic_state_and_claims`,
which needs a reachable Redis and fails identically on a clean `main` tree
(verified by stashing). `make lint` prints `All checks passed!`;
`make architecture` prints `Architecture ratchet passed (12 inherited import
violations, 0 inherited cycles)` — unchanged from the baseline.

New tests assert the wire request itself, not just the helpers: that Opus
carries `bit_rate=48000`, that transcription asks for `nova-3` + `language=multi`
and no `detect_language`, that a rejected voice falls back rather than failing
the reply, and that a transcribed voice note is never offered to the agent as a
file to read while a failed one still is.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **API surface** — `agent_tool_schemas.json` regenerated via
      `uv run python scripts/export_agent_tool_schemas.py` (the `listen`/`say`
      descriptions and the new `language` field are model-facing). No OpenAPI
      route changed, so neither SDK needed regenerating; the route inventory
      check confirms it is current.
- [x] **Security** — no new secret in a log, response, or queued payload. The
      Deepgram key handling is untouched.
- [x] **Rollback** — plain revert. No migration, no persisted state, no data
      shape change.

## Compatibility and rollback notes

`SpeechProvider.synthesize` gains a keyword-only `language` argument. Deepgram
is the only implementation; the two test stubs are updated in this change. Any
out-of-tree provider would need the parameter added.

Reverting restores the previous behaviour exactly — the three new settings are
read only by the code being reverted, and nothing was written anywhere that
outlives the run.

## Known limitation, deliberately not fixed here

Aura-2 speaks en/es/de/fr/nl/it/ja and **has no Hindi voice**. A Hindi reply is
still read aloud by an English voice. Nothing on Deepgram fixes that; it needs a
second TTS vendor (ElevenLabs or OpenAI), which the existing pluggable
`SpeechProvider` interface already accommodates as a purely additive change.
This PR was deliberately scoped to Deepgram.
