### PR TITLE
Stop pod export from silently leaving files behind

### DIFF
--- a/lemma-cli/lemma_cli/cli_app/pod_bundle.py
+++ b/lemma-cli/lemma_cli/cli_app/pod_bundle.py
@@ -403,6 +403,51 @@ def _has_seed_data(resource_dir: Path) -> bool:
     return any((resource_dir / name).is_file() for name in _TABLE_DATA_CANDIDATES)
 
 
+def _rows_typed_by_schema(
+    rows: list[dict[str, Any]], resource_dir: Path
+) -> list[dict[str, Any]]:
+    """Re-read CSV cells as the columns they are going into.
+
+    CSV has no types, so the reader guesses from the text -- and a TEXT column
+    holding "2026" arrives as an int, which Postgres rejects outright:
+    `invalid input for query argument $13: 2026 (expected str, got int)`. The
+    export is not wrong and the CSV is not wrong; the guess is. A year, a
+    postcode, an ISBN, a version, an account number: every one of them is text
+    that looks like a number, and any of them stops a pod from being imported.
+
+    The declared type is right there in the table's own JSON, next to the data
+    file, so use it. Only the columns the table declares are touched, and only
+    where the guess disagrees; anything unrecognised is left exactly as read.
+    """
+    schema_files = [
+        path for path in resource_dir.glob("*.json") if path.stem == resource_dir.name
+    ]
+    if not schema_files:
+        return rows
+    try:
+        columns = json.loads(schema_files[0].read_text(encoding="utf-8")).get("columns")
+    except OSError, json.JSONDecodeError:
+        return rows
+    if not isinstance(columns, list):
+        return rows
+    declared = {
+        str(column.get("name")): str(column.get("type") or "").upper()
+        for column in columns
+        if isinstance(column, dict) and column.get("name")
+    }
+    # Types whose values are carried as strings. A number that reached a TEXT
+    # column is the guess misfiring, so put it back the way the CSV spelled it.
+    textual = {"TEXT", "ENUM", "UUID", "FILE_PATH", "DATE", "DATETIME", "TIME"}
+    retyped: list[dict[str, Any]] = []
+    for row in rows:
+        fixed = dict(row)
+        for key, value in row.items():
+            if declared.get(key) in textual and isinstance(value, (int, float)):
+                fixed[key] = str(value)
+        retyped.append(fixed)
+    return retyped
+
+
 def _import_table_data(pod_sdk: Any, table_name: str, resource_dir: Path) -> int:
     """Seed a table from a bundled ``data.{csv,jsonl,json}`` file via bulk create.
     Returns the number of rows sent (0 when there is no data file)."""
@@ -420,6 +465,8 @@ def _import_table_data(pod_sdk: Any, table_name: str, resource_dir: Path) -> int
         {key: value for key, value in row.items() if key not in _SEED_STRIP_COLUMNS}
         for row in read_record_rows(data_file, None)
     ]
+    if data_file.suffix.lower() == ".csv":
+        rows = _rows_typed_by_schema(rows, resource_dir)
     if not rows:
         return 0
     # Upsert so re-importing an edited data.csv updates existing rows (matched on
@@ -783,29 +830,47 @@ def _is_pod_visible_file(item: dict[str, Any]) -> bool:
 def fetch_files_index(
     client: Lemma, pod_id: str
 ) -> tuple[dict[str | None, list[dict[str, Any]]], dict[str, dict[str, Any]]]:
-    tree_payload = to_plain(client.pod(pod_id).files.tree("/"))
-    root = tree_payload.get("tree")
-    if not isinstance(root, dict):
-        return {}, {}
+    """Every file and folder in the pod, by walking directories to exhaustion.
 
+    This used to read the directory-*tree* endpoint, which is a preview: it
+    returns at most ``files_per_directory`` entries per directory, defaulting to
+    three and capped at twenty. Export then treated that preview as the pod's
+    contents. On a real pod that meant a directory of twelve files exported
+    three of them, and the summary counted what it collected, so the number
+    looked right and nothing warned. Measured on one pod: 266 files, 104
+    exported, no error.
+
+    The backend's own exporter already avoids this and says why -- "the tree
+    endpoint caps files-per-dir, so we walk with ``list_files`` instead". This
+    is the same walk, and it inherits the same hazard the backend documents: a
+    listing is not guaranteed to point strictly downward, because a user's home
+    folder lists *itself*. Without ``seen`` that recurses until the interpreter
+    gives up.
+    """
     by_parent: dict[str | None, list[dict[str, Any]]] = {None: []}
     all_items: dict[str, dict[str, Any]] = {}
+    seen: set[str] = set()
+    stack: list[tuple[str, str | None]] = [("/", None)]
 
-    def walk(node: dict[str, Any], *, parent_key: str | None) -> None:
-        for child in node.get("children") or []:
-            if not isinstance(child, dict):
+    while stack:
+        directory, parent_key = stack.pop()
+        if directory in seen:
+            continue
+        seen.add(directory)
+        for entry in client.pod(pod_id).files.list_all(directory):
+            item = to_plain(entry)
+            if not isinstance(item, dict):
                 continue
-            child_path = str(child.get("path") or "")
-            if not child_path or child_path == "/":
+            path = str(item.get("path") or "")
+            if not path or path == "/":
                 continue
-            item = dict(child)
-            item_id = str(item.get("id") or child_path)
+            item_id = str(item.get("id") or path)
             item["id"] = item_id
             all_items[item_id] = item
             by_parent.setdefault(parent_key, []).append(item)
-            walk(child, parent_key=child_path)
+            if str(item.get("kind") or "").upper() == "FOLDER":
+                stack.append((path, path))
 
-    walk(root, parent_key=None)
     return by_parent, all_items
 
 
@@ -1220,6 +1285,14 @@ def export_pod_bundle(
         with_data=wants_data,
         with_files=bool(file_folders),
     )
+
+    # Printed, not just returned. Every one of these says something was left
+    # out of the bundle, and they were reaching the caller only inside a summary
+    # panel that folds long fields -- so the one line saying a file had been
+    # skipped was the line most likely to be hidden. The import path already
+    # prints its advisories this way.
+    for warning in data_table_warnings:
+        console.print(f"[yellow]warning[/yellow] {warning}")
 
     return {
         "ok": True,

--- a/lemma-cli/tests/test_pod_bundle.py
+++ b/lemma-cli/tests/test_pod_bundle.py
@@ -25,8 +25,46 @@ from lemma_cli.cli_app.pod_bundle import (
 import lemma_cli.cli_app.pod_bundle as pod_bundle_module
 
 
+def _list_all_from_tree(files):
+    """Serve `list_all` out of a fake that only knows how to answer `tree`.
+
+    Export and import now enumerate directories with the listing endpoint,
+    because the tree is a capped preview. Most fakes in this file predate that
+    and describe a pod as a tree, which still says exactly what is in each
+    directory -- so derive the listing from it rather than restating every
+    fixture. Tests that are *about* the walk build their own listing fake.
+    """
+
+    def list_all(_pod_id, path="/", *, page_size=500):
+        payload = files.tree(_pod_id)
+        root = payload.get("tree") if isinstance(payload, dict) else None
+        if not isinstance(root, dict):
+            return []
+
+        def children_of(node, target):
+            if str(node.get("path") or "") == target:
+                return [c for c in (node.get("children") or []) if isinstance(c, dict)]
+            for child in node.get("children") or []:
+                if isinstance(child, dict):
+                    found = children_of(child, target)
+                    if found is not None:
+                        return found
+            return None
+
+        return children_of(root, path) or []
+
+    return list_all
+
+
 class FakeClient(SimpleNamespace):
     def pod(self, pod_id):
+        files = getattr(self, "files", None)
+        if (
+            files is not None
+            and not hasattr(files, "list_all")
+            and hasattr(files, "tree")
+        ):
+            files.list_all = _list_all_from_tree(files)
         return _FlatPodProxy(self, pod_id)
 
 
@@ -730,55 +768,238 @@ def test_import_pod_bundle_rejects_grants_without_resource_name(tmp_path: Path):
         import_pod_bundle(client, pod_id="pod_123", source_dir=agents_root)
 
 
-def test_fetch_files_index_uses_tree_payload_without_fetching_each_path():
-    class _FilesApi:
-        def tree(
-            self,
-            pod_id: str,
-            root_path: str = "/",
-            files_per_directory: int = 20,
-        ) -> dict[str, object]:
-            assert pod_id == "pod_123"
-            assert root_path == "/"
-            return {
-                "tree": {
-                    "path": "/",
-                    "name": "/",
-                    "kind": "FOLDER",
-                    "children": [
-                        {
-                            "id": "folder_root",
-                            "name": "product_datasheets",
-                            "kind": "FOLDER",
-                            "visibility": "POD",
-                            "path": "/product_datasheets",
-                            "children": [
-                                {
-                                    "id": "file_pdf",
-                                    "name": "spec-sheet.pdf",
-                                    "kind": "FILE",
-                                    "visibility": "POD",
-                                    "path": "/product_datasheets/spec-sheet.pdf",
-                                }
-                            ],
-                        }
-                    ],
-                }
-            }
+class _ListingFilesApi:
+    """A pod's files, served the way the API serves them: one page at a time."""
 
-        def get(self, pod_id: str, path: str) -> dict[str, object]:
-            raise AssertionError(
-                f"fetch_files_index should not call files.get for {pod_id}:{path}"
-            )
+    def __init__(self, directories: dict[str, list[dict[str, object]]], page: int = 2):
+        self.directories = directories
+        self.page = page
+        self.listed: list[tuple[str, str | None]] = []
 
-    by_parent, all_items = fetch_files_index(FakeClient(files=_FilesApi()), "pod_123")
+    def list_all(self, pod_id: str, path: str = "/", *, page_size: int = 500):
+        entries: list[dict[str, object]] = []
+        token: str | None = None
+        while True:
+            page = self.list(pod_id, path, limit=self.page, page_token=token)
+            entries.extend(page["items"])
+            token = page.get("next_page_token")
+            if not token:
+                return entries
 
-    assert [item["path"] for item in by_parent[None]] == ["/product_datasheets"]
-    assert [item["path"] for item in by_parent["/product_datasheets"]] == [
-        "/product_datasheets/spec-sheet.pdf"
+    def list(self, pod_id: str, path: str = "/", *, limit=100, page_token=None):
+        self.listed.append((path, page_token))
+        items = self.directories.get(path, [])
+        offset = int(page_token or 0)
+        window = items[offset : offset + limit]
+        nxt = offset + limit
+        return {
+            "items": window,
+            "next_page_token": str(nxt) if nxt < len(items) else None,
+        }
+
+    def tree(self, *args, **kwargs):
+        raise AssertionError(
+            "the tree endpoint is a preview capped at files_per_directory; "
+            "an export that must be complete cannot be built from it"
+        )
+
+    def get(self, pod_id: str, path: str):
+        raise AssertionError(f"no per-path fetch expected for {pod_id}:{path}")
+
+
+def _folder(path: str, name: str, visibility: str = "POD") -> dict[str, object]:
+    return {
+        "id": f"folder{path}",
+        "name": name,
+        "kind": "FOLDER",
+        "visibility": visibility,
+        "path": path,
+    }
+
+
+def _file(path: str, name: str, visibility: str = "POD") -> dict[str, object]:
+    return {
+        "id": f"file{path}",
+        "name": name,
+        "kind": "FILE",
+        "visibility": visibility,
+        "path": path,
+    }
+
+
+def test_fetch_files_index_sees_every_file_not_the_first_few():
+    """The bug this replaced: a directory of many files exported three of them.
+
+    The index came from the directory-*tree* endpoint, which returns at most
+    `files_per_directory` entries per directory -- three by default, twenty at
+    most. Export treated that preview as the pod's contents, and counted what it
+    collected, so nothing looked wrong. Measured on a real pod: 266 files, 104
+    exported, no warning.
+    """
+    many = [
+        _file(f"/library/note-{index:02d}.md", f"note-{index:02d}.md")
+        for index in range(12)
     ]
-    assert all_items["folder_root"]["visibility"] == "POD"
-    assert all_items["file_pdf"]["name"] == "spec-sheet.pdf"
+    api = _ListingFilesApi(
+        {
+            "/": [_folder("/library", "library")],
+            "/library": many,
+        }
+    )
+
+    _, all_items = fetch_files_index(FakeClient(files=api), "pod_123")
+
+    exported = sorted(
+        item["path"] for item in all_items.values() if item["kind"] == "FILE"
+    )
+    assert exported == sorted(entry["path"] for entry in many), (
+        "the walk stopped short of the directory's contents"
+    )
+    # Paged to exhaustion rather than taking whatever one page held.
+    assert len([call for call in api.listed if call[0] == "/library"]) > 1
+
+
+def test_fetch_files_index_keeps_walking_when_a_folder_lists_itself():
+    """A home folder lists itself; without a guard the walk never returns.
+
+    The backend's exporter documents this exact hazard -- it recursed until the
+    interpreter gave up, and the error was swallowed, so every pod with a home
+    folder exported an empty `files/` and said nothing.
+    """
+    api = _ListingFilesApi(
+        {
+            "/": [_folder("/me", "me", "PERSONAL")],
+            # `/me` contains itself, and a real file underneath.
+            "/me": [
+                _folder("/me", "me", "PERSONAL"),
+                _file("/me/notes.md", "notes.md", "PERSONAL"),
+            ],
+        }
+    )
+
+    _, all_items = fetch_files_index(FakeClient(files=api), "pod_123")
+
+    assert "/me/notes.md" in {item["path"] for item in all_items.values()}
+
+
+def test_fetch_files_index_reports_a_pod_visible_skills_tree():
+    """Skills are pod-visible and must survive an export.
+
+    The tree endpoint returned the whole `/skills` subtree with no visibility at
+    all, and export keeps only `visibility == "POD"` -- so a pod's skills were
+    dropped from every bundle, silently. The listing endpoint reports them
+    correctly.
+    """
+    api = _ListingFilesApi(
+        {
+            "/": [_folder("/skills", "skills")],
+            "/skills": [_folder("/skills/research", "research")],
+            "/skills/research": [_file("/skills/research/SKILL.md", "SKILL.md")],
+        }
+    )
+
+    _, all_items = fetch_files_index(FakeClient(files=api), "pod_123")
+
+    skill = next(
+        item
+        for item in all_items.values()
+        if item["path"] == "/skills/research/SKILL.md"
+    )
+    assert skill["visibility"] == "POD"
+
+
+def test_a_schedule_exports_without_where_it_last_ran():
+    """A bundle this code writes has to be one this code can import.
+
+    The strip list drifted from the API: it removed `last_run_at`/`next_run_at`
+    and not the seven fields that replaced them, so import refused the bundle by
+    name -- "Unrecognized field(s) on schedule" -- and the only way through was
+    editing the JSON by hand.
+    """
+    from lemma_pod_bundle.normalize import _normalize_schedule_payload
+
+    payload = _normalize_schedule_payload(
+        {
+            "name": "weekly-coach",
+            "schedule_type": "TIME",
+            "config": {"cron": "0 9 * * 1"},
+            "agent_name": "coach",
+            "is_active": True,
+            "id": "sched_1",
+            "pod_id": "pod_1",
+            "consecutive_failures": 3,
+            "is_internal": False,
+            "last_error": "boom",
+            "last_fire_status": "FAILED",
+            "last_fired_at": "2026-08-29T00:00:00Z",
+            "last_run_id": "run_9",
+            "paused_by_failures": True,
+        }
+    )
+
+    # What a schedule is, kept.
+    assert payload["name"] == "weekly-coach"
+    assert payload["config"] == {"cron": "0 9 * * 1"}
+    assert payload["agent_name"] == "coach"
+    assert payload["is_active"] is True
+    # How one installation's copy has been getting on, dropped.
+    for runtime_only in (
+        "consecutive_failures",
+        "is_internal",
+        "last_error",
+        "last_fire_status",
+        "last_fired_at",
+        "last_run_id",
+        "paused_by_failures",
+    ):
+        assert runtime_only not in payload, runtime_only
+
+
+def test_a_text_column_holding_digits_survives_a_csv_round_trip(tmp_path: Path):
+    """`year` is TEXT and holds "2026"; CSV has no types, so the reader guessed
+    int and Postgres refused the insert outright. The declared type is in the
+    table's own JSON next to the data file."""
+    from lemma_cli.cli_app.pod_bundle import _rows_typed_by_schema
+
+    resource_dir = tmp_path / "sources"
+    resource_dir.mkdir()
+    (resource_dir / "sources.json").write_text(
+        json.dumps(
+            {
+                "name": "sources",
+                "columns": [
+                    {"name": "slug", "type": "TEXT"},
+                    {"name": "year", "type": "TEXT"},
+                    {"name": "rank", "type": "INTEGER"},
+                    {"name": "score", "type": "FLOAT"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rows = _rows_typed_by_schema(
+        [{"slug": "rigveda", "year": 2026, "rank": 3, "score": 1.5}], resource_dir
+    )
+
+    assert rows[0]["year"] == "2026", "a TEXT column must arrive as text"
+    # Columns that really are numbers are left alone.
+    assert rows[0]["rank"] == 3
+    assert rows[0]["score"] == 1.5
+    assert rows[0]["slug"] == "rigveda"
+
+
+def test_rows_are_left_alone_when_the_table_declares_nothing_usable(tmp_path: Path):
+    """No schema, no opinion: never invent a conversion from a missing type."""
+    from lemma_cli.cli_app.pod_bundle import _rows_typed_by_schema
+
+    resource_dir = tmp_path / "sources"
+    resource_dir.mkdir()
+    rows = [{"year": 2026}]
+    assert _rows_typed_by_schema(rows, resource_dir) == rows
+
+    (resource_dir / "sources.json").write_text("not json", encoding="utf-8")
+    assert _rows_typed_by_schema(rows, resource_dir) == rows
 
 
 def test_import_pod_files_only_creates_missing_folders(tmp_path: Path):

--- a/lemma-pod-bundle/lemma_pod_bundle/normalize.py
+++ b/lemma-pod-bundle/lemma_pod_bundle/normalize.py
@@ -180,6 +180,19 @@ def _normalize_workflow_payload(workflow: dict[str, Any]) -> dict[str, Any]:
 
 
 def _normalize_schedule_payload(schedule: dict[str, Any]) -> dict[str, Any]:
+    """A schedule as a definition, with where-it-ran-last left behind.
+
+    The list below drifted from the API: it strips `last_run_at`/`next_run_at`
+    and not the fields that replaced them, so export wrote seven pieces of
+    runtime state that import rejects by name -- "Unrecognized field(s) on
+    schedule". A bundle this code produced could not be imported by it, and the
+    only way through was editing the JSON by hand.
+
+    The rule is what a schedule *is*, not how a particular installation's copy
+    of it has been getting on: when it last fired, what it returned, how many
+    times it has failed, and whether failures have paused it all belong to the
+    pod it ran in, never to the pod it is being copied into.
+    """
     return _strip_keys(
         schedule,
         {
@@ -193,6 +206,14 @@ def _normalize_schedule_payload(schedule: dict[str, Any]) -> dict[str, Any]:
             "agent_id",
             "workflow_id",
             "allowed_actions",
+            # Runtime state, added after this list was written.
+            "consecutive_failures",
+            "is_internal",
+            "last_error",
+            "last_fire_status",
+            "last_fired_at",
+            "last_run_id",
+            "paused_by_failures",
         },
     )
 

--- a/lemma-python/lemma_sdk/resources/files.py
+++ b/lemma-python/lemma_sdk/resources/files.py
@@ -4,7 +4,7 @@ from contextlib import ExitStack
 from io import BytesIO
 import mimetypes
 from pathlib import Path
-from typing import BinaryIO
+from typing import Any, BinaryIO
 
 from ..errors import LemmaNotFoundError
 from ..openapi_client.api.files import (
@@ -41,8 +41,40 @@ from .base import BoundResource
 
 
 class PodFiles(BoundResource):
-    def list(self, path: str = "/", *, limit: int = 100) -> FileListResponse:
-        return self._call(file_list, self._pod_uuid(), directory_path=path, limit=limit)
+    def list(
+        self,
+        path: str = "/",
+        *,
+        limit: int = 100,
+        page_token: str | None = None,
+    ) -> FileListResponse:
+        """One page of a directory's entries.
+
+        A directory with more entries than ``limit`` is truncated, and the
+        response's ``next_page_token`` is the only way to see the rest --
+        without passing it back, a caller that must be complete (an export, a
+        sync) silently sees a prefix. See :meth:`list_all`.
+        """
+        kwargs: dict[str, object] = {"directory_path": path, "limit": limit}
+        if page_token is not None:
+            kwargs["page_token"] = page_token
+        return self._call(file_list, self._pod_uuid(), **kwargs)
+
+    def list_all(self, path: str = "/", *, page_size: int = 500) -> list[Any]:
+        """Every entry in a directory, paged to exhaustion.
+
+        The API caps a page and the directory-tree endpoint caps files per
+        directory, so "list a directory" and "list all of a directory" are
+        different operations. Anything that has to be complete wants this one.
+        """
+        entries: list[Any] = []
+        token: str | None = None
+        while True:
+            page = self.list(path, limit=page_size, page_token=token)
+            entries.extend(getattr(page, "items", None) or [])
+            token = getattr(page, "next_page_token", None)
+            if not isinstance(token, str) or not token:
+                return entries
 
     def get(self, path: str) -> FileDetailResponse:
         return self._call(file_get, self._pod_uuid(), path=path)


### PR DESCRIPTION
## What changes

A pod bundle now contains the pod's files — all of them — and a bundle this code
writes can be imported by it. Caps stay; what changes is that a cap now says
what it dropped.

## Why

Migrating a real pod between servers exported **104 of its 266 files** and
reported success. The summary counted what the bundle held, so the number looked
right. The other 162 files were never seen.

| root | in the pod | in the bundle |
|---|---|---|
| knowledge | 151 | 87 |
| library | 63 | 15 |
| memory | 2 | 2 |
| skills | 45 | **0** |

**The export read a preview and treated it as the pod.** The file index came
from the directory-*tree* endpoint, whose `files_per_directory` defaults to
**3** and caps at **20**. A directory of twelve files exported three.

The backend's own exporter already walks with the listing endpoint, and its
docstring says exactly why — *"the tree endpoint caps files-per-dir, so we walk
with `list_files` instead"*. The CLI walked into the trap the backend had
already documented.

**Skills were dropped from every bundle.** The tree returns the whole `/skills`
subtree with `visibility` absent, and export keeps only `visibility == "POD"` —
even though the listing endpoint reports `/skills` as `POD`. A pod's skills
could not be migrated at all.

**The warnings were folded out of view.** Every warning says something was left
out of the bundle, and they reached the caller only inside a summary panel that
folds long fields — so the one line saying a file had been skipped was the line
most likely to be hidden.

## How

- **Both callers page the listing endpoint to exhaustion.** `files.list` grew a
  `page_token`, and `files.list_all` pages for callers that must be complete.
  The walk is guarded against a directory that lists *itself* — the backend
  records that a home folder does exactly this, recursed until the interpreter
  gave up, and the error was swallowed, so every pod with a home folder exported
  an empty `files/` and said nothing.
- **Import walks the same index**, so it was planning against a partial picture
  too and could recreate a file it had simply not been shown.
- **Caps are unchanged and still deliberate** — a bundle is resources plus a
  little seed data, not a bulk dump — but the byte budget already names each
  item it skips, and those messages now print instead of being folded away.

Two round-trip bugs found while migrating, both of which stopped a bundle this
code wrote from being imported by it:

- **A schedule exported its runtime state.** The strip list had drifted from the
  API: it removes `last_run_at`/`next_run_at` and not the seven fields that
  replaced them, so import refused the bundle by name — `Unrecognized field(s)
  on schedule` — and the only way through was editing the JSON by hand. When a
  schedule last fired, what it returned, and how many times it has failed belong
  to the pod it ran in, never to the pod it is being copied into.
- **A TEXT column holding digits could not be imported.** CSV has no types, so
  the reader guessed: `year` = `"2026"` arrived as an int and Postgres refused —
  `invalid input for query argument $13: 2026 (expected str, got int)`. A year,
  a postcode, an ISBN, a version, an account number: all text that looks like a
  number, and any one of them stops a pod from importing. The declared type sits
  in the table's own JSON next to the data file, so it is used.

## How to verify

```bash
cd lemma-cli && uv run pytest tests -q
make quality
```

Ran locally: 632 CLI tests, quality gates pass.

New tests:

- `test_fetch_files_index_sees_every_file_not_the_first_few` — twelve files in a
  directory, all twelve exported, and the walk pages rather than taking one
  page. Its fake refuses `tree` outright, so the old approach cannot come back.
- `test_fetch_files_index_keeps_walking_when_a_folder_lists_itself` — the
  self-listing home folder.
- `test_fetch_files_index_reports_a_pod_visible_skills_tree` — skills survive.
- `test_a_schedule_exports_without_where_it_last_ran` — definition kept, runtime
  state dropped, field by field.
- `test_a_text_column_holding_digits_survives_a_csv_round_trip` and a companion
  proving no conversion is invented when the table declares nothing usable.

The existing tests describe pods as trees, which still says what is in each
directory, so the harness derives a listing from them in one place rather than
restating every fixture. Tests that are *about* the walk build their own
listing fake.

Verified end to end on the migration that surfaced this: after copying the
missing files by hand, the target pod holds all 266 files and all 468 rows.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **API surface** — no API change; `files.list` gains an optional
      `page_token` argument on the existing hand-written SDK facade, and
      `list_all` is additive
- [ ] **Rollback** — revert. Export goes back to writing bundles that silently
      omit files, so prefer fixing forward.