### PR TITLE
Mint every inbound address in one place, and give a pod's assistant one at creation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -370,8 +370,11 @@ Point a Resend webhook at `POST /surfaces/webhooks/resend` and select
   addresses are minted on it (`{agent}.{pod}@{domain}`, and `{pod}@{domain}` for
   the pod's own assistant) and inbound routing matches on it, so a wrong value
   means mail that bounces on the way out and matches no surface on the way back.
-- **The key and the domain together are the switch.** Set both and agents get
-  mailboxes; leave either unset and they do not. There is no separate enable
+  The domain is one catch-all shared by every organization, so role addresses are
+  reserved: a pod named "Postmaster" gets `postmaster-k3p9@`, never
+  `postmaster@`.
+- **The key and the domain together are the switch.** Set both and every pod
+  and agent gets a mailbox as it is created; leave either unset and they do not. There is no separate enable
   flag — there was one, and being read per process it could be on where the
   surfaces catalog runs and off where sends run, which presents as the UI
   offering email while delivery reports that the pod has no surface.

--- a/lemma-backend/app/composition/agent_email_surface.py
+++ b/lemma-backend/app/composition/agent_email_surface.py
@@ -1,17 +1,17 @@
-"""Giving a new agent its own mailbox, at the moment it is created.
+"""Giving a new agent — or a new pod's assistant — its own mailbox at creation.
 
 The provisioning itself lives in
-``agent_surfaces.services.email_surface_provisioning`` — notification delivery
-provisions lazily through the same function, and two implementations is how the
-readable address and the ``pod-{hex}`` one came to coexist.
+``agent_surfaces.services.email_surface_provisioning``, which every caller now
+goes through — notification delivery lazily, the surfaces API and the bundle
+applier with their own name and config, and these two eagerly.
 
-This wrapper exists for one reason: the agent module must not import
+These wrappers exist for one reason: the agent and pod modules must not import
 ``agent_surfaces``, so the call is made from ``composition`` with lazy imports —
 same rule, and same shape, as ``workflow_notifications.py``.
 
-Best-effort. Creating an agent must not fail because a mail domain is unset or
-Resend is unreachable: the agent is still perfectly usable over chat and in the
-app, and an address can be added later.
+Best-effort. Creating an agent or a pod must not fail because a mail domain is
+unset or Resend is unreachable: both are still perfectly usable over chat and in
+the app, and an address can be added later.
 """
 
 from __future__ import annotations
@@ -43,6 +43,39 @@ async def provision_agent_email_surface(
     return surface.surface_identity_email if surface else None
 
 
+async def provision_pod_assistant_email_surface(
+    uow, *, pod_id: UUID, pod_name: str | None
+) -> str | None:
+    """Create the pod assistant's mailbox, returning its address.
+
+    Both ``agent_id`` and ``agent_name`` are None. That is not "unset": a surface
+    with no agent of its own is exactly what ``surfaces_for_agent`` looks for on
+    the assistant's behalf, and a None name is what makes the address the pod's
+    own — ``acme@`` rather than ``pod-default.acme@``.
+
+    The pod's name is passed in rather than looked up. The caller is pod creation
+    and already holds it, and the row a lookup would read is the one it just
+    wrote.
+
+    Best-effort, on the same terms as an agent's: None when email is not
+    configured or provisioning failed, and both are survivable.
+    """
+    from app.modules.agent_surfaces.api.dependencies import get_surface_service
+    from app.modules.agent_surfaces.services.email_surface_provisioning import (
+        provision_email_surface,
+    )
+
+    surface, _ = await provision_email_surface(
+        get_surface_service(uow),
+        uow.session,
+        pod_id=pod_id,
+        agent_id=None,
+        agent_name=None,
+        pod_name=pod_name,
+    )
+    return surface.surface_identity_email if surface else None
+
+
 async def _pod_name(uow, pod_id: UUID) -> str | None:
     from app.modules.pod.infrastructure.pod_repositories import PodRepository
 
@@ -50,4 +83,7 @@ async def _pod_name(uow, pod_id: UUID) -> str | None:
     return getattr(pod, "name", None)
 
 
-__all__ = ["provision_agent_email_surface"]
+__all__ = [
+    "provision_agent_email_surface",
+    "provision_pod_assistant_email_surface",
+]

--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -127,6 +127,7 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'agent_surfaces.credential_resolver.could_not_resolve_provider_account.diagnostic': EventSpec('debug', frozenset()),
     'agent_surfaces.display_resource_content.enrichment_skipped.diagnostic': EventSpec('debug', frozenset({'conversation_id', 'path', 'step'})),
     'agent_surfaces.email_attachments.skipping_oversize_workspace_email_attachment.diagnostic': EventSpec('debug', frozenset({'count', 'inline_cap_bytes'})),
+    'agent_surfaces.email_surface_provisioning.address_taken.degraded': EventSpec('warning', frozenset({'agent_id', 'attempt', 'pod_id'})),
     'agent_surfaces.email_surface_provisioning.address_unavailable.degraded': EventSpec('warning', frozenset({'agent_id', 'pod_id'})),
     'agent_surfaces.email_surface_provisioning.failed.degraded': EventSpec('warning', frozenset({'agent_id', 'failure_code', 'failure_type', 'pod_id'})),
     'agent_surfaces.event_receiver_service.could_not_load_telegram_polling.observed': EventSpec('debug', frozenset()),

--- a/lemma-backend/app/modules/agent_surfaces/api/controllers/surface_controller.py
+++ b/lemma-backend/app/modules/agent_surfaces/api/controllers/surface_controller.py
@@ -303,9 +303,9 @@ async def create_surface(
         agent_service=agent_service,
         ctx=ctx,
     )
-    surface = await service.create_surface(
+    surface = await service.create_surface_minting_address(
         pod_id=pod_id,
-        agent_id=agent.id if agent else None,
+        agent=agent,
         platform=request.platform,
         name=request.name,
         config=config,

--- a/lemma-backend/app/modules/agent_surfaces/api/dependencies.py
+++ b/lemma-backend/app/modules/agent_surfaces/api/dependencies.py
@@ -65,6 +65,7 @@ from app.modules.agent_surfaces.services.telegram_manager_service import (
     TelegramManagerService,
 )
 from app.composition.surface_identity import create_surface_user_repository
+from app.modules.agent_surfaces.services.pod_name_lookup import pod_name_for
 from app.composition.surface_connectors import get_connector_service
 from app.composition.surface_connectors import (
     ConnectorTriggerRepository,
@@ -154,18 +155,10 @@ def _build_system_email_provisioner(uow: UoWDep):
             pod_id=pod_id,
             agent_id=agent_id,
             agent_name=agent_name,
-            pod_name=await _pod_name(uow, pod_id),
+            pod_name=await pod_name_for(uow, pod_id),
         )
 
     return provision
-
-
-async def _pod_name(uow: UoWDep, pod_id: UUID) -> str | None:
-    """The pod's name, for the readable half of the address."""
-    from app.modules.pod.infrastructure.pod_repositories import PodRepository
-
-    pod = await PodRepository(uow).get(pod_id)
-    return getattr(pod, "name", None)
 
 
 def get_surface_webhook_security_service(

--- a/lemma-backend/app/modules/agent_surfaces/services/email_address_allocation.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/email_address_allocation.py
@@ -6,6 +6,12 @@ both are unique. That readability is exactly what makes collisions possible,
 which is why the local part is derived deterministically and a random suffix is
 added only when the deterministic form is already taken.
 
+The pod assistant's address is the pod slug alone, with no agent half — it is
+the pod answering, not one agent among several. That makes it the one local part
+minted here that is a bare word, and a bare word on a catch-all domain shared by
+every organization is claimable as ``postmaster@`` or ``abuse@`` by whoever names
+a pod that. Stopping it is what :data:`RESERVED_LOCAL_PARTS` is for.
+
 Pure functions. Uniqueness is ultimately enforced by a unique index on
 ``agent_surfaces.surface_identity_email`` — the database is the arbiter, and
 these helpers exist to make a clash rare and to produce the next candidate when
@@ -26,6 +32,58 @@ MAX_LOCAL_PART = 64
 _SUFFIX_LENGTH = 4
 _SUFFIX_ALPHABET = "abcdefghijkmnpqrstuvwxyz23456789"  # no look-alikes
 
+# Local parts nobody may be allocated, whatever they named their pod.
+#
+# The backbone is RFC 2142, which reserves these on any domain that receives
+# mail: a person is expected behind ``postmaster@`` and ``abuse@``, and handing
+# either to the first tenant who named a pod that would route bounce and abuse
+# traffic into a stranger's agent conversation. The rest are addresses a
+# platform sends *from*, or that a reader takes to mean "this is Lemma talking,
+# not one of its tenants".
+#
+# Reachable, not theoretical. The pod assistant takes the pod slug alone, so a
+# pod named "Support" asks for `support@` on a domain every organization shares.
+# `candidate_addresses` drops the request and falls through to a suffixed form —
+# the same thing it already does when another pod holds the name.
+RESERVED_LOCAL_PARTS = frozenset(
+    {
+        # RFC 2142 §3-5: operations, protocol support, business roles.
+        "abuse",
+        "noc",
+        "security",
+        "postmaster",
+        "hostmaster",
+        "webmaster",
+        "usenet",
+        "news",
+        "www",
+        "uucp",
+        "ftp",
+        "info",
+        "marketing",
+        "sales",
+        "support",
+        # Conventional senders and system mailboxes.
+        "admin",
+        "administrator",
+        "root",
+        "help",
+        "billing",
+        "contact",
+        "hello",
+        "noreply",
+        "no-reply",
+        "donotreply",
+        "do-not-reply",
+        "bounce",
+        "bounces",
+        "mailer-daemon",
+        # Lemma's own identity on Lemma's own domain.
+        "lem",
+        "lemma",
+    }
+)
+
 
 def slugify(value: str | None, *, fallback: str = "agent") -> str:
     """Lower-case, hyphenated, safe for the local part of an address."""
@@ -35,6 +93,16 @@ def slugify(value: str | None, *, fallback: str = "agent") -> str:
 
 def random_suffix() -> str:
     return "".join(secrets.choice(_SUFFIX_ALPHABET) for _ in range(_SUFFIX_LENGTH))
+
+
+def is_reserved(local_part: str) -> bool:
+    """Whether this local part is one nobody may be allocated.
+
+    Matches the whole local part, never a prefix: ``triage.support@`` is an
+    agent in a pod named "Support" and is fine, while ``support@`` is the shared
+    domain's business address and is not.
+    """
+    return local_part.strip().lower() in RESERVED_LOCAL_PARTS
 
 
 def build_local_part(
@@ -50,6 +118,9 @@ def build_local_part(
     ``acme@`` rather than ``acme.acme@``. The assistant is not one agent among
     several, it is the pod answering, so the pod's own name is the honest
     address — and it is the shortest thing a person can be asked to type.
+
+    Bare is also why :func:`is_reserved` exists: ``acme@`` is fine and
+    ``postmaster@`` is not, and only the assistant's form can produce either.
     """
     pod = slugify(pod_name, fallback="pod")
     tail = f"-{suffix}" if suffix else ""
@@ -80,24 +151,51 @@ def build_agent_email(
 def candidate_addresses(
     *, agent_name: str | None, pod_name: str | None, domain: str, attempts: int = 5
 ) -> list[str]:
-    """The plain address first, then suffixed alternatives to try in order."""
-    first = build_agent_email(agent_name=agent_name, pod_name=pod_name, domain=domain)
-    return [first] + [
-        build_agent_email(
+    """The plain address first, then suffixed alternatives to try in order.
+
+    A reserved form is dropped rather than offered and refused, and the list
+    grows to keep the budget at ``attempts``. Spending one of five attempts on an
+    address that can never be allocated would make a reserved name likelier to
+    end with no mailbox at all — the one outcome worse than an ugly address.
+
+    Every candidate is screened, not only the plain one. A suffixed form is
+    vanishingly unlikely to be reserved, but working out *why* means reasoning
+    about whether any entry ends in a four-character hyphenated segment, and
+    that reasoning silently expires the day somebody adds one. The generation
+    loop is bounded for the same reason: a filter that can reject must not be
+    able to spin.
+    """
+    wanted = max(1, attempts)
+    candidates: list[str] = []
+    plain = build_agent_email(agent_name=agent_name, pod_name=pod_name, domain=domain)
+    if not is_reserved(_local_part_of(plain)):
+        candidates.append(plain)
+
+    for _ in range(wanted * 4):
+        if len(candidates) >= wanted:
+            break
+        address = build_agent_email(
             agent_name=agent_name,
             pod_name=pod_name,
             domain=domain,
             suffix=random_suffix(),
         )
-        for _ in range(max(0, attempts - 1))
-    ]
+        if not is_reserved(_local_part_of(address)):
+            candidates.append(address)
+    return candidates
+
+
+def _local_part_of(address: str) -> str:
+    return address.split("@", 1)[0]
 
 
 __all__ = [
     "MAX_LOCAL_PART",
+    "RESERVED_LOCAL_PARTS",
     "build_agent_email",
     "build_local_part",
     "candidate_addresses",
+    "is_reserved",
     "random_suffix",
     "slugify",
 ]

--- a/lemma-backend/app/modules/agent_surfaces/services/email_surface_provisioning.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/email_surface_provisioning.py
@@ -1,19 +1,28 @@
-"""Giving an agent a mailbox — the one place that does it.
+"""Giving a surface its inbound address — the one place that does it.
 
-There were two. Agent creation minted the readable ``{agent}.{pod}@domain`` with
-insert-and-retry, while notification delivery minted ``pod-{hex}@domain`` through
-a different function with different failure behaviour. Two schemes meant the
-address a person saw depended on which code path happened to create it, and only
-one of them was typeable.
+There were three ways in, and they disagreed. Agent creation minted the readable
+``{agent}.{pod}@domain`` with insert-and-retry; notification delivery minted
+``pod-{hex}@domain`` through a different function; and anything arriving through
+the API or a bundle import got the ``pod-{hex}`` form by default, from a
+fallback inside ``create_surface`` that existed precisely so a caller need not
+know about any of this. So the address a person saw depended on which door their
+surface came through, only one of those doors produced something typeable, and
+two of them skipped ``RESERVED_LOCAL_PARTS`` entirely — which is how a pod named
+"Postmaster" could have taken ``postmaster@`` on a shared domain.
 
-Both callers now come here:
+Every caller now comes here:
 
-- ``create_agent`` provisions eagerly, so an address exists before anyone can
-  write to the agent. Nobody can email an agent whose mailbox is conditional on
-  it having sent something first.
-- Notification delivery provisions lazily, for an agent that turns out to have no
-  way to reach anyone — the pod assistant, or an agent that predates per-agent
-  mailboxes.
+- ``create_agent`` and ``create_pod`` provision eagerly, so an address exists
+  before anyone can write to the agent or the pod. Nobody can email something
+  whose mailbox is conditional on it having sent a message first.
+- Notification delivery provisions lazily, for an agent that turns out to have
+  no way to reach anyone — one that predates per-agent mailboxes.
+- The surfaces API and the bundle applier come through
+  :func:`create_surface_on_minted_address`, which is the same allocation with
+  the caller's own name, config and credentials.
+
+``create_surface`` no longer has a fallback to reach for: a Resend surface
+without an address is now an error, so a fourth door cannot open quietly.
 
 ``agent_id=None`` is the pod assistant. That is not "unset": a surface with no
 agent of its own is exactly what ``surfaces_for_agent`` looks for on its behalf,
@@ -22,6 +31,7 @@ so the pod's own mailbox is what the assistant sends from.
 
 from __future__ import annotations
 
+from typing import Any
 from uuid import UUID
 
 from httpx import HTTPError
@@ -29,7 +39,10 @@ from sqlalchemy.exc import IntegrityError
 
 from app.core.log.log import get_logger
 from app.modules.agent_surfaces.config import surface_settings
-from app.modules.agent_surfaces.domain.errors import AgentSurfaceError
+from app.modules.agent_surfaces.domain.errors import (
+    AgentSurfaceError,
+    AgentSurfaceValidationError,
+)
 from app.modules.agent_surfaces.domain.entities import (
     AgentSurfaceEntity,
     SurfaceConfig,
@@ -43,6 +56,7 @@ from app.modules.agent_surfaces.services.email_address_allocation import (
     candidate_addresses,
     slugify,
 )
+from app.modules.agent_surfaces.services.pod_name_lookup import pod_name_for
 
 logger = get_logger(__name__)
 
@@ -67,6 +81,82 @@ def surface_name_for(agent_name: str | None) -> str:
     return f"resend-{slugify(agent_name)}" if agent_name else "resend"
 
 
+async def _insert_on_first_free_address(
+    service,
+    session,
+    *,
+    pod_id: UUID,
+    agent_id: UUID | None,
+    agent_name: str | None,
+    pod_name: str | None,
+    name: str | None,
+    config: SurfaceConfig,
+    credential_mode: SurfaceCredentialMode | None,
+    account_id: UUID | None = None,
+    ctx: Any = None,
+) -> AgentSurfaceEntity | None:
+    """Insert on the first candidate address the database will accept.
+
+    ``None`` when every candidate was taken. Mail-system failures — a refused
+    domain, Resend unreachable, a surface name already used in this pod — are
+    raised rather than swallowed, because the two callers want opposite things
+    from them and only they can decide.
+
+    Insert and retry rather than check-then-insert: the unique index on
+    ``surface_identity_email`` is the arbiter, and a pre-check would still race.
+
+    Each attempt gets a savepoint. This runs inside the caller's transaction,
+    and a unique violation aborts a Postgres transaction outright — so without
+    one, the second attempt raises PendingRollbackError, the commit fails, and
+    *creating an agent* returns 500 because two of them wanted the same address.
+    Same reasoning, and the same shape, as `notification_repository.create`.
+    """
+    domain = surface_settings.resend_inbound_domain or ""
+    addresses = candidate_addresses(
+        agent_name=agent_name, pod_name=pod_name, domain=domain
+    )
+
+    for attempt, address in enumerate(addresses):
+        try:
+            async with session.begin_nested():
+                surface = await service.create_surface(
+                    pod_id=pod_id,
+                    platform=SurfacePlatform.RESEND,
+                    agent_id=agent_id,
+                    name=name,
+                    config=config,
+                    credential_mode=credential_mode,
+                    account_id=account_id,
+                    surface_identity_email=address,
+                    ctx=ctx,
+                )
+            if attempt:
+                # Provisioning succeeded, on a worse address than intended: the
+                # readable form was already held, and on a deployment-wide
+                # namespace that usually means by another organization's pod.
+                # Nothing else says so — creation returns 201 and the UI prints
+                # whichever address exists — so the first person to notice was
+                # the one asked to type `acme-p7k3@`.
+                logger.warning(
+                    "agent_surfaces.email_surface_provisioning.address_taken.degraded",
+                    pod_id=str(pod_id),
+                    agent_id=str(agent_id) if agent_id else None,
+                    attempt=attempt,
+                )
+            return surface
+        except IntegrityError:
+            # The address (or the surface name) is taken. Try the next candidate;
+            # the savepoint means the outer transaction is still usable.
+            continue
+
+    logger.warning(
+        "agent_surfaces.email_surface_provisioning.address_unavailable.degraded",
+        pod_id=str(pod_id),
+        agent_id=str(agent_id) if agent_id else None,
+    )
+    return None
+
+
 async def provision_email_surface(
     service,
     session,
@@ -82,78 +172,124 @@ async def provision_email_surface(
     strips ``error`` fields, so a caller that wants to *tell somebody* why has
     no other way to find out.
 
-    Best-effort by construction. Creating an agent must not fail because a mail
-    domain is unset, and a notification that cannot be delivered is already a
-    handled outcome — the row exists and the inbox has it. What must *not*
-    happen is a silent success where the surface exists with an address nobody
-    can receive on, which is why an unconfigured deployment returns None rather
-    than inventing a domain.
+    Best-effort by construction. Creating an agent or a pod must not fail
+    because a mail domain is unset, and a notification that cannot be delivered
+    is already a handled outcome — the row exists and the inbox has it. What
+    must *not* happen is a silent success where the surface exists with an
+    address nobody can receive on, which is why an unconfigured deployment
+    returns None rather than inventing a domain.
     """
     if not email_is_configured():
         return None, "not_configured"
 
-    domain = surface_settings.resend_inbound_domain
-    if not domain:  # pragma: no cover - email_is_configured already requires it
+    if not surface_settings.resend_inbound_domain:  # pragma: no cover
         return None, "not_configured"
 
-    addresses = candidate_addresses(
-        agent_name=agent_name, pod_name=pod_name, domain=domain
-    )
+    try:
+        surface = await _insert_on_first_free_address(
+            service,
+            session,
+            pod_id=pod_id,
+            agent_id=agent_id,
+            agent_name=agent_name,
+            pod_name=pod_name,
+            name=surface_name_for(agent_name),
+            config=SurfaceConfig(),
+            credential_mode=SurfaceCredentialMode.SYSTEM,
+        )
+    except (AgentSurfaceError, HTTPError, OSError) as exc:
+        # Deliberately not a bare ``Exception``. These three are the mail
+        # system saying no — a refused domain, Resend unreachable, a name
+        # already taken. A ``TypeError`` from our own code is not that, and
+        # swallowing it would turn a bug into agents that quietly have no
+        # mailbox for as long as nobody looks.
+        #
+        # Type and code, never ``error=str(exc)``: the log pipeline strips
+        # any field named ``error`` outright, because exception text can
+        # carry keys and personal data. So the one line that said why
+        # provisioning failed arrived in production with the cause removed,
+        # and diagnosing it needed a database. These two are bounded,
+        # non-secret, and enough to name the branch that refused.
+        logger.warning(
+            "agent_surfaces.email_surface_provisioning.failed.degraded",
+            pod_id=str(pod_id),
+            agent_id=str(agent_id) if agent_id else None,
+            failure_type=type(exc).__name__,
+            failure_code=str(getattr(exc, "code", "") or "") or None,
+        )
+        return None, _cause_of(exc)
 
-    # Insert and retry rather than check-then-insert: the unique index on
-    # surface_identity_email is the arbiter, and a pre-check would still race.
-    #
-    # Each attempt gets a savepoint. This runs inside the caller's transaction,
-    # and a unique violation aborts a Postgres transaction outright — so without
-    # one, the second attempt raises PendingRollbackError, the commit fails, and
-    # *creating an agent* returns 500 because two of them wanted the same
-    # address. Same reasoning, and the same shape, as
-    # `notification_repository.create`.
-    for address in addresses:
-        try:
-            async with session.begin_nested():
-                surface = await service.create_surface(
-                    pod_id=pod_id,
-                    platform=SurfacePlatform.RESEND,
-                    agent_id=agent_id,
-                    name=surface_name_for(agent_name),
-                    config=SurfaceConfig(),
-                    credential_mode=SurfaceCredentialMode.SYSTEM,
-                    surface_identity_email=address,
-                )
-            return surface, None
-        except IntegrityError:
-            # The address (or the surface name) is taken. Try the next candidate;
-            # the savepoint means the outer transaction is still usable.
-            continue
-        except (AgentSurfaceError, HTTPError, OSError) as exc:
-            # Deliberately not a bare ``Exception``. These three are the mail
-            # system saying no — a refused domain, Resend unreachable, a name
-            # already taken. A ``TypeError`` from our own code is not that, and
-            # swallowing it would turn a bug into agents that quietly have no
-            # mailbox for as long as nobody looks.
-            #
-            # Type and code, never ``error=str(exc)``: the log pipeline strips
-            # any field named ``error`` outright, because exception text can
-            # carry keys and personal data. So the one line that said why
-            # provisioning failed arrived in production with the cause removed,
-            # and diagnosing it needed a database. These two are bounded,
-            # non-secret, and enough to name the branch that refused.
-            logger.warning(
-                "agent_surfaces.email_surface_provisioning.failed.degraded",
-                pod_id=str(pod_id),
-                agent_id=str(agent_id) if agent_id else None,
-                failure_type=type(exc).__name__,
-                failure_code=str(getattr(exc, "code", "") or "") or None,
-            )
-            return None, _cause_of(exc)
+    if surface is None:
+        return None, "every candidate address was already taken"
+    return surface, None
 
-    logger.warning(
-        "agent_surfaces.email_surface_provisioning.address_unavailable.degraded",
-        pod_id=str(pod_id),
-        agent_id=str(agent_id) if agent_id else None,
+
+async def create_surface_on_minted_address(
+    service,
+    uow,
+    *,
+    pod_id: UUID,
+    agent_id: UUID | None,
+    agent_name: str | None,
+    platform: SurfacePlatform,
+    name: str | None,
+    config: SurfaceConfig,
+    credential_mode: SurfaceCredentialMode | None,
+    account_id: UUID | None = None,
+    ctx: Any = None,
+) -> AgentSurfaceEntity:
+    """``create_surface``, with a readable inbound address when it needs one.
+
+    For the callers a person drives — the surfaces API and the bundle applier —
+    which carry their own name, config and credentials and so cannot use
+    :func:`provision_email_surface`. Every other platform passes straight
+    through, so a caller does not have to know which ones are email.
+
+    Raises rather than degrading. These callers are answering a request that
+    said "connect this surface": handing back a surface with an address nobody
+    can receive on would be a worse answer than a refusal.
+
+    Takes the unit of work rather than its session because the minting branch
+    needs both halves of it — a savepoint per attempt, and the pod's name for the
+    readable part of the address — while every other platform needs neither.
+    """
+    if platform is not SurfacePlatform.RESEND:
+        return await service.create_surface(
+            pod_id=pod_id,
+            agent_id=agent_id,
+            platform=platform,
+            name=name,
+            config=config,
+            credential_mode=credential_mode,
+            account_id=account_id,
+            ctx=ctx,
+        )
+
+    if not email_is_configured() or not surface_settings.resend_inbound_domain:
+        raise AgentSurfaceValidationError(
+            "Email is not configured for this deployment: set "
+            "RESEND_INBOUND_DOMAIN to a verified catch-all domain."
+        )
+
+    surface = await _insert_on_first_free_address(
+        service,
+        uow.session,
+        pod_id=pod_id,
+        agent_id=agent_id,
+        agent_name=agent_name,
+        pod_name=await pod_name_for(uow, pod_id),
+        name=name,
+        config=config,
+        credential_mode=credential_mode,
+        account_id=account_id,
+        ctx=ctx,
     )
-    return None, "every candidate address was already taken"
+    if surface is None:
+        raise AgentSurfaceValidationError(
+            "Could not find a free inbound address for this surface. Renaming "
+            "the pod or the agent will free one up."
+        )
+    return surface
 
 
 def _cause_of(exc: Exception) -> str:
@@ -167,6 +303,7 @@ def _cause_of(exc: Exception) -> str:
 
 
 __all__ = [
+    "create_surface_on_minted_address",
     "email_is_configured",
     "provision_email_surface",
     "surface_name_for",

--- a/lemma-backend/app/modules/agent_surfaces/services/email_surface_provisioning.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/email_surface_provisioning.py
@@ -265,7 +265,13 @@ async def create_surface_on_minted_address(
             ctx=ctx,
         )
 
-    if not email_is_configured() or not surface_settings.resend_inbound_domain:
+    # The inbound domain alone, deliberately not ``email_is_configured()``.
+    # Minting an address needs somewhere to mint it; whether *Lemma* holds a
+    # Resend key is a question about credentials, and this caller may be
+    # bringing a connected account that has its own. Gating on both turned a
+    # surface authenticating with its own key into a refusal — something the
+    # domain-only fallback this replaced never did.
+    if not surface_settings.resend_inbound_domain:
         raise AgentSurfaceValidationError(
             "Email is not configured for this deployment: set "
             "RESEND_INBOUND_DOMAIN to a verified catch-all domain."
@@ -278,7 +284,13 @@ async def create_surface_on_minted_address(
         agent_id=agent_id,
         agent_name=agent_name,
         pod_name=await pod_name_for(uow, pod_id),
-        name=name,
+        # `create_surface` would default this to the platform — "resend" — and
+        # the pod's own assistant already holds that name from the moment the
+        # pod was created. So an unnamed second Resend surface, which is what
+        # connecting email for an agent looks like from the UI, would come back
+        # as "already exists". `surface_name_for` is the same name the eager and
+        # lazy paths pick, so all three now agree.
+        name=name or surface_name_for(agent_name),
         config=config,
         credential_mode=credential_mode,
         account_id=account_id,

--- a/lemma-backend/app/modules/agent_surfaces/services/pod_name_lookup.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/pod_name_lookup.py
@@ -1,0 +1,22 @@
+"""The pod's name, for the readable half of an inbound address.
+
+One place, because everything that mints an address needs it and none of them
+should reach for ``PodRepository`` themselves. Keeping the lookup here leaves
+``agent_surfaces`` holding a single import edge into the pod module instead of
+one per call site.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+
+async def pod_name_for(uow, pod_id: UUID) -> str | None:
+    """``None`` for a pod that is gone — the caller falls back to a slug."""
+    from app.modules.pod.infrastructure.pod_repositories import PodRepository
+
+    pod = await PodRepository(uow).get(pod_id)
+    return getattr(pod, "name", None)
+
+
+__all__ = ["pod_name_for"]

--- a/lemma-backend/app/modules/agent_surfaces/services/surface_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/surface_service.py
@@ -170,13 +170,25 @@ class AgentSurfaceService(
         )
         # Resend is a system-credentialed email surface: it needs an inbound
         # address that routing matches on and outbound uses as the From. (Other
-        # email surfaces get this from their connected account.) Callers that
-        # allocate a readable per-agent address pass it in; the pod-level
-        # fallback derives one that cannot collide.
+        # email surfaces get this from their connected account.)
+        #
+        # Required, not defaulted. There used to be a fallback here deriving
+        # `pod-<pod_id.hex>@domain` — unique by construction and unreadable —
+        # so that a caller need not know how addresses are allocated. Two of
+        # the three callers duly did not know, which meant the address a person
+        # saw depended on whether their surface arrived through the API or
+        # through agent creation, and neither of those two paths was screened
+        # against `RESERVED_LOCAL_PARTS`. Allocation lives in
+        # `email_surface_provisioning`; anything reaching here without an
+        # address has gone around it, and that is a bug rather than a default.
         if platform is SurfacePlatform.RESEND and not entity.surface_identity_email:
-            entity.surface_identity_email = (
-                surface_identity_email or self._provision_resend_address(pod_id)
-            )
+            if not surface_identity_email:
+                raise AgentSurfaceValidationError(
+                    "A Resend surface needs an inbound address. Create it "
+                    "through email_surface_provisioning, which allocates a "
+                    "readable one and retries when it is taken."
+                )
+            entity.surface_identity_email = surface_identity_email
         self._validate_runtime_supported(entity)
         await self._ensure_unique_org_credential_binding(entity)
         telegram_credentials: dict[str, Any] | None = None
@@ -196,24 +208,47 @@ class AgentSurfaceService(
         await notify_surface_receiver_config_changed(synced.id)
         return synced
 
-    @staticmethod
-    def _provision_resend_address(pod_id: UUID) -> str:
-        """Derive a unique per-pod inbound/outbound Resend address.
+    async def create_surface_minting_address(
+        self,
+        *,
+        pod_id: UUID,
+        agent: Any | None,
+        platform: SurfacePlatform,
+        name: str | None = None,
+        config: SurfaceConfig | None = None,
+        credential_mode: SurfaceCredentialMode | None = None,
+        account_id: UUID | None = None,
+        ctx: Context | None = None,
+    ) -> AgentSurfaceEntity:
+        """:meth:`create_surface`, minting an address when the platform needs one.
 
-        Uses the pod id for uniqueness under a catch-all inbound domain
-        (``*@<domain>`` → one webhook), so no per-address API registration. The
-        full 32-char hex is used (not a prefix) so two pods can never collide on
-        the same address — ``get_active_by_address`` would otherwise misroute one
-        pod's inbound mail to the other. ``pod-`` + 32 hex = 36 chars, within the
-        64-char local-part limit.
+        For the two callers a person drives — the surfaces API and the bundle
+        applier. They bring their own name, config and credentials, so they
+        cannot use ``provision_email_surface``, and calling ``create_surface``
+        straight through is what used to land them on the ``pod-<hex>@``
+        fallback: unreadable, and never screened for reserved local parts.
+
+        ``agent`` is the resolved agent or None rather than an id, because the
+        readable half of the address is its *name* and both callers already hold
+        the entity.
         """
-        domain = surface_settings.resend_inbound_domain
-        if not domain:
-            raise AgentSurfaceValidationError(
-                "Email is not configured for this deployment: set "
-                "RESEND_INBOUND_DOMAIN to a verified catch-all domain."
-            )
-        return f"pod-{pod_id.hex}@{domain}"
+        from app.modules.agent_surfaces.services.email_surface_provisioning import (
+            create_surface_on_minted_address,
+        )
+
+        return await create_surface_on_minted_address(
+            self,
+            self.surface_repository.uow,
+            pod_id=pod_id,
+            agent_id=getattr(agent, "id", None),
+            agent_name=getattr(agent, "name", None),
+            platform=platform,
+            name=name,
+            config=config or SurfaceConfig(),
+            credential_mode=credential_mode,
+            account_id=account_id,
+            ctx=ctx,
+        )
 
     async def get_surface(self, surface_id: UUID) -> AgentSurfaceEntity:
         surface = await self.surface_repository.get(surface_id)

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_resend_surface_e2e.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/test_resend_surface_e2e.py
@@ -177,7 +177,7 @@ async def test_resend_webhook_routes_raw_envelope_to_provisioned_address(
         surface_model = await db_session.get(AgentSurface, UUID(surface["id"]))
         assistant_address = surface_model.surface_identity_email
     assert assistant_address
-    # Provisioned per-pod, not a fixed constant (see _provision_resend_address).
+    # Minted per agent by `email_surface_provisioning`, not a fixed constant.
     assert assistant_address.endswith("@ops.asur.work")
 
     envelope = _raw_resend_envelope(

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_email_address_allocation.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_email_address_allocation.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 from app.modules.agent_surfaces.services.email_address_allocation import (
     MAX_LOCAL_PART,
+    RESERVED_LOCAL_PARTS,
     build_agent_email,
     build_local_part,
     candidate_addresses,
+    is_reserved,
     slugify,
 )
 
@@ -110,3 +112,56 @@ def test_a_very_long_pod_name_is_cut_to_the_rfc_limit():
 
     assert len(local) <= MAX_LOCAL_PART
     assert local.endswith("-k3p9")
+
+
+# ------------------------------------------------- addresses nobody may hold
+
+
+def test_a_pod_named_after_a_role_address_never_gets_the_bare_form():
+    """The assistant's shape is the only one that can produce ``postmaster@``.
+
+    The inbound domain is one catch-all shared by every organization, so this is
+    not the pod's address to take: mail systems and abuse desks expect a person
+    behind it, and the first tenant to name a pod "Postmaster" would be the one
+    reading their bounce traffic.
+    """
+    candidates = candidate_addresses(
+        agent_name=None, pod_name="Postmaster", domain="ops.example.com", attempts=5
+    )
+
+    assert "postmaster@ops.example.com" not in candidates
+    assert all(address.startswith("postmaster-") for address in candidates)
+    assert len(candidates) == 5, "dropping it must not cost a retry"
+    assert len(set(candidates)) == len(candidates)
+
+
+def test_an_ordinary_pod_name_is_still_offered_plain_first():
+    """The guard is a denylist, not a policy of suffixing everything."""
+    candidates = candidate_addresses(
+        agent_name=None, pod_name="Acme Ops", domain="ops.example.com"
+    )
+
+    assert candidates[0] == "acme-ops@ops.example.com"
+
+
+def test_an_agent_inside_a_role_named_pod_is_left_alone():
+    """``triage.support@`` is nobody's role address, so nothing should stop it."""
+    candidates = candidate_addresses(
+        agent_name="Triage", pod_name="Support", domain="ops.example.com"
+    )
+
+    assert candidates[0] == "triage.support@ops.example.com"
+
+
+def test_reserved_matches_the_whole_local_part_not_a_prefix():
+    assert is_reserved("support")
+    assert is_reserved("  Postmaster  ")
+    assert not is_reserved("triage.support")
+    assert not is_reserved("support-triage.acme")
+
+
+def test_the_rfc_2142_roles_are_all_covered():
+    """The ones a mail system or an abuse desk expects a human behind."""
+    assert {"postmaster", "abuse", "hostmaster", "webmaster", "security"} <= (
+        RESERVED_LOCAL_PARTS
+    )

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_resend_surface.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_resend_surface.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 from uuid import uuid4
 
 import pytest
@@ -114,35 +114,91 @@ async def test_resend_send_email_builds_resend_api_payload():
     assert body["attachments"][0]["filename"] == "note.txt"
 
 
-def test_provision_resend_address_is_unique_per_pod(monkeypatch):
-    from app.modules.agent_surfaces.config import surface_settings
+async def test_a_resend_surface_without_an_address_is_refused(monkeypatch):
+    """The `pod-<hex>@` fallback is gone, and its absence is the point.
 
-    monkeypatch.setattr(surface_settings, "resend_inbound_domain", "ops.asur.work")
-    pod_id = uuid4()
-    address = AgentSurfaceService._provision_resend_address(pod_id)
-    assert address.endswith("@ops.asur.work")
-    assert pod_id.hex[:12] in address
-    # Different pods get different addresses.
-    assert address != AgentSurfaceService._provision_resend_address(uuid4())
+    It existed so a caller need not know how addresses are allocated, and two of
+    the three callers duly did not: the surfaces API and the bundle applier both
+    landed on it, so whether a person got `ops.acme@` or `pod-9f3c1e…@` came down
+    to which door their surface arrived through. Neither of those paths was
+    screened against `RESERVED_LOCAL_PARTS` either. Refusing is what keeps a
+    fourth caller from re-opening that quietly.
+    """
+    from app.modules.agent_surfaces.domain.errors import AgentSurfaceValidationError
+
+    repo = AsyncMock()
+    repo.get_by_pod_and_name.return_value = None
+    binder = AsyncMock()
+    binder.resolve_binding.return_value = (None, None, None)
+    service = AgentSurfaceService(
+        surface_repository=repo, account_binding_resolver=binder
+    )
+
+    with pytest.raises(AgentSurfaceValidationError, match="needs an inbound address"):
+        await service.create_surface(
+            pod_id=uuid4(),
+            agent_id=None,
+            platform=SurfacePlatform.RESEND,
+            name="resend",
+            config=SurfaceConfig(),
+            credential_mode=SurfaceCredentialMode.SYSTEM,
+        )
+
+    repo.create.assert_not_awaited()
 
 
-def test_provisioning_without_a_domain_says_so_instead_of_inventing_one():
+async def test_minting_without_a_domain_says_so_instead_of_inventing_one(monkeypatch):
     """A default domain is worse than an error.
 
     ``ops.asur.work`` used to be the fallback, so an unconfigured deployment
     silently minted addresses on a domain it does not own: outbound bounced and
     replies matched no surface, with nothing anywhere saying why.
     """
-    from app.modules.agent_surfaces.config import surface_settings
     from app.modules.agent_surfaces.domain.errors import AgentSurfaceValidationError
+    from app.modules.agent_surfaces.services import email_surface_provisioning
+    from app.modules.agent_surfaces.config import surface_settings
 
-    original = surface_settings.resend_inbound_domain
-    surface_settings.resend_inbound_domain = None
-    try:
-        with pytest.raises(AgentSurfaceValidationError, match="RESEND_INBOUND_DOMAIN"):
-            AgentSurfaceService._provision_resend_address(uuid4())
-    finally:
-        surface_settings.resend_inbound_domain = original
+    monkeypatch.setattr(surface_settings, "resend_inbound_domain", None)
+
+    with pytest.raises(AgentSurfaceValidationError, match="RESEND_INBOUND_DOMAIN"):
+        await email_surface_provisioning.create_surface_on_minted_address(
+            AsyncMock(),
+            AsyncMock(),
+            pod_id=uuid4(),
+            agent_id=None,
+            agent_name=None,
+            platform=SurfacePlatform.RESEND,
+            name="inbox",
+            config=SurfaceConfig(),
+            credential_mode=SurfaceCredentialMode.SYSTEM,
+        )
+
+
+async def test_a_non_email_surface_passes_straight_through(monkeypatch):
+    """The helper is a substitute for `create_surface`, not a special case.
+
+    Both callers create every platform through it, so Slack and Telegram must
+    not acquire an inbound address or a domain requirement on the way past.
+    """
+    from app.modules.agent_surfaces.services import email_surface_provisioning
+    from app.modules.agent_surfaces.config import surface_settings
+
+    monkeypatch.setattr(surface_settings, "resend_inbound_domain", None)
+    service = AsyncMock()
+
+    await email_surface_provisioning.create_surface_on_minted_address(
+        service,
+        AsyncMock(),
+        pod_id=uuid4(),
+        agent_id=None,
+        agent_name=None,
+        platform=SurfacePlatform.SLACK,
+        name="slack",
+        config=SurfaceConfig(),
+        credential_mode=SurfaceCredentialMode.SYSTEM,
+    )
+
+    assert "surface_identity_email" not in service.create_surface.await_args.kwargs
 
 
 def test_normalize_resend_inbound_handles_envelope_and_shapes():
@@ -792,7 +848,7 @@ async def test_a_restricted_api_key_does_not_lose_a_reply_we_can_already_read():
     full and the person who wrote it heard nothing back.
     """
     import httpx
-    from unittest.mock import AsyncMock, patch
+    from unittest.mock import patch
 
     from app.modules.agent_surfaces.platforms.resend.adapter import (
         ResendSurfaceAdapter,

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_resend_surface.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_resend_surface.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -172,6 +173,81 @@ async def test_minting_without_a_domain_says_so_instead_of_inventing_one(monkeyp
             config=SurfaceConfig(),
             credential_mode=SurfaceCredentialMode.SYSTEM,
         )
+
+
+async def test_a_connected_account_does_not_need_the_deployment_s_key(monkeypatch):
+    """Minting an address is not a question about whose credentials send it.
+
+    A Resend surface can authenticate with a connected account, and one did:
+    `test_resend_webhook_routes_raw_envelope_to_provisioned_address` sets the
+    inbound domain and no system key. Gating this path on `email_is_configured`
+    — key *and* domain, which is the right test for a SYSTEM mailbox — turned
+    that into a refusal. Somewhere to mint the address is all this needs.
+    """
+    from app.core.config import settings as core_settings
+    from app.modules.agent_surfaces.services import email_surface_provisioning
+    from app.modules.agent_surfaces.config import surface_settings
+
+    monkeypatch.setattr(surface_settings, "resend_inbound_domain", "ops.asur.work")
+    monkeypatch.setattr(core_settings, "resend_api_key", None)
+    monkeypatch.setattr(
+        email_surface_provisioning, "pod_name_for", AsyncMock(return_value="Acme")
+    )
+    assert not email_surface_provisioning.email_is_configured()
+
+    service = AsyncMock()
+    session = AsyncMock()
+    session.begin_nested = MagicMock(return_value=AsyncMock())
+
+    await email_surface_provisioning.create_surface_on_minted_address(
+        service,
+        SimpleNamespace(session=session),
+        pod_id=uuid4(),
+        agent_id=uuid4(),
+        agent_name="Ops",
+        platform=SurfacePlatform.RESEND,
+        name="inbox",
+        config=SurfaceConfig(),
+        credential_mode=SurfaceCredentialMode.CUSTOM,
+        account_id=uuid4(),
+    )
+
+    address = service.create_surface.await_args.kwargs["surface_identity_email"]
+    assert address == "ops.acme@ops.asur.work"
+
+
+async def test_an_unnamed_second_mailbox_does_not_collide_with_the_pod_s(monkeypatch):
+    """Every pod's assistant holds the surface named "resend" from creation.
+
+    `create_surface` defaults an unnamed surface to its platform, so connecting
+    email for an agent — no name given, which is what the UI sends — would come
+    back "already exists". The agent-derived name is what the eager and lazy
+    provisioning paths already pick.
+    """
+    from app.modules.agent_surfaces.services import email_surface_provisioning
+    from app.modules.agent_surfaces.config import surface_settings
+
+    monkeypatch.setattr(surface_settings, "resend_inbound_domain", "ops.asur.work")
+    monkeypatch.setattr(
+        email_surface_provisioning, "pod_name_for", AsyncMock(return_value="Acme")
+    )
+    service = AsyncMock()
+    session = AsyncMock()
+    session.begin_nested = MagicMock(return_value=AsyncMock())
+
+    await email_surface_provisioning.create_surface_on_minted_address(
+        service,
+        SimpleNamespace(session=session),
+        pod_id=uuid4(),
+        agent_id=uuid4(),
+        agent_name="Ops Assistant",
+        platform=SurfacePlatform.RESEND,
+        name=None,
+        config=SurfaceConfig(),
+        credential_mode=SurfaceCredentialMode.SYSTEM,
+    )
+
+    assert service.create_surface.await_args.kwargs["name"] == "resend-ops-assistant"
 
 
 async def test_a_non_email_surface_passes_straight_through(monkeypatch):

--- a/lemma-backend/app/modules/pod/services/pod_service.py
+++ b/lemma-backend/app/modules/pod/services/pod_service.py
@@ -82,6 +82,26 @@ class PodService:
                 added_by_user_id=creator_user_id,
             )
 
+        # The pod's assistant gets its mailbox here, the way an agent gets one in
+        # `create_agent`. It used to be minted on the assistant's first outbound
+        # notification instead, which reads as thrift and is not: inbound routes
+        # on the address, so until something was sent, mail to the obvious guess
+        # matched no surface and started nothing. A pod that cannot be written to
+        # is not cheaper than one that can.
+        #
+        # Best-effort by design, exactly as for an agent: creating a pod must not
+        # fail because a mail domain is unset. `_uow` is absent only where a
+        # caller built the service without one -- the same guard `delete_pod`
+        # uses for its role-cache hook.
+        if self._uow is not None:
+            from app.composition.agent_email_surface import (
+                provision_pod_assistant_email_surface,
+            )
+
+            await provision_pod_assistant_email_surface(
+                self._uow, pod_id=pod.id, pod_name=pod.name
+            )
+
         return pod
 
     async def get_pod(

--- a/lemma-backend/app/modules/pod/tests/unit/test_pod_service.py
+++ b/lemma-backend/app/modules/pod/tests/unit/test_pod_service.py
@@ -95,6 +95,95 @@ async def test_create_pod_success_adds_admin_and_domain_event(
 
 
 @pytest.mark.asyncio
+async def test_create_pod_gives_the_pod_assistant_its_mailbox(
+    pod_repository_mock: AsyncMock,
+    pod_member_repository_mock: AsyncMock,
+    organization_repository_mock: AsyncMock,
+    authorization_service_mock: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A pod is writable-to from the moment it exists.
+
+    The address used to be minted on the assistant's first outbound
+    notification. Inbound routes on that address, so until something had been
+    sent, mail to the obvious guess matched no surface and started nothing.
+    """
+    provision = AsyncMock(return_value="test-pod@mail.example.com")
+    monkeypatch.setattr(
+        "app.composition.agent_email_surface.provision_pod_assistant_email_surface",
+        provision,
+    )
+    uow = object()
+    service = PodService(
+        pod_repository=pod_repository_mock,
+        pod_member_repository=pod_member_repository_mock,
+        organization_repository=organization_repository_mock,
+        authorization_service=authorization_service_mock,
+        uow=uow,
+    )
+
+    creator_id = uuid4()
+    organization_id = uuid4()
+    org_member = _make_org_member(
+        user_id=creator_id,
+        organization_id=organization_id,
+        role=OrganizationRole.ORG_OWNER,
+    )
+    pod = _make_pod(organization_id=organization_id, user_id=creator_id)
+    organization_repository_mock.get_member.return_value = org_member
+    pod_repository_mock.create.return_value = pod
+    pod_member_repository_mock.create.return_value = PodMemberEntity(
+        pod_id=pod.id,
+        organization_member_id=org_member.id,
+        role=PodRole.ADMIN,
+    )
+
+    created = await service.create_pod(pod, creator_id)
+
+    provision.assert_awaited_once_with(uow, pod_id=created.id, pod_name=created.name)
+
+
+@pytest.mark.asyncio
+async def test_create_pod_survives_a_mailbox_that_cannot_be_minted(
+    pod_repository_mock: AsyncMock,
+    pod_member_repository_mock: AsyncMock,
+    organization_repository_mock: AsyncMock,
+    authorization_service_mock: AsyncMock,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """A deployment with no mail domain still gets a perfectly good pod."""
+    monkeypatch.setattr(
+        "app.composition.agent_email_surface.provision_pod_assistant_email_surface",
+        AsyncMock(return_value=None),
+    )
+    service = PodService(
+        pod_repository=pod_repository_mock,
+        pod_member_repository=pod_member_repository_mock,
+        organization_repository=organization_repository_mock,
+        authorization_service=authorization_service_mock,
+        uow=object(),
+    )
+
+    creator_id = uuid4()
+    organization_id = uuid4()
+    org_member = _make_org_member(
+        user_id=creator_id,
+        organization_id=organization_id,
+        role=OrganizationRole.ORG_OWNER,
+    )
+    pod = _make_pod(organization_id=organization_id, user_id=creator_id)
+    organization_repository_mock.get_member.return_value = org_member
+    pod_repository_mock.create.return_value = pod
+    pod_member_repository_mock.create.return_value = PodMemberEntity(
+        pod_id=pod.id,
+        organization_member_id=org_member.id,
+        role=PodRole.ADMIN,
+    )
+
+    assert await service.create_pod(pod, creator_id) == pod
+
+
+@pytest.mark.asyncio
 async def test_create_pod_requires_org_membership(
     pod_service: PodService,
     organization_repository_mock: AsyncMock,

--- a/lemma-backend/app/modules/pod_bundle/infrastructure/applier.py
+++ b/lemma-backend/app/modules/pod_bundle/infrastructure/applier.py
@@ -589,9 +589,9 @@ class BundleApplier:
                 agent_service=agent_service,
                 ctx=self._ctx,
             )
-            surface = await service.create_surface(
+            surface = await service.create_surface_minting_address(
                 pod_id=self._pod_id,
-                agent_id=agent.id if agent else None,
+                agent=agent,
                 platform=platform,
                 name=resolved_name,
                 config=config,

--- a/lemma-backend/app/modules/pod_bundle/tests/unit/test_applier.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/unit/test_applier.py
@@ -610,6 +610,12 @@ class FakeSurfaceService:
         }
         return SimpleNamespace(id=_uuid4(), config=config)
 
+    async def create_surface_minting_address(self, *, agent, **kwargs):
+        """What the applier calls. The real one mints an inbound address for an
+        email surface and then delegates here; these bundles are Slack and
+        Teams, so the interesting half is that the agent still arrives."""
+        return await self.create_surface(agent_id=getattr(agent, "id", None), **kwargs)
+
     async def update_surface(self, **kwargs):
         from types import SimpleNamespace
 

--- a/tests/scenarios/journeys/surfaces_and_notifications/test_email_surfaces.py
+++ b/tests/scenarios/journeys/surfaces_and_notifications/test_email_surfaces.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import hmac
+import re
 import time
 from uuid import uuid4
 
@@ -130,6 +131,21 @@ async def test_an_email_surface_has_an_address(mailbox):
     assert address.endswith(inbound_email_domain()), (
         f"the surface's address is not under this deployment's inbound domain, "
         f"so mail to it will never arrive: {address!r}"
+    )
+
+    # Readable, because a person types it. Connecting a surface through the API
+    # used to fall to a `pod-<32 hex>@` form that only the database was happy
+    # with, so which of the two you got depended on whether your surface came
+    # from agent creation or from this endpoint. Asserted by shape rather than
+    # by slug so the scenario does not restate how the address is built: two
+    # halves separated by a dot, and not the hex form.
+    local_part = address.split("@", 1)[0]
+    assert not re.fullmatch(r"pod-[0-9a-f]{32}", local_part), (
+        f"the surface fell back to the unreadable per-pod address: {address!r}"
+    )
+    assert "." in local_part, (
+        f"an agent's address should read as agent-and-pod, not one opaque "
+        f"word: {address!r}"
     )
 
 


### PR DESCRIPTION
## What changes

Every pod's assistant gets an inbound mailbox when the pod is created, instead of when it first happens to send something — inbound routes on the address, so until now mail to the obvious guess matched no surface and started nothing.

And every Resend address is now minted in one place. Connecting an email surface through the API, or importing a bundle that declares one, used to yield `pod-9f3c1e2a…@domain`; it now yields the same readable `ops-assistant.acme@domain` that agent creation has always produced, screened against reserved role addresses and retried on a clash like everything else.

## Why

Three doors led to a Resend address and they disagreed:

| Door | Address it minted |
|---|---|
| `create_agent` | `{agent}.{pod}@` — readable, insert-and-retry |
| Notification delivery (lazy) | same, via the same function |
| Surfaces API / bundle applier | `pod-<32 hex>@` |

The third came from a fallback inside `create_surface` that existed *so a caller need not know how allocation works*. Two of the three callers duly did not know. So which address a person saw came down to which door their surface arrived through, only one of the three produced something typeable, and the two that bypassed the allocator also bypassed its reserved-name screening.

Separately, the pod assistant had no address until its first outbound notification. That reads as thrift and is not: a pod nobody can write to is not cheaper than one they can.

The reserved-name guard matters because the assistant's address is the pod slug **alone** — no agent half. On an inbound domain shared by every organization, that let whoever named a pod "Postmaster" ask for `postmaster@`, where a mail system or an abuse desk expects a person. It now falls through to a suffixed form, exactly as a name another pod already holds does.

## How to verify

```bash
cd lemma-backend && uv run pytest -m "not e2e" -q
```

`5609 passed, 153 skipped`. One failure, `test_redis_store_enforces_atomic_state_and_claims`, is pre-existing — it needs Redis and fails identically on a clean `main`.

```bash
cd lemma-backend && uv run python scripts/check_architecture.py
```

`Architecture ratchet passed (12 inherited import violations, 0 inherited cycles)`

```bash
cd lemma-backend && uv run ruff check app && uv run ruff format --check app && uv run python scripts/check_contracts.py && uv run python scripts/dump_openapi_spec.py --check && uv run python ../scripts/generate_logging_event_catalogs.py --check
```

All clean; the OpenAPI spec is unchanged, so no SDK regeneration.

Behaviour, through the real allocator:

```bash
cd lemma-backend && uv run python -c "
from app.modules.agent_surfaces.services.email_address_allocation import candidate_addresses as c
for n in ('Acme Corp','Postmaster','Support'):
    print(n, '->', c(agent_name=None, pod_name=n, domain='mail.example.com')[0])
print('agent ->', c(agent_name='Ops Assistant', pod_name='Support', domain='mail.example.com')[0])
"
```

```
Acme Corp -> acme-corp@mail.example.com
Postmaster -> postmaster-wbr8@mail.example.com
Support -> support-vrtp@mail.example.com
agent -> ops-assistant.support@mail.example.com
```

**Not run:** the e2e and scenario suites need Docker. That includes the strengthened assertion in `test_an_email_surface_has_an_address`.

## Notes for a reviewer

**Why a service method rather than a direct import at the call sites.** `surface_controller.py` and `applier.py` are both on the oversized-file baseline, where any growth fails the ratchet. Routing through `AgentSurfaceService.create_surface_minting_address` keeps each call site a two-line diff and both files at exactly their baseline (627 and 773). Same reason `pod_name_for` moved into a new `services/pod_name_lookup.py` — it keeps `agent_surfaces → pod` at its baseline of 2 import edges rather than adding a third.

**Two failure contracts on one core.** `_insert_on_first_free_address` holds the candidates, savepoints and retry. `provision_email_surface` wraps it best-effort, because creating an agent or a pod must not fail over mail. `create_surface_on_minted_address` raises, because a caller who asked to connect a surface is better served by a refusal than by a surface nobody can receive on.

**Every candidate is screened, not just the plain form.** Screening only the plain one was safe, but only because no reserved entry ends in a four-character hyphenated segment — reasoning that expires the day someone adds `abuse-team`. The generation loop is bounded so a filter that can reject cannot spin.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **API surface** — no request/response change; `dump_openapi_spec.py --check` reports the spec current, so no SDK regeneration
- [x] **Security** — the new log line carries `pod_id`, `agent_id` and an attempt number, no address and no free text; reserved role addresses can no longer be claimed by a tenant on the shared inbound domain

## Compatibility and rollback notes

**Forward-only, by design.** Nothing re-mints an address, so pods and agents holding an address today keep it, including any `pod-<hex>@` minted through the old API path. That is the right behaviour for email — a published address should not move — but it means the fix applies to new surfaces only. Worth a look at production data for a pod already sitting on a role address via the lazy path.

Rollback is a plain revert: no migration, no schema change, and no address is rewritten on the way out. Surfaces created while this was deployed keep their readable addresses and keep routing, since inbound matches on the stored value either way.

**One thing this makes more reachable, not fixed here.** `delete_pod` soft-deletes and renames immediately, freeing the org-unique name, while surface teardown runs off the pod-deleted event in the worker. Deleting a pod and recreating it under the same name therefore gives a different permanent address depending on queue lag — either the new pod takes a suffixed form and the plain one is orphaned, or it inherits an address the deleted pod's correspondents still have. Previously that only affected pods that had sent mail; now every pod holds an address. Worth its own change: either tear surfaces down inline in `delete_pod`, or have the recreate path reclaim its freed address.
