### PR TITLE
Fit the progress update to the surface showing it, and wait two minutes before saying "still working"

### DIFF
--- a/lemma-backend/app/modules/agent_surfaces/platforms/platform_capabilities.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/platform_capabilities.py
@@ -81,6 +81,15 @@ class PlatformCapabilities:
     # ``ProgressStyle`` — the observer branches on this instead of on three
     # hand-maintained platform sets.
     progress_style: ProgressStyle = ProgressStyle.NONE
+    # Does the progress update land somewhere that holds only one line?
+    #
+    # Telegram's is a ``tg-thinking`` chip, and its HTML collapses newlines the
+    # way a browser does: a five-line checklist arrives as one run-on sentence
+    # with the ✅/⏳/⬜ marks stranded mid-paragraph, dimmed to the point of
+    # looking like glyphs the font is missing. The fix is not per-platform
+    # escaping — the text is already plain — it is sending one line where one
+    # line is what will be shown.
+    progress_is_one_line: bool = False
     # Hours after the person's last inbound message during which free-form
     # replies are allowed. WhatsApp's 24h customer-service rule is real: past it
     # a send is refused unless it is a pre-approved template. None means no
@@ -220,6 +229,12 @@ PLATFORM_CAPABILITIES: dict[str, PlatformCapabilities] = {
         formatting_style=_TELEGRAM_FORMATTING,
         soft_char_limit=3500,
         progress_style=ProgressStyle.EDIT,
+        # A DM's live update is a thinking chip — one line, newlines collapsed.
+        # A group's is a plain edited message, which would hold a checklist, but
+        # a platform showing two different shapes of the same update is worth
+        # less than either shape: the DM is where nearly every run is watched,
+        # and one line is what a DM can show.
+        progress_is_one_line=True,
     ),
     "GMAIL": PlatformCapabilities(
         platform="GMAIL",

--- a/lemma-backend/app/modules/agent_surfaces/services/progress_display.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/progress_display.py
@@ -14,7 +14,9 @@ the whole design:
     same message is closed with it, so steps and answer are one thing. Slack.
 ``EDIT``
     One live message, rewritten as the work moves. Cheap — an edit costs no new
-    notification — so it can be refreshed freely. Telegram, Teams.
+    notification — so it can be refreshed freely. Telegram, Teams. How much fits
+    in it is the platform's own answer (``progress_is_one_line``): Teams holds
+    the checklist, Telegram's thinking chip holds a line.
 ``POST``
     No edit API at all. An update can only be a *new* message in someone's chat,
     which costs their attention and, on WhatsApp, sits inside a metered 24-hour
@@ -36,7 +38,10 @@ from app.modules.agent_surfaces.platforms.platform_capabilities import (
 from app.modules.agent_surfaces.services.progress_events import (
     _progress_text_from_event,
 )
-from app.modules.agent_surfaces.services.progress_plan import render_plan
+from app.modules.agent_surfaces.services.progress_plan import (
+    render_plan,
+    render_plan_line,
+)
 
 # How often a live, edited progress message may be rewritten. Slack never comes
 # through here: it streams the answer token by token, and a step chunk appended
@@ -48,11 +53,20 @@ _MIN_TEXT_PROGRESS_INTERVAL_SECONDS = 2.0
 # an agent only writes one for real multi-step work, and "here are the five
 # things I am about to do" is the most useful thing the person can be told at the
 # start of a long run. Everything after it waits its turn.
-_POST_PROGRESS_MIN_INTERVAL_SECONDS = 45.0
+#
+# Two minutes, not the 45s this started at. The number is not a throttle on how
+# fast we *could* send; it is how long a person is willing to be told nothing
+# before they read silence as broken. Under a minute is well inside the time an
+# ordinary multi-step run takes to move one step, so the second message arrived
+# saying nearly the same thing as the first — which is how a progress feed turns
+# into noise. At two minutes an update means a step actually landed.
+_POST_PROGRESS_MIN_INTERVAL_SECONDS = 120.0
 _POST_PROGRESS_MAX_PER_RUN = 5
 # With no plan there is nothing substantive to report, so a long run gets one
-# acknowledgement that it is still alive and nothing more.
-_POST_HEARTBEAT_DELAY_SECONDS = 60.0
+# acknowledgement that it is still alive and nothing more. Held to the same two
+# minutes: a run that finishes in ninety seconds should never have said anything
+# at all, and at a minute most of them were still going to beat the answer to it.
+_POST_HEARTBEAT_DELAY_SECONDS = 120.0
 _POST_HEARTBEAT_TEXT = (
     "Still working on this — it is a longer one. "
     "I will send the answer as soon as I have it."
@@ -80,11 +94,21 @@ class ProgressDisplayMixin:
             return
         activity = _progress_text_from_event(event)
         if capabilities.progress_style is ProgressStyle.EDIT:
-            await self._edit_live_progress(conversation_id, activity)
+            await self._edit_live_progress(
+                conversation_id,
+                activity,
+                one_line=capabilities.progress_is_one_line,
+            )
         elif capabilities.progress_style is ProgressStyle.POST:
             await self._maybe_post_progress(conversation_id, activity)
 
-    async def _edit_live_progress(self, conversation_id, activity: str | None) -> None:
+    async def _edit_live_progress(
+        self,
+        conversation_id,
+        activity: str | None,
+        *,
+        one_line: bool,
+    ) -> None:
         """Rewrite the one live message: the plan, then what is happening now.
 
         A plan that has moved is always worth an edit — that is the update the
@@ -105,7 +129,7 @@ class ProgressDisplayMixin:
                 < _MIN_TEXT_PROGRESS_INTERVAL_SECONDS
             ):
                 return
-        body = self._live_progress_body(activity)
+        body = self._live_progress_body(activity, one_line=one_line)
         if not body:
             return
         self._last_text_progress = activity
@@ -114,8 +138,22 @@ class ProgressDisplayMixin:
             self._shown_plan_signature = self._plan.signature
         await self._stream_progress(conversation_id, body)
 
-    def _live_progress_body(self, activity: str | None) -> str:
-        """The checklist over the current step, for a message that gets edited."""
+    def _live_progress_body(self, activity: str | None, *, one_line: bool) -> str:
+        """The checklist over the current step, for a message that gets edited.
+
+        Where the surface holds one line, the plan is drawn as that one line and
+        the activity is dropped rather than appended: the step being worked on
+        already names the moment the tool name was naming, and a chip that has
+        to choose is better off saying "Render the video" than "Using
+        execute_python". With no plan there is nothing but the activity, which is
+        what this showed before plans were drawn at all — folded onto one line
+        too, because a tool's comment is free text and a surface that collapses
+        newlines will run a two-line one together without the space.
+        """
+        if one_line:
+            if self._plan is not None:
+                return render_plan_line(self._plan)
+            return " ".join((activity or "").split())
         plan_text = render_plan(self._plan) if self._plan is not None else ""
         if plan_text and activity:
             return f"{plan_text}\n\n{activity}"

--- a/lemma-backend/app/modules/agent_surfaces/services/progress_plan.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/progress_plan.py
@@ -12,9 +12,16 @@ steps are done" is the whole answer to "is this still working". Here the
 checklist is parsed back out of the tool's own return value and drawn as a
 checklist.
 
-The drawing is deliberately emoji and plain text — no Markdown. It renders
-identically on WhatsApp, Telegram and Teams, and it cannot unbalance a delimiter
-or need per-platform escaping on the way out.
+The drawing is deliberately emoji and plain text — no Markdown. It cannot
+unbalance a delimiter or need per-platform escaping on the way out.
+
+It is drawn two ways, because a surface either has room for a checklist or it
+does not. WhatsApp and Teams get the checklist. Telegram's live update is a
+``tg-thinking`` chip whose HTML collapses newlines, so the checklist arrived
+there as one run-on sentence with the marks stranded between the words — five
+lines of structure flattened into something that read like a fault. What fits a
+chip is one line, and :func:`render_plan_line` draws it: how far along the run
+is, and the step it is on.
 """
 
 from __future__ import annotations
@@ -122,10 +129,36 @@ def render_plan(plan: SurfacePlan) -> str:
     return "\n".join(lines)
 
 
+def render_plan_line(plan: SurfacePlan) -> str:
+    """Draw the plan as one line, for a surface with room for exactly one.
+
+    Telegram's live progress is a thinking chip: one line of dimmed text, whose
+    HTML eats the newlines a checklist is made of. So the checklist is not
+    shortened here, it is replaced — by the count, which says whether the run is
+    moving, and the step it is on, which says what it is doing. The marks go
+    with the lines they belonged to: with nothing above or below it, ``⏳`` has
+    nothing left to distinguish.
+
+    The step also displaces the tool. A chip that said ``Using execute_python``
+    was reporting the same moment as "Render the video" in the language of the
+    machine rather than the language of the ask.
+    """
+    if not plan.items:
+        return ""
+    if plan.done_count >= plan.total:
+        return _headline(plan)
+    active = next(item for item in plan.items if not item.done)
+    return f"{_progress_count(plan)} · {_clip(active.text)}"
+
+
 def _headline(plan: SurfacePlan) -> str:
     if plan.done_count >= plan.total:
         return f"All {plan.total} steps done — writing up the answer now."
-    return f"Working on it — {plan.done_count} of {plan.total} steps done."
+    return f"{_progress_count(plan)}."
+
+
+def _progress_count(plan: SurfacePlan) -> str:
+    return f"Working on it — {plan.done_count} of {plan.total} steps done"
 
 
 def _body_lines(plan: SurfacePlan) -> list[str]:

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_progress_observer.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_progress_observer.py
@@ -1035,7 +1035,7 @@ async def test_the_plan_is_drawn_as_a_checklist_not_as_using_write_todos():
     """
     service = _SurfaceService()
     observer = _observer(service)
-    conversation = _conversation("TELEGRAM")
+    conversation = _conversation("TEAMS")
 
     await observer.on_event(
         _plan_return("- [x] Pull the Q3 numbers", "- [ ] Draft the summary"),
@@ -1048,6 +1048,28 @@ async def test_the_plan_is_drawn_as_a_checklist_not_as_using_write_todos():
     assert "Working on it — 1 of 2 steps done." in body
     assert "✅ Pull the Q3 numbers" in body
     assert "⏳ Draft the summary" in body
+
+
+async def test_telegram_gets_the_plan_as_one_line_because_its_chip_holds_one():
+    """A checklist in a ``tg-thinking`` chip is a run-on sentence.
+
+    The chip collapses newlines, so five lines arrived as one paragraph with the
+    marks stranded between the words — and the tool name trailing it said the
+    same thing as the step, worse.
+    """
+    service = _SurfaceService()
+    observer = _observer(service)
+    conversation = _conversation("TELEGRAM")
+
+    await observer.on_event(
+        _plan_return("- [x] Write the scene", "- [ ] Render the video"),
+        conversation,
+        SimpleNamespace(),
+    )
+
+    body = service.progress[-1]["progress_text"]
+    assert body == "Working on it — 1 of 2 steps done · Render the video"
+    assert "\n" not in body
 
 
 async def test_a_plan_that_has_not_moved_does_not_spend_an_update():
@@ -1189,3 +1211,26 @@ async def test_email_gets_no_indicator_from_the_observer():
 
     assert service.calls == []
     assert service.streamed == []
+
+
+async def test_a_one_line_surface_folds_a_multi_line_tool_comment():
+    """A tool's comment is free text, and Telegram's chip eats the newlines.
+
+    Two lines run together into one word without them, so the fold happens here
+    rather than in the surface that cannot show it.
+    """
+    service = _SurfaceService()
+    observer = _observer(service)
+    conversation = _conversation("TELEGRAM")
+    event = AgentEvent(
+        type=AgentEventType.MESSAGE,
+        data=MessageDraft.of_tool_call(
+            tool_name="execute_python",
+            tool_call_id="tool-2",
+            tool_args={"request": {"comment": "Rendering the scene\nat 1080p"}},
+        ),
+    )
+
+    await observer.on_event(event, conversation, SimpleNamespace())
+
+    assert service.progress[-1]["progress_text"] == "Rendering the scene at 1080p"

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_progress_plan.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_progress_plan.py
@@ -12,6 +12,7 @@ from app.modules.agent.domain.value_objects import (
 from app.modules.agent_surfaces.services.progress_plan import (
     plan_from_event,
     render_plan,
+    render_plan_line,
 )
 
 
@@ -99,3 +100,34 @@ def test_the_rendering_carries_no_markdown():
     plan = plan_from_event(_return({"todos": ["- [ ] Ship **it**"]}))
     assert plan is not None
     assert render_plan(plan) == "Working on it — 0 of 1 steps done.\n⏳ Ship **it**"
+
+
+def test_a_one_line_surface_gets_the_count_and_the_step_it_is_on():
+    """Telegram's thinking chip collapses newlines, so it gets one line.
+
+    Not a shortened checklist — the marks mean nothing with no lines to
+    distinguish, and what is left is the two things the person is asking: is it
+    moving, and what is it doing.
+    """
+    plan = plan_from_event(
+        _return({"todos": ["- [x] Write the scene", "- [ ] Render", "- [ ] Verify"]})
+    )
+    assert plan is not None
+    line = render_plan_line(plan)
+    assert line == "Working on it — 1 of 3 steps done · Render"
+    assert "\n" not in line
+
+
+def test_a_finished_plan_says_so_on_one_line_too():
+    # No step left to be on, so the headline is the whole line.
+    plan = plan_from_event(_return({"todos": ["- [x] One", "- [x] Two"]}))
+    assert plan is not None
+    assert render_plan_line(plan) == "All 2 steps done — writing up the answer now."
+
+
+def test_the_one_line_step_is_clipped_like_the_checklist_one():
+    plan = plan_from_event(_return({"todos": ["- [ ] " + "x" * 200]}))
+    assert plan is not None
+    line = render_plan_line(plan)
+    assert line.endswith("…")
+    assert len(line) < 130


### PR DESCRIPTION
## What changes

Two fixes to the surface progress update shipped in #465.

**Telegram gets one line instead of a collapsed checklist.** A DM's live progress is a `sendRichMessageDraft` → `<tg-thinking>` chip, and that HTML collapses newlines the way a browser does. The checklist arrived as one run-on paragraph with the marks stranded mid-sentence and dimmed until they read as glyphs the font is missing:

- before — `Working on it — 1 of 3 steps done. ⬜Write the Manim scene (First Law of Motion) ⏳ Render the video ⬜ Verify output and deliver Using execute_python`
- after — `Working on it — 1 of 3 steps done · Render the video`
- finishing — `All 3 steps done — writing up the answer now.`

A surface now declares whether its update holds one line (`progress_is_one_line`, true for Telegram) and `render_plan_line` draws it: the count, plus the step it is on. No marks — with no lines above or below, `⏳` has nothing left to distinguish — and no trailing tool name, since "Render the video" reports the same moment as "Using execute_python" in the language of the ask. WhatsApp and Teams keep the full checklist, which renders properly there.

**"Still working" waits two minutes, not 45–60 seconds.** `_POST_PROGRESS_MIN_INTERVAL_SECONDS` 45s → 120s and `_POST_HEARTBEAT_DELAY_SECONDS` 60s → 120s.

Also folds a multi-line tool comment onto one line for a one-line surface.

## Why

Reported from a real Telegram run: the update looked broken, and the follow-up message came too early to be worth its interruption. Neither delay is a throttle on how fast we *could* send — it is how long someone will be told nothing before they read silence as broken. Under a minute is inside the time an ordinary multi-step run takes to move one step, so the second message said nearly what the first did, and a run finishing in ninety seconds should never have said "still working on this" at all.

Telegram groups take the one-line shape too, even though their fallback is a plain edited message that *would* hold a checklist: one platform showing two shapes of the same update is worth less than either shape, and the DM is where nearly every run is watched.

## How to verify

```bash
cd lemma-backend && uv run pytest app/modules/agent_surfaces/tests/unit -q \
  --deselect app/modules/agent_surfaces/tests/unit/test_telegram_manager_service.py::test_redis_store_enforces_atomic_state_and_claims
make lint
make architecture
```

- `897 passed, 1 deselected` — the deselected test needs a local Redis and fails on `main` too.
- `make architecture` → `Architecture ratchet passed (12 inherited import violations, 0 inherited cycles)`, settings and route-inventory checks current.
- `make lint` clean (frontend eslint skipped locally: needs `npm ci`).

New tests: `test_telegram_gets_the_plan_as_one_line_because_its_chip_holds_one`, `test_a_one_line_surface_folds_a_multi_line_tool_comment`, and three for `render_plan_line`. The existing checklist assertion moved to a Teams conversation, which is now the platform that shows one.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

Copy and timing only — no migration, no API or SDK surface, no new dependency. `progress_is_one_line` is a new capability field defaulting to `False`, so every other platform is untouched. Revert the commit to restore the previous behaviour; nothing persists across a deploy.

## Reviewer note

I could not verify from here whether `<tg-thinking>` would honour an explicit `<br>` and so could keep a real checklist. One line is the right shape for a status chip regardless, but if we would rather keep the structure on Telegram, that is the thing to test against the live bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
