### PR TITLE
Normalize every component to 0.7.1 for the 0.7.1 release

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2580,7 +2580,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lemma-agent-host"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2613,7 +2613,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-desktop"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64 0.22.1",
  "interprocess",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-guestd"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "libc",
  "serde",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-locald"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "base64 0.22.1",
  "getrandom 0.3.4",
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-runtime"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-runtime-manager"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "getrandom 0.3.4",
  "libc",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -43,7 +43,7 @@ default-members = ["."]
 [workspace.package]
 # One version for six crates. Release used to rewrite desktop/Cargo.toml alone,
 # so the moment the other five moved in here they would have drifted silently.
-version = "0.7.0"
+version = "0.7.1"
 
 [workspace.dependencies]
 # Hoisted because feature unification makes the *emergent* feature set of a

--- a/desktop/runtime/lemma-local.json
+++ b/desktop/runtime/lemma-local.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "0.7.0",
+  "version": "0.7.1",
   "artifact_source": "ci-build-check",
   "host_packs": {
     "aarch64-apple-darwin": {
@@ -11,7 +11,7 @@
       "format": "zip",
       "platform": "macos",
       "architecture": "aarch64",
-      "runtime_version": "0.7.0"
+      "runtime_version": "0.7.1"
     },
     "x86_64-pc-windows-msvc": {
       "url": "https://downloads.example.invalid/lemma-host-pack.zip",
@@ -21,7 +21,7 @@
       "format": "zip",
       "platform": "windows",
       "architecture": "x86_64",
-      "runtime_version": "0.7.0"
+      "runtime_version": "0.7.1"
     }
   },
   "guest_runtimes": {
@@ -33,7 +33,7 @@
       "format": "zip",
       "platform": "linux",
       "architecture": "aarch64",
-      "runtime_version": "0.7.0"
+      "runtime_version": "0.7.1"
     },
     "windows-x86_64": {
       "url": "https://downloads.example.invalid/lemma-guest-runtime.zip",
@@ -43,7 +43,7 @@
       "format": "zip",
       "platform": "linux",
       "architecture": "x86_64",
-      "runtime_version": "0.7.0"
+      "runtime_version": "0.7.1"
     }
   }
 }

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Lemma",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "identifier": "work.lemma.desktop",
   "build": {
     "frontendDist": "ui"

--- a/lemma-backend/app/version.py
+++ b/lemma-backend/app/version.py
@@ -29,4 +29,4 @@ Use a normal MAJOR.MINOR.PATCH string.
 
 from __future__ import annotations
 
-API_VERSION = "0.7.0"
+API_VERSION = "0.7.1"

--- a/lemma-backend/lemma-connectors/pyproject.toml
+++ b/lemma-backend/lemma-connectors/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-connectors"
-version = "0.7.0"
+version = "0.7.1"
 description = "OpenAPI-native native connector packages for Lemma"
 readme = "README.md"
 requires-python = ">=3.14,<3.15"

--- a/lemma-backend/lemma-connectors/uv.lock
+++ b/lemma-backend/lemma-connectors/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "lemma-connectors"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },

--- a/lemma-backend/pyproject.toml
+++ b/lemma-backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-backend"
-version = "0.7.0"
+version = "0.7.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.14,<3.15"

--- a/lemma-backend/sandbox-images/templates/function-python/uv.lock
+++ b/lemma-backend/sandbox-images/templates/function-python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.14.*"
 
 [[package]]
@@ -168,7 +168,7 @@ requires-dist = [
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.0"
+version = "0.7.1"
 source = { directory = "../../../../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/lemma-backend/sandbox-images/templates/workspace-python/uv.lock
+++ b/lemma-backend/sandbox-images/templates/workspace-python/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.14.*"
 resolution-markers = [
     "sys_platform == 'win32'",
@@ -78,7 +78,7 @@ name = "cffi"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
 wheels = [
@@ -640,12 +640,12 @@ wheels = [
 
 [[package]]
 name = "lemma-pod-bundle"
-version = "0.7.0"
+version = "0.7.1"
 source = { directory = "../../../../lemma-pod-bundle" }
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.0"
+version = "0.7.1"
 source = { directory = "../../../../lemma-python" }
 dependencies = [
     { name = "attrs" },
@@ -970,7 +970,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [

--- a/lemma-backend/uv.lock
+++ b/lemma-backend/uv.lock
@@ -1823,7 +1823,7 @@ wheels = [
 
 [[package]]
 name = "lemma-backend"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -1989,7 +1989,7 @@ dev = [
 
 [[package]]
 name = "lemma-connectors"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "lemma-connectors" }
 dependencies = [
     { name = "attrs" },
@@ -2016,12 +2016,12 @@ dev = [
 
 [[package]]
 name = "lemma-pod-bundle"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "../lemma-pod-bundle" }
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/lemma-cli/lemma_cli/__init__.py
+++ b/lemma-cli/lemma_cli/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 __all__ = ["__version__"]
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 if sys.platform == "win32":
     for _stream in (sys.stdout, sys.stderr):

--- a/lemma-cli/pyproject.toml
+++ b/lemma-cli/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   # >= the version that has the endpoints the current commands use, so a fresh
   # `uv tool install` upgrades an already-installed older lemma-sdk. The release
   # workflow rewrites this to the release version on every tagged build.
-  "lemma-sdk>=0.7.0",
+  "lemma-sdk>=0.7.1",
   "click>=8.3.0",
   "typer>=0.12.5",
   "rich>=13.9.4",

--- a/lemma-cli/uv.lock
+++ b/lemma-cli/uv.lock
@@ -314,12 +314,12 @@ wheels = [
 
 [[package]]
 name = "lemma-pod-bundle"
-version = "0.7.0"
+version = "0.7.1"
 source = { directory = "../lemma-pod-bundle" }
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.0"
+version = "0.7.1"
 source = { directory = "../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/lemma-frontend/content/changelog/0-7-1.mdx
+++ b/lemma-frontend/content/changelog/0-7-1.mdx
@@ -1,0 +1,79 @@
+---
+title: 0.7.1
+description: Lemma Desktop becomes installable and recoverable, and agents get a memory of their own.
+published: 2026-08-27
+tags:
+  - release
+---
+
+## Lemma Desktop ships
+
+Installing the 0.7.0 nightly and watching it fail surfaced two ways the app
+could lose a user's data outright: Postgres 18 moved where it stores its
+cluster and the volume mount never followed, so a fresh install wrote its
+database into a container's throwaway volume instead of the one people are
+told holds their data; and a secrets file that went missing — not just
+corrupted — was treated as a first run instead of the permanent loss it is.
+Both are fixed, and the auto-updater has a signing key for the first time, so
+a release can finally be followed by another one without a manual reinstall.
+
+That sits on top of a full adversarial review of the app, its CI, and its
+recovery paths, which found and closed 10 blockers, 26 serious issues, and
+40+ polish items — the app now gets itself unstuck instead of leaving a dead
+end, and a quit that used to hang now closes. Pod apps and pod functions,
+which worked everywhere except Desktop, now carry a session and an address
+like they do on the web.
+
+Underneath, the Agent Host — the bridge to Codex, Claude Code, and other
+ACP-compatible coding agents — reattaches to a run you walked away from,
+retries a failed run without dying on two missing methods, and stops
+rejecting a run for naming the harness revision the host itself just
+published.
+
+## Agents remember, and you choose what they run on
+
+Agents can now hold onto things: `/memory` for facts a whole pod should
+share, `/me` for what's private to you, both built on the pod-file model that
+already backs everything else an agent reads. Memory is a capability you
+grant like any other, not something every agent silently has — and it
+collapses what an agent can do from twelve switches down to five.
+
+Choosing a model is a popover now, not a window that stops the app — the chip
+in the composer opens with the default, five recent picks by number key, and
+the full catalog one row away. Models themselves moved into Pod settings,
+next to Access and Automation, because every question people ask of the
+catalog — what a chat runs on, why an agent can't reach a laptop — starts
+from inside a pod. And an agent's reasoning is recorded as reasoning: it can
+no longer be shown, or returned, as its answer.
+
+## Messaging gets more precise
+
+An agent can now say where a message goes. `message_user` takes a channel —
+email, Slack, Teams, Telegram, WhatsApp — and either delivers there or
+refuses, never silently swaps it for another. A pod's assistant gets its
+inbound mailbox the moment the pod exists, not the first time it happens to
+send something. A second Slack workspace or Teams tenant no longer goes
+permanently unreachable, WhatsApp gets progress messages on runs that can't
+stream, and a voice note is transcribed once, in the language it was actually
+spoken.
+
+## Security and correctness sweep
+
+Every open CodeQL finding is closed, `ruff format` is now enforced across all
+883 first-party Python files, and the scenario suite runs at the SSRF
+strictness a real deployment uses instead of a permissive stand-in. Closing
+the last 19 gaps in the scenario suite's coverage found and fixed 17 real
+bugs on the way, including one that let a pod's sole owner make it
+permanently unadministrable.
+
+## Fixes
+
+- A widget in a conversation renders at its own height instead of being cut
+  off at 480px, and opens in its own tab instead of overwriting another
+- Retrying a failed run works again on every surface that offers it — the
+  API, Telegram's `/retry`, and the retry button
+- A message sent while an agent is working now reaches the run that's
+  already going, instead of starting a second one
+- Files sent from a conversation arrive as an attachment, not a link only a
+  Lemma account can open
+- The pod settings tab formerly called "Access" is now "Members"

--- a/lemma-frontend/package-lock.json
+++ b/lemma-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemma-frontend",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lemma-frontend",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "@noble/hashes": "^2.2.0",
@@ -85,7 +85,7 @@
     },
     "../lemma-typescript": {
       "name": "lemma-sdk",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "supertokens-web-js": "^0.16.0"

--- a/lemma-frontend/package.json
+++ b/lemma-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemma-frontend",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "engines": {
     "node": ">=24 <25"
   },

--- a/lemma-frontend/public/openapi.json
+++ b/lemma-frontend/public/openapi.json
@@ -17585,7 +17585,7 @@
   "info": {
     "description": "Authentication API with JWT, user management, and OAuth support",
     "title": "Lemma Backend",
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/lemma-pod-bundle/pyproject.toml
+++ b/lemma-pod-bundle/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-pod-bundle"
-version = "0.7.0"
+version = "0.7.1"
 description = "Shared pod bundle format vocabulary for the Lemma CLI and backend"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/lemma-pod-bundle/uv.lock
+++ b/lemma-pod-bundle/uv.lock
@@ -4,5 +4,5 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "lemma-pod-bundle"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -12,5 +12,5 @@ SDK and the server it is talking to.
 
 from __future__ import annotations
 
-API_VERSION = "0.7.0"
+API_VERSION = "0.7.1"
 SPEC_SHA256 = "38fcee55213bedc9e8456ac60049e6026c5b7e7c43b3206e94e7a5eb1a46a45c"

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -13,4 +13,4 @@ SDK and the server it is talking to.
 from __future__ import annotations
 
 API_VERSION = "0.7.1"
-SPEC_SHA256 = "38fcee55213bedc9e8456ac60049e6026c5b7e7c43b3206e94e7a5eb1a46a45c"
+SPEC_SHA256 = "e4eb65f0d0563094f3b23ce0d48726bec0bab733927cd42c2cd39dd0bb60a6bf"

--- a/lemma-python/lemma_sdk/openapi_spec.json
+++ b/lemma-python/lemma_sdk/openapi_spec.json
@@ -17585,7 +17585,7 @@
   "info": {
     "description": "Authentication API with JWT, user management, and OAuth support",
     "title": "Lemma Backend",
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/lemma-python/pyproject.toml
+++ b/lemma-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-sdk"
-version = "0.7.0"
+version = "0.7.1"
 description = "Python SDK for Lemma"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/lemma-python/uv.lock
+++ b/lemma-python/uv.lock
@@ -130,7 +130,7 @@ wheels = [
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },

--- a/lemma-stack/pyproject.toml
+++ b/lemma-stack/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-stack"
-version = "0.7.0"
+version = "0.7.1"
 description = "Installer and management tool for a fully-local Lemma stack"
 readme = "README.md"
 requires-python = ">=3.14,<3.15"

--- a/lemma-stack/uv.lock
+++ b/lemma-stack/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "lemma-stack"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },

--- a/lemma-typescript/package-lock.json
+++ b/lemma-typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemma-sdk",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lemma-sdk",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "supertokens-web-js": "^0.16.0"

--- a/lemma-typescript/package.json
+++ b/lemma-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemma-sdk",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "engines": {
     "node": ">=24 <25"
   },

--- a/lemma-typescript/public/lemma-client.js
+++ b/lemma-typescript/public/lemma-client.js
@@ -9850,7 +9850,7 @@ var LemmaClient = (() => {
   }
 
   // src/version.ts
-  var SDK_VERSION = "0.7.0";
+  var SDK_VERSION = "0.7.1";
   var CLIENT_HEADER_NAME = "X-Lemma-Client";
   var APP_HEADER_NAME = "X-Lemma-App";
   var KNOWN_CLIENTS = [
@@ -10277,7 +10277,7 @@ var LemmaClient = (() => {
   // src/openapi_client/core/OpenAPI.ts
   var OpenAPI = {
     BASE: "",
-    VERSION: "0.7.0",
+    VERSION: "0.7.1",
     WITH_CREDENTIALS: false,
     CREDENTIALS: "include",
     TOKEN: void 0,

--- a/lemma-typescript/src/openapi_client/core/OpenAPI.ts
+++ b/lemma-typescript/src/openapi_client/core/OpenAPI.ts
@@ -21,7 +21,7 @@ export type OpenAPIConfig = {
 
 export const OpenAPI: OpenAPIConfig = {
     BASE: '',
-    VERSION: '0.7.0',
+    VERSION: '0.7.1',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',
     TOKEN: undefined,

--- a/lemma-typescript/src/version.ts
+++ b/lemma-typescript/src/version.ts
@@ -1,6 +1,6 @@
 // Keep SDK_VERSION in sync with package.json "version". The CI codegen/drift
 // gate (workstream A) asserts they match so this can't silently drift.
-export const SDK_VERSION = "0.7.0";
+export const SDK_VERSION = "0.7.1";
 
 /** Sent as `X-Lemma-Client` when it will not add an otherwise avoidable browser
  *  preflight, so the backend can log which client + version hit an endpoint. */


### PR DESCRIPTION
## What changes

Bumps every Lemma-owned component that carries the mono-version — `API_VERSION`,
the Python and TypeScript SDKs, the CLI, Desktop (Cargo workspace, tauri.conf.json,
the bundled runtime manifest), and the internal packages that ship with them — from
0.7.0 to 0.7.1, mirroring #262. Regenerates every lockfile and generated bundle that
embeds the version (`uv.lock` x9, the TypeScript SDK's browser bundle, the frontend's
synced `openapi.json`, both `package-lock.json`s) rather than hand-editing them, so
each stays exactly what its own tool would have produced.

Adds the `0.7.1` changelog entry, covering Desktop's install/data-safety fixes and
the review that closed 10 blockers + 26 serious issues before it ships, agent
memory (`/memory` + `/me`) and the new model-picker, multi-channel `message_user`
routing, and the CodeQL/ruff-format/SSRF correctness sweep — drawn from the merged
PRs on `main` since the 0.7.0 tag.

## Why

`scripts/check_version_consistency.py` gates every release workflow on the
components agreeing with the tag before it publishes anything (SDK wheels, npm
package, Desktop installer). Nothing bumps per-PR by design, so this is the one
commit that has to land before `v0.7.1` can be tagged.

## How to verify

```bash
python3 scripts/check_version_consistency.py --expect 0.7.1
# All 12 components declare 0.7.1.

cd lemma-backend && uv run pytest app/tests/unit/test_version_policy.py -q
# 4 passed
```

## Checklist

- [x] Tests cover the behavioral change (`test_version_policy.py` reads the
      version out of each component's own source file)
- [x] Lint, typecheck, and architecture gates pass locally

- [ ] **Migrations** — n/a, no schema change
- [x] **API surface** — `openapi_spec.json`'s `info.version` and the frontend's
      synced copy are updated; no schema change otherwise, so no client
      regeneration was needed beyond the version bump
- [ ] **Compatibility** — n/a, no breaking change
- [ ] **Security** — n/a, no new secret, log, or authorization path touched
- [x] **Rollback** — revert this commit before tagging; nothing here is
      destructive or hard to undo

## Compatibility and rollback notes

None — this is a version-string bump plus a documentation-only changelog entry.
Nothing here changes behavior.