### PR TITLE
Put the Telegram webhook back, and stop a local run taking a deployment's bot

### DIFF
--- a/tests/scenarios/harness/provision.py
+++ b/tests/scenarios/harness/provision.py
@@ -566,6 +566,8 @@ async def _standing_reach(holder: Person, pods: dict[str, JSON], ledger: Ledger)
         surfaces = {str(s.get("name")) for s in await holder.surfaces_in(pod)}
         if reach.name in surfaces:
             ledger.already(f"surface {reach.name!r} is on {reach.pod!r}")
+            if reach.platform == "TELEGRAM":
+                await _repair_telegram_reach(holder, pod, reach, ledger)
             continue
         account = await holder.account_for(
             reach.connector, in_organization=holder.organization
@@ -596,6 +598,59 @@ async def _standing_reach(holder: Person, pods: dict[str, JSON], ledger: Ledger)
             ledger.did(f"created surface {reach.name!r} on {reach.pod!r}")
         except Exception as exc:
             ledger.did(f"could not create surface {reach.name!r}: {_one_line(exc)}")
+
+
+async def _repair_telegram_reach(
+    holder: Person, pod: JSON, reach: Any, ledger: Ledger
+) -> None:
+    """Put the webhook back if the platform no longer has one.
+
+    A surface is only reachable while Telegram holds a webhook for its bot, and
+    that registration lives at Telegram rather than here — so anything that
+    calls `deleteWebhook` on that bot silently un-reaches the surface, and Lemma
+    has no way to notice. A run in polling mode against the same bot token does
+    exactly that; so does anyone clearing a webhook by hand.
+
+    What it looks like when it happens is worth writing down, because it reads
+    like a product failure: every scenario that messages the bot waits its full
+    timeout and reports that nothing came back. The messages are not lost, they
+    are queued at Telegram with nobody collecting them — `getWebhookInfo` shows
+    a rising `pending_update_count` and an empty `url`.
+
+    The product cannot repair this on its own: `_telegram_transition` registers
+    only when the surface becomes enabled or its binding changes, so a surface
+    that is already enabled and already has a secret is left alone however long
+    the platform has forgotten it. Off and on again is the smallest thing that
+    satisfies that rule, and it is idempotent — the check below is what stops it
+    happening on a run where nothing is wrong.
+    """
+    token = os.getenv("TELEGRAM_BOT_TOKEN", "").strip()
+    if not token:
+        return
+    try:
+        import httpx
+
+        async with httpx.AsyncClient(timeout=20.0) as client:
+            answered = await client.get(
+                f"https://api.telegram.org/bot{token}/getWebhookInfo"
+            )
+        registered = ((answered.json() or {}).get("result") or {}).get("url") or ""
+    except Exception as exc:  # noqa: BLE001 — a check that fails must not stop provisioning
+        ledger.did(f"could not ask Telegram about the webhook: {_one_line(exc)}")
+        return
+    if registered:
+        ledger.already(f"Telegram is delivering {reach.name!r} to {registered}")
+        return
+    try:
+        await holder.changes_surface(reach.name, in_pod=pod, is_enabled=False)
+        await holder.changes_surface(reach.name, in_pod=pod, is_enabled=True)
+    except Exception as exc:  # noqa: BLE001
+        ledger.did(f"could not re-register {reach.name!r}: {_one_line(exc)}")
+        return
+    ledger.did(
+        f"re-registered {reach.name!r} with Telegram — the platform had no "
+        f"webhook for this bot, so nothing was reaching the surface"
+    )
 
 
 async def _connect_telegram_bot(holder: Person, ledger: Ledger) -> JSON | None:

--- a/tests/scenarios/harness/stack.py
+++ b/tests/scenarios/harness/stack.py
@@ -908,9 +908,65 @@ def _migrate(python_bin: str, env: dict[str, str]) -> None:
         )
 
 
+def refuse_to_take_a_deployments_bot() -> None:
+    """Stop a local run from un-reaching a deployment's Telegram surface.
+
+    Polling and webhooks are exclusive at Telegram: a bot that starts polling
+    has its webhook deleted. So a stack booted with `SCENARIOS_TELEGRAM_POLLING`
+    and a bot token that some deployment is *also* using takes that bot away —
+    the deployment's surface stops receiving, silently, and neither side says
+    anything. Its scenarios then wait their full timeout and report that the
+    agent never answered, which reads as a product failure and is not one.
+
+    That is not hypothetical: it happened here, and the mistake that caused it
+    is easy to repeat. The two `.env` files held different bot tokens, so the
+    run looked safe — but the deployment's token had been exported into the
+    shell, and `_configured()` puts the environment *over* the file. Comparing
+    the files proved nothing about what the stack was actually handed.
+
+    So this asks Telegram instead of asking configuration: if the bot already
+    has a webhook, somebody else is being delivered to, and this run does not
+    get to take it.
+    """
+    if os.getenv("SCENARIOS_TELEGRAM_POLLING", "false").lower() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        return
+    token = _configured_or("TELEGRAM_BOT_TOKEN", "")
+    if not token:
+        return
+    try:
+        import json as _json
+        import urllib.request
+
+        with urllib.request.urlopen(
+            f"https://api.telegram.org/bot{token}/getWebhookInfo", timeout=15
+        ) as answered:
+            registered = (
+                (_json.loads(answered.read()) or {}).get("result") or {}
+            ).get("url") or ""
+    except Exception:  # noqa: BLE001 — an unreachable Telegram is not this check's business
+        return
+    if not registered:
+        return
+    raise StackError(
+        f"refusing to start: TELEGRAM_BOT_TOKEN names a bot that Telegram is "
+        f"already delivering to {registered}, and polling would delete that "
+        f"registration — leaving whichever deployment owns it unable to receive "
+        f"anything, with nothing to say why.\n\n"
+        f"Use a bot of your own for local runs. If the token came from your "
+        f"shell rather than from lemma-backend/.env, that is the usual cause: "
+        f"the environment wins over the file, so a run can be handed a "
+        f"deployment's bot without anyone choosing it."
+    )
+
+
 def start_stack():
     """Start everything and yield a :class:`Stack`. Generator, for a fixture."""
     require_docker()
+    refuse_to_take_a_deployments_bot()
 
     containers: list[str] = []
     processes: list[subprocess.Popen] = []


### PR DESCRIPTION
Every Telegram scenario on dev failed with the same sentence:

```
waited 120s for the agent to answer on Telegram (a real account on real
Telegram) and it never did. The message was delivered; nothing came back.
```

They were right that nothing came back, and wrong about why. Telegram held **no
webhook for that bot at all**, and seven of the suite's own messages were
sitting in `pending_update_count` with nobody collecting them:

```
getWebhookInfo -> url: (none)   pending_update_count: 7   last_error: -
```

**I caused it.** A local stack was booted with `SCENARIOS_TELEGRAM_POLLING=true`
and dev's bot token, and polling deletes the webhook. The mistake is worth
naming because it is easy to repeat: the two `.env` files held *different* bot
tokens, so the run looked safe — but the deployment's token had been exported
into the shell, and `_configured()` puts the environment **over** the file.
Comparing the files proved nothing about what the stack was actually handed.

## Repair

Provisioning asks Telegram whether the standing surface's bot has a webhook, and
re-registers by toggling the surface when it does not.

The product cannot repair this on its own, and that is not an oversight so much
as an unconsidered case — `_telegram_transition` registers when a surface
becomes enabled or its binding changes:

```python
register = is_enabled and (not was_enabled or binding_changed or not current.webhook_secret)
```

A surface that is already enabled and already holds a secret is left alone
however long the platform has forgotten it. Off and on again is the smallest
thing that satisfies that rule, and the `getWebhookInfo` check is what stops it
firing on a run where nothing is wrong.

This heals dev on its next run without anyone needing credentials by hand.

## Prevention

The stack now refuses to boot in polling mode against a bot Telegram is already
delivering somewhere, and names where:

```
refusing to start: TELEGRAM_BOT_TOKEN names a bot that Telegram is already
delivering to https://api.asur.work/surfaces/…/webhook, and polling would
delete that registration — leaving whichever deployment owns it unable to
receive anything, with nothing to say why.
```

It asks Telegram rather than asking configuration, deliberately: configuration
is exactly what was misleading.

## Verified

* the refusal fires, with the URL in the message
* it stays quiet when polling is off, and when the bot is unused
* all 86 harness-contract tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)