### PR TITLE
Render the approval that is pending, not whatever pause is oldest

### DIFF
--- a/lemma-backend/app/modules/agent/services/conversation_service.py
+++ b/lemma-backend/app/modules/agent/services/conversation_service.py
@@ -319,6 +319,29 @@ class ConversationService:
             tool_names=("ask_user",),
         )
 
+    async def get_pending_approval(
+        self,
+        *,
+        conversation_id: UUID,
+    ) -> dict[str, object] | None:
+        """Oldest unresolved ``request_approval`` pause, or ``None``.
+
+        The approval counterpart of :meth:`get_pending_ask_user`, and it has to
+        be its own lookup rather than a filter applied to
+        :meth:`get_pending_user_interaction`. That one answers "what is this
+        conversation waiting on", of *any* pausing kind, which is right for
+        routing a typed reply back — a person answering in words answers
+        whatever is pending. It is wrong for rendering, because a conversation
+        can hold more than one unresolved pause at a time: an `ask_user` nobody
+        ever tapped stays unresolved forever, and being older it is the one
+        returned. The approval card then had nothing to render and the run sat
+        WAITING with nobody told.
+        """
+        return await self.approvals.oldest_unresolved_pause(
+            conversation_id=conversation_id,
+            tool_names=("request_approval",),
+        )
+
     async def get_pending_user_interaction(
         self,
         *,

--- a/lemma-backend/app/modules/agent_surfaces/services/surface_egress.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/surface_egress.py
@@ -413,7 +413,15 @@ class SurfaceEgressMixin(SurfaceEgressTargetMixin):
             )
             return False
 
-        pending = await self.conversation_service.get_pending_user_interaction(
+        # The approval pause specifically, not "whatever this conversation is
+        # waiting on". `get_pending_user_interaction` answers the second, across
+        # every pausing tool, and the check below then threw away anything that
+        # was not an approval — so a single `ask_user` nobody ever tapped, being
+        # older, shadowed every approval that followed it in that conversation
+        # for good. On a chat surface, where one conversation stands for the
+        # whole relationship with a person, that is permanent: dev's standing
+        # Telegram chat stopped rendering approval cards entirely.
+        pending = await self.conversation_service.get_pending_approval(
             conversation_id=conversation_id
         )
         if not isinstance(pending, dict) or pending.get("kind") != "request_approval":

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_ingress_service.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_ingress_service.py
@@ -1975,7 +1975,7 @@ async def test_send_approval_prompt_renders_native_buttons():
     adapter.send_approval.return_value = True  # platform rendered native buttons
     service = _build_service(adapter=adapter, surfaces=[surface], existing_link=link)
     service.conversation_link_repository.get_by_conversation_id.return_value = link
-    service.conversation_service.get_pending_user_interaction.return_value = {
+    service.conversation_service.get_pending_approval.return_value = {
         "tool_call_id": "tool-2",
         "kind": "request_approval",
         "tool_args": _REQUEST_APPROVAL_TOOL_ARGS,
@@ -1997,6 +1997,64 @@ async def test_send_approval_prompt_renders_native_buttons():
     adapter.send_message.assert_not_awaited()
 
 
+async def test_an_older_unanswered_question_does_not_shadow_the_approval():
+    """The bug this pairing exists to catch.
+
+    A conversation can hold more than one unresolved pause. An `ask_user`
+    nobody ever tapped stays unresolved forever, and being older it is what
+    "what is this conversation waiting on" returns — so the approval renderer,
+    which asked that question and then discarded anything that was not an
+    approval, delivered nothing at all and left the run WAITING with nobody
+    told. On a chat surface, where one conversation stands for the whole
+    relationship with a person, that is permanent: dev's standing Telegram chat
+    stopped rendering approval cards entirely.
+
+    Wired through a stand-in that filters the way the real lookup does, so this
+    fails if the renderer goes back to asking the unfiltered question.
+    """
+    surface = _slack_surface()
+    conversation_id = uuid4()
+    parsed_event = _slack_event()
+    link = await _ask_user_link(surface, conversation_id, parsed_event)
+    adapter = AsyncMock()
+    adapter.send_approval.return_value = True
+    service = _build_service(adapter=adapter, surfaces=[surface], existing_link=link)
+    service.conversation_link_repository.get_by_conversation_id.return_value = link
+
+    stale_question = {
+        "tool_call_id": "tool-ask",
+        "kind": "ask_user",
+        "tool_args": {},
+        "agent_run_id": uuid4(),
+    }
+    the_approval = {
+        "tool_call_id": "tool-2",
+        "kind": "request_approval",
+        "tool_args": _REQUEST_APPROVAL_TOOL_ARGS,
+        "agent_run_id": uuid4(),
+    }
+    # Oldest first, exactly as `oldest_unresolved_pause` walks them.
+    pauses = [stale_question, the_approval]
+
+    async def oldest_of_any_kind(*, conversation_id):
+        return pauses[0]
+
+    async def oldest_approval(*, conversation_id):
+        return next((p for p in pauses if p["kind"] == "request_approval"), None)
+
+    service.conversation_service.get_pending_user_interaction = oldest_of_any_kind
+    service.conversation_service.get_pending_approval = oldest_approval
+
+    sent = await service.send_approval_prompt_for_conversation(
+        conversation_id=conversation_id, tool_call_id="tool-2"
+    )
+
+    assert sent is True
+    plan = adapter.send_approval.await_args.kwargs["approval_plan"]
+    assert plan.title == "Write a record"
+    assert [b.decision for b in plan.buttons] == ["APPROVE_ONCE", "DENY"]
+
+
 async def test_send_approval_prompt_falls_back_to_text():
     surface = _slack_surface()
     conversation_id = uuid4()
@@ -2006,7 +2064,7 @@ async def test_send_approval_prompt_falls_back_to_text():
     adapter.send_approval.return_value = False  # platform has no native buttons
     service = _build_service(adapter=adapter, surfaces=[surface], existing_link=link)
     service.conversation_link_repository.get_by_conversation_id.return_value = link
-    service.conversation_service.get_pending_user_interaction.return_value = {
+    service.conversation_service.get_pending_approval.return_value = {
         "tool_call_id": "tool-2",
         "kind": "request_approval",
         "tool_args": _REQUEST_APPROVAL_TOOL_ARGS,
@@ -2032,7 +2090,7 @@ async def test_send_approval_prompt_adds_session_button_with_permission_ids():
     adapter.send_approval.return_value = True
     service = _build_service(adapter=adapter, surfaces=[surface], existing_link=link)
     service.conversation_link_repository.get_by_conversation_id.return_value = link
-    service.conversation_service.get_pending_user_interaction.return_value = {
+    service.conversation_service.get_pending_approval.return_value = {
         "tool_call_id": "tool-2",
         "kind": "request_approval",
         "tool_args": {
@@ -2061,7 +2119,7 @@ async def test_send_approval_prompt_skips_when_no_pending():
     adapter = AsyncMock()
     service = _build_service(adapter=adapter, surfaces=[surface], existing_link=link)
     service.conversation_link_repository.get_by_conversation_id.return_value = link
-    service.conversation_service.get_pending_user_interaction.return_value = None
+    service.conversation_service.get_pending_approval.return_value = None
 
     sent = await service.send_approval_prompt_for_conversation(
         conversation_id=conversation_id


### PR DESCRIPTION
Fixes the last red dev scenario, `test_an_approval_is_offered_with_native_controls` — red for nine straight runs. An approval card stopped reaching Telegram entirely: the run paused, the person saw an empty streaming placeholder and nothing else, and the run sat `WAITING` for an answer nobody had been asked for.

## The bug

`send_approval_prompt_for_conversation` asked `get_pending_user_interaction` — *"what is this conversation waiting on"*, across every pausing tool — and then discarded the answer unless it happened to be an approval:

```python
pending = await self.conversation_service.get_pending_user_interaction(...)
if not isinstance(pending, dict) or pending.get("kind") != "request_approval":
    return False   # nothing delivered
```

`PAUSING_TOOL_NAMES` is `("ask_user", "request_approval", "snooze")`, and `oldest_unresolved_pause` returns the **oldest** match of any of them.

A conversation can hold more than one unresolved pause. `ask_user` resolves when somebody taps an option, so **a question nobody ever answered stays unresolved for good** — and being older, it is what that lookup returns. From then on every approval in that conversation rendered nothing.

On a chat surface that is permanent rather than transient, because one conversation stands for the whole relationship with a person. Dev's standing Telegram chat had exactly one such orphaned question — left by the sibling scenario, which asserts the buttons arrived and never taps one — which is why this went from intermittent to constant, and why it reproduced on no local stack: a fresh conversation has nothing to shadow it.

## The fix

The renderer asks for the approval specifically. `get_pending_approval` is the counterpart of the `get_pending_ask_user` that has always existed, and **the asymmetry was the bug** — the question renderer was already filtered and never had this problem.

`get_pending_user_interaction` keeps its unfiltered meaning for the one caller that wants it: routing a *typed* reply back, where a person answering in words answers whatever is pending.

## How it was found, and what that corrects

I reproduced the pause outside Telegram: `lemma agent run` with the scenario's own prompt against dev returned an **empty answer**, and the conversation behind it was `WAITING` with `last_run_status: COMPLETED`, ending on a `request_approval` tool call with no text message.

So the model was calling the tool correctly all along, and the empty Telegram message was the *absence of any reply*, not a malformed one. My earlier guess — that the prompt never told the agent approvals existed — was wrong; nothing was reaching the surface at all.

The sharp discriminator was that the sibling scenario, `test_a_question_is_asked_with_native_controls`, passes on the same surface in the same lane. Same buttons, same delivery path — only the approval lookup differs.

## Tests

The three existing approval-prompt tests now stub the filtered lookup. One new test puts an older unanswered question in front of an approval and asserts the card still renders, wired through a stand-in that filters the way the real lookup does. All four fail against the previous wiring.

`make quality` passes (architecture ratchet included), along with 2484 unit tests and the full agent_surfaces e2e suite (177 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)