### PR TITLE
Unblock provisioning on a long-lived deployment, and two findings from the first dev run

### DIFF
--- a/docs/product/coverage.md
+++ b/docs/product/coverage.md
@@ -11,8 +11,8 @@ only a promise marked `covered` with no test is.
 
 | Status | Scenarios |
 | --- | ---: |
-| `covered` | 157 |
-| `gap` | 0 |
+| `covered` | 156 |
+| `gap` | 1 |
 | `manual` | 4 |
 | `planned` | 0 |
 | `withdrawn` | 0 |
@@ -226,7 +226,7 @@ the module suites may cover it — but it is untested *as product*.
 | Scenario | Status | Proven by |
 | --- | --- | --- |
 | `PS-DATA-001` A person creates a table by declaring its columns | `covered` | `test_a_table_is_created_from_its_columns`, `test_a_duplicate_table_name_is_refused`, `test_a_bad_column_name_is_refused` |
-| `PS-DATA-002` A table's shape can change without losing what is in it | `covered` | `test_a_tables_settings_can_change`, `test_adding_and_removing_columns_keeps_the_records`, `test_the_primary_key_column_cannot_be_removed`, `test_a_duplicate_column_is_refused` |
+| `PS-DATA-002` A table's shape can change without losing what is in it | `gap` | `test_a_tables_settings_can_change`, `test_adding_and_removing_columns_keeps_the_records`, `test_the_primary_key_column_cannot_be_removed`, `test_a_duplicate_column_is_refused` |
 | `PS-DATA-003` Deleting a table is destructive and says so | `covered` | `test_deleting_a_table_takes_its_records` |
 | `PS-DATA-010` A person adds records and the system holds them to the shape | `covered` | `test_the_python_sdk_writes_a_record`, `test_a_record_goes_in_and_comes_back`, `test_a_wrongly_typed_value_is_refused`, `test_a_missing_required_value_is_refused` |
 | `PS-DATA-011` A person finds the records they want without reading all of them | `covered` | `test_the_cli_reads_tables_and_records`, `test_paging_returns_every_record_once`, `test_records_can_be_sorted`, `test_a_page_is_bounded` |

--- a/docs/product/journeys/working-with-data.md
+++ b/docs/product/journeys/working-with-data.md
@@ -37,7 +37,14 @@ put it there having to think about it on every operation.
 **Contracts:** `table.create`, `table.get`, `table.list`, `table.created`
 
 ### PS-DATA-002 — A table's shape can change without losing what is in it
-**Status:** covered
+**Status:** gap
+
+> **Gap:** removing a column keeps the records, and then makes them unreadable.
+> The next read of that table answers 400 `cached statement plan`, because
+> dropping a column invalidates asyncpg's per-connection prepared-statement
+> cache and nothing catches it. The connection is pooled, so it is not confined
+> to whoever ran the change, and it clears when the connection recycles — the
+> table appears to break and then fix itself. `DEV-DATA-004`.
 
 - When a person adds a column to a table with records in it, the system shall
   keep every existing record and leave the new column empty on them.

--- a/issues.md
+++ b/issues.md
@@ -35,3 +35,55 @@ message, or a code comment resolves to something.
 Severity `question` means the divergence may be deliberate and the spec may be
 the thing that is wrong — resolve it with a product decision before writing code.
 
+## Open
+
+### DEV-DATA-004 — Removing a column makes the table unreadable until the connection recycles
+**Violates:** `PS-DATA-002`
+**Severity:** high
+**Where:** [`db/session.py:33-52`](lemma-backend/app/core/infrastructure/db/session.py#L33)
+— `_build_connect_args` sets `server_settings` and nothing else. Neither engine
+passes `statement_cache_size`, and no handler for asyncpg's
+`InvalidCachedStatementError` exists anywhere in the codebase.
+
+**Required:** A table's shape can change without losing what is in it. Somebody
+removes a column they no longer want and reads the table.
+
+**Actual:** The read answers **400**, body `cached statement plan`. Exactly
+reproducible, and the order matters:
+
+```
+create table (subject, body); add a record
+add column `priority`  -> read OK, priority is null on the existing row
+remove column `body`   -> read 400  <- here
+```
+
+**Why:** asyncpg keeps a per-connection prepared-statement cache. Dropping a
+column invalidates the cached plan for the statement that reads that table, and
+the next borrower of that pooled connection gets the driver error rather than
+rows. Nothing catches it, so it leaves as a 400.
+
+**Why it matters:** the connection is *pooled*, so the damage is not confined to
+whoever ran the DDL. Any request that lands on that connection sees the table as
+broken, and it stays that way until the connection is recycled (`pool_recycle`,
+300s on the datastore engine). A person who removes a column sees their table
+stop working, then start working again, with nothing they did in between — which
+is close to unreportable.
+
+**Not established:** why the `add` case survives and only `remove` fails. The
+run above shows the read after `add column` succeeding, but both are DDL against
+the same relation, so the difference may be which pooled connection each request
+happened to land on rather than anything about the operation. Worth settling
+before choosing the fix, because "invalidate on drop" would be the wrong shape
+if add is equally affected and merely luckier.
+
+**Fix:** the two standard shapes are `statement_cache_size=0` in `connect_args`
+(simple, costs the cache everywhere) or catching `InvalidCachedStatementError`
+and retrying once on a fresh statement (keeps the cache, and is what the error
+is for). Choosing between them wants the answer to the paragraph above.
+
+**Found by:**
+[`test_adding_and_removing_columns_keeps_the_records`](tests/scenarios/journeys/working_with_data/test_tables_and_records.py),
+against dev. It passes against a locally booted stack, where the pool is small
+and short-lived enough that the poisoned connection is rarely the next one
+borrowed — which is why a deployment run found it and 400+ local scenarios did
+not.

--- a/tests/scenarios/harness/provision.py
+++ b/tests/scenarios/harness/provision.py
@@ -328,6 +328,24 @@ async def _clear_run_debris(
             continue
         ledger.did(f"removed surface {name!r} from {pod.get('name')!r}")
 
+    # Agents, for a reason that only shows up after a few hundred runs and then
+    # stops the suite dead. Listing agents is paginated at 100, and provisioning
+    # decides whether the standing `frontdesk` exists by looking for it in that
+    # list. Once a standing pod holds more than a page of leftovers, the one
+    # agent that has to be there falls off the end, provisioning tries to create
+    # it, and the deployment answers 409 for a name that was there all along.
+    # Dev reached exactly that. `_standing_reach` no longer decides by scanning
+    # a page, and this stops the page filling up in the first place.
+    for agent in await owner.agents_in(pod):
+        name = str(agent.get("name", ""))
+        if not mine(name):
+            continue
+        try:
+            await owner.deletes_agent(name, in_pod=pod)
+        except AssertionError:
+            continue
+        ledger.did(f"removed agent {name!r} from {pod.get('name')!r}")
+
     entries = _tree_entries(await owner.file_tree_of(pod))
     # Deepest first: removing a folder takes what is inside it, so a child that
     # has already gone would otherwise 404 and stop the sweep on its way past.
@@ -527,8 +545,11 @@ async def _standing_reach(holder: Person, pods: dict[str, JSON], ledger: Ledger)
         pod = pods.get(reach.pod)
         if pod is None:
             continue
-        agents = {str(a.get("name")) for a in await holder.agents_in(pod)}
-        if reach.agent not in agents:
+        # Asked for by name rather than looked for in a list. The list is
+        # paginated at 100 and a standing pod accumulates, so "not in the first
+        # page" was being read as "does not exist" — which turns an idempotent
+        # step into a 409 that stops provisioning, and with it the whole run.
+        if not await holder.has_agent(reach.agent, in_pod=pod):
             await holder.creates_an_agent(
                 in_pod=pod,
                 named=reach.agent,

--- a/tests/scenarios/harness/steps/agent.py
+++ b/tests/scenarios/harness/steps/agent.py
@@ -113,6 +113,18 @@ class AgentSteps:
             what=f"{self.label} opening agent {name!r}",
         )
 
+    async def has_agent(self, name: str, *, in_pod: JSON) -> bool:
+        """Is this agent in this pod? Asked by name, and that is the point.
+
+        `agents_in` is the obvious way to answer it and the wrong one: the list
+        endpoint pages at 100, so on a pod holding more than that "not in the
+        list" means "not on the first page" and nothing more. Provisioning read
+        it as "does not exist", tried to create the standing agent, and a real
+        deployment answered 409 for a name that had been there all along.
+        """
+        answered = await self.api.call("GET", f"/pods/{in_pod['id']}/agents/{name}")
+        return answered.status_code == 200
+
     async def agents_in(self, pod: JSON) -> list[JSON]:
         return items_of(await self.api.get(f"/pods/{pod['id']}/agents"))
 

--- a/tests/scenarios/journeys/connectors_and_accounts/test_catalog_details.py
+++ b/tests/scenarios/journeys/connectors_and_accounts/test_catalog_details.py
@@ -117,7 +117,16 @@ async def test_an_oauth_connector_needs_credentials(world):
     unconfigured = [
         connector["id"]
         for connector in catalogue
-        for kind in connector.get("kinds") or []
+        # One kind only. This request names a connector and no kind, so a
+        # connector installable as more than one is refused for being ambiguous
+        # — correctly, and before credentials are looked at, since which
+        # credentials are wanted depends on the kind. Picking one of those meant
+        # asserting the credentials sentence against the ambiguity sentence.
+        # Dev's catalogue has `airtable` as both `package` and `composio`; a
+        # booted stack's does not, which is why this passed everywhere except
+        # the deployment.
+        if len(connector.get("kinds") or []) == 1
+        for kind in connector["kinds"]
         # The system default is the only thing that decides it: this installs
         # without naming a config source, so the product looks for a system
         # default and says so when there is none. Whether the connector *could*

--- a/tests/scenarios/journeys/surfaces_and_notifications/test_native_controls.py
+++ b/tests/scenarios/journeys/surfaces_and_notifications/test_native_controls.py
@@ -90,7 +90,12 @@ async def test_an_approval_is_offered_with_native_controls(reachable):
         f"an approval reached the person without a control to approve it: "
         f"{labels or 'no buttons at all'}"
     )
-    assert any(word in labels for word in ("den", "reject", "no", "decline")), (
+    # "cancel" is in this list because the product uses it, and it is a refusal
+    # a person reads as one. Asserting on a vocabulary the product does not
+    # share is how a scenario reports a working control as a missing one.
+    assert any(
+        word in labels for word in ("den", "reject", "decline", "cancel", "no")
+    ), (
         f"an approval reached the person without a control to refuse it: "
         f"{labels or 'no buttons at all'}"
     )


### PR DESCRIPTION
Three things, all from the first dev runs that actually exercised the new lane.
The first one is blocking: the dev suite currently does not run at all.

## 1. Provisioning stops dead on a long-lived deployment

```
provisioning stopped: daniel creating agent 'frontdesk' answered 409
```

409 for a name that had been there all along. `_standing_reach` decided whether
the standing agent exists by looking for it in `agents_in(pod)` — and that list
**pages at 100**. Once a standing pod holds more than a page of leftovers, the
one agent that must be there falls off the end, provisioning tries to create it,
the deployment refuses, and the entire run is skipped. Dev reached that point.

Two changes, because either alone leaves the trap set:

* **Ask by name.** `GET /pods/{id}/agents/{name}` answers exactly the question
  being asked and cannot be wrong about it however long the list gets.
* **Sweep run-made agents.** `_clear_run_debris` swept tables and surfaces and
  never agents, so they accumulated forever — which is what filled the page. The
  same shape as the 163 leftover surfaces the surface sweep was added for, and
  it refills without this.

Ruled out rather than assumed: agents have no `deleted_at` and the constraint is
a plain `UniqueConstraint(pod_id, name)`, so this is not a soft-deleted row
holding the name. It really was taken, and really was invisible to a first-page
lookup.

## 2. A scenario picking a connector it cannot install unambiguously

`test_an_oauth_connector_needs_credentials` wants an OAuth connector with no
system default, installs it, and expects a refusal naming what is missing. It
built that list by iterating each connector's `kinds` while keeping only the
connector id — so a connector installable more than one way was a candidate, and
the request names no kind:

```
installing 'airtable' -> {"reason":"ambiguous_kind",
                          "supported_kinds":["package","composio"]}
```

The product is right: which credentials are wanted depends on the kind, so
ambiguity is resolved first. The scenario was asserting the credentials sentence
against the ambiguity sentence. It now picks a connector with exactly one kind.

Dev's catalogue has `airtable` both ways and a booted stack's does not — so this
passed locally and in CI and failed only on the deployment it exists to check.

## 3. `DEV-DATA-004` — removing a column makes the table unreadable

Filed, not fixed.

```
create table (subject, body); add a record
add column `priority`  -> read OK
remove column `body`   -> read 400  "cached statement plan"
```

asyncpg keeps a per-connection prepared-statement cache; dropping a column
invalidates the plan and the next borrower of that **pooled** connection gets
the driver error rather than rows. Nothing catches it — `_build_connect_args`
sets `server_settings` and nothing else, neither engine passes
`statement_cache_size`, and `InvalidCachedStatementError` appears nowhere.

So it is not confined to whoever ran the DDL, and it heals when the connection
recycles: a person removes a column, their table stops working, then starts
working again with nothing they did in between.

The entry deliberately does not claim why `add column` survives — that may be
which connection each request landed on rather than anything about the
operation, and the answer decides whether the fix is "invalidate on drop" or
something broader.

## Verified

* provisioning reconciles clean locally; **4 passed, 1 xfailed**
* **24 passed** across `journeys/connectors_and_accounts`
* all **86** harness-contract tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)