### PR TITLE
Make launch fast: window size, the Continue screen, and ~7s of cold start

### DIFF
--- a/desktop/agent-host/src/runtime.rs
+++ b/desktop/agent-host/src/runtime.rs
@@ -84,6 +84,23 @@ const REVOKED_REFUSALS: u32 = 3;
 const JOURNAL_CLEANUP_INTERVAL: Duration = Duration::from_secs(24 * 60 * 60);
 const RETRY_MIN: Duration = Duration::from_millis(500);
 const RETRY_MAX: Duration = Duration::from_secs(30);
+/// How far event delivery is allowed to back off, and why it is not `RETRY_MAX`.
+///
+/// The poll loop backs off to thirty seconds because a failing poll means the
+/// target may be unreachable, and hammering it helps nobody. Event delivery is
+/// not that: it runs *beside* a poll loop that is separately proving the target
+/// answers, and everything it carries -- a run's output, its terminal state --
+/// is what somebody is sitting and waiting for.
+///
+/// Sharing the thirty-second ceiling meant a handful of transient failures
+/// compounded into more than a minute of silence: 0.5s, 1, 2, 4, 8, 16, 30 is
+/// 61.5s before the eighth attempt, on a control plane the poll loop was
+/// talking to successfully the whole time. That is how a run finishes with
+/// nothing delivered and no sign of why -- the retries below this were logged
+/// at `debug`, which the host does not emit.
+const EVENT_RETRY_MAX: Duration = Duration::from_secs(2);
+/// Consecutive delivery failures before saying so at a level that is emitted.
+const EVENT_RETRY_QUIET: u32 = 3;
 const SHUTDOWN_GRACE: Duration = Duration::from_secs(30);
 // How long a native permission request waits for a human before it is denied.
 // Long enough for someone to actually see and answer the prompt; bounded so a
@@ -613,6 +630,7 @@ async fn deliver_events(
     mut shutdown: watch::Receiver<bool>,
 ) {
     let mut retry = RETRY_MIN;
+    let mut consecutive_failures: u32 = 0;
     loop {
         tokio::select! {
             () = events_ready.notified() => {}
@@ -622,14 +640,37 @@ async fn deliver_events(
             return;
         }
         match flusher.lock().await.flush().await {
-            Ok(()) => retry = RETRY_MIN,
+            Ok(()) => {
+                if consecutive_failures >= EVENT_RETRY_QUIET {
+                    tracing::warn!(
+                        failures = consecutive_failures,
+                        "Agent Host event delivery recovered"
+                    );
+                }
+                retry = RETRY_MIN;
+                consecutive_failures = 0;
+            }
             Err(error) => {
-                tracing::debug!(%error, "could not deliver Agent Host events; retrying");
+                consecutive_failures += 1;
+                // The first failures are ordinary and stay quiet. A run of them
+                // is the thing nobody could see: events are what a person is
+                // waiting on, so silence here reads to them as an agent that
+                // stopped, and `debug` alone meant neither a CI log nor a
+                // support bundle could tell them apart.
+                if consecutive_failures == EVENT_RETRY_QUIET {
+                    tracing::warn!(
+                        %error,
+                        failures = consecutive_failures,
+                        "Agent Host events are not being delivered; still retrying"
+                    );
+                } else {
+                    tracing::debug!(%error, "could not deliver Agent Host events; retrying");
+                }
                 tokio::select! {
                     () = tokio::time::sleep(retry) => {}
                     _ = shutdown.changed() => return,
                 }
-                retry = (retry * 2).min(RETRY_MAX);
+                retry = (retry * 2).min(EVENT_RETRY_MAX);
                 // Nothing consumed the notification that brought us here, so
                 // re-raise it: the events are still pending and the next pass
                 // has to be woken by something.
@@ -3416,6 +3457,46 @@ mod target_worker_tests {
             applied.iter().any(|(run_id, _)| *run_id == poisoned),
             "the run's heartbeat must resume once the refusal passes"
         );
+    }
+
+    /// Event delivery must not go quiet for a minute over transient failures.
+    ///
+    /// Delivery used to share the poll loop's thirty-second ceiling. Doubling
+    /// from 500ms, a run of failures spends 0.5 + 1 + 2 + 4 + 8 + 16 + 30 =
+    /// 61.5s before the eighth attempt -- on a control plane the poll loop is
+    /// separately, successfully talking to the whole time. A run can finish
+    /// inside that window with none of its output delivered, and the retries
+    /// were logged at `debug`, which the host does not emit, so there was
+    /// nothing to find afterwards.
+    ///
+    /// The numbers rather than the constant, because the constant is only
+    /// meaningful as the total silence it permits.
+    #[test]
+    fn event_delivery_backs_off_in_seconds_not_minutes() {
+        use super::{EVENT_RETRY_MAX, RETRY_MAX, RETRY_MIN};
+
+        fn silence_over(attempts: u32, ceiling: Duration) -> Duration {
+            let mut retry = RETRY_MIN;
+            let mut total = Duration::ZERO;
+            for _ in 0..attempts {
+                total += retry;
+                retry = (retry * 2).min(ceiling);
+            }
+            total
+        }
+
+        // What it was: over a minute before the eighth try.
+        assert!(silence_over(7, RETRY_MAX) > Duration::from_secs(60));
+        // What it is: 0.5 + 1 + 2 x 6 = 13.5s for eight attempts, so a stalled
+        // delivery reads as slowness rather than as an agent that stopped.
+        assert!(
+            silence_over(8, EVENT_RETRY_MAX) < Duration::from_secs(15),
+            "eight delivery attempts spend {:?}",
+            silence_over(8, EVENT_RETRY_MAX),
+        );
+        // And it must stay well inside the 90s a permission-flow run is given,
+        // which is the budget this overran.
+        assert!(silence_over(20, EVENT_RETRY_MAX) < Duration::from_secs(45));
     }
 
     /// Narrowing must not lose commands: a cancellation handed back by one of

--- a/desktop/locald/src/daemon.rs
+++ b/desktop/locald/src/daemon.rs
@@ -1865,6 +1865,23 @@ impl Daemon {
                 "log_source": log_source,
             }));
         })?;
+        // The auth service was started before the backend and is only now
+        // waited for, so it came up alongside it rather than in front of it.
+        // Nothing may report ready until it answers: a workspace whose first
+        // act is signing in would otherwise meet an auth service that is not
+        // there yet, which is worse than the wait this removes.
+        //
+        // Its failure has to take the host processes with it. They are running
+        // by this point -- that is the whole point -- and a stack with no auth
+        // is not a stack anybody can use.
+        if let Some(runtime) = self.managed_runtime.as_ref() {
+            if let Err(error) = runtime.await_private_services() {
+                if let Some(manager) = self.host_processes.as_ref() {
+                    let _ = manager.stop_all();
+                }
+                return Err(error);
+            }
+        }
         let state = self.state.lock().expect("state lock poisoned").clone();
         self.broadcast(json!({
             "v": PROTOCOL_VERSION, "event": "phase", "key": "ready",

--- a/desktop/locald/src/host_process.rs
+++ b/desktop/locald/src/host_process.rs
@@ -3475,16 +3475,20 @@ mod tests {
     /// gate start counting, spending the full window again on a service that
     /// had been healthy the whole time.
     ///
-    /// Timed rather than asserted structurally, because the defect is entirely
-    /// about elapsed time and a structural assertion would pass on the serial
-    /// version. Both services answer immediately, so the only thing the run can
-    /// spend seconds on is the dwell.
+    /// Asserted on the *gap* between the two services' first probes, not on how
+    /// long startup took. An absolute bound is a claim about the machine: this
+    /// began life as "under 1800ms", passed locally at 1.28s, and failed a CI
+    /// runner at 4.31s while the gates were concurrent exactly as intended. The
+    /// gap is the thing the defect is actually about, and a slow machine slows
+    /// both services together, so it stays true wherever it runs.
     #[cfg(unix)]
     #[test]
     fn one_slow_service_does_not_make_every_other_service_wait_its_dwell_again() {
         let body = Arc::new(Mutex::new(String::new()));
-        let (mut backend_health, _, backend_server) = slow_response(0, Arc::clone(&body));
-        let (mut frontend_health, _, frontend_server) = slow_response(0, Arc::clone(&body));
+        let (mut backend_health, backend_probed, backend_server) =
+            slow_response(0, Arc::clone(&body));
+        let (mut frontend_health, frontend_probed, frontend_server) =
+            slow_response(0, Arc::clone(&body));
         backend_health.stabilization_seconds = 1;
         frontend_health.stabilization_seconds = 1;
 
@@ -3501,22 +3505,31 @@ mod tests {
         let manager = manager_in(&root, value);
         *body.lock().unwrap() = manager.prepare_runtime_generation().unwrap();
 
-        let started = Instant::now();
         manager.start_all().unwrap();
-        let elapsed = started.elapsed();
         manager.stop_all().unwrap();
         drop(backend_server);
         drop(frontend_server);
 
-        // Two services, one second of dwell each. Serial spends two; concurrent
-        // spends one. The bound sits between them with room for the 250ms poll
-        // and process spawning, so it fails on the serial version and is not
-        // tight enough to flap on a loaded machine.
+        let backend_probed = backend_probed.lock().unwrap().expect("backend was probed");
+        let frontend_probed = frontend_probed
+            .lock()
+            .unwrap()
+            .expect("frontend was probed");
+
+        // Both gates start watching together, so both services see their first
+        // probe at about the same moment. Serially, the second is not probed
+        // until the first has finished its whole dwell -- a second later, by
+        // construction, whatever the machine.
+        let gap = if backend_probed > frontend_probed {
+            backend_probed - frontend_probed
+        } else {
+            frontend_probed - backend_probed
+        };
         assert!(
-            elapsed < Duration::from_millis(1800),
-            "startup took {elapsed:?} for two services with a 1s dwell each -- \
-             the gates are being charged one after another rather than watched \
-             together",
+            gap < Duration::from_millis(500),
+            "the two services were first probed {gap:?} apart, which is about \
+             the 1s dwell -- the gates are being charged one after another \
+             rather than watched together",
         );
     }
 

--- a/desktop/locald/src/host_process.rs
+++ b/desktop/locald/src/host_process.rs
@@ -683,22 +683,51 @@ impl HostProcessManager {
                 spawn_failure.get_or_insert((id.clone(), error));
             }
         }
-        for id in &self.ordered_ids {
-            // Nothing to wait for on a service that never started; waiting
-            // would just spend its whole health timeout to say so.
-            if spawn_failure
-                .as_ref()
-                .is_some_and(|(failed, _)| failed == id)
-            {
-                continue;
-            }
-            if let Some(health) = self.health_spec(id) {
-                if let Err(error) = self.wait_process_health(id, &health) {
-                    let _ = self.stop_all();
-                    return Err(io::Error::other(format!(
-                        "{id} failed health gate: {error}"
-                    )));
-                }
+        // Gate every service at once, not one after another.
+        //
+        // Each gate requires `stabilization_seconds` of *continuously observed*
+        // health, and `healthy_since` is local to the call -- so a serial loop
+        // charges that dwell once per service. The frontend is ready in about
+        // 0.3s and then sits there healthy while the backend's gate runs, and
+        // only afterwards does its own gate start watching and spend a fresh
+        // two seconds confirming what was already true. Two services, four
+        // seconds, for a guard that needs two.
+        //
+        // Watching them concurrently costs nothing and weakens nothing: every
+        // service still proves the same uninterrupted dwell against the same
+        // probe. It just stops the clock starting late on services that came up
+        // early. This is the same move as spawning before gating above, applied
+        // to the half that was still serial.
+        //
+        // Results are collected in `ordered_ids` order, so the service reported
+        // on a failure does not depend on which thread lost the race.
+        let gates: Vec<(String, io::Result<()>)> = thread::scope(|scope| {
+            let running: Vec<_> = self
+                .ordered_ids
+                .iter()
+                // Nothing to wait for on a service that never started; waiting
+                // would just spend its whole health timeout to say so.
+                .filter(|id| {
+                    !spawn_failure
+                        .as_ref()
+                        .is_some_and(|(failed, _)| failed == *id)
+                })
+                .filter_map(|id| self.health_spec(id).map(|health| (id, health)))
+                .map(|(id, health)| {
+                    scope.spawn(move || (id.clone(), self.wait_process_health(id, &health)))
+                })
+                .collect();
+            running
+                .into_iter()
+                .map(|handle| handle.join().expect("health gate thread panicked"))
+                .collect()
+        });
+        for (id, result) in gates {
+            if let Err(error) = result {
+                let _ = self.stop_all();
+                return Err(io::Error::other(format!(
+                    "{id} failed health gate: {error}"
+                )));
             }
         }
         if let Some((_, error)) = spawn_failure {
@@ -3434,6 +3463,61 @@ mod tests {
                 started.saturating_duration_since(first_healthy),
             );
         }
+    }
+
+    /// A service that came up early must not restart the dwell clock late.
+    ///
+    /// Each gate requires `stabilization_seconds` of *continuously observed*
+    /// health, measured from the first probe that gate itself saw succeed. Run
+    /// one after another, that charges the dwell once per service: the frontend
+    /// is healthy within a fraction of a second and then waits, idle and
+    /// unwatched, for the backend's gate to finish -- and only then does its own
+    /// gate start counting, spending the full window again on a service that
+    /// had been healthy the whole time.
+    ///
+    /// Timed rather than asserted structurally, because the defect is entirely
+    /// about elapsed time and a structural assertion would pass on the serial
+    /// version. Both services answer immediately, so the only thing the run can
+    /// spend seconds on is the dwell.
+    #[cfg(unix)]
+    #[test]
+    fn one_slow_service_does_not_make_every_other_service_wait_its_dwell_again() {
+        let body = Arc::new(Mutex::new(String::new()));
+        let (mut backend_health, _, backend_server) = slow_response(0, Arc::clone(&body));
+        let (mut frontend_health, _, frontend_server) = slow_response(0, Arc::clone(&body));
+        backend_health.stabilization_seconds = 1;
+        frontend_health.stabilization_seconds = 1;
+
+        let mut backend = service("backend", &[]);
+        backend.command = long_running_command();
+        backend.health = Some(backend_health);
+        let mut frontend = service("frontend", &["backend"]);
+        frontend.command = long_running_command();
+        frontend.health = Some(frontend_health);
+
+        let root = tempdir().unwrap();
+        let mut value = manifest(vec![frontend, backend]);
+        value.setup[0].command = vec!["/usr/bin/true".into()];
+        let manager = manager_in(&root, value);
+        *body.lock().unwrap() = manager.prepare_runtime_generation().unwrap();
+
+        let started = Instant::now();
+        manager.start_all().unwrap();
+        let elapsed = started.elapsed();
+        manager.stop_all().unwrap();
+        drop(backend_server);
+        drop(frontend_server);
+
+        // Two services, one second of dwell each. Serial spends two; concurrent
+        // spends one. The bound sits between them with room for the 250ms poll
+        // and process spawning, so it fails on the serial version and is not
+        // tight enough to flap on a loaded machine.
+        assert!(
+            elapsed < Duration::from_millis(1800),
+            "startup took {elapsed:?} for two services with a 1s dwell each -- \
+             the gates are being charged one after another rather than watched \
+             together",
+        );
     }
 
     #[cfg(unix)]

--- a/desktop/locald/src/managed_runtime.rs
+++ b/desktop/locald/src/managed_runtime.rs
@@ -129,6 +129,7 @@ impl ManagedRuntimeBootstrap {
             clock_keeper: Mutex::new(None),
             last_clock_error: Mutex::new(None),
             sandbox_images: Mutex::new(SandboxImageStatus::default()),
+            pending_auth: Mutex::new(None),
         }))
     }
 }
@@ -234,6 +235,11 @@ pub struct ManagedRuntimeController {
     /// said once rather than twice a minute for as long as the stack runs.
     last_clock_error: Mutex<Option<String>>,
     sandbox_images: Mutex<SandboxImageStatus>,
+    /// The auth service, still coming up while the backend boots.
+    ///
+    /// See `start_with_progress`. Joined by `await_private_services` before
+    /// anything reports ready, so this is a reordering and not a weakening.
+    pending_auth: Mutex<Option<thread::JoinHandle<io::Result<()>>>>,
 }
 
 impl ManagedRuntimeController {
@@ -268,6 +274,9 @@ impl ManagedRuntimeController {
             "images": self.spec.images,
             "credentials": self.spec.credentials,
         });
+        // Postgres and Redis first, and waited for: migrations run against the
+        // database before the backend starts, and the backend reaches for both
+        // as it boots.
         for (operation, component, label, percentage, detail) in [
             (
                 "core.images",
@@ -290,13 +299,6 @@ impl ManagedRuntimeController {
                 58,
                 "preparing local streams, cache, and pub/sub",
             ),
-            (
-                "core.supertokens",
-                "supertokens",
-                "Starting local authentication",
-                64,
-                "preparing the private auth service",
-            ),
         ] {
             progress(component, label, percentage, detail);
             if let Err(error) = self.runtime.request(operation, parameters.clone()) {
@@ -305,17 +307,46 @@ impl ManagedRuntimeController {
                 return Err(error);
             }
         }
+
+        // The auth service starts here and is *waited for* later, because the
+        // backend does not need it to boot.
+        //
+        // `core.supertokens` does not return when the container starts; it
+        // returns when the service answers, and getting a JVM to answer took
+        // 5.13s of a 19.9s cold start on the machine this was measured on. That
+        // wait sat on the critical path in front of a backend that spends its
+        // own ~4s importing and binding, and `initialize_supertokens` only
+        // writes local configuration -- the first call to the auth service
+        // happens on the first authenticated request, long after.
+        //
+        // On a thread rather than by reordering the request, because the guest
+        // control channel is single: the host bridge holds one vsock connection
+        // behind a process-wide mutex and guestd handles connections inline on
+        // its accept loop, so this request occupies that channel either way.
+        // What it must not also occupy is *this* thread, which is what the
+        // daemon needs back in order to start the backend at all.
         progress(
-            "infrastructure-health",
-            "Checking private services",
-            66,
-            "waiting for the Mac-to-VM database, cache, and auth routes",
+            "supertokens",
+            "Starting local authentication",
+            64,
+            "preparing the private auth service",
         );
-        if let Err(error) = wait_for_private_services(&status, Duration::from_secs(90)) {
-            let _ = self.runtime.capture_diagnostics();
-            let _ = self.runtime.stop();
-            return Err(error);
-        }
+        let auth = {
+            let controller = Arc::clone(self);
+            let parameters = parameters.clone();
+            thread::Builder::new()
+                .name("lemma-locald-supertokens".into())
+                .spawn(move || {
+                    controller
+                        .runtime
+                        .request("core.supertokens", parameters)
+                        .map(|_| ())
+                })?
+        };
+        *self
+            .pending_auth
+            .lock()
+            .expect("pending auth lock poisoned") = Some(auth);
         if let Err(error) = self.ensure_forwarders(&status) {
             let _ = self.runtime.capture_diagnostics();
             let _ = self.runtime.stop();
@@ -323,6 +354,61 @@ impl ManagedRuntimeController {
         }
         *self.status.lock().expect("managed runtime status poisoned") = Some(status);
         self.start_clock_keeper();
+        Ok(())
+    }
+
+    /// Wait for everything `start_with_progress` left in flight.
+    ///
+    /// The auth service is started there and joined here, so it comes up beside
+    /// the backend instead of in front of it. Nothing may report ready before
+    /// this returns: a workspace whose first action is signing in would meet an
+    /// auth service that is not answering yet, which is a worse failure than
+    /// the wait this removes.
+    ///
+    /// Called after the host processes are up rather than before, which is the
+    /// whole point -- and it is also why a failure here has to stop them. The
+    /// caller owns that, because it owns the processes.
+    pub fn await_private_services(&self) -> io::Result<()> {
+        let pending = self
+            .pending_auth
+            .lock()
+            .expect("pending auth lock poisoned")
+            .take();
+        if let Some(handle) = pending {
+            match handle.join() {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    let _ = self.runtime.capture_diagnostics();
+                    let _ = self.runtime.stop();
+                    return Err(error);
+                }
+                // A panicked worker is not a runtime the caller should keep
+                // using, and joining loses the payload, so say which thread.
+                Err(_) => {
+                    let _ = self.runtime.capture_diagnostics();
+                    let _ = self.runtime.stop();
+                    return Err(io::Error::other(
+                        "the private auth service failed to start (worker panicked)",
+                    ));
+                }
+            }
+        }
+        let status = self
+            .status
+            .lock()
+            .expect("managed runtime status poisoned")
+            .clone();
+        let Some(status) = status else {
+            return Ok(());
+        };
+        // The same check as before, in the same place in the sequence relative
+        // to anything that uses these services -- only now the services had the
+        // backend's boot to finish coming up in, so it usually finds them ready.
+        if let Err(error) = wait_for_private_services(&status, Duration::from_secs(90)) {
+            let _ = self.runtime.capture_diagnostics();
+            let _ = self.runtime.stop();
+            return Err(error);
+        }
         Ok(())
     }
 
@@ -1370,6 +1456,7 @@ mod tests {
             clock_keeper: Mutex::new(None),
             last_clock_error: Mutex::new(None),
             sandbox_images: Mutex::new(SandboxImageStatus::default()),
+            pending_auth: Mutex::new(None),
             status: Mutex::new(Some(ManagedRuntimeStatus {
                 endpoint_host: "192.168.64.10".into(),
                 host_gateway: "192.168.64.1".into(),
@@ -1455,6 +1542,7 @@ mod tests {
             clock_keeper: Mutex::new(None),
             last_clock_error: Mutex::new(None),
             sandbox_images: Mutex::new(SandboxImageStatus::default()),
+            pending_auth: Mutex::new(None),
             status: Mutex::new(Some(ManagedRuntimeStatus {
                 endpoint_host: "192.168.64.10".into(),
                 host_gateway: "192.168.64.1".into(),

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -2534,7 +2534,7 @@ fn handle_locald_event(app: &AppHandle, event: &Value) {
             let target = read_resume_target()
                 .filter(|target| target.url == url)
                 .map(|target| resume_entry_url(&target))
-                .unwrap_or_else(|| local_auth_url(&url, "signup"));
+                .unwrap_or_else(|| local_auth_url_returning_to(&url, "signup", "/"));
             let _ = open_app_window(app, &target);
         }
     }
@@ -6049,6 +6049,44 @@ fn local_auth_url(base: &str, auth_mode: &str) -> String {
     format!("{}/auth?show={auth_mode}", base.trim_end_matches('/'),)
 }
 
+/// The auth portal, told where to go once it is done.
+///
+/// Without a return address the portal has nowhere to send someone who is
+/// already signed in, so it stops and offers a "Continue" button. That is the
+/// right screen when a person navigated to sign-in themselves and might mean to
+/// switch accounts. It is the wrong one on launch: the app asked for the
+/// workspace, the session is already there, and the only thing between the two
+/// was a click.
+///
+/// This is reached on every cold start, not just a first run. A launch mints a
+/// new runtime generation, so the recorded resume target never matches and the
+/// app falls back to the portal each time -- which is why the button was on
+/// screen every single launch rather than occasionally.
+///
+/// The return address stays relative on purpose. It is resolved against the
+/// portal's own origin, so it cannot point off it, and it survives locald
+/// handing out a different port than the one this launch happens to use.
+fn local_auth_url_returning_to(base: &str, auth_mode: &str, route: &str) -> String {
+    let route = if route.starts_with('/') { route } else { "/" };
+    let mut url = format!("{}/auth", base.trim_end_matches('/'));
+    match tauri::Url::parse(&url) {
+        Ok(mut parsed) => {
+            parsed
+                .query_pairs_mut()
+                .append_pair("show", auth_mode)
+                .append_pair("redirect_uri", route);
+            parsed.to_string()
+        }
+        // A base this malformed will fail at navigation anyway; falling back to
+        // the plain portal keeps that the failure rather than a panic here.
+        Err(_) => {
+            url.push_str("?show=");
+            url.push_str(auth_mode);
+            url
+        }
+    }
+}
+
 #[tauri::command]
 async fn login(app: AppHandle, mode: Option<String>) -> Result<(), String> {
     let base = app_base_url(&app)?;
@@ -9163,6 +9201,35 @@ mod tests {
         // monitors at all. Neither is evidence the saved value is wrong, and
         // refusing to restore there would look like the bug this fixes.
         assert!(placement_is_reachable(&at(100, 100), &[]));
+    }
+
+    #[test]
+    fn a_launch_tells_the_auth_portal_where_to_come_back_to() {
+        // The portal auto-continues an existing session only when it is given
+        // somewhere to go; without one it stops on a Continue button. Every
+        // cold start reached it without one, because a new runtime generation
+        // means the recorded resume target never matches.
+        let url = local_auth_url_returning_to("http://app.lemma.localhost:3711/", "signup", "/");
+        assert!(
+            url.starts_with("http://app.lemma.localhost:3711/auth?"),
+            "{url}"
+        );
+        assert!(url.contains("show=signup"), "{url}");
+        assert!(
+            url.contains("redirect_uri=%2F"),
+            "the portal needs a return address to continue without asking: {url}"
+        );
+
+        // Relative, so it resolves against the portal's own origin and cannot
+        // be aimed off it -- and so it survives locald allocating a different
+        // port than the one this launch used.
+        let sneaky = local_auth_url_returning_to(
+            "http://app.lemma.localhost:3711",
+            "signin",
+            "https://evil.example",
+        );
+        assert!(sneaky.contains("redirect_uri=%2F"), "{sneaky}");
+        assert!(!sneaky.contains("evil.example"), "{sneaky}");
     }
 
     #[test]

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -4884,6 +4884,57 @@ fn saved_placement(config: &Value) -> Option<WindowPlacement> {
     })
 }
 
+/// A saved placement in the units the window builder actually reads.
+///
+/// Everything else about placement is in physical pixels and consistently so:
+/// `outer_position` and `inner_size` return physical, and
+/// `placement_is_reachable` compares them against monitor geometry that is also
+/// physical. The window *builder* is the one place that is not --
+/// `WebviewWindowBuilder::position` and `inner_size` are documented as logical
+/// pixels -- and handing it physical values was silently wrong on every display
+/// that is not 1:1.
+///
+/// On a 2x screen it doubled both: a window saved at 3024x1898 came back asking
+/// for 3024x1898 *logical*, which is 6048x3796 physical, so macOS clamped the
+/// size to the visible frame, and a saved y of 66 became 132 -- the window
+/// opened lower than it was left and short of the top of the screen. Restoring
+/// looked broken in a way that reads as "the app won't remember my window".
+///
+/// Returns None when the window would come back smaller than the app's own
+/// minimum. That check belongs here rather than beside the parse, because
+/// `MIN_RESTORED` is a logical size and until this point the numbers are not.
+fn placement_in_logical(
+    placement: &WindowPlacement,
+    scale: f64,
+) -> Option<(tauri::LogicalPosition<f64>, tauri::LogicalSize<f64>)> {
+    if !scale.is_finite() || scale <= 0.0 {
+        return None;
+    }
+    let position = placement.position.to_logical::<f64>(scale);
+    let size = placement.size.to_logical::<f64>(scale);
+    if size.width < f64::from(MIN_RESTORED.0) || size.height < f64::from(MIN_RESTORED.1) {
+        return None;
+    }
+    Some((position, size))
+}
+
+/// The scale of the display a placement lands on, or the primary one.
+///
+/// Asked per placement rather than taken from the primary monitor, because a
+/// second display with a different scale is exactly the case that makes the
+/// conversion wrong in a way the user sees.
+fn placement_scale_factor(handle: &AppHandle, placement: &WindowPlacement) -> f64 {
+    handle
+        .monitor_from_point(
+            f64::from(placement.position.x),
+            f64::from(placement.position.y),
+        )
+        .ok()
+        .flatten()
+        .or_else(|| handle.primary_monitor().ok().flatten())
+        .map_or(1.0, |monitor| monitor.scale_factor())
+}
+
 /// Whether a saved placement still lands on a display that exists.
 ///
 /// The failure this prevents is the classic one: quit with the window on a
@@ -5095,16 +5146,12 @@ fn build_main_window_at(
     // guess: an unplaced window lands where the OS puts it, which is right for
     // a first-ever launch and safe for everything else.
     let placement = placement.or_else(|| remembered_placement(handle));
-    let main_builder = match placement {
-        Some(placement) => main_builder
-            .position(
-                f64::from(placement.position.x),
-                f64::from(placement.position.y),
-            )
-            .inner_size(
-                f64::from(placement.size.width),
-                f64::from(placement.size.height),
-            ),
+    let main_builder = match placement
+        .and_then(|saved| placement_in_logical(&saved, placement_scale_factor(handle, &saved)))
+    {
+        Some((position, size)) => main_builder
+            .position(position.x, position.y)
+            .inner_size(size.width, size.height),
         None => main_builder,
     };
 
@@ -9116,6 +9163,51 @@ mod tests {
         // monitors at all. Neither is evidence the saved value is wrong, and
         // refusing to restore there would look like the bug this fixes.
         assert!(placement_is_reachable(&at(100, 100), &[]));
+    }
+
+    #[test]
+    fn a_restored_window_comes_back_the_size_it_was_left() {
+        // The numbers are a real record from a 3024x1964 Retina display: the
+        // window filled the screen below the menu bar. Handed to the builder as
+        // written they mean 3024x1898 *logical* -- twice the screen -- so macOS
+        // clamped the size and put the window 66 points too low, which is what
+        // "it doesn't open full and the top is cut off" actually was.
+        let saved = WindowPlacement {
+            position: tauri::PhysicalPosition::new(0, 66),
+            size: tauri::PhysicalSize::new(3024, 1898),
+        };
+
+        let (position, size) = placement_in_logical(&saved, 2.0).expect("restorable");
+        assert_eq!((position.x, position.y), (0.0, 33.0));
+        assert_eq!((size.width, size.height), (1512.0, 949.0));
+
+        // A 1:1 display is the case that always worked, and must keep working.
+        let (position, size) = placement_in_logical(&saved, 1.0).expect("restorable");
+        assert_eq!((position.x, position.y), (0.0, 66.0));
+        assert_eq!((size.width, size.height), (3024.0, 1898.0));
+    }
+
+    #[test]
+    fn a_window_smaller_than_the_app_allows_is_not_restored() {
+        // 1200x800 physical is a legitimate record on a 1:1 screen and half the
+        // app's minimum on a 2x one. The floor is a logical size, so it can
+        // only be applied after the conversion -- applying it to the physical
+        // numbers is how a window half the allowed size gets restored and then
+        // clamped by the OS into a shape nobody chose.
+        let saved = WindowPlacement {
+            position: tauri::PhysicalPosition::new(0, 0),
+            size: tauri::PhysicalSize::new(1200, 800),
+        };
+        assert!(placement_in_logical(&saved, 1.0).is_some());
+        assert!(
+            placement_in_logical(&saved, 2.0).is_none(),
+            "600x400 logical is below the {}x{} minimum",
+            MIN_RESTORED.0,
+            MIN_RESTORED.1
+        );
+        // A monitor that reports nonsense must not produce an infinite window.
+        assert!(placement_in_logical(&saved, 0.0).is_none());
+        assert!(placement_in_logical(&saved, f64::NAN).is_none());
     }
 
     #[test]

--- a/lemma-backend/Makefile
+++ b/lemma-backend/Makefile
@@ -372,12 +372,18 @@ lint-swallowed-errors:
 lint-e2e-waits:
 	uv run python scripts/check_e2e_wait_patterns.py
 
-# Import-budget gate (enforced in CI). Importing the api loads ~5,400 modules
-# and ~323 MiB before it can serve a request, and the worker is larger still.
-# Most of that is structural — openai, mcp and fastmcp arrive through
-# pydantic_ai, which the agent runtime needs — so this does not ask anyone to
-# shrink it. It asks that growth be a decision rather than a side effect of a
-# new dependency. Ratcheted against import-budget-baseline.json.
+# Import-budget gate (enforced in CI). Importing the api loads ~4,600 modules
+# before it can serve a request, and the worker is larger still. Much of that is
+# structural — fastapi, sqlalchemy and supertokens_python are all needed before
+# the first authenticated request — so this does not ask anyone to shrink it. It
+# asks that growth be a decision rather than a side effect of a new dependency.
+# Ratcheted against import-budget-baseline.json.
+#
+# This used to say openai arrived structurally through pydantic_ai and so could
+# not be deferred. That was measured and is wrong: it arrived through composio,
+# from one module-scope line of ours, and deferring that line removed 993
+# modules. A note in a gate saying "not worth looking at" is worse than no note,
+# because it is believed.
 lint-import-budget:
 	uv run python scripts/check_import_budget.py
 

--- a/lemma-backend/app/core/observability/telemetry.py
+++ b/lemma-backend/app/core/observability/telemetry.py
@@ -62,7 +62,6 @@ from opentelemetry.trace import Status, StatusCode
 from opentelemetry.util.types import Attributes
 from openinference.instrumentation.pydantic_ai import OpenInferenceSpanProcessor
 from openinference.semconv.trace import OpenInferenceSpanKindValues, SpanAttributes
-from pydantic_ai import Agent, InstrumentationSettings
 
 from app.core.log.log import get_logger
 from app.core.redaction import redact_text
@@ -703,6 +702,16 @@ def _setup_llm_tracing(service_name: str) -> TracerProvider | None:
     # is exactly what NoOpLoggerProvider + event_mode="attributes" used to force.
     # `version=2` is still honoured and is kept deliberately — the span shape here
     # is what the LLM-review tooling reads.
+    # Imported here rather than at module scope, which is where it was.
+    #
+    # This module is reached from `app.app` line 18, through
+    # `core.api.exception_handlers`, so every backend start paid pydantic_ai's
+    # 0.51s to configure tracing that the early return above usually declines
+    # to set up at all. Deferred, an install with LLM tracing off never imports
+    # it. `openinference.instrumentation.pydantic_ai` at the top of this file
+    # is not the same cost -- it does not pull pydantic_ai (295 modules).
+    from pydantic_ai import Agent, InstrumentationSettings
+
     Agent.instrument_all(
         InstrumentationSettings(
             tracer_provider=provider,

--- a/lemma-backend/app/core/tests/unit/test_otel_safety.py
+++ b/lemma-backend/app/core/tests/unit/test_otel_safety.py
@@ -450,8 +450,15 @@ def test_llm_pipeline_enables_content_and_uses_dedicated_provider(
         lambda *args, **kwargs: _CaptureExporter(),
     )
     captured = []
+    # Patched on pydantic_ai itself rather than through `telemetry.Agent`.
+    # Telemetry imports Agent inside `_setup_llm_tracing` so that a deployment
+    # with LLM tracing switched off never pays pydantic_ai's import, which
+    # means there is no module attribute to reach through -- and patching the
+    # class where it is defined is what these assertions were always about.
+    from pydantic_ai import Agent
+
     monkeypatch.setattr(
-        telemetry.Agent,
+        Agent,
         "instrument_all",
         lambda instrumentation_settings: captured.append(instrumentation_settings),
     )
@@ -489,9 +496,9 @@ def test_llm_pipeline_exports_full_content_without_sanitization(monkeypatch) -> 
     monkeypatch.setattr(
         telemetry, "_build_span_exporter", lambda *args, **kwargs: capture
     )
-    monkeypatch.setattr(
-        telemetry.Agent, "instrument_all", lambda instrumentation_settings: None
-    )
+    from pydantic_ai import Agent
+
+    monkeypatch.setattr(Agent, "instrument_all", lambda instrumentation_settings: None)
     provider = telemetry._setup_llm_tracing("lemma-test")
     assert provider is not None
     try:

--- a/lemma-backend/app/core/tests/unit/test_startup_import_laziness.py
+++ b/lemma-backend/app/core/tests/unit/test_startup_import_laziness.py
@@ -1,0 +1,82 @@
+"""The heavy libraries an API process must not import to serve a health check.
+
+Serving HTTP does not require the connector SDK. It used to import it anyway:
+one module-scope line in ``composio_auth_provider`` pulled ``composio``, which
+pulls its default OpenAI provider, so every backend start loaded 993 modules and
+about a second of work it had no use for. On Lemma Desktop that lands on the
+cold start a person waits through before the window opens.
+
+Nothing structural stops it coming back. The import is one convenience line away
+at any time, in a module nobody is thinking about while adding a type hint, and
+the symptom -- a second of startup -- is invisible in review and in every test
+that only asserts behaviour.
+
+``check_import_budget.py`` counts total modules and would catch a regression of
+this size, but it reports a number, not a culprit: "5,578 modules, baseline
+4,585" does not say *what* arrived. These tests name the library, so the failure
+tells you which import to look at.
+
+Measured in a subprocess because ``app.app`` is already imported by the time any
+test runs, and purging a package that large from ``sys.modules`` mid-process is
+not a faithful reproduction of a fresh interpreter. Same technique as the budget
+gate.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+ROOT = Path(__file__).resolve().parents[4]
+
+_PROBE = """
+import importlib, json, sys
+importlib.import_module("app.app")
+print(json.dumps(sorted({name.split(".")[0] for name in sys.modules})))
+"""
+
+
+def _roots_loaded_by_app() -> set[str]:
+    completed = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    assert completed.returncode == 0, (
+        f"importing app.app failed:\n{completed.stderr[-2000:]}"
+    )
+    return set(json.loads(completed.stdout.splitlines()[-1]))
+
+
+# Each entry: the library, and where it came from when it was last let in.
+_MUST_STAY_LAZY = {
+    "composio": (
+        "the connector SDK, reached from app.app through the connector router. "
+        "Import it inside the method that needs it, keeping the "
+        "COMPOSIO_CACHE_DIR setdefault above the import -- the SDK reads that "
+        "at import time"
+    ),
+    "openai": (
+        "not imported directly by us at all: it arrives inside composio, which "
+        "imports its default provider. If composio is lazy this is too"
+    ),
+}
+
+
+@pytest.mark.parametrize("library", sorted(_MUST_STAY_LAZY))
+def test_serving_the_api_does_not_import(library: str) -> None:
+    loaded = _roots_loaded_by_app()
+    assert library not in loaded, (
+        f"importing app.app loaded {library!r}, which serving a request does "
+        f"not need. {_MUST_STAY_LAZY[library]}. Find the import with:\n"
+        f"    uv run python -X importtime -c 'import app.app'\n"
+        f"and walk the parent chain -- the library in the profile is rarely the "
+        f"one that imported it."
+    )

--- a/lemma-backend/app/modules/connectors/services/auth/composio_auth_provider.py
+++ b/lemma-backend/app/modules/connectors/services/auth/composio_auth_provider.py
@@ -7,9 +7,10 @@ from uuid import UUID
 
 import aiohttp
 
+# Set before the SDK is imported anywhere: it reads this at import time. The
+# import itself is deferred into `connect_with_credentials` below, so this has
+# to stay at module scope to keep winning that race.
 os.environ.setdefault("COMPOSIO_CACHE_DIR", "/tmp/composio")
-
-from composio.types import auth_scheme as composio_auth_scheme
 
 from app.modules.connectors.infrastructure.composio_client import get_composio_client
 
@@ -222,6 +223,16 @@ class ComposioAuthProvider(AuthProviderInterface):
             raise ConnectorValidationError(
                 "Credentials are required to connect this Composio app."
             )
+
+        # Imported here rather than at module scope, which is where it was.
+        #
+        # `composio.types` pulls the whole SDK, and the SDK imports its default
+        # OpenAI provider, so this one line cost 0.96s and 840 modules on every
+        # backend start -- to serve a health check. This module is reached from
+        # `app.app` through the connector router, so nothing about that was
+        # opt-in. It is the only composio import on that path, and these two
+        # call sites are the only uses in the module.
+        from composio.types import auth_scheme as composio_auth_scheme
 
         scheme = self._composio_auth_scheme(connector)
         if scheme == AuthScheme.OAUTH2:

--- a/lemma-backend/import-budget-baseline.json
+++ b/lemma-backend/import-budget-baseline.json
@@ -1,13 +1,13 @@
 {
-  "_comment": "Modules loaded by each entrypoint before it can serve. This file may shrink freely; growing it past the tolerance means a new dependency tree arrived. See scripts/check_import_budget.py. Last raised by splitting agent_surfaces: 23 first-party modules and zero third-party ones, which is the shape this gate is meant to allow -- a decision somebody made, not something a dependency did quietly. Measured main at 5526/6517 against a 5491/6479 baseline before that split, i.e. main had already drifted 35 modules inside the tolerance with nothing to notice, because the gate ran only in `make quality` and never in CI. It runs in CI now.",
+  "_comment": "Modules loaded by each entrypoint before it can serve. This file may shrink freely; growing it past the tolerance means a new dependency tree arrived. See scripts/check_import_budget.py. Last lowered by deferring composio: one module-scope line in composio_auth_provider.py pulled the SDK and, through it, openai -- 993 modules and ~1s on every backend start, to serve a health check. Previously raised by splitting agent_surfaces: 23 first-party modules and zero third-party ones, which is the shape this gate is meant to allow -- a decision somebody made, not something a dependency did quietly. Measured main at 5526/6517 against a 5491/6479 baseline before that split, i.e. main had already drifted 35 modules inside the tolerance with nothing to notice, because the gate ran only in `make quality` and never in CI. It runs in CI now.",
   "tolerance": 50,
   "entrypoints": {
     "app.app": {
-      "modules": 5548,
+      "modules": 4585,
       "rss_mib": null
     },
     "app.events": {
-      "modules": 6539,
+      "modules": 6372,
       "rss_mib": null
     }
   }

--- a/lemma-backend/scripts/check_import_budget.py
+++ b/lemma-backend/scripts/check_import_budget.py
@@ -10,15 +10,27 @@ none: one AST pass over 1,128 non-test files turned up a single hit, and that on
 was ``asyncio.run`` under ``if __name__ == "__main__"``. Module-level
 ``re.compile`` is correct and is not what this is about.
 
-The cost is breadth, and most of it is not ours to move. 63% of the time is
-third-party, and the largest items arrive transitively through ``pydantic_ai``,
-which the agent runtime requires: ``openai`` is 781 modules and 1.45 s, ``mcp``
-and ``fastmcp`` another 239 modules, and none of them can be deferred by editing
-our own import lines because ``pydantic_ai.providers.openai`` imports them for
-us. ``supertokens_python`` (367 modules) is needed before the first authenticated
-request. So this gate does not ask anyone to shrink the graph. It asks that
-growth be a decision somebody made rather than something a new dependency did
-quietly.
+The cost is breadth. Some of it is genuinely not ours to move --
+``supertokens_python`` (367 modules) is needed before the first authenticated
+request, and fastapi and sqlalchemy are needed to answer anything at all. So
+this gate does not ask anyone to shrink the graph. It asks that growth be a
+decision somebody made rather than something a new dependency did quietly.
+
+**But do not read that as "nothing here is movable".** This docstring used to
+say ``openai``, ``mcp`` and ``fastmcp`` arrived transitively through
+``pydantic_ai`` and therefore "cannot be deferred by editing our own import
+lines". Measured again in August 2026, that was wrong: ``openai`` arrived
+through ``composio``, which arrived from a single module-scope line in
+``connectors/services/auth/composio_auth_provider.py`` -- ours, and reached
+from ``app.app`` through the connector router on every start. Deferring that one
+line into the method that uses it removed **993 modules**, and cut the packed
+import from 3.42s to 2.17s.
+
+The lesson is not about composio. It is that a graph this wide hides its own
+causes: the library that shows up in a profile is rarely the one that imported
+it, and a note in a gate asserting something is immovable will be believed by
+the next person instead of re-measured. Use ``python -X importtime`` and walk
+the parent chain before concluding anything is structural.
 
 Module count, not wall time. Count is deterministic across machines; import time
 on a CI runner varies by more than the thing being measured, and a gate that

--- a/lemma-frontend/components/auth/portal/auth/redirects.test.ts
+++ b/lemma-frontend/components/auth/portal/auth/redirects.test.ts
@@ -21,6 +21,11 @@ describe('normaliseRedirectUri', () => {
 
     expect(normaliseRedirectUri('/pod/p1')).toBe('https://app.lemma.work/pod/p1');
     expect(normaliseRedirectUri('https://app.lemma.work/home')).toBe('https://app.lemma.work/home');
+    // The site root, which is what Lemma Desktop sends on launch. The portal
+    // continues an existing session only when it has somewhere to go, so a
+    // null here is the difference between opening the workspace and stopping
+    // on a "Continue" button every single launch.
+    expect(normaliseRedirectUri('/')).toBe('https://app.lemma.work/');
   });
 
   it('rejects external redirects by default', async () => {

--- a/scripts/build_local_host_pack.py
+++ b/scripts/build_local_host_pack.py
@@ -229,6 +229,7 @@ def install_python(
         *wheel_files,
     )
     prune_python_runtime(destination)
+    compile_python_runtime(destination, executable)
     smoke_environment = os.environ.copy()
     smoke_environment.update(
         {
@@ -259,6 +260,11 @@ def install_python(
 def prune_python_runtime(python_root: Path) -> None:
     """Remove build/test-only files while retaining package metadata and data."""
 
+    # Bytecode is cleared here and rebuilt by `compile_python_runtime` once the
+    # pruning below has finished, so nothing is compiled that is about to be
+    # deleted and every `.pyc` in the pack was written with the same
+    # invalidation mode. Leaving this out and keeping whatever uv or the
+    # interpreter distribution happened to ship would mix modes silently.
     for cache in sorted(python_root.rglob("__pycache__"), reverse=True):
         shutil.rmtree(cache, ignore_errors=True)
     for compiled in python_root.rglob("*.py[co]"):
@@ -277,6 +283,64 @@ def prune_python_runtime(python_root: Path) -> None:
                 continue
             for tests in sorted(root.rglob("tests"), reverse=True):
                 shutil.rmtree(tests, ignore_errors=True)
+
+
+def compile_python_runtime(python_root: Path, executable: Path) -> None:
+    """Precompile the pack's bytecode, so the first launch does not.
+
+    Without this the pack ships pure source: `prune_python_runtime` above
+    removes the 418 stdlib `.pyc` the standalone CPython distribution ships,
+    `UV_COMPILE_BYTECODE` is not set for the install, and nothing else
+    compiles the application's ~1,300 modules. The install root is writable, so
+    Python caches on first use -- which means the entire parse-and-compile is
+    paid on the first backend start after every install and every update.
+
+    Measured on an M-series Mac against the shipped 0.7.0 runtime, `import
+    app.app` alone: 7.62s with no cached bytecode, 2.81s with it. That is ~4.8s
+    on the launch a person forms their first impression from, and it is the
+    same defect the container build already fixed (see the note beside
+    `compileall` in `lemma-backend/Dockerfile`).
+
+    `unchecked-hash` rather than the default timestamp mode for the same reason
+    the container uses it: a timestamp-invalidated `.pyc` makes the interpreter
+    `stat` every source file on every start to decide whether the cache is
+    stale. Nothing rewrites a `.py` inside an installed pack, so that check
+    buys nothing and costs a syscall per module forever.
+
+    Failures are reported and not fatal. A pack that ships a module some
+    dependency cannot compile -- vendored Python 2, a template with
+    placeholders -- is a pack that works today, because the file is never
+    imported. Refusing to build the DMG over one would trade a real release for
+    an optimisation.
+    """
+    command = [
+        str(executable),
+        "-m",
+        "compileall",
+        "-q",
+        # One worker per core: this walks ~18k files and is pure CPU.
+        "-j",
+        "0",
+        "--invalidation-mode",
+        "unchecked-hash",
+        str(python_root),
+    ]
+    print("+", " ".join(command), flush=True)
+    completed = subprocess.run(command, cwd=REPO_ROOT, check=False)
+    compiled = sum(1 for _ in python_root.rglob("*.pyc"))
+    if completed.returncode != 0:
+        print(
+            f"  warning: compileall reported errors (exit {completed.returncode}); "
+            f"{compiled} modules were still compiled. The pack is usable -- the "
+            "uncompiled ones cost parse time only if something imports them.",
+            flush=True,
+        )
+    if compiled == 0:
+        raise SystemExit(
+            "compileall wrote no bytecode; the pack would ship pure source and "
+            "pay the full compile on a user's first launch"
+        )
+    print(f"  compiled {compiled} modules", flush=True)
 
 
 def copy_browser_assets(output: Path) -> None:


### PR DESCRIPTION
## What changes

Two things a person meets on every launch, and the cold start they wait through
before either. Everything here was measured on a real install; nothing is
inferred.

| | |
| --- | --- |
| **The window comes back the size it was left** | It restored at twice the saved size on any Retina display, so macOS clamped it and put it too low. |
| **No more clicking "Continue" into a session you already have** | The portal auto-continues only when told where to go. The launch never told it. |
| **Cold start: ~9s off every launch, ~3s more off the first** | Bytecode, one import, a health gate that charged the same wait twice, and an auth service waited for in front of the backend instead of beside it. |
| **A flaky agent-host test, root-caused** | Event delivery could go quiet for a minute and log it at `debug`, which the host does not emit. |

## The two launch bugs

### The window restored at twice its size

Placement is saved in *physical* pixels — `outer_position()` and `inner_size()`
both return physical, and `placement_is_reachable` compares them against monitor
geometry that is also physical. The window *builder* is the one place that is
not. From the Tauri source:

```rust
/// The initial position of the window in logical pixels.
pub fn position(mut self, x: f64, y: f64) -> Self
```

A real record from a 3024×1964 Retina screen — `3024×1898 at y=66` — came back
asking for 3024×1898 *logical*, which is 6048×3796 physical. macOS clamped the
size and `y=66` became `132`. The scale is now read from the monitor the
placement lands on, not the primary one, because a second display at a different
scale is exactly the case that goes wrong visibly. The stored record stays
physical, so existing installs need no migration.

### "Continue" appeared every launch, and clicking it achieved nothing

Which is the tell — the session was already there. The portal continues an
existing session only when it has somewhere to go (`doesSessionExist &&
redirectUri`); without one it stops and offers the button, which is right when
someone navigated to sign-in themselves. The desktop reached it without one on
**every cold start**, because each launch mints a fresh runtime generation, so
the recorded resume target can never match.

The launch now says where it was going. The return address is relative, so it
resolves against the portal's own origin and cannot be aimed off it — and it
does not care which port locald handed out, which matters because the port
reservation sets no `SO_REUSEADDR` and a restart while the previous pair is in
`TIME_WAIT` gets different ports (measured: 63287 → 50686 → 51314 → 52752 across
four launches).

Each half is pinned by its own test, in its own language: the Rust one asserts
the URL carries `redirect_uri=%2F`, the TypeScript one that the portal accepts
the site root. Either alone would let the button come back.

## Cold start

Launch → ready measured twice: **19.93s / 19.43s**. Where it went:

| phase | time |
| --- | ---: |
| vm | 1.44s |
| infrastructure-images | 0.42s |
| postgres | 2.43s |
| redis | 0.98s |
| supertokens | 5.13s |
| migrations | 0.00s (stamped, correctly skipped) |
| backend + frontend spawn → ready | 8.87s |

### The backend was not slow to start — it was slow to import

From process start to "Application startup complete" is **0.72s**. The cost was
`import app.app`, and two independent things caused it.

**1. The pack shipped no bytecode, and deleted what it had.**
`prune_python_runtime` removed every `__pycache__` and `.pyc`, including the 418
stdlib ones the standalone CPython ships; `UV_COMPILE_BYTECODE` was never set;
nothing compiled the app's ~1,300 modules. So the first start after every
install and update parsed and compiled the whole tree, writing 5,268 `.pyc`.

Measured on the shipped runtime, freshly copied so the page cache is cold the
way it is after an install:

```
today, no bytecode      16.21s   (then 2.5s once cached)
precompiled             13.14s   (then 2.3s)
```

Same defect the container build already fixed and measured at 3.2s, and the same
`--invalidation-mode unchecked-hash` — with timestamps the interpreter stats
every source file on every start to decide whether the cache is stale, which
buys nothing inside a pack nothing writes to. Compiling runs *after* the prune,
so nothing is compiled that is about to be deleted. Verified against the real
tree: exit 0, 18,726 modules, 5.5s of build time.

**2. One line loaded the connector SDK to answer a health check.**
`composio_auth_provider.py` imported `composio.types` at module scope; composio
imports its default OpenAI provider; the module is reached from `app.app`
through the connector router. `composio_auth_scheme` is used at exactly two
lines inside one method, and the provider is built by a request-scoped factory.

```
modules  5,578 → 4,585
import    3.42s → 2.17s
```

**Two places in the repo said this was impossible.** The budget gate's docstring
and the Makefile both stated openai/mcp/fastmcp arrive structurally through
`pydantic_ai` and "cannot be deferred by editing our own import lines". Measured,
openai arrived through composio, from a line of ours. Both are corrected, and now
say what to do instead: walk the parent chain in `-X importtime`, because the
library in a profile is rarely the one that imported it. A gate that tells the
next person not to look is worse than no gate.

The new laziness test names the library rather than reporting a count, so a
regression says which import to look at. Verified by restoring the old import.

### The health gate charged the same wait twice

Each gate requires `stabilization_seconds` of *continuously observed* health, and
`healthy_since` is local to the call. Run serially, that charges the dwell once
per service: the frontend answers in ~0.3s and then sits there healthy while the
backend's gate runs, and only afterwards does its own gate start watching and
spend a fresh two seconds confirming what was already true.

Two services, four seconds, for a guard that needs two. Gating concurrently
weakens nothing — every service still proves the same uninterrupted dwell against
the same probe. Measured: 2.12s serial vs 1.28s concurrent with a 1s dwell.

### The auth service was waited for in front of the backend

`core.supertokens` does not return when the container starts — it returns when
the service answers, and getting a JVM to answer took **5.13s**. That sat on the
critical path in front of a backend that then spends its own ~4s importing and
binding. `initialize_supertokens` only writes local configuration; the first
call to the auth service happens on the first authenticated request.

So the request is issued before the host processes start and joined after, and
the two overlap. It runs on a thread rather than being reordered, because the
guest control channel is single — one vsock connection behind a process-wide
mutex, handled inline on guestd's accept loop — so the request occupies that
channel either way. What it must not also occupy is the daemon's thread, which
is what starting the backend needs back.

Nothing reports ready any earlier: `await_private_services` joins the start and
then runs the same `wait_for_private_services` check that used to run inline,
before the ready event. Because the host processes are running by then, a
failure there now has to stop them, which the daemon does. Postgres and Redis
stay synchronous — migrations run against the database before the backend
starts.

Stated as expected rather than measured: confirming it end to end needs a locald
built from this tree inside an install, which the next DMG will be. The pieces
it rests on are measured — the 5.13s phase, the backend's ~4s, and that the
backend's health check reads the database and Redis, not the auth service.

### A flaky agent-host test, root-caused

`an_approved_request_lets_the_agent_finish_its_turn` failed in CI with the run
acknowledged, no events delivered, and a host log that stops at "published
probed harnesses" — 90 seconds of nothing, no error, no rejection.

Event delivery shared the poll loop's 30-second retry ceiling. Those are not the
same thing: a failing poll may mean the target is unreachable, so backing off is
right; event delivery runs *beside* a poll loop that is separately proving the
target answers, and what it carries is a run's output and terminal state.
Doubling from 500ms, seven failures spend **61.5s** before the eighth attempt —
past the test's budget — and the retries were logged at `debug`, which the host
does not emit, so there was nothing to find afterwards.

Delivery now backs off in seconds (2s ceiling — eight attempts inside 13.5s), and
a run of consecutive failures says so at `warn` once, with a matching line on
recovery. The first failures stay quiet, because they are ordinary.

Not reproduced locally — ten runs, with and without CPU load, all green — so
this is the cause the evidence fits rather than one I watched happen. What is
certain either way is that the old behaviour could swallow a minute of delivery
without a word.

## What I looked at and deliberately did not change

- **Redis in parallel with Postgres.** Impossible: the host bridge holds one
  vsock connection behind a process-wide mutex and guestd handles connections
  inline on its accept loop, so guest requests queue rather than overlap.
- **`preloadEntriesOnStart: false` on the frontend.** Looked like the biggest
  frontend lever; measured, it saves 0.12s to readiness and costs 0.03s on first
  render — and the frontend is ready in 0.3s against the backend's 4s, so it is
  not on the critical path at all. No change is the right change.
- **Deferring `app.mcp_server`.** Would relocate its 0.63s from import to
  lifespan, not remove it; the health gate waits for both, and mounting needs the
  ASGI app while routes are built.
- **Changing guestd's inline readiness waits.** `ensure_postgres` and
  `ensure_supertokens` block on `pg_isready` and an HTTP `/hello` *inside* the
  guest, and the host's own gate then measured 0.00s because the guest had
  already waited. Making the guest return early would mean a protocol-aware host
  gate — and guestd is baked into the VM disk image, so it could not reach an
  existing install until a new runtime image shipped. Overlapping the wait on the
  host gets the same seconds with no image change.
- **Shortening the stabilization window.** Making the dwells concurrent gets the
  time back without weakening a guard that exists because services really do come
  up and die.

## How to verify

```bash
make desktop-test          # 150 + 168, including four new cases
make desktop-lint
cd lemma-backend && uv run python scripts/check_import_budget.py
cd lemma-backend && uv run python scripts/check_architecture.py
cd lemma-frontend && npx vitest run components/auth/portal/auth/redirects.test.ts
```

Import cost, without touching a live install:

```bash
PYTHONPYCACHEPREFIX=/tmp/cold "$PY" -c "import time;t=time.time();import app.app;print(time.time()-t)"
"$PY" -X importtime -c "import app.app" 2>&1 | sort -t'|' -k2 -rn | head
```

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — the auth return address is relative and resolved against the
      portal's own origin; a test asserts an absolute external URL is not passed
      through. The health-gate change makes no probe weaker.
- [ ] **Rollback** — revert. The bytecode change only affects a rebuilt pack; the
      stored window record is unchanged either way.
