### PR TITLE
Write every model down once, and let each row say whether it can be picked

### DIFF
--- a/lemma-frontend/components/agents/agent-runtime-helpers.ts
+++ b/lemma-frontend/components/agents/agent-runtime-helpers.ts
@@ -341,6 +341,16 @@ export function describeHarness(
     logo: string | undefined;
     /** The agent's version and model count — the two facts a reader can act on. */
     facts: string[];
+    /**
+     * The same two facts, apart, for a caller that wants only one of them.
+     *
+     * The models ledger wants the model count and not the version: the version
+     * string an agent publishes routinely carries its own name — "2.1.233
+     * (Claude Code)" — so printing it beside a row already titled Claude Code
+     * said the name twice and buried the one fact worth reading.
+     */
+    version: string | null;
+    modelCount: number;
     statusLabel: string;
     usable: boolean;
     /** What to say when the row cannot take work and the status alone won't explain it. */
@@ -355,6 +365,8 @@ export function describeHarness(
             harness.upstream_version ? `agent ${harness.upstream_version}` : null,
             modelCount ? `${modelCount} model${modelCount === 1 ? '' : 's'}` : null,
         ].filter((fact): fact is string => fact !== null),
+        version: harness.upstream_version ?? null,
+        modelCount,
         // Reachability decides first: a healthy agent on a sleeping laptop is
         // not "Ready", whatever the harness itself last reported.
         statusLabel: hostOnline ? health.label : 'Computer offline',

--- a/lemma-frontend/components/agents/models-settings.tsx
+++ b/lemma-frontend/components/agents/models-settings.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { useCallback, useState, type ReactNode } from 'react';
 import { RuntimeProfileKind, RuntimeProfileScope } from 'lemma-sdk';
 import type { AgentRuntimeProfileResponse } from 'lemma-sdk';
-import { Cpu, Download, KeyRound, Pencil, Plus, RefreshCw, RotateCcw, Sparkles, TerminalSquare, Trash2 } from '@/components/ui/icons';
+import { Cpu, Download, KeyRound, Pencil, Plus, RefreshCw, RotateCcw, Sparkles, TerminalSquare } from '@/components/ui/icons';
 import { toast } from 'sonner';
 
 import { Button } from '@/components/ui/button';
@@ -21,6 +21,7 @@ import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
+    DropdownMenuLabel,
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
@@ -87,14 +88,17 @@ const PROVIDER_PRESETS: ProviderPreset[] = [
 ];
 
 /**
- * A ledger, not a stack of forms.
+ * One ledger, not two lists that look the same.
  *
- * This read as four boxes and a floating paragraph to answer one question. It
- * now reads the way Access and Automation do, and for the same reason: a lead
- * paragraph, then bare rows. Nothing here is a card, because a card is a
- * promise that its contents belong together and are separate from what follows
- * — and "the models you can pick" and "the computers some of them run on" are
- * one page, read top to bottom, not two places to be switched between.
+ * This page used to state Models and Computers as peers, in one row grammar, so
+ * eight rows read as eight peers — and a coding agent that had been added
+ * appeared in both, under the same name, with the same logo, both saying
+ * "Ready". Nothing on the page said they were one thing.
+ *
+ * They were never peers. A computer is where some of these models *come from*,
+ * so it is a group heading inside the list rather than a second section under
+ * it, and every model — bought key or local agent — is written down exactly
+ * once, in the place it comes from.
  */
 export function ModelsSettings({
     organizationId,
@@ -115,6 +119,18 @@ export function ModelsSettings({
     onRefresh?: () => void | Promise<void>;
 }) {
     const [showArchived, setShowArchived] = useState(false);
+    const [providerDialog, setProviderDialog] = useState<ProviderDialogTarget | null>(null);
+    // A profile is edited through the form that made it. Collapsing the two row
+    // types into one `LedgerRow` must not collapse this with them: a coding
+    // agent's settings are its harness's config options, and opening a base-URL
+    // and API-key form over one edits fields it does not have.
+    const [harnessDialog, setHarnessDialog] = useState<HarnessDialogTarget | null>(null);
+    const [connectingComputer, setConnectingComputer] = useState(false);
+    // Which paired computer is the one the user is sitting at. Only the desktop
+    // app can answer that; in a browser it stays null and the list is unchanged.
+    const [thisHostId, setThisHostId] = useState<string | null>(null);
+    const onHostIdChange = useCallback((hostId: string | null) => setThisHostId(hostId), []);
+
     // Archived profiles come down with everything else and are split below, so
     // the toggle can name its own count instead of being a switch that might
     // reveal nothing.
@@ -124,13 +140,33 @@ export function ModelsSettings({
     // A revoked host stays readable through the API for audit, but it can never
     // take work again, so it has no place in a "what can I use" list.
     const activeHosts = (hosts.data?.items ?? []).filter((host) => host.status !== 'REVOKED');
-    const harnessOwners = useAgentHostHarnessOwners(activeHosts);
+    const { owners: harnessOwners, isPending: ownersPending } = useAgentHostHarnessOwners(activeHosts);
+    const isDesktop = useIsDesktopShell();
     const isRefreshing = managed.isFetching || hosts.isFetching;
 
-    const live = profiles.filter((profile) => !isArchivedProfile(profile));
-    const archived = profiles.filter(isArchivedProfile);
-    const providers = live.filter((profile) => profile.kind === RuntimeProfileKind.MODEL_PROVIDER);
-    const codingAgents = live.filter((profile) => profile.kind === RuntimeProfileKind.HARNESS);
+    const providers = profiles.filter((profile) => profile.kind === RuntimeProfileKind.MODEL_PROVIDER);
+    const harnessProfiles = profiles.filter((profile) => profile.kind === RuntimeProfileKind.HARNESS);
+
+    // A saved coding agent is drawn under the computer that published its
+    // harness. What is left over is a profile whose computer is not in this
+    // list — unpaired, or still loading — and it has to keep a row of its own
+    // or it would simply vanish from a page that claims to list everything.
+    //
+    // Held back until the per-host queries settle: every harness looks detached
+    // for the first frame, and rows that appear at the top and then jump into a
+    // group below are the same disorientation this page was rebuilt to remove.
+    const detached = ownersPending
+        ? []
+        : harnessProfiles.filter((profile) => !profile.harness_id || !harnessOwners.has(profile.harness_id));
+
+    // Only the rows the toggle actually hides. A harness that is archived is
+    // still drawn under its computer either way — the machine has it installed
+    // whatever Lemma thinks of the profile — so counting it here would promise
+    // more than the toggle reveals.
+    const hidden = [...providers, ...detached].filter(isArchivedProfile);
+    const rows = [...providers, ...detached].filter(
+        (profile) => showArchived || !isArchivedProfile(profile),
+    );
 
     const refreshAll = () => {
         void managed.refetch();
@@ -138,11 +174,17 @@ export function ModelsSettings({
         void onRefresh?.();
     };
 
+    // In a browser there is no "this computer" to offer, so the page asks for
+    // the app instead — but only once there is nothing else here to read.
+    const showGetTheApp = !isDesktop && !hosts.isLoading && activeHosts.length === 0;
+    const isEmpty = !managed.isLoading && rows.length === 0 && activeHosts.length === 0;
+
     return (
         <div className="space-y-5">
             <p className="text-sm leading-6 text-[var(--text-secondary)]">
                 Everything this pod can pick in a chat. The list is shared with every pod in the
-                organization; coding agents run on the computer they came from.
+                organization; coding agents run on the computer they came from, and that computer&apos;s
+                credentials never leave it.
             </p>
 
             {/* Recheck sits on the pod default's line rather than above the lead
@@ -167,179 +209,149 @@ export function ModelsSettings({
                 </div>
             ) : null}
 
-            <ModelsSection
-                organizationId={organizationId}
-                providers={providers}
-                codingAgents={codingAgents}
-                archived={showArchived ? archived : []}
-                archivedCount={archived.length}
-                showArchived={showArchived}
-                onToggleArchived={() => setShowArchived((current) => !current)}
-                harnessOwners={harnessOwners}
-                loading={managed.isLoading}
-                onRefresh={refreshAll}
-            />
-
-            <ComputersSection
-                organizationId={organizationId}
-                hosts={activeHosts}
-                loadingHosts={hosts.isLoading}
-                savedProfiles={[...codingAgents, ...archived]}
-                onRefresh={refreshAll}
-            />
-        </div>
-    );
-}
-
-/**
- * A group heading with its own actions on the same line.
- *
- * Both groups use it, so "Connect a provider" and "Connect a computer" land on
- * the same right edge at the same height in their sections instead of one
- * dangling under a list and the other under a paragraph.
- */
-function LedgerSectionHeader({
-    title,
-    hint,
-    actions,
-}: {
-    title: string;
-    hint?: string;
-    actions?: ReactNode;
-}) {
-    return (
-        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
-            <div className="flex min-w-0 flex-wrap items-baseline gap-x-2.5 gap-y-0.5">
-                <h3 className="type-eyebrow">{title}</h3>
-                {hint ? <p className="text-xs text-[var(--text-tertiary)]">{hint}</p> : null}
-            </div>
-            {actions ? <div className="flex shrink-0 items-center gap-1">{actions}</div> : null}
-        </div>
-    );
-}
-
-/**
- * Everything the model picker can offer, in one list.
- *
- * A key and a laptop are different things to *operate*, which is why the
- * computers keep their own group below — but they are the same thing to
- * *choose*, and splitting the choice across two lists meant a fresh
- * organization opened on a section whose entire content was "None yet, add one
- * from a paired computer below". A section that exists to point at another
- * section is a section the reader has to assemble themselves.
- */
-function ModelsSection({
-    organizationId,
-    providers,
-    codingAgents,
-    archived,
-    archivedCount,
-    showArchived,
-    onToggleArchived,
-    harnessOwners,
-    loading,
-    onRefresh,
-}: {
-    organizationId: string;
-    providers: AgentRuntimeProfileResponse[];
-    codingAgents: AgentRuntimeProfileResponse[];
-    archived: AgentRuntimeProfileResponse[];
-    archivedCount: number;
-    showArchived: boolean;
-    onToggleArchived: () => void;
-    harnessOwners: Map<string, string>;
-    loading: boolean;
-    onRefresh?: () => void;
-}) {
-    const [providerDialog, setProviderDialog] = useState<ProviderDialogTarget | null>(null);
-    const [harnessDialog, setHarnessDialog] = useState<HarnessDialogTarget | null>(null);
-    const rows = [...providers, ...codingAgents, ...archived];
-
-    return (
-        <section className="space-y-2">
-            <LedgerSectionHeader
-                title="Models"
-                actions={(
-                    <>
+            <section className="space-y-2">
+                <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
+                    <h3 className="type-eyebrow">Models</h3>
+                    <div className="flex shrink-0 items-center gap-1">
                         {/* Only when there is something behind it. A permanent
                             "Show archived" is an invitation to look at nothing. */}
-                        {archivedCount > 0 ? (
-                            <Button type="button" variant="quiet" size="sm" onClick={onToggleArchived}>
-                                {showArchived ? 'Hide archived' : `Show archived (${archivedCount})`}
+                        {hidden.length > 0 ? (
+                            <Button
+                                type="button"
+                                variant="quiet"
+                                size="sm"
+                                onClick={() => setShowArchived((current) => !current)}
+                            >
+                                {showArchived ? 'Hide archived' : `Show archived (${hidden.length})`}
                             </Button>
                         ) : null}
-                        <ConnectProviderMenu onPick={setProviderDialog} />
-                    </>
+                        <ConnectMenu
+                            onPickProvider={setProviderDialog}
+                            onPickComputer={() => setConnectingComputer(true)}
+                        />
+                    </div>
+                </div>
+
+                {managed.isLoading ? <ListSkeleton rows={3} /> : isEmpty ? (
+                    <EmptyState
+                        variant="region"
+                        icon={<Sparkles className="h-5 w-5" />}
+                        title="No models yet"
+                        description="Connect a provider key, or pair a computer to bring the coding agents already installed on it."
+                    />
+                ) : (
+                    /*
+                     * One bordered surface for the whole ledger.
+                     *
+                     * The rows used to float on the page under a hairline that
+                     * stopped at 68% of the row and pointed at nothing, which is
+                     * what read as unfinished. A panel gives the list an edge to
+                     * meet, lets the dividers run the full width, and — because
+                     * the computers are inside it rather than under it — draws
+                     * the one claim this page is making: these are all one list.
+                     */
+                    <div className="overflow-hidden rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-1)]">
+                        {rows.length > 0 ? (
+                            <ul className="lemma-index-list lemma-panel-list">
+                                {rows.map((profile) => (
+                                    <ProfileRow
+                                        key={profile.id}
+                                        profile={profile}
+                                        organizationId={organizationId}
+                                        onEdit={() => (
+                                            profile.kind === RuntimeProfileKind.HARNESS
+                                                ? setHarnessDialog({ mode: 'edit', profile })
+                                                : setProviderDialog({ mode: 'edit', profile })
+                                        )}
+                                        onRefresh={refreshAll}
+                                    />
+                                ))}
+                            </ul>
+                        ) : null}
+
+                        {hosts.isLoading ? (
+                            <div className="px-3"><ListSkeleton rows={2} /></div>
+                        ) : null}
+
+                        {activeHosts.map((host, index) => (
+                            <ComputerGroup
+                                key={host.id}
+                                host={host}
+                                organizationId={organizationId}
+                                isThisComputer={host.id === thisHostId}
+                                savedProfiles={harnessProfiles}
+                                // The band draws the rule that separates it from
+                                // whatever is above. When it *is* the top of the
+                                // panel there is nothing above but the panel's
+                                // own border, and two lines a pixel apart read
+                                // as one thick one.
+                                isPanelTop={rows.length === 0 && index === 0}
+                                onRefresh={refreshAll}
+                            />
+                        ))}
+                    </div>
                 )}
-            />
-            {loading ? <ListSkeleton rows={3} /> : rows.length === 0 ? (
-                <EmptyState
-                    variant="region"
-                    icon={<Sparkles className="h-5 w-5" />}
-                    title="No models yet"
-                    description="Connect a provider key, or pair a computer to bring the coding agents already installed on it."
-                />
-            ) : (
-                <ul className="lemma-index-list">
-                    {rows.map((profile) => (
-                        profile.kind === RuntimeProfileKind.HARNESS ? (
-                            <CodingAgentRow
-                                key={profile.id}
-                                profile={profile}
-                                organizationId={organizationId}
-                                computer={
-                                    profile.harness_id ? harnessOwners.get(profile.harness_id) ?? null : null
-                                }
-                                onEdit={() => setHarnessDialog({ mode: 'edit', profile })}
-                                onRefresh={onRefresh}
-                            />
-                        ) : (
-                            <ProviderRow
-                                key={profile.id}
-                                profile={profile}
-                                organizationId={organizationId}
-                                onEdit={() => setProviderDialog({ mode: 'edit', profile })}
-                                onRefresh={onRefresh}
-                            />
-                        )
-                    ))}
-                </ul>
-            )}
+
+                {/* Reporting on the Agent Host process running beside this tab —
+                    troubleshooting, not choosing — so it sits under the list
+                    rather than interrupting it. Mounted on every desktop render
+                    regardless: it is what pairs this machine in the first place,
+                    and what tells the groups above which one it is. */}
+                <ThisComputerCard onHostIdChange={onHostIdChange} onPaired={refreshAll} />
+
+                {showGetTheApp ? <GetTheAppCard /> : null}
+            </section>
 
             <ProviderProfileDialog
                 target={providerDialog}
                 organizationId={organizationId}
                 onClose={() => setProviderDialog(null)}
-                onSaved={onRefresh}
+                onSaved={refreshAll}
             />
             <HarnessProfileDialog
                 target={harnessDialog}
                 organizationId={organizationId}
                 onClose={() => setHarnessDialog(null)}
-                onSaved={onRefresh}
+                onSaved={refreshAll}
             />
-        </section>
+            <ConnectComputerDialog
+                open={connectingComputer}
+                onClose={() => setConnectingComputer(false)}
+            />
+        </div>
     );
 }
 
-// One button instead of eleven chips. The chips were a wall of equal-weight
-// names that made choosing a provider look like the main thing this page is
-// for, when for most organizations the built-in models already answer it.
-function ConnectProviderMenu({ onPick }: { onPick: (target: ProviderDialogTarget) => void }) {
+/**
+ * One button for everything this list can gain.
+ *
+ * There were two, on two section headers, and which one you wanted depended on
+ * knowing that a coding agent arrives through a machine rather than a key —
+ * which is the thing the page is supposed to be teaching, not asking. Adding
+ * anything starts in the same place now, and the menu draws the distinction.
+ */
+function ConnectMenu({
+    onPickProvider,
+    onPickComputer,
+}: {
+    onPickProvider: (target: ProviderDialogTarget) => void;
+    onPickComputer: () => void;
+}) {
     return (
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
                 <Button type="button" variant="secondary" size="sm" className="gap-1.5">
                     <Plus className="size-3.5" />
-                    Connect a provider
+                    Connect
                 </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-56">
+            <DropdownMenuContent align="end" className="w-56">
+                <DropdownMenuLabel>A provider key</DropdownMenuLabel>
                 {PROVIDER_PRESETS.map((preset) => (
                     <DropdownMenuItem
                         key={preset.id}
                         onSelect={() =>
-                            onPick({
+                            onPickProvider({
                                 mode: 'connect',
                                 kind: preset.kind,
                                 name: preset.name,
@@ -350,12 +362,11 @@ function ConnectProviderMenu({ onPick }: { onPick: (target: ProviderDialogTarget
                         {preset.name}
                     </DropdownMenuItem>
                 ))}
-                <DropdownMenuSeparator />
                 {CUSTOM_PROVIDER_OPTIONS.map((option) => (
                     <DropdownMenuItem
                         key={option.kind}
                         onSelect={() =>
-                            onPick({
+                            onPickProvider({
                                 mode: 'connect',
                                 kind: option.kind,
                                 name: '',
@@ -366,38 +377,41 @@ function ConnectProviderMenu({ onPick }: { onPick: (target: ProviderDialogTarget
                         {option.kind === 'openai' ? 'Anything OpenAI-compatible' : 'Anything Anthropic-compatible'}
                     </DropdownMenuItem>
                 ))}
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel>A computer</DropdownMenuLabel>
+                <DropdownMenuItem onSelect={onPickComputer}>
+                    Bring its coding agents…
+                </DropdownMenuItem>
             </DropdownMenuContent>
         </DropdownMenu>
     );
 }
 
-/**
- * One status per row, answering one question: can I use this right now?
- *
- * The rows used to carry up to four badges — archived, scope, availability,
- * built-in — which mixed what a thing *is* with who *owns* it and whether it
- * *works*, so none of them read as status. Ownership only appears when it is
- * the exception (a personal profile in a shared organization); everything else
- * folds into this one label.
- */
-function modelStatus(profile: AgentRuntimeProfileResponse): { label: string; tone: StatusTone } {
-    if (isArchivedProfile(profile)) return { label: 'Archived', tone: 'muted' };
-    if (profile.scope === RuntimeProfileScope.SYSTEM) return { label: 'Built in', tone: 'ok' };
-    const availability = runtimeAvailabilityLabel(profile);
-    if (availability) return { label: availability, tone: 'muted' };
-    return { label: 'Ready', tone: 'ok' };
-}
-
 type StatusTone = 'ok' | 'warn' | 'muted';
+
+/**
+ * Can a chat pick this right now — asked of every row, answered on every row.
+ *
+ * The old column said "Ready" five times on a page of eight rows and meant
+ * three different things by it: a key that works, a saved profile, an installed
+ * agent nobody had added. The defect there was that one word covered three
+ * questions, not that the column was answered — so this states one question,
+ * and every row answers it in the same vocabulary.
+ *
+ * A row that leaves it blank is worse than a repetitive one. "Is Claude Code
+ * available?" is the question the page exists to answer, and inferring yes from
+ * the absence of an Add button is not answering it.
+ */
+function profileStatus(profile: AgentRuntimeProfileResponse): { label: string; tone: StatusTone } {
+    if (isArchivedProfile(profile)) return { label: 'Archived', tone: 'muted' };
+    const availability = runtimeAvailabilityLabel(profile);
+    if (availability) return { label: availability, tone: 'warn' };
+    return { label: 'Available', tone: 'ok' };
+}
 
 /**
  * Status the way every other ledger in the pod states it: a coloured dot and a
  * word, at the right edge of the row.
- *
- * The pill this replaces was a filled shape on a line that already had one for
- * the icon, so a list of four models was eight filled shapes and two of them
- * were the same grey. Triggers, runs and members have all read as dot-plus-word
- * for a while; this page was the holdout.
  */
 function StatusDot({ label, tone }: { label: string; tone: StatusTone }) {
     return (
@@ -417,54 +431,75 @@ function StatusDot({ label, tone }: { label: string; tone: StatusTone }) {
     );
 }
 
-function ModelRow({
+/**
+ * Every row on this page, drawn once.
+ *
+ * A bought key, a coding agent on a laptop and a profile whose machine is gone
+ * are the same object to a reader — a thing a chat can pick — so they are the
+ * same row, and only what fills the slots differs. The trailing menu keeps its
+ * 28px whether or not there is a menu in it, which is the whole of why the
+ * status column used to be ragged: rows with a menu pushed their status inward
+ * and rows without it did not, so no two words in the column shared an edge.
+ */
+function LedgerRow({
     icon,
     name,
     detail,
-    profile,
-    organizationId,
-    onEdit,
-    onRefresh,
+    chip,
+    /** A fuller sentence about why this row cannot be used, under the name. */
+    note,
+    status,
+    /** The row's own affordance — "Add", "Restore" — left of the menu slot. */
+    action,
+    menu,
+    dimmed,
 }: {
     icon: ReactNode;
     name: string;
-    /** Empty when there is nothing to add beyond the name. */
-    detail: string;
-    profile: AgentRuntimeProfileResponse;
-    organizationId: string;
-    onEdit: () => void;
-    onRefresh?: () => void;
+    detail?: string;
+    chip?: ReactNode;
+    note?: string | null;
+    status?: { label: string; tone: StatusTone } | null;
+    action?: ReactNode;
+    menu?: ReactNode;
+    dimmed?: boolean;
 }) {
-    const status = modelStatus(profile);
-    const scope = scopeBadge(profile.scope);
-
     return (
-        <li className="lemma-index-row group flex items-center gap-2.5">
-            <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-[var(--surface-1)] text-[var(--text-secondary)]">
+        <li className={cn('lemma-index-row group flex items-center gap-2.5', dimmed && 'opacity-60')}>
+            <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-[var(--surface-2)] text-[var(--text-secondary)]">
                 {icon}
             </span>
             {/* Name and detail on one line, not stacked. A two-line row for
-                "Lemma / 4 models" is a paragraph where a sentence would do, and
-                it is what made four models fill a screen. */}
-            <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-0.5">
-                <span className="truncate text-sm font-medium text-[var(--text-primary)]">{name}</span>
-                {detail ? (
-                    <span className="truncate text-xs text-[var(--text-tertiary)]">{detail}</span>
+                "Lemma / 6 models" is a paragraph where a sentence would do. The
+                note is the exception, and it is the reason Cursor's failure used
+                to break the grid: as a full-width line inside the row's own flex
+                it wrapped the status down to the left margin. */}
+            <div className="min-w-0 flex-1">
+                <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5">
+                    <span className="truncate text-sm font-medium text-[var(--text-primary)]">{name}</span>
+                    {detail ? (
+                        <span className="truncate text-xs text-[var(--text-tertiary)]">{detail}</span>
+                    ) : null}
+                    {chip}
+                </div>
+                {note ? (
+                    <p className="mt-0.5 text-xs text-[var(--text-tertiary)]">{note}</p>
                 ) : null}
-                {scope ? <span className="chip chip-sm chip-muted">{scope.label}</span> : null}
             </div>
-            <StatusDot label={status.label} tone={status.tone} />
-            <ProfileRowActions
-                profile={profile}
-                organizationId={organizationId}
-                onEdit={onEdit}
-                onRefresh={onRefresh}
-            />
+            <div className="flex shrink-0 items-center justify-end gap-1">
+                {action}
+                {status ? <StatusDot label={status.label} tone={status.tone} /> : null}
+                <span className="flex size-7 shrink-0 items-center justify-center">{menu}</span>
+            </div>
         </li>
     );
 }
 
-function ProviderRow({
+/**
+ * A saved profile with no live harness behind it: a bought provider key, or a
+ * coding agent whose computer is not in the list.
+ */
+function ProfileRow({
     profile,
     organizationId,
     onEdit,
@@ -476,66 +511,47 @@ function ProviderRow({
     onRefresh?: () => void;
 }) {
     const isSystem = profile.scope === RuntimeProfileScope.SYSTEM;
+    const isHarness = profile.kind === RuntimeProfileKind.HARNESS;
+    const logo = isHarness ? harnessLogo(profileHarnessKey(profile)) : undefined;
     const modelCount = profile.model_catalog?.length ?? 0;
-    // "Built in" is the row's status badge. Printing it here as well made every
-    // built-in row say the same word twice, three inches apart.
+    const scope = scopeBadge(profile.scope);
+
+    // "Built in" is what this row *is*, not how it is doing — a fact that never
+    // changes, printed once, next to the other facts. It spent this page's
+    // whole history in the status column saying the same word forever.
     const detail = [
-        isSystem ? null : 'Shared key',
+        isSystem ? 'Built in' : isHarness ? null : 'Shared key',
         modelCount ? `${modelCount} model${modelCount === 1 ? '' : 's'}` : null,
     ].filter(Boolean).join(' · ');
 
+    const status = profileStatus(profile)
+        ?? (isHarness ? { label: 'Computer not connected', tone: 'muted' as StatusTone } : null);
+
     return (
-        <ModelRow
+        <LedgerRow
             icon={
-                isSystem ? (
+                logo ? (
+                    <Image src={logo} alt="" width={18} height={18} className="size-4.5 object-contain" />
+                ) : isSystem ? (
                     <Sparkles className="size-4 text-[var(--delight)]" />
+                ) : isHarness ? (
+                    <TerminalSquare className="size-4" />
                 ) : (
                     <KeyRound className="size-4" />
                 )
             }
             name={profile.name}
             detail={detail}
-            profile={profile}
-            organizationId={organizationId}
-            onEdit={onEdit}
-            onRefresh={onRefresh}
-        />
-    );
-}
-
-function CodingAgentRow({
-    profile,
-    organizationId,
-    computer,
-    onEdit,
-    onRefresh,
-}: {
-    profile: AgentRuntimeProfileResponse;
-    organizationId: string;
-    /** Null while the owning computer's harness list is still loading. */
-    computer: string | null;
-    onEdit: () => void;
-    onRefresh?: () => void;
-}) {
-    const logo = harnessLogo(profileHarnessKey(profile));
-
-    return (
-        <ModelRow
-            icon={
-                logo ? (
-                    <Image src={logo} alt="" width={18} height={18} className="size-4.5 object-contain" />
-                ) : (
-                    <TerminalSquare className="size-4" />
-                )
-            }
-            name={profile.name}
-            detail={`${computer ? `On ${computer}` : 'On a connected computer'} · ${
-                profile.default_model_name ?? 'agent picks the model'
-            }`}
-            profile={profile}
-            organizationId={organizationId}
-            onEdit={onEdit}
-            onRefresh={onRefresh}
+            chip={scope ? <span className="chip chip-sm chip-muted">{scope.label}</span> : null}
+            status={status}
+            menu={(
+                <ProfileActionsMenu
+                    profile={profile}
+                    organizationId={organizationId}
+                    onEdit={onEdit}
+                    onRefresh={onRefresh}
+                />
+            )}
         />
     );
 }
@@ -545,7 +561,7 @@ function CodingAgentRow({
  * Lemma's own built-ins — there is nothing here a workspace may change, so they
  * get no menu at all rather than a menu of disabled items.
  */
-function ProfileRowActions({
+function ProfileActionsMenu({
     profile,
     organizationId,
     onEdit,
@@ -638,95 +654,6 @@ function ProfileRowActions({
     );
 }
 
-
-/**
- * The machines that run the coding agents in the Models list.
- *
- * Not a peer of Models — it is where those rows come from — which is why it is
- * a view of the same ledger rather than a second card stacked under it. A
- * computer holds a scoped, separately revocable secret and reaches Lemma over
- * outbound HTTPS, so nothing here needs an inbound port or the user's own
- * session on that machine.
- */
-function ComputersSection({
-    organizationId,
-    hosts,
-    loadingHosts,
-    savedProfiles,
-    onRefresh,
-}: {
-    organizationId: string;
-    hosts: AgentHost[];
-    loadingHosts: boolean;
-    savedProfiles: AgentRuntimeProfileResponse[];
-    onRefresh?: () => void;
-}) {
-    const isDesktop = useIsDesktopShell();
-    const [connecting, setConnecting] = useState(false);
-    // Which paired computer is the one the user is sitting at. Only the desktop
-    // app can answer that; in a browser it stays null and the list is unchanged.
-    const [thisHostId, setThisHostId] = useState<string | null>(null);
-    const onHostIdChange = useCallback((hostId: string | null) => setThisHostId(hostId), []);
-
-    // Harnesses already saved as runtime profiles, so a row can say "added"
-    // instead of leaving the user guessing whether picking this agent in a chat
-    // is possible yet. Built from the management listing rather than the
-    // catalog: an archived profile is absent from the catalog, so the row would
-    // offer "Add to models" again and then 409 on the unique-name index.
-    const savedProfileByHarnessId = new Map<string, AgentRuntimeProfileResponse>();
-    for (const profile of savedProfiles) {
-        if (profile.harness_id) savedProfileByHarnessId.set(profile.harness_id, profile);
-    }
-
-    // In a browser there is no "this computer" to offer, so an empty section
-    // would just be a heading. The app is the thing that makes this work, so
-    // that is what the empty state asks for.
-    const showGetTheApp = !isDesktop && !loadingHosts && hosts.length === 0;
-
-    return (
-        <section className="space-y-2">
-            <LedgerSectionHeader
-                title="Computers"
-                hint="Their credentials never leave the machine."
-                actions={(
-                    <Button
-                        type="button"
-                        variant="secondary"
-                        size="sm"
-                        className="gap-1.5"
-                        onClick={() => setConnecting(true)}
-                    >
-                        <Plus className="size-3.5" />
-                        {hosts.length ? 'Connect another' : 'Connect a computer'}
-                    </Button>
-                )}
-            />
-
-            <ThisComputerCard onHostIdChange={onHostIdChange} onPaired={onRefresh} />
-
-            {loadingHosts ? <ListSkeleton rows={2} /> : null}
-
-            {hosts.map((host) => (
-                <AgentHostGroup
-                    key={host.id}
-                    host={host}
-                    organizationId={organizationId}
-                    isThisComputer={host.id === thisHostId}
-                    savedProfileByHarnessId={savedProfileByHarnessId}
-                    onRefresh={onRefresh}
-                />
-            ))}
-
-            {showGetTheApp ? <GetTheAppCard /> : null}
-
-            <ConnectComputerDialog
-                open={connecting}
-                onClose={() => setConnecting(false)}
-            />
-        </section>
-    );
-}
-
 /** The empty state in a plain browser: the app is what makes this work. */
 function GetTheAppCard() {
     return (
@@ -759,8 +686,8 @@ function GetTheAppCard() {
  * This used to be the page's opening move: a code box expanded before anything
  * was paired, three raw commands and a live single-use credential taking up
  * most of the viewport, while the one-click path in the app appeared nowhere.
- * It is the fallback, so it lives behind a button and says so — install the app
- * over there and it is one click; run these if that machine has no screen.
+ * It is the fallback, so it lives behind a menu item and says so — install the
+ * app over there and it is one click.
  */
 function ConnectComputerDialog({
     open,
@@ -815,25 +742,28 @@ function ConnectComputerDialog({
 }
 
 /**
- * One computer and the agents it published, as a group heading over its rows.
+ * One computer, as a heading over the models it brings.
  *
- * This was a bordered card holding a header and a second bordered region of
- * filled sub-cards — three surfaces deep for one laptop with three agents on
- * it, inside a panel that was a fourth. The computer is a heading now, and its
- * agents are rows underneath, which is the same shape Access uses for a person
- * and their roles.
+ * Not a card, not a section, and not indented: its agents are rows in the same
+ * ledger as the provider keys above, sharing one left edge, one separator
+ * origin and one right edge. A hairline and a smaller eyebrow are the whole of
+ * what says "these came from here" — which is all the difference there is.
  */
-function AgentHostGroup({
+function ComputerGroup({
     host,
     organizationId,
     isThisComputer,
-    savedProfileByHarnessId,
+    savedProfiles,
+    isPanelTop,
     onRefresh,
 }: {
     host: AgentHost;
     organizationId: string;
     isThisComputer: boolean;
-    savedProfileByHarnessId: Map<string, AgentRuntimeProfileResponse>;
+    /** Every saved harness profile, live and archived, keyed off below. */
+    savedProfiles: AgentRuntimeProfileResponse[];
+    /** Whether this band is the first thing inside the panel. */
+    isPanelTop?: boolean;
     onRefresh?: () => void;
 }) {
     const harnesses = useAgentHostHarnesses(host.id);
@@ -859,6 +789,16 @@ function AgentHostGroup({
     const online = host.status === 'ONLINE';
     const items = harnesses.data?.items ?? [];
 
+    // Profiles already created from this computer's harnesses, so a row can say
+    // what it is in the picker instead of leaving the user guessing. Built from
+    // the management listing rather than the catalog: an archived profile is
+    // absent from the catalog, so the row would offer "Add" again and then 409
+    // on the unique-name index.
+    const savedByHarnessId = new Map<string, AgentRuntimeProfileResponse>();
+    for (const profile of savedProfiles) {
+        if (profile.harness_id) savedByHarnessId.set(profile.harness_id, profile);
+    }
+
     const remove = async () => {
         try {
             await revoke.mutateAsync(host.id);
@@ -871,70 +811,79 @@ function AgentHostGroup({
 
     return (
         <section>
-            <div className="group flex items-center gap-2.5 px-1 py-1.5">
-                <TerminalSquare className="size-4 shrink-0 text-[var(--text-tertiary)]" />
-                <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-0.5">
-                    <span className="truncate text-sm font-medium text-[var(--text-primary)]">
-                        {host.display_name}
-                    </span>
-                    {isThisComputer ? <span className="chip chip-sm chip-muted">This computer</span> : null}
-                    <span className="truncate text-xs text-[var(--text-tertiary)]">
-                        Agent Host {host.host_release} · {activeRuns}
-                        {maxRuns === null ? '' : `/${maxRuns}`} running
-                        {host.last_seen_at ? ` · seen ${new Date(host.last_seen_at).toLocaleTimeString()}` : ''}
-                    </span>
-                </div>
-                <StatusDot label={agentHostStatusLabel(host.status)} tone={online ? 'ok' : 'muted'} />
-                <Button
-                    type="button"
-                    variant="quiet"
-                    size="sm"
-                    className="h-7 w-7 shrink-0 p-0 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
-                    onClick={() => void harnesses.refetch()}
-                    disabled={harnesses.isFetching}
-                    aria-label={`Recheck ${host.display_name}`}
-                >
-                    <RefreshCw className={cn('size-4', harnesses.isFetching && 'lemma-spin')} />
-                </Button>
-                {/*
-                  * Only for a machine you are *not* at. Removing this computer
-                  * revokes a credential the app would mint again on the next
-                  * page, so the button could only ever be honest with a flag
-                  * remembering that you meant it — which is exactly the state
-                  * this lifecycle no longer keeps. Revoking a remote machine
-                  * sticks by construction: it is not there to re-pair itself.
-                  */}
-                {isThisComputer ? null : (
-                    <>
-                        <Button
-                            type="button"
-                            variant="quiet"
-                            size="sm"
-                            className="h-7 w-7 shrink-0 p-0 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
-                            onClick={() => setConfirmRemove(true)}
-                            loading={revoke.isPending}
-                            aria-label={`Remove ${host.display_name}`}
-                        >
-                            <Trash2 className="size-4" />
-                        </Button>
-                        <DestructiveConfirmationDialog
-                            open={confirmRemove}
-                            onOpenChange={setConfirmRemove}
-                            title={`Remove ${host.display_name}?`}
-                            description="Its credential is revoked immediately and new runs stop."
-                            resourceName={host.display_name}
-                            confirmationText=""
-                            consequences={[
-                                'Coding agents added from this computer stop being available.',
-                                'Opening Lemma on that computer connects it again.',
-                            ]}
-                            confirmLabel="Remove"
-                            pendingLabel="Removing..."
-                            isPending={revoke.isPending}
-                            onConfirm={() => void remove()}
-                        />
-                    </>
+            <div
+                className={cn(
+                    'group flex items-center gap-2 border-b border-[var(--border-subtle)] bg-[var(--surface-2)] px-3 py-2',
+                    isPanelTop ? null : 'border-t',
                 )}
+            >
+                <TerminalSquare className="size-3.5 shrink-0 text-[var(--text-tertiary)]" />
+                <h4 className="type-eyebrow-sm truncate">{host.display_name}</h4>
+                {isThisComputer ? <span className="chip chip-sm chip-muted">This computer</span> : null}
+                <span className="min-w-0 flex-1 truncate text-xs text-[var(--text-tertiary)]">
+                    Agent Host {host.host_release} · {activeRuns}
+                    {maxRuns === null ? '' : `/${maxRuns}`} running
+                    {/* When it is online, "Online" is the last-seen. Printing a
+                        second-precision clock beside it said the same thing
+                        twice and put a number on the page that changes on its
+                        own. It is worth reading only once it has stopped. */}
+                    {!online && host.last_seen_at
+                        ? ` · last seen ${new Date(host.last_seen_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`
+                        : ''}
+                </span>
+                {/* A computer's own reachability is the first half of "can I use
+                    the agents on it", so it is stated the same way its agents
+                    are — and from the same right edge, which is why the two
+                    hover buttons that used to sit here are one menu now. */}
+                <StatusDot
+                    label={agentHostStatusLabel(host.status)}
+                    tone={online ? 'ok' : 'muted'}
+                />
+                <ResourceActionsMenu
+                    ariaLabel={`Actions for ${host.display_name}`}
+                    align="end"
+                    triggerClassName="h-7 w-7 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100"
+                >
+                    <DropdownMenuItem
+                        onSelect={(event) => {
+                            event.preventDefault();
+                            void harnesses.refetch();
+                        }}
+                    >
+                        <RefreshCw className={cn('mr-2 h-4 w-4', harnesses.isFetching && 'lemma-spin')} />
+                        Look for agents again
+                    </DropdownMenuItem>
+                    {/*
+                      * Removing is only for a machine you are *not* at. Removing
+                      * this computer revokes a credential the app would mint
+                      * again on the next page, so the item could only ever be
+                      * honest with a flag remembering that you meant it — which
+                      * is exactly the state this lifecycle no longer keeps.
+                      * Revoking a remote machine sticks by construction: it is
+                      * not there to re-pair itself.
+                      */}
+                    {isThisComputer ? null : (
+                        <DestructiveResourceActionItem onSelect={() => setConfirmRemove(true)}>
+                            Remove
+                        </DestructiveResourceActionItem>
+                    )}
+                </ResourceActionsMenu>
+                <DestructiveConfirmationDialog
+                    open={confirmRemove}
+                    onOpenChange={setConfirmRemove}
+                    title={`Remove ${host.display_name}?`}
+                    description="Its credential is revoked immediately and new runs stop."
+                    resourceName={host.display_name}
+                    confirmationText=""
+                    consequences={[
+                        'Coding agents added from this computer stop being available.',
+                        'Opening Lemma on that computer connects it again.',
+                    ]}
+                    confirmLabel="Remove"
+                    pendingLabel="Removing..."
+                    isPending={revoke.isPending}
+                    onConfirm={() => void remove()}
+                />
             </div>
 
             {/*
@@ -946,26 +895,26 @@ function AgentHostGroup({
               * minutes on a machine's first pairing.
               */}
             {harnesses.isLoading || discovering ? (
-                <p className="flex items-center gap-2 px-1 py-2 pl-8 text-xs text-[var(--text-tertiary)]">
+                <p className="flex items-center gap-2 px-3 py-2.5 text-xs text-[var(--text-tertiary)]">
                     <RefreshCw className="size-3 lemma-spin" />
                     Looking for agents on this computer…
                     {isThisComputer ? ' The first time takes a few seconds longer.' : null}
                 </p>
             ) : items.length === 0 ? (
-                <p className="px-1 py-2 pl-8 text-xs text-[var(--text-tertiary)]">
+                <p className="px-3 py-2.5 text-xs text-[var(--text-tertiary)]">
                     No agents published yet. {isThisComputer
                         ? 'Use the recheck button above to look again now.'
                         : 'That computer publishes what it finds as soon as it changes.'}
                 </p>
             ) : (
-                <ul className="lemma-index-list pl-7">
+                <ul className="lemma-index-list lemma-panel-list">
                     {items.map((harness) => (
-                        <AgentHostHarnessRow
+                        <ComputerAgentRow
                             key={harness.id}
                             harness={harness}
                             organizationId={organizationId}
                             hostOnline={online}
-                            savedProfile={savedProfileByHarnessId.get(harness.id) ?? null}
+                            savedProfile={savedByHarnessId.get(harness.id) ?? null}
                             onRefresh={onRefresh}
                             onRecheck={isThisComputer ? onRecheckThisComputer : undefined}
                         />
@@ -977,14 +926,16 @@ function AgentHostGroup({
 }
 
 /**
- * One agent on one computer, as a row under that computer's heading.
+ * One coding agent on one computer — and, if it has been added, the profile it
+ * is in the picker as. One row, because they are one thing.
  *
- * Uses `describeHarness` rather than `HarnessRow`: onboarding meets this list
- * as a standalone card and wants the fuller treatment, while here the computer
- * directly above already carries the icon, the reachability and the actions.
- * What the harness *is* still comes from one place; only the layout differs.
+ * They used to be two: this row, and a second row for the saved profile in a
+ * separate Models list above. Same name, same logo, both reading "Ready",
+ * nothing connecting them. Whether a chat can pick this agent is a fact *about
+ * the agent*, not a second object, so it is drawn here — as the presence or
+ * absence of an Add.
  */
-function AgentHostHarnessRow({
+function ComputerAgentRow({
     harness,
     organizationId,
     hostOnline,
@@ -1002,7 +953,18 @@ function AgentHostHarnessRow({
     const [dialog, setDialog] = useState<HarnessDialogTarget | null>(null);
     const restore = useRestoreAgentRuntime();
     const archived = savedProfile ? isArchivedProfile(savedProfile) : false;
-    const { logo, facts, statusLabel, usable, blockedReason } = describeHarness(harness, { hostOnline });
+    const added = Boolean(savedProfile) && !archived;
+    const { logo, modelCount, statusLabel, usable, blockedReason } = describeHarness(harness, { hostOnline });
+    const scope = savedProfile ? scopeBadge(savedProfile.scope) : null;
+
+    // The name a chat will offer, when there is one — that is what this row is
+    // for. The harness keeps its own name as a fact whenever the two differ, so
+    // renaming a profile never orphans the thing it was made from.
+    const name = savedProfile?.name ?? harness.display_name;
+    const detail = [
+        savedProfile && savedProfile.name !== harness.display_name ? harness.display_name : null,
+        modelCount ? `${modelCount} model${modelCount === 1 ? '' : 's'}` : null,
+    ].filter(Boolean).join(' · ');
 
     const restoreSaved = async () => {
         if (!savedProfile) return;
@@ -1016,12 +978,12 @@ function AgentHostHarnessRow({
     };
 
     /*
-     * "Add to models" is offered only when the computer can actually take the
-     * profile. Creating one binds it to a live harness — the backend reads the
-     * host's config options to validate the selections — so offering this
-     * against a sleeping laptop meant taking the user through the whole dialog
-     * and then failing on save. Everything else on the row still renders while
-     * offline; only creating is withheld.
+     * "Add" is offered only when the computer can actually take the profile.
+     * Creating one binds it to a live harness — the backend reads the host's
+     * config options to validate the selections — so offering this against a
+     * sleeping laptop meant taking the user through the whole dialog and then
+     * failing on save. Everything else on the row still renders while offline;
+     * only creating is withheld.
      */
     const action = archived ? (
         <Button
@@ -1036,7 +998,7 @@ function AgentHostHarnessRow({
             <RotateCcw className="size-3.5" />
             Restore
         </Button>
-    ) : savedProfile || !usable ? null : (
+    ) : added || !usable ? null : (
         <Button
             type="button"
             size="sm"
@@ -1045,60 +1007,83 @@ function AgentHostHarnessRow({
             onClick={() => setDialog({ mode: 'create', harness })}
         >
             <Plus className="size-3.5" />
-            Add to models
+            Add
         </Button>
     );
 
+    /*
+     * The same question the provider rows answer, in the same words. "Available"
+     * means a chat can pick this now; "Not added" means the computer has it and
+     * Lemma does not yet. The Add button beside "Not added" is the verb for that
+     * state, not a repeat of it — the column is what makes the page scannable,
+     * and an agent whose row went blank is exactly what could not be read.
+     *
+     * "Setting up" is the one non-ready state that is not a fault: the computer
+     * is mid-probe and will finish on its own, so it stays grey while a genuine
+     * failure — signed out, unsupported, could not start — is warned about.
+     */
+    const status: { label: string; tone: StatusTone } = archived
+        ? { label: 'Archived', tone: 'muted' }
+        : !hostOnline
+            ? { label: 'Computer offline', tone: 'muted' }
+            : !usable
+                ? { label: statusLabel, tone: harness.health === 'INSTALLING' ? 'muted' : 'warn' }
+                : added
+                    ? { label: 'Available', tone: 'ok' }
+                    : { label: 'Not added', tone: 'muted' };
+
     return (
-        <li className="lemma-index-row group flex flex-wrap items-center gap-x-2.5 gap-y-1">
-            <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-[var(--surface-1)]">
-                {logo ? (
-                    <Image src={logo} alt="" width={14} height={14} className="size-3.5 object-contain" />
-                ) : (
-                    <TerminalSquare className="size-3.5 text-[var(--text-tertiary)]" />
+        <>
+            <LedgerRow
+                icon={
+                    logo ? (
+                        <Image src={logo} alt="" width={18} height={18} className="size-4.5 object-contain" />
+                    ) : (
+                        <TerminalSquare className="size-4" />
+                    )
+                }
+                name={name}
+                detail={detail}
+                chip={scope ? <span className="chip chip-sm chip-muted">{scope.label}</span> : null}
+                // Stated only when the computer itself is reachable — otherwise
+                // the heading directly above already said it, and repeating it
+                // under every agent it owns is the same sentence three times.
+                note={blockedReason}
+                status={status}
+                dimmed={!hostOnline}
+                action={(
+                    <>
+                        {/*
+                          * The copy for AUTH_REQUIRED already says "then let
+                          * Agent Host re-probe", and there was nothing anywhere
+                          * to press. Probing is otherwise on a fifteen-minute
+                          * timer, so someone who signed in did so and then
+                          * watched nothing happen.
+                          */}
+                        {onRecheck && harness.health === 'AUTH_REQUIRED' ? (
+                            <Button
+                                type="button"
+                                size="sm"
+                                variant="quiet"
+                                className="shrink-0 gap-1.5 px-2"
+                                onClick={onRecheck}
+                            >
+                                <RefreshCw className="size-3.5" />
+                                I&apos;ve signed in — re-check
+                            </Button>
+                        ) : null}
+                        {action}
+                    </>
                 )}
-            </span>
-            <div className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2 gap-y-0.5">
-                <span className="truncate text-sm font-medium text-[var(--text-primary)]">
-                    {harness.display_name}
-                </span>
-                {facts.length > 0 ? (
-                    <span className="truncate text-xs text-[var(--text-tertiary)]">{facts.join(' · ')}</span>
+                menu={savedProfile ? (
+                    <ProfileActionsMenu
+                        profile={savedProfile}
+                        organizationId={organizationId}
+                        onEdit={() => setDialog({ mode: 'edit', profile: savedProfile })}
+                        onRefresh={onRefresh}
+                    />
                 ) : null}
-                {savedProfile ? (
-                    <span className="chip chip-sm chip-muted">
-                        {archived ? `Archived as ${savedProfile.name}` : `Added as ${savedProfile.name}`}
-                    </span>
-                ) : null}
-            </div>
-            {/*
-              * Only stated when the computer itself is reachable — otherwise the
-              * heading directly above already said it, and repeating it on every
-              * agent it owns is the same sentence three times.
-              */}
-            {blockedReason ? (
-                <span className="basis-full pl-8 text-xs text-[var(--text-tertiary)]">{blockedReason}</span>
-            ) : null}
-            {/*
-              * The copy for AUTH_REQUIRED already says "then let Agent Host
-              * re-probe", and there was nothing anywhere to press. Probing is
-              * otherwise on a fifteen-minute timer, so someone who signed in did
-              * so and then watched nothing happen.
-              */}
-            {onRecheck && harness.health === 'AUTH_REQUIRED' ? (
-                <Button
-                    type="button"
-                    size="sm"
-                    variant="quiet"
-                    className="shrink-0 gap-1.5 px-2"
-                    onClick={onRecheck}
-                >
-                    <RefreshCw className="size-3.5" />
-                    I&apos;ve signed in — re-check
-                </Button>
-            ) : null}
-            {action}
-            {hostOnline ? <StatusDot label={statusLabel} tone={usable ? 'ok' : 'muted'} /> : null}
+            />
 
             <HarnessProfileDialog
                 target={dialog}
@@ -1106,6 +1091,6 @@ function AgentHostHarnessRow({
                 onClose={() => setDialog(null)}
                 onSaved={onRefresh}
             />
-        </li>
+        </>
     );
 }

--- a/lemma-frontend/lib/hooks/use-agent-runtime.ts
+++ b/lemma-frontend/lib/hooks/use-agent-runtime.ts
@@ -149,7 +149,11 @@ export const useAgentHostHarnessOwners = (hosts: readonly AgentHost[]) => {
             owners.set(harness.id, host.display_name);
         }
     });
-    return owners;
+    // Whether the map can be trusted yet. Callers use it to decide which
+    // profiles have a computer to sit under, and on the first frame it is empty
+    // for every one of them — so a caller that read it as settled would draw
+    // every coding agent as orphaned and then move it a moment later.
+    return { owners, isPending: results.some((result) => result.isPending) };
 };
 
 // A paired computer belongs to the person who paired it, not to a workspace:

--- a/lemma-frontend/styles/features/builders-and-ledgers.css
+++ b/lemma-frontend/styles/features/builders-and-ledgers.css
@@ -443,6 +443,38 @@
   background: color-mix(in srgb, var(--state-warning) 22%, var(--card-bg));
 }
 
+/*
+ * A ledger that lives inside a bordered surface.
+ *
+ * `.lemma-index-row`'s hairline is a 68%-wide taper anchored to the row's left.
+ * Under a dense list that reads as a deliberate tick; under a sparse one — a
+ * name, two facts and a state, on a 48rem measure — it stops dead in open space
+ * and reads as a broken underline, which is what the models page kept being
+ * told it looked like. A row inside a panel takes the panel's own full-width
+ * divider instead, and gives up its rounding so it can meet the panel's edges.
+ *
+ * Sits beside `.lemma-run-list` rather than changing `.lemma-index-row`: the
+ * taper is right everywhere it is already used, and this is a second shape for
+ * the same row, not a correction to the first.
+ */
+.lemma-panel-list {
+  padding: 0;
+}
+
+.lemma-panel-list > .lemma-index-row {
+  border-radius: 0;
+  padding-left: var(--space-3);
+  padding-right: var(--space-3);
+}
+
+.lemma-panel-list > .lemma-index-row::after {
+  display: none;
+}
+
+.lemma-panel-list > .lemma-index-row + .lemma-index-row {
+  border-top: 1px solid color-mix(in srgb, var(--border-subtle) 70%, transparent);
+}
+
 .lemma-run-list {
   gap: var(--space-2);
 }


### PR DESCRIPTION
## What changes

The pod's Models settings page becomes one ledger instead of two lists that
looked identical.

`Models` and `Computers` were stated as peers, in one row grammar, so eight rows
read as eight peers — and a coding agent that had been added appeared in **both**
lists, under the same name, with the same logo, both saying `Ready`. Nothing on
the page said they were one thing. A computer is where some of these models come
from, so it is now a group *inside* the ledger, and every model — bought key or
local agent — is written down exactly once, in the place it comes from.

The status column answers one question, and every row answers it: `Available`,
`Not added`, `Sign-in needed`, `Probe failed`, `Computer offline`, `Archived`.
The old column said `Ready` five times and meant three different things by it —
a key that works, a saved profile, an installed agent nobody had added.

Also: the ledger sits in one bordered surface with full-width dividers; the
trailing menu slot is reserved at 28px so the status column has a single right
edge; a harness failure is a second line inside the name column instead of a
full-width line that wrapped the status to the left margin; two connect buttons
are one menu; and an online computer no longer prints a second-precision clock
beside the word `Online`.

## Why

The page was reported as disorienting, and the cause was structural rather than
cosmetic: the same object drawn twice, in two lists the eye could not tell
apart. Polishing that structure would only have made a confusing page prettier.

Two rounds of review on the running app shaped the rest. An earlier pass made
status *exception-only* — a healthy row said nothing — on the theory that a word
on almost every row is wallpaper. That was wrong: "is Claude Code available?" is
the question this page exists to answer, and inferring *yes* from the absence of
an Add button is not answering it. The real defect was one word covering three
questions, so the fix was one vocabulary, not removal.

## How to verify

```bash
cd lemma-frontend
npm run lint
npm run typecheck
npm run design:audit:ci
npx vitest run
```

All clean: `eslint` no findings in the touched files, `tsc` no errors in them,
`Design audit passed productStrict=0 informational=101 protectedAssistant=1`,
and `Test Files 105 passed (105) / Tests 1161 passed (1161)`.

Manually, against a workspace with a paired computer: the route compiles and
serves 200 with no server errors, and the page shows each coding agent once —
under its computer, with an availability state — rather than once there and
again in a separate Models list.

## Checklist

- [x] Tests cover the behavioral change — the suite passes; the changed
      surface is presentational and has no unit tests of its own, and
      `agent-runtime-helpers.test.ts` (45 cases) covers the helper that gained
      `version`/`modelCount`.
- [x] Lint, typecheck, and architecture gates pass locally

## Reviewer notes

**A new row shape, not a change to the existing one.** `.lemma-panel-list` sits
beside `.lemma-run-list` in `builders-and-ledgers.css`. `.lemma-index-row`'s
hairline is a 68%-wide taper, which reads as a deliberate tick under a dense
list and as a broken underline under this one — a name, two facts and a state on
a 48rem measure. Members and every other ledger are untouched.

**One behavioral bug fixed by the merge.** A coding-agent profile whose computer
is not connected used to open the *provider* editor — a base URL and an API key
— over a profile whose settings are its harness's config options. Edits now
route by `kind`.

**A hook signature changed.** `useAgentHostHarnessOwners` returns
`{ owners, isPending }` rather than a bare `Map`. It has one caller. The flag is
load-bearing: the map is empty on the first frame, so without it every coding
agent draws at the top as orphaned and then jumps into a group below.

**Deliberately left alone.** The `Model | Kimi K3` control in the Pod default
strip is a pill wrapped around a chip — the last place on the page where one
setting wears three shapes. It is `RuntimeModelPicker`, shared with the chat
composer, so changing it reaches past this page.

## Compatibility and rollback notes

Frontend-only and presentational. No migration, no API surface change, no
generated-client change. Reverting the commit fully restores the previous page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
