### PR TITLE
Regenerate the markup, and don't ask a PDF font for emoji

### DIFF
--- a/lemma-skills/lemma-artifact-author/SKILL.md
+++ b/lemma-skills/lemma-artifact-author/SKILL.md
@@ -101,7 +101,9 @@ selected format. Read only the relevant format sections.
 
 Build an outline, slide map, workbook model, or page structure before styling.
 Use real content and representative data; do not leave placeholder copy unless
-the user requested a template.
+the user requested a template. Keep that model the thing you edit: change
+generated output by regenerating it, not by patching the rendered file with
+`sed -i` or another regex-substitution tool.
 
 For revisions, make the smallest defensible change in the native source. Preserve
 styles, section and sheet structure, references, metadata, embedded assets, and

--- a/lemma-skills/lemma-artifact-author/references/formats.md
+++ b/lemma-skills/lemma-artifact-author/references/formats.md
@@ -38,6 +38,11 @@ distribution, or accessibility value.
 - Keep JavaScript purposeful. Provide a readable static state if scripting fails,
   and avoid remote dependencies unless the user accepts their availability and
   privacy tradeoffs.
+- Revise generated markup by regenerating it from the content model, not by
+  patching the rendered file. When a patch is unavoidable, rewrite the file or
+  use a literal string replacement such as Python `str.replace`; never `sed -i`,
+  whose `&` and `/` are replacement syntax, so a swap silently duplicates the
+  matched text or grafts the replacement onto a fragment meant to be deleted.
 - Validate DOM structure and links, then render desktop, narrow mobile, and print
   output. Exercise interactions, overflow states, long content, and empty states.
 - Route an authenticated or data-backed Lemma app to `lemma-app-design` and
@@ -71,6 +76,10 @@ distribution, or accessibility value.
 - Preserve searchable text, selectable links, bookmarks, page labels, annotations,
   form behavior, fonts, page boxes, and metadata when they are part of the job.
   Preserve original scan images even when adding an OCR text layer.
+- Do not rely on emoji anywhere in a document rendered to PDF unless a font with
+  emoji coverage is confirmed present in the rendering environment. Engines such
+  as WeasyPrint draw uncovered codepoints as empty boxes, and only a page render
+  exposes it. Use text labels, inline SVG, or plain typographic marks instead.
 - Check file integrity, page count, page dimensions/orientation, text extraction,
   link targets, font substitution, blank pages, and forms where applicable.
 - Render every page. Inspect overview thumbnails plus dense pages at full size for


### PR DESCRIPTION
## What changes

Three additions to the `lemma-artifact-author` skill — nine lines in
`references/formats.md`, three in `SKILL.md`:

- **HTML section** — revise generated markup by regenerating it from the content
  model, not by patching the rendered file. When a patch is unavoidable, rewrite
  the file or use a literal string replacement such as Python `str.replace`;
  never `sed -i`.
- **PDF section** — no emoji in anything rendered to PDF unless a font with emoji
  coverage is confirmed present in the rendering environment. Use text labels,
  inline SVG, or plain typographic marks.
- **SKILL.md §4** — the general form of the first rule, in the section that
  already assumes a content model exists.

## Why

Two failure modes from a real dev run where the pod assistant built a PDF through
this skill (HTML → WeasyPrint).

**`sed` corrupted the generated HTML.** The agent swapped emoji for words with
`sed -i`, using replacement text containing `&` and `/`. In a sed replacement `&`
means the whole match, which produced a duplicated heading fragment
(`<h2>Infra & Tooling Infra &amp; Tooling Updates (past week)</h2>`) and grafted a
replacement onto text meant to be deleted (`Prepared for a friend an open-source
fan`). It cost five extra turns to notice and repair, and was caught only because
a rendered page was visually inspected. The agent's eventual fix was a Python
heredoc doing plain `str.replace` — which is what should have run from the start.

**Emoji rendered as tofu boxes.** Section headings used 🔴 ⚡ ⚙️ and the footer
used ✌️; all came out as empty rectangles because the container's font stack has
no emoji coverage. Caught only by rasterising a page to PNG and looking at it.

Both are cheap to prevent with guidance, and both are invisible to every check
short of looking at a rendered page — which is exactly the kind of rule this
skill exists to carry.

The HTML bullet deliberately leads with *regenerate, don't patch* so it parallels
the PDF section's existing "Edit the native source and regenerate whenever
possible instead of patching the PDF" — the same rule, one step earlier in the
delivery chain.

## How to verify

Docs-only change to one skill. The skill still loads and bundles:

```bash
cd lemma-cli && uv run pytest tests/test_skills_bundle.py -q
```

Printed `8 passed in 0.19s`.

Added lines stay under 80 columns; the only long lines in either file are the
pre-existing frontmatter `description` and the format-routing table rows:

```bash
awk 'length > 88 {print FILENAME": "FNR}' lemma-skills/lemma-artifact-author/SKILL.md lemma-skills/lemma-artifact-author/references/formats.md
```

## Reviewer notes

**The skill is not duplicated in the tree.** `lemma-cli/lemma_cli/skills/` looks
like a second copy but does not exist in the repo — it is a build artifact.
`_vendor_skills()` in `lemma-cli/setup.py` rmtree's that destination and
`copytree`s each skill from repo-root `lemma-skills/` during sdist and wheel
builds, failing loudly if the source is missing and no vendored copy is already
in place. The backend (`skill_loader.py`) and `lemma-stack` read `lemma-skills/`
directly too, so this PR touches the single source of truth and no sync step is
needed.

## Checklist

- [x] Lint, typecheck, and architecture gates pass locally

Tests cover the behavioral change: not applicable — this is skill prose, with no
executable behavior to assert beyond the bundle test above.

## Compatibility and rollback notes

Nothing to note. Documentation-only, additive, and revertable with a plain
`git revert`.
