### PR TITLE
Stop the frontend's optimistic title from blocking real generation

### DIFF
--- a/lemma-backend/app/modules/agent/api/controllers/conversation_controller.py
+++ b/lemma-backend/app/modules/agent/api/controllers/conversation_controller.py
@@ -182,13 +182,19 @@ async def create_conversation(
         agent_name=data.agent_name,
         user_id=user.id,
         title=data.title,
+        title_is_placeholder=data.title_is_placeholder,
         instructions=data.instructions,
         agent_runtime=data.agent_runtime,
         parent_id=data.parent_id,
         type=data.type,
         metadata=data.metadata,
     )
-    return ConversationResponse.model_validate(conversation)
+    response = ConversationResponse.model_validate(conversation)
+    if data.title_is_placeholder and data.title:
+        # Not persisted (see create_conversation) so title generation still
+        # runs, but the caller's own optimistic UI still gets it back once.
+        response.title = data.title
+    return response
 
 
 @router.get(

--- a/lemma-backend/app/modules/agent/api/schemas.py
+++ b/lemma-backend/app/modules/agent/api/schemas.py
@@ -216,6 +216,13 @@ class ApprovalDecisionResponse(BaseModel):
 class CreateConversationRequest(BaseModel):
     agent_name: str | None = None
     title: str | None = None
+    # True when `title` is a client-side UX seed (e.g. the first message,
+    # shown immediately so the sidebar is never blank) rather than a title the
+    # caller actually chose. A seed is not persisted as the conversation's
+    # title -- see ConversationService.create_conversation -- so
+    # ConversationTitleService still generates a real one. Ignored when
+    # `title` is unset.
+    title_is_placeholder: bool = False
     instructions: str | None = None
     agent_runtime: AgentRuntimeConfig | None = None
     parent_id: UUID | None = None

--- a/lemma-backend/app/modules/agent/events/handlers.py
+++ b/lemma-backend/app/modules/agent/events/handlers.py
@@ -201,11 +201,24 @@ async def _process_agent_control_event(
 ) -> None:
     if isinstance(parsed, AgentRunStartedEvent):
         await enqueue_agent_run(parsed, fs_logger=fs_logger, job_queue=job_queue)
+        # The title only needs the user's first message -- already saved by
+        # the time this event fires -- not the agent's reply, so it does not
+        # need to wait for the run to finish. Starting it here rather than on
+        # completion means a slow or long-running turn no longer leaves the
+        # conversation title-less for its whole duration. The deterministic
+        # job id dedups across turns, so this runs at most once per
+        # conversation; the job itself no-ops if a title already exists.
+        await job_queue.enqueue(
+            "generate_conversation_title",
+            context={"conversation_id": str(parsed.conversation_id)},
+            _job_id=conversation_title_job_id(parsed.conversation_id),
+        )
         return
     if isinstance(parsed, AgentRunCompletedEvent):
-        # Generate a title once the first run finishes. The deterministic job id
-        # dedups across turns, so this runs at most once per conversation; the
-        # job itself no-ops if a title already exists.
+        # Belt and suspenders: the same deterministic job id means this is a
+        # no-op on the (now-common) path where the run-started enqueue above
+        # already generated the title, and a fallback for anything that
+        # reaches completion without having gone through that event.
         await job_queue.enqueue(
             "generate_conversation_title",
             context={"conversation_id": str(parsed.conversation_id)},

--- a/lemma-backend/app/modules/agent/services/conversation_service.py
+++ b/lemma-backend/app/modules/agent/services/conversation_service.py
@@ -103,6 +103,7 @@ class ConversationService:
         agent_name: str | None,
         user_id: UUID,
         title: str | None = None,
+        title_is_placeholder: bool = False,
         instructions: str | None = None,
         agent_runtime: AgentRuntimeConfig | None = None,
         parent_id: UUID | None = None,
@@ -147,12 +148,19 @@ class ConversationService:
         else:
             conversation_type = type
 
+        # A placeholder is a client-side UX seed (typically the first message,
+        # so the sidebar is never blank), not a title the caller chose. It is
+        # never persisted: ConversationTitleService.generate_title_if_absent
+        # skips any conversation that already has a title, so persisting the
+        # seed would make it permanent and the LLM/fallback title would never
+        # run. The caller still gets it back for its own optimistic UI --
+        # see the controller, which overlays it onto the create response.
         conversation = Conversation(
             user_id=user_id,
             pod_id=pod_id,
             organization_id=organization_id,
             agent_id=agent.id if agent else None,
-            title=title,
+            title=None if title_is_placeholder else title,
             instructions=instructions,
             agent_runtime=agent_runtime,
             parent_id=parent_id,

--- a/lemma-backend/app/modules/agent/tests/e2e/test_conversation_title_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_conversation_title_e2e.py
@@ -173,6 +173,54 @@ class TestConversationTitleServiceAgainstRealDb:
         )
         assert fetched_again.json()["title"] == "Tokyo Vegetarian Food Tour"
 
+    async def test_placeholder_title_is_not_persisted_and_generation_still_runs(
+        self,
+        authenticated_client,
+        fixed_test_org,
+        monkeypatch,
+    ):
+        """The frontend seeds `title` with the first message so the sidebar is
+        never blank, marked `title_is_placeholder` because it is a UX seed, not
+        a choice. Real conversation 01a04c1c-57cb-73a0-b346-922cc0f54264 showed
+        what happens when that seed is trusted as final: the conversation's
+        title stayed the raw, unsanitized first message forever, because
+        `generate_title_if_absent` treats any non-empty title as already done.
+        """
+        _stub_llm(monkeypatch, output='  "Tokyo Vegetarian Food Tour".  ')
+        pod_id = await _create_pod(authenticated_client, fixed_test_org)
+        seed = "help me plan a 3-day vegetarian food tour of tokyo"
+
+        create = await authenticated_client.post(
+            f"/pods/{pod_id}/conversations",
+            json={
+                "agent_runtime": {"profile_id": "system:lemma"},
+                "title": seed,
+                "title_is_placeholder": True,
+            },
+        )
+        assert create.status_code == 201, create.text
+        conversation_id = UUID(create.json()["id"])
+        # The create response still carries the seed, for the caller's own
+        # optimistic UI -- it is just never written to Postgres.
+        assert create.json()["title"] == seed
+
+        fetched = await authenticated_client.get(
+            f"/pods/{pod_id}/conversations/{conversation_id}"
+        )
+        assert fetched.json()["title"] is None
+
+        await _seed_opening_exchange(conversation_id)
+        service = ConversationTitleService(
+            uow_factory=SessionUnitOfWorkFactory(async_session_maker)
+        )
+        title = await service.generate_title_if_absent(conversation_id)
+        assert title == "Tokyo Vegetarian Food Tour"
+
+        fetched_after = await authenticated_client.get(
+            f"/pods/{pod_id}/conversations/{conversation_id}"
+        )
+        assert fetched_after.json()["title"] == "Tokyo Vegetarian Food Tour"
+
     async def test_skips_when_no_user_message(
         self,
         authenticated_client,

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_event_handlers.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_event_handlers.py
@@ -8,6 +8,7 @@ from streaq.task import TaskStatus
 
 from app.modules.agent.domain.events import (
     AgentRunCompletedEvent,
+    AgentRunStartedEvent,
     AgentRunStopRequestedEvent,
 )
 from app.modules.agent.events.handlers import conversation_title_job_id
@@ -165,6 +166,47 @@ async def test_completed_event_enqueues_dedup_title_job() -> None:
             conversation_title_job_id(completed_event.conversation_id),
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_started_event_also_enqueues_dedup_title_job() -> None:
+    """The title only needs the user's first message, already saved by the
+    time this event fires, so it starts on run-start rather than waiting for
+    the run to finish -- a long-running turn should not leave the
+    conversation title-less for its whole duration."""
+    job_queue = _JobQueue(TaskStatus.SCHEDULED)
+    started_event = AgentRunStartedEvent(
+        conversation_id=uuid4(),
+        agent_run_id=uuid4(),
+        user_id=uuid4(),
+        pod_id=uuid4(),
+        agent_name="hello",
+    )
+
+    await handlers.handle_agent_control_event(
+        started_event.model_dump(mode="json"),
+        fs_logger=_Logger(),
+        job_queue=job_queue,
+        uow_factory=_UowFactory(),
+        inbox=PassthroughEventInbox(),
+    )
+
+    assert (
+        "process_agent_run",
+        {
+            "agent_run_id": str(started_event.agent_run_id),
+            "conversation_id": str(started_event.conversation_id),
+            "user_id": str(started_event.user_id),
+            "pod_id": str(started_event.pod_id),
+            "agent_name": started_event.agent_name,
+        },
+        handlers.agent_run_job_id(started_event.agent_run_id),
+    ) in job_queue.enqueued
+    assert (
+        "generate_conversation_title",
+        {"conversation_id": str(started_event.conversation_id)},
+        conversation_title_job_id(started_event.conversation_id),
+    ) in job_queue.enqueued
 
 
 @pytest.mark.asyncio

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -13,4 +13,4 @@ SDK and the server it is talking to.
 from __future__ import annotations
 
 API_VERSION = "0.7.1"
-SPEC_SHA256 = "1db0fd03f13d31a78280d71fe947ae786c2bf753dc6e94fc9fd93fdb0a9a135e"
+SPEC_SHA256 = "fe22bd84c3e2f12fffb197ba6e8cf247187e798e2c880a431afbf743ec470f10"

--- a/lemma-python/lemma_sdk/openapi_client/models/create_conversation_request.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/create_conversation_request.py
@@ -30,6 +30,7 @@ class CreateConversationRequest:
         metadata (CreateConversationRequestMetadataType0 | None | Unset):
         parent_id (None | Unset | UUID):
         title (None | str | Unset):
+        title_is_placeholder (bool | Unset):  Default: False.
         type_ (ConversationType | Unset): User-visible conversation behavior.
     """
 
@@ -39,6 +40,7 @@ class CreateConversationRequest:
     metadata: CreateConversationRequestMetadataType0 | None | Unset = UNSET
     parent_id: None | Unset | UUID = UNSET
     title: None | str | Unset = UNSET
+    title_is_placeholder: bool | Unset = False
     type_: ConversationType | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -90,6 +92,8 @@ class CreateConversationRequest:
         else:
             title = self.title
 
+        title_is_placeholder = self.title_is_placeholder
+
         type_: str | Unset = UNSET
         if not isinstance(self.type_, Unset):
             type_ = self.type_.value
@@ -109,6 +113,8 @@ class CreateConversationRequest:
             field_dict["parent_id"] = parent_id
         if title is not UNSET:
             field_dict["title"] = title
+        if title_is_placeholder is not UNSET:
+            field_dict["title_is_placeholder"] = title_is_placeholder
         if type_ is not UNSET:
             field_dict["type"] = type_
 
@@ -203,6 +209,8 @@ class CreateConversationRequest:
 
         title = _parse_title(d.pop("title", UNSET))
 
+        title_is_placeholder = d.pop("title_is_placeholder", UNSET)
+
         _type_ = d.pop("type", UNSET)
         type_: ConversationType | Unset
         if isinstance(_type_, Unset):
@@ -217,6 +225,7 @@ class CreateConversationRequest:
             metadata=metadata,
             parent_id=parent_id,
             title=title,
+            title_is_placeholder=title_is_placeholder,
             type_=type_,
         )
 

--- a/lemma-python/lemma_sdk/openapi_spec.json
+++ b/lemma-python/lemma_sdk/openapi_spec.json
@@ -4688,6 +4688,11 @@
             ],
             "title": "Title"
           },
+          "title_is_placeholder": {
+            "default": false,
+            "title": "Title Is Placeholder",
+            "type": "boolean"
+          },
           "type": {
             "$ref": "#/components/schemas/ConversationType",
             "default": "CHAT"

--- a/lemma-typescript/src/openapi_client/models/CreateConversationRequest.ts
+++ b/lemma-typescript/src/openapi_client/models/CreateConversationRequest.ts
@@ -11,5 +11,6 @@ export type CreateConversationRequest = {
     metadata?: (Record<string, any> | null);
     parent_id?: (string | null);
     title?: (string | null);
+    title_is_placeholder?: boolean;
     type?: ConversationType;
 };

--- a/lemma-typescript/src/react/useAssistantController.ts
+++ b/lemma-typescript/src/react/useAssistantController.ts
@@ -1648,6 +1648,9 @@ export function useAssistantController({
 
     const createdConversation = await sessionCreateConversation({
       title: titleSeed.slice(0, 120),
+      // A seed for the sidebar while the real title generates, not a chosen
+      // one -- see CreateConversationInput.titleIsPlaceholder.
+      titleIsPlaceholder: true,
       instructions: typeof options.instructions === "undefined" ? instructions : options.instructions,
       metadata: options.metadata ?? undefined,
       model: conversationModel as unknown as never,

--- a/lemma-typescript/src/react/useAssistantSession.ts
+++ b/lemma-typescript/src/react/useAssistantSession.ts
@@ -55,6 +55,14 @@ export interface UseAssistantSessionOptions {
 
 export interface CreateConversationInput {
   title?: string | null;
+  /**
+   * `title` is a UX seed (e.g. the first message, shown immediately so the
+   * conversation is never blank) rather than a title actually chosen for
+   * this conversation. The server does not persist a seed, so title
+   * generation still runs once the conversation has content; the caller
+   * still gets it back once, for its own optimistic display.
+   */
+  titleIsPlaceholder?: boolean;
   instructions?: string | null;
   metadata?: Record<string, unknown> | null;
   model?: ConversationModel | null;
@@ -592,6 +600,7 @@ export function useAssistantSession(options: UseAssistantSessionOptions): UseAss
 
       const payload = {
         title: input.title ?? undefined,
+        title_is_placeholder: input.titleIsPlaceholder ?? undefined,
         instructions: typeof input.instructions === "undefined"
           ? defaultInstructions ?? undefined
           : input.instructions,


### PR DESCRIPTION
## Summary
- User-reported: a real dev conversation stayed titled as the raw first message forever. Confirmed via the streaq job record (ran, `{'s': True, 'r': None}` — did nothing) and reproduced live by creating a conversation through the actual web UI: its title equaled the first message the instant it was created, before any agent reply.
- Root cause: `useAssistantController.ensureConversation` seeds `title` with the trimmed first message at creation, so the sidebar is never blank — a deliberate UX choice. But `ConversationTitleService.generate_title_if_absent` treats any non-empty title as "done" (`if conversation.title: return None`), with no way to distinguish a real title from a UX placeholder. Every web-created conversation's title was permanent from creation.
- Fix: `CreateConversationRequest.title_is_placeholder`. When set, the seed is **not persisted** — `create_conversation` stores `None` instead — so title generation still runs; the create response still carries the seed once for the caller's own optimistic display.
- Second finding from the same conversation: its run took 2m16s, and the title job — triggered on `AgentRunCompletedEvent` — only ever needed the already-saved first message, not the reply. Moved the enqueue to also fire on `AgentRunStartedEvent`, so a long-running turn no longer leaves the conversation title-less the whole time. Deterministic job id makes the completion-time enqueue a harmless no-op afterward; kept as a fallback.
- Both SDKs regenerated (`dump_openapi_spec.py` + `generate_openapi_client.sh` ×2) since this adds a request field.

## Test plan
- [x] 1211 agent unit tests pass, including a new test asserting the title job also enqueues on `AgentRunStartedEvent`
- [x] 157 agent e2e tests pass (real Postgres + Redis, LLM boundary stubbed), including a new test that creates a conversation with `title_is_placeholder=True` through the real API and confirms the seed is never persisted while generation still succeeds
- [x] `tsc --noEmit` clean on the TypeScript SDK
- [x] `dump_openapi_spec.py --check` and `check_contracts.py` clean after regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)