### PR TITLE
Ask the deployment whether its model is real, not the suite

### DIFF
--- a/tests/scenarios/journeys/surfaces_and_notifications/conftest.py
+++ b/tests/scenarios/journeys/surfaces_and_notifications/conftest.py
@@ -38,7 +38,8 @@ from uuid import uuid4
 
 import pytest
 
-from harness.credentials import REAL_MODEL, TELEGRAM, TELEGRAM_APP, TELEGRAM_PERSON, needs
+from harness.credentials import TELEGRAM, TELEGRAM_APP, TELEGRAM_PERSON, needs
+from harness.environment import MODEL_IS_REAL
 from harness.telegram_chat import (
     Chat,
     ForgedChat,
@@ -197,7 +198,16 @@ async def _forged(world, run, egress):
 
 async def _live(world):
     """A real account, on real Telegram, messaging the deployment's own bot."""
-    needs(TELEGRAM, TELEGRAM_APP, TELEGRAM_PERSON, REAL_MODEL)
+    # MODEL_IS_REAL, not credentials.REAL_MODEL. The two sound alike and are
+    # asked of different people: REAL_MODEL asks whether *this suite* holds an
+    # API key, which is the right question only when the suite is booting the
+    # stack itself. Here the target is somebody's deployment, and whether it
+    # runs agents on a real model is its own business — it says so at
+    # /health/capabilities, and dev answers `llm_mode: real`. Demanding the key
+    # instead would skip every one of these on the one target they exist for,
+    # because a deployment run has no reason to be given model credentials and
+    # is not given any.
+    needs(TELEGRAM, TELEGRAM_APP, TELEGRAM_PERSON, MODEL_IS_REAL)
     from harness.telegram_person import a_person_on_telegram
     from harness.tenant import CONNECTOR_HOLDER, STANDING_REACH
 


### PR DESCRIPTION
Follow-up to #484, found while wiring the dev runner up to the lane that PR
added. It would have skipped everything.

`_live()` demanded `credentials.REAL_MODEL` — satisfied by the **suite** holding
`LEMMA_OPENAI_API_KEY` and `LEMMA_OPENAI_DEFAULT_MODEL`. That is the right
question when the suite boots the stack and has to configure the model it will
run. Against somebody's deployment it is the wrong question twice:

* whether that deployment runs agents on a real model is *its* business, and it
  already answers at `/health/capabilities` — dev says `llm_mode: real`;
* a deployment run has no reason to be handed model credentials, and is not.
  The runner pointing this suite at dev passes a Telegram session, a Resend key
  and the cast's password. Nothing about a model, correctly.

So every scenario taking `reachable` would have skipped on the one target the
live lane exists for, asking for a key nobody should put there.

`harness.environment.MODEL_IS_REAL` asks the target instead, and
`EnvironmentCapability` is deliberately shaped so the two are interchangeable at
a `needs(...)` call site — same `name`, `missing`, `available`, `how`. Which is
also most of how this happened: the two names are one word apart and mean
opposite things. The comment now says which is which.

Verified: **41 passed, 1 skipped** across `journeys/surfaces_and_notifications`
locally, and all 86 harness-contract tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)