### PR TITLE
Attach the file, instead of a link only a Lemma account can open

### DIFF
--- a/lemma-backend/app/modules/agent_surfaces/domain/ports.py
+++ b/lemma-backend/app/modules/agent_surfaces/domain/ports.py
@@ -342,7 +342,8 @@ class SurfacePlatformAdapterPort(Protocol):
     ) -> bool: ...
 
     # True when the file was delivered natively; False → caller should fall back
-    # to sending an app/public URL link instead.
+    # to sending a Lemma app deep link instead (not a public download URL —
+    # it only opens for a recipient with pod access).
 
     async def list_channels(
         self, *, credentials: dict[str, Any]

--- a/lemma-backend/app/modules/agent_surfaces/platforms/attachment_limits.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/attachment_limits.py
@@ -1,38 +1,105 @@
 """Per-platform attachment size caps for surface file delivery.
 
 Egress (``display_resource`` type=FILE and email replies) attaches a file's
-bytes natively when the file is at or below the platform's cap, and otherwise
-falls back to an app/public URL link. Inbound auto-ingest skips downloading
-attachments larger than ``INBOUND_ATTACHMENT_BYTE_CAP``.
+bytes natively when the file is at or below the platform's cap. What the
+fallback is differs by surface, and the difference matters: an email reply
+appends a *signed* download URL that anyone holding it can fetch, while a chat
+surface falls back to a Lemma app deep link that only opens for a recipient who
+can sign in to the pod. A chat recipient without a Lemma account gets nothing
+they can open, so the chat caps below are a delivery guarantee for them, not a
+formatting preference. Inbound auto-ingest skips downloading attachments larger
+than ``INBOUND_ATTACHMENT_BYTE_CAP``.
 
-Caps are conservative approximations of each platform's documented limits; they
-are the inline-vs-link threshold, not a hard API guarantee.
+Three things the numbers here have to respect, each of which was wrong once:
+
+* **A ceiling can depend on the media type.** WhatsApp's Cloud API caps an image
+  at 5 MB and a document at 100 MB — a twentyfold spread behind one platform
+  name. One number per platform meant either refusing documents we could send or
+  attempting images Meta rejects, so ``attachment_cap`` takes the media kind.
+* **Email is measured after base64.** A MIME attachment goes on the wire
+  base64-encoded, ~4 bytes per 3, so a provider's 25 MB ceiling is roughly
+  17 MB of file. ``email_inline_cap`` does that conversion; the table holds the
+  provider's on-the-wire number, not a pre-adjusted one.
+* **The soft cap is a chat idea.** It exists so a chat stays light, and it costs
+  nothing there because a smaller file is still delivered. On email it would
+  only downgrade a working attachment to a link, so email does not apply it.
 """
 
 from __future__ import annotations
 
+from enum import StrEnum
+
+_KB = 1024
 _MB = 1024 * 1024
 
-# Native-attachment ceilings per platform (bytes). At or below → attach inline;
-# above → deliver a URL link instead.
+
+class MediaKind(StrEnum):
+    """How a platform will send a file, derived from its MIME type.
+
+    The values double as WhatsApp's Cloud API send types (``resolve_whatsapp_send_type``
+    returns these), so the cap consulted here and the endpoint the sender actually
+    calls cannot disagree — which is the only way a per-type cap is worth having.
+    """
+
+    IMAGE = "image"
+    AUDIO = "audio"
+    VIDEO = "video"
+    STICKER = "sticker"
+    DOCUMENT = "document"
+
+
+def media_kind_for_mime(mime_type: str | None) -> MediaKind:
+    """Classify a MIME type into the kind of send a platform will perform."""
+    mime = str(mime_type or "").strip().lower()
+    if mime.startswith("image/"):
+        return MediaKind.IMAGE
+    if mime.startswith("audio/"):
+        return MediaKind.AUDIO
+    if mime.startswith("video/"):
+        return MediaKind.VIDEO
+    return MediaKind.DOCUMENT
+
+
+# Hard ceiling for one native attachment, as each platform's own API documents
+# it: bytes on the wire. For email that is the encoded size, so callers there
+# want ``email_inline_cap`` rather than this.
 SURFACE_ATTACHMENT_BYTE_CAPS: dict[str, int] = {
     "SLACK": 30 * _MB,
     "TELEGRAM": 50 * _MB,  # Bot API sendDocument ceiling
-    "WHATSAPP": 16 * _MB,  # Cloud API media ceiling (documents)
+    "WHATSAPP": 100 * _MB,  # documents; other kinds are far lower, see below
     "TEAMS": 25 * _MB,
     "GMAIL": 25 * _MB,
     "OUTLOOK": 25 * _MB,
-    "RESEND": 25 * _MB,  # Resend total-message ceiling is ~40 MB
+    "RESEND": 40 * _MB,  # total-message ceiling
+}
+
+# WhatsApp is the one platform whose ceiling moves with the media type. Keyed by
+# ``MediaKind``; anything absent falls back to the platform's entry above.
+_PER_MEDIA_BYTE_CAPS: dict[str, dict[MediaKind, int]] = {
+    "WHATSAPP": {
+        MediaKind.IMAGE: 5 * _MB,
+        MediaKind.AUDIO: 16 * _MB,
+        MediaKind.VIDEO: 16 * _MB,
+        MediaKind.STICKER: 100 * _KB,
+        MediaKind.DOCUMENT: 100 * _MB,
+    },
 }
 
 # Default cap for any platform not listed above.
 _DEFAULT_ATTACHMENT_BYTE_CAP = 16 * _MB
 
-# Universal soft cap on inline attachments: above this we prefer a tidy link even
-# when the platform's hard ceiling is higher. Keeps chats light and avoids pushing
-# large payloads when a link reads better. The effective inline cap is the smaller
-# of this and the platform's hard ceiling.
-SURFACE_INLINE_SOFT_BYTE_CAP = 5 * _MB
+# Universal soft cap on inline attachments to a *chat* surface: above this we
+# prefer a tidy link even when the platform's hard ceiling is higher. The
+# effective chat cap is the smaller of this and the platform's ceiling. Raising
+# it trades worker memory (the whole file is held in memory to upload) for a
+# delivery guarantee, which is the better trade whenever the recipient may have
+# no Lemma account and so cannot open the link fallback at all.
+SURFACE_INLINE_SOFT_BYTE_CAP = 20 * _MB
+
+# Raw bytes per 10 bytes on the wire, for an email attachment. base64 is 4 chars
+# per 3 bytes (a 1.333x expansion); the rest of the margin covers the encoder's
+# line breaks, the MIME headers, and the message body sharing the same ceiling.
+_EMAIL_RAW_BYTES_PER_TEN_WIRE = 7
 
 # Largest inbound attachment we will download + persist to the datastore.
 INBOUND_ATTACHMENT_BYTE_CAP = 50 * _MB
@@ -43,24 +110,97 @@ INBOUND_ATTACHMENT_BYTE_CAP = 50 * _MB
 INBOUND_VOICE_TRANSCRIBE_BYTE_CAP = 25 * _MB
 
 
-def attachment_cap(platform: str | None) -> int:
-    """Return the native-attachment hard byte ceiling for a platform."""
+def attachment_cap(platform: str | None, *, media_kind: MediaKind | None = None) -> int:
+    """Hard on-the-wire ceiling for one native attachment.
+
+    ``media_kind`` matters only where a platform caps media types separately
+    (WhatsApp); elsewhere it is ignored and the platform's single ceiling applies.
+    """
     key = str(platform or "").upper()
+    per_media = _PER_MEDIA_BYTE_CAPS.get(key)
+    if per_media is not None and media_kind is not None:
+        capped = per_media.get(media_kind)
+        if capped is not None:
+            return capped
     return SURFACE_ATTACHMENT_BYTE_CAPS.get(key, _DEFAULT_ATTACHMENT_BYTE_CAP)
 
 
-def inline_cap(platform: str | None) -> int:
-    """Effective inline cap: min(platform hard ceiling, universal soft cap)."""
-    return min(attachment_cap(platform), SURFACE_INLINE_SOFT_BYTE_CAP)
+def inline_cap(platform: str | None, *, media_kind: MediaKind | None = None) -> int:
+    """Effective chat inline cap: ``min(platform ceiling, universal soft cap)``."""
+    return min(
+        attachment_cap(platform, media_kind=media_kind),
+        SURFACE_INLINE_SOFT_BYTE_CAP,
+    )
 
 
-def fits_inline(platform: str | None, size_bytes: int | None) -> bool:
-    """True when a file of ``size_bytes`` should be attached natively on ``platform``.
+def email_inline_cap(platform: str | None) -> int:
+    """Largest *raw* file whose base64 form still fits the provider's ceiling.
 
-    Uses the effective inline cap (``min(hard ceiling, 5 MB soft cap)``). Unknown
-    size (``None``) is treated as too large → prefer a URL link, since we cannot
-    guarantee it fits.
+    No soft cap: an oversize email attachment degrades to a signed URL the
+    recipient can actually fetch, so shrinking the threshold would only mean
+    sending a link where an attachment would have worked.
+    """
+    return attachment_cap(platform) * _EMAIL_RAW_BYTES_PER_TEN_WIRE // 10
+
+
+def fits_inline(
+    platform: str | None,
+    size_bytes: int | None,
+    *,
+    mime_type: str | None = None,
+) -> bool:
+    """True when a file should be attached natively on a chat ``platform``.
+
+    Uses the effective chat cap for the kind of send ``mime_type`` implies.
+    Unknown size (``None``) is treated as too large → prefer a link, since we
+    cannot guarantee it fits.
     """
     if size_bytes is None:
         return False
-    return 0 <= size_bytes <= inline_cap(platform)
+    cap = inline_cap(platform, media_kind=media_kind_for_mime(mime_type))
+    return 0 <= size_bytes <= cap
+
+
+def media_cap_summary(platform: str | None) -> str | None:
+    """Human phrase for the kinds a platform caps below its headline number.
+
+    ``None`` when one number covers every kind, which is every platform but
+    WhatsApp. Used to keep the agent-facing guidance honest without hard-coding
+    Meta's table into a prompt string.
+    """
+    key = str(platform or "").upper()
+    per_media = _PER_MEDIA_BYTE_CAPS.get(key)
+    if not per_media:
+        return None
+    headline = inline_cap(platform, media_kind=MediaKind.DOCUMENT)
+    lower = {
+        kind: min(cap, SURFACE_INLINE_SOFT_BYTE_CAP)
+        for kind, cap in per_media.items()
+        if kind is not MediaKind.STICKER
+        and min(cap, SURFACE_INLINE_SOFT_BYTE_CAP) < headline
+    }
+    if not lower:
+        return None
+    by_cap: dict[int, list[str]] = {}
+    for kind, cap in sorted(lower.items(), key=lambda item: item[1]):
+        by_cap.setdefault(cap, []).append(_MEDIA_KIND_LABELS[kind])
+    return "; ".join(
+        f"{_join(kinds)} up to {cap // _MB} MB" for cap, kinds in by_cap.items()
+    )
+
+
+# Plain-English label per kind, for ``media_cap_summary``. Not derivable by
+# adding an "s" — "audios" is not a word.
+_MEDIA_KIND_LABELS: dict[MediaKind, str] = {
+    MediaKind.IMAGE: "images",
+    MediaKind.AUDIO: "audio",
+    MediaKind.VIDEO: "video",
+    MediaKind.STICKER: "stickers",
+    MediaKind.DOCUMENT: "documents",
+}
+
+
+def _join(parts: list[str]) -> str:
+    if len(parts) == 1:
+        return parts[0]
+    return f"{', '.join(parts[:-1])} and {parts[-1]}"

--- a/lemma-backend/app/modules/agent_surfaces/platforms/base.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/base.py
@@ -364,7 +364,8 @@ class BaseSurfaceAdapter:
         """Deliver a file's bytes natively on the platform.
 
         Default: platform has no native file send → return False so the caller
-        falls back to sending an app/public URL link.
+        falls back to sending a Lemma app deep link (not a public download
+        URL — it only opens for a recipient with pod access).
         """
         del credentials, event, file_name, file_bytes, mime_type, caption
         return False

--- a/lemma-backend/app/modules/agent_surfaces/platforms/gmail/service.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/gmail/service.py
@@ -17,7 +17,7 @@ from app.modules.agent_surfaces.domain.models import (
 from app.modules.agent_surfaces.domain.surface_event_metadata import (
     GmailSurfaceEventMetadata,
 )
-from app.modules.agent_surfaces.platforms.attachment_limits import inline_cap
+from app.modules.agent_surfaces.platforms.attachment_limits import email_inline_cap
 from app.modules.agent_surfaces.platforms.common import text_or_none
 from app.modules.agent_surfaces.platforms.email_attachments import (
     append_attachment_links,
@@ -194,7 +194,7 @@ class GmailPlatformService:
             attachments, links = await resolve_outbound_email_attachments(
                 ctx.deps,
                 request.attachment_paths,
-                inline_cap_bytes=inline_cap("GMAIL"),
+                inline_cap_bytes=email_inline_cap("GMAIL"),
             )
             return append_attachment_links(request.content, links), attachments, None
 

--- a/lemma-backend/app/modules/agent_surfaces/platforms/outlook/service.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/outlook/service.py
@@ -17,7 +17,7 @@ from app.modules.agent_surfaces.domain.models import (
 from app.modules.agent_surfaces.domain.surface_event_metadata import (
     OutlookSurfaceEventMetadata,
 )
-from app.modules.agent_surfaces.platforms.attachment_limits import inline_cap
+from app.modules.agent_surfaces.platforms.attachment_limits import email_inline_cap
 from app.modules.agent_surfaces.platforms.email_attachments import (
     append_attachment_links,
     resolve_outbound_email_attachment_urls,
@@ -222,7 +222,7 @@ class OutlookPlatformService:
             inline_files, links = await resolve_outbound_email_attachments(
                 ctx.deps,
                 request.attachment_paths,
-                inline_cap_bytes=inline_cap("OUTLOOK"),
+                inline_cap_bytes=email_inline_cap("OUTLOOK"),
             )
             return (
                 append_attachment_links(request.content, links),

--- a/lemma-backend/app/modules/agent_surfaces/platforms/platform_capabilities.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/platform_capabilities.py
@@ -18,8 +18,11 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 from app.modules.agent_surfaces.platforms.attachment_limits import (
+    MediaKind,
     attachment_cap,
+    email_inline_cap,
     inline_cap,
+    media_cap_summary,
 )
 
 
@@ -127,8 +130,26 @@ class PlatformCapabilities:
 
     @property
     def inline_mb_cap(self) -> int:
-        """Effective inline cap in MB: ``min(hard ceiling, 5 MB soft cap)``."""
-        return inline_cap(self.platform) // (1024 * 1024)
+        """Effective inline cap in MB, as the number to quote to the agent.
+
+        The two surface families measure the file differently, and quoting the
+        wrong one is how the prompt came to promise email attachments the
+        provider would reject: a chat cap is raw bytes bounded by the soft cap,
+        while an email cap is raw bytes whose *base64* form must clear the
+        provider ceiling. On a platform with per-media ceilings this is the
+        document number — ``media_cap_summary`` carries the smaller kinds.
+        """
+        effective = (
+            email_inline_cap(self.platform)
+            if self.is_email
+            else inline_cap(self.platform, media_kind=MediaKind.DOCUMENT)
+        )
+        return effective // (1024 * 1024)
+
+    @property
+    def media_cap_note(self) -> str | None:
+        """Phrase for kinds capped below ``inline_mb_cap``, or None if uniform."""
+        return None if self.is_email else media_cap_summary(self.platform)
 
 
 _SLACK_FORMATTING = (
@@ -177,7 +198,12 @@ PLATFORM_CAPABILITIES: dict[str, PlatformCapabilities] = {
         platform="TEAMS",
         display_name="Microsoft Teams",
         supports_native_choices=True,
-        supports_native_files=True,
+        # False, and not an oversight: `TeamsSurfaceAdapter` never overrides
+        # `send_file_attachment`, so the base adapter's stub refuses and every
+        # Teams file — any size — is delivered as a link. Claiming True here told
+        # the agent its files would arrive as attachments, which they never do.
+        # Flip this back the day an outbound Teams file upload exists.
+        supports_native_files=False,
         is_email=False,
         is_channel_capable=True,
         markdown_mode="limited_markdown",
@@ -330,12 +356,33 @@ def platform_agent_guidance(platform: str | None) -> str:
         # Chat surfaces: files always, forms only where native.
         delivery: list[str] = ["## Delivering things"]
         if caps.supports_native_files:
+            media_note = (
+                f" {caps.display_name} is stricter about some kinds: "
+                f"{caps.media_cap_note} — over that they become a link too."
+                if caps.media_cap_note
+                else ""
+            )
             delivery.append(
-                "- Files: call `display_resource` with `type=FILE, path=<workspace "
-                "path>`. The surface delivers the file to the user automatically — "
-                "never paste raw bytes or a link. Files up to "
-                f"{caps.inline_mb_cap} MB attach natively; larger files are sent "
-                "as a download link automatically."
+                "- Files: call `display_resource` with `type=FILE, path=<pod file "
+                "path>` — a pod path such as `/me/reports/q3.pdf`, never a "
+                "sandbox/workspace path. The surface delivers the file to the user "
+                "automatically — never paste raw bytes or a link. Files up to "
+                f"{caps.inline_mb_cap} MB arrive as a real attachment in the chat."
+                f"{media_note} A file over the limit cannot be attached, so it is "
+                "sent as a link into Lemma instead — and that link only opens for "
+                "someone who can sign in to this pod. If the person may not have a "
+                "Lemma account, get the file under the limit (compress it, split "
+                "it, or send the part that matters) so it arrives as an attachment."
+            )
+        else:
+            delivery.append(
+                "- Files: call `display_resource` with `type=FILE, path=<pod file "
+                "path>` — a pod path such as `/me/reports/q3.pdf`, never a "
+                f"sandbox/workspace path. {caps.display_name} cannot receive a file "
+                "attachment from Lemma, so the file is always delivered as a link "
+                "into Lemma, which only opens for someone who can sign in to this "
+                "pod. If the person may not have a Lemma account, put what the file "
+                "would have told them in your reply as well."
             )
         if caps.supports_native_choices:
             delivery.append(

--- a/lemma-backend/app/modules/agent_surfaces/platforms/resend/service.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/resend/service.py
@@ -25,7 +25,7 @@ from app.modules.agent_surfaces.domain.models import (
 from app.modules.agent_surfaces.domain.surface_event_metadata import (
     ResendSurfaceEventMetadata,
 )
-from app.modules.agent_surfaces.platforms.attachment_limits import attachment_cap
+from app.modules.agent_surfaces.platforms.attachment_limits import email_inline_cap
 from app.modules.agent_surfaces.platforms.email_attachments import (
     append_attachment_links,
     resolve_outbound_email_attachments,
@@ -279,7 +279,7 @@ class ResendPlatformService:
         attachments, attachment_links = await resolve_outbound_email_attachments(
             ctx.deps,
             request.attachment_paths,
-            inline_cap_bytes=attachment_cap("RESEND"),
+            inline_cap_bytes=email_inline_cap("RESEND"),
         )
         content = append_attachment_links(request.content, attachment_links)
 

--- a/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/payloads.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/payloads.py
@@ -23,6 +23,7 @@ from app.modules.agent_surfaces.domain.models import (
     SurfaceDisplayRenderPlan,
     SurfaceQuestion,
 )
+from app.modules.agent_surfaces.platforms.attachment_limits import media_kind_for_mime
 from app.modules.agent_surfaces.platforms.rendering import chunk_text
 from app.modules.agent_surfaces.platforms.whatsapp.text_format import (
     balance_whatsapp_delimiters,
@@ -132,16 +133,17 @@ def build_whatsapp_approval_interactive(
 
 
 def resolve_whatsapp_send_type(*, delivery_mode: str, mime_type: str) -> str:
+    """The Cloud API media type this file will be sent as.
+
+    Delegates the ``auto`` case to ``media_kind_for_mime`` because Meta caps each
+    media type separately (an image at 5 MB, a document at 100 MB) and
+    ``attachment_cap`` reads those caps off the same classification. Two copies of
+    this branch would let the size check clear a file the send then rejects.
+    """
     requested = str(delivery_mode or "auto").lower()
     if requested != "auto":
         return requested
-    if mime_type.startswith("image/"):
-        return "image"
-    if mime_type.startswith("audio/"):
-        return "audio"
-    if mime_type.startswith("video/"):
-        return "video"
-    return "document"
+    return media_kind_for_mime(mime_type).value
 
 
 def whatsapp_message_bodies(message: str) -> list[str]:

--- a/lemma-backend/app/modules/agent_surfaces/services/surface_egress.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/surface_egress.py
@@ -218,7 +218,9 @@ class SurfaceEgressMixin(SurfaceEgressTargetMixin):
             tool_output=tool_output,
         )
         # A FILE resource is delivered as a native attachment when it fits the
-        # platform's cap; otherwise we fall through to the card+URL render plan.
+        # platform's cap; otherwise we fall through to the card render plan, whose
+        # action is a Lemma app deep link — openable only by a recipient with pod
+        # access, so this fallback is a dead end for an outside contact.
         if (
             display_request.type is DisplayResourceType.FILE
             and display_request.path
@@ -524,7 +526,8 @@ class SurfaceEgressMixin(SurfaceEgressTargetMixin):
         """Attach a pod file's bytes natively when it fits the platform cap.
 
         Returns True only when the file was delivered natively; on any failure
-        or an oversize file returns False so the caller sends a URL link instead.
+        or an oversize file returns False so the caller sends a Lemma app deep
+        link instead — which only opens for a recipient who can sign in to the pod.
         """
         platform = target.surface.surface_type.value
         try:
@@ -545,7 +548,12 @@ class SurfaceEgressMixin(SurfaceEgressTargetMixin):
                 entity = await file_service.get_file_by_path(
                     target.surface.pod_id, path, auth_ctx
                 )
-                if not fits_inline(platform, entity.size_bytes):
+                # The MIME type decides which ceiling applies on a platform that
+                # caps media types separately (WhatsApp: 5 MB an image, 100 MB a
+                # document), so pass it rather than let the largest one stand in.
+                if not fits_inline(
+                    platform, entity.size_bytes, mime_type=entity.mime_type
+                ):
                     return False
                 _entity, content = await file_service.download_file_content_by_path(
                     target.surface.pod_id, path, auth_ctx

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_display_resource_matrix_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_display_resource_matrix_e2e.py
@@ -8,24 +8,27 @@ tool entirely. These tests script the tool as a genuine LLM tool call so the
 tool's own size check and the surface's native-vs-link decision both run for
 real.
 
+The oversize cases lower ``SURFACE_INLINE_SOFT_BYTE_CAP`` rather than seeding a
+file past the real 20 MB cap — see ``_oversize_bytes``.
+
 N/A cells:
 - **Teams has no native file-send implementation at all**
   (``TeamsSurfaceAdapter`` doesn't override ``send_file_attachment``, so the
   base adapter's stub always returns ``False``) — every Teams file, regardless
   of size, falls back to a link card. Only one Teams case is needed since
   there is no size-threshold behavior to prove.
-- **WhatsApp's large-file link fallback isn't separately tested** — the
-  size-threshold decision (``fits_inline``) is generic, platform-agnostic
-  logic already proven on both Slack and Telegram; a third repetition would
-  just re-prove the same shared code path.
-- **Gmail/Outlook attachments never reach the recipient** — both use Composio
-  in this matrix (matching the existing Gmail/Outlook e2e pattern), and
-  Composio-connected Gmail/Outlook accounts don't support outbound
-  attachments yet (see ``GmailPlatformService.reply_email`` /
-  ``OutlookPlatformService.reply_email``): the tool call succeeds but reports
-  ``attachment_count=0`` with an explanatory message. That is the real,
-  current production behavior, so it's what's asserted here — not a
-  successful delivery.
+- **WhatsApp's per-media-kind thresholds are unit-tested, not covered here** —
+  ``fits_inline`` is no longer uniform across platforms: WhatsApp caps an image
+  at 5 MB and a document at 100 MB, so its threshold is the one that does *not*
+  follow from the Slack and Telegram cases. That branch is proven in
+  ``tests/unit/test_attachment_limits.py``; an e2e case driving an oversize
+  WhatsApp image through a real upload rejection is a genuine gap.
+- **Composio-connected Gmail/Outlook attach exactly one file, by URL** —
+  Composio's action takes a public/signed URL and fetches it server-side, so a
+  datastore path becomes a signed URL and any file after the first is appended
+  to the body as a link (see ``GmailPlatformService._resolve_reply_attachments``).
+  Both cases here assert ``attachment_count == 1``. Workspace paths cannot be
+  signed and come back as an "unresolved" note instead — also uncovered.
 """
 
 from __future__ import annotations
@@ -53,9 +56,7 @@ from app.modules.agent_surfaces.domain.ingress_request import (
     SurfaceScheduleIngress,
 )
 from app.modules.agent_surfaces.infrastructure.models import AgentSurface
-from app.modules.agent_surfaces.platforms.attachment_limits import (
-    SURFACE_INLINE_SOFT_BYTE_CAP,
-)
+from app.modules.agent_surfaces.platforms import attachment_limits
 from app.modules.agent_surfaces.tests.e2e.helpers import (
     REAL_TEAMS_CHANNEL_ID,
     REAL_TEAMS_TENANT_ID,
@@ -93,6 +94,21 @@ pytestmark = pytest.mark.e2e
 
 
 _TOOL_CALL_ID = "tool-display-1"
+
+# Threshold the oversize cases are driven at. The real soft cap is 20 MB, and a
+# 20 MB payload seeded through the datastore only to prove a branch that reads one
+# integer is memory and wall-clock for nothing — so lower the cap instead of
+# inflating the file. `inline_cap` reads the module global per call, which is what
+# makes this work.
+_TINY_INLINE_CAP_BYTES = 2048
+
+
+def _oversize_bytes(monkeypatch) -> bytes:
+    """Bytes guaranteed to exceed the inline cap, with the cap lowered to match."""
+    monkeypatch.setattr(
+        attachment_limits, "SURFACE_INLINE_SOFT_BYTE_CAP", _TINY_INLINE_CAP_BYTES
+    )
+    return b"x" * (_TINY_INLINE_CAP_BYTES + 1024)
 
 
 class _FakeScheduleManager:
@@ -206,7 +222,7 @@ async def test_display_resource_slack_large_file_falls_back_to_link(
         config={"type": "SLACK", "account_id": str(account.id)},
         toolsets=["USER_INTERACTION"],
     )
-    big = b"x" * (SURFACE_INLINE_SOFT_BYTE_CAP + 1024)
+    big = _oversize_bytes(monkeypatch)
     path = await _seed_pod_file(
         db_session,
         user_id=fixed_test_user["id"],
@@ -640,7 +656,7 @@ async def test_display_resource_telegram_large_file_falls_back_to_link(
         external_user_id=str(sender_id),
         resolved_user_id=UUID(fixed_test_user["id"]),
     )
-    big = b"x" * (SURFACE_INLINE_SOFT_BYTE_CAP + 1024)
+    big = _oversize_bytes(monkeypatch)
     path = await _seed_pod_file(
         db_session,
         user_id=fixed_test_user["id"],

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_attachment_limits.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_attachment_limits.py
@@ -1,0 +1,130 @@
+"""The inline-vs-link threshold, and the three ways it used to be wrong.
+
+Every test here corresponds to a file that either was refused when the platform
+would have taken it, or was attempted when the platform would not.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from app.modules.agent_surfaces.platforms.attachment_limits import (
+    SURFACE_ATTACHMENT_BYTE_CAPS,
+    SURFACE_INLINE_SOFT_BYTE_CAP,
+    MediaKind,
+    attachment_cap,
+    email_inline_cap,
+    fits_inline,
+    inline_cap,
+    media_cap_summary,
+    media_kind_for_mime,
+)
+from app.modules.agent_surfaces.platforms.whatsapp.payloads import (
+    resolve_whatsapp_send_type,
+)
+
+_MB = 1024 * 1024
+
+
+@pytest.mark.parametrize(
+    ("mime", "expected"),
+    [
+        ("image/png", MediaKind.IMAGE),
+        ("IMAGE/JPEG", MediaKind.IMAGE),
+        ("audio/ogg; codecs=opus", MediaKind.AUDIO),
+        ("video/mp4", MediaKind.VIDEO),
+        ("application/pdf", MediaKind.DOCUMENT),
+        ("", MediaKind.DOCUMENT),
+        (None, MediaKind.DOCUMENT),
+    ],
+)
+def test_media_kind_for_mime(mime, expected):
+    assert media_kind_for_mime(mime) is expected
+
+
+def test_whatsapp_send_type_and_cap_read_the_same_classification():
+    """The size check must agree with the endpoint the sender actually calls.
+
+    A per-type cap consulted from one MIME branch while the send picks its type
+    from another is worse than no per-type cap: it clears a file the API then
+    rejects, after a full download and upload.
+    """
+    for mime in ("image/png", "audio/ogg", "video/mp4", "application/pdf"):
+        send_type = resolve_whatsapp_send_type(delivery_mode="auto", mime_type=mime)
+        assert send_type == media_kind_for_mime(mime).value
+
+
+def test_whatsapp_caps_each_media_kind_separately():
+    """One number per platform was wrong by twentyfold across WhatsApp's own types."""
+    assert attachment_cap("WHATSAPP", media_kind=MediaKind.IMAGE) == 5 * _MB
+    assert attachment_cap("WHATSAPP", media_kind=MediaKind.AUDIO) == 16 * _MB
+    assert attachment_cap("WHATSAPP", media_kind=MediaKind.VIDEO) == 16 * _MB
+    assert attachment_cap("WHATSAPP", media_kind=MediaKind.DOCUMENT) == 100 * _MB
+
+
+def test_a_whatsapp_image_over_5mb_is_not_attempted_inline():
+    """Meta refuses it, so paying for the download and upload first is waste."""
+    assert fits_inline("WHATSAPP", 4 * _MB, mime_type="image/png") is True
+    assert fits_inline("WHATSAPP", 6 * _MB, mime_type="image/png") is False
+    # Same bytes, sent as a document: comfortably inside the 20 MB soft cap.
+    assert fits_inline("WHATSAPP", 6 * _MB, mime_type="application/pdf") is True
+
+
+def test_a_16mb_document_now_attaches_instead_of_becoming_a_link():
+    """The soft cap moved 5 MB -> 20 MB; this is the file that changed hands."""
+    for platform in ("SLACK", "TELEGRAM", "WHATSAPP"):
+        assert fits_inline(platform, 16 * _MB, mime_type="application/pdf") is True
+
+
+def test_platforms_below_the_soft_cap_still_govern():
+    """The soft cap raises nothing — a lower platform ceiling still wins."""
+    assert inline_cap("WHATSAPP", media_kind=MediaKind.IMAGE) == 5 * _MB
+    assert inline_cap("WHATSAPP", media_kind=MediaKind.AUDIO) == 16 * _MB
+
+
+@pytest.mark.parametrize("platform", sorted(SURFACE_ATTACHMENT_BYTE_CAPS))
+def test_no_chat_cap_exceeds_the_soft_cap(platform):
+    assert inline_cap(platform) <= SURFACE_INLINE_SOFT_BYTE_CAP
+
+
+def test_unknown_size_prefers_a_link():
+    """An unstamped size cannot be guaranteed to fit, so it must not be attempted."""
+    assert fits_inline("SLACK", None) is False
+    assert fits_inline("SLACK", None, mime_type="application/pdf") is False
+
+
+def test_unknown_platform_falls_back_to_a_default():
+    assert attachment_cap("DISCORD") == 16 * _MB
+    assert attachment_cap(None) == 16 * _MB
+
+
+@pytest.mark.parametrize("platform", ["GMAIL", "OUTLOOK", "RESEND"])
+def test_email_cap_leaves_room_for_base64(platform):
+    """The provider measures the encoded bytes, so the raw cap must be smaller.
+
+    A cap set at the provider's own number sent a 25 MB file as ~34 MB on the
+    wire and the whole reply failed — attachment and body together.
+    """
+    raw = email_inline_cap(platform)
+    encoded = len(base64.b64encode(b"x" * 1024)) * raw // 1024
+    assert encoded < SURFACE_ATTACHMENT_BYTE_CAPS[platform]
+
+
+def test_email_ignores_the_chat_soft_cap():
+    """Email's fallback is a signed URL that works, so shrinking it buys nothing.
+
+    Applying the chat soft cap here would turn a 25 MB Resend attachment the
+    provider accepts into a link, for a reason that only applies to chat.
+    """
+    assert email_inline_cap("RESEND") > SURFACE_INLINE_SOFT_BYTE_CAP
+
+
+def test_media_cap_summary_only_speaks_when_kinds_differ():
+    assert media_cap_summary("SLACK") is None
+    assert media_cap_summary("TELEGRAM") is None
+    assert media_cap_summary(None) is None
+    assert media_cap_summary("WHATSAPP") == (
+        "images up to 5 MB; audio and video up to 16 MB"
+    )

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_platform_capabilities.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_platform_capabilities.py
@@ -50,7 +50,7 @@ def test_slack_guidance_has_native_choices_channel_and_mrkdwn():
     assert "ask_user" in text and "native tappable options" in text
     assert "Channel background context" in text
     assert "mrkdwn" in text
-    assert "5 MB" in text  # effective inline cap = min(30MB hard, 5MB soft)
+    assert "20 MB" in text  # effective inline cap = min(30MB hard, 20MB soft)
 
 
 def test_whatsapp_guidance_has_native_choices_and_omits_channel():
@@ -79,3 +79,57 @@ def test_email_guidance_points_to_reply_tool_not_display_resource():
     assert "type=FILE" not in text
     assert "## Delivering things" not in text
     assert "does NOT reach the email recipient" in text
+
+
+def test_whatsapp_guidance_names_the_kinds_capped_below_the_headline():
+    """The headline number is the document cap; the smaller kinds must be said.
+
+    WhatsApp takes a 20 MB PDF and refuses a 6 MB PNG. An agent told only "20 MB"
+    would compress a report it never needed to and hand over an image that comes
+    out the other side as a link.
+    """
+    text = platform_agent_guidance("WHATSAPP")
+    assert "20 MB" in text  # documents: min(100MB hard, 20MB soft)
+    assert "images up to 5 MB" in text
+    assert "audio and video up to 16 MB" in text
+
+
+def test_uniform_platforms_carry_no_per_kind_caveat():
+    assert get_platform_capabilities("SLACK").media_cap_note is None
+    assert get_platform_capabilities("TELEGRAM").media_cap_note is None
+    assert "stricter about some kinds" not in platform_agent_guidance("TELEGRAM")
+
+
+def test_teams_files_are_link_only_and_say_so():
+    """Teams has no outbound file upload, so the guidance must not promise one."""
+    caps = get_platform_capabilities("TEAMS")
+    assert caps.supports_native_files is False
+    text = platform_agent_guidance("TEAMS")
+    assert "cannot receive a file attachment from Lemma" in text
+    assert "arrive as a real attachment" not in text
+
+
+def test_chat_guidance_asks_for_a_pod_path_not_a_workspace_path():
+    """`display_resource` rejects workspace paths, so the prompt cannot ask for one."""
+    for platform in ("SLACK", "TELEGRAM", "WHATSAPP", "TEAMS"):
+        text = platform_agent_guidance(platform)
+        assert "path=<pod file path>" in text
+        assert "path=<workspace path>" not in text
+
+
+def test_chat_guidance_does_not_call_the_fallback_a_download_link():
+    """The chat fallback is a pod-authenticated deep link, not a download URL.
+
+    Promising a "download link" to an agent talking to an outside contact is how
+    a file silently becomes nothing the recipient can open.
+    """
+    for platform in ("SLACK", "TELEGRAM", "WHATSAPP", "TEAMS"):
+        text = platform_agent_guidance(platform)
+        assert "download link" not in text
+        assert "only opens for someone who can sign in to this pod" in text
+
+
+def test_email_quotes_the_base64_adjusted_cap_not_the_chat_cap():
+    """A 25 MB provider ceiling is ~17 MB of file once base64 has had its 33%."""
+    assert get_platform_capabilities("GMAIL").inline_mb_cap == 17
+    assert "17 MB" in platform_agent_guidance("GMAIL")


### PR DESCRIPTION
## What changes

A file the agent sends to a chat surface now arrives as a real attachment up to
**20 MB** instead of 5 MB, and WhatsApp's per-media-type ceilings are respected
rather than averaged into one wrong number. Email attachments are sized after
base64, which takes Gmail and Outlook from 5 MB to 17 MB. Teams no longer tells
the agent its files will be attached, because they never are.

| surface | before | after |
|---|---|---|
| Slack, Telegram | 5 MB | 20 MB |
| WhatsApp document | 5 MB | 20 MB |
| WhatsApp image | 5 MB (by luck) | 5 MB (by rule) |
| WhatsApp audio / video | 5 MB | 16 MB |
| Gmail, Outlook | 5 MB | 17 MB |
| Resend | 25 MB raw, ~34 MB on the wire | 28 MB |
| Teams | link only, prompt said attachment | link only, prompt says so |

## Why

The link a file falls back to on a chat surface is
`{frontend_url}/pod/{id}/files?file=...` — the Lemma app's own deep link, behind
a login. Chat egress never calls `create_signed_url`; only the email path does.
So for a WhatsApp contact or a Slack guest who has no Lemma account, every file
over 5 MB was **nothing they could open**, while four docstrings and the agent's
own system prompt described it as a "download link". That makes the inline cap a
delivery guarantee rather than a preference about keeping chats tidy, and 5 MB
was far below what every platform involved will accept.

Raising it needed three problems fixed first, because one integer per platform
was carrying three different meanings:

1. **A ceiling can depend on the media type.** WhatsApp's Cloud API caps an
   image at 5 MB and a document at 100 MB. The single `16 MB` entry — commented
   "documents", the type it was furthest off on — refused documents Meta would
   have taken, and at 20 MB would have downloaded and re-uploaded images Meta
   always rejects. `attachment_cap` now takes a `MediaKind` whose values *are*
   WhatsApp's send types, and `resolve_whatsapp_send_type` reads the same
   classifier — a per-type cap decided by a second copy of the MIME branch is
   worse than no per-type cap, since it clears a file the send then refuses.
2. **Email is measured after base64.** All three email paths base64-encode the
   bytes (~4 per 3), so a 25 MB provider ceiling is about 17 MB of file. A 20 MB
   soft cap applied naively would have put ~27 MB on the wire and failed the
   whole reply, attachment and body together. `email_inline_cap` does the
   conversion, so the table holds each provider's real number — which is why
   `RESEND` moves from a hand-adjusted 25 MB to its actual 40 MB.
3. **The soft cap is a chat idea.** On chat a smaller file is still delivered;
   on email it would only downgrade a working attachment to a signed URL the
   recipient can genuinely fetch. Email no longer applies it.

Two prompt-honesty bugs fell out of the same reading. Teams set
`supports_native_files=True` while `TeamsSurfaceAdapter` never overrode
`send_file_attachment`, so the base stub refused every Teams file at any size
while the agent was told attachments would arrive — and the guidance had no
`else` branch, so a platform without native files got no file instructions at
all. The chat prose also asked for `path=<workspace path>` while
`DisplayResourceRequest` validates that field as "Never a workspace path",
i.e. it instructed the agent to pass the one thing that gets rejected.

## How to verify

```bash
cd lemma-backend
uv run pytest app/modules/agent_surfaces/tests/unit app/modules/agent/tests/unit -q
uv run ruff check app/modules/agent_surfaces
uv run basedpyright --level error app/modules/agent_surfaces/platforms/attachment_limits.py app/modules/agent_surfaces/platforms/platform_capabilities.py app/modules/agent_surfaces/platforms/whatsapp/payloads.py
make architecture
```

Printed:

- `924 passed` (agent_surfaces unit) and `1108 passed, 29 skipped` (agent unit).
  The one failure, `test_telegram_manager_service.py::test_redis_store_enforces_atomic_state_and_claims`,
  wants Redis on `localhost:6379` and fails identically on a clean tree — it is
  not from this change.
- `All checks passed!` / `286 files already formatted`
- `0 errors, 0 warnings, 0 notes`
- `Architecture ratchet passed (12 inherited import violations, 0 inherited cycles).`

New `tests/unit/test_attachment_limits.py` (26 cases) covers each threshold as a
file that was previously refused when the platform would have taken it, or
attempted when it would not — plus a base64 round-trip asserting the *encoded*
size clears every provider ceiling, and a check that the WhatsApp send type and
its cap read the same classification. `test_platform_capabilities.py` gains the
Teams, pod-path, per-kind-caveat, and no-"download link" guarantees.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload; no
      authorization boundary touched (the egress path's `build_user_context` /
      RLS handling is unchanged)
- [x] **Rollback** — revert the commit; the caps are constants read per call,
      with no persisted state and no migration

## Compatibility and rollback notes

No API, SDK, or schema change — nothing to regenerate, no migration. The
behavioral changes are all in outbound delivery and in the agent's
system-prompt fragment, so a revert restores the previous thresholds
immediately with nothing to undo.

Worth a reviewer's attention:

- **Peak worker memory per delivery goes up 4×.** `_try_send_file_attachment`
  holds the whole file in memory to upload it, so the 5 MB → 20 MB move is also
  5 MB → 20 MB of transient heap per concurrent file send. Called out in the
  constant's comment. If that is the wrong trade for our worker sizing, the
  cap is the one line to change.
- **One e2e gap, deliberately left open.** The old justification for skipping a
  WhatsApp size case — "`fits_inline` is generic, platform-agnostic logic" — is
  no longer true, since WhatsApp is now precisely the platform whose thresholds
  do *not* follow from Slack and Telegram. That branch is unit-covered, but an
  e2e driving an oversize WhatsApp image through a real upload rejection is
  missing. I did not add one because the e2e suite needs Docker and I could not
  run it locally; committing an unverified e2e test seemed worse than recording
  the gap, which is now documented in the matrix module's docstring.
- **The e2e oversize cases now lower the soft cap** via `_oversize_bytes`
  instead of seeding a 20 MB file through the datastore, which would be memory
  and wall-clock spent to prove a branch that reads one integer.
- **Stale docstring corrected.** The matrix module's header claimed Composio
  Gmail/Outlook attachments "never reach the recipient" and report
  `attachment_count=0`, while the tests beneath it already asserted
  `attachment_count == 1`. It now describes the real one-file-by-signed-URL
  behavior.
