### PR TITLE
Sweep the surfaces a run leaves behind, and match the mark the product gives back

### DIFF
--- a/tests/scenarios/harness/provision.py
+++ b/tests/scenarios/harness/provision.py
@@ -293,11 +293,18 @@ async def _clear_run_debris(
     each other's work half way through. An operator running `--reset` takes
     every run's, which is the point of asking.
 
-    Tables and the top level of the file tree. A file inside a run-made folder
-    goes when the folder does; agents, schedules and workflows a run leaves
-    behind are still there afterwards — said plainly, because a cleanup that
-    quietly covers half of what it looks like it covers is worse than one that
-    admits its edges.
+    Tables, surfaces, and the top level of the file tree. A file inside a
+    run-made folder goes when the folder does; agents, schedules and workflows
+    a run leaves behind are still there afterwards — said plainly, because a
+    cleanup that quietly covers half of what it looks like it covers is worse
+    than one that admits its edges.
+
+    Surfaces are here for the reason `_uninstall_run_connectors` gives about
+    installations, and they had the same outcome: a standing pod reached 163
+    leftover Resend surfaces on a real deployment. Every inbound email then has
+    163 candidates to resolve against, and every run adds more — so the pod
+    gets slower and less predictable at exactly the thing the surfaces journey
+    is trying to prove.
     """
     for table in await owner.tables_in(pod):
         name = str(table.get("name", ""))
@@ -309,6 +316,18 @@ async def _clear_run_debris(
     # long as it exists, and a standing pod that accumulates a few runs' worth of
     # them starves document work for everything else in that pod. That is not
     # hygiene, it is the reason a later run sees a converter that never answers.
+    # A surface a run made is inert once the run ends — its agent may be gone,
+    # its account may be gone — but it still competes to receive.
+    for surface in await owner.surfaces_in(pod):
+        name = str(surface.get("name", ""))
+        if not mine(name):
+            continue
+        try:
+            await owner.deletes_surface(name, in_pod=pod)
+        except AssertionError:
+            continue
+        ledger.did(f"removed surface {name!r} from {pod.get('name')!r}")
+
     entries = _tree_entries(await owner.file_tree_of(pod))
     # Deepest first: removing a folder takes what is inside it, so a child that
     # has already gone would otherwise 404 and stop the sweep on its way past.

--- a/tests/scenarios/harness/run.py
+++ b/tests/scenarios/harness/run.py
@@ -38,7 +38,15 @@ JOIN = "_"
 #: A trailing extension is allowed, because a file keeps one — `notes_scn7f3a1`
 #: and `notes_scn7f3a1.txt` are both this run's, and matching only the first
 #: would leave every uploaded file invisible to cleanup.
-MADE_BY_A_RUN = re.compile(rf"{JOIN}{MARK}[0-9a-f]{{4,}}(\.[A-Za-z0-9]{{1,8}})?$")
+#: Cleanup matches a hyphen as well as the join, because the product derives
+#: names from the ones we give it and slugifies them on the way. An agent
+#: called `agent_c2a102_scn7f3a1` gets an auto-provisioned Resend surface named
+#: `resend-agent-c2a102-scn7f3a1` (email_surface_provisioning.py), and the mark
+#: survives the slug in spirit but not in the separator. Requiring the join
+#: exactly meant those never matched, so nothing ever swept them: one standing
+#: pod on a real deployment reached 163 orphaned surfaces, every one of them
+#: still competing to receive inbound mail.
+MADE_BY_A_RUN = re.compile(rf"[{JOIN}-]{MARK}[0-9a-f]{{4,}}(\.[A-Za-z0-9]{{1,8}})?$")
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
## Found on a real deployment

A standing pod had **163 leftover Resend surfaces**. Every one still competes to receive inbound mail, and every run adds more — so the pod gets slower and less predictable at exactly the thing the surfaces journey is trying to prove. Same shape as the connector-installation accumulation `_uninstall_run_connectors` was written for.

## Two causes, and the second is the interesting one

**Cleanup never looked at surfaces.** `_clear_run_debris` swept tables and the file tree, and its docstring admitted its edges — surfaces just weren't on the list.

**But adding the sweep alone changed nothing.** The suite names an agent `agent_c2a102_scn7f3a1`; the product then auto-provisions a Resend surface for it named `resend-agent-c2a102-scn7f3a1` — `email_surface_provisioning.py:67` builds it with `slugify`, which turns the join into a hyphen. `MADE_BY_A_RUN` is anchored on the literal `_`, so it said **no** to all 163:

```
made_by_a_run('resend-agent-c2a102-scnb7c48f')  ->  False
```

A whole resource class was silently un-sweepable.

## The change

Cleanup matches a hyphen as well as the join. Not a loosening for its own sake — it's what *"everything durable carries the run's mark"* has to mean once the product **derives** names from the ones we give it. The standing names still don't match, which is the property that matters:

```
resend-agent-c2a102-scnb7c48f -> True     telegram      -> False
orders_scn7f3a1               -> True     company-wide  -> False
```

## Verified against the deployment that had them

197 surfaces swept over two passes, then zero, leaving exactly the two standing ones (`resend-frontdesk`, `telegram`). Guards: 86 passed.

## One edge left rather than hidden

The sweep reads one page of surfaces, so a tenant this far behind needs more than one `--reset` to converge. It does converge, and a tenant swept every run never gets near a page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)