### PR TITLE
Send the message where the agent said, and stop losing the second Slack workspace

### DIFF
--- a/docs/product/coverage.md
+++ b/docs/product/coverage.md
@@ -11,8 +11,8 @@ only a promise marked `covered` with no test is.
 
 | Status | Scenarios |
 | --- | ---: |
-| `covered` | 157 |
-| `gap` | 0 |
+| `covered` | 156 |
+| `gap` | 1 |
 | `manual` | 4 |
 | `planned` | 0 |
 | `withdrawn` | 0 |
@@ -216,7 +216,7 @@ the module suites may cover it — but it is untested *as product*.
 | `PS-SURF-020` The answer comes back where the question was asked | `covered` | `test_a_real_message_reaches_a_real_person`, `test_a_message_is_answered`, `test_an_unknown_sender_is_told_how_to_get_access` |
 | `PS-SURF-021` Questions and approvals work on every platform | `covered` | `test_a_question_is_asked_with_native_controls`, `test_an_approval_is_offered_with_native_controls` |
 | `PS-SURF-022` Email surfaces behave like email | `manual` | `test_an_email_surface_has_an_address`, `test_mail_reaches_the_pod_that_owns_the_address`, `test_mail_to_an_unknown_address_starts_nothing`, `test_an_unsigned_email_is_refused` |
-| `PS-SURF-023` A person reached on several platforms gets one predictable answer | `covered` | `test_channels_are_listable`, `test_a_default_surface_can_be_chosen`, `test_my_surfaces_are_listable` |
+| `PS-SURF-023` A person reached on several platforms gets one predictable answer | `gap` | `test_channels_are_listable`, `test_a_default_surface_can_be_chosen`, `test_my_surfaces_are_listable` |
 | `PS-SURF-030` A person has one place to see what needs them | `covered` | `test_a_notification_arrives_in_the_inbox`, `test_an_outsider_sees_no_notifications`, `test_removal_closes_the_inbox_it_left_behind` |
 | `PS-SURF-031` A person clears what they have dealt with | `covered` | `test_reading_clears_the_unread_count`, `test_read_all_clears_everything`, `test_read_state_is_personal` |
 | `PS-SURF-032` A person can answer from the notification | `covered` | `test_a_notification_can_be_answered`, `test_a_notification_can_be_acknowledged` |

--- a/docs/product/journeys/surfaces-and-notifications.md
+++ b/docs/product/journeys/surfaces-and-notifications.md
@@ -177,7 +177,14 @@ dropped.
 **Contracts:** `agent.surface.create`, `surface.webhook.handle_platform`, `agent.surface.send`
 
 ### PS-SURF-023 — A person reached on several platforms gets one predictable answer
-**Status:** covered
+**Status:** gap
+
+> **Gap:** the default holds for messages a person starts, not for messages the
+> system starts. Agent-initiated contact ranks the *sending agent's* own surfaces
+> and never reads the preference, and the stored preference is per platform —
+> it chooses which pod's surface answers on WhatsApp, not whether to use WhatsApp
+> at all. See `DEV-SURF-004`, which is a question for the product rather than a
+> bug: the second half of this promise may be the part that is wrong.
 
 - Where a person has chosen a default surface, the system shall reach them there
   when it starts the contact, whatever platform any earlier conversation used.

--- a/issues.md
+++ b/issues.md
@@ -35,3 +35,45 @@ message, or a code comment resolves to something.
 Severity `question` means the divergence may be deliberate and the spec may be
 the thing that is wrong — resolve it with a product decision before writing code.
 
+---
+
+## SURF — surfaces and notifications
+
+### DEV-SURF-004 — A person's default surface governs where they are answered, not where they are reached
+**Violates:** PS-SURF-023
+**Severity:** question
+**Where:** [`notification_delivery.py`](lemma-backend/app/modules/agent_surfaces/services/notification_delivery.py):33,
+[`notification_channels.py`](lemma-backend/app/modules/agent_surfaces/services/notification_channels.py):113
+
+**Required:** "Where a person has chosen a default surface, the system shall
+reach them there when it starts the contact, whatever platform any earlier
+conversation used." Starting the contact is what a notification does.
+
+**Actual:** Delivery never reads the preference. Candidates are the *sending
+agent's* surfaces, ranked: the surface the run is already on, then its other
+chat surfaces by freshest inbound, then its mailbox. The preference is read only
+by inbound routing (`surface_routing._default_surface`) and by surface
+configuration authorization.
+
+The deeper mismatch is in the mechanism the promise names.
+[`UserPreferences.default_surfaces`](lemma-backend/app/modules/identity/domain/user_preferences.py):12
+maps *platform → surface id*, and exists so that one external identity resolving
+to several pods lands in the pod the person meant. There is no cross-platform
+"reach me here" for the outbound path to honour, so the clause "whatever platform
+any earlier conversation used" describes a preference nobody can express.
+
+Found by reading delivery against this journey while adding `message_user`'s
+`channel` argument, which widens the same gap: the sending agent can now name a
+channel outright, and the recipient still cannot.
+
+**Why it matters:** Someone who sets a default expects proactive messages to
+arrive there. They arrive instead on whichever of the sending agent's surfaces
+they last wrote to — and the setting that looks like it controls this controls
+something else, which is worse than having no setting.
+
+**Fix:** A product decision before code. Either amend PS-SURF-023 to scope the
+default to inbound pod disambiguation, and say plainly that agent-initiated
+contact is ranked by sender identity — the identity argument in
+`notification_delivery`'s docstring is the case for it — or add a real outbound
+preference and give it precedence over freshness, below an explicit `channel`
+and above the ranking.

--- a/lemma-backend/agent_tool_schemas.json
+++ b/lemma-backend/agent_tool_schemas.json
@@ -905,7 +905,7 @@
   {
     "tool_name": "list_pod_members",
     "toolset": "MESSAGING",
-    "description": "Look up who is in this pod, to find who to `message_user`.\n\n`message_user` needs an id or an exact email address \u2014 a name won't resolve\n\u2014 so start here whenever you know a person by name. Each result carries a\n`to` value to pass straight through.\n\nSearches names and email addresses; omit `search` to list everyone.",
+    "description": "Look up who is in this pod, to find who to `message_user`.\n\n`message_user` needs an id or an exact email address \u2014 a name won't resolve\n\u2014 so start here whenever you know a person by name. Each result carries a\n`to` value to pass straight through.\n\nAlso tells you `reachable_on`: the channels that can carry a message to each\nperson right now. Read it before setting `message_user`'s `channel`, and\ndon't ask for one that isn't listed \u2014 the send will be refused rather than\nrerouted.\n\nSearches names and email addresses; omit `search` to list everyone.",
     "input_schema": {
       "properties": {
         "search": {
@@ -968,6 +968,13 @@
               "default": false,
               "description": "True for the person this run belongs to.",
               "type": "boolean"
+            },
+            "reachable_on": {
+              "description": "Channels that can carry a message to them right now \u2014 pass one as message_user's `channel`. Empty means only their Lemma inbox.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
             }
           },
           "required": [
@@ -1447,8 +1454,22 @@
   {
     "tool_name": "message_user",
     "toolset": "MESSAGING",
-    "description": "Message a pod member who is not in this conversation.\n\nReaches them on the chat app they last used, or by email, and always leaves\na copy in their Lemma inbox.\n\nIt does **not** pause your turn, and their reply never comes back as a tool\nresult. To get an answer: send every message you need, give each a\n`background_instruction`, `snooze` once for as long as a person realistically\ntakes, then `check_messages`.\n\nTo answer the person you are already talking to, just reply \u2014 don't use this.",
+    "description": "Message a pod member who is not in this conversation.\n\nReaches them on the chat app they last used, or by email, and always leaves\na copy in their Lemma inbox.\n\nIt does **not** pause your turn, and their reply never comes back as a tool\nresult. To get an answer: send every message you need, give each a\n`background_instruction`, `snooze` once for as long as a person realistically\ntakes, then `check_messages`.\n\nLeave `channel` unset unless you have a reason to pick one \u2014 the default is\nalready the app they last spoke to you on. When you do name one it is\nhonoured or refused, never swapped, so read `reachable_on` from\n`list_pod_members` before choosing.\n\nTo answer the person you are already talking to, just reply \u2014 don't use this.",
     "input_schema": {
+      "$defs": {
+        "MessageChannel": {
+          "description": "Where a message goes, when the agent has a reason to say.\n\nChannels, not surface ids: you think \"reach her on WhatsApp\", not \"send\nthrough surface 3f2a\u2026\". Every mail provider is one `email`, because which\none carries it is a deployment detail.",
+          "enum": [
+            "email",
+            "slack",
+            "teams",
+            "telegram",
+            "whatsapp"
+          ],
+          "title": "MessageChannel",
+          "type": "string"
+        }
+      },
       "properties": {
         "to": {
           "description": "Pod member id, user id, or email address.",
@@ -1482,6 +1503,18 @@
           ],
           "default": null,
           "description": "Inbox label and email subject. Defaults to the message."
+        },
+        "channel": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MessageChannel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Where to send it. Omit unless you have a reason to choose \u2014 the default reaches them where they last spoke to you. Name one and it is that channel or nothing: it is never quietly swapped for another. Check `reachable_on` from list_pod_members first, because a chat app they have never messaged this agent on cannot be used."
         },
         "expects_response": {
           "default": true,

--- a/lemma-backend/app/composition/agent_notifications.py
+++ b/lemma-backend/app/composition/agent_notifications.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from app.core.infrastructure.db.session import async_session_maker
 from app.core.infrastructure.db.uow_factory import SessionUnitOfWorkFactory
 
@@ -51,6 +53,7 @@ async def send_notification(
     expects_response: bool,
     expires_in_seconds: int | None,
     idempotency_key: str | None,
+    channel: str | None = None,
 ) -> dict:
     """Create and deliver, returning the flat shape the tool hands the model."""
     from app.modules.agent_surfaces.domain.notification import (
@@ -72,6 +75,7 @@ async def send_notification(
             origin_id=origin_agent_run_id,
             origin_conversation_id=origin_conversation_id,
             origin_surface_id=origin_surface_id,
+            channel=channel,
             actor_user_id=actor_user_id,
             actor_agent_id=actor_agent_id,
             agent_name=agent_name,
@@ -87,6 +91,33 @@ async def send_notification(
             "delivered_via": notification.delivery_platform,
             "undeliverable_reason": notification.delivery_error,
         }
+
+
+async def reachable_channels(
+    *,
+    pod_id: UUID,
+    recipients: dict[UUID, str | None],
+    actor_agent_id: UUID | None,
+) -> dict[UUID, list[str]]:
+    """``{user_id: channels}`` this agent can reach each person on right now.
+
+    Degrades to "we do not know" rather than failing the lookup it decorates:
+    an agent that cannot see the member list because reachability broke is worse
+    off than one that sees the list without it, and ``message_user`` still
+    routes on its own when no channel is named.
+
+    Infrastructure only, deliberately not bare ``Exception``. This runs in a
+    second unit of work after the member list has already come back, so the
+    failure worth surviving is a transient one; a bug in our own code should
+    still reach the tool result rather than read as "nowhere to reach them".
+    """
+    try:
+        async with SessionUnitOfWorkFactory(async_session_maker)() as uow:
+            return await _service(uow).reachable_channels(
+                pod_id=pod_id, recipients=recipients, actor_agent_id=actor_agent_id
+            )
+    except SQLAlchemyError, OSError:
+        return {}
 
 
 async def check_notifications(

--- a/lemma-backend/app/composition/agent_pod_members.py
+++ b/lemma-backend/app/composition/agent_pod_members.py
@@ -50,6 +50,8 @@ def _summarize(member, *, requester_user_id: UUID) -> dict:
         "email": member.user_email,
         "role": member.role.value if member.role else None,
         "is_you": member.user_id == requester_user_id,
+        "user_id": member.user_id,
+        "reachable_on": [],
     }
 
 
@@ -59,12 +61,17 @@ async def list_pod_members(
     requester_user_id: UUID,
     search: str | None = None,
     limit: int = 50,
+    actor_agent_id: UUID | None = None,
 ) -> tuple[list[dict], int, bool] | None:
     """``(members, total_matched, truncated)``, or None when access is refused.
 
     None rather than an exception because the caller is a tool: an agent asking
     about a pod it cannot see should get an answer it can act on, not a
     traceback the model has to interpret.
+
+    Each member carries the channels ``actor_agent_id`` can reach them on, so
+    that choosing one is a read rather than a guess a refused send has to
+    correct.
     """
     from app.modules.pod.api.dependencies import get_pod_member_service
     from app.modules.pod.domain.errors import PodAccessDeniedError, PodNotFoundError
@@ -93,7 +100,37 @@ async def list_pod_members(
             return None
 
     total = len(matched)
-    return matched[:limit], total, total > limit
+    page = matched[:limit]
+    # Only the page that is actually returned: reachability costs queries per
+    # surface, and answering it for members nobody will see is work spent on
+    # rows the model never reads.
+    await _attach_reach(page, pod_id=pod_id, actor_agent_id=actor_agent_id)
+    return page, total, total > limit
+
+
+async def _attach_reach(
+    members: list[dict], *, pod_id: UUID, actor_agent_id: UUID | None
+) -> None:
+    """Fill in each member's ``reachable_on``, then drop the id it needed.
+
+    ``user_id`` is the key reachability is computed against and is not part of
+    what the tool returns — ``to`` is the value the model copies, and offering a
+    second id would only invite it to pass the wrong one.
+    """
+    from app.composition.agent_notifications import reachable_channels
+
+    recipients = {
+        member["user_id"]: member["email"] for member in members if member["user_id"]
+    }
+    reach = (
+        await reachable_channels(
+            pod_id=pod_id, recipients=recipients, actor_agent_id=actor_agent_id
+        )
+        if recipients
+        else {}
+    )
+    for member in members:
+        member["reachable_on"] = reach.get(member.pop("user_id"), [])
 
 
 __all__ = ["MAX_SCANNED_MEMBERS", "list_pod_members"]

--- a/lemma-backend/app/modules/agent/prompts/messaging.md
+++ b/lemma-backend/app/modules/agent/prompts/messaging.md
@@ -2,11 +2,13 @@
 
 `message_user` returns immediately and their reply never arrives as a tool result. To get an answer back:
 
-0. **Find out who you are messaging.** `to` takes a pod member id, a user id, or an exact email address — a name will not resolve. If you know someone as "Priya", call `list_pod_members` (optionally with a `search`) and pass the `to` value it hands back.
+0. **Find out who you are messaging.** `to` takes a pod member id, a user id, or an exact email address — a name will not resolve. If you know someone as "Priya", call `list_pod_members` (optionally with a `search`) and pass the `to` value it hands back. The same result carries `reachable_on` — the channels that can carry a message to them right now.
 1. **Send every message first** — one call per person, not one-then-wait.
 2. **Give each a `background_instruction`.** It is never shown to them; it tells the agent handling their reply what counts as an answer and where to put it — "record their status update as the response summary", "write the PO number into `purchase_orders.po_number`". Without one, their reply is just chat and nothing reaches you.
 3. **`snooze` once**, sized to how long a person actually takes — ten minutes mid-conversation, an hour or more for a standup. Not a poll loop: every wake replays this whole conversation. (`snooze` warns against waiting on a person; that rule is about whoever you are already talking to, whose reply starts a fresh run on its own. Nothing resumes you here.)
 4. **`check_messages`**, plus wherever your instruction told their agent to write.
+
+**Leave `channel` alone unless you have a reason.** The default reaches someone where they last spoke to you, which is usually where they are looking. Set it when the situation says otherwise — "she's travelling, use WhatsApp", "this needs to be on the record, email it". A channel you name is used or refused, never swapped for another, so pick one from that person's `reachable_on`: a chat app they have never messaged this agent on cannot be used, because bots cannot start a conversation.
 
 `RESPONDED` is the only status that means somebody answered; `DELIVERED` just means it reached their phone. `UNDELIVERABLE` is not a failure — no chat app or mailbox could carry it and it is in their Lemma inbox; pass on `undeliverable_reason`, which usually means they have never messaged the bot.
 

--- a/lemma-backend/app/modules/agent/tests/unit/test_messaging_tools.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_messaging_tools.py
@@ -16,8 +16,15 @@ from pydantic_ai.tools import RunContext
 from pydantic_ai.usage import RunUsage
 
 from app.modules.agent.tools.context import BaseAgentContext
-from app.modules.agent.tools.messaging.models import ListPodMembersRequest
-from app.modules.agent.tools.messaging.pydantic_adapter import list_pod_members
+from app.modules.agent.tools.messaging.models import (
+    ListPodMembersRequest,
+    MessageChannel,
+    MessageUserRequest,
+)
+from app.modules.agent.tools.messaging.pydantic_adapter import (
+    list_pod_members,
+    message_user,
+)
 
 pytestmark = pytest.mark.asyncio
 
@@ -77,8 +84,13 @@ def _members() -> list[dict]:
 
 
 def _patch(monkeypatch, result):
-    async def _fake(*, pod_id, requester_user_id, search, limit):
-        _fake.seen = {"search": search, "limit": limit, "pod_id": pod_id}
+    async def _fake(*, pod_id, requester_user_id, search, limit, actor_agent_id=None):
+        _fake.seen = {
+            "search": search,
+            "limit": limit,
+            "pod_id": pod_id,
+            "actor_agent_id": actor_agent_id,
+        }
         return result
 
     monkeypatch.setattr(
@@ -237,3 +249,103 @@ async def test_a_real_agent_still_reports_its_own_id(monkeypatch):
 
     assert sent["actor_agent_id"] == agent_id
     assert sent["agent_name"] == "Ops"
+
+
+# ------------------------------------------------- choosing where it goes
+
+
+def _sent(monkeypatch, **result):
+    """Stand in for the whole delivery stack, and record what it was asked for."""
+    payload = {
+        "notification_id": uuid4(),
+        "delivery_status": "DELIVERED",
+        "delivered_via": "TELEGRAM",
+        "undeliverable_reason": None,
+    }
+    payload.update(result)
+
+    async def _resolve(*, pod_id, reference):
+        return PRIYA
+
+    async def _send(**kwargs):
+        _send.seen = kwargs
+        return payload
+
+    monkeypatch.setattr(
+        "app.modules.agent.tools.messaging.pydantic_adapter.resolve_recipient",
+        _resolve,
+    )
+    monkeypatch.setattr(
+        "app.modules.agent.tools.messaging.pydantic_adapter.send_notification", _send
+    )
+    return _send
+
+
+async def test_the_channel_the_agent_named_reaches_the_router(monkeypatch):
+    """Passed as the plain channel name, which is the whole vocabulary.
+
+    The tool speaks in channels because that is what an agent can reason about;
+    surface ids and mail providers are not things it can choose between.
+    """
+    send = _sent(monkeypatch, delivered_via="WHATSAPP")
+
+    await message_user(
+        _ctx(),
+        MessageUserRequest(
+            to=str(PRIYA), message="Standup?", channel=MessageChannel.WHATSAPP
+        ),
+    )
+
+    assert send.seen["channel"] == "whatsapp"
+
+
+async def test_leaving_the_channel_out_leaves_the_routing_alone(monkeypatch):
+    """The default has to stay the default: no channel means no filter."""
+    send = _sent(monkeypatch)
+
+    await message_user(_ctx(), MessageUserRequest(to=str(PRIYA), message="Standup?"))
+
+    assert send.seen["channel"] is None
+
+
+async def test_a_refused_channel_does_not_read_as_a_routing_failure(monkeypatch):
+    """ "No chat app could carry this" is true of routing and false of this.
+
+    Something could have carried it. What stopped the send was the agent's own
+    choice, and unless the answer says so the model reads the generic sentence,
+    concludes the person is unreachable, and gives up on someone it could have
+    reached by dropping one argument.
+    """
+    _sent(
+        monkeypatch,
+        delivery_status="UNDELIVERABLE",
+        delivered_via=None,
+        undeliverable_reason=(
+            "They have not messaged this agent on WhatsApp. Nothing was sent "
+            "elsewhere; email would reach them."
+        ),
+    )
+
+    result = await message_user(
+        _ctx(),
+        MessageUserRequest(
+            to=str(PRIYA), message="Standup?", channel=MessageChannel.WHATSAPP
+        ),
+    )
+
+    assert result.success is True
+    assert "you asked for whatsapp" in result.message
+    assert "email would reach them" in result.message
+
+
+async def test_the_lookup_says_which_channels_can_reach_each_person(monkeypatch):
+    """So that naming a channel is reading an answer, not guessing at one."""
+    members = _members()
+    members[0]["reachable_on"] = ["email", "telegram"]
+    members[1]["reachable_on"] = []
+    _patch(monkeypatch, (members, 2, False))
+
+    result = await list_pod_members(_ctx(), ListPodMembersRequest())
+
+    assert result.members[0].reachable_on == ["email", "telegram"]
+    assert result.members[1].reachable_on == []

--- a/lemma-backend/app/modules/agent/tools/messaging/models.py
+++ b/lemma-backend/app/modules/agent/tools/messaging/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from enum import StrEnum
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -15,6 +16,25 @@ MAX_TITLE_LENGTH = 120
 # four people; anything reaching for fifty is polling, which is the failure mode
 # the prompt guidance exists to prevent.
 MAX_STATUS_CHECK = 25
+
+
+# Declared here rather than imported from ``agent_surfaces``, which the agent
+# module must not depend on. That leaves two lists that have to agree with no
+# compiler to make them, so a test does it instead:
+# ``test_the_tool_offers_exactly_the_channels_routing_can_produce``.
+class MessageChannel(StrEnum):
+    """Where a message goes, when the agent has a reason to say.
+
+    Channels, not surface ids: you think "reach her on WhatsApp", not "send
+    through surface 3f2a…". Every mail provider is one `email`, because which
+    one carries it is a deployment detail.
+    """
+
+    EMAIL = "email"
+    SLACK = "slack"
+    TEAMS = "teams"
+    TELEGRAM = "telegram"
+    WHATSAPP = "whatsapp"
 
 
 class MessageUserRequest(BaseModel):
@@ -34,6 +54,16 @@ class MessageUserRequest(BaseModel):
         default=None,
         max_length=MAX_TITLE_LENGTH,
         description="Inbox label and email subject. Defaults to the message.",
+    )
+    channel: MessageChannel | None = Field(
+        default=None,
+        description=(
+            "Where to send it. Omit unless you have a reason to choose — the "
+            "default reaches them where they last spoke to you. Name one and it "
+            "is that channel or nothing: it is never quietly swapped for "
+            "another. Check `reachable_on` from list_pod_members first, because "
+            "a chat app they have never messaged this agent on cannot be used."
+        ),
     )
     expects_response: bool = Field(default=True, description="False for a pure FYI.")
     expires_in_seconds: int | None = Field(
@@ -105,6 +135,13 @@ class PodMemberSummary(BaseModel):
     role: str | None = None
     is_you: bool = Field(
         default=False, description="True for the person this run belongs to."
+    )
+    reachable_on: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Channels that can carry a message to them right now — pass one as "
+            "message_user's `channel`. Empty means only their Lemma inbox."
+        ),
     )
 
 

--- a/lemma-backend/app/modules/agent/tools/messaging/pydantic_adapter.py
+++ b/lemma-backend/app/modules/agent/tools/messaging/pydantic_adapter.py
@@ -34,6 +34,7 @@ from app.modules.agent.tools.messaging.models import (
     CheckMessagesResponse,
     ListPodMembersRequest,
     ListPodMembersResponse,
+    MessageChannel,
     MessageUserRequest,
     MessageUserResponse,
     NotificationStatusReport,
@@ -54,6 +55,38 @@ def _title_for(request: MessageUserRequest) -> str:
     return first_line[: MAX_TITLE_LENGTH - 1].rstrip() + "…"
 
 
+def _outcome(result: dict, *, requested: MessageChannel | None) -> str:
+    """What the model is told happened, in the terms it asked in.
+
+    A refused channel gets its own wording. The generic "no chat app or mailbox
+    could carry this" is true of a routing failure and false of this: something
+    could have carried it, and the agent needs to see that its own choice is
+    what stopped the send — otherwise it retries the same call and reads the
+    same sentence.
+    """
+    reason = result["undeliverable_reason"] or ""
+    status = result["delivery_status"]
+    if status == "DELIVERED":
+        return (
+            f"Sent on {result['delivered_via']}. They have not answered yet — "
+            "check with check_messages after giving them time."
+        )
+    if status == "UNDELIVERABLE" and requested is not None:
+        return (
+            f"Not sent: you asked for {requested.value}. {reason} It is in "
+            "their Lemma inbox."
+        ).strip()
+    if status == "UNDELIVERABLE":
+        return (
+            "No chat app or mailbox could carry this, so it is in their Lemma "
+            f"inbox only. {reason}"
+        ).strip()
+    return (
+        "Delivery failed, but the notification exists and is in their Lemma "
+        f"inbox. {reason}"
+    ).strip()
+
+
 async def message_user(
     ctx: RunContext[BaseAgentContext], request: MessageUserRequest
 ) -> MessageUserResponse:
@@ -66,6 +99,11 @@ async def message_user(
     result. To get an answer: send every message you need, give each a
     `background_instruction`, `snooze` once for as long as a person realistically
     takes, then `check_messages`.
+
+    Leave `channel` unset unless you have a reason to pick one — the default is
+    already the app they last spoke to you on. When you do name one it is
+    honoured or refused, never swapped, so read `reachable_on` from
+    `list_pod_members` before choosing.
 
     To answer the person you are already talking to, just reply — don't use this.
     """
@@ -118,6 +156,9 @@ async def message_user(
         # Reach out from the surface this run is already on, so the recipient
         # hears from the same bot rather than another of the agent's surfaces.
         origin_surface_id=deps.surface_id,
+        # Only when the agent asked. Everything above is a default the router
+        # applies; this is an instruction it either follows or refuses.
+        channel=request.channel.value if request.channel else None,
         background_instruction=request.background_instruction,
         expects_response=request.expects_response,
         expires_in_seconds=request.expires_in_seconds,
@@ -131,30 +172,13 @@ async def message_user(
         ),
     )
 
-    delivery_status = result["delivery_status"]
-    if delivery_status == "DELIVERED":
-        message = (
-            f"Sent on {result['delivered_via']}. They have not answered yet — "
-            "check with check_messages after giving them time."
-        )
-    elif delivery_status == "UNDELIVERABLE":
-        message = (
-            "No chat app or mailbox could carry this, so it is in their Lemma "
-            f"inbox only. {result['undeliverable_reason'] or ''}".strip()
-        )
-    else:
-        message = (
-            "Delivery failed, but the notification exists and is in their Lemma "
-            f"inbox. {result['undeliverable_reason'] or ''}".strip()
-        )
-
     return MessageUserResponse(
         success=True,
+        message=_outcome(result, requested=request.channel),
         notification_id=result["notification_id"],
-        delivery_status=delivery_status,
+        delivery_status=result["delivery_status"],
         delivered_via=result["delivered_via"],
         undeliverable_reason=result["undeliverable_reason"],
-        message=message,
     )
 
 
@@ -210,6 +234,11 @@ async def list_pod_members(
     — so start here whenever you know a person by name. Each result carries a
     `to` value to pass straight through.
 
+    Also tells you `reachable_on`: the channels that can carry a message to each
+    person right now. Read it before setting `message_user`'s `channel`, and
+    don't ask for one that isn't listed — the send will be refused rather than
+    rerouted.
+
     Searches names and email addresses; omit `search` to list everyone.
     """
     deps = ctx.deps
@@ -224,6 +253,10 @@ async def list_pod_members(
         requester_user_id=deps.user_id,
         search=request.search,
         limit=request.limit,
+        # Whose reach to report. Same sentinel handling as message_user: the pod
+        # assistant is not a row in `agents`, and its surfaces are the ones with
+        # no agent of their own.
+        actor_agent_id=None if deps.is_pod_default_agent else deps.workload_id,
     )
     if result is None:
         return ListPodMembersResponse(

--- a/lemma-backend/app/modules/agent_surfaces/infrastructure/repositories/external_user_repository.py
+++ b/lemma-backend/app/modules/agent_surfaces/infrastructure/repositories/external_user_repository.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime, timezone
+from uuid import UUID
 
 from sqlalchemy import func, select, update
 from sqlalchemy.exc import IntegrityError
@@ -36,29 +38,38 @@ class ExternalSurfaceUserRepository:
         instance = result.scalar_one_or_none()
         return instance.to_entity() if instance else None
 
-    async def get_by_resolved_user(
+    async def list_by_resolved_users(
         self,
         *,
         platform: str,
-        resolved_user_id,
-    ) -> ExternalSurfaceUserEntity | None:
-        """Reverse lookup: the cached external identity for a Lemma user.
+        resolved_user_ids: Sequence[UUID],
+    ) -> list[ExternalSurfaceUserEntity]:
+        """Reverse lookup: cached external identities for Lemma users.
 
-        Used by ``surface.send`` to reach a pod member on a platform without a
-        prior inbound event in hand. Returns the most recently seen record.
+        Used by ``surface.send`` and notification delivery to reach a pod member
+        on a platform without a prior inbound event in hand.
+
+        Plural in both directions, and that is the point. One person can hold
+        several identities on one platform — Slack ids are per workspace, Teams
+        ids per tenant — and this used to return only the most recently *seen*
+        one. That is not the same as the one that can reach them on the surface
+        in hand: a pod with two Slack workspaces had one of them silently
+        unreachable, reported as "they have never messaged us". The caller holds
+        the surface and does the picking; this only supplies the candidates,
+        freshest first so that picking any of them is a defensible default.
         """
+        if not resolved_user_ids:
+            return []
         stmt = (
             select(AgentSurfaceExternalUser)
             .where(
                 AgentSurfaceExternalUser.platform == platform,
-                AgentSurfaceExternalUser.resolved_user_id == resolved_user_id,
+                AgentSurfaceExternalUser.resolved_user_id.in_(resolved_user_ids),
             )
             .order_by(AgentSurfaceExternalUser.last_seen_at.desc().nullslast())
-            .limit(1)
         )
         result = await self.session.execute(stmt)
-        instance = result.scalars().first()
-        return instance.to_entity() if instance else None
+        return [instance.to_entity() for instance in result.scalars().all()]
 
     async def upsert(
         self,

--- a/lemma-backend/app/modules/agent_surfaces/infrastructure/repositories/surface_repository.py
+++ b/lemma-backend/app/modules/agent_surfaces/infrastructure/repositories/surface_repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from typing import Any
 from uuid import UUID
@@ -424,29 +425,59 @@ class SurfaceConversationLinkRepository:
         (and its valid reply target) to reach a member proactively — bots can't
         cold-DM, so a prior interaction is required.
 
+        One member's slice of ``list_latest_by_surface_and_external_users``,
+        which owns the ordering — see there for why it is inbound recency.
+        """
+        links = await self.list_latest_by_surface_and_external_users(
+            surface_id=surface_id, external_user_ids=[external_user_id]
+        )
+        return links.get(external_user_id)
+
+    async def list_latest_by_surface_and_external_users(
+        self,
+        *,
+        surface_id: UUID,
+        external_user_ids: Sequence[str],
+    ) -> dict[str, AgentSurfaceConversationLink]:
+        """``{external_user_id: their most recent thread}`` on one surface.
+
         Ordered by inbound recency, not ``updated_at``: an outbound message also
         bumps ``updated_at``, so ranking by it would mean "the thread we last
         talked *at* them on" rather than "the thread they last talked to us on".
         Only the second is evidence of where they are actually looking. COALESCE
         keeps pre-migration rows, where the two were the same thing, in the sort.
+
+        DISTINCT ON picks per person in the database rather than dragging a busy
+        surface's whole history back to reduce it here. The single-member form
+        delegates to this one so a reachability check and the send that follows
+        it can never disagree about which thread is theirs.
         """
+        if not external_user_ids:
+            return {}
+        recency = func.coalesce(
+            AgentSurfaceConversationLinkModel.last_inbound_at,
+            AgentSurfaceConversationLinkModel.updated_at,
+        )
         stmt = (
             select(AgentSurfaceConversationLinkModel)
             .where(
                 AgentSurfaceConversationLinkModel.surface_id == surface_id,
-                AgentSurfaceConversationLinkModel.external_user_id == external_user_id,
+                AgentSurfaceConversationLinkModel.external_user_id.in_(
+                    external_user_ids
+                ),
             )
+            .distinct(AgentSurfaceConversationLinkModel.external_user_id)
             .order_by(
-                func.coalesce(
-                    AgentSurfaceConversationLinkModel.last_inbound_at,
-                    AgentSurfaceConversationLinkModel.updated_at,
-                ).desc()
+                AgentSurfaceConversationLinkModel.external_user_id,
+                recency.desc(),
             )
-            .limit(1)
         )
         result = await self.session.execute(stmt)
-        model = result.scalars().first()
-        return model.to_entity() if model else None
+        return {
+            link.external_user_id: link
+            for link in (model.to_entity() for model in result.scalars().all())
+            if link.external_user_id
+        }
 
     async def get_by_conversation_id(
         self,

--- a/lemma-backend/app/modules/agent_surfaces/services/notification_channels.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/notification_channels.py
@@ -11,6 +11,11 @@ through, so a recipient hears from the bot they already know that agent as. See
 ``notification_delivery.surfaces_for_agent`` for why that beats the recipient's
 own preferred surface.
 
+That ordering is a default, not a policy. An agent that names a ``channel`` gets
+that channel or a refusal — never a different one — because an agent picks a
+channel for reasons the router cannot see ("she is travelling, use WhatsApp"),
+and silently overriding it would leave the agent certain of something untrue.
+
 When an agent has no surface at all, one is minted here rather than the caller
 being told to go and connect something. That used to happen only when the *pod*
 had none, which left a hole big enough to break the pod assistant permanently:
@@ -34,11 +39,16 @@ from app.modules.agent_surfaces.services.email_surface_provisioning import (
     email_is_configured,
 )
 from app.modules.agent_surfaces.services.notification_delivery import (
+    EMAIL_CHANNEL,
     DeliveryChannel,
     UndeliverableReason,
+    channel_for_platform,
+    channel_refused,
+    channels_of,
     rank_candidates,
     reply_window_open,
     surfaces_for_agent,
+    surfaces_on_channel,
 )
 
 logger = get_logger(__name__)
@@ -86,10 +96,14 @@ class NotificationChannelResolver:
         actor_agent_id: UUID | None = None,
         origin_surface_id: UUID | None = None,
         agent_name: str | None = None,
+        channel: str | None = None,
     ) -> tuple[list[DeliveryChannel], str]:
         """Every way this agent can reach this person, best first.
 
         Returns the reason alongside, so an empty list is never a silent no.
+
+        ``channel`` narrows the whole thing to one channel the agent chose. It
+        is a filter, not a preference: nothing outside it is tried.
         """
         # ``list_by_pod`` is paginated and returns ``(items, next_cursor)``. A pod
         # with more surfaces than one page is not a real shape — they are bots a
@@ -97,6 +111,20 @@ class NotificationChannelResolver:
         all_surfaces, _ = await self.surfaces.list_by_pod(pod_id)
         active = [surface for surface in all_surfaces if surface.is_active]
         surfaces = surfaces_for_agent(active, actor_agent_id=actor_agent_id)
+
+        # Before provisioning, not after: a mailbox is what "reach them somehow"
+        # falls back to, and minting one to answer "reach them on Telegram" hands
+        # out an address nobody asked for and that then has to keep working.
+        if channel:
+            return await self._resolve_on_channel(
+                surfaces,
+                channel=channel,
+                pod_id=pod_id,
+                recipient_user_id=recipient_user_id,
+                actor_agent_id=actor_agent_id,
+                agent_name=agent_name,
+                origin_surface_id=origin_surface_id,
+            )
 
         if not surfaces:
             provisioned, reason = await self.provision_mailbox(
@@ -138,6 +166,99 @@ class NotificationChannelResolver:
         if saw_chat_surface:
             return [], UndeliverableReason.NEVER_INTERACTED
         return [], UndeliverableReason.NO_EMAIL_ADDRESS
+
+    async def _resolve_on_channel(
+        self,
+        surfaces: list[AgentSurfaceEntity],
+        *,
+        channel: str,
+        pod_id: UUID,
+        recipient_user_id: UUID,
+        actor_agent_id: UUID | None,
+        agent_name: str | None,
+        origin_surface_id: UUID | None,
+    ) -> tuple[list[DeliveryChannel], str]:
+        """This channel or nothing, with the refusal saying what would work.
+
+        No email fallback and no rerouting: both exist to rescue a router that
+        was guessing, and this one was told. The ranking still runs, because a
+        channel can hold several surfaces and the freshest thread is still the
+        best of them.
+        """
+        wanted = surfaces_on_channel(surfaces, channel=channel)
+        cause = ""
+        if not wanted and channel == EMAIL_CHANNEL:
+            # Asking for email is the one request worth minting a surface for:
+            # a mailbox is the only channel we can create on demand, and this is
+            # the same first-need provisioning the default path already does. A
+            # failure keeps its own reason — "the mail domain is unset" and "this
+            # agent has no mailbox" send you to different places.
+            provisioned, cause = await self.provision_mailbox(
+                pod_id, actor_agent_id, agent_name
+            )
+            wanted = [provisioned] if provisioned is not None else []
+
+        candidates, _, window_closed = await self._channels_from(
+            wanted, recipient_user_id
+        )
+        if candidates:
+            return rank_candidates(candidates, origin_surface_id=origin_surface_id), ""
+
+        return [], channel_refused(
+            channel,
+            cause=cause
+            or self._refusal_cause(channel, wanted=wanted, window_closed=window_closed),
+            alternatives=await self._reachable_elsewhere(
+                surfaces, channel=channel, recipient_user_id=recipient_user_id
+            ),
+        )
+
+    @staticmethod
+    def _refusal_cause(
+        channel: str, *, wanted: list[AgentSurfaceEntity], window_closed: bool
+    ) -> str:
+        """Which of the four ways a named channel fails this one was."""
+        if not wanted:
+            return UndeliverableReason.no_surface_on(channel)
+        if window_closed:
+            return UndeliverableReason.window_closed_on(channel)
+        if channel == EMAIL_CHANNEL:
+            return UndeliverableReason.no_address_on(channel)
+        return UndeliverableReason.never_interacted_on(channel)
+
+    async def _reachable_elsewhere(
+        self,
+        surfaces: list[AgentSurfaceEntity],
+        *,
+        channel: str,
+        recipient_user_id: UUID,
+    ) -> list[str]:
+        """The channels that would have worked, for the refusal to name.
+
+        Costs a second resolution pass, which is why it only runs once the
+        requested channel has already failed. A refusal that cannot say what to
+        do instead just moves the guessing into the model.
+        """
+        others = [
+            surface
+            for surface in surfaces
+            if channel_for_platform(surface.surface_type) != channel
+        ]
+        candidates, _, _ = await self._channels_from(others, recipient_user_id)
+        alternatives = channels_of(candidates)
+        # A mailbox this agent does not have yet still counts, because dropping
+        # the channel argument would mint one and the message would go. Saying
+        # "no other channel can reach them" there would talk an agent out of the
+        # one call that works.
+        if (
+            EMAIL_CHANNEL not in alternatives
+            and channel != EMAIL_CHANNEL
+            and email_is_configured()
+            and self.surface_provisioner is not None
+            and await self.membership.get_user_email(recipient_user_id)
+        ):
+            alternatives = sorted([*alternatives, EMAIL_CHANNEL])
+        return alternatives
 
     async def provision_mailbox(
         self,
@@ -247,32 +368,47 @@ class NotificationChannelResolver:
         the person has written to that surface before. ``window_closed`` is
         reported separately because "they went quiet too long ago" is a
         different thing to tell somebody than "they have never messaged us".
+
+        Every identity the person holds on the platform is tried, not just the
+        most recently seen one. Slack ids are per workspace and Teams ids per
+        tenant, so a pod with two Slack surfaces gives one person two identities
+        — and taking whichever was seen last made the other surface permanently
+        unreachable while reporting it as "they have never messaged us". The
+        surface's own tenant narrows the list first; that check is permissive
+        where the tenant was never recorded, so surfaces predating it keep
+        working.
         """
-        external = await self.external_users.get_by_resolved_user(
+        identities = await self.external_users.list_by_resolved_users(
             platform=surface.surface_type.value,
-            resolved_user_id=recipient_user_id,
+            resolved_user_ids=[recipient_user_id],
         )
-        if external is None or not external.external_user_id:
-            return None, False
-        link = await self.links.get_latest_by_surface_and_external_user(
-            surface_id=surface.id,
-            external_user_id=external.external_user_id,
-        )
-        if link is None:
-            return None, False
-        if not reply_window_open(
-            platform=surface.surface_type,
-            last_inbound_at=link.inbound_activity_at,
-        ):
-            return None, True
-        return (
-            DeliveryChannel(
-                surface=surface,
+        window_closed = False
+        for external in identities:
+            if not external.external_user_id:
+                continue
+            if not surface.matches_tenant(external.tenant_id):
+                continue
+            link = await self.links.get_latest_by_surface_and_external_user(
+                surface_id=surface.id,
                 external_user_id=external.external_user_id,
-                link=link,
-            ),
-            False,
-        )
+            )
+            if link is None:
+                continue
+            if not reply_window_open(
+                platform=surface.surface_type,
+                last_inbound_at=link.inbound_activity_at,
+            ):
+                window_closed = True
+                continue
+            return (
+                DeliveryChannel(
+                    surface=surface,
+                    external_user_id=external.external_user_id,
+                    link=link,
+                ),
+                False,
+            )
+        return None, window_closed
 
     async def _email_channel(
         self, surface: AgentSurfaceEntity, recipient_user_id: UUID
@@ -281,6 +417,83 @@ class NotificationChannelResolver:
         if not address:
             return None
         return DeliveryChannel(surface=surface, email_address=address)
+
+    async def reachable_channels(
+        self,
+        *,
+        pod_id: UUID,
+        recipients: dict[UUID, str | None],
+        actor_agent_id: UUID | None = None,
+    ) -> dict[UUID, list[str]]:
+        """Which channels this agent could reach each of these people on now.
+
+        The question an agent has to answer before it can sensibly *choose* a
+        channel. Without it, picking one is a guess that costs a refused send to
+        discover, and the guess would be wrong in exactly the case the argument
+        exists for.
+
+        Deliberately does not provision anything: a lookup that mints a mailbox
+        as a side effect hands out an address nobody asked for. Where email is
+        configured but the agent has no mailbox yet, email is still reported —
+        the send path would create one, so reporting otherwise would be a
+        forecast we know to be wrong. Emails come from the caller, which is
+        already holding the member list, rather than a lookup per person.
+        """
+        all_surfaces, _ = await self.surfaces.list_by_pod(pod_id)
+        active = [surface for surface in all_surfaces if surface.is_active]
+        surfaces = surfaces_for_agent(active, actor_agent_id=actor_agent_id)
+
+        reachable: dict[UUID, set[str]] = {user_id: set() for user_id in recipients}
+        can_mail = any(can_cold_open(surface) for surface in surfaces) or (
+            email_is_configured() and self.surface_provisioner is not None
+        )
+        if can_mail:
+            for user_id, email in recipients.items():
+                if email:
+                    reachable[user_id].add(EMAIL_CHANNEL)
+
+        for surface in surfaces:
+            if not can_cold_open(surface):
+                await self._add_chat_reach(surface, recipients, reachable)
+
+        return {user_id: sorted(names) for user_id, names in reachable.items()}
+
+    async def _add_chat_reach(
+        self,
+        surface: AgentSurfaceEntity,
+        recipients: dict[UUID, str | None],
+        reachable: dict[UUID, set[str]],
+    ) -> None:
+        """Add one chat surface's reach for everyone at once.
+
+        Two queries per surface rather than two per surface *per person*: this
+        runs on a tool the model calls before every message, and a pod of thirty
+        would otherwise spend a hundred round trips answering a lookup.
+        """
+        identities = await self.external_users.list_by_resolved_users(
+            platform=surface.surface_type.value,
+            resolved_user_ids=list(recipients),
+        )
+        owners = {
+            external.external_user_id: external.resolved_user_id
+            for external in identities
+            if external.external_user_id
+            and external.resolved_user_id in reachable
+            and surface.matches_tenant(external.tenant_id)
+        }
+        if not owners:
+            return
+
+        links = await self.links.list_latest_by_surface_and_external_users(
+            surface_id=surface.id, external_user_ids=list(owners)
+        )
+        channel = channel_for_platform(surface.surface_type)
+        for external_user_id, link in links.items():
+            if reply_window_open(
+                platform=surface.surface_type,
+                last_inbound_at=link.inbound_activity_at,
+            ):
+                reachable[owners[external_user_id]].add(channel)
 
 
 __all__ = ["NotificationChannelResolver", "SurfaceProvisioner", "can_cold_open"]

--- a/lemma-backend/app/modules/agent_surfaces/services/notification_delivery.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/notification_delivery.py
@@ -25,6 +25,11 @@ So the candidate set is the surfaces this agent serves, and the ordering is:
    has the notification. What must never happen is a silent nothing, so the
    reason travels with the result and reaches the API.
 
+An agent that has a reason to prefer one channel says so, and then the ranking
+above is not consulted at all: the request is honoured or it fails, never
+quietly rerouted. See :func:`surfaces_on_channel` and
+``NotificationChannelResolver._resolve_on_channel``.
+
 The recipient's own ``UserPreferences.default_surfaces`` deliberately plays no
 part here. It remains authoritative for *inbound* routing
 (``ingress_service._select_surface``), where the question is genuinely "which of
@@ -48,6 +53,72 @@ from app.modules.agent_surfaces.domain.entities import (
 from app.modules.agent_surfaces.platforms.platform_capabilities import (
     get_platform_capabilities,
 )
+
+
+# The name an agent uses for "reach them by mail", whichever provider carries it.
+EMAIL_CHANNEL = "email"
+
+
+def channel_for_platform(platform: SurfacePlatform) -> str:
+    """The channel name an agent uses for a platform.
+
+    Every mail platform collapses to ``email``. Which provider carries it is a
+    deployment detail — an agent asked to choose between "gmail" and "resend" is
+    being asked a question it has no way to answer, and whose answer it cannot
+    act on. Chat platforms keep their own name, because that name is the thing
+    the recipient is actually looking at.
+    """
+    capabilities = get_platform_capabilities(platform.value)
+    if capabilities is not None and capabilities.is_email:
+        return EMAIL_CHANNEL
+    return platform.value.lower()
+
+
+def channel_label(channel: str) -> str:
+    """How to name a channel inside a sentence — "WhatsApp", not "whatsapp"."""
+    if channel == EMAIL_CHANNEL:
+        return EMAIL_CHANNEL
+    capabilities = get_platform_capabilities(channel)
+    return capabilities.display_name if capabilities is not None else channel
+
+
+def surfaces_on_channel(
+    surfaces: list[AgentSurfaceEntity], *, channel: str
+) -> list[AgentSurfaceEntity]:
+    """The subset of an agent's surfaces that sit on one channel.
+
+    More than one is normal and is the reason this returns a list: an agent can
+    hold two Slack workspaces or two bots on the same platform, and "send it on
+    Slack" means any of them that can actually reach the person.
+    """
+    return [
+        surface
+        for surface in surfaces
+        if channel_for_platform(surface.surface_type) == channel
+    ]
+
+
+def channels_of(candidates: list["DeliveryChannel"]) -> list[str]:
+    """The distinct channels a resolved candidate set covers."""
+    return sorted({channel_for_platform(channel.platform) for channel in candidates})
+
+
+def channel_refused(channel: str, *, cause: str, alternatives: list[str]) -> str:
+    """Why a requested channel could not carry this, and what could instead.
+
+    Always ends by saying nothing was sent elsewhere. An agent that named a
+    channel had a reason for naming it, and quietly using another one leaves it
+    believing something happened that did not — which would make the argument
+    advisory in all but name. Naming the alternatives is what makes the refusal
+    actionable: send again on one of them, or tell the person why you did not.
+    """
+    if alternatives:
+        reachable = ", ".join(channel_label(name) for name in alternatives)
+        return f"{cause} Nothing was sent elsewhere; {reachable} would reach them."
+    return (
+        f"{cause} Nothing was sent elsewhere, and no other channel can reach "
+        "them either."
+    )
 
 
 class UndeliverableReason:
@@ -92,6 +163,30 @@ class UndeliverableReason:
         "The pod's only mailbox surface cannot start a new email thread. Ask "
         "them to email the pod address once, or connect a chat surface."
     )
+
+    # The four below take the channel the agent asked for. They are methods
+    # rather than constants because a refusal that does not name the channel
+    # reads as though routing failed, when what happened is that a specific
+    # request could not be met — a different thing to tell an agent, and a
+    # different thing for it to do next.
+    @staticmethod
+    def no_surface_on(channel: str) -> str:
+        return f"This agent has no {channel_label(channel)} surface to send from."
+
+    @staticmethod
+    def never_interacted_on(channel: str) -> str:
+        return (
+            f"They have not messaged this agent on {channel_label(channel)}, and "
+            "chat bots cannot start a conversation."
+        )
+
+    @staticmethod
+    def window_closed_on(channel: str) -> str:
+        return f"Their {channel_label(channel)} reply window has closed."
+
+    @staticmethod
+    def no_address_on(channel: str) -> str:
+        return f"No {channel_label(channel)} address is on file for this person."
 
 
 @dataclass(frozen=True)

--- a/lemma-backend/app/modules/agent_surfaces/services/notification_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/notification_service.py
@@ -141,6 +141,9 @@ class NotificationService:
         # The surface this run is answering on, when it is on one. Lets the
         # agent reach out from the same bot the person is already talking to.
         origin_surface_id: UUID | None = None,
+        # A channel the agent chose on purpose. Honoured or refused, never
+        # swapped: see ``notification_channels._resolve_on_channel``.
+        channel: str | None = None,
         actor_user_id: UUID | None = None,
         actor_agent_id: UUID | None = None,
         agent_name: str | None = None,
@@ -214,6 +217,7 @@ class NotificationService:
             agent_name=agent_name,
             actor_display_name=actor_display_name,
             origin_surface_id=origin_surface_id,
+            channel=channel,
         )
 
     # ---------------------------------------------------------------- delivery
@@ -225,6 +229,7 @@ class NotificationService:
         agent_name: str | None = None,
         actor_display_name: str | None = None,
         origin_surface_id: UUID | None = None,
+        channel: str | None = None,
     ) -> NotificationEntity:
         channels, fallback_reason = await self.resolve_channels(
             pod_id=notification.pod_id,
@@ -232,6 +237,7 @@ class NotificationService:
             actor_agent_id=notification.actor_agent_id,
             origin_surface_id=origin_surface_id,
             agent_name=agent_name,
+            channel=channel,
         )
         if not channels:
             notification.mark_undeliverable(fallback_reason)
@@ -333,6 +339,7 @@ class NotificationService:
         actor_agent_id: UUID | None = None,
         origin_surface_id: UUID | None = None,
         agent_name: str | None = None,
+        channel: str | None = None,
     ) -> tuple[list[DeliveryChannel], str]:
         """Every way *this agent* can reach this person, best first.
 
@@ -345,6 +352,19 @@ class NotificationService:
             actor_agent_id=actor_agent_id,
             origin_surface_id=origin_surface_id,
             agent_name=agent_name,
+            channel=channel,
+        )
+
+    async def reachable_channels(
+        self,
+        *,
+        pod_id: UUID,
+        recipients: dict[UUID, str | None],
+        actor_agent_id: UUID | None = None,
+    ) -> dict[UUID, list[str]]:
+        """``{user_id: channels}`` — what an agent can choose between, per person."""
+        return await self.channels.reachable_channels(
+            pod_id=pod_id, recipients=recipients, actor_agent_id=actor_agent_id
         )
 
     # --------------------------------------------------------------- lifecycle

--- a/lemma-backend/app/modules/agent_surfaces/services/surface_egress.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/surface_egress.py
@@ -115,19 +115,24 @@ class SurfaceEgressMixin(SurfaceEgressTargetMixin):
         external_user_repository = getattr(self, "external_user_repository", None)
         if external_user_repository is None:
             return False
-        ext = await external_user_repository.get_by_resolved_user(
-            platform=surface.surface_type.value, resolved_user_id=user_id
+        # Every identity they hold on this platform, not just the most recently
+        # seen one: Slack ids are per workspace and Teams ids per tenant, so
+        # taking one made a pod's second workspace unreachable. The surface's own
+        # tenant narrows the list, permissively where none was ever recorded.
+        identities = await external_user_repository.list_by_resolved_users(
+            platform=surface.surface_type.value, resolved_user_ids=[user_id]
         )
-        if ext is None or not ext.external_user_id:
-            return False
-        link = await self.conversation_link_repository.get_latest_by_surface_and_external_user(
-            surface_id=surface.id, external_user_id=ext.external_user_id
-        )
-        if link is None:
-            return False
-        return await self.send_agent_message_for_conversation(
-            conversation_id=link.conversation_id, message=message
-        )
+        for ext in identities:
+            if not ext.external_user_id or not surface.matches_tenant(ext.tenant_id):
+                continue
+            link = await self.conversation_link_repository.get_latest_by_surface_and_external_user(
+                surface_id=surface.id, external_user_id=ext.external_user_id
+            )
+            if link is not None:
+                return await self.send_agent_message_for_conversation(
+                    conversation_id=link.conversation_id, message=message
+                )
+        return False
 
     async def open_cold_email_thread(
         self,

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_ingress_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_ingress_service.py
@@ -2074,8 +2074,10 @@ async def test_send_to_member_reuses_existing_thread():
         get_user_pod_ids=AsyncMock(return_value=[surface.pod_id])
     )
     service.external_user_repository = AsyncMock(
-        get_by_resolved_user=AsyncMock(
-            return_value=SimpleNamespace(external_user_id=link.external_user_id)
+        list_by_resolved_users=AsyncMock(
+            return_value=[
+                SimpleNamespace(external_user_id=link.external_user_id, tenant_id=None)
+            ]
         )
     )
     service.conversation_link_repository.get_latest_by_surface_and_external_user = (
@@ -2124,8 +2126,8 @@ async def test_send_to_member_uses_requested_surface_latest_thread():
         get_user_pod_ids=AsyncMock(return_value=[surface.pod_id])
     )
     service.external_user_repository = AsyncMock(
-        get_by_resolved_user=AsyncMock(
-            return_value=SimpleNamespace(external_user_id="777")
+        list_by_resolved_users=AsyncMock(
+            return_value=[SimpleNamespace(external_user_id="777", tenant_id=None)]
         )
     )
     service.conversation_link_repository.get_latest_by_surface_and_external_user = (
@@ -2197,8 +2199,8 @@ async def test_send_to_member_does_not_confuse_system_and_custom_threads():
         )
     )
     service.external_user_repository = AsyncMock(
-        get_by_resolved_user=AsyncMock(
-            return_value=SimpleNamespace(external_user_id="777")
+        list_by_resolved_users=AsyncMock(
+            return_value=[SimpleNamespace(external_user_id="777", tenant_id=None)]
         )
     )
     service.conversation_link_repository.get_latest_by_surface_and_external_user = (
@@ -2256,8 +2258,8 @@ async def test_send_to_member_returns_false_without_reachable_thread():
         get_user_pod_ids=AsyncMock(return_value=[surface.pod_id])
     )
     service.external_user_repository = AsyncMock(
-        get_by_resolved_user=AsyncMock(
-            return_value=SimpleNamespace(external_user_id="U-MEMBER")
+        list_by_resolved_users=AsyncMock(
+            return_value=[SimpleNamespace(external_user_id="U-MEMBER", tenant_id=None)]
         )
     )
     service.conversation_link_repository.get_latest_by_surface_and_external_user = (

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_notification_domain.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_notification_domain.py
@@ -460,3 +460,96 @@ def test_an_agent_with_its_own_surface_does_not_borrow_the_pods():
     own.agent_id = agent_id
 
     assert surfaces_for_agent([pod_surface, own], actor_agent_id=agent_id) == [own]
+
+
+def test_every_mail_platform_is_one_email_channel():
+    """An agent choosing a channel must not be asked which mail vendor.
+
+    Gmail, Outlook and Resend are the same choice to the person receiving it —
+    mail — and which one carries it depends on what the deployment connected,
+    which no agent can reason about. Chat platforms keep their own name, because
+    that name *is* the thing the recipient is looking at.
+    """
+    from app.modules.agent_surfaces.services.notification_delivery import (
+        EMAIL_CHANNEL,
+        channel_for_platform,
+    )
+
+    assert {
+        channel_for_platform(platform)
+        for platform in (
+            SurfacePlatform.GMAIL,
+            SurfacePlatform.OUTLOOK,
+            SurfacePlatform.RESEND,
+        )
+    } == {EMAIL_CHANNEL}
+    assert channel_for_platform(SurfacePlatform.WHATSAPP) == "whatsapp"
+
+
+def test_the_tool_offers_exactly_the_channels_routing_can_produce():
+    """The agent's vocabulary and the router's, held together.
+
+    ``MessageChannel`` is declared in the agent module because the agent module
+    must not import ``agent_surfaces``. That leaves two lists that have to agree
+    and no compiler to make them, so this is the thing that makes them: a
+    platform the router can route to and the tool cannot name is unreachable,
+    and a name the tool offers that the router cannot produce is a value the
+    model will spend a refused send discovering.
+    """
+    from app.modules.agent.tools.messaging.models import MessageChannel
+    from app.modules.agent_surfaces.services.notification_delivery import (
+        channel_for_platform,
+    )
+
+    assert {channel.value for channel in MessageChannel} == {
+        channel_for_platform(platform) for platform in SurfacePlatform
+    }
+
+
+def test_a_channel_holds_every_surface_the_agent_has_on_that_platform():
+    """ "Send it on Slack" means any Slack bot that can reach them, not the first.
+
+    A pod with two workspaces has two Slack surfaces, and only one of them may
+    have a thread with this person.
+    """
+    from app.modules.agent_surfaces.services.notification_delivery import (
+        surfaces_on_channel,
+    )
+
+    workspace_a = _surface(SurfacePlatform.SLACK)
+    workspace_b = _surface(SurfacePlatform.SLACK)
+    mailbox = _surface(SurfacePlatform.RESEND)
+
+    assert surfaces_on_channel(
+        [workspace_a, mailbox, workspace_b], channel="slack"
+    ) == [workspace_a, workspace_b]
+    assert surfaces_on_channel([workspace_a, mailbox], channel="email") == [mailbox]
+
+
+def test_a_refusal_says_nothing_was_sent_elsewhere_and_what_would_have():
+    """Both halves matter, and they matter to different readers.
+
+    "Nothing was sent elsewhere" is what stops an agent believing a message
+    landed somewhere it did not. Naming the alternatives is what lets it do
+    something about that in the same turn instead of asking a person.
+    """
+    from app.modules.agent_surfaces.services.notification_delivery import (
+        UndeliverableReason,
+        channel_refused,
+    )
+
+    refused = channel_refused(
+        "whatsapp",
+        cause=UndeliverableReason.window_closed_on("whatsapp"),
+        alternatives=["email", "telegram"],
+    )
+    assert "WhatsApp reply window has closed" in refused
+    assert "Nothing was sent elsewhere" in refused
+    assert "email, Telegram would reach them" in refused
+
+    nowhere = channel_refused(
+        "telegram",
+        cause=UndeliverableReason.never_interacted_on("telegram"),
+        alternatives=[],
+    )
+    assert "no other channel can reach them either" in nowhere

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_notification_egress.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_notification_egress.py
@@ -397,7 +397,9 @@ def _notification_service(
     # surface into a deliverable channel and makes "they never messaged the bot"
     # untestable.
     external_users = create_autospec(ExternalSurfaceUserRepository, instance=True)
-    external_users.get_by_resolved_user.return_value = external_user
+    external_users.list_by_resolved_users.return_value = (
+        [external_user] if external_user is not None else []
+    )
 
     return NotificationService(
         uow=AsyncMock(),
@@ -760,7 +762,7 @@ async def test_a_chat_channel_does_not_spend_the_email_budget(monkeypatch):
     chat_surface = _surface_for(agent_id, SurfacePlatform.SLACK)
     service = _notification_service(
         surfaces=(chat_surface,),
-        external_user=SimpleNamespace(external_user_id="U123"),
+        external_user=SimpleNamespace(external_user_id="U123", tenant_id=None),
     )
     link = _link_for(chat_surface)
     service.channels.links.get_latest_by_surface_and_external_user = AsyncMock(
@@ -847,7 +849,7 @@ async def test_the_connection_is_released_before_the_platform_send(monkeypatch):
     chat_surface = _surface_for(agent_id, SurfacePlatform.SLACK)
     service = _notification_service(
         surfaces=(chat_surface,),
-        external_user=SimpleNamespace(external_user_id="U123"),
+        external_user=SimpleNamespace(external_user_id="U123", tenant_id=None),
     )
     link = _link_for(chat_surface)
     service.channels.links.get_latest_by_surface_and_external_user = AsyncMock(
@@ -876,3 +878,189 @@ async def test_the_connection_is_released_before_the_platform_send(monkeypatch):
     assert order.index("commit") < order.index("send"), (
         f"connection held across the send; call order was {order}"
     )
+
+
+# ------------------------------------------- the channel the agent chose
+
+
+def _identity(external_user_id: str, *, user_id=None):
+    """One cached platform identity. ``tenant_id`` is what scopes it."""
+    return SimpleNamespace(
+        external_user_id=external_user_id, tenant_id=None, resolved_user_id=user_id
+    )
+
+
+async def test_a_named_channel_beats_the_ranking_that_would_have_won():
+    """The whole point of the argument: the agent knows something we do not.
+
+    Left alone, chat outranks email and the Telegram thread wins — the right
+    default, because it is where they last spoke to us. An agent told "she is
+    off this week, put it in writing" has a reason that no signal in the
+    database carries, so naming a channel has to beat the ranking outright
+    rather than nudge it.
+    """
+    agent_id = uuid4()
+    chat = _surface_for(agent_id, SurfacePlatform.TELEGRAM)
+    mailbox = _surface_for(agent_id, SurfacePlatform.RESEND)
+    service = _notification_service(
+        surfaces=(chat, mailbox), external_user=_identity("U123")
+    )
+    service.channels.links.get_latest_by_surface_and_external_user = AsyncMock(
+        return_value=_link_for(chat)
+    )
+    recipient = uuid4()
+
+    by_default, _ = await service.resolve_channels(
+        pod_id=chat.pod_id, recipient_user_id=recipient, actor_agent_id=agent_id
+    )
+    chosen, reason = await service.resolve_channels(
+        pod_id=chat.pod_id,
+        recipient_user_id=recipient,
+        actor_agent_id=agent_id,
+        channel="email",
+    )
+
+    assert [c.surface.id for c in by_default] == [chat.id, mailbox.id]
+    assert reason == ""
+    assert [c.surface.id for c in chosen] == [mailbox.id]
+
+
+async def test_an_unreachable_named_channel_is_refused_not_rerouted():
+    """Sending it on email anyway would be worse than not sending it.
+
+    The agent asked for Telegram for a reason it does not restate, and it never
+    finds out the message went somewhere else — it reads DELIVERED and carries
+    on. So the send stops, and the refusal names both facts the agent needs:
+    that nothing went out, and what would have worked instead.
+    """
+    agent_id = uuid4()
+    chat = _surface_for(agent_id, SurfacePlatform.TELEGRAM)
+    mailbox = _surface_for(agent_id, SurfacePlatform.RESEND)
+    # Nobody has written to the bot, so there is no thread to reply into.
+    service = _notification_service(surfaces=(chat, mailbox))
+
+    channels, reason = await service.resolve_channels(
+        pod_id=chat.pod_id,
+        recipient_user_id=uuid4(),
+        actor_agent_id=agent_id,
+        channel="telegram",
+    )
+
+    assert channels == []
+    assert "have not messaged this agent on Telegram" in reason
+    assert "Nothing was sent elsewhere" in reason
+    assert "email would reach them" in reason
+
+
+async def test_asking_for_a_channel_the_agent_does_not_have_says_so():
+    """A different fix to a different person: connect one, or pick another."""
+    agent_id = uuid4()
+    service = _notification_service(
+        surfaces=(_surface_for(agent_id, SurfacePlatform.RESEND),)
+    )
+
+    channels, reason = await service.resolve_channels(
+        pod_id=uuid4(),
+        recipient_user_id=uuid4(),
+        actor_agent_id=agent_id,
+        channel="slack",
+    )
+
+    assert channels == []
+    assert "no Slack surface" in reason
+    assert "email would reach them" in reason
+
+
+async def test_asking_for_chat_mints_no_mailbox_but_still_offers_one(monkeypatch):
+    """Two halves of the same judgement about a pod that has no surface yet.
+
+    A mailbox is what "reach them somehow" falls back to. Minting one to answer
+    "reach them on Telegram" hands out an address nobody asked for, and an
+    address handed out is one that has to keep working forever. But the refusal
+    still has to name email, because dropping the argument *would* mint one and
+    the message would go — an agent told nothing can reach them gives up on
+    someone who was one argument away.
+    """
+    _email_configured(monkeypatch)
+    provisioner = AsyncMock(return_value=(_email_surface(), None))
+    service = _notification_service(provisioner=provisioner, surfaces=())
+
+    channels, reason = await service.resolve_channels(
+        pod_id=uuid4(),
+        recipient_user_id=uuid4(),
+        actor_agent_id=uuid4(),
+        channel="telegram",
+    )
+
+    assert channels == []
+    provisioner.assert_not_awaited()
+    assert "no Telegram surface" in reason
+    assert "email would reach them" in reason
+
+
+async def test_the_workspace_they_actually_use_is_found_among_their_identities():
+    """A pod with two Slack workspaces had one of them permanently unreachable.
+
+    Slack ids are per workspace, so this person is two rows, and delivery used
+    to take whichever was seen most recently and look for a thread under it. On
+    the other surface that id matches nothing — so the surface they are actively
+    chatting on yielded no channel, and the reason handed back said they had
+    never messaged us.
+    """
+    agent_id = uuid4()
+    seen_last = _surface_for(agent_id, SurfacePlatform.SLACK)
+    where_they_talk = _surface_for(agent_id, SurfacePlatform.SLACK)
+    service = _notification_service(surfaces=(seen_last, where_they_talk))
+    service.channels.external_users.list_by_resolved_users = AsyncMock(
+        # Freshest first, which is the order the repository returns.
+        return_value=[_identity("U-OTHER"), _identity("U-THEIRS")]
+    )
+    thread = AgentSurfaceConversationLink(
+        surface_id=where_they_talk.id,
+        conversation_id=uuid4(),
+        platform="SLACK",
+        external_thread_id="C1",
+        external_user_id="U-THEIRS",
+        last_inbound_at=datetime.now(timezone.utc),
+    )
+    service.channels.links.get_latest_by_surface_and_external_user = AsyncMock(
+        side_effect=lambda *, surface_id, external_user_id: (
+            thread
+            if surface_id == where_they_talk.id and external_user_id == "U-THEIRS"
+            else None
+        )
+    )
+
+    channels, reason = await service.resolve_channels(
+        pod_id=seen_last.pod_id, recipient_user_id=uuid4(), actor_agent_id=agent_id
+    )
+
+    assert reason == ""
+    assert [c.surface.id for c in channels] == [where_they_talk.id]
+
+
+async def test_reachability_says_what_the_agent_can_choose_between():
+    """What `list_pod_members` shows, so that choosing is a read not a guess.
+
+    Per person, because reachability is per person: the same agent can hold a
+    Telegram thread with one colleague and nothing but an address for another.
+    """
+    agent_id = uuid4()
+    chat = _surface_for(agent_id, SurfacePlatform.TELEGRAM)
+    mailbox = _surface_for(agent_id, SurfacePlatform.RESEND)
+    priya, bob = uuid4(), uuid4()
+    service = _notification_service(surfaces=(chat, mailbox))
+    service.channels.external_users.list_by_resolved_users = AsyncMock(
+        return_value=[_identity("U-PRIYA", user_id=priya)]
+    )
+    service.channels.links.list_latest_by_surface_and_external_users = AsyncMock(
+        return_value={"U-PRIYA": _link_for(chat)}
+    )
+
+    reach = await service.reachable_channels(
+        pod_id=chat.pod_id,
+        recipients={priya: "priya@example.com", bob: None},
+        actor_agent_id=agent_id,
+    )
+
+    assert reach == {priya: ["email", "telegram"], bob: []}

--- a/lemma-skills/lemma-builder/references/agent-tools.md
+++ b/lemma-skills/lemma-builder/references/agent-tools.md
@@ -79,6 +79,12 @@ interval, then calls `check_messages`. Compare:
 | `ask_user` | the person already in this conversation | yes | back in this run, as the tool's return |
 | `message_user` | any pod member, wherever they are | **no** | on the notification, read later with `check_messages` |
 
+By default it reaches someone wherever they last spoke to *this* agent, falling back to
+the agent's mailbox. An agent with a reason to choose passes `channel` — `email`, `slack`,
+`teams`, `telegram` or `whatsapp` — and a channel it names is used or refused, never
+swapped for another; `list_pod_members` reports each member's `reachable_on` so the choice
+is a read rather than a guess.
+
 `MESSAGING` is opt-in and withheld from sub-agents; holding it is the whole grant. Every
 delivered message names both the agent and the human whose authority the run carries — the
 recipient sees the pod's bot and extends it the trust they extend to Lemma, so an

--- a/tests/scenarios/harness/stack.py
+++ b/tests/scenarios/harness/stack.py
@@ -944,9 +944,9 @@ def refuse_to_take_a_deployments_bot() -> None:
         with urllib.request.urlopen(
             f"https://api.telegram.org/bot{token}/getWebhookInfo", timeout=15
         ) as answered:
-            registered = (
-                (_json.loads(answered.read()) or {}).get("result") or {}
-            ).get("url") or ""
+            registered = ((_json.loads(answered.read()) or {}).get("result") or {}).get(
+                "url"
+            ) or ""
     except Exception:  # noqa: BLE001 — an unreachable Telegram is not this check's business
         return
     if not registered:


### PR DESCRIPTION
## What changes

An agent can now say **where** a message goes. `message_user` takes a `channel` — `email`, `slack`, `teams`, `telegram` or `whatsapp` — and a channel it names is used or refused, never quietly swapped for another. Left unset, routing is exactly as it was: the surface the run is on, then the agent's other chat surfaces by freshest inbound, then its mailbox.

`list_pod_members` reports each member's `reachable_on`, so picking a channel is a read rather than a guess that costs a refused send to discover.

Underneath, a delivery bug is fixed: a pod with two Slack workspaces (or two Teams tenants) had one of them permanently unreachable, reported as "this person has not messaged any of the pod's chat surfaces".

## Why

Routing picks well on average and cannot pick well in the cases that matter — "she's travelling, use WhatsApp", "this needs to be on the record". Those are reasons no signal in the database carries.

The refusal-rather-than-reroute rule is the part worth arguing about. If a named channel silently fell back to another, the agent would read `DELIVERED`, believe the message went where it asked, and never learn otherwise — the argument would be advisory in all but name. So the send stops and the reason names what would have worked instead, which is what lets the agent act in the same turn rather than asking a person.

The identity bug is a prerequisite: without it, "send it on Slack" resolves against the wrong workspace's identity and reports the person unreachable. External identities are unique on `(platform, tenant_id, external_user_id)`, but the reverse lookup filtered on platform alone and returned the single most recently *seen* row — which is not the same as the one that can reach someone on the surface in hand.

## How to verify

```bash
cd lemma-backend && uv run pytest app/modules/agent_surfaces/tests/unit app/modules/agent/tests/unit -q
make quality
```

The first prints `2112 passed` (plus one pre-existing failure, `test_redis_store_enforces_atomic_state_and_claims`, which needs a local Redis and fails the same way on `main`). The second ends `✓ quality gates pass`.

To see the identity fix catch the old behaviour, make `_chat_channel` take only the first identity (`for external in identities[:1]:` in `notification_channels.py`) and run:

```bash
cd lemma-backend && uv run pytest app/modules/agent_surfaces/tests/unit/test_notification_egress.py -k workspace_they_actually_use -q
```

It fails with `assert 'This person ...mail surface.' == ''` — the misleading "never messaged us" reason, from a person who is actively chatting on that surface.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **API surface** — no HTTP surface changed; `agent_tool_schemas.json` regenerated, and the OpenAPI freshness check passes untouched
- [x] **Security** — no new authorization path. Pod membership still fails closed in `notify()`, and a named channel only narrows the surfaces the sending agent already holds; it can never reach one belonging to another agent
- [x] **Rollback** — plain revert, see below

## Compatibility and rollback notes

No migration. `channel` is optional and absent behaviour is byte-for-byte the old routing, so a revert costs nothing beyond agents losing the argument.

One repository method was renamed rather than added alongside: `ExternalSurfaceUserRepository.get_by_resolved_user` → `list_by_resolved_users`. It has two call sites, both updated, and leaving the old one in place would have left a method whose contract is the bug.

## Filed, not fixed

`DEV-SURF-004` — PS-SURF-023 promises that a person's chosen default surface is where the system reaches them *when it starts the contact*. Delivery has never read that preference, and the mechanism the promise names cannot express it: `default_surfaces` maps platform → surface id, to decide which pod answers on WhatsApp, not whether to use WhatsApp at all. This change widens the same gap — the sender can now name a channel and the recipient still cannot. It is a product decision, not a patch, so the promise is marked `gap` with a note rather than left green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
