### PR TITLE
fix(release-desktop): raise the online installer's size budget to 30 MiB

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -408,10 +408,14 @@ jobs:
           check "no legacy bundled uv binary" test ! -e "${app}/Contents/MacOS/uv"
 
           app_bytes="$(du -sk "${app}" | awk '{print $1 * 1024}')"
-          limit=$((25 * 1024 * 1024))
-          echo "app size: ${app_bytes} bytes (limit ${limit} bytes / 25 MiB)"
+          # 25 MiB didn't have room for lemma-agent-host (added as a Desktop
+          # sidecar after this budget was set) -- v0.7.1's bundle came in at
+          # 26,423,296 bytes, 208,896 bytes over. 30 MiB gives that real
+          # addition headroom without leaving the budget meaningless.
+          limit=$((30 * 1024 * 1024))
+          echo "app size: ${app_bytes} bytes (limit ${limit} bytes / 30 MiB)"
           if [[ "${app_bytes}" -gt "${limit}" ]]; then
-            echo "::error::online app bundle is ${app_bytes} bytes, over the 25 MiB budget by $((app_bytes - limit)) bytes"
+            echo "::error::online app bundle is ${app_bytes} bytes, over the 30 MiB budget by $((app_bytes - limit)) bytes"
             failed=1
           fi
 


### PR DESCRIPTION
## What changes

Raises the macOS online installer's bundle-size budget from 25 MiB to 30 MiB
in `release-desktop.yml`.

## Why

The v0.7.1 Desktop release (https://github.com/lemma-work/lemma-platform/actions/runs/33045918121)
was the first real release run since `lemma-agent-host` got bundled as a
Desktop sidecar. The new fail-loudly verification step (#527) reported
exactly what happened -- every other check passed clean:

```
app size: 26,423,296 bytes (limit 26,214,400 bytes / 25 MiB)
::error::online app bundle is 26,423,296 bytes, over the 25 MiB budget by 208,896 bytes
```

Bundle contents confirm the cause: `lemma-desktop` 12.1 MB, `lemma-agent-host`
8.2 MB, `lemma-locald` 4.1 MB, `lemma-runtime` 0.5 MB, resources 0.3 MB. The
25 MiB budget predates agent-host's addition; the bundle is over by 204 KiB,
not bloated. 30 MiB gives that real addition headroom.

The Windows online-installer budget (still 25 MiB, `release-desktop.yml:876`)
is untouched -- out of scope here.

## How to verify

Will be verified by the next `release-desktop.yml` dispatch for v0.7.1.

## Checklist

- [x] Tests cover the behavioral change (the check itself is the test, and it
      now reports the real number on every run per #527)
- [ ] **Migrations** — n/a
- [ ] **API surface** — n/a
- [ ] **Compatibility** — n/a
- [ ] **Security** — n/a, raises a size ceiling, doesn't weaken any signing/
      notarization check
- [x] **Rollback** — plain revert if 30 MiB turns out to be the wrong number