### PR TITLE
Make the checks that gate a merge actually gate it, and unbreak the host pack

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,6 +62,17 @@ updates:
       github-actions-security-updates:
         applies-to: security-updates
         patterns: ["*"]
+    # `dtolnay/rust-toolchain`'s tag is not the action's version, it is the Rust
+    # version the action installs -- so Dependabot reads the newest Rust release
+    # tag on the action repository and proposes it as an upgrade. It proposed
+    # 1.100.0, which is not a Rust release at all, and every desktop job in the
+    # group PR died with "could not download nonexistent rust version". Worse,
+    # a tag that *does* exist would be just as wrong: rust-toolchain.toml pins
+    # the channel, the two must agree, and Dependabot only ever moves one of
+    # them. Bumping Rust here is the deliberate two-file change CONTRIBUTING
+    # describes, not something to receive monthly.
+    ignore:
+      - dependency-name: dtolnay/rust-toolchain
 
   - package-ecosystem: docker
     directories:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,10 +170,11 @@ jobs:
     needs: changes
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
+    # Inherits the workflow's `contents: read` / `pull-requests: read`. This
+    # job asked for `pull-requests: write` and `issues: write` back when it
+    # posted the coverage table as a PR comment; that moved to the job summary
+    # and then to backend-coverage.yml, and the grant stayed behind. Nothing
+    # here writes anything to GitHub but an artifact.
     defaults:
       run:
         working-directory: lemma-backend
@@ -872,9 +873,25 @@ jobs:
         run: |
           echo "TAURI_CLI=@tauri-apps/cli@$(tr -d '[:space:]' < desktop/scripts/tauri-cli-version.txt)" >> "$GITHUB_ENV"
 
-      - name: Build and codesign online DMG
+      # The .app always; the .dmg only where a broken one would be caught.
+      #
+      # The same trade the Windows job already makes for NSIS, for the same
+      # reason: wrapping the .app in a disk image is the one step here whose
+      # output is discarded, and nothing outside `desktop_packaging` can change
+      # its result. It is also the flakiest thing in this job -- `bundle_dmg.sh`
+      # fails on a busy `hdiutil` often enough to have shown up twice in the
+      # last twenty runs -- so on an ordinary Rust pull request it is pure
+      # noise. Everything this job actually asserts (it compiles, it codesigns,
+      # the sidecars are embedded, the refusal marker survives) is asserted on
+      # the .app, which is built either way.
+      - name: Build and codesign the online app
         working-directory: desktop
-        run: npx -y "$TAURI_CLI" build --config tauri.online.conf.json
+        env:
+          BUNDLES: >-
+            ${{ (github.event_name == 'push'
+            || needs.changes.outputs.desktop_packaging == 'true')
+            && 'app,dmg' || 'app' }}
+        run: npx -y "$TAURI_CLI" build --config tauri.online.conf.json --bundles "$BUNDLES"
 
       - name: Verify application signature
         shell: bash
@@ -934,7 +951,11 @@ jobs:
               )
           ' "${manifest}"
 
+      # Only exists when the step above was asked for it.
       - name: Upload macOS build-check DMG
+        if: >-
+          github.event_name == 'push'
+          || needs.changes.outputs.desktop_packaging == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: lemma-desktop-macos-buildcheck-${{ github.sha }}
@@ -981,9 +1002,18 @@ jobs:
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-      - uses: actions/setup-node@v4
+      # `.nvmrc`, like every other Node job here and — the reason this matters
+      # — like release-local-images.yml, which builds the pack that actually
+      # ships. This said `node-version: 22`, the one literal pin left in the
+      # repository, and the two facts it hid took three days of red main to
+      # surface: both package.json files declare `engines: node >=24 <25`, so
+      # the frontend was built by an interpreter it does not support, and the
+      # runner's tool-cache build of 22.23.1 links `@rpath/libnode.127.dylib`
+      # while 24.x is a single static executable. `copy_node_runtime` copies
+      # the executable alone, so the packed Node could not start at all.
+      - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version-file: .nvmrc
 
       # Digests nobody resolves. The pack embeds a release manifest, and this
       # job is about the pack's own layout and interpreters -- not about which
@@ -1237,3 +1267,90 @@ jobs:
           CI_EVENT_NAME: ${{ github.event_name }}
         run: uv run --no-project --with pyyaml python scripts/check_ci_job_results.py
       - run: echo "All required CI suites passed (or were skipped as unaffected)."
+
+  # Who notices a red main.
+  #
+  # Nobody did. "Host pack builds and runs (macOS)" broke on 25 August and was
+  # red on every push for the next three days, through eleven merges, and the
+  # run list read green the whole time -- because that job is deliberately
+  # outside the `ci` aggregator, so the check people look at was reporting on
+  # everything except the job that was failing. That is the correct design for
+  # the merge gate (a release-time check must not block a review-time PR) and
+  # it leaves a hole exactly the size of one unwatched job.
+  #
+  # So this watches the run rather than the gate: every job in the workflow,
+  # `host-pack-macos` included, and only on a push to main, where there is no
+  # PR conversation for a failure to show up in.
+  #
+  # It is not a gate. It cannot fail the run -- there is nothing left to fail
+  # by the time it runs -- and it says so out loud rather than failing when
+  # SLACK_WEBHOOK_URL is unset, so a fork or a repository without the secret
+  # gets a warning in the log instead of a red job about the notifier.
+  main-red:
+    name: Report a red main
+    timeout-minutes: 10
+    if: >-
+      always() && github.event_name == 'push' &&
+      (contains(needs.*.result, 'failure') ||
+      contains(needs.*.result, 'cancelled'))
+    needs:
+      - changes
+      - backend-unit
+      - backend-lint
+      - backend-migration
+      - python-sdk
+      - cli-packaging
+      - typescript-sdk
+      - codegen-drift
+      - frontend
+      - dev-workflow
+      - windows-cli
+      - desktop
+      - desktop-contract
+      - desktop-guestd
+      - desktop-windows
+      # The whole reason this job exists.
+      - host-pack-macos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post the failure to Slack
+        env:
+          WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          NEEDS_JSON: ${{ toJSON(needs) }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT: ${{ github.sha }}
+          SUBJECT: ${{ github.event.head_commit.message }}
+        run: |
+          python3 - <<'PY'
+          import json, os, urllib.request
+
+          failed = sorted(
+              name
+              for name, result in json.loads(os.environ["NEEDS_JSON"]).items()
+              if result.get("result") in {"failure", "cancelled"}
+          )
+          subject = os.environ["SUBJECT"].splitlines()[0]
+          text = (
+              f"*CI is red on main* — {', '.join(failed)}\n"
+              f"{os.environ['COMMIT'][:12]} {subject}\n"
+              f"{os.environ['RUN_URL']}"
+          )
+          print(text)
+
+          webhook = os.environ["WEBHOOK"]
+          if not webhook:
+              print(
+                  "::warning title=No Slack webhook configured::main is red and "
+                  "nothing was notified. Set the SLACK_WEBHOOK_URL repository "
+                  "secret to route this somewhere a person reads."
+              )
+              raise SystemExit(0)
+
+          request = urllib.request.Request(
+              webhook,
+              data=json.dumps({"text": text}).encode(),
+              headers={"Content-Type": "application/json"},
+          )
+          with urllib.request.urlopen(request, timeout=30) as response:
+              print(f"Slack responded {response.status}")
+          PY

--- a/.github/workflows/scenarios.yml
+++ b/.github/workflows/scenarios.yml
@@ -149,6 +149,28 @@ jobs:
       - name: Run journey
         working-directory: tests/scenarios
         run: uv run pytest ${{ matrix.journey.path }} -q --junitxml=results.xml
+
+      # The nightly lane's whole purpose is a signal somebody reads without
+      # opening CI, and `report_scenarios_to_slack.py` was written to be that
+      # signal -- it turns this XML into the product's own sentences and, as
+      # its docstring insists, reports skips as loudly as failures, because a
+      # lane whose credentials expired goes green while testing nothing. It has
+      # never been called by anything. So the nightly ran, the XML was uploaded
+      # to an artifact with a seven-day retention, and the only way to learn
+      # what the product does was to go looking.
+      #
+      # Scheduled runs only: a labelled pull request is somebody already
+      # watching. Without SLACK_WEBHOOK_URL the script prints and exits 0, by
+      # design -- a missing webhook must not fail a lane that passed.
+      - name: Say what the product did
+        if: always() && github.event_name == 'schedule'
+        working-directory: tests/scenarios
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SCENARIO_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: >-
+          python3 ../../scripts/report_scenarios_to_slack.py results.xml
+          --lane "${{ matrix.journey.name }}"
       # The stack writes the server and worker to one file. Without it a
       # CI-only failure is undiagnosable from CI: the scenario says what it
       # waited for, and the reason it never happened is in the worker's log.
@@ -213,6 +235,17 @@ jobs:
       - name: Run the sandbox lane
         working-directory: tests/scenarios
         run: uv run pytest -m sandbox -q --junitxml=sandbox-results.xml
+
+      # See the journey matrix above for why this step exists at all.
+      - name: Say what the product did
+        if: always() && github.event_name == 'schedule'
+        working-directory: tests/scenarios
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SCENARIO_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: >-
+          python3 ../../scripts/report_scenarios_to_slack.py sandbox-results.xml
+          --lane "sandbox"
       # A sandbox failure is a container failure, and the container is gone by
       # the time anyone reads this. `schema_extraction` failing with a bare
       # ConnectError says only that nothing answered on the published port —

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -230,3 +230,37 @@ jobs:
           scanners: vuln
           vuln-type: os,library
           severity: HIGH,CRITICAL
+
+  # The single check that can be required for this workflow.
+  #
+  # Every job above is path-filtered, so none of them can be named in a branch
+  # ruleset: a required check that skips on a docs-only change leaves the pull
+  # request waiting on a status that will never arrive. That is why nothing
+  # here gated a merge at all -- gitleaks, CodeQL, the dependency audit and the
+  # image scan could all go red and the merge button stayed green -- while
+  # ci.yml and e2e.yml each solved exactly this problem with an aggregator.
+  # This is the same shape, so the same solution is available.
+  #
+  # `!cancelled()` rather than `always()`, for the reason "Backend E2E passed"
+  # records: `cancel-in-progress` above cancels every superseded push, and
+  # `always()` then reports failure for a run that was simply replaced.
+  security-passed:
+    name: Security passed
+    timeout-minutes: 10
+    if: ${{ !cancelled() }}
+    needs:
+      - changes
+      - dependency-review
+      - codeql-python
+      - codeql-javascript
+      - secrets
+      - python-audit
+      - container
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any security check failed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "::error::One or more security checks failed or were cancelled."
+          exit 1
+      - run: echo "Security checks passed (or were skipped as unaffected)."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,11 @@ produces them.
 make quality
 ```
 
+`make quality` is Python only, all the way down. If you touched the frontend or
+the TypeScript SDK, add `make quality-frontend` — eslint, `tsc`, the
+design-system audit and the education anchors, the four gates CI runs that
+`quality` cannot see. (`make check` is both, plus CodeQL.)
+
 Then the checks for the component you touched, from the table in
 `CONTRIBUTING.md`. The pull request template lists what the description needs —
 including the exact commands you ran and what they printed.

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ SHELL := /bin/bash
         scenario-coverage scenarios-code-coverage \
         coverage coverage-backend coverage-backend-unit coverage-backend-e2e \
         coverage-backend-module coverage-cli coverage-cli-unit coverage-cli-e2e coverage-frontend \
-        lint quality check architecture pre-push codeql codeql-python codeql-javascript codeql-all migrate
+        lint quality quality-frontend check architecture pre-push codeql codeql-python codeql-javascript codeql-all migrate
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 
@@ -376,7 +376,7 @@ help:
 	@echo "    make pre-push           the fast subset — run this on every push"
 	@echo "    make quality            every gate the 'quality gates' CI job runs"
 	@echo "    make architecture       backend architecture ratchet + route inventory"
-	@echo "    make check              quality + CodeQL on this branch's changes"
+	@echo "    make check              quality + frontend gates + CodeQL on this branch's changes"
 	@echo "    make lint               ruff + eslint across all components"
 	@echo "    make version-check      every Lemma component declares the same version"
 	@echo ""
@@ -1811,8 +1811,28 @@ codeql-javascript:
 codeql-all:
 	@./scripts/run_codeql.sh --all
 
+# The frontend half of the pre-PR pass.
+#
+# `quality` above is entirely Python: `format-check` covers the backend, the
+# CLI, both SDKs and the scenarios, and stops at the language boundary. So a
+# frontend-only change could pass every gate this repository offers locally and
+# still meet eslint, tsc, the design-system audit and the education-anchor
+# check for the first time in CI, ten minutes after pushing -- which is the
+# shape of gate `rust-toolchain.toml`'s own comment argues against.
+#
+# Skipped rather than failed when the dependencies are not installed. A backend
+# contributor who has never run `npm ci` should not have `make check` break on
+# them; CI is the gate, this is the shortcut.
+quality-frontend:
+	@if [ ! -d "$(FRONTEND_DIR)/node_modules" ] || [ ! -d "$(TS_DIR)/node_modules" ]; then \
+		echo "→ Frontend gates skipped — run 'npm ci' in $(TS_DIR) and $(FRONTEND_DIR) to include them"; \
+	else \
+		echo "→ Frontend lint, types, design audit, education anchors…"; \
+		cd $(FRONTEND_DIR) && npm run --silent check; \
+	fi
+
 # Everything a PR is judged on, short of the test suites themselves.
-check: quality codeql
+check: quality quality-frontend codeql
 
 # ── Migrations ────────────────────────────────────────────────────────────────
 

--- a/scripts/build_local_host_pack.py
+++ b/scripts/build_local_host_pack.py
@@ -398,16 +398,92 @@ def node_root(explicit: Path | None) -> Path:
     return root
 
 
+def node_rpath_libraries(executable: Path, root: Path) -> list[Path]:
+    """The dylibs inside the Node installation that its executable needs.
+
+    The nodejs.org tarballs are a single static executable, and for a long time
+    that was the whole story: copy `bin/node` and nothing else. It is not true
+    of every build. The GitHub tool-cache build of Node 22.23.1 for macOS arm64
+    links `@rpath/libnode.127.dylib`, and Homebrew's links a dozen of its own
+    kegs. Copying the executable alone from either produces a pack that unpacks
+    cleanly, passes every file-existence check, and dies with a dyld error the
+    first time the app tries to serve a page.
+
+    Only `@rpath`/`@loader_path` entries are followed, and only to files inside
+    the Node root. A dylib in /usr/lib is part of the OS and is there on the
+    user's machine too; a Homebrew keg outside the root is not relocatable and
+    is a Node that should not be packed at all, which `check_host_pack.py`
+    then says out loud.
+    """
+    if sys.platform != "darwin":
+        return []
+    try:
+        listing = subprocess.run(
+            ["otool", "-L", str(executable)], text=True, capture_output=True, check=True
+        ).stdout
+    except OSError, subprocess.CalledProcessError:
+        # Not a Mach-O binary, or no Xcode command line tools. Either way the
+        # probe below is the one that decides whether this pack is usable.
+        return []
+    names = [line.strip().split(" (", 1)[0] for line in listing.splitlines()[1:]]
+    return _resolve_rpath_libraries(root, executable, names)
+
+
+def _resolve_rpath_libraries(
+    root: Path, executable: Path, names: list[str]
+) -> list[Path]:
+    """The `otool -L` names that resolve to a file inside the Node root."""
+    libraries = []
+    for name in names:
+        if not name.startswith(("@rpath/", "@loader_path/")):
+            continue
+        leaf = name.split("/", 1)[1]
+        for candidate in (root / "lib" / leaf, executable.parent / leaf):
+            if candidate.is_file():
+                libraries.append(candidate)
+                break
+    return libraries
+
+
 def copy_node_runtime(frontend: Path, explicit_root: Path | None) -> None:
     root = node_root(explicit_root)
     relative = Path("node.exe") if os.name == "nt" else Path("bin/node")
     source = root / relative
     destination = frontend / "node" / relative
     destination.parent.mkdir(parents=True, exist_ok=True)
-    # The official Node executable is self-contained on both target platforms.
-    # Copying the whole installation would also bundle npm and any unrelated
-    # globally installed packages from the build runner.
+    # The executable and the libraries it carries an @rpath to, and nothing
+    # else. Copying the whole installation would also bundle npm and any
+    # unrelated globally installed packages from the build runner.
     shutil.copy2(source, destination)
+    for library in node_rpath_libraries(source, root):
+        # `bin/node` resolves @rpath through `@loader_path/../lib`, so the
+        # layout inside the pack has to be the layout it came from.
+        packed = destination.parent.parent / "lib" / library.name
+        packed.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(library, packed)
+
+    # Ask the copy the only question that matters, here rather than in a later
+    # job: a Node that cannot start is a frontend that never serves, and every
+    # cheaper check -- the file exists, it is executable, it is the right
+    # version -- passes on one that cannot.
+    try:
+        probe = subprocess.run(
+            [str(destination), "--version"], text=True, capture_output=True
+        )
+        failure = (
+            None
+            if probe.returncode == 0
+            else f"exited {probe.returncode}\n{probe.stderr.strip()}"
+        )
+    except OSError as error:
+        failure = f"could not be started at all: {error}"
+    if failure is not None:
+        raise SystemExit(
+            f"the packed Node cannot start: {destination} {failure}\n"
+            f"It was copied from {source}. A Node that links libraries outside "
+            f"its own installation cannot be packed; use a distribution from "
+            f"nodejs.org (which `.nvmrc` and actions/setup-node give you)."
+        )
 
 
 def standalone_server(root: Path) -> Path:

--- a/scripts/check_ci_aggregators.py
+++ b/scripts/check_ci_aggregators.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python3
 """Assert every aggregator job watches every job in its workflow.
 
-"CI passed" and "Backend E2E passed" are the checks the branch ruleset
-requires. They are only as good as their `needs:` list, and that list is
-hand-written: ci.yml already carries a comment recording the time a job went
-missing from it and a wheel shipped without its skills while the aggregator
-stayed green.
+"CI passed", "Backend E2E passed" and "Security passed" are the checks the
+branch ruleset is meant to require. They are only as good as their `needs:`
+list, and that list is hand-written: ci.yml already carries a comment recording
+the time a job went missing from it and a wheel shipped without its skills
+while the aggregator stayed green.
+
+This file cannot see the ruleset, and the ruleset has been wrong. As of the CI
+audit it required "lemma-backend unit" and "Backend E2E passed" -- so the whole
+of ci.yml except one job, and the whole of security.yml, could go red without
+blocking a merge, and "lemma-backend unit" is path-filtered anyway, meaning it
+reported `skipped` (which GitHub counts as satisfied) on every pull request
+that did not touch the backend. Keep the three names above and the ruleset in
+agreement; there is no gate that can do it for you.
 
 Also checks that every job declares `timeout-minutes`. Without one a job runs
 to GitHub's six-hour default, which is not a timeout so much as a way to
@@ -26,6 +34,10 @@ WORKFLOWS = REPO_ROOT / ".github" / "workflows"
 AGGREGATORS = {
     "ci.yml": "ci",
     "e2e.yml": "e2e-passed",
+    # Added when the ruleset was found to require neither it nor "CI passed".
+    # Every job in security.yml is path-filtered, so none of them can be named
+    # in a ruleset directly; this is the one that can.
+    "security.yml": "security-passed",
 }
 
 # Jobs that legitimately stand outside their workflow's aggregator: they are
@@ -40,6 +52,11 @@ EXEMPT = {
     # job that never starts, since its `if:` includes `github.event_name ==
     # 'push'`. A red one is "look in the morning".
     ("ci.yml", "host-pack-macos"),
+    # The notifier, not a suite. It reports on the aggregator's blind spot --
+    # `host-pack-macos` -- so it necessarily runs after every job the
+    # aggregator waits for, and putting it inside `ci`.needs would be a cycle.
+    # It also cannot fail a run: there is nothing left to fail by then.
+    ("ci.yml", "main-red"),
 }
 
 # Every workflow is checked for timeouts, not just the two with aggregators.
@@ -83,12 +100,42 @@ def unknown_change_outputs(workflow: str, jobs: dict) -> list[str]:
     return problems
 
 
+def literal_node_versions(workflow: str, jobs: dict) -> list[str]:
+    """`.nvmrc` is the one place the Node version is written down.
+
+    CONTRIBUTING says so, both package.json files declare the same range under
+    `engines`, and the frontend Dockerfile builds on the matching image -- and
+    one job disagreed. `host-pack-macos` said `node-version: 22` while the
+    release job that builds the very same pack read `.nvmrc`, so CI's copy of
+    the artifact was assembled by an interpreter the packages do not support,
+    from a tool-cache build that links `@rpath/libnode.127.dylib` where 24.x is
+    a single static executable. The pack's Node could not start, and main was
+    red for three days on a job nothing was watching.
+
+    Cheap to write down, so it is written down: a literal `node-version:` in a
+    workflow is the drift, whatever it happens to be set to today.
+    """
+    problems = []
+    for name, job in jobs.items():
+        for step in job.get("steps") or []:
+            if not isinstance(step, dict):
+                continue
+            if "node-version" in (step.get("with") or {}):
+                problems.append(
+                    f"{workflow}: job '{name}' pins node-version literally. Use "
+                    f"`node-version-file: .nvmrc`, which every other Node job "
+                    f"and every release workflow reads."
+                )
+    return problems
+
+
 def main() -> int:
     problems: list[str] = []
 
     for path in sorted(WORKFLOWS.glob("*.yml")):
         document = yaml.safe_load(path.read_text())
         jobs = document.get("jobs") or {}
+        problems.extend(literal_node_versions(path.name, jobs))
 
         if path.name not in NO_TIMEOUT_REQUIRED:
             for name, job in jobs.items():

--- a/tests/test_build_local_host_pack.py
+++ b/tests/test_build_local_host_pack.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 
 from scripts.build_local_host_pack import (
+    _resolve_rpath_libraries,
     copy_browser_assets,
     copy_node_runtime,
     npm_executable,
@@ -85,9 +86,12 @@ def test_the_node_binary_lands_where_the_app_starts_it(tmp_path: Path) -> None:
     directory over is an install that downloads half a gigabyte and then cannot
     start.
     """
-    fake_node_root = tmp_path / "node-v22"
+    fake_node_root = tmp_path / "node-v24"
     (fake_node_root / "bin").mkdir(parents=True)
-    (fake_node_root / "bin" / "node").write_bytes(b"#!/bin/sh\nexit 0\n")
+    fake_node = fake_node_root / "bin" / "node"
+    # Executable, because `copy_node_runtime` now starts what it copied.
+    fake_node.write_text("#!/bin/sh\nexit 0\n")
+    fake_node.chmod(0o755)
     frontend = tmp_path / "pack" / "frontend"
 
     copy_node_runtime(frontend, fake_node_root)
@@ -108,6 +112,52 @@ def test_the_node_binary_lands_where_the_app_starts_it(tmp_path: Path) -> None:
         f"node was staged at {sorted(landed)}, and the app looks in "
         f"{sorted(candidates)}"
     )
+
+
+def test_a_node_that_cannot_start_is_refused_at_build_time(tmp_path: Path) -> None:
+    """The failure this pack has no other way of noticing.
+
+    A Node copied out of a build that links `@rpath/libnode.<abi>.dylib` --
+    which the GitHub tool-cache build of 22.23.1 does, and Homebrew's does with
+    a dozen kegs -- lands as a file of the right name, the right size and the
+    right permissions, and dies in dyld the first time the app serves a page.
+    Every check that reads the pack rather than running it says the pack is
+    fine. So the copy is started, and refused here rather than on a user's
+    machine four minutes into a first run.
+    """
+    fake_node_root = tmp_path / "node-broken"
+    (fake_node_root / "bin").mkdir(parents=True)
+    fake_node = fake_node_root / "bin" / "node"
+    fake_node.write_text("#!/bin/sh\necho 'dyld: Library not loaded' >&2\nexit 6\n")
+    fake_node.chmod(0o755)
+
+    with pytest.raises(SystemExit) as refusal:
+        copy_node_runtime(tmp_path / "pack" / "frontend", fake_node_root)
+
+    assert "cannot start" in str(refusal.value)
+
+
+def test_the_libraries_node_carries_an_rpath_to_are_packed_beside_it(
+    tmp_path: Path,
+) -> None:
+    """`bin/node` resolves `@rpath` through `@loader_path/../lib`.
+
+    So a library that has to travel with the executable travels to
+    `frontend/node/lib`, not next to the binary and not left behind. Asserted
+    on the resolver rather than on a real Mach-O binary, because the whole
+    point is that most builds have nothing here and one build did.
+    """
+    root = tmp_path / "node-shared"
+    (root / "bin").mkdir(parents=True)
+    (root / "lib").mkdir()
+    (root / "bin" / "node").write_text("")
+    (root / "lib" / "libnode.127.dylib").write_text("")
+
+    resolved = _resolve_rpath_libraries(
+        root, root / "bin" / "node", ["@rpath/libnode.127.dylib", "/usr/lib/libz.1.dylib"]
+    )
+
+    assert resolved == [root / "lib" / "libnode.127.dylib"]
 
 
 def test_the_browser_bundles_land_where_the_backend_serves_them(


### PR DESCRIPTION
## What changes

`Host pack builds and runs (macOS)` goes green, and the checks that are supposed
to gate a merge start gating it.

The red job is the visible half. It was the only job left pinning a literal
`node-version: 22`; every other Node job — including the release job that builds
the very same pack — reads `.nvmrc`, which says 24. Two failures hid behind that
one literal:

- both `package.json` files declare `engines: node >=24 <25`, so CI was building
  the frontend on an interpreter the packages do not support (`npm warn
  EBADENGINE` on every run), and
- the runner's tool-cache build of 22.23.1 links `@rpath/libnode.127.dylib`,
  where 24.x is a single static executable. `copy_node_runtime` copies
  `bin/node` and nothing else, so the packed Node died in dyld:
  `Library not loaded: @rpath/libnode.127.dylib`.

The invisible half is why it stayed red from 25 August through eleven merges:
the job is deliberately outside the `ci` aggregator — right for the merge gate,
since it guards release-time breakage — and nothing else was watching main.

Then, from auditing the rest of CI:

| | |
|---|---|
| **Nothing in `security.yml` gated a merge** | Every job in it is path-filtered, so none could be named in a ruleset — gitleaks, both CodeQL suites, the dependency audit and the image scan could all go red and the merge button stayed green. It now has a `Security passed` aggregator, the same shape `ci.yml` and `e2e.yml` already use. |
| **Dependabot kept proposing a Rust that does not exist** | `dtolnay/rust-toolchain`'s tag is the *Rust* version, not the action's. Dependabot read the newest tag and proposed `1.100.0`; every desktop job in #438 died with `could not download nonexistent rust version`. A tag that does exist would be just as wrong — `rust-toolchain.toml` has to move with it. Ignored, with the reason written down. |
| **The macOS DMG was rebuilt on every desktop PR and thrown away** | Now built only on a push or when `desktop_packaging` changed, matching the trade the Windows job already makes for NSIS. It is also the flakiest step in the job (`bundle_dmg.sh` on a busy `hdiutil`, twice in the last twenty runs). Everything the job asserts is asserted on the `.app`, which is still built every time. |
| **`backend-unit` held `pull-requests: write` and `issues: write`** | Left over from when it posted the coverage table as a PR comment. That moved to the job summary and then to `backend-coverage.yml`; the grant stayed. |
| **`report_scenarios_to_slack.py` had no callers** | It was written so somebody reads the nightly without opening CI, and reports skips as loudly as failures — "a live lane whose credentials expired goes green while testing nothing". The nightly lanes wrote the XML it reads and nothing ever read it. Now wired into the journey and sandbox lanes, scheduled runs only. |
| **`make quality` stops at the language boundary** | It is Python all the way down, so a frontend change could pass every local gate and meet eslint, `tsc`, the design-system audit and the education anchors for the first time in CI. `make quality-frontend` runs those four; `make check` is both plus CodeQL. It skips with a note rather than failing when `node_modules` is absent. |

## Why

Three days of red main on a job nobody could see, and a merge gate that was
gating one job out of fifteen.

The ruleset required `lemma-backend unit` and `Backend E2E passed`. `CI passed`
— the aggregator the whole of `ci.yml` is built around, whose `needs:` list has
its own gate — was not required at all, so frontend, TypeScript SDK, desktop,
codegen-drift and every lint gate could fail and still merge. `lemma-backend
unit` is path-filtered besides, so on any PR that did not touch the backend it
reported `skipped`, which GitHub counts as satisfied.

**Already applied outside this diff:** the `protect-main` ruleset now requires
`CI passed` and `Backend E2E passed`. `Security passed` should be added to it
once this merges — naming a check that does not yet exist on other branches
would block every open PR.

**Still needs a person:** `SLACK_WEBHOOK_URL` is not set as a repository secret.
Until it is, `main-red` prints the message and raises a warning annotation
instead of posting, and the scenario lanes do the same. Neither fails.

## How to verify

```bash
make quality                      # ✓ quality gates pass
uv run --no-project --with pytest --with pyyaml python -m pytest tests/ -q
python3 -m unittest tests.test_dev_workflow
make quality-frontend             # check-edu-anchors: 9 anchors verified.
```

`tests/` is 67 passed, including two new ones: a Node that cannot start is
refused at build time, and the libraries it holds an `@rpath` to are packed
beside it. `check_ci_aggregators.py` reports `Aggregator and timeout checks
passed (13 workflows)` and now also refuses a literal `node-version:` anywhere
in `.github/workflows`.

The host-pack job itself only runs on a push to main, so it proves itself after
this merges.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — `backend-unit` drops two write scopes it did not use; no
      new secret is read anywhere it could be logged (the Slack webhook is
      passed through `env` and never echoed)
- [x] **Rollback** — every change is a workflow, a Makefile target, or a script;
      reverting the commit restores the previous behaviour exactly. The one
      thing revert does not undo is the ruleset change, which is a repository
      setting.

## Compatibility and rollback notes

No migrations, no API surface, no SDK changes.

The pack layout gains `frontend/node/lib/` when — and only when — the build
machine's Node needs it. `desktop/contracts/host-pack-layout.json` describes
required paths, and this adds none, so both halves of the contract are
unchanged.
