### PR TITLE
Stop a shared fake remembering one test's traffic, and floor coverage at what it measures

### DIFF
--- a/.github/workflows/backend-coverage.yml
+++ b/.github/workflows/backend-coverage.yml
@@ -283,13 +283,27 @@ jobs:
                 body,
               });
             }
+      # `agent_surfaces` sits at 79 rather than 80, and the reason is measured
+      # rather than aspirational. Across 38 runs where this gate actually
+      # executed it reported 79.56 to 79.98 and failed 32 of them -- the floor
+      # was set fractionally above the value it measures, so the gate was red
+      # on `main` most of the time and the six passes squeaked over by
+      # hundredths. Four separate head SHAs produced both a pass and a failure,
+      # so the variance is real and not a stuck number: this is coverage
+      # measured across worker subprocesses under xdist, and
+      # `.github/e2e-shards.json` already records a ~0.4-point per-run spread
+      # for `agent` from the same cause.
+      #
+      # A gate that is red most of the time gates nothing, because nobody reads
+      # it. 79 keeps roughly half a point of headroom below the observed floor.
+      # Raise it deliberately when real coverage moves, not to express a hope.
       - name: Enforce critical-module E2E floors
         run: >-
           uv run python scripts/check_coverage_thresholds.py
           coverage-backend/e2e-union.json
           --min-total 0
           --min-module agent=80
-          --min-module agent_surfaces=80
+          --min-module agent_surfaces=79
           --min-module datastore=80
           --min-module function=80
       - name: Enforce total and module floors

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -271,7 +271,19 @@ jobs:
     # once, where a job missing from `needs` kept the check green while it
     # failed.
     timeout-minutes: 10
-    if: always()
+    # `!cancelled()`, not `always()`. `always()` runs this job even when the
+    # *run* was cancelled -- which `cancel-in-progress` above does to every
+    # superseded push -- and it then reported failure for a run that was
+    # simply replaced by a newer one. 13 of 84 observed Backend E2E runs were
+    # cancelled, and every one of them read as a failure. Nothing was ever
+    # blocked, because GitHub judges the newest run; what it cost was the
+    # ability to read the run list and tell whether CI is actually flaky.
+    #
+    # The step below still refuses a cancelled *shard*, which is a different
+    # thing: `fail-fast: false` means the matrix never cancels its own
+    # siblings, so a cancelled shard with a live run means somebody stopped one
+    # job, and a required check must not go green on a run that did not finish.
+    if: ${{ !cancelled() }}
     needs: [changes, backend-e2e]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sandbox-e2b-conformance.yml
+++ b/.github/workflows/sandbox-e2b-conformance.yml
@@ -36,8 +36,22 @@ jobs:
       - name: Install with the E2B extra
         run: uv sync --extra local --extra e2b --locked
       - name: Verify E2B configuration is present
-        # Fail loudly rather than letting the suite skip itself into a green
-        # tick, which is exactly how this provider went unverified before.
+        id: e2b_config
+        # Loud when somebody asked for this run, quiet when the clock did.
+        #
+        # The original rule was "always fail loudly", to stop the suite
+        # skipping itself into a green tick — which is exactly how this
+        # provider went unverified before, and is still the right instinct.
+        # But on a deployment that has never held E2B credentials the daily
+        # cron then fails every single day, and a job that is always red says
+        # nothing when it goes red for a real reason. It failed 100% of its
+        # runs on an empty `E2B_API_KEY`, and the artifact upload failed after
+        # it with `No files were found`.
+        #
+        # So: a scheduled run with no credentials reports that it was not
+        # configured and stops. A `workflow_dispatch` run still fails — a
+        # person asking for this suite by hand and getting a silent pass is
+        # the failure mode the original comment is about.
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
           E2B_WORKSPACE_TEMPLATE: ${{ vars.E2B_WORKSPACE_TEMPLATE }}
@@ -54,15 +68,24 @@ jobs:
             fi
           done
           if [ -n "$missing" ]; then
-            echo "Missing required E2B configuration:$missing" >&2
-            exit 1
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo "Missing required E2B configuration:$missing" >&2
+              exit 1
+            fi
+            echo "::notice::E2B is not configured on this deployment" \
+              "($missing); skipping the conformance suite. Set the secrets to" \
+              "turn this into a real gate, or run it by hand to see it fail."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          echo "configured=true" >> "$GITHUB_OUTPUT"
       # Named explicitly rather than by directory, so a suite is only run
       # because someone chose to run it against a real, billed account. The
       # cost of that choice is that a new suite is invisible until it is added:
       # `test_e2b_lifecycle_real.py` and `test_e2b_function_liveness_real.py`
       # existed for months, nineteen tests between them, and ran nowhere.
       - name: Real E2B provider contract
+        if: steps.e2b_config.outputs.configured == 'true'
         timeout-minutes: 30
         env:
           E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
@@ -81,7 +104,10 @@ jobs:
           -m ""
           --junitxml=e2b-e2e.xml
       - name: Upload results
-        if: always()
+        # Not `always()`: with no credentials the suite above never ran, so
+        # there is no junit file and `if-no-files-found: error` turned a clean
+        # skip back into a red tick.
+        if: always() && steps.e2b_config.outputs.configured == 'true' 
         uses: actions/upload-artifact@v4
         with:
           name: sandbox-e2b-e2e

--- a/lemma-backend/app/core/tests/unit/test_e2e_workflow_contract.py
+++ b/lemma-backend/app/core/tests/unit/test_e2e_workflow_contract.py
@@ -124,7 +124,15 @@ def test_e2e_union_gate_is_separate_from_unit_aggregate() -> None:
 
     assert "coverage-backend/e2e-union.json" in workflow
     assert "--min-module agent=80" in workflow
-    assert "--min-module agent_surfaces=80" in workflow
+    # 79, not 80, and pinned here so moving it stays a deliberate act. The
+    # floor was set fractionally above the value it measures: across 38 runs
+    # where this gate executed, `agent_surfaces` reported 79.56 to 79.98 and
+    # failed 32 of them, with four head SHAs producing both a pass and a
+    # failure. That is xdist coverage variance -- the same cause
+    # `.github/e2e-shards.json` records a ~0.4-point spread for on `agent` --
+    # not a number anybody can push over the line. Raise it when real coverage
+    # moves.
+    assert "--min-module agent_surfaces=79" in workflow
     assert "--min-module datastore=80" in workflow
     assert "--min-module function=80" in workflow
     assert workflow.index("Combine E2E-only coverage") > workflow.index(

--- a/lemma-backend/app/modules/agent/tests/e2e/test_long_running_and_research_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_long_running_and_research_e2e.py
@@ -16,10 +16,12 @@ Covers:
 from __future__ import annotations
 
 import time
+from dataclasses import dataclass
 from types import SimpleNamespace
 from uuid import UUID, uuid4
 
 import pytest
+from aiohttp import web
 from fastapi import status
 
 import app.modules.workspace.services.workspace_tool_runtime as workspace_runtime
@@ -42,6 +44,51 @@ from app.modules.test_support.e2e.waiters import eventually
 # invisible until something is held across the boundary: a pooled Postgres
 # connection opened during fixture setup and reused in the test body dies with
 # "got Future attached to a different loop".
+
+
+@dataclass
+class _FetchablePage:
+    """One page of HTML on loopback, so the good URL in the batch is local."""
+
+    url: str = ""
+    _runner: "web.AppRunner | None" = None
+
+    async def start(self) -> None:
+        app = web.Application()
+        app.router.add_get("/", self._page)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, "127.0.0.1", 0)
+        await site.start()
+        sockets = site._server.sockets if site._server else []  # noqa: SLF001
+        assert sockets
+        self.url = f"http://127.0.0.1:{sockets[0].getsockname()[1]}/"
+
+    async def stop(self) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()
+
+    async def _page(self, request: web.Request) -> web.Response:
+        del request
+        # Comfortably over `_THIN_CONTENT_CHARS` (120). Below it, extraction is
+        # read as degenerate and the fetch is retried through the browser --
+        # which is a real behaviour worth keeping, and would make the
+        # `fetched_with == "http"` assertion below silently untrue. The
+        # in-tree comment notes example.com extracts to 167 clean characters;
+        # this is deliberately in the same range.
+        return web.Response(
+            text=(
+                "<html><body><h1>A fetchable page</h1>"
+                "<p>This page exists so the plain HTTP fetch path has something "
+                "local to read. It carries enough ordinary prose to clear the "
+                "thin-content floor, so extraction succeeds on the first pass "
+                "and no browser render is spent re-reading a page that was "
+                "already read correctly.</p></body></html>"
+            ),
+            content_type="text/html",
+        )
+
+
 pytestmark = [pytest.mark.e2e, pytest.mark.asyncio]
 
 # Long enough that it cannot finish inside one default wait window, short enough
@@ -454,27 +501,52 @@ async def test_web_fetch_rejects_malformed_and_unsafe_urls_before_fetching(
     fixed_test_org,
     fixed_test_user,
     configure_workspace_api_url,
+    monkeypatch,
 ):
     """`_validate` and `assert_safe_url` run for every URL before either fetch
-    path starts, and a bad URL in the batch must not sink the good ones."""
+    path starts, and a bad URL in the batch must not sink the good ones.
+
+    The good URL is served from this process. It used to be
+    `https://example.com/`, which put a live internet fetch inside a *required*
+    check — `@pytest.mark.fast_workspace` suppresses the `workspace` marker, so
+    this runs in the merge-gating `agent` shard, and `timeout(300)` meant a
+    slow DNS answer burned five minutes of it.
+
+    Reaching a loopback address needs the self-hosting hatch, and turning it on
+    makes the test say more rather than less: `_is_disallowed_address` keeps
+    link-local denied even with `allow_private` set, precisely because
+    169.254.169.254 is the cloud metadata service and never a fetch target. So
+    the metadata assertion below is now also a statement that opening the hatch
+    for your own subnet does not open it for your instance credentials.
+    """
     del configure_workspace_api_url
+    from app.core.config import settings
     from app.modules.agent.tools.web.models import WebFetchRequest
     from app.modules.agent.tools.web.web_fetch import web_fetch_internal
 
-    ctx = await _agent_context(authenticated_client, fixed_test_org, fixed_test_user)
+    monkeypatch.setattr(settings, "connector_allow_private_network_targets", True)
 
-    result = await web_fetch_internal(
-        ctx,
-        WebFetchRequest(
-            urls=[
-                "ftp://example.com/file",
-                "https://",
-                "http://169.254.169.254/latest/meta-data",
-                "https://example.com/",
-            ],
-            comment="mixed malformed, unsafe, and valid URLs",
-        ),
-    )
+    served = _FetchablePage()
+    await served.start()
+    try:
+        ctx = await _agent_context(
+            authenticated_client, fixed_test_org, fixed_test_user
+        )
+
+        result = await web_fetch_internal(
+            ctx,
+            WebFetchRequest(
+                urls=[
+                    "ftp://example.com/file",
+                    "https://",
+                    "http://169.254.169.254/latest/meta-data",
+                    served.url,
+                ],
+                comment="mixed malformed, unsafe, and valid URLs",
+            ),
+        )
+    finally:
+        await served.stop()
 
     assert result.success, "one good URL among the bad ones must still succeed"
     by_url = {page.url: page for page in result.pages}
@@ -482,9 +554,9 @@ async def test_web_fetch_rejects_malformed_and_unsafe_urls_before_fetching(
     assert "no host" in (by_url["https://"].error or "")
     assert "not a permitted fetch target" in (
         by_url["http://169.254.169.254/latest/meta-data"].error or ""
-    )
-    assert by_url["https://example.com/"].success
-    assert by_url["https://example.com/"].fetched_with == "http"
+    ), "the metadata service must stay refused even with private targets allowed"
+    assert by_url[served.url].success
+    assert by_url[served.url].fetched_with == "http"
 
 
 @pytest.mark.fast_workspace

--- a/lemma-backend/app/modules/datastore/tests/e2e/conftest.py
+++ b/lemma-backend/app/modules/datastore/tests/e2e/conftest.py
@@ -97,6 +97,18 @@ async def datastore_outbox_dispatcher(e2e_settings, db_manager):
         yield
 
 
+@pytest.fixture(autouse=True)
+def _forget_document_processor_traffic(request):
+    """Give each test the shared fake with an empty ledger.
+
+    Autouse and lazy: it only touches the server for tests that actually asked
+    for it, so nothing else pays for a session fixture it does not use.
+    """
+    if "fake_document_processor_server" in request.fixturenames:
+        request.getfixturevalue("fake_document_processor_server").forget_traffic()
+    yield
+
+
 @pytest_asyncio.fixture(scope="session")
 async def fake_document_processor_server() -> AsyncIterator[
     FakeDocumentProcessorServer

--- a/lemma-backend/app/modules/datastore/tests/e2e/fake_document_processors.py
+++ b/lemma-backend/app/modules/datastore/tests/e2e/fake_document_processors.py
@@ -26,6 +26,20 @@ class FakeDocumentProcessorServer:
         self._docling_polls: Counter[str] = Counter()
         self._runner: web.AppRunner | None = None
 
+    def forget_traffic(self) -> None:
+        """Drop what this server has been asked, keeping it running.
+
+        The server is session-scoped so every test in the module shares it, and
+        several of them assert "this document was extracted exactly once". Those
+        assertions are only about the test that makes them if the counters start
+        empty — otherwise two tests that happen to use the same filename see
+        each other's requests, and the second one fails with `2 == 1` for a
+        product that did nothing wrong.
+        """
+        self.requests.clear()
+        self._docling_tasks.clear()
+        self._docling_polls.clear()
+
     async def start(self) -> None:
         app = web.Application()
         app.router.add_post("/extract", self._kreuzberg_extract)

--- a/lemma-backend/app/modules/datastore/tests/e2e/test_document_worker_journeys_e2e.py
+++ b/lemma-backend/app/modules/datastore/tests/e2e/test_document_worker_journeys_e2e.py
@@ -136,16 +136,31 @@ async def test_kreuzberg_upload_indexes_a_document_and_makes_it_searchable(
         )
         assert hit["page_number"] == 1
 
-        assert fake_document_processor_server.requests["kreuzberg:success.pdf"] == 1
-
         # Redis redelivery carries the same durable event id. The inbox must
         # acknowledge it without creating another extraction/job side effect.
+        #
+        # Measured as "unchanged by the redelivery", not "exactly one, ever.
+        # The absolute form asserted that no transient retry had happened on
+        # the way here, which is not something the product promises and is not
+        # what this test is about: `KREUZBERG_REQUEST_TIMEOUT_SECONDS` is 1, so
+        # a loaded runner can time the first extract out, `release_claim`
+        # returns the row to PENDING with its attempt refunded (PS-DATA-041),
+        # and the re-drive extracts again — correct behaviour that read as a
+        # duplicate. It cost a red required check on an unrelated pull request.
+        before_redelivery = fake_document_processor_server.requests[
+            "kreuzberg:success.pdf"
+        ]
+        assert before_redelivery >= 1, "the document was never extracted at all"
+
         event = await _outbox_event_for_file(db_manager, uploaded["id"])
         bus = get_message_bus()
         await bus.publish(event.stream, event.payload)
         await bus.publish(event.stream, event.payload)
         await asyncio.sleep(0.5)
-        assert fake_document_processor_server.requests["kreuzberg:success.pdf"] == 1
+        assert (
+            fake_document_processor_server.requests["kreuzberg:success.pdf"]
+            == before_redelivery
+        ), "a redelivered event with the same id extracted the document again"
 
 
 # `slow` keeps this out of the fast lane every PR runs and puts it in the


### PR DESCRIPTION
## What changes

Two things that make CI red without anything being wrong, found by auditing 600
workflow runs (2026-08-23 → 08-25, 68 failures, all logs classified).

**A session-scoped fake never forgets what it was asked.**
`FakeDocumentProcessorServer.requests` is a `Counter` shared by every test in
the datastore document module, and two of them upload a file called
`success.pdf` and then assert it was extracted exactly once. The second sees
both and fails `2 == 1`, for a product that did nothing wrong.

CI has been spared by an accident of selection — the PR lane runs `not slow`,
the protected lane runs `slow`, so the two never meet there. But `make
test-e2e` and `make coverage-e2e` select both, which makes the documented "run
every e2e test" target fail **deterministically**. There is no
`pytest-randomly` here and `--dist loadscope` keeps a module on one worker, so
this is arithmetic, not a race.

**The `agent_surfaces` E2E coverage floor is set above the value it measures.**

| | |
|---|---|
| Runs where the gate actually executed | 38 |
| Failed | **32 (84%)** |
| Observed range | 79.56 – 79.98 |
| Floor | 80.00 |

The six passes cleared it by hundredths. **Four separate head SHAs produced
both a pass and a failure**, so this is variance rather than a stuck value —
coverage measured across worker subprocesses under xdist, the same cause
`.github/e2e-shards.json` already records a ~0.4-point spread for on `agent`.

A gate that is red most of the time gates nothing, because nobody reads it. 79
keeps about half a point of headroom below the observed floor; raise it
deliberately when real coverage moves, not to express a hope.

Neither of these is a required check, which is why both have been quietly wrong.

## How to verify

```bash
cd lemma-backend && uv run pytest app/modules/datastore/tests/e2e/test_document_worker_journeys_e2e.py -q
make quality
```

```
before the fix   FAILED …::test_kreuzberg_extractor_behaviour_matrix - assert 2 == 1
after the fix    4 passed, 1 skipped
make quality     ✓ quality gates pass
```

## Also fixed here

**A required-lane test fetched `https://example.com/` over the internet.**
`test_web_fetch_rejects_malformed_and_unsafe_urls_before_fetching` carries
`fast_workspace`, which suppresses the `workspace` marker and lands it in the
merge-gating `agent` shard with `timeout(300)`. The good URL is now served from
this process — **14s instead of up to 300**.

Reaching loopback needs the self-hosting hatch, and turning it on makes the
test say *more*: `_is_disallowed_address` keeps link-local denied even with
`allow_private` set, because 169.254.169.254 is the metadata service and never
a fetch target. The metadata assertion is now also a statement that opening the
hatch for your own subnet does not open it for your instance credentials.

**A test asserted that no transient retry had ever happened.** The document
wiring test read `requests["kreuzberg:success.pdf"] == 1` *before* exercising
the thing it is about — redelivery idempotency.
`KREUZBERG_REQUEST_TIMEOUT_SECONDS` is 1, so a loaded runner times the first
extract out, `release_claim` returns the row to PENDING with its attempt
refunded (`PS-DATA-041`), and the re-drive extracts again. Correct behaviour,
read as a duplicate, failing a required check on an unrelated PR. It now
measures the count before redelivery and asserts the redelivery did not change
it.

> **Correcting a first diagnosis, because it was wrong and worth recording.**
> That failure was initially attributed to the dispatch cron re-enqueuing
> in-flight files. The cron does do that — `list_pending_dispatch_candidates`
> has no age floor and the dispatcher passes `bypass_admission=True` — but it
> **cannot cause a second extraction**: `claim_for_processing` is a conditional
> `UPDATE` off `PENDING` and it runs *before* the extract, so a redundant job's
> claim no-ops. The duplicate needed the row to return to `PENDING`, which only
> the transient path does. The redundant enqueue is wasted queue traffic worth
> tidying one day; it is not this bug.

**`e2e-passed` failed every superseded run.** `always()` runs it even when the
run itself was cancelled — which `cancel-in-progress` does to every superseded
push, 13 of 84 Backend E2E runs, each reading as a failure that blocked nothing.
`!cancelled()` leaves those neutral. The step still refuses a cancelled
*shard*: `fail-fast: false` means the matrix never cancels its own siblings, so
that means somebody stopped a job, and a required check must not go green on a
run that did not finish.

**The E2B conformance suite failed 100% of its runs on an empty API key.** It
is a daily cron, never a PR check, so on a deployment that has never held those
credentials it was red every day — and a job that is always red says nothing
when it goes red for a reason. A scheduled run with no credentials now reports
that and stops; a `workflow_dispatch` run still fails, because a person asking
for this suite by hand and getting a silent pass is the failure mode the
original comment was guarding against.

## Not flakiness, and worth separating when reading CI

`spec traceability`, the frontend bundle-size budgets, and several mass-e2e
runs are **deterministic** failures of real content. Counting them as flakes is
part of why the rate looks worse than it is.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Rollback** — plain revert; no migration, no API change, no data change

## Compatibility and rollback notes

No migrations, no API surface change. The coverage floor is a CI threshold
only. Revert is a plain revert.
