### PR TITLE
Report a backend whose worker has died as not ready

### DIFF
--- a/lemma-backend/app/app.py
+++ b/lemma-backend/app/app.py
@@ -736,6 +736,48 @@ def create_app(modules=OSS_MODULES) -> FastAPI:
         }
         return JSONResponse(payload, status_code=200 if healthy else 503)
 
+    #: How stale the worker heartbeat may be before readiness calls it stalled.
+    #:
+    #: The watchdog refreshes it every `loop_lag_watchdog_interval_seconds`
+    #: (0.5s by default), so a minute is roughly two orders of magnitude of
+    #: headroom -- generous enough that a busy machine or a long GC pause is
+    #: never mistaken for a dead worker, and short enough that a person does
+    #: not sit in front of a spinner for hours, which is what happened.
+    WORKER_HEARTBEAT_MAX_AGE_SECONDS = 60.0
+
+    def _embedded_worker_state() -> str | None:
+        """Whether this process's own worker is still ticking, or None.
+
+        None where the question does not apply: an API process that runs no
+        worker (the cloud topology, where the worker is its own deployment)
+        must not report itself unready because it has no heartbeat to read.
+        Only the single-process desktop build sets `embedded_worker`.
+
+        The gap this closes is one a desktop install sat in for hours. The
+        heartbeat file exists so a Kubernetes liveness probe can restart a
+        wedged worker -- and on desktop nothing read it. `/health/ready`
+        answered 200 on the strength of the database and Redis while the
+        worker had been dead since a lifespan teardown two hours earlier, so
+        locald's health gate saw a healthy backend, never restarted it, and
+        every agent run queued behind a worker that was not there. The UI
+        showed "thinking" and no log said otherwise.
+
+        A missing file is not a stalled worker: it is a process that has not
+        written one yet, which is every start before the first tick.
+        """
+        if not getattr(app.state, "embedded_worker", False):
+            return None
+        path = settings.worker_heartbeat_path
+        if not path:
+            return None
+        try:
+            with open(path, encoding="utf-8") as handle:
+                written = float(handle.read().strip())
+        except OSError, ValueError:
+            return None
+        age = time.time() - written
+        return "ok" if age <= WORKER_HEARTBEAT_MAX_AGE_SECONDS else "stalled"
+
     # Readiness: bounded, concurrent checks for dependencies required to serve
     # new work. Each check has ~1 s; the whole endpoint has a ~2 s deadline.
     # 503 when not ready; only generic component states are exposed, never
@@ -787,7 +829,10 @@ def create_app(modules=OSS_MODULES) -> FastAPI:
             "db": "ok" if db_ok else "down",
             "redis": "ok" if redis_ok else "down",
         }
-        ready = bool(db_ok) and bool(redis_ok)
+        worker_state = _embedded_worker_state()
+        if worker_state is not None:
+            components["worker"] = worker_state
+        ready = bool(db_ok) and bool(redis_ok) and worker_state != "stalled"
         payload = {
             "status": "ready" if ready else "not_ready",
             "components": components,

--- a/lemma-backend/app/tests/unit/test_health_endpoints.py
+++ b/lemma-backend/app/tests/unit/test_health_endpoints.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 from unittest.mock import AsyncMock
 
 import pytest
@@ -68,6 +70,71 @@ def test_ready_returns_200_when_dependencies_ok(client, monkeypatch):
     body = r.json()
     assert body["status"] == "ready"
     assert body["components"] == {"db": "ok", "redis": "ok"}
+
+
+def test_ready_is_not_ready_when_the_embedded_worker_has_stopped(
+    client, monkeypatch, tmp_path
+):
+    """A dead worker must not read as a healthy backend.
+
+    This is the failure it was found in. On a desktop install the worker
+    stopped during a lifespan teardown and never came back, while the database
+    and Redis stayed perfectly fine -- so readiness answered 200, locald's
+    health gate saw nothing wrong and never restarted the process, and every
+    agent run queued behind a worker that was not there. The person watching
+    got a spinner for two hours and no log said why.
+
+    The heartbeat file already existed for exactly this: it is what a
+    Kubernetes liveness probe reads to restart a wedged worker. Nothing on
+    desktop read it.
+    """
+    monkeypatch.setattr(appmod, "get_engine", lambda: _FakeEngineOk())
+    monkeypatch.setattr(appmod.channel_service, "ping", AsyncMock(return_value=True))
+
+    heartbeat = tmp_path / "worker_heartbeat"
+    heartbeat.write_text(str(time.time() - 3600), encoding="utf-8")
+    monkeypatch.setattr(appmod.settings, "worker_heartbeat_path", str(heartbeat))
+    monkeypatch.setattr(appmod.app.state, "embedded_worker", True, raising=False)
+
+    r = client.get("/health/ready")
+
+    assert r.status_code == 503
+    body = r.json()
+    assert body["status"] == "not_ready"
+    assert body["components"]["worker"] == "stalled"
+    # The dependencies it does not own are still reported honestly.
+    assert body["components"]["db"] == "ok"
+
+    # A fresh heartbeat is ready again, so a restart clears it.
+    heartbeat.write_text(str(time.time()), encoding="utf-8")
+    assert client.get("/health/ready").status_code == 200
+
+
+def test_ready_ignores_the_worker_where_this_process_runs_none(
+    client, monkeypatch, tmp_path
+):
+    """The cloud topology runs the worker as its own deployment.
+
+    An API process there has no heartbeat to read, and must not call itself
+    unready for the absence. Nor may a process that has simply not written its
+    first heartbeat yet -- which is every start before the first tick.
+    """
+    monkeypatch.setattr(appmod, "get_engine", lambda: _FakeEngineOk())
+    monkeypatch.setattr(appmod.channel_service, "ping", AsyncMock(return_value=True))
+
+    monkeypatch.setattr(appmod.app.state, "embedded_worker", False, raising=False)
+    monkeypatch.setattr(
+        appmod.settings, "worker_heartbeat_path", str(tmp_path / "never-written")
+    )
+    r = client.get("/health/ready")
+    assert r.status_code == 200
+    assert "worker" not in r.json()["components"]
+
+    # Embedded, but the file is not there yet: still starting, not stalled.
+    monkeypatch.setattr(appmod.app.state, "embedded_worker", True, raising=False)
+    r = client.get("/health/ready")
+    assert r.status_code == 200
+    assert "worker" not in r.json()["components"]
 
 
 def test_ready_echoes_runtime_instance_id(client, monkeypatch):


### PR DESCRIPTION
## What changes

A desktop backend whose worker has stopped now reports itself not ready, so
locald's existing health gate restarts it. Before this it reported 200 and sat
there.

## Why

Found on a running install, agents not responding, UI showing "thinking"
indefinitely. Everything that gets checked was healthy:

| | |
| --- | --- |
| Agent Host | polling every 25s, all 200s, right up to the minute |
| Event loop | `/livez` 200, 5ms lag |
| `/health/ready` | 200 |
| **Worker** | **dead for 2h24m** |

```
worker.heartbeat        last at 12:01:07Z
/tmp/worker_heartbeat   age 8,691s
```

It stopped during a lifespan teardown — an anyio cancel-scope error out of the
MCP session manager — while uvicorn carried on serving HTTP. Every agent run
queued behind a worker that was not there, and nothing said so: the last 40
minutes of backend log contained only HTTP requests, no heartbeat, no stream
cycle.

**The heartbeat file already exists for exactly this.** Its own description says
a Kubernetes liveness probe execs a freshness check on it so a wedged worker
gets restarted. On desktop nothing read it. Readiness tests the database and
Redis — both perfectly fine — so locald's health gate saw a healthy backend and
never restarted it. In Kubernetes this restarts; on the desktop it hangs until
somebody quits the app.

## What it deliberately does not do

- **Report on a worker this process does not own.** The cloud topology runs the
  worker as its own deployment; an API pod has no heartbeat to read and must not
  fail readiness for the absence. Only the single-process desktop build sets
  `embedded_worker`.
- **Treat a missing heartbeat file as a stall.** That is every start before the
  first tick.

Sixty seconds of staleness against a watchdog that writes every 0.5s — two
orders of magnitude of headroom, so a busy machine or a long pause is never
mistaken for a dead worker.

## What it does not fix

The teardown that killed the worker. That is an anyio cancel-scope violation
inside the MCP session manager's lifespan, and it deserves its own change. This
makes that failure visible and recoverable rather than silent and permanent,
which is the part that cost an afternoon.

## How to verify

```bash
cd lemma-backend && uv run pytest app/tests/unit/test_health_endpoints.py -q
```

12 pass. Verified by removing the worker from the readiness expression and
watching the new test fail `assert 200 == 503` — so it pins the behaviour rather
than the implementation.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, import budget and architecture gates pass locally
- [ ] **Rollback** — revert. A dead worker goes back to reporting healthy.