### PR TITLE
Stop re-summing already-cumulative streamed usage

### DIFF
--- a/lemma-backend/app/modules/agent/services/runtime_system_profiles.py
+++ b/lemma-backend/app/modules/agent/services/runtime_system_profiles.py
@@ -177,6 +177,20 @@ def _system_lemma_openai_profile() -> AgentRuntimeProfile | None:
         config=OpenAICompatibleRuntimeConfig(
             base_url=os.getenv("LEMMA_OPENAI_BASE_URL")
             or settings.lemma_openai_base_url,
+            # pydantic-ai defaults to `self._usage += chunk_usage` per streamed
+            # SSE chunk, correct only for a provider that sends usage once (on
+            # the final chunk) or true per-chunk deltas. Verified directly
+            # against Fireworks that some models (glm-5.3-flash) instead send
+            # already-cumulative usage on every chunk -- prompt_tokens constant,
+            # completion_tokens counting up -- which the default `+=` then sums
+            # again on top of itself. One real agent turn recorded 193M input
+            # tokens this way. `openai_continuous_usage_stats` switches
+            # pydantic-ai to `self._usage = chunk_usage` (replace), which is
+            # correct for both conventions: a single final chunk still lands on
+            # the right total, and a cumulative-per-chunk stream stops being
+            # re-summed. Provider-wide, not glm-5.3-flash-specific -- deepseek-
+            # v4-flash-0731 sends usage once, so this is a no-op there.
+            model_settings={"openai_continuous_usage_stats": True},
         ),
         credentials=ApiKeyRuntimeCredentials(api_key=api_key),
     )

--- a/lemma-backend/app/modules/agent/tests/unit/test_system_openai_catalog_customizer.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_system_openai_catalog_customizer.py
@@ -56,6 +56,22 @@ def test_default_catalog_uses_names_verbatim(openai_env):
         assert RuntimeModelCapability.VISION not in entry.capabilities
 
 
+def test_openai_compat_profile_replaces_rather_than_sums_streamed_usage(openai_env):
+    """pydantic-ai's OpenAI streaming handler defaults to `usage += chunk_usage`
+    per SSE chunk -- correct only when a provider sends usage on a single final
+    chunk. Verified directly against Fireworks that glm-5.3-flash instead sends
+    already-cumulative usage on *every* chunk (prompt_tokens constant,
+    completion_tokens counting up), which the default then re-sums on top of
+    itself -- one real agent turn recorded 193M input tokens this way.
+    `openai_continuous_usage_stats` switches pydantic-ai to `usage =
+    chunk_usage` (replace), correct under both conventions. Set at the profile
+    level, not per model, so it protects every model behind this provider."""
+    profiles = AgentRuntimeProfileService().system_profiles()
+    assert profiles, "system profile should exist when the API key is set"
+    config = profiles[0].config
+    assert config.model_settings.get("openai_continuous_usage_stats") is True
+
+
 def test_pricing_catalog_is_empty_when_no_models_are_configured(monkeypatch):
     from app.core.config import settings
 


### PR DESCRIPTION
## Root cause, verified rather than assumed
`glm-5.3-flash` was pulled from the catalog after a real dev conversation recorded 193M input tokens / \$137.97 in a single `agent_run`. [#556](https://github.com/lemma-work/lemma-platform/pull/556) surfaced this and added a warning, assuming the provider's number was simply unusable — it wasn't investigated further at the time.

Checked our own logic first, per request, before re-blaming the provider:
- Reconstructed the exact `cost_usd` of the worst corrupted row from its stored `input_tokens` using our pricing formula — matched to 8 decimal places. Pricing math is correct.
- Traced both usage-accumulation sites (retry-carry, per-run emit) — both sum every field through the same loop, so a bug there inflates every field together. The actual observation (`cache_read_tokens` sane, `input_tokens` alone exploded) rules that out.
- Sent a realistic multi-turn payload directly to Fireworks, non-streaming: proportional response, no anomaly.

The difference was streaming. A raw curl against Fireworks' streaming endpoint for `glm-5.3-flash` shows `usage` populated on **every** SSE chunk — `prompt_tokens` constant, `completion_tokens` counting up, both already the cumulative total. `deepseek-v4-flash-0731` (our default model) sends `usage` once, on the final chunk only — unaffected, which is why this went unnoticed for the model most traffic actually uses.

`pydantic_ai`'s OpenAI streaming handler defaults to `self._usage += chunk_usage` for every chunk with usage present — correct for a single-final-snapshot provider, wrong for one that sends a running cumulative total on every chunk (each one gets re-added on top of the last). `pydantic_ai` ships exactly the flag for this case, `openai_continuous_usage_stats`, which switches to `self._usage = chunk_usage` (replace) — we never set it.

## Fix
Set `openai_continuous_usage_stats: True` on the system OpenAI-compatible profile's `config.model_settings` — provider-wide, not model-specific, so every model behind this provider is protected, not only the one that surfaced it. No-op for a model that only ever sends one usage-bearing chunk.

## Test plan
- [x] 1403 agent unit tests pass, including a new one asserting the profile config carries this setting