### PR TITLE
Teach the agent to keep a memory true, and to answer a hello

### DIFF
--- a/lemma-backend/app/modules/agent/domain/prompts.py
+++ b/lemma-backend/app/modules/agent/domain/prompts.py
@@ -76,13 +76,20 @@ def load_agent_base_prompt() -> str:
 
 
 def load_replies_prompt() -> str:
-    """What an assistant message is, and how long it is allowed to be.
+    """What an assistant message is, how long it may be, and when the right
+    answer is a reply rather than a run.
 
     Not keyed to a toolset: every agent replies, whatever tools it has, and the
     reply is the one thing the person always sees. Gating it on a toolset is how
     the narration in the Lemma UI went unruled for so long -- the equivalent
     rules existed only in the per-platform surface fragment, so a run with no
     surface platform (the web UI) was told nothing about length or narration.
+
+    The trailing "not every message is a task" section is here for the same
+    reason. "When you know enough to act, act" is the loudest line in either
+    base prompt, and applied to "hi" it yields an interrogation or a tool
+    spree -- so the rule that some messages want a sentence back has to sit
+    with the reply rules, on the one path every agent takes.
     """
     return _read_required_prompt(_REPLIES_PROMPT_PATH)
 

--- a/lemma-backend/app/modules/agent/infrastructure/context_brief_repository.py
+++ b/lemma-backend/app/modules/agent/infrastructure/context_brief_repository.py
@@ -1,4 +1,4 @@
-"""Reads behind AgentContextBriefBuilder (pod name, user email, agent grants).
+"""Reads behind AgentContextBriefBuilder (pod name, user profile, agent grants).
 
 Keeps the brief builder SQLAlchemy-free; it aggregates read-only display data
 across pod, identity, and core authorization, so the raw queries live here.
@@ -6,6 +6,7 @@ across pod, identity, and core authorization, so the raw queries live here.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from uuid import UUID
 
 from sqlalchemy import select
@@ -17,6 +18,20 @@ from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
 from app.composition.agent_context_models import Pod, User
 
 
+@dataclass(frozen=True, slots=True)
+class UserProfile:
+    """The identity fields the runtime brief puts in front of the agent.
+
+    A name and a timezone, not only an address, because the brief is the
+    agent's only source for either: it addresses the person by what it reads
+    here, and every clock it is handed reads UTC.
+    """
+
+    email: str | None = None
+    display_name: str | None = None
+    timezone: str | None = None
+
+
 class AgentContextBriefRepository:
     def __init__(self, uow: SqlAlchemyUnitOfWork) -> None:
         self._session = uow.session
@@ -26,11 +41,24 @@ class AgentContextBriefRepository:
             await self._session.execute(select(Pod.name).where(Pod.id == pod_id))
         ).scalar_one_or_none()
 
-    async def get_user_email(self, user_id: UUID) -> str | None:
+    async def get_user_profile(self, user_id: UUID) -> UserProfile:
+        """Name, address and timezone in one read.
+
+        The row was already being fetched whole for the address alone, so the
+        other two are free -- and an empty profile for a missing user rather
+        than a raise, because a brief is still worth rendering without one.
+        """
         user = (
             await self._session.execute(select(User).where(User.id == user_id))
         ).scalar_one_or_none()
-        return user.email if user is not None else None
+        if user is None:
+            return UserProfile()
+        name = " ".join(
+            part.strip() for part in (user.first_name, user.last_name) if part
+        ).strip()
+        return UserProfile(
+            email=user.email, display_name=name or None, timezone=user.timezone
+        )
 
     async def get_agent_grants(
         self, *, pod_id: UUID, agent_id: UUID

--- a/lemma-backend/app/modules/agent/prompts/memory.md
+++ b/lemma-backend/app/modules/agent/prompts/memory.md
@@ -2,7 +2,17 @@
 
 Durable facts belong in files, not in chat, where they die with the conversation. This pod's shared knowledge goes in `/memory`; what you know about the person you are talking to goes in `/me`, which only they can read. Your four exact folders, and which fact belongs in which, are named in `## Your Memory` below — use those paths, never one you worked out yourself.
 
-Check the relevant file before answering when past context could change your answer. The moment you learn a durable fact, preference, or correction — not a one-off detail — write it without being asked. One topic per file, organised in folders as it grows; look for an existing file to update before creating a near-duplicate. Never write transient chat content or secrets.
+Check the relevant file before answering when past context could change your answer.
+
+**What is worth writing.** Anything still true next week that would change an answer: who someone is and how they work, a decision and the reasoning under it, how this team names things and does things, a standing constraint, a correction to something you got wrong. Write the fact, not the conversation — a line someone can act on months from now without the thread it came from — and carry the *why* when the why is what makes it useful. Resolve anything relative before it goes in: "next Tuesday" is worthless in a file read three weeks later, so write the date. Skip what the pod already records, and never write transient chat content, credentials, or secrets.
+
+**Where it goes is a privacy decision.** `/memory` is the whole pod; `/me` is one person. What someone tells you about themselves — how they like to work, what they are dealing with, anything they would not have said in a channel — goes in `/me`, even when it would be more useful pod-wide.
+
+**Write it silently.** The moment you learn something durable, write it: in that turn, unasked, and without saying you did. "I've saved that to memory" is a filing report, not an answer — it costs the person a message and tells them nothing they wanted. Mention a write only when the memory is what they asked about, or when you have overwritten something they told you differently and would want to know you changed.
+
+**Keep it true when it changes.** A fact that replaces an older one is a rewrite, not an addition: open the file, correct the line, delete what is now false. Two versions of one fact in a file are worse than neither, because the next read cannot tell which is current. When the change itself is the interesting part — a version, an owner, a price, a policy — record the change and not only the new value: "Postgres 16 (from 15, upgraded August 2026)" leaves a question about the previous state answerable, where "Postgres 16" destroys it. Search and read before you write, or one topic becomes two half-true files; and re-read a file immediately before editing it, since another agent may have written to it since you last looked.
+
+**What you remember is what you were told, not what is true now.** Live data beats a remembered fact every time. When a memory names a table, a file, or a person and the pod says otherwise, act on the pod and correct the memory in the same turn.
 
 Memory is ordinary pod files, so search finds it:
 
@@ -12,4 +22,6 @@ lemma files write /memory/pricing.md "..."           # or pod_write_file, path="
 lemma files write /me/preferences.md "..."           # private — only this user sees it
 ```
 
-Each `AGENTS.md` is the one file you never have to go looking for — and the one that costs you on every single turn. Keep it a short index: one line per topic pointing at the file with the detail, never the detail itself. Only the beginning of each reaches your prompt; past that it is truncated and you are told so, so a bloated index silently pushes out the entries below it.
+One topic per file, organised in folders as it grows.
+
+Each `AGENTS.md` is the one file you never have to go looking for — and the one that costs you on every single turn. Keep it a short index: one line per topic pointing at the file with the detail, never the detail itself. Only the beginning of each reaches your prompt; past that it is truncated and you are told so, so a bloated index silently pushes out the entries below it. Fix the index in the same turn you add, rename, merge, or delete a topic file — an index pointing at a file that moved is worse than no index. As it fills, group related topics onto one line rather than adding one per file: twenty entries you can see beat a hundred you cannot.

--- a/lemma-backend/app/modules/agent/prompts/replies.md
+++ b/lemma-backend/app/modules/agent/prompts/replies.md
@@ -6,3 +6,12 @@ Assistant text is delivered to the person — in Lemma's own UI, and on WhatsApp
 - **Every message has to earn its place.** Before you send one mid-run, ask what the person learns from it. A plan that changed, a wait longer than they'd expect, or something you need from them is worth a line, once. When in doubt, stay quiet and put it in the answer.
 - **Keep the answer under ~1200 characters.** Lead with it. A few short lines or bullets, no preamble, no restating the question back at them.
 - **End on the answer.** Not on a menu of what else you could do. If one follow-up is genuinely worth offering, make it one sentence.
+
+## Not every message is a task
+
+Some messages want a reply, not a run. A greeting, a thank-you, a question about you, an opener like "can you help me with something?" — none of them is work to go and do.
+
+- **Answer a greeting with a greeting.** A line or two, no tool calls, nothing produced. Don't go looking for something to show, and don't answer with a menu of what you could do. If something real is waiting on them, one line of it makes a good hello — "morning; the invoice run finished Friday, three rows need your call" — a list of it does not.
+- **Greet once.** At the start of a conversation, not at the start of every message in it.
+- **You have met this person before.** What you remember about them is already in front of you — their name, how they work, what you were doing last time. Use it. Don't reintroduce yourself to someone you speak to daily, and don't ask what you have already been told.
+- **Match the register.** A one-line message gets a one-line reply. Length belongs to the work, not to politeness.

--- a/lemma-backend/app/modules/agent/services/agent_context_brief.py
+++ b/lemma-backend/app/modules/agent/services/agent_context_brief.py
@@ -40,6 +40,7 @@ from app.modules.agent.domain.value_objects import AgentToolset
 from app.modules.agent.config import agent_settings
 from app.modules.agent.infrastructure.context_brief_repository import (
     AgentContextBriefRepository,
+    UserProfile,
 )
 from app.modules.agent.infrastructure.repositories import AgentRepository
 from app.modules.agent.services.agent_memory_brief import AgentMemoryBriefBuilder
@@ -201,12 +202,11 @@ class AgentContextBriefBuilder:
         async with self.uow_factory() as uow:
             repo = AgentContextBriefRepository(uow)
             pod_name = await repo.get_pod_name(pod_id) or "(unknown)"
-            email = await repo.get_user_email(user_id)
-        user_line = f"{email} ({user_id})" if email else str(user_id)
+            profile = await repo.get_user_profile(user_id)
         lines = [
             "# Runtime Context",
             f"- Pod: {pod_name} ({pod_id})",
-            f"- User: {user_line}",
+            *_user_lines(profile, user_id),
         ]
 
         if is_default:
@@ -404,6 +404,42 @@ def _more_note(shown: int, total: object, noun: str) -> list[str]:
         f"- … and {total - shown} more {noun} not listed here "
         f"(showing {shown}). Use your tools to list them all."
     ]
+
+
+def _user_lines(profile: UserProfile, user_id: UUID) -> list[str]:
+    """Who the agent is talking to, and what time it is where they are.
+
+    Both halves used to be missing, and neither is recoverable from anywhere
+    else in the prompt. The brief named an address and a UUID, so an agent
+    asked to greet somebody by name had nothing to read one from -- it either
+    said the email address out loud or hoped a past agent had written the name
+    into `/me`. And the only clock a run is given is UTC, which is the wrong
+    answer to "this morning" and the wrong date to write into a memory file.
+
+    Said plainly when the timezone is unset, rather than left out: an agent
+    told nothing assumes the clock in front of it is the person's.
+    """
+    identity = profile.email or "(unknown)"
+    if profile.display_name:
+        identity = (
+            f"{profile.display_name} <{profile.email}>"
+            if profile.email
+            else profile.display_name
+        )
+    lines = [f"- User: {identity} ({user_id})"]
+    if profile.timezone:
+        lines.append(
+            f"- Their timezone: {profile.timezone}. The clock you are given "
+            "reads UTC — convert before naming a time of day or resolving a "
+            "date for them."
+        )
+    else:
+        lines.append(
+            "- Their timezone is not set, and the clock you are given reads "
+            "UTC, which may not be theirs. Don't name a time of day or resolve "
+            '"today" on their behalf without asking.'
+        )
+    return lines
 
 
 def _table_line(table) -> str:

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_context_brief.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_context_brief.py
@@ -15,8 +15,10 @@ from app.modules.agent.domain.value_objects import AgentToolset
 from app.modules.datastore.contracts import DatastoreFileNotFoundError
 from app.modules.agent.services import agent_context_brief as brief_mod
 from app.modules.agent.services import agent_memory_brief as memory_mod
+from app.modules.agent.infrastructure.context_brief_repository import UserProfile
 from app.modules.agent.services.agent_context_brief import (
     AgentContextBriefBuilder,
+    _user_lines,
 )
 
 
@@ -78,8 +80,8 @@ class _FakeBriefRepo:
     async def get_pod_name(self, pod_id):
         return "Acme"
 
-    async def get_user_email(self, user_id):
-        return "a@b.co"
+    async def get_user_profile(self, user_id):
+        return UserProfile(email="a@b.co")
 
     async def get_agent_grants(self, **kwargs):
         return []
@@ -461,3 +463,44 @@ class TestEveryCapSaysWhatItLeftOut:
         entries = _top_level_file_entries(tree)
 
         assert any("4 more top-level entries" in entry for entry in entries)
+
+
+class TestTheUserLine:
+    """What the brief says about the person, which is all the agent knows.
+
+    Nothing else in the prompt carries a name or a timezone, so an omission
+    here is not a thinner brief -- it is an agent that greets an email address
+    and calls 09:00 UTC "this morning" to somebody eight hours away.
+    """
+
+    def test_a_name_leads_the_line_and_the_address_stays(self):
+        user_id = uuid4()
+
+        lines = _user_lines(
+            UserProfile(email="ada@example.com", display_name="Ada Lovelace"),
+            user_id,
+        )
+
+        assert lines[0] == f"- User: Ada Lovelace <ada@example.com> ({user_id})"
+
+    def test_an_unnamed_user_still_reads_as_it_always_did(self):
+        user_id = uuid4()
+
+        lines = _user_lines(UserProfile(email="ada@example.com"), user_id)
+
+        assert lines[0] == f"- User: ada@example.com ({user_id})"
+
+    def test_a_known_timezone_is_named_with_what_to_do_about_it(self):
+        lines = _user_lines(
+            UserProfile(email="ada@example.com", timezone="Asia/Kolkata"), uuid4()
+        )
+
+        assert "Asia/Kolkata" in lines[1]
+        assert "UTC" in lines[1]
+
+    def test_a_missing_timezone_is_said_rather_than_left_out(self):
+        """Silence reads as "the clock in front of you is theirs"."""
+        lines = _user_lines(UserProfile(email="ada@example.com"), uuid4())
+
+        assert "not set" in lines[1]
+        assert "UTC" in lines[1]


### PR DESCRIPTION
## What changes

Two gaps in the standing agent prompt, plus the one piece of runtime context the
second of them needs.

**Memory keeps working when a fact changes.** `prompts/memory.md` said when to
write and where, and nothing about what to do when something you remember stops
being true. It now rules that a replacing fact is a rewrite rather than an
addition, that two versions of one fact in a file are worse than neither, and
that when the change itself is the interesting part it gets recorded as a change
— "Postgres 16 (from 15, upgraded August 2026)" — instead of only the new value.
Around that, the four things the fragment never said: what is actually worth
writing (the fact, not the transcript, with relative dates resolved), that `/me`
versus `/memory` is a privacy decision, that a write is silent, and that live pod
data beats a remembered fact when the two disagree. The `AGENTS.md` index rules
gain the two maintenance cases they were missing.

**A greeting gets a greeting.** `prompts/replies.md` ruled how to answer and
never whether the message was a task. It now carries a "not every message is a
task" section: a hello answered in a line or two with no tool calls, once per
conversation rather than once per message, from someone who remembers meeting
this person.

**The runtime brief names the person and their timezone.** `- User:` was an
email address and a UUID. It now reads `Ada Lovelace <ada@example.com> (uuid)`
and adds a line for the user's timezone — or says plainly that it is unset.

## Why

The memory rule comes from a real failure. An adversarial run over a 30-session
pod found that an ownership chain survived across sessions while a version chain
was destroyed, and the only difference was how the user phrased the update:
"moved from X to Y" put the transition in the file, "we're on 15 now" caused an
overwrite that took the prior value with it. Whether history survives should not
depend on the user's sentence.

The greeting rule is the other side of the base prompt working as intended.
"When you know enough to act, act" is the loudest line in both base prompts, and
met with "hi" it produces either an interrogation or a spree of tool calls to
have something to show. Nothing anywhere told the agent that some messages want a
sentence back.

The brief change is what makes that possible. Nothing else in the prompt carries
a name, so an agent asked to greet someone could only read out the email address
or hope a past agent had written the name into `/me` — while `first_name` sat on
the user row the brief already fetched whole and kept one column of. `timezone`
was on the same row with no reader anywhere in the backend, which is why every
run resolves "this morning" and "next Tuesday" against UTC.

## How to verify

```bash
cd lemma-backend
uv run pytest app/modules/agent/tests/unit -q      # 1410 passed, 29 skipped
uv run ruff check app/modules/agent                # All checks passed!
cd .. && make architecture                         # ratchet + settings + routes pass
```

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

`TestTheUserLine` in `test_agent_context_brief.py` covers the four rendering
cases (named/unnamed, timezone known/unset). The two prompt fragments are not
asserted on — no test in the repo pins prompt copy, and pinning it would make
every future wording change a test edit.

## Compatibility and rollback notes

No migration, no API or SDK surface, no new secret in a log or payload. The
brief's `get_user_email` became `get_user_profile` over the same row; it is
private to the agent module and has one caller (the surfaces module's
identically-named port on `PodMembershipPort` is a different class and is
untouched). Both commits revert cleanly on their own.

One thing deliberately not done: the runtime note still reads UTC, and the
conversion to local time is left to the agent. Rendering it there would mean
threading the timezone onto the run context for a value that changes every turn,
and `CurrentTimeCapability` is placed the way it is specifically to keep volatile
content out of the cached prompt prefix.
