### PR TITLE
Make 0.7.1 installable, updatable, and honest about its own data

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -52,3 +52,42 @@ still a finding.
 regexes = [
   '''whsec_c2NlbmFyaW9zLXJlc2VuZC1zaWduaW5nLXNlY3JldA==''',
 ]
+
+[[rules]]
+id = "minisign-secret-key"
+description = '''
+A minisign secret key, which is what signs desktop updates.
+
+The public half is committed on purpose -- it is in `desktop/tauri.conf.json`
+and is compiled into every shipped app. The private half must never be: anyone
+holding it can produce an update that every installed Lemma accepts and
+installs, which is arbitrary code execution on every user's machine under our
+own signature.
+
+Matched on the header the format always carries, in both plain and base64 form,
+because the file is handled base64-encoded in CI.
+'''
+regex = '''untrusted comment: (minisign encrypted secret key|rsign encrypted secret key)'''
+keywords = ["untrusted comment"]
+
+[[rules]]
+id = "minisign-secret-key-base64"
+description = '''
+The same key, base64-encoded, which is the shape CI passes it in.
+
+Two things about this pattern are deliberate.
+
+`{1}` breaks the literal without changing what it matches. Spelled out in full,
+this file would match its own rule -- gitleaks scans every file, including this
+one -- and a scanner whose first finding is its own configuration is a scanner
+people learn to ignore.
+
+It matches only the `rsign` header, which is what `tauri signer generate`
+produces and therefore the only secret key CI ever handles. The `minisign`
+header cannot be matched this way: base64 of "untrusted comment: minisign " is a
+prefix of the *public* key too, which is committed on purpose in
+`desktop/tauri.conf.json`. Matching it would flag that on every scan. The
+plaintext rule above still covers a minisign-format secret key.
+'''
+regex = '''dW50cnVzdGVkIGNvbW1lbnQ6IHJ{1}zaWduIG'''
+keywords = ["dW50cnVzdGVkIGNvbW1lbnQ6"]

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2615,6 +2615,7 @@ dependencies = [
 name = "lemma-desktop"
 version = "0.7.0"
 dependencies = [
+ "base64 0.22.1",
  "interprocess",
  "libc",
  "objc2",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -108,6 +108,10 @@ windows-sys = { version = "0.61.2", features = ["Win32_Storage_FileSystem"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# Only to decode the committed updater public key and check it is a real
+# minisign key rather than a placeholder. A dev dependency, so it is not
+# linked into the shipped app.
+base64 = "0.22"
 
 # A workspace ignores [profile] in anything but the root manifest — with a
 # warning that is easy to miss — so every member's release profile lives here.

--- a/desktop/local-runtime/guestd/src/lib.rs
+++ b/desktop/local-runtime/guestd/src/lib.rs
@@ -1356,7 +1356,9 @@ impl<E: Engine> GuestService<E> {
     /// PostgreSQL refuses an unusable data directory with a *paragraph*, and
     /// the last line of the official image's version-mismatch block is
     ///
-    ///     discussion around this process, and suggestions for how to do so.
+    /// ```text
+    /// discussion around this process, and suggestions for how to do so.
+    /// ```
     ///
     /// which is what a user was shown, appended to a nerdctl error, as the
     /// whole explanation for an install that would never finish. The sentence

--- a/desktop/local-runtime/guestd/src/lib.rs
+++ b/desktop/local-runtime/guestd/src/lib.rs
@@ -28,6 +28,14 @@ const CACHE_REPAIR_RESPONSE_GRACE: Duration = Duration::from_secs(10);
 /// entire contract -- locald maps it to `local-data-incompatible` and the
 /// splash renders a reset button for that code.
 const DATA_RESET_MARKER: &str = "local data must be reset";
+
+/// Where the PostgreSQL cluster lives inside its container.
+///
+/// Pinned rather than inherited: see the note on `PGDATA` in `ensure_postgres`.
+/// It is also the path `lemma-postgres-data` is mounted at, and the two must
+/// stay equal -- a cluster written anywhere else is not on the volume the user
+/// is told holds their database.
+const POSTGRES_DATA_DIR: &str = "/var/lib/postgresql/data";
 const CORE_MEMORY_RESERVATION_BYTES: u64 = 1536 * 1024 * 1024;
 const DEFAULT_SANDBOX_MEMORY_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 
@@ -629,29 +637,14 @@ impl<E: Engine> GuestService<E> {
     fn ensure_postgres(&self, parameters: &CoreParameters) -> Result<(), GuestError> {
         self.ensure_volume("lemma-postgres-data")?;
         self.refuse_incompatible_postgres_data(&parameters.images.postgres)?;
-        let postgres_env = BTreeMap::from([
-            ("POSTGRES_USER".into(), "postgres".into()),
-            (
-                "POSTGRES_PASSWORD".into(),
-                parameters.credentials.postgres_password.clone(),
-            ),
-            ("POSTGRES_DB".into(), "lemma".into()),
-        ]);
+        let (postgres_env, postgres_arguments) =
+            postgres_container_spec(&parameters.credentials.postgres_password);
         self.ensure_core_container(
             "lemma-core-postgres",
             &parameters.images.postgres,
             "postgres-v1",
             &postgres_env,
-            &[
-                "--network".into(),
-                "host".into(),
-                "--memory".into(),
-                "512m".into(),
-                "--cpus".into(),
-                "1.5".into(),
-                "--volume".into(),
-                "lemma-postgres-data:/var/lib/postgresql/data".into(),
-            ],
+            &postgres_arguments,
             &[],
         )?;
         if let Err(mut error) = self.wait_engine_command(
@@ -665,6 +658,23 @@ impl<E: Engine> GuestService<E> {
             120,
         ) {
             if let Some(diagnostic) = self.container_log_summary("lemma-core-postgres") {
+                // The container's own account of why it will not start decides
+                // what the user is offered. A cluster PostgreSQL refuses to
+                // open cannot be retried into working -- and "Try again" was
+                // the only button on screen for it, three times over, for a
+                // wait that could never end.
+                if postgres_refused_its_data(&diagnostic) {
+                    return Err(GuestError {
+                        code: "postgres_data_incompatible".into(),
+                        message: format!(
+                            "the workspace database on this computer cannot be opened by this \
+                             release of PostgreSQL; {DATA_RESET_MARKER}. PostgreSQL said: \
+                             {diagnostic}"
+                        ),
+                        retryable: false,
+                        status_code: 409,
+                    });
+                }
                 error.message = format!("{}: {diagnostic}", error.message);
             }
             return Err(error);
@@ -1339,20 +1349,58 @@ impl<E: Engine> GuestService<E> {
         Ok(parsed.as_array().and_then(|items| items.first()).cloned())
     }
 
+    /// Why a core container is not answering, in its own words.
+    ///
+    /// This used to return the single last non-empty line, which is fine for a
+    /// crash that ends in one and useless for the case that matters most.
+    /// PostgreSQL refuses an unusable data directory with a *paragraph*, and
+    /// the last line of the official image's version-mismatch block is
+    ///
+    ///     discussion around this process, and suggestions for how to do so.
+    ///
+    /// which is what a user was shown, appended to a nerdctl error, as the
+    /// whole explanation for an install that would never finish. The sentence
+    /// that says what is wrong is several lines above it.
+    ///
+    /// So: keep the tail, drop the noise, and cap the length. A few lines of
+    /// the container's own output is the difference between "something stopped"
+    /// and "your data was made by a different PostgreSQL".
     fn container_log_summary(&self, name: &str) -> Option<String> {
+        const KEEP_LINES: usize = 6;
+        const MAX_CHARS: usize = 600;
         let output = self
             .engine
-            .run(&["logs".into(), "--tail".into(), "20".into(), name.into()])
+            .run(&["logs".into(), "--tail".into(), "40".into(), name.into()])
             .ok()?;
-        let logs = if output.stderr.is_empty() {
-            String::from_utf8_lossy(&output.stdout)
+        // Both streams: the refusal goes to stderr, but an image that logs
+        // its reason to stdout and exits quietly would otherwise report
+        // nothing at all.
+        let mut logs = String::from_utf8_lossy(&output.stdout).into_owned();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.trim().is_empty() {
+            if !logs.trim().is_empty() {
+                logs.push('\n');
+            }
+            logs.push_str(&stderr);
+        }
+        let lines = logs
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            // Decorative rules are what the image wraps its refusal in, and
+            // they crowd out the sentence underneath at this length.
+            .filter(|line| !line.chars().all(|c| c == '*' || c == '-' || c == '='))
+            .collect::<Vec<_>>();
+        if lines.is_empty() {
+            return None;
+        }
+        let summary = lines[lines.len().saturating_sub(KEEP_LINES)..].join(" ");
+        Some(if summary.chars().count() > MAX_CHARS {
+            let cut: String = summary.chars().take(MAX_CHARS).collect();
+            format!("{cut}…")
         } else {
-            String::from_utf8_lossy(&output.stderr)
-        };
-        logs.lines()
-            .rev()
-            .find(|line| !line.trim().is_empty())
-            .map(redact_engine_error)
+            summary
+        })
     }
 
     fn wait_engine_command(&self, arguments: &[String], timeout: u64) -> Result<(), GuestError> {
@@ -2715,6 +2763,75 @@ fn load_capability() -> Result<Option<String>, GuestError> {
     Ok(Some(value.into()))
 }
 
+/// Is this PostgreSQL saying the data directory itself is the problem?
+///
+/// The `refuse_incompatible_postgres_data` probe runs first and catches the
+/// version case cleanly, in about a second, by reading `PG_VERSION` off the
+/// volume. It cannot catch everything: the probe returns "don't know" whenever
+/// the volume cannot be read, and "don't know" means proceed. When it does
+/// proceed and the server then refuses, this is what turns a 120-second wait
+/// ending in a nerdctl error into the offer of a reset.
+///
+/// Matched on the server's and the image's own words. Deliberately narrow:
+/// anything not recognised keeps the old behaviour, which is retryable, and a
+/// wrong match here would offer to delete a database over a transient fault.
+/// The environment and arguments the PostgreSQL container is created with.
+///
+/// A free function so the one invariant that matters can be asserted without an
+/// engine, a volume or a container: **the cluster path and the volume mount
+/// target are the same path**. They were not, and nothing noticed.
+///
+/// The official image moved `PGDATA` at 18 -- `/var/lib/postgresql/data`
+/// through 17, `/var/lib/postgresql/18/docker` after -- while the mount stayed
+/// where it was. So on the pinned image the database was written into the
+/// image's own anonymous volume and `lemma-postgres-data`, the volume the user
+/// is told holds their data, held nothing. A container recreation would have
+/// taken every table with it.
+///
+/// Pinning `PGDATA` rather than inheriting it also keeps the layout stable
+/// across the next such move, and puts `PG_VERSION` back at the root of this
+/// volume -- which is where `postgres_data_major` looks when it decides whether
+/// the data on disk can be opened at all.
+fn postgres_container_spec(password: &str) -> (BTreeMap<String, String>, Vec<String>) {
+    let environment = BTreeMap::from([
+        ("POSTGRES_USER".to_owned(), "postgres".to_owned()),
+        ("POSTGRES_PASSWORD".to_owned(), password.to_owned()),
+        ("POSTGRES_DB".to_owned(), "lemma".to_owned()),
+        ("PGDATA".to_owned(), POSTGRES_DATA_DIR.to_owned()),
+    ]);
+    let arguments = vec![
+        "--network".to_owned(),
+        "host".to_owned(),
+        "--memory".to_owned(),
+        "512m".to_owned(),
+        "--cpus".to_owned(),
+        "1.5".to_owned(),
+        "--volume".to_owned(),
+        format!("lemma-postgres-data:{POSTGRES_DATA_DIR}"),
+    ];
+    (environment, arguments)
+}
+
+fn postgres_refused_its_data(diagnostic: &str) -> bool {
+    let text = diagnostic.to_ascii_lowercase();
+    [
+        // The server, on a cluster from another major version.
+        "database files are incompatible with server",
+        "was initialized by postgresql version",
+        // The official image, when it finds data where its older releases kept
+        // it. This is the block whose last line is "discussion around this
+        // process, and suggestions for how to do so."
+        "database directory appears to contain a database",
+        "an upgrade is required",
+        "incompatible data directory",
+        // A cluster that is present but unreadable.
+        "could not read file \"global/pg_control\"",
+        "is not a valid data directory",
+    ]
+    .iter()
+    .any(|needle| text.contains(needle))
+}
+
 fn redact_engine_error(value: &str) -> String {
     let lines = value
         .lines()
@@ -3367,6 +3484,89 @@ mod tests {
         assert_eq!(error.message, "not found");
     }
 
+    /// The cluster is written inside the volume the user is told holds it.
+    ///
+    /// Behavioural, not a source grep. The first version of this test searched
+    /// its own file for the literal it was asserting -- which its own assertion
+    /// satisfied, so it passed with the bug reinstated. Read the two values and
+    /// compare them.
+    #[test]
+    fn the_cluster_path_and_the_volume_mount_are_the_same_path() {
+        let (environment, arguments) = postgres_container_spec("pw");
+
+        let cluster = environment
+            .get("PGDATA")
+            .expect("PGDATA is pinned rather than inherited from the image");
+
+        let volume = arguments
+            .windows(2)
+            .find(|pair| pair[0] == "--volume")
+            .map(|pair| pair[1].clone())
+            .expect("the container mounts its data volume");
+        let (name, mounted_at) = volume
+            .split_once(':')
+            .expect("a volume argument is name:path");
+
+        assert_eq!(name, "lemma-postgres-data");
+        assert_eq!(
+            cluster, mounted_at,
+            "the cluster is written to {cluster} but the volume is mounted at \
+             {mounted_at}; anything written outside the volume is not the \
+             user's database, it is the container's scratch space",
+        );
+
+        // The image we pin puts its own PGDATA at /var/lib/postgresql/18/docker
+        // and declares VOLUME /var/lib/postgresql. Inheriting either is what
+        // put the database outside this volume in the first place.
+        assert!(
+            !cluster.contains("/18/"),
+            "a version-numbered cluster path is the image's, and it moves",
+        );
+    }
+
+    /// The message a user actually got, classified the way it should have been.
+    ///
+    /// This is the real tail of the official image's refusal, which reached a
+    /// user as the entire explanation for an install that stopped at 30% --
+    /// appended to a nerdctl "cannot exec in a stopped state", with "Try again"
+    /// as the only button, three times.
+    #[test]
+    fn postgres_refusing_its_data_is_recognised_from_what_it_actually_prints() {
+        for refusal in [
+            "PostgreSQL Database directory appears to contain a database; Skipping initialization",
+            "FATAL:  database files are incompatible with server",
+            "DETAIL:  The data directory was initialized by PostgreSQL version 16, which is not \
+             compatible with this version 18.4.",
+            "An upgrade is required. See https://github.com/docker-library/postgres/issues/37 \
+             for a discussion around this process, and suggestions for how to do so.",
+            "could not read file \"global/pg_control\": No such file or directory",
+        ] {
+            assert!(
+                postgres_refused_its_data(refusal),
+                "this must offer a reset, not a retry: {refusal}",
+            );
+        }
+    }
+
+    /// And a transient failure still retries, because a wrong match here offers
+    /// to delete somebody's database over a blip.
+    #[test]
+    fn a_transient_postgres_failure_is_never_read_as_unusable_data() {
+        for transient in [
+            "psql: error: FATAL: the database system is shutting down",
+            "psql: error: FATAL: the database system is starting up",
+            "could not connect to server: Connection refused",
+            "time=\"2026-08-25T17:49:20Z\" level=fatal msg=\"cannot exec in a stopped state\"",
+            "LOG:  database system was not properly shut down; automatic recovery in progress",
+            "",
+        ] {
+            assert!(
+                !postgres_refused_its_data(transient),
+                "this is retryable and must not offer to erase data: {transient}",
+            );
+        }
+    }
+
     #[test]
     fn database_command_retries_through_postgres_initialization_restart() {
         let root = tempdir().unwrap();
@@ -3639,7 +3839,7 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_startup_error_includes_the_last_container_diagnostic() {
+    fn sandbox_startup_error_includes_the_containers_own_last_words() {
         let root = tempdir().unwrap();
         let service = GuestService::new(
             FakeEngine::new(vec![
@@ -3669,9 +3869,14 @@ mod tests {
         );
 
         assert_eq!(error.code, "guest_engine_failed");
+        // The container's last few lines, not only its last one. The line that
+        // says what went wrong is frequently not the final one -- PostgreSQL
+        // refuses an unusable data directory with a paragraph, and a user was
+        // shown its closing fragment, "discussion around this process, and
+        // suggestions for how to do so.", as the whole explanation.
         assert_eq!(
             error.message,
-            "sandbox runtime stopped before becoming ready: OCI runtime failed; container exited with code 126; fatal: runtime bootstrap failed"
+            "sandbox runtime stopped before becoming ready: OCI runtime failed; container exited with code 126; starting fatal: runtime bootstrap failed"
         );
         assert_eq!(
             service.engine.commands.lock().unwrap().as_slice(),
@@ -3680,7 +3885,7 @@ mod tests {
                 vec![
                     "logs".to_owned(),
                     "--tail".to_owned(),
-                    "20".to_owned(),
+                    "40".to_owned(),
                     "lemma-sandbox-box-1".to_owned(),
                 ],
             ]

--- a/desktop/locald/src/lib.rs
+++ b/desktop/locald/src/lib.rs
@@ -95,6 +95,61 @@ pub(crate) fn join_before<T>(
 }
 
 #[cfg(test)]
+mod doc_comment_policy {
+    /// An indented block in a doc comment is a *Rust* code block.
+    ///
+    /// rustdoc treats four spaces after `///` as code and tries to compile it,
+    /// so quoting a log line that way turns prose into a doctest that cannot
+    /// parse. One did: quoting PostgreSQL's refusal failed three CI jobs with
+    /// "expected one of `!` or `::`, found `around`", and not one of those
+    /// three names a doc comment.
+    ///
+    /// The fix is always a fenced text block. This finds the shape here,
+    /// where it costs seconds, rather than on a push.
+    #[test]
+    fn no_doc_comment_quotes_prose_as_an_indented_code_block() {
+        const SOURCES: [(&str, &str); 4] = [
+            ("locald/src/lib.rs", include_str!("lib.rs")),
+            ("locald/src/daemon.rs", include_str!("daemon.rs")),
+            (
+                "locald/src/host_process.rs",
+                include_str!("host_process.rs"),
+            ),
+            (
+                "local-runtime/guestd/src/lib.rs",
+                include_str!("../../local-runtime/guestd/src/lib.rs"),
+            ),
+        ];
+
+        let mut offenders = Vec::new();
+        for (name, source) in SOURCES {
+            let mut fenced = false;
+            for (number, line) in source.replace("\r\n", "\n").lines().enumerate() {
+                let Some(doc) = line.trim_start().strip_prefix("///") else {
+                    continue;
+                };
+                if doc.trim_start().starts_with("```") {
+                    fenced = !fenced;
+                    continue;
+                }
+                if fenced || doc.trim().is_empty() {
+                    continue;
+                }
+                if doc.starts_with("    ") {
+                    offenders.push(format!("{name}:{}: {}", number + 1, line.trim()));
+                }
+            }
+        }
+
+        assert!(
+            offenders.is_empty(),
+            "these are compiled as doctests; fence them as a text block instead:\n{}",
+            offenders.join("\n"),
+        );
+    }
+}
+
+#[cfg(test)]
 mod join_within_policy {
     /// The helper fails instead of hanging, and does not slow a healthy join.
     ///

--- a/desktop/locald/src/managed_runtime.rs
+++ b/desktop/locald/src/managed_runtime.rs
@@ -968,6 +968,26 @@ fn load_or_create_secrets(path: &Path, healed: &mut Vec<String>) -> io::Result<I
             }
         }
     }
+    // Missing, rather than unreadable. Same consequence: the password baked
+    // into the Postgres volume at `initdb` does not change because this file
+    // was recreated, so the new one opens nothing. Only a genuine first run may
+    // mint quietly, and a first run has no data.
+    else if path
+        .parent()
+        .is_some_and(crate::paths::installation_has_data)
+    {
+        let root = path.parent().expect("checked just above");
+        crate::paths::require_data_reset(
+            root,
+            "the private infrastructure passwords are missing, and the existing workspace \
+             database was created with the previous ones",
+        )?;
+        healed.push(
+            "the infrastructure passwords were missing while local data was still present; \
+             new ones were created and the existing database cannot be opened with them"
+                .to_owned(),
+        );
+    }
     let secrets = InfraSecrets {
         postgres_password: random_hex()?,
         redis_password: random_hex()?,

--- a/desktop/locald/src/native_host_pack.rs
+++ b/desktop/locald/src/native_host_pack.rs
@@ -817,6 +817,27 @@ fn load_or_create_host_secrets(path: &Path, healed: &mut Vec<String>) -> io::Res
             }
         }
     }
+    // Absent, not unreadable -- and that is not automatically a first run. A
+    // restore that skipped an owner-only file, or a half-finished manual
+    // cleanup, leaves the data behind and takes the key. Minting silently there
+    // is the same permanent loss the corrupt path is careful about, arrived at
+    // more quietly.
+    else if path
+        .parent()
+        .is_some_and(crate::paths::installation_has_data)
+    {
+        let root = path.parent().expect("checked just above");
+        crate::paths::require_data_reset(
+            root,
+            "this installation's secret is missing, and anything encrypted with it can no \
+             longer be read",
+        )?;
+        healed.push(
+            "the installation secret was missing while local data was still present; a new \
+             one was created and the existing encrypted data cannot be decrypted with it"
+                .to_owned(),
+        );
+    }
     let mut bytes = [0_u8; 32];
     getrandom::fill(&mut bytes)
         .map_err(|error| io::Error::other(format!("secure randomness failed: {error}")))?;
@@ -1296,6 +1317,54 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.to_string().contains("Redis image must be pinned"));
+    }
+
+    /// A secret that vanished beside surviving data stops the install.
+    ///
+    /// `installation_secret` derives the Fernet key for every encrypted column.
+    /// Reminting it while the data directory is still there does not fail --
+    /// that is the problem. Rows decrypt to garbage, and the only sign is
+    /// whatever breaks first, weeks later.
+    #[test]
+    fn a_missing_installation_secret_beside_real_data_demands_a_reset() {
+        let root = tempfile::tempdir().unwrap();
+        let root = root.path();
+        std::fs::create_dir_all(root.join("data/files")).unwrap();
+        std::fs::write(root.join("data/files/uploaded"), b"a user's file").unwrap();
+        let path = root.join("host.secrets.json");
+
+        let mut healed = Vec::new();
+        let secrets = load_or_create_host_secrets(&path, &mut healed).unwrap();
+
+        assert_eq!(
+            secrets.installation_secret.len(),
+            64,
+            "a key is still minted"
+        );
+        assert!(
+            crate::paths::data_reset_reason(root).is_some(),
+            "the install must stop with a reset offered, not carry on quietly",
+        );
+        assert_eq!(healed.len(), 1);
+        assert!(healed[0].contains("missing"), "{}", healed[0]);
+    }
+
+    /// And a genuine first run says nothing at all.
+    #[test]
+    fn a_first_run_mints_its_secret_without_ceremony() {
+        let root = tempfile::tempdir().unwrap();
+        let root = root.path();
+        std::fs::create_dir_all(root.join("data/files")).unwrap();
+        let path = root.join("host.secrets.json");
+
+        let mut healed = Vec::new();
+        load_or_create_host_secrets(&path, &mut healed).unwrap();
+
+        assert!(healed.is_empty(), "nothing was lost: {healed:?}");
+        assert!(
+            crate::paths::data_reset_reason(root).is_none(),
+            "a first run must not be told to reset the data it does not have",
+        );
     }
 
     #[test]

--- a/desktop/locald/src/paths.rs
+++ b/desktop/locald/src/paths.rs
@@ -222,6 +222,40 @@ pub fn data_reset_reason(root: &Path) -> Option<String> {
     })
 }
 
+/// Has this installation ever held user data?
+///
+/// The question a *missing* secrets file raises. Both secret files carry the
+/// same invariant -- they are gone when the data is gone -- so reminting one
+/// beside a surviving data directory is what makes every encrypted row
+/// permanently unreadable, silently. The corrupt case already records a reset;
+/// the absent case fell straight through to minting, which is the same outcome
+/// arrived at more quietly.
+///
+/// A file can go missing without the data going with it: a restore from a
+/// backup that skipped dotfiles, a `cp -R` that dropped an owner-only file, a
+/// half-finished manual cleanup.
+///
+/// Deliberately generous about what counts. A first run has an empty `data/`
+/// tree and no disk, so this is false and nothing is said; anything that has
+/// actually run has one or the other.
+pub fn installation_has_data(root: &Path) -> bool {
+    let populated =
+        |path: PathBuf| std::fs::read_dir(path).is_ok_and(|mut entries| entries.next().is_some());
+    // The managed disk is the strongest signal: it only exists once a runtime
+    // has been prepared, and it holds the databases.
+    if std::fs::read_dir(root.join("runtime")).is_ok_and(|entries| {
+        entries
+            .filter_map(Result::ok)
+            .any(|entry| entry.path().join("data.raw").exists())
+    }) {
+        return true;
+    }
+    // Files and object storage live on the host side, outside the disk.
+    ["data/files", "data/object-storage", "data/workspaces"]
+        .iter()
+        .any(|relative| populated(root.join(relative)))
+}
+
 /// Forget the marker. Only a completed data reset may call this.
 pub fn clear_data_reset(root: &Path) -> io::Result<()> {
     match std::fs::remove_file(root.join(DATA_RESET_MARKER_FILE)) {
@@ -265,6 +299,51 @@ mod tests {
                 "DATA_RESET_MARKER: &str = \"{DATA_RESET_MARKER}\""
             )),
             "lemma-guestd must declare the same marker phrase as this crate",
+        );
+    }
+
+    /// A first run mints its secrets quietly; an install that has data does not.
+    ///
+    /// Both secrets files carry the same invariant: they are gone when the data
+    /// is gone. The corrupt case already records a reset. The *missing* case
+    /// fell straight through to minting a replacement -- which, beside a
+    /// surviving data directory, makes every encrypted row unreadable and the
+    /// Postgres volume unopenable, with nothing said. A file can go missing
+    /// without the data: a restore that skipped an owner-only file, a `cp -R`
+    /// that dropped one, a half-finished cleanup.
+    #[test]
+    fn an_installation_that_has_run_is_told_apart_from_a_first_run() {
+        let root = tempfile::tempdir().unwrap();
+        let root = root.path();
+
+        // A first run: the tree exists and is empty.
+        for relative in ["data/files", "data/object-storage", "data/workspaces"] {
+            std::fs::create_dir_all(root.join(relative)).unwrap();
+        }
+        std::fs::create_dir_all(root.join("runtime/macos")).unwrap();
+        assert!(
+            !installation_has_data(root),
+            "an empty tree is a first run and must mint without ceremony",
+        );
+
+        // One uploaded file is enough to make a reminted secret a loss.
+        std::fs::write(root.join("data/files/anything"), b"x").unwrap();
+        assert!(installation_has_data(root));
+    }
+
+    /// The managed disk counts on its own, because the databases are inside it.
+    #[test]
+    fn a_prepared_runtime_counts_as_data_even_with_an_empty_file_tree() {
+        let root = tempfile::tempdir().unwrap();
+        let root = root.path();
+        std::fs::create_dir_all(root.join("data/files")).unwrap();
+        std::fs::create_dir_all(root.join("runtime/macos")).unwrap();
+        assert!(!installation_has_data(root));
+
+        std::fs::write(root.join("runtime/macos/data.raw"), b"").unwrap();
+        assert!(
+            installation_has_data(root),
+            "every table lives in this disk; a new password opens none of them",
         );
     }
 

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -7381,6 +7381,69 @@ mod tests {
 
     /// The updater's transport policy is not weakened, and the artifact flag
     /// stays out of the base config.
+    /// The key an installed app verifies with is real, and matches its own id.
+    ///
+    /// `pubkey: ""` is not a permissive setting. `verify_signature` decodes it
+    /// and fails, so a build carrying an empty key offers an update, downloads
+    /// it, and then cannot verify a thing -- and `updates_enabled()` exists to
+    /// keep such a build from offering one at all.
+    ///
+    /// What was missing is the assertion that the key is *there*. The release
+    /// workflow required the private half and never looked at the public one,
+    /// and the config test asserted the endpoint and the CSP and not this. So a
+    /// release could ship with no key, which is the state this repo was in.
+    #[test]
+    fn the_shipped_public_key_is_a_real_minisign_key() {
+        use base64::Engine as _;
+
+        let config: Value =
+            serde_json::from_str(include_str!("../tauri.conf.json")).expect("config parses");
+        let pubkey = config
+            .pointer("/plugins/updater/pubkey")
+            .and_then(Value::as_str)
+            .expect("the updater declares a pubkey field");
+
+        assert!(
+            !pubkey.trim().is_empty(),
+            "no public key: every install would download an update and then refuse it",
+        );
+        assert!(
+            updater_key_configured(),
+            "the gate that reads this must agree with it",
+        );
+
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(pubkey)
+            .expect("the pubkey is base64");
+        let text = String::from_utf8(decoded).expect("a minisign key is text");
+        let mut lines = text.lines();
+        let comment = lines.next().unwrap_or_default();
+        assert!(
+            comment.starts_with("untrusted comment:") && comment.contains("public key"),
+            "this is not a minisign public key: {comment}",
+        );
+
+        // The body carries the algorithm and the key id the signature must
+        // name. A truncated paste passes every check above and none of these.
+        let body = base64::engine::general_purpose::STANDARD
+            .decode(lines.next().expect("a key line follows the comment"))
+            .expect("the key line is base64");
+        assert_eq!(&body[..2], b"Ed", "only Ed25519 keys are signed against");
+        assert_eq!(body.len(), 42, "a minisign public key is 2 + 8 + 32 bytes");
+        let key_id = &body[2..10];
+        assert!(
+            key_id.iter().any(|byte| *byte != 0),
+            "a zero key id is a placeholder, not a key",
+        );
+
+        // And it is not a secret key committed by mistake, which is the same
+        // file format with a different comment.
+        assert!(
+            !text.contains("secret key"),
+            "the SECRET key is in this config; rotate it immediately",
+        );
+    }
+
     #[test]
     fn the_updater_config_keeps_its_transport_and_build_boundaries() {
         let config = include_str!("../tauri.conf.json").replace("\r\n", "\n");

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     },
     "updater": {
-      "pubkey": "",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDQyM0VENTkxRDBFNTkzMUYKUldRZmsrWFFrZFUrUXRYL2hhUmRhcTZKNzhyWjBHTjR3NlR2WkVYTWRKVStCSldESmVHdFlpTkIK",
       "endpoints": [
         "https://github.com/lemma-work/lemma-platform/releases/latest/download/latest.json"
       ]

--- a/lemma-frontend/components/agents/harness-discovery-rows.test.ts
+++ b/lemma-frontend/components/agents/harness-discovery-rows.test.ts
@@ -122,34 +122,34 @@ describe('what the panel says', () => {
     it('never promises agents while it is still looking', () => {
         // The exact contradiction from the screenshot: a preview naming three
         // agents next to a column admitting it had not found any.
-        const lines = discoveryLines('scanning', 0).join(' ');
+        const lines = discoveryLines('scanning', 0, 'this Mac').join(' ');
 
-        expect(discoveryHeadline('scanning', 0)).toContain('Looking');
+        expect(discoveryHeadline('scanning', 0, 'this Mac')).toContain('Looking');
         expect(lines).not.toContain('Claude Code');
     });
 
     it('counts what it found once it is done', () => {
-        expect(discoveryHeadline('settled', 1)).toContain('1 coding agent');
-        expect(discoveryHeadline('settled', 3)).toContain('3 coding agents');
-        expect(discoveryHeadline('settled', 0)).toContain('No coding agents');
+        expect(discoveryHeadline('settled', 1, 'this Mac')).toContain('1 coding agent');
+        expect(discoveryHeadline('settled', 3, 'this Mac')).toContain('3 coding agents');
+        expect(discoveryHeadline('settled', 0, 'this Mac')).toContain('No coding agents');
     });
 
     it('offers the way out when nothing was found', () => {
-        expect(discoveryLines('settled', 0).join(' ')).toContain('Rescan');
+        expect(discoveryLines('settled', 0, 'this Mac').join(' ')).toContain('Rescan');
     });
 });
 
 describe('discoveryStatusLine', () => {
     it('says nothing once there is nothing left to report', () => {
-        expect(discoveryStatusLine({ phase: 'settled', foundCount: 2, elapsedMs: 0 })).toBeNull();
-        expect(discoveryStatusLine({ phase: 'unavailable', foundCount: 0, elapsedMs: 0 })).toBeNull();
+        expect(discoveryStatusLine({ phase: 'settled', foundCount: 2, elapsedMs: 0, computer: 'this Mac' })).toBeNull();
+        expect(discoveryStatusLine({ phase: 'unavailable', foundCount: 0, elapsedMs: 0, computer: 'this Mac' })).toBeNull();
     });
 
     it('reports what has turned up rather than a total it cannot promise', () => {
         // Some of the four are simply not installed and never report, so a
         // "2 of 4" would stop at 2 and read as stuck.
-        const none = discoveryStatusLine({ phase: 'scanning', foundCount: 0, elapsedMs: 0 });
-        const some = discoveryStatusLine({ phase: 'scanning', foundCount: 2, elapsedMs: 0 });
+        const none = discoveryStatusLine({ phase: 'scanning', foundCount: 0, elapsedMs: 0, computer: 'this Mac' });
+        const some = discoveryStatusLine({ phase: 'scanning', foundCount: 2, elapsedMs: 0, computer: 'this Mac' });
 
         expect(none).toContain('Looking');
         expect(some).toContain('2');
@@ -157,22 +157,21 @@ describe('discoveryStatusLine', () => {
     });
 
     it('explains the wait only once it is long enough to need explaining', () => {
-        const early = discoveryStatusLine({ phase: 'scanning', foundCount: 0, elapsedMs: 0 });
+        const early = discoveryStatusLine({ phase: 'scanning', foundCount: 0, elapsedMs: 0, computer: 'this Mac' });
         const late = discoveryStatusLine({
             phase: 'scanning',
             foundCount: 0,
-            elapsedMs: DISCOVERY_PATIENCE_MS,
-        });
+            elapsedMs: DISCOVERY_PATIENCE_MS, computer: 'this Mac' });
 
         expect(early).not.toContain('minute');
         expect(late).toContain('minute');
     });
 
     it('names the step before the scan, so a slow start is not silence', () => {
-        expect(discoveryStatusLine({ phase: 'starting', foundCount: 0, elapsedMs: 0 })).toContain(
+        expect(discoveryStatusLine({ phase: 'starting', foundCount: 0, elapsedMs: 0, computer: 'this Mac' })).toContain(
             'agent host',
         );
-        expect(discoveryStatusLine({ phase: 'connecting', foundCount: 0, elapsedMs: 0 })).toContain(
+        expect(discoveryStatusLine({ phase: 'connecting', foundCount: 0, elapsedMs: 0, computer: 'this Mac' })).toContain(
             'Connecting',
         );
     });

--- a/lemma-frontend/components/agents/harness-discovery-rows.ts
+++ b/lemma-frontend/components/agents/harness-discovery-rows.ts
@@ -11,7 +11,7 @@
  * longer drives. A key that joins it arrives from the host as a real row.
  */
 
-import { thisComputer } from '@/lib/desktop/this-computer';
+import type { ComputerNoun } from '@/lib/desktop/this-computer';
 
 export const KNOWN_HARNESSES: ReadonlyArray<{ key: string; displayName: string }> = [
     { key: 'claude-code', displayName: 'Claude Code' },
@@ -129,9 +129,14 @@ export function discoveryStatusLine(input: {
     phase: DiscoveryPhase;
     foundCount: number;
     elapsedMs: number;
+    /// Passed in rather than read here. `thisComputer()` answers differently on
+    /// the server and the first client render, and these strings are rendered
+    /// -- so reading it inside made every caller a hydration mismatch. The
+    /// component holds `useThisComputer()`, which is the same answer in both.
+    computer: ComputerNoun;
 }): string | null {
     if (input.phase === 'settled' || input.phase === 'unavailable') return null;
-    if (input.phase === 'starting') return `Starting the agent host on ${thisComputer()}…`;
+    if (input.phase === 'starting') return `Starting the agent host on ${input.computer}…`;
     if (input.phase === 'connecting') return 'Connecting this computer…';
     // Counted, not promised. Some of the four are simply not installed and will
     // never report, so "2 of 4" would be a progress bar that stops at 2 and
@@ -146,22 +151,30 @@ export function discoveryStatusLine(input: {
 }
 
 /** What the panel says while it resolves, in one voice. */
-export function discoveryHeadline(phase: DiscoveryPhase, foundCount: number): string {
+export function discoveryHeadline(
+    phase: DiscoveryPhase,
+    foundCount: number,
+    computer: ComputerNoun,
+): string {
     if (phase === 'unavailable') return 'This build of Lemma cannot run local agents';
-    if (phase === 'starting') return `Starting the agent host on ${thisComputer()}`;
+    if (phase === 'starting') return `Starting the agent host on ${computer}`;
     if (phase === 'connecting') return 'Connecting this computer';
-    if (phase === 'scanning') return `Looking for coding agents on ${thisComputer()}`;
-    if (foundCount === 0) return `No coding agents found on ${thisComputer()}`;
+    if (phase === 'scanning') return `Looking for coding agents on ${computer}`;
+    if (foundCount === 0) return `No coding agents found on ${computer}`;
     return foundCount === 1
-        ? `Found 1 coding agent on ${thisComputer()}`
-        : `Found ${foundCount} coding agents on ${thisComputer()}`;
+        ? `Found 1 coding agent on ${computer}`
+        : `Found ${foundCount} coding agents on ${computer}`;
 }
 
-export function discoveryLines(phase: DiscoveryPhase, foundCount: number): string[] {
+export function discoveryLines(
+    phase: DiscoveryPhase,
+    foundCount: number,
+    computer: ComputerNoun,
+): string[] {
     if (phase === 'unavailable') {
         return [
             'Connect an API provider below to get a working model.',
-            `Ollama and LM Studio run on ${thisComputer()} and need no key.`,
+            `Ollama and LM Studio run on ${computer} and need no key.`,
         ];
     }
     if (phase !== 'settled') {
@@ -192,7 +205,7 @@ export function discoveryLines(phase: DiscoveryPhase, foundCount: number): strin
     }
     return [
         'A coding agent needs no API key and no model id.',
-        `It runs on ${thisComputer()} with its own credentials.`,
+        `It runs on ${computer} with its own credentials.`,
         'Add one to use it in chats; you can add more later.',
     ];
 }

--- a/lemma-frontend/components/onboarding/local-setup-steps.tsx
+++ b/lemma-frontend/components/onboarding/local-setup-steps.tsx
@@ -287,7 +287,12 @@ export function LocalIntelligenceStep({
     // and the user does not -- but a wait is only worth explaining once it has
     // gone on long enough to be worth explaining.
     const elapsedMs = useElapsedWhile(working);
-    const statusLine = discoveryStatusLine({ phase, foundCount, elapsedMs });
+    const statusLine = discoveryStatusLine({
+        phase,
+        foundCount,
+        elapsedMs,
+        computer: computerNoun,
+    });
     // Asking the host to look again, which is a different act from asking the
     // server what it was told last time. The host reads the request off its
     // control file on a five-second beat and then probes every agent, so the
@@ -383,8 +388,8 @@ export function LocalIntelligenceStep({
             preview={
                 <LocalPreview
                     icon={<Sparkles className="size-5" />}
-                    headline={discoveryHeadline(phase, foundCount)}
-                    lines={discoveryLines(phase, foundCount)}
+                    headline={discoveryHeadline(phase, foundCount, computerNoun)}
+                    lines={discoveryLines(phase, foundCount, computerNoun)}
                     working={working}
                 />
             }

--- a/lemma-frontend/lib/desktop/__tests__/this-computer.test.ts
+++ b/lemma-frontend/lib/desktop/__tests__/this-computer.test.ts
@@ -68,11 +68,26 @@ describe('what to call the machine Lemma is installed on', () => {
 });
 
 describe('the copy that reaches the screen', () => {
-    it('names the right machine in the empty state a Windows user actually sees', () => {
-        pretendToBe({ platform: 'Win32', userAgent: 'Mozilla/5.0 (Windows NT 10.0)' });
-        expect(discoveryHeadline('settled', 0)).toBe('No coding agents found on this PC');
-        expect(discoveryHeadline('scanning', 0)).toBe('Looking for coding agents on this PC');
-        expect(discoveryHeadline('settled', 3)).toBe('Found 3 coding agents on this PC');
+    it('renders whichever machine it is handed, and reads no globals of its own', () => {
+        // The noun is a parameter now. It used to be read inside these
+        // functions, which answered "this computer" on the server and "this
+        // Mac" on the first client render -- a hydration mismatch on every
+        // string here. The component holds `useThisComputer()`, which is the
+        // same answer in both renders.
+        //
+        // Pinned by making `navigator` disagree with the argument: if these
+        // functions still consulted it, these assertions would fail.
+        pretendToBe({ platform: 'MacIntel', userAgent: 'Macintosh; Intel Mac OS X' });
+        expect(discoveryHeadline('settled', 0, 'this PC')).toBe(
+            'No coding agents found on this PC',
+        );
+        expect(discoveryHeadline('scanning', 0, 'this PC')).toBe(
+            'Looking for coding agents on this PC',
+        );
+        expect(discoveryHeadline('settled', 3, 'this PC')).toBe(
+            'Found 3 coding agents on this PC',
+        );
+        expect(discoveryLines('unavailable', 0, 'this PC').join(' ')).toContain('this PC');
     });
 
     it('keeps its line count the same on every platform', () => {
@@ -81,12 +96,9 @@ describe('the copy that reaches the screen', () => {
         // React repairs those by discarding the server subtree rather than by
         // patching the text. The line about file access is phrased to be true
         // everywhere instead of being dropped off macOS.
-        pretendToBe({ platform: 'Win32', userAgent: 'Mozilla/5.0 (Windows NT 10.0)' });
-        const onWindows = discoveryLines('scanning', 0);
-        pretendToBe({ platform: 'MacIntel', userAgent: 'Macintosh; Intel Mac OS X' });
-        const onMac = discoveryLines('scanning', 0);
-        pretendToBe(undefined);
-        const onTheServer = discoveryLines('scanning', 0);
+        const onWindows = discoveryLines('scanning', 0, 'this PC');
+        const onMac = discoveryLines('scanning', 0, 'this Mac');
+        const onTheServer = discoveryLines('scanning', 0, 'this computer');
 
         expect(onWindows).toHaveLength(onMac.length);
         expect(onTheServer).toHaveLength(onMac.length);


### PR DESCRIPTION
## What changes

Four things a 0.7.1 desktop release cannot ship without. The first was found by
installing the 0.7.0 nightly and watching it fail.

### The install stopped at 30% and could never finish

```
time="..." level=fatal msg="cannot exec in a stopped state":
discussion around this process, and suggestions for how to do so.
```

Three times, with "Try again" as the only button.

**The database was not on the volume.** The official PostgreSQL image moved
`PGDATA` at 18 — `/var/lib/postgresql/data` through 17,
`/var/lib/postgresql/18/docker` after — and the mount never moved with it. The
pinned image's own config says so:

| | |
|---|---|
| image `PGDATA` | `/var/lib/postgresql/18/docker` |
| image `VOLUME` | `/var/lib/postgresql` |
| we mounted | `lemma-postgres-data` → `/var/lib/postgresql/data` |

So a fresh install wrote its cluster into the image's anonymous volume, and
`lemma-postgres-data` — the volume the user is told holds their data, the one
both reset tiers are careful about, the one the pg-major guard reads
`PG_VERSION` from — held nothing. A container recreation would have taken every
table with it. An install carried over from an older image *does* have its
cluster on the volume, at the path 18 no longer uses, and the entrypoint refuses
it. That is what this user hit.

`PGDATA` is pinned to the mount now, so the two cannot drift again, and
`refuse_incompatible_postgres_data` — which has been silently answering "don't
know" (which means proceed) since the 18 image landed — can see `PG_VERSION`
again.

Two smaller defects in the same failure. `container_log_summary` returned the
single last non-empty line, and PostgreSQL refuses with a *paragraph* — so that
closing fragment, appended to a nerdctl error, was the entire explanation
offered. And the failure was not classified as a data problem, so the splash
offered a retry that could never work instead of the reset that would.

### A missing secret was treated as a first run

Both secrets files carry an invariant their own doc comments state: they are
gone when the data is gone. The *unreadable* case was careful — quarantine,
record `data-reset-required`, refuse with a button. The *missing* case fell
through to minting a replacement and returning success. Same permanent loss,
reached more quietly: `host.secrets.json` derives the Fernet key for every
encrypted column, and `infra.secrets.json` holds the password baked into the
Postgres volume at `initdb`, which does not change because the file was
recreated.

A file can go missing without the data: a restore that skipped an owner-only
file, a `cp -R` that dropped one, a half-finished cleanup.

### The updater had no key, so 0.7.1 could not have reached 0.7.2

`pubkey` shipped empty, which is not permissive — `verify_signature` decodes it
and fails. `updates_enabled()` already refuses to offer an update in that state,
which is correct and means every release so far could only be replaced by hand.

A keypair exists now: the private half and its password are repository secrets,
the public half is in `tauri.conf.json`. Verified by signing a payload with the
stored secret and checking it against the committed key — by key id, then by
Ed25519 over the BLAKE2b digest the `ED` algorithm byte selects.

### The machine's name changed between the two renders

`discoveryHeadline` and its siblings read `thisComputer()` themselves, which
answers "this computer" where there is no `navigator` and "this Mac" where there
is — a hydration mismatch on every string the agent panel shows. The component
beside them already holds `useThisComputer()`, which exists for exactly this. It
just was not being passed down.

## How to verify

```bash
make desktop-test
```

504 desktop tests, 1062 frontend. Every fix was checked by reinstating the bug
and watching the test fail:

- removing the `PGDATA` pin → "PGDATA is pinned rather than inherited from the image"
- removing the missing-secret guard → "the install must stop with a reset offered, not carry on quietly"
- emptying `pubkey` → "no public key: every install would download an update and then refuse it"

The first version of the `PGDATA` test grepped its own source for the literal it
was asserting, which its own assertion satisfied — so it passed with the bug
reinstated. It reads the two values and compares them now.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload
- [x] **Compatibility** — breaking changes called out below

## Compatibility and rollback notes

**Sequence the runtime first.** The `PGDATA` fix is in `lemma-guestd`, which
ships in the guest runtime, not the app — so `release-local-images.yml` has to
run before the DMG that depends on it.

**Existing installs need a reset**, and now get offered one. Any install whose
volume was written by the older image cannot be opened by this one; that is not
a regression this introduces, it is the state they are already in, surfaced
properly instead of as a stalled progress bar.

Two gitleaks rules cover the updater's private key, in plain and base64 form.
Both were checked against a real secret key (caught), the public key this PR
commits (ignored), and the rule file itself (ignored — `{1}` breaks the literal,
so the scanner's first finding is not its own configuration).

**Operationally:** GitHub secrets are write-only. If that private key is lost,
every already-installed copy becomes permanently un-updatable, because the
public half is compiled into the app people already have. It needs to live in a
password manager.