### PR TITLE
Let a truncating row measure against the dialog, and open a public document that lives in a folder

### DIFF
--- a/lemma-backend/app/modules/datastore/services/files/authorizer.py
+++ b/lemma-backend/app/modules/datastore/services/files/authorizer.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from typing import Sequence
 from uuid import UUID
 
-from app.core.authorization.context import ActorType, Context
+from app.core.authorization.context import (
+    ActorType,
+    Context,
+    ResourceVisibility,
+    normalize_resource_visibility,
+)
 from app.core.log.log import get_logger
 from app.modules.datastore.config import datastore_settings
 from app.modules.datastore.domain.errors import DatastoreAccessDeniedError
@@ -164,6 +169,31 @@ class FileAuthorizer:
             # human path below does for RESTRICTED-folder visibility) would defeat
             # a deep-folder grant — e.g. a grant on /docs/eng/runbooks would still
             # fail because the agent lacks a separate grant on /docs and /docs/eng.
+            await self.authz.require_document_read(
+                user_id=requester_user_id,
+                pod_id=file_entity.pod_id,
+                resource_id=file_entity.id,
+                resource_name=file_entity.path,
+                ctx=ctx,
+            )
+            return
+
+        if (
+            normalize_resource_visibility(file_entity.visibility)
+            == ResourceVisibility.PUBLIC
+        ):
+            # Shared with every signed-in account, so the folders it happens to
+            # sit in are not a second gate. Walking them was: a non-member holds
+            # no pod permissions, and an ancestor folder is POD by default, so a
+            # document explicitly opened to anyone still 403'd unless it lived at
+            # the datastore root. The share dialog said "anyone with a Lemma
+            # account can open it" and the download disagreed — and the preview
+            # route, which authorizes the document alone, said yes right before
+            # the download said no.
+            #
+            # Only reads reach here (require_document_read), and only the
+            # document's OWN visibility short-circuits, so a POD file inside a
+            # RESTRICTED folder is still covered by the walk below.
             await self.authz.require_document_read(
                 user_id=requester_user_id,
                 pod_id=file_entity.pod_id,

--- a/lemma-backend/app/modules/datastore/tests/unit/test_file_authorizer_workload.py
+++ b/lemma-backend/app/modules/datastore/tests/unit/test_file_authorizer_workload.py
@@ -1,23 +1,35 @@
 """Unit: a workload (agent/function) authorizes a pod file via the file alone
 (grant cascade covers ancestor-folder grants), while a human still walks the
-ancestor chain (RESTRICTED-folder visibility)."""
+ancestor chain (RESTRICTED-folder visibility) — except for a PUBLIC document,
+which is authorized on its own so the folders above it are not a second gate."""
 
 from __future__ import annotations
 
+from dataclasses import replace
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
 
-from app.core.authorization.context import ActorType
+from app.core.authorization.context import (
+    ActorType,
+    Context,
+    ResourceVisibility,
+)
+from app.core.authorization.service import Authorizer
+from app.core.domain.errors import DomainError
 from app.modules.datastore.domain.file_entities import (
     DatastoreFileEntity,
     FileKind,
     FileStatus,
 )
+from app.modules.datastore.services.authorization import DatastoreAuthorization
 from app.modules.datastore.services.files.authorizer import FileAuthorizer
 from app.modules.datastore.services.files.path_resolver import PathResolver
+
+#: Signed in, but in no pod and no organization of the pod under test.
+OUTSIDER_ID = uuid4()
 
 
 def _file(pod_id, path: str) -> DatastoreFileEntity:
@@ -158,3 +170,129 @@ class TestListingAgreesWithOpening:
         )
 
         assert visible == set()
+
+
+class TestAPublicDocumentIsNotGatedByItsFolders:
+    """A document opened to every signed-in account has to actually open.
+
+    The ancestor walk asks for `folder.read` on each folder above the file. A
+    non-member holds no pod permissions and a folder is POD by default, so the
+    walk denied every PUBLIC document that was not sitting at the datastore root
+    — while the share dialog promised "anyone with a Lemma account can open it",
+    and `/pods/{id}/resources/document/preview`, which authorizes the document
+    alone, said yes immediately before the download said no.
+    """
+
+    @staticmethod
+    def _public(pod_id, path: str) -> DatastoreFileEntity:
+        entity = _file(pod_id, path)
+        entity.visibility = "PUBLIC"
+        return entity
+
+    @pytest.mark.asyncio
+    async def test_only_the_document_itself_is_checked(self):
+        pod_id = uuid4()
+        user_id = uuid4()
+        authz = AsyncMock()
+        file_repo = AsyncMock()
+        authorizer = FileAuthorizer(authz, file_repo, PathResolver())
+
+        file_entity = self._public(pod_id, "/library/brand-directions.md")
+        ctx = SimpleNamespace(actor_type=ActorType.USER, user_id=user_id)
+        await authorizer._ensure_pod_document_path_access(file_entity, user_id, ctx=ctx)
+
+        assert authz.require_document_read.await_count == 1
+        _, kwargs = authz.require_document_read.await_args
+        assert kwargs["resource_name"] == "/library/brand-directions.md"
+        file_repo.get_by_paths.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_pod_document_still_walks_its_folders(self):
+        """The other direction: only the document's OWN visibility short-circuits,
+        so a RESTRICTED folder still contains what is inside it."""
+        pod_id = uuid4()
+        user_id = uuid4()
+        authz = AsyncMock()
+        file_repo = AsyncMock()
+        file_repo.get_by_paths.return_value = [_folder(pod_id, "/library")]
+        authorizer = FileAuthorizer(authz, file_repo, PathResolver())
+
+        file_entity = _file(pod_id, "/library/brand-directions.md")
+        ctx = SimpleNamespace(actor_type=ActorType.USER, user_id=user_id)
+        await authorizer._ensure_pod_document_path_access(file_entity, user_id, ctx=ctx)
+
+        # The folder and the file.
+        assert authz.require_document_read.await_count == 2
+
+
+class TestANonMemberActuallyGetsIn:
+    """The same thing one layer down, against the real `Authorizer`.
+
+    The shape tests above pin *which* resources are checked; these pin what the
+    answer is, because the bug was a denial, not a call count.
+    """
+
+    @staticmethod
+    def _ctx(rows) -> Context:
+        """A signed-in user with no pod membership and no grants."""
+        by_id = {row.id: row for row in rows}
+        authorizer = Authorizer(session=None)
+
+        async def _hydrate(resource):
+            # Stands in for the DB read: `_require_document_action` builds a bare
+            # ResourceRef, and visibility is exactly what this decision turns on.
+            row = by_id.get(resource.resource_id)
+            if row is None:
+                return resource
+            return replace(
+                resource,
+                visibility=ResourceVisibility(row.visibility),
+                owner_user_id=row.owner_user_id,
+                path=row.path,
+            )
+
+        authorizer._hydrate_resource = _hydrate
+        return Context(
+            actor_type=ActorType.USER,
+            actor_id=str(OUTSIDER_ID),
+            user_id=OUTSIDER_ID,
+            organization_id=uuid4(),
+            pod_id=rows[0].pod_id,
+            permission_ids=frozenset(),
+            principal_refs=frozenset(),
+            authorizer=authorizer,
+        )
+
+    @staticmethod
+    def _authorizer(rows) -> FileAuthorizer:
+        file_repo = AsyncMock()
+        file_repo.get_by_paths.side_effect = lambda pod_id, paths: [
+            row for row in rows if row.path in paths
+        ]
+        return FileAuthorizer(
+            DatastoreAuthorization(object()), file_repo, PathResolver()
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_public_document_inside_a_folder_opens(self):
+        pod_id = uuid4()
+        folder = _folder(pod_id, "/library")
+        doc = _file(pod_id, "/library/brand-directions.md")
+        doc.visibility = "PUBLIC"
+        rows = [folder, doc]
+
+        await self._authorizer(rows).ensure_file_path_access(
+            doc, OUTSIDER_ID, ctx=self._ctx(rows)
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_pod_document_inside_the_same_folder_does_not(self):
+        pod_id = uuid4()
+        folder = _folder(pod_id, "/library")
+        doc = _file(pod_id, "/library/brand-directions.md")
+        rows = [folder, doc]
+
+        with pytest.raises(DomainError):
+            await self._authorizer(rows).ensure_file_path_access(
+                doc, OUTSIDER_ID, ctx=self._ctx(rows)
+            )

--- a/lemma-frontend/components/ui/dialog.tsx
+++ b/lemma-frontend/components/ui/dialog.tsx
@@ -33,12 +33,19 @@ const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
+  // `grid-cols-1` below, rather than the implicit column a bare `grid` makes: an
+  // implicit track is sized `auto`, so it grows to the widest child's min-content
+  // — and a child that truncates is `white-space: nowrap`, whose min-content is
+  // the whole unwrapped line. One long title or option description therefore
+  // pushed the track past `max-w`, and the row ran off the side under
+  // `overflow-hidden` instead of ellipsising. `minmax(0, 1fr)` pins the track to
+  // the dialog's own width, which is what truncation needs to measure against.
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "dialog-content-motion fixed left-[50%] top-[50%] z-50 grid w-[calc(100vw-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border border-[color:var(--border-subtle)] bg-[var(--surface-1)] p-5 text-[var(--text-primary)] shadow-[var(--shadow-lg)] outline-none focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--field-border-focus)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 max-h-[calc(100dvh-2rem)]",
+        "dialog-content-motion fixed left-[50%] top-[50%] z-50 grid grid-cols-1 w-[calc(100vw-2rem)] max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border border-[color:var(--border-subtle)] bg-[var(--surface-1)] p-5 text-[var(--text-primary)] shadow-[var(--shadow-lg)] outline-none focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--field-border-focus)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 max-h-[calc(100dvh-2rem)]",
         className
       )}
       {...props}

--- a/lemma-frontend/components/ui/radio-group.tsx
+++ b/lemma-frontend/components/ui/radio-group.tsx
@@ -11,8 +11,13 @@ const RadioGroup = React.forwardRef<
     React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
 >(({ className, ...props }, ref) => {
     return (
+        // `grid-cols-1`, not a bare `grid`: an implicit track is `auto`-sized and
+        // grows to the widest option's min-content, which for a truncating
+        // (`white-space: nowrap`) label is its whole unwrapped line. That is how a
+        // long option description widened the rows past their container instead of
+        // ellipsising inside it. See the same note on DialogContent.
         <RadioGroupPrimitive.Root
-            className={cn("grid gap-2", className)}
+            className={cn("grid grid-cols-1 gap-2", className)}
             {...props}
             ref={ref}
         />

--- a/tests/scenarios/journeys/surfaces_and_notifications/test_native_controls.py
+++ b/tests/scenarios/journeys/surfaces_and_notifications/test_native_controls.py
@@ -93,9 +93,7 @@ async def test_an_approval_is_offered_with_native_controls(reachable):
     # "cancel" is in this list because the product uses it, and it is a refusal
     # a person reads as one. Asserting on a vocabulary the product does not
     # share is how a scenario reports a working control as a missing one.
-    assert any(
-        word in labels for word in ("den", "reject", "decline", "cancel", "no")
-    ), (
+    assert any(word in labels for word in ("den", "reject", "decline", "cancel", "no")), (
         f"an approval reached the person without a control to refuse it: "
         f"{labels or 'no buttons at all'}"
     )


### PR DESCRIPTION
## What changes

Two fixes behind one report ("share modal is getting cut, and does public doc sharing actually work?").

**The share dialog no longer clips its own rows.** The general-access options and a long dialog title ran off the right edge instead of ellipsising. Fixed in the two shared primitives, so it applies to every dialog and every radio group in the app, not just this one.

**A document shared with "anyone signed in" now actually opens** — previously it only worked if the file happened to sit at the datastore root. Anything inside a folder 403'd for the person it was shared with.

## Why

**The clipping.** `DialogContent` and `RadioGroup` are both `display: grid` with an *implicit* column. An implicit track is `auto`-sized, so it grows to the widest child's min-content — and a child carrying `truncate` is `white-space: nowrap`, whose min-content is the whole unwrapped line. So the longest option description ("Anyone with a Lemma account can open it, including people outside your team.") sized the column, pushed the rows past `max-w-[560px]`, and `overflow-hidden` sliced them off. Truncation never fired, because the box was never narrower than the text. `grid-cols-1` is `minmax(0, 1fr)`, which pins the track to the container's own width — what truncation needs to measure against.

Measured on an isolated repro of the exact computed styles:

| | option row width | body scrollWidth / clientWidth | description ellipsised |
|---|---|---|---|
| before | 547px | 567 / 560 | no |
| after | 520px | 560 / 560 | yes |

The header has the same bug; the screenshot in the report doesn't show it only because that filename is short. A long one runs the title 61px past the edge (dialog scrollWidth 670 in a 560px box).

**The sharing.** `_ensure_pod_document_path_access` walked every ancestor folder for a human reader and required `folder.read` on each. A non-member holds no pod permissions and a folder is `POD` by default, so the walk denied the document that its own visibility had just opened.

The two halves of the flow openly disagreed. `/pods/{id}/resources/document/preview` authorizes the document alone — and its docstring promises it "can never report access that the read path would then refuse" — so it said yes, the guest view rendered, and then `files/download` walked the folders and said no. The reader got "This document could not be loaded."

A `PUBLIC` document now authorizes on its own, mirroring the workload branch directly above it. Deliberately narrow: reads only (`require_document_read` is the only caller), and only the document's *own* visibility short-circuits — a `POD` file inside a `RESTRICTED` folder still walks the chain.

## How to verify

The sharing bug reproduces against the real `Authorizer`; both new tests fail without the fix and pass with it.

```bash
cd lemma-backend && uv run pytest app/modules/datastore/tests/unit/test_file_authorizer_workload.py app/core/authorization/tests/unit -q
```

`70 passed`. Without the fix: `2 failed, 9 passed`, the first being `Missing permission folder.read on document` on the *ancestor folder* of a `PUBLIC` file.

```bash
cd lemma-backend && uv run pytest app/modules/datastore/tests/unit -q
```

`535 passed`.

```bash
make architecture
```

`Architecture ratchet passed (12 inherited import violations, 0 inherited cycles).`

```bash
cd lemma-frontend && node scripts/audit-design-system.mjs --strict --baseline scripts/design-audit-baseline.json --quiet
```

`Design audit passed productStrict=0 informational=104 protectedAssistant=1`.

### What I could not run

The worktree has no `node_modules`, so `npm run check` (lint + typecheck) did not run here — CI covers it. In its place I parsed both edited `.tsx` files through the TypeScript compiler (`parseDiagnostics` empty on each) and measured the CSS in a standalone repro of the exact computed styles rather than in the running app. The authorization fix is verified at the authorization layer; I did not exercise the share flow end to end in a browser with two real accounts.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally — except frontend lint/typecheck, see above
- [x] **Security** — authorization checked at the boundary; the widening is reads-only and keyed on the resource's own visibility, and the accompanying test pins that a `POD` document under the same folder is still refused

## Compatibility and rollback notes

No migration, no API surface change, no SDK regeneration. Both fixes are self-contained and revert cleanly with `git revert`.

One behavioral note worth a reviewer's attention: this widens who can read a document, by design. A file whose visibility is `PUBLIC` becomes readable by any signed-in account even when it sits under a `POD` or `RESTRICTED` folder. That is what the share dialog has been promising ("Anyone with a Lemma account can open it, including people outside your team"), and what the preview route already reported — but if the intent was ever that a `RESTRICTED` folder overrides a child's own `PUBLIC` visibility, this is the change to push back on, and the fix belongs in the dialog's copy instead.
