### PR TITLE
Answer a stream that says "reconnect" by reconnecting, and stop an answer vanishing at the end of its turn

### DIFF
--- a/lemma-backend/app/modules/agent/api/controllers/conversation_streaming.py
+++ b/lemma-backend/app/modules/agent/api/controllers/conversation_streaming.py
@@ -66,8 +66,17 @@ async def start_and_stream_run(
                 agent_run_id=str(result.agent_run_id),
                 exc_info=True,
             )
+            # `stream_error`, not `error`. The two say opposite things about
+            # the run: `error` is the run failing, and a client that sees one
+            # is right to stop and offer a retry. This is the *transport*
+            # giving up — the subscription was evicted or Redis dropped it —
+            # while the run carries on writing messages nobody is listening
+            # for. Sent under the same name, the sentence "Reconnect to
+            # continue" reached a client that had just decided the run was
+            # over, so the one frame that asks for a reconnect was the one
+            # frame that guaranteed there would not be one.
             yield encode_stream_chunk(
-                event_type="error",
+                event_type="stream_error",
                 data="Realtime stream interrupted. Reconnect to continue.",
                 agent_run_id=result.agent_run_id,
             )

--- a/lemma-backend/app/modules/agent/tests/unit/test_conversation_controller.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_conversation_controller.py
@@ -394,7 +394,15 @@ async def test_stream_conversation_forwards_active_run_events(monkeypatch) -> No
 
 
 @pytest.mark.asyncio
-async def test_send_message_encodes_stream_failures_as_sse_errors(monkeypatch) -> None:
+async def test_send_message_encodes_a_dead_subscription_as_stream_error(
+    monkeypatch,
+) -> None:
+    """A dead subscription is not a failed run, and must not be named like one.
+
+    `stream_error` is what tells the client to reconnect; `error` is what tells
+    it the run is over. Sending the second while the run is still writing left
+    the client sitting on a transcript that stopped moving.
+    """
     result = AgentRunStartResult(
         conversation_id=uuid4(),
         agent_run_id=uuid4(),
@@ -424,7 +432,7 @@ async def test_send_message_encodes_stream_failures_as_sse_errors(monkeypatch) -
     payload = json.loads(chunks[0].removeprefix("data: ").strip())
 
     assert payload == {
-        "type": "error",
+        "type": "stream_error",
         "data": "Realtime stream interrupted. Reconnect to continue.",
         "agent_run_id": str(result.agent_run_id),
     }

--- a/lemma-typescript/public/lemma-client.js
+++ b/lemma-typescript/public/lemma-client.js
@@ -44,9 +44,9 @@ var LemmaClient = (() => {
   var __privateAdd = (obj, member, value) => member.has(obj) ? __typeError("Cannot add the same private member more than once") : member instanceof WeakSet ? member.add(obj) : member.set(obj, value);
   var __privateSet = (obj, member, value, setter) => (__accessCheck(obj, member, "write to private field"), setter ? setter.call(obj, value) : member.set(obj, value), value);
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/windowHandler/defaultImplementation.js
+  // node_modules/supertokens-website/lib/build/utils/windowHandler/defaultImplementation.js
   var require_defaultImplementation = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/windowHandler/defaultImplementation.js"(exports) {
+    "node_modules/supertokens-website/lib/build/utils/windowHandler/defaultImplementation.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -315,9 +315,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/windowHandler/index.js
+  // node_modules/supertokens-website/lib/build/utils/windowHandler/index.js
   var require_windowHandler = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/windowHandler/index.js"(exports) {
+    "node_modules/supertokens-website/lib/build/utils/windowHandler/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.WindowHandlerReference = void 0;
@@ -354,9 +354,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/utils/windowHandler/index.js
+  // node_modules/supertokens-website/utils/windowHandler/index.js
   var require_windowHandler2 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/utils/windowHandler/index.js"(exports) {
+    "node_modules/supertokens-website/utils/windowHandler/index.js"(exports) {
       "use strict";
       function __export2(m) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -366,9 +366,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/windowHandler/index.js
+  // node_modules/supertokens-web-js/lib/build/windowHandler/index.js
   var require_windowHandler3 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/windowHandler/index.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/windowHandler/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.WindowHandlerReference = void 0;
@@ -382,9 +382,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/constants.js
+  // node_modules/supertokens-web-js/lib/build/constants.js
   var require_constants = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/constants.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/constants.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.SSR_ERROR = exports.DEFAULT_API_BASE_PATH = void 0;
@@ -393,9 +393,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/normalisedURLDomain.js
+  // node_modules/supertokens-web-js/lib/build/normalisedURLDomain.js
   var require_normalisedURLDomain = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/normalisedURLDomain.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/normalisedURLDomain.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       var NormalisedURLDomain = (
@@ -458,9 +458,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/normalisedURLPath.js
+  // node_modules/supertokens-web-js/lib/build/normalisedURLPath.js
   var require_normalisedURLPath = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/normalisedURLPath.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/normalisedURLPath.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       var NormalisedURLPath = (
@@ -530,9 +530,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/types.js
+  // node_modules/supertokens-web-js/lib/build/types.js
   var require_types = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/types.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/types.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.nonPublicConfigProperties = void 0;
@@ -540,9 +540,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/normalisedURLDomain.js
+  // node_modules/supertokens-website/lib/build/normalisedURLDomain.js
   var require_normalisedURLDomain2 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/normalisedURLDomain.js"(exports) {
+    "node_modules/supertokens-website/lib/build/normalisedURLDomain.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.isAnIpAddress = void 0;
@@ -607,9 +607,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/normalisedURLPath.js
+  // node_modules/supertokens-website/lib/build/normalisedURLPath.js
   var require_normalisedURLPath2 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/normalisedURLPath.js"(exports) {
+    "node_modules/supertokens-website/lib/build/normalisedURLPath.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       var NormalisedURLPath = (
@@ -679,9 +679,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/index.js
+  // node_modules/supertokens-website/lib/build/utils/index.js
   var require_utils = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/index.js"(exports) {
+    "node_modules/supertokens-website/lib/build/utils/index.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -953,9 +953,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/processState.js
+  // node_modules/supertokens-website/lib/build/processState.js
   var require_processState = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/processState.js"(exports) {
+    "node_modules/supertokens-website/lib/build/processState.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -1137,9 +1137,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/version.js
+  // node_modules/supertokens-website/lib/build/version.js
   var require_version = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/version.js"(exports) {
+    "node_modules/supertokens-website/lib/build/version.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.supported_fdi = exports.package_version = void 0;
@@ -1148,9 +1148,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/cookieHandler/defaultImplementation.js
+  // node_modules/supertokens-website/lib/build/utils/cookieHandler/defaultImplementation.js
   var require_defaultImplementation2 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/cookieHandler/defaultImplementation.js"(exports) {
+    "node_modules/supertokens-website/lib/build/utils/cookieHandler/defaultImplementation.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -1284,9 +1284,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/cookieHandler/index.js
+  // node_modules/supertokens-website/lib/build/utils/cookieHandler/index.js
   var require_cookieHandler = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/cookieHandler/index.js"(exports) {
+    "node_modules/supertokens-website/lib/build/utils/cookieHandler/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.CookieHandlerReference = void 0;
@@ -1323,9 +1323,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/browser-tabs-lock/processLock.js
+  // node_modules/browser-tabs-lock/processLock.js
   var require_processLock = __commonJS({
-    "../../../../lemma-typescript/node_modules/browser-tabs-lock/processLock.js"(exports) {
+    "node_modules/browser-tabs-lock/processLock.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       var ProcessLocking = (
@@ -1391,9 +1391,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/browser-tabs-lock/index.js
+  // node_modules/browser-tabs-lock/index.js
   var require_browser_tabs_lock = __commonJS({
-    "../../../../lemma-typescript/node_modules/browser-tabs-lock/index.js"(exports) {
+    "node_modules/browser-tabs-lock/index.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         return new (P || (P = Promise))(function(resolve2, reject) {
@@ -1838,9 +1838,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/lockFactory/index.js
+  // node_modules/supertokens-website/lib/build/utils/lockFactory/index.js
   var require_lockFactory = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/lockFactory/index.js"(exports) {
+    "node_modules/supertokens-website/lib/build/utils/lockFactory/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.LockFactoryReference = void 0;
@@ -1878,9 +1878,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/logger.js
+  // node_modules/supertokens-website/lib/build/logger.js
   var require_logger = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/logger.js"(exports) {
+    "node_modules/supertokens-website/lib/build/logger.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.logDebugMessage = exports.disableLogging = exports.enableLogging = void 0;
@@ -1906,9 +1906,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/dateProvider/defaultImplementation.js
+  // node_modules/supertokens-website/lib/build/utils/dateProvider/defaultImplementation.js
   var require_defaultImplementation3 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/dateProvider/defaultImplementation.js"(exports) {
+    "node_modules/supertokens-website/lib/build/utils/dateProvider/defaultImplementation.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.DateProvider = void 0;
@@ -1961,9 +1961,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/dateProvider/index.js
+  // node_modules/supertokens-website/lib/build/utils/dateProvider/index.js
   var require_dateProvider = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/dateProvider/index.js"(exports) {
+    "node_modules/supertokens-website/lib/build/utils/dateProvider/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.DateProviderReference = void 0;
@@ -1999,9 +1999,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/fetch.js
+  // node_modules/supertokens-website/lib/build/fetch.js
   var require_fetch = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/fetch.js"(exports) {
+    "node_modules/supertokens-website/lib/build/fetch.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -3305,9 +3305,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/sessionClaimValidatorStore.js
+  // node_modules/supertokens-website/lib/build/utils/sessionClaimValidatorStore.js
   var require_sessionClaimValidatorStore = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/sessionClaimValidatorStore.js"(exports) {
+    "node_modules/supertokens-website/lib/build/utils/sessionClaimValidatorStore.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.SessionClaimValidatorStore = void 0;
@@ -3331,9 +3331,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/globalClaimValidators.js
+  // node_modules/supertokens-website/lib/build/utils/globalClaimValidators.js
   var require_globalClaimValidators = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/globalClaimValidators.js"(exports) {
+    "node_modules/supertokens-website/lib/build/utils/globalClaimValidators.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.getGlobalClaimValidators = void 0;
@@ -3354,9 +3354,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/utils/globalClaimValidators/index.js
+  // node_modules/supertokens-website/utils/globalClaimValidators/index.js
   var require_globalClaimValidators2 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/utils/globalClaimValidators/index.js"(exports) {
+    "node_modules/supertokens-website/utils/globalClaimValidators/index.js"(exports) {
       "use strict";
       function __export2(m) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -3366,9 +3366,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/utils.js
+  // node_modules/supertokens-web-js/lib/build/utils.js
   var require_utils2 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/utils.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/utils.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -3582,9 +3582,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/recipeModule/index.js
+  // node_modules/supertokens-web-js/lib/build/recipe/recipeModule/index.js
   var require_recipeModule = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/recipeModule/index.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/recipe/recipeModule/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       var RecipeModule = (
@@ -3600,9 +3600,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/axiosError.js
+  // node_modules/supertokens-website/lib/build/axiosError.js
   var require_axiosError = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/axiosError.js"(exports) {
+    "node_modules/supertokens-website/lib/build/axiosError.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -3811,9 +3811,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/axios.js
+  // node_modules/supertokens-website/lib/build/axios.js
   var require_axios = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/axios.js"(exports) {
+    "node_modules/supertokens-website/lib/build/axios.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -4520,9 +4520,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/error.js
+  // node_modules/supertokens-website/lib/build/error.js
   var require_error = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/error.js"(exports) {
+    "node_modules/supertokens-website/lib/build/error.js"(exports) {
       "use strict";
       var __extends = exports && exports.__extends || /* @__PURE__ */ (function() {
         var extendStatics = function(d, b) {
@@ -4564,9 +4564,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/xmlhttprequest.js
+  // node_modules/supertokens-website/lib/build/xmlhttprequest.js
   var require_xmlhttprequest = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/xmlhttprequest.js"(exports) {
+    "node_modules/supertokens-website/lib/build/xmlhttprequest.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -5342,9 +5342,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/recipeImplementation.js
+  // node_modules/supertokens-website/lib/build/recipeImplementation.js
   var require_recipeImplementation = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/recipeImplementation.js"(exports) {
+    "node_modules/supertokens-website/lib/build/recipeImplementation.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -5901,9 +5901,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-js-override/lib/build/getProxyObject.js
+  // node_modules/supertokens-js-override/lib/build/getProxyObject.js
   var require_getProxyObject = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-js-override/lib/build/getProxyObject.js"(exports) {
+    "node_modules/supertokens-js-override/lib/build/getProxyObject.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -5944,9 +5944,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-js-override/lib/build/index.js
+  // node_modules/supertokens-js-override/lib/build/index.js
   var require_build = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-js-override/lib/build/index.js"(exports) {
+    "node_modules/supertokens-js-override/lib/build/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.OverrideableBuilder = void 0;
@@ -6020,9 +6020,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/claims/primitiveClaim.js
+  // node_modules/supertokens-website/lib/build/claims/primitiveClaim.js
   var require_primitiveClaim = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/claims/primitiveClaim.js"(exports) {
+    "node_modules/supertokens-website/lib/build/claims/primitiveClaim.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.PrimitiveClaim = void 0;
@@ -6101,9 +6101,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/claims/primitiveArrayClaim.js
+  // node_modules/supertokens-website/lib/build/claims/primitiveArrayClaim.js
   var require_primitiveArrayClaim = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/claims/primitiveArrayClaim.js"(exports) {
+    "node_modules/supertokens-website/lib/build/claims/primitiveArrayClaim.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -6598,9 +6598,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/claims/booleanClaim.js
+  // node_modules/supertokens-website/lib/build/claims/booleanClaim.js
   var require_booleanClaim = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/claims/booleanClaim.js"(exports) {
+    "node_modules/supertokens-website/lib/build/claims/booleanClaim.js"(exports) {
       "use strict";
       var __extends = exports && exports.__extends || /* @__PURE__ */ (function() {
         var extendStatics = function(d, b) {
@@ -6657,9 +6657,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/index.js
+  // node_modules/supertokens-website/lib/build/index.js
   var require_build2 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/index.js"(exports) {
+    "node_modules/supertokens-website/lib/build/index.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -6971,9 +6971,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/index.js
+  // node_modules/supertokens-website/index.js
   var require_supertokens_website = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/index.js"(exports) {
+    "node_modules/supertokens-website/index.js"(exports) {
       "use strict";
       function __export2(m) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -6983,9 +6983,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/emailverification/constants.js
+  // node_modules/supertokens-web-js/lib/build/recipe/emailverification/constants.js
   var require_constants2 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/emailverification/constants.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/recipe/emailverification/constants.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.EMAILVERIFICATION_CLAIM_ID = void 0;
@@ -6993,9 +6993,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/session/recipe.js
+  // node_modules/supertokens-web-js/lib/build/recipe/session/recipe.js
   var require_recipe = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/session/recipe.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/recipe/session/recipe.js"(exports) {
       "use strict";
       var __extends = exports && exports.__extends || /* @__PURE__ */ (function() {
         var extendStatics = function(d, b) {
@@ -7310,9 +7310,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/session/index.js
+  // node_modules/supertokens-web-js/lib/build/recipe/session/index.js
   var require_session = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/session/index.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/recipe/session/index.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -7553,9 +7553,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/recipe/session/index.js
+  // node_modules/supertokens-web-js/recipe/session/index.js
   var require_session2 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/recipe/session/index.js"(exports) {
+    "node_modules/supertokens-web-js/recipe/session/index.js"(exports) {
       "use strict";
       function __export2(m) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -7565,9 +7565,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/utils/cookieHandler/index.js
+  // node_modules/supertokens-website/utils/cookieHandler/index.js
   var require_cookieHandler2 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/utils/cookieHandler/index.js"(exports) {
+    "node_modules/supertokens-website/utils/cookieHandler/index.js"(exports) {
       "use strict";
       function __export2(m) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -7577,9 +7577,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/cookieHandler/index.js
+  // node_modules/supertokens-web-js/lib/build/cookieHandler/index.js
   var require_cookieHandler3 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/cookieHandler/index.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/cookieHandler/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.CookieHandlerReference = void 0;
@@ -7593,9 +7593,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/postSuperTokensInitCallbacks.js
+  // node_modules/supertokens-web-js/lib/build/postSuperTokensInitCallbacks.js
   var require_postSuperTokensInitCallbacks = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/postSuperTokensInitCallbacks.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/postSuperTokensInitCallbacks.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.PostSuperTokensInitCallbacks = void 0;
@@ -7621,9 +7621,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/recipeModule/utils.js
+  // node_modules/supertokens-web-js/lib/build/recipe/recipeModule/utils.js
   var require_utils3 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/recipeModule/utils.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/recipe/recipeModule/utils.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -7767,9 +7767,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/authRecipe/utils.js
+  // node_modules/supertokens-web-js/lib/build/recipe/authRecipe/utils.js
   var require_utils4 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/authRecipe/utils.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/recipe/authRecipe/utils.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.normaliseAuthRecipe = void 0;
@@ -7781,9 +7781,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/multitenancy/utils.js
+  // node_modules/supertokens-web-js/lib/build/recipe/multitenancy/utils.js
   var require_utils5 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/multitenancy/utils.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/recipe/multitenancy/utils.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -7813,9 +7813,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/version.js
+  // node_modules/supertokens-web-js/lib/build/version.js
   var require_version2 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/version.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/version.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.supported_fdi = exports.package_version = void 0;
@@ -7824,9 +7824,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/utils/error/index.js
+  // node_modules/supertokens-website/utils/error/index.js
   var require_error2 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/utils/error/index.js"(exports) {
+    "node_modules/supertokens-website/utils/error/index.js"(exports) {
       "use strict";
       function __export2(m) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -7844,9 +7844,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/error.js
+  // node_modules/supertokens-web-js/lib/build/error.js
   var require_error3 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/error.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/error.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       var error_1 = require_error2();
@@ -7854,9 +7854,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/querier.js
+  // node_modules/supertokens-web-js/lib/build/querier.js
   var require_querier = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/querier.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/querier.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -8307,9 +8307,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/multitenancy/recipeImplementation.js
+  // node_modules/supertokens-web-js/lib/build/recipe/multitenancy/recipeImplementation.js
   var require_recipeImplementation2 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/multitenancy/recipeImplementation.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/recipe/multitenancy/recipeImplementation.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -8504,9 +8504,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/authRecipe/index.js
+  // node_modules/supertokens-web-js/lib/build/recipe/authRecipe/index.js
   var require_authRecipe = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/authRecipe/index.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/recipe/authRecipe/index.js"(exports) {
       "use strict";
       var __extends = exports && exports.__extends || /* @__PURE__ */ (function() {
         var extendStatics = function(d, b) {
@@ -8665,9 +8665,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/multitenancy/recipe.js
+  // node_modules/supertokens-web-js/lib/build/recipe/multitenancy/recipe.js
   var require_recipe2 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/multitenancy/recipe.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/recipe/multitenancy/recipe.js"(exports) {
       "use strict";
       var __extends = exports && exports.__extends || /* @__PURE__ */ (function() {
         var extendStatics = function(d, b) {
@@ -8765,9 +8765,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-website/utils/dateProvider/index.js
+  // node_modules/supertokens-website/utils/dateProvider/index.js
   var require_dateProvider2 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-website/utils/dateProvider/index.js"(exports) {
+    "node_modules/supertokens-website/utils/dateProvider/index.js"(exports) {
       "use strict";
       function __export2(m) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -8777,9 +8777,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/dateProvider/index.js
+  // node_modules/supertokens-web-js/lib/build/dateProvider/index.js
   var require_dateProvider3 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/dateProvider/index.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/dateProvider/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.DateProviderReference = void 0;
@@ -8793,9 +8793,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/versionChecker.js
+  // node_modules/supertokens-web-js/lib/build/versionChecker.js
   var require_versionChecker = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/versionChecker.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/versionChecker.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.isVersionCompatible = void 0;
@@ -8880,9 +8880,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/supertokens.js
+  // node_modules/supertokens-web-js/lib/build/supertokens.js
   var require_supertokens = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/supertokens.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/supertokens.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -9054,9 +9054,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/index.js
+  // node_modules/supertokens-web-js/lib/build/index.js
   var require_build3 = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/index.js"(exports) {
+    "node_modules/supertokens-web-js/lib/build/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.init = void 0;
@@ -9077,9 +9077,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // ../../../../lemma-typescript/node_modules/supertokens-web-js/index.js
+  // node_modules/supertokens-web-js/index.js
   var require_supertokens_web_js = __commonJS({
-    "../../../../lemma-typescript/node_modules/supertokens-web-js/index.js"(exports) {
+    "node_modules/supertokens-web-js/index.js"(exports) {
       "use strict";
       function __export2(m) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];

--- a/lemma-typescript/public/lemma-client.js
+++ b/lemma-typescript/public/lemma-client.js
@@ -44,9 +44,9 @@ var LemmaClient = (() => {
   var __privateAdd = (obj, member, value) => member.has(obj) ? __typeError("Cannot add the same private member more than once") : member instanceof WeakSet ? member.add(obj) : member.set(obj, value);
   var __privateSet = (obj, member, value, setter) => (__accessCheck(obj, member, "write to private field"), setter ? setter.call(obj, value) : member.set(obj, value), value);
 
-  // node_modules/supertokens-website/lib/build/utils/windowHandler/defaultImplementation.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/windowHandler/defaultImplementation.js
   var require_defaultImplementation = __commonJS({
-    "node_modules/supertokens-website/lib/build/utils/windowHandler/defaultImplementation.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/windowHandler/defaultImplementation.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -315,9 +315,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/utils/windowHandler/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/windowHandler/index.js
   var require_windowHandler = __commonJS({
-    "node_modules/supertokens-website/lib/build/utils/windowHandler/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/windowHandler/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.WindowHandlerReference = void 0;
@@ -354,9 +354,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/utils/windowHandler/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/utils/windowHandler/index.js
   var require_windowHandler2 = __commonJS({
-    "node_modules/supertokens-website/utils/windowHandler/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/utils/windowHandler/index.js"(exports) {
       "use strict";
       function __export2(m) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -366,9 +366,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/windowHandler/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/windowHandler/index.js
   var require_windowHandler3 = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/windowHandler/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/windowHandler/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.WindowHandlerReference = void 0;
@@ -382,9 +382,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/constants.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/constants.js
   var require_constants = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/constants.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/constants.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.SSR_ERROR = exports.DEFAULT_API_BASE_PATH = void 0;
@@ -393,9 +393,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/normalisedURLDomain.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/normalisedURLDomain.js
   var require_normalisedURLDomain = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/normalisedURLDomain.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/normalisedURLDomain.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       var NormalisedURLDomain = (
@@ -458,9 +458,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/normalisedURLPath.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/normalisedURLPath.js
   var require_normalisedURLPath = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/normalisedURLPath.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/normalisedURLPath.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       var NormalisedURLPath = (
@@ -530,9 +530,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/types.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/types.js
   var require_types = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/types.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/types.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.nonPublicConfigProperties = void 0;
@@ -540,9 +540,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/normalisedURLDomain.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/normalisedURLDomain.js
   var require_normalisedURLDomain2 = __commonJS({
-    "node_modules/supertokens-website/lib/build/normalisedURLDomain.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/normalisedURLDomain.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.isAnIpAddress = void 0;
@@ -607,9 +607,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/normalisedURLPath.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/normalisedURLPath.js
   var require_normalisedURLPath2 = __commonJS({
-    "node_modules/supertokens-website/lib/build/normalisedURLPath.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/normalisedURLPath.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       var NormalisedURLPath = (
@@ -679,9 +679,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/utils/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/index.js
   var require_utils = __commonJS({
-    "node_modules/supertokens-website/lib/build/utils/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/index.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -953,9 +953,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/processState.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/processState.js
   var require_processState = __commonJS({
-    "node_modules/supertokens-website/lib/build/processState.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/processState.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -1137,9 +1137,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/version.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/version.js
   var require_version = __commonJS({
-    "node_modules/supertokens-website/lib/build/version.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/version.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.supported_fdi = exports.package_version = void 0;
@@ -1148,9 +1148,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/utils/cookieHandler/defaultImplementation.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/cookieHandler/defaultImplementation.js
   var require_defaultImplementation2 = __commonJS({
-    "node_modules/supertokens-website/lib/build/utils/cookieHandler/defaultImplementation.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/cookieHandler/defaultImplementation.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -1284,9 +1284,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/utils/cookieHandler/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/cookieHandler/index.js
   var require_cookieHandler = __commonJS({
-    "node_modules/supertokens-website/lib/build/utils/cookieHandler/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/cookieHandler/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.CookieHandlerReference = void 0;
@@ -1323,9 +1323,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/browser-tabs-lock/processLock.js
+  // ../../../../lemma-typescript/node_modules/browser-tabs-lock/processLock.js
   var require_processLock = __commonJS({
-    "node_modules/browser-tabs-lock/processLock.js"(exports) {
+    "../../../../lemma-typescript/node_modules/browser-tabs-lock/processLock.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       var ProcessLocking = (
@@ -1391,9 +1391,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/browser-tabs-lock/index.js
+  // ../../../../lemma-typescript/node_modules/browser-tabs-lock/index.js
   var require_browser_tabs_lock = __commonJS({
-    "node_modules/browser-tabs-lock/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/browser-tabs-lock/index.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         return new (P || (P = Promise))(function(resolve2, reject) {
@@ -1838,9 +1838,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/utils/lockFactory/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/lockFactory/index.js
   var require_lockFactory = __commonJS({
-    "node_modules/supertokens-website/lib/build/utils/lockFactory/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/lockFactory/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.LockFactoryReference = void 0;
@@ -1878,9 +1878,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/logger.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/logger.js
   var require_logger = __commonJS({
-    "node_modules/supertokens-website/lib/build/logger.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/logger.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.logDebugMessage = exports.disableLogging = exports.enableLogging = void 0;
@@ -1906,9 +1906,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/utils/dateProvider/defaultImplementation.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/dateProvider/defaultImplementation.js
   var require_defaultImplementation3 = __commonJS({
-    "node_modules/supertokens-website/lib/build/utils/dateProvider/defaultImplementation.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/dateProvider/defaultImplementation.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.DateProvider = void 0;
@@ -1961,9 +1961,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/utils/dateProvider/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/dateProvider/index.js
   var require_dateProvider = __commonJS({
-    "node_modules/supertokens-website/lib/build/utils/dateProvider/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/dateProvider/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.DateProviderReference = void 0;
@@ -1999,9 +1999,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/fetch.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/fetch.js
   var require_fetch = __commonJS({
-    "node_modules/supertokens-website/lib/build/fetch.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/fetch.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -3305,9 +3305,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/utils/sessionClaimValidatorStore.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/sessionClaimValidatorStore.js
   var require_sessionClaimValidatorStore = __commonJS({
-    "node_modules/supertokens-website/lib/build/utils/sessionClaimValidatorStore.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/sessionClaimValidatorStore.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.SessionClaimValidatorStore = void 0;
@@ -3331,9 +3331,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/utils/globalClaimValidators.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/globalClaimValidators.js
   var require_globalClaimValidators = __commonJS({
-    "node_modules/supertokens-website/lib/build/utils/globalClaimValidators.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/utils/globalClaimValidators.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.getGlobalClaimValidators = void 0;
@@ -3354,9 +3354,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/utils/globalClaimValidators/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/utils/globalClaimValidators/index.js
   var require_globalClaimValidators2 = __commonJS({
-    "node_modules/supertokens-website/utils/globalClaimValidators/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/utils/globalClaimValidators/index.js"(exports) {
       "use strict";
       function __export2(m) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -3366,9 +3366,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/utils.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/utils.js
   var require_utils2 = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/utils.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/utils.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -3582,9 +3582,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/recipe/recipeModule/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/recipeModule/index.js
   var require_recipeModule = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/recipe/recipeModule/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/recipeModule/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       var RecipeModule = (
@@ -3600,9 +3600,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/axiosError.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/axiosError.js
   var require_axiosError = __commonJS({
-    "node_modules/supertokens-website/lib/build/axiosError.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/axiosError.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -3811,9 +3811,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/axios.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/axios.js
   var require_axios = __commonJS({
-    "node_modules/supertokens-website/lib/build/axios.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/axios.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -4520,9 +4520,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/error.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/error.js
   var require_error = __commonJS({
-    "node_modules/supertokens-website/lib/build/error.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/error.js"(exports) {
       "use strict";
       var __extends = exports && exports.__extends || /* @__PURE__ */ (function() {
         var extendStatics = function(d, b) {
@@ -4564,9 +4564,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/xmlhttprequest.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/xmlhttprequest.js
   var require_xmlhttprequest = __commonJS({
-    "node_modules/supertokens-website/lib/build/xmlhttprequest.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/xmlhttprequest.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -5342,9 +5342,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/recipeImplementation.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/recipeImplementation.js
   var require_recipeImplementation = __commonJS({
-    "node_modules/supertokens-website/lib/build/recipeImplementation.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/recipeImplementation.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -5901,9 +5901,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-js-override/lib/build/getProxyObject.js
+  // ../../../../lemma-typescript/node_modules/supertokens-js-override/lib/build/getProxyObject.js
   var require_getProxyObject = __commonJS({
-    "node_modules/supertokens-js-override/lib/build/getProxyObject.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-js-override/lib/build/getProxyObject.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -5944,9 +5944,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-js-override/lib/build/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-js-override/lib/build/index.js
   var require_build = __commonJS({
-    "node_modules/supertokens-js-override/lib/build/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-js-override/lib/build/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.OverrideableBuilder = void 0;
@@ -6020,9 +6020,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/claims/primitiveClaim.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/claims/primitiveClaim.js
   var require_primitiveClaim = __commonJS({
-    "node_modules/supertokens-website/lib/build/claims/primitiveClaim.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/claims/primitiveClaim.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.PrimitiveClaim = void 0;
@@ -6101,9 +6101,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/claims/primitiveArrayClaim.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/claims/primitiveArrayClaim.js
   var require_primitiveArrayClaim = __commonJS({
-    "node_modules/supertokens-website/lib/build/claims/primitiveArrayClaim.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/claims/primitiveArrayClaim.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -6598,9 +6598,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/claims/booleanClaim.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/claims/booleanClaim.js
   var require_booleanClaim = __commonJS({
-    "node_modules/supertokens-website/lib/build/claims/booleanClaim.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/claims/booleanClaim.js"(exports) {
       "use strict";
       var __extends = exports && exports.__extends || /* @__PURE__ */ (function() {
         var extendStatics = function(d, b) {
@@ -6657,9 +6657,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/lib/build/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/lib/build/index.js
   var require_build2 = __commonJS({
-    "node_modules/supertokens-website/lib/build/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/lib/build/index.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -6971,9 +6971,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/index.js
   var require_supertokens_website = __commonJS({
-    "node_modules/supertokens-website/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/index.js"(exports) {
       "use strict";
       function __export2(m) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -6983,9 +6983,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/recipe/emailverification/constants.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/emailverification/constants.js
   var require_constants2 = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/recipe/emailverification/constants.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/emailverification/constants.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.EMAILVERIFICATION_CLAIM_ID = void 0;
@@ -6993,9 +6993,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/recipe/session/recipe.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/session/recipe.js
   var require_recipe = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/recipe/session/recipe.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/session/recipe.js"(exports) {
       "use strict";
       var __extends = exports && exports.__extends || /* @__PURE__ */ (function() {
         var extendStatics = function(d, b) {
@@ -7310,9 +7310,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/recipe/session/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/session/index.js
   var require_session = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/recipe/session/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/session/index.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -7553,9 +7553,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/recipe/session/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/recipe/session/index.js
   var require_session2 = __commonJS({
-    "node_modules/supertokens-web-js/recipe/session/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/recipe/session/index.js"(exports) {
       "use strict";
       function __export2(m) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -7565,9 +7565,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/utils/cookieHandler/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/utils/cookieHandler/index.js
   var require_cookieHandler2 = __commonJS({
-    "node_modules/supertokens-website/utils/cookieHandler/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/utils/cookieHandler/index.js"(exports) {
       "use strict";
       function __export2(m) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -7577,9 +7577,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/cookieHandler/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/cookieHandler/index.js
   var require_cookieHandler3 = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/cookieHandler/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/cookieHandler/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.CookieHandlerReference = void 0;
@@ -7593,9 +7593,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/postSuperTokensInitCallbacks.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/postSuperTokensInitCallbacks.js
   var require_postSuperTokensInitCallbacks = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/postSuperTokensInitCallbacks.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/postSuperTokensInitCallbacks.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.PostSuperTokensInitCallbacks = void 0;
@@ -7621,9 +7621,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/recipe/recipeModule/utils.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/recipeModule/utils.js
   var require_utils3 = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/recipe/recipeModule/utils.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/recipeModule/utils.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -7767,9 +7767,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/recipe/authRecipe/utils.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/authRecipe/utils.js
   var require_utils4 = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/recipe/authRecipe/utils.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/authRecipe/utils.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.normaliseAuthRecipe = void 0;
@@ -7781,9 +7781,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/recipe/multitenancy/utils.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/multitenancy/utils.js
   var require_utils5 = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/recipe/multitenancy/utils.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/multitenancy/utils.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -7813,9 +7813,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/version.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/version.js
   var require_version2 = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/version.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/version.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.supported_fdi = exports.package_version = void 0;
@@ -7824,9 +7824,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/utils/error/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/utils/error/index.js
   var require_error2 = __commonJS({
-    "node_modules/supertokens-website/utils/error/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/utils/error/index.js"(exports) {
       "use strict";
       function __export2(m) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -7844,9 +7844,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/error.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/error.js
   var require_error3 = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/error.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/error.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       var error_1 = require_error2();
@@ -7854,9 +7854,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/querier.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/querier.js
   var require_querier = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/querier.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/querier.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -8307,9 +8307,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/recipe/multitenancy/recipeImplementation.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/multitenancy/recipeImplementation.js
   var require_recipeImplementation2 = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/recipe/multitenancy/recipeImplementation.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/multitenancy/recipeImplementation.js"(exports) {
       "use strict";
       var __awaiter = exports && exports.__awaiter || function(thisArg, _arguments, P, generator) {
         function adopt(value) {
@@ -8504,9 +8504,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/recipe/authRecipe/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/authRecipe/index.js
   var require_authRecipe = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/recipe/authRecipe/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/authRecipe/index.js"(exports) {
       "use strict";
       var __extends = exports && exports.__extends || /* @__PURE__ */ (function() {
         var extendStatics = function(d, b) {
@@ -8665,9 +8665,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/recipe/multitenancy/recipe.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/multitenancy/recipe.js
   var require_recipe2 = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/recipe/multitenancy/recipe.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/recipe/multitenancy/recipe.js"(exports) {
       "use strict";
       var __extends = exports && exports.__extends || /* @__PURE__ */ (function() {
         var extendStatics = function(d, b) {
@@ -8765,9 +8765,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-website/utils/dateProvider/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-website/utils/dateProvider/index.js
   var require_dateProvider2 = __commonJS({
-    "node_modules/supertokens-website/utils/dateProvider/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-website/utils/dateProvider/index.js"(exports) {
       "use strict";
       function __export2(m) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
@@ -8777,9 +8777,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/dateProvider/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/dateProvider/index.js
   var require_dateProvider3 = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/dateProvider/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/dateProvider/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.DateProviderReference = void 0;
@@ -8793,9 +8793,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/versionChecker.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/versionChecker.js
   var require_versionChecker = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/versionChecker.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/versionChecker.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.isVersionCompatible = void 0;
@@ -8880,9 +8880,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/supertokens.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/supertokens.js
   var require_supertokens = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/supertokens.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/supertokens.js"(exports) {
       "use strict";
       var __assign = exports && exports.__assign || function() {
         __assign = Object.assign || function(t) {
@@ -9054,9 +9054,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/lib/build/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/index.js
   var require_build3 = __commonJS({
-    "node_modules/supertokens-web-js/lib/build/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/lib/build/index.js"(exports) {
       "use strict";
       Object.defineProperty(exports, "__esModule", { value: true });
       exports.init = void 0;
@@ -9077,9 +9077,9 @@ var LemmaClient = (() => {
     }
   });
 
-  // node_modules/supertokens-web-js/index.js
+  // ../../../../lemma-typescript/node_modules/supertokens-web-js/index.js
   var require_supertokens_web_js = __commonJS({
-    "node_modules/supertokens-web-js/index.js"(exports) {
+    "../../../../lemma-typescript/node_modules/supertokens-web-js/index.js"(exports) {
       "use strict";
       function __export2(m) {
         for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];

--- a/lemma-typescript/public/lemma-ui.js
+++ b/lemma-typescript/public/lemma-ui.js
@@ -235,7 +235,7 @@ var LemmaUI = (() => {
     return void 0;
   }
   function parseAssistantStreamEvent(value) {
-    var _a, _b;
+    var _a, _b, _c;
     const directMessage = toConversationMessage(value);
     if (directMessage) {
       return { message: directMessage };
@@ -265,10 +265,16 @@ var LemmaUI = (() => {
     if (eventType === "stopped") {
       return { status: "STOPPED" };
     }
-    if (eventType === "error" || eventType === "stream_error") {
+    if (eventType === "stream_error") {
+      return {
+        interrupted: true,
+        error: (_b = extractErrorMessage(payload)) != null ? _b : "Realtime stream interrupted."
+      };
+    }
+    if (eventType === "error") {
       return {
         status: "FAILED",
-        error: (_b = extractErrorMessage(payload)) != null ? _b : "Agent run failed."
+        error: (_c = extractErrorMessage(payload)) != null ? _c : "Agent run failed."
       };
     }
     return {};
@@ -636,6 +642,7 @@ var LemmaUI = (() => {
         this.clearStreamingText();
         this.clearStreamingThinking();
         let sawTerminalStatus = false;
+        let unclaimedAnswer = false;
         let streamFailure = null;
         try {
           for await (const event of readSSE(stream)) {
@@ -643,6 +650,9 @@ var LemmaUI = (() => {
             const payload = parseSSEJson(event);
             (_b = (_a = this.options).onEvent) == null ? void 0 : _b.call(_a, event, payload);
             const parsed = parseAssistantStreamEvent(payload);
+            if (parsed.interrupted) {
+              continue;
+            }
             if (parsed.error) {
               const streamError = new Error(parsed.error);
               this.patch({ error: streamError });
@@ -690,6 +700,7 @@ var LemmaUI = (() => {
               this.setConversationStatus(parsed.status);
               if (!isConversationRunningStatus(parsed.status)) {
                 sawTerminalStatus = true;
+                unclaimedAnswer = this.streamingBuffer.trim().length > 0;
                 this.clearStreamingText();
                 this.clearStreamingThinking();
                 this.clearStreamingTool();
@@ -740,9 +751,14 @@ var LemmaUI = (() => {
                   streamFailure = reconnectError;
                 }
               }
-            } else if (syncConversationId && (syncAfterStream != null ? syncAfterStream : this.options.syncOnTurnEnd)) {
-              await this.refreshConversation(syncConversationId);
-              await this.loadMessages({ conversationId: syncConversationId, limit: 100 });
+            } else if (syncConversationId) {
+              const answerWentMissing = unclaimedAnswer || this.streamingBuffer.trim().length > 0;
+              if (syncAfterStream != null ? syncAfterStream : this.options.syncOnTurnEnd) {
+                await this.refreshConversation(syncConversationId);
+                await this.loadMessages({ conversationId: syncConversationId, limit: 100 });
+              } else if (answerWentMissing) {
+                await this.loadMessages({ conversationId: syncConversationId, limit: 100 });
+              }
             }
             if (!controller.signal.aborted && streamFailure) {
               const normalized = normalizeError(streamFailure, "Failed to stream conversation.");

--- a/lemma-typescript/src/__tests__/live-run-recovery.test.ts
+++ b/lemma-typescript/src/__tests__/live-run-recovery.test.ts
@@ -1,0 +1,458 @@
+/**
+ * What happens to a transcript when the realtime stream lets it down.
+ *
+ * The web chat has one source of truth on screen: the SSE stream a send opens.
+ * There is no poller behind it, so anything that ends that stream while the
+ * conversation is still being written to leaves a transcript that stops moving
+ * until the page is reloaded — with every message sitting in the database the
+ * whole time, which is what made it look like a rendering bug rather than a
+ * delivery one.
+ *
+ * Three ways that happened, one test each, plus the guard that the healthy path
+ * did not pick up any extra requests to pay for them.
+ */
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LemmaClient } from "../client.js";
+import type { Conversation } from "../types.js";
+import {
+  useAssistantController,
+  useAssistantSession,
+  type UseAssistantControllerResult,
+  type UseAssistantSessionResult,
+} from "../react/index.js";
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const roots: Root[] = [];
+
+function conversation(id: string, status: string): Conversation {
+  return {
+    id,
+    pod_id: "pod-1",
+    title: id,
+    status,
+    created_at: "2026-08-24T12:00:00.000Z",
+    updated_at: "2026-08-24T12:00:00.000Z",
+  } as Conversation;
+}
+
+/** A stream the test pushes frames into, one at a time. */
+function pushableStream() {
+  const encoder = new TextEncoder();
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+  });
+  return {
+    stream,
+    push(frame: unknown) {
+      controller.enqueue(encoder.encode(`data: ${JSON.stringify(frame)}\n\n`));
+    },
+    close() {
+      controller.close();
+    },
+  };
+}
+
+const T0 = Date.parse("2026-08-24T12:00:00.000Z");
+
+function messageFrame(
+  id: string,
+  role: string,
+  text: string,
+  offsetMs: number,
+  extra: Record<string, unknown> = {},
+) {
+  return {
+    type: "message",
+    data: {
+      id,
+      role,
+      kind: "TEXT",
+      text,
+      conversation_id: "c1",
+      created_at: new Date(T0 + offsetMs).toISOString(),
+      ...extra,
+    },
+  };
+}
+
+async function settle(rounds = 8) {
+  for (let index = 0; index < rounds; index += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    });
+  }
+}
+
+/**
+ * Pump until the thing we are waiting for happens, rather than for a fixed
+ * stretch of wall clock. Both recovery paths are on real timers — a reconnect
+ * backoff, a resume ladder — and a fixed sleep long enough on an idle machine
+ * is a coin toss on a loaded one.
+ */
+async function waitUntil(
+  condition: () => boolean,
+  { timeoutMs = 15_000, label = "condition" }: { timeoutMs?: number; label?: string } = {},
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    });
+  }
+  throw new Error(`Timed out waiting for ${label}`);
+}
+
+/** For the negative cases: let the whole ladder run out, then look. */
+async function waitMs(ms: number) {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  });
+  await settle();
+}
+
+/**
+ * A server whose conversation status the test can move, whose transcript it can
+ * write to directly (that is the database, which a reload reads), and whose
+ * streams it holds open.
+ */
+function fakeServer(options: { status: string; persisted?: unknown[] }) {
+  const state = { status: options.status };
+  const persisted = options.persisted ?? [];
+  const sendStreams: ReturnType<typeof pushableStream>[] = [];
+  const resumeStreams: ReturnType<typeof pushableStream>[] = [];
+
+  const sendMessageStream = vi.fn(async () => {
+    const next = pushableStream();
+    sendStreams.push(next);
+    return next.stream;
+  });
+  const resumeStream = vi.fn(async () => {
+    const next = pushableStream();
+    resumeStreams.push(next);
+    return next.stream;
+  });
+  const get = vi.fn(async (id: string) => conversation(id, state.status));
+  const messagesList = vi.fn(async () => ({
+    items: [...persisted],
+    limit: 100,
+    next_page_token: null,
+  }));
+  const resolveApproval = vi.fn(async () => ({
+    approval_id: "a1",
+    decision: "APPROVE",
+    // What an approved `request_approval` answers: the decision is committed,
+    // the run that resumes from it is a job somebody else has to pick up.
+    status: "queued",
+  }));
+
+  const client = {
+    podId: "pod-1",
+    withPod() {
+      return this;
+    },
+    conversations: {
+      list: vi.fn(async () => ({
+        items: [conversation("c1", state.status)],
+        limit: 30,
+        next_page_token: null,
+        total: 1,
+      })),
+      get,
+      create: vi.fn(async () => conversation("c1", state.status)),
+      listModels: vi.fn(async () => ({ items: [] })),
+      messages: { list: messagesList },
+      sendMessageStream,
+      retryFailedRun: vi.fn(),
+      resumeStream,
+      stopRun: vi.fn(),
+      update: vi.fn(),
+      approvals: { resolve: resolveApproval },
+    },
+  } as unknown as LemmaClient;
+
+  return {
+    client,
+    state,
+    persisted,
+    sendStreams,
+    resumeStreams,
+    sendMessageStream,
+    resumeStream,
+    get,
+    messagesList,
+  };
+}
+
+async function mount(client: LemmaClient) {
+  const controller = { current: null as UseAssistantControllerResult | null };
+  function Harness() {
+    controller.current = useAssistantController({ client, podId: "pod-1", autoLoadMessages: true });
+    return null;
+  }
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  await act(async () => {
+    root.render(createElement(Harness));
+  });
+  await settle();
+  return controller;
+}
+
+function transcript(controller: { current: UseAssistantControllerResult | null }): string[] {
+  return (controller.current?.messages ?? [])
+    .map((message) => message.content)
+    .filter((content): content is string => !!content && content.trim().length > 0);
+}
+
+afterEach(async () => {
+  while (roots.length > 0) {
+    const root = roots.pop();
+    if (!root) continue;
+    await act(async () => root.unmount());
+  }
+  document.body.innerHTML = "";
+});
+
+describe("a stream the transport gives up on", () => {
+  it("reconnects, because `stream_error` is not the run failing", async () => {
+    const server = fakeServer({ status: "WAITING" });
+    const controller = await mount(server.client);
+    await act(async () => controller.current?.openConversation("c1"));
+    await settle();
+
+    await act(async () => {
+      void controller.current?.sendMessage("do the long thing");
+    });
+    await settle();
+    server.state.status = "RUNNING";
+
+    server.sendStreams[0].push(messageFrame("m-user", "user", "do the long thing", 0));
+    await settle();
+
+    // The subscription behind the stream died. The run has not.
+    server.sendStreams[0].push({
+      type: "stream_error",
+      data: "Realtime stream interrupted. Reconnect to continue.",
+    });
+    server.sendStreams[0].close();
+    await waitUntil(() => server.resumeStream.mock.calls.length > 0, {
+      label: "the client to reconnect",
+    });
+
+    expect(server.resumeStream).toHaveBeenCalledTimes(1);
+    // And nothing was reported to the reader as a failure: the run is fine.
+    expect(controller.current?.error).toBeFalsy();
+  });
+
+  it("still stops on a real `error`, which is the run failing", async () => {
+    const server = fakeServer({ status: "WAITING" });
+    const controller = await mount(server.client);
+    await act(async () => controller.current?.openConversation("c1"));
+    await settle();
+
+    await act(async () => {
+      void controller.current?.sendMessage("do the impossible thing");
+    });
+    await settle();
+    server.state.status = "FAILED";
+
+    server.sendStreams[0].push({ type: "error", data: "the agent fell over" });
+    server.sendStreams[0].close();
+    await waitMs(1400);
+
+    expect(server.resumeStream).not.toHaveBeenCalled();
+    expect(controller.current?.error).toBeTruthy();
+  });
+});
+
+describe("an answer whose durable frame never arrives", () => {
+  it("keeps the streamed words on screen and lists the transcript once", async () => {
+    // The row is in the database. Only its realtime frame went missing —
+    // publishing is best-effort, and the fan-out drops a slow subscriber.
+    const server = fakeServer({ status: "WAITING" });
+    const controller = await mount(server.client);
+    await act(async () => controller.current?.openConversation("c1"));
+    await settle();
+    const listsAfterOpen = server.messagesList.mock.calls.length;
+
+    await act(async () => {
+      void controller.current?.sendMessage("write me the report");
+    });
+    await settle();
+    server.state.status = "RUNNING";
+
+    // Quiet tool work, then the one thing the reader is waiting for.
+    server.sendStreams[0].push(messageFrame("m-tool", "assistant", "", 1000, {
+      kind: "TOOL_CALL",
+      tool_name: "pod_write_file",
+      tool_call_id: "tc-1",
+      tool_args: {},
+    }));
+    await settle();
+    for (const token of ["The ", "report ", "is ", "ready."]) {
+      server.sendStreams[0].push({ type: "token", kind: "text", data: token });
+    }
+    await settle();
+    expect(transcript(controller)).toContain("The report is ready.");
+
+    // Its message frame never comes, but the row exists.
+    server.persisted.push(messageFrame("m-answer", "assistant", "The report is ready.", 3000).data);
+    server.state.status = "WAITING";
+    server.sendStreams[0].push({
+      type: "completed",
+      data: { conversation_id: "c1", status: "COMPLETED", conversation_status: "WAITING" },
+    });
+    server.sendStreams[0].close();
+    await settle();
+
+    // The answer never blinked out, and the store now really holds it.
+    expect(transcript(controller)).toContain("The report is ready.");
+    expect(server.messagesList.mock.calls.length).toBe(listsAfterOpen + 1);
+  });
+});
+
+describe("answering a question the agent asked", () => {
+  it("waits for the queued resume run instead of reading once and giving up", async () => {
+    const server = fakeServer({ status: "WAITING" });
+    const controller = await mount(server.client);
+    await act(async () => controller.current?.openConversation("c1"));
+    await settle();
+
+    await act(async () => {
+      await controller.current?.resolveUserApproval?.("a1", "APPROVE" as never);
+    });
+    await settle();
+    // Still WAITING at this point: the worker has not picked the job up.
+    expect(server.resumeStream).not.toHaveBeenCalled();
+
+    server.state.status = "RUNNING";
+    await waitUntil(() => server.resumeStream.mock.calls.length > 0, {
+      label: "the client to attach to the resumed run",
+    });
+
+    expect(server.resumeStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up on a conversation that really is not running", async () => {
+    const server = fakeServer({ status: "WAITING" });
+    const controller = await mount(server.client);
+    await act(async () => controller.current?.openConversation("c1"));
+    await settle();
+
+    await act(async () => {
+      await controller.current?.resolveUserApproval?.("a1", "APPROVE" as never);
+    });
+    await waitMs(4000);
+
+    expect(server.resumeStream).not.toHaveBeenCalled();
+  });
+});
+
+describe("the healthy path", () => {
+  it("costs the same as before: one stream per turn, nothing read back", async () => {
+    const server = fakeServer({ status: "WAITING" });
+    const controller = await mount(server.client);
+    await act(async () => controller.current?.openConversation("c1"));
+    await settle();
+
+    // Opening reads the record and its transcript, once each.
+    const readsAfterOpen = server.get.mock.calls.length;
+    const listsAfterOpen = server.messagesList.mock.calls.length;
+
+    for (const [index, text] of ["first", "second"].entries()) {
+      await act(async () => {
+        void controller.current?.sendMessage(text);
+      });
+      await settle();
+      const stream = server.sendStreams[index];
+      stream.push(messageFrame(`m-user-${index}`, "user", text, index * 10_000));
+      stream.push(messageFrame(`m-asst-${index}`, "assistant", `answer ${index}`, index * 10_000 + 1000));
+      await settle();
+      stream.push({
+        type: "completed",
+        data: { conversation_id: "c1", status: "COMPLETED", conversation_status: "WAITING" },
+      });
+      stream.close();
+      await settle();
+    }
+
+    expect(server.sendMessageStream).toHaveBeenCalledTimes(2);
+    // A turn that delivered its own messages asks the server for nothing.
+    expect(server.get.mock.calls.length).toBe(readsAfterOpen);
+    expect(server.messagesList.mock.calls.length).toBe(listsAfterOpen);
+    expect(transcript(controller)).toEqual(
+      expect.arrayContaining(["answer 0", "answer 1"]),
+    );
+  });
+
+  it("re-reading a conversation that has not moved does not re-render", async () => {
+    // What keeps the recovery paths cheap. A run whose ending is in doubt is
+    // now re-read — by the reconnect loop, and once per attempt while waiting
+    // for a queued resume — and nearly every one of those reads comes back
+    // holding exactly what was already on screen. Everything downstream of the
+    // record renders on its identity, so handing back a new object for the same
+    // record is a whole transcript re-rendering for nothing.
+    const server = fakeServer({ status: "WAITING" });
+    let renders = 0;
+    const session = { current: null as UseAssistantSessionResult | null };
+    function Harness() {
+      renders += 1;
+      session.current = useAssistantSession({
+        client: server.client,
+        conversationId: "c1",
+        podId: "pod-1",
+        autoLoad: false,
+      });
+      return null;
+    }
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    roots.push(root);
+    await act(async () => {
+      root.render(createElement(Harness));
+    });
+    await settle();
+
+    // Two warm-up reads: the first record landing is a real change, and the
+    // effects that settle behind it are one-time.
+    for (let warmUp = 0; warmUp < 2; warmUp += 1) {
+      await act(async () => {
+        await session.current?.refreshConversation("c1");
+      });
+      await settle();
+    }
+    const settledRenders = renders;
+    const settledRecord = session.current?.conversation;
+
+    // Now the steady state: three more reads of a conversation that has not
+    // moved, which is what the resume ladder does while it waits.
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      await act(async () => {
+        await session.current?.refreshConversation("c1");
+      });
+      await settle();
+    }
+
+    expect(server.get.mock.calls.length).toBeGreaterThanOrEqual(5);
+    expect(renders).toBe(settledRenders);
+    expect(session.current?.conversation).toBe(settledRecord);
+
+    // A record that did move still lands, or the transcript would go stale.
+    server.state.status = "RUNNING";
+    await act(async () => {
+      await session.current?.refreshConversation("c1");
+    });
+    await settle();
+    expect(session.current?.conversation?.status).toBe("RUNNING");
+  });
+});

--- a/lemma-typescript/src/assistant-events.ts
+++ b/lemma-typescript/src/assistant-events.ts
@@ -26,6 +26,12 @@ export interface ParsedAssistantStreamEvent {
   token?: string;
   tokenKind?: string;
   error?: string;
+  /**
+   * The transport gave up, not the run. Carries no status on purpose: the run
+   * is still going, and a consumer that treats this as an ending stops reading
+   * a conversation the server is still writing to.
+   */
+  interrupted?: boolean;
 }
 
 function isRecord(value: unknown): value is ParsedRecord {
@@ -155,7 +161,17 @@ export function parseAssistantStreamEvent(value: unknown): ParsedAssistantStream
     return { status: "STOPPED" };
   }
 
-  if (eventType === "error" || eventType === "stream_error") {
+  if (eventType === "stream_error") {
+    // The subscription behind the stream died while the run kept going. No
+    // status: the run's own is unchanged, and reporting FAILED here is what
+    // turned a reconnect instruction into a dead transcript.
+    return {
+      interrupted: true,
+      error: extractErrorMessage(payload) ?? "Realtime stream interrupted.",
+    };
+  }
+
+  if (eventType === "error") {
     return {
       status: "FAILED",
       error: extractErrorMessage(payload) ?? "Agent run failed.",

--- a/lemma-typescript/src/core/agent/agent-controller.ts
+++ b/lemma-typescript/src/core/agent/agent-controller.ts
@@ -632,6 +632,8 @@ export class AgentController {
     this.clearStreamingText();
     this.clearStreamingThinking();
     let sawTerminalStatus = false;
+    // Set where the buffer is cleared, read where the turn is reconciled.
+    let unclaimedAnswer = false;
     let streamFailure: unknown = null;
 
     try {
@@ -642,6 +644,12 @@ export class AgentController {
         this.options.onEvent?.(event, payload);
 
         const parsed = parseAssistantStreamEvent(payload);
+        if (parsed.interrupted) {
+          // The transport gave up, not the run. Leaving `sawTerminalStatus`
+          // false is what sends this into the catch-up-and-reconnect path
+          // below, which is what the server is asking for.
+          continue;
+        }
         if (parsed.error) {
           const streamError = new Error(parsed.error);
           this.patch({ error: streamError });
@@ -694,6 +702,9 @@ export class AgentController {
           this.setConversationStatus(parsed.status);
           if (!isConversationRunningStatus(parsed.status)) {
             sawTerminalStatus = true;
+            // Read before the clear below: an answer still in the buffer when
+            // the run ends never got its durable message.
+            unclaimedAnswer = this.streamingBuffer.trim().length > 0;
             this.clearStreamingText();
             this.clearStreamingThinking();
             this.clearStreamingTool();
@@ -749,9 +760,22 @@ export class AgentController {
               streamFailure = reconnectError;
             }
           }
-        } else if (syncConversationId && (syncAfterStream ?? this.options.syncOnTurnEnd)) {
-          await this.refreshConversation(syncConversationId);
-          await this.loadMessages({ conversationId: syncConversationId, limit: 100 });
+        } else if (syncConversationId) {
+          // Text streamed as tokens that no durable message ever claimed is a
+          // frame that never arrived: every assistant or tool message clears
+          // the buffer as it lands, so anything left in it here is missing
+          // from the transcript. Publishing is best-effort — it swallows its
+          // own failures, and the fan-out drops a subscriber that falls behind
+          // — so one list, when we can see something is gone. The buffer and
+          // not the patched state: the state trails it by a flush.
+          const answerWentMissing = unclaimedAnswer
+            || this.streamingBuffer.trim().length > 0;
+          if (syncAfterStream ?? this.options.syncOnTurnEnd) {
+            await this.refreshConversation(syncConversationId);
+            await this.loadMessages({ conversationId: syncConversationId, limit: 100 });
+          } else if (answerWentMissing) {
+            await this.loadMessages({ conversationId: syncConversationId, limit: 100 });
+          }
         }
 
         if (!controller.signal.aborted && streamFailure) {

--- a/lemma-typescript/src/react/useAssistantController.ts
+++ b/lemma-typescript/src/react/useAssistantController.ts
@@ -297,6 +297,70 @@ export function resolveStreamingThinking({
   return pending.text;
 }
 
+export interface HeldStreamingText {
+  conversationId: string;
+  text: string;
+}
+
+/** Bridge the streamed answer to its durable message.
+ *
+ * The same one-commit gap `resolveStreamingThinking` covers, with one rule
+ * changed: a thought that outlives its run is noise, so that bridge drops on
+ * `!isRunning`. An *answer* that outlives its run is the answer. Dropping it
+ * there is what made a reply type itself out in front of the reader and then
+ * vanish the moment the turn settled — with the text sitting in the database
+ * the whole time, which is why reloading brought it back.
+ *
+ * The frame can genuinely go missing: publishing is best-effort and the
+ * realtime fan-out drops a subscriber that falls behind. The session reconciles
+ * that with one list when it sees a buffer nothing claimed; this keeps the
+ * words on screen until they do land, so the recovery is invisible rather than
+ * a blank turn followed by a reappearance.
+ *
+ * Bounded by the things that make the buffer meaningless rather than by time:
+ * the durable message landing, the conversation changing, a new turn being
+ * sent, or the run ending in a failure that is now the truer thing to show.
+ */
+export function resolveStreamingText({
+  held,
+  conversationId,
+  streamed,
+  messages,
+  failed,
+}: {
+  held: { current: HeldStreamingText | null };
+  conversationId: string;
+  streamed: string;
+  messages: AssistantApiConversationMessage[];
+  failed: boolean;
+}): string {
+  if (streamed.length > 0) {
+    held.current = { conversationId, text: streamed };
+    return streamed;
+  }
+
+  const pending = held.current;
+  if (!pending || pending.conversationId !== conversationId || failed) {
+    held.current = null;
+    return "";
+  }
+
+  // Backwards: the message this is waiting for is the last thing the run wrote,
+  // and in the steady state there is no pending buffer to scan for at all.
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message.role !== "assistant" || message.kind === "THINKING") continue;
+    if (typeof message.text !== "string") continue;
+    // Prefix, not equality: the durable text is the buffer plus whatever the
+    // model emitted between the last token flush and the message.
+    if (message.text.trim().startsWith(pending.text)) {
+      held.current = null;
+      return "";
+    }
+  }
+  return pending.text;
+}
+
 function normalizeToolResult(value: unknown): Record<string, unknown> {
   if (isRecord(value)) return value;
   if (Array.isArray(value)) return { output: value };
@@ -571,6 +635,12 @@ function approvalResultPresent(
   );
 }
 
+/** A run that ended badly: its error is the truer thing to show than whatever
+ *  text it had streamed before it went. */
+function isConversationFailed(status: unknown): boolean {
+  return typeof status === "string" && status.trim().toLowerCase() === "failed";
+}
+
 function isConversationRunning(status: unknown): boolean {
   if (typeof status !== "string") return false;
   const normalized = status.trim().toLowerCase();
@@ -702,6 +772,7 @@ export function useAssistantController({
   const activeConversationIdRef = useRef<string | null>(null);
   const conversationsRef = useRef<Conversation[]>([]);
   const heldStreamingThinkingRef = useRef<HeldStreamingThinking | null>(null);
+  const heldStreamingTextRef = useRef<HeldStreamingText | null>(null);
   const isStreamingRef = useRef(false);
   const sessionIsStreamingRef = useRef(false);
   // Which conversations have had their history loaded in this session. A set,
@@ -1154,6 +1225,7 @@ export function useAssistantController({
       && sessionStreamingText.trim().length === 0
       && sessionStreamingThinking.trim().length === 0
       && heldStreamingThinkingRef.current === null
+      && heldStreamingTextRef.current === null
     ) return [];
 
     const nextMessages = mapConversationMessages(normalized);
@@ -1184,7 +1256,13 @@ export function useAssistantController({
         kind: "THINKING",
       });
     }
-    const pendingText = sessionStreamingText.trim();
+    const pendingText = resolveStreamingText({
+      held: heldStreamingTextRef,
+      conversationId: activeConversationId,
+      streamed: sessionStreamingText.trim(),
+      messages: normalized,
+      failed: isConversationFailed(sessionStatus),
+    });
     if (pendingText.length > 0) {
       const streamingId = `streaming-${activeConversationId}`;
       nextMessages.push({
@@ -1609,6 +1687,9 @@ export function useAssistantController({
     }
 
     let conversationId = forceNewConversation ? null : activeConversationId;
+    // A new turn is where the held answer from the last one stops being worth
+    // holding: whatever it was waiting for either arrived, or is not coming.
+    heldStreamingTextRef.current = null;
     // Raised before the create, not after it. This is what the transcript reads
     // to know it is no longer an empty conversation, so leaving it down for the
     // length of the round-trip left the empty state and its centred composer on
@@ -1784,7 +1865,13 @@ export function useAssistantController({
         { pod_id: resolvedPodId ?? undefined },
       );
       await loadConversationMessages(conversationId);
-      void sessionResumeIfRunning(conversationId).catch((error) => {
+      // Answering is what starts the next run, so this is the one caller that
+      // knows one is coming. An approved `request_approval` reconciles in a
+      // worker and answers `"queued"`, which means the record can still read
+      // WAITING for a moment after this returns — and a single read landing
+      // there is how the answer to a question you just answered ended up
+      // needing a reload to see.
+      void sessionResumeIfRunning(conversationId, { expectRun: true }).catch((error) => {
         setLocalError((prev) => prev || (error instanceof Error ? error.message : "Failed to resume conversation"));
       });
     } catch (err) {
@@ -1794,7 +1881,8 @@ export function useAssistantController({
       // self-clears and the user can keep chatting instead of retrying a dead card.
       const items = await loadConversationMessages(conversationId);
       if (approvalResultPresent(items, approvalId)) {
-        void sessionResumeIfRunning(conversationId).catch(() => {});
+        // The decision did land, so a run is still coming — same race.
+        void sessionResumeIfRunning(conversationId, { expectRun: true }).catch(() => {});
         return;
       }
       setLocalError(err instanceof Error ? err.message : "Failed to resolve approval");

--- a/lemma-typescript/src/react/useAssistantSession.ts
+++ b/lemma-typescript/src/react/useAssistantSession.ts
@@ -137,7 +137,15 @@ export interface UseAssistantSessionResult {
   resume: (conversationId?: string | null | ResumeAssistantOptions) => Promise<void>;
   resumeIfRunning: (
     conversationId?: string | null,
-    options?: { knownConversation?: Conversation | null },
+    options?: {
+      knownConversation?: Conversation | null;
+      /**
+       * The caller just did something that starts a run. Keeps asking for a
+       * few seconds rather than concluding from one read that nothing is
+       * running — a resume handed to a worker has not started yet.
+       */
+      expectRun?: boolean;
+    },
   ) => Promise<boolean>;
   stop: (conversationId?: string | null) => Promise<void>;
   cancel: () => void;
@@ -191,6 +199,37 @@ function isConversationRunningStatus(status: unknown): boolean {
   const normalized = normalizeConversationStatus(status);
   if (!normalized) return false;
   return normalized === "RUNNING" || normalized === "IN_PROGRESS" || normalized === "PROCESSING";
+}
+
+/** Did a re-read of the conversation actually bring anything back?
+ *
+ * The record is small, flat and server-shaped, so its serialization is stable
+ * enough to compare whole — and comparing whole is what keeps this honest as
+ * fields are added. Naming the handful the UI reads today would quietly stop
+ * noticing the next one.
+ */
+function sameConversationRecord(left: Conversation, right: Conversation): boolean {
+  if (left.id !== right.id) return false;
+  try {
+    return JSON.stringify(left) === JSON.stringify(right);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * How long to keep asking whether the run somebody just triggered has started.
+ *
+ * Answering an `ask_user` card resolves inline, but an approved
+ * `request_approval` hands its reconciliation to a worker and returns
+ * `"queued"` — so the conversation is still WAITING for the moment it takes
+ * that job to be picked up. One read landed inside that window, concluded
+ * nothing was running, and left the transcript still until a reload.
+ */
+const RESUME_RACE_DELAYS_MS = [400, 900, 2000];
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function waitForStreamReconnect(attempt: number, signal: AbortSignal): Promise<boolean> {
@@ -346,7 +385,16 @@ export function useAssistantSession(options: UseAssistantSessionOptions): UseAss
 
   // The only way the conversation record is written, so the ref above can never
   // drift from the state it shadows.
+  //
+  // A re-read that comes back identical keeps the identity already on screen.
+  // Everything downstream of the record — the header, the retry affordance, the
+  // composer's disabled state — re-renders on its identity, and now that a
+  // record is re-read whenever a turn's ending is in doubt, most of those reads
+  // return exactly what was already held.
   const rememberConversation = useCallback((next: Conversation | null) => {
+    const previous = conversationRecordRef.current;
+    if (previous === next) return;
+    if (previous && next && sameConversationRecord(previous, next)) return;
     conversationRecordRef.current = next;
     setConversation(next);
   }, []);
@@ -699,6 +747,8 @@ export function useAssistantSession(options: UseAssistantSessionOptions): UseAss
     // live on the conversation record, and they are what decides whether the
     // transcript offers a Retry.
     let sawFailedStatus = false;
+    // Set where the buffer is cleared, read where the turn is reconciled.
+    let unclaimedAnswer = false;
     let streamFailure: unknown = null;
 
     try {
@@ -711,6 +761,13 @@ export function useAssistantSession(options: UseAssistantSessionOptions): UseAss
         onEventRef.current?.(event, payload);
 
         const parsed = parseAssistantStreamEvent(payload);
+        if (parsed.interrupted) {
+          // The transport died, not the run. Deliberately no error state and
+          // no terminal flag: falling out of this loop with `sawTerminalStatus`
+          // still false is what puts us on the catch-up-and-reconnect path
+          // below, which is what the server asked for by sending this.
+          continue;
+        }
         if (parsed.error) {
           const streamError = new Error(parsed.error);
           setError(streamError);
@@ -764,6 +821,11 @@ export function useAssistantSession(options: UseAssistantSessionOptions): UseAss
           if (!isConversationRunningStatus(parsed.status)) {
             sawTerminalStatus = true;
             if (parsed.status === "FAILED") sawFailedStatus = true;
+            // Read before the clear on the next line, which is the only place
+            // this fact survives to: an answer still sitting in the token
+            // buffer when the run ends is one whose durable message never
+            // arrived.
+            unclaimedAnswer = streamingTextRef.current.trim().length > 0;
             clearStreamingText();
             clearStreamingThinking();
             clearStreamingTool();
@@ -828,13 +890,24 @@ export function useAssistantSession(options: UseAssistantSessionOptions): UseAss
           // discarded the answer anyway, because it dedups on the last message
           // id and that id had not moved. Only an explicit opt-in re-lists now.
           const shouldReloadMessages = syncAfterStream ?? syncOnTurnEnd;
+          // ...with one exception, and it is not an opt-in. Text streamed as
+          // tokens that no durable message ever claimed is an answer that
+          // exists only in a buffer this function is about to clear: every
+          // assistant or tool message clears the buffer as it lands, so
+          // anything left in it at the end is a frame that never arrived.
+          // Publishing is best-effort by design — it swallows its own failures
+          // and the fan-out drops a subscriber that falls behind — so "the
+          // stream said everything" is a description of the happy path, not a
+          // guarantee. One list, only when we can see something is missing.
+          const answerWentMissing = !sawFailedStatus
+            && (unclaimedAnswer || streamingTextRef.current.trim().length > 0);
           // The record is still worth re-reading after a failure: the retry
           // affordance is driven by `last_run_retryable`, which only the
           // conversation carries.
           if (shouldReloadMessages || sawFailedStatus || streamFailure) {
             await refreshConversation(syncConversationId);
           }
-          if (shouldReloadMessages) {
+          if (shouldReloadMessages || answerWentMissing) {
             await loadMessages({ conversationId: syncConversationId, limit: 100 });
           }
         }
@@ -1047,7 +1120,7 @@ export function useAssistantSession(options: UseAssistantSessionOptions): UseAss
 
   const resumeIfRunning = useCallback(async (
     explicitConversationId?: string | null,
-    options?: { knownConversation?: Conversation | null },
+    options?: { knownConversation?: Conversation | null; expectRun?: boolean },
   ): Promise<boolean> => {
     const id = explicitConversationId ?? conversationId;
     if (!id) return false;
@@ -1071,10 +1144,32 @@ export function useAssistantSession(options: UseAssistantSessionOptions): UseAss
       rememberConversation(knownConversation);
       setConversationStatus(statusKey);
     } else if (!isConversationRunningStatus(statusRef.current)) {
-      const latestConversation = await refreshConversation(id);
-      if (!latestConversation || !isConversationRunningStatus(latestConversation.status)) {
-        return false;
+      // `expectRun` is a caller saying it just did the thing that starts a run.
+      // The read then has to survive the gap between "the server accepted it"
+      // and "the run exists": an approved `request_approval` commits its
+      // decision and hands the resume to a worker, so the record still reads
+      // WAITING for as long as that job waits to be picked up. Without the
+      // ladder the single read landed in that gap, answered "nothing is
+      // running", and nothing ever asked again — the follow-on run then wrote a
+      // whole answer into a conversation with no listener.
+      //
+      // Only for a caller that expects one. Everywhere else this stays one
+      // read, because everywhere else a not-running conversation is just a
+      // conversation that is not running.
+      const attempts = options?.expectRun ? RESUME_RACE_DELAYS_MS.length + 1 : 1;
+      let started = false;
+      for (let attempt = 0; attempt < attempts; attempt += 1) {
+        if (attempt > 0) await delay(RESUME_RACE_DELAYS_MS[attempt - 1]);
+        // Someone else got there first (a send, or a stream that attached while
+        // this was waiting). The ref, not the state: this is inside an await.
+        if (abortRef.current !== null) return false;
+        const latestConversation = await refreshConversation(id);
+        if (latestConversation && isConversationRunningStatus(latestConversation.status)) {
+          started = true;
+          break;
+        }
       }
+      if (!started) return false;
     }
 
     const previousResumeKey = autoResumedKeyRef.current;


### PR DESCRIPTION
## What changes

Three ways the web chat's transcript could stop updating mid-conversation and
only come back on a reload, all closed:

- A dead realtime subscription now says `stream_error` rather than `error`, and
  the client reconnects instead of reporting the run as failed. The frame that
  asks for a reconnect now causes one.
- Answering an in-chat card keeps asking whether the resumed run has started
  (400ms/900ms/2000ms) instead of concluding from a single read that nothing is
  running. An approved `request_approval` reconciles in a worker, so the record
  still reads WAITING for a moment after the call returns.
- A streamed answer stays on screen until its durable message lands, and the
  session re-lists the transcript once when it sees a token buffer that no
  message ever claimed. Before, the reply typed itself out and vanished as the
  turn settled.

No change to the healthy path: one stream per turn, nothing read back.

## Why

The transcript has one source of truth on screen — the SSE stream a send opens
— and nothing polls behind it. So anything that ends that stream while the
conversation is still being written to freezes the view, with every message
sitting in the database the whole time. That is why it looked like a rendering
fault rather than a delivery one, and why reloading always fixed it.

Publishing is best-effort by design: `publish_conversation_event` swallows its
own failures, and the realtime fan-out drops a subscriber that falls behind
256 frames. "A stream that ran to a terminal status delivered every durable
message" describes the happy path, not a guarantee — and #446 removed the
turn-end re-list that had been reconciling the difference.

#480 is what made it visible. It took a run from twenty-four assistant messages
down to about one, so a single lost frame stopped being invisible and started
being the whole answer. That was the right change; it removed the redundancy
that had been hiding this, not the cause.

Reproduced before fixing, as an A/B against `33671ebb~1` on the same scenario —
a quiet run whose answer streams as tokens and whose durable frame is lost,
with the row present in the database:

| | while streaming | after the turn ends | transcript re-listed |
|---|---|---|---|
| main | `"The report is ready."` | *(gone)* | 1 (the open only) |
| pre-#446 | `"The report is ready."` | `"The report is ready."` | 2 |

## How to verify

```bash
# SDK — 7 new tests, one per failure mode plus two cost guards
cd lemma-typescript && npm install && npx vitest run src/__tests__/live-run-recovery.test.ts
# → Tests  7 passed (7)

# whole SDK suite and typecheck
npx vitest run && npx tsc -p tsconfig.json --noEmit
# → Test Files  28 passed (28) / Tests  226 passed (226), typecheck clean

# backend
cd ../lemma-backend && uv run pytest app/modules/agent/tests/unit -q
# → 1116 passed, 29 skipped
make lint && make lint-async && make typecheck-critical && make architecture
# → all clean; architecture ratchet 12 inherited violations, 0 inherited cycles
```

Render cost was measured rather than assumed, on the same two-turn conversation
(open, send, tool call, tool result, streamed answer, durable answer, completed,
twice), with the fixes stashed and unstashed:

| | renders after open | total | per turn |
|---|---|---|---|
| before | 7 | 33 | 13 |
| after | 7 | 33 | 13 |

Two of the new tests keep it that way: one asserts a healthy two-turn
conversation still costs zero re-reads and zero re-lists, the other that
repeated reads of an unchanged conversation produce no renders and keep the
record's identity — which is what `rememberConversation` now guarantees, and
what stops the resume ladder costing three transcript re-renders per answered
card.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **API surface** — no OpenAPI change; the SSE event type is not part of the
      described schema. Both committed browser bundles are rebuilt from source
      in this change, and the route inventory check passes.
- [x] **Compatibility** — see below
- [x] **Security** — no new data in any log, response, or queued payload; no
      authorization paths touched
- [x] **Rollback** — plain revert, no state to unwind

## Compatibility and rollback notes

The `stream_error` rename is safe in both directions during a rolling deploy,
because the old client already handled that event type in the same branch as
`error`:

- **Old client, new backend** — receives `stream_error`, treats it as a failed
  run. Exactly today's behaviour, no worse.
- **New client, old backend** — receives `error` for an interruption, stops as
  it does today. The other two fixes are client-side and still apply.

Revert is a plain `git revert`; nothing persists state.

## Notes for a reviewer

- The scenario suite still only asserts the conversation stream's content-type,
  so none of this is covered black-box. The scenario worth adding — answer a
  card, assert the follow-on run's messages arrive without a re-fetch — needs
  Docker, so it is not in this PR.
- `lemma-backend/app/modules/workflow/api/workflow_run_controller.py:371` sends
  the same sentence under `error`. Left alone deliberately: that view polls
  behind its stream and never had this failure mode.
- The new tests poll for their condition rather than sleeping a fixed stretch.
  They were fixed sleeps first and flaked under CPU load, which is worth knowing
  before anyone reintroduces one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
