### PR TITLE
Let an agent be saved as a contact, and let its face leave the app

### DIFF
--- a/lemma-frontend/app/api/contact-card/[...path]/route.tsx
+++ b/lemma-frontend/app/api/contact-card/[...path]/route.tsx
@@ -1,0 +1,210 @@
+/* eslint-disable no-restricted-syntax -- The photo is rasterised by Satori, which lays out with serializable inline styles rather than app CSS. */
+import { ImageResponse } from 'next/og';
+import type { NextRequest } from 'next/server';
+
+import { config } from '@/lib/config';
+import { beingDataUri } from '@/lib/identity/being-svg';
+import {
+    buildVCard,
+    contactCardFilename,
+    contactCardParams,
+    readContactCardSpec,
+    type ContactCardSpec,
+    type VCardPhoto,
+} from '@/lib/share/contact-card';
+import { SHARE_NAME_PARAM } from '@/lib/share/share-link';
+import { identityVariantSeed, parseResourceIcon } from '@/lib/utils/resource-icon-value';
+
+export const runtime = 'edge';
+
+/**
+ * Large enough that a contact app's own crop still has pixels to work with,
+ * small enough that the base64 of it stays a few kilobytes — the whole file is
+ * copied into an address book and synced to every device on the account.
+ */
+const PHOTO_SIZE = 256;
+
+/** A picture past this is not an icon; refuse it rather than inline it. */
+const MAX_ICON_BYTES = 512 * 1024;
+
+/**
+ * Base64 without `Buffer`, which the edge runtime does not have.
+ *
+ * Chunked because `String.fromCharCode(...bytes)` spreads every byte as an
+ * argument, and a photo is tens of thousands of them — enough to overflow the
+ * call stack on exactly the inputs this is for.
+ */
+function base64(bytes: Uint8Array): string {
+    let binary = '';
+    for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+        binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+    }
+    return btoa(binary);
+}
+
+/**
+ * May we fetch this icon?
+ *
+ * The URL arrives in a query string anyone can type, and this runs on our own
+ * origin — so an unchecked fetch is a request-forgery gadget pointed at whatever
+ * the edge can reach. Two conditions, both required: a host we publish from, and
+ * the managed icon route, which is the only path on it that serves user
+ * pictures. Anything else falls through to the generated face, which is a
+ * perfectly good answer rather than an error.
+ */
+function isFetchableIcon(url: URL, requestOrigin: string): boolean {
+    const allowed = new Set(
+        [requestOrigin, config.SITE_URL, config.API_URL]
+            .map((value) => {
+                try {
+                    return new URL(value).origin;
+                } catch {
+                    return null;
+                }
+            })
+            .filter((origin): origin is string => Boolean(origin)),
+    );
+    return allowed.has(url.origin) && url.pathname.includes('/public/icons/');
+}
+
+async function uploadedPhoto(rawUrl: string, requestOrigin: string): Promise<VCardPhoto | null> {
+    let url: URL;
+    try {
+        url = new URL(rawUrl, requestOrigin);
+    } catch {
+        return null;
+    }
+    if (!isFetchableIcon(url, requestOrigin)) return null;
+
+    try {
+        const response = await fetch(url, { signal: AbortSignal.timeout(4000) });
+        if (!response.ok) return null;
+
+        const type = response.headers.get('content-type') ?? '';
+        // vCard 3.0 names the format bare, and these are the two every contact
+        // app decodes. An SVG or a GIF is served by the icon route but would
+        // arrive as an unreadable photo, so it is left to the generated face.
+        const format = type.includes('png') ? 'PNG' : type.includes('jpeg') ? 'JPEG' : null;
+        if (!format) return null;
+
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        if (bytes.length === 0 || bytes.length > MAX_ICON_BYTES) return null;
+        return { data: base64(bytes), type: format };
+    } catch {
+        // A slow or missing icon must not cost someone their contact card.
+        return null;
+    }
+}
+
+/**
+ * The agent's generated face, rasterised.
+ *
+ * The being is an SVG, and no contact app renders one in a `PHOTO` — so it goes
+ * through the same Satori pipeline the social card uses, as a data URI, and
+ * comes back as the PNG that address books actually draw.
+ */
+async function generatedPhoto(seed: string): Promise<VCardPhoto | null> {
+    try {
+        const image = new ImageResponse(
+            (
+                <div style={{ display: 'flex', width: '100%', height: '100%' }}>
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img src={beingDataUri({ seed })} width={PHOTO_SIZE} height={PHOTO_SIZE} alt="" />
+                </div>
+            ),
+            { width: PHOTO_SIZE, height: PHOTO_SIZE },
+        );
+        return { data: base64(new Uint8Array(await image.arrayBuffer())), type: 'PNG' };
+    } catch {
+        // A card with no picture is still a card worth saving.
+        return null;
+    }
+}
+
+/**
+ * The face to save, resolved by the same rule the workspace draws by: an
+ * uploaded picture and a typed emoji are explicit choices, the generated being
+ * is what fills the silence.
+ *
+ * An emoji is the one branch that cannot be honoured. Satori draws glyphs from
+ * fonts it is handed, and shipping an emoji font to the edge to render one
+ * character costs megabytes per request — so a pod that typed one gets the
+ * generated face rather than a blank square where a picture should be.
+ */
+async function resolvePhoto(
+    spec: ContactCardSpec,
+    requestOrigin: string,
+): Promise<VCardPhoto | null> {
+    const icon = parseResourceIcon(spec.icon);
+
+    if (icon?.kind === 'url') {
+        const uploaded = await uploadedPhoto(icon.url, requestOrigin);
+        if (uploaded) return uploaded;
+    }
+
+    const variant = icon?.kind === 'identity' ? icon.variant : 0;
+    return generatedPhoto(identityVariantSeed(spec.seed, variant));
+}
+
+/**
+ * The saveable file behind a contact card's "Save contact" button.
+ *
+ * Everything it needs is in the query — the same link the page renders from, so
+ * the file and the page cannot disagree — which is what lets this answer a
+ * reader who has no session and never will.
+ *
+ * The path mirrors the page's, segment for segment, rather than being a bare
+ * endpoint with the identity in the query. That is what lets the file name the
+ * page it came from: a saved contact carrying a `URL` back to `/s/contact/…` is
+ * a card that can be re-opened and re-saved when a handle moves, which is the
+ * only repair available once a vCard is sitting in someone else's phone.
+ */
+export async function GET(
+    request: NextRequest,
+    context: { params: Promise<{ path?: string[] }> },
+): Promise<Response> {
+    const params = request.nextUrl.searchParams;
+    const spec = readContactCardSpec(params, params.get(SHARE_NAME_PARAM));
+    const segments = (await context.params).path?.filter(Boolean) ?? [];
+
+    // The same shape the share page accepts, checked for the same reason: these
+    // segments are pasted into a URL the file hands back to a contact app.
+    if (!spec || segments[0] !== 'pod' || !segments[1]) {
+        return new Response('This link names no contact.', {
+            status: 400,
+            headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+        });
+    }
+
+    const origin = request.nextUrl.origin;
+    const photo = await resolvePhoto(spec, origin);
+    const page = new URL(`/s/contact/${segments.map(encodeURIComponent).join('/')}`, origin);
+    // Rebuilt from the parsed card rather than copied from the incoming query.
+    // A catch-all route hands its own segments back in `searchParams`, so
+    // copying wrote `&path=pod&path=p1…` into a URL that a contact app keeps
+    // forever — and it would carry any other junk the link happened to hold.
+    const cardQuery = contactCardParams(spec);
+    cardQuery.set(SHARE_NAME_PARAM, spec.name);
+    page.search = cardQuery.toString();
+    const vcard = buildVCard(spec, {
+        photo,
+        // Scoped to the pod the path names. An agent's seed is its id and would
+        // have been unique already; Lem's is one constant every pod shares, so
+        // without this a second pod's Lem would overwrite the first one saved.
+        uid: `${segments[1]}:${spec.seed}`,
+        // The card's own page, so a saved contact keeps a way back to the thing
+        // that minted it — and to a fresher copy of itself.
+        url: page.toString(),
+    });
+
+    return new Response(vcard, {
+        headers: {
+            'Content-Type': 'text/vcard; charset=utf-8',
+            'Content-Disposition': `attachment; filename="${contactCardFilename(spec)}"`,
+            // Everything here is a pure function of the query, so a shared link
+            // is worth caching — briefly, since `REV` moves with each mint.
+            'Cache-Control': 'public, max-age=300',
+            'X-Content-Type-Options': 'nosniff',
+        },
+    });
+}

--- a/lemma-frontend/app/pod/[id]/agents/[agentId]/page.tsx
+++ b/lemma-frontend/app/pod/[id]/agents/[agentId]/page.tsx
@@ -377,6 +377,8 @@ export default function AgentDetailPage({
                                     ) : null}
                                     <AgentHome
                                         podId={podId}
+                                        agentId={localAgent.id}
+                                        agentSlug={localAgent.name}
                                         agentName={displayName}
                                         description={localAgent.description}
                                         iconUrl={localAgent.icon_url}

--- a/lemma-frontend/app/pod/[id]/ai/page.tsx
+++ b/lemma-frontend/app/pod/[id]/ai/page.tsx
@@ -16,7 +16,7 @@ import {
 import { toast } from 'sonner';
 
 import { ResourceIdentity } from '@/components/shared/resource-identity';
-import { LEM_SEED } from '@/lib/identity/seeded-identity';
+import { LEM_SEED, agentIdentitySeed } from '@/lib/identity/seeded-identity';
 import { DEFAULT_RESPONDER_NAME } from '@/lib/utils/agents';
 import { Button } from '@/components/ui/button';
 import { DestructiveConfirmationDialog } from '@/components/shared/destructive-confirmation-dialog';
@@ -442,7 +442,7 @@ function AgentProfileCard({
                         label={agent.name}
                         imageClassName="object-contain p-1"
                         className="h-11 w-11 shrink-0 rounded-lg bg-transparent"
-                        identitySeed={agent.id || agent.name}
+                        identitySeed={agentIdentitySeed(agent)}
                         identitySize={44}
                         fallback={<AgentMonogram name={agent.name} />}
                     />

--- a/lemma-frontend/app/s/[kind]/[...path]/contact-landing.tsx
+++ b/lemma-frontend/app/s/[kind]/[...path]/contact-landing.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import QRCode from 'react-qr-code';
+
+import { Button } from '@/components/ui/button';
+import { ArrowRight, Download, Mail } from '@/components/ui/icons';
+import { ResourceIcon } from '@/components/shared/resource-icon';
+import { captureEvent } from '@/lib/analytics/client';
+import { contactChannels, type ContactCardSpec } from '@/lib/share/contact-card';
+import { getSurfaceDefinition } from '@/lib/surfaces/registry';
+
+interface ContactLandingProps {
+    card: ContactCardSpec;
+    /** Workspace-relative path, already validated as `/pod/…` on the server. */
+    destination: string;
+    /** Same-origin path to the `.vcf`, built from this page's own segments. */
+    downloadHref: string;
+    /** This page's own absolute URL — what the QR encodes. */
+    pageUrl: string;
+}
+
+/**
+ * An agent, offered the way a person's contact details are offered.
+ *
+ * Nothing on this page is fetched. The name, the handles and the face all
+ * arrive in the link, which is what lets it answer the reader it is actually
+ * for: someone who was sent this in a group chat, has no Lemma account, and is
+ * not about to make one before deciding whether to say hello.
+ *
+ * So the workspace is the quiet link at the bottom rather than the button in
+ * the middle. `ShareLanding` is built the other way round — it asks whether you
+ * can open the resource and sends you into the pod — and that is the right shape
+ * for a document and the wrong one here. The promise a contact card makes is
+ * that you never have to come to Lemma at all.
+ */
+export function ContactLanding({
+    card,
+    destination,
+    downloadHref,
+    pageUrl,
+}: ContactLandingProps) {
+    const channels = contactChannels(card);
+
+    useEffect(() => {
+        captureEvent('share_link.viewed', { kind: 'contact', viewer_is_member: false });
+    }, []);
+
+    return (
+        <main className="flex min-h-dvh items-center justify-center px-6 py-16">
+            <div className="w-full max-w-sm">
+                <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[var(--surface-2)] p-6 shadow-[var(--shadow-md)]">
+                    <div className="flex flex-col items-center text-center">
+                        <ResourceIcon
+                            iconUrl={card.icon}
+                            alt={`${card.name} picture`}
+                            label={card.name}
+                            identityKind="being"
+                            identitySeed={card.seed}
+                            identitySize={88}
+                            className="h-22 w-22 rounded-2xl"
+                        />
+                        <h1 className="mt-4 text-xl font-medium text-[var(--text-primary)]">
+                            {card.name}
+                        </h1>
+                        <p className="mt-1 text-sm text-[var(--text-secondary)]">
+                            {/* Lem's card is named for its pod, because its own
+                                name is the same in every pod — which would print
+                                that pod twice, once on each line, if the subtitle
+                                repeated it unconditionally. */}
+                            {card.org && !card.name.includes(card.org)
+                                ? `${card.org} · Agent on Lemma`
+                                : 'Agent on Lemma'}
+                        </p>
+                        {card.note ? (
+                            <p className="mt-3 text-sm text-[var(--text-secondary)]">{card.note}</p>
+                        ) : null}
+                    </div>
+
+                    {channels.length > 0 ? (
+                        <ul className="mt-6 flex flex-col gap-2">
+                            {channels.map((channel) => {
+                                const definition = getSurfaceDefinition(channel.platform);
+                                return (
+                                    <li key={channel.key}>
+                                        <a
+                                            href={channel.href}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            onClick={() =>
+                                                captureEvent('share_link.contact_opened', {
+                                                    channel: channel.key,
+                                                })
+                                            }
+                                            className="flex items-center gap-3 rounded-md border border-[color:var(--border-subtle)] px-3 py-2 text-left hover:bg-[var(--surface-3)]"
+                                        >
+                                            {definition?.logoSrc ? (
+                                                // eslint-disable-next-line @next/next/no-img-element -- a fixed-size mark, nothing for the optimizer to do.
+                                                <img
+                                                    src={definition.logoSrc}
+                                                    alt=""
+                                                    width={18}
+                                                    height={18}
+                                                    className="h-[18px] w-[18px] shrink-0"
+                                                />
+                                            ) : (
+                                                <Mail className="h-[18px] w-[18px] shrink-0 text-[var(--text-secondary)]" />
+                                            )}
+                                            <span className="min-w-0 flex-1">
+                                                <span className="block text-sm text-[var(--text-primary)]">
+                                                    {channel.label}
+                                                </span>
+                                                <span className="block truncate text-xs text-[var(--text-tertiary)]">
+                                                    {channel.value}
+                                                </span>
+                                            </span>
+                                            <ArrowRight className="h-4 w-4 shrink-0 text-[var(--text-tertiary)]" />
+                                        </a>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    ) : (
+                        /* A card with no rows is not a broken page — it is an
+                           agent nobody has given an outside address yet, and
+                           saying so is more use than an empty list. */
+                        <p className="mt-6 rounded-md border border-[color:var(--border-subtle)] px-3 py-2 text-center text-sm text-[var(--text-secondary)]">
+                            This agent has no outside address yet. It answers inside Lemma.
+                        </p>
+                    )}
+
+                    {channels.length > 0 ? (
+                        <div className="mt-4 flex flex-col items-center gap-4">
+                            {/* The one thing a reader has to know before saving,
+                                and the one the card cannot deliver on its own:
+                                inbound senders are resolved to a Lemma user, and
+                                an unrecognised one gets a signup or request-access
+                                link instead of the agent (`surface_inbound.py`).
+                                Said here it is a fact about who to ask for an
+                                invite; found out after saving, it reads as the
+                                agent ignoring you. Same promise the reach card
+                                makes inside the workspace, worded for the person
+                                who is not in it yet. */}
+                            <p className="text-center text-xs text-[var(--text-tertiary)]">
+                                Answers members of this pod. Anyone else gets a link to request
+                                access.
+                            </p>
+
+                            <Button variant="primary" asChild size="lg" className="w-full gap-2">
+                                {/* A plain navigation, not a scripted save: the
+                                    response carries its own Content-Disposition,
+                                    which is the one route that works in an
+                                    in-app browser as well as a real one. */}
+                                <a
+                                    href={downloadHref}
+                                    onClick={() => captureEvent('share_link.contact_saved', {})}
+                                >
+                                    <Download className="h-4 w-4" />
+                                    Save contact
+                                </a>
+                            </Button>
+
+                            <div className="flex flex-col items-center gap-2">
+                                <div className="text-[var(--text-primary)]" aria-hidden>
+                                    <QRCode
+                                        value={pageUrl}
+                                        size={104}
+                                        bgColor="transparent"
+                                        fgColor="currentColor"
+                                    />
+                                </div>
+                                <p className="text-xs text-[var(--text-tertiary)]">
+                                    Scan to save it on your phone
+                                </p>
+                            </div>
+                        </div>
+                    ) : null}
+                </div>
+
+                <p className="mt-6 text-center text-xs text-[var(--text-tertiary)]">
+                    <Link
+                        href={destination}
+                        prefetch={false}
+                        className="hover:text-[var(--text-secondary)]"
+                    >
+                        Open it in Lemma
+                    </Link>
+                </p>
+            </div>
+        </main>
+    );
+}

--- a/lemma-frontend/app/s/[kind]/[...path]/page.tsx
+++ b/lemma-frontend/app/s/[kind]/[...path]/page.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
+import { ContactLanding } from './contact-landing';
 import { ShareLanding } from './share-landing';
+import { contactCardDownloadPath, readContactCardSpec } from '@/lib/share/contact-card';
+import { config } from '@/lib/config';
 import {
     getShareKindCopy,
     isShareKind,
@@ -20,6 +23,16 @@ interface SharePageProps {
 
 function firstValue(value: string | string[] | undefined): string | undefined {
     return Array.isArray(value) ? value[0] : value;
+}
+
+/** The query as the card reader wants it, first value wins. */
+function toSearchParams(query: Record<string, string | string[] | undefined>): URLSearchParams {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(query)) {
+        const first = firstValue(value);
+        if (first !== undefined) params.set(key, first);
+    }
+    return params;
 }
 
 /**
@@ -47,7 +60,19 @@ async function readShare({ params, searchParams }: SharePageProps) {
     // still renders for a crawler that will never hold a session.
     const target = resolveShareTarget(kind, raw.path, query);
 
-    return { kind, copy, destination, name, card, target };
+    // Read only for the one kind that has one, so an ordinary share link never
+    // pays for parsing params it does not carry.
+    const search = kind === 'contact' ? toSearchParams(query) : null;
+    const contact = search ? readContactCardSpec(search, name) : null;
+    const downloadHref = search ? contactCardDownloadPath(raw.path, search) : null;
+    // Built from the canonical site URL rather than read off the client after
+    // mount: the QR is the point of a card on a screen someone else is looking
+    // at, and one that appears a beat late is one nobody scans.
+    const pageUrl = search
+        ? `${config.SITE_URL.replace(/\/$/, '')}/s/${kind}/${(raw.path ?? []).join('/')}?${search}`
+        : null;
+
+    return { kind, copy, destination, name, card, target, contact, downloadHref, pageUrl };
 }
 
 export async function generateMetadata(props: SharePageProps): Promise<Metadata> {
@@ -89,6 +114,20 @@ export async function generateMetadata(props: SharePageProps): Promise<Metadata>
 export default async function SharePage(props: SharePageProps) {
     const share = await readShare(props);
     if (!share) notFound();
+
+    // A contact card answers a reader who has no session and is not going to get
+    // one, so it renders straight from the link — no access check, nothing
+    // fetched, none of the signed-in branching `ShareLanding` exists to do.
+    if (share.kind === 'contact' && share.contact && share.downloadHref && share.pageUrl) {
+        return (
+            <ContactLanding
+                card={share.contact}
+                destination={share.destination}
+                downloadHref={share.downloadHref}
+                pageUrl={share.pageUrl}
+            />
+        );
+    }
 
     return (
         <ShareLanding

--- a/lemma-frontend/components/agents/agent-contact-share.tsx
+++ b/lemma-frontend/components/agents/agent-contact-share.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import { Check, Copy } from '@/components/ui/icons';
+import { usePod } from '@/lib/hooks/use-pods';
+import { buildContactLink } from '@/lib/share/share-link';
+import type { ContactCardSpec } from '@/lib/share/contact-card';
+import { contactChannels } from '@/lib/share/contact-card';
+import { agentEmailAddress, getSurfaceIdentity, getSurfacePlatformKey } from '@/lib/utils/surfaces';
+import type { AssistantSurface } from '@/lib/types';
+
+interface AgentContactShareProps {
+    podId: string;
+    /**
+     * Where this responder lives in the workspace, e.g.
+     * `/pod/p1/agents/support_triage` or `/pod/p1/ai/assistant` for Lem. The
+     * share link wraps it, and the card page offers it as "Open it in Lemma".
+     */
+    workspacePath: string;
+    /** The display name, which is what goes on the card someone reads. */
+    agentName: string;
+    /** What the face is drawn from — an agent's identity, or `LEM_SEED` for Lem. */
+    seed: string;
+    iconUrl?: string | null;
+    description?: string | null;
+    /** True for Lem, whose name is the same in every pod. */
+    isAssistant?: boolean;
+    /**
+     * Only the surfaces that reach *this* responder, already filtered by the
+     * caller with the same predicate the reach row above uses. Passing the full
+     * list would advertise a bot whose DMs belong to somebody else.
+     */
+    surfaces: AssistantSurface[];
+}
+
+/** The handle a platform publishes, preferring the resolved reach over the stored one. */
+function handleFor(surfaces: AssistantSurface[], platform: string): string | null {
+    for (const surface of surfaces) {
+        if (getSurfacePlatformKey(surface) !== platform) continue;
+        const handle = surface.reach?.handle || getSurfaceIdentity(surface);
+        if (handle) return handle;
+    }
+    return null;
+}
+
+/**
+ * The card, as the agent's own page can mint it.
+ *
+ * Minting happens here because this is where the reach already is: the row above
+ * has just told someone they can talk to this agent on Telegram or WhatsApp, and
+ * the obvious next thought is to pass that on to a person who does not have a
+ * Lemma account. Everything the card needs is already loaded — no second fetch,
+ * and no endpoint that has to decide whether a stranger may ask.
+ *
+ * What it copies is a link, not a file. The `.vcf` is one click further on, on a
+ * page that also unfurls in the chat someone pastes it into — and a preview card
+ * with the agent's face on it is what makes the link worth opening. A bare file
+ * attachment says nothing until it is already saved.
+ *
+ * **Lem gets one too.** It is the pod's front door, so its card is the most
+ * useful one a pod can hand out — but it is also the same name and the same face
+ * in every pod, which no other agent is. So its card is named for the pod it
+ * answers for; without that, saving Lem from two pods leaves an address book with
+ * two identical rows and no way to tell which is which.
+ */
+export function AgentContactShare({
+    podId,
+    workspacePath,
+    agentName,
+    seed,
+    iconUrl,
+    description,
+    isAssistant,
+    surfaces,
+}: AgentContactShareProps) {
+    const [copied, setCopied] = useState(false);
+    // Already in cache — the workspace shell reads the same key on the way in.
+    const { data: pod } = usePod(podId);
+    const podName = pod?.name?.trim() || null;
+
+    const card: ContactCardSpec = {
+        // Lem's own name identifies it inside a pod and nowhere else. An address
+        // book is the "nowhere else".
+        name: isAssistant && podName ? `${agentName} · ${podName}` : agentName,
+        seed,
+        icon: iconUrl,
+        org: podName,
+        note: description,
+        telegram: handleFor(surfaces, 'TELEGRAM'),
+        whatsapp: handleFor(surfaces, 'WHATSAPP'),
+        email: agentEmailAddress(surfaces),
+    };
+
+    // Nowhere to reach it means no card worth sending. The reach row above still
+    // has something to say — "connect Telegram" — but a contact carrying no
+    // address is a promise this cannot keep.
+    //
+    // A handle shared with other pods is *not* that case, though an earlier
+    // version of this treated it as one. One number fronting many pods is the
+    // deployment's design, not a fault: a DM to it asks which pod was meant
+    // (`contended_surface_ids`), which is a step rather than a dead end — and
+    // excluding it hid the card from every pod that had not brought a bot of
+    // its own, which is nearly all of them.
+    if (contactChannels(card).length === 0) return null;
+
+    const copy = async () => {
+        const link = buildContactLink({
+            canonicalUrl: `${window.location.origin}${workspacePath}`,
+            card,
+        });
+        if (!link) {
+            toast.error('Could not build a contact link');
+            return;
+        }
+        try {
+            await navigator.clipboard.writeText(link);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1500);
+        } catch {
+            toast.error('Could not copy to clipboard');
+        }
+    };
+
+    return (
+        <button
+            type="button"
+            onClick={copy}
+            className="agent-home-reach-chip custom-focus-ring"
+            title="A link anyone can open to save this agent to their contacts"
+        >
+            {copied ? (
+                <Check className="h-4 w-4" aria-hidden="true" />
+            ) : (
+                <Copy className="h-4 w-4" aria-hidden="true" />
+            )}
+            <span>{copied ? 'Link copied' : 'Share my contact card'}</span>
+        </button>
+    );
+}

--- a/lemma-frontend/components/agents/agent-home.tsx
+++ b/lemma-frontend/components/agents/agent-home.tsx
@@ -28,7 +28,8 @@ import type { AssistantSurface, Conversation, Schedule } from '@/lib/types';
 import { describeScheduleConfig } from '@/lib/utils/schedules';
 import { formatRelativeTime } from '@/lib/utils/relative-time';
 import { formatAgentName } from '@/lib/utils/agents';
-import { LEM_SEED } from '@/lib/identity/seeded-identity';
+import { AgentContactShare } from '@/components/agents/agent-contact-share';
+import { LEM_SEED, agentIdentitySeed } from '@/lib/identity/seeded-identity';
 
 /**
  * One place someone can start talking to this agent, outside this app.
@@ -120,6 +121,8 @@ function reachTargets(surfaces: AssistantSurface[]): AgentReachTarget[] {
  */
 export function AgentHome({
     podId,
+    agentId,
+    agentSlug,
     agentName,
     description,
     iconUrl,
@@ -130,6 +133,17 @@ export function AgentHome({
     isAssistant,
 }: {
     podId: string;
+    /**
+     * The agent's id, which is what its face is seeded from.
+     *
+     * Separate from `agentName` because the name arriving here is already a
+     * *display* name — so seeding on it drew this page a different creature from
+     * the one in the sidebar, which seeds on the stored name, and a third from
+     * the header, which seeds on the id. See `agentIdentitySeed`.
+     */
+    agentId?: string | null;
+    /** The stored name, which is what `/pod/…/agents/…` routes on. */
+    agentSlug?: string | null;
     agentName: string;
     description?: string | null;
     iconUrl?: string | null;
@@ -158,9 +172,14 @@ export function AgentHome({
         router.push(`/pod/${encodeURIComponent(podId)}/conversations/new?${params.toString()}`);
     };
 
-    const reach = reachTargets(surfaces.filter((surface) => (isAssistant
+    /* Matched on the *stored* name, not the display one. `surfaceDefaultAgent`
+       compares against `surface.agent_name`, which is what the pod typed — so
+       an agent named `support_triage` was asking whether a surface answers for
+       "Support Triage" and getting no for every chip on the row. */
+    const reachableSurfaces = surfaces.filter((surface) => (isAssistant
         ? surfaceReachesDefaultAgent(surface)
-        : surfaceReachesAgent(surface, agentName))));
+        : surfaceReachesAgent(surface, agentSlug || agentName)));
+    const reach = reachTargets(reachableSurfaces);
 
     return (
         <div className="agent-home">
@@ -189,7 +208,7 @@ export function AgentHome({
                     alt=""
                     label={label}
                     identityKind="being"
-                    identitySeed={agentName}
+                    identitySeed={agentIdentitySeed({ id: agentId, name: agentName })}
                     identitySize={64}
                     className="agent-home-face h-16 w-16 rounded-2xl"
                 />
@@ -344,6 +363,25 @@ export function AgentHome({
                             </Link>
                         );
                     })}
+                    {/* Last in the row. Lem is included: it answers on the pod's
+                        own surfaces, which is an address worth handing out — and
+                        the card says which pod, since Lem's name does not. */}
+                    {isAssistant || agentSlug ? (
+                        <AgentContactShare
+                            podId={podId}
+                            workspacePath={
+                                isAssistant
+                                    ? `/pod/${encodeURIComponent(podId)}/ai/assistant`
+                                    : `/pod/${encodeURIComponent(podId)}/agents/${encodeURIComponent(agentSlug!)}`
+                            }
+                            agentName={label}
+                            seed={isAssistant ? LEM_SEED : agentIdentitySeed({ id: agentId, name: agentSlug })}
+                            iconUrl={iconUrl}
+                            description={description}
+                            isAssistant={isAssistant}
+                            surfaces={reachableSurfaces}
+                        />
+                    ) : null}
                 </div>
             ) : null}
 

--- a/lemma-frontend/components/agents/agent-identity-header.tsx
+++ b/lemma-frontend/components/agents/agent-identity-header.tsx
@@ -25,6 +25,7 @@ import { resolvePodDefaultRuntime } from '@/components/agents/agent-runtime-help
 import { podModelsHref } from '@/lib/navigation/pod-settings';
 import { formatAgentName } from '@/lib/utils/agents';
 import type { Agent } from '@/lib/types';
+import { agentIdentitySeed } from '@/lib/identity/seeded-identity';
 
 /**
  * Who this agent is — stated once, at the top of its page.
@@ -76,7 +77,7 @@ export function AgentIdentityHeader({
             label={label}
             imageClassName="object-contain p-1"
             className="h-full w-full rounded-xl"
-            identitySeed={agent.id || agent.name}
+            identitySeed={agentIdentitySeed(agent)}
             identitySize={32}
             fallback={(
                 <span className="resource-monogram flex h-full w-full items-center justify-center rounded-xl text-sm font-semibold">
@@ -198,7 +199,7 @@ export function AgentIdentityHeader({
                     </DialogHeader>
                     <AgentAvatarPicker
                         name={label}
-                        seed={agent.id || agent.name}
+                        seed={agentIdentitySeed(agent)}
                         value={agent.icon_url}
                         onChange={(iconUrl) => onUpdate({ icon_url: iconUrl || undefined })}
                     />

--- a/lemma-frontend/components/pod/workspace-sidebar.tsx
+++ b/lemma-frontend/components/pod/workspace-sidebar.tsx
@@ -56,7 +56,7 @@ import { flowsQueryOptions } from '@/lib/hooks/use-flows';
 import { useAccessiblePods, type AccessiblePod, type AccessiblePodGroup } from '@/lib/hooks/use-pods';
 import { useScopedConversations } from '@/lib/hooks/use-assistants';
 import { identityHueClass } from '@/lib/utils/resource-icon-value';
-import { LEM_SEED } from '@/lib/identity/seeded-identity';
+import { LEM_SEED, agentIdentitySeed } from '@/lib/identity/seeded-identity';
 import {
     filterSidebarConversations,
     getConversationMark,
@@ -899,7 +899,7 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
                                     title={displayName}
                                     className={cn(
                                         'lemma-sidebar-row workspace-sidebar-resource-row custom-focus-ring',
-                                        identityHueClass(agent.icon_url, agent.name),
+                                        identityHueClass(agent.icon_url, agentIdentitySeed(agent)),
                                     )}
                                 >
                                     <ResourceIcon
@@ -907,7 +907,7 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
                                         alt={`${displayName} icon`}
                                         label={displayName}
                                         identityKind="being"
-                                        identitySeed={agent.name}
+                                        identitySeed={agentIdentitySeed(agent)}
                                         identitySize={32}
                                         className="workspace-sidebar-resource-icon h-8 w-8 shrink-0 rounded-md"
                                     />

--- a/lemma-frontend/lib/analytics/catalog.test.ts
+++ b/lemma-frontend/lib/analytics/catalog.test.ts
@@ -85,6 +85,9 @@ describe("declared events are emitted or named as gaps", () => {
         // everything below it.
         const emitted = [
             "share_link.viewed",
+            // Both raised by app/s/[kind]/[...path]/contact-landing.tsx.
+            "share_link.contact_opened",
+            "share_link.contact_saved",
             "import.started",
             "client.error",
             // lib/analytics/onboarding.ts is the only emitter of these five.

--- a/lemma-frontend/lib/analytics/catalog.ts
+++ b/lemma-frontend/lib/analytics/catalog.ts
@@ -30,6 +30,13 @@ export const CLIENT_CATALOG = {
     /** A shared link opened. `kind` and `viewer_is_member` must stay identical to
      *  the backend entry of the same name. */
     "share_link.viewed": { properties: ["bundle_id", "kind", "viewer_is_member"] },
+    /** A contact card's channel row pressed — the moment the reader leaves for
+     *  Telegram, WhatsApp or their mail client. `channel` is the bounded
+     *  `ContactChannel` key and never the handle behind it, which is an address. */
+    "share_link.contact_opened": { properties: ["channel"] },
+    /** The vCard saved. The card's real conversion, and the last thing we can
+     *  see: everything after it happens in an address book we have no view of. */
+    "share_link.contact_saved": { properties: [] },
     /** The import button pressed — the step the server never sees, because an
      *  abandoned import makes no API call. */
     "import.started": { properties: ["bundle_id", "is_remix"] },

--- a/lemma-frontend/lib/identity/being-svg.test.ts
+++ b/lemma-frontend/lib/identity/being-svg.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { beingDataUri, renderBeingSvg } from './being-svg';
+import { IDENTITY_TONES } from './identity-palette';
+import { CRESTS, FORMS, identityGenes } from './seeded-identity';
+
+const SEEDS = ['a1b2c3d4', 'support-triage', 'Ops Bot', '__lem__', 'ग्राहक'];
+
+describe('a being, rendered outside the app', () => {
+    it.each(SEEDS)('draws %s the same way every time', (seed) => {
+        expect(renderBeingSvg({ seed })).toBe(renderBeingSvg({ seed }));
+    });
+
+    it('draws the body the component would have drawn', () => {
+        const genes = identityGenes('a1b2c3d4');
+        const svg = renderBeingSvg({ seed: 'a1b2c3d4' });
+        expect(svg).toContain(FORMS[genes.form]);
+        expect(svg).toContain(IDENTITY_TONES[genes.tone]);
+    });
+
+    /*
+     * The whole reason this renderer exists. A `currentColor` or a `var(--…)`
+     * surviving into the output is not a visual nit — there is no cascade where
+     * this is looked at, so the shape it names renders black or not at all, and
+     * the failure only shows up inside somebody's address book.
+     */
+    it.each(SEEDS)('leaves nothing for a stylesheet to resolve in %s', (seed) => {
+        const svg = renderBeingSvg({ seed });
+        expect(svg).not.toContain('currentColor');
+        expect(svg).not.toContain('var(--');
+    });
+
+    it('resolves the paints inside a crest, which are the ones that hide', () => {
+        // Find a seed whose crest is drawn at all — an empty crest would pass the
+        // assertion above without ever exercising the substitution.
+        const seed = SEEDS.find((candidate) => CRESTS[identityGenes(candidate).crest]);
+        expect(seed, 'no fixture seed rolls a crest').toBeDefined();
+        expect(CRESTS[identityGenes(seed!).crest]).toContain('currentColor');
+        expect(renderBeingSvg({ seed: seed! })).not.toContain('currentColor');
+    });
+
+    it('paints a ground by default and drops it on request', () => {
+        expect(renderBeingSvg({ seed: 'a1b2c3d4' })).toContain('<rect x="-2" y="-2"');
+        expect(renderBeingSvg({ seed: 'a1b2c3d4', background: false })).not.toContain(
+            '<rect x="-2" y="-2"',
+        );
+    });
+
+    it('gives Lem its own reserved body', () => {
+        expect(renderBeingSvg({ seed: '__lem__' })).toContain(FORMS[FORMS.length - 1]);
+    });
+
+    it('writes a size only when asked for one', () => {
+        expect(renderBeingSvg({ seed: 'a1', size: 256 })).toContain('width="256" height="256"');
+        expect(renderBeingSvg({ seed: 'a1' })).not.toContain('width="256"');
+    });
+
+    it('rounds the derived geometry instead of printing float noise', () => {
+        expect(renderBeingSvg({ seed: 'a1b2c3d4' })).not.toMatch(/\d\.\d{4,}/);
+    });
+
+    it('encodes a data URI that survives its own hex colours', () => {
+        const uri = beingDataUri({ seed: 'a1b2c3d4' });
+        expect(uri.startsWith('data:image/svg+xml;base64,')).toBe(true);
+        // A percent-encoded URI would have truncated at the first `#`.
+        expect(atob(uri.slice('data:image/svg+xml;base64,'.length))).toBe(
+            renderBeingSvg({ seed: 'a1b2c3d4' }),
+        );
+    });
+});

--- a/lemma-frontend/lib/identity/being-svg.ts
+++ b/lemma-frontend/lib/identity/being-svg.ts
@@ -1,0 +1,142 @@
+/**
+ * A seeded being, drawn as a standalone SVG string.
+ *
+ * `ResourceIdentity` already draws this creature, and draws it better: it
+ * animates, it carries a state pip, it re-colours itself when the appearance
+ * changes. What it cannot do is leave the app. It is a client component whose
+ * every fill is `currentColor` or a custom property, so the picture only exists
+ * where React mounted it and a stylesheet is in scope.
+ *
+ * A contact card needs the same face somewhere neither is true — inside a
+ * `PHOTO` property in a vCard, rasterised on the edge, opened in an address
+ * book. So this renders the same genes to a string with every colour already
+ * resolved, and imports the geometry — `FORMS`, `FORM_DEPTH`, `CRESTS` — from
+ * the same module the component draws from. Two renderers, one set of shapes:
+ * a body that changes in `seeded-identity.ts` changes in both, and the face on
+ * someone's phone stays the face in the sidebar.
+ *
+ * Deliberately **static and stateless**. The component varies eyes and pip by
+ * `IdentityState`, which is a live reading of what an agent is doing right now;
+ * a saved photo is looked at days later and would be lying by then. Every being
+ * here is drawn `idle` — eyes open, no pip — which is what the roster shows at
+ * rest anyway.
+ */
+
+import {
+    CRESTS,
+    FORMS,
+    FORM_DEPTH,
+    identityGenes,
+    type IdentityGenes,
+} from './seeded-identity';
+import {
+    IDENTITY_PUPIL,
+    IDENTITY_SCLERA,
+    IDENTITY_SHADE,
+    IDENTITY_SOFTS,
+    toneColor,
+} from './identity-palette';
+
+/** The component's viewBox, so a crest that rises above y=0 is not clipped off. */
+const VIEW_BOX = '-2 -2 104 104';
+
+export interface BeingSvgOptions {
+    /** Stable per resource — an id where one exists, a name only as a fallback. */
+    seed: string;
+    /** Pixel size written onto the root element, for rasterisers that need one. */
+    size?: number;
+    /**
+     * Paint the tone's tinted ground behind the body.
+     *
+     * On by default, and the default matters more here than in the app. The
+     * component draws on transparency because it sits on a surface the product
+     * controls; a contact photo is composited by an address book onto a ground
+     * nobody told us about, and a violet body on an unknown one is a coin flip.
+     */
+    background?: boolean;
+}
+
+/** Trim float noise — `8.960000000000001` is three bytes of vCard for nothing. */
+function round(value: number): number {
+    return Math.round(value * 1000) / 1000;
+}
+
+/**
+ * Resolve the two names the shared geometry leaves to the cascade.
+ *
+ * The strings in `seeded-identity.ts` are written for a stylesheet: crests
+ * stroke themselves in `currentColor` and the body rim reads
+ * `var(--identity-shade)`. Both are dead outside the app, and an unresolved
+ * paint does not fail loudly — it renders black, or renders nothing.
+ */
+function resolvePaints(markup: string, tone: string): string {
+    return markup
+        .replaceAll('currentColor', tone)
+        .replaceAll('var(--identity-shade)', IDENTITY_SHADE);
+}
+
+function eyes(genes: IdentityGenes): string {
+    const radius = genes.eyeR;
+    const centres = [50 - genes.eyeSpacing, 50 + genes.eyeSpacing];
+    const sclera = centres
+        .map(
+            (cx) =>
+                `<ellipse cx="${cx}" cy="${genes.eyeY}" rx="${radius}" ry="${round(radius * 1.12)}" fill="${IDENTITY_SCLERA}"/>`,
+        )
+        .join('');
+    const pupils = centres
+        .map(
+            (cx) =>
+                `<circle cx="${cx}" cy="${genes.eyeY}" r="${round(radius * 0.46)}" fill="${IDENTITY_PUPIL}"/>`,
+        )
+        .join('');
+    return sclera + pupils;
+}
+
+/**
+ * The being for a seed, as SVG markup.
+ *
+ * The layer order is the component's, and the order is load-bearing: the crest
+ * is drawn *under* the body so it reads as rising out of a solid crown rather
+ * than as a sticker laid on top, and the depth overlay is clipped to the body
+ * so a blunt half-plane can shade a curved silhouette without spilling past it.
+ */
+export function renderBeingSvg({ seed, size, background = true }: BeingSvgOptions): string {
+    const genes = identityGenes(seed);
+    const tone = toneColor(genes.tone);
+    const form = FORMS[genes.form] ?? FORMS[0];
+    // A clip path is referenced by id, and two of these can end up in one
+    // document — an OG card drawing a roster, say. Seeded from the genes rather
+    // than a counter so the markup stays a pure function of the seed.
+    const clipId = `lm-being-${genes.tone}${genes.form}${genes.crest}${genes.eyeSpacing}${genes.eyeY}`;
+    const dimensions = size ? ` width="${size}" height="${size}"` : '';
+
+    return [
+        `<svg xmlns="http://www.w3.org/2000/svg" viewBox="${VIEW_BOX}"${dimensions}>`,
+        `<defs><clipPath id="${clipId}"><path d="${form}"/></clipPath></defs>`,
+        background
+            ? `<rect x="-2" y="-2" width="104" height="104" fill="${IDENTITY_SOFTS[genes.tone] ?? IDENTITY_SOFTS[0]}"/>`
+            : '',
+        `<g fill="${tone}">${resolvePaints(CRESTS[genes.crest] ?? '', tone)}</g>`,
+        `<path d="${form}" fill="${tone}"/>`,
+        `<g clip-path="url(#${clipId})">${FORM_DEPTH[genes.form] ?? ''}</g>`,
+        `<path d="${form}" fill="none" stroke="${IDENTITY_SHADE}" stroke-opacity=".14" stroke-width="1.5"/>`,
+        eyes(genes),
+        '</svg>',
+    ].join('');
+}
+
+/**
+ * The same being as a `data:` URI.
+ *
+ * Base64 rather than percent-encoded: the markup carries `#` in every fill, and
+ * a raw `#` inside a data URI starts a fragment — the picture silently truncates
+ * at the first colour.
+ */
+export function beingDataUri(options: BeingSvgOptions): string {
+    const svg = renderBeingSvg(options);
+    // The markup is ASCII by construction — path data, hex colours, and an id
+    // built from integers — so `btoa` is safe and works on the edge, where
+    // `Buffer` does not exist.
+    return `data:image/svg+xml;base64,${btoa(svg)}`;
+}

--- a/lemma-frontend/lib/identity/identity-palette.test.ts
+++ b/lemma-frontend/lib/identity/identity-palette.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    IDENTITY_PUPIL,
+    IDENTITY_SCLERA,
+    IDENTITY_SHADE,
+    IDENTITY_SOFTS,
+    IDENTITY_STYLESHEET,
+    IDENTITY_TONES,
+    toneColor,
+} from './identity-palette';
+import { TONE_COUNT } from './seeded-identity';
+
+const frontendRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/**
+ * The light ramp, read out of the stylesheet's first `:root` block.
+ *
+ * Scoped to that block deliberately: `.dark` redeclares every one of these
+ * names, and a whole-file scan would happily match the dark value and call the
+ * palette correct while a contact photo drew a violet meant for a black ground.
+ */
+function stylesheetLightRamp(): Map<string, string> {
+    const css = readFileSync(join(frontendRoot, IDENTITY_STYLESHEET), 'utf8');
+    const start = css.indexOf(':root {');
+    expect(start, 'stylesheet has a :root block').toBeGreaterThanOrEqual(0);
+    const end = css.indexOf('}', start);
+    const block = css.slice(start, end);
+
+    const ramp = new Map<string, string>();
+    for (const [, name, value] of block.matchAll(/(--identity-[a-z0-9-]+)\s*:\s*([^;]+);/g)) {
+        ramp.set(name, value.trim());
+    }
+    return ramp;
+}
+
+describe('identity palette', () => {
+    const ramp = stylesheetLightRamp();
+
+    it('carries one tone per gene the generator can roll', () => {
+        expect(IDENTITY_TONES).toHaveLength(TONE_COUNT);
+        expect(IDENTITY_SOFTS).toHaveLength(TONE_COUNT);
+    });
+
+    it.each(IDENTITY_TONES.map((color, tone) => ({ tone, color })))(
+        'tone $tone matches the stylesheet',
+        ({ tone, color }) => {
+            expect(ramp.get(`--identity-tone-${tone}`)).toBe(color);
+        },
+    );
+
+    it.each(IDENTITY_SOFTS.map((color, tone) => ({ tone, color })))(
+        'soft $tone matches the stylesheet',
+        ({ tone, color }) => {
+            expect(ramp.get(`--identity-soft-${tone}`)).toBe(color);
+        },
+    );
+
+    it('matches the stylesheet on the values shared by every tone', () => {
+        expect(ramp.get('--identity-sclera')).toBe(IDENTITY_SCLERA);
+        expect(ramp.get('--identity-pupil')).toBe(IDENTITY_PUPIL);
+        expect(ramp.get('--identity-shade')).toBe(IDENTITY_SHADE);
+    });
+
+    it('never hands back nothing, whatever index it is asked for', () => {
+        // `tone` is a rolled integer today, but a stored variant or a widened
+        // TONE_COUNT could outrun the array, and a face with no fill is invisible
+        // rather than obviously wrong.
+        expect(toneColor(TONE_COUNT)).toBe(IDENTITY_TONES[0]);
+        expect(toneColor(TONE_COUNT * 3 + 2)).toBe(IDENTITY_TONES[2]);
+    });
+});

--- a/lemma-frontend/lib/identity/identity-palette.ts
+++ b/lemma-frontend/lib/identity/identity-palette.ts
@@ -1,0 +1,55 @@
+/**
+ * The identity palette, frozen as literals.
+ *
+ * `styles/features/resource-identity.css` is where these live for the product,
+ * as custom properties, so a body can re-colour itself when the appearance
+ * changes without re-rendering — the thing that file calls out as the reason a
+ * PNG mascot was never good enough.
+ *
+ * Nothing outside the app can read them. A contact photo is looked at inside
+ * someone's address book, and the being it draws has to arrive as pixels with
+ * its colour already in it: no stylesheet, no `currentColor`, no `.dark` class
+ * to answer to. `social-card.ts` hit the same wall on the edge and answered it
+ * the same way — frozen literals, stated as a deliberate exception rather than
+ * smuggled in as a default.
+ *
+ * **Light values only, on purpose.** A saved photo is a file, not a themed
+ * surface: it is copied into a contact app that paints whatever ground it likes
+ * and never tells us which. Shipping the dark ramp instead would put a `#8b7af5`
+ * body on a white contact card, which is the same mistake as `#e6e0ff` on
+ * `#131311` — the one the stylesheet already learned not to make.
+ *
+ * `identity-palette.test.ts` reads the stylesheet and compares, so a tone that
+ * moves there cannot leave a stale twin here.
+ */
+
+/** Where the values above are published for the product. Read by the test. */
+export const IDENTITY_STYLESHEET = 'styles/features/resource-identity.css';
+
+/** Jewel tones, indexed by `IdentityGenes.tone`. */
+export const IDENTITY_TONES: readonly string[] = [
+    '#5a3fd4',
+    '#11743c',
+    '#8a6400',
+    '#c22f15',
+    '#d97757',
+];
+
+/** The tinted grounds a mark sits on, indexed the same way. */
+export const IDENTITY_SOFTS: readonly string[] = [
+    '#e6e0ff',
+    '#d9f5e3',
+    '#f7edd4',
+    '#ffe1da',
+    '#f2ebe6',
+];
+
+export const IDENTITY_SCLERA = '#fdfcf8';
+export const IDENTITY_PUPIL = '#2b2924';
+/** Darkens whatever tone sits under it, so one value serves all five. */
+export const IDENTITY_SHADE = '#000000';
+
+/** The tone a set of genes draws in, wrapped so an out-of-range index cannot blank a face. */
+export function toneColor(tone: number): string {
+    return IDENTITY_TONES[tone % IDENTITY_TONES.length] ?? IDENTITY_TONES[0];
+}

--- a/lemma-frontend/lib/identity/seeded-identity.ts
+++ b/lemma-frontend/lib/identity/seeded-identity.ts
@@ -124,6 +124,27 @@ export function identitySeed(...parts: Array<string | null | undefined>): string
 }
 
 /**
+ * The one seed an agent is drawn from, wherever it is drawn.
+ *
+ * The rule above — id when there is one, name only as a fallback — was left to
+ * each call site to remember, and the sidebar forgot: it seeded its rows on
+ * `agent.name` while the agent's own header seeded on `agent.id`, so the same
+ * agent wore two different faces on two halves of one screen. Nothing catches
+ * that, because both faces are valid output for the seed each was handed.
+ *
+ * So the rule lives here now, and a caller passes the agent rather than a
+ * string. The fallback is still worth keeping: an agent being composed in the
+ * "new agent" flow has a name before it has an id, and a face that appears only
+ * after the first save would be worse than one that settles on it.
+ */
+export function agentIdentitySeed(agent: {
+    id?: string | null;
+    name?: string | null;
+}): string {
+    return agent.id?.trim() || agent.name?.trim() || '';
+}
+
+/**
  * The pod's default responder is the same creature in every pod, so its genes
  * are written down rather than rolled.
  *

--- a/lemma-frontend/lib/share/contact-card.test.ts
+++ b/lemma-frontend/lib/share/contact-card.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    buildVCard,
+    contactCardFilename,
+    contactCardParams,
+    contactChannels,
+    normalizeEmail,
+    normalizeTelegram,
+    normalizeWhatsApp,
+    readContactCardSpec,
+    type ContactCardSpec,
+} from './contact-card';
+
+const REVISION = new Date('2026-08-29T10:30:00.000Z');
+
+function spec(overrides: Partial<ContactCardSpec> = {}): ContactCardSpec {
+    return {
+        name: 'Support Triage',
+        seed: 'a1b2c3d4',
+        icon: null,
+        telegram: '@support_triage_bot',
+        whatsapp: '+15551234567',
+        email: 'triage@pod.lemma.work',
+        org: 'Acme Support',
+        note: 'Answers customer mail and files the rest.',
+        ...overrides,
+    };
+}
+
+/** Properties, unfolded, the way an importer reads them back. */
+function properties(vcard: string): string[] {
+    return vcard.replace(/\r\n /g, '').split('\r\n').filter(Boolean);
+}
+
+describe('normalizers', () => {
+    it('accepts the handle shapes each platform actually issues', () => {
+        expect(normalizeTelegram('support_bot')).toBe('@support_bot');
+        expect(normalizeTelegram('@support_bot')).toBe('@support_bot');
+        expect(normalizeWhatsApp('+1 (555) 123-4567')).toBe('+15551234567');
+        expect(normalizeWhatsApp('15551234567')).toBe('+15551234567');
+        expect(normalizeEmail('  Triage@Pod.Lemma.Work ')).toBe('triage@pod.lemma.work');
+    });
+
+    it('drops what it cannot vouch for rather than repairing it', () => {
+        expect(normalizeTelegram('a b')).toBeNull();
+        expect(normalizeTelegram('no')).toBeNull();
+        expect(normalizeTelegram('bad-handle!')).toBeNull();
+        expect(normalizeWhatsApp('call me')).toBeNull();
+        expect(normalizeWhatsApp('+0123')).toBeNull();
+        expect(normalizeEmail('triage@pod')).toBeNull();
+        expect(normalizeEmail('a b@pod.work')).toBeNull();
+    });
+});
+
+describe('reading a card off a link', () => {
+    it('round-trips a full card', () => {
+        const params = contactCardParams(spec());
+        const read = readContactCardSpec(params, 'Support Triage');
+        expect(read).toEqual(spec());
+    });
+
+    it('names nothing without a name', () => {
+        expect(readContactCardSpec(new URLSearchParams(), null)).toBeNull();
+        expect(readContactCardSpec(new URLSearchParams(), '   ')).toBeNull();
+    });
+
+    it('falls back to the name when the link carries no seed', () => {
+        const read = readContactCardSpec(new URLSearchParams(), 'Support Triage');
+        expect(read?.seed).toBe('Support Triage');
+    });
+
+    it('keeps a card that only some channels reached', () => {
+        const params = contactCardParams(spec({ whatsapp: null, email: null }));
+        const read = readContactCardSpec(params, 'Support Triage');
+        expect(read?.telegram).toBe('@support_triage_bot');
+        expect(read?.whatsapp).toBeNull();
+        expect(contactChannels(read!)).toHaveLength(1);
+    });
+
+    it('offers Telegram first, then WhatsApp, then mail', () => {
+        expect(contactChannels(spec()).map((channel) => channel.key)).toEqual([
+            'telegram',
+            'whatsapp',
+            'email',
+        ]);
+    });
+
+    it('builds links each platform actually opens', () => {
+        const channels = contactChannels(spec());
+        expect(channels[0].href).toBe('https://t.me/support_triage_bot');
+        expect(channels[1].href).toBe('https://wa.me/15551234567');
+        expect(channels[2].href).toBe('mailto:triage@pod.lemma.work');
+    });
+});
+
+describe('the vCard', () => {
+    it('writes the properties a contact app reads', () => {
+        const lines = properties(buildVCard(spec(), { revision: REVISION }));
+        expect(lines[0]).toBe('BEGIN:VCARD');
+        expect(lines[1]).toBe('VERSION:3.0');
+        expect(lines).toContain('FN:Support Triage');
+        expect(lines).toContain('ORG:Acme Support');
+        expect(lines).toContain('TEL;TYPE=CELL:+15551234567');
+        expect(lines).toContain('EMAIL;TYPE=INTERNET:triage@pod.lemma.work');
+        expect(lines).toContain('URL;TYPE=Telegram:https://t.me/support_triage_bot');
+        expect(lines).toContain('REV:20260829T103000Z');
+        expect(lines.at(-1)).toBe('END:VCARD');
+    });
+
+    it('ends every line, including the last, with CRLF', () => {
+        const vcard = buildVCard(spec(), { revision: REVISION });
+        expect(vcard.endsWith('END:VCARD\r\n')).toBe(true);
+        expect(vcard.includes('\n\n')).toBe(false);
+        for (const line of vcard.split('\r\n').slice(0, -1)) {
+            expect(line).not.toContain('\n');
+        }
+    });
+
+    it('keys two pods\' Lems apart, though they share a seed and a face', () => {
+        // Lem's seed is one constant across every pod. Keyed on the seed alone,
+        // saving a second pod's Lem would overwrite the first one in the address
+        // book — the same UID means "this contact", not "another contact".
+        const acme = buildVCard(spec({ name: 'Lem · Acme', seed: '__lem__' }), {
+            uid: 'pod-acme:__lem__',
+            revision: REVISION,
+        });
+        const beta = buildVCard(spec({ name: 'Lem · Beta', seed: '__lem__' }), {
+            uid: 'pod-beta:__lem__',
+            revision: REVISION,
+        });
+
+        expect(properties(acme)).toContain('UID:urn:lemma:agent:pod-acme:__lem__');
+        expect(properties(beta)).toContain('UID:urn:lemma:agent:pod-beta:__lem__');
+    });
+
+    it('falls back to the seed when no caller scopes the uid', () => {
+        expect(properties(buildVCard(spec(), { revision: REVISION }))).toContain(
+            'UID:urn:lemma:agent:a1b2c3d4',
+        );
+    });
+
+    it('keys the contact on the agent, not on its name', () => {
+        const renamed = buildVCard(spec({ name: 'Triage' }), { revision: REVISION });
+        expect(properties(renamed)).toContain('UID:urn:lemma:agent:a1b2c3d4');
+        expect(properties(buildVCard(spec(), { revision: REVISION }))).toContain(
+            'UID:urn:lemma:agent:a1b2c3d4',
+        );
+    });
+
+    /*
+     * The link is typed by anyone and the file is saved by someone who trusts it,
+     * so a value that can close its own property and open another is the whole
+     * risk this format carries.
+     */
+    it('cannot be talked into writing properties of its own', () => {
+        const params = new URLSearchParams({ o: 'Acme\r\nTEL;TYPE=CELL:+19998887777' });
+        const read = readContactCardSpec(params, 'Support\r\nEMAIL:evil@example.com');
+        const lines = properties(buildVCard(read!, { revision: REVISION }));
+
+        expect(lines).toContain('FN:Support EMAIL:evil@example.com');
+        expect(lines.some((line) => line.startsWith('EMAIL:'))).toBe(false);
+        expect(lines.some((line) => line.startsWith('TEL;TYPE=CELL:+19998887777'))).toBe(false);
+    });
+
+    it('escapes the separators a value is allowed to contain', () => {
+        const read = readContactCardSpec(new URLSearchParams(), 'Sales; Support, and C:\\Ops');
+        const lines = properties(buildVCard(read!, { revision: REVISION }));
+        expect(lines).toContain('FN:Sales\\; Support\\, and C:\\\\Ops');
+    });
+
+    it('folds a long property and unfolds back to what it was', () => {
+        const photo = { data: 'A'.repeat(4000), type: 'PNG' as const };
+        const vcard = buildVCard(spec(), { photo, revision: REVISION });
+
+        for (const line of vcard.split('\r\n')) {
+            expect(new TextEncoder().encode(line).length).toBeLessThanOrEqual(75);
+        }
+        expect(properties(vcard)).toContain(`PHOTO;ENCODING=b;TYPE=PNG:${photo.data}`);
+    });
+
+    it('folds multi-byte names without splitting a character', () => {
+        const name = 'ग्राहक सहायता एजेंट'.repeat(6);
+        const vcard = buildVCard(spec({ name, seed: 'a1' }), { revision: REVISION });
+
+        for (const line of vcard.split('\r\n')) {
+            expect(new TextEncoder().encode(line).length).toBeLessThanOrEqual(75);
+        }
+        expect(properties(vcard)).toContain(`FN:${name}`);
+        expect(vcard).not.toContain('\ufffd');
+    });
+
+    it('names the download after the agent', () => {
+        expect(contactCardFilename(spec())).toBe('support-triage.vcf');
+        expect(contactCardFilename(spec({ name: '???' }))).toBe('agent.vcf');
+    });
+});

--- a/lemma-frontend/lib/share/contact-card.ts
+++ b/lemma-frontend/lib/share/contact-card.ts
@@ -1,0 +1,357 @@
+/**
+ * An agent as a saveable contact.
+ *
+ * The end of "chat where you already chat" is that the agent stops being
+ * something you open and becomes a row in the address book, next to people. So
+ * this hands out a vCard: name, face, and the handles it answers on — saved to
+ * a phone, and from then on the agent is reachable the way a person is.
+ *
+ * Everything on the card rides in the link, exactly as `share-link.ts` does it,
+ * and for the same reason: the page renders for a stranger who will never hold
+ * a session, and `ResourceVisibility.PUBLIC` is documented as *never anonymous*.
+ * That is not a workaround here — a Telegram handle and a WhatsApp number are
+ * public addresses by construction. Handing them to strangers is the point of
+ * the card, so a link that carries them discloses nothing its sender did not
+ * mean to send.
+ *
+ * The cost is that a card is frozen when it is minted. A rotated bot token
+ * changes the handle, and the cards already saved in other people's phones keep
+ * the old one — nothing can reach in and correct them. `UID` and `REV` are what
+ * make that survivable: re-sharing the link updates the saved contact in place
+ * instead of adding a second one.
+ *
+ * This module is the spec both renderers draw from — the landing page and
+ * `/api/contact-card` — so the rows someone reads can never disagree with the
+ * file they save, the same arrangement `social-card.ts` has with its renderer.
+ */
+
+/**
+ * Query keys, kept to two characters.
+ *
+ * A contact card is the one share link that gets printed as a QR code, and QR
+ * density is driven by payload length — long keys cost scan reliability at the
+ * far end of a room.
+ */
+export const CONTACT_PARAMS = {
+    /** The identity the face is drawn from — the agent's id. See `agentIdentitySeed`. */
+    seed: 'sd',
+    /** Raw `icon_url`: an uploaded picture, a typed emoji, or a variant sentinel. */
+    icon: 'ic',
+    org: 'o',
+    note: 'd',
+    telegram: 'tg',
+    whatsapp: 'wa',
+    email: 'em',
+} as const;
+
+export interface ContactCardSpec {
+    name: string;
+    seed: string;
+    icon?: string | null;
+    org?: string | null;
+    note?: string | null;
+    /** Normalised to a leading `@`. */
+    telegram?: string | null;
+    /** Normalised to E.164. */
+    whatsapp?: string | null;
+    email?: string | null;
+}
+
+/** One row on the card: somewhere a person can actually start a conversation. */
+export interface ContactChannel {
+    key: 'telegram' | 'whatsapp' | 'email';
+    /**
+     * The surface platform behind the row, so the page can take its logo and
+     * label from the surface registry instead of keeping a second copy of both.
+     */
+    platform: 'TELEGRAM' | 'WHATSAPP' | 'RESEND';
+    label: string;
+    /** What to print — `@triage_bot`, `+1 555…`, an address. */
+    value: string;
+    /** Where the button goes. Always set; a row with no link is not a row. */
+    href: string;
+}
+
+/*
+ * Every value below arrives from a URL that anyone can type, and lands in a file
+ * someone saves to their phone. The formats are narrow on purpose: a handle is
+ * the character set Telegram allows and nothing else, a number is digits. What
+ * fails these is dropped rather than repaired — a card that silently omits a row
+ * is honest, a card that prints an attacker's text under the agent's name is not.
+ */
+const TELEGRAM_HANDLE = /^@?[A-Za-z0-9_]{4,32}$/;
+const E164 = /^\+?[1-9]\d{6,14}$/;
+const EMAIL = /^[^\s@,;:<>"'\\]+@[^\s@,;:<>"'\\]+\.[^\s@,;:<>"'\\]{2,}$/;
+
+/** Long enough for a sentence about the agent, short enough to keep the QR scannable. */
+const MAX_NOTE = 200;
+const MAX_NAME = 120;
+const MAX_ORG = 120;
+
+function clean(value: string | null | undefined, max: number): string | null {
+    // Control characters go first and unconditionally. A newline reaching the
+    // vCard writer is the whole injection surface — CRLF is the property
+    // separator, so one smuggled through a display name would let a link append
+    // properties of its own to a file somebody is about to trust.
+    const trimmed = value
+        ?.replace(/[\u0000-\u001f\u007f]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+    return trimmed ? trimmed.slice(0, max) : null;
+}
+
+export function normalizeTelegram(value: string | null | undefined): string | null {
+    const trimmed = clean(value, 33);
+    if (!trimmed || !TELEGRAM_HANDLE.test(trimmed)) return null;
+    return `@${trimmed.replace(/^@/, '')}`;
+}
+
+export function normalizeWhatsApp(value: string | null | undefined): string | null {
+    // Minted from a display phone number, which arrives spaced and bracketed the
+    // way the provider prints it; E.164 is what both `wa.me` and a phone's dialer
+    // want back.
+    const digits = clean(value, 24)?.replace(/[^\d+]/g, '');
+    if (!digits) return null;
+    const e164 = `+${digits.replace(/\+/g, '')}`;
+    return E164.test(e164) ? e164 : null;
+}
+
+export function normalizeEmail(value: string | null | undefined): string | null {
+    const trimmed = clean(value, 254)?.toLowerCase();
+    if (!trimmed || !EMAIL.test(trimmed)) return null;
+    return trimmed;
+}
+
+/** Read a card off a link, or null when the link names nothing to draw. */
+export function readContactCardSpec(
+    query: URLSearchParams,
+    name: string | null,
+): ContactCardSpec | null {
+    const displayName = clean(name, MAX_NAME);
+    if (!displayName) return null;
+
+    const spec: ContactCardSpec = {
+        name: displayName,
+        // The face falls back to the name only when the link carries no seed —
+        // the same id-or-name rule the workspace draws by.
+        seed: clean(query.get(CONTACT_PARAMS.seed), MAX_NAME) || displayName,
+        icon: clean(query.get(CONTACT_PARAMS.icon), 512),
+        org: clean(query.get(CONTACT_PARAMS.org), MAX_ORG),
+        note: clean(query.get(CONTACT_PARAMS.note), MAX_NOTE),
+        telegram: normalizeTelegram(query.get(CONTACT_PARAMS.telegram)),
+        whatsapp: normalizeWhatsApp(query.get(CONTACT_PARAMS.whatsapp)),
+        email: normalizeEmail(query.get(CONTACT_PARAMS.email)),
+    };
+    return spec;
+}
+
+/** The card's params, for building a link. Empty values are left out entirely. */
+export function contactCardParams(spec: ContactCardSpec): URLSearchParams {
+    const params = new URLSearchParams();
+    const entries: Array<[string, string | null | undefined]> = [
+        [CONTACT_PARAMS.seed, spec.seed === spec.name ? null : spec.seed],
+        [CONTACT_PARAMS.icon, spec.icon],
+        [CONTACT_PARAMS.org, spec.org],
+        [CONTACT_PARAMS.note, spec.note],
+        [CONTACT_PARAMS.telegram, normalizeTelegram(spec.telegram)],
+        [CONTACT_PARAMS.whatsapp, normalizeWhatsApp(spec.whatsapp)],
+        [CONTACT_PARAMS.email, normalizeEmail(spec.email)],
+    ];
+    for (const [key, value] of entries) {
+        if (value) params.set(key, value);
+    }
+    return params;
+}
+
+/**
+ * The rows to show, in the order they are worth offering.
+ *
+ * Telegram first: it is the one platform where an agent can hold an identity
+ * genuinely its own — its own bot, its own handle, at no cost — so it is the
+ * row most likely to be the agent rather than the pod it lives in.
+ */
+export function contactChannels(spec: ContactCardSpec): ContactChannel[] {
+    const channels: ContactChannel[] = [];
+    if (spec.telegram) {
+        channels.push({
+            key: 'telegram',
+            platform: 'TELEGRAM',
+            label: 'Telegram',
+            value: spec.telegram,
+            href: `https://t.me/${spec.telegram.replace(/^@/, '')}`,
+        });
+    }
+    if (spec.whatsapp) {
+        channels.push({
+            key: 'whatsapp',
+            platform: 'WHATSAPP',
+            label: 'WhatsApp',
+            value: spec.whatsapp,
+            href: `https://wa.me/${spec.whatsapp.replace(/\D/g, '')}`,
+        });
+    }
+    if (spec.email) {
+        channels.push({
+            key: 'email',
+            platform: 'RESEND',
+            label: 'Email',
+            value: spec.email,
+            href: `mailto:${spec.email}`,
+        });
+    }
+    return channels;
+}
+
+/**
+ * Where the `.vcf` for a card page lives.
+ *
+ * The two paths mirror each other segment for segment — `/s/contact/pod/…` and
+ * `/api/contact-card/pod/…` — so the page can point at its own file without
+ * either of them knowing how the other is routed.
+ */
+export function contactCardDownloadPath(
+    segments: string[] | undefined,
+    query: URLSearchParams,
+): string {
+    const path = (segments ?? []).filter(Boolean).map(encodeURIComponent).join('/');
+    const search = query.toString();
+    return `/api/contact-card/${path}${search ? `?${search}` : ''}`;
+}
+
+/** A filename someone can find again in their downloads. */
+export function contactCardFilename(spec: ContactCardSpec): string {
+    const slug = spec.name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+    return `${slug || 'agent'}.vcf`;
+}
+
+/**
+ * Escape a vCard TEXT value (RFC 2426 §2.4.2).
+ *
+ * `clean` has already taken the newlines, so this is the second of two passes
+ * rather than the only one — the separators a value could otherwise impersonate
+ * are `;` and `,`, and a literal backslash has to go first or it would escape
+ * the escapes.
+ */
+function escapeText(value: string): string {
+    return value
+        .replace(/\\/g, '\\\\')
+        .replace(/;/g, '\\;')
+        .replace(/,/g, '\\,')
+        .replace(/\r?\n/g, '\\n');
+}
+
+/**
+ * Fold to 75 octets (RFC 2426 §2.6), which is not optional in practice.
+ *
+ * An embedded photo is a single property some tens of kilobytes long, and the
+ * importers that reject an unfolded line do it by dropping the whole card — the
+ * failure people report as "it saved with a blank name".
+ *
+ * Measured in octets, not characters, and never split mid-sequence: an agent
+ * named in Devanagari folds at three bytes per glyph, and half a code point on
+ * each side of the break is mojibake in someone's address book.
+ */
+function foldLine(line: string): string {
+    const encoder = new TextEncoder();
+    if (encoder.encode(line).length <= 75) return line;
+
+    const parts: string[] = [];
+    let current = '';
+    let octets = 0;
+    // Continuation lines start with a space, which costs one of the 75.
+    const limit = () => (parts.length === 0 ? 75 : 74);
+
+    for (const char of line) {
+        const width = encoder.encode(char).length;
+        if (octets + width > limit()) {
+            parts.push(current);
+            current = '';
+            octets = 0;
+        }
+        current += char;
+        octets += width;
+    }
+    if (current) parts.push(current);
+
+    return parts.join('\r\n ');
+}
+
+export interface VCardPhoto {
+    /** Base64, already encoded. */
+    data: string;
+    /** vCard 3.0 names the format bare — `PNG`, `JPEG`. */
+    type: 'PNG' | 'JPEG';
+}
+
+/**
+ * The saveable file.
+ *
+ * **Version 3.0, not 4.0.** 4.0 is the better spec and the worse choice here:
+ * iOS, Android, Outlook and Google Contacts all read 3.0, and where they
+ * disagree about 4.0 they disagree silently. The same conservatism picks
+ * `TYPE=CELL` over a `TEL;VALUE=uri` and an embedded photo over a `URI` one.
+ */
+export function buildVCard(
+    spec: ContactCardSpec,
+    options: {
+        photo?: VCardPhoto | null;
+        url?: string | null;
+        revision?: Date;
+        /**
+         * What this contact *is*, across every mint of it. Defaults to the seed,
+         * which is the agent's own id and unique on its own.
+         *
+         * Passed separately because Lem breaks the assumption the seed encodes:
+         * its seed is one constant shared by every pod, so keying on it would
+         * make every pod's Lem the same contact — and saving a second one would
+         * silently overwrite the first in the address book. Callers that know
+         * the pod scope it; nothing else has to change.
+         */
+        uid?: string | null;
+    } = {},
+): string {
+    const lines: string[] = ['BEGIN:VCARD', 'VERSION:3.0'];
+    const name = escapeText(spec.name);
+
+    // N is structured (family;given;…) and its separators are real semicolons,
+    // so it is assembled from an escaped value rather than escaped as a whole.
+    lines.push(`N:;${name};;;`);
+    lines.push(`FN:${name}`);
+    if (spec.org) lines.push(`ORG:${escapeText(spec.org)}`);
+    lines.push('TITLE:Agent on Lemma');
+    if (spec.note) lines.push(`NOTE:${escapeText(spec.note)}`);
+
+    if (spec.whatsapp) lines.push(`TEL;TYPE=CELL:${escapeText(spec.whatsapp)}`);
+    if (spec.email) lines.push(`EMAIL;TYPE=INTERNET:${escapeText(spec.email)}`);
+    if (spec.telegram) {
+        const handle = spec.telegram.replace(/^@/, '');
+        // Two spellings of one fact: iOS renders `X-SOCIALPROFILE` as a tappable
+        // row, everything else at least keeps the URL. Neither is universal, and
+        // a contact that knows the handle but cannot show it is still worth more
+        // than one that dropped it.
+        lines.push(`URL;TYPE=Telegram:https://t.me/${handle}`);
+        lines.push(`X-SOCIALPROFILE;TYPE=telegram:https://t.me/${handle}`);
+    }
+    if (options.url) lines.push(`URL:${escapeText(options.url)}`);
+
+    if (options.photo) {
+        lines.push(`PHOTO;ENCODING=b;TYPE=${options.photo.type}:${options.photo.data}`);
+    }
+
+    // Stable across every mint of this agent's card, so re-sharing an updated
+    // link merges into the contact already saved rather than adding a twin.
+    lines.push(`UID:urn:lemma:agent:${escapeText(options.uid || spec.seed)}`);
+    lines.push(`REV:${formatRevision(options.revision ?? new Date())}`);
+    lines.push('END:VCARD');
+
+    // CRLF between properties and a trailing one at the end, both required.
+    return `${lines.map(foldLine).join('\r\n')}\r\n`;
+}
+
+/** `REV` takes a basic-format UTC timestamp — no separators, `Z` suffix. */
+function formatRevision(date: Date): string {
+    return `${date.toISOString().replace(/[-:]/g, '').replace(/\.\d{3}/, '')}`;
+}

--- a/lemma-frontend/lib/share/share-link.test.ts
+++ b/lemma-frontend/lib/share/share-link.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+    buildContactLink,
     buildShareLink,
     isShareKind,
     humanizeResourceName,
@@ -182,5 +183,68 @@ describe('humanizeResourceName', () => {
     it('keeps a name it cannot improve', () => {
         expect(humanizeResourceName('')).toBe('');
         expect(humanizeResourceName('/')).toBe('/');
+    });
+});
+
+describe('contact links', () => {
+    const card = {
+        name: 'Support Triage',
+        seed: 'a1b2c3d4',
+        telegram: '@support_triage_bot',
+        whatsapp: '+15551234567',
+        email: 'triage@pod.lemma.work',
+    };
+
+    it('is a share link with the card riding along', () => {
+        const link = buildContactLink({
+            canonicalUrl: 'https://lemma.work/pod/p1/agents/support_triage',
+            card,
+        });
+        const url = new URL(link!);
+
+        expect(url.pathname).toBe('/s/contact/pod/p1/agents/support_triage');
+        expect(url.searchParams.get('n')).toBe('Support Triage');
+        expect(url.searchParams.get('tg')).toBe('@support_triage_bot');
+        expect(url.searchParams.get('sd')).toBe('a1b2c3d4');
+    });
+
+    it('refuses a URL that is not a workspace one', () => {
+        expect(buildContactLink({ canonicalUrl: 'https://evil.example/pod/p1', card })).not.toBeNull();
+        expect(buildContactLink({ canonicalUrl: 'https://lemma.work/blog/x', card })).toBeNull();
+        expect(buildContactLink({ canonicalUrl: 'not a url', card })).toBeNull();
+    });
+
+    it('points at an agent, so a reader can ask whether they may see it', () => {
+        expect(resolveShareTarget('contact', ['pod', 'p1', 'agents', 'support_triage'])).toEqual({
+            podId: 'p1',
+            resourceType: 'agent',
+            resourceName: 'support_triage',
+        });
+    });
+
+    it('is a kind the router will accept', () => {
+        expect(isShareKind('contact')).toBe(true);
+    });
+
+    /*
+     * The card's params describe the picture on the share page and mean nothing
+     * to the workspace. Left in, an "Open it in Lemma" click would carry the
+     * agent's phone number into a member's address bar on the way to a page with
+     * no use for it.
+     */
+    it('leaves the card behind when it hands over to the workspace', () => {
+        const destination = resolveShareDestination(['pod', 'p1', 'agents', 'support_triage'], {
+            n: 'Support Triage',
+            tg: '@support_triage_bot',
+            wa: '+15551234567',
+            em: 'triage@pod.lemma.work',
+            sd: 'a1b2c3d4',
+            ic: 'lemma-identity:3',
+            o: 'Acme',
+            d: 'Answers mail.',
+            tab: 'orders',
+        });
+
+        expect(destination).toBe('/pod/p1/agents/support_triage?tab=orders');
     });
 });

--- a/lemma-frontend/lib/share/share-link.ts
+++ b/lemma-frontend/lib/share/share-link.ts
@@ -11,11 +11,21 @@
  * cannot leak anything the link itself did not already contain.
  */
 
+import { CONTACT_PARAMS, contactCardParams, type ContactCardSpec } from '@/lib/share/contact-card';
 import type { SocialCardVariant } from '@/lib/share/social-card';
 
 /** Short, URL-friendly names for the resource types that can be shared. */
 export type ShareKind =
     | 'agent'
+    /**
+     * An agent, shared to be *messaged* rather than opened.
+     *
+     * A second kind pointing at the same resource type, because the kind is the
+     * intent and not the type: `/s/agent/…` sends someone to the workspace, and
+     * this sends them to whichever of Telegram, WhatsApp or mail the agent
+     * already answers on — for a reader who may well never sign in at all.
+     */
+    | 'contact'
     | 'app'
     | 'workflow'
     | 'function'
@@ -57,6 +67,7 @@ interface ShareKindCopy {
 
 const SHARE_KIND_COPY: Record<ShareKind, ShareKindCopy> = {
     agent: { noun: 'Agent', article: 'an agent', variant: 'agent' },
+    contact: { noun: 'Contact', article: 'an agent you can message', variant: 'contact' },
     app: { noun: 'App', article: 'an app', variant: 'app' },
     workflow: { noun: 'Workflow', article: 'a workflow', variant: 'workflow' },
     function: { noun: 'Function', article: 'a function', variant: 'function' },
@@ -116,6 +127,36 @@ export function buildShareLink(input: {
 }
 
 /**
+ * A contact link, carrying the handles the agent answers on.
+ *
+ * Minted inside the workspace, where the reach is already on hand and the
+ * minter is already authorized to see it. From then on the link is the whole
+ * card: `/s/contact/…` reads it back without asking the backend anything, which
+ * is what lets the page render for someone who will never sign in.
+ */
+export function buildContactLink(input: {
+    /** Absolute canonical URL, e.g. https://lemma.work/pod/p1/agents/triage. */
+    canonicalUrl: string;
+    card: ContactCardSpec;
+}): string | null {
+    const base = buildShareLink({
+        kind: 'contact',
+        canonicalUrl: input.canonicalUrl,
+        name: input.card.name,
+    });
+    if (!base) return null;
+
+    const url = new URL(base);
+    for (const [key, value] of contactCardParams(input.card)) {
+        url.searchParams.set(key, value);
+    }
+    return url.toString();
+}
+
+/** Params that describe the card and mean nothing to the workspace. */
+const CARD_ONLY_PARAMS = new Set<string>(Object.values(CONTACT_PARAMS));
+
+/**
  * Rebuilds the workspace path a share link points at.
  *
  * Returns null unless the result is a workspace-relative `/pod/…` path. The
@@ -132,6 +173,12 @@ export function resolveShareDestination(
 
     const params = new URLSearchParams();
     for (const [key, value] of Object.entries(query ?? {})) {
+        // The rest of the query rides along verbatim because that is where apps
+        // and tables keep their identity. A card's handles are the exception:
+        // they describe the picture on the share page, and appending them to the
+        // workspace URL would put an agent's phone number in a member's address
+        // bar on the way to a page that has no use for it.
+        if (CARD_ONLY_PARAMS.has(key)) continue;
         if (key === SHARE_NAME_PARAM || value === undefined) continue;
         for (const entry of Array.isArray(value) ? value : [value]) {
             params.append(key, entry);
@@ -154,6 +201,8 @@ export interface ShareTarget {
 
 const RESOURCE_TYPE_BY_KIND: Record<ShareKind, ShareResourceType | null> = {
     agent: 'agent',
+    // A contact link points at an agent; only the intent differs.
+    contact: 'agent',
     app: 'app',
     workflow: 'workflow',
     function: 'function',

--- a/lemma-frontend/lib/share/social-card.ts
+++ b/lemma-frontend/lib/share/social-card.ts
@@ -50,6 +50,7 @@ export type SocialCardVariant =
     | 'join'
     | 'app'
     | 'agent'
+    | 'contact'
     | 'workflow'
     | 'function'
     | 'table'
@@ -127,6 +128,14 @@ const VARIANT_COPY: Record<
         eyebrow: 'AN AGENT ON LEMMA',
         title: 'A Lemma agent',
         detail: 'Give it the work. Watch what it does.',
+        label: 'lemma.work',
+        accent: '#e4b52d',
+        layer: 'agents',
+    },
+    contact: {
+        eyebrow: 'AN AGENT YOU CAN MESSAGE',
+        title: 'Save the contact.',
+        detail: 'Then talk to it where you already talk.',
         label: 'lemma.work',
         accent: '#e4b52d',
         layer: 'agents',


### PR DESCRIPTION
## What changes

An agent can be handed out as a saveable contact. Its home gains a **Share my
contact card** chip beside the reach row; the link it copies opens
`/s/contact/pod/…/agents/…`, a page showing the agent's face, the handles it
answers on, a QR, and a **Save contact** button that downloads a vCard. Saved,
the agent sits in a phone's address book next to people.

Lem gets one too, named for its pod.

Three bugs in the existing identity code are fixed along the way — see below.

## Why

An agent already answers on Telegram, WhatsApp and mail, but the only way to
pass that reach to someone was to type the handle out. A contact card is the end
of "chat where you already chat": the agent stops being something you open and
becomes a row in the address book.

**Everything rides in the link**, the way every other `/s/…` page works and for
the same reason. The page answers a reader who has no session and never will,
and `ResourceVisibility.PUBLIC` is documented as *never anonymous*. A Telegram
handle is a public address by construction, so a link carrying one discloses
nothing its sender did not mean to send — and no new endpoint has to decide
whether a stranger may ask. **No backend change, no new visibility tier.**

**The face could not travel.** `ResourceIdentity` fills every shape with
`currentColor` or a custom property, so the creature only exists where React
mounted it with a stylesheet in scope — useless inside a vCard `PHOTO`.
`being-svg.ts` renders the same genes to a string with the paints resolved,
importing the geometry from the module the component draws from so the two
cannot diverge. `identity-palette.ts` freezes the light ramp, with a test that
fails if `resource-identity.css` moves a tone.

### Bugs fixed

- **The identity seed had drifted four ways.** The sidebar seeded an agent on
  its stored name, its header on its id, its own home on its *display* name — so
  one agent wore up to three different faces across the app. Nothing caught it,
  because each face is valid output for the seed it was handed.
  `agentIdentitySeed` holds the rule now.
- **The agent home's reach row was empty for most agents.** It matched the
  display name against `surface.agent_name`, which holds the stored one, so an
  agent named `support_triage` asked whether a surface answers for "Support
  Triage" and got no for every chip.
- **Lem's card would have eaten contacts.** `LEM_SEED` is one constant in every
  pod, so keying the vCard `UID` on the seed made every pod's Lem the *same*
  contact — saving a second would silently overwrite the first. The `UID` is now
  scoped to the pod; the seed still draws Lem's own face everywhere.

### Reviewer notes

- **vCard escaping is a security boundary, not tidiness.** Every value arrives
  from a URL anyone can type and lands in a file someone saves and trusts. CRLF
  is the property separator, so an unescaped newline in a display name would let
  a link append `TEL:`/`EMAIL:` properties of its own. Values are stripped of
  control characters, then escaped per RFC 2426; handles are narrow allowlists
  and what fails is dropped rather than repaired. There is a test that tries the
  injection.
- **The icon fetch is allowlisted against SSRF.** The uploaded-picture path runs
  on our origin with a URL from the query, so it is gated on a published origin
  *and* the managed `/public/icons/` route, with a timeout and a size cap.
- **vCard 3.0, not 4.0** — the interop floor across iOS, Android, Outlook and
  Google Contacts. Lines fold at 75 octets on character boundaries; an unfolded
  photo is what makes an importer drop a card with a blank name.
- **The card states its audience.** Inbound senders resolve to a Lemma user, and
  an unrecognised one gets a signup or pod-access link rather than the agent
  (`surface_inbound.py:192`). The page carries the promise the reach card
  already makes inside the workspace, worded for someone not yet in the pod. A
  card handed to a stranger does **not** currently reach the agent; letting an
  agent opt into answering unresolved senders is follow-up work that touches the
  authorization seam and is deliberately not in this PR.
- **A saved card is frozen at mint time.** A rotated bot token strands copies
  already in address books; `UID` + `REV` make re-sharing a repair rather than a
  duplicate. True revocation would need the anonymous visibility tier that
  `ResourceVisibility` currently refuses — worth its own discussion.

## How to verify

```bash
cd lemma-frontend && npm run check && npm test
```

```
Design audit passed productStrict=0 informational=103 protectedAssistant=1
check-edu-anchors: 9 anchors verified.
Test Files  105 passed (105)
     Tests  1158 passed (1158)
```

Manually, against a dev server:

```bash
curl -s "http://localhost:3000/api/contact-card/pod/p1/agents/support_triage?n=Support+Triage&sd=a1b2c3d4&tg=%40support_triage_bot&wa=%2B15551234567&em=triage%40pod.lemma.work" | head -20
```

Returns `text/vcard` with a real 8.9 KB PNG of the agent's own generated face,
no line over 75 octets, and a `URL` back to its page. The page itself renders in
light and dark, on mobile, with and without channels, and unfurls with the new
`contact` social-card variant. Two pods' Lem cards were checked for distinct
`UID`s (`p1:__lem__` vs `p2:__lem__`).

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload; vCard
      injection and SSRF both closed and tested; no new authorization surface
      (nothing is read from the backend for an anonymous reader)
- [x] **Rollback** — pure revert. No migration, no API change, no persisted
      state. Links already minted stop resolving; vCards already saved keep
      working, since they hold platform handles rather than anything of ours.

Not applicable: no migrations, and no API surface change — the frontend reads
`agent.surface.list`, which already returned `reach`.

## Compatibility and rollback notes

Nothing to migrate and nothing to roll forward. The one durable artifact is the
vCard in someone's address book, which contains only handles the platforms
themselves own.
