### PR TITLE
Stop one running conversation from freezing the rest of the pod

### DIFF
--- a/lemma-frontend/app/pod/[id]/app/pages/page.tsx
+++ b/lemma-frontend/app/pod/[id]/app/pages/page.tsx
@@ -6,7 +6,6 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { ArrowRight, ExternalLink, PanelsTopLeft, Plus, Share2 } from '@/components/ui/icons';
 import { toast } from 'sonner';
 
-import { useAIAssistant } from '@/components/ai/ai-assistant-context';
 import { ConceptHint } from '@/components/education/concept-hint';
 import { SectionPrimer } from '@/components/education/section-primer';
 import { ResourceHeader, ResourceIndexShell } from '@/components/pod/resource-layout';
@@ -53,7 +52,6 @@ export default function AppPagesRoute({ params }: { params: Promise<{ id: string
     const { pages, isLoading } = useAppPages(podId);
     const { mutate: deleteApp, isPending: isDeletingApp } = useDeleteApp();
     const { mutateAsync: updateAppVisibility } = useUpdateAppVisibility();
-    const assistant = useAIAssistant();
     const { launchRecipe } = useLaunchRecipe(podId);
     const [appPendingDelete, setAppPendingDelete] = useState<AppPageRef | null>(null);
 
@@ -111,14 +109,9 @@ export default function AppPagesRoute({ params }: { params: Promise<{ id: string
                             onClick={() => {
                                 void createAppWithAssistant();
                             }}
-                            disabled={assistant.isLoading || assistant.isOpenedConversationRunning}
                             className="h-9 w-fit gap-2 rounded-md px-3 text-sm"
                         >
-                            {assistant.isLoading || assistant.isOpenedConversationRunning ? (
-                                <StepLoader size="sm" />
-                            ) : (
-                                <Plus className="h-4 w-4" />
-                            )}
+                            <Plus className="h-4 w-4" />
                             New app
                         </Button>
                     ) : null

--- a/lemma-frontend/app/pod/[id]/page.tsx
+++ b/lemma-frontend/app/pod/[id]/page.tsx
@@ -161,7 +161,11 @@ function PodBlankChatHome({ podId }: { podId: string }) {
 
     const isLaunchingComposer = launchAnimation !== null;
     const isBlankingHome = isLaunchingComposer || isRouteHandoff;
-    const isBusy = isSending || isBlankingHome || assistant.isLoading || assistant.isOpenedConversationRunning || assistant.isUploadingFiles;
+    // Only what *this* composer is doing. The assistant is one instance for the
+    // whole pod, so gating on its shared streaming state let a conversation
+    // running anywhere freeze the one control whose entire job is to start a
+    // different one.
+    const isBusy = isSending || isBlankingHome || assistant.isUploadingFiles;
     const podDefaultRuntime = resolvePodDefaultRuntime(pod?.config, runtimeCatalog);
     const selectedCommandRuntime = assistant.conversationRuntime ?? null;
     const isLoadingHomeState =
@@ -345,7 +349,12 @@ function PodBlankChatHome({ podId }: { podId: string }) {
         startComposerLaunchAnimation(message);
         setIsSending(true);
         try {
-            assistant.clearMessages();
+            // Not `clearMessages()`: it resets the shared session, and the reset
+            // calls `stop()` — a real `stopRun` against whatever conversation was
+            // still open. So sending from home killed a turn that was still
+            // running, and cleared the files just attached to this one.
+            // `forceNewConversation` closes the open conversation first, which
+            // detaches from it without stopping it, and keeps the attachments.
             await assistant.sendMessage(message, {
                 forceNewConversation: true,
                 instructions: launchInstructionsRef.current || undefined,

--- a/lemma-frontend/components/pod/pod-new-workspace.tsx
+++ b/lemma-frontend/components/pod/pod-new-workspace.tsx
@@ -21,7 +21,6 @@ import {
     Workflow,
 } from '@/components/ui/icons';
 
-import { useAIAssistant } from '@/components/ai/ai-assistant-context';
 import { ConnectorIcon } from '@/components/connectors/connector-icon';
 import { formatRelativeTime } from '@/components/pod/recent-conversations';
 import { THEME_LOGOS } from '@/components/recipes/starter-theme-card';
@@ -351,15 +350,13 @@ export function PodNewWorkspace({
     // nothing sits above the panel for a height change to disturb.
     const isBelowComposer = placement === 'below-composer';
     const panelHeight = isBelowComposer ? PANEL_HEIGHT_NATURAL : PANEL_HEIGHT;
-    const assistant = useAIAssistant();
     const podAccess = usePodAccess(podId);
     const { data: pod } = usePod(podId);
     const podName = formatPodName(pod?.name);
     const { launchRecipe } = useLaunchRecipe(podId, { podName });
     const { signals, recentConversations, isLoading } = usePodStartSignals(podId);
     const canWriteConversations = podAccess.can('conversation.write');
-    const isBusy = assistant.isLoading || assistant.isOpenedConversationRunning;
-    const disabled = !canWriteConversations || isBusy;
+    const disabled = !canWriteConversations;
 
     const facts = useMemo(() => buildPodFacts(signals), [signals]);
     const doActions = useMemo(() => buildPodDoActions(signals), [signals]);

--- a/lemma-typescript/src/__tests__/conversation-send-fetches.test.ts
+++ b/lemma-typescript/src/__tests__/conversation-send-fetches.test.ts
@@ -71,6 +71,7 @@ function fakeClient(items: Conversation[], streamLines: string[] = CLEAN_TURN) {
   const create = vi.fn(async () => conversation("c-new", "WAITING"));
   const messagesList = vi.fn(async () => ({ items: [], limit: 100, next_page_token: null }));
   const sendMessageStream = vi.fn(async () => sse([...streamLines]));
+  const stopRun = vi.fn();
 
   const client = {
     podId: "pod-1",
@@ -86,12 +87,12 @@ function fakeClient(items: Conversation[], streamLines: string[] = CLEAN_TURN) {
       sendMessageStream,
       retryFailedRun: vi.fn(),
       resumeStream: vi.fn(),
-      stopRun: vi.fn(),
+      stopRun,
       update: vi.fn(),
     },
   } as unknown as LemmaClient;
 
-  return { client, list, get, create, messagesList, sendMessageStream };
+  return { client, list, get, create, messagesList, sendMessageStream, stopRun };
 }
 
 async function settle() {
@@ -342,5 +343,51 @@ describe("a conversation opened as the controller mounts", () => {
 
     expect(controller.current?.activeConversationId).toBe("c1");
     expect(messagesList).toHaveBeenCalled();
+  });
+});
+
+describe("starting a new conversation while one is running", () => {
+  // Pod home starts a fresh conversation on every send, and the assistant is
+  // one instance for the whole pod — so the turn it is holding is usually one
+  // the person is still watching somewhere else. Leaving it must not end it.
+  it("creates the new conversation and leaves the running one alone", async () => {
+    const { client, create, stopRun } = fakeClient([conversation("c1", "RUNNING")]);
+    const controller = await mount(client);
+
+    await act(async () => controller.current?.openConversation("c1"));
+    await settle();
+
+    // The order a caller has to keep: close first, then send. Closing drops the
+    // active id and the live stream, so the reset inside the forced-new send
+    // finds nothing to stop. Skip the close and the send is refused outright —
+    // `sendMessage` returns early while it believes a run is live — so this
+    // pins the order as much as the outcome.
+    await act(async () => controller.current?.closeConversation());
+    await settle();
+    await act(async () => {
+      await controller.current?.sendMessage("something else", { forceNewConversation: true });
+    });
+    await settle();
+
+    expect(stopRun).not.toHaveBeenCalled();
+    expect(create).toHaveBeenCalledOnce();
+  });
+
+  // The other half of the contract, and the reason the order above matters:
+  // `clearMessages` is not a cheaper `closeConversation`. It resets the shared
+  // session, and the reset ends the run. Pod home used to call it before every
+  // send, which killed whatever turn the assistant still had open.
+  it("stops the run when the session is reset instead of closed", async () => {
+    const { client, stopRun } = fakeClient([conversation("c1", "RUNNING")]);
+    const controller = await mount(client);
+
+    await act(async () => controller.current?.openConversation("c1"));
+    await settle();
+
+    await act(async () => controller.current?.clearMessages());
+    await settle();
+
+    expect(stopRun).toHaveBeenCalledOnce();
+    expect(stopRun.mock.calls[0]?.[0]).toBe("c1");
   });
 });


### PR DESCRIPTION
## What changes

While any conversation is running, the pod stops letting you start anything
else. "New app" on the Apps index greys out and spins, the pod home composer
refuses the send and shows a loader with no stop button, and every tile in the
home launcher — Build, Create, Do — goes dead. This makes all of them
independent of whatever the assistant is doing.

It also stops pod home from ending a turn you are still watching, and stops it
from dropping files you attached before sending.

## Why

`AIAssistantProvider` is mounted once at the pod layout, so one assistant backs
every route under `/pod/[id]/*`. `openedConversationId` is set by
`openConversation()` and never cleared on navigation — the conversations layout
has no unmount cleanup. So `isOpenedConversationRunning` and `isLoading` stay
true pod-wide for as long as the run lasts, and three surfaces were reading them
as "the app is busy".

None of them had a reason to. `createAppWithAssistant` is one `router.push`; the
launcher's `onPreparePrompt` is one `setDraft`. The strongest evidence the gates
were vestigial: the same function behind the gated "New app" header button is
already wired, **ungated**, to the "Describe your own" card directly below it —
same action, blocked in one place and allowed in the other. The sidebar's "New
conversation" and its whole Create menu were never gated either.

Pod home was the one real coupling, and it was a bug rather than a constraint.
`submit()` called `assistant.clearMessages()` before every send:

```
clearMessages() → resetConversationState(false) → stop() → sessionStop(id)
                → conversations.stopRun(id)
```

`stopRun` is a real server-side stop, and `stop()` fires it precisely when a run
is live. So the gate was load-bearing — remove it alone and typing on home would
have killed a turn running elsewhere. The fix is to remove the call instead:
`sendMessage(..., { forceNewConversation: true })` already calls
`closeConversation()` first, which detaches without stopping. The SDK says so
itself, at `useAssistantController.ts:1513`: the turn we are walking out on keeps
going without us.

Dropping that call fixes a second bug for free. `clearMessages()` is
`resetConversationState(false)` — `false` meaning *do not* keep pending files —
while the forced-new send deliberately passes `true`. Home was wiping the
attachments a moment before sending them, so attach-then-send from pod home
never worked.

Not changed: the agent test panel and flow run-steps read the same flag but each
builds its own `useAssistantController`, so they are isolated from the pod-wide
assistant and were never affected.

## How to verify

```bash
npm --prefix lemma-typescript run test
npm --prefix lemma-frontend run test
npm --prefix lemma-frontend run check
```

```
SDK        Test Files 29 passed   Tests 237 passed
frontend   Test Files 105 passed  Tests 1160 passed
check      design audit passed (productStrict=0) · eslint clean ·
           tsc --noEmit clean · check-edu-anchors: 9 anchors verified
```

Manually, the behaviour needs a live run: start a conversation, and while it is
still streaming go to Apps (button pressable), then pod home (composer accepts
typing, send arrow rather than a spinner, launcher tiles live). Send from home —
it should open a new conversation while the original keeps running.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

## Notes for the reviewer

The two new tests live in `conversation-send-fetches.test.ts` and pin the SDK
contract the fix depends on: close-then-send creates a conversation without
stopping the old one, and `clearMessages()` *does* stop it — which is why the
frontend must not call it.

Worth knowing how the first one is scoped. I mutation-checked it, and dropping
the `closeConversation()` fails it on `create` (0 calls), not on `stopRun` — the
SDK refuses to send at all while it believes a run is live, which masks the stop
in that fixture. So it pins the required *ordering* rather than the stop itself.
It is named and commented for that, rather than left with a name claiming more
than it proves. The `clearMessages()` test is the load-bearing one.

## Compatibility and rollback notes

Frontend-only, no API or schema surface. Straight revert if needed.
