### PR TITLE
Send the vision scenario an image something can actually see

### DIFF
--- a/tests/scenarios/journeys/surfaces_and_notifications/test_being_answered.py
+++ b/tests/scenarios/journeys/surfaces_and_notifications/test_being_answered.py
@@ -32,10 +32,21 @@ pytestmark = [
     capability("Receive a message from outside"),
 ]
 
-#: A 1×1 red PNG. Small enough to inline, and a real image — Telegram rejects
-#: bytes that are not, and the model is being asked to look at it.
+#: A 64×64 solid red PNG, still small enough to inline.
+#:
+#: It was 1×1, which is a real PNG and which Telegram accepts — and which the
+#: model then refused: "the file that came through is only 288 bytes and isn't
+#: recognized as a valid image". Telegram re-encodes an inbound photo, and a
+#: one-pixel image comes out below what a vision preprocessor will look at. The
+#: scenario was asserting that the agent can see a picture while handing it one
+#: nothing can see, so a red result would have been luck and the red result it
+#: got was a refusal.
+#:
+#: 64×64 is still trivially and unambiguously red, and survives re-encoding.
 A_RED_DOT = base64.b64decode(
-    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAAAS0lEQVR42u3PQQkAAAgAsetf"
+    "WiP4FgYrsKZeS0BAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBA"
+    "QEDgsqnc8OJg6Ln3AAAAAElFTkSuQmCC"
 )
 
 


### PR DESCRIPTION
## What changes

`test_an_image_is_understood` asserts an agent **looks at** a picture rather
than noticing one arrived — and it was sending a **1×1 PNG**. Telegram accepts
that and re-encodes it, and the model answered:

> I can't see the image — the file that came through is only 288 bytes and
> isn't recognized as a valid image, so it didn't arrive properly.

Which is a fair answer to a one-pixel photo.

So the scenario was asserting the agent can see a picture while handing it one
nothing can see. It could only ever have passed by luck, and the failure it
produced pointed at a broken attachment pipeline. **The pipeline is fine** — the
same scenario passes now, against real Telegram, with the agent naming the
colour.

64×64 solid red: still inline, still trivially unambiguous, and it survives
re-encoding. Built by hand rather than pasted so the comment can explain why the
size matters — the next person to shrink it should know what breaks.

## How to verify

Needs a real Telegram account signed in (`TELEGRAM_SESSION`, see
[LIVE.md](tests/scenarios/LIVE.md)) and `SCENARIOS_MAILBOX` exported.

```bash
cd tests/scenarios
SCENARIOS_STANDING_STACK=1 SCENARIOS_USE_DEPLOYMENT_ENV=1 SCENARIOS_LLM_MODE=real \
  SCENARIOS_EGRESS=off SCENARIOS_TELEGRAM_POLLING=true \
  uv run pytest journeys/surfaces_and_notifications/test_being_answered.py -q
```

```
before   ✗ An image sent to the agent is looked at, not just noticed
           "…only 288 bytes and isn't recognized as a valid image"
after    ✓ Somebody messages the agent on a surface and is answered there   9.4s
         ✓ An image sent to the agent is looked at, not just noticed       25.2s
         2/2 scenarios passing

journeys/live      6/6 scenarios passing
make quality       ✓ 161 scenarios (157 covered, 0 gap), 235/235 ops, 28/28 events
make scenarios-guards   86 passed
```

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Rollback** — plain revert; test fixture only, no product code

## Compatibility and rollback notes

Test fixture only. No product code, no migration, no API change.
