### PR TITLE
Let the sidebar show a conversation being renamed

### DIFF
--- a/lemma-frontend/components/pod/workspace-sidebar.tsx
+++ b/lemma-frontend/components/pod/workspace-sidebar.tsx
@@ -57,6 +57,7 @@ import {
 import { flowsQueryOptions } from '@/lib/hooks/use-flows';
 import { useAccessiblePods, type AccessiblePod, type AccessiblePodGroup } from '@/lib/hooks/use-pods';
 import { useScopedConversations } from '@/lib/hooks/use-assistants';
+import { useTypedRename } from '@/lib/hooks/use-typed-rename';
 import { identityHueClass } from '@/lib/utils/resource-icon-value';
 import { LEM_SEED, agentIdentitySeed } from '@/lib/identity/seeded-identity';
 import {
@@ -1316,13 +1317,24 @@ export function ConversationRow({
        draws *nothing*. The slot stays reserved either way so every title keeps
        one left edge, and the empty ones carry the status dot they always had. */
     const face = showResponder && mark?.kind === 'agent' ? mark : null;
+    /* The server names a conversation a few seconds after it starts, and that
+       rename arrives on the live stream rather than on a refetch. Typed in, so
+       the row visibly gets its name instead of silently swapping one. */
+    const label = conversation.title || 'Untitled conversation';
+    const typedLabel = useTypedRename(label);
+    /* Named off the settled title, so a row focused mid-animation never offers a
+       half-typed name — and carrying the status the dot shows visually, which
+       is what the sibling `sr-only` span used to do before a name existed to
+       fold it into. */
+    const rowLabel = signal.label ? `${label}, ${signal.label}` : label;
 
     return (
         <button
             type="button"
             onClick={onOpen}
             data-active={active ? 'true' : undefined}
-            title={conversation.title || 'Untitled conversation'}
+            title={label}
+            aria-label={rowLabel}
             className={cn(
                 'lemma-sidebar-row workspace-sidebar-conversation-row custom-focus-ring',
                 showResponder ? 'workspace-sidebar-conversation-row-marked' : null,
@@ -1367,9 +1379,8 @@ export function ConversationRow({
                 </span>
             )}
             <span className="min-w-0 flex-1 truncate">
-                {conversation.title || 'Untitled conversation'}
+                {typedLabel}
             </span>
-            {signal.label ? <span className="sr-only">{signal.label}</span> : null}
         </button>
     );
 }

--- a/lemma-frontend/lib/hooks/__tests__/use-typed-rename.test.ts
+++ b/lemma-frontend/lib/hooks/__tests__/use-typed-rename.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { planRename, renameStepMs } from '@/lib/hooks/use-typed-rename';
+
+describe('planRename', () => {
+    it('types a server-generated title in over the local stand-in', () => {
+        const plan = planRename('who has the most centuries', "Ashwin's records", false);
+
+        expect(plan.kind).toBe('type');
+        expect(plan.kind === 'type' && plan.characters.join('')).toBe("Ashwin's records");
+    });
+
+    it('does not animate a row seeing its title for the first time', () => {
+        // Otherwise every row in a freshly loaded sidebar types itself in at once.
+        expect(planRename('', 'Quarterly numbers', false)).toEqual({
+            kind: 'settle',
+            text: 'Quarterly numbers',
+        });
+    });
+
+    it('does not animate a title going away', () => {
+        expect(planRename('Quarterly numbers', '', false)).toEqual({ kind: 'settle', text: '' });
+    });
+
+    it('respects a reduced-motion preference', () => {
+        expect(planRename('draft', 'Quarterly numbers', true)).toEqual({
+            kind: 'settle',
+            text: 'Quarterly numbers',
+        });
+    });
+
+    it('steps by code point, so a title in any script survives the reveal', () => {
+        // Sliced by code unit, the halfway frame of this one is a replacement box.
+        const plan = planRename('trip', '日本の春 🌸', false);
+
+        expect(plan.kind === 'type' && plan.characters).toEqual(['日', '本', 'の', '春', ' ', '🌸']);
+    });
+});
+
+describe('renameStepMs', () => {
+    it('slows a short title down and speeds a long one up', () => {
+        expect(renameStepMs(4)).toBeGreaterThan(renameStepMs(80));
+    });
+
+    it('keeps even a maximum-length title short enough to sit through', () => {
+        // The generated ones are 3-6 words; 120 is the cap on the fallback cut
+        // from the user's own message, and the floor below is what stops it
+        // ticking sub-frame rather than what sets its length.
+        expect(renameStepMs(120) * 120).toBeLessThan(1500);
+    });
+
+    it('never ticks faster than the eye can follow', () => {
+        expect(renameStepMs(10_000)).toBeGreaterThanOrEqual(12);
+    });
+});

--- a/lemma-frontend/lib/hooks/use-typed-rename.ts
+++ b/lemma-frontend/lib/hooks/use-typed-rename.ts
@@ -1,0 +1,87 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+/** How long a whole rename takes, however long the title turns out to be. */
+const RENAME_DURATION_MS = 700;
+const MIN_STEP_MS = 12;
+const MAX_STEP_MS = 32;
+
+/**
+ * One tick per character, paced so a 120-character title does not spend four
+ * seconds typing itself into a row nobody is looking at any more.
+ */
+export function renameStepMs(characterCount: number): number {
+    if (characterCount <= 0) return MAX_STEP_MS;
+    return Math.min(MAX_STEP_MS, Math.max(MIN_STEP_MS, Math.round(RENAME_DURATION_MS / characterCount)));
+}
+
+export type RenamePlan =
+    /** Put the new title up whole, with no animation. */
+    | { kind: 'settle'; text: string }
+    /** Type it in, one code point per `stepMs`. */
+    | { kind: 'type'; characters: string[]; stepMs: number };
+
+/**
+ * Whether a title change is a rename worth showing, and how fast to show it.
+ *
+ * Separated from the hook because this is the whole decision: everything around
+ * it is a timer.
+ */
+export function planRename(previous: string, next: string, reducedMotion: boolean): RenamePlan {
+    // A row rendering its title for the first time is being named, not renamed —
+    // which is what every row in a freshly loaded list is doing, and fifteen of
+    // them typing at once is a screen that cannot be read. Losing a title is not
+    // a rename either: there is nothing to type.
+    if (!previous || !next || reducedMotion) return { kind: 'settle', text: next };
+
+    // Code points, not code units: a title is generated in the writer's own
+    // script, and slicing through a surrogate pair renders a replacement box.
+    const characters = Array.from(next);
+    return { kind: 'type', characters, stepMs: renameStepMs(characters.length) };
+}
+
+function prefersReducedMotion(): boolean {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/**
+ * Types a title in when it changes under a row that is already on screen.
+ *
+ * A conversation is named twice: once locally, from the first thing you typed,
+ * and once by the server a few seconds later, from a model that read the same
+ * message. The second one arrives on the conversation's own stream while the
+ * agent is still answering, so the row rewrites itself under your eyes. With
+ * nothing marking the moment that reads as a glitch — the title you were looking
+ * at is simply a different title now. Typing it in says the rename happened, and
+ * that something did it on purpose.
+ */
+export function useTypedRename(title: string): string {
+    const [typed, setTyped] = useState(title);
+    const previousRef = useRef(title);
+
+    useEffect(() => {
+        const previous = previousRef.current;
+        previousRef.current = title;
+        if (title === previous) return;
+
+        const plan = planRename(previous, title, prefersReducedMotion());
+        if (plan.kind === 'settle') {
+            setTyped(plan.text);
+            return;
+        }
+
+        let count = 1;
+        setTyped(plan.characters[0] ?? '');
+        const timer = setInterval(() => {
+            count += 1;
+            setTyped(plan.characters.slice(0, count).join(''));
+            if (count >= plan.characters.length) clearInterval(timer);
+        }, plan.stepMs);
+
+        return () => clearInterval(timer);
+    }, [title]);
+
+    return typed;
+}

--- a/lemma-typescript/public/lemma-ui.js
+++ b/lemma-typescript/public/lemma-ui.js
@@ -215,6 +215,16 @@ var LemmaUI = (() => {
     }
     return normalizeStatus(payload);
   }
+  function extractTitle(payload) {
+    const title = typeof payload === "string" ? payload : isRecord2(payload) && typeof payload.title === "string" ? payload.title : void 0;
+    return title && title.trim().length > 0 ? title.trim() : void 0;
+  }
+  function extractConversationId(payload) {
+    var _a;
+    if (!isRecord2(payload)) return void 0;
+    const conversationId = (_a = payload.conversation_id) != null ? _a : payload.conversationId;
+    return typeof conversationId === "string" && conversationId.trim().length > 0 ? conversationId : void 0;
+  }
   function extractErrorMessage(payload) {
     if (typeof payload === "string") {
       const message = payload.trim();
@@ -264,6 +274,10 @@ var LemmaUI = (() => {
     }
     if (eventType === "stopped") {
       return { status: "STOPPED" };
+    }
+    if (eventType === "title") {
+      const title = extractTitle(payload);
+      return title ? { title, conversationId: extractConversationId(payload) } : {};
     }
     if (eventType === "stream_error") {
       return {
@@ -637,7 +651,7 @@ var LemmaUI = (() => {
         streamConversationId,
         syncAfterStream
       }) => {
-        var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k;
+        var _a, _b, _c, _d, _e, _f, _g, _h, _i, _j, _k, _l, _m;
         this.patch({ isStreaming: true, error: null });
         this.clearStreamingText();
         this.clearStreamingThinking();
@@ -696,6 +710,12 @@ var LemmaUI = (() => {
                 this.clearStreamingTool();
               }
             }
+            if (parsed.title) {
+              this.setConversationTitle(
+                parsed.title,
+                (_i = (_h = parsed.conversationId) != null ? _h : streamConversationId) != null ? _i : this.state.conversationId
+              );
+            }
             if (parsed.status) {
               this.setConversationStatus(parsed.status);
               if (!isConversationRunningStatus(parsed.status)) {
@@ -720,7 +740,7 @@ var LemmaUI = (() => {
                 const latestConversation = await this.refreshConversation(syncConversationId);
                 await this.loadMessages({ conversationId: syncConversationId, limit: 100 });
                 if (controller.signal.aborted) break;
-                const latestStatus = (_h = latestConversation == null ? void 0 : latestConversation.status) != null ? _h : this.state.status;
+                const latestStatus = (_j = latestConversation == null ? void 0 : latestConversation.status) != null ? _j : this.state.status;
                 if (!isConversationRunningStatus(latestStatus)) {
                   this.streamReconnectCount = 0;
                   streamFailure = null;
@@ -736,7 +756,7 @@ var LemmaUI = (() => {
                   const scope = normalizeScope(this.client, this.scopeDefaults);
                   const scopedClient = applyPodScope(this.client, scope.podId);
                   const newStream = await scopedClient.conversations.resumeStream(syncConversationId, {
-                    pod_id: (_i = scope.podId) != null ? _i : void 0,
+                    pod_id: (_k = scope.podId) != null ? _k : void 0,
                     signal: controller.signal
                   });
                   this.streamReconnectCount = 0;
@@ -763,7 +783,7 @@ var LemmaUI = (() => {
             if (!controller.signal.aborted && streamFailure) {
               const normalized = normalizeError(streamFailure, "Failed to stream conversation.");
               this.patch({ error: normalized });
-              (_k = (_j = this.options).onError) == null ? void 0 : _k.call(_j, streamFailure);
+              (_m = (_l = this.options).onError) == null ? void 0 : _m.call(_l, streamFailure);
             }
           }
         } finally {
@@ -953,6 +973,15 @@ var LemmaUI = (() => {
       if (normalized) {
         (_b = (_a = this.options).onStatus) == null ? void 0 : _b.call(_a, normalized);
       }
+    }
+    /** Apply a rename that arrived on the stream to the record we already hold. */
+    setConversationTitle(title, conversationId) {
+      var _a, _b;
+      const conversation = this.state.conversation;
+      if (conversation && (!conversationId || conversation.id === conversationId)) {
+        this.patch({ conversation: { ...conversation, title } });
+      }
+      (_b = (_a = this.options).onTitle) == null ? void 0 : _b.call(_a, title, conversationId);
     }
     // -- streaming text buffering ----------------------------------------------
     appendStreamingToken(token) {

--- a/lemma-typescript/src/__tests__/conversation-rename-stream.test.ts
+++ b/lemma-typescript/src/__tests__/conversation-rename-stream.test.ts
@@ -1,0 +1,174 @@
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { parseAssistantStreamEvent } from "../assistant-events.js";
+import type { LemmaClient } from "../client.js";
+import { AgentController } from "../core/agent/index.js";
+import { useAssistantSession, type UseAssistantSessionResult } from "../react/index.js";
+
+/**
+ * The server names a conversation from its first user message, in a background
+ * job started when the run starts — so the title lands *mid-turn*, on the
+ * conversation channel rather than the run's, and reaches every client that is
+ * already streaming. These pin the client half of that trip: the frame the
+ * backend actually publishes, and what holding it does to the record on screen.
+ */
+
+/** Exactly what `encode_stream_chunk` puts on the wire for a rename. */
+function titleFrame(conversationId: string, title: string) {
+  return { type: "title", data: { conversation_id: conversationId, title }, agent_run_id: null };
+}
+
+function sseStream(events: unknown[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+      }
+      controller.close();
+    },
+  });
+}
+
+function fakeClient(events: unknown[]): LemmaClient {
+  return {
+    podId: "pod-1",
+    withPod() {
+      return this as unknown as LemmaClient;
+    },
+    conversations: {
+      create: async () => ({ id: "conv-1", status: "WAITING", pod_id: "pod-1", title: null }),
+      get: async (id: string) => ({ id, status: "COMPLETED" }),
+      list: async () => ({ items: [], limit: 20, next_page_token: null }),
+      messages: { list: async () => ({ items: [], limit: 100, next_page_token: null }) },
+      sendMessageStream: async () => sseStream(events),
+      resumeStream: async () => sseStream([]),
+    },
+  } as unknown as LemmaClient;
+}
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const roots: Root[] = [];
+
+afterEach(async () => {
+  while (roots.length > 0) {
+    const root = roots.pop();
+    if (!root) continue;
+    await act(async () => root.unmount());
+  }
+  document.body.innerHTML = "";
+});
+
+async function render(element: ReturnType<typeof createElement>) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  await act(async () => {
+    root.render(element);
+    await Promise.resolve();
+  });
+}
+
+describe("the rename frame", () => {
+  it("carries the new title and the conversation it belongs to", () => {
+    expect(parseAssistantStreamEvent(titleFrame("conv-1", "Japan Spring Trip Plan"))).toEqual({
+      title: "Japan Spring Trip Plan",
+      conversationId: "conv-1",
+    });
+  });
+
+  it("says nothing about the run", () => {
+    // A rename arrives while the agent is still working. Reading any status off
+    // it would end a turn that has not ended.
+    const parsed = parseAssistantStreamEvent(titleFrame("conv-1", "Quarterly numbers"));
+    expect(parsed.status).toBeUndefined();
+    expect(parsed.message).toBeUndefined();
+    expect(parsed.error).toBeUndefined();
+  });
+
+  it("is ignored when it carries no title", () => {
+    expect(parseAssistantStreamEvent({ type: "title", data: { title: "   " } })).toEqual({});
+  });
+});
+
+describe("AgentController rename handling", () => {
+  it("renames the conversation it is holding, mid-stream", async () => {
+    const onTitle = vi.fn();
+    const controller = new AgentController({
+      client: fakeClient([
+        { type: "token", data: "Look", kind: "text" },
+        titleFrame("conv-1", "Ashwin's records"),
+        { type: "completed" },
+      ]),
+      scope: { podId: "pod-1", agentName: "triage" },
+      onTitle,
+    });
+
+    await controller.createConversation();
+    expect(controller.getState().conversation?.title).toBeNull();
+
+    await controller.sendMessage("who has the most centuries");
+
+    expect(controller.getState().conversation?.title).toBe("Ashwin's records");
+    expect(onTitle).toHaveBeenCalledWith("Ashwin's records", "conv-1");
+    // The turn ran to its own end: the rename did not terminate it.
+    expect(controller.getState().status).toBe("COMPLETED");
+  });
+
+  it("leaves another conversation's record alone", async () => {
+    const onTitle = vi.fn();
+    const controller = new AgentController({
+      client: fakeClient([
+        titleFrame("conv-other", "Not this one"),
+        { type: "completed" },
+      ]),
+      scope: { podId: "pod-1" },
+      onTitle,
+    });
+
+    await controller.createConversation();
+    await controller.sendMessage("hi");
+
+    expect(controller.getState().conversation?.title).toBeNull();
+    // Still reported: a caller holding a list of conversations owns the row the
+    // controller does not, and that row is the one being renamed.
+    expect(onTitle).toHaveBeenCalledWith("Not this one", "conv-other");
+  });
+});
+
+describe("useAssistantSession rename handling", () => {
+  it("renames the record on screen and reports the rename to its owner", async () => {
+    // The hook the product renders through: `useAssistantController` wraps this
+    // one, and the sidebar row it renames is a record the controller owns, not
+    // this hook's.
+    const onTitle = vi.fn();
+    const client = fakeClient([
+      { type: "token", data: "Look", kind: "text" },
+      titleFrame("conv-1", "Ashwin's records"),
+      { type: "completed" },
+    ]);
+
+    let session: UseAssistantSessionResult | null = null;
+    function Harness() {
+      session = useAssistantSession({ client, podId: "pod-1", autoLoad: false, onTitle });
+      return null;
+    }
+
+    await render(createElement(Harness));
+    await act(async () => {
+      await session!.createConversation();
+    });
+    expect(session!.conversation?.title).toBeNull();
+
+    await act(async () => {
+      await session!.sendMessage("who has the most centuries");
+    });
+
+    expect(session!.conversation?.title).toBe("Ashwin's records");
+    expect(onTitle).toHaveBeenCalledWith("Ashwin's records", "conv-1");
+    expect(session!.status).toBe("COMPLETED");
+  });
+});

--- a/lemma-typescript/src/assistant-events.ts
+++ b/lemma-typescript/src/assistant-events.ts
@@ -27,6 +27,18 @@ export interface ParsedAssistantStreamEvent {
   tokenKind?: string;
   error?: string;
   /**
+   * The conversation was renamed. Generated from the first user message while
+   * the run is still going, so it arrives mid-stream and belongs to the
+   * conversation rather than to any one run.
+   */
+  title?: string;
+  /**
+   * Which conversation a conversation-scoped frame is about. Only set by frames
+   * that name it; run frames leave it undefined and are already filtered to the
+   * stream's own run by the server.
+   */
+  conversationId?: string;
+  /**
    * The transport gave up, not the run. Carries no status on purpose: the run
    * is still going, and a consumer that treats this as an ending stops reading
    * a conversation the server is still writing to.
@@ -86,6 +98,24 @@ function extractStatus(payload: unknown): string | undefined {
   }
 
   return normalizeStatus(payload);
+}
+
+function extractTitle(payload: unknown): string | undefined {
+  const title = typeof payload === "string"
+    ? payload
+    : isRecord(payload) && typeof payload.title === "string"
+      ? payload.title
+      : undefined;
+
+  return title && title.trim().length > 0 ? title.trim() : undefined;
+}
+
+function extractConversationId(payload: unknown): string | undefined {
+  if (!isRecord(payload)) return undefined;
+  const conversationId = payload.conversation_id ?? payload.conversationId;
+  return typeof conversationId === "string" && conversationId.trim().length > 0
+    ? conversationId
+    : undefined;
 }
 
 function extractErrorMessage(payload: unknown): string | undefined {
@@ -159,6 +189,13 @@ export function parseAssistantStreamEvent(value: unknown): ParsedAssistantStream
 
   if (eventType === "stopped") {
     return { status: "STOPPED" };
+  }
+
+  if (eventType === "title") {
+    // No status and no message: a rename says nothing about the run, and a
+    // consumer that reads it as one would end a turn that is still going.
+    const title = extractTitle(payload);
+    return title ? { title, conversationId: extractConversationId(payload) } : {};
   }
 
   if (eventType === "stream_error") {

--- a/lemma-typescript/src/core/agent/agent-controller.ts
+++ b/lemma-typescript/src/core/agent/agent-controller.ts
@@ -96,6 +96,8 @@ export interface AgentControllerOptions {
   onEvent?: (event: SseRawEvent, payload: unknown | null) => void;
   onStatus?: (status: string) => void;
   onMessage?: (message: ConversationMessage) => void;
+  /** The conversation was renamed mid-stream by the server's title generator. */
+  onTitle?: (title: string, conversationId: string | null) => void;
   onError?: (error: unknown) => void;
 }
 
@@ -342,6 +344,15 @@ export class AgentController {
     if (normalized) {
       this.options.onStatus?.(normalized);
     }
+  }
+
+  /** Apply a rename that arrived on the stream to the record we already hold. */
+  private setConversationTitle(title: string, conversationId: string | null): void {
+    const conversation = this.state.conversation;
+    if (conversation && (!conversationId || conversation.id === conversationId)) {
+      this.patch({ conversation: { ...conversation, title } });
+    }
+    this.options.onTitle?.(title, conversationId);
   }
 
   // -- streaming text buffering ----------------------------------------------
@@ -697,6 +708,12 @@ export class AgentController {
             this.clearStreamingThinking();
             this.clearStreamingTool();
           }
+        }
+        if (parsed.title) {
+          this.setConversationTitle(
+            parsed.title,
+            parsed.conversationId ?? streamConversationId ?? this.state.conversationId,
+          );
         }
         if (parsed.status) {
           this.setConversationStatus(parsed.status);

--- a/lemma-typescript/src/react/useAssistantController.ts
+++ b/lemma-typescript/src/react/useAssistantController.ts
@@ -873,6 +873,21 @@ export function useAssistantController({
     setLocalError((prev) => prev || (sessionError instanceof Error ? sessionError.message : "Agent session failed"));
   }, []);
 
+  // The server generates a title from the first user message and publishes it
+  // on the conversation channel while the run is still streaming. Applying it
+  // here is what renames the row in place mid-turn instead of leaving the local
+  // stand-in up until the next list fetch. Deliberately not `touchConversation`:
+  // a rename is not activity, and moving `updated_at` would reorder the list
+  // under the person reading it.
+  const handleConversationTitle = useCallback((title: string, conversationId: string | null) => {
+    if (!conversationId) return;
+    setConversations((previous) => previous.map((conversation) => (
+      conversation.id === conversationId && conversation.title !== title
+        ? { ...conversation, title }
+        : conversation
+    )));
+  }, []);
+
   const assistantSession = useAssistantSession({
     client,
     podId: scope.podId ?? undefined,
@@ -883,6 +898,7 @@ export function useAssistantController({
     instructions,
     conversationId: activeConversationId ?? undefined,
     autoLoad: false,
+    onTitle: handleConversationTitle,
     onError: handleAssistantSessionError,
   });
 

--- a/lemma-typescript/src/react/useAssistantSession.ts
+++ b/lemma-typescript/src/react/useAssistantSession.ts
@@ -50,6 +50,8 @@ export interface UseAssistantSessionOptions {
   onEvent?: (event: SseRawEvent, payload: unknown | null) => void;
   onStatus?: (status: string) => void;
   onMessage?: (message: ConversationMessage) => void;
+  /** The conversation was renamed mid-stream by the server's title generator. */
+  onTitle?: (title: string, conversationId: string | null) => void;
   onError?: (error: unknown) => void;
 }
 
@@ -357,6 +359,7 @@ export function useAssistantSession(options: UseAssistantSessionOptions): UseAss
     onEvent,
     onStatus,
     onMessage,
+    onTitle,
     onError,
   } = options;
 
@@ -388,6 +391,7 @@ export function useAssistantSession(options: UseAssistantSessionOptions): UseAss
   const onEventRef = useRef(onEvent);
   const onStatusRef = useRef(onStatus);
   const onMessageRef = useRef(onMessage);
+  const onTitleRef = useRef(onTitle);
   const onErrorRef = useRef(onError);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const consumeRef = useRef<(opts: any) => Promise<void>>(null!);
@@ -470,6 +474,10 @@ export function useAssistantSession(options: UseAssistantSessionOptions): UseAss
   useEffect(() => {
     onMessageRef.current = onMessage;
   }, [onMessage]);
+
+  useEffect(() => {
+    onTitleRef.current = onTitle;
+  }, [onTitle]);
 
   useEffect(() => {
     onErrorRef.current = onError;
@@ -826,6 +834,19 @@ export function useAssistantSession(options: UseAssistantSessionOptions): UseAss
             clearStreamingTool();
           }
         }
+        if (parsed.title) {
+          // Conversation-scoped, not run-scoped: the title is generated from
+          // the first user message while the run is still going, so it lands
+          // mid-turn and says nothing about the run's status.
+          const renamedConversationId = parsed.conversationId
+            ?? streamConversationId
+            ?? conversationIdRef.current;
+          const renamed = conversationRecordRef.current;
+          if (renamed && (!renamedConversationId || renamed.id === renamedConversationId)) {
+            rememberConversation({ ...renamed, title: parsed.title });
+          }
+          onTitleRef.current?.(parsed.title, renamedConversationId ?? null);
+        }
         if (parsed.status) {
           setConversationStatus(parsed.status);
           if (!isConversationRunningStatus(parsed.status)) {
@@ -949,6 +970,7 @@ export function useAssistantSession(options: UseAssistantSessionOptions): UseAss
     defaultScope,
     loadMessages,
     refreshConversation,
+    rememberConversation,
     setConversationStatus,
     syncOnTurnEnd,
   ]);


### PR DESCRIPTION
## What changes

A conversation now visibly renames itself in the sidebar while the agent is
still answering, instead of keeping the local stand-in until some later list
fetch replaces it. The row types the new name in.

## Why

The backend has been publishing the generated title all along. The title job
starts on `AgentRunStartedEvent`, and when it lands
`conversation_title_service` publishes a `title` frame on the conversation's
SSE channel — carried past the per-run filter on purpose, because a rename
belongs to the conversation and not to any one run (`shared.py:116`, pinned by
`test_sse_frames.py`).

Nothing on the client read it. `parseAssistantStreamEvent` handled `token`,
`message`, `status`, `completed`, `stopped`, `stream_error` and `error`, and
returned `{}` for everything else — so the frame arrived in the browser and
died there. Backend ✅, transport ✅, client ❌.

Two halves here:

**Route it.** The parser gains `title` and the `conversationId` the frame
names. Both stream consumers (`AgentController.consume`,
`useAssistantSession.consume`) apply it to the record they hold, guarded on
that id, and report it through a new `onTitle` option.
`useAssistantController` renames the matching row in `conversations` — the
list the workspace sidebar and the assistant panel header both render from.
Deliberately *not* `touchConversation`: that moves `updated_at`, and a rename
is not activity. Reordering the list under someone reading it is a different
bug.

**Show it.** A title that silently becomes a different title reads as a
glitch. `useTypedRename` types the new one in over ~700ms. Only a *change*
animates — a row rendering its title for the first time is being named, not
renamed, which is what every row in a freshly loaded list is doing, and
fifteen of them typing at once is a screen that cannot be read. Reveal is by
code point, so a title in the writer's own script never flashes a replacement
box, and the whole thing is skipped under `prefers-reduced-motion`.

In practice that works out to exactly one animation per conversation: the row
mounts showing your first message, then the generated title types over it a
few seconds into the run.

## How to verify

```bash
npm --prefix lemma-typescript test
npm --prefix lemma-frontend run test
npm --prefix lemma-frontend run check
```

- SDK: 250 tests / 31 files pass; `tsc --noEmit` clean.
- Frontend: 1195 tests / 108 files pass.
- `check` (design audit + lint + typecheck + edu anchors + openapi spec) passes;
  design audit reports `productStrict=0 informational=101`, baseline unchanged.

New coverage:

- `lemma-typescript/src/__tests__/conversation-rename-stream.test.ts` — the exact
  frame `encode_stream_chunk` puts on the wire, through the parser, the
  controller and the session hook, including that a rename carries no status
  (it must not end a turn that is still going) and that another conversation's
  rename leaves the held record alone.
- `lemma-frontend/lib/hooks/__tests__/use-typed-rename.test.ts` — which title
  changes animate and which settle instantly, plus the pacing bounds.

Not verified end to end against a live stack: seeing the real rename needs the
backend, the worker and an actual model call to generate a title, so each hop
is covered by tests instead of a screenshot. Two backend-side preconditions for
anyone testing this against a deployment: `CONVERSATION_TITLE_MODEL` must be
set (without it the fallback title is the first message with whitespace
collapsed, which is close enough to the local stand-in that there is often
nothing to animate), and the API must include the conversation-scoped
passthrough from #339.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

No migrations. No API-surface change: this is hand-written SDK code, not
generated — the OpenAPI spec and generated clients are untouched.
`lemma-typescript/public/lemma-ui.js` is the committed UI bundle, regenerated
by `npm run build` as the repo expects.

## Compatibility and rollback notes

Additive only. `onTitle` is a new optional option on `AgentControllerOptions`
and `UseAssistantSessionOptions`; `title` and `conversationId` are new optional
fields on `ParsedAssistantStreamEvent`. Existing consumers that ignore the
`title` frame behave exactly as they do today.

Rollback is a plain revert — the backend keeps publishing the frame and the
client goes back to ignoring it, which is the current behaviour on `main`.
