### PR TITLE
Call a skill's pod path a pod path, not a workspace path

### DIFF
--- a/lemma-backend/agent_tool_schemas.json
+++ b/lemma-backend/agent_tool_schemas.json
@@ -1054,12 +1054,12 @@
               "description": "Backing path to the skill's `SKILL.md` file. Pod skills use `/skills/...` paths.",
               "type": "string"
             },
-            "workspace_path": {
-              "description": "Workspace-visible absolute path to the skill's `SKILL.md` file.",
+            "pod_path": {
+              "description": "Pod file path of the skill's `SKILL.md`. This is a pod file path, not a path on the workspace filesystem: nothing mounts `/skills` inside the workspace container, so `cat`/`ls` on it fail. Read it with `load_skill`, or with `lemma files cat <path>` from a workspace shell.",
               "type": "string"
             },
-            "workspace_dir": {
-              "description": "Workspace-visible absolute path to the root directory for this skill.",
+            "pod_dir": {
+              "description": "Pod file path of this skill's root directory. This is a pod file path, not a path on the workspace filesystem: nothing mounts `/skills` inside the workspace container, so `cat`/`ls` on it fail. Read it with `load_skill`, or with `lemma files cat <path>` from a workspace shell.",
               "type": "string"
             }
           },
@@ -1067,8 +1067,8 @@
             "name",
             "description",
             "path",
-            "workspace_path",
-            "workspace_dir"
+            "pod_path",
+            "pod_dir"
           ],
           "title": "SkillSummary",
           "type": "object"
@@ -1247,11 +1247,11 @@
         "SkillResourceSummary": {
           "properties": {
             "path": {
-              "description": "Relative path to the resource inside the skill directory.",
+              "description": "Relative path to the resource inside the skill directory. Pass it back as `load_skill`'s `resource_path` to read the resource.",
               "type": "string"
             },
-            "workspace_path": {
-              "description": "Workspace-visible absolute path to the resource file.",
+            "pod_path": {
+              "description": "Pod file path of the resource. This is a pod file path, not a path on the workspace filesystem: nothing mounts `/skills` inside the workspace container, so `cat`/`ls` on it fail. Read it with `load_skill`, or with `lemma files cat <path>` from a workspace shell.",
               "type": "string"
             },
             "kind": {
@@ -1265,7 +1265,7 @@
           },
           "required": [
             "path",
-            "workspace_path",
+            "pod_path",
             "kind",
             "executable"
           ],

--- a/lemma-backend/app/modules/agent/tests/unit/test_skill_loader.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_skill_loader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from types import SimpleNamespace
 from uuid import uuid4
 
@@ -14,7 +15,11 @@ from app.modules.agent.tools.skills.skill_loader import (
     read_workspace_skill_resource,
 )
 from app.modules.agent.tools.skills import pydantic_adapter as skills_adapter
-from app.modules.agent.tools.skills.models import SkillLookupRequest
+from app.modules.agent.tools.skills.models import (
+    SkillLookupRequest,
+    SkillResourceSummary,
+    SkillSummary,
+)
 from app.modules.agent.tools.context import BaseAgentContext
 from app.modules.datastore.domain.errors import DatastoreFileNotFoundError
 
@@ -117,8 +122,8 @@ async def test_pod_skill_loader_lists_system_and_custom_skills_with_skill_md():
     )
 
     assert [item["name"] for item in skills] == ["browser", "custom-skill"]
-    assert skills[1]["workspace_path"] == "/skills/custom-skill/SKILL.md"
-    assert skills[1]["workspace_dir"] == "/skills/custom-skill"
+    assert skills[1]["pod_path"] == "/skills/custom-skill/SKILL.md"
+    assert skills[1]["pod_dir"] == "/skills/custom-skill"
 
 
 @pytest.mark.asyncio
@@ -159,13 +164,13 @@ async def test_pod_skill_loader_reads_skill_content_and_resources():
     assert resources == [
         {
             "path": "references/example.md",
-            "workspace_path": "/skills/custom-skill/references/example.md",
+            "pod_path": "/skills/custom-skill/references/example.md",
             "kind": "text",
             "executable": "false",
         },
         {
             "path": "scripts/setup.sh",
-            "workspace_path": "/skills/custom-skill/scripts/setup.sh",
+            "pod_path": "/skills/custom-skill/scripts/setup.sh",
             "kind": "script",
             "executable": "true",
         },
@@ -293,3 +298,63 @@ async def test_skill_download_releases_uow_before_storage_read():
 
     assert content == "content"
     assert order == ["resolve", "commit", "read"]
+
+
+_SANDBOX_IMAGES = Path(__file__).resolve().parents[5] / "sandbox-images"
+_WORKSPACE_IMAGE_SOURCES = (
+    _SANDBOX_IMAGES / "Dockerfile.workspace",
+    _SANDBOX_IMAGES / "templates" / "e2b" / "build_templates.py",
+)
+
+
+@pytest.mark.asyncio
+async def test_skill_resources_advertise_a_readable_path_not_a_container_path():
+    """The advertised path must be one the agent can actually read.
+
+    Resources used to carry `workspace_path`, which reads as "a path in the
+    workspace container" — so an agent ran `cat /skills/<skill>/references/<f>.md`
+    (empty), then `ls` (no such directory), then `find /` across the container
+    before finding the real copies under /opt and /workspace. `/skills` is a pod
+    file path; the tool is what resolves it.
+    """
+    name = "lemma-artifact-author"
+
+    resources = await list_workspace_skill_resources(name)
+
+    assert resources
+    for item in resources:
+        assert set(item) == {"path", "pod_path", "kind", "executable"}
+        assert item["pod_path"] == f"/skills/{name}/{item['path']}"
+        # The advertised route reads it; the advertised path is not a filesystem
+        # path and is never presented as one.
+        assert await read_workspace_skill_resource(name, item["path"])
+
+
+def test_skill_output_never_advertises_a_workspace_filesystem_path():
+    fields = {**SkillSummary.model_fields, **SkillResourceSummary.model_fields}
+
+    assert "workspace_path" not in fields
+    assert "workspace_dir" not in fields
+
+    for field_name in ("pod_path", "pod_dir"):
+        description = fields[field_name].description or ""
+        assert "not a path on the workspace filesystem" in description
+        assert "load_skill" in description
+
+
+@pytest.mark.parametrize("source", _WORKSPACE_IMAGE_SOURCES, ids=lambda p: p.name)
+def test_workspace_image_creates_no_skills_directory(source: Path):
+    """The claim the field descriptions make, checked against the images.
+
+    Both workspace builds put the shipped skills under `/sdk/lemma-skills` and
+    inside the installed `lemma_cli` package; neither creates `/skills`. If one
+    ever mounts or symlinks it, this fails — and `pod_path` should go back to
+    advertising a real container path.
+    """
+    offenders = [
+        line
+        for line in source.read_text(encoding="utf-8").splitlines()
+        if "/skills" in line.replace("lemma-skills", "").replace("lemma_cli/skills", "")
+    ]
+
+    assert offenders == []

--- a/lemma-backend/app/modules/agent/tools/skills/models.py
+++ b/lemma-backend/app/modules/agent/tools/skills/models.py
@@ -24,26 +24,37 @@ class SkillLookupRequest(BaseModel):
     )
 
 
+_POD_PATH_NOTE = (
+    "This is a pod file path, not a path on the workspace filesystem: nothing "
+    "mounts `/skills` inside the workspace container, so `cat`/`ls` on it fail. "
+    "Read it with `load_skill`, or with `lemma files cat <path>` from a "
+    "workspace shell."
+)
+
+
 class SkillSummary(BaseModel):
     name: str = Field(description="Unique skill name.")
     description: str = Field(description="Short description of what the skill does.")
     path: str = Field(
         description="Backing path to the skill's `SKILL.md` file. Pod skills use `/skills/...` paths."
     )
-    workspace_path: str = Field(
-        description="Workspace-visible absolute path to the skill's `SKILL.md` file."
+    pod_path: str = Field(
+        description=f"Pod file path of the skill's `SKILL.md`. {_POD_PATH_NOTE}"
     )
-    workspace_dir: str = Field(
-        description="Workspace-visible absolute path to the root directory for this skill."
+    pod_dir: str = Field(
+        description=f"Pod file path of this skill's root directory. {_POD_PATH_NOTE}"
     )
 
 
 class SkillResourceSummary(BaseModel):
     path: str = Field(
-        description="Relative path to the resource inside the skill directory."
+        description=(
+            "Relative path to the resource inside the skill directory. Pass it "
+            "back as `load_skill`'s `resource_path` to read the resource."
+        )
     )
-    workspace_path: str = Field(
-        description="Workspace-visible absolute path to the resource file."
+    pod_path: str = Field(
+        description=f"Pod file path of the resource. {_POD_PATH_NOTE}"
     )
     kind: str = Field(
         description="High-level resource type such as `text`, `script`, or `file`."

--- a/lemma-backend/app/modules/agent/tools/skills/skill_loader.py
+++ b/lemma-backend/app/modules/agent/tools/skills/skill_loader.py
@@ -18,6 +18,17 @@ from app.composition.authorization import create_authorization_service
 from functools import lru_cache
 
 _FRONTMATTER_NAME_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$")
+
+# Where skills live in the *pod file tree*: pod-authored skills are stored
+# there, and the system skills shipped in `lemma-skills/` are spliced in
+# read-only by `SystemSkillFileProvider`. It is not a directory in the
+# workspace container — the workspace image (sandbox-images/Dockerfile.workspace)
+# creates no `/skills`, and the shipped copies land at `/sdk/lemma-skills` and
+# inside the installed `lemma_cli` package instead. These paths were once
+# emitted as `workspace_path`/`workspace_dir`, and agents did the reasonable
+# thing: `cat /skills/<name>/references/<file>.md`, then `ls`, then `find /`.
+# They are named `pod_path`/`pod_dir` now, and the way to read one is
+# `load_skill(resource_path=...)` or `lemma files cat`.
 _SKILLS_ROOT = "/skills"
 
 
@@ -26,8 +37,8 @@ class SkillEntry:
     name: str
     description: str
     path: str
-    workspace_path: str
-    workspace_dir: str
+    pod_path: str
+    pod_dir: str
 
 
 @dataclass(frozen=True)
@@ -153,8 +164,8 @@ def _build_system_skill_catalog() -> dict[str, SkillEntry]:
             name=name,
             description=description,
             path=str(skill_md.relative_to(repo_root)),
-            workspace_path=_skill_file_path(name),
-            workspace_dir=_skill_dir_path(name),
+            pod_path=_skill_file_path(name),
+            pod_dir=_skill_dir_path(name),
         )
 
     return entries
@@ -322,8 +333,8 @@ async def _build_pod_skill_catalog(
                 name=name,
                 description=description,
                 path=skill_md_path,
-                workspace_path=skill_md_path,
-                workspace_dir=_skill_dir_path(name),
+                pod_path=skill_md_path,
+                pod_dir=_skill_dir_path(name),
             )
     return entries
 
@@ -380,8 +391,8 @@ async def list_workspace_skills(
                 "name": entry.name,
                 "description": entry.description,
                 "path": entry.path,
-                "workspace_path": entry.workspace_path,
-                "workspace_dir": entry.workspace_dir,
+                "pod_path": entry.pod_path,
+                "pod_dir": entry.pod_dir,
             }
         )
     return items
@@ -463,7 +474,7 @@ async def list_workspace_skill_resources(
                 resources.append(
                     {
                         "path": relative.as_posix(),
-                        "workspace_path": item.path,
+                        "pod_path": item.path,
                         "kind": _resource_kind(relative),
                         "executable": "true" if relative.suffix == ".sh" else "false",
                     }
@@ -489,7 +500,7 @@ def _list_system_skill_resources(name: str) -> list[dict[str, str]]:
         resources.append(
             {
                 "path": str(relative),
-                "workspace_path": _skill_file_path(name, relative),
+                "pod_path": _skill_file_path(name, relative),
                 "kind": _resource_kind(relative),
                 "executable": "true" if path.suffix == ".sh" else "false",
             }

--- a/tests/scenarios/harness/egress_addon.py
+++ b/tests/scenarios/harness/egress_addon.py
@@ -125,8 +125,11 @@ class Recorder:
             self._provider = fake_upstreams.start_fake_provider()
             ctx.log.info(
                 "egress serving the provider fake"
-                + ("; Telegram goes to Telegram" if ctx.options.real_telegram
-                   else " and the Telegram fake")
+                + (
+                    "; Telegram goes to Telegram"
+                    if ctx.options.real_telegram
+                    else " and the Telegram fake"
+                )
             )
 
     async def request(self, flow: http.HTTPFlow) -> None:

--- a/tests/scenarios/harness/telegram_chat.py
+++ b/tests/scenarios/harness/telegram_chat.py
@@ -112,8 +112,7 @@ def telegram_is_live() -> bool:
     if egress_module.wanted_mode() in {"fake", "replay"}:
         return False
     return all(
-        capability.available
-        for capability in (TELEGRAM, TELEGRAM_APP, TELEGRAM_PERSON)
+        capability.available for capability in (TELEGRAM, TELEGRAM_APP, TELEGRAM_PERSON)
     )
 
 

--- a/tests/scenarios/journeys/surfaces_and_notifications/conftest.py
+++ b/tests/scenarios/journeys/surfaces_and_notifications/conftest.py
@@ -79,9 +79,7 @@ class Reachable:
     async def conversations(self) -> list[Any]:
         """The conversations this scenario opened, newest excluded of nothing."""
         found = await self.alice.conversations_in(self.pod)
-        return [
-            thread for thread in found if str(_thread_id(thread)) not in self._before
-        ]
+        return [thread for thread in found if str(_thread_id(thread)) not in self._before]
 
     def only_forged(self, why: str) -> None:
         """Skip unless this lane can deliver what Telegram never sent."""

--- a/tests/scenarios/journeys/surfaces_and_notifications/test_being_answered.py
+++ b/tests/scenarios/journeys/surfaces_and_notifications/test_being_answered.py
@@ -64,9 +64,7 @@ UNREADABLE_ON_REAL_TELEGRAM = pytest.mark.xfail(
 @proves("PS-SURF-010", "PS-SURF-020")
 @covers("surface.webhook.handle_platform", "agent.surface.send")
 async def test_a_message_is_answered(reachable):
-    await reachable.says(
-        "Hello — reply with a short greeting so I know you are there."
-    )
+    await reachable.says("Hello — reply with a short greeting so I know you are there.")
 
     answer = await reachable.waits_for_a_reply()
 

--- a/tests/scenarios/journeys/surfaces_and_notifications/test_surface_management.py
+++ b/tests/scenarios/journeys/surfaces_and_notifications/test_surface_management.py
@@ -19,9 +19,7 @@ async def connected(world, run, egress):
     alice = await world.person("daniel")
     pod = await alice.creates_a_pod(named=run.name("pod"))
     agent = await alice.creates_an_agent(in_pod=pod)
-    surface = await alice.becomes_reachable_on_telegram(
-        in_pod=pod, agent=agent["name"]
-    )
+    surface = await alice.becomes_reachable_on_telegram(in_pod=pod, agent=agent["name"])
     yield alice, pod, agent, surface, fake
 
 


### PR DESCRIPTION
## What changes

`load_skill` no longer advertises a filesystem path that does not exist. The `workspace_path` / `workspace_dir` fields on skills and their resources become `pod_path` / `pod_dir`, and each description now says plainly that the value is a pod file path, that `cat`/`ls` on it will fail, and that `load_skill(resource_path=...)` — or `lemma files cat <path>` from a workspace shell — is how to read it.

## Why

`/skills` is a pod file path. Pod-authored skills are stored there in the datastore, and the shipped `lemma-skills/` are spliced into every pod's tree read-only by `SystemSkillFileProvider`. Calling it `workspace_path` told the agent it was a path in the workspace container, so it used it as one. From a real dev run (pod assistant, `lemma-artifact-author`):

1. `load_skill(name="lemma-artifact-author")` → `resources: [{path: "references/formats.md", workspace_path: "/skills/lemma-artifact-author/references/formats.md"}, ...]`
2. `cat /skills/lemma-artifact-author/references/formats.md` → empty
3. `ls -la /skills/lemma-artifact-author/references/` → No such file or directory
4. `find / -name "formats.md" -path "*artifact*"` → the real copies, under `/opt/lemma-python/.../lemma_cli/skills/` and `/workspace/.../lemma-skills/`

Three wasted tool calls plus a full-filesystem scan, on every skill that ships `resources`.

Checking what the workspace image provides settled which fix is right. `sandbox-images/Dockerfile.workspace` never creates `/skills` — the shipped skills land at `/sdk/lemma-skills` (line 225) and inside the installed `lemma_cli` package; the e2b template builder is the same. So:

- **Emitting the real on-disk path** can't work. It would produce an image-layout path for shipped skills and *nothing at all* for pod-authored ones, which exist only in the datastore.
- **Mounting or symlinking `/skills`** would need a per-session sync from object storage for pod skills, going stale the moment an agent edits one. Half-true is worse than the current state.
- **Naming the field for what it is** costs nothing and makes the output match the filesystem: the path is real and useful (it is what `lemma files cat` and the skill-creator flow take), it just isn't a container path.

Nothing else consumed these fields — the frontend tool card reads `name` / `path` / `resource_path` only — so this is a pure output-contract change with no caller migration.

## How to verify

```bash
cd lemma-backend && uv run pytest app/modules/agent/tests/unit -q
```

`1119 passed, 29 skipped` (the skips are redis-dependent tests in `test_agent_host_event_stream.py`), plus the 10 in `test_skill_loader.py`. Also clean: `uv run ruff check` and `ruff format --check` on the touched files, `app/modules/agent/tests/unit/test_tool_schema_compat.py` (9 passed), and `uv run python scripts/check_architecture.py` — "Architecture ratchet passed (12 inherited import violations, 0 inherited cycles)".

Three tests in `test_skill_loader.py` assert the advertised path is honest rather than merely present:

- every resource of a real shipped skill has exactly the keys `path`/`pod_path`/`kind`/`executable`, and each one reads back through the documented route;
- neither `SkillSummary` nor `SkillResourceSummary` carries a `workspace_*` field, and both `pod_*` descriptions disclaim the filesystem and name `load_skill`;
- neither workspace image source creates `/skills` — parametrized over `Dockerfile.workspace` and the e2b `build_templates.py`. If one ever mounts it, that test fails and forces the field to be revisited instead of quietly becoming a lie again.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **API surface** — `agent_tool_schemas.json` regenerated via `uv run python scripts/export_agent_tool_schemas.py` and committed. No OpenAPI or SDK surface is touched: the skills toolset is agent-facing only.
- [x] **Compatibility** — see below

## Compatibility and rollback notes

This renames two fields in the `list_skills` / `load_skill` tool results, which are consumed by the model, not by stored data or an external client. No migration, no persisted state, nothing to backfill; reverting the commit fully restores the previous behaviour.

One thing left alone, worth a reviewer's eye: `SkillSummary.path` is repo-relative (`lemma-skills/browser/SKILL.md`) in the system-only catalog branch, which is the same class of path-shaped hazard. That branch only runs when `pod_id`/`user_id` are absent, and both are non-optional on `AgentContext`, so no real agent run reaches it today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
