### PR TITLE
Give a new agent web search and memory, and say "Computer" where the word means a computer

### DIFF
--- a/lemma-backend/app/modules/agent/api/schemas.py
+++ b/lemma-backend/app/modules/agent/api/schemas.py
@@ -22,6 +22,7 @@ from app.modules.agent.domain.value_objects import (
     JsonValue,
     MessageKind,
 )
+from app.modules.agent.tools.toolset_selection import NEW_AGENT_DEFAULT_TOOLSETS
 from app.modules.agent.api.agent_host_schemas import AgentHostHarnessResponse
 from app.modules.agent.domain.agent_host import AgentHostStatus
 from app.modules.agent.domain.runtime_profiles import (
@@ -240,7 +241,16 @@ class CreateAgentRequest(BaseModel):
     description: str | None = None
     icon_url: str | None = None
     agent_runtime: AgentRuntimeConfig | None = None
-    toolsets: list[AgentToolset] = Field(default_factory=list)
+    # Omitting toolsets means "the sensible ones", not "none" -- see
+    # NEW_AGENT_DEFAULT_TOOLSETS. An explicit empty list still means none, so a
+    # bundle or an editor that states the toolsets keeps stating them exactly.
+    toolsets: list[AgentToolset] = Field(
+        default_factory=lambda: list(NEW_AGENT_DEFAULT_TOOLSETS),
+        description=(
+            "Toolsets the agent declares. Omit the field to start with web "
+            "search and memory; pass an explicit empty list for none."
+        ),
+    )
     input_schema: JsonObject | None = None
     output_schema: JsonObject | None = None
     visibility: ResourceVisibility = ResourceVisibility.POD

--- a/lemma-backend/app/modules/agent/services/agent_memory_grant.py
+++ b/lemma-backend/app/modules/agent/services/agent_memory_grant.py
@@ -29,14 +29,12 @@ from app.core.authorization.grants import (
     replace_resource_grantee_grant,
 )
 from app.core.authorization.permissions import Permissions
+from app.core.domain.errors import DomainError
 from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
 from app.core.log.log import get_logger
 from app.composition.agent_datastore import build_file_service
 from app.modules.agent.domain.value_objects import AgentToolset
-from app.modules.datastore.contracts import (
-    DatastoreAccessDeniedError,
-    DatastoreConflictError,
-)
+from app.modules.datastore.contracts import DatastoreConflictError
 
 logger = get_logger(__name__)
 
@@ -117,11 +115,21 @@ async def _memory_folder_id(
             await build_file_service(uow).create_folder(pod_id, MEMORY_FOLDER_PATH, ctx)
         except DatastoreConflictError:
             pass  # Already there — the ordinary case after the first agent.
-        except DatastoreAccessDeniedError:
+        except DomainError as denial:
             # Editing an agent and writing pod files are different permissions.
             # Someone who holds the first but not the second should still be
             # able to save the agent; the grant lands the next time it is
             # edited by someone who can create the folder.
+            #
+            # Any 403, not `DatastoreAccessDeniedError` alone: the denial that
+            # actually arrives here is raised by the authorization context
+            # (`INSUFFICIENT_PERMISSION` on `folder.write`), which never passes
+            # through the datastore's own error type. Catching only that one
+            # meant this guard had never fired -- a role holding `agent.create`
+            # without `folder.write` got a 403 on the whole request instead of
+            # an agent, which is what turning memory on by default surfaced.
+            if denial.status_code != 403:
+                raise
             logger.warning("agent.memory.folder_provisioning_denied.observed")
             return None
     try:

--- a/lemma-backend/app/modules/agent/tests/e2e/test_inline_grant_parity_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_inline_grant_parity_e2e.py
@@ -64,11 +64,22 @@ def _grants(table_name: str) -> dict:
 
 
 async def _granted_tables(authenticated_client, pod_id: str, kind: str, name: str):
+    """Only the table grants, which is what this file is about.
+
+    It used to return every grant, and read as if it returned tables because an
+    agent had no other kind. Then MEMORY became a default and each agent arrived
+    holding a derived `/memory` folder grant, which is not the subject here and
+    must not be able to break an exact comparison against it.
+    """
     response = await authenticated_client.get(
         f"/pods/{pod_id}/{kind}s/{name}/permissions"
     )
     assert response.status_code == status.HTTP_200_OK, response.text
-    return {grant["resource_name"] for grant in response.json().get("grants") or []}
+    return {
+        grant["resource_name"]
+        for grant in response.json().get("grants") or []
+        if grant["resource_type"] == "datastore_table"
+    }
 
 
 @pytest.mark.asyncio

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_memory_grant.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_memory_grant.py
@@ -1,0 +1,131 @@
+"""Provisioning `/memory` must never cost the caller their request.
+
+The service had a guard for exactly this and it had never fired: it caught
+`DatastoreAccessDeniedError`, while the denial that actually arrives is a
+`DomainError` raised by the authorization context. Nothing tested the service at
+all, so the dead branch read as working code — until memory went on by default
+and every creator without `folder.write` got a 403 instead of an agent.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from app.core.domain.errors import DomainError
+from app.modules.agent.domain.value_objects import AgentToolset
+from app.modules.agent.services import agent_memory_grant as grant_mod
+from app.modules.agent.services.agent_memory_grant import sync_memory_folder_grant
+from app.modules.datastore.contracts import DatastoreConflictError
+
+
+def _uow():
+    return SimpleNamespace(session=object())
+
+
+def _file_service(monkeypatch, create_folder: AsyncMock):
+    monkeypatch.setattr(
+        grant_mod,
+        "build_file_service",
+        lambda uow: SimpleNamespace(create_folder=create_folder),
+    )
+    return create_folder
+
+
+def _grant_spies(monkeypatch, *, folder_id=None):
+    """Stand in for the three authorization helpers the service calls."""
+    replace = AsyncMock()
+    delete = AsyncMock()
+    monkeypatch.setattr(grant_mod, "replace_resource_grantee_grant", replace)
+    monkeypatch.setattr(grant_mod, "delete_resource_grantee_grant", delete)
+    monkeypatch.setattr(
+        grant_mod,
+        "normalize_pod_resource_grants",
+        AsyncMock(
+            return_value=([SimpleNamespace(resource_id=folder_id)] if folder_id else [])
+        ),
+    )
+    return replace, delete
+
+
+async def _sync(uow, *, toolsets):
+    await sync_memory_folder_grant(
+        uow,
+        pod_id=uuid4(),
+        agent_id=uuid4(),
+        toolsets=toolsets,
+        ctx=SimpleNamespace(),
+        created_by_user_id=uuid4(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_folder_write_denial_leaves_the_agent_saved_and_the_grant_deferred(
+    monkeypatch,
+):
+    """The case a create-only role hits: no `folder.write`, still gets an agent."""
+    denial = DomainError(
+        "Missing permission folder.write on document",
+        code="INSUFFICIENT_PERMISSION",
+        status_code=403,
+    )
+    _file_service(monkeypatch, AsyncMock(side_effect=denial))
+    replace, delete = _grant_spies(monkeypatch, folder_id=uuid4())
+
+    await _sync(_uow(), toolsets=[AgentToolset.MEMORY])
+
+    replace.assert_not_awaited()
+    delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_failure_that_is_not_a_denial_still_reaches_the_caller(monkeypatch):
+    """Swallowing every `DomainError` would hide real breakage behind a warning."""
+    _file_service(
+        monkeypatch,
+        AsyncMock(side_effect=DomainError("Path must point to a folder")),
+    )
+    _grant_spies(monkeypatch, folder_id=uuid4())
+
+    with pytest.raises(DomainError):
+        await _sync(_uow(), toolsets=[AgentToolset.MEMORY])
+
+
+@pytest.mark.asyncio
+async def test_memory_grants_folder_write_on_the_provisioned_folder(monkeypatch):
+    folder_id = uuid4()
+    _file_service(monkeypatch, AsyncMock())
+    replace, delete = _grant_spies(monkeypatch, folder_id=folder_id)
+
+    await _sync(_uow(), toolsets=[AgentToolset.MEMORY])
+
+    delete.assert_not_awaited()
+    assert replace.await_args.kwargs["resource_id"] == folder_id
+    assert replace.await_args.kwargs["permission_ids"] == ["folder.write"]
+
+
+@pytest.mark.asyncio
+async def test_the_second_agent_on_a_pod_reuses_the_folder(monkeypatch):
+    """`/memory` already exists after the first agent; a conflict is the norm."""
+    folder_id = uuid4()
+    _file_service(monkeypatch, AsyncMock(side_effect=DatastoreConflictError("exists")))
+    replace, _ = _grant_spies(monkeypatch, folder_id=folder_id)
+
+    await _sync(_uow(), toolsets=[AgentToolset.MEMORY])
+
+    assert replace.await_args.kwargs["resource_id"] == folder_id
+
+
+@pytest.mark.asyncio
+async def test_memory_off_revokes_without_provisioning_anything(monkeypatch):
+    create_folder = _file_service(monkeypatch, AsyncMock())
+    replace, delete = _grant_spies(monkeypatch, folder_id=uuid4())
+
+    await _sync(_uow(), toolsets=[AgentToolset.WEB_SEARCH])
+
+    create_folder.assert_not_awaited()
+    replace.assert_not_awaited()
+    delete.assert_awaited_once()

--- a/lemma-backend/app/modules/agent/tests/unit/test_toolset_selection.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_toolset_selection.py
@@ -176,3 +176,26 @@ def test_the_pod_default_assistant_still_gets_its_fixed_set():
     resolved = resolve_toolsets(None, _conversation())
 
     assert set(POD_DEFAULT_AGENT_TOOLSETS) <= set(resolved.names)
+
+
+def test_a_new_agent_starts_with_web_search_and_memory():
+    """Creating an agent without naming toolsets is not a request for none. The
+    two defaults are the ones every author turns on anyway; the expensive
+    decisions -- a sandbox, fan-out, a voice bill -- stay off."""
+    from app.modules.agent.api.schemas import CreateAgentRequest
+    from app.modules.agent.tools.toolset_selection import NEW_AGENT_DEFAULT_TOOLSETS
+
+    request = CreateAgentRequest(name="scout", instruction="look things up")
+
+    assert request.toolsets == list(NEW_AGENT_DEFAULT_TOOLSETS)
+    assert request.toolsets == [AgentToolset.WEB_SEARCH, AgentToolset.MEMORY]
+    assert set(NEW_AGENT_DEFAULT_TOOLSETS) <= set(DECLARABLE_TOOLSETS)
+
+
+def test_an_explicit_empty_toolset_list_still_means_none():
+    """A bundle or an editor that states the toolsets is stating them exactly —
+    the default fills an absent field, never an empty one, or importing an agent
+    with no tools would quietly hand it two."""
+    from app.modules.agent.api.schemas import CreateAgentRequest
+
+    assert CreateAgentRequest(name="inert", instruction="x", toolsets=[]).toolsets == []

--- a/lemma-backend/app/modules/agent/tools/toolset_selection.py
+++ b/lemma-backend/app/modules/agent/tools/toolset_selection.py
@@ -56,6 +56,23 @@ DECLARABLE_TOOLSETS: tuple[AgentToolset, ...] = (
     AgentToolset.MEMORY,
 )
 
+# What a new agent starts with when its creator did not say. Both are cheap and
+# both are things people turn on immediately anyway: an agent that cannot look
+# anything up answers from a two-year-old training set, and one that cannot
+# remember re-learns the same fact every conversation. Turning either off is one
+# click in the agent's Tools; discovering months later that it was never on is
+# not.
+#
+# WORKSPACE_CLI, SUBAGENTS and SPEECH stay off: a sandbox, fan-out and a voice
+# bill are decisions, not conveniences.
+#
+# Applies only where the field is *absent* -- an explicit ``[]`` from a bundle
+# import or the agent editor still means exactly none.
+NEW_AGENT_DEFAULT_TOOLSETS: tuple[AgentToolset, ...] = (
+    AgentToolset.WEB_SEARCH,
+    AgentToolset.MEMORY,
+)
+
 # Given to every agent. None of these reaches pod data, the internet, or a
 # sandbox; each is either a way to involve a person or conversation-scoped
 # scratch.

--- a/lemma-backend/app/modules/pod/tests/e2e/test_permission_api_e2e.py
+++ b/lemma-backend/app/modules/pod/tests/e2e/test_permission_api_e2e.py
@@ -1081,6 +1081,72 @@ async def test_workload_create_permissions_do_not_imply_update_or_delete_e2e(
     )
 
 
+async def test_agent_create_without_folder_write_defers_the_memory_grant_e2e(
+    authenticated_client,
+    async_client,
+    fixed_test_org,
+):
+    """Creating an agent must not require the permissions its toolsets imply.
+
+    A new agent starts with MEMORY, and MEMORY derives a `/memory` folder grant
+    — which means provisioning a pod folder now happens inside every create. A
+    role that can build agents but not write pod files got the folder's 403 as
+    the answer to its create, so `agent.create` silently stopped being enough to
+    create an agent. The agent is saved instead, still declaring MEMORY, and the
+    grant lands the next time someone who can write files edits it.
+    """
+    pod_id = await _create_pod(authenticated_client, fixed_test_org, "Deferred Memory")
+
+    role_response = await authenticated_client.post(
+        f"/pods/{pod_id}/roles",
+        json={
+            "name": "agent_builders",
+            "permission_ids": ["pod.read", "agent.create"],
+        },
+    )
+    assert role_response.status_code == status.HTTP_201_CREATED, role_response.text
+
+    builder = await signup_user(async_client, "memory-no-folder-write")
+    builder_org_member = await invite_org_member(
+        authenticated_client,
+        async_client,
+        org_id=fixed_test_org["id"],
+        user=builder,
+    )
+    await add_pod_member(
+        authenticated_client,
+        pod_id=pod_id,
+        organization_member_id=builder_org_member["id"],
+        role="POD_VIEWER",
+        roles=["POD_VIEWER", "AGENT_BUILDERS"],
+    )
+
+    name = f"builder_agent_{uuid4().hex[:8]}"
+    created = await async_client.post(
+        f"/pods/{pod_id}/agents",
+        headers=auth_headers(builder),
+        json={"name": name, "instruction": "Remember what matters."},
+    )
+    assert created.status_code == status.HTTP_201_CREATED, created.text
+    assert "MEMORY" in created.json()["toolsets"], created.text
+
+    grants = await authenticated_client.get(f"/pods/{pod_id}/agents/{name}/permissions")
+    assert grants.status_code == status.HTTP_200_OK, grants.text
+    assert "/memory" not in {
+        grant["resource_name"] for grant in grants.json()["grants"]
+    }, "the folder could not be provisioned, so there is nothing to grant on yet"
+
+    # The owner can write files, so their edit is what completes it.
+    updated = await authenticated_client.patch(
+        f"/pods/{pod_id}/agents/{name}",
+        json={"description": "Edited by someone who can write files."},
+    )
+    assert updated.status_code == status.HTTP_200_OK, updated.text
+    grants = await authenticated_client.get(f"/pods/{pod_id}/agents/{name}/permissions")
+    assert grants.status_code == status.HTTP_200_OK, grants.text
+    assert "/memory" in {grant["resource_name"] for grant in grants.json()["grants"]}
+
+
 async def _create_pod(authenticated_client, fixed_test_org, prefix: str) -> str:
     pod_response = await authenticated_client.post(
         "/pods",
@@ -1298,13 +1364,16 @@ async def test_agent_update_preserves_workload_capability_grants_e2e(
         f"/pods/{pod_id}/agents/caller_agent/permissions"
     )
     assert permissions.status_code == status.HTTP_200_OK, permissions.text
-    assert permissions.json()["grants"] == [
-        {
-            "resource_type": "agent",
-            "resource_name": "callee_agent",
-            "permission_ids": ["agent.execute"],
-        }
-    ]
+    # As a set of tuples, not the response list: `/memory` is derived from the
+    # MEMORY toolset every new agent starts with, and two grants have no
+    # guaranteed order between them.
+    assert {
+        (grant["resource_type"], grant["resource_name"], tuple(grant["permission_ids"]))
+        for grant in permissions.json()["grants"]
+    } == {
+        ("agent", "callee_agent", ("agent.execute",)),
+        ("folder", "/memory", ("folder.write",)),
+    }
 
 
 async def test_resource_access_unknown_name_returns_404_e2e(
@@ -1398,8 +1467,12 @@ async def test_pod_editor_can_rewire_the_resources_they_author_e2e(
         headers=editor_headers,
     )
     assert agent_grants.status_code == status.HTTP_200_OK, agent_grants.text
+    # `/memory` survives a replace it was not named in: the memory grant is
+    # re-derived from the toolsets on every write, which is what keeps the
+    # capability from quietly losing its permission on an unrelated edit.
     assert {grant["resource_name"] for grant in agent_grants.json()["grants"]} == {
-        table_name
+        table_name,
+        "/memory",
     }
 
     function_grants = await async_client.put(

--- a/lemma-frontend/components/agents/agent-access-dialog.tsx
+++ b/lemma-frontend/components/agents/agent-access-dialog.tsx
@@ -65,12 +65,25 @@ type AccessCategory = {
     /** Rail label — the one noun this concept goes by everywhere in the product. */
     label: string;
     icon: LemmaIcon;
-    /** What granting this category actually lets the agent do. */
+    /**
+     * What granting this category actually lets the agent do, in one sentence or
+     * two. The header stays the thinnest thing in the dialog on purpose: it is
+     * read once, and the rows under it are what someone came here to switch.
+     */
     blurb: string;
 };
 
 const CATEGORIES: AccessCategory[] = [
-    { id: 'tools', label: 'Tools', icon: Wrench, blurb: 'Built-in abilities every conversation can draw on.' },
+    {
+        id: 'tools',
+        label: 'Tools',
+        icon: Wrench,
+        // The second half used to be its own paragraph listing all five always-on
+        // abilities by name, which cost eight lines of header to answer a question
+        // nobody had yet. What a person actually needs to know here is that the
+        // absent switches are absent on purpose.
+        blurb: 'Built-in abilities every conversation can draw on. Asking a person, task lists, messaging and pause-and-resume are always on; pod data and connected apps come from grants, not from a switch here.',
+    },
     { id: 'connectors', label: 'Connectors', icon: Plug, blurb: 'Outside apps this agent can act in, and whose account it uses.' },
     { id: 'tables', label: 'Tables', icon: TableIcon, blurb: 'Pod data it can read, and what it may change.' },
     { id: 'folders', label: 'Folders', icon: FolderOpen, blurb: 'Documents it can search, read, and cite.' },
@@ -89,8 +102,12 @@ const CATEGORIES: AccessCategory[] = [
  */
 const TOOL_COPY: Record<string, { label: string; description: string; icon: LemmaIcon }> = {
     WORKSPACE_CLI: {
-        label: 'Workspace',
-        description: 'Run shell commands and Python in its own sandbox.',
+        // "Computer", not "Workspace": the thing it gets is a machine it can run
+        // commands on. Said as "its own" because "This computer" elsewhere in
+        // the product means the *person's* paired machine, and these are not
+        // the same computer.
+        label: 'Computer',
+        description: 'Run shell commands and Python on a computer of its own.',
         icon: SquareTerminal,
     },
     POD: {
@@ -114,7 +131,7 @@ const TOOL_COPY: Record<string, { label: string; description: string; icon: Lemm
         icon: MessageCircle,
     },
     SUBAGENTS: {
-        label: 'Delegation',
+        label: 'Sub agents',
         description: 'Spawn other agents and collect what they find.',
         icon: Bot,
     },
@@ -183,17 +200,6 @@ const TOOL_ORDER: string[] = [
 ];
 
 const EACH_PERSON_ACCOUNT = '__each_person__';
-
-/**
- * Memory keeps its facts in pod files and carries no tools of its own to read or
- * write them with. Pod access is no longer a switch — it comes from granting a
- * folder or a table — so the two ways to make memory work are the workspace
- * shell or any data grant. Say so on the row rather than letting someone turn it
- * on and wonder why the agent never remembers.
- */
-function memoryNeedsAFileTool(tool: string, selected: readonly string[], grantedData: boolean) {
-    return tool === 'MEMORY' && !selected.includes('WORKSPACE_CLI') && !grantedData;
-}
 
 function toolCopy(tool: string) {
     return TOOL_COPY[tool] ?? {
@@ -484,9 +490,11 @@ export function AgentAccessDialog({
         setQuery('');
     };
 
-    // The folder tree browses rather than lists, so it brings its own
-    // navigation; a search box above it would filter nothing.
-    const isSearchable = category !== 'folders';
+    // Search is for lists that can outgrow the pane. The folder tree browses
+    // rather than lists, so it brings its own navigation and a box above it would
+    // filter nothing; Tools is a fixed five rows, all of them on screen at once,
+    // where a search box is a control that can only ever hide something.
+    const isSearchable = category !== 'folders' && category !== 'tools';
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
@@ -529,13 +537,6 @@ export function AgentAccessDialog({
                     <section className="agent-access-pane" aria-label={activeCategory.label}>
                         <header className="agent-access-pane-header">
                             <p className="agent-access-pane-blurb">{activeCategory.blurb}</p>
-                            {category === 'tools' ? (
-                                <p className="agent-access-pane-blurb">
-                                    Every agent can already ask you a question, request approval, keep a task
-                                    list, message people in this pod, and pause and resume. Reaching pod data
-                                    and connected apps comes from granting them, not from a switch here.
-                                </p>
-                            ) : null}
                             {isSearchable ? (
                                 <div className="agent-access-search">
                                     <Search className="agent-access-search-icon h-4 w-4" />
@@ -556,15 +557,9 @@ export function AgentAccessDialog({
                                 <div className="agent-access-list">
                                     {TOOL_ORDER
                                         .filter((tool) => Object.values(ToolSet).includes(tool as ToolSet))
-                                        .filter((tool) => matches(query, toolCopy(tool).label, toolCopy(tool).description))
                                         .map((tool) => {
                                             const copy = toolCopy(tool);
                                             const Icon = copy.icon;
-                                            const unmet = memoryNeedsAFileTool(
-                                                tool,
-                                                selectedTools,
-                                                selectedFolders.length > 0 || selectedTables.length > 0,
-                                            );
 
                                             return (
                                                 <AccessRow
@@ -572,11 +567,7 @@ export function AgentAccessDialog({
                                                     selected={selectedTools.includes(tool as ToolSet)}
                                                     icon={<Icon className="h-4 w-4" />}
                                                     title={copy.label}
-                                                    description={
-                                                        unmet
-                                                            ? `${copy.description} Add Workspace, or grant it a folder or table — without one of those it has no way to read or write its files.`
-                                                            : copy.description
-                                                    }
+                                                    description={copy.description}
                                                     onToggle={() => toggleTool(tool as ToolSet)}
                                                 />
                                             );

--- a/lemma-frontend/public/openapi.json
+++ b/lemma-frontend/public/openapi.json
@@ -4405,6 +4405,7 @@
             "description": "Optional resource grants to apply to the new agent in the same request. Equivalent to calling the permissions-replace endpoint right after create — grants are keyed by resource_name."
           },
           "toolsets": {
+            "description": "Toolsets the agent declares. Omit the field to start with web search and memory; pass an explicit empty list for none.",
             "items": {
               "$ref": "#/components/schemas/AgentToolset"
             },
@@ -15748,6 +15749,11 @@
             "format": "uuid",
             "title": "Pod Id",
             "type": "string"
+          },
+          "shares_address": {
+            "default": false,
+            "title": "Shares Address",
+            "type": "boolean"
           }
         },
         "required": [
@@ -15760,7 +15766,7 @@
         "type": "object"
       },
       "UserSurfacePlatformGroup": {
-        "description": "All of a user's surfaces for one platform. ``conflict`` is true when more\nthan one surface could answer them (they should pick a ``default``).",
+        "description": "All of a user's surfaces for one platform. ``conflict`` is true when two\nof them answer at the same address, so the user has to say which pod hears\nthem (the ``shares_address`` surfaces are the ones to choose between).",
         "properties": {
           "conflict": {
             "default": false,
@@ -32113,7 +32119,7 @@
     },
     "/surfaces/me": {
       "get": {
-        "description": "Every surface across the current user's pods, grouped by platform, with\nthe chosen default and a ``conflict`` flag when more than one could answer.",
+        "description": "Every surface across the current user's pods, grouped by platform, with\nthe chosen default and a ``conflict`` flag when two of them answer at the\nsame address.",
         "operationId": "agent.surface.list_mine",
         "responses": {
           "200": {

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -13,4 +13,4 @@ SDK and the server it is talking to.
 from __future__ import annotations
 
 API_VERSION = "0.7.0"
-SPEC_SHA256 = "8e0e16e2dccf06af44a241c44c3e5b1720376fb5983ea9bf528ad29f4ae866c3"
+SPEC_SHA256 = "38fcee55213bedc9e8456ac60049e6026c5b7e7c43b3206e94e7a5eb1a46a45c"

--- a/lemma-python/lemma_sdk/openapi_client/models/create_agent_request.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/create_agent_request.py
@@ -44,7 +44,8 @@ class CreateAgentRequest:
         permissions (AgentPermissionsReplaceRequest | None | Unset): Optional resource grants to apply to the new agent
             in the same request. Equivalent to calling the permissions-replace endpoint right after create — grants are
             keyed by resource_name.
-        toolsets (list[AgentToolset] | Unset):
+        toolsets (list[AgentToolset] | Unset): Toolsets the agent declares. Omit the field to start with web search and
+            memory; pass an explicit empty list for none.
         visibility (ResourceVisibility | Unset):
     """
 

--- a/lemma-python/lemma_sdk/openapi_spec.json
+++ b/lemma-python/lemma_sdk/openapi_spec.json
@@ -4405,6 +4405,7 @@
             "description": "Optional resource grants to apply to the new agent in the same request. Equivalent to calling the permissions-replace endpoint right after create \u2014 grants are keyed by resource_name."
           },
           "toolsets": {
+            "description": "Toolsets the agent declares. Omit the field to start with web search and memory; pass an explicit empty list for none.",
             "items": {
               "$ref": "#/components/schemas/AgentToolset"
             },

--- a/lemma-typescript/src/openapi_client/models/CreateAgentRequest.ts
+++ b/lemma-typescript/src/openapi_client/models/CreateAgentRequest.ts
@@ -19,6 +19,9 @@ export type CreateAgentRequest = {
      * Optional resource grants to apply to the new agent in the same request. Equivalent to calling the permissions-replace endpoint right after create — grants are keyed by resource_name.
      */
     permissions?: (AgentPermissionsReplaceRequest | null);
+    /**
+     * Toolsets the agent declares. Omit the field to start with web search and memory; pass an explicit empty list for none.
+     */
     toolsets?: Array<AgentToolset>;
     visibility?: ResourceVisibility;
 };


### PR DESCRIPTION
## What changes

The agent's **Tools** pane loses eight lines of header and a search box, two toolsets are renamed, and a new agent now starts with web search and memory instead of nothing.

- **Header thinned.** The paragraph naming all five always-on abilities is now one clause of the pane's own blurb: *"Built-in abilities every conversation can draw on. Asking a person, task lists, messaging and pause-and-resume are always on; pod data and connected apps come from grants, not from a switch here."* Two lines instead of eight, so the rows start near the top of the pane.
- **Search removed from Tools only.** Five rows, all on screen at once, where a search field can only ever hide one of them. It stays on Connectors, Tables, Functions and Agents, whose lists genuinely outgrow the pane, and Folders keeps browsing as before.
- **`WORKSPACE_CLI` is "Computer"** (was "Workspace"), described as *"Run shell commands and Python on a computer of its own"*. **`SUBAGENTS` is "Sub agents"** (was "Delegation").
- **A new agent starts with `WEB_SEARCH` + `MEMORY`.** Turning either off is one click; discovering months later that it was never on is not.
- **Memory's unmet-prerequisite warning is gone** — it was already wrong, see below.

## Why

The pane was reduced to five real decisions in #459, and the header never shrank with it: it answered "where did the other switches go?" at eight lines, above the rows someone actually came to switch.

The two renames are one-noun-per-concept repairs. "Workspace" was a fifth meaning of a word already carrying four (the per-user sandbox, `WorkspaceStatus`, `PodWorkspaceTab`, and the checkout strip); what an agent gets here is a computer, so the row says so. "of its own" is deliberate — **"This computer" elsewhere in the product means the person's own paired Mac**, and these are not the same computer. Reviewers may want to weigh in on whether that wording carries enough weight. "Delegation" named the act rather than the thing you get.

On the defaults: omitting `toolsets` was read as "none", so every agent was created unable to look anything up (answering from a stale training set) and unable to remember (re-learning the same fact every conversation) — and every author turned both on by hand as their first edit. The costly decisions — a sandbox, fan-out, a voice bill — stay off.

The Memory row's *"Add Workspace, or grant it a folder or table…"* caution was stale before this change: turning `MEMORY` on makes the server grant `/memory` via `sync_memory_folder_grant`, which derives `POD`, so memory works without a sandbox. With memory on by default, every brand-new agent would have opened this dialog to a warning about a capability that already works.

## Reviewer notes

**The default fills an absent field, never an empty one.** `CreateAgentRequest.toolsets` defaults to `[WEB_SEARCH, MEMORY]`; an explicit `[]` still means exactly none. Pod-bundle import passes a literal list (empty when the bundle declares none) straight to the service, so importing a no-tools agent cannot quietly gain two. Existing agents are not migrated — this is only what a *new* one starts with.

**Not verified in a browser.** The dialog sits behind login on a running stack; the change is copy plus one conditional, covered by typecheck and lint.

**Generated artifacts.** The schema's new `description` propagates to the committed spec, both SDK clients, and the frontend's public copy. That last file also picks up `shares_address` from #466 — it had drifted on `main` because nothing regenerates it in CI (it is produced by `predev`/`prebuild`). Regenerating rather than leaving it knowingly stale; happy to drop that file from the PR if you would rather keep it out.

## How to verify

```bash
cd lemma-backend && uv run pytest app/modules/agent/tests/unit/test_toolset_selection.py -q
cd lemma-backend && uv run python scripts/dump_openapi_spec.py --check
cd lemma-backend && make architecture
cd lemma-frontend && npx eslint components/agents/agent-access-dialog.tsx
```

- `20 passed` — includes the two new cases (default set; explicit `[]` still means none).
- `OpenAPI spec is current: …/lemma-python/lemma_sdk/openapi_spec.json`
- `Architecture ratchet passed (12 inherited import violations, 0 inherited cycles).` / `Route inventory is current`
- eslint clean. `npx tsc --noEmit` reports only pre-existing errors in unrelated files (`components/settings/user-surfaces-panel.tsx`, `lib/assistant/turns.ts`) — the `shares_address` ones are the same stale-artifact drift noted above.

Codegen drift was reproduced locally the way CI does it, regenerating both clients and the L2 hooks from the committed spec; only `CreateAgentRequest` changed in each, and the hooks were unchanged.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **API surface** — OpenAPI spec regenerated, both SDKs regenerated, all committed in this change
- [x] **Compatibility** — no breaking change; see the note above on absent vs. empty `toolsets`

## Compatibility and rollback notes

Additive and revertible with a plain `git revert` — no migration, no data change. The only behavioral carry-over is that agents created while this is deployed hold `WEB_SEARCH` and `MEMORY` on their row; after a revert those agents keep both (they are ordinary declared toolsets), and newly created ones go back to starting empty. Memory-on also provisions the pod's `/memory` folder on first use, which is harmless if it outlives a revert.
