### PR TITLE
Unbreak the Windows host pack, and stop syntax reaching it that CI cannot parse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SHELL := /bin/bash
         desktop-concepts desktop-concepts-check \
         desktop-runtime-fetch desktop-dmg desktop-exe desktop-verify-agents \
         desktop-verify-guest desktop-clean \
-        version-check local-domain-check \
+        version-check local-domain-check script-portability-check \
         test-dev-workflow \
         test test-backend test-backend-unit test-backend-e2e \
         test-frontend test-cli test-cli-unit test-cli-e2e test-python \
@@ -1341,6 +1341,14 @@ local-domain-check:
 	@echo "→ Local domain lists…"
 	@python3 scripts/check_local_domain_consistency.py
 
+# CI runs scripts/ with a bare `python`, which on the Windows and macOS runners
+# is not the 3.14 the backend pins. Syntax they cannot parse is not a failing
+# step, it is a SyntaxError before the first line -- which is how one
+# unparenthesised `except` stopped every Windows host pack from building.
+script-portability-check:
+	@echo "→ Script portability…"
+	@python3 scripts/check_script_portability.py
+
 # ── Tests ─────────────────────────────────────────────────────────────────────
 
 test: test-dev-workflow test-backend-unit test-backend-e2e test-cli test-python test-frontend
@@ -1779,6 +1787,8 @@ quality:
 	@cd $(BACKEND_DIR) && $(MAKE) --no-print-directory lint-e2e-waits
 	@echo "→ Local domain lists…"
 	@$(MAKE) --no-print-directory local-domain-check
+	@echo "→ Script portability…"
+	@$(MAKE) --no-print-directory script-portability-check
 	@echo "→ CI aggregators + job timeouts…"
 	@cd $(BACKEND_DIR) && uv run python ../scripts/check_ci_aggregators.py
 	@echo "→ Test census (no suite has quietly stopped running)…"

--- a/scripts/build_local_host_pack.py
+++ b/scripts/build_local_host_pack.py
@@ -421,7 +421,11 @@ def node_rpath_libraries(executable: Path, root: Path) -> list[Path]:
         listing = subprocess.run(
             ["otool", "-L", str(executable)], text=True, capture_output=True, check=True
         ).stdout
-    except OSError, subprocess.CalledProcessError:
+    # Parenthesised on purpose. Unlike the backend, which pins 3.14, this
+    # script is run by CI as a bare `python` -- so it must parse on whatever
+    # interpreter the runner happens to have. PEP 758's unparenthesised form
+    # is a SyntaxError before 3.14, and it took the Windows host pack with it.
+    except (OSError, subprocess.CalledProcessError):
         # Not a Mach-O binary, or no Xcode command line tools. Either way the
         # probe below is the one that decides whether this pack is usable.
         return []

--- a/scripts/check_script_portability.py
+++ b/scripts/check_script_portability.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Scripts CI runs with a bare `python` must parse on an old one.
+
+The backend pins Python 3.14 and uses its syntax deliberately -- PEP 758's
+unparenthesised `except A, B:` among it. `scripts/` is different: CI invokes
+these with whatever `python` the runner provides, which on the Windows and
+macOS images is not 3.14. Syntax the runner cannot parse is not a failing
+build step, it is a `SyntaxError` before the first line runs.
+
+That is not hypothetical. One unparenthesised `except` reached
+`build_local_host_pack.py` and every Windows host pack stopped building --
+in the same change whose title was about unbreaking the host pack. The
+repository's own CLAUDE.md warns about this exact trap from the other
+direction, where an old interpreter reports correct 3.14 code as broken.
+
+So this parses each script under an older grammar and fails naming the file
+and the line. It does not run anything, and it makes no claim about
+behaviour: only that CI can get as far as executing it.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+#: The oldest interpreter a CI runner has plausibly offered. Raising this is a
+#: decision about which runners are still supported, not a formality.
+OLDEST_SUPPORTED = (3, 9)
+
+
+def main() -> int:
+    failures: list[str] = []
+    checked = 0
+    for script in sorted(ROOT.joinpath("scripts").glob("*.py")):
+        source = script.read_text(encoding="utf-8")
+        checked += 1
+        try:
+            ast.parse(source, filename=str(script), feature_version=OLDEST_SUPPORTED)
+        except SyntaxError as error:
+            failures.append(f"- {script.relative_to(ROOT)}:{error.lineno}: {error.msg}")
+
+    version = ".".join(str(part) for part in OLDEST_SUPPORTED)
+    if failures:
+        print(
+            f"Scripts must parse on Python {version}; CI runs them with a bare `python`:"
+        )
+        print("\n".join(failures))
+        print(
+            "\nThe backend may use 3.14 syntax because it pins 3.14. These may not: "
+            "a runner that cannot parse the file fails before the first statement, "
+            "and the error names a line rather than the thing that broke."
+        )
+        return 1
+
+    print(f"{checked} scripts parse on Python {version}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What changes

Every Windows host pack build has failed since #538. One character fixes it; the
gate stops the next one.

## Why

```
except OSError, subprocess.CalledProcessError:
SyntaxError: multiple exception types must be parenthesized
```

PEP 758's unparenthesised form needs Python 3.14. The backend may use it,
because it pins 3.14. `scripts/` may not: CI invokes these with a bare
`python`, and the Windows runner's is older.

The failure mode is worth naming. It is not a build step that fails — it is a
`SyntaxError` before the first line runs, so the error names a line in a helper
rather than the thing that broke. It landed in the change titled "unbreak the
host pack", and it blocked every DMG build after it.

`build_local_host_pack.py` is the only script in that directory using 3.14
syntax at all, so this was the only site.

## The gate

`make script-portability-check` parses every `scripts/*.py` under the oldest
grammar a runner has plausibly offered. It runs nothing and claims nothing about
behaviour — only that CI can get as far as executing the file.

The repository's CLAUDE.md already warns about this trap from the other
direction: an old interpreter reporting correct 3.14 code as broken, which once
had an audit call a working module defective. This is the same boundary, crossed
the other way, and it now has a check on it.

## How to verify

```bash
make script-portability-check
```

Verified by putting the syntax back — it fails, naming the file and the line —
and then restoring it.

## Checklist

- [x] Lint and gates pass locally
- [ ] **Rollback** — revert. Windows host packs stop building again.