### PR TITLE
Stop five test threads being able to hang their whole binary

### DIFF
--- a/desktop/local-runtime/hostctl/src/lib.rs
+++ b/desktop/local-runtime/hostctl/src/lib.rs
@@ -269,6 +269,23 @@ fn local_root() -> PathBuf {
 // unix-only rather than skipped.
 #[cfg(all(test, unix))]
 mod tests {
+
+    /// Join the server thread, or fail rather than hang the binary.
+    ///
+    /// It blocks in `accept()`; if the client under test never connects, an
+    /// unconditional `join()` waits forever and takes every remaining test with
+    /// it. `lemma-locald` has the same helper for the same reason -- a separate
+    /// crate, and one function does not justify sharing one.
+    fn join_within<T>(handle: std::thread::JoinHandle<T>, what: &str) -> T {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+        while std::time::Instant::now() < deadline {
+            if handle.is_finished() {
+                return handle.join().expect("the server thread panicked");
+            }
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+        panic!("{what} never finished; it is still blocked on the socket");
+    }
     use super::*;
     use std::os::unix::fs::PermissionsExt;
     use std::os::unix::net::UnixListener;
@@ -312,7 +329,7 @@ mod tests {
         )
         .unwrap();
 
-        server.join().unwrap();
+        join_within(server, "the stand-in guest");
         assert!(ok);
         assert_eq!(
             serde_json::from_slice::<Value>(&output).unwrap()["result"]["status"],

--- a/desktop/locald/src/host_process.rs
+++ b/desktop/locald/src/host_process.rs
@@ -2656,7 +2656,7 @@ mod tests {
         for status in [401, 404, 503] {
             let (unhealthy, server) = one_response(status, "runtime-123");
             assert!(probe_http(&unhealthy).is_err());
-            server.join().unwrap();
+            crate::join_within(server, "the health endpoint");
         }
 
         let (stale, stale_server) = one_response(200, "runtime-old");
@@ -2665,11 +2665,11 @@ mod tests {
             error.to_string().contains("different runtime instance"),
             "{error}"
         );
-        stale_server.join().unwrap();
+        crate::join_within(stale_server, "the stale health endpoint");
 
         let (healthy, healthy_server) = one_response(200, "runtime-123");
         probe_http(&healthy).unwrap();
-        healthy_server.join().unwrap();
+        crate::join_within(healthy_server, "the healthy endpoint");
     }
 
     #[test]

--- a/desktop/locald/src/lib.rs
+++ b/desktop/locald/src/lib.rs
@@ -52,6 +52,90 @@ pub(crate) const CREATE_NO_WINDOW: u32 = 0x0800_0000;
 #[cfg(windows)]
 pub(crate) const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
 
+/// Join a test's server thread, or fail rather than hang the binary.
+///
+/// These tests spawn a thread that blocks in `accept()` and then reads a fixed
+/// number of bytes. If the client under test connects zero times, or one time
+/// too few, or sends a byte less than expected, that thread never returns -- and
+/// an unconditional `join()` waits with it, forever, taking every remaining
+/// test in the binary with it. `host_process.rs` carries the note about how
+/// that "burned 44 minutes of a CI runner before it was cancelled rather than
+/// failing".
+///
+/// The blocked thread is left where it is: a thread parked in a syscall cannot
+/// be cancelled in Rust, and it dies with the process at the end of the run.
+/// What changes is that the run reaches the end.
+///
+/// Here rather than in each module because there are five of these across four
+/// files, and the first fix copied it into one of them.
+#[cfg(test)]
+pub(crate) fn join_within<T>(handle: std::thread::JoinHandle<T>, what: &str) -> T {
+    join_before(handle, what, std::time::Duration::from_secs(20))
+}
+
+/// The same, with the deadline named.
+///
+/// Only the helper's own test passes one: it needs to prove the deadline fires,
+/// and paying the real twenty seconds to do that would put this file's tests
+/// among the slowest in the crate for no extra confidence.
+#[cfg(test)]
+pub(crate) fn join_before<T>(
+    handle: std::thread::JoinHandle<T>,
+    what: &str,
+    timeout: std::time::Duration,
+) -> T {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if handle.is_finished() {
+            return handle.join().expect("the server thread panicked");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    panic!("{what} never finished; it is still blocked on the socket");
+}
+
+#[cfg(test)]
+mod join_within_policy {
+    /// The helper fails instead of hanging, and does not slow a healthy join.
+    ///
+    /// The behaviour is the whole point: five tests across four files hand it a
+    /// thread that is blocked in `accept()`, and the failure mode it replaces is
+    /// a test binary that never exits.
+    #[test]
+    fn a_thread_that_never_finishes_fails_rather_than_hanging() {
+        let started = std::time::Instant::now();
+        // Never signalled, so the thread parks for the life of the process --
+        // exactly like an `accept()` nobody connects to.
+        let (_keep, receiver) = std::sync::mpsc::channel::<()>();
+        let stuck = std::thread::spawn(move || receiver.recv());
+
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            super::join_before(
+                stuck,
+                "a thread that never finishes",
+                std::time::Duration::from_millis(200),
+            )
+        }));
+
+        assert!(panicked.is_err(), "it must fail, not return");
+        // Bounded by its deadline rather than by the life of the run, which is
+        // the whole property. Generous ceiling so a loaded machine does not
+        // turn this into the flake it exists to prevent.
+        assert!(started.elapsed() < std::time::Duration::from_secs(5));
+    }
+
+    #[test]
+    fn a_thread_that_finishes_is_joined_immediately() {
+        let started = std::time::Instant::now();
+        let quick = std::thread::spawn(|| 7);
+        assert_eq!(super::join_within(quick, "a thread that finishes"), 7);
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(2),
+            "a healthy join must not pay the polling interval",
+        );
+    }
+}
+
 #[cfg(test)]
 mod http_client_policy {
     /// Every HTTP client locald builds must opt out of the system proxy.

--- a/desktop/locald/src/port_reservation.rs
+++ b/desktop/locald/src/port_reservation.rs
@@ -157,6 +157,6 @@ mod tests {
         client.read_to_string(&mut answer).unwrap();
 
         assert_eq!(answer, "served");
-        server.join().unwrap();
+        crate::join_within(server, "the stand-in listener");
     }
 }

--- a/desktop/locald/src/provider_probe.rs
+++ b/desktop/locald/src/provider_probe.rs
@@ -280,6 +280,6 @@ mod tests {
             HttpModelProviderProbe.discover(&profile, None).unwrap(),
             vec!["alpha", "zeta"]
         );
-        server.join().unwrap();
+        crate::join_within(server, "the probe's stand-in provider");
     }
 }

--- a/desktop/locald/src/sharing.rs
+++ b/desktop/locald/src/sharing.rs
@@ -1801,30 +1801,6 @@ fn terminate_owned_child(child: &mut Child) {
 #[cfg(test)]
 mod tests {
 
-    /// Join a test's server thread, or fail rather than hang.
-    ///
-    /// Each of these threads blocks in `accept()` and then `read_exact`s a
-    /// fixed number of bytes. If the client under test connects zero times, or
-    /// once too few, or sends a byte less than expected, the thread never
-    /// returns -- and an unconditional `join()` then hangs the whole test
-    /// binary. `host_process.rs` carries the note about how that "burned 44
-    /// minutes of a CI runner before it was cancelled rather than failing";
-    /// these are its siblings, which were not given the same treatment.
-    ///
-    /// The blocked thread is left where it is: a thread parked in a syscall
-    /// cannot be cancelled in Rust, and it dies with the process at the end of
-    /// the run. What changes is that the run *reaches* the end.
-    fn join_within<T>(handle: thread::JoinHandle<T>, what: &str) -> T {
-        let deadline = Instant::now() + Duration::from_secs(20);
-        while Instant::now() < deadline {
-            if handle.is_finished() {
-                return handle.join().expect("the server thread panicked");
-            }
-            thread::sleep(Duration::from_millis(20));
-        }
-        panic!("{what} never finished; it is still blocked on the socket");
-    }
-
     use super::*;
     use std::io::{Read, Write};
     use std::sync::mpsc;
@@ -2170,7 +2146,7 @@ mod tests {
             observed.extend_from_slice(&buffer[..read]);
         }
         gateway.stop();
-        join_within(server, "the upstream server");
+        crate::join_within(server, "the upstream server");
     }
 
     #[test]
@@ -2225,7 +2201,7 @@ mod tests {
         assert_eq!(response.status(), reqwest::StatusCode::OK);
         assert_eq!(response.bytes().unwrap().as_ref(), payload.as_slice());
         gateway.stop();
-        join_within(server, "the upstream server");
+        crate::join_within(server, "the upstream server");
     }
 
     #[test]
@@ -2273,6 +2249,6 @@ mod tests {
         client.read_exact(&mut echoed).unwrap();
         assert_eq!(&echoed, b"hello");
         gateway.stop();
-        join_within(server, "the upstream server");
+        crate::join_within(server, "the upstream server");
     }
 }


### PR DESCRIPTION
## What changes

Five test threads spawn a server that blocks in `accept()`, reads a fixed number
of bytes, and is joined unconditionally. If the client under test connects zero
times, or one time too few, or sends a byte less than expected, that thread never
returns — and the join waits with it, forever, taking every remaining test in the
binary with it.

The only backstop is the job's `timeout-minutes`, which reports a *cancellation*
rather than a failure and tells you nothing about which test it was.

`host_process.rs` already carries the note about how this "burned 44 minutes of a
CI runner before it was cancelled rather than failing", and one site there was
rewritten as a bounded accept. Its siblings were not:

| file | sites |
|---|---|
| `locald/src/host_process.rs` | 3 |
| `locald/src/provider_probe.rs` | 1 |
| `locald/src/port_reservation.rs` | 1 |
| `local-runtime/hostctl/src/lib.rs` | 1 |

A previous fix copied a local helper into `sharing.rs` for three others, which is
how a seventh copy gets written next time. There is one helper in the crate root
now, used by all of them, with that local copy removed. `lemma-runtime` keeps its
own — a separate crate, and one function does not justify sharing one.

The helper has its own tests, because "fails instead of hanging" is the entire
property and nothing else asserted it: a thread parked on a channel that is never
signalled makes it panic rather than return, and a thread that finishes is joined
without paying the polling interval.

The deadline is a parameter so that first test can use 200 ms. Proving the
deadline fires at the real twenty seconds would have made this file's tests among
the slowest in the crate for no extra confidence — the first version measured
20.01 s, which is how I know the deadline is what fires. It runs in 0.22 s now.

The blocked thread is deliberately left where it is: a thread parked in a syscall
cannot be cancelled in Rust, and it dies with the process. What changes is that
the process reaches the end.

## How to verify

```bash
make desktop-test
```

496 tests. `make desktop-check-windows` cross-checks the Windows paths from a
Mac, which is new in the previous PR and is what caught the last round of
Windows-only breakage before pushing.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload
- [x] **Compatibility** — test-only; no shipping code path changes

## Compatibility and rollback notes

Test-only. The helper is `#[cfg(test)]`, so nothing here is compiled into a
shipped binary. Reverting is safe and restores the previous hang-forever
behaviour.