### PR TITLE
Stop a filename in chat from shouting over the sentence carrying it

### DIFF
--- a/lemma-frontend/components/lemma/assistant/assistant-experience-helpers.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-experience-helpers.tsx
@@ -203,7 +203,7 @@ export function markdownComponentsForMessage(isUserMessage: boolean): Components
       <blockquote className={cn("my-3 border-l-2 pl-4 first:mt-0 last:mb-0", borderClassName, softTextClassName, className)} {...stripMarkdownNode(props)} />
     ),
     code: ({ className, ...props }) => (
-      <code className={cn("rounded px-1 py-0.5 font-mono text-sm", codeClassName, className)} {...stripMarkdownNode(props)} />
+      <code className={cn("lchat-code", className)} {...stripMarkdownNode(props)} />
     ),
     // Fenced blocks tagged json — and untagged fences that turn out to be JSON —
     // get the dedicated block. The raw source only survives on the hast node, so

--- a/lemma-frontend/components/lemma/assistant/assistant-turn.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-turn.tsx
@@ -114,7 +114,7 @@ const docComponents: Components = {
     <blockquote className={cn("my-2 border-l-2 border-[var(--border-strong)] pl-4 text-[var(--text-secondary)] first:mt-0 last:mb-0", className)} {...stripMarkdownNode(props)} />
   ),
   code: ({ className, ...props }) => (
-    <code className={cn("rounded bg-[var(--surface-2)] px-1 py-0.5 font-mono text-xs text-[var(--text-primary)]", className)} {...stripMarkdownNode(props)} />
+    <code className={cn("lchat-code", className)} {...stripMarkdownNode(props)} />
   ),
   // Same JSON-fence detection as the transcript map, so a payload inside a
   // document still gets the structured block instead of raw text.

--- a/lemma-frontend/styles/features/assistant-chat.css
+++ b/lemma-frontend/styles/features/assistant-chat.css
@@ -402,18 +402,22 @@
    warm off-white punched into the bubble's neutral grey (in dark, a slightly
    darker rectangle that just looked like a smudge).
 
-   So the value is sized against the sentence rather than in absolute px, and
-   its plate is mixed out of the surrounding ink rather than named — one rule
-   that lands correctly on the assistant's grey, the user's brand fill and the
-   doc card alike, with no per-context override. */
+   So the value drops a step down the type scale — --text-xs against speech set
+   at --text-sm is where DM Mono's x-height meets Inter's — and its plate is
+   mixed out of the surrounding ink rather than named, so one rule lands
+   correctly on the assistant's grey, the user's brand fill and the doc card
+   alike, with no per-context override and no dark-mode variant.
+
+   The plate's padding is the pair `.tiptap-editor code` already uses, so the
+   value a document writes and the value the agent says it back in are set the
+   same way. */
 .lchat-code {
     border-radius: var(--radius-sm);
     background: color-mix(in srgb, currentColor 8%, transparent);
-    padding: 0.1em 0.32em;
+    padding: var(--space-0-5) var(--space-1-5);
     color: inherit;
     font-family: var(--font-mono-family);
-    /* Where DM Mono's x-height meets Inter's. */
-    font-size: 0.9em;
+    font-size: var(--text-xs);
     /* A path or a long identifier breaks instead of pushing the bubble wide. */
     overflow-wrap: anywhere;
 }

--- a/lemma-frontend/styles/features/assistant-chat.css
+++ b/lemma-frontend/styles/features/assistant-chat.css
@@ -393,6 +393,38 @@
     color: var(--action-primary);
 }
 
+/* --- inline code: a machine value inside speech ------------------------------- */
+
+/* `FirstLaw_of_Motion.mp4` used to be DM Mono set at the sentence's own 14px on
+   a fixed --surface-2 plate. Two things went wrong. Mono's wider advance and
+   taller x-height made it read a size *up* from the words around it, so the
+   filename shouted louder than the sentence carrying it; and the plate was a
+   warm off-white punched into the bubble's neutral grey (in dark, a slightly
+   darker rectangle that just looked like a smudge).
+
+   So the value is sized against the sentence rather than in absolute px, and
+   its plate is mixed out of the surrounding ink rather than named — one rule
+   that lands correctly on the assistant's grey, the user's brand fill and the
+   doc card alike, with no per-context override. */
+.lchat-code {
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, currentColor 8%, transparent);
+    padding: 0.1em 0.32em;
+    color: inherit;
+    font-family: var(--font-mono-family);
+    /* Where DM Mono's x-height meets Inter's. */
+    font-size: 0.9em;
+    /* A path or a long identifier breaks instead of pushing the bubble wide. */
+    overflow-wrap: anywhere;
+}
+
+/* Inside a fence the plate belongs to the block; the span must not double it. */
+pre .lchat-code {
+    background: none;
+    padding: 0;
+    font-size: inherit;
+}
+
 /* --- artifact cards ----------------------------------------------------------- */
 
 .lchat-atts {


### PR DESCRIPTION
## What changes

A machine value inside chat speech — `FirstLaw_of_Motion.mp4`, a path, a
command — stops reading as the loudest thing in the message.

Two things were wrong with the old treatment. The span was DM Mono set at the
sentence's own 14px (`text-sm`); mono's wider advance and taller x-height mean
that at equal px it reads a size *up* from the words around it. And its plate
was a fixed token: `--surface-2` is a warm off-white (`#f7f5ef`) sitting on the
bubble's neutral grey (`#efefef`), so it landed as a lighter,
differently-tinted rectangle punched into the fill. In dark that inverted into
`#212120` on `#262626` — a smudge — and the user's brand bubble needed a third
override (white at 15%) to show a plate at all.

Now the span sits a step down the type scale (`--text-xs`) and its plate is
**mixed out of the surrounding ink** (`currentColor` at 8%) rather than naming a
surface token. That second half is the real fix: one rule now lands correctly on
the assistant's grey, the user's brand fill and the doc card, with no
per-context branch and no dark-mode variant. Two smaller ones ride along — a
long path wraps instead of pushing the bubble wide, and a span inside a fence
drops the plate the block already draws.

The face stays mono: `design.md` reserves DM Mono for "a path, a code value, or
a machine," and a filename is one. The chip was never the problem; its sizing
and its plate were.

## Why

Reported from the product: inline code in chat "looks weird." It did, and the
two causes above are why.

Along the way this collapses real drift. The two markdown maps that render
assistant text had grown two *different* hardcoded inline-code styles —
`text-sm` for bubbles in `assistant-experience-helpers.tsx`, `text-xs` for the
doc card in `assistant-turn.tsx` — so the same filename changed size depending
on whether the answer was short enough to be a bubble. Both now point at one
class, `.lchat-code`, and the surviving size is the doc card's.

## How to verify

Visual: open a conversation and send a message containing a filename, a long
path, and a fenced block. The filename should sit level with the sentence, its
plate a gentle tint of the bubble rather than a lighter rectangle; the fenced
block should not draw a plate inside a plate. Check light and dark, and both an
assistant bubble and your own (brand-fill) bubble — they are now the same rule.

```bash
cd lemma-frontend && npm run check   # design audit, lint, typecheck, edu anchors
cd lemma-frontend && npm test        # 97 files, 1051 tests passed
```

## Note on the second commit

The first cut of this rule used `font-size: 0.9em` and `padding: 0.1em 0.32em`,
which moved two design-audit counters (`rawFontSizeDeclaration` 9 → 10,
`rawSpacingDeclaration` 1 → 2) and turned CI red. That gate is a ratchet and the
counters are hand-picked values in a feature stylesheet — precisely the drift it
exists to catch, and precisely what `assistant-chat.css`'s own header promises
the sheet never does. Fixed by putting the values on the scales, not by moving
the baseline, which is untouched.

Relative sizing was the wrong instrument regardless: it reads as a general
solution but buys nothing here, because every voice in the transcript is already
`--text-sm`, so `0.9em` and `--text-xs` land within half a pixel of each other.

## Checklist

- [x] Lint, typecheck, and architecture gates pass locally — `npm run check` is
      green apart from one *local-only* eslint error in `lib/auth/logout.ts`
      (untouched here): my `node_modules` carries
      `@next/eslint-plugin-next@16.2.9` while `package-lock.json` pins 16.3.2,
      which is the version that defines the rule the file disables. CI runs
      `npm ci`, so the comment resolves there.

Tests: no behavioral change to cover — this is presentation, and the assertion
that would catch a regression is a class name, which breaks on every restyle
without catching a design mistake. The verification is visual, described above.

## Compatibility and rollback notes

Frontend CSS and two className strings. Nothing generated, no API surface, no
migration. Revert the commits.
