### PR TITLE
Stop a wrong device clock from posting a message twice

### DIFF
--- a/lemma-typescript/src/__tests__/skewed-device-clock.test.ts
+++ b/lemma-typescript/src/__tests__/skewed-device-clock.test.ts
@@ -1,0 +1,236 @@
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ConversationMessage } from "../types.js";
+import {
+  useAssistantRuntime,
+  type UseAssistantRuntimeResult,
+} from "../react/useAssistantRuntime.js";
+
+// A provisional turn is stamped from the DEVICE clock and its echo from the
+// SERVER clock, so the store cannot pair them by comparing the two: on a
+// machine whose clock is wrong — Windows with a dead time service, a dual-boot
+// box reading the RTC as local time, a VM resumed from sleep — the gap is the
+// skew, not the round-trip. The echo used to be filed as a second message, and
+// the sender watched their own message appear twice: once at the time their
+// machine believes it is, once where the server put it.
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const roots: Root[] = [];
+
+afterEach(() => {
+  vi.useRealTimers();
+  act(() => {
+    roots.splice(0).forEach((root) => root.unmount());
+  });
+});
+
+const CONVERSATION_ID = "conv-1";
+/** What the server's clock reads while the test runs. */
+const SERVER_NOW = new Date("2026-08-30T12:00:00.000Z");
+
+function serverEcho(id: string, text: string): ConversationMessage {
+  return {
+    id,
+    role: "user",
+    kind: "TEXT",
+    text,
+    created_at: SERVER_NOW.toISOString(),
+    conversation_id: CONVERSATION_ID,
+  } as ConversationMessage;
+}
+
+function mountRuntime() {
+  let latest: UseAssistantRuntimeResult | null = null;
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  roots.push(root);
+
+  function Probe() {
+    latest = useAssistantRuntime({ conversationId: CONVERSATION_ID });
+    return null;
+  }
+
+  act(() => {
+    root.render(createElement(Probe));
+  });
+
+  return {
+    get current(): UseAssistantRuntimeResult {
+      if (!latest) throw new Error("Runtime is not mounted.");
+      return latest;
+    },
+    userMessages(text: string) {
+      return this.current.runtimeMessages.filter(
+        (message) => message.role === "user" && message.text === text,
+      );
+    },
+  };
+}
+
+/** Send a turn from a device whose clock is `skewMs` away from the server's,
+ *  then let the server's echo of it arrive. */
+function sendWithSkew(skewMs: number, text: string) {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(SERVER_NOW.getTime() + skewMs));
+
+  const runtime = mountRuntime();
+  let provisionalId = "";
+  act(() => {
+    provisionalId = runtime.current.appendOptimisticUserMessage(text, {
+      conversationId: CONVERSATION_ID,
+    }).id;
+  });
+  act(() => {
+    runtime.current.mergeMessages([serverEcho("srv-1", text)]);
+  });
+
+  return { runtime, provisionalId };
+}
+
+const MINUTE = 60 * 1000;
+
+describe("a sender whose device clock is wrong", () => {
+  it("sees one message, not two, when the clock runs hours fast", () => {
+    const { runtime } = sendWithSkew(3 * 60 * MINUTE, "ship it");
+    expect(runtime.userMessages("ship it")).toHaveLength(1);
+  });
+
+  it("sees one message, not two, when the clock runs days slow", () => {
+    const { runtime } = sendWithSkew(-2 * 24 * 60 * MINUTE, "ship it");
+    expect(runtime.userMessages("ship it")).toHaveLength(1);
+  });
+
+  it("keeps the turn's identity across the echo, so it does not remount", () => {
+    const { runtime, provisionalId } = sendWithSkew(3 * 60 * MINUTE, "ship it");
+    const [only] = runtime.userMessages("ship it");
+    expect(only?.id).toBe("srv-1");
+    expect((only as { optimistic_id?: string } | undefined)?.optimistic_id).toBe(provisionalId);
+  });
+
+  // The other half of a wrong clock. Even paired correctly, a turn stamped from
+  // a device running days behind sorts before the entire transcript — the
+  // sender's own message opens the conversation until the echo lands and moves
+  // it. It has to go last from the moment it is shown.
+  it("still sends the turn to the end of a transcript it did not stamp", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(SERVER_NOW.getTime() - 2 * 24 * 60 * MINUTE));
+
+    const runtime = mountRuntime();
+    act(() => {
+      runtime.current.mergeMessages([
+        serverEcho("srv-old", "what did we decide?"),
+        {
+          id: "srv-old-reply",
+          role: "assistant",
+          kind: "TEXT",
+          text: "We shipped it.",
+          created_at: SERVER_NOW.toISOString(),
+          conversation_id: CONVERSATION_ID,
+        } as ConversationMessage,
+      ]);
+    });
+    act(() => {
+      runtime.current.appendOptimisticUserMessage("and after that?", {
+        conversationId: CONVERSATION_ID,
+      });
+    });
+
+    const transcript = runtime.current.runtimeMessages.map((message) => message.text);
+    expect(transcript).toEqual(["what did we decide?", "We shipped it.", "and after that?"]);
+  });
+});
+
+// Pairing used to break a tie between two provisional turns of the same text by
+// picking whichever sat closest in time. That tie-break is gone with the clocks,
+// and store order replaces it — which on a device running behind is order alone,
+// because every provisional turn anchors to the same server message and they all
+// come out holding the identical stamp.
+describe("two turns of the same text, both in flight", () => {
+  it("pairs each echo with the turn that was actually sent first", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(SERVER_NOW.getTime() - 2 * 24 * 60 * MINUTE));
+
+    const runtime = mountRuntime();
+    act(() => {
+      runtime.current.mergeMessages([
+        {
+          id: "srv-prompt",
+          role: "assistant",
+          kind: "TEXT",
+          text: "Ready when you are.",
+          created_at: SERVER_NOW.toISOString(),
+          conversation_id: CONVERSATION_ID,
+        } as ConversationMessage,
+      ]);
+    });
+
+    let firstId = "";
+    let secondId = "";
+    act(() => {
+      firstId = runtime.current.appendOptimisticUserMessage("go", { conversationId: CONVERSATION_ID }).id;
+      secondId = runtime.current.appendOptimisticUserMessage("go", { conversationId: CONVERSATION_ID }).id;
+    });
+    expect(runtime.userMessages("go").map((message) => message.id)).toEqual([firstId, secondId]);
+
+    act(() => {
+      runtime.current.mergeMessages([serverEcho("srv-go-1", "go")]);
+    });
+    act(() => {
+      runtime.current.mergeMessages([
+        { ...serverEcho("srv-go-2", "go"), created_at: new Date(SERVER_NOW.getTime() + 1000).toISOString() } as ConversationMessage,
+      ]);
+    });
+
+    const settled = runtime.userMessages("go");
+    expect(settled.map((message) => message.id)).toEqual(["srv-go-1", "srv-go-2"]);
+    expect(settled.map((message) => (message as { optimistic_id?: string }).optimistic_id))
+      .toEqual([firstId, secondId]);
+  });
+});
+
+// Pairing is by text, so the reason it cannot pair a provisional turn with some
+// older message that happens to read the same is recency — and recency is now
+// judged on the server's timeline. That has to keep holding.
+describe("history arriving while a turn is in flight", () => {
+  it("does not let an old message of the same text take the turn's place", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(SERVER_NOW);
+
+    const runtime = mountRuntime();
+    act(() => {
+      runtime.current.mergeMessages([
+        {
+          id: "srv-recent",
+          role: "assistant",
+          kind: "TEXT",
+          text: "Anything else?",
+          created_at: SERVER_NOW.toISOString(),
+          conversation_id: CONVERSATION_ID,
+        } as ConversationMessage,
+      ]);
+    });
+    act(() => {
+      runtime.current.appendOptimisticUserMessage("yes", { conversationId: CONVERSATION_ID });
+    });
+
+    const lastYear = new Date(SERVER_NOW.getTime() - 365 * 24 * 60 * MINUTE).toISOString();
+    act(() => {
+      runtime.current.mergeMessages([
+        { ...serverEcho("srv-ancient", "yes"), created_at: lastYear } as ConversationMessage,
+      ]);
+    });
+
+    expect(runtime.userMessages("yes")).toHaveLength(2);
+    expect(runtime.userMessages("yes").map((message) => message.id))
+      .toEqual(["srv-ancient", expect.stringMatching(/^optimistic-user-/)]);
+
+    // ...and the real echo still has a provisional turn waiting to claim.
+    act(() => {
+      runtime.current.mergeMessages([serverEcho("srv-1", "yes")]);
+    });
+    expect(runtime.userMessages("yes").map((message) => message.id))
+      .toEqual(["srv-ancient", "srv-1"]);
+  });
+});

--- a/lemma-typescript/src/react/useAssistantRuntime.ts
+++ b/lemma-typescript/src/react/useAssistantRuntime.ts
@@ -70,7 +70,64 @@ function isOptimisticId(messageId: string): boolean {
   return messageId.startsWith("optimistic-user-");
 }
 
-const OPTIMISTIC_MATCH_WINDOW_MS = 2 * 60 * 1000;
+/**
+ * How far back on the SERVER's own timeline an incoming user message may sit
+ * and still be read as the echo of a turn just sent, rather than as history
+ * being loaded. Generous on purpose: all it has to separate is "the message I
+ * just sent" from "a transcript from an earlier session", and those are hours
+ * or days apart, never minutes.
+ */
+const ECHO_RECENCY_WINDOW_MS = 60 * 60 * 1000;
+
+/**
+ * The newest moment the SERVER has stamped, across every message the store
+ * holds. Provisional turns are excluded deliberately: their times come from the
+ * device clock, and it is mixing the two clocks that this whole file has to
+ * avoid. Everything left is stamped by the one clock all senders share, so the
+ * maximum is the best estimate of "now" available without asking.
+ */
+function newestServerTime(messages: RuntimeConversationMessage[]): number | null {
+  let newest: number | null = null;
+  messages.forEach((message) => {
+    if (isOptimisticId(message.id)) return;
+    const time = messageTime(message);
+    if (newest === null || time > newest) newest = time;
+  });
+  return newest;
+}
+
+/**
+ * Whether this message is recent enough on the server's timeline to be an echo
+ * of something just sent. Server time is compared only against server time, so
+ * a device clock that is hours or days out cannot make a fresh echo look stale.
+ * With nothing server-stamped to compare against, the store holds no history
+ * for the echo to be confused with, and the question does not arise.
+ */
+function isRecentOnServerTimeline(
+  held: RuntimeConversationMessage[],
+  incoming: RuntimeConversationMessage,
+): boolean {
+  const newest = newestServerTime(held);
+  if (newest === null) return true;
+  return messageTime(incoming) >= newest - ECHO_RECENCY_WINDOW_MS;
+}
+
+/**
+ * When to say a turn was sent, for the second it takes the server to say so
+ * itself. The device clock is the obvious answer and the wrong one: on a
+ * machine whose clock is off — Windows with a dead time service, a dual-boot
+ * box reading the RTC as local time, a VM resumed from sleep — it files the
+ * turn hours or days from where it belongs, above the entire transcript on a
+ * clock that is behind. Until the echo lands, this value is what orders the
+ * turn, what the transcript prints under it, and what its duration is measured
+ * from. Anchoring past the newest thing the server has stamped keeps the turn
+ * last in the conversation whatever the device believes the time is.
+ */
+function optimisticCreatedAt(held: RuntimeConversationMessage[]): string {
+  const deviceNow = Date.now();
+  const newest = newestServerTime(held);
+  return new Date(newest === null ? deviceNow : Math.max(deviceNow, newest + 1)).toISOString();
+}
 
 function upsertRuntimeMessage(
   previous: RuntimeConversationMessage[],
@@ -92,32 +149,34 @@ function upsertRuntimeMessage(
     return next;
   }
 
-  if (incoming.role === "user") {
+  // Only a message the server has stamped can take a provisional turn's place.
+  // Without that, appending a second provisional turn made it pair with the
+  // first one of the same text and quietly take its place: send "go" twice and
+  // the first bubble vanished, to reappear only when its echo came back.
+  if (incoming.role === "user" && !isOptimisticId(incoming.id)) {
     const incomingText = messageText(incoming);
+    // Pairing used to ask how far apart the two stamps were — a provisional
+    // turn's, from the device clock, against its echo's, from the server's.
+    // On a device whose clock is wrong that distance is the skew rather than
+    // the round-trip, no echo ever matched, and the sender watched their own
+    // message land twice: once where their machine thinks it is now, once
+    // where the server put it. Nothing below compares the two clocks.
     if (incomingText) {
-      const incomingTimestamp = messageTime(incoming);
-      let optimisticIndex = -1;
-      let bestDistance = Number.POSITIVE_INFINITY;
+      // First match wins. Echoes come back in the order their sends went out,
+      // so two turns sharing their text pair up in that same order — and store
+      // order is the ordering to read it from, never the stamps.
+      const optimisticIndex = next.findIndex((message) => (
+        message.role === "user"
+        && isOptimisticId(message.id)
+        && messageText(message) === incomingText
+      ));
 
-      next.forEach((message, index) => {
-        if (
-          message.role !== "user"
-          || !isOptimisticId(message.id)
-          || messageText(message) !== incomingText
-        ) {
-          return;
-        }
-
-        const distance = Math.abs(messageTime(message) - incomingTimestamp);
-        if (distance > OPTIMISTIC_MATCH_WINDOW_MS || distance >= bestDistance) {
-          return;
-        }
-
-        optimisticIndex = index;
-        bestDistance = distance;
-      });
-
-      if (optimisticIndex >= 0) {
+      // Recency is asked second on purpose. Finding a candidate is string work
+      // over a list that almost never holds a provisional turn at all; judging
+      // recency parses a date per held message. Loading a transcript merges
+      // hundreds of user messages through here and must not pay that per
+      // message — only a send with an echo actually waiting for it does.
+      if (optimisticIndex >= 0 && isRecentOnServerTimeline(next, incoming)) {
         // The echo takes the provisional turn's place *and* remembers whose
         // place it took, so whoever keys turns can keep them the same one.
         next[optimisticIndex] = {
@@ -221,7 +280,7 @@ export function useAssistantRuntime({
       role: "user",
       kind: "TEXT",
       text: trimmed,
-      created_at: new Date().toISOString(),
+      created_at: optimisticCreatedAt(runtimeMessagesRef.current),
       metadata: null,
       ...(optimisticConversationId ? { conversation_id: optimisticConversationId } : {}),
     };


### PR DESCRIPTION
## What changes

On a device whose clock is wrong, sending a message showed it **twice** — once where the machine thinks it is now, once where the server put it. That stops.

The runtime store paired a provisional turn with the server's echo by comparing how far apart their timestamps were. One is stamped by the device, the other by the server, so on a machine with a bad clock — Windows with a dead time service, a dual-boot box reading the RTC as local time, a VM resumed from sleep — that distance measured the *skew*, not the round-trip. Past two minutes of it nothing ever matched and the echo was filed as a new message. There is no server-side correlation id to fall back on: `optimistic_id` is invented on the client and the backend never sees it.

Pairing now asks a question only one clock answers — is this message recent on the *server's own* timeline? Server time is compared against server time, so skew cancels, while the check still does the job the old window was really there for: keeping a loaded transcript from claiming a turn that is still in flight.

Ordering was the other half. A provisional turn stamped from a clock running behind sorts above the entire transcript, and until the echo lands that stamp is also what the transcript prints under the turn and what its duration is measured from — a fresh turn reading "Worked for 2d". Provisional turns now anchor past the newest moment the server has stamped, so they stay last whatever the device believes the time is.

**On a correct clock, nothing about any of this changes.**

## Why

Reported from the field: users on Windows machines with broken time sync see every message they send appear twice.

## How to verify

Four of the five new skew cases fail on `main` and pass here; the fifth is a regression guard that must pass on both.

```bash
cd lemma-typescript
npx tsc --noEmit -p tsconfig.json          # OK
npx tsc --noEmit -p tsconfig.test.json     # OK
npx vitest run                             # 31 files, 250 tests passed
npx vitest run src/__tests__/skewed-device-clock.test.ts   # 6 passed
```

To watch it fail first, stash the source change and re-run the last command — 4 of 6 fail (3h fast, 2 days slow, turn identity, ordering).

Also verified: `lemma-frontend` suite green (1187 tests, though it resolves `lemma-sdk` to the built dist and does not exercise this module); the committed `public/lemma-client.js` does not contain this module, so the "Browser bundle is fresh" gate needs no regeneration.

## Reviewer notes

Three things worth a second opinion.

**The window moved from 2 minutes to 1 hour, on a different axis.** It is no longer cross-clock distance but server-timeline recency. That swaps one rare failure for another. Gone: any clock skew breaks pairing (100% reproducible on an affected machine). New and rare: if pagination of older messages lands in the same instant as a send, *and* that page holds a byte-identical user message under an hour old, it could claim the pending turn — four coincidences, and the result is a duplicate rather than corruption. I chose an hour deliberately, because the opposite failure (an assistant message from the run arriving before the user echo) is far likelier now that #524 lets a follow-up sit queued for minutes.

**A pre-existing bug is fixed here too, and it is beyond the reported one — happy to split it out.** The pairing branch never checked that the incoming message was server-stamped, so appending a second provisional turn paired it with the first one of the same text and took its place: send "go" twice and the first bubble vanished until its echo came back. Confirmed against `main`, now covered by the FIFO test.

**Store order replaced a tie-break.** Two same-text pending turns used to be disambiguated by nearest timestamp; they are now taken in store order. On a skewed device they all anchor to the same server message and get byte-identical stamps, so this leans on `Array.prototype.sort` being stable (guaranteed since ES2019). Stated here because it is load-bearing and easy to miss; the FIFO test locks it down.

## Not fixed

Same root cause, different symptom, left alone: `lemma-frontend/lib/utils/relative-time.ts` diffs server timestamps against the device's `Date.now()`, so a skewed machine reads everything in the conversation list as "just now" or "3h ago". Cosmetic, and a proper fix wants a server-clock offset plumbed from HTTP response `Date` headers rather than inferred.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

No migration, no API surface change, no generated-client drift — one module in `lemma-typescript` plus its test. Reverting the commit fully restores previous behavior, including the duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
