### PR TITLE
Turn off reasoning for conversation-title generation

### DIFF
--- a/lemma-backend/app/modules/agent/services/conversation_title_service.py
+++ b/lemma-backend/app/modules/agent/services/conversation_title_service.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from uuid import UUID
 
 from opentelemetry import metrics
-from pydantic_ai import Agent as PydanticAIAgent, UsageLimits
+from pydantic_ai import Agent as PydanticAIAgent, ModelSettings, UsageLimits
 
 from app.modules.agent.config import agent_settings
 from app.core.infrastructure.db.uow_factory import UnitOfWorkFactory
@@ -69,6 +69,14 @@ _TITLE_USAGE_LIMITS = UsageLimits(
     total_tokens_limit=12_256,
     count_tokens_before_request=True,
 )
+
+# The title itself is 3-6 words (well under 20 tokens). Reasoning models spend
+# the rest of the budget above on a hidden chain-of-thought trace nobody
+# reads: verified directly against deepseek-v4-flash-0731 that the exact
+# title prompt used 246 completion tokens with 239 of them reasoning, and the
+# same call with reasoning_effort='none' produced the identical title in 5.
+# Providers that don't recognize this key ignore it.
+_TITLE_MODEL_SETTINGS: ModelSettings = {"openai_reasoning_effort": "none"}
 
 _TITLE_SYSTEM_PROMPT = (
     "You generate a concise title for a chat conversation. "
@@ -208,6 +216,7 @@ class ConversationTitleService:
             result = await agent.run(
                 _build_user_prompt(user_text, reply_text),
                 usage_limits=usage_limits_for(model, _TITLE_USAGE_LIMITS),
+                model_settings=_TITLE_MODEL_SETTINGS,
             )
             await record_pydantic_ai_result_usage(
                 ctx=usage_context,

--- a/lemma-backend/app/modules/agent/tests/e2e/test_conversation_title_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_conversation_title_e2e.py
@@ -59,8 +59,8 @@ def _stub_llm(monkeypatch: pytest.MonkeyPatch, *, output: str) -> None:
         def __init__(self, model, system_prompt=None):
             pass
 
-        async def run(self, prompt, *, usage_limits=None):
-            del usage_limits
+        async def run(self, prompt, *, usage_limits=None, model_settings=None):
+            del usage_limits, model_settings
             return SimpleNamespace(output=output)
 
     async def _noop_reserve(*, organization_id, user_id, runtime_profile):

--- a/lemma-backend/app/modules/agent/tests/unit/test_conversation_title_service.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_conversation_title_service.py
@@ -172,10 +172,11 @@ def _patch_llm(
             capture["model"] = model
             capture["system_prompt"] = system_prompt
 
-        async def run(self, prompt, *, usage_limits=None):
+        async def run(self, prompt, *, usage_limits=None, model_settings=None):
             capture["run_calls"] = int(capture["run_calls"]) + 1
             capture["prompt"] = prompt
             capture["usage_limits"] = usage_limits
+            capture["model_settings"] = model_settings
             if raise_on_run:
                 raise RuntimeError("llm boom")
             return SimpleNamespace(output=output)
@@ -267,6 +268,10 @@ async def test_generates_persists_and_publishes(
     ]
     # Reply text is fed into the prompt alongside the user message.
     assert "Assistant's reply" in str(capture["prompt"])
+    # A reasoning model must not spend the token budget on a hidden
+    # chain-of-thought trace for a 3-6 word title (see conversation_title_service
+    # module docstring / _TITLE_MODEL_SETTINGS).
+    assert capture["model_settings"] == {"openai_reasoning_effort": "none"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Root cause of the "conversation titles fail half the time" bug (visibility fixed by #534, mechanism found by live debugging in dev): `deepseek-v4-flash` is a reasoning model, and the title-generation call was spending most of its `output_tokens_limit=256` on a hidden `reasoning_content` chain-of-thought trace the caller never reads, not on the title itself.
- Verified directly against the Fireworks API with the exact title prompt: 246 completion tokens, 239 of them reasoning, for a 5-token answer. The same call with `reasoning_effort='none'` produced the identical title in 5 completion tokens, 0 reasoning.
- Fix: pass `ModelSettings(openai_reasoning_effort="none")` on the title-generation `agent.run()` call. `pydantic_ai` forwards this straight into the request body regardless of provider, so it's inert (not an error) for any model that doesn't support it. `output_tokens_limit` is left at 256 — it was never wrong, it just had nothing to spend on once reasoning is off.

## Test plan
- [x] 1202 agent-module unit tests pass, including a new assertion that the title call now carries `openai_reasoning_effort="none"`
- [ ] Ship to dev, burst-test conversation titling to confirm it no longer falls back

🤖 Generated with [Claude Code](https://claude.com/claude-code)