### PR TITLE
Let this computer pair with a workspace that moved off .localhost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SHELL := /bin/bash
         desktop-concepts desktop-concepts-check \
         desktop-runtime-fetch desktop-dmg desktop-exe desktop-verify-agents \
         desktop-verify-guest desktop-clean \
-        version-check \
+        version-check local-domain-check \
         test-dev-workflow \
         test test-backend test-backend-unit test-backend-e2e \
         test-frontend test-cli test-cli-unit test-cli-e2e test-python \
@@ -379,6 +379,7 @@ help:
 	@echo "    make check              quality + frontend gates + CodeQL on this branch's changes"
 	@echo "    make lint               ruff + eslint across all components"
 	@echo "    make version-check      every Lemma component declares the same version"
+	@echo "    make local-domain-check the shell, capability and SDK know every base domain"
 	@echo ""
 	@echo "  Other"
 	@echo "    make migrate            apply backend database migrations"
@@ -1331,6 +1332,15 @@ version-check:
 	@echo "→ Component versions…"
 	@python3 scripts/check_version_consistency.py
 
+# The base domain an install serves under is decided at runtime and spelled out
+# in four places, in three languages. Nothing tied them together, and the cost
+# was a shipped build where this computer could not pair with its own workspace:
+# two loopback checks still said `.localhost` after the base had moved, so the
+# refusal was silent and onboarding waited for ever.
+local-domain-check:
+	@echo "→ Local domain lists…"
+	@python3 scripts/check_local_domain_consistency.py
+
 # ── Tests ─────────────────────────────────────────────────────────────────────
 
 test: test-dev-workflow test-backend-unit test-backend-e2e test-cli test-python test-frontend
@@ -1767,6 +1777,8 @@ quality:
 	@cd $(BACKEND_DIR) && uv run python scripts/check_contracts.py
 	@echo "→ E2E wait patterns…"
 	@cd $(BACKEND_DIR) && $(MAKE) --no-print-directory lint-e2e-waits
+	@echo "→ Local domain lists…"
+	@$(MAKE) --no-print-directory local-domain-check
 	@echo "→ CI aggregators + job timeouts…"
 	@cd $(BACKEND_DIR) && uv run python ../scripts/check_ci_aggregators.py
 	@echo "→ Test census (no suite has quietly stopped running)…"

--- a/desktop/agent-host/src/api.rs
+++ b/desktop/agent-host/src/api.rs
@@ -274,8 +274,51 @@ impl TargetClient {
 /// API URL and the host refused it as a non-loopback plain-HTTP target.
 #[must_use]
 pub fn is_loopback_host(host: Option<&str>) -> bool {
-    matches!(host, Some("localhost" | "127.0.0.1" | "::1"))
-        || host.is_some_and(|host| host.ends_with(".localhost"))
+    let Some(host) = host else {
+        return false;
+    };
+    // The spellings that are loopback by definition, answered without asking
+    // the resolver: `localhost` and `.localhost` are reserved to loopback by
+    // RFC 6761, and the literals are self-evident.
+    if matches!(host, "localhost" | "127.0.0.1" | "::1" | "[::1]") || host.ends_with(".localhost") {
+        return true;
+    }
+    // Otherwise ask what the name actually is.
+    //
+    // A hardcoded list of spellings is what broke this. Lemma Desktop stopped
+    // serving itself on `*.localhost` -- a browser derives no registrable
+    // domain from it, so a pod app framed by the workspace can hold no session
+    // -- and now serves `app.127.0.0.1.sslip.io:<port>` instead. That is
+    // loopback in every way that matters: the name resolves to 127.0.0.1 and
+    // the backend binds there. It matched none of the spellings above, so the
+    // host refused to pair with the workspace that asked it to, and onboarding
+    // sat on "Connecting this computer" with no error anywhere.
+    //
+    // Resolving answers the question the list was approximating, and keeps
+    // answering it when the domain moves again. It is deliberately strict:
+    // every address the name resolves to must be loopback, so a name that
+    // answers both 127.0.0.1 and a routable address is refused rather than
+    // accepted on the strength of its first answer.
+    resolves_only_to_loopback(host)
+}
+
+/// Whether every address `host` resolves to is loopback, and there is at least
+/// one. Used only to decide whether plain HTTP is acceptable to this target.
+fn resolves_only_to_loopback(host: &str) -> bool {
+    use std::net::ToSocketAddrs;
+
+    // Port 0 -- this is a name lookup, not a connection.
+    let Ok(addresses) = (host, 0u16).to_socket_addrs() else {
+        return false;
+    };
+    let mut resolved = false;
+    for address in addresses {
+        resolved = true;
+        if !address.ip().is_loopback() {
+            return false;
+        }
+    }
+    resolved
 }
 
 pub fn validate_target_url(url: &Url, allow_insecure_http: bool) -> anyhow::Result<()> {
@@ -414,6 +457,39 @@ mod tests {
         assert!(!is_loopback_host(Some("localhost.attacker.example")));
         assert!(!is_loopback_host(Some("notlocalhost")));
         assert!(!is_loopback_host(None));
+    }
+
+    /// A name that resolves to loopback is loopback, whatever it is spelled.
+    ///
+    /// The spelling list is what broke pairing: Lemma Desktop moved off
+    /// `*.localhost`, because a browser derives no registrable domain from it
+    /// and a framed pod app can then hold no session, and started serving
+    /// `app.127.0.0.1.sslip.io`. That resolves to 127.0.0.1 and is served by a
+    /// backend bound there, and the list did not have it -- so the host refused
+    /// to pair with the workspace that asked it to, silently.
+    ///
+    /// Needs a resolver, so it is skipped where there is none rather than
+    /// failing: the assertion is about what this function concludes from an
+    /// answer, not about the machine having one.
+    #[test]
+    fn a_name_that_answers_loopback_is_loopback_however_it_is_spelled() {
+        use std::net::ToSocketAddrs;
+
+        let resolvable = |host: &str| (host, 0u16).to_socket_addrs().is_ok();
+
+        if resolvable("app.127.0.0.1.sslip.io") {
+            assert!(
+                is_loopback_host(Some("app.127.0.0.1.sslip.io")),
+                "the domain a shipped install serves itself on must be loopback"
+            );
+        }
+        // Somebody else's machine, spelled the same way. This is why the check
+        // reads the address rather than the shape of the name.
+        if resolvable("app.10.0.0.7.sslip.io") {
+            assert!(!is_loopback_host(Some("app.10.0.0.7.sslip.io")));
+        }
+        // A public name stays refused whether or not it resolves here.
+        assert!(!is_loopback_host(Some("lemma.work")));
     }
 
     fn status(status: StatusCode) -> ApiError {

--- a/desktop/locald/src/agent_host.rs
+++ b/desktop/locald/src/agent_host.rs
@@ -523,6 +523,16 @@ fn summarize_target(target: &Value) -> Value {
 /// Loopback HTTP is the one plain-HTTP case the host accepts, and only when
 /// asked. A development backend is served that way.
 fn is_loopback_http(url: &str) -> bool {
+    is_loopback_http_for(url, &crate::local_domain::LocalDomain::from_env())
+}
+
+/// The check with the install's domain handed in.
+///
+/// Split so the tests can state which domain they mean. `from_env` probes DNS
+/// and caches the answer for the process, so a test that leaned on it would
+/// assert one thing on a machine with a network and the opposite on one
+/// without -- and a gate that flips with the weather gets switched off.
+fn is_loopback_http_for(url: &str, domain: &crate::local_domain::LocalDomain) -> bool {
     let Some(rest) = url.strip_prefix("http://") else {
         return false;
     };
@@ -531,12 +541,26 @@ fn is_loopback_http(url: &str) -> bool {
         Some((host, port)) if !port.is_empty() && port.chars().all(|c| c.is_ascii_digit()) => host,
         _ => authority,
     };
-    // `.localhost` is reserved to loopback by RFC 6761, and Lemma Desktop serves
-    // its own workspace and API on `app.lemma.localhost`. Matching only the
-    // three literal spellings meant this flag was never passed for a desktop
-    // install's own URL, so the host refused to pair with the very workspace
-    // that asked it to.
-    matches!(host, "localhost" | "127.0.0.1" | "[::1]") || host.ends_with(".localhost")
+    // Twice now. `.localhost` is reserved to loopback by RFC 6761, and matching
+    // only the three literal spellings meant this flag was never passed for a
+    // desktop install's own URL, so the host refused to pair with the very
+    // workspace that asked it to. Adding `.localhost` fixed that -- and then the
+    // base domain stopped being `.localhost`.
+    //
+    // An install now serves itself under whatever `LocalDomain` resolved,
+    // because a browser derives no registrable domain from `*.localhost` and a
+    // pod app framed by the workspace needs one. On such an install the URL is
+    // `app.127.0.0.1.sslip.io:<port>`: loopback in every way that matters --
+    // the name resolves to 127.0.0.1 and the backend binds there -- and matched
+    // by none of the spellings above. Pairing failed silently, and the
+    // onboarding step sat on "Connecting this computer" for ever.
+    //
+    // So the question this asks is the one it always meant: is this address
+    // this installation's own? Asking `LocalDomain` means the next time the
+    // domain moves, this moves with it.
+    matches!(host, "localhost" | "127.0.0.1" | "[::1]")
+        || host.ends_with(".localhost")
+        || domain.owns_host(host)
 }
 
 /// Strip anything from a subprocess message that we passed in as a secret.
@@ -1097,6 +1121,10 @@ mod tests {
 
     #[test]
     fn plain_http_is_opted_into_only_on_loopback() {
+        use crate::local_domain::LocalDomain;
+        let sslip = LocalDomain::parse(Some("sslip"));
+        let is_loopback_http = |url: &str| is_loopback_http_for(url, &sslip);
+
         assert!(is_loopback_http("http://localhost:8710"));
         assert!(is_loopback_http("http://127.0.0.1:8710/api"));
         assert!(is_loopback_http("http://[::1]:8710"));
@@ -1108,7 +1136,21 @@ mod tests {
         assert!(is_loopback_http(
             "http://apps.lemma.localhost:52502/internal"
         ));
+        // And the hostname it serves itself on now. A shipped install resolves
+        // to the loopback wildcard, because a browser derives no registrable
+        // domain from `*.localhost` and a framed pod app needs one. This is the
+        // same failure as the line above, one domain later: pairing died
+        // silently and onboarding sat on "Connecting this computer" for ever.
+        assert!(is_loopback_http("http://app.127.0.0.1.sslip.io:61624"));
+        assert!(is_loopback_http(
+            "http://apps.127.0.0.1.sslip.io:61624/internal"
+        ));
         // A LAN or public address over plain HTTP stays refused.
+        // Somebody else's sslip host is somebody else's machine, not ours.
+        assert!(!is_loopback_http("http://app.10.0.0.7.sslip.io:61624"));
+        assert!(!is_loopback_http(
+            "http://app.127.0.0.1.sslip.io.evil:61624"
+        ));
         assert!(!is_loopback_http("http://192.168.1.10:8710"));
         assert!(!is_loopback_http("http://localhost.evil.example:8710"));
         // ".localhost" must be the suffix, not a substring someone else owns.

--- a/scripts/check_local_domain_consistency.py
+++ b/scripts/check_local_domain_consistency.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Every list of "what host this install serves" must name the same domains.
+
+Lemma Desktop does not serve one fixed hostname. `LocalDomain` picks a base
+domain at runtime -- `*.localhost` when nothing else resolves, a loopback
+wildcard otherwise -- because a browser derives no registrable domain from
+`*.localhost`, so a pod app framed by the workspace can hold no session there.
+
+Four places have to agree about the result, in three languages:
+
+* ``desktop/locald/src/local_domain.rs`` decides it. Source of truth.
+* ``desktop/src/main.rs`` trusts it for navigation -- an allowlist rather than a
+  resolver lookup on purpose, since an attacker who controls DNS should not be
+  able to talk a security gate into trusting a name.
+* ``desktop/capabilities/workspace.json`` grants the workspace its IPC, and a
+  workspace served on an origin missing from it reaches no shell command at all.
+* ``lemma-python/lemma_sdk/config.py`` believes locald's recorded endpoint, so a
+  base it does not know means ``--server local`` stops finding the install.
+
+Nothing tied them together, and the cost of that was a shipped build in which
+this computer could not pair with its own workspace: the base moved to
+``127.0.0.1.sslip.io`` and two loopback checks still spelled out
+``.localhost``, so pairing was refused with nothing logged and onboarding sat
+on "Connecting this computer" for ever.
+
+This does not ask anyone to keep one list. It asks that the lists say the same
+thing, and it fails by naming the file that is behind.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+LOCAL_DOMAIN = ROOT / "desktop/locald/src/local_domain.rs"
+SHELL = ROOT / "desktop/src/main.rs"
+CAPABILITY = ROOT / "desktop/capabilities/workspace.json"
+SDK = ROOT / "lemma-python/lemma_sdk/config.py"
+
+
+def declared_bases() -> set[str]:
+    """The domains `LocalDomain` can serve, from its own constants."""
+    text = LOCAL_DOMAIN.read_text(encoding="utf-8")
+    found = set(re.findall(r'pub const \w+_BASE: &str = "([^"]+)"', text))
+    if not found:
+        raise SystemExit(f"no *_BASE constants found in {LOCAL_DOMAIN}")
+    return found
+
+
+def shell_bases() -> set[str]:
+    text = SHELL.read_text(encoding="utf-8")
+    match = re.search(r"const TRUSTED_LOCAL_BASES: &\[&str\] = &\[([^\]]*)\]", text)
+    if not match:
+        raise SystemExit(f"TRUSTED_LOCAL_BASES not found in {SHELL}")
+    return set(re.findall(r'"([^"]+)"', match.group(1)))
+
+
+def capability_bases() -> set[str]:
+    urls = json.loads(CAPABILITY.read_text(encoding="utf-8"))["remote"]["urls"]
+    bases = set()
+    for url in urls:
+        match = re.match(r"https?://app\.([^:/]+)", url)
+        if match:
+            bases.add(match.group(1))
+    return bases
+
+
+def sdk_bases() -> set[str]:
+    text = SDK.read_text(encoding="utf-8")
+    match = re.search(r"_DESKTOP_LOCAL_BASES = \(([^)]*)\)", text)
+    if not match:
+        raise SystemExit(f"_DESKTOP_LOCAL_BASES not found in {SDK}")
+    return set(re.findall(r'"([^"]+)"', match.group(1)))
+
+
+def main() -> int:
+    expected = declared_bases()
+    consumers = {
+        "desktop/src/main.rs (TRUSTED_LOCAL_BASES)": shell_bases(),
+        "desktop/capabilities/workspace.json (remote.urls)": capability_bases(),
+        "lemma-python/lemma_sdk/config.py (_DESKTOP_LOCAL_BASES)": sdk_bases(),
+    }
+
+    failures = []
+    for name, bases in consumers.items():
+        missing = expected - bases
+        if missing:
+            failures.append(
+                f"- {name} does not cover {sorted(missing)}; "
+                f"it has {sorted(bases)}"
+            )
+
+    if failures:
+        print("Local domain lists disagree with local_domain.rs:")
+        print("\n".join(failures))
+        print(
+            "\nEvery base LocalDomain can serve has to appear in all of them. A "
+            "base missing from the shell is a workspace that cannot navigate, "
+            "from the capability is a workspace with no IPC at all, and from the "
+            "SDK is `--server local` failing to find the install."
+        )
+        return 1
+
+    print(f"Local domain lists agree on {sorted(expected)}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What changes

This computer can pair with its own workspace again. On a build serving the
loopback wildcard it could not, so no coding agent was ever detected and
onboarding sat on "Connecting this computer" indefinitely — with nothing on
screen and nothing in any log.

## Why

Found on a real install. The evidence, end to end:

| | |
| --- | --- |
| Agent Host config | `"targets": []` — never paired |
| Backend | issued pairing tokens fine: `POST /me/runtime/agent-host-pairings → 200`, twice |
| Workspace | polled `/me/runtime/agent-hosts` **122 times**, waiting |
| Agent Host log | stops at "re-probing"; nothing at all for the second attempt |

With no target there is no poll loop, so nothing probes the agents on the
machine and nothing is published. The empty list on screen was that.

Plain HTTP is accepted only for a loopback target, and **both** sides decided
"loopback" by spelling:

```rust
matches!(host, "localhost" | "127.0.0.1" | "::1") || host.ends_with(".localhost")
```

An install now serves `app.127.0.0.1.sslip.io:<port>` — a browser derives no
registrable domain from `*.localhost`, so a pod app framed by the workspace can
hold no session there. That name resolves to `127.0.0.1` and is served by a
backend bound there: loopback in every way that matters, and matched by neither
list. The pairing was refused as a validation error on a command nobody was
watching.

**The comment above locald's copy already recorded this exact failure happening
once before**, when the list held only the three literals and had to learn
`.localhost`. So the fix is not another entry:

- **locald** asks `LocalDomain` — the thing that decides what this install
  serves — so the next move takes this with it.
- **The Agent Host** cannot see that type, so it asks the resolver: every
  address the name answers must be loopback, and there must be at least one.
  That is the question the spelling list was approximating. Deliberately strict
  — a name answering both `127.0.0.1` and a routable address is refused rather
  than accepted on its first answer — so `app.10.0.0.7.sslip.io` stays out.

Both were needed: locald passes `--allow-insecure-http`, the host then applies
its own check, so either fix alone still refuses.

## The part that stops the next one

The base domain is decided at runtime and four places must agree, in three
languages: `local_domain.rs` decides it, `main.rs` trusts it for navigation,
`capabilities/workspace.json` grants the workspace its IPC on it, and
`lemma_sdk/config.py` believes locald's recorded endpoint because of it. Nothing
tied them together, which is how two of them fell behind and shipped.

`make local-domain-check` now reads all four and fails naming the file that is
behind. It does not ask for a single shared list — they are in different
languages, and the shell's is deliberately an allowlist rather than a resolver
lookup, because a security gate should not be talkable into trusting a name by
whoever answers DNS. It asks only that they say the same thing.

## Swept for the same bug elsewhere

- **Rust**: the two fixed here were the only spelling-based loopback checks that
  touch the install's own domain. `local_destination` in the shell already
  learned the domain; the remaining `localhost` literals are Tauri's own asset
  scheme, the dev asset server, and a legacy dev-port guard — none domain-bound.
- **Python**: clean. Every loopback check there resolves and tests the address
  (`ip.is_loopback`), which is the pattern the Agent Host now uses.
- **TypeScript**: two `isLoopbackHost` helpers, both for CLI loopback callbacks
  on a literal `http://127.0.0.1:<port>` — spelling is correct for that.

## How to verify

```bash
make local-domain-check
make desktop-test
make desktop-lint
```

Tests take the domain explicitly rather than reading `LocalDomain::from_env()`,
which probes DNS and caches per process — a test leaning on that asserts one
thing on a machine with a network and the opposite on one without. The
resolver-based test skips where there is no resolver rather than failing: the
claim is about what the function concludes from an answer, not about the machine
having one.

The consistency gate was verified by dropping a base from the SDK list — the
shape of the next domain move — and watching it fail, naming the file.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint and gates pass locally
- [x] **Security** — the Agent Host's resolver check is strict (all addresses
      must be loopback, at least one required), and the shell's navigation
      allowlist is deliberately left as an allowlist
- [ ] **Rollback** — revert. Pairing returns to refusing on any base that is not
      spelled `.localhost`.
