### PR TITLE
Mount an HTML preview once, on the document the reader is meant to see

### DIFF
--- a/lemma-frontend/components/documents/document-preview.tsx
+++ b/lemma-frontend/components/documents/document-preview.tsx
@@ -124,10 +124,29 @@ export function DocumentPreviewBody({
     }
 
     if (previewType === 'html' && !showHtmlSource) {
+        const htmlDocument = htmlSrcDoc || buildHtmlPreviewSrcDoc(content);
         return (
+            // Keyed, so a document that arrives in two passes — the raw file,
+            // then the same file with its assets inlined a moment later — gets a
+            // fresh frame for the second pass instead of having `srcdoc`
+            // rewritten underneath it.
+            //
+            // Rewriting the attribute re-navigates a frame that is usually still
+            // loading the first document, and a frame that loses that race stays
+            // blank for good: the attribute already holds the right markup, so
+            // no later render touches it again. That is the preview that shows
+            // up only once something forces a whole-document style recalculation
+            // — switching theme, which `disableTransitionOnChange` does by
+            // design.
+            //
+            // Length is the discriminator because the alternative is hashing a
+            // document that runs to megabytes on every render. Inlining an asset
+            // only ever grows the file, so the two passes differ in length
+            // whenever they differ at all.
             <iframe
+                key={`html-${htmlDocument.length}`}
                 title={name}
-                srcDoc={htmlSrcDoc || buildHtmlPreviewSrcDoc(content)}
+                srcDoc={htmlDocument}
                 sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads allow-top-navigation-by-user-activation"
                 className="embedded-canvas block h-full min-h-[78vh] w-full border-0"
                 referrerPolicy="strict-origin-when-cross-origin"
@@ -279,7 +298,7 @@ export function useDocumentPreview({
 
     // Assets are followed against the reader's own permissions, so one this
     // reader may not open resolves to nothing and the page renders without it.
-    const { data: htmlPreview } = useQuery({
+    const htmlQuery = useQuery({
         queryKey: ['document-preview-html', podId, path, content.length],
         queryFn: () => buildHtmlPreviewDocument({
             contentHtml: content,
@@ -322,13 +341,19 @@ export function useDocumentPreview({
     // a PDF that fails to rasterise has no result either, and waiting for one
     // that is never coming would hold the skeleton up forever instead of
     // showing the fallback that offers Download.
-    const isRenderPending = pdfQuery.isLoading || docxQuery.isLoading;
+    //
+    // HTML counts for the same reason the other two do, and was missing: the
+    // frame used to mount on the raw file and then swap to the inlined one, so
+    // every shared page flashed once with its stylesheet and images unresolved,
+    // and the swap itself is the navigation a frame can lose. Waiting means the
+    // iframe mounts once, on the document the reader is meant to see.
+    const isRenderPending = pdfQuery.isLoading || docxQuery.isLoading || htmlQuery.isLoading;
 
     return {
         previewType,
         officeKind,
         content,
-        htmlSrcDoc: htmlPreview?.srcDoc ?? null,
+        htmlSrcDoc: htmlQuery.data?.srcDoc ?? null,
         imageUrl,
         pdf: pdfQuery.data ?? null,
         docxSrcDoc: docxQuery.data?.html ? buildDocxPreviewSrcDoc(docxQuery.data.html) : '',


### PR DESCRIPTION
## What changes

A shared `.html` file on `/s/` sometimes rendered as a blank frame, and appeared
only once the reader switched theme. It now renders on first paint, and it
renders with its stylesheet and images already resolved rather than flashing an
asset-less version first.

## Why

Every HTML preview navigated its iframe **twice**.

`useDocumentPreview` runs two queries for an `.html` file: one for the file's
text, and one that follows every relative `link`, `img` and `script` and inlines
it as a data URL. Only the first gated the skeleton:

```ts
const isRenderPending = pdfQuery.isLoading || docxQuery.isLoading;   // no html
```

So the frame mounted on the raw file — stylesheet and images unresolved — and
then `srcdoc` was rewritten on that same live element when the inlining resolved
some unpredictable time later.

That rewrite re-navigates a frame that is usually still loading the first
document, which is what makes the failure intermittent and worse for asset-heavy
pages. A frame that loses the race stays blank for good: React only touches an
attribute when its value changes, so once the rewrite lands, `srcdoc` holds the
correct markup forever and no later render can repair the frame.

Switching theme repairs it because `disableTransitionOnChange` on the theme
provider (`app/providers.tsx`) is implemented by injecting a global
`transition: none !important` rule and forcing a synchronous whole-document
style and layout recalculation. That is a full repaint, and it is the only thing
on the page that can get the stuck frame to commit — nothing about it is
theme-specific, which matches the original report of "switching themes etc".

Two changes, both in `components/documents/document-preview.tsx`:

- **The inlining query joins `isRenderPending`**, so the share route mounts the
  frame once, on the finished document. This also fixes a visual bug present on
  every *successful* load: a flash of the page with its CSS and images missing.
- **The iframe is keyed on the document**, so a change replaces the element
  instead of re-navigating a live one. Keyed on length rather than a hash,
  because the string can run to megabytes and this is on the render path;
  inlining only ever grows the document, so the two passes differ in length
  whenever they differ at all.

The workspace viewer (`document-viewer.tsx`) paints the raw file first on
purpose for speed and swaps later. It feeds the same component, so the key makes
its swap a remount too. Its paint-first strategy is deliberately left alone.

## How to verify

```bash
cd lemma-frontend
npx tsc --noEmit --pretty false --skipLibCheck
npx eslint components/documents/document-preview.tsx
npx vitest run lib/files/html-preview.test.ts components/documents/preview-renderers.test.ts
```

- `tsc` reports no error in the changed file. The 9 pre-existing errors on this
  branch are all SDK type drift in `surfaces`/`user-surfaces-panel`/
  `use-pod-surfaces`, untouched here.
- `eslint` exits clean.
- `vitest`: `Test Files 2 passed (2)`, `Tests 28 passed (28)`.

Not reproduced live: the route needs a backend with a real shared HTML file. The
double-navigation is established from the code path; that it is what leaves the
frame blank is inference that fits the symptom, including the theme-switch tell.

## Checklist

- [ ] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

`vitest.config.ts` scopes the frontend suite to pure-logic tests only — "no
component/DOM stack" — and the repo has no `testing-library` or `jsdom`
dependency. Asserting on iframe mount identity needs a DOM, so covering this
would mean standing up a component-testing stack, which is well outside this
change. Flagging rather than checking the box.

## Compatibility and rollback notes

No API, schema, or SDK surface touched. A single frontend component file;
revert the commit to roll back, with no migration or coordination needed.

The one behavior trade-off worth a reviewer's attention: an HTML preview on `/s/`
now shows the skeleton until every asset has been inlined, where it previously
painted the raw file immediately. For an asset-heavy page that is a longer
skeleton — deliberate, and consistent with how PDF and DOCX already gate, and
with the existing comment above `isRenderPending`. A page shown without its
stylesheet looks broken; an honest skeleton does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
