### PR TITLE
Keep the ports a restart was using, instead of handing out new ones

### DIFF
--- a/desktop/locald/src/network.rs
+++ b/desktop/locald/src/network.rs
@@ -1,8 +1,9 @@
 use std::env;
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
+use std::net::{Ipv4Addr, SocketAddr, TcpStream};
 use std::path::Path;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
@@ -48,6 +49,21 @@ impl NetworkPorts {
     }
 }
 
+/// Whether both remembered ports are free of a live server.
+///
+/// Deliberately a connect rather than a bind: a bind cannot tell a port that is
+/// being served from one that merely held a connection recently, and it is the
+/// difference between the two that decides whether reusing the pair is safe.
+/// Loopback only, which is where the services themselves listen.
+fn nothing_is_serving(ports: NetworkPorts) -> bool {
+    [ports.frontend_port, ports.backend_port]
+        .into_iter()
+        .all(|port| {
+            let address = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+            TcpStream::connect_timeout(&address, Duration::from_millis(250)).is_err()
+        })
+}
+
 pub fn load_or_allocate(paths: &LocalPaths) -> io::Result<NetworkPorts> {
     if let Some(overrides) = override_ports()? {
         return Ok(overrides);
@@ -63,6 +79,29 @@ pub fn load_or_allocate(paths: &LocalPaths) -> io::Result<NetworkPorts> {
                 // socket that is about to disappear.
                 if let Some(reserved) = reserve_pair(existing) {
                     reserved.release();
+                    return Ok(existing);
+                }
+                // A refused reservation is not proof the pair is taken.
+                //
+                // The reservation binds without SO_REUSEADDR, so it also fails
+                // on the TIME_WAIT our *own* previous run leaves behind: the
+                // backend served requests, exited, and for the next half minute
+                // nothing can bind that port even though nothing is serving on
+                // it. Every restart inside that window abandoned the remembered
+                // pair and allocated a new one.
+                //
+                // The cost was not cosmetic. The Agent Host stores its pairing
+                // as a URL with the port in it, so a reallocation left it
+                // talking to a port nothing answers -- this computer stopped
+                // being reachable until it was paired again. The recorded
+                // resume target went stale the same way, which is why every
+                // launch landed on the auth portal instead of the workspace.
+                //
+                // So ask the question the reservation was standing in for: is
+                // anything actually serving here? A listener answers a connect;
+                // a TIME_WAIT socket refuses it. Only the second is safe to
+                // reuse, and it is the common case.
+                if nothing_is_serving(existing) {
                     return Ok(existing);
                 }
             }
@@ -252,6 +291,73 @@ fn now_ms() -> u128 {
 
 #[cfg(test)]
 mod tests {
+    /// A restart must keep the ports the last run used.
+    ///
+    /// The Agent Host stores its pairing as a URL with the port in it, and the
+    /// resume target records one too. Reallocating on restart strands both --
+    /// this computer stops being reachable, and every launch lands on the auth
+    /// portal instead of the workspace.
+    ///
+    /// The trap is that the reservation binds without SO_REUSEADDR, so it fails
+    /// on the TIME_WAIT our own previous run leaves: a port that served a
+    /// connection cannot be re-bound for about half a minute even though
+    /// nothing is serving on it. This reproduces that exactly -- serve a
+    /// connection, close everything, then ask.
+    #[test]
+    fn a_port_our_last_run_used_is_still_reusable_while_it_lingers() {
+        use std::io::Read;
+        use std::net::{Ipv4Addr, TcpListener, TcpStream};
+
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let mut client = TcpStream::connect((Ipv4Addr::LOCALHOST, port)).unwrap();
+        let (server, _) = listener.accept().unwrap();
+        drop(server);
+        let mut sink = Vec::new();
+        let _ = client.read_to_end(&mut sink);
+        drop(client);
+        drop(listener);
+
+        let ports = NetworkPorts {
+            schema_version: NETWORK_SCHEMA_VERSION,
+            frontend_port: port,
+            backend_port: port,
+            allocated_at_ms: 0,
+        };
+        assert!(
+            nothing_is_serving(ports),
+            "a port whose server has gone must read as free, or every restart \
+             inside TIME_WAIT hands out new ports and strands the Agent Host",
+        );
+
+        // And a port that *is* being served must not.
+        let live = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+        let live_port = live.local_addr().unwrap().port();
+        let served = NetworkPorts {
+            schema_version: NETWORK_SCHEMA_VERSION,
+            frontend_port: live_port,
+            backend_port: live_port,
+            allocated_at_ms: 0,
+        };
+        assert!(!nothing_is_serving(served));
+        drop(live);
+
+        // A pair is only reusable if *both* halves are free.
+        let mixed = NetworkPorts {
+            schema_version: NETWORK_SCHEMA_VERSION,
+            frontend_port: port,
+            backend_port: TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+                .map(|l| {
+                    let p = l.local_addr().unwrap().port();
+                    std::mem::forget(l);
+                    p
+                })
+                .unwrap(),
+            allocated_at_ms: 0,
+        };
+        assert!(!nothing_is_serving(mixed));
+    }
+
     use super::*;
     use std::net::{Ipv4Addr, TcpListener};
     use tempfile::tempdir;


### PR DESCRIPTION
## What changes

A restart keeps the ports the previous run used. Before this it usually got new
ones, and everything that records a port broke.

## Why

Found while investigating "I got logged out on restart". On the install:

```
agent-host target : http://app.127.0.0.1.sslip.io:58353/
backend now       : port 56771
```

The Agent Host stores its pairing as a URL with the port in it. After a restart
it was addressing a port nothing answers — this computer went unreachable until
it was paired again. The recorded resume target goes stale the same way, which
is why launches land on the auth portal rather than the workspace. Observed
across four launches: `63287 → 50686 → 51314 → 52752 → 56770`.

The remembered pair is tested by reserving it, and the reservation binds without
`SO_REUSEADDR`. That also fails on the TIME_WAIT our **own** previous run leaves
behind. Reproduced directly:

```
port 58282 after a served connection closed:
  bind without SO_REUSEADDR : FAILED (Address already in use)   <- what locald does
  bind with    SO_REUSEADDR : OK
  anything LISTENING there  : no
```

A port that served a connection cannot be re-bound for about half a minute even
though nothing is serving on it — and a restart lands squarely inside that
window.

## The fix

A refused reservation is no longer taken as proof the pair is taken. It asks the
question the reservation was standing in for: **is anything actually serving
here?** A listener answers a connect; a TIME_WAIT socket refuses it.

The reservation is unchanged, including its deliberate lack of `SO_REUSEADDR` —
it still refuses to hand over a pair another locald is racing for. This only
adds a second question after it says no. Both halves must be free, so a pair
with one live service is still abandoned.

## What this fixes downstream

- The Agent Host stays paired across restarts.
- The resume target stays valid, so a launch returns to the workspace. (The
  relative `redirect_uri` added earlier made that failure survivable; this
  removes the cause.)

## How to verify

```bash
cd desktop && cargo test -p lemma-locald a_port_our_last_run
make desktop-test && make desktop-lint
```

The test reproduces the real sequence — serve a connection, close everything,
then ask — rather than asserting on the implementation. It also pins that a port
being served still reads as taken, and that a pair with one live half is not
reused.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint and desktop tests pass locally
- [ ] **Rollback** — revert. Restarts go back to reallocating ports and
      unpairing the Agent Host.