### PR TITLE
Install a connector the deployment will actually accept

### DIFF
--- a/tests/scenarios/journeys/connectors_and_accounts/test_lifecycle.py
+++ b/tests/scenarios/journeys/connectors_and_accounts/test_lifecycle.py
@@ -77,43 +77,26 @@ async def installed(world, stack):
 
 
 async def _a_connector_anyone_can_connect(alice) -> str:
-    """A connector from the catalogue that needs no consent to connect.
+    """A connector from the catalogue this fixture can install unaided.
 
     Asked of the deployment rather than named here. Which connectors a
     deployment carries is its own business — naming one would make this pass on
     the deployment it was written against and skip on every other.
 
-    One kind only, so installing it without saying which is unambiguous; not
-    OAuth2, because connecting one of those means a person in a browser; and —
-    the part this file needs — one that actually *offers* operations.
+    Three requirements, and the third is the one that bites. One kind only, so
+    installing it without saying which is unambiguous. Not OAuth2, because
+    connecting one of those means a person in a browser. And **nothing required
+    in its config schema**: installing is a single call with no configuration,
+    so a kind that needs a host, a spec URL or a broker key answers 400 and the
+    whole file fails on setup.
 
-    That last filter replaces a preference for `telegram`, which was chosen
-    because installing it asks nobody anything: its kind declares
-    `discovery: none`, so there is no live call to a broker and no dependency
-    on somebody else's uptime. True, and it selected the one connector in the
-    catalogue guaranteed to be useless here — Telegram is a bot-messaging
-    *surface*, and it ships zero operations. `test_an_operation_is_readable`
-    went red against dev for it, reporting a discovery failure that had not
-    happened.
-
-    `discovery` is the wrong question, in both directions. It says where a
-    connector's operations come from, not whether it has any: `none` means the
-    catalogue already holds every one of them, which is the property worth
-    keeping, not a sign of emptiness. So ask for what is actually wanted — a
-    connector whose catalogue entry carries operations — and rank the survivors
-    by how little installing one has to ask of anybody else.
-
-    Two things make an install reach outside, and they are independent. A kind
-    that discovers on install (`openapi`, `mcp`) calls out to read its own
-    shape. A kind that is brokered — one naming a `toolkit_slug` or a
-    `package_name` — is fronted by somebody else's service even when its
-    operations are already catalogued. Preferring neither is what the old
-    Telegram preference was reaching for, and stating it this way gets it
-    without also selecting for zero operations.
-
-    `operations` is on the detail response and not on the list, so this costs
-    one GET per candidate. The two filters above run first, so that is a
-    handful of connectors rather than the whole catalogue.
+    That last one is why a preference for a connector that carries operations
+    does not belong here. On a real deployment the two are close to disjoint —
+    everything with operations wants credentials or an address first, and the
+    ones that install unaided are messaging surfaces with none. Ranking on
+    operations picked `sql`, which needs `dialect`, `host` and `database`, and
+    took eleven scenarios down with it. `test_an_operation_is_readable` asks the
+    operations question for itself, where a lane can answer it.
     """
     catalogue = items_of(await alice.api.get("/connectors"))
     connectable = [
@@ -121,28 +104,29 @@ async def _a_connector_anyone_can_connect(alice) -> str:
         for connector in catalogue
         if len(connector.get("kinds") or []) == 1
         and str((connector["kinds"][0]).get("auth_scheme", "")).upper() != "OAUTH2"
+        and not ((connector["kinds"][0]).get("config_schema") or {}).get("required")
     ]
-
-    ranked: list[tuple[int, str]] = []
-    for connector_id in connectable:
-        detail = await alice.api.get(f"/connectors/{connector_id}")
-        if not (detail.get("operations") or {}):
-            continue
-        kind = (detail.get("kinds") or [{}])[0]
-        brokered = bool(kind.get("toolkit_slug") or kind.get("package_name"))
-        discovers_on_install = str(kind.get("discovery", "")).lower() != "none"
-        # Lowest rank wins: built in and already catalogued comes first, a
-        # broker's uptime last. Ties break on the id, so a given catalogue
-        # always yields the same choice.
-        ranked.append((brokered + 2 * discovers_on_install, connector_id))
-    if ranked:
-        return min(ranked)[1]
-
+    for preferred in ("telegram",):
+        if preferred in connectable:
+            return preferred
+    if connectable:
+        return connectable[0]
     pytest.skip(
         "this deployment's catalogue has no single-kind connector that can be "
-        "connected without consent *and* offers any operation, so there is "
-        "nothing to install whose operations a scenario could then read"
+        "installed without configuration and connected without consent, so "
+        "there is nothing to install that a scenario could also connect an "
+        "account to"
     )
+
+
+def _a_provider_is_stood_in(stack) -> bool:
+    """Is something answering for a third party on this run?
+
+    The same question the `installed` fixture branches on, asked in one place so
+    a scenario can tell which kind of connector it ended up with.
+    """
+    proxy = getattr(stack, "egress", None)
+    return proxy is not None and getattr(proxy, "mode", "off") in {"fake", "replay"}
 
 
 @scenario("An admin installs a connector and its operations are discovered")
@@ -367,7 +351,7 @@ class TestUsingAConnector:
     @scenario("A person reads what an operation takes before running it")
     @proves("PS-CONN-030")
     @covers("connector.operation.detail", "connector.operation.search")
-    async def test_an_operation_is_readable(self, installed):
+    async def test_an_operation_is_readable(self, installed, stack):
         alice, organization, auth_config, _account = installed
 
         # Whichever operation this connector offers, rather than one named
@@ -375,11 +359,20 @@ class TestUsingAConnector:
         # before running it — true of any operation, and naming one tied this
         # to the spec the suite serves rather than to the product.
         offered = await alice.operations_of(auth_config, in_organization=organization)
-        # Asserted, not skipped. This used to skip when `offered` was empty —
-        # which is to say it stood down at exactly the moment its own
-        # precondition had failed. Operation discovery regressing is the thing
-        # most worth hearing about here, and a skip is not a failure: it would
-        # have been reported as "not run" and nobody would have looked.
+        if not offered and not _a_provider_is_stood_in(stack):
+            # Which connector this run could install is the deployment's
+            # business, and the ones that install unaided are messaging
+            # surfaces that carry no operations — nothing here has failed.
+            #
+            # Not the skip this used to have, which fired in *either* lane and
+            # so stood down at exactly the moment discovery had broken. Where a
+            # provider is stood in the spec is served by this suite, operations
+            # are guaranteed, and an empty list falls through to the assert.
+            pytest.skip(
+                "the connector this deployment let the fixture install offers "
+                "no operations, so there is nothing whose shape a person could "
+                "read. Run against a stack the suite booted to get this one"
+            )
         assert offered, (
             "this connector discovered no operations at all, so there is nothing "
             "whose shape a person could read before running it. The installation "


### PR DESCRIPTION
Fixes the regression #560 put on `main` (`4e6a2a9c`): eleven connector scenarios now fail on setup with

```
priya installing 'sql' answered 400, expected 200 or 201
```

## What I got wrong

I changed `_a_connector_anyone_can_connect` to rank catalogue connectors by whether they carry operations. That picked `sql`, whose kind requires `dialect`, `host` and `database`. `installs_connector` sends only a connector id and a name, so the deployment answered 400 and every scenario sharing the `installed` fixture failed on setup.

The requirement I dropped was the real content of the old preference for `telegram`. *"Installing it asks nobody anything"* meant two things — no discovery call **and** nothing required in its config schema — and I read only the first. The filter now says it outright: one kind, not OAuth2, and no required config.

## Why ranking on operations cannot be rescued

On a real deployment the two properties are close to disjoint. Measured against dev's live catalogue:

| connector | operations | installs with no config |
|---|---:|---|
| `apollo` | 48 | no — wants a broker key |
| `sql` | 3 | no — wants a database |
| `mcp` | 0 | no — wants a server URL |
| `openapi` | 0 | no — wants a spec URL |
| `telegram` | 0 | **yes** |
| `whatsapp` | 0 | **yes** |

Nothing is both. Everything carrying operations wants credentials or an address first, and the two that install unaided are messaging surfaces with none.

## So the operations question moved, per lane

`test_an_operation_is_readable` now asks it for itself:

- **Provider stood in** — the spec is served by this suite, so operations are guaranteed. An empty list is the bug the scenario exists for, and still fails.
- **Against a deployment** — the connector comes from a catalogue whose contents are the deployment's business, and a messaging surface offering none is a fact, not a failure. It skips, naming the lane that would answer.

This is not the skip it replaced. The old one fired in *either* lane, which is exactly why it stood down at the moment discovery had broken. This one cannot fire where discovery is guaranteed.

## Verification

Against dev's live catalogue the filter selects `telegram` — what ran green for twenty-two runs before I changed it. `installs_connector` was re-read to confirm it sends no config, which is what makes the required-config filter the right one.

Scenario coverage gate, 88 harness guards and ruff all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)