### PR TITLE
Follow the pages when listing conversations, and stop hammering the scan

### DIFF
--- a/tests/scenarios/harness/steps/agent.py
+++ b/tests/scenarios/harness/steps/agent.py
@@ -182,8 +182,34 @@ class AgentSteps:
             await self.says(saying, in_conversation=conversation, in_pod=in_pod)
         return conversation
 
-    async def conversations_in(self, pod: JSON) -> list[JSON]:
-        return items_of(await self.api.get(f"/pods/{pod['id']}/conversations"))
+    async def conversations_in(self, pod: JSON, *, pages: int = 20) -> list[JSON]:
+        """Every conversation in the pod, following the pages.
+
+        Asking once returns twenty, ordered by id descending — and ids are
+        time-ordered, so that is newest first. On a pod that stands between runs
+        this buries anything an earlier run opened under everything opened
+        since, and a scenario looking for it concluded the product had lost the
+        message. The same shape as the agent list capped at 100: a default page
+        size read as "all of them".
+
+        `pages` is a bound rather than a limit anyone should hit — twenty pages
+        of a hundred is two thousand conversations. It exists so a bug in the
+        cursor cannot spin here forever.
+        """
+        found: list[JSON] = []
+        token: str | None = None
+        for _ in range(pages):
+            params: JSON = {"limit": 100}
+            if token:
+                params["page_token"] = token
+            answered = await self.api.get(
+                f"/pods/{pod['id']}/conversations", params=params
+            )
+            found.extend(items_of(answered))
+            token = (answered or {}).get("next_page_token")
+            if not token:
+                break
+        return found
 
     async def opens_conversation(self, conversation: JSON, *, in_pod: JSON) -> JSON:
         return await self.api.get(

--- a/tests/scenarios/journeys/surfaces_and_notifications/conftest.py
+++ b/tests/scenarios/journeys/surfaces_and_notifications/conftest.py
@@ -103,6 +103,14 @@ class Reachable:
                 held.append(thread)
         return held
 
+    #: How often to re-scan for the conversation. Slow on purpose: one scan is
+    #: a page walk plus a message read per conversation, and on a pod that
+    #: stands between runs that is not a cheap question. Asked twice a second —
+    #: which is what the default waiter did — it is hundreds of requests to
+    #: learn the same thing, and the deployment feels it more than the scenario
+    #: gains from it.
+    LOOK_AGAIN_EVERY = 6.0
+
     async def waits_for_a_conversation_holding(self, *said: str) -> Any:
         """The one conversation carrying all of `said`, once it is there.
 
@@ -112,13 +120,21 @@ class Reachable:
         went, and asking directly removes a dependence on reply timing that made
         the scenario fail for a reason it was not about.
         """
-        from harness.waiting import eventually
+        import asyncio
 
-        held = await eventually(
-            lambda: self.conversations_holding(*said),
-            bool,
-            describe=f"a conversation holding {' and '.join(repr(t) for t in said)}",
-            timeout=180.0,
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 180.0
+        held: list[Any] = []
+        while True:
+            held = await self.conversations_holding(*said)
+            if held or loop.time() >= deadline:
+                break
+            await asyncio.sleep(self.LOOK_AGAIN_EVERY)
+        assert held, (
+            f"nothing in {self.pod.get('name')!r} holds "
+            f"{' and '.join(repr(t) for t in said)} after 180s. The message was "
+            f"delivered and the surface accepted it; either it opened no "
+            f"conversation or it opened one this could not see."
         )
         assert len(held) == 1, (
             f"{len(held)} conversations hold these messages; they belong in one, "


### PR DESCRIPTION
Two Telegram scenarios failed on dev saying nothing in the pod held the message
they had just sent:

```
waited for a conversation holding 'first thing' and 'and a second thing',
and it never happened. gave up after 180s and 284 checks
```

The message was there. `GET /pods/{id}/conversations` answers **twenty** by
default, ordered `id DESC` — and ids are time-ordered, so that is newest first.
On a pod that stands between runs, the conversation a person's chat opened long
ago sits under everything opened since. The scenario looked at the newest twenty
and concluded the product had lost the message.

This is the **same shape** as the agent list capped at 100 that stopped
provisioning dead in gappyai/gappy-infra last week: a default page size read as
"all of them". `conversations_in` now follows the cursor the API already
returns, bounded at twenty pages so a broken cursor cannot spin.

## And the scan was too eager

284 checks in 180 seconds — roughly twice a second — where one check is a page
walk plus a message read per conversation. That is not a cheap question on a
standing pod, all of the checks did the same work, and the deployment feels it
more than the scenario gains. Six seconds apart now.

The failure message also names which of the two things went wrong, since they
need different investigations:

> either it opened no conversation or it opened one this could not see

## Verified

75 passed across `surfaces_and_notifications` and `agents_and_conversations`
locally.

## Not fixed here, and worth knowing

The same dev run showed `test_adding_and_removing_columns_keeps_the_records`
still returning 400. That is **not** the #505 fix failing — it is not deployed.
The running image has zero occurrences of `statement_cache_size`:

```
release.sha: 9365304ab5f76fac6bd0b536df0d18be12b2d229
statement_cache_size occurrences in the running image: 0
```

It goes green on the first release built after #505.