### PR TITLE
Split the 200s function file, drop the agent shard's image, and fix two flakes

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -19,3 +19,9 @@ paths-ignore:
   # editing, so findings would be noise no one can act on.
   - "lemma-python/lemma_sdk/openapi_client"
   - "lemma-typescript/src/openapi_client"
+  # Generated connector clients, for the same reason and at four times the
+  # scale: 3,222 files and 459k of the repository's 1.11M tracked Python lines
+  # sit under `lemma-connectors/src/lemma_connectors/*/generated/`, emitted by
+  # scripts/generate_*.py from each provider's OpenAPI document. Extracting them
+  # was roughly 40% of a six-minute Python analysis that no PR can act on.
+  - "**/generated"

--- a/.github/e2e-shards.json
+++ b/.github/e2e-shards.json
@@ -4,29 +4,51 @@
     "serial_seconds": 1558.5,
     "tests": 819,
     "directories": 14,
-    "files": 125
+    "files": 126
   },
   "shards": [
     {
       "name": "sandbox",
-      "args": "app/modules/function/tests/e2e app/modules/workspace/tests/e2e",
+      "args": "app/modules/function/tests/e2e app/modules/workspace/tests/e2e --ignore=app/modules/function/tests/e2e/test_function_e2e.py --ignore=app/modules/workspace/tests/e2e/test_sandbox_end_to_end.py --ignore=app/modules/workspace/tests/e2e/test_workspace_cli_concurrency_bench.py --ignore=app/modules/workspace/tests/e2e/test_workspace_durability_e2e.py",
       "workers": 1,
       "markers": "e2e and not slow and not provider and not local_cli and not indexing and not protected",
       "needs_sandbox_images": true,
-      "serial_seconds": 310.3,
-      "tests": 54,
-      "estimated_seconds": 444.3,
+      "serial_seconds": 154.4,
+      "tests": 27,
+      "estimated_seconds": 288.4,
       "why_serial": "real Docker sandbox provisioning contends for the runner's CPU"
     },
     {
-      "name": "agent",
-      "args": "app/modules/agent/tests/e2e",
+      "name": "sandbox-2",
+      "args": "app/modules/function/tests/e2e/test_function_e2e.py app/modules/workspace/tests/e2e/test_sandbox_end_to_end.py app/modules/workspace/tests/e2e/test_workspace_cli_concurrency_bench.py app/modules/workspace/tests/e2e/test_workspace_durability_e2e.py",
+      "workers": 1,
+      "markers": "e2e and not slow and not provider and not local_cli and not indexing and not protected",
+      "needs_sandbox_images": true,
+      "serial_seconds": 155.9,
+      "tests": 27,
+      "estimated_seconds": 289.9,
+      "why_serial": "real Docker sandbox provisioning contends for the runner's CPU"
+    },
+    {
+      "name": "agent-workspace",
+      "args": "app/modules/agent/tests/e2e/test_agent_hermetic_journeys_e2e.py app/modules/agent/tests/e2e/test_long_running_and_research_e2e.py",
       "workers": 1,
       "markers": "e2e and not slow and not workspace and not provider and not local_cli and not indexing and not protected",
       "needs_sandbox_images": true,
-      "serial_seconds": 192.7,
-      "tests": 123,
-      "estimated_seconds": 326.7,
+      "serial_seconds": 99.2,
+      "tests": 27,
+      "estimated_seconds": 233.2,
+      "why_serial": "provisions a real Docker workspace, same CPU contention as sandbox"
+    },
+    {
+      "name": "agent",
+      "args": "app/modules/agent/tests/e2e --ignore=app/modules/agent/tests/e2e/test_agent_hermetic_journeys_e2e.py --ignore=app/modules/agent/tests/e2e/test_long_running_and_research_e2e.py",
+      "workers": 1,
+      "markers": "e2e and not slow and not workspace and not provider and not local_cli and not indexing and not protected",
+      "needs_sandbox_images": false,
+      "serial_seconds": 93.5,
+      "tests": 96,
+      "estimated_seconds": 205.5,
       "why_serial": "MEASURED 2026-08-22: xdist coverage race disproven, but the per-run spread is 0.4pt against a 0.2pt bar -- re-measure before raising"
     },
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,14 @@ jobs:
             lemma-backend/coverage-backend/summary.json
             lemma-backend/coverage-backend/coverage.json
             lemma-backend/coverage-backend/coverage.xml
+            # `make coverage-backend-unit` has always written this and nothing
+            # has ever collected it, so the unit lane's slow tail is invisible
+            # -- 195 seconds with no way to see whether that is a broad spread
+            # or three slow tests, which is the difference between needing
+            # per-worker database isolation for xdist and needing to split
+            # three tests. The e2e shards upload theirs and get a slowest-tests
+            # summary out of it; this is the same line.
+            lemma-backend/coverage-backend/junit-*.xml
             lemma-backend/coverage-backend/html
           if-no-files-found: ignore
   backend-lint:

--- a/lemma-backend/app/modules/function/tests/e2e/test_function_e2e.py
+++ b/lemma-backend/app/modules/function/tests/e2e/test_function_e2e.py
@@ -1,86 +1,58 @@
+"""Function shape: lifecycle, authorization, and datastore writes.
+
+The runtime journeys -- queueing, concurrency, timeouts, cancellation and
+connector operations -- are in `test_function_execution_e2e.py`. The two were
+one 200-second file, which was the floor for the whole Backend E2E workflow:
+the shard planner could not split a file, and `--dist loadscope` groups a
+module's functions onto one xdist worker, so no worker count could either.
+Halves land on separate runners.
+
+The line is what a test is *about*. Everything here is a claim about a
+function's shape or who may touch it, and reaches the sandbox only far enough
+to prove the claim.
+"""
+
 from __future__ import annotations
 
-import asyncio
 import time
-from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
 from fastapi import status
 
-from app.modules.connectors.infrastructure.models.account import Account
-from app.modules.connectors.infrastructure.models.auth_config import AuthConfig
-from app.modules.connectors.infrastructure.models.connector import Connector
-from app.modules.connectors.infrastructure.models.connector_operation import (
-    ConnectorOperation,
+from app.modules.test_support.e2e.function_helpers import (
+    bulk_facade_function_code,
+    create_folder,
+    create_function,
+    create_table,
+    function_payload,
+    record_grant_function_code,
+    replace_function_resource_grants,
+    replace_role_resource_grants,
+    run_function,
+    typed_function_code,
+    wait_for_run_completion,
 )
-from app.modules.identity.infrastructure.models.user_models import User
-from app.modules.test_support.e2e.waiters import eventually, wait_for_status
 from app.modules.test_support.e2e_authz import (
     create_role_visibility_context,
     item_names,
 )
 
-# `usefixtures` is deliberately NOT here. At module scope it made all 29 tests
-# boot a uvicorn backend server and a local sandbox server, including the four
+# `usefixtures` is deliberately NOT here. At module scope it made every test
+# boot a uvicorn backend server and a local sandbox server, including the ones
 # that never supply `code` and only assert status codes -- the duplicate-name
 # check measured 18.8s in CI to prove a 409. It is applied per test below, to
 # the ones that actually reach the runtime.
 #
 # `workspace` stays at module scope: it is what the sandbox shard's marker
-# filter selects on, and moving it would change which shard these run in.
+# filter selects on, and moving it would change which shard these run in. Both
+# halves of the split carry it for that reason, and a contract test
+# (test_workspace_marked_files_are_routed_consistently_within_a_directory)
+# fails if they ever disagree.
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.workspace,
 ]
-
-
-async def _wait_for_run_completion(
-    authenticated_client,
-    pod_id: str,
-    function_name: str,
-    run_id: str,
-    timeout_seconds: int = 60,
-):
-    async def probe() -> dict:
-        res = await authenticated_client.get(
-            f"/pods/{pod_id}/functions/{function_name}/runs/{run_id}"
-        )
-        assert res.status_code == status.HTTP_200_OK, res.text
-        return res.json()
-
-    # failed=set(): several callers (e.g. the API-timeout test) legitimately
-    # wait FOR a "FAILED" terminus and assert on it themselves afterward --
-    # preserve the original loop's behavior of returning on either terminal
-    # status rather than fail-fasting on FAILED.
-    return await wait_for_status(
-        label=f"function {function_name} run {run_id}",
-        probe=probe,
-        expected={"COMPLETED", "FAILED"},
-        failed=set(),
-        timeout_seconds=timeout_seconds,
-        interval_seconds=0.15,
-    )
-
-
-async def _create_function(authenticated_client, pod_id: str, payload: dict) -> dict:
-    response = await authenticated_client.post(
-        f"/pods/{pod_id}/functions",
-        json=payload,
-        follow_redirects=True,
-    )
-    assert response.status_code == status.HTTP_201_CREATED, response.text
-    return response.json()
-
-
-def _function_payload(name: str, visibility: str | None = None) -> dict:
-    payload = {
-        "name": name,
-        "description": "Function visibility e2e",
-    }
-    if visibility is not None:
-        payload["visibility"] = visibility
-    return payload
 
 
 @pytest.mark.asyncio
@@ -93,284 +65,18 @@ async def test_create_function_rejects_duplicate_name_in_same_pod(
 
     first = await authenticated_client.post(
         f"/pods/{pod_id}/functions",
-        json=_function_payload(function_name),
+        json=function_payload(function_name),
         follow_redirects=True,
     )
     assert first.status_code == status.HTTP_201_CREATED, first.text
 
     second = await authenticated_client.post(
         f"/pods/{pod_id}/functions",
-        json=_function_payload(function_name),
+        json=function_payload(function_name),
         follow_redirects=True,
     )
     assert second.status_code == status.HTTP_409_CONFLICT, second.text
     assert second.json()["code"] == "FUNCTION_CONFLICT"
-
-
-async def _run_function(
-    authenticated_client,
-    pod_id: str,
-    function_name: str,
-    input_data: dict,
-    *,
-    expected_status: str = "COMPLETED",
-) -> dict:
-    response = await authenticated_client.post(
-        f"/pods/{pod_id}/functions/{function_name}/runs",
-        json={"input_data": input_data},
-        follow_redirects=True,
-    )
-    assert response.status_code == status.HTTP_200_OK, response.text
-    run_id = response.json()["id"]
-    final_run = await _wait_for_run_completion(
-        authenticated_client,
-        pod_id,
-        function_name,
-        run_id,
-    )
-    assert final_run["status"] == expected_status, {
-        "status": final_run["status"],
-        "error": final_run.get("error"),
-        "run_id": final_run["id"],
-    }
-    return final_run
-
-
-async def _create_table(
-    authenticated_client,
-    pod_id: str,
-    table_name: str,
-    *,
-    visibility: str | None = None,
-    enable_rls: bool = True,
-) -> dict:
-    payload = {
-        "name": table_name,
-        "primary_key_column": "id",
-        "enable_rls": enable_rls,
-        "columns": [
-            {"name": "id", "type": "UUID", "required": True, "auto": True},
-            {"name": "title", "type": "TEXT", "required": True},
-            {"name": "note", "type": "TEXT", "required": False},
-        ],
-    }
-    if visibility is not None:
-        payload["visibility"] = visibility
-    response = await authenticated_client.post(
-        f"/pods/{pod_id}/datastore/tables",
-        json=payload,
-    )
-    assert response.status_code == status.HTTP_201_CREATED, response.text
-    return response.json()
-
-
-async def _create_folder(
-    authenticated_client,
-    pod_id: str,
-    path: str,
-    *,
-    visibility: str | None = None,
-) -> dict:
-    payload = {"path": path}
-    if visibility is not None:
-        payload["visibility"] = visibility
-    response = await authenticated_client.post(
-        f"/pods/{pod_id}/datastore/files/folders",
-        json=payload,
-    )
-    assert response.status_code == status.HTTP_201_CREATED, response.text
-    return response.json()
-
-
-async def _replace_role_resource_grants(
-    authenticated_client,
-    pod_id: str,
-    role_name: str,
-    grants: list[dict],
-) -> dict:
-    response = await authenticated_client.put(
-        f"/pods/{pod_id}/roles/{role_name}/permissions",
-        json={"grants": grants},
-    )
-    assert response.status_code == status.HTTP_200_OK, response.text
-    return response.json()
-
-
-async def _replace_function_resource_grants(
-    authenticated_client,
-    pod_id: str,
-    function_name: str,
-    grants: list[dict],
-) -> dict:
-    response = await authenticated_client.put(
-        f"/pods/{pod_id}/functions/{function_name}/permissions",
-        json={"grants": grants},
-    )
-    assert response.status_code == status.HTTP_200_OK, response.text
-    return response.json()
-
-
-async def _seed_connector_operation(
-    db_session,
-    *,
-    connector_id: str,
-    organization_id: str,
-    user_id=None,
-    api_key: str | None = None,
-):
-    app = await db_session.get(Connector, connector_id)
-    if app is None:
-        app = Connector(
-            id=connector_id,
-            title=f"{connector_id} title",
-            description="Mock app for function e2e",
-            kinds=[
-                {
-                    "kind": "package",
-                    "auth_scheme": "API_KEY",
-                    "system_default_available": True,
-                }
-            ],
-            is_active=True,
-        )
-        db_session.add(app)
-
-    auth_config = AuthConfig(
-        id=uuid4(),
-        organization_id=organization_id,
-        connector_id=connector_id,
-        name=connector_id,
-        kind="package",
-        config_source="SYSTEM_DEFAULT",
-        status="ACTIVE",
-    )
-    db_session.add(auth_config)
-
-    operation = await db_session.get(
-        ConnectorOperation,
-        f"{connector_id}:send_payload",
-    )
-    if operation is None:
-        db_session.add(
-            ConnectorOperation(
-                id=f"{connector_id}:send_payload",
-                connector_id=connector_id,
-                name="send_payload",
-                provider_operation_name="send_payload",
-                display_name="Send Payload",
-                description="Mock send payload operation",
-                input_schema={
-                    "type": "object",
-                    "properties": {
-                        "message": {"type": "string"},
-                        "caller_user_id": {"type": "string"},
-                    },
-                    "required": ["message", "caller_user_id"],
-                },
-                output_schema={
-                    "type": "object",
-                    "properties": {
-                        "echoed_message": {"type": "string"},
-                        "used_api_key": {"type": "string"},
-                    },
-                    "required": ["echoed_message", "used_api_key"],
-                },
-            )
-        )
-
-    account = None
-    if user_id is not None:
-        account = Account(
-            id=uuid4(),
-            connector_id=connector_id,
-            organization_id=organization_id,
-            auth_config_id=auth_config.id,
-            user_id=user_id,
-            credentials={"api_key": api_key},
-        )
-        db_session.add(account)
-    await db_session.commit()
-    return account
-
-
-async def _seed_user(db_session):
-    user = User(
-        id=uuid4(),
-        email=f"function-e2e-{uuid4().hex[:12]}@example.test",
-        is_verified=True,
-        is_active=True,
-    )
-    db_session.add(user)
-    await db_session.commit()
-    return user
-
-
-def _connector_function_code(
-    function_name: str,
-    connector_id: str,
-    *,
-    account_id: str | None = None,
-) -> str:
-    account_id_argument = f',\n        account_id="{account_id}"' if account_id else ""
-    return f"""#input_type_name: SendPayloadInput
-#output_type_name: SendPayloadResult
-#function_name: {function_name}
-
-from pydantic import BaseModel
-from lemma_sdk import FunctionContext, Pod
-
-class SendPayloadInput(BaseModel):
-    message: str
-
-class SendPayloadResult(BaseModel):
-    echoed_message: str
-    used_api_key: str
-    caller_user_id: str
-
-async def {function_name}(ctx: FunctionContext, data: SendPayloadInput) -> SendPayloadResult:
-    pod = Pod.from_env()
-    response = pod.connectors.execute(
-        "{connector_id}",
-        "send_payload",
-        {{
-            "message": data.message,
-            "caller_user_id": str(ctx.user_id),
-        }}{account_id_argument},
-    )
-    result = response.result
-    return SendPayloadResult(
-        echoed_message=result["echoed_message"],
-        used_api_key=result["used_api_key"],
-        caller_user_id=result["caller_user_id"],
-    )"""
-
-
-def _patch_connector_operation_execution(connector_id: str):
-    expected_connector_id = connector_id
-
-    async def fake_execute_operation(
-        _self,
-        connector_id,
-        operation_name,
-        payload,
-        third_party_credentials,
-        auth_token=None,
-        api_url=None,
-    ):
-        del auth_token, api_url
-        assert connector_id == expected_connector_id
-        assert operation_name == "send_payload"
-        return {
-            "echoed_message": payload["message"],
-            "used_api_key": third_party_credentials["api_key"],
-            "caller_user_id": payload["caller_user_id"],
-        }
-
-    return patch(
-        "app.modules.connectors.infrastructure.adapters.lemma_operation_gateway."
-        "LemmaOperationGateway.execute_operation",
-        new=fake_execute_operation,
-    )
 
 
 @pytest.mark.asyncio
@@ -395,7 +101,7 @@ class UppercaseResult(BaseModel):
 async def {func_name}(ctx: FunctionContext, data: UppercaseInput) -> UppercaseResult:
     return UppercaseResult(result=data.text.upper())"""
 
-    func = await _create_function(
+    func = await create_function(
         authenticated_client,
         pod_id,
         {
@@ -447,18 +153,16 @@ async def test_function_list_and_access_respects_pod_roles(
     editor_name = f"editor_func_{uuid4().hex[:8]}"
     custom_name = f"custom_func_{uuid4().hex[:8]}"
 
-    await _create_function(
-        authenticated_client, pod_id, _function_payload(default_name)
-    )
-    await _create_function(
+    await create_function(authenticated_client, pod_id, function_payload(default_name))
+    await create_function(
         authenticated_client,
         pod_id,
-        _function_payload(editor_name, "RESTRICTED"),
+        function_payload(editor_name, "RESTRICTED"),
     )
-    await _create_function(
+    await create_function(
         authenticated_client,
         pod_id,
-        _function_payload(custom_name, "RESTRICTED"),
+        function_payload(custom_name, "RESTRICTED"),
     )
 
     editor_function = await authenticated_client.get(
@@ -606,13 +310,13 @@ async def test_function_execution_datastore_and_file_round_trip(
     table_name = f"expenses_{suffix}"
     folder_path = f"/function-grants-{suffix}"
 
-    table = await _create_table(
+    table = await create_table(
         authenticated_client,
         pod_id,
         table_name,
         visibility="RESTRICTED",
     )
-    folder = await _create_folder(
+    folder = await create_folder(
         authenticated_client,
         pod_id,
         folder_path,
@@ -668,7 +372,7 @@ async def {function_name}(ctx: FunctionContext, data: SaveExpenseInput) -> SaveE
         caller_user_email=ctx.user_email,
     )"""
 
-    function = await _create_function(
+    function = await create_function(
         authenticated_client,
         pod_id,
         {
@@ -696,20 +400,20 @@ async def {function_name}(ctx: FunctionContext, data: SaveExpenseInput) -> SaveE
         },
     ]
     grants = [function_self_grant, *table_and_folder_grants]
-    await _replace_role_resource_grants(
+    await replace_role_resource_grants(
         authenticated_client,
         pod_id,
         "POD_ADMIN",
         grants,
     )
-    await _replace_function_resource_grants(
+    await replace_function_resource_grants(
         authenticated_client,
         pod_id,
         function_name,
         [function_self_grant],
     )
 
-    denied_run = await _run_function(
+    denied_run = await run_function(
         authenticated_client,
         pod_id,
         function_name,
@@ -718,14 +422,14 @@ async def {function_name}(ctx: FunctionContext, data: SaveExpenseInput) -> SaveE
     )
     assert denied_run["error"]
 
-    await _replace_function_resource_grants(
+    await replace_function_resource_grants(
         authenticated_client,
         pod_id,
         function_name,
         grants,
     )
 
-    final_run = await _run_function(
+    final_run = await run_function(
         authenticated_client,
         pod_id,
         function_name,
@@ -763,59 +467,6 @@ async def {function_name}(ctx: FunctionContext, data: SaveExpenseInput) -> SaveE
     assert download_response.text == "airport pickup"
 
 
-def _record_grant_function_code(function_name: str, table_name: str) -> str:
-    """Function body that writes a record and reads it back.
-
-    Data-access failures are caught and surfaced as structured output so the
-    test can assert on the real HTTP status/code instead of an opaque run
-    failure. Reads/writes are gated by record permissions only.
-    """
-    # Uses typing.Optional on purpose: under Python 3.14 (PEP 649) deferred
-    # annotations, schema extraction must resolve typing names from the
-    # function's namespace, not just builtins. This guards the sandbox runtime's
-    # fix that registers the execution namespace as a real module.
-    return f"""#input_type_name: WriteInput
-#output_type_name: WriteResult
-#function_name: {function_name}
-
-from typing import Optional
-from pydantic import BaseModel
-from lemma_sdk import FunctionContext, Pod
-from lemma_sdk.errors import LemmaAPIError
-
-class WriteInput(BaseModel):
-    title: str
-    note: str
-
-class WriteResult(BaseModel):
-    denied: bool
-    status_code: Optional[int] = None
-    error_code: Optional[str] = None
-    record_id: Optional[str] = None
-    read_title: Optional[str] = None
-
-async def {function_name}(ctx: FunctionContext, data: WriteInput) -> WriteResult:
-    pod = Pod.from_env()
-    try:
-        record = pod.table("{table_name}").create(
-            {{"title": data.title, "note": data.note}}
-        )
-    except LemmaAPIError as exc:
-        return WriteResult(
-            denied=True,
-            status_code=exc.status_code,
-            error_code=exc.code,
-        )
-    row = record
-    fetched = pod.table("{table_name}").get(str(row["id"]))
-    read_row = fetched
-    return WriteResult(
-        denied=False,
-        record_id=str(row["id"]),
-        read_title=str(read_row["title"]),
-    )"""
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "function_type,enable_rls",
@@ -842,21 +493,21 @@ async def test_function_record_write_honors_record_grants_for_all_table_types(
     function_name = f"rec_writer_{suffix}"
     table_name = f"sync_runs_{suffix}"
 
-    await _create_table(
+    await create_table(
         authenticated_client,
         pod_id,
         table_name,
         enable_rls=enable_rls,
     )
 
-    await _create_function(
+    await create_function(
         authenticated_client,
         pod_id,
         {
             "name": function_name,
             "description": "Record write grant matrix",
             "type": function_type,
-            "code": _record_grant_function_code(function_name, table_name),
+            "code": record_grant_function_code(function_name, table_name),
         },
     )
 
@@ -867,14 +518,14 @@ async def test_function_record_write_honors_record_grants_for_all_table_types(
     }
 
     # No table grant at all -> the data call must fail with a real 403.
-    await _replace_function_resource_grants(
+    await replace_function_resource_grants(
         authenticated_client,
         pod_id,
         function_name,
         [function_self_grant],
     )
 
-    denied_run = await _run_function(
+    denied_run = await run_function(
         authenticated_client,
         pod_id,
         function_name,
@@ -889,7 +540,7 @@ async def test_function_record_write_honors_record_grants_for_all_table_types(
 
     # Grant record read/write (plus table.read for metadata). Notably NOT
     # table.update: data access is governed by record permissions only.
-    await _replace_function_resource_grants(
+    await replace_function_resource_grants(
         authenticated_client,
         pod_id,
         function_name,
@@ -907,7 +558,7 @@ async def test_function_record_write_honors_record_grants_for_all_table_types(
         ],
     )
 
-    granted_run = await _run_function(
+    granted_run = await run_function(
         authenticated_client,
         pod_id,
         function_name,
@@ -926,59 +577,6 @@ async def test_function_record_write_honors_record_grants_for_all_table_types(
     assert payload["total"] == 1
     assert payload["items"][0]["id"] == output["record_id"]
     assert payload["items"][0]["title"] == "granted"
-
-
-def _bulk_facade_function_code(function_name: str, table_name: str) -> str:
-    """A function that writes a realistic number of rows the way one should.
-
-    Every call here goes through ``pod.table(...)``, which until now had no
-    batch path at all -- ``list/create/get/update/delete`` and nothing else. A
-    caller holding a table handle therefore wrote N rows as N ``create`` calls,
-    and from inside a sandbox each one is a full round trip back to the API. A
-    benchmark probe did exactly that and spent 17 of its 17.3 seconds on them.
-    """
-    return f"""#input_type_name: BulkInput
-#output_type_name: BulkResult
-#function_name: {function_name}
-
-from pydantic import BaseModel
-from lemma_sdk import FunctionContext, Pod
-
-class BulkInput(BaseModel):
-    rows: int
-
-class BulkResult(BaseModel):
-    created: int
-    updated: int
-    deleted: int
-    upserted: int
-    first_id: str
-    retitled: str
-
-async def {function_name}(ctx: FunctionContext, data: BulkInput) -> BulkResult:
-    pod = Pod.from_env()
-    t = pod.table("{table_name}")
-
-    created = t.bulk_create(
-        [{{"title": f"row-{{index}}", "note": "seed"}} for index in range(data.rows)]
-    )
-    rows = t.list(limit=data.rows).to_dict()["items"]
-    ids = sorted(str(row["id"]) for row in rows)
-
-    updated = t.bulk_update([{{"id": ids[0], "title": "renamed"}}])
-    # An upsert on an existing primary key must update, not fail the request --
-    # this is what makes re-seeding idempotent.
-    upserted = t.bulk_create([{{"id": ids[1], "title": "upserted"}}], upsert=True)
-    deleted = t.bulk_delete(ids[-2:])
-
-    return BulkResult(
-        created=created,
-        updated=updated,
-        deleted=deleted,
-        upserted=upserted,
-        first_id=ids[0],
-        retitled=str(t.get(ids[0])["title"]),
-    )"""
 
 
 @pytest.mark.asyncio
@@ -1000,18 +598,18 @@ async def test_a_function_writes_many_rows_through_the_table_facade(
     table_name = f"bulk_rows_{suffix}"
     rows = 50
 
-    await _create_table(authenticated_client, pod_id, table_name, enable_rls=False)
-    await _create_function(
+    await create_table(authenticated_client, pod_id, table_name, enable_rls=False)
+    await create_function(
         authenticated_client,
         pod_id,
         {
             "name": function_name,
             "description": "Batch writes through the bound table helper",
             "type": "API",
-            "code": _bulk_facade_function_code(function_name, table_name),
+            "code": bulk_facade_function_code(function_name, table_name),
         },
     )
-    await _replace_function_resource_grants(
+    await replace_function_resource_grants(
         authenticated_client,
         pod_id,
         function_name,
@@ -1033,7 +631,7 @@ async def test_a_function_writes_many_rows_through_the_table_facade(
         ],
     )
 
-    run = await _run_function(
+    run = await run_function(
         authenticated_client, pod_id, function_name, {"rows": rows}
     )
     output = run["output_data"]
@@ -1073,21 +671,21 @@ async def test_function_record_write_requires_record_write_not_table_update(
     function_name = f"rec_writer_perm_{suffix}"
     table_name = f"shared_log_{suffix}"
 
-    await _create_table(
+    await create_table(
         authenticated_client,
         pod_id,
         table_name,
         enable_rls=False,
     )
 
-    await _create_function(
+    await create_function(
         authenticated_client,
         pod_id,
         {
             "name": function_name,
             "description": "record write requires record.write",
             "type": "JOB",
-            "code": _record_grant_function_code(function_name, table_name),
+            "code": record_grant_function_code(function_name, table_name),
         },
     )
 
@@ -1098,7 +696,7 @@ async def test_function_record_write_requires_record_write_not_table_update(
     }
 
     # Schema permissions only (table.read + table.update), no record.write.
-    await _replace_function_resource_grants(
+    await replace_function_resource_grants(
         authenticated_client,
         pod_id,
         function_name,
@@ -1115,7 +713,7 @@ async def test_function_record_write_requires_record_write_not_table_update(
         ],
     )
 
-    denied_run = await _run_function(
+    denied_run = await run_function(
         authenticated_client,
         pod_id,
         function_name,
@@ -1129,7 +727,7 @@ async def test_function_record_write_requires_record_write_not_table_update(
     )
 
     # Swap table.update for record.write -> the write now succeeds.
-    await _replace_function_resource_grants(
+    await replace_function_resource_grants(
         authenticated_client,
         pod_id,
         function_name,
@@ -1147,7 +745,7 @@ async def test_function_record_write_requires_record_write_not_table_update(
         ],
     )
 
-    granted_run = await _run_function(
+    granted_run = await run_function(
         authenticated_client,
         pod_id,
         function_name,
@@ -1156,94 +754,6 @@ async def test_function_record_write_requires_record_write_not_table_update(
     output = granted_run["output_data"]
     assert output["denied"] is False, output
     assert output["read_title"] == "granted", output
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("configure_workspace_api_url")
-async def test_api_function_concurrent_hot_runs_reports_average_execution_time(
-    authenticated_client,
-    test_pod,
-    worker,
-):
-    pod_id = test_pod["id"]
-    suffix = uuid4().hex[:8]
-    function_name = f"hot_api_{suffix}"
-    total_runs = 20
-    concurrency = 5
-
-    code = f"""#input_type_name: HotInput
-#output_type_name: HotResult
-#function_name: {function_name}
-
-from pydantic import BaseModel
-from lemma_sdk import FunctionContext
-
-class HotInput(BaseModel):
-    value: int
-
-class HotResult(BaseModel):
-    value: int
-    doubled: int
-    caller_user_id: str
-
-async def {function_name}(ctx: FunctionContext, data: HotInput) -> HotResult:
-    return HotResult(
-        value=data.value,
-        doubled=data.value * 2,
-        caller_user_id=str(ctx.user_id),
-    )"""
-
-    await _create_function(
-        authenticated_client,
-        pod_id,
-        {
-            "name": function_name,
-            "description": "Hot API concurrency and latency smoke test",
-            "type": "API",
-            "code": code,
-        },
-    )
-
-    warm_run = await _run_function(
-        authenticated_client,
-        pod_id,
-        function_name,
-        {"value": -1},
-    )
-    assert warm_run["output_data"]["doubled"] == -2
-
-    semaphore = asyncio.Semaphore(concurrency)
-
-    async def run_one(index: int) -> tuple[int, float, dict]:
-        async with semaphore:
-            started = time.perf_counter()
-            final_run = await _run_function(
-                authenticated_client,
-                pod_id,
-                function_name,
-                {"value": index},
-            )
-            elapsed = time.perf_counter() - started
-            return index, elapsed, final_run
-
-    wall_started = time.perf_counter()
-    results = await asyncio.gather(*(run_one(index) for index in range(total_runs)))
-    wall_elapsed = time.perf_counter() - wall_started
-
-    durations = [elapsed for _, elapsed, _ in results]
-    average_elapsed = sum(durations) / len(durations)
-    print(
-        "Function API hot concurrency benchmark: "
-        f"runs={total_runs} concurrency={concurrency} "
-        f"avg={average_elapsed:.3f}s wall={wall_elapsed:.3f}s "
-        f"min={min(durations):.3f}s max={max(durations):.3f}s"
-    )
-
-    for index, _elapsed, final_run in results:
-        output = final_run["output_data"]
-        assert output["value"] == index
-        assert output["doubled"] == index * 2
-        assert output["caller_user_id"]
 
 
 @pytest.mark.asyncio
@@ -1260,7 +770,7 @@ async def test_api_function_datastore_read_write_latency_sequence(
     reader_name = f"latency_reader_{suffix}"
     total_hot_runs = 12
 
-    table = await _create_table(authenticated_client, pod_id, table_name)
+    table = await create_table(authenticated_client, pod_id, table_name)
 
     writer_code = f"""#input_type_name: WriteInput
 #output_type_name: WriteResult
@@ -1315,7 +825,7 @@ async def {reader_name}(ctx: FunctionContext, data: ReadInput) -> ReadResult:
         note=row.get("note"),
     )"""
 
-    await _create_function(
+    await create_function(
         authenticated_client,
         pod_id,
         {
@@ -1325,7 +835,7 @@ async def {reader_name}(ctx: FunctionContext, data: ReadInput) -> ReadResult:
             "code": writer_code,
         },
     )
-    await _create_function(
+    await create_function(
         authenticated_client,
         pod_id,
         {
@@ -1335,7 +845,7 @@ async def {reader_name}(ctx: FunctionContext, data: ReadInput) -> ReadResult:
             "code": reader_code,
         },
     )
-    await _replace_function_resource_grants(
+    await replace_function_resource_grants(
         authenticated_client,
         pod_id,
         writer_name,
@@ -1350,7 +860,7 @@ async def {reader_name}(ctx: FunctionContext, data: ReadInput) -> ReadResult:
             }
         ],
     )
-    await _replace_function_resource_grants(
+    await replace_function_resource_grants(
         authenticated_client,
         pod_id,
         reader_name,
@@ -1365,7 +875,7 @@ async def {reader_name}(ctx: FunctionContext, data: ReadInput) -> ReadResult:
             }
         ],
     )
-    await _replace_role_resource_grants(
+    await replace_role_resource_grants(
         authenticated_client,
         pod_id,
         "POD_ADMIN",
@@ -1384,7 +894,7 @@ async def {reader_name}(ctx: FunctionContext, data: ReadInput) -> ReadResult:
 
     async def timed_run(function_name: str, input_data: dict) -> tuple[float, dict]:
         started = time.perf_counter()
-        final_run = await _run_function(
+        final_run = await run_function(
             authenticated_client,
             pod_id,
             function_name,
@@ -1442,723 +952,6 @@ async def {reader_name}(ctx: FunctionContext, data: ReadInput) -> ReadResult:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("configure_workspace_api_url")
-async def test_function_connector_operation_resolves_user_owned_account_in_backend(
-    authenticated_client,
-    test_pod,
-    fixed_test_user,
-    db_session,
-    worker,
-):
-    pod_id = test_pod["id"]
-    suffix = uuid4().hex[:8]
-    connector_id = f"dynamic_app_{suffix}"
-    function_name = f"dynamic_app_func_{suffix}"
-    await _seed_connector_operation(
-        db_session,
-        connector_id=connector_id,
-        organization_id=test_pod["organization_id"],
-        user_id=fixed_test_user["id"],
-        api_key="dynamic-secret",
-    )
-
-    function = await _create_function(
-        authenticated_client,
-        pod_id,
-        {
-            "name": function_name,
-            "description": "Function app operation using dynamic account resolution",
-            "code": _connector_function_code(
-                function_name,
-                connector_id,
-            ),
-        },
-    )
-    await _replace_function_resource_grants(
-        authenticated_client,
-        pod_id,
-        function_name,
-        [
-            {
-                "resource_type": "function",
-                "resource_name": function["name"],
-                "permission_ids": ["function.read"],
-            },
-            {
-                "resource_type": "connector",
-                "resource_name": connector_id,
-                "permission_ids": ["connector.use"],
-            },
-        ],
-    )
-    await _replace_role_resource_grants(
-        authenticated_client,
-        pod_id,
-        "POD_ADMIN",
-        [
-            {
-                "resource_type": "function",
-                "resource_name": function["name"],
-                "permission_ids": ["function.read"],
-            },
-            {
-                "resource_type": "connector",
-                "resource_name": connector_id,
-                "permission_ids": ["connector.use"],
-            },
-        ],
-    )
-
-    with _patch_connector_operation_execution(connector_id):
-        final_run = await _run_function(
-            authenticated_client,
-            pod_id,
-            function_name,
-            {"message": "hello-dynamic"},
-        )
-
-    output = final_run["output_data"]
-    assert output["echoed_message"] == "hello-dynamic"
-    assert output["used_api_key"] == "dynamic-secret"
-    assert output["caller_user_id"] == str(fixed_test_user["id"])
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("configure_workspace_api_url")
-async def test_function_connector_operation_resolves_agent_owned_account_in_backend(
-    authenticated_client,
-    test_pod,
-    fixed_test_user,
-    db_session,
-    worker,
-):
-    pod_id = test_pod["id"]
-    suffix = uuid4().hex[:8]
-    connector_id = f"fixed_app_{suffix}"
-    function_name = f"fixed_app_func_{suffix}"
-    fixed_account_owner = await _seed_user(db_session)
-    account = await _seed_connector_operation(
-        db_session,
-        connector_id=connector_id,
-        organization_id=test_pod["organization_id"],
-        user_id=fixed_account_owner.id,
-        api_key="fixed-secret",
-    )
-
-    function = await _create_function(
-        authenticated_client,
-        pod_id,
-        {
-            "name": function_name,
-            "description": "Function app operation using fixed account resolution",
-            "code": _connector_function_code(
-                function_name,
-                connector_id,
-                account_id=str(account.id),
-            ),
-        },
-    )
-    await _replace_function_resource_grants(
-        authenticated_client,
-        pod_id,
-        function_name,
-        [
-            {
-                "resource_type": "function",
-                "resource_name": function["name"],
-                "permission_ids": ["function.read"],
-            },
-            {
-                "resource_type": "connector",
-                "resource_name": connector_id,
-                "permission_ids": ["connector.use"],
-            },
-            {
-                "resource_type": "connector_account",
-                "resource_name": str(account.id),
-                "permission_ids": ["connector_account.use"],
-            },
-        ],
-    )
-    await _replace_role_resource_grants(
-        authenticated_client,
-        pod_id,
-        "POD_ADMIN",
-        [
-            {
-                "resource_type": "function",
-                "resource_name": function["name"],
-                "permission_ids": ["function.read"],
-            },
-            {
-                "resource_type": "connector",
-                "resource_name": connector_id,
-                "permission_ids": ["connector.use"],
-            },
-            {
-                "resource_type": "connector_account",
-                "resource_name": str(account.id),
-                "permission_ids": ["connector_account.use"],
-            },
-        ],
-    )
-
-    with _patch_connector_operation_execution(connector_id):
-        final_run = await _run_function(
-            authenticated_client,
-            pod_id,
-            function_name,
-            {"message": "hello-fixed"},
-        )
-
-    output = final_run["output_data"]
-    assert output["echoed_message"] == "hello-fixed"
-    assert output["used_api_key"] == "fixed-secret"
-    assert output["caller_user_id"] == str(fixed_test_user["id"])
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("configure_workspace_api_url")
-async def test_function_connector_operation_fails_when_user_owned_account_missing(
-    authenticated_client,
-    test_pod,
-    fixed_test_user,
-    db_session,
-    worker,
-):
-    pod_id = test_pod["id"]
-    suffix = uuid4().hex[:8]
-    connector_id = f"missing_account_app_{suffix}"
-    function_name = f"missing_account_func_{suffix}"
-    await _seed_connector_operation(
-        db_session,
-        connector_id=connector_id,
-        organization_id=test_pod["organization_id"],
-    )
-
-    function = await _create_function(
-        authenticated_client,
-        pod_id,
-        {
-            "name": function_name,
-            "description": "Function app operation missing user account",
-            "code": _connector_function_code(
-                function_name,
-                connector_id,
-            ),
-        },
-    )
-    await _replace_function_resource_grants(
-        authenticated_client,
-        pod_id,
-        function_name,
-        [
-            {
-                "resource_type": "function",
-                "resource_name": function["name"],
-                "permission_ids": ["function.read"],
-            },
-            {
-                "resource_type": "connector",
-                "resource_name": connector_id,
-                "permission_ids": ["connector.use"],
-            },
-        ],
-    )
-    await _replace_role_resource_grants(
-        authenticated_client,
-        pod_id,
-        "POD_ADMIN",
-        [
-            {
-                "resource_type": "function",
-                "resource_name": function["name"],
-                "permission_ids": ["function.read"],
-            },
-            {
-                "resource_type": "connector",
-                "resource_name": connector_id,
-                "permission_ids": ["connector.use"],
-            },
-        ],
-    )
-
-    final_run = await _run_function(
-        authenticated_client,
-        pod_id,
-        function_name,
-        {"message": "hello-missing"},
-        expected_status="FAILED",
-    )
-
-    assert final_run["error"]
-    assert "ACCOUNT_RESOLUTION_ERROR" in final_run["error"]
-    assert "Connect your account first" in final_run["error"]
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("configure_workspace_api_url")
-async def test_api_function_timeout_marks_run_failed_and_stops_execution(
-    authenticated_client,
-    test_pod,
-    monkeypatch,
-):
-    from app.core.config import settings as backend_settings
-
-    pod_id = test_pod["id"]
-    suffix = uuid4().hex[:8]
-    function_name = f"api_timeout_{suffix}"
-    table_name = f"timeout_records_{suffix}"
-
-    await _create_table(authenticated_client, pod_id, table_name)
-
-    code = f"""#input_type_name: TimeoutInput
-#output_type_name: TimeoutResult
-#function_name: {function_name}
-
-import asyncio
-from pydantic import BaseModel
-from lemma_sdk import FunctionContext, Pod
-
-class TimeoutInput(BaseModel):
-    title: str
-
-class TimeoutResult(BaseModel):
-    record_id: str
-
-async def {function_name}(ctx: FunctionContext, data: TimeoutInput) -> TimeoutResult:
-    await asyncio.sleep(5)
-    pod = Pod.from_env()
-    record = pod.table("{table_name}").create(
-        {{
-            "title": data.title,
-        }}
-    )
-    row = record
-    return TimeoutResult(record_id=str(row["id"]))"""
-
-    await _create_function(
-        authenticated_client,
-        pod_id,
-        {
-            "name": function_name,
-            "description": "API function timeout smoke test",
-            "type": "API",
-            "code": code,
-        },
-    )
-
-    # Function creation performs schema extraction and prewarms the revision
-    # worker. Restrict only the execution whose timeout behavior this test owns.
-    monkeypatch.setattr(backend_settings, "function_api_deadline_seconds", 2)
-    response = await authenticated_client.post(
-        f"/pods/{pod_id}/functions/{function_name}/runs",
-        json={"input_data": {"title": "should-not-write"}},
-        follow_redirects=True,
-    )
-    assert response.status_code == status.HTTP_200_OK, response.text
-    run_id = response.json()["id"]
-
-    final_run = await _wait_for_run_completion(
-        authenticated_client,
-        pod_id,
-        function_name,
-        run_id,
-        timeout_seconds=15,
-    )
-    assert final_run["status"] == "FAILED", final_run
-    assert final_run["error"]
-    assert "timed out" in final_run["error"].lower()
-
-    await asyncio.sleep(4)
-
-    rerun_response = await authenticated_client.get(
-        f"/pods/{pod_id}/functions/{function_name}/runs/{run_id}"
-    )
-    assert rerun_response.status_code == status.HTTP_200_OK, rerun_response.text
-    assert rerun_response.json()["status"] == "FAILED"
-
-    records_response = await authenticated_client.get(
-        f"/pods/{pod_id}/datastore/tables/{table_name}/records",
-    )
-    assert records_response.status_code == status.HTTP_200_OK, records_response.text
-    assert records_response.json()["total"] == 0
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("configure_workspace_api_url")
-async def test_job_function_run_completes_via_worker(
-    authenticated_client,
-    test_pod,
-    worker,
-):
-    pod_id = test_pod["id"]
-    suffix = uuid4().hex[:8]
-    function_name = f"job_func_{suffix}"
-
-    code = f"""#input_type_name: JobInput
-#output_type_name: JobResult
-#function_name: {function_name}
-
-import asyncio
-from pydantic import BaseModel
-from lemma_sdk import FunctionContext
-
-class JobInput(BaseModel):
-    text: str
-
-class JobResult(BaseModel):
-    result: str
-
-async def {function_name}(ctx: FunctionContext, data: JobInput) -> JobResult:
-    await asyncio.sleep(1)
-    return JobResult(result=data.text.upper())"""
-
-    await _create_function(
-        authenticated_client,
-        pod_id,
-        {
-            "name": function_name,
-            "description": "Queued function execution smoke test",
-            "type": "JOB",
-            "code": code,
-        },
-    )
-
-    response = await authenticated_client.post(
-        f"/pods/{pod_id}/functions/{function_name}/runs",
-        json={"input_data": {"text": "queued hello"}},
-        follow_redirects=True,
-    )
-    assert response.status_code == status.HTTP_200_OK, response.text
-    run = response.json()
-    assert run["status"] in {"PENDING", "RUNNING"}
-    assert run["job_id"]
-
-    final_run = await _wait_for_run_completion(
-        authenticated_client,
-        pod_id,
-        function_name,
-        run["id"],
-        timeout_seconds=30,
-    )
-    assert final_run["status"] == "COMPLETED", final_run
-    assert final_run["output_data"]["result"] == "QUEUED HELLO"
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("configure_workspace_api_url")
-async def test_job_function_execution_writes_datastore_record(
-    authenticated_client,
-    test_pod,
-    worker,
-):
-    pod_id = test_pod["id"]
-    suffix = uuid4().hex[:8]
-    function_name = f"job_store_{suffix}"
-    table_name = f"expenses_{suffix}"
-
-    response = await authenticated_client.post(
-        f"/pods/{pod_id}/datastore/tables",
-        json={
-            "name": table_name,
-            "primary_key_column": "id",
-            "enable_rls": True,
-            "columns": [
-                {"name": "title", "type": "TEXT", "required": True},
-                {"name": "note", "type": "TEXT", "required": False},
-            ],
-        },
-    )
-    assert response.status_code == status.HTTP_201_CREATED, response.text
-    table = response.json()
-
-    code = f"""#input_type_name: SaveExpenseInput
-#output_type_name: SaveExpenseResult
-#function_name: {function_name}
-
-from pydantic import BaseModel
-from lemma_sdk import FunctionContext, Pod
-
-class SaveExpenseInput(BaseModel):
-    title: str
-    note: str
-
-class SaveExpenseResult(BaseModel):
-    record_id: str
-    caller_user_id: str
-    caller_user_email: str | None = None
-
-async def {function_name}(ctx: FunctionContext, data: SaveExpenseInput) -> SaveExpenseResult:
-    pod = Pod.from_env()
-    record = pod.table("{table_name}").create(
-        {{
-            "title": data.title,
-            "note": data.note,
-        }}
-    )
-    row = record
-    return SaveExpenseResult(
-        record_id=str(row["id"]),
-        caller_user_id=str(ctx.user_id),
-        caller_user_email=ctx.user_email,
-    )"""
-
-    await _create_function(
-        authenticated_client,
-        pod_id,
-        {
-            "name": function_name,
-            "description": "Queued datastore write smoke test",
-            "type": "JOB",
-            "code": code,
-        },
-    )
-    await _replace_function_resource_grants(
-        authenticated_client,
-        pod_id,
-        function_name,
-        [
-            {
-                "resource_type": "datastore_table",
-                "resource_name": table["name"],
-                "permission_ids": [
-                    "datastore.table.read",
-                    "datastore.record.write",
-                ],
-            }
-        ],
-    )
-    await _replace_role_resource_grants(
-        authenticated_client,
-        pod_id,
-        "POD_ADMIN",
-        [
-            {
-                "resource_type": "datastore_table",
-                "resource_name": table["name"],
-                "permission_ids": [
-                    "datastore.table.read",
-                    "datastore.record.read",
-                    "datastore.record.write",
-                ],
-            }
-        ],
-    )
-
-    final_run = await _run_function(
-        authenticated_client,
-        pod_id,
-        function_name,
-        {"title": "Taxi", "note": "airport pickup"},
-    )
-    assert final_run["status"] == "COMPLETED", final_run
-    output = final_run["output_data"]
-    assert output["caller_user_id"]
-
-    records_response = await authenticated_client.get(
-        f"/pods/{pod_id}/datastore/tables/{table_name}/records",
-    )
-    assert records_response.status_code == status.HTTP_200_OK, records_response.text
-    records_payload = records_response.json()
-    assert records_payload["total"] == 1
-    assert records_payload["items"][0]["id"] == output["record_id"]
-    assert records_payload["items"][0]["title"] == "Taxi"
-    assert records_payload["items"][0]["note"] == "airport pickup"
-    assert records_payload["items"][0]["user_id"] == output["caller_user_id"]
-
-
-@pytest.mark.slow
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("configure_workspace_api_url")
-async def test_job_function_long_run_is_not_destroyed_while_active(
-    authenticated_client,
-    test_pod,
-    worker,
-):
-    """An active run prevents function-sandbox idle release without heartbeats.
-
-    The idle window is squeezed to five seconds so a sixty-second run is many
-    times longer than it, which is what makes the assertion mean something:
-    the run finishing proves activity held the sandbox, not that the sweep
-    simply never came round.
-    """
-    from app.modules.workspace.config import workspace_settings
-
-    original_idle = workspace_settings.idle_release_seconds
-    workspace_settings.idle_release_seconds = 5
-    try:
-        pod_id = test_pod["id"]
-        suffix = uuid4().hex[:8]
-        function_name = f"job_long_{suffix}"
-        code = f"""#input_type_name: JobInput
-#output_type_name: JobResult
-#function_name: {function_name}
-
-import asyncio
-from pydantic import BaseModel
-from lemma_sdk import FunctionContext
-
-class JobInput(BaseModel):
-    seconds: int
-
-class JobResult(BaseModel):
-    slept: int
-
-async def {function_name}(ctx: FunctionContext, data: JobInput) -> JobResult:
-    await asyncio.sleep(data.seconds)
-    return JobResult(slept=data.seconds)"""
-
-        await _create_function(
-            authenticated_client,
-            pod_id,
-            {
-                "name": function_name,
-                "description": "Long-running job: sandbox keepalive smoke test",
-                "type": "JOB",
-                "code": code,
-            },
-        )
-
-        response = await authenticated_client.post(
-            f"/pods/{pod_id}/functions/{function_name}/runs",
-            json={"input_data": {"seconds": 60}},
-            follow_redirects=True,
-        )
-        assert response.status_code == status.HTTP_200_OK, response.text
-        run = response.json()
-
-        final_run = await _wait_for_run_completion(
-            authenticated_client,
-            pod_id,
-            function_name,
-            run["id"],
-            timeout_seconds=150,
-        )
-        assert final_run["status"] == "COMPLETED", final_run
-        assert final_run["output_data"]["slept"] == 60
-    finally:
-        workspace_settings.idle_release_seconds = original_idle
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("configure_workspace_api_url")
-async def test_concurrent_api_function_runs_all_complete(
-    authenticated_client,
-    test_pod,
-):
-    """3-4 API runs fired together (same user -> shared sandbox) all complete.
-
-    Concurrent cold-start callers must coordinate on one sandbox creation
-    (Redis creation lock) and then share the RUNNING sandbox; none should fail
-    with a sandbox readiness / "Sandbox not found" race.
-    """
-    pod_id = test_pod["id"]
-    suffix = uuid4().hex[:8]
-    function_name = f"api_concurrent_{suffix}"
-    code = f"""#input_type_name: ConcInput
-#output_type_name: ConcResult
-#function_name: {function_name}
-
-import asyncio
-from pydantic import BaseModel
-from lemma_sdk import FunctionContext
-
-class ConcInput(BaseModel):
-    n: int
-
-class ConcResult(BaseModel):
-    doubled: int
-
-async def {function_name}(ctx: FunctionContext, data: ConcInput) -> ConcResult:
-    await asyncio.sleep(2)
-    return ConcResult(doubled=data.n * 2)"""
-
-    await _create_function(
-        authenticated_client,
-        pod_id,
-        {
-            "name": function_name,
-            "description": "concurrency smoke (API)",
-            "type": "API",
-            "code": code,
-        },
-    )
-
-    async def run_one(n: int) -> dict:
-        return await _run_function(
-            authenticated_client, pod_id, function_name, {"n": n}
-        )
-
-    results = await asyncio.gather(*(run_one(n) for n in range(1, 5)))
-    for n, final in zip(range(1, 5), results):
-        assert final["status"] == "COMPLETED", final
-        assert final["output_data"]["doubled"] == n * 2
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("configure_workspace_api_url")
-async def test_concurrent_job_function_runs_all_complete(
-    authenticated_client,
-    test_pod,
-    worker,
-):
-    """3-4 JOB runs fired together (same user -> shared sandbox) all complete."""
-    pod_id = test_pod["id"]
-    suffix = uuid4().hex[:8]
-    function_name = f"job_concurrent_{suffix}"
-    code = f"""#input_type_name: ConcInput
-#output_type_name: ConcResult
-#function_name: {function_name}
-
-import asyncio
-from pydantic import BaseModel
-from lemma_sdk import FunctionContext
-
-class ConcInput(BaseModel):
-    n: int
-
-class ConcResult(BaseModel):
-    doubled: int
-
-async def {function_name}(ctx: FunctionContext, data: ConcInput) -> ConcResult:
-    await asyncio.sleep(3)
-    return ConcResult(doubled=data.n * 2)"""
-
-    await _create_function(
-        authenticated_client,
-        pod_id,
-        {
-            "name": function_name,
-            "description": "concurrency smoke (JOB)",
-            "type": "JOB",
-            "code": code,
-        },
-    )
-
-    async def trigger(n: int) -> str:
-        resp = await authenticated_client.post(
-            f"/pods/{pod_id}/functions/{function_name}/runs",
-            json={"input_data": {"n": n}},
-            follow_redirects=True,
-        )
-        assert resp.status_code == status.HTTP_200_OK, resp.text
-        return resp.json()["id"]
-
-    run_ids = await asyncio.gather(*(trigger(n) for n in range(1, 5)))
-    finals = await asyncio.gather(
-        *(
-            _wait_for_run_completion(
-                authenticated_client, pod_id, function_name, rid, timeout_seconds=150
-            )
-            for rid in run_ids
-        )
-    )
-    for final in finals:
-        assert final["status"] == "COMPLETED", final
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("configure_workspace_api_url")
 async def test_function_execute_requires_only_execute_not_read(
     authenticated_client,
     async_client,
@@ -2191,7 +984,7 @@ async def test_function_execute_requires_only_execute_not_read(
         f"async def {name}(ctx: FunctionContext, data: PingInput) -> PingResult:\n"
         "    return PingResult(doubled=data.n * 2)\n"
     )
-    function = await _create_function(
+    function = await create_function(
         authenticated_client,
         pod_id,
         {
@@ -2230,229 +1023,11 @@ async def test_function_execute_requires_only_execute_not_read(
     assert run_response.status_code == status.HTTP_200_OK, run_response.text
 
     # Confirm it actually executed (poll as admin, who can read the run).
-    final_run = await _wait_for_run_completion(
+    final_run = await wait_for_run_completion(
         authenticated_client, pod_id, name, run_response.json()["id"]
     )
     assert final_run["status"] == "COMPLETED", final_run
     assert final_run["output_data"]["doubled"] == 42
-
-
-def _mcp_function_code(function_name: str, auth_config_name: str) -> str:
-    return f"""#input_type_name: AddInput
-#output_type_name: AddResult
-#function_name: {function_name}
-
-from pydantic import BaseModel
-from lemma_sdk import FunctionContext, Pod
-
-class AddInput(BaseModel):
-    a: int
-    b: int
-
-class AddResult(BaseModel):
-    total: int
-
-async def {function_name}(ctx: FunctionContext, data: AddInput) -> AddResult:
-    pod = Pod.from_env()
-    response = pod.connectors.execute(
-        "{auth_config_name}",
-        "add",
-        {{"a": data.a, "b": data.b}},
-    )
-    result = response.result
-    text = str(result)
-    digits = "".join(c for c in text if c.isdigit())
-    return AddResult(total=int(digits))"""
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("configure_workspace_api_url")
-async def test_function_runs_a_tenant_connector_operation_for_real(
-    authenticated_client,
-    test_pod,
-    fixed_test_user,
-    db_session,
-    worker,
-    monkeypatch,
-):
-    """A function calls an MCP server through `pod.connectors.execute`.
-
-    The other connector function tests patch the gateway, so they prove the
-    delegated-workload authorization path but stop short of a real call. This
-    one runs a live MCP server, installs it as a tenant connector, and has a
-    function in the pod runtime execute one of its discovered tools -- so
-    nothing between the function and the server is a stand-in.
-    """
-    import asyncio
-    import contextlib
-    import socket
-    from uuid import UUID
-
-    from fastmcp import FastMCP
-
-    from app.core.config import settings
-    from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
-    from app.modules.connectors.api.dependencies import get_connector_service
-    from app.modules.connectors.domain.auth_config import AuthConfigSource
-    from app.modules.connectors.infrastructure.models.connector import Connector
-
-    monkeypatch.setattr(settings, "connector_allow_private_network_targets", True)
-
-    server = FastMCP("function-runtime")
-
-    @server.tool
-    def add(a: int, b: int) -> int:
-        """Add two integers."""
-        return a + b
-
-    with socket.socket() as probe:
-        probe.bind(("127.0.0.1", 0))
-        port = probe.getsockname()[1]
-    task = asyncio.create_task(
-        server.run_async(
-            transport="http", host="127.0.0.1", port=port, show_banner=False
-        )
-    )
-
-    async def probe_port() -> bool:
-        if task.done():
-            raise RuntimeError(f"MCP server failed to start: {task.exception()}")
-        _, writer = await asyncio.open_connection("127.0.0.1", port)
-        writer.close()
-        await writer.wait_closed()
-        return True
-
-    # retry_exceptions=(OSError,): connection refused just means the listener
-    # isn't up yet, not a real failure -- same as the original loop's
-    # `except OSError: sleep`. A RuntimeError from a dead task still
-    # propagates immediately since it isn't in retry_exceptions.
-    await eventually(
-        label=f"MCP server on 127.0.0.1:{port}",
-        probe=probe_port,
-        done=lambda ready: ready,
-        retry_exceptions=(OSError,),
-        timeout_seconds=5,
-        interval_seconds=0.05,
-    )
-
-    try:
-        suffix = uuid4().hex[:8]
-        connector_id = f"mcp_fn_{suffix}"
-        function_name = f"mcp_fn_func_{suffix}"
-
-        db_session.add(
-            Connector(
-                id=connector_id,
-                title="Function MCP",
-                description="MCP server reached from a function.",
-                kinds=[
-                    {
-                        "kind": "mcp",
-                        "auth_scheme": "API_KEY",
-                        "discovery": "mcp",
-                        "auth_config_schema": {
-                            "type": "object",
-                            "required": ["server_url"],
-                            "properties": {"server_url": {"type": "string"}},
-                            "additionalProperties": False,
-                        },
-                    }
-                ],
-                is_active=True,
-            )
-        )
-        await db_session.commit()
-
-        org_id = UUID(str(test_pod["organization_id"]))
-        user_id = UUID(str(fixed_test_user["id"]))
-        service = get_connector_service(SqlAlchemyUnitOfWork(db_session))
-        install = await service.create_auth_config(
-            user_id=user_id,
-            organization_id=org_id,
-            connector_id=connector_id,
-            config_source=AuthConfigSource.SYSTEM_DEFAULT.value,
-            config={"server_url": f"http://127.0.0.1:{port}/mcp"},
-            name=f"mcp-fn-{suffix}",
-        )
-        await service.create_account(
-            user_id=user_id,
-            organization_id=org_id,
-            auth_config_id=install.id,
-            credentials={"api_key": "unused-by-this-server"},
-        )
-
-        function = await _create_function(
-            authenticated_client,
-            test_pod["id"],
-            {
-                "name": function_name,
-                "description": "Runs an MCP tool through the connectors SDK",
-                "code": _mcp_function_code(function_name, install.name),
-            },
-        )
-        grants = [
-            {
-                "resource_type": "function",
-                "resource_name": function["name"],
-                "permission_ids": ["function.read"],
-            },
-            {
-                "resource_type": "connector",
-                "resource_name": connector_id,
-                "permission_ids": ["connector.use"],
-            },
-        ]
-        await _replace_function_resource_grants(
-            authenticated_client, test_pod["id"], function_name, grants
-        )
-        await _replace_role_resource_grants(
-            authenticated_client, test_pod["id"], "POD_ADMIN", grants
-        )
-
-        final_run = await _run_function(
-            authenticated_client,
-            test_pod["id"],
-            function_name,
-            {"a": 17, "b": 25},
-        )
-        # 17 + 25, computed by the MCP server, reached from inside the pod
-        # runtime through the connectors SDK.
-        assert final_run["output_data"]["total"] == 42
-    finally:
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
-
-
-# -- FunctionUseCases sagas with no direct HTTP entry point of their own -----
-#
-# update_function/delete_function DO have HTTP endpoints (PATCH/DELETE above),
-# but test_function_lifecycle only exercises their no-op-code, no-icon-change
-# shape. execute_function_as_workload (agent-as-tool) and
-# dispatch_function_for_workflow/cancel_function_run (workflow node control)
-# have no HTTP surface at all -- they're built the same way their real callers
-# build them (app/modules/agent/tools/callable_tool_factory.py,
-# app/composition/workflow_function.py) via `build_function_use_cases`, against
-# the live e2e database and the real Docker sandbox, same pattern as
-# test_function_sandbox_execution_e2e.py's dispatcher-construction tests.
-
-
-def _typed_function_code(function_name: str, *, expression: str) -> str:
-    return f"""#input_type_name: Input
-#output_type_name: Output
-#function_name: {function_name}
-
-from pydantic import BaseModel
-from lemma_sdk import FunctionContext
-
-class Input(BaseModel):
-    value: int
-
-class Output(BaseModel):
-    result: int
-
-async def {function_name}(ctx: FunctionContext, data: Input) -> Output:
-    return Output(result={expression})"""
 
 
 @pytest.mark.asyncio
@@ -2467,8 +1042,8 @@ async def test_update_function_replaces_code_and_activates_new_revision(
     pod_id = test_pod["id"]
     func_name = f"update_code_{uuid4().hex[:8]}"
 
-    original_code = _typed_function_code(func_name, expression="data.value * 2")
-    func = await _create_function(
+    original_code = typed_function_code(func_name, expression="data.value * 2")
+    func = await create_function(
         authenticated_client,
         pod_id,
         {"name": func_name, "description": "before", "code": original_code},
@@ -2476,12 +1051,12 @@ async def test_update_function_replaces_code_and_activates_new_revision(
     original_revision = func["revision_hash"]
     assert original_revision and func["status"] == "READY"
 
-    original_result = await _run_function(
+    original_result = await run_function(
         authenticated_client, pod_id, func_name, {"value": 10}
     )
     assert original_result["output_data"]["result"] == 20
 
-    updated_code = _typed_function_code(func_name, expression="data.value * 3")
+    updated_code = typed_function_code(func_name, expression="data.value * 3")
     update_response = await authenticated_client.patch(
         f"/pods/{pod_id}/functions/{func_name}",
         json={"code": updated_code},
@@ -2493,7 +1068,7 @@ async def test_update_function_replaces_code_and_activates_new_revision(
     # the same row with a new description.
     assert updated["revision_hash"] != original_revision
 
-    updated_result = await _run_function(
+    updated_result = await run_function(
         authenticated_client, pod_id, func_name, {"value": 10}
     )
     assert updated_result["output_data"]["result"] == 30
@@ -2510,7 +1085,7 @@ async def test_update_function_replaces_icon_and_the_change_persists(
     pod_id = test_pod["id"]
     func_name = f"update_icon_{uuid4().hex[:8]}"
 
-    func = await _create_function(
+    func = await create_function(
         authenticated_client,
         pod_id,
         {
@@ -2547,7 +1122,7 @@ async def test_delete_function_cleans_up_icon_and_the_function_becomes_unreachab
     pod_id = test_pod["id"]
     func_name = f"delete_icon_{uuid4().hex[:8]}"
 
-    await _create_function(
+    await create_function(
         authenticated_client,
         pod_id,
         {
@@ -2573,297 +1148,3 @@ async def test_delete_function_cleans_up_icon_and_the_function_becomes_unreachab
         follow_redirects=True,
     )
     assert run_response.status_code == status.HTTP_404_NOT_FOUND
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("configure_workspace_api_url")
-async def test_upsert_function_for_import_creates_then_idempotently_updates(
-    authenticated_client, test_pod, fixed_test_user, db_manager
-):
-    """``upsert_function_for_import`` is the bundle/CLI import saga
-    (``app/modules/pod_bundle/infrastructure/function_builder.py::FunctionStepRunner``):
-    create-if-absent, update-if-present, by name, with no request object.
-    It has no HTTP endpoint of its own, so this builds the same
-    ``FunctionUseCases`` the real import path builds."""
-    from uuid import UUID
-
-    from app.core.infrastructure.db.uow_factory import SessionUnitOfWorkFactory
-    from app.modules.function.api.dependencies import build_function_use_cases
-    from app.modules.function.domain.entities import (
-        FunctionEntity,
-        FunctionStatus,
-        FunctionType,
-        FunctionUpdateEntity,
-    )
-
-    pod_id = UUID(test_pod["id"])
-    user_id = UUID(fixed_test_user["id"])
-    func_name = f"import_fn_{uuid4().hex[:8]}"
-    use_cases = build_function_use_cases(
-        SessionUnitOfWorkFactory(db_manager.session_factory)
-    )
-
-    def _entity() -> FunctionEntity:
-        return FunctionEntity(
-            pod_id=pod_id,
-            user_id=user_id,
-            name=func_name,
-            description="imported",
-            type=FunctionType.API,
-            visibility="POD",
-        )
-
-    first_code = _typed_function_code(func_name, expression="data.value + 1")
-    created = await use_cases.upsert_function_for_import(
-        entity=_entity(),
-        update_entity=FunctionUpdateEntity(
-            description="imported", code=first_code, type=FunctionType.API
-        ),
-        code=first_code,
-        user_id=user_id,
-    )
-    assert created.status == FunctionStatus.READY
-    first_revision = created.revision_hash
-    assert first_revision
-
-    # Applying the bundle again (e.g. `lemma pods import` re-run) must UPDATE
-    # the existing row by name, not raise FUNCTION_CONFLICT.
-    second_code = _typed_function_code(func_name, expression="data.value + 2")
-    updated = await use_cases.upsert_function_for_import(
-        entity=_entity(),
-        update_entity=FunctionUpdateEntity(
-            description="imported again", code=second_code, type=FunctionType.API
-        ),
-        code=second_code,
-        user_id=user_id,
-    )
-    assert updated.id == created.id
-    assert updated.description == "imported again"
-    assert updated.revision_hash != first_revision
-
-    # Visible + executable through the normal HTTP surface, reflecting the
-    # second import's code.
-    final_run = await _run_function(
-        authenticated_client, str(pod_id), func_name, {"value": 10}
-    )
-    assert final_run["output_data"]["result"] == 12
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("configure_workspace_api_url")
-async def test_execute_function_as_workload_runs_under_the_agent_delegated_context(
-    authenticated_client, test_pod, fixed_test_user, db_manager
-):
-    """``execute_function_as_workload`` is the agent-as-tool delegated path
-    (``app/modules/agent/tools/callable_tool_factory.py``): it authorizes as
-    the delegated AGENT principal on behalf of the calling user and runs the
-    sandbox with no ctx held. Drive it exactly the way the tool factory does."""
-    from uuid import UUID
-
-    from app.core.authorization.permissions import Permissions
-    from app.core.infrastructure.db.uow_factory import SessionUnitOfWorkFactory
-    from app.modules.function.api.dependencies import build_function_use_cases
-    from app.modules.function.domain.entities import FunctionRunStatus
-
-    pod_id = UUID(test_pod["id"])
-    user_id = UUID(fixed_test_user["id"])
-    func_name = f"workload_fn_{uuid4().hex[:8]}"
-
-    await _create_function(
-        authenticated_client,
-        str(pod_id),
-        {
-            "name": func_name,
-            "description": "workload test",
-            "code": _typed_function_code(func_name, expression="data.value * 2"),
-        },
-    )
-
-    # execute_function_as_workload authorizes the AGENT principal against a
-    # real per-resource grant (ResourcePermissionGrantModel) -- exactly the
-    # grant callable_tool_factory.py relies on when it exposes a function as
-    # an agent tool. A bare uuid4() principal has none, so build one for
-    # real: create the agent, then grant it function.execute through the
-    # agent-permissions endpoint (the resource-access-grant endpoint only
-    # accepts ROLE/POD_MEMBER grantees, not AGENT).
-    agent_name = f"workload_agent_{uuid4().hex[:8]}"
-    agent_response = await authenticated_client.post(
-        f"/pods/{pod_id}/agents",
-        json={"name": agent_name, "instruction": "Answer briefly."},
-    )
-    assert agent_response.status_code == status.HTTP_201_CREATED, agent_response.text
-    agent_id = UUID(agent_response.json()["id"])
-
-    grant_response = await authenticated_client.put(
-        f"/pods/{pod_id}/agents/{agent_name}/permissions",
-        json={
-            "grants": [
-                {
-                    "resource_type": "function",
-                    "resource_name": func_name,
-                    "permission_ids": [Permissions.FUNCTION_EXECUTE],
-                }
-            ]
-        },
-    )
-    assert grant_response.status_code == status.HTTP_200_OK, grant_response.text
-
-    use_cases = build_function_use_cases(
-        SessionUnitOfWorkFactory(db_manager.session_factory)
-    )
-    run = await use_cases.execute_function_as_workload(
-        pod_id=pod_id,
-        name=func_name,
-        input_data={"value": 5},
-        user_id=user_id,
-        principal_type="AGENT",
-        principal_id=agent_id,
-        delegation_scope=frozenset([Permissions.FUNCTION_EXECUTE]),
-        delegation_actor_name="Test Agent",
-    )
-
-    assert run.status == FunctionRunStatus.COMPLETED, run.error
-    assert run.output_data == {"result": 10}
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("configure_workspace_api_url")
-async def test_dispatch_function_for_workflow_enqueues_and_the_worker_completes_it(
-    authenticated_client, test_pod, fixed_test_user, db_manager, worker
-):
-    """``dispatch_function_for_workflow`` is the workflow-node path
-    (``app/composition/workflow_function.py::FunctionControlAdapter.execute_function``):
-    it forces ASYNCHRONOUS dispatch even for an API function and returns
-    PENDING without running the sandbox inline, so the workflow engine can
-    suspend on the run id and let the ``FunctionRunCompleted`` event resume
-    it. Drive it against the real queue + worker."""
-    from uuid import UUID
-
-    from app.core.infrastructure.db.uow_factory import SessionUnitOfWorkFactory
-    from app.modules.function.api.dependencies import build_function_use_cases
-    from app.modules.function.domain.entities import FunctionRunStatus
-
-    pod_id = UUID(test_pod["id"])
-    user_id = UUID(fixed_test_user["id"])
-    func_name = f"workflow_fn_{uuid4().hex[:8]}"
-
-    await _create_function(
-        authenticated_client,
-        str(pod_id),
-        {
-            "name": func_name,
-            "description": "workflow dispatch test",
-            "type": "API",
-            "code": _typed_function_code(func_name, expression="data.value + 1"),
-        },
-    )
-
-    use_cases = build_function_use_cases(
-        SessionUnitOfWorkFactory(db_manager.session_factory)
-    )
-    dispatched = await use_cases.dispatch_function_for_workflow(
-        pod_id=pod_id,
-        name=func_name,
-        input_data={"value": 41},
-        user_id=user_id,
-    )
-
-    # PENDING, and NOT run inline even though this is an API function -- the
-    # whole point of the workflow path is that the caller never blocks on the
-    # sandbox round-trip.
-    assert dispatched.status == FunctionRunStatus.PENDING
-    assert dispatched.job_id
-    assert dispatched.id is not None
-
-    final_run = await _wait_for_run_completion(
-        authenticated_client,
-        str(pod_id),
-        func_name,
-        str(dispatched.id),
-    )
-    assert final_run["status"] == "COMPLETED", final_run
-    assert final_run["output_data"]["result"] == 42
-
-
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("configure_workspace_api_url")
-async def test_cancel_function_run_stops_a_dispatched_run_before_it_completes(
-    authenticated_client, test_pod, worker, db_manager
-):
-    """``cancel_function_run`` is used when a workflow run that was waiting on
-    a dispatched function is itself cancelled
-    (``app/composition/workflow_function.py::FunctionControlAdapter.cancel_run``),
-    so the sandbox stops doing work nobody is waiting for. A run that is still
-    PENDING or RUNNING is cancellable; confirm a long JOB run actually ends
-    CANCELLED instead of completing."""
-    from uuid import UUID
-
-    from app.core.infrastructure.db.uow_factory import SessionUnitOfWorkFactory
-    from app.modules.function.api.dependencies import build_function_use_cases
-
-    pod_id = test_pod["id"]
-    suffix = uuid4().hex[:8]
-    function_name = f"cancel_job_{suffix}"
-    code = f"""#input_type_name: JobInput
-#output_type_name: JobResult
-#function_name: {function_name}
-
-import asyncio
-from pydantic import BaseModel
-from lemma_sdk import FunctionContext
-
-class JobInput(BaseModel):
-    seconds: int
-
-class JobResult(BaseModel):
-    slept: int
-
-async def {function_name}(ctx: FunctionContext, data: JobInput) -> JobResult:
-    await asyncio.sleep(data.seconds)
-    return JobResult(slept=data.seconds)"""
-
-    await _create_function(
-        authenticated_client,
-        pod_id,
-        {
-            "name": function_name,
-            "description": "cancel smoke test",
-            "type": "JOB",
-            "code": code,
-        },
-    )
-
-    response = await authenticated_client.post(
-        f"/pods/{pod_id}/functions/{function_name}/runs",
-        json={"input_data": {"seconds": 20}},
-        follow_redirects=True,
-    )
-    assert response.status_code == status.HTTP_200_OK, response.text
-    run = response.json()
-    assert run["status"] in {"PENDING", "RUNNING"}
-
-    use_cases = build_function_use_cases(
-        SessionUnitOfWorkFactory(db_manager.session_factory)
-    )
-    # Cancel promptly, well inside the function's 20-second sleep -- a run is
-    # cancellable in either PENDING or RUNNING, so there is no race to win.
-    await use_cases.cancel_function_run(UUID(run["id"]))
-
-    async def probe() -> dict:
-        res = await authenticated_client.get(
-            f"/pods/{pod_id}/functions/{function_name}/runs/{run['id']}"
-        )
-        assert res.status_code == status.HTTP_200_OK, res.text
-        return res.json()
-
-    final_run = await wait_for_status(
-        label=f"cancelled function run {run['id']}",
-        probe=probe,
-        expected={"CANCELLED"},
-        # A run that finishes or fails instead of cancelling is the actual
-        # bug under test -- fail fast rather than waiting out the timeout.
-        failed={"COMPLETED", "FAILED"},
-        timeout_seconds=15,
-        interval_seconds=0.15,
-    )
-    assert final_run["status"] == "CANCELLED", final_run

--- a/lemma-backend/app/modules/function/tests/e2e/test_function_execution_e2e.py
+++ b/lemma-backend/app/modules/function/tests/e2e/test_function_execution_e2e.py
@@ -1,0 +1,1325 @@
+"""Function runtime: the queue, concurrency, timeouts, and connectors.
+
+Split from `test_function_e2e.py`, which keeps the shape-and-authorization
+half. That file was 200 seconds of the sandbox shard's 310 in one module, and
+neither the shard planner (which could only weigh directories) nor xdist (whose
+`loadscope` puts a module on one worker) could break it up. These two files
+run on separate runners.
+
+The line is what a test is *about*. Everything here is a claim about what
+happens when a function actually executes: dispatched through the real streaq
+worker, run concurrently, timed out, cancelled, or reaching a connector.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from uuid import uuid4
+
+import pytest
+from fastapi import status
+
+from app.modules.test_support.e2e.function_helpers import (
+    connector_function_code,
+    create_function,
+    create_table,
+    mcp_function_code,
+    patch_connector_operation_execution,
+    replace_function_resource_grants,
+    replace_role_resource_grants,
+    run_function,
+    seed_connector_operation,
+    seed_user,
+    typed_function_code,
+    wait_for_run_completion,
+)
+from app.modules.test_support.e2e.waiters import eventually, wait_for_status
+
+# `usefixtures` is deliberately NOT here. At module scope it made every test
+# boot a uvicorn backend server and a local sandbox server, including the ones
+# that never supply `code` and only assert status codes -- the duplicate-name
+# check measured 18.8s in CI to prove a 409. It is applied per test below, to
+# the ones that actually reach the runtime.
+#
+# `workspace` stays at module scope: it is what the sandbox shard's marker
+# filter selects on, and moving it would change which shard these run in. Both
+# halves of the split carry it for that reason, and a contract test
+# (test_workspace_marked_files_are_routed_consistently_within_a_directory)
+# fails if they ever disagree.
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.workspace,
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_workspace_api_url")
+async def test_api_function_concurrent_hot_runs_reports_average_execution_time(
+    authenticated_client,
+    test_pod,
+    worker,
+):
+    pod_id = test_pod["id"]
+    suffix = uuid4().hex[:8]
+    function_name = f"hot_api_{suffix}"
+    total_runs = 20
+    concurrency = 5
+
+    code = f"""#input_type_name: HotInput
+#output_type_name: HotResult
+#function_name: {function_name}
+
+from pydantic import BaseModel
+from lemma_sdk import FunctionContext
+
+class HotInput(BaseModel):
+    value: int
+
+class HotResult(BaseModel):
+    value: int
+    doubled: int
+    caller_user_id: str
+
+async def {function_name}(ctx: FunctionContext, data: HotInput) -> HotResult:
+    return HotResult(
+        value=data.value,
+        doubled=data.value * 2,
+        caller_user_id=str(ctx.user_id),
+    )"""
+
+    await create_function(
+        authenticated_client,
+        pod_id,
+        {
+            "name": function_name,
+            "description": "Hot API concurrency and latency smoke test",
+            "type": "API",
+            "code": code,
+        },
+    )
+
+    warm_run = await run_function(
+        authenticated_client,
+        pod_id,
+        function_name,
+        {"value": -1},
+    )
+    assert warm_run["output_data"]["doubled"] == -2
+
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def run_one(index: int) -> tuple[int, float, dict]:
+        async with semaphore:
+            started = time.perf_counter()
+            final_run = await run_function(
+                authenticated_client,
+                pod_id,
+                function_name,
+                {"value": index},
+            )
+            elapsed = time.perf_counter() - started
+            return index, elapsed, final_run
+
+    wall_started = time.perf_counter()
+    results = await asyncio.gather(*(run_one(index) for index in range(total_runs)))
+    wall_elapsed = time.perf_counter() - wall_started
+
+    durations = [elapsed for _, elapsed, _ in results]
+    average_elapsed = sum(durations) / len(durations)
+    print(
+        "Function API hot concurrency benchmark: "
+        f"runs={total_runs} concurrency={concurrency} "
+        f"avg={average_elapsed:.3f}s wall={wall_elapsed:.3f}s "
+        f"min={min(durations):.3f}s max={max(durations):.3f}s"
+    )
+
+    for index, _elapsed, final_run in results:
+        output = final_run["output_data"]
+        assert output["value"] == index
+        assert output["doubled"] == index * 2
+        assert output["caller_user_id"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_workspace_api_url")
+async def test_function_connector_operation_resolves_user_owned_account_in_backend(
+    authenticated_client,
+    test_pod,
+    fixed_test_user,
+    db_session,
+    worker,
+):
+    pod_id = test_pod["id"]
+    suffix = uuid4().hex[:8]
+    connector_id = f"dynamic_app_{suffix}"
+    function_name = f"dynamic_app_func_{suffix}"
+    await seed_connector_operation(
+        db_session,
+        connector_id=connector_id,
+        organization_id=test_pod["organization_id"],
+        user_id=fixed_test_user["id"],
+        api_key="dynamic-secret",
+    )
+
+    function = await create_function(
+        authenticated_client,
+        pod_id,
+        {
+            "name": function_name,
+            "description": "Function app operation using dynamic account resolution",
+            "code": connector_function_code(
+                function_name,
+                connector_id,
+            ),
+        },
+    )
+    await replace_function_resource_grants(
+        authenticated_client,
+        pod_id,
+        function_name,
+        [
+            {
+                "resource_type": "function",
+                "resource_name": function["name"],
+                "permission_ids": ["function.read"],
+            },
+            {
+                "resource_type": "connector",
+                "resource_name": connector_id,
+                "permission_ids": ["connector.use"],
+            },
+        ],
+    )
+    await replace_role_resource_grants(
+        authenticated_client,
+        pod_id,
+        "POD_ADMIN",
+        [
+            {
+                "resource_type": "function",
+                "resource_name": function["name"],
+                "permission_ids": ["function.read"],
+            },
+            {
+                "resource_type": "connector",
+                "resource_name": connector_id,
+                "permission_ids": ["connector.use"],
+            },
+        ],
+    )
+
+    with patch_connector_operation_execution(connector_id):
+        final_run = await run_function(
+            authenticated_client,
+            pod_id,
+            function_name,
+            {"message": "hello-dynamic"},
+        )
+
+    output = final_run["output_data"]
+    assert output["echoed_message"] == "hello-dynamic"
+    assert output["used_api_key"] == "dynamic-secret"
+    assert output["caller_user_id"] == str(fixed_test_user["id"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_workspace_api_url")
+async def test_function_connector_operation_resolves_agent_owned_account_in_backend(
+    authenticated_client,
+    test_pod,
+    fixed_test_user,
+    db_session,
+    worker,
+):
+    pod_id = test_pod["id"]
+    suffix = uuid4().hex[:8]
+    connector_id = f"fixed_app_{suffix}"
+    function_name = f"fixed_app_func_{suffix}"
+    fixed_account_owner = await seed_user(db_session)
+    account = await seed_connector_operation(
+        db_session,
+        connector_id=connector_id,
+        organization_id=test_pod["organization_id"],
+        user_id=fixed_account_owner.id,
+        api_key="fixed-secret",
+    )
+
+    function = await create_function(
+        authenticated_client,
+        pod_id,
+        {
+            "name": function_name,
+            "description": "Function app operation using fixed account resolution",
+            "code": connector_function_code(
+                function_name,
+                connector_id,
+                account_id=str(account.id),
+            ),
+        },
+    )
+    await replace_function_resource_grants(
+        authenticated_client,
+        pod_id,
+        function_name,
+        [
+            {
+                "resource_type": "function",
+                "resource_name": function["name"],
+                "permission_ids": ["function.read"],
+            },
+            {
+                "resource_type": "connector",
+                "resource_name": connector_id,
+                "permission_ids": ["connector.use"],
+            },
+            {
+                "resource_type": "connector_account",
+                "resource_name": str(account.id),
+                "permission_ids": ["connector_account.use"],
+            },
+        ],
+    )
+    await replace_role_resource_grants(
+        authenticated_client,
+        pod_id,
+        "POD_ADMIN",
+        [
+            {
+                "resource_type": "function",
+                "resource_name": function["name"],
+                "permission_ids": ["function.read"],
+            },
+            {
+                "resource_type": "connector",
+                "resource_name": connector_id,
+                "permission_ids": ["connector.use"],
+            },
+            {
+                "resource_type": "connector_account",
+                "resource_name": str(account.id),
+                "permission_ids": ["connector_account.use"],
+            },
+        ],
+    )
+
+    with patch_connector_operation_execution(connector_id):
+        final_run = await run_function(
+            authenticated_client,
+            pod_id,
+            function_name,
+            {"message": "hello-fixed"},
+        )
+
+    output = final_run["output_data"]
+    assert output["echoed_message"] == "hello-fixed"
+    assert output["used_api_key"] == "fixed-secret"
+    assert output["caller_user_id"] == str(fixed_test_user["id"])
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_workspace_api_url")
+async def test_function_connector_operation_fails_when_user_owned_account_missing(
+    authenticated_client,
+    test_pod,
+    fixed_test_user,
+    db_session,
+    worker,
+):
+    pod_id = test_pod["id"]
+    suffix = uuid4().hex[:8]
+    connector_id = f"missing_account_app_{suffix}"
+    function_name = f"missing_account_func_{suffix}"
+    await seed_connector_operation(
+        db_session,
+        connector_id=connector_id,
+        organization_id=test_pod["organization_id"],
+    )
+
+    function = await create_function(
+        authenticated_client,
+        pod_id,
+        {
+            "name": function_name,
+            "description": "Function app operation missing user account",
+            "code": connector_function_code(
+                function_name,
+                connector_id,
+            ),
+        },
+    )
+    await replace_function_resource_grants(
+        authenticated_client,
+        pod_id,
+        function_name,
+        [
+            {
+                "resource_type": "function",
+                "resource_name": function["name"],
+                "permission_ids": ["function.read"],
+            },
+            {
+                "resource_type": "connector",
+                "resource_name": connector_id,
+                "permission_ids": ["connector.use"],
+            },
+        ],
+    )
+    await replace_role_resource_grants(
+        authenticated_client,
+        pod_id,
+        "POD_ADMIN",
+        [
+            {
+                "resource_type": "function",
+                "resource_name": function["name"],
+                "permission_ids": ["function.read"],
+            },
+            {
+                "resource_type": "connector",
+                "resource_name": connector_id,
+                "permission_ids": ["connector.use"],
+            },
+        ],
+    )
+
+    final_run = await run_function(
+        authenticated_client,
+        pod_id,
+        function_name,
+        {"message": "hello-missing"},
+        expected_status="FAILED",
+    )
+
+    assert final_run["error"]
+    assert "ACCOUNT_RESOLUTION_ERROR" in final_run["error"]
+    assert "Connect your account first" in final_run["error"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_workspace_api_url")
+async def test_api_function_timeout_marks_run_failed_and_stops_execution(
+    authenticated_client,
+    test_pod,
+    monkeypatch,
+):
+    from app.core.config import settings as backend_settings
+
+    pod_id = test_pod["id"]
+    suffix = uuid4().hex[:8]
+    function_name = f"api_timeout_{suffix}"
+    table_name = f"timeout_records_{suffix}"
+
+    await create_table(authenticated_client, pod_id, table_name)
+
+    code = f"""#input_type_name: TimeoutInput
+#output_type_name: TimeoutResult
+#function_name: {function_name}
+
+import asyncio
+from pydantic import BaseModel
+from lemma_sdk import FunctionContext, Pod
+
+class TimeoutInput(BaseModel):
+    title: str
+
+class TimeoutResult(BaseModel):
+    record_id: str
+
+async def {function_name}(ctx: FunctionContext, data: TimeoutInput) -> TimeoutResult:
+    await asyncio.sleep(5)
+    pod = Pod.from_env()
+    record = pod.table("{table_name}").create(
+        {{
+            "title": data.title,
+        }}
+    )
+    row = record
+    return TimeoutResult(record_id=str(row["id"]))"""
+
+    await create_function(
+        authenticated_client,
+        pod_id,
+        {
+            "name": function_name,
+            "description": "API function timeout smoke test",
+            "type": "API",
+            "code": code,
+        },
+    )
+
+    # Function creation performs schema extraction and prewarms the revision
+    # worker. Restrict only the execution whose timeout behavior this test owns.
+    monkeypatch.setattr(backend_settings, "function_api_deadline_seconds", 2)
+    response = await authenticated_client.post(
+        f"/pods/{pod_id}/functions/{function_name}/runs",
+        json={"input_data": {"title": "should-not-write"}},
+        follow_redirects=True,
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    run_id = response.json()["id"]
+
+    final_run = await wait_for_run_completion(
+        authenticated_client,
+        pod_id,
+        function_name,
+        run_id,
+        timeout_seconds=15,
+    )
+    assert final_run["status"] == "FAILED", final_run
+    assert final_run["error"]
+    assert "timed out" in final_run["error"].lower()
+
+    await asyncio.sleep(4)
+
+    rerun_response = await authenticated_client.get(
+        f"/pods/{pod_id}/functions/{function_name}/runs/{run_id}"
+    )
+    assert rerun_response.status_code == status.HTTP_200_OK, rerun_response.text
+    assert rerun_response.json()["status"] == "FAILED"
+
+    records_response = await authenticated_client.get(
+        f"/pods/{pod_id}/datastore/tables/{table_name}/records",
+    )
+    assert records_response.status_code == status.HTTP_200_OK, records_response.text
+    assert records_response.json()["total"] == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_workspace_api_url")
+async def test_job_function_run_completes_via_worker(
+    authenticated_client,
+    test_pod,
+    worker,
+):
+    pod_id = test_pod["id"]
+    suffix = uuid4().hex[:8]
+    function_name = f"job_func_{suffix}"
+
+    code = f"""#input_type_name: JobInput
+#output_type_name: JobResult
+#function_name: {function_name}
+
+import asyncio
+from pydantic import BaseModel
+from lemma_sdk import FunctionContext
+
+class JobInput(BaseModel):
+    text: str
+
+class JobResult(BaseModel):
+    result: str
+
+async def {function_name}(ctx: FunctionContext, data: JobInput) -> JobResult:
+    await asyncio.sleep(1)
+    return JobResult(result=data.text.upper())"""
+
+    await create_function(
+        authenticated_client,
+        pod_id,
+        {
+            "name": function_name,
+            "description": "Queued function execution smoke test",
+            "type": "JOB",
+            "code": code,
+        },
+    )
+
+    response = await authenticated_client.post(
+        f"/pods/{pod_id}/functions/{function_name}/runs",
+        json={"input_data": {"text": "queued hello"}},
+        follow_redirects=True,
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    run = response.json()
+    assert run["status"] in {"PENDING", "RUNNING"}
+    assert run["job_id"]
+
+    final_run = await wait_for_run_completion(
+        authenticated_client,
+        pod_id,
+        function_name,
+        run["id"],
+        timeout_seconds=30,
+    )
+    assert final_run["status"] == "COMPLETED", final_run
+    assert final_run["output_data"]["result"] == "QUEUED HELLO"
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_workspace_api_url")
+async def test_job_function_execution_writes_datastore_record(
+    authenticated_client,
+    test_pod,
+    worker,
+):
+    pod_id = test_pod["id"]
+    suffix = uuid4().hex[:8]
+    function_name = f"job_store_{suffix}"
+    table_name = f"expenses_{suffix}"
+
+    response = await authenticated_client.post(
+        f"/pods/{pod_id}/datastore/tables",
+        json={
+            "name": table_name,
+            "primary_key_column": "id",
+            "enable_rls": True,
+            "columns": [
+                {"name": "title", "type": "TEXT", "required": True},
+                {"name": "note", "type": "TEXT", "required": False},
+            ],
+        },
+    )
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+    table = response.json()
+
+    code = f"""#input_type_name: SaveExpenseInput
+#output_type_name: SaveExpenseResult
+#function_name: {function_name}
+
+from pydantic import BaseModel
+from lemma_sdk import FunctionContext, Pod
+
+class SaveExpenseInput(BaseModel):
+    title: str
+    note: str
+
+class SaveExpenseResult(BaseModel):
+    record_id: str
+    caller_user_id: str
+    caller_user_email: str | None = None
+
+async def {function_name}(ctx: FunctionContext, data: SaveExpenseInput) -> SaveExpenseResult:
+    pod = Pod.from_env()
+    record = pod.table("{table_name}").create(
+        {{
+            "title": data.title,
+            "note": data.note,
+        }}
+    )
+    row = record
+    return SaveExpenseResult(
+        record_id=str(row["id"]),
+        caller_user_id=str(ctx.user_id),
+        caller_user_email=ctx.user_email,
+    )"""
+
+    await create_function(
+        authenticated_client,
+        pod_id,
+        {
+            "name": function_name,
+            "description": "Queued datastore write smoke test",
+            "type": "JOB",
+            "code": code,
+        },
+    )
+    await replace_function_resource_grants(
+        authenticated_client,
+        pod_id,
+        function_name,
+        [
+            {
+                "resource_type": "datastore_table",
+                "resource_name": table["name"],
+                "permission_ids": [
+                    "datastore.table.read",
+                    "datastore.record.write",
+                ],
+            }
+        ],
+    )
+    await replace_role_resource_grants(
+        authenticated_client,
+        pod_id,
+        "POD_ADMIN",
+        [
+            {
+                "resource_type": "datastore_table",
+                "resource_name": table["name"],
+                "permission_ids": [
+                    "datastore.table.read",
+                    "datastore.record.read",
+                    "datastore.record.write",
+                ],
+            }
+        ],
+    )
+
+    final_run = await run_function(
+        authenticated_client,
+        pod_id,
+        function_name,
+        {"title": "Taxi", "note": "airport pickup"},
+    )
+    assert final_run["status"] == "COMPLETED", final_run
+    output = final_run["output_data"]
+    assert output["caller_user_id"]
+
+    records_response = await authenticated_client.get(
+        f"/pods/{pod_id}/datastore/tables/{table_name}/records",
+    )
+    assert records_response.status_code == status.HTTP_200_OK, records_response.text
+    records_payload = records_response.json()
+    assert records_payload["total"] == 1
+    assert records_payload["items"][0]["id"] == output["record_id"]
+    assert records_payload["items"][0]["title"] == "Taxi"
+    assert records_payload["items"][0]["note"] == "airport pickup"
+    assert records_payload["items"][0]["user_id"] == output["caller_user_id"]
+
+
+@pytest.mark.slow
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_workspace_api_url")
+async def test_job_function_long_run_is_not_destroyed_while_active(
+    authenticated_client,
+    test_pod,
+    worker,
+):
+    """An active run prevents function-sandbox idle release without heartbeats.
+
+    The idle window is squeezed to five seconds so a sixty-second run is many
+    times longer than it, which is what makes the assertion mean something:
+    the run finishing proves activity held the sandbox, not that the sweep
+    simply never came round.
+    """
+    from app.modules.workspace.config import workspace_settings
+
+    original_idle = workspace_settings.idle_release_seconds
+    workspace_settings.idle_release_seconds = 5
+    try:
+        pod_id = test_pod["id"]
+        suffix = uuid4().hex[:8]
+        function_name = f"job_long_{suffix}"
+        code = f"""#input_type_name: JobInput
+#output_type_name: JobResult
+#function_name: {function_name}
+
+import asyncio
+from pydantic import BaseModel
+from lemma_sdk import FunctionContext
+
+class JobInput(BaseModel):
+    seconds: int
+
+class JobResult(BaseModel):
+    slept: int
+
+async def {function_name}(ctx: FunctionContext, data: JobInput) -> JobResult:
+    await asyncio.sleep(data.seconds)
+    return JobResult(slept=data.seconds)"""
+
+        await create_function(
+            authenticated_client,
+            pod_id,
+            {
+                "name": function_name,
+                "description": "Long-running job: sandbox keepalive smoke test",
+                "type": "JOB",
+                "code": code,
+            },
+        )
+
+        response = await authenticated_client.post(
+            f"/pods/{pod_id}/functions/{function_name}/runs",
+            json={"input_data": {"seconds": 60}},
+            follow_redirects=True,
+        )
+        assert response.status_code == status.HTTP_200_OK, response.text
+        run = response.json()
+
+        final_run = await wait_for_run_completion(
+            authenticated_client,
+            pod_id,
+            function_name,
+            run["id"],
+            timeout_seconds=150,
+        )
+        assert final_run["status"] == "COMPLETED", final_run
+        assert final_run["output_data"]["slept"] == 60
+    finally:
+        workspace_settings.idle_release_seconds = original_idle
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_workspace_api_url")
+async def test_concurrent_api_function_runs_all_complete(
+    authenticated_client,
+    test_pod,
+):
+    """3-4 API runs fired together (same user -> shared sandbox) all complete.
+
+    Concurrent cold-start callers must coordinate on one sandbox creation
+    (Redis creation lock) and then share the RUNNING sandbox; none should fail
+    with a sandbox readiness / "Sandbox not found" race.
+    """
+    pod_id = test_pod["id"]
+    suffix = uuid4().hex[:8]
+    function_name = f"api_concurrent_{suffix}"
+    code = f"""#input_type_name: ConcInput
+#output_type_name: ConcResult
+#function_name: {function_name}
+
+import asyncio
+from pydantic import BaseModel
+from lemma_sdk import FunctionContext
+
+class ConcInput(BaseModel):
+    n: int
+
+class ConcResult(BaseModel):
+    doubled: int
+
+async def {function_name}(ctx: FunctionContext, data: ConcInput) -> ConcResult:
+    await asyncio.sleep(2)
+    return ConcResult(doubled=data.n * 2)"""
+
+    await create_function(
+        authenticated_client,
+        pod_id,
+        {
+            "name": function_name,
+            "description": "concurrency smoke (API)",
+            "type": "API",
+            "code": code,
+        },
+    )
+
+    async def run_one(n: int) -> dict:
+        return await run_function(authenticated_client, pod_id, function_name, {"n": n})
+
+    results = await asyncio.gather(*(run_one(n) for n in range(1, 5)))
+    for n, final in zip(range(1, 5), results):
+        assert final["status"] == "COMPLETED", final
+        assert final["output_data"]["doubled"] == n * 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_workspace_api_url")
+async def test_concurrent_job_function_runs_all_complete(
+    authenticated_client,
+    test_pod,
+    worker,
+):
+    """3-4 JOB runs fired together (same user -> shared sandbox) all complete."""
+    pod_id = test_pod["id"]
+    suffix = uuid4().hex[:8]
+    function_name = f"job_concurrent_{suffix}"
+    code = f"""#input_type_name: ConcInput
+#output_type_name: ConcResult
+#function_name: {function_name}
+
+import asyncio
+from pydantic import BaseModel
+from lemma_sdk import FunctionContext
+
+class ConcInput(BaseModel):
+    n: int
+
+class ConcResult(BaseModel):
+    doubled: int
+
+async def {function_name}(ctx: FunctionContext, data: ConcInput) -> ConcResult:
+    await asyncio.sleep(3)
+    return ConcResult(doubled=data.n * 2)"""
+
+    await create_function(
+        authenticated_client,
+        pod_id,
+        {
+            "name": function_name,
+            "description": "concurrency smoke (JOB)",
+            "type": "JOB",
+            "code": code,
+        },
+    )
+
+    async def trigger(n: int) -> str:
+        resp = await authenticated_client.post(
+            f"/pods/{pod_id}/functions/{function_name}/runs",
+            json={"input_data": {"n": n}},
+            follow_redirects=True,
+        )
+        assert resp.status_code == status.HTTP_200_OK, resp.text
+        return resp.json()["id"]
+
+    run_ids = await asyncio.gather(*(trigger(n) for n in range(1, 5)))
+    finals = await asyncio.gather(
+        *(
+            wait_for_run_completion(
+                authenticated_client, pod_id, function_name, rid, timeout_seconds=150
+            )
+            for rid in run_ids
+        )
+    )
+    for final in finals:
+        assert final["status"] == "COMPLETED", final
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_workspace_api_url")
+async def test_function_runs_a_tenant_connector_operation_for_real(
+    authenticated_client,
+    test_pod,
+    fixed_test_user,
+    db_session,
+    worker,
+    monkeypatch,
+):
+    """A function calls an MCP server through `pod.connectors.execute`.
+
+    The other connector function tests patch the gateway, so they prove the
+    delegated-workload authorization path but stop short of a real call. This
+    one runs a live MCP server, installs it as a tenant connector, and has a
+    function in the pod runtime execute one of its discovered tools -- so
+    nothing between the function and the server is a stand-in.
+    """
+    import asyncio
+    import contextlib
+    import socket
+    from uuid import UUID
+
+    from fastmcp import FastMCP
+
+    from app.core.config import settings
+    from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
+    from app.modules.connectors.api.dependencies import get_connector_service
+    from app.modules.connectors.domain.auth_config import AuthConfigSource
+    from app.modules.connectors.infrastructure.models.connector import Connector
+
+    monkeypatch.setattr(settings, "connector_allow_private_network_targets", True)
+
+    server = FastMCP("function-runtime")
+
+    @server.tool
+    def add(a: int, b: int) -> int:
+        """Add two integers."""
+        return a + b
+
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+    task = asyncio.create_task(
+        server.run_async(
+            transport="http", host="127.0.0.1", port=port, show_banner=False
+        )
+    )
+
+    async def probe_port() -> bool:
+        if task.done():
+            raise RuntimeError(f"MCP server failed to start: {task.exception()}")
+        _, writer = await asyncio.open_connection("127.0.0.1", port)
+        writer.close()
+        await writer.wait_closed()
+        return True
+
+    # retry_exceptions=(OSError,): connection refused just means the listener
+    # isn't up yet, not a real failure -- same as the original loop's
+    # `except OSError: sleep`. A RuntimeError from a dead task still
+    # propagates immediately since it isn't in retry_exceptions.
+    await eventually(
+        label=f"MCP server on 127.0.0.1:{port}",
+        probe=probe_port,
+        done=lambda ready: ready,
+        retry_exceptions=(OSError,),
+        timeout_seconds=5,
+        interval_seconds=0.05,
+    )
+
+    try:
+        suffix = uuid4().hex[:8]
+        connector_id = f"mcp_fn_{suffix}"
+        function_name = f"mcp_fn_func_{suffix}"
+
+        db_session.add(
+            Connector(
+                id=connector_id,
+                title="Function MCP",
+                description="MCP server reached from a function.",
+                kinds=[
+                    {
+                        "kind": "mcp",
+                        "auth_scheme": "API_KEY",
+                        "discovery": "mcp",
+                        "auth_config_schema": {
+                            "type": "object",
+                            "required": ["server_url"],
+                            "properties": {"server_url": {"type": "string"}},
+                            "additionalProperties": False,
+                        },
+                    }
+                ],
+                is_active=True,
+            )
+        )
+        await db_session.commit()
+
+        org_id = UUID(str(test_pod["organization_id"]))
+        user_id = UUID(str(fixed_test_user["id"]))
+        service = get_connector_service(SqlAlchemyUnitOfWork(db_session))
+        install = await service.create_auth_config(
+            user_id=user_id,
+            organization_id=org_id,
+            connector_id=connector_id,
+            config_source=AuthConfigSource.SYSTEM_DEFAULT.value,
+            config={"server_url": f"http://127.0.0.1:{port}/mcp"},
+            name=f"mcp-fn-{suffix}",
+        )
+        await service.create_account(
+            user_id=user_id,
+            organization_id=org_id,
+            auth_config_id=install.id,
+            credentials={"api_key": "unused-by-this-server"},
+        )
+
+        function = await create_function(
+            authenticated_client,
+            test_pod["id"],
+            {
+                "name": function_name,
+                "description": "Runs an MCP tool through the connectors SDK",
+                "code": mcp_function_code(function_name, install.name),
+            },
+        )
+        grants = [
+            {
+                "resource_type": "function",
+                "resource_name": function["name"],
+                "permission_ids": ["function.read"],
+            },
+            {
+                "resource_type": "connector",
+                "resource_name": connector_id,
+                "permission_ids": ["connector.use"],
+            },
+        ]
+        await replace_function_resource_grants(
+            authenticated_client, test_pod["id"], function_name, grants
+        )
+        await replace_role_resource_grants(
+            authenticated_client, test_pod["id"], "POD_ADMIN", grants
+        )
+
+        final_run = await run_function(
+            authenticated_client,
+            test_pod["id"],
+            function_name,
+            {"a": 17, "b": 25},
+        )
+        # 17 + 25, computed by the MCP server, reached from inside the pod
+        # runtime through the connectors SDK.
+        assert final_run["output_data"]["total"] == 42
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+# -- FunctionUseCases sagas with no direct HTTP entry point of their own -----
+#
+# upsert_function_for_import (bundle import), execute_function_as_workload
+# (agent-as-tool) and dispatch_function_for_workflow/cancel_function_run
+# (workflow node control) have no HTTP surface at all -- they're built the same
+# way their real callers build them (app/modules/agent/tools/
+# callable_tool_factory.py, app/composition/workflow_function.py) via
+# `build_function_use_cases`, against the live e2e database and the real Docker
+# sandbox, same pattern as test_function_sandbox_execution_e2e.py's
+# dispatcher-construction tests.
+#
+# update_function/delete_function are the other half of this group and DO have
+# HTTP endpoints, so they stayed in test_function_e2e.py with the rest of the
+# shape surface.
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_workspace_api_url")
+async def test_upsert_function_for_import_creates_then_idempotently_updates(
+    authenticated_client, test_pod, fixed_test_user, db_manager
+):
+    """``upsert_function_for_import`` is the bundle/CLI import saga
+    (``app/modules/pod_bundle/infrastructure/function_builder.py::FunctionStepRunner``):
+    create-if-absent, update-if-present, by name, with no request object.
+    It has no HTTP endpoint of its own, so this builds the same
+    ``FunctionUseCases`` the real import path builds."""
+    from uuid import UUID
+
+    from app.core.infrastructure.db.uow_factory import SessionUnitOfWorkFactory
+    from app.modules.function.api.dependencies import build_function_use_cases
+    from app.modules.function.domain.entities import (
+        FunctionEntity,
+        FunctionStatus,
+        FunctionType,
+        FunctionUpdateEntity,
+    )
+
+    pod_id = UUID(test_pod["id"])
+    user_id = UUID(fixed_test_user["id"])
+    func_name = f"import_fn_{uuid4().hex[:8]}"
+    use_cases = build_function_use_cases(
+        SessionUnitOfWorkFactory(db_manager.session_factory)
+    )
+
+    def _entity() -> FunctionEntity:
+        return FunctionEntity(
+            pod_id=pod_id,
+            user_id=user_id,
+            name=func_name,
+            description="imported",
+            type=FunctionType.API,
+            visibility="POD",
+        )
+
+    first_code = typed_function_code(func_name, expression="data.value + 1")
+    created = await use_cases.upsert_function_for_import(
+        entity=_entity(),
+        update_entity=FunctionUpdateEntity(
+            description="imported", code=first_code, type=FunctionType.API
+        ),
+        code=first_code,
+        user_id=user_id,
+    )
+    assert created.status == FunctionStatus.READY
+    first_revision = created.revision_hash
+    assert first_revision
+
+    # Applying the bundle again (e.g. `lemma pods import` re-run) must UPDATE
+    # the existing row by name, not raise FUNCTION_CONFLICT.
+    second_code = typed_function_code(func_name, expression="data.value + 2")
+    updated = await use_cases.upsert_function_for_import(
+        entity=_entity(),
+        update_entity=FunctionUpdateEntity(
+            description="imported again", code=second_code, type=FunctionType.API
+        ),
+        code=second_code,
+        user_id=user_id,
+    )
+    assert updated.id == created.id
+    assert updated.description == "imported again"
+    assert updated.revision_hash != first_revision
+
+    # Visible + executable through the normal HTTP surface, reflecting the
+    # second import's code.
+    final_run = await run_function(
+        authenticated_client, str(pod_id), func_name, {"value": 10}
+    )
+    assert final_run["output_data"]["result"] == 12
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_workspace_api_url")
+async def test_execute_function_as_workload_runs_under_the_agent_delegated_context(
+    authenticated_client, test_pod, fixed_test_user, db_manager
+):
+    """``execute_function_as_workload`` is the agent-as-tool delegated path
+    (``app/modules/agent/tools/callable_tool_factory.py``): it authorizes as
+    the delegated AGENT principal on behalf of the calling user and runs the
+    sandbox with no ctx held. Drive it exactly the way the tool factory does."""
+    from uuid import UUID
+
+    from app.core.authorization.permissions import Permissions
+    from app.core.infrastructure.db.uow_factory import SessionUnitOfWorkFactory
+    from app.modules.function.api.dependencies import build_function_use_cases
+    from app.modules.function.domain.entities import FunctionRunStatus
+
+    pod_id = UUID(test_pod["id"])
+    user_id = UUID(fixed_test_user["id"])
+    func_name = f"workload_fn_{uuid4().hex[:8]}"
+
+    await create_function(
+        authenticated_client,
+        str(pod_id),
+        {
+            "name": func_name,
+            "description": "workload test",
+            "code": typed_function_code(func_name, expression="data.value * 2"),
+        },
+    )
+
+    # execute_function_as_workload authorizes the AGENT principal against a
+    # real per-resource grant (ResourcePermissionGrantModel) -- exactly the
+    # grant callable_tool_factory.py relies on when it exposes a function as
+    # an agent tool. A bare uuid4() principal has none, so build one for
+    # real: create the agent, then grant it function.execute through the
+    # agent-permissions endpoint (the resource-access-grant endpoint only
+    # accepts ROLE/POD_MEMBER grantees, not AGENT).
+    agent_name = f"workload_agent_{uuid4().hex[:8]}"
+    agent_response = await authenticated_client.post(
+        f"/pods/{pod_id}/agents",
+        json={"name": agent_name, "instruction": "Answer briefly."},
+    )
+    assert agent_response.status_code == status.HTTP_201_CREATED, agent_response.text
+    agent_id = UUID(agent_response.json()["id"])
+
+    grant_response = await authenticated_client.put(
+        f"/pods/{pod_id}/agents/{agent_name}/permissions",
+        json={
+            "grants": [
+                {
+                    "resource_type": "function",
+                    "resource_name": func_name,
+                    "permission_ids": [Permissions.FUNCTION_EXECUTE],
+                }
+            ]
+        },
+    )
+    assert grant_response.status_code == status.HTTP_200_OK, grant_response.text
+
+    use_cases = build_function_use_cases(
+        SessionUnitOfWorkFactory(db_manager.session_factory)
+    )
+    run = await use_cases.execute_function_as_workload(
+        pod_id=pod_id,
+        name=func_name,
+        input_data={"value": 5},
+        user_id=user_id,
+        principal_type="AGENT",
+        principal_id=agent_id,
+        delegation_scope=frozenset([Permissions.FUNCTION_EXECUTE]),
+        delegation_actor_name="Test Agent",
+    )
+
+    assert run.status == FunctionRunStatus.COMPLETED, run.error
+    assert run.output_data == {"result": 10}
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_workspace_api_url")
+async def test_dispatch_function_for_workflow_enqueues_and_the_worker_completes_it(
+    authenticated_client, test_pod, fixed_test_user, db_manager, worker
+):
+    """``dispatch_function_for_workflow`` is the workflow-node path
+    (``app/composition/workflow_function.py::FunctionControlAdapter.execute_function``):
+    it forces ASYNCHRONOUS dispatch even for an API function and returns
+    PENDING without running the sandbox inline, so the workflow engine can
+    suspend on the run id and let the ``FunctionRunCompleted`` event resume
+    it. Drive it against the real queue + worker."""
+    from uuid import UUID
+
+    from app.core.infrastructure.db.uow_factory import SessionUnitOfWorkFactory
+    from app.modules.function.api.dependencies import build_function_use_cases
+    from app.modules.function.domain.entities import FunctionRunStatus
+
+    pod_id = UUID(test_pod["id"])
+    user_id = UUID(fixed_test_user["id"])
+    func_name = f"workflow_fn_{uuid4().hex[:8]}"
+
+    await create_function(
+        authenticated_client,
+        str(pod_id),
+        {
+            "name": func_name,
+            "description": "workflow dispatch test",
+            "type": "API",
+            "code": typed_function_code(func_name, expression="data.value + 1"),
+        },
+    )
+
+    use_cases = build_function_use_cases(
+        SessionUnitOfWorkFactory(db_manager.session_factory)
+    )
+    dispatched = await use_cases.dispatch_function_for_workflow(
+        pod_id=pod_id,
+        name=func_name,
+        input_data={"value": 41},
+        user_id=user_id,
+    )
+
+    # PENDING, and NOT run inline even though this is an API function -- the
+    # whole point of the workflow path is that the caller never blocks on the
+    # sandbox round-trip.
+    assert dispatched.status == FunctionRunStatus.PENDING
+    assert dispatched.job_id
+    assert dispatched.id is not None
+
+    final_run = await wait_for_run_completion(
+        authenticated_client,
+        str(pod_id),
+        func_name,
+        str(dispatched.id),
+    )
+    assert final_run["status"] == "COMPLETED", final_run
+    assert final_run["output_data"]["result"] == 42
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("configure_workspace_api_url")
+async def test_cancel_function_run_stops_a_dispatched_run_before_it_completes(
+    authenticated_client, test_pod, worker, db_manager
+):
+    """``cancel_function_run`` is used when a workflow run that was waiting on
+    a dispatched function is itself cancelled
+    (``app/composition/workflow_function.py::FunctionControlAdapter.cancel_run``),
+    so the sandbox stops doing work nobody is waiting for. A run that is still
+    PENDING or RUNNING is cancellable; confirm a long JOB run actually ends
+    CANCELLED instead of completing."""
+    from uuid import UUID
+
+    from app.core.infrastructure.db.uow_factory import SessionUnitOfWorkFactory
+    from app.modules.function.api.dependencies import build_function_use_cases
+
+    pod_id = test_pod["id"]
+    suffix = uuid4().hex[:8]
+    function_name = f"cancel_job_{suffix}"
+    code = f"""#input_type_name: JobInput
+#output_type_name: JobResult
+#function_name: {function_name}
+
+import asyncio
+from pydantic import BaseModel
+from lemma_sdk import FunctionContext
+
+class JobInput(BaseModel):
+    seconds: int
+
+class JobResult(BaseModel):
+    slept: int
+
+async def {function_name}(ctx: FunctionContext, data: JobInput) -> JobResult:
+    await asyncio.sleep(data.seconds)
+    return JobResult(slept=data.seconds)"""
+
+    await create_function(
+        authenticated_client,
+        pod_id,
+        {
+            "name": function_name,
+            "description": "cancel smoke test",
+            "type": "JOB",
+            "code": code,
+        },
+    )
+
+    response = await authenticated_client.post(
+        f"/pods/{pod_id}/functions/{function_name}/runs",
+        json={"input_data": {"seconds": 20}},
+        follow_redirects=True,
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    run = response.json()
+    assert run["status"] in {"PENDING", "RUNNING"}
+
+    use_cases = build_function_use_cases(
+        SessionUnitOfWorkFactory(db_manager.session_factory)
+    )
+    # Cancel promptly, well inside the function's 20-second sleep -- a run is
+    # cancellable in either PENDING or RUNNING, so there is no race to win.
+    await use_cases.cancel_function_run(UUID(run["id"]))
+
+    async def probe() -> dict:
+        res = await authenticated_client.get(
+            f"/pods/{pod_id}/functions/{function_name}/runs/{run['id']}"
+        )
+        assert res.status_code == status.HTTP_200_OK, res.text
+        return res.json()
+
+    final_run = await wait_for_status(
+        label=f"cancelled function run {run['id']}",
+        probe=probe,
+        expected={"CANCELLED"},
+        # A run that finishes or fails instead of cancelling is the actual
+        # bug under test -- fail fast rather than waiting out the timeout.
+        failed={"COMPLETED", "FAILED"},
+        timeout_seconds=15,
+        interval_seconds=0.15,
+    )
+    assert final_run["status"] == "CANCELLED", final_run

--- a/lemma-backend/app/modules/function/tests/e2e/test_function_execution_e2e.py
+++ b/lemma-backend/app/modules/function/tests/e2e/test_function_execution_e2e.py
@@ -14,6 +14,7 @@ worker, run concurrently, timed out, cancelled, or reaching a connector.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import time
 from uuid import uuid4
 
@@ -884,8 +885,6 @@ async def test_function_runs_a_tenant_connector_operation_for_real(
     function in the pod runtime execute one of its discovered tools -- so
     nothing between the function and the server is a stand-in.
     """
-    import asyncio
-    import contextlib
     import socket
     from uuid import UUID
 

--- a/lemma-backend/app/modules/function/tests/e2e/test_function_execution_e2e.py
+++ b/lemma-backend/app/modules/function/tests/e2e/test_function_execution_e2e.py
@@ -847,7 +847,17 @@ async def {function_name}(ctx: FunctionContext, data: ConcInput) -> ConcResult:
     finals = await asyncio.gather(
         *(
             wait_for_run_completion(
-                authenticated_client, pod_id, function_name, rid, timeout_seconds=150
+                authenticated_client,
+                pod_id,
+                function_name,
+                rid,
+                # Under the shard's `-o timeout=120`, not over it. At 150 this
+                # wait could never report: pytest-timeout killed the test at
+                # 120 first, so a real stall showed up as a bare SIGKILL with
+                # no mention of which run never finished. The four runs are
+                # concurrent and measure ~11s, so anything near this is a
+                # failure either way -- the only question is whether it says so.
+                timeout_seconds=110,
             )
             for rid in run_ids
         )

--- a/lemma-backend/app/modules/function/tests/e2e/test_function_sandbox_execution_e2e.py
+++ b/lemma-backend/app/modules/function/tests/e2e/test_function_sandbox_execution_e2e.py
@@ -51,6 +51,24 @@ from app.modules.test_support.e2e.waiters import eventually
 pytestmark = [pytest.mark.e2e, pytest.mark.real_sandbox]
 
 
+#: How long a test here waits for a run to reach a terminal status.
+_TERMINAL_WAIT_SECONDS = 45
+#: What goes in the run row's own `deadline_at`, which the reaper enforces.
+#:
+#: Deliberately far above the wait, and not equal to it. Both were 45s, started
+#: at different moments -- the row's clock begins when the row is created, the
+#: test's when it starts waiting, which is after a second run is created and
+#: committed. So the row's budget always expired first, and on a runner slow
+#: enough to matter (a cold Docker sandbox pull, a shard already at four
+#: workers) the test gave up while the reaper was still deciding. That is a
+#: race between two pieces of scaffolding, and it failed three times on three
+#: unrelated branches; run 32811225427 passed on a bare retry of the same SHA.
+#:
+#: Nothing here tests the deadline. `test_api_function_timeout_marks_run_failed`
+#: does that, on purpose, with a deadline chosen to expire.
+_RUN_DEADLINE_SECONDS = 4 * _TERMINAL_WAIT_SECONDS
+
+
 _CODE = """# input_type_name: Input
 # output_type_name: Output
 # function_name: execute
@@ -121,7 +139,7 @@ async def _create_run(
     await session.flush()
 
     run_id = uuid7()
-    deadline = datetime.now(timezone.utc) + timedelta(seconds=45)
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=_RUN_DEADLINE_SECONDS)
     session.add(
         FunctionRunModel(
             id=run_id,
@@ -158,7 +176,7 @@ async def _wait_for_terminal(db_manager, run_id: UUID) -> FunctionRunModel:
                 FunctionRunStatus.CANCELLED,
             }
         ),
-        timeout_seconds=45,
+        timeout_seconds=_TERMINAL_WAIT_SECONDS,
         interval_seconds=0.05,
     )
     assert run is not None

--- a/lemma-backend/app/modules/identity/tests/e2e/test_identity_e2e.py
+++ b/lemma-backend/app/modules/identity/tests/e2e/test_identity_e2e.py
@@ -1031,13 +1031,24 @@ async def test_organization_slug_is_globally_unique(
         signup_user(email=f"slug-b-{uuid4().hex[:8]}@slug-b.example"),
     )
 
+    # The emails were already randomized; the *name* was not, and the slug it
+    # produces is unique across the whole deployment. So this asserted that
+    # nothing anywhere had ever taken "global-slug-collision" -- and when
+    # something had, the first organization was seated at
+    # "global-slug-collision-2" and the test failed for a reason that had
+    # nothing to do with the rule it is about. The rule is that two names which
+    # slugify alike get different handles, and that holds at any starting
+    # handle, so the starting handle is now this run's.
+    token = uuid4().hex[:8]
+    expected_slug = f"global-slug-collision-{token}"
+
     first = await async_client.post(
         "/organizations",
         headers=_auth_headers(first_owner["token"]),
-        json={"name": "Global Slug Collision"},
+        json={"name": f"Global Slug Collision {token}"},
     )
     assert first.status_code == 201, first.text
-    assert first.json()["slug"] == "global-slug-collision"
+    assert first.json()["slug"] == expected_slug
 
     # Neither of these owners typed a handle, and the two display names are not
     # even the same -- they merely slugify alike. Refusing the second would
@@ -1046,10 +1057,10 @@ async def test_organization_slug_is_globally_unique(
     second = await async_client.post(
         "/organizations",
         headers=_auth_headers(second_owner["token"]),
-        json={"name": "Global-Slug Collision"},
+        json={"name": f"Global-Slug Collision {token}"},
     )
     assert second.status_code == 201, second.text
-    assert second.json()["name"] == "Global-Slug Collision"
+    assert second.json()["name"] == f"Global-Slug Collision {token}"
     assert second.json()["slug"] != first.json()["slug"], (
         "two organizations ended up sharing a handle; the handle is the address "
         "people are given, and it has to resolve to one of them"
@@ -1060,7 +1071,7 @@ async def test_organization_slug_is_globally_unique(
     chosen = await async_client.post(
         "/organizations",
         headers=_auth_headers(second_owner["token"]),
-        json={"name": "Something Else", "slug": "global-slug-collision"},
+        json={"name": "Something Else", "slug": expected_slug},
     )
     assert chosen.status_code == 409, chosen.text
     assert "slug" in chosen.json()["message"].lower()

--- a/lemma-backend/app/modules/test_support/e2e/function_helpers.py
+++ b/lemma-backend/app/modules/test_support/e2e/function_helpers.py
@@ -1,0 +1,497 @@
+"""Shared helpers for the function module's e2e journeys.
+
+Extracted when `test_function_e2e.py` was split in two. Both halves build
+functions, run them, seed connectors and grant resources the same way, so the
+helpers had to live somewhere neither half owns.
+
+Here rather than in a sibling `helpers.py`, because
+`app/modules/function/tests/e2e/` has no `__init__.py` and the suite runs under
+`--import-mode=importlib`, so a sibling module is not reliably importable. This
+package already is, and it is where `waiters.py`, `builders.py` and
+`e2e_authz.py` live -- the same job.
+
+Names lost their leading underscore on the way in. A `_private` name imported
+from another module is a lie about its scope.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+from uuid import uuid4
+
+from fastapi import status
+
+from app.modules.connectors.infrastructure.models.account import Account
+from app.modules.connectors.infrastructure.models.auth_config import AuthConfig
+from app.modules.connectors.infrastructure.models.connector import Connector
+from app.modules.connectors.infrastructure.models.connector_operation import (
+    ConnectorOperation,
+)
+from app.modules.identity.infrastructure.models.user_models import User
+from app.modules.test_support.e2e.waiters import wait_for_status
+
+
+async def wait_for_run_completion(
+    authenticated_client,
+    pod_id: str,
+    function_name: str,
+    run_id: str,
+    timeout_seconds: int = 60,
+):
+    async def probe() -> dict:
+        res = await authenticated_client.get(
+            f"/pods/{pod_id}/functions/{function_name}/runs/{run_id}"
+        )
+        assert res.status_code == status.HTTP_200_OK, res.text
+        return res.json()
+
+    # failed=set(): several callers (e.g. the API-timeout test) legitimately
+    # wait FOR a "FAILED" terminus and assert on it themselves afterward --
+    # preserve the original loop's behavior of returning on either terminal
+    # status rather than fail-fasting on FAILED.
+    return await wait_for_status(
+        label=f"function {function_name} run {run_id}",
+        probe=probe,
+        expected={"COMPLETED", "FAILED"},
+        failed=set(),
+        timeout_seconds=timeout_seconds,
+        interval_seconds=0.15,
+    )
+
+
+async def create_function(authenticated_client, pod_id: str, payload: dict) -> dict:
+    response = await authenticated_client.post(
+        f"/pods/{pod_id}/functions",
+        json=payload,
+        follow_redirects=True,
+    )
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+    return response.json()
+
+
+def function_payload(name: str, visibility: str | None = None) -> dict:
+    payload = {
+        "name": name,
+        "description": "Function visibility e2e",
+    }
+    if visibility is not None:
+        payload["visibility"] = visibility
+    return payload
+
+
+async def run_function(
+    authenticated_client,
+    pod_id: str,
+    function_name: str,
+    input_data: dict,
+    *,
+    expected_status: str = "COMPLETED",
+) -> dict:
+    response = await authenticated_client.post(
+        f"/pods/{pod_id}/functions/{function_name}/runs",
+        json={"input_data": input_data},
+        follow_redirects=True,
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    run_id = response.json()["id"]
+    final_run = await wait_for_run_completion(
+        authenticated_client,
+        pod_id,
+        function_name,
+        run_id,
+    )
+    assert final_run["status"] == expected_status, {
+        "status": final_run["status"],
+        "error": final_run.get("error"),
+        "run_id": final_run["id"],
+    }
+    return final_run
+
+
+async def create_table(
+    authenticated_client,
+    pod_id: str,
+    table_name: str,
+    *,
+    visibility: str | None = None,
+    enable_rls: bool = True,
+) -> dict:
+    payload = {
+        "name": table_name,
+        "primary_key_column": "id",
+        "enable_rls": enable_rls,
+        "columns": [
+            {"name": "id", "type": "UUID", "required": True, "auto": True},
+            {"name": "title", "type": "TEXT", "required": True},
+            {"name": "note", "type": "TEXT", "required": False},
+        ],
+    }
+    if visibility is not None:
+        payload["visibility"] = visibility
+    response = await authenticated_client.post(
+        f"/pods/{pod_id}/datastore/tables",
+        json=payload,
+    )
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+    return response.json()
+
+
+async def create_folder(
+    authenticated_client,
+    pod_id: str,
+    path: str,
+    *,
+    visibility: str | None = None,
+) -> dict:
+    payload = {"path": path}
+    if visibility is not None:
+        payload["visibility"] = visibility
+    response = await authenticated_client.post(
+        f"/pods/{pod_id}/datastore/files/folders",
+        json=payload,
+    )
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+    return response.json()
+
+
+async def replace_role_resource_grants(
+    authenticated_client,
+    pod_id: str,
+    role_name: str,
+    grants: list[dict],
+) -> dict:
+    response = await authenticated_client.put(
+        f"/pods/{pod_id}/roles/{role_name}/permissions",
+        json={"grants": grants},
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    return response.json()
+
+
+async def replace_function_resource_grants(
+    authenticated_client,
+    pod_id: str,
+    function_name: str,
+    grants: list[dict],
+) -> dict:
+    response = await authenticated_client.put(
+        f"/pods/{pod_id}/functions/{function_name}/permissions",
+        json={"grants": grants},
+    )
+    assert response.status_code == status.HTTP_200_OK, response.text
+    return response.json()
+
+
+async def seed_connector_operation(
+    db_session,
+    *,
+    connector_id: str,
+    organization_id: str,
+    user_id=None,
+    api_key: str | None = None,
+):
+    app = await db_session.get(Connector, connector_id)
+    if app is None:
+        app = Connector(
+            id=connector_id,
+            title=f"{connector_id} title",
+            description="Mock app for function e2e",
+            kinds=[
+                {
+                    "kind": "package",
+                    "auth_scheme": "API_KEY",
+                    "system_default_available": True,
+                }
+            ],
+            is_active=True,
+        )
+        db_session.add(app)
+
+    auth_config = AuthConfig(
+        id=uuid4(),
+        organization_id=organization_id,
+        connector_id=connector_id,
+        name=connector_id,
+        kind="package",
+        config_source="SYSTEM_DEFAULT",
+        status="ACTIVE",
+    )
+    db_session.add(auth_config)
+
+    operation = await db_session.get(
+        ConnectorOperation,
+        f"{connector_id}:send_payload",
+    )
+    if operation is None:
+        db_session.add(
+            ConnectorOperation(
+                id=f"{connector_id}:send_payload",
+                connector_id=connector_id,
+                name="send_payload",
+                provider_operation_name="send_payload",
+                display_name="Send Payload",
+                description="Mock send payload operation",
+                input_schema={
+                    "type": "object",
+                    "properties": {
+                        "message": {"type": "string"},
+                        "caller_user_id": {"type": "string"},
+                    },
+                    "required": ["message", "caller_user_id"],
+                },
+                output_schema={
+                    "type": "object",
+                    "properties": {
+                        "echoed_message": {"type": "string"},
+                        "used_api_key": {"type": "string"},
+                    },
+                    "required": ["echoed_message", "used_api_key"],
+                },
+            )
+        )
+
+    account = None
+    if user_id is not None:
+        account = Account(
+            id=uuid4(),
+            connector_id=connector_id,
+            organization_id=organization_id,
+            auth_config_id=auth_config.id,
+            user_id=user_id,
+            credentials={"api_key": api_key},
+        )
+        db_session.add(account)
+    await db_session.commit()
+    return account
+
+
+async def seed_user(db_session):
+    user = User(
+        id=uuid4(),
+        email=f"function-e2e-{uuid4().hex[:12]}@example.test",
+        is_verified=True,
+        is_active=True,
+    )
+    db_session.add(user)
+    await db_session.commit()
+    return user
+
+
+def connector_function_code(
+    function_name: str,
+    connector_id: str,
+    *,
+    account_id: str | None = None,
+) -> str:
+    account_id_argument = f',\n        account_id="{account_id}"' if account_id else ""
+    return f"""#input_type_name: SendPayloadInput
+#output_type_name: SendPayloadResult
+#function_name: {function_name}
+
+from pydantic import BaseModel
+from lemma_sdk import FunctionContext, Pod
+
+class SendPayloadInput(BaseModel):
+    message: str
+
+class SendPayloadResult(BaseModel):
+    echoed_message: str
+    used_api_key: str
+    caller_user_id: str
+
+async def {function_name}(ctx: FunctionContext, data: SendPayloadInput) -> SendPayloadResult:
+    pod = Pod.from_env()
+    response = pod.connectors.execute(
+        "{connector_id}",
+        "send_payload",
+        {{
+            "message": data.message,
+            "caller_user_id": str(ctx.user_id),
+        }}{account_id_argument},
+    )
+    result = response.result
+    return SendPayloadResult(
+        echoed_message=result["echoed_message"],
+        used_api_key=result["used_api_key"],
+        caller_user_id=result["caller_user_id"],
+    )"""
+
+
+def patch_connector_operation_execution(connector_id: str):
+    expected_connector_id = connector_id
+
+    async def fake_execute_operation(
+        _self,
+        connector_id,
+        operation_name,
+        payload,
+        third_party_credentials,
+        auth_token=None,
+        api_url=None,
+    ):
+        del auth_token, api_url
+        assert connector_id == expected_connector_id
+        assert operation_name == "send_payload"
+        return {
+            "echoed_message": payload["message"],
+            "used_api_key": third_party_credentials["api_key"],
+            "caller_user_id": payload["caller_user_id"],
+        }
+
+    return patch(
+        "app.modules.connectors.infrastructure.adapters.lemma_operation_gateway."
+        "LemmaOperationGateway.execute_operation",
+        new=fake_execute_operation,
+    )
+
+
+def record_grant_function_code(function_name: str, table_name: str) -> str:
+    """Function body that writes a record and reads it back.
+
+    Data-access failures are caught and surfaced as structured output so the
+    test can assert on the real HTTP status/code instead of an opaque run
+    failure. Reads/writes are gated by record permissions only.
+    """
+    # Uses typing.Optional on purpose: under Python 3.14 (PEP 649) deferred
+    # annotations, schema extraction must resolve typing names from the
+    # function's namespace, not just builtins. This guards the sandbox runtime's
+    # fix that registers the execution namespace as a real module.
+    return f"""#input_type_name: WriteInput
+#output_type_name: WriteResult
+#function_name: {function_name}
+
+from typing import Optional
+from pydantic import BaseModel
+from lemma_sdk import FunctionContext, Pod
+from lemma_sdk.errors import LemmaAPIError
+
+class WriteInput(BaseModel):
+    title: str
+    note: str
+
+class WriteResult(BaseModel):
+    denied: bool
+    status_code: Optional[int] = None
+    error_code: Optional[str] = None
+    record_id: Optional[str] = None
+    read_title: Optional[str] = None
+
+async def {function_name}(ctx: FunctionContext, data: WriteInput) -> WriteResult:
+    pod = Pod.from_env()
+    try:
+        record = pod.table("{table_name}").create(
+            {{"title": data.title, "note": data.note}}
+        )
+    except LemmaAPIError as exc:
+        return WriteResult(
+            denied=True,
+            status_code=exc.status_code,
+            error_code=exc.code,
+        )
+    row = record
+    fetched = pod.table("{table_name}").get(str(row["id"]))
+    read_row = fetched
+    return WriteResult(
+        denied=False,
+        record_id=str(row["id"]),
+        read_title=str(read_row["title"]),
+    )"""
+
+
+def bulk_facade_function_code(function_name: str, table_name: str) -> str:
+    """A function that writes a realistic number of rows the way one should.
+
+    Every call here goes through ``pod.table(...)``, which until now had no
+    batch path at all -- ``list/create/get/update/delete`` and nothing else. A
+    caller holding a table handle therefore wrote N rows as N ``create`` calls,
+    and from inside a sandbox each one is a full round trip back to the API. A
+    benchmark probe did exactly that and spent 17 of its 17.3 seconds on them.
+    """
+    return f"""#input_type_name: BulkInput
+#output_type_name: BulkResult
+#function_name: {function_name}
+
+from pydantic import BaseModel
+from lemma_sdk import FunctionContext, Pod
+
+class BulkInput(BaseModel):
+    rows: int
+
+class BulkResult(BaseModel):
+    created: int
+    updated: int
+    deleted: int
+    upserted: int
+    first_id: str
+    retitled: str
+
+async def {function_name}(ctx: FunctionContext, data: BulkInput) -> BulkResult:
+    pod = Pod.from_env()
+    t = pod.table("{table_name}")
+
+    created = t.bulk_create(
+        [{{"title": f"row-{{index}}", "note": "seed"}} for index in range(data.rows)]
+    )
+    rows = t.list(limit=data.rows).to_dict()["items"]
+    ids = sorted(str(row["id"]) for row in rows)
+
+    updated = t.bulk_update([{{"id": ids[0], "title": "renamed"}}])
+    # An upsert on an existing primary key must update, not fail the request --
+    # this is what makes re-seeding idempotent.
+    upserted = t.bulk_create([{{"id": ids[1], "title": "upserted"}}], upsert=True)
+    deleted = t.bulk_delete(ids[-2:])
+
+    return BulkResult(
+        created=created,
+        updated=updated,
+        deleted=deleted,
+        upserted=upserted,
+        first_id=ids[0],
+        retitled=str(t.get(ids[0])["title"]),
+    )"""
+
+
+def mcp_function_code(function_name: str, auth_config_name: str) -> str:
+    return f"""#input_type_name: AddInput
+#output_type_name: AddResult
+#function_name: {function_name}
+
+from pydantic import BaseModel
+from lemma_sdk import FunctionContext, Pod
+
+class AddInput(BaseModel):
+    a: int
+    b: int
+
+class AddResult(BaseModel):
+    total: int
+
+async def {function_name}(ctx: FunctionContext, data: AddInput) -> AddResult:
+    pod = Pod.from_env()
+    response = pod.connectors.execute(
+        "{auth_config_name}",
+        "add",
+        {{"a": data.a, "b": data.b}},
+    )
+    result = response.result
+    text = str(result)
+    digits = "".join(c for c in text if c.isdigit())
+    return AddResult(total=int(digits))"""
+
+
+def typed_function_code(function_name: str, *, expression: str) -> str:
+    return f"""#input_type_name: Input
+#output_type_name: Output
+#function_name: {function_name}
+
+from pydantic import BaseModel
+from lemma_sdk import FunctionContext
+
+class Input(BaseModel):
+    value: int
+
+class Output(BaseModel):
+    result: int
+
+async def {function_name}(ctx: FunctionContext, data: Input) -> Output:
+    return Output(result={expression})"""

--- a/scripts/plan_e2e_shards.py
+++ b/scripts/plan_e2e_shards.py
@@ -72,8 +72,34 @@ PINNED = [
         # groups that need the built images, and splitting them meant paying
         # the same image build twice against one racing cache key.
         "why": "real Docker sandbox provisioning contends for the runner's CPU",
-        # One bin keeps today's grouping. Raising it needs the 200s file inside
-        # this group split first, or the extra bin has nothing to take.
+        # Two bins, now that the 200s file is two ~100s files and there is
+        # something for the second bin to take. Split across runners rather
+        # than across xdist workers: the reason above is about two workers
+        # inside *one* four-vCPU runner, and separate jobs each get their own.
+        "bins": 2,
+    },
+    {
+        # The agent module's `fast_workspace` journeys, and only those. They
+        # provision a real Docker workspace, so wherever they run pays ~67s to
+        # restore the image -- and while they sat in the `agent` shard, all 123
+        # of its tests waited for that restore on behalf of five of them.
+        #
+        # Its own group rather than folded into `sandbox`, because the marker
+        # filter is the whole point. `fast_workspace` suppresses the auto-added
+        # `workspace` marker, so these are selected under FAST_MARKERS; under
+        # SANDBOX_MARKERS the same two files would also select eleven
+        # `workspace` tests that belong to the protected lane and have never
+        # run on a PR. Measured, not assumed: 27 selected under FAST_MARKERS,
+        # 38 under SANDBOX_MARKERS.
+        "name": "agent-workspace",
+        "dirs": [
+            "app/modules/agent/tests/e2e/test_agent_hermetic_journeys_e2e.py",
+            "app/modules/agent/tests/e2e/test_long_running_and_research_e2e.py",
+        ],
+        "workers": 1,
+        "markers": FAST_MARKERS,
+        "needs_sandbox_images": True,
+        "why": "provisions a real Docker workspace, same CPU contention as sandbox",
         "bins": 1,
     },
     {
@@ -81,16 +107,17 @@ PINNED = [
         "dirs": ["app/modules/agent/tests/e2e"],
         "workers": 1,
         "markers": FAST_MARKERS,
-        # True, even though the agent module is not the sandbox module. Its
-        # `fast_workspace` journeys provision a real Docker workspace, and
-        # conftest exempts them from the `workspace` marker precisely so they
-        # stay in the fast lane -- so this shard needs the image too. Without
-        # this it still got one: the `workspace_image` fixture built it on
-        # demand, inside the test step, uncached, and invisibly (pytest
-        # captures the build output, so the job log shows no build at all). The
-        # sandbox shard pays 79s to build and 27s to restore from cache; this
-        # shard was paying the 79s every run with nothing to show for it.
-        "needs_sandbox_images": True,
+        # False now, and derived rather than declared: with the two
+        # `fast_workspace` files in their own group above, nothing left in this
+        # shard asks for an image, and
+        # test_every_shard_that_provisions_a_sandbox_declares_the_image reads
+        # that off the sources rather than believing this line. It was True for
+        # a real reason -- without it the `workspace_image` fixture built the
+        # image on demand, inside the test step, uncached and invisibly,
+        # because pytest captures the build output, so the job log showed no
+        # build at all and the shard paid 79s every run. The fix then was to
+        # declare it. The fix now is not to need it.
+        "needs_sandbox_images": False,
         # MEASURED 2026-08-22, kept. The original reason -- "worker-subprocess
         # coverage files race under xdist" -- is false: .coveragerc sets
         # parallel=true and relative_files=true, so filenames cannot collide.


### PR DESCRIPTION
Stacked on #501 — merge that first; this diff is the split, the re-lane, and the CI-side wins.

## What changes

Backend E2E's predicted wall clock goes **444s → ~290s**, in seven shards instead of five. CodeQL's Python analysis loses ~40% of its input. Two confirmed flakes go away.

| shard | serial | tests | est. job |
|---|---|---|---|
| sandbox | 154.4s | 27 | ~288s |
| sandbox-2 | 155.9s | 27 | ~290s |
| agent-workspace | 99.2s | 27 | ~233s |
| agent | 93.5s | 96 | ~206s |
| schedule / datastore / surfaces | ~352s each | 217 / 162 / 263 | ~288s each |

## Why

### The wall was one file

`test_function_e2e.py` was 200.4s of the sandbox shard's 310s in 29 tests, and nothing in the layout could move it: bin-packing the sandbox group four ways still returns a 200s bin, and `--dist loadscope` puts a module's functions on one xdist worker, so no worker count splits it either.

It is now two files, cut on what a test is *about* — which turned out to be the same cut as by weight, because 26 of 29 pay a cold `docker run` and item cost is nearly uniform. `test_function_e2e.py` keeps the shape surface (lifecycle, the authorization matrix, record-grant and table-facade writes); `test_function_execution_e2e.py` takes the runtime (the queue, concurrency, timeouts, cancellation, connector operations, and the four use-case sagas with no HTTP entry point).

Shared helpers move to `app/modules/test_support/e2e/function_helpers.py` and lose the leading underscore — a `_private` name imported from another module is a lie about its scope. Not a sibling `helpers.py`: `app/modules/function/tests/e2e/` has no `__init__.py` and the suite runs under `--import-mode=importlib`, so a sibling is not reliably importable, while that package already is and is where `waiters.py` and `e2e_authz.py` live.

Both halves carry `pytestmark = [e2e, workspace]`. That is load-bearing: `workspace` is what the sandbox lane's filter selects on, so a half that lost it would be collected, deselected, and reported as a green shard that ran none of it. The contract test added in #501 fails if the two ever disagree.

### 123 agent tests waited on an image for the sake of five

The `agent` shard paid ~67s per run to restore the sandbox image so five of its tests could provision a workspace. Those five live in two files, which now form their own `agent-workspace` group. `agent` drops to `needs_sandbox_images: false` — *derived*, not declared: the contract test reads the answer off the sources, so removing the last `fast_workspace` test from the shard is what changes the flag.

That group is not folded into `sandbox`, because its marker filter is the point. `fast_workspace` suppresses the auto-added `workspace` marker, so these two files select **27 tests under FAST_MARKERS and 38 under SANDBOX_MARKERS** — the extra eleven are protected-lane `workspace` tests that have never run on a PR, and promoting them into the required lane is not what this change is for.

**Seven shards, not eight.** An eighth bin takes the image lane from ~290s to ~250s, but the packed lane is at ~288s and would become the wall — so it buys nothing until the per-test fixture cost comes down, and it costs a concurrency slot against a 20-job cap a full PR push already exceeds.

### Two flakes, confirmed from CI history rather than suspected

- **`test_api_and_job_execute_through_one_per_pod_docker_sandbox`** failed three times on three unrelated branches, and [run 32811225427](https://github.com/lemma-work/lemma-platform/actions/runs/32811225427) went green on a bare retry of the same SHA. Two 45s budgets were racing: the run row's `deadline_at`, whose clock starts when the row is created, and the test's wait for that row to go terminal, which starts after a *second* run is created and committed. The row always expired first. Its deadline is now 4× the wait, both named constants so they cannot drift back together.
- **`test_organization_slug_is_globally_unique`** randomised its emails and not its name, then asserted the slug equalled `global-slug-collision` — a handle unique across the whole deployment. So it asserted nothing anywhere had ever taken it. The rule it is actually about (two names that slugify alike get different handles) holds at any starting handle, so the starting handle is now this run's.

Also: `test_concurrent_job_function_runs_all_complete` waited 150s under a shard passing `-o timeout=120`, so pytest-timeout killed it first and a real stall arrived as a bare SIGKILL naming no run. Now 110s.

**Deliberately not touching `test_workspace_cli_concurrency_bench`**, which an audit flagged as a wall-clock assertion on a shared runner. It is one — but its 20s bound has 10s of headroom against the 30s yield window it guards, its docstring already says not to read it as a latency SLO, and it has not failed once in 150 runs. Dropping it from the PR lane would trade a real regression guard for 10.2s in a shard that is not the wall.

### CodeQL was extracting 459k lines of generated connector clients

3,222 files under `lemma-connectors/src/lemma_connectors/*/generated/`, emitted by `scripts/generate_*.py` from each provider's OpenAPI document — 459k of the repository's 1.11M tracked Python lines. `paths-ignore` already excluded the two OpenAPI SDK clients on exactly this reasoning, and this is the same rule at four times the scale. Every `generated/` directory in the tree is machine-emitted, including `lemma-typescript/src/react/generated`, whose files open with "do not edit by hand".

### The unit lane's JUnit is now uploaded

`make coverage-backend-unit` has always written it and nothing has ever collected it, so the 195s unit step's slow tail is invisible — and that step becomes the PR floor once e2e drops below ~240s. Parallelising it needs per-worker databases (`-m "not e2e"` includes eleven integration files sharing one Postgres with truncation between tests), which is real work and worth sizing against the tail first: if the 195s is three slow tests, splitting three tests is the cheaper fix. This is the measurement that decides.

## How to verify

The load-bearing claim is that the split moved tests between files and nothing else:

```bash
uv run pytest ${=args} -m "$mk" --collect-only -q -p no:cacheprovider \
  -o addopts="--import-mode=importlib --strict-markers"
```

```
sandbox 27  sandbox-2 27  agent-workspace 27  agent 96
schedule 217  datastore 162  surfaces 263        union: 819

819 test names, identical to main's selection
exactly 14 node IDs now report a different file (the 15th moved test is `slow`)
all 21 pairwise shard intersections: empty
```

Run for real, locally, against the real Docker sandbox:

```bash
uv run pytest app/modules/function/tests/e2e -m "e2e and not slow and not provider and not local_cli and not indexing and not protected" -n 0
```

- function directory after the split: **39 passed** — the same 39 as before it
- the new `agent-workspace` shard: **27 passed, 12 deselected** in 89s
- the three flake-fix files: **45 passed, 1 deselected**
- `make quality`, `plan_e2e_shards.py --verify`, and the 8 contract tests: green

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

Adds two shard jobs (5 → 7). Shard names change; no required check depends on them — `protect-main` requires `Backend E2E passed`, the aggregator. The CodeQL change only narrows what is scanned, so it cannot introduce a finding; reverting it restores the old scope. Revert is a plain revert throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)