### PR TITLE
Name the agent in the email it sends, and render the markdown it wrote

### DIFF
--- a/lemma-backend/agent_tool_schemas.json
+++ b/lemma-backend/agent_tool_schemas.json
@@ -1455,7 +1455,7 @@
           "type": "string"
         },
         "message": {
-          "description": "Delivered verbatim. Write it to them, not about them.",
+          "description": "Markdown \u2014 every surface renders it, and on email that includes headings, lists and tables. Delivered verbatim otherwise: write it to them, not about them.",
           "type": "string"
         },
         "background_instruction": {

--- a/lemma-backend/app/modules/agent/tools/messaging/models.py
+++ b/lemma-backend/app/modules/agent/tools/messaging/models.py
@@ -20,7 +20,11 @@ MAX_STATUS_CHECK = 25
 class MessageUserRequest(BaseModel):
     to: str = Field(description="Pod member id, user id, or email address.")
     message: str = Field(
-        description="Delivered verbatim. Write it to them, not about them."
+        description=(
+            "Markdown — every surface renders it, and on email that includes "
+            "headings, lists and tables. Delivered verbatim otherwise: write "
+            "it to them, not about them."
+        )
     )
     background_instruction: str | None = Field(
         default=None,

--- a/lemma-backend/app/modules/agent_surfaces/platforms/email_render.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/email_render.py
@@ -66,6 +66,61 @@ def render_email_content(
     )
 
 
+_LIST_ITEM = re.compile(r"^[ \t]*(?:[-*+]|\d{1,9}[.)])[ \t]+\S")
+
+
+def _blank_line_before_lists(content: str) -> str:
+    """Let a list interrupt a paragraph, the way CommonMark already would.
+
+    Python-Markdown requires a blank line before a list. Without one, a label
+    line followed straight by bullets is one paragraph, and because HTML does
+    not preserve newlines the whole thing arrives as a single flowed sentence
+    with hyphens loose in it -- "What you can do - Land results - Run agents".
+
+    That shape is close to the modal form of model output, so it is worth
+    meeting rather than correcting: no docstring reliably stops a model writing
+    a list directly under its heading, and every agent already deployed writes
+    it that way today.
+
+    Only the email path needs this. A chat surface renders newlines as
+    newlines, so the same message already reads as a list there.
+
+    ``in_list`` is what keeps a lazy continuation safe. Inside a list an
+    unindented line belongs to the item above it, so a break inserted before
+    the next item would split one list in two:
+
+        - item one
+          continued on the next line
+        - item two
+    """
+    out: list[str] = []
+    in_list = False
+    in_fence = False
+    fence = ""
+    for line in content.split("\n"):
+        stripped = line.strip()
+        if in_fence:
+            if stripped.startswith(fence):
+                in_fence = False
+            out.append(line)
+            continue
+        # A hyphen inside a fenced block is code, not a bullet.
+        if stripped.startswith("```") or stripped.startswith("~~~"):
+            in_fence, fence = True, stripped[:3]
+            out.append(line)
+            continue
+        if not stripped:
+            in_list = False
+            out.append(line)
+            continue
+        if _LIST_ITEM.match(line):
+            if not in_list and out and out[-1].strip():
+                out.append("")
+            in_list = True
+        out.append(line)
+    return "\n".join(out)
+
+
 def _markdown_to_email_html(content: str) -> str:
     """Render markdown with the extensions agents actually write against.
 
@@ -75,7 +130,7 @@ def _markdown_to_email_html(content: str) -> str:
     """
     return style_stashed_code_blocks(
         markdown_lib.markdown(
-            content,
+            _blank_line_before_lists(content),
             extensions=[*EMAIL_MARKDOWN_EXTENSIONS, EmailStylesExtension()],
         )
     )

--- a/lemma-backend/app/modules/agent_surfaces/platforms/email_sender_identity.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/email_sender_identity.py
@@ -1,0 +1,109 @@
+"""Who an agent's email says it is from.
+
+The *address* already identifies the agent — ``email_address_allocation`` mints
+``priya.acme@`` per agent, and inbound routes back on it. The display name did
+not: it was one deployment-wide setting, so every agent in every pod arrived as
+"Lemma" and the only trace of who was asking sat in the ``attribute()`` header
+inside the body. An inbox list shows the display name and never the body, which
+is exactly where that attribution was worth having.
+
+Three things go in it, and the order is the design rather than a preference. The
+sender column truncates at roughly 18 characters on a phone and 25-30 in a
+desktop client, so whatever comes third is decorative:
+
+1. the **agent** — the unique part, and the "who is talking to me"
+2. the **person** it acts for — the "why is this in my inbox"
+3. the **product** — identical on every message we ever send, and already
+   carried by the sending domain, so it is the part that can afford to be cut
+
+Length is handled by dropping whole parts rather than by cutting characters. An
+agent name is 255 characters of free text as far as the API is concerned, and
+two long names would push the human out of the visible window while leaving a
+header that reads as complete. Degrading to a first name, then to no actor at
+all, keeps every form that is shown a form that is true.
+
+Pure string composition on purpose: the caller owns the RFC 5322 quoting (see
+``formataddr`` in the Resend service), so nothing here has to know that a comma
+in an agent name would otherwise split one address into two.
+"""
+
+from __future__ import annotations
+
+# Past this the display name is doing nothing a reader will ever see: no client
+# renders that far. Well under the RFC 5322 line limit, so composing one never
+# forces the header to fold.
+MAX_DISPLAY_NAME = 64
+
+
+def _clean(value: str | None) -> str:
+    """Collapse whitespace — including the newlines a header must never carry."""
+    return " ".join(str(value or "").split())
+
+
+def _is_real_name(value: str) -> bool:
+    """Whether this is a name, or the email address stood in for one.
+
+    ``get_user_display_name`` falls back to the user's email when first and last
+    are both empty, and does so deliberately: the body header promises "on
+    behalf of <someone>" and must always have a someone. That trade is right for
+    prose and wrong here — ``Priya (dj@gmail.com) via Lemma`` puts an unrelated
+    address inside a From display name, which is the shape both spam filters and
+    people read as a forgery.
+    """
+    return bool(value) and "@" not in value
+
+
+def sender_display_name(
+    *,
+    agent_name: str | None,
+    actor_display_name: str | None = None,
+    product_name: str,
+) -> str:
+    """``Priya (Deepak Jha) via Lemma`` — as much of it as fits.
+
+    ``product_name`` is the deployment's own ``RESEND_FROM_NAME``, so a
+    self-hosted instance brands the third slot without a second setting, and a
+    send that knows neither an agent nor an actor returns exactly what it
+    returned before this existed.
+    """
+    product = _clean(product_name) or "Lemma"
+    agent = _clean(agent_name)
+    actor = _clean(actor_display_name)
+
+    if not _is_real_name(actor):
+        actor = ""
+    # An agent-less surface reports its display name as the product already (see
+    # ``_egress_metadata_with_agent_name``). Letting that through would compose
+    # "Lemma (Deepak Jha) via Lemma".
+    if agent.casefold() == product.casefold():
+        agent = ""
+
+    # Best first. Each fallback drops a whole part rather than trimming one, so
+    # every candidate is a name that is true as written.
+    candidates: list[str] = []
+    if agent and actor:
+        candidates.append(f"{agent} ({actor}) via {product}")
+        first_name = actor.split(" ")[0]
+        if first_name != actor:
+            candidates.append(f"{agent} ({first_name}) via {product}")
+    if agent:
+        candidates.append(f"{agent} via {product}")
+    elif actor:
+        candidates.append(f"{actor} via {product}")
+
+    for candidate in candidates:
+        if len(candidate) <= MAX_DISPLAY_NAME:
+            return candidate
+
+    # Only reachable from an agent name long enough that no form of it fits.
+    # Cut the name rather than falling back to the bare product: a clipped
+    # "support-triage-escalation-…" still tells the reader which agent this is,
+    # and "Lemma" tells them nothing they could not read off the domain.
+    if agent:
+        room = MAX_DISPLAY_NAME - len(f" via {product}")
+        if room > 0:
+            return f"{agent[:room].rstrip()} via {product}"
+    return product
+
+
+__all__ = ["MAX_DISPLAY_NAME", "sender_display_name"]

--- a/lemma-backend/app/modules/agent_surfaces/platforms/resend/service.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/resend/service.py
@@ -9,6 +9,7 @@ Gmail/Outlook for the agent, but over native HTTP rather than Composio.
 from __future__ import annotations
 
 import base64
+from email.utils import formataddr
 from typing import Any
 
 import httpx
@@ -36,6 +37,9 @@ from app.modules.agent_surfaces.platforms.email_render import (
     coerce_display_resource_plans,
     render_email_content,
 )
+from app.modules.agent_surfaces.platforms.email_sender_identity import (
+    sender_display_name,
+)
 from app.modules.agent_surfaces.platforms.email_text import reply_subject
 from app.modules.agent_surfaces.platforms.email_models import (
     ResendReplyEmailParams,
@@ -51,6 +55,22 @@ class ResendPlatformService:
         self._from_address = str(credentials.get("from_address") or "")
         self._from_name = str(credentials.get("from_name") or "Lemma")
         self._api_base = str(credentials.get("api_base_url") or _RESEND_API_BASE)
+
+    def _sender_name(self, metadata: dict[str, Any] | None) -> str:
+        """The display name for this send, from whatever the caller knew.
+
+        Read off metadata rather than added to every signature between here and
+        the notification service: ``agent_display_name`` already travels that
+        way for the chat platforms, and both send paths already forward the
+        dict. A caller that knows neither name gets ``self._from_name`` back,
+        which is what the header said before any of this existed.
+        """
+        data = metadata or {}
+        return sender_display_name(
+            agent_name=data.get("agent_display_name"),
+            actor_display_name=data.get("actor_display_name"),
+            product_name=self._from_name,
+        )
 
     async def fetch_sender_profile(
         self, event: ParsedInboundSurfaceEvent
@@ -82,6 +102,7 @@ class ResendPlatformService:
             display_resource_plans=coerce_display_resource_plans(
                 (metadata or {}).get("display_resource_plans")
             ),
+            from_name=self._sender_name(metadata),
         )
 
     def _raise_unsendable(self, recipient_email: str) -> None:
@@ -228,6 +249,7 @@ class ResendPlatformService:
                 (metadata or {}).get("display_resource_plans")
             ),
             is_reply=False,
+            from_name=self._sender_name(metadata),
         )
         return ColdEmailSendResult(
             external_thread_id=thread_seed_id,
@@ -256,6 +278,7 @@ class ResendPlatformService:
             content_type="markdown",
             attachments=[],
             display_resource_plans=[render_plan],
+            from_name=self._sender_name(metadata),
         )
 
     async def add_processing_indicator(
@@ -300,6 +323,9 @@ class ResendPlatformService:
                 content=content,
                 content_type=request.content_type,
                 attachments=attachments,
+                from_name=self._sender_name(
+                    {"agent_display_name": ctx.deps.agent_display_name}
+                ),
             )
         except Exception as exc:
             return ResendReplyEmailResult(
@@ -326,6 +352,7 @@ class ResendPlatformService:
         attachments: list[tuple[str, bytes, str]],
         display_resource_plans: list[SurfaceDisplayRenderPlan] | None = None,
         is_reply: bool = True,
+        from_name: str | None = None,
     ) -> dict[str, Any]:
         if not recipient_email or not self._api_key or not self._from_address:
             self._raise_unsendable(recipient_email)
@@ -335,11 +362,13 @@ class ResendPlatformService:
             content_type=content_type,  # type: ignore[arg-type]
             display_resource_plans=display_resource_plans,
         )
-        sender = (
-            f"{self._from_name} <{self._from_address}>"
-            if self._from_name
-            else self._from_address
-        )
+        # ``formataddr``, never an f-string. The display name now carries an
+        # agent name, which is 255 characters of unvalidated free text: an agent
+        # called "Priya, Ops" interpolated bare produces a header that parses as
+        # *two* addresses, and one called "x <evil@example.com>" is worse. This
+        # quotes the specials and RFC 2047-encodes anything non-ASCII, so a
+        # hostile name degrades to an inert display name on the right address.
+        sender = formataddr((from_name or self._from_name, self._from_address))
         payload: dict[str, Any] = {
             "from": sender,
             "to": [recipient_email],

--- a/lemma-backend/app/modules/agent_surfaces/services/notification_egress.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/notification_egress.py
@@ -65,6 +65,8 @@ class NotificationEgress:
         conversation_id: UUID,
         notification: NotificationEntity,
         message: str,
+        agent_name: str | None = None,
+        actor_display_name: str | None = None,
     ) -> bool:
         """Hand the message to the platform.
 
@@ -74,8 +76,22 @@ class NotificationEgress:
         whose ``can_cold_open`` says so, which is why a chat channel never
         reaches the second branch — it would have had no candidate without a
         link in the first place.
+
+        Both names travel in the metadata because email puts them in the ``From``
+        display name, where an inbox list will actually show them — the body
+        header from ``attribute()`` is not visible until the message is opened.
+        A chat platform ignores them; its bot identity is the surface's, and the
+        body header is the whole attribution it gets.
         """
-        metadata = {"notification_id": str(notification.id)}
+        metadata: dict[str, Any] = {"notification_id": str(notification.id)}
+        # Set only when known. ``_egress_metadata_with_agent_name`` fills
+        # ``agent_display_name`` from the surface with ``setdefault``, and an
+        # explicit None here is a present key — it would win, and every chat
+        # bot would lose the name and icon it replies under.
+        if agent_name:
+            metadata["agent_display_name"] = agent_name
+        if actor_display_name:
+            metadata["actor_display_name"] = actor_display_name
         if channel.link is not None:
             return await self.egress.send_agent_message_for_conversation(
                 conversation_id=conversation_id,

--- a/lemma-backend/app/modules/agent_surfaces/services/notification_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/notification_service.py
@@ -294,6 +294,11 @@ class NotificationService:
                     conversation_id=conversation_id,
                     notification=notification,
                     message=message,
+                    # The same two names ``attribute()`` puts in the body. On
+                    # email they also become the From display name, so the
+                    # attribution survives an inbox list nobody has opened yet.
+                    agent_name=agent_name,
+                    actor_display_name=actor_display_name,
                 )
                 if not sent:
                     last_error = (

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_email_markdown_rendering.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_email_markdown_rendering.py
@@ -151,3 +151,48 @@ class TestEveryEmailPlatformRendersTheSameWay:
         plain, html = render_email_content(content="**not bold**", content_type="text")
         assert plain == "**not bold**"
         assert html is None
+
+
+class TestAListMayInterruptAParagraph:
+    """The shape models actually write, and the one Python-Markdown refuses.
+
+    A label line followed straight by bullets was one paragraph, and HTML does
+    not preserve newlines — so it arrived as a flowed sentence with hyphens
+    loose in it. Reported from a real send: "WHAT YOU CAN DO - Land results in
+    tables and files - Run agents and workflows for multi-step work".
+    """
+
+    def test_bullets_under_a_label_become_a_real_list(self):
+        html = _html("What you can do\n- Land results\n- Run agents")
+        assert html.count("<li") == 2
+        assert "<ul" in html
+
+    def test_numbered_items_under_a_label_too(self):
+        html = _html("Steps\n1. Connect the surface\n2. Send a message")
+        assert html.count("<li") == 2
+        assert "<ol" in html
+
+    def test_a_lazy_continuation_does_not_split_one_list_in_two(self):
+        """An unindented line inside a list belongs to the item above it.
+
+        Inserting a break before the next item would end the list and start a
+        second one, which is a worse outcome than the bug being fixed.
+        """
+        html = _html("- item one\n  continued on the next line\n- item two")
+        assert html.count("<ul") == 1
+        assert html.count("<li") == 2
+
+    def test_a_hyphen_inside_a_fenced_block_stays_code(self):
+        html = _html("Run it\n```\nnpm run build\n- not a bullet\n```")
+        assert "<li" not in html
+        assert "- not a bullet" in html
+
+    def test_a_list_that_was_already_correct_is_unchanged(self):
+        html = _html("What you can do\n\n- Land results\n- Run agents")
+        assert html.count("<li") == 2
+        assert html.count("<ul") == 1
+
+    def test_prose_containing_a_dash_is_not_turned_into_a_list(self):
+        """An em-dash aside and a hyphenated word are not bullets."""
+        html = _html("Lemma is durable — it stays in the pod.\nWell-formed too.")
+        assert "<li" not in html

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_email_sender_identity.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_email_sender_identity.py
@@ -1,0 +1,153 @@
+"""What an agent's email says in its ``From`` display name.
+
+The rules worth pinning are the degradations, not the happy path: every one of
+them exists because a form that fits is worth more than a form that is complete,
+and the ordering (agent, then person, then product) is what decides which half
+survives a mail client's truncation.
+"""
+
+from __future__ import annotations
+
+from email.utils import formataddr, getaddresses
+
+from app.modules.agent_surfaces.platforms.email_sender_identity import (
+    MAX_DISPLAY_NAME,
+    sender_display_name,
+)
+
+
+def test_all_three_parts_in_priority_order():
+    assert (
+        sender_display_name(
+            agent_name="Priya",
+            actor_display_name="Deepak Jha",
+            product_name="Lemma",
+        )
+        == "Priya (Deepak Jha) via Lemma"
+    )
+
+
+def test_no_human_behind_the_run_leaves_the_agent_and_the_product():
+    """A schedule or a trigger fired this; there is nobody to name."""
+    assert (
+        sender_display_name(
+            agent_name="Priya", actor_display_name=None, product_name="Lemma"
+        )
+        == "Priya via Lemma"
+    )
+
+
+def test_an_email_address_is_never_shown_as_the_person():
+    """``get_user_display_name`` falls back to the email when a name is unset.
+
+    Right for the body header, which promises "on behalf of <someone>". Wrong
+    here: an unrelated address inside a From display name is what both a spam
+    filter and a person read as forgery, so the actor is dropped instead.
+    """
+    assert (
+        sender_display_name(
+            agent_name="Priya",
+            actor_display_name="deepak@gmail.com",
+            product_name="Lemma",
+        )
+        == "Priya via Lemma"
+    )
+
+
+def test_an_agentless_surface_does_not_repeat_the_product():
+    """``_egress_metadata_with_agent_name`` reports "Lemma" when there is no agent.
+
+    Passing that through composes "Lemma (Deepak Jha) via Lemma".
+    """
+    assert (
+        sender_display_name(
+            agent_name="Lemma",
+            actor_display_name="Deepak Jha",
+            product_name="Lemma",
+        )
+        == "Deepak Jha via Lemma"
+    )
+
+
+def test_nothing_known_is_what_the_header_said_before_any_of_this():
+    assert (
+        sender_display_name(
+            agent_name=None, actor_display_name=None, product_name="Lemma"
+        )
+        == "Lemma"
+    )
+
+
+def test_a_self_hosted_deployment_brands_the_third_slot():
+    """``product_name`` is the deployment's own RESEND_FROM_NAME, not a constant."""
+    assert (
+        sender_display_name(
+            agent_name="Priya", actor_display_name="Deepak Jha", product_name="Acme"
+        )
+        == "Priya (Deepak Jha) via Acme"
+    )
+
+
+def test_a_long_pair_degrades_to_a_first_name_before_it_degrades_further():
+    """The person is worth keeping; their surname is what the budget buys."""
+    composed = sender_display_name(
+        agent_name="Support Triage Escalations",
+        actor_display_name="Bartholomew Fotheringay-Smythe",
+        product_name="Lemma",
+    )
+    assert composed == "Support Triage Escalations (Bartholomew) via Lemma"
+    assert len(composed) <= MAX_DISPLAY_NAME
+
+
+def test_two_long_names_drop_the_person_rather_than_cutting_mid_word():
+    """Not a truncation of the full form: a clipped name reads as a real one."""
+    composed = sender_display_name(
+        agent_name="Customer Escalations And Billing Assistant",
+        actor_display_name="Bartholomew Fotheringay-Smythe",
+        product_name="Lemma",
+    )
+    assert composed == "Customer Escalations And Billing Assistant via Lemma"
+    assert len(composed) <= MAX_DISPLAY_NAME
+
+
+def test_an_absurd_agent_name_is_cut_rather_than_replaced_by_the_product():
+    """A clipped agent name still says which agent; "Lemma" says nothing.
+
+    255 characters is what the agent API accepts, so this is reachable input
+    rather than a hypothetical.
+    """
+    composed = sender_display_name(
+        agent_name="x" * 255, actor_display_name="Deepak Jha", product_name="Lemma"
+    )
+    assert len(composed) <= MAX_DISPLAY_NAME
+    assert composed.startswith("xxxx")
+    assert composed.endswith(" via Lemma")
+
+
+def test_newlines_in_a_name_cannot_reach_the_header():
+    """Header injection's other door: an agent name is free text from the API."""
+    composed = sender_display_name(
+        agent_name="Priya\r\nBcc: evil@example.com",
+        actor_display_name=None,
+        product_name="Lemma",
+    )
+    assert "\r" not in composed and "\n" not in composed
+    assert composed == "Priya Bcc: evil@example.com via Lemma"
+
+
+def test_a_hostile_name_survives_formataddr_as_an_inert_display_name():
+    """The composed name is quoted by the caller, not sanitised here.
+
+    An agent called ``x <evil@example.com>`` must not become a second address,
+    and one with a comma must not split into two. This is the contract the
+    Resend service relies on by calling ``formataddr`` rather than an f-string.
+    """
+    composed = sender_display_name(
+        agent_name="x <evil@example.com>, Ops",
+        actor_display_name=None,
+        product_name="Lemma",
+    )
+    header = formataddr((composed, "priya.acme@updates.lemma.work"))
+    parsed = getaddresses([header])
+    assert len(parsed) == 1
+    assert parsed[0][1] == "priya.acme@updates.lemma.work"

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_notification_egress.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_notification_egress.py
@@ -876,3 +876,73 @@ async def test_the_connection_is_released_before_the_platform_send(monkeypatch):
     assert order.index("commit") < order.index("send"), (
         f"connection held across the send; call order was {order}"
     )
+
+
+async def test_a_cold_open_carries_both_names_to_the_platform():
+    """Email puts the attribution in the From line, so it has to travel.
+
+    ``attribute()`` writes "Priya, on behalf of Deepak" into the body, which is
+    invisible until the message is opened. The sender column is what a person
+    scans in a list, and it named the deployment rather than the agent.
+    """
+    surface = _email_surface()
+    notification = _notification()
+    conversation_id = uuid4()
+    seed = cold_thread_seed_id(notification_id=notification.id, surface=surface)
+
+    egress_port = _egress_double()
+    egress_port.open_cold_email_thread.return_value = _thread_for(
+        surface, seed, "bob@example.com"
+    )
+
+    egress = NotificationEgress(
+        egress=egress_port,
+        conversation_service=_conversation_service(conversation_id),
+        conversation_link_repository=_links(),
+    )
+
+    await egress.send(
+        DeliveryChannel(surface=surface, email_address="bob@example.com"),
+        conversation_id=conversation_id,
+        notification=notification,
+        message="What did you ship?",
+        agent_name="Priya",
+        actor_display_name="Deepak Jha",
+    )
+
+    metadata = egress_port.open_cold_email_thread.await_args.kwargs["metadata"]
+    assert metadata["agent_display_name"] == "Priya"
+    assert metadata["actor_display_name"] == "Deepak Jha"
+
+
+async def test_an_unknown_agent_name_is_absent_rather_than_None():
+    """A present key beats ``setdefault``, and would unname every chat bot.
+
+    ``_egress_metadata_with_agent_name`` fills ``agent_display_name`` from the
+    surface with ``setdefault``, so writing an explicit None here does not mean
+    "we don't know" — it wins, and the reply goes out with no name and no icon
+    on a platform that had both.
+    """
+    surface = _email_surface()
+    link = _link_for(surface)
+    conversation_id = uuid4()
+    egress_port = _egress_double()
+
+    egress = NotificationEgress(
+        egress=egress_port,
+        conversation_service=_conversation_service(conversation_id),
+        conversation_link_repository=_links(),
+    )
+
+    await egress.send(
+        DeliveryChannel(surface=surface, external_user_id="U123", link=link),
+        conversation_id=conversation_id,
+        notification=_notification(),
+        message="What did you ship?",
+        agent_name=None,
+        actor_display_name=None,
+    )
+
+    kwargs = egress_port.send_agent_message_for_conversation.await_args.kwargs
+    assert "agent_display_name" not in kwargs["metadata"]
+    assert "actor_display_name" not in kwargs["metadata"]

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_resend_surface.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_resend_surface.py
@@ -889,3 +889,144 @@ def test_a_non_http_failure_still_reports_something_usable():
     assert failure.failure_type == "OSError"
     assert failure.status_code is None
     assert failure.provider_error is None
+
+
+@pytest.mark.asyncio
+async def test_the_from_header_names_the_agent_and_the_person_it_acts_for():
+    """The attribution has to survive an inbox list nobody has opened.
+
+    ``attribute()`` puts "Priya, on behalf of Deepak" in the body, which is the
+    right place for it and invisible until the message is opened. The sender
+    column is what a person scans, and it used to say "Lemma" for every agent in
+    every pod.
+    """
+    service = ResendPlatformService(
+        {
+            "api_key": "re_test",
+            "from_address": "priya.acme@ops.asur.work",
+            "from_name": "Lemma",
+        }
+    )
+    captured = {}
+
+    async def _fake_post(self, url, json, headers):  # noqa: ANN001
+        captured["json"] = json
+
+        class _Resp:
+            content = b"{}"
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"id": "email-1"}
+
+        return _Resp()
+
+    with patch("httpx.AsyncClient.post", new=_fake_post):
+        await service.send_cold_email(
+            recipient_email="bob@example.com",
+            subject="Standup",
+            message="What did you ship?",
+            thread_seed_id="<seed@ops.asur.work>",
+            metadata={
+                "agent_display_name": "Priya",
+                "actor_display_name": "Deepak Jha",
+            },
+        )
+
+    # Quoted, and the quotes are load-bearing rather than cosmetic: parentheses
+    # are RFC 5322 *comment* syntax, so the same header unquoted parses as the
+    # display name "Priya via Lemma" with "(Deepak Jha)" split off as a comment
+    # that most clients never render. Which is the second reason this send path
+    # had to move off an f-string, independent of the injection one below.
+    assert (
+        captured["json"]["from"]
+        == '"Priya (Deepak Jha) via Lemma" <priya.acme@ops.asur.work>'
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_agent_name_cannot_inject_a_second_address_into_from():
+    """An agent name is 255 characters of unvalidated free text.
+
+    This send path built the header with an f-string, which was safe only while
+    the display name was a fixed environment string. Putting an agent name in it
+    makes ``Priya, Ops`` a header that parses as two addresses, so the
+    construction moved to ``formataddr``.
+    """
+    from email.utils import getaddresses
+
+    service = ResendPlatformService(
+        {
+            "api_key": "re_test",
+            "from_address": "priya.acme@ops.asur.work",
+            "from_name": "Lemma",
+        }
+    )
+    captured = {}
+
+    async def _fake_post(self, url, json, headers):  # noqa: ANN001
+        captured["json"] = json
+
+        class _Resp:
+            content = b"{}"
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"id": "email-1"}
+
+        return _Resp()
+
+    with patch("httpx.AsyncClient.post", new=_fake_post):
+        await service.send_cold_email(
+            recipient_email="bob@example.com",
+            subject="Standup",
+            message="hello",
+            thread_seed_id="<seed@ops.asur.work>",
+            metadata={"agent_display_name": "Ops <evil@example.com>, Priya"},
+        )
+
+    parsed = getaddresses([captured["json"]["from"]])
+    assert len(parsed) == 1
+    assert parsed[0][1] == "priya.acme@ops.asur.work"
+
+
+@pytest.mark.asyncio
+async def test_a_send_that_knows_no_agent_keeps_the_deployment_default():
+    """Every non-agent send — and every existing caller — is unchanged."""
+    service = ResendPlatformService(
+        {
+            "api_key": "re_test",
+            "from_address": "acme@ops.asur.work",
+            "from_name": "Lemma",
+        }
+    )
+    captured = {}
+
+    async def _fake_post(self, url, json, headers):  # noqa: ANN001
+        captured["json"] = json
+
+        class _Resp:
+            content = b"{}"
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"id": "email-1"}
+
+        return _Resp()
+
+    with patch("httpx.AsyncClient.post", new=_fake_post):
+        await service.send_cold_email(
+            recipient_email="bob@example.com",
+            subject="Standup",
+            message="hello",
+            thread_seed_id="<seed@ops.asur.work>",
+            metadata=None,
+        )
+
+    assert captured["json"]["from"] == "Lemma <acme@ops.asur.work>"


### PR DESCRIPTION
## What changes

Outbound agent email now says who sent it and renders what the agent wrote.

**The `From` line names the agent.** The address was already per-agent
(`priya.acme@updates.lemma.work`); the display name was a single
deployment-wide `RESEND_FROM_NAME`, so every agent in every pod arrived as
`Lemma`. It now reads `Priya (Deepak Jha) via Lemma`.

**Markdown renders.** A message written as a label line followed by bullets
arrived as one flowed paragraph with hyphens loose in it. It now becomes a
real list, and `message_user` tells the agent the body is markdown so it
writes headings instead of ALL-CAPS.

## Why

Attribution existed only in the message body, via `attribute()`'s
`*Priya*, on behalf of Deepak:` header. That is invisible until the message
is opened, and the sender column is what a person scans. `attribute()`'s own
docstring calls the header mandatory rather than cosmetic — "an agent that
can message colleagues is a phishing primitive" — and the envelope was
carrying none of it.

The rendering half came from a real send. The renderer was never at fault:
it already emits inline-styled headings, lists and tables, and that email
*was* styled HTML — it had nothing structural to style. Python-Markdown
refuses to let a list interrupt a paragraph, and nothing told the agent the
body was markdown. The agent went on to tell the recipient, in the email,
that "the messaging gateway sends plain text, so I can't embed rich HTML/CSS
styling" — false, and user-visible.

## Notable for a reviewer

**`formataddr` replaces an f-string, and this one is load-bearing twice.**
`f"{name} <{addr}>"` was safe only while the display name was a fixed
environment string. An agent name is 255 characters of unvalidated free text
(`schemas.py:239`), so `Priya, Ops` yields a header parsing as *two*
addresses and `x <evil@example.com>` is worse. Separately, the chosen format
requires quoting on its own merits: parentheses are RFC 5322 comment syntax,
so the same header unquoted parses as `Priya via Lemma` with the person's
name split into a comment most clients never render.

**Length degrades by dropping parts, not cutting characters.** The sender
column truncates near 18 characters on mobile, so the order (agent, person,
product) decides what survives; the product is already carried by the
sending domain. Over budget: full name → first name → no actor. Every form
shown is true as written.

**Two inputs that must not reach the header.**
`get_user_display_name` falls back to the user's *email* when first and last
are empty — right for the body header's "on behalf of <someone>" promise,
wrong in a `From` line, so a non-name actor is dropped. And an agentless
surface reports its display name as the product already, which would compose
`Lemma (Deepak Jha) via Lemma`.

**A near-miss that would have unnamed every chat bot.** The two names travel
in the send metadata, which already carried `agent_display_name` for chat.
They are set only when known: `_egress_metadata_with_agent_name` fills that
key with `setdefault`, and an explicit `None` is a *present* key that wins —
stripping the name and icon off every Slack and Telegram reply. Pinned by
`test_an_unknown_agent_name_is_absent_rather_than_None`.

**The list fix is email-only and defensive.** Chat surfaces render newlines
as newlines, so the same message already reads as a list there.
`_blank_line_before_lists` tracks `in_list` so a lazy continuation stays one
list rather than splitting in two, and skips fenced blocks so a hyphen in a
code sample stays code.

**Scope.** Gmail/Outlook surfaces are untouched for the sender name — they
send through a connected account whose display name Google and Microsoft
own. They do share the renderer, so they get the list fix.

`agent_tool_schemas.json` is regenerated because
`test_checked_in_agent_tool_schemas_match_live_tools` pins model-facing tool
documentation against the live toolsets. One line, `message_user` only.

## Not done

No product scenario. The nearest promise, `PS-SURF-022 Email surfaces behave
like email`, is already `manual` and its scenarios are all inbound; covering
this needs `fake_upstreams` to capture Resend outbound, which it cannot do
today. That is its own piece of harness work rather than something to bury
here. Behaviour is covered by 31 unit tests at the composition rule, the
wire format, and the metadata threading.

## How to verify

```bash
cd lemma-backend
uv run pytest app/modules/agent_surfaces/tests/unit/test_email_sender_identity.py \
              app/modules/agent_surfaces/tests/unit/test_resend_surface.py \
              app/modules/agent_surfaces/tests/unit/test_notification_egress.py \
              app/modules/agent_surfaces/tests/unit/test_email_markdown_rendering.py -q
```

`115 passed`.

Full gates, all green:

```bash
cd lemma-backend && make test-unit && make lint && make lint-async && make typecheck-critical && make architecture
```

`make test-unit` is `1 failed, 5623 passed` — the failure is
`test_redis_store_enforces_atomic_state_and_claims`, which needs a reachable
Redis and fails identically on a clean tree (confirmed with `git stash`).

Module e2e was not run: it needs Docker, unavailable here.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload; this
      *closes* a header-injection path rather than opening one

## Compatibility and rollback notes

No migration, no API change, no SDK change. A deployment that sets no agent
name gets `Lemma <addr>` exactly as before, so existing non-agent sends are
byte-identical. Both commits are pure revert candidates — nothing persists
the new display name, and the list normalizer is a render-time pre-pass.
