### PR TITLE
Two ways a working tool looked broken: the Agent Host, and agent-browser

### DIFF
--- a/desktop/locald/src/agent_host.rs
+++ b/desktop/locald/src/agent_host.rs
@@ -69,9 +69,42 @@ pub struct AgentHostSupervisor {
     executable: Option<PathBuf>,
     data_dir: PathBuf,
     log_path: PathBuf,
+    /// Where the running sidecar's identity is written down, so the next
+    /// daemon can recognise one this daemon did not live to stop.
+    record_path: PathBuf,
+    /// This installation, so a record written by another one is never acted on.
+    installation_id: Option<String>,
     state: Mutex<SupervisorState>,
     details: Mutex<Option<(Instant, Value)>>,
 }
+
+/// What was running, written down while it runs.
+///
+/// The sidecar takes an exclusive lock on its data directory and refuses to
+/// start when something else holds it -- correctly, since two of them fight
+/// over one pairing. The lock is released when its holder dies, and the code
+/// that takes it says there is "nothing stale to clean up after a crash",
+/// which is true of a crash and not of the case that actually happened: the
+/// sidecar *outlived* the daemon that started it, was reparented to init, and
+/// went on holding the lock. Every launch after that logged
+/// `another Agent Host is already serving` and retried, forever -- 3,295 lines
+/// of it in one installation -- while chat answered "Fetch is aborted" and
+/// nothing anywhere named the cause.
+///
+/// `Drop` on the supervisor covers the ordinary exits. It cannot cover the
+/// ones that matter here: the daemon killed outright, or the machine losing
+/// power. So the running process is recorded, and the next daemon reclaims
+/// what it finds before starting its own.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct AgentHostRecord {
+    schema_version: u32,
+    installation_id: String,
+    pid: u32,
+    executable: String,
+    start_identity: String,
+}
+
+const AGENT_HOST_RECORD_SCHEMA_VERSION: u32 = 1;
 
 impl AgentHostSupervisor {
     pub fn discover(locald_root: &Path) -> Self {
@@ -96,6 +129,11 @@ impl AgentHostSupervisor {
             executable,
             data_dir: shared_root.clone(),
             log_path: shared_root.join("agent-host.log"),
+            record_path: shared_root.join("serve-process.json"),
+            // Best effort: without it nothing is reclaimed, which is the
+            // behaviour that existed before this record did. It is never a
+            // reason to fail to start.
+            installation_id: crate::host_process::installation_identity(locald_root).ok(),
             state: Mutex::new(SupervisorState {
                 child: None,
                 desired_running,
@@ -163,6 +201,10 @@ impl AgentHostSupervisor {
         if let Some(mut child) = state.child.take() {
             state.last_exit_code = terminate_process_tree(&mut child)?;
         }
+        // Stopped on purpose is not a leftover: clear the record whether or
+        // not there was a child, so a stale one cannot outlive the thing it
+        // describes and get some later daemon to kill an innocent pid.
+        self.forget_running();
         state.started_at = None;
         state.started_at_ms = None;
         self.invalidate_details();
@@ -396,11 +438,86 @@ impl AgentHostSupervisor {
         Ok(String::from_utf8_lossy(&output.stdout).into_owned())
     }
 
+    /// Stop a sidecar this installation started and never got to stop.
+    ///
+    /// Runs before every spawn rather than once at startup, so it covers the
+    /// restart and reconcile paths too, and costs one small file read when
+    /// there is nothing to do.
+    ///
+    /// The identity check is against the *record*, not against today's
+    /// discovered executable: what has to be proved is that this pid is the
+    /// very process we wrote down -- the guard is against a pid the kernel has
+    /// since handed to something else, which `start_identity` (the process
+    /// start time) settles. Comparing against today's sidecar path instead
+    /// would refuse to reclaim across an update that moved the binary, which is
+    /// exactly a case where the leftover has to go.
+    fn reclaim_leftover(&self) {
+        let Some(installation_id) = self.installation_id.as_deref() else {
+            return;
+        };
+        let Ok(raw) = std::fs::read(&self.record_path) else {
+            return;
+        };
+        let Ok(record) = serde_json::from_slice::<AgentHostRecord>(&raw) else {
+            // Unreadable means unusable, and a record naming nothing is worse
+            // than none at all: clear it rather than reading it every spawn.
+            let _ = std::fs::remove_file(&self.record_path);
+            return;
+        };
+        if record.schema_version != AGENT_HOST_RECORD_SCHEMA_VERSION
+            || record.installation_id != installation_id
+        {
+            return;
+        }
+        if let Ok(identity) = crate::host_process::process_identity(record.pid) {
+            if identity.executable == record.executable
+                && identity.start_identity == record.start_identity
+            {
+                let _ = crate::host_process::terminate_verified_process(record.pid);
+            }
+        }
+        let _ = std::fs::remove_file(&self.record_path);
+    }
+
+    /// Write down what is running, so the next daemon can find it.
+    ///
+    /// Failing to record is not failing to start. The sidecar is up either
+    /// way; all that is lost is the next daemon's ability to reclaim it, which
+    /// is where this started.
+    fn record_running(&self, child: &mut Child) {
+        let Some(installation_id) = self.installation_id.clone() else {
+            return;
+        };
+        let Ok(identity) = crate::host_process::process_identity(child.id()) else {
+            return;
+        };
+        let record = AgentHostRecord {
+            schema_version: AGENT_HOST_RECORD_SCHEMA_VERSION,
+            installation_id,
+            pid: child.id(),
+            executable: identity.executable,
+            start_identity: identity.start_identity,
+        };
+        if let Ok(encoded) = serde_json::to_vec(&record) {
+            let _ = std::fs::write(&self.record_path, encoded);
+        }
+    }
+
+    fn forget_running(&self) {
+        let _ = std::fs::remove_file(&self.record_path);
+    }
+
     fn spawn_locked(&self, state: &mut SupervisorState) -> io::Result<()> {
+        // Before taking the lock for ourselves, give up any we already hold.
+        // A sidecar left over from a daemon that did not live to stop it holds
+        // that lock against every future launch, and the new one can do
+        // nothing but log and retry.
+        self.reclaim_leftover();
         // Every failure arms the backoff, not just a failed `spawn`: an
         // unwritable data directory would otherwise be retried every tick.
         match self.spawn_process() {
-            Ok(child) => {
+            Ok(mut child) => {
+                self.record_running(&mut child);
                 state.child = Some(child);
                 state.restart_count = state.restart_count.saturating_add(1);
                 state.started_at = Some(Instant::now());
@@ -717,6 +834,7 @@ impl Drop for AgentHostSupervisor {
         if let Some(mut child) = state.child.take() {
             let _ = terminate_process_tree(&mut child);
         }
+        self.forget_running();
     }
 }
 
@@ -731,6 +849,143 @@ fn now_ms() -> u128 {
 mod tests {
     use super::*;
     use tempfile::tempdir;
+
+    /// A sidecar the last daemon did not live to stop is stopped by this one.
+    ///
+    /// This is the bug in full: the Agent Host outlived its daemon, was
+    /// reparented to init, and kept the exclusive lock on its data directory.
+    /// Every launch afterwards could only log `another Agent Host is already
+    /// serving` and retry -- one installation had 3,295 lines of it -- while
+    /// the app said "Fetch is aborted" and no local agent ever answered again.
+    ///
+    /// A real process, because the whole mechanism is about a real pid: the
+    /// record is written the way a spawn writes it, and reclaiming has to leave
+    /// the process dead and the record gone.
+    #[cfg(unix)]
+    #[test]
+    fn a_sidecar_that_outlived_its_daemon_is_reclaimed_before_the_next_spawn() {
+        use std::os::unix::process::ExitStatusExt;
+
+        let home = tempdir().unwrap();
+        let supervisor = AgentHostSupervisor::discover(&home.path().join("locald"));
+        std::fs::create_dir_all(&supervisor.data_dir).unwrap();
+
+        let mut leftover = Command::new("/bin/sleep").arg("30").spawn().unwrap();
+        supervisor.record_running(&mut leftover);
+        assert!(
+            supervisor.record_path.is_file(),
+            "a running sidecar has to be written down, or nothing can reclaim it",
+        );
+
+        // Reaped in parallel: `terminate_verified_process` waits for the pid to
+        // stop existing, and a child nobody reaps is a zombie that still
+        // answers `kill(pid, 0)`. A real leftover is init's to reap.
+        let reaper = std::thread::spawn(move || leftover.wait().unwrap());
+        supervisor.reclaim_leftover();
+        let status = reaper.join().unwrap();
+
+        assert!(
+            status.signal().is_some(),
+            "the leftover exited on its own rather than being reclaimed: {status:?}",
+        );
+        assert!(
+            !supervisor.record_path.exists(),
+            "a reclaimed sidecar must not be left in the record to be killed twice",
+        );
+    }
+
+    /// Reclaiming must never kill something that merely inherited the pid.
+    ///
+    /// Pids are reused, and a record can outlive its process by days. The only
+    /// thing that makes killing by pid safe is proving the process there now is
+    /// the one that was written down, which is what `start_identity` is for.
+    #[cfg(unix)]
+    #[test]
+    fn a_pid_that_belongs_to_something_else_now_is_left_alone() {
+        let home = tempdir().unwrap();
+        let supervisor = AgentHostSupervisor::discover(&home.path().join("locald"));
+        std::fs::create_dir_all(&supervisor.data_dir).unwrap();
+
+        let mut bystander = Command::new("/bin/sleep").arg("30").spawn().unwrap();
+        supervisor.record_running(&mut bystander);
+
+        // The same pid, described as a process that started at a different
+        // time -- which is what a recycled pid looks like from the record's
+        // side.
+        let raw = std::fs::read(&supervisor.record_path).unwrap();
+        let mut record: AgentHostRecord = serde_json::from_slice(&raw).unwrap();
+        record.start_identity = format!("{}-not-the-same-process", record.start_identity);
+        std::fs::write(
+            &supervisor.record_path,
+            serde_json::to_vec(&record).unwrap(),
+        )
+        .unwrap();
+
+        supervisor.reclaim_leftover();
+
+        assert!(
+            bystander.try_wait().unwrap().is_none(),
+            "reclaiming killed a process that only happened to hold the pid",
+        );
+        assert!(
+            !supervisor.record_path.exists(),
+            "a record that cannot be acted on is cleared, not read again every spawn",
+        );
+        let _ = bystander.kill();
+        let _ = bystander.wait();
+    }
+
+    /// Another installation's record is not this installation's business.
+    #[cfg(unix)]
+    #[test]
+    fn a_record_from_another_installation_is_never_acted_on() {
+        let home = tempdir().unwrap();
+        let supervisor = AgentHostSupervisor::discover(&home.path().join("locald"));
+        std::fs::create_dir_all(&supervisor.data_dir).unwrap();
+
+        let mut other = Command::new("/bin/sleep").arg("30").spawn().unwrap();
+        supervisor.record_running(&mut other);
+        let raw = std::fs::read(&supervisor.record_path).unwrap();
+        let mut record: AgentHostRecord = serde_json::from_slice(&raw).unwrap();
+        record.installation_id = "ffffffffffffffffffffffffffffffff".into();
+        std::fs::write(
+            &supervisor.record_path,
+            serde_json::to_vec(&record).unwrap(),
+        )
+        .unwrap();
+
+        supervisor.reclaim_leftover();
+
+        assert!(
+            other.try_wait().unwrap().is_none(),
+            "reclaiming crossed an installation boundary",
+        );
+        assert!(
+            supervisor.record_path.is_file(),
+            "another installation's record is left for its owner to clear",
+        );
+        let _ = other.kill();
+        let _ = other.wait();
+    }
+
+    /// Stopping on purpose clears the record.
+    ///
+    /// Otherwise a record outlives the process it describes, and the next
+    /// daemon reads it and aims `kill` at whatever holds that pid by then.
+    #[test]
+    fn stopping_clears_the_record_so_no_later_daemon_acts_on_it() {
+        let home = tempdir().unwrap();
+        let supervisor = AgentHostSupervisor::discover(&home.path().join("locald"));
+        std::fs::create_dir_all(&supervisor.data_dir).unwrap();
+        std::fs::write(&supervisor.record_path, b"{}").unwrap();
+
+        supervisor.stop().unwrap();
+
+        assert!(
+            !supervisor.record_path.exists(),
+            "a deliberate stop left the sidecar written down as still running",
+        );
+    }
 
     /// A sidecar that will not stay up stops being restarted, and says so.
     ///

--- a/lemma-backend/sandbox-images/scripts/lemma-node-tool
+++ b/lemma-backend/sandbox-images/scripts/lemma-node-tool
@@ -11,9 +11,51 @@ fi
 NODE_PROJECT="${LEMMA_NODE_PROJECT:-/opt/lemma-node}"
 tool="$(basename "$0")"
 
+# Bring the browser up before a command that needs it.
+#
+# `start-browser` is what writes the config and starts Xvfb, and the skill says
+# to call it first. An agent that goes straight for `agent-browser` instead --
+# the obvious thing to type, and what a model does when it has used this CLI
+# anywhere else -- got one of two errors, neither of which names the remedy:
+#
+#     ⚠ config file not found: /tmp/lemma-browser/config.json
+#     Missing X server or $DISPLAY
+#
+# Both mean "start-browser has not run". Neither says so, so the reasonable
+# conclusion from inside the sandbox is that the browser tooling is broken, and
+# the fallback an agent reaches for is downloading Playwright and its own
+# Chromium -- into a 2 GB sandbox, to do what the installed browser already
+# does. Observed in a real transcript; this is the fix.
+#
+# Ordering stops being something the caller has to know. Info-only flags are
+# left alone so `--version` never starts an X server, and the guard variable
+# keeps `start-browser`'s own nested calls from coming back through here.
+ensure_browser_started() {
+  if [ -n "${LEMMA_BROWSER_BOOTSTRAP:-}" ]; then
+    return 0
+  fi
+  case "${1:-}" in
+    ""|--version|-v|--help|-h|help)
+      return 0
+      ;;
+  esac
+  config="${AGENT_BROWSER_CONFIG:-/tmp/lemma-browser/config.json}"
+  display="${DISPLAY:-:99}"
+  display_number="${display#:}"
+  display_number="${display_number%%.*}"
+  if [ -f "$config" ] && [ -S "/tmp/.X11-unix/X${display_number}" ]; then
+    return 0
+  fi
+  command -v start-browser >/dev/null 2>&1 || return 0
+  # Its output is the bootstrap's, not the caller's: the caller asked for a
+  # snapshot, not for the blank page that had to be opened to take one.
+  LEMMA_BROWSER_BOOTSTRAP=1 start-browser >/tmp/agent-browser-bootstrap.log 2>&1 || true
+}
+
 case "$tool" in
   agent-browser)
     pattern='*/node_modules/agent-browser/bin/agent-browser.js'
+    ensure_browser_started "${1:-}"
     ;;
   lit|liteparse)
     pattern='*/node_modules/@llamaindex/liteparse/dist/cli.js'

--- a/lemma-backend/sandbox_runtime/tests/test_agent_browser_bootstrap.py
+++ b/lemma-backend/sandbox_runtime/tests/test_agent_browser_bootstrap.py
@@ -1,0 +1,175 @@
+"""`agent-browser` has to work whether or not `start-browser` ran first.
+
+The browser skill says to call `start-browser` once before anything else, and
+that is the flow that was tested. An agent that goes straight for
+`agent-browser` -- the obvious thing to type -- got one of two errors instead:
+
+    ⚠ config file not found: /tmp/lemma-browser/config.json
+    Missing X server or $DISPLAY
+
+Both mean "start-browser has not run yet". Neither says so. From inside the
+sandbox the reasonable conclusion is that the browser tooling is broken, and the
+fallback a model reaches for is installing Playwright and downloading its own
+Chromium -- into a 2 GB sandbox, to do what the browser already sitting there
+does. That happened in a real transcript.
+
+The wrapper on `PATH` now brings the browser up itself. These tests drive that
+wrapper directly with a stub `start-browser` on `PATH`, because what has to be
+right is the decision -- when to bootstrap, and just as importantly when not to.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import socket
+import subprocess
+
+import pytest
+
+# Bound display sockets, closed and unlinked after each test so a second run
+# does not find the first one's address already taken.
+_SOCKETS: list[socket.socket] = []
+
+
+@pytest.fixture(autouse=True)
+def _release_display_sockets():
+    yield
+    while _SOCKETS:
+        listener = _SOCKETS.pop()
+        address = listener.getsockname()
+        listener.close()
+        Path(address).unlink(missing_ok=True)
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "sandbox-images/scripts/lemma-node-tool"
+
+
+def _workspace(tmp_path: Path, *, config: bool, display: bool) -> dict[str, str]:
+    """A sandbox in a given state, with `start-browser` stubbed to leave a mark."""
+    binaries = tmp_path / "bin"
+    binaries.mkdir()
+    marker = tmp_path / "start-browser-ran"
+    start_browser = binaries / "start-browser"
+    start_browser.write_text(
+        f'#!/bin/sh\necho "$LEMMA_BROWSER_BOOTSTRAP" > "{marker}"\n'
+    )
+    start_browser.chmod(0o755)
+
+    # The entrypoint the wrapper execs. Present so the wrapper reaches its own
+    # exit rather than the "not installed" path, and echoing its arguments so a
+    # test can prove the caller's command survived the bootstrap.
+    node_project = tmp_path / "node"
+    entrypoint = (
+        node_project
+        / "node_modules/.pnpm/agent-browser@0/node_modules/agent-browser/bin"
+    )
+    entrypoint.mkdir(parents=True)
+    (entrypoint / "agent-browser.js").write_text("")
+    node = binaries / "fake-node"
+    node.write_text('#!/bin/sh\nshift\necho "agent-browser $*"\n')
+    node.chmod(0o755)
+
+    config_path = tmp_path / "config.json"
+    if config:
+        config_path.write_text("{}")
+
+    # A display is "up" exactly when a socket exists at the path X clients look
+    # for, which is what the wrapper tests. An unusual display number keeps this
+    # away from any real X server on the machine running the tests.
+    display_number = 77 if display else 78
+    if display:
+        os.makedirs("/tmp/.X11-unix", exist_ok=True)
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        listener.bind(f"/tmp/.X11-unix/X{display_number}")
+        _SOCKETS.append(listener)
+
+    return {
+        "PATH": f"{binaries}:/usr/bin:/bin",
+        "HOME": str(tmp_path),
+        "LEMMA_NODE_BINARY": str(node),
+        "LEMMA_NODE_PROJECT": str(node_project),
+        "AGENT_BROWSER_CONFIG": str(config_path),
+        "DISPLAY": f":{display_number}",
+        "_MARKER": str(marker),
+    }
+
+
+def _run(environment: dict[str, str], *arguments: str) -> subprocess.CompletedProcess:
+    invoked_as = Path(environment["HOME"]) / "bin-agent-browser"
+    invoked_as.write_text(SCRIPT.read_text())
+    invoked_as.chmod(0o755)
+    # Invoked under the name the image symlinks, since the wrapper switches on
+    # its own basename.
+    linked = invoked_as.parent / "agent-browser"
+    linked.write_text(SCRIPT.read_text())
+    linked.chmod(0o755)
+    return subprocess.run(
+        [str(linked), *arguments],
+        capture_output=True,
+        text=True,
+        env={k: v for k, v in environment.items() if not k.startswith("_")},
+    )
+
+
+def _bootstrapped(environment: dict[str, str]) -> bool:
+    return Path(environment["_MARKER"]).exists()
+
+
+def test_a_command_with_no_browser_running_starts_one(tmp_path: Path) -> None:
+    """The bug, directly: this used to fail instead of starting the browser."""
+    environment = _workspace(tmp_path, config=False, display=False)
+    result = _run(environment, "open", "https://example.com")
+
+    assert _bootstrapped(environment), (
+        "agent-browser ran with no browser up and did not start one"
+    )
+    # The caller's command still runs, and still carries its arguments.
+    assert "open https://example.com" in result.stdout
+    assert result.returncode == 0
+
+
+def test_a_missing_display_alone_is_enough_to_bootstrap(tmp_path: Path) -> None:
+    """Config written but Xvfb gone is the second failure, and the same cause."""
+    environment = _workspace(tmp_path, config=True, display=False)
+    _run(environment, "snapshot", "-i")
+    assert _bootstrapped(environment)
+
+
+def test_a_browser_already_up_is_not_restarted(tmp_path: Path) -> None:
+    """Bootstrapping a live session would reopen a blank page over the
+    agent's work."""
+    environment = _workspace(tmp_path, config=True, display=True)
+
+    _run(environment, "snapshot", "-i")
+
+    assert not _bootstrapped(environment), (
+        "a running browser was restarted out from under the agent"
+    )
+
+
+def test_version_never_starts_an_x_server(tmp_path: Path) -> None:
+    """Asking which version is installed must not cost a browser."""
+    environment = _workspace(tmp_path, config=False, display=False)
+    result = _run(environment, "--version")
+
+    assert not _bootstrapped(environment)
+    assert result.returncode == 0
+
+
+def test_start_browser_own_calls_do_not_recurse(tmp_path: Path) -> None:
+    """`start-browser` runs `agent-browser` itself; without the guard that is a
+    fork bomb rather than a bootstrap."""
+    environment = _workspace(tmp_path, config=False, display=False)
+    environment["LEMMA_BROWSER_BOOTSTRAP"] = "1"
+    _run(environment, "open")
+
+    assert not _bootstrapped(environment)
+
+
+def test_the_guard_is_set_for_the_nested_calls(tmp_path: Path) -> None:
+    """The recursion guard only works if the bootstrap actually exports it."""
+    environment = _workspace(tmp_path, config=False, display=False)
+    _run(environment, "open")
+
+    assert Path(environment["_MARKER"]).read_text().strip() == "1"


### PR DESCRIPTION
Two unrelated bugs with the same shape: a tool that was fine, failing in a way
that named no cause, so the only available conclusion was "it's broken".

Both were found from user reports this session and both are verified against the
real thing — a live installation, and the workspace image.

## 1. An Agent Host that outlived its daemon

Reported as: agents stopped answering, chat says **"Fetch is aborted"**.

`agent-host.log` was 3,295 lines, all identical:

```
Error: another Agent Host is already serving .../Lemma/agent-host.
Stop it first (quit Lemma, or stop the other process)
```

| | |
|---|---|
| Agent Host | pid 52261, **PPID 1**, started Aug 29 20:04 |
| Desktop app | pid 39972, started Aug 30 20:12 |

The sidecar takes an exclusive lock on its data directory and refuses to start
while something else holds it — right, since two of them fight over one pairing.
The comment on that lock says an OS lock means "there is nothing stale to clean
up after a crash". True of a crash; not of this. The sidecar **outlived its
daemon by a day**, was reparented to init, and went on holding the lock while
perfectly healthy.

From then on the installation was finished. Every launch logged the error and
retried, no local agent ever replied, and nothing named the cause anywhere a
user looks. Quitting and reopening could not help — the process being waited on
was not the app's to begin with. Clearing it took a SIGKILL by hand; it ignored
SIGTERM.

`Drop` on the supervisor covers the ordinary exits, and `suspend()` already
documents that the sidecar stops when the app quits. Neither can cover what
produces an orphan — the daemon killed outright, or the machine losing power —
because neither runs.

**Fix.** The running sidecar is written down, and the next daemon reclaims what
it finds before spawning its own. Checked before every spawn rather than once at
startup, so restart and reconcile are covered too; one small file read when
there is nothing to do.

Killing by pid is only safe if the process there now is the one written down, so
this reuses locald's existing identity machinery (`process_identity`,
`terminate_verified_process` — the same checks that already reclaim leftover
backend and frontend processes, which the Agent Host was simply never enrolled
in). Recorded executable **and** start identity must both still match; a record
from another installation is never acted on; identity is compared against the
*record*, not today's sidecar path, so an update that moved the binary can still
reclaim what the old one left; and stopping on purpose clears the record so it
can never outlive what it describes.

## 2. agent-browser, when nobody called start-browser first

Reported as: an agent transcript where the browser CLI did not work, and the
agent downloaded Playwright instead.

Nothing was broken. In the workspace image `agent-browser` is on `PATH`, its
environment is set, and the documented order works — `start-browser about:blank`
then `agent-browser snapshot -i` both succeed. But an agent that goes straight
for `agent-browser`, which is the obvious thing to type, got one of two errors:

```
⚠ config file not found: /tmp/lemma-browser/config.json
Missing X server or $DISPLAY
```

Both mean "`start-browser` has not run". Neither says so. The browser skill does
say to call it first, but the error names a missing file, not a remedy — so the
conclusion from inside the sandbox is that the tooling is broken, and the
fallback is installing Playwright and downloading its own Chromium into a 2 GB
sandbox, to do what the browser already sitting there does.

**Fix.** The wrapper that already fronts `agent-browser` brings the browser up
when a command needs one and none is running, so ordering stops being something
the caller has to know. Info-only flags are left alone so `--version` never
starts an X server; a guard variable keeps `start-browser`'s own nested calls
from re-entering the bootstrap; and a browser already up is never restarted,
because reopening a blank page over a live session would lose the agent's work.

## How to verify

```bash
make desktop-test && make desktop-lint
cd desktop && cargo test -p lemma-locald --locked
cd lemma-backend && uv run pytest sandbox_runtime/tests -q
make quality
```

Ran locally: 174 locald tests, 58 sandbox-runtime tests, whole desktop suite,
clippy clean, quality gates pass.

**Agent Host** — four tests, all against real processes because the mechanism is
about a real pid: a recorded leftover is reclaimed and its record cleared; a
recycled pid is left alone; another installation's record is not acted on;
stopping clears the record. Verified on the affected machine — killing the
orphan let the app start its own host immediately (parented to the app, not
init), publishing `claude-code=Ready opencode=Ready`, and chat recovered.

**agent-browser** — six tests driving the wrapper with a stubbed
`start-browser`, covering both failure states, the already-running case, the
info-flag case and the recursion guard. Verified in the workspace image itself:
before, `agent-browser open https://example.com` gave `rc=1` and a config
warning; after, `✓ Example Domain` with `rc=0`, a following `snapshot -i`
returning real refs, and `--version` still starting nothing.

## Note on scope

These are one PR at the author's request. They are independent — the second
touches only `sandbox-images/scripts/lemma-node-tool` and its test, and will
trigger a workspace image rebuild.

## Known gap

An Agent Host orphaned by a build *older* than this one has no record, so the
first launch after updating cannot reclaim it. That window closes as soon as
this ships, since every spawn from here on records.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — killing by pid is guarded by executable + start identity +
      installation id, each with a test
- [ ] **Rollback** — revert. Orphaned Agent Hosts can accumulate again, and
      `agent-browser` goes back to requiring `start-browser` first.