### PR TITLE
Put adding people in the room, and let sharing finish without a Save button

### DIFF
--- a/lemma-frontend/app/pod/[id]/ai/page.tsx
+++ b/lemma-frontend/app/pod/[id]/ai/page.tsx
@@ -512,7 +512,6 @@ function AgentProfileCard({
                                 resourceName={formatAgentName(agent.name)}
                                 shareUrl={agentShareUrl}
                                 onChange={onShareVisibilityChange}
-                                className="contents"
                                 trigger={({ openShare, disabled }) => (
                                     <DropdownMenuItem
                                         disabled={disabled}

--- a/lemma-frontend/app/pod/[id]/app/pages/page.tsx
+++ b/lemma-frontend/app/pod/[id]/app/pages/page.tsx
@@ -266,7 +266,6 @@ export default function AppPagesRoute({ params }: { params: Promise<{ id: string
                                                     onChange={async (visibility: ResourceVisibilityValue) => {
                                                         await updateAppVisibility({ podId, name: appName, visibility });
                                                     }}
-                                                    className="contents"
                                                     trigger={({ openShare, disabled }) => (
                                                         <DropdownMenuItem
                                                             disabled={disabled}

--- a/lemma-frontend/app/pod/[id]/flows/page.tsx
+++ b/lemma-frontend/app/pod/[id]/flows/page.tsx
@@ -760,7 +760,6 @@ function WorkflowCard({
                                 resourceName={flow.name}
                                 shareUrl={workflowShareUrl}
                                 onChange={onShareVisibilityChange}
-                                className="contents"
                                 trigger={({ openShare, disabled }) => (
                                     <DropdownMenuItem
                                         disabled={disabled}

--- a/lemma-frontend/app/pod/[id]/settings/members/page.tsx
+++ b/lemma-frontend/app/pod/[id]/settings/members/page.tsx
@@ -7,6 +7,7 @@ import { formatDistanceToNow } from 'date-fns';
 import { toast } from 'sonner';
 
 import { ProtectedRoute } from '@/components/auth/protected-route';
+import { AddPeopleDialog } from '@/components/members/add-people-dialog';
 import { PodSettingsShell } from '@/components/pod/pod-settings-shell';
 import { ResourceMetricButton, ResourceMetricStrip } from '@/components/pod/resource-layout';
 import { DestructiveConfirmationDialog } from '@/components/shared/destructive-confirmation-dialog';
@@ -22,7 +23,6 @@ import {
     DialogFooter,
     DialogHeader,
     DialogTitle,
-    DialogTrigger,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import {
@@ -32,13 +32,10 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { useInviteMember, useOrganizationInvitations, useOrganizationMembers, useRevokeInvitation } from '@/lib/hooks/use-organizations';
-import { useApps } from '@/lib/hooks/use-app';
+import { useOrganizationInvitations, useOrganizationMembers, useRevokeInvitation } from '@/lib/hooks/use-organizations';
 import { useApprovePodJoinRequest, usePodJoinRequests } from '@/lib/hooks/use-pod-join-requests';
 import {
     usePodMembers,
-    useAddPodMember,
     useRemovePodMember,
     useUpdatePodMemberRoles,
     usePodRoles,
@@ -51,7 +48,6 @@ import { usePodAccess } from '@/lib/hooks/use-pod-access';
 import { usePod } from '@/lib/hooks/use-pods';
 import { useProfile } from '@/lib/hooks/use-user';
 import { OrganizationRole, PodRole } from '@/lib/types';
-import { buildPodInviteRedirectUri, getPodInviteRedirectOptions } from '@/lib/utils/invite-redirects';
 import { PodSettingsLedgerFill } from '@/components/pod/route-skeletons';
 import { SettingsPanel } from '@/components/settings/settings-kit';
 import { StepLoader } from '@/components/brand/loader';
@@ -79,7 +75,6 @@ function PodMembersPageContent({ params }: { params: Promise<{ id: string }> }) 
     const { data: pod } = usePod(podId);
     const { data: profile } = useProfile();
     const { data: membersData, isLoading: loadingMembers } = usePodMembers(podId);
-    const { data: apps = [] } = useApps(podId);
     const { data: orgMembersData } = useOrganizationMembers(pod?.organization_id || '');
     const { data: invitationsData, isLoading: loadingInvitations } = useOrganizationInvitations(pod?.organization_id || '');
     const {
@@ -107,11 +102,9 @@ function PodMembersPageContent({ params }: { params: Promise<{ id: string }> }) 
 
     const { mutate: removeMember, isPending: isRemoving } = useRemovePodMember(podId);
     const { mutate: updateRoles, isPending: isUpdatingRoles } = useUpdatePodMemberRoles(podId);
-    const { mutate: addMember, isPending: isAdding } = useAddPodMember(podId);
     const { data: rolesData } = usePodRoles(podId);
     const { data: permissionCatalogData } = usePodPermissionCatalog(podId);
     const { mutate: approveJoinRequest, isPending: isApprovingJoinRequest } = useApprovePodJoinRequest(podId);
-    const { mutate: inviteMember, isPending: isInviting } = useInviteMember(pod?.organization_id || '');
     const { mutate: revokeInvitation, isPending: isRevokingInvitation } = useRevokeInvitation(pod?.organization_id || '');
     const { mutate: createPodRole, isPending: isCreatingRole } = useCreatePodRole(podId);
     const { mutate: updatePodRole, isPending: isSavingRole } = useUpdatePodRole(podId);
@@ -119,12 +112,6 @@ function PodMembersPageContent({ params }: { params: Promise<{ id: string }> }) 
 
     const [addDialogOpen, setAddDialogOpen] = useState(false);
     const [createRoleDialogOpen, setCreateRoleDialogOpen] = useState(false);
-    const [selectedOrgMemberId, setSelectedOrgMemberId] = useState('');
-    const [selectedRole, setSelectedRole] = useState<PodRole>(PodRole.POD_USER);
-    const [inviteEmail, setInviteEmail] = useState('');
-    const [inviteOrgRole, setInviteOrgRole] = useState<OrganizationRole>(OrganizationRole.ORG_MEMBER);
-    const [invitePodRole, setInvitePodRole] = useState<PodRole>(PodRole.POD_USER);
-    const [selectedInviteRedirectUri, setSelectedInviteRedirectUri] = useState<string | null>(null);
     const [revokingInvitationId, setRevokingInvitationId] = useState<string | null>(null);
     const [memberPendingRemove, setMemberPendingRemove] = useState<{ id: string; label: string } | null>(null);
     const [invitationPendingRevoke, setInvitationPendingRevoke] = useState<{ id: string; email: string } | null>(null);
@@ -150,22 +137,6 @@ function PodMembersPageContent({ params }: { params: Promise<{ id: string }> }) 
     const activeEditingRoleName = editingRoleName || roles[0]?.name || null;
     const editingRole = roles.find((role) => role.name === activeEditingRoleName) || null;
     const groupedPermissions = useMemo(() => groupPermissionCatalog(permissionCatalog), [permissionCatalog]);
-    const defaultInviteRedirectUri = useMemo(
-        () => buildPodInviteRedirectUri({
-            podId,
-            podRole: invitePodRole,
-            apps,
-        }),
-        [apps, invitePodRole, podId]
-    );
-    const redirectOptions = useMemo(
-        () => getPodInviteRedirectOptions({ podId, apps }),
-        [apps, podId]
-    );
-    const inviteRedirectUri = redirectOptions.some((option) => option.value === selectedInviteRedirectUri)
-        ? selectedInviteRedirectUri as string
-        : defaultInviteRedirectUri;
-
     const resolveApprovalConfig = (requestId: string) =>
         approvalConfigByRequestId[requestId] || {
             orgRole: OrganizationRole.ORG_MEMBER,
@@ -190,53 +161,6 @@ function PodMembersPageContent({ params }: { params: Promise<{ id: string }> }) 
                 },
             };
         });
-    };
-
-    const handleAddMember = () => {
-        if (!canManageMembers || !selectedOrgMemberId) return;
-
-        addMember(
-            { organization_member_id: selectedOrgMemberId, role: selectedRole },
-            {
-                onSuccess: () => {
-                    toast.success('Member added to pod');
-                    setAddDialogOpen(false);
-                    setSelectedOrgMemberId('');
-                    setSelectedRole(PodRole.POD_USER);
-                },
-                onError: (err) => toast.error(`Failed to add member: ${err.message}`),
-            }
-        );
-    };
-
-    const handleInviteByEmail = () => {
-        const email = inviteEmail.trim();
-        if (!email || !pod?.organization_id) return;
-        if (!canInviteByEmail) {
-            toast.error('Only organization owners and editors can invite new people by email.');
-            return;
-        }
-
-        inviteMember(
-            {
-                email,
-                role: inviteOrgRole,
-                pod_id: podId,
-                pod_role: invitePodRole,
-                redirect_uri: inviteRedirectUri.trim() || defaultInviteRedirectUri,
-            },
-            {
-                onSuccess: () => {
-                    toast.success(`Invitation sent to ${email}`);
-                    setAddDialogOpen(false);
-                    setInviteEmail('');
-                    setInviteOrgRole(OrganizationRole.ORG_MEMBER);
-                    setInvitePodRole(PodRole.POD_USER);
-                    setSelectedInviteRedirectUri(null);
-                },
-                onError: (err) => toast.error(getInviteErrorMessage(err)),
-            }
-        );
     };
 
     const handleRevokeInvitation = () => {
@@ -369,146 +293,13 @@ function PodMembersPageContent({ params }: { params: Promise<{ id: string }> }) 
             podId={podId}
             title="Members"
             action={canManageMembers ? (
-                <Dialog open={addDialogOpen} onOpenChange={setAddDialogOpen}>
-                    <DialogTrigger asChild>
-                        <Button variant="primary" className="gap-2">
-                            <Plus className="h-4 w-4" />
-                            Add person
-                        </Button>
-                    </DialogTrigger>
-                    <DialogContent className="sm:max-w-[520px] gap-3">
-                        <DialogHeader className="pr-8">
-                            <DialogTitle>Add access to pod</DialogTitle>
-                            <DialogDescription>
-                                Invite by email or add an existing organization member.
-                            </DialogDescription>
-                        </DialogHeader>
-                        <Tabs defaultValue={canInviteByEmail ? 'email' : 'existing'} className="pt-2">
-                            <TabsList className={`grid w-full ${canInviteByEmail ? 'grid-cols-2' : 'grid-cols-1'}`}>
-                                {canInviteByEmail ? <TabsTrigger value="email">Invite by email</TabsTrigger> : null}
-                                <TabsTrigger value="existing">Existing member</TabsTrigger>
-                            </TabsList>
-                            {canInviteByEmail ? (
-                                <TabsContent value="email" className="mt-4 space-y-3">
-                                    <div className="space-y-1.5">
-                                        <label htmlFor="pod-invite-email" className="text-sm font-medium">Email</label>
-                                        <Input
-                                            id="pod-invite-email"
-                                            type="email"
-                                            autoComplete="email"
-                                            placeholder="person@example.com"
-                                            value={inviteEmail}
-                                            onChange={(event) => setInviteEmail(event.target.value)}
-                                        />
-                                    </div>
-                                    <div className="grid gap-3 sm:grid-cols-2">
-                                        <div className="space-y-1.5">
-                                            <label className="text-sm font-medium">Organization role</label>
-                                            <Select value={inviteOrgRole} onValueChange={(value) => setInviteOrgRole(value as OrganizationRole)}>
-                                                <SelectTrigger>
-                                                    <SelectValue />
-                                                </SelectTrigger>
-                                                <SelectContent>
-                                                    <SelectItem value={OrganizationRole.ORG_OWNER}>Owner</SelectItem>
-                                                    <SelectItem value={OrganizationRole.ORG_EDITOR}>Editor</SelectItem>
-                                                    <SelectItem value={OrganizationRole.ORG_MEMBER}>Member</SelectItem>
-                                                </SelectContent>
-                                            </Select>
-                                        </div>
-                                        <div className="space-y-1.5">
-                                            <label className="text-sm font-medium">Pod role</label>
-                                            <Select value={invitePodRole} onValueChange={(value) => setInvitePodRole(value as PodRole)}>
-                                                <SelectTrigger>
-                                                    <SelectValue />
-                                                </SelectTrigger>
-                                                <SelectContent>
-                                                    <SelectItem value={PodRole.POD_ADMIN}>Admin</SelectItem>
-                                                    <SelectItem value={PodRole.POD_EDITOR}>Editor</SelectItem>
-                                                    <SelectItem value={PodRole.POD_USER}>User</SelectItem>
-                                                    <SelectItem value={PodRole.POD_VIEWER}>Viewer</SelectItem>
-                                                </SelectContent>
-                                            </Select>
-                                        </div>
-                                    </div>
-                                    <div className="space-y-1.5">
-                                        <label htmlFor="pod-invite-redirect" className="text-sm font-medium">Redirect after accept</label>
-                                        <Select
-                                            value={inviteRedirectUri}
-                                            onValueChange={setSelectedInviteRedirectUri}
-                                        >
-                                            <SelectTrigger id="pod-invite-redirect">
-                                                <SelectValue />
-                                            </SelectTrigger>
-                                            <SelectContent>
-                                                {redirectOptions.map((option) => (
-                                                    <SelectItem key={option.value} value={option.value}>
-                                                        {option.label}
-                                                    </SelectItem>
-                                                ))}
-                                            </SelectContent>
-                                        </Select>
-                                        <p className="break-all text-xs text-[var(--text-tertiary)]">
-                                            {inviteRedirectUri}
-                                        </p>
-                                    </div>
-                                    <DialogFooter className="pt-1">
-                                        <Button variant="quiet" onClick={() => setAddDialogOpen(false)}>Cancel</Button>
-                                        <Button variant="primary" onClick={handleInviteByEmail} disabled={!inviteEmail.trim() || !pod?.organization_id || isInviting}>
-                                            {isInviting ? 'Sending...' : 'Send invite'}
-                                        </Button>
-                                    </DialogFooter>
-                                </TabsContent>
-                            ) : null}
-                            <TabsContent value="existing" className="mt-4 space-y-3">
-                                {!canInviteByEmail ? (
-                                    <div className="surface-panel-muted px-4 py-3 text-sm text-[var(--text-secondary)]">
-                                        Only organization owners and editors can invite new people by email. You can still add existing organization members to this pod.
-                                    </div>
-                                ) : null}
-                                <div className="space-y-1.5">
-                                    <label className="text-sm font-medium">Member</label>
-                                    <Select value={selectedOrgMemberId} onValueChange={setSelectedOrgMemberId}>
-                                        <SelectTrigger>
-                                            <SelectValue placeholder="Select a member" />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            {availableMembers.map((member) => (
-                                                <SelectItem key={member.id} value={member.id}>
-                                                    {member.user?.full_name || member.user?.email || 'Unknown User'}
-                                                </SelectItem>
-                                            ))}
-                                            {availableMembers.length === 0 ? (
-                                                <div className="p-2 text-center text-sm text-[var(--text-tertiary)]">No more members to add</div>
-                                            ) : null}
-                                        </SelectContent>
-                                    </Select>
-                                </div>
-                                <div className="space-y-1.5">
-                                    <label className="text-sm font-medium">Role</label>
-                                    <Select value={selectedRole} onValueChange={(value) => setSelectedRole(value as PodRole)}>
-                                        <SelectTrigger>
-                                            <SelectValue />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            <SelectItem value={PodRole.POD_ADMIN}>Admin</SelectItem>
-                                            <SelectItem value={PodRole.POD_EDITOR}>Editor</SelectItem>
-                                            <SelectItem value={PodRole.POD_USER}>User</SelectItem>
-                                            <SelectItem value={PodRole.POD_VIEWER}>Viewer</SelectItem>
-                                        </SelectContent>
-                                    </Select>
-                                </div>
-                                <DialogFooter className="pt-1">
-                                    <Button variant="quiet" onClick={() => setAddDialogOpen(false)}>Cancel</Button>
-                                    <Button variant="primary" onClick={handleAddMember} disabled={!selectedOrgMemberId || isAdding}>
-                                        {isAdding ? 'Adding...' : 'Add member'}
-                                    </Button>
-                                </DialogFooter>
-                            </TabsContent>
-                        </Tabs>
-                    </DialogContent>
-                </Dialog>
+                <Button variant="primary" className="gap-2" onClick={() => setAddDialogOpen(true)}>
+                    <Plus className="h-4 w-4" />
+                    Add people
+                </Button>
             ) : null}
         >
+            <AddPeopleDialog podId={podId} open={addDialogOpen} onOpenChange={setAddDialogOpen} />
             {/* The view strip and the "Add person" action are known before the
                 member list is, so the wait fills the ledger and leaves the rest
                 of the page where it already was. */}

--- a/lemma-frontend/app/s/[kind]/[...path]/page.tsx
+++ b/lemma-frontend/app/s/[kind]/[...path]/page.tsx
@@ -7,6 +7,7 @@ import {
     isShareKind,
     resolveShareDestination,
     resolveShareName,
+    resolveSharePodId,
     resolveShareTarget,
     SHARE_NAME_PARAM,
     type ShareKind,
@@ -46,8 +47,9 @@ async function readShare({ params, searchParams }: SharePageProps) {
     // Resolved on the server from the link alone — no backend call, so this page
     // still renders for a crawler that will never hold a session.
     const target = resolveShareTarget(kind, raw.path, query);
+    const podId = resolveSharePodId(raw.path);
 
-    return { kind, copy, destination, name, card, target };
+    return { kind, copy, destination, name, card, target, podId };
 }
 
 export async function generateMetadata(props: SharePageProps): Promise<Metadata> {
@@ -96,6 +98,7 @@ export default async function SharePage(props: SharePageProps) {
             name={share.name}
             kind={share.kind}
             target={share.target}
+            podId={share.podId}
             article={share.copy.article}
             detail={share.card.detail}
             cardPath={socialCardPath({

--- a/lemma-frontend/app/s/[kind]/[...path]/share-landing.tsx
+++ b/lemma-frontend/app/s/[kind]/[...path]/share-landing.tsx
@@ -26,6 +26,8 @@ interface ShareLandingProps {
     kind: ShareKind;
     /** What the link points at, or null when it names no readable resource. */
     target: ShareTarget | null;
+    /** The pod the link lives in — set for a pod link, which has no target. */
+    podId: string | null;
 }
 
 /**
@@ -44,9 +46,17 @@ interface ShareLandingProps {
  * it points at, and bouncing a member into the workspace answered a question
  * they had not asked — losing the document they came for, and their place in a
  * long one. Members get the same page with an "Open in pod" button on it, which
- * is the workspace offered rather than imposed. Two cases still redirect: a pod
- * link, which names no resource to render, and a member who cannot read this
- * particular resource, where only the pod can explain itself.
+ * is the workspace offered rather than imposed. One case still redirects: a
+ * member who cannot read this particular resource, where only the pod can
+ * explain itself.
+ *
+ * A pod link is the other half of that. It names no resource, so a member is
+ * still sent straight into the workspace — but everyone else used to be sent
+ * there too, and landed on an access wall. That made the one link you would
+ * actually paste into a group chat the one link that could not let anybody in,
+ * while `/s/agent/…` two routes over has offered `JoinPodPanel` all along. A
+ * pod link now makes the same offer, and the pod's own join policy decides
+ * whether it lands instantly or waits for an admin.
  */
 export function ShareLanding({
     destination,
@@ -56,24 +66,28 @@ export function ShareLanding({
     cardPath,
     kind,
     target,
+    podId,
 }: ShareLandingProps) {
     const router = useRouter();
     const { isAuthenticated, isLoading } = useLemmaAuth();
+    // A link naming a pod and nothing inside it.
+    const isPodLink = !target && Boolean(podId);
+    const accessPodId = target?.podId ?? podId;
 
     // Does this reader have the pod itself? `pods.get` is the cheapest honest
     // question — it is exactly what the workspace shell asks first, so agreeing
     // with it means no one is redirected into a wall.
     const { data: hasPodAccess, isPending: isCheckingPod } = useQuery({
-        queryKey: ['share-pod-access', target?.podId],
+        queryKey: ['share-pod-access', accessPodId],
         queryFn: async () => {
             try {
-                await getLemmaClient().pods.get(target!.podId);
+                await getLemmaClient().pods.get(accessPodId!);
                 return true;
             } catch {
                 return false;
             }
         },
-        enabled: Boolean(isAuthenticated && target),
+        enabled: Boolean(isAuthenticated && accessPodId),
         retry: false,
         staleTime: 30_000,
     });
@@ -107,8 +121,14 @@ export function ShareLanding({
 
     useEffect(() => {
         if (isLoading || !isAuthenticated) return;
-        // No addressable resource (a pod link) — keep the old behaviour and let
-        // the workspace explain itself.
+        if (isPodLink) {
+            // A member already has the workspace; anyone else is shown the ask
+            // rather than the wall.
+            if (hasPodAccess === true) router.replace(destination);
+            return;
+        }
+        // A malformed link that names neither a resource nor a pod. Nothing to
+        // render, so the workspace explains itself as it always did.
         if (!target) {
             router.replace(destination);
             return;
@@ -117,12 +137,15 @@ export function ShareLanding({
         // rendered here and the pod is the only place that can say why, so this
         // is the one case that still redirects.
         if (hasPodAccess && preview === null) router.replace(destination);
-    }, [isAuthenticated, isLoading, destination, router, target, hasPodAccess, preview]);
+    }, [isAuthenticated, isLoading, destination, router, target, isPodLink, hasPodAccess, preview]);
 
     // The pod check only decides whether an "Open in pod" button appears, so it
     // no longer holds the document up — except when there is no preview to show,
     // where it is what separates "redirect a member" from "ask to join".
     const isResolving = isLoading
+        // A pod link has nothing to draw until the membership answer is in: the
+        // card and the join ask would only flash before the redirect.
+        || (isAuthenticated && isPodLink && (isCheckingPod || hasPodAccess === true))
         || (isAuthenticated && Boolean(target) && isCheckingPreview)
         || (isAuthenticated && Boolean(target) && !preview && isCheckingPod)
         || (isAuthenticated && Boolean(target) && !preview && hasPodAccess === true);
@@ -150,6 +173,15 @@ export function ShareLanding({
     }
 
     const isDeniedToSignedInReader = isAuthenticated && Boolean(target) && !preview;
+    // Who to offer the way in to, and null when there is nothing to ask for —
+    // a signed-out reader signs in first, and a member is already through.
+    const joinPodId = !isAuthenticated
+        ? null
+        : isPodLink && hasPodAccess === false
+            ? podId
+            : isDeniedToSignedInReader
+                ? target?.podId ?? null
+                : null;
 
     return (
         <main className="flex min-h-dvh items-center justify-center px-6 py-16">
@@ -172,6 +204,8 @@ export function ShareLanding({
                     <p className="mt-1 text-sm text-[var(--text-secondary)]">
                         {isDeniedToSignedInReader ? (
                             'This isn’t shared with you. It may have been deleted, or it may only be open to the pod it lives in.'
+                        ) : joinPodId ? (
+                            `${name ? `${name} is a pod` : 'This is a pod'} on Lemma — the people, agents and work inside one boundary.`
                         ) : (
                             <>
                                 {name ? `${name} is ${article} on Lemma. ` : ''}
@@ -181,11 +215,16 @@ export function ShareLanding({
                     </p>
                 </div>
 
-                {isDeniedToSignedInReader && target ? (
+                {joinPodId ? (
                     // The ask belongs at the refusal, not somewhere else in the
                     // product the reader has no way to find.
                     <div className="mt-6">
-                        <JoinPodPanel podId={target.podId} />
+                        <JoinPodPanel
+                            podId={joinPodId}
+                            intro={isPodLink
+                                ? 'You’re not in this pod yet. Join it to open the workspace and everything the pod shares.'
+                                : undefined}
+                        />
                     </div>
                 ) : (
                     <div className="mt-6 flex flex-col items-center gap-3">

--- a/lemma-frontend/components/documents/document-space.tsx
+++ b/lemma-frontend/components/documents/document-space.tsx
@@ -18,6 +18,7 @@ import { toast } from 'sonner';
 
 import { DocumentViewer } from '@/components/documents/document-viewer';
 import { FileIndexStatusBadge } from '@/components/documents/file-index-status-badge';
+import { FileTypeIcon } from '@/components/documents/file-type-icon';
 import {
     FolderUploadConfirmDialog,
     FolderUploadProgress,
@@ -810,7 +811,6 @@ export function DocumentSpace({ podId }: { podId: string }) {
                             resourceName={entry.name}
                             shareUrl={buildShareableHref(entry)}
                             onChange={(visibility) => handleShareEntryVisibilityChange(entry, visibility)}
-                            className="contents"
                             trigger={({ openShare, disabled }) => (
                                 <DropdownMenuItem
                                     disabled={disabled}
@@ -848,7 +848,9 @@ export function DocumentSpace({ podId }: { podId: string }) {
                         className="document-space-entry-button custom-focus-ring flex min-w-0 flex-1 items-center gap-2.5 rounded text-left"
                     >
                         <span className="flex h-5 w-5 shrink-0 items-center justify-center">
-                            <ProductIcon kind={folder ? 'folders' : 'docs'} size="sm" />
+                            {folder
+                                ? <ProductIcon kind="folders" size="sm" />
+                                : <FileTypeIcon filename={entry.name} size="sm" />}
                         </span>
                         <span className="min-w-0 flex-1 truncate text-[var(--text-primary)]">{entry.name}</span>
                         {/* What a row is, how big it is, whether the pod can read

--- a/lemma-frontend/components/documents/document-viewer.tsx
+++ b/lemma-frontend/components/documents/document-viewer.tsx
@@ -10,7 +10,6 @@ import {
     CopyCheck,
     Download,
     Eye,
-    File as FileIcon,
     FileText,
     Maximize2,
     Minimize2,
@@ -30,6 +29,7 @@ import { usePodTopbar } from '@/components/pod/pod-topbar-context';
 import { resourceAllows } from '@/lib/authz/resource-actions';
 import { isPersonalPath } from '@/lib/files/doc-sections';
 import { FileIndexStatusBadge } from '@/components/documents/file-index-status-badge';
+import { FileTypeIcon } from '@/components/documents/file-type-icon';
 import {
     MarkdownAttachmentControl,
     canAttachDocumentMarkdown,
@@ -705,7 +705,7 @@ export function DocumentViewer({
 
         topbar?.setTopbar({
             title: doc?.name || documentPath,
-            icon: <FileIcon className="h-4 w-4" />,
+            icon: <FileTypeIcon filename={doc?.name || documentPath} size="sm" />,
             meta: doc ? <FileIndexStatusBadge file={doc} /> : undefined,
             backHref: topbarBackHref,
             backLabel: topbarBackLabel || backLabel,

--- a/lemma-frontend/components/documents/file-index-status-badge.tsx
+++ b/lemma-frontend/components/documents/file-index-status-badge.tsx
@@ -55,6 +55,17 @@ const STATE_CONFIG: Record<
     },
 };
 
+/**
+ * Says something only when there is something to say.
+ *
+ * "Searchable" is the steady state of every document in the pod, so a green
+ * pill announcing it appeared on every file, in every list, next to every
+ * title — a badge that is always on is not a status, it is decoration, and it
+ * sat in the doc header competing with the filename for the eye. The three
+ * states worth a badge are the ones that break the expectation: still
+ * indexing, indexing failed, or stored without being indexed at all — that
+ * last one being the answer to "why can't the agent find this file?".
+ */
 export function FileIndexStatusBadge({
     file,
     className,
@@ -65,6 +76,7 @@ export function FileIndexStatusBadge({
     if (!file?.status) return null;
 
     const state = resolveIndexState(file.status);
+    if (state === 'searchable') return null;
     const config = STATE_CONFIG[state];
     const Icon = config.icon;
     const title = state === 'failed' && file.last_processing_error

--- a/lemma-frontend/components/documents/file-type-icon.tsx
+++ b/lemma-frontend/components/documents/file-type-icon.tsx
@@ -27,56 +27,68 @@ const sizeClasses = {
     xl: 'w-12 h-12',
 };
 
-const iconColors = {
-    document: 'text-[var(--state-info)]',
-    spreadsheet: 'text-[var(--state-success)]',
-    presentation: 'text-[var(--state-warning)]',
-    pdf: 'text-[var(--state-error)]',
-    image: 'text-[var(--state-info)]',
-    video: 'text-[var(--state-error)]',
-    audio: 'text-[var(--state-info)]',
-    code: 'text-[var(--state-success)]',
-    json: 'text-[var(--state-warning)]',
-    archive: 'text-[var(--state-warning)]',
-    text: 'text-[var(--text-tertiary)]',
-    default: 'text-[var(--text-tertiary)]',
-};
+/**
+ * What kind of file this is — the shape, and nothing else.
+ *
+ * There used to be a colour per kind here, and every one of them was a *state*
+ * token: `--state-error` for PDFs, `--state-success` for spreadsheets and
+ * source files, `--state-warning` for slides, JSON and archives. A PDF is not
+ * an error and a `.py` is not a success. It is the same mistake the presence
+ * avatars were built out of, and the note there puts it best: a hue cannot mean
+ * two things at once, so a hue that means "failed" somewhere else cannot also
+ * mean "this is a PDF".
+ *
+ * The glyph already carries the type, legibly, at 16px. So the icon inherits
+ * `currentColor` and sits at `--text-tertiary` by default; a caller that wants
+ * it tinted passes a class.
+ */
+export type FileKind =
+    | 'document'
+    | 'spreadsheet'
+    | 'presentation'
+    | 'pdf'
+    | 'image'
+    | 'video'
+    | 'audio'
+    | 'code'
+    | 'json'
+    | 'archive'
+    | 'text'
+    | 'default';
 
-export function getFileType(filename: string): keyof typeof iconColors {
+export function getFileType(filename: string): FileKind {
     const ext = filename.split('.').pop()?.toLowerCase() || '';
 
     // Documents
-    if (['doc', 'docx', 'odt', 'rtf'].includes(ext)) return 'document';
-    if (['xls', 'xlsx', 'csv', 'ods'].includes(ext)) return 'spreadsheet';
-    if (['ppt', 'pptx', 'odp'].includes(ext)) return 'presentation';
+    if (['doc', 'docx', 'odt', 'rtf', 'pages'].includes(ext)) return 'document';
+    if (['xls', 'xlsx', 'csv', 'tsv', 'ods', 'numbers', 'parquet'].includes(ext)) return 'spreadsheet';
+    if (['ppt', 'pptx', 'odp', 'key'].includes(ext)) return 'presentation';
     if (ext === 'pdf') return 'pdf';
 
     // Media
-    if (['jpg', 'jpeg', 'png', 'gif', 'svg', 'webp', 'bmp', 'ico'].includes(ext)) return 'image';
+    if (['jpg', 'jpeg', 'png', 'gif', 'svg', 'webp', 'bmp', 'ico', 'avif', 'heic'].includes(ext)) return 'image';
     if (['mp4', 'avi', 'mov', 'wmv', 'flv', 'webm', 'mkv'].includes(ext)) return 'video';
     if (['mp3', 'wav', 'ogg', 'flac', 'm4a', 'aac'].includes(ext)) return 'audio';
 
     // Code
-    if (['js', 'ts', 'jsx', 'tsx', 'py', 'rb', 'go', 'rs', 'java', 'c', 'cpp', 'h', 'hpp', 'cs', 'php', 'swift', 'kt'].includes(ext)) return 'code';
-    if (['json', 'yaml', 'yml', 'toml'].includes(ext)) return 'json';
-    if (['html', 'css', 'scss', 'sass', 'less'].includes(ext)) return 'code';
+    if (['js', 'ts', 'jsx', 'tsx', 'mjs', 'cjs', 'py', 'rb', 'go', 'rs', 'java', 'c', 'cpp', 'h', 'hpp', 'cs', 'php', 'swift', 'kt', 'sh', 'bash', 'zsh', 'sql', 'r', 'lua'].includes(ext)) return 'code';
+    if (['json', 'jsonl', 'yaml', 'yml', 'toml', 'xml', 'ini', 'env'].includes(ext)) return 'json';
+    if (['html', 'htm', 'css', 'scss', 'sass', 'less'].includes(ext)) return 'code';
 
     // Archives
-    if (['zip', 'rar', '7z', 'tar', 'gz', 'bz2'].includes(ext)) return 'archive';
+    if (['zip', 'rar', '7z', 'tar', 'gz', 'bz2', 'xz'].includes(ext)) return 'archive';
 
     // Text
-    if (['txt', 'md', 'markdown', 'log'].includes(ext)) return 'text';
+    if (['txt', 'md', 'mdx', 'markdown', 'log', 'rst'].includes(ext)) return 'text';
 
     return 'default';
 }
 
 export function FileTypeIcon({ filename, className, size = 'md' }: FileTypeIconProps) {
     const fileType = getFileType(filename);
-    const sizeClass = sizeClasses[size];
-    const colorClass = iconColors[fileType];
 
     const iconProps = {
-        className: cn(sizeClass, colorClass, className),
+        className: cn(sizeClasses[size], 'text-[var(--text-tertiary)]', className),
     };
 
     switch (fileType) {

--- a/lemma-frontend/components/members/add-people-dialog.tsx
+++ b/lemma-frontend/components/members/add-people-dialog.tsx
@@ -1,0 +1,564 @@
+'use client';
+
+import { useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
+import { ChevronDown, Copy, Mail, X } from '@/components/ui/icons';
+
+import { Button } from '@/components/ui/button';
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from '@/components/ui/command';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { useApps } from '@/lib/hooks/use-app';
+import { useOrganizationMembers, useInviteMember } from '@/lib/hooks/use-organizations';
+import { usePodAccess } from '@/lib/hooks/use-pod-access';
+import { useAddPodMember, usePodMembers } from '@/lib/hooks/use-pod-members';
+import { usePod } from '@/lib/hooks/use-pods';
+import { useProfile } from '@/lib/hooks/use-user';
+import { buildShareLink } from '@/lib/share/share-link';
+import { OrganizationRole, PodJoinPolicy, PodRole } from '@/lib/types';
+import {
+    buildPodInviteRedirectUri,
+    getPodInviteRedirectOptions,
+    getSiteOrigin,
+} from '@/lib/utils/invite-redirects';
+import { cn } from '@/lib/utils';
+
+/**
+ * Adding someone to a pod.
+ *
+ * One field. You type who, not what kind of record they are.
+ *
+ * The surface this replaces asked for the taxonomy first — a tab bar reading
+ * "Invite by email" / "Existing member" — which is the membership table leaking
+ * into the one moment a person is thinking about a person. Nobody knows offhand
+ * whether Priya already has a row in `organization_members`; they know they
+ * want Priya in the pod. So the box takes a name or an email, matches
+ * colleagues as you type, and offers to invite the address when it matches
+ * nobody. Which endpoint that becomes is ours to work out, not theirs.
+ *
+ * Everything that is genuinely about *this* addition stays on screen: who, and
+ * what they can do here. The two knobs that are about the invitation *email* —
+ * the organization role it grants and where it lands afterwards — sit behind a
+ * disclosure that only exists once there is an email invite to send, because
+ * until then they decide nothing.
+ */
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** How the pod's own policy answers someone who opens the invite link. */
+const JOIN_POLICY_HINT: Record<string, string> = {
+    [PodJoinPolicy.INVITE_ONLY]: 'Whoever opens it can ask to join, and you approve the request.',
+    [PodJoinPolicy.ORG_MEMBERS]: 'Anyone in your organization who opens it joins straight away.',
+    [PodJoinPolicy.PUBLIC]: 'Anyone with a Lemma account who opens it joins straight away.',
+};
+
+const POD_ROLE_OPTIONS: Array<{ value: PodRole; label: string; hint: string }> = [
+    { value: PodRole.POD_ADMIN, label: 'Admin', hint: 'Runs the pod, including who else is in it.' },
+    { value: PodRole.POD_EDITOR, label: 'Editor', hint: 'Builds and changes what the pod is made of.' },
+    { value: PodRole.POD_USER, label: 'User', hint: 'Uses the pod day to day.' },
+    { value: PodRole.POD_VIEWER, label: 'Viewer', hint: 'Reads, changes nothing.' },
+];
+
+/** A person the composer is holding, before anything has been committed. */
+type Draft =
+    | { key: string; kind: 'member'; organizationMemberId: string; name: string; email: string | null }
+    | { key: string; kind: 'email'; email: string };
+
+function isEmail(value: string): boolean {
+    return EMAIL_PATTERN.test(value.trim());
+}
+
+function initialOf(label: string): string {
+    const trimmed = label.trim();
+    return trimmed ? trimmed[0].toUpperCase() : '?';
+}
+
+function inviteErrorMessage(error: Error): string {
+    const details = error as Error & { code?: string };
+    if (details.code === 'IDENTITY_ACCESS_DENIED') {
+        return 'Only organization owners and editors can invite people by email.';
+    }
+    return error.message;
+}
+
+export function AddPeopleDialog({
+    podId,
+    open,
+    onOpenChange,
+}: {
+    podId: string;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}) {
+    const podAccess = usePodAccess(podId);
+
+    if (!podAccess.can('pod.member.manage')) return null;
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="gap-0 sm:max-w-[560px]">
+                {/* Radix unmounts this on close, which is the whole reset: a
+                    half-typed name never survives into the next time you open
+                    the box, and no effect has to remember to clear it. */}
+                <AddPeopleComposer podId={podId} onClose={() => onOpenChange(false)} />
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function AddPeopleComposer({ podId, onClose }: { podId: string; onClose: () => void }) {
+    const podAccess = usePodAccess(podId);
+    const { data: pod } = usePod(podId);
+    const { data: profile } = useProfile();
+    const organizationId = pod?.organization_id || '';
+    const { data: membersData } = usePodMembers(podId);
+    const { data: orgMembersData } = useOrganizationMembers(organizationId);
+    const { data: apps = [] } = useApps(podId);
+
+    const { mutateAsync: addMember } = useAddPodMember(podId);
+    const { mutateAsync: inviteMember } = useInviteMember(organizationId);
+
+    const [drafts, setDrafts] = useState<Draft[]>([]);
+    const [query, setQuery] = useState('');
+    const [podRole, setPodRole] = useState<PodRole>(PodRole.POD_USER);
+    const [orgRole, setOrgRole] = useState<OrganizationRole>(OrganizationRole.ORG_MEMBER);
+    const [chosenRedirectUri, setChosenRedirectUri] = useState<string | null>(null);
+    const [advancedOpen, setAdvancedOpen] = useState(false);
+    const [submitting, setSubmitting] = useState(false);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const members = useMemo(() => membersData?.items || [], [membersData?.items]);
+    const orgMembers = useMemo(() => orgMembersData?.items || [], [orgMembersData?.items]);
+
+    const canManageMembers = podAccess.can('pod.member.manage');
+    const currentOrgRole = orgMembers.find((member) => member.user_id === profile?.id)?.role;
+    const canInviteByEmail =
+        canManageMembers &&
+        (currentOrgRole === OrganizationRole.ORG_OWNER || currentOrgRole === OrganizationRole.ORG_EDITOR);
+
+    // Everyone in the organization who is not already in the pod and not
+    // already sitting in the composer.
+    const candidates = useMemo(() => {
+        const inPod = new Set(members.map((member) => member.user_id));
+        const drafted = new Set(
+            drafts.flatMap((draft) => (draft.kind === 'member' ? [draft.organizationMemberId] : [])),
+        );
+
+        return orgMembers
+            .filter((member) => !inPod.has(member.user_id) && !drafted.has(member.id))
+            .map((member) => ({
+                id: member.id,
+                name: member.user?.full_name
+                    || [member.user?.first_name, member.user?.last_name].filter(Boolean).join(' ').trim()
+                    || member.user?.email
+                    || 'Unknown person',
+                email: member.user?.email || null,
+            }));
+    }, [drafts, members, orgMembers]);
+
+    const trimmedQuery = query.trim();
+    const matches = useMemo(() => {
+        if (!trimmedQuery) return candidates.slice(0, 50);
+        const needle = trimmedQuery.toLowerCase();
+        return candidates
+            .filter((candidate) =>
+                candidate.name.toLowerCase().includes(needle)
+                || (candidate.email || '').toLowerCase().includes(needle))
+            .slice(0, 50);
+    }, [candidates, trimmedQuery]);
+
+    const draftedEmails = useMemo(
+        () => new Set(drafts.map((draft) => (draft.kind === 'email' ? draft.email : draft.email || '').toLowerCase())),
+        [drafts],
+    );
+    // Only offered once the address matches nobody we could simply add: a
+    // colleague already in the organization is added, never re-invited.
+    const offersInvite =
+        isEmail(trimmedQuery)
+        && !draftedEmails.has(trimmedQuery.toLowerCase())
+        && !candidates.some((candidate) => candidate.email?.toLowerCase() === trimmedQuery.toLowerCase())
+        && !members.some((member) => (member.user_email || '').toLowerCase() === trimmedQuery.toLowerCase());
+
+    const emailDrafts = drafts.filter((draft): draft is Extract<Draft, { kind: 'email' }> => draft.kind === 'email');
+    const hasEmailInvites = emailDrafts.length > 0;
+
+    const redirectOptions = useMemo(
+        () => getPodInviteRedirectOptions({ podId, apps }),
+        [apps, podId],
+    );
+    const defaultRedirectUri = useMemo(
+        () => buildPodInviteRedirectUri({ podId, podRole, apps }),
+        [apps, podId, podRole],
+    );
+    const redirectUri = redirectOptions.some((option) => option.value === chosenRedirectUri)
+        ? (chosenRedirectUri as string)
+        : defaultRedirectUri;
+
+    const inviteLink = useMemo(
+        () => buildShareLink({
+            kind: 'pod',
+            canonicalUrl: `${getSiteOrigin()}/pod/${podId}`,
+            name: pod?.name,
+        }),
+        [pod?.name, podId],
+    );
+    const joinPolicyHint = JOIN_POLICY_HINT[String(pod?.config?.join_policy || PodJoinPolicy.INVITE_ONLY)]
+        ?? JOIN_POLICY_HINT[PodJoinPolicy.INVITE_ONLY];
+
+    const addDraft = (draft: Draft) => {
+        setDrafts((current) => [...current, draft]);
+        setQuery('');
+        inputRef.current?.focus();
+    };
+
+    const addEmailDraft = (email: string) => {
+        if (!canInviteByEmail) {
+            toast.error('Only organization owners and editors can invite people by email.');
+            return;
+        }
+        addDraft({ key: `email:${email.toLowerCase()}`, kind: 'email', email: email.trim() });
+    };
+
+    const removeDraft = (key: string) => {
+        setDrafts((current) => current.filter((draft) => draft.key !== key));
+    };
+
+    /** A list pasted from a spreadsheet or a mail client becomes chips, not one
+     *  unusable line of text. */
+    const handlePaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
+        const text = event.clipboardData.getData('text');
+        if (!/[\s,;]/.test(text)) return;
+
+        const emails = Array.from(new Set(
+            text.split(/[\s,;]+/).map((part) => part.trim()).filter(isEmail),
+        ));
+        if (emails.length === 0) return;
+
+        event.preventDefault();
+        if (!canInviteByEmail) {
+            toast.error('Only organization owners and editors can invite people by email.');
+            return;
+        }
+
+        const byEmail = new Map(candidates.map((candidate) => [candidate.email?.toLowerCase(), candidate]));
+        const additions: Draft[] = [];
+        for (const email of emails) {
+            const key = email.toLowerCase();
+            if (draftedEmails.has(key) || additions.some((draft) => draft.key.endsWith(key))) continue;
+            // Someone already in the organization is added outright — pasting a
+            // list should not mail an invitation to the desk next to you.
+            const known = byEmail.get(key);
+            if (known) {
+                additions.push({
+                    key: `member:${known.id}`,
+                    kind: 'member',
+                    organizationMemberId: known.id,
+                    name: known.name,
+                    email: known.email,
+                });
+                continue;
+            }
+            additions.push({ key: `email:${key}`, kind: 'email', email });
+        }
+
+        if (additions.length === 0) return;
+        setDrafts((current) => [...current, ...additions]);
+        setQuery('');
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+        if (event.key !== 'Backspace' || query.length > 0 || drafts.length === 0) return;
+        event.preventDefault();
+        setDrafts((current) => current.slice(0, -1));
+    };
+
+    const copyInviteLink = async () => {
+        if (!inviteLink) return;
+        try {
+            await navigator.clipboard.writeText(inviteLink);
+            toast.success('Invite link copied');
+        } catch {
+            toast.error('Could not copy to clipboard');
+        }
+    };
+
+    const submitLabel = (() => {
+        const count = drafts.length || 1;
+        if (drafts.length > 0 && emailDrafts.length === drafts.length) {
+            return count === 1 ? 'Send invite' : `Send ${count} invites`;
+        }
+        return count === 1 ? 'Add person' : `Add ${count} people`;
+    })();
+
+    const handleSubmit = async () => {
+        if (!canManageMembers || drafts.length === 0 || submitting) return;
+        setSubmitting(true);
+
+        const failures: string[] = [];
+        let added = 0;
+        let invited = 0;
+
+        for (const draft of drafts) {
+            try {
+                if (draft.kind === 'member') {
+                    await addMember({ organization_member_id: draft.organizationMemberId, role: podRole });
+                    added += 1;
+                } else {
+                    await inviteMember({
+                        email: draft.email,
+                        role: orgRole,
+                        pod_id: podId,
+                        pod_role: podRole,
+                        redirect_uri: redirectUri.trim() || defaultRedirectUri,
+                    });
+                    invited += 1;
+                }
+            } catch (error) {
+                const label = draft.kind === 'member' ? draft.name : draft.email;
+                failures.push(`${label} — ${inviteErrorMessage(error as Error)}`);
+            }
+        }
+
+        setSubmitting(false);
+
+        const done: string[] = [];
+        if (added) done.push(added === 1 ? '1 person added' : `${added} people added`);
+        if (invited) done.push(invited === 1 ? '1 invite sent' : `${invited} invites sent`);
+        if (done.length) toast.success(done.join(', '));
+        // Named individually: "2 failed" leaves you re-typing the whole list to
+        // work out which two.
+        for (const failure of failures) toast.error(failure);
+
+        if (failures.length === 0) {
+            onClose();
+            return;
+        }
+        // Whoever failed stays in the box, so a retry is one click.
+        setDrafts((current) => current.filter((draft) => {
+            const label = draft.kind === 'member' ? draft.name : draft.email;
+            return failures.some((failure) => failure.startsWith(`${label} — `));
+        }));
+    };
+
+    if (!canManageMembers) return null;
+
+    return (
+        <>
+            <DialogHeader className="pr-8">
+                <DialogTitle>Add people to {pod?.name || 'this pod'}</DialogTitle>
+                <DialogDescription>
+                    {canInviteByEmail
+                        ? 'Type a name to add a colleague, or an email to invite someone new.'
+                        : 'Type a name to add a colleague from your organization.'}
+                </DialogDescription>
+            </DialogHeader>
+
+            <Command shouldFilter={false} className="mt-4 overflow-visible border-0 bg-transparent shadow-none">
+                {drafts.length > 0 ? (
+                    <div className="mb-2 flex flex-wrap gap-1.5">
+                        {drafts.map((draft) => {
+                            const label = draft.kind === 'member' ? draft.name : draft.email;
+                            return (
+                                <span key={draft.key} className="chip chip-sm chip-muted gap-1.5 pr-1">
+                                    {draft.kind === 'email' ? <Mail className="h-3 w-3 shrink-0" /> : null}
+                                    <span className="truncate">{label}</span>
+                                    <button
+                                        type="button"
+                                        aria-label={`Remove ${label}`}
+                                        onClick={() => removeDraft(draft.key)}
+                                        className="resource-remove-button custom-focus-ring h-4 w-4"
+                                    >
+                                        <X className="h-3 w-3" />
+                                    </button>
+                                </span>
+                            );
+                        })}
+                    </div>
+                ) : null}
+
+                <div className="overflow-hidden rounded-lg border border-[color:var(--border-subtle)]">
+                    <CommandInput
+                        ref={inputRef}
+                        value={query}
+                        onValueChange={setQuery}
+                        onPaste={handlePaste}
+                        onKeyDown={handleKeyDown}
+                        placeholder={canInviteByEmail ? 'Name or email' : 'Name'}
+                    />
+                    <CommandList className="max-h-56">
+                        {matches.length > 0 ? (
+                            <CommandGroup heading="In your organization">
+                                {matches.map((candidate) => (
+                                    <CommandItem
+                                        key={candidate.id}
+                                        value={`member:${candidate.id}`}
+                                        onSelect={() => addDraft({
+                                            key: `member:${candidate.id}`,
+                                            kind: 'member',
+                                            organizationMemberId: candidate.id,
+                                            name: candidate.name,
+                                            email: candidate.email,
+                                        })}
+                                        className="gap-2"
+                                    >
+                                        <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--surface-3)] text-xs text-[var(--text-secondary)]">
+                                            {initialOf(candidate.name)}
+                                        </span>
+                                        <span className="truncate">{candidate.name}</span>
+                                        {candidate.email && candidate.email !== candidate.name ? (
+                                            <span className="ml-auto truncate text-xs text-[var(--text-tertiary)]">
+                                                {candidate.email}
+                                            </span>
+                                        ) : null}
+                                    </CommandItem>
+                                ))}
+                            </CommandGroup>
+                        ) : null}
+
+                        {offersInvite && canInviteByEmail ? (
+                            <CommandGroup heading={matches.length > 0 ? 'Not here yet' : undefined}>
+                                <CommandItem
+                                    value={`invite:${trimmedQuery}`}
+                                    onSelect={() => addEmailDraft(trimmedQuery)}
+                                    className="gap-2"
+                                >
+                                    <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-[var(--surface-3)]">
+                                        <Mail className="h-3 w-3 text-[var(--text-secondary)]" />
+                                    </span>
+                                    <span className="truncate">
+                                        Invite <span className="text-[var(--text-primary)]">{trimmedQuery}</span>
+                                    </span>
+                                </CommandItem>
+                            </CommandGroup>
+                        ) : null}
+
+                        <CommandEmpty>
+                            {trimmedQuery && !canInviteByEmail
+                                ? 'Nobody by that name. Only organization owners and editors can invite people by email.'
+                                : trimmedQuery
+                                    ? 'Nobody by that name. Type a full email address to invite them.'
+                                    : 'Everyone in your organization is already in this pod.'}
+                        </CommandEmpty>
+                    </CommandList>
+                </div>
+            </Command>
+
+            <div className="mt-4 flex items-center gap-3">
+                <label htmlFor="add-people-role" className="shrink-0 text-sm font-medium">
+                    Role in this pod
+                </label>
+                <Select value={podRole} onValueChange={(value) => setPodRole(value as PodRole)}>
+                    <SelectTrigger id="add-people-role" className="flex-1">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {POD_ROLE_OPTIONS.map((option) => (
+                            <SelectItem key={option.value} value={option.value}>
+                                {option.label}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
+            </div>
+            <p className="mt-1.5 text-xs text-[var(--text-tertiary)]">
+                {POD_ROLE_OPTIONS.find((option) => option.value === podRole)?.hint}
+            </p>
+
+            {/* Only once there is an invitation to send: until then neither
+                of these decides anything, and a disclosure promising
+                settings that do nothing is worse than no disclosure. */}
+            {hasEmailInvites ? (
+                <div className="mt-3">
+                    <Button
+                        variant="quiet"
+                        size="xs"
+                        onClick={() => setAdvancedOpen((current) => !current)}
+                        className="-ml-2.5 gap-1 text-[var(--text-tertiary)]"
+                        aria-expanded={advancedOpen}
+                    >
+                        <ChevronDown className={cn('h-3.5 w-3.5 transition-transform', advancedOpen && 'rotate-180')} />
+                        Invitation settings
+                    </Button>
+                    {advancedOpen ? (
+                        <div className="mt-2 grid gap-3 rounded-lg border border-[color:var(--border-subtle)] p-3 sm:grid-cols-2">
+                            <div className="space-y-1.5">
+                                <label className="text-sm font-medium">Organization role</label>
+                                <Select value={orgRole} onValueChange={(value) => setOrgRole(value as OrganizationRole)}>
+                                    <SelectTrigger>
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        <SelectItem value={OrganizationRole.ORG_OWNER}>Owner</SelectItem>
+                                        <SelectItem value={OrganizationRole.ORG_EDITOR}>Editor</SelectItem>
+                                        <SelectItem value={OrganizationRole.ORG_MEMBER}>Member</SelectItem>
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                            <div className="space-y-1.5">
+                                <label className="text-sm font-medium">Land them on</label>
+                                <Select value={redirectUri} onValueChange={setChosenRedirectUri}>
+                                    <SelectTrigger>
+                                        <SelectValue />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                        {redirectOptions.map((option) => (
+                                            <SelectItem key={option.value} value={option.value}>
+                                                {option.label}
+                                            </SelectItem>
+                                        ))}
+                                    </SelectContent>
+                                </Select>
+                            </div>
+                        </div>
+                    ) : null}
+                </div>
+            ) : null}
+
+            {inviteLink ? (
+                <div className="mt-4 flex items-center justify-between gap-3 rounded-lg border border-dashed border-[color:var(--border-subtle)] px-3 py-2">
+                    <div className="min-w-0">
+                        <p className="text-sm text-[var(--text-primary)]">Invite link</p>
+                        <p className="text-xs text-[var(--text-tertiary)]">{joinPolicyHint}</p>
+                    </div>
+                    <Button variant="quiet" size="sm" className="shrink-0 gap-1.5" onClick={copyInviteLink}>
+                        <Copy className="h-3.5 w-3.5" />
+                        Copy
+                    </Button>
+                </div>
+            ) : null}
+
+            <DialogFooter className="pt-4">
+                <Button variant="quiet" onClick={onClose}>Cancel</Button>
+                <Button
+                    variant="primary"
+                    onClick={handleSubmit}
+                    disabled={drafts.length === 0 || submitting}
+                    loading={submitting}
+                    loadingLabel="Adding..."
+                >
+                    {submitLabel}
+                </Button>
+            </DialogFooter>
+        </>
+    );
+}

--- a/lemma-frontend/components/pod/pod-home-presence.tsx
+++ b/lemma-frontend/components/pod/pod-home-presence.tsx
@@ -1,14 +1,18 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
+
+import { AddPeopleDialog } from '@/components/members/add-people-dialog';
+import { Plus } from '@/components/ui/icons';
 
 import { useAgents } from '@/lib/hooks/use-agents';
 import { usePodMembers } from '@/lib/hooks/use-pod-members';
 import { usePodSurfaces } from '@/lib/hooks/use-pod-surfaces';
 import { usePodAccess } from '@/lib/hooks/use-pod-access';
 import { useSchedules } from '@/lib/hooks/use-schedules';
+import { useProfile } from '@/lib/hooks/use-user';
 import { TONE_COUNT as IDENTITY_TONE_COUNT } from '@/lib/identity/seeded-identity';
 import { getSurfaceDefinition } from '@/lib/surfaces/registry';
 import { getSurfacePlatformKey } from '@/lib/utils/surfaces';
@@ -76,6 +80,9 @@ export function PodHomePresence({
     conversations: Conversation[];
 }) {
     const podAccess = usePodAccess(podId);
+    const canAddPeople = podAccess.can('pod.member.manage');
+    const [addPeopleOpen, setAddPeopleOpen] = useState(false);
+    const { data: profile } = useProfile();
     const canReadAgents = podAccess.can('agent.read');
     const canReadSchedules = podAccess.can('schedule.read');
     const canReadSurfaces = podAccess.canAccessRoute('surfaces');
@@ -139,22 +146,29 @@ export function PodHomePresence({
         return [...seen.values()];
     }, [surfaces]);
 
-    const peopleLabel = members.length === 1 ? '1 person' : `${members.length} people`;
+    // A pod of one is the state this row most needs to name, because it is the
+    // one with something to do about it. "1 person" reads as a tally of other
+    // people; "Just you" reads as an empty room, which is what it is.
+    const isAloneHere = members.length === 1 && members[0].user_id === profile?.id;
+    const peopleLabel = isAloneHere
+        ? 'Just you'
+        : members.length === 1 ? '1 person' : `${members.length} people`;
     const hasPeople = members.length > 0;
     const hasDuty = onDuty.length > 0;
     const hasSurfaces = surfacePlatforms.length > 0;
 
-    if (!hasPeople && !hasDuty && !hasSurfaces) return null;
+    if (!hasPeople && !hasDuty && !hasSurfaces && !canAddPeople) return null;
 
     return (
         <div className="pod-home-presence">
             {faces.length > 0 ? (
-                <span className="pod-home-presence-faces" aria-hidden="true">
+                <span className="pod-home-presence-faces">
                     {faces.map((face) => (
                         <span
                             key={face.key}
                             className={`pod-home-presence-avatar pod-home-presence-avatar-${face.kind} ${avatarToneClass(face.label)}`}
                             title={face.label}
+                            aria-hidden="true"
                         >
                             {face.iconUrl ? (
                                 <Image src={face.iconUrl} alt="" width={16} height={16} className="object-contain" />
@@ -163,14 +177,35 @@ export function PodHomePresence({
                             )}
                         </span>
                     ))}
+                    {canAddPeople ? (
+                        <button
+                            type="button"
+                            onClick={() => setAddPeopleOpen(true)}
+                            className="pod-home-presence-add custom-focus-ring"
+                            aria-label="Add people to this pod"
+                            title="Add people"
+                        >
+                            <Plus className="h-3 w-3" />
+                        </button>
+                    ) : null}
                 </span>
             ) : null}
 
             <span className="pod-home-presence-copy">
                 {hasPeople ? (
-                    <Link href={`/pod/${podId}/settings/members`} className="pod-home-presence-link custom-focus-ring">
-                        {peopleLabel}
-                    </Link>
+                    isAloneHere && canAddPeople ? (
+                        <button
+                            type="button"
+                            onClick={() => setAddPeopleOpen(true)}
+                            className="pod-home-presence-link custom-focus-ring"
+                        >
+                            Just you — add people
+                        </button>
+                    ) : (
+                        <Link href={`/pod/${podId}/settings/members`} className="pod-home-presence-link custom-focus-ring">
+                            {peopleLabel}
+                        </Link>
+                    )
                 ) : null}
 
                 {hasPeople && hasDuty ? <span className="pod-home-presence-sep" aria-hidden="true" /> : null}
@@ -211,6 +246,10 @@ export function PodHomePresence({
                     </Link>
                 ) : null}
             </span>
+
+            {canAddPeople ? (
+                <AddPeopleDialog podId={podId} open={addPeopleOpen} onOpenChange={setAddPeopleOpen} />
+            ) : null}
         </div>
     );
 }

--- a/lemma-frontend/components/pod/workspace-sidebar.tsx
+++ b/lemma-frontend/components/pod/workspace-sidebar.tsx
@@ -15,6 +15,7 @@ import {
     Search,
     Share2,
     Upload,
+    UserPlus,
     X,
 } from '@/components/ui/icons';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
@@ -24,6 +25,7 @@ import { POD_DEFAULT_AGENT_SELECTOR } from 'lemma-sdk';
 import { useAIAssistant } from '@/components/ai/ai-assistant-context';
 import { Logo } from '@/components/brand/logo';
 import { LocalSettingsButton } from '@/components/desktop/local-settings-button';
+import { AddPeopleDialog } from '@/components/members/add-people-dialog';
 import { ShareSheet } from '@/components/bundle/share-sheet';
 import { ImportDialog } from '@/components/bundle/import-dialog';
 import { ProductIcon, type ProductIconKind } from '@/components/pod/product-icon';
@@ -229,6 +231,7 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
     const [assistantCreationKind, setAssistantCreationKind] = useState<AssistantCreationKind | null>(null);
     const [assistantCreationPrompt, setAssistantCreationPrompt] = useState('');
     const [bundleShareOpen, setBundleShareOpen] = useState(false);
+    const [addPeopleOpen, setAddPeopleOpen] = useState(false);
     const [bundleImportOpen, setBundleImportOpen] = useState(false);
     const [podSwitcherOpen, setPodSwitcherOpen] = useState(false);
     const [conversationFilter, setConversationFilter] = useState('');
@@ -267,6 +270,7 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
     const canCreateWorkflows = podAccess.can('workflow.create');
     const canCreateTables = podAccess.can('datastore.table.create');
     const canUpdatePod = podAccess.can('pod.update');
+    const canAddPeople = podAccess.can('pod.member.manage');
     const basePath = `/pod/${podId}`;
     const isActive = (href: string) => pathname === href || pathname.startsWith(`${href}/`);
 
@@ -656,6 +660,7 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
                             router={router}
                             side="bottom"
                             onShare={() => setBundleShareOpen(true)}
+                            onAddPeople={canAddPeople ? () => setAddPeopleOpen(true) : undefined}
                         />
                     </DropdownMenu.Root>
                 </div>
@@ -1009,6 +1014,9 @@ export function WorkspaceSidebar({ podId, podName, podIconUrl, onCollapse }: Wor
                 onOpenChange={setBundleShareOpen}
                 canPublish={canUpdatePod}
             />
+            {canAddPeople ? (
+                <AddPeopleDialog podId={podId} open={addPeopleOpen} onOpenChange={setAddPeopleOpen} />
+            ) : null}
             {canUpdatePod ? (
                 <ImportDialog
                     podId={podId}
@@ -1375,6 +1383,8 @@ type PodSwitcherMenuProps = {
     router: ReturnType<typeof useRouter>;
     side: 'top' | 'bottom';
     onShare: () => void;
+    /** Absent when this member cannot manage the roster. */
+    onAddPeople?: () => void;
 };
 
 function PodSwitcherMenu(props: PodSwitcherMenuProps) {
@@ -1398,6 +1408,7 @@ function PodSwitcherPanel({
     router,
     side,
     onShare,
+    onAddPeople,
 }: PodSwitcherMenuProps) {
     const [podFilter, setPodFilter] = useState('');
     const contentRef = useRef<HTMLDivElement>(null);
@@ -1440,6 +1451,15 @@ function PodSwitcherPanel({
                 setPodFilter((current) => current + event.key);
             }}
         >
+            {onAddPeople ? (
+                <DropdownMenu.Item
+                    onSelect={onAddPeople}
+                    className="lemma-menu-row shrink-0"
+                >
+                    <UserPlus className="h-3.5 w-3.5" />
+                    Add people
+                </DropdownMenu.Item>
+            ) : null}
             <DropdownMenu.Item
                 onSelect={onShare}
                 className="lemma-menu-row shrink-0"

--- a/lemma-frontend/components/share/join-pod-panel.tsx
+++ b/lemma-frontend/components/share/join-pod-panel.tsx
@@ -19,7 +19,15 @@ import { getLemmaClient } from '@/lib/sdk/lemma-client';
  * queues the request. The response says which happened rather than guessing up
  * front, because the policy is not readable from out here.
  */
-export function JoinPodPanel({ podId }: { podId: string }) {
+export function JoinPodPanel({
+    podId,
+    intro,
+}: {
+    podId: string;
+    /** Overrides the ask for a link that *is* the pod, where "this lives in a
+     *  pod you're not part of" describes nothing the reader clicked. */
+    intro?: string;
+}) {
     const queryClient = useQueryClient();
     const client = getLemmaClient();
     const requestKey = ['share-join-request', podId];
@@ -83,8 +91,12 @@ export function JoinPodPanel({ podId }: { podId: string }) {
     return (
         <section className="rounded-lg border border-[color:var(--border-subtle)] bg-[var(--surface-1)] p-5 text-center">
             <p className="text-sm text-[var(--text-secondary)]">
-                This lives in a pod you&apos;re not part of. Join it to open this and everything
-                else the pod shares.
+                {intro ?? (
+                    <>
+                        This lives in a pod you&apos;re not part of. Join it to open this and everything
+                        else the pod shares.
+                    </>
+                )}
             </p>
             <Button
                 type="button"

--- a/lemma-frontend/components/share/social-card-panel.tsx
+++ b/lemma-frontend/components/share/social-card-panel.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/icons';
 import { toast } from 'sonner';
 
+import { Skeleton } from '@/components/shared/loading';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import {
@@ -113,6 +114,7 @@ export function SocialCardPanel({
     className,
 }: SocialCardPanelProps) {
     const [busy, setBusy] = useState<'copy' | 'download' | null>(null);
+    const [cardState, setCardState] = useState<'loading' | 'ready'>('loading');
 
     const cardPath = useMemo(
         () =>
@@ -183,20 +185,36 @@ export function SocialCardPanel({
         }
     }
 
+    /* `/api/social-card` renders the PNG per request — measured at ~1.3s cold
+       and ~0.6s warm, and every distinct title is a fresh render, so the cold
+       number is the usual one. The intrinsic size already reserves the right
+       box, so nothing moves; what was missing was any sign the box was going to
+       fill. An empty bordered rectangle for a second reads as broken. */
     const preview = (
         <div
             className={cn(
-                'overflow-hidden rounded-md border border-[color:var(--border-subtle)] bg-[var(--surface-2)]',
+                'relative overflow-hidden rounded-md border border-[color:var(--border-subtle)] bg-[var(--surface-2)]',
                 layout === 'compact' ? 'w-40 shrink-0 self-start' : 'rounded-lg',
             )}
         >
+            {cardState === 'loading' ? (
+                <Skeleton shape="block" className="absolute inset-0 rounded-none" />
+            ) : null}
             {/* eslint-disable-next-line @next/next/no-img-element -- the card is a dynamic route response, not a static asset for the image optimizer. */}
             <img
                 src={cardPath}
                 alt={`Share card for ${name || 'this pod'}`}
                 width={1200}
                 height={630}
-                className="block h-auto w-full"
+                onLoad={() => setCardState('ready')}
+                // `ready` rather than a third state: a card that will not render
+                // is not worth a message inside a share popover, and pulsing
+                // forever would claim it is still coming.
+                onError={() => setCardState('ready')}
+                className={cn(
+                    'block h-auto w-full transition-opacity duration-200',
+                    cardState === 'loading' && 'opacity-0',
+                )}
             />
         </div>
     );

--- a/lemma-frontend/components/shared/resource-visibility.tsx
+++ b/lemma-frontend/components/shared/resource-visibility.tsx
@@ -1,25 +1,18 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { useMemo, useState, type ReactNode } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Globe2, LockKeyhole, Share2, Trash2, UserRound, UsersRound, type LemmaIcon } from '@/components/ui/icons';
+import { Check, ChevronLeft, ChevronRight, Globe2, LockKeyhole, Share2, Trash2, UserRound, UsersRound, type LemmaIcon } from '@/components/ui/icons';
 import type { PodMemberResponse, ResourceAccessGrantResponse, ResourceAccessResponse } from 'lemma-sdk';
 
 import { ConceptHint } from '@/components/education/concept-hint';
 import { ShareLinkRow } from '@/components/share/share-link-row';
 import { SocialCardPanel } from '@/components/share/social-card-panel';
+import { StepLoader } from '@/components/brand/loader';
+import { Command, CommandInput } from '@/components/ui/command';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
-import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-} from '@/components/ui/dialog';
-import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { getLemmaClient } from '@/lib/sdk/lemma-client';
@@ -65,8 +58,6 @@ type ResourceVisibilityCopy = {
     className: string;
 };
 
-const NO_GRANTEE_VALUE = '__none__';
-
 /**
  * Only the things a stranger can meaningfully open get a social card. A table
  * or a folder is shared *into* a team, not out to a timeline, and "Run it on
@@ -76,18 +67,6 @@ const SOCIAL_CARD_VARIANT_BY_RESOURCE: Partial<Record<ShareableResourceType, Soc
     agent: 'agent',
     app: 'app',
     workflow: 'workflow',
-};
-
-/** Human name for the kind of thing being shared, shown under the dialog title. */
-const RESOURCE_NOUN: Record<ShareableResourceType, string> = {
-    agent: 'Agent',
-    function: 'Function',
-    workflow: 'Workflow',
-    schedule: 'Schedule',
-    datastore_table: 'Table',
-    document: 'Document',
-    folder: 'Folder',
-    app: 'App',
 };
 
 type AccessLevel = {
@@ -233,17 +212,6 @@ function grantKey(grant: Pick<ResourceAccessGrantResponse, 'grantee_type' | 'gra
     return `${grant.grantee_type}:${grant.grantee_id}`;
 }
 
-function sameGrantLists(left: ResourceAccessGrantResponse[], right: ResourceAccessGrantResponse[]) {
-    if (left.length !== right.length) return false;
-    const rightByKey = new Map(right.map((grant) => [grantKey(grant), grant]));
-
-    return left.every((leftGrant) => {
-        const rightGrant = rightByKey.get(grantKey(leftGrant));
-        if (!rightGrant) return false;
-        return samePermissions(leftGrant.permission_ids || [], rightGrant.permission_ids || []);
-    });
-}
-
 function getAccessLabel(resourceType: ShareableResourceType, permissionIds: string[]) {
     const levels = ACCESS_LEVELS_BY_RESOURCE[resourceType] || [];
     const exact = levels.find((level) => samePermissions(level.permissionIds, permissionIds));
@@ -334,56 +302,174 @@ export function ResourceVisibilityBadge({
     );
 }
 
+/** Which of the three things the share popover is showing. */
+type ShareView = 'access' | 'people' | 'card';
+
 /**
  * One choice in the general-access list.
  *
  * All four options stay on screen instead of hiding behind a dropdown — the
- * whole point of this dialog is comparing "only me" against "anyone with the
+ * whole point of this surface is comparing "only me" against "anyone with the
  * link", and you cannot compare what you cannot see.
+ *
+ * The row applies its own choice, so it also carries the answer: a spinner
+ * while the change is in flight, a tick once it holds. That used to be a radio
+ * you set and a Save button somewhere below that told you nothing about why it
+ * was grey.
  */
 function VisibilityOption({
     copy,
     selected,
+    saving,
     onSelect,
+    children,
 }: {
     copy: ResourceVisibilityCopy;
     selected: boolean;
+    saving: boolean;
     onSelect: () => void;
+    /** The inline confirmation, when this is the choice being confirmed. */
+    children?: ReactNode;
 }) {
     const Icon = copy.icon;
 
     return (
-        <label
+        <div
             className={cn(
-                'flex cursor-pointer items-center gap-3 rounded-md border px-3 py-2.5 transition-gentle',
-                selected
+                'rounded-md border transition-gentle',
+                selected || children
                     ? 'border-[color:var(--action-primary)] bg-[var(--action-primary-soft)]'
-                    : 'border-[color:var(--border-subtle)] bg-[var(--surface-1)] hover:border-[var(--border-strong)] hover:bg-[var(--surface-2)]',
+                    : 'border-transparent',
             )}
         >
-            <RadioGroupItem value={copy.value} id={`visibility-${copy.value}`} onClick={onSelect} />
-            <span
+            <button
+                type="button"
+                data-visibility-row=""
+                onClick={onSelect}
                 className={cn(
-                    'flex h-8 w-8 shrink-0 items-center justify-center rounded-md',
-                    selected
-                        ? 'bg-[var(--action-primary)] text-[var(--text-on-brand)]'
-                        : 'bg-[var(--surface-3)] text-[var(--text-tertiary)]',
+                    'resource-share-choice-button flex w-full items-center gap-2.5 rounded-md px-2 py-2 text-left transition-colors focus-visible:outline-none',
+                    !selected && !children && 'hover:bg-[var(--surface-2)] focus-visible:bg-[var(--surface-2)]',
                 )}
             >
-                <Icon className="h-4 w-4" />
-            </span>
-            <span className="min-w-0 flex-1">
-                <span className="block truncate text-sm font-medium text-[var(--text-primary)]">
-                    {copy.label}
+                <span
+                    className={cn(
+                        'flex h-7 w-7 shrink-0 items-center justify-center rounded-md',
+                        selected
+                            ? 'bg-[var(--action-primary)] text-[var(--text-on-brand)]'
+                            : 'bg-[var(--surface-3)] text-[var(--text-tertiary)]',
+                    )}
+                >
+                    <Icon className="h-3.5 w-3.5" />
                 </span>
-                <span className="block truncate text-xs text-[var(--text-secondary)]">
-                    {copy.description}
+                <span className="min-w-0 flex-1">
+                    <span className="block truncate text-sm text-[var(--text-primary)]">{copy.label}</span>
+                    <span className="block truncate text-xs text-[var(--text-tertiary)]">
+                        {copy.shortDescription}
+                    </span>
                 </span>
-            </span>
-        </label>
+                {saving ? (
+                    <StepLoader size="sm" />
+                ) : (
+                    <Check
+                        className={cn(
+                            'size-3.5 shrink-0',
+                            selected ? 'text-[var(--action-primary)]' : 'text-transparent',
+                        )}
+                    />
+                )}
+            </button>
+            {children}
+        </div>
     );
 }
 
+/** A row that leads to one of the other two views, in the picker's idiom. */
+function ShareNavRow({
+    label,
+    meta,
+    onClick,
+}: {
+    label: string;
+    meta?: string;
+    onClick: () => void;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="resource-share-nav-button flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-sm text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-2)] focus-visible:bg-[var(--surface-2)] focus-visible:outline-none"
+        >
+            <span className="min-w-0 flex-1 truncate">{label}</span>
+            {meta ? <span className="shrink-0 text-xs text-[var(--text-tertiary)]">{meta}</span> : null}
+            <ChevronRight className="size-3.5 shrink-0 text-[var(--text-tertiary)]" />
+        </button>
+    );
+}
+
+/** The back arrow takes the leading slot, as it does in the model picker. */
+function ShareViewHeader({
+    title,
+    onBack,
+    children,
+}: {
+    title: string;
+    onBack: () => void;
+    children?: ReactNode;
+}) {
+    return (
+        // The back arrow takes the search glyph's slot rather than sitting
+        // beside it: two marks before the placeholder read as decoration, and
+        // only one of them is a control.
+        <div className="flex items-center gap-1 border-b border-[color:var(--border-subtle)] bg-[var(--surface-2)] px-1 [&_[cmdk-input-wrapper]]:min-w-0 [&_[cmdk-input-wrapper]]:flex-1 [&_[cmdk-input-wrapper]]:border-0 [&_[cmdk-input-wrapper]]:bg-transparent [&_[cmdk-input-wrapper]]:pl-0 [&_[cmdk-input-wrapper]_svg]:hidden">
+            <Button
+                type="button"
+                variant="quiet"
+                size="icon"
+                onClick={onBack}
+                aria-label="Back to general access"
+                className="size-8 shrink-0 rounded-md text-[var(--text-tertiary)]"
+            >
+                <ChevronLeft className="size-4" />
+            </Button>
+            {children ?? (
+                <span className="min-w-0 flex-1 truncate py-2 text-sm text-[var(--text-primary)]">{title}</span>
+            )}
+        </div>
+    );
+}
+
+type GranteeType = ResourceAccessGrantResponse['grantee_type'];
+
+/** One change to one person's access, applied on its own. */
+type GrantOp = {
+    kind: 'set' | 'remove';
+    key: string;
+    granteeType: GranteeType;
+    granteeId: string;
+    permissionIds?: string[];
+};
+
+/**
+ * Share, as a popover.
+ *
+ * It was a 560px dialog with a scrolling body and a Save button, and the Save
+ * button was the problem. It went grey for two unrelated reasons — the grants
+ * request still in flight, and an unticked acknowledgement further down the
+ * page — and said neither, so choosing "anyone signed in" looked like a click
+ * that had failed. Meanwhile selecting it mounted the social card above the
+ * list you had just clicked and smooth-scrolled the page out from under the
+ * cursor while a ~1.3s image rendered into an empty box.
+ *
+ * So: no Save. Every choice applies when you make it, the row itself carries
+ * the spinner and the tick, and the two steps that cannot be walked back ask
+ * for confirmation *in the row you clicked* rather than through a checkbox
+ * wired to a button somewhere else. The card moves behind the link it belongs
+ * to, one view over, where its render time costs nothing.
+ *
+ * The shape is the model picker's: a short list you act on directly, and named
+ * rows leading to the longer surfaces. Same reason, too — this is a thing
+ * people open often and want to leave quickly.
+ */
 export function ResourceShareButton({
     value,
     onChange,
@@ -393,7 +479,6 @@ export function ResourceShareButton({
     resourceLabel,
     resourceName,
     shareUrl,
-    className,
     buttonClassName,
     disabled = false,
     options = VISIBILITY_VALUES,
@@ -407,7 +492,6 @@ export function ResourceShareButton({
     resourceLabel?: string;
     resourceName?: string | null;
     shareUrl?: string | null;
-    className?: string;
     buttonClassName?: string;
     disabled?: boolean;
     options?: ResourceVisibilityValue[];
@@ -416,84 +500,86 @@ export function ResourceShareButton({
     const current = normalizeResourceVisibility(value);
     const queryClient = useQueryClient();
     const [open, setOpen] = useState(false);
-    const [draftVisibility, setDraftVisibility] = useState<ResourceVisibilityValue>(current);
-    const [selectedGrantee, setSelectedGrantee] = useState<string>(NO_GRANTEE_VALUE);
-    const [selectedAccessLevel, setSelectedAccessLevel] = useState<string>('viewer');
-    const [draftGrants, setDraftGrants] = useState<ResourceAccessGrantResponse[]>([]);
-    const [saveError, setSaveError] = useState<string | null>(null);
-    const [hasAcknowledgedPublic, setHasAcknowledgedPublic] = useState(false);
-    const cardSectionRef = useRef<HTMLElement | null>(null);
-    const hasVisibilityChange = draftVisibility !== current;
+    const [view, setView] = useState<ShareView>('access');
+    const [confirming, setConfirming] = useState<ResourceVisibilityValue | null>(null);
+    /** What the rows show while the change is in flight, so a click lands now. */
+    const [optimistic, setOptimistic] = useState<ResourceVisibilityValue | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [peopleQuery, setPeopleQuery] = useState('');
+
     const canManageSpecificAccess = Boolean(podId && resourceType && resourceId);
     const accessLevels = resourceType ? ACCESS_LEVELS_BY_RESOURCE[resourceType] : [];
-    const selectedAccess = accessLevels.find((level) => level.value === selectedAccessLevel) || accessLevels[0];
     const accessQueryKey = ['pods', podId, 'resources', resourceType, resourceId, 'access'];
     const optionCopies = useMemo(
         () => options.map((option) => getResourceVisibilityCopy(option, resourceLabel, resourceType)),
         [options, resourceLabel, resourceType],
     );
+
     const { data: accessData, isLoading: isAccessLoading } = useQuery({
         queryKey: accessQueryKey,
         queryFn: () => getLemmaClient(podId!).resourceAccess.get(resourceType!, resourceId!) as Promise<ResourceAccessResponse>,
         enabled: open && canManageSpecificAccess,
     });
+    // Only the people view needs the roster, and most opens never reach it.
     const { data: membersData } = useQuery({
         queryKey: ['pods', podId, 'members'],
         queryFn: () => getLemmaClient().podMembers.list(podId!) as Promise<{ items: PodMemberResponse[] }>,
-        enabled: open && canManageSpecificAccess,
+        enabled: open && view === 'people' && canManageSpecificAccess,
     });
+
     const grants = useMemo(() => accessData?.grants || [], [accessData]);
-    const members = membersData?.items || [];
-    const granteeOptions = members.map((member) => ({
-        value: `POD_MEMBER:${member.pod_member_id}`,
-        label: member.user_name || member.email || member.user_email,
-        detail: member.email || member.user_email,
-        granteeType: 'POD_MEMBER',
-        granteeId: member.pod_member_id,
-        grant: {
-            resource_type: resourceType,
-            resource_name: resourceId,
-            grantee_type: 'POD_MEMBER',
-            grantee_id: member.pod_member_id,
-            permission_ids: selectedAccess?.permissionIds || [],
-            user_id: member.user_id,
-            email: member.email || member.user_email || null,
-            display_name: member.user_name || member.email || member.user_email || null,
-        } as ResourceAccessGrantResponse,
-    }));
-    const directAccessEnabled = draftVisibility !== 'PERSONAL';
-    const effectiveDraftGrants = useMemo(
-        () => (draftVisibility === 'PERSONAL'
-            ? []
-            : draftGrants.filter((grant) => grant.grantee_type === 'POD_MEMBER')),
-        [draftVisibility, draftGrants],
+    const memberGrants = useMemo(
+        () => grants.filter((grant) => grant.grantee_type === 'POD_MEMBER'),
+        [grants],
     );
-    const removedRoleGrantCount = directAccessEnabled
-        ? draftGrants.filter((grant) => grant.grantee_type === 'ROLE').length
-        : 0;
-    const removedPersonalGrantCount = draftVisibility === 'PERSONAL' ? draftGrants.length : 0;
-    const hasGrantChanges = canManageSpecificAccess && Boolean(accessData) && !sameGrantLists(grants, effectiveDraftGrants);
-    const hasChanges = hasVisibilityChange || hasGrantChanges;
-    /**
-     * Leaving the organization is the one step here that cannot be walked back
-     * by editing a member list, so it is the one step that asks twice. Only on
-     * newly selecting it — reopening the dialog on an already-public resource
-     * does not re-prompt.
-     */
-    const needsPublicConfirmation = draftVisibility === 'PUBLIC' && current !== 'PUBLIC';
-    const isBlockedOnConfirmation = needsPublicConfirmation && !hasAcknowledgedPublic;
-    const accessSectionTitle = draftVisibility === 'RESTRICTED' ? 'People with access' : 'Additional people';
-    const accessSectionDescription = draftVisibility === 'RESTRICTED'
-        ? 'Only these people can open it.'
-        : 'Added on top of workspace access.';
+    const members = useMemo(() => membersData?.items || [], [membersData?.items]);
 
-    // Granted people already in the list should not be offered again.
-    const grantedKeys = new Set(effectiveDraftGrants.map((grant) => grantKey(grant)));
-    const addableOptions = granteeOptions.filter(
-        (option) => !grantedKeys.has(`${option.granteeType}:${option.granteeId}`),
-    );
+    const shownVisibility = optimistic ?? current;
+    const directAccessEnabled = shownVisibility !== 'PERSONAL';
 
-    const cardVariant = resourceType ? SOCIAL_CARD_VARIANT_BY_RESOURCE[resourceType] : undefined;
+    const applyVisibility = useMutation({
+        mutationFn: async (next: ResourceVisibilityValue) => {
+            await onChange(next);
+            return next;
+        },
+        onMutate: (next: ResourceVisibilityValue) => {
+            setError(null);
+            setOptimistic(next);
+        },
+        onError: (mutationError) => {
+            setOptimistic(null);
+            setError(mutationError instanceof Error
+                ? mutationError.message
+                : 'Could not change who can open this.');
+        },
+    });
+
+    const applyGrant = useMutation({
+        mutationFn: async (op: GrantOp) => {
+            const client = getLemmaClient(podId!);
+            if (op.kind === 'remove') {
+                await client.resourceAccess.deleteGrant(resourceType!, resourceId!, op.granteeType, op.granteeId);
+                return;
+            }
+            await client.resourceAccess.replaceGrant(
+                resourceType!,
+                resourceId!,
+                op.granteeType,
+                op.granteeId,
+                { permission_ids: op.permissionIds || [] },
+            );
+        },
+        onMutate: () => setError(null),
+        onError: (mutationError) => {
+            setError(mutationError instanceof Error ? mutationError.message : 'Could not update access.');
+        },
+        onSettled: () => {
+            void queryClient.invalidateQueries({ queryKey: accessQueryKey });
+        },
+    });
+
+    const savingVisibility = applyVisibility.isPending ? applyVisibility.variables : null;
+    const pendingGrantKey = applyGrant.isPending ? applyGrant.variables?.key ?? null : null;
 
     /**
      * A `/pod/…` URL is signed-in-only and drops anyone without pod access on a
@@ -505,125 +591,108 @@ export function ResourceShareButton({
      */
     const outsidePodShareUrl = useMemo(() => {
         if (!shareUrl || !resourceType) return null;
-        if (!reachesOutsidePod(draftVisibility)) return null;
+        if (!reachesOutsidePod(shownVisibility)) return null;
         return buildShareLink({
             kind: shareKindForResourceType(resourceType),
             canonicalUrl: shareUrl,
             name: resourceName,
         });
-    }, [shareUrl, resourceType, resourceName, draftVisibility]);
+    }, [shareUrl, resourceType, resourceName, shownVisibility]);
 
     const linkToShare = outsidePodShareUrl ?? shareUrl;
+    const cardVariant = resourceType ? SOCIAL_CARD_VARIANT_BY_RESOURCE[resourceType] : undefined;
     // A card only exists where a link reaches past the pod — anything narrower
     // has no `/s/…` URL to unfurl in the first place.
     const canShowCard = Boolean(cardVariant && outsidePodShareUrl);
 
-    const saveSharing = useMutation({
-        mutationFn: async () => {
-            if (hasVisibilityChange) {
-                await onChange(draftVisibility);
-            }
-
-            if (!canManageSpecificAccess || !accessData || !podId || !resourceType || !resourceId) {
-                return null;
-            }
-
-            const finalByKey = new Map(effectiveDraftGrants.map((grant) => [grantKey(grant), grant]));
-            const initialByKey = new Map(grants.map((grant) => [grantKey(grant), grant]));
-            const grantsToDelete = grants.filter((grant) => !finalByKey.has(grantKey(grant)));
-            const grantsToReplace = effectiveDraftGrants.filter((grant) => {
-                const initial = initialByKey.get(grantKey(grant));
-                return !initial || !samePermissions(initial.permission_ids || [], grant.permission_ids || []);
-            });
-
-            await Promise.all([
-                ...grantsToDelete.map((grant) =>
-                    getLemmaClient(podId).resourceAccess.deleteGrant(
-                        resourceType,
-                        resourceId,
-                        grant.grantee_type,
-                        grant.grantee_id,
-                    )
-                ),
-                ...grantsToReplace.map((grant) =>
-                    getLemmaClient(podId).resourceAccess.replaceGrant(
-                        resourceType,
-                        resourceId,
-                        grant.grantee_type,
-                        grant.grantee_id,
-                        { permission_ids: grant.permission_ids || [] },
-                    )
-                ),
-            ]);
-
-            return null;
-        },
-        onSuccess: () => {
-            setSaveError(null);
-            setOpen(false);
-            void queryClient.invalidateQueries({ queryKey: accessQueryKey });
-        },
-        onError: (error) => {
-            setSaveError(error instanceof Error ? error.message : 'Failed to save sharing changes.');
-        },
-    });
-
-    useEffect(() => {
-        if (!open || !accessData) return;
-        // eslint-disable-next-line react-hooks/set-state-in-effect
-        setDraftGrants(accessData.grants || []);
-    }, [accessData, open]);
-
-    // Switching to "anyone signed in" reveals the card further up the dialog;
-    // bring it into view so the change is visible wherever the reader is.
-    useEffect(() => {
-        if (!canShowCard) return;
-        cardSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-    }, [canShowCard]);
-
-    const addDraftGrant = (granteeValue: string, access = selectedAccess) => {
-        if (granteeValue === NO_GRANTEE_VALUE || !access) return;
-        const option = granteeOptions.find((candidate) => candidate.value === granteeValue);
-        if (!option) return;
-        const nextGrant = {
-            ...option.grant,
-            permission_ids: access.permissionIds,
-        };
-        setDraftGrants((prev) => [
-            ...prev.filter((grant) => grantKey(grant) !== grantKey(nextGrant)),
-            nextGrant,
-        ]);
-        setSelectedGrantee(NO_GRANTEE_VALUE);
-    };
-
-    const handleSelectedGranteeChange = (nextGrantee: string) => {
-        setSelectedGrantee(nextGrantee);
-        addDraftGrant(nextGrantee);
-    };
-
-    const handleRemoveDraftGrant = (grant: ResourceAccessGrantResponse) => {
-        setDraftGrants((prev) => prev.filter((candidate) => grantKey(candidate) !== grantKey(grant)));
-    };
-
-    const handleDraftGrantAccessChange = (grant: ResourceAccessGrantResponse, accessLevel: string) => {
-        const nextAccess = accessLevels.find((level) => level.value === accessLevel);
-        if (!nextAccess) return;
-        setDraftGrants((prev) => prev.map((candidate) => (
-            grantKey(candidate) === grantKey(grant)
-                ? { ...candidate, permission_ids: nextAccess.permissionIds }
-                : candidate
-        )));
-    };
+    const grantedKeys = new Set(grants.map((grant) => grantKey(grant)));
+    const addableMembers = members.filter(
+        (member) => !grantedKeys.has(`POD_MEMBER:${member.pod_member_id}`),
+    );
+    const peopleNeedle = peopleQuery.trim().toLowerCase();
+    const matchingMembers = peopleNeedle
+        ? addableMembers.filter((member) => (
+            `${member.user_name || ''} ${member.email || ''} ${member.user_email || ''}`
+                .toLowerCase()
+                .includes(peopleNeedle)
+        ))
+        : addableMembers;
 
     const handleOpenChange = (nextOpen: boolean) => {
-        setDraftVisibility(current);
-        setDraftGrants(accessData?.grants || []);
-        setSelectedGrantee(NO_GRANTEE_VALUE);
-        setSelectedAccessLevel('viewer');
-        setSaveError(null);
-        setHasAcknowledgedPublic(false);
+        if (nextOpen) {
+            setView('access');
+            setConfirming(null);
+            setOptimistic(null);
+            setError(null);
+            setPeopleQuery('');
+        }
         setOpen(nextOpen);
     };
+
+    /**
+     * Leaving the pod, and shutting the door behind you, are the two steps here
+     * that a member list cannot walk back. They ask once — in the row, so the
+     * question and the answer are the same object. Reopening on an already
+     * public resource does not re-ask: `current` is what it is compared against.
+     */
+    const chooseVisibility = (next: ResourceVisibilityValue) => {
+        if (next === shownVisibility) {
+            setConfirming(null);
+            return;
+        }
+        if (next === 'PUBLIC' && current !== 'PUBLIC') {
+            setConfirming('PUBLIC');
+            return;
+        }
+        if (next === 'PERSONAL' && memberGrants.length > 0) {
+            setConfirming('PERSONAL');
+            return;
+        }
+        setConfirming(null);
+        applyVisibility.mutate(next);
+    };
+
+    const commitConfirmed = (next: ResourceVisibilityValue) => {
+        setConfirming(null);
+        applyVisibility.mutate(next, {
+            onSuccess: async () => {
+                if (next !== 'PERSONAL' || !canManageSpecificAccess) return;
+                // The confirmation said these would go, so they go — and only
+                // once the visibility change itself has landed.
+                for (const grant of memberGrants) {
+                    await applyGrant
+                        .mutateAsync({
+                            kind: 'remove',
+                            key: grantKey(grant),
+                            granteeType: grant.grantee_type,
+                            granteeId: grant.grantee_id,
+                        })
+                        .catch(() => null);
+                }
+            },
+        });
+    };
+
+    const addPersonGrant = (member: PodMemberResponse) => {
+        const level = accessLevels[0];
+        if (!level) return;
+        applyGrant.mutate({
+            kind: 'set',
+            key: `POD_MEMBER:${member.pod_member_id}`,
+            granteeType: 'POD_MEMBER' as GranteeType,
+            granteeId: member.pod_member_id,
+            permissionIds: level.permissionIds,
+        });
+        setPeopleQuery('');
+    };
+
+    const confirmCopy = confirming === 'PUBLIC'
+        ? optionCopies.find((option) => option.value === 'PUBLIC')?.description
+            ?? 'Anyone with a Lemma account will be able to open it.'
+        : `Only you will be able to open it. ${memberGrants.length} ${memberGrants.length === 1 ? 'person' : 'people'} with direct access will lose it.`;
+    const confirmAction = confirming === 'PUBLIC'
+        ? (optionCopies.find((option) => option.value === 'PUBLIC')?.label ?? 'Make public')
+        : 'Only me';
 
     const triggerNode = trigger?.({ openShare: () => handleOpenChange(true), disabled }) ?? (
         <Button
@@ -639,251 +708,236 @@ export function ResourceShareButton({
         </Button>
     );
 
-    const handleDone = () => {
-        if (!hasChanges) {
-            setOpen(false);
-            return;
-        }
-        if (isBlockedOnConfirmation) return;
-        void saveSharing.mutate();
-    };
-
-    const resourceNoun = resourceType ? RESOURCE_NOUN[resourceType] : null;
-
     return (
-        <div className={className}>
-            {triggerNode}
+        // `modal`, because four call sites open this from inside a dropdown
+        // menu. A non-modal popover leaves the menu's own dismiss layer live, so
+        // the first click *into* the panel reads as a click outside the menu:
+        // the menu closes, taking this whole component down with it. The dialog
+        // this replaced was modal and never had the problem.
+        <Popover open={open} onOpenChange={handleOpenChange} modal>
+            {/* Anchor rather than Trigger, and a real wrapper rather than
+                `asChild`, for two different reasons.
 
-            <Dialog open={open} onOpenChange={handleOpenChange}>
-                <DialogContent className="max-w-[560px] gap-0 overflow-hidden p-0">
-                    <DialogHeader className="gap-1 border-b border-[color:var(--border-subtle)] px-5 py-4 pr-12 text-left">
-                        <DialogTitle className="truncate">
-                            {resourceName ? `Share ${resourceName}` : 'Share'}
-                        </DialogTitle>
-                        <DialogDescription className="text-xs">
-                            {resourceNoun
-                                ? `${resourceNoun} · choose who can open it and what they can do.`
-                                : 'Choose who can open it and what they can do.'}
-                        </DialogDescription>
-                    </DialogHeader>
+                Not Trigger: the caller's node already owns its onClick, and
+                Trigger would add a second, competing one.
 
-                    <div className="max-h-[min(70dvh,34rem)] space-y-5 overflow-y-auto px-5 py-4">
-                        <ShareLinkRow
-                            url={linkToShare}
-                            name={resourceName}
-                            allowNativeShare={draftVisibility === 'PUBLIC'}
-                            emptyHint="A link is available once this is created."
-                        />
+                Not `asChild`: `trigger` returns whatever the caller wants, and
+                two of them return a `<Tooltip>` — a Radix root that renders no
+                host element. Slot hands it a ref it has nowhere to put, so the
+                popover ends up with no anchor and paints nothing at all.
 
-                        {/* Once it is open to anyone signed in, the card *is* the
-                            share — so it sits with the link rather than behind a
-                            toggle at the bottom of a scrolling dialog. */}
-                        {canShowCard && cardVariant ? (
-                            <section ref={cardSectionRef}>
-                                <SocialCardPanel
-                                    layout="compact"
-                                    variant={cardVariant}
-                                    name={resourceName}
-                                    url={outsidePodShareUrl}
-                                    unfurls
-                                />
-                            </section>
-                        ) : null}
+                Which leaves a wrapper, whose one rule is that it must have a
+                box. Four call sites used to pass `className="contents"` to
+                suppress exactly that, which is what put the panel in the corner
+                of the screen: a box is what Radix measures. So the wrapper takes
+                no class from the caller, and those four no longer pass one. */}
+            <PopoverAnchor>{triggerNode}</PopoverAnchor>
 
-                        <section className="space-y-2">
-                            <div className="flex items-center justify-between gap-3">
-                                <h3 className="flex items-center gap-1.5 text-sm font-medium text-[var(--text-primary)]">
-                                    General access
-                                    <ConceptHint concept="grant" />
-                                </h3>
-                                {hasVisibilityChange ? (
-                                    <span className="text-xs text-[var(--state-warning)]">Unsaved</span>
-                                ) : null}
-                            </div>
-                            <RadioGroup
-                                className="gap-1.5"
-                                value={draftVisibility}
-                                onValueChange={(next) => setDraftVisibility(next as ResourceVisibilityValue)}
-                            >
-                                {optionCopies.map((option) => (
-                                    <VisibilityOption
-                                        key={option.value}
-                                        copy={option}
-                                        selected={draftVisibility === option.value}
-                                        onSelect={() => setDraftVisibility(option.value)}
-                                    />
-                                ))}
-                            </RadioGroup>
-
-                            {needsPublicConfirmation ? (
-                                <label className="state-surface-warning flex cursor-pointer items-start gap-2.5 rounded-md px-3 py-2.5">
-                                    <Checkbox
-                                        className="mt-0.5 shrink-0"
-                                        checked={hasAcknowledgedPublic}
-                                        onCheckedChange={(checked) =>
-                                            setHasAcknowledgedPublic(checked === true)
-                                        }
-                                    />
-                                    <span className="text-xs text-[var(--text-secondary)]">
-                                        Anyone with a Lemma account — including people you do not
-                                        work with — will be able to open{' '}
-                                        {resourceName ? <strong>{resourceName}</strong> : 'this'} using the
-                                        link.
-                                    </span>
-                                </label>
-                            ) : null}
-                        </section>
-
-                        {canManageSpecificAccess && directAccessEnabled ? (
-                            <section className="space-y-2">
-                                <div className="flex items-baseline justify-between gap-3">
-                                    <h3 className="text-sm font-medium text-[var(--text-primary)]">
-                                        {accessSectionTitle}
-                                    </h3>
-                                    <span className="text-xs text-[var(--text-tertiary)]">
-                                        {isAccessLoading ? 'Loading…' : accessSectionDescription}
-                                    </span>
-                                </div>
-
-                                <div className="grid gap-2 sm:grid-cols-[minmax(0,1fr)_8rem]">
-                                    <Select
-                                        value={selectedGrantee}
-                                        onValueChange={handleSelectedGranteeChange}
-                                        disabled={addableOptions.length === 0}
-                                    >
-                                        {/* SelectTrigger line-clamps its direct span child, which
-                                            collapses any flex layout nested inside it — so the
-                                            trigger keeps a plain SelectValue and nothing else. */}
-                                        <SelectTrigger className="h-9 min-w-0 text-sm">
-                                            <SelectValue
-                                                placeholder={
-                                                    addableOptions.length === 0
-                                                        ? 'Everyone here already has access'
-                                                        : 'Add a person…'
-                                                }
-                                            />
-                                        </SelectTrigger>
-                                        <SelectContent className="min-w-[20rem]">
-                                            {addableOptions.map((option) => (
-                                                <SelectItem key={option.value} value={option.value}>
-                                                    <span className="flex min-w-0 flex-col">
-                                                        <span className="truncate text-sm text-[var(--text-primary)]">
-                                                            {option.label}
-                                                        </span>
-                                                        <span className="truncate text-xs text-[var(--text-tertiary)]">
-                                                            {option.detail}
-                                                        </span>
-                                                    </span>
-                                                </SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
-                                    <Select value={selectedAccessLevel} onValueChange={setSelectedAccessLevel}>
-                                        <SelectTrigger className="h-9 text-sm">
-                                            <SelectValue />
-                                        </SelectTrigger>
-                                        <SelectContent>
-                                            {accessLevels.map((level) => (
-                                                <SelectItem key={level.value} value={level.value}>
-                                                    {level.label}
-                                                </SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
-                                </div>
-
-                                {effectiveDraftGrants.length === 0 ? (
-                                    <p className="rounded-md border border-dashed border-[color:var(--border-subtle)] px-3 py-2.5 text-xs text-[var(--text-tertiary)]">
-                                        {draftVisibility === 'RESTRICTED'
-                                            ? 'No one can open this yet — add the people who need it.'
-                                            : 'No one has been added directly.'}
-                                    </p>
-                                ) : (
-                                    <ul className="divide-y divide-[color:var(--border-subtle)] rounded-md border border-[color:var(--border-subtle)] bg-[var(--surface-1)]">
-                                        {effectiveDraftGrants.map((grant) => (
-                                            <li
-                                                key={grantKey(grant)}
-                                                className="flex items-center gap-3 px-3 py-2"
-                                            >
-                                                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-[var(--surface-3)] text-xs font-semibold text-[var(--text-secondary)]">
-                                                    {grant.grantee_type === 'ROLE' ? <UsersRound className="h-4 w-4" /> : getGrantInitials(grant)}
+            <PopoverContent align="end" sideOffset={8} className="w-[23rem] overflow-hidden p-0">
+                {view === 'people' ? (
+                    <Command shouldFilter={false} className="h-auto overflow-visible rounded-none border-0 bg-transparent shadow-none">
+                        <ShareViewHeader title="People with access" onBack={() => setView('access')}>
+                            <CommandInput
+                                value={peopleQuery}
+                                onValueChange={setPeopleQuery}
+                                placeholder="Search people"
+                                className="h-9"
+                                autoFocus
+                            />
+                        </ShareViewHeader>
+                        <div className="max-h-[19rem] overflow-y-auto p-1">
+                            {grants.length > 0 ? (
+                                <>
+                                    <p className="px-2 pb-1 pt-1.5 type-eyebrow">With access</p>
+                                    <ul className="space-y-0.5">
+                                        {grants.map((grant) => (
+                                            <li key={grantKey(grant)} className="flex items-center gap-2 rounded-md px-2 py-1.5">
+                                                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[var(--surface-3)] text-xs text-[var(--text-secondary)]">
+                                                    {grant.grantee_type === 'ROLE'
+                                                        ? <UsersRound className="h-3.5 w-3.5" />
+                                                        : getGrantInitials(grant)}
                                                 </span>
-                                                <div className="min-w-0 flex-1">
-                                                    <div className="truncate text-sm font-medium text-[var(--text-primary)]">
+                                                <span className="min-w-0 flex-1">
+                                                    <span className="block truncate text-sm text-[var(--text-primary)]">
                                                         {getGrantLabel(grant)}
-                                                    </div>
-                                                    <div className="truncate text-xs text-[var(--text-tertiary)]">
-                                                        {grant.email || getAccessLabel(resourceType!, grant.permission_ids || [])}
-                                                    </div>
-                                                </div>
-                                                <Select
-                                                    value={accessLevels.find((level) => samePermissions(level.permissionIds, grant.permission_ids || []))?.value || ''}
-                                                    onValueChange={(next) => handleDraftGrantAccessChange(grant, next)}
-                                                >
-                                                    <SelectTrigger className="h-8 w-[6.5rem] text-xs">
-                                                        <SelectValue placeholder={getAccessLabel(resourceType!, grant.permission_ids || [])} />
-                                                    </SelectTrigger>
-                                                    <SelectContent>
-                                                        {accessLevels.map((level) => (
-                                                            <SelectItem key={level.value} value={level.value}>
-                                                                {level.label}
-                                                            </SelectItem>
-                                                        ))}
-                                                    </SelectContent>
-                                                </Select>
+                                                    </span>
+                                                    <span className="block truncate text-xs text-[var(--text-tertiary)]">
+                                                        {grant.grantee_type === 'ROLE'
+                                                            ? 'Role'
+                                                            : grant.email || getAccessLabel(resourceType!, grant.permission_ids || [])}
+                                                    </span>
+                                                </span>
+                                                {grant.grantee_type === 'ROLE' ? null : (
+                                                    <Select
+                                                        value={accessLevels.find((level) => samePermissions(level.permissionIds, grant.permission_ids || []))?.value || ''}
+                                                        onValueChange={(next) => {
+                                                            const level = accessLevels.find((candidate) => candidate.value === next);
+                                                            if (!level) return;
+                                                            applyGrant.mutate({
+                                                                kind: 'set',
+                                                                key: grantKey(grant),
+                                                                granteeType: grant.grantee_type,
+                                                                granteeId: grant.grantee_id,
+                                                                permissionIds: level.permissionIds,
+                                                            });
+                                                        }}
+                                                    >
+                                                        <SelectTrigger className="h-7 w-[5.5rem] shrink-0 text-xs">
+                                                            <SelectValue placeholder={getAccessLabel(resourceType!, grant.permission_ids || [])} />
+                                                        </SelectTrigger>
+                                                        <SelectContent>
+                                                            {accessLevels.map((level) => (
+                                                                <SelectItem key={level.value} value={level.value}>
+                                                                    {level.label}
+                                                                </SelectItem>
+                                                            ))}
+                                                        </SelectContent>
+                                                    </Select>
+                                                )}
                                                 <Button
                                                     type="button"
                                                     variant="quiet"
                                                     size="icon"
-                                                    className="h-8 w-8 shrink-0"
-                                                    onClick={() => handleRemoveDraftGrant(grant)}
-                                                    disabled={saveSharing.isPending}
+                                                    className="h-7 w-7 shrink-0"
+                                                    onClick={() => applyGrant.mutate({
+                                                        kind: 'remove',
+                                                        key: grantKey(grant),
+                                                        granteeType: grant.grantee_type,
+                                                        granteeId: grant.grantee_id,
+                                                    })}
+                                                    loading={pendingGrantKey === grantKey(grant)}
                                                     aria-label={`Remove ${getGrantLabel(grant)}`}
                                                 >
-                                                    <Trash2 className="h-4 w-4" />
+                                                    <Trash2 className="h-3.5 w-3.5" />
                                                 </Button>
                                             </li>
                                         ))}
                                     </ul>
-                                )}
+                                </>
+                            ) : null}
 
-                                {removedRoleGrantCount > 0 ? (
-                                    <p className="text-xs text-[var(--state-warning)]">
-                                        Role-based access is not available here and will be removed when you save.
-                                    </p>
-                                ) : null}
-                            </section>
+                            <p className="px-2 pb-1 pt-2 type-eyebrow">Add</p>
+                            {matchingMembers.length === 0 ? (
+                                <p className="px-2 py-2 text-xs text-[var(--text-tertiary)]">
+                                    {peopleNeedle
+                                        ? 'Nobody in this pod by that name.'
+                                        : 'Everyone in this pod already has access.'}
+                                </p>
+                            ) : (
+                                <ul className="space-y-0.5">
+                                    {matchingMembers.map((member) => (
+                                        <li key={member.pod_member_id}>
+                                            <button
+                                                type="button"
+                                                onClick={() => addPersonGrant(member)}
+                                                className="resource-share-nav-button flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-[var(--surface-2)] focus-visible:bg-[var(--surface-2)] focus-visible:outline-none"
+                                            >
+                                                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[var(--surface-3)] text-xs text-[var(--text-secondary)]">
+                                                    <UserRound className="h-3.5 w-3.5" />
+                                                </span>
+                                                <span className="min-w-0 flex-1 truncate text-sm text-[var(--text-primary)]">
+                                                    {member.user_name || member.email || member.user_email}
+                                                </span>
+                                            </button>
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
+                        </div>
+                    </Command>
+                ) : view === 'card' && canShowCard && cardVariant ? (
+                    <>
+                        <ShareViewHeader title="Share card" onBack={() => setView('access')} />
+                        <div className="max-h-[21rem] overflow-y-auto p-3">
+                            <SocialCardPanel
+                                variant={cardVariant}
+                                name={resourceName}
+                                url={outsidePodShareUrl}
+                                unfurls
+                            />
+                        </div>
+                    </>
+                ) : (
+                    <>
+                        <div className="space-y-1.5 border-b border-[color:var(--border-subtle)] p-2">
+                            <ShareLinkRow
+                                url={linkToShare}
+                                name={resourceName}
+                                allowNativeShare={shownVisibility === 'PUBLIC'}
+                                emptyHint="A link is available once this is created."
+                            />
+                            {canShowCard ? (
+                                <ShareNavRow label="Share card" onClick={() => setView('card')} />
+                            ) : null}
+                        </div>
+
+                        <div className="p-1">
+                            <p className="flex items-center gap-1.5 px-2 pb-1 pt-1.5 type-eyebrow">
+                                General access
+                                <ConceptHint concept="grant" />
+                            </p>
+                            <div className="space-y-0.5">
+                                {optionCopies.map((option) => (
+                                    <VisibilityOption
+                                        key={option.value}
+                                        copy={option}
+                                        selected={shownVisibility === option.value}
+                                        saving={savingVisibility === option.value}
+                                        onSelect={() => chooseVisibility(option.value)}
+                                    >
+                                        {confirming === option.value ? (
+                                            <div className="px-2 pb-2">
+                                                <p className="text-xs text-[var(--text-secondary)]">{confirmCopy}</p>
+                                                <div className="mt-2 flex justify-end gap-1.5">
+                                                    <Button
+                                                        type="button"
+                                                        variant="quiet"
+                                                        size="xs"
+                                                        onClick={() => setConfirming(null)}
+                                                    >
+                                                        Not now
+                                                    </Button>
+                                                    <Button
+                                                        type="button"
+                                                        variant="primary"
+                                                        size="xs"
+                                                        onClick={() => commitConfirmed(option.value)}
+                                                    >
+                                                        {confirmAction}
+                                                    </Button>
+                                                </div>
+                                            </div>
+                                        ) : null}
+                                    </VisibilityOption>
+                                ))}
+                            </div>
+                        </div>
+
+                        {canManageSpecificAccess && directAccessEnabled ? (
+                            <div className="border-t border-[color:var(--border-subtle)] p-1">
+                                <ShareNavRow
+                                    label={shownVisibility === 'RESTRICTED' ? 'People with access' : 'Additional people'}
+                                    meta={isAccessLoading ? '…' : String(grants.length)}
+                                    onClick={() => setView('people')}
+                                />
+                            </div>
                         ) : null}
 
-                        {canManageSpecificAccess && !directAccessEnabled && removedPersonalGrantCount > 0 ? (
-                            <p className="rounded-md bg-[var(--surface-2)] px-3 py-2.5 text-xs text-[var(--state-warning)]">
-                                Existing direct access will be removed when you save.
+                        {shownVisibility === 'RESTRICTED' && !isAccessLoading && grants.length === 0 ? (
+                            <p className="border-t border-[color:var(--border-subtle)] px-3 py-2 text-xs text-[var(--state-warning)]">
+                                No one can open this yet — add the people who need it.
                             </p>
                         ) : null}
 
-                        {saveError ? (
-                            <p className="text-sm text-[var(--state-error)]">{saveError}</p>
+                        {error ? (
+                            <p className="border-t border-[color:var(--border-subtle)] px-3 py-2 text-xs text-[var(--state-error)]">
+                                {error}
+                            </p>
                         ) : null}
-                    </div>
-
-                    <DialogFooter className="items-center border-t border-[color:var(--border-subtle)] px-5 py-3 sm:justify-end">
-                        <Button type="button" variant="secondary" size="sm" onClick={() => setOpen(false)}>
-                            Cancel
-                        </Button>
-                        <Button variant="primary"
-                            type="button"
-                            size="sm"
-                            onClick={handleDone}
-                            loading={saveSharing.isPending}
-                            loadingLabel="Saving"
-                            disabled={(canManageSpecificAccess && isAccessLoading) || isBlockedOnConfirmation}
-                        >
-                            {hasChanges ? 'Save' : 'Done'}
-                        </Button>
-                    </DialogFooter>
-                </DialogContent>
-            </Dialog>
-        </div>
+                    </>
+                )}
+            </PopoverContent>
+        </Popover>
     );
 }
 

--- a/lemma-frontend/lib/share/share-link.test.ts
+++ b/lemma-frontend/lib/share/share-link.test.ts
@@ -7,6 +7,7 @@ import {
     prettifySlug,
     resolveShareDestination,
     resolveShareName,
+    resolveSharePodId,
     resolveShareTarget,
     shareKindForResourceType,
 } from './share-link';
@@ -77,6 +78,17 @@ describe('share links', () => {
             resourceName: 'open_orders',
         });
         expect(resolveShareName({ segments: ['pod', 'p1', 'tables'], query })).toBe('Open Orders');
+    });
+
+    it('names the pod behind a link that points at no resource', () => {
+        // A pod link has no target — there is nothing inside it to preview — but
+        // the landing page still needs the pod so it can offer a way in rather
+        // than redirecting a non-member into an access wall.
+        expect(resolveShareTarget('pod', ['pod', 'p1'])).toBeNull();
+        expect(resolveSharePodId(['pod', 'p1'])).toBe('p1');
+        expect(resolveSharePodId(['pod', 'p1', 'agents', 'triage'])).toBe('p1');
+        expect(resolveSharePodId(['pod'])).toBeNull();
+        expect(resolveSharePodId(undefined)).toBeNull();
     });
 
     it('prettifies slugs without dragging extensions along', () => {

--- a/lemma-frontend/lib/share/share-link.ts
+++ b/lemma-frontend/lib/share/share-link.ts
@@ -186,6 +186,20 @@ function firstQueryValue(value: string | string[] | undefined): string | undefin
 }
 
 /**
+ * The pod a share link lives in, whatever it points at.
+ *
+ * `resolveShareTarget` returns null for a pod link, because a whole pod is not
+ * a previewable resource. The pod is still the thing being shared, though, and
+ * the landing page needs its id to offer the reader a way in rather than
+ * bouncing them into a wall they cannot read.
+ */
+export function resolveSharePodId(segments: string[] | undefined): string | null {
+    const parts = (segments ?? []).filter(Boolean);
+    if (parts[0] !== 'pod' || !parts[1]) return null;
+    return parts[1];
+}
+
+/**
  * Resolve what a share link points at, so a viewer who is not a pod member can
  * ask whether they may read it.
  *

--- a/lemma-frontend/scripts/audit-design-system.mjs
+++ b/lemma-frontend/scripts/audit-design-system.mjs
@@ -654,6 +654,8 @@ const informationalChecks = [
         /\blemma-sidebar-icon-button\b/.test(match) ||
         /\blemma-shell-icon-button\b/.test(match) ||
         /\bworkspace-sidebar-trigger-button\b/.test(match) ||
+        /\bpod-home-presence-add\b/.test(match) ||
+        /\bpod-home-presence-link\b/.test(match) ||
         /\bworkspace-sidebar-inline-action-button\b/.test(match) ||
         /\bflow-execution-row-button\b/.test(match) ||
         /\bflow-execution-trace-button\b/.test(match) ||
@@ -682,6 +684,8 @@ const informationalChecks = [
         /\bagent-runtime-model-button\b/.test(match) ||
         /\bagent-runtime-scope-button\b/.test(match) ||
         /\bmodel-picker-choice-button\b/.test(match) ||
+        /\bresource-share-choice-button\b/.test(match) ||
+        /\bresource-share-nav-button\b/.test(match) ||
         /\bmodels-settings-scope-button\b/.test(match) ||
         /\bmodels-settings-provider-button\b/.test(match) ||
         /\bworkspace-sidebar-suggestion-chip-button\b/.test(match) ||

--- a/lemma-frontend/scripts/design-audit-baseline.json
+++ b/lemma-frontend/scripts/design-audit-baseline.json
@@ -14,7 +14,7 @@
     "rawFontSizeDeclaration": 9,
     "rawRadiusDeclaration": 0,
     "rawSpacingDeclaration": 1,
-    "multiplePrimaryButtons": 19,
+    "multiplePrimaryButtons": 17,
     "headerSlotPrimaryButtons": 0
   },
   "protectedAssistant": {

--- a/lemma-frontend/styles/features/pod-home.css
+++ b/lemma-frontend/styles/features/pod-home.css
@@ -267,6 +267,36 @@
   background: var(--lm-identity-tone);
 }
 
+/* The way into the room, standing in it.
+   Adding someone to a pod used to live three levels down — behind a collapsed
+   nav disclosure, inside Settings, on the third tab — which filed the most
+   social act in the product under administration. It belongs at the end of the
+   face pile, where the people already are. Dashed and unfilled so it reads as
+   an opening rather than a sixth person. */
+.pod-home-presence-add {
+  display: inline-flex;
+  width: 1.625rem;
+  height: 1.625rem;
+  align-items: center;
+  justify-content: center;
+  margin-left: var(--space-1);
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--text-tertiary);
+  transition:
+    color var(--dur-fast) var(--ease-standard),
+    border-color var(--dur-fast) var(--ease-standard),
+    background-color var(--dur-fast) var(--ease-standard);
+}
+
+.pod-home-presence-add:hover,
+.pod-home-presence-add:focus-visible {
+  border-color: var(--text-secondary);
+  background: var(--surface-2);
+  color: var(--text-primary);
+}
+
 .pod-home-presence-live {
   width: 6px;
   height: 6px;


### PR DESCRIPTION
## What changes

**Adding people to a pod is reachable and is one field.** A `+` at the end of the
pod-home face pile and an "Add people" row above "Share this pod" in the pod
menu, both opening a composer that takes a name *or* an email in one box —
matching colleagues as you type, offering to invite an address that matches
nobody. Chips let you queue several; a pasted list becomes chips, and anyone in
it who is already an org member is *added* rather than mailed an invite.

**A pod link now lets people in.** `/s/pod/…` already existed with a social
card, but the landing redirected every reader into the workspace. Members still
go straight through; everyone else now gets the card and the existing
`JoinPodPanel`, with the pod's own join policy deciding instant vs queued.

**The resource share dialog is a popover with no Save button.** Each access row
applies its own choice and carries its own spinner and tick. Going public — or
going private over people who currently have direct access — confirms inline, in
the row you clicked. The social card moves one view over, behind the link, and
gets a loading skeleton.

**Files show what they are.** `FileTypeIcon` is wired into the doc viewer and the
Docs list, and the "Searchable" badge stops announcing the steady state.

## Why

Adding a person is the most social act in a multiplayer product and it was filed
under administration: sidebar → `More` (closed by default) → Pod settings →
Members → a modal whose first question was a tab bar reading "Invite by email" /
"Existing member". That is the `organization_members` table leaking into the one
moment someone is thinking about a *person*.

The share dialog had two measured defects. Its Save button went grey for two
unrelated reasons — the grants request in flight, and an unticked
acknowledgement further down a scrolling body — and explained neither, so
choosing "anyone signed in" read as a click that failed. Selecting it also
mounted the social card *above* the list you had just clicked and
smooth-scrolled the page out from under the cursor while `/api/social-card`
rendered: **1288ms first hit, ~620ms warm**, measured locally, and every distinct
title is a fresh render.

`FileTypeIcon` already existed in the tree and was imported by nothing, so every
file drew a generic page glyph. Wiring it up first meant removing its palette,
which spent *state* tokens on file kinds — a PDF was `--state-error`, a `.py`
was `--state-success`. That is the mistake `pod-home-presence.tsx` already
documents: a hue cannot mean "failed" in one place and "spreadsheet" in another.

## How to verify

```bash
cd lemma-frontend
npm run check   # design audit (incl. baseline byte-compare), eslint, tsc, edu-anchors
npx vitest run
```

Both clean: `Design audit passed productStrict=0 informational=101` and
`Test Files 102 passed | Tests 1106 passed`. The design-audit baseline
**tightens** — `multiplePrimaryButtons` 19 → 17, from deleting the tabbed
dialog's two competing primaries. Two new named row classes are allowlisted the
same way `model-picker-choice-button` is, so `rawButtonElements` does not move.

Manual passes worth doing, because the share trigger has four shapes that fail
differently: Tooltip-wrapped (file viewer, app-launch), menu item (Docs rows,
app cards, agents, workflows), plain chip (agent header, function editor, flow
detail), and default button (table toolbar).

## Checklist

- [x] Tests cover the behavioral change — *partially; see below*
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload; every
      new surface gates on `pod.member.manage` / the existing resource-access
      permissions, and the invite link grants nothing on its own (the pod's
      `join_policy` still decides)
- [x] **Rollback** — pure frontend, no migration and no API change; reverting the
      commit is sufficient

Not applicable: migrations, API surface (no endpoint or schema touched — this
uses the existing `resourceAccess`, `podMembers`, `organizations.invitations` and
`podJoinRequests` calls), compatibility.

### On test coverage, honestly

`lib/share/share-link.test.ts` covers the new `resolveSharePodId`. Nothing covers
the popover interactions, and this PR does not add it: `vitest.config.ts` is
deliberately pure-logic-only — it names each included file and says the include
is kept tight so vitest "never tries to load broad Next/React component
surfaces." There is no jsdom or testing-library in the repo. Adding one to cover
this would be an architectural change beyond this PR's scope, so the popover
rests on review and manual verification. Reviewers should know that the anchor
broke twice during development (once positioning into the viewport corner, once
rendering nothing at all under a `<Tooltip>` trigger) — that is precisely the
part no automated gate here can catch.

## Compatibility and rollback notes

`ResourceShareButton` keeps its prop signature except for `className`, which was
removed: it existed to style a wrapper `<div>`, and the only four callers that
passed it passed `className="contents"` to suppress that wrapper's box — which
is what put the popover in the corner, since a box is what Radix measures. Those
four call sites are updated in this change; no caller is left passing it.

One behavioral change worth a reviewer's eye: role-based grants used to be
deleted implicitly by *any* save. They are now listed with a `Role` label and
removed only on purpose. That is strictly less destructive, but it does mean role
grants persist where they previously would have been silently cleared.
