### PR TITLE
Find the people in a pod under "Members", the way the organization settings already name them

### DIFF
--- a/lemma-frontend/app/pod/[id]/settings/members/loading.tsx
+++ b/lemma-frontend/app/pod/[id]/settings/members/loading.tsx
@@ -1,6 +1,6 @@
 import { PodSettingsLedgerSkeleton } from '@/components/pod/route-skeletons';
 
-/** Access settles into a people ledger under its view strip. */
+/** Members settles into a people ledger under its view strip. */
 export default function PodMembersLoading() {
     return <PodSettingsLedgerSkeleton tabs={5} />;
 }

--- a/lemma-frontend/app/pod/[id]/settings/members/page.tsx
+++ b/lemma-frontend/app/pod/[id]/settings/members/page.tsx
@@ -367,7 +367,7 @@ function PodMembersPageContent({ params }: { params: Promise<{ id: string }> }) 
     return (
         <PodSettingsShell
             podId={podId}
-            title="Access"
+            title="Members"
             action={canManageMembers ? (
                 <Dialog open={addDialogOpen} onOpenChange={setAddDialogOpen}>
                     <DialogTrigger asChild>
@@ -517,7 +517,7 @@ function PodMembersPageContent({ params }: { params: Promise<{ id: string }> }) 
                 <ResourceMetricStrip className="lemma-index-tabs-left">
                     <ResourceMetricButton active={activeView === 'people'} label="People" count={members.length} onClick={() => setActiveView('people')} />
                     <ResourceMetricButton active={activeView === 'invites'} label="Email invites" count={pendingPodInvitations.length} onClick={() => setActiveView('invites')} />
-                    <ResourceMetricButton active={activeView === 'requests'} label="Access requests" count={pendingJoinRequests.length} onClick={() => setActiveView('requests')} />
+                    <ResourceMetricButton active={activeView === 'requests'} label="Join requests" count={pendingJoinRequests.length} onClick={() => setActiveView('requests')} />
                     <ResourceMetricButton active={activeView === 'roles'} label="Roles" count={roles.length || ROLE_GUIDANCE.length} onClick={() => setActiveView('roles')} />
                     {canManageMembers ? (
                         <ResourceMetricButton active={activeView === 'available'} label="Available" count={availableMembers.length} onClick={() => setActiveView('available')} />

--- a/lemma-frontend/components/pod/pod-settings-nav.tsx
+++ b/lemma-frontend/components/pod/pod-settings-nav.tsx
@@ -17,7 +17,7 @@ const ITEMS = [
         segment: 'models',
     },
     {
-        label: 'Access',
+        label: 'Members',
         description: 'Who can enter the pod and what role they hold.',
         segment: 'members',
     },

--- a/lemma-frontend/components/pod/pod-settings-shell.tsx
+++ b/lemma-frontend/components/pod/pod-settings-shell.tsx
@@ -17,7 +17,7 @@ interface PodSettingsStat {
 interface PodSettingsShellProps {
     podId: string;
     /**
-     * This tab's own name — "General", "Access" — not the area's. The context
+     * This tab's own name — "General", "Members" — not the area's. The context
      * bar prints it, and a bar that says "Pod Settings" on every route
      * tells you nothing you did not already know. The workspace tab keeps
      * reading "Settings" (see `tabTitle` below) because every route shares


### PR DESCRIPTION
## What changes

The pod settings tab that lists people is called **Members** now, not
"Access". Its context-bar title changes with it, and the view strip inside
it reads **Join requests** instead of "Access requests".

Nothing else moves: same route (`/pod/[id]/settings/members`), same
permissions, same API. Four user-visible strings and two stale comments.

## Why

"Access" named the mechanism rather than the page. The tab has always
routed to `/settings/members` and has always listed people, email
invitations, join requests, and roles — the label was the only part
describing a permission model instead of a roster, and it read as a
different concept from the one the page delivers.

It also collided with the other "Access" in the product: the dialogs where
an agent or a function is granted access to a resource
([agent-access-dialog.tsx](lemma-frontend/components/agents/agent-access-dialog.tsx),
[function-access-dialog.tsx](lemma-frontend/components/functions/function-access-dialog.tsx)).
Those keep the word, because there it is the right one. One noun per
concept.

Organization settings has said "Members" for the equivalent page since it
was written ([organization-settings-nav.tsx:9](lemma-frontend/components/organizations/organization-settings-nav.tsx)),
so the pod and the organization now agree instead of naming the same thing
two ways.

"Access requests" went to "Join requests" for the same reason at a smaller
scale — it is the noun the code already uses (`pendingJoinRequests`), and
it no longer repeats the name of the section it sits inside.

The prose that legitimately uses the word — "they will lose access to this
pod", "read-only access for stakeholders" — is untouched.

## How to verify

```bash
cd lemma-frontend && npm run lint && npm run typecheck && npm run design:audit:ci
```

All three pass:

- `eslint` — exit 0, no output
- `tsc --noEmit` — clean
- design audit — `productStrict=0 informational=104 protectedAssistant=1`, no
  baseline growth

Grep confirms no remaining call site prints the old label, and no test or doc
asserts on it:

```bash
grep -rn "Access requests\|label: 'Access'" lemma-frontend --include="*.tsx" --include="*.ts"
```

By hand: open a pod → Settings. The third tab reads "Members"; opening it
puts "Members" in the context bar and shows People / Email invites / Join
requests / Roles / Available. The `?view=requests` deep link from the pod
home nudge ([page.tsx:733](lemma-frontend/app/pod/[id]/page.tsx)) still lands on
the right view.

## Checklist

- [x] Lint, typecheck, and architecture gates pass locally

Tests are not part of this change — there was no test asserting on the old
label, and a test that asserts a nav string is spelled a particular way
would only need editing the next time the wording improves.

## Compatibility and rollback notes

Nothing to note. No migration, no API or SDK surface, no generated code.
Rollback is `git revert` of a single commit touching four frontend files.
