### PR TITLE
Let a deployment's own Svix secret sign the inbound-email scenarios

### DIFF
--- a/tests/scenarios/harness/stack.py
+++ b/tests/scenarios/harness/stack.py
@@ -114,6 +114,19 @@ RESEND_WEBHOOK_SECRET = (
 )
 
 
+def webhook_signing_secret() -> str:
+    """The key a signed inbound email must be signed with, wherever this points.
+
+    The constant above is what a stack the suite boots is configured with, and
+    asserting it against a deployment fails on a correct product for exactly
+    the reason `inbound_email_domain` gives one line down: the deployment has
+    its own, and ours describes a different machine. Signed with the
+    placeholder, a real deployment answers 401 `SURFACE_WEBHOOK_AUTH_FAILED` —
+    a scenario reporting the product broken when the product was right.
+    """
+    return _configured_or("RESEND_WEBHOOK_SECRET", RESEND_WEBHOOK_SECRET)
+
+
 def sandbox_images_present() -> bool:
     """Whether the sandbox images have been built.
 

--- a/tests/scenarios/journeys/surfaces_and_notifications/test_email_surfaces.py
+++ b/tests/scenarios/journeys/surfaces_and_notifications/test_email_surfaces.py
@@ -26,7 +26,7 @@ from uuid import uuid4
 import pytest
 
 from harness import capability, covers, journey, proves, scenario
-from harness.stack import RESEND_WEBHOOK_SECRET, inbound_email_domain
+from harness.stack import inbound_email_domain, webhook_signing_secret
 from harness.waiting import eventually
 
 pytestmark = [
@@ -48,7 +48,7 @@ def _svix_headers(body: bytes) -> dict[str, str]:
     """
     message_id = f"msg_{uuid4().hex[:16]}"
     timestamp = str(int(time.time()))
-    secret = base64.b64decode(RESEND_WEBHOOK_SECRET.removeprefix("whsec_"))
+    secret = base64.b64decode(webhook_signing_secret().removeprefix("whsec_"))
     signature = base64.b64encode(
         hmac.new(
             secret, f"{message_id}.{timestamp}.{body.decode()}".encode(), hashlib.sha256


### PR DESCRIPTION
## The bug

`inbound_email_domain()` reads the deployment's `RESEND_INBOUND_DOMAIN`, and its docstring already states the principle:

> A stack the suite boots uses the placeholder below. A deployment has its own, and asserting the placeholder against it fails on a correct product.

`RESEND_WEBHOOK_SECRET` has precisely that problem and never got the same treatment. It stayed a module-level constant imported straight into the scenario, so a deployment run signs with the placeholder and the deployment — correctly — refuses it.

## Found against a real deployment

Two scenarios reporting the product broken while the product was right:

```
An email surface has its own address
  -> 'pod-…@ops.asur.work' is not under this deployment's inbound domain

Mail to a surface's address reaches the pod that owns it
  -> a correctly signed email was rejected: 401 {"code":"SURFACE_WEBHOOK_AUTH_FAILED"}
```

(The first is a caller gap — `RESEND_INBOUND_DOMAIN` simply wasn't supplied — and it's fixed on our side by passing it. The second could not be fixed by any caller, because there was no way to override the key.)

## The change

The constant stays; a booted stack is configured with it. `webhook_signing_secret()` is the same `_configured_or` accessor sitting beside `inbound_email_domain`, and the scenario asks for the signing key rather than importing one.

## Verified

```
default        -> True     # a booted stack is unchanged
override wins  -> True     # a deployment's own key is used
guards         -> 86 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)