### PR TITLE
Treat a message typed past a card as a message, not as its answer

### DIFF
--- a/lemma-backend/app/modules/agent_surfaces/services/free_text_answer.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/free_text_answer.py
@@ -1,0 +1,98 @@
+"""Remembering that somebody asked to type their answer rather than tap one.
+
+A question rendered with native controls offers an "Other" button, and tapping
+it means "I will type it". That intent lived nowhere: the tap was acknowledged
+and forgotten, so the only way to honour it was to treat *every* typed message
+on the surface as an answer to whatever was pending. Which is how a question
+nobody ever answered came to swallow the next thing somebody said — their
+instruction recorded as the answer, and no run started for it.
+
+So the intent is written down, against the specific call it belongs to, and
+spent once. Anything typed without it is what it looks like: a new message.
+
+Kept in the conversation's own metadata rather than a new table: it is one
+short-lived flag per conversation, read on the next inbound message and cleared
+there, and `todo_storage` and the Agent Host's session memory already use that
+seam for the same kind of state.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+#: Holds the ``tool_call_id`` of the pause whose answer is being typed.
+_KEY = "surface_free_text_answer_for"
+
+
+def tool_call_id_of(plan: Any) -> str:
+    """The paused call a render plan belongs to.
+
+    ``callback_id`` is ``"{conversation_id}|{tool_call_id}"`` — the shape a
+    tapped button carries back, and the only place a plan keeps the id.
+    """
+    return str(getattr(plan, "callback_id", "") or "").partition("|")[2]
+
+
+async def remember_answer_will_be_typed(
+    repository: Any,
+    *,
+    conversation_id: UUID,
+    tool_call_id: str,
+) -> None:
+    """Record that this pause was delivered as text, so typing is the only reply.
+
+    Set wherever the native render did not happen — a platform with no buttons,
+    or a card whose render failed and fell back to a formatted message. Asking
+    the *platform* whether it supports buttons is not the same question: Slack
+    supports them and still falls back when a block payload is rejected, and
+    somebody looking at plain text has nothing to tap.
+    """
+    await remember_free_text_answer_wanted(
+        repository,
+        conversation_id=conversation_id,
+        tool_call_id=tool_call_id,
+    )
+
+
+async def remember_free_text_answer_wanted(
+    repository: Any,
+    *,
+    conversation_id: UUID,
+    tool_call_id: str,
+) -> None:
+    """Record that the next typed message answers ``tool_call_id``."""
+    if not tool_call_id:
+        return
+    await repository.set_conversation_metadata_key(
+        conversation_id,
+        _KEY,
+        tool_call_id,
+    )
+
+
+async def free_text_answer_wanted_for(
+    repository: Any,
+    *,
+    conversation_id: UUID,
+    tool_call_id: str,
+) -> bool:
+    """Did somebody ask to type the answer to *this* pause?
+
+    Matched on the call rather than merely "some free-text answer was wanted",
+    so an "Other" tapped against a question two turns ago cannot be spent on an
+    unrelated pause that happens to be pending now.
+    """
+    if not tool_call_id:
+        return False
+    stored = await repository.get_conversation_metadata_key(conversation_id, _KEY)
+    return isinstance(stored, str) and stored == tool_call_id
+
+
+async def forget_free_text_answer_wanted(
+    repository: Any,
+    *,
+    conversation_id: UUID,
+) -> None:
+    """Spend the intent, so it answers one message and not every later one."""
+    await repository.set_conversation_metadata_key(conversation_id, _KEY, None)

--- a/lemma-backend/app/modules/agent_surfaces/services/pending_interaction_resume.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/pending_interaction_resume.py
@@ -20,8 +20,118 @@ from app.modules.agent.domain.value_objects import AgentRunApprovalDecision
 from app.modules.agent.services.conversation_service import ConversationService
 from app.modules.agent.tools.user_interaction.models import AskUserRequest
 from app.modules.agent_surfaces.domain.ingress_context import SurfaceChatContext
+from app.modules.agent_surfaces.services.free_text_answer import (
+    forget_free_text_answer_wanted,
+    free_text_answer_wanted_for,
+)
 
 logger = get_logger(__name__)
+
+
+_APPROVAL_WORDS = {
+    "approve",
+    "yes",
+    "y",
+    "ok",
+    "okay",
+    "confirm",
+    "run",
+    "allow",
+    "go",
+    "deny",
+    "no",
+    "n",
+    "reject",
+    "decline",
+    "cancel",
+    "stop",
+}
+
+
+def _plainly_answers(pending: dict[str, Any], text: str) -> bool:
+    """Is this text unmistakably the answer, rather than a new request?
+
+    A person with buttons in front of them may still type "approve", or "2", or
+    the option's own words — that is answering, and it would be perverse to
+    treat it as a new instruction. So an exact match is still taken as one,
+    whatever the platform can render.
+
+    Deliberately narrow. `_parse_ask_user_reply` falls back to the raw text as a
+    free-form answer and `_parse_approval_decision` reads anything unrecognised
+    as a denial; either would call *every* message an answer, which is the thing
+    being fixed. Only a recognised option, index or decision word counts here.
+    """
+    stripped = text.strip()
+    if not stripped:
+        return False
+    if str(pending.get("kind") or "") == "request_approval":
+        return stripped.lower() in _APPROVAL_WORDS
+    raw_request = _ask_user_request_dict(pending.get("tool_args"))
+    if raw_request is None:
+        return False
+    try:
+        questions = AskUserRequest.model_validate(raw_request).questions
+    except ValidationError:
+        return False
+    if len(questions) != 1:
+        return False
+    options = getattr(questions[0], "options", None) or []
+    if stripped.isdigit():
+        return 0 <= int(stripped) - 1 < len(options)
+    return any(
+        (getattr(option, "label", "") or "").lower() == stripped.lower()
+        for option in options
+    )
+
+
+async def _is_an_answer(
+    context: SurfaceChatContext,
+    *,
+    conversation_service: ConversationService,
+    pending: dict[str, Any],
+    text: str,
+    tool_call_id: str,
+) -> bool:
+    """Is this typed message answering the pause, or getting on with something else?
+
+    The composer stays enabled while a conversation is WAITING, so somebody can
+    type straight past a card — and until this asked, every such message was
+    taken as the answer to whatever was pending, however old. A question nobody
+    tapped therefore swallowed the next instruction anybody sent, recorded it as
+    the answer, and started no run for it. Only surfaces behaved that way; a new
+    message from the web or the CLI supersedes a stale pause and carries on (see
+    `ConversationTurns.start` -> `supersede_stale_pending_interactions`).
+
+    Three cases are genuinely an answer:
+
+    * the words plainly answer it — an offered option, its number, "approve";
+    * they asked to type it, by tapping "Other" on the card, and this is the
+      pause they tapped it on;
+    * the card reached them as text, so typing is the only way to answer at all.
+
+    That last one is recorded where the text is sent rather than inferred from
+    the platform, because the two differ: Slack renders buttons and still falls
+    back to a formatted message when a block payload is rejected, and somebody
+    looking at plain text has nothing to tap whatever the platform can do.
+
+    Anything else is a new message, and saying so is what lets the normal path
+    mark the pause unanswered, tell the agent, and run what was actually asked.
+    """
+    # Asked before the platform, because an unmistakable answer is one wherever
+    # it was typed — and because it needs nothing but the words.
+    if _plainly_answers(pending, text):
+        return True
+    repository = conversation_service.conversation_repository
+    if await free_text_answer_wanted_for(
+        repository,
+        conversation_id=context.conversation_id,
+        tool_call_id=tool_call_id,
+    ):
+        await forget_free_text_answer_wanted(
+            repository, conversation_id=context.conversation_id
+        )
+        return True
+    return False
 
 
 def _ask_user_request_dict(tool_args: object) -> dict[str, Any] | None:
@@ -145,6 +255,19 @@ async def maybe_resume_pending_interaction(
             conversation_id=context.conversation_id
         )
         if not isinstance(pending, dict):
+            return False
+        if not await _is_an_answer(
+            context,
+            conversation_service=conversation_service,
+            pending=pending,
+            text=text,
+            tool_call_id=str(pending.get("tool_call_id") or ""),
+        ):
+            # A new message, not an answer. Falling through is the whole fix:
+            # `add_user_message_and_start_run` supersedes the unanswered pause,
+            # writes the tool return that tells the agent it was never answered
+            # (an approval always as a denial, never an approval), and runs what
+            # the person actually asked for.
             return False
         kind = str(pending.get("kind") or "")
         conversation = (

--- a/lemma-backend/app/modules/agent_surfaces/services/surface_egress.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/surface_egress.py
@@ -54,6 +54,10 @@ from app.modules.agent_surfaces.services.display_resource_renderer import (
 from app.core.file_types import is_untyped_mime
 from app.core.log.log import get_logger
 
+from app.modules.agent_surfaces.services.free_text_answer import (
+    remember_answer_will_be_typed,
+    tool_call_id_of,
+)
 from app.modules.agent_surfaces.services.surface_egress_target import (
     SurfaceEgressTargetMixin,
 )
@@ -369,6 +373,13 @@ class SurfaceEgressMixin(SurfaceEgressTargetMixin):
                     message=render_questions_as_text(plan),
                     metadata=metadata,
                 )
+                # Delivered as words, so words are the only way back.
+                # See `free_text_answer`.
+                await remember_answer_will_be_typed(
+                    self.conversation_service.conversation_repository,
+                    conversation_id=conversation_id,
+                    tool_call_id=str(pending.get("tool_call_id") or tool_call_id or ""),
+                )
             except Exception:
                 # The comment above says "surface it loudly"; this used to be a
                 # debug record that production never emitted. The question has
@@ -476,6 +487,12 @@ class SurfaceEgressMixin(SurfaceEgressTargetMixin):
                     event=target.event,
                     message=plan.to_plain_text(),
                     metadata=metadata,
+                )
+                # Delivered as words: "approve"/"deny" typed back is the answer.
+                await remember_answer_will_be_typed(
+                    self.conversation_service.conversation_repository,
+                    conversation_id=conversation_id,
+                    tool_call_id=tool_call_id_of(plan),
                 )
             except Exception:
                 # The docstring above promises this is "reported rather than

--- a/lemma-backend/app/modules/agent_surfaces/services/surface_interactions.py
+++ b/lemma-backend/app/modules/agent_surfaces/services/surface_interactions.py
@@ -26,6 +26,9 @@ from app.modules.agent_surfaces.domain.ingress_request import (
     SurfaceDirectWebhookIngress,
     SurfacePlatformWebhookIngress,
 )
+from app.modules.agent_surfaces.services.free_text_answer import (
+    remember_free_text_answer_wanted,
+)
 from app.modules.agent_surfaces.services.display_resource_renderer import (
     merge_other_answers,
 )
@@ -122,6 +125,17 @@ class SurfaceInteractionMixin:
             conversation_id = link.conversation_id
 
             if parsed.interaction_state == "other":
+                # Remember that they asked to type the answer. Without this the
+                # next message is indistinguishable from any other, and the only
+                # way to honour "Other" was to treat *every* typed message as an
+                # answer — which is how an unanswered question came to swallow
+                # whatever somebody said next. Recorded against the specific
+                # call, so it cannot be spent on a later, unrelated one.
+                await remember_free_text_answer_wanted(
+                    self.uow,
+                    conversation_id=conversation_id,
+                    tool_call_id=tool_call_id,
+                )
                 async with connection_released(self.uow.session):
                     await adapter.acknowledge_interaction(
                         credentials=credentials,

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_typed_message_is_not_always_an_answer.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_typed_message_is_not_always_an_answer.py
@@ -1,0 +1,212 @@
+"""Typing past a card on a surface: an answer, or a new instruction?
+
+The composer stays enabled while a conversation is WAITING, so somebody can
+type straight past a question. Every such message used to be taken as the
+answer to whatever was pending, however old — so a question nobody tapped
+swallowed the next instruction anybody sent, recorded it as the answer, and
+started no run for it. Their request was simply lost.
+
+Only surfaces behaved that way. A new message from the web or the CLI
+supersedes the stale pause and carries on
+(`ConversationTurns.start` -> `supersede_stale_pending_interactions`), which is
+the behaviour these tests pin surfaces to.
+
+Returning False here is what hands the message to that path, so False is the
+assertion that matters: it means the pause gets marked unanswered, the agent is
+told, and the person's actual instruction runs.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from app.modules.agent_surfaces.services.pending_interaction_resume import (
+    maybe_resume_pending_interaction,
+)
+
+A_QUESTION = {
+    "tool_call_id": "call-the-question",
+    "kind": "ask_user",
+    "tool_args": {
+        "request": {
+            "questions": [
+                {
+                    "header": "report",
+                    "question": "Which report?",
+                    "options": [{"label": "Weekly summary"}, {"label": "Full ledger"}],
+                }
+            ]
+        }
+    },
+    "agent_run_id": uuid4(),
+}
+
+AN_APPROVAL = {
+    "tool_call_id": "call-the-approval",
+    "kind": "request_approval",
+    "tool_args": {"tool_name": "pod_write_record", "title": "Write a record"},
+    "agent_run_id": uuid4(),
+}
+
+#: What somebody types when they have moved on from the card.
+A_NEW_INSTRUCTION = "Create a table called approvals_probe with a column named note."
+
+
+def _service(pending: dict, *, free_text_wanted_for: str | None = None):
+    """A conversation waiting on `pending`, on a surface that renders buttons."""
+    conversation_id = uuid4()
+    service = AsyncMock()
+    service.get_pending_user_interaction.return_value = dict(pending)
+    service.conversation_repository.get_conversation.return_value = SimpleNamespace(
+        id=conversation_id
+    )
+    service.conversation_repository.get_conversation_metadata_key.return_value = (
+        free_text_wanted_for
+    )
+    return service, conversation_id
+
+
+def _context(conversation_id, platform: str = "TELEGRAM"):
+    return SimpleNamespace(
+        conversation_id=conversation_id,
+        user_id=uuid4(),
+        pod_id=uuid4(),
+        platform=platform,
+        agent_name=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_typing_past_a_question_is_a_new_message() -> None:
+    """The bug, in one assertion.
+
+    A question is on screen with two buttons. Somebody ignores it and asks for
+    something else. That instruction is theirs, not an answer to "Which report?".
+    """
+    service, conversation_id = _service(A_QUESTION)
+
+    consumed = await maybe_resume_pending_interaction(
+        _context(conversation_id), A_NEW_INSTRUCTION, conversation_service=service
+    )
+
+    assert consumed is False
+    service.resolve_user_approval_internal.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_typing_past_an_approval_is_a_new_message() -> None:
+    """Same for an approval card, and it matters more.
+
+    Anything that is not an approval word was read as a denial, so an unrelated
+    instruction silently denied whatever was waiting *and* was lost itself.
+    Falling through denies it too — but through the path that also tells the
+    agent and runs what was asked.
+    """
+    service, conversation_id = _service(AN_APPROVAL)
+
+    consumed = await maybe_resume_pending_interaction(
+        _context(conversation_id), A_NEW_INSTRUCTION, conversation_service=service
+    )
+
+    assert consumed is False
+    service.resolve_user_approval_internal.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_an_answer_typed_after_tapping_other_still_answers() -> None:
+    """The affordance this must not break.
+
+    "Other" means "I will type it", so the next message *is* the answer.
+    """
+    service, conversation_id = _service(
+        A_QUESTION, free_text_wanted_for="call-the-question"
+    )
+
+    consumed = await maybe_resume_pending_interaction(
+        _context(conversation_id), "Weekly summary", conversation_service=service
+    )
+
+    assert consumed is True
+    resolved = service.resolve_user_approval_internal.await_args.kwargs
+    assert resolved["approval_id"] == "call-the-question"
+
+
+@pytest.mark.asyncio
+async def test_other_tapped_on_a_different_question_is_not_spent_here() -> None:
+    """The intent belongs to one call, not to the conversation.
+
+    Otherwise an "Other" tapped two turns ago would go on making every later
+    message an answer — the same bug with more steps.
+    """
+    service, conversation_id = _service(
+        A_QUESTION, free_text_wanted_for="call-some-other-question"
+    )
+
+    consumed = await maybe_resume_pending_interaction(
+        _context(conversation_id), A_NEW_INSTRUCTION, conversation_service=service
+    )
+
+    assert consumed is False
+
+
+@pytest.mark.asyncio
+async def test_typing_an_offered_option_still_answers() -> None:
+    """Buttons on screen, and they typed one of the options anyway.
+
+    That is answering, and reading it as a new instruction would be perverse.
+    Matched narrowly — an offered label or its 1-based index — because the
+    parser's own fallback treats *any* text as a free-form answer, which is the
+    behaviour being fixed.
+    """
+    service, conversation_id = _service(A_QUESTION)
+
+    for typed in ("Full ledger", "2"):
+        consumed = await maybe_resume_pending_interaction(
+            _context(conversation_id), typed, conversation_service=service
+        )
+        assert consumed is True, typed
+
+
+@pytest.mark.asyncio
+async def test_typing_a_decision_still_answers_an_approval() -> None:
+    """ "approve" and "deny" are answers wherever they are typed.
+
+    Both directions, because only approve-words were ever recognised — anything
+    else was read as a denial, which is what let an unrelated instruction deny a
+    pending action silently.
+    """
+    for typed in ("approve", "deny"):
+        service, conversation_id = _service(AN_APPROVAL)
+        consumed = await maybe_resume_pending_interaction(
+            _context(conversation_id), typed, conversation_service=service
+        )
+        assert consumed is True, typed
+
+
+@pytest.mark.asyncio
+async def test_a_card_that_arrived_as_text_is_answered_by_typing() -> None:
+    """Nothing to tap, so a typed reply has to be read as the answer.
+
+    This is the text fallback, and it is the reason the resume path exists.
+    Recorded when the text is sent rather than inferred from the platform:
+    Slack renders buttons and still falls back when a block payload is
+    rejected, and somebody looking at plain text has nothing to tap.
+
+    Free text on purpose — an offered label would pass on the plain-answer
+    rule instead, and prove nothing about this one.
+    """
+    service, conversation_id = _service(
+        A_QUESTION, free_text_wanted_for="call-the-question"
+    )
+
+    consumed = await maybe_resume_pending_interaction(
+        _context(conversation_id),
+        "whichever you think is best",
+        conversation_service=service,
+    )
+
+    assert consumed is True

--- a/tests/scenarios/journeys/surfaces_and_notifications/test_native_controls.py
+++ b/tests/scenarios/journeys/surfaces_and_notifications/test_native_controls.py
@@ -68,6 +68,19 @@ async def test_a_question_is_asked_with_native_controls(reachable):
         f"pressing a button; the buttons were {offered}"
     )
 
+    # Leave nothing waiting behind. A person has one chat with a bot and it
+    # stands between runs, so a question this scenario never answers is still
+    # pending when the next one starts — and that is not hypothetical: it is
+    # what made the approval scenario fail for nine runs, its message taken as
+    # the answer to this question instead of as a request of its own.
+    #
+    # Said rather than tapped because saying it is what clears it: a typed
+    # message on a surface with buttons is a new message, and starting one
+    # supersedes whatever was still pending. Nothing is asserted about that
+    # here — this scenario is about the buttons arriving — but the chat is
+    # handed on clean.
+    await reachable.says("Never mind that, thanks.")
+
 
 @scenario("An agent's approval request reaches the person as native buttons")
 @proves("PS-SURF-021", "PS-AGENT-020")


### PR DESCRIPTION
Fixes the last red dev scenario, `An agent's approval request reaches the person as native buttons` — red for nine runs. The cause turned out to be much bigger than the scenario.

## The bug

The composer stays enabled while a conversation is `WAITING`, so somebody can type straight past a question. On a **surface**, every such message was taken as the answer to whatever was pending — however old, whatever it said.

Proved against the real code — a question left on screen, then an unrelated instruction:

```
consumed as an answer to the stale question: True
resolved approval_id: call-old-question
answer recorded: {'answers': {'report': 'Create a table called approvals_probe ...'}}
```

The question is marked answered with their instruction, and **no run starts for it**. Their request is lost.

Only surfaces behaved this way. The same message from the web or the CLI supersedes the stale pause and carries on (`ConversationTurns.start` → `supersede_stale_pending_interactions`), which marks it unanswered, writes the tool return telling the agent so, and runs what was asked — an approval always denied there, never approved. **So this is surfaces catching up with the rest of the product, not new behaviour.**

## Why the scenario failed

`test_a_question_is_asked_with_native_controls` runs first in the same file, asks with buttons, asserts they arrived, and never taps one. The approval scenario's message into the same standing Telegram chat was then eaten as the answer to that question — no new run, no approval card, an empty placeholder, fail at 150s.

Deterministic on a standing chat and impossible on a fresh one, which is why it never reproduced locally. That scenario now clears up after itself as well.

## What still counts as an answer

In the order asked:

1. **Words that plainly answer it** — an offered option, its 1-based number, `approve`/`deny`. Narrow on purpose: `_parse_ask_user_reply` falls back to raw text and `_parse_approval_decision` reads anything unrecognised as a denial, so either would call every message an answer again.
2. **"Other" tapped on *this* call.** That intent had nowhere to live — the tap was acknowledged and forgotten — which is precisely why the only way to honour it was to treat everything as an answer. It is now written down, against the specific call, and spent once.
3. **The card reached them as text**, so there is nothing to tap.

Point 3 is recorded *where the text is sent*, not inferred from the platform, and that difference is load-bearing: Slack renders buttons and still falls back when a block payload is rejected. My first attempt keyed on "does this platform support buttons" and broke exactly that case — `test_ask_user_slack_native_failure_falls_back_to_text_and_typed_reply` caught it.

## Notes

`free_text_answer` takes whatever repository the caller holds rather than importing `agent`'s. The architecture ratchet was right that `agent_surfaces` should not reach across for this.

Seven new tests cover the cases above; the three that should catch the regression fail without the gate.

`make quality` passes (ratchet included), with 2504 unit tests and 177 agent_surfaces e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)