### PR TITLE
Let an Agent Host run last hours, not fifty minutes

### DIFF
--- a/lemma-backend/app/core/infrastructure/jobs/streaq_runtime.py
+++ b/lemma-backend/app/core/infrastructure/jobs/streaq_runtime.py
@@ -265,13 +265,21 @@ _SHUTDOWN_STEP_TIMEOUT_SECONDS = 5.0
 JOB_TIMEOUT_SECONDS = 1800
 # An agent run is the one task whose ceiling is not ours to pick freely: it
 # advertises a deadline to something outside this process (an Agent Host on a
-# user's machine) and hands it a credential that expires. If the task dies
-# first, Lemma reports the run failed while the remote agent keeps executing
-# tools for it. This must therefore stay strictly above the Agent Host run
-# window (DEFAULT_AGENT_HOST_EVENT_TIMEOUT_SECONDS, 50 min) with enough margin
-# for the harness to cancel the host run and finalize, and strictly below the
-# one-hour validity of the MCP credential minted at dispatch.
-AGENT_RUN_JOB_TIMEOUT_SECONDS = 3300
+# user's machine). If the task dies first, Lemma reports the run failed while
+# the remote agent keeps executing tools for it. This must therefore stay above
+# the Agent Host run window (DEFAULT_AGENT_HOST_EVENT_TIMEOUT_SECONDS) with
+# enough margin for the harness to cancel the host run and finalize.
+#
+# It used to also have to stay under the one-hour validity of the MCP
+# credential minted at dispatch. That stopped being true when the harness
+# started refreshing that credential mid-run, and the note saying otherwise
+# outlived the constraint it described -- long enough to hold every run to
+# fifty minutes for a reason that no longer applied.
+#
+# A task this long occupies an interactive-lane slot for its whole life. That
+# is affordable at the default concurrency of 50 and is the real thing to watch
+# if these runs ever become common.
+AGENT_RUN_JOB_TIMEOUT_SECONDS = 14700
 JOB_MAX_RETRIES = 3
 # Keep completed task metadata around long enough for the UI to be useful.
 JOB_RESULT_TTL_SECONDS = 60 * 60 * 24

--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -52,7 +52,6 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'agent.harnesses.agent_host.credential_expiry_unknown.degraded': EventSpec('warning', frozenset({'agent_run_id'})),
     'agent.harnesses.agent_host.credential_refresh_failed.degraded': EventSpec('warning', frozenset({'agent_run_id', 'error_type'})),
     'agent.harnesses.agent_host.event_stream_read.degraded': EventSpec('warning', frozenset({'agent_run_id', 'attempt', 'error_type'})),
-    'agent.harnesses.agent_host.run_deadline_capped_by_credential.degraded': EventSpec('warning', frozenset({'agent_run_id', 'timeout_seconds'})),
     'agent.history.compacted.observed': EventSpec('info', frozenset({'folded_pin_count', 'kept_count', 'pinned_count', 'size_after', 'size_before', 'summarized_count'})),
     'agent.history.summarization_failed.degraded': EventSpec('warning', frozenset({'transcript_length'})),
     'agent.history.token_ceiling_enforced.degraded': EventSpec('warning', frozenset({'dropped_count', 'size_after', 'size_before'})),

--- a/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host/run_window.py
+++ b/lemma-backend/app/modules/agent/infrastructure/harnesses/agent_host/run_window.py
@@ -27,20 +27,31 @@ from app.modules.agent.infrastructure.harnesses.agent_host.events import (
 logger = get_logger(__name__)
 
 # The deadline we hand the host, and therefore the real lifetime of the run.
-# It is bounded from above by two things that are not negotiable:
 #
-#   * the worker task that drives the harness (AGENT_RUN_JOB_TIMEOUT_SECONDS,
-#     55 minutes). Past that, streaq cancels the job and Lemma reports the run
-#     failed - so a deadline beyond it is a deadline we cannot honour, and the
-#     host would keep executing a run we have already given up on;
-#   * the MCP credential encrypted into START_RUN, which the SuperTokens core
-#     issues with a one-hour validity and which nothing refreshes.
+# This was 50 minutes, and the reason given was the MCP credential encrypted
+# into START_RUN: the SuperTokens core issues it with a one-hour validity, and
+# "nothing refreshes" it. Something does now -- `refresh_credential` mints a
+# replacement and sends it to the host as a command, on the margin below -- so
+# the credential stopped being the ceiling and the 50 minutes outlived its own
+# justification. What it cost was an agent working steadily on a real task
+# being killed at minute fifty with "run deadline elapsed", which is a system
+# failure wearing the clothes of a policy.
 #
-# 50 minutes sits inside both with room for the harness to notice its own
-# deadline, cancel the host run, and finalize before either ceiling bites. It
-# also comfortably exceeds the host's 30-minute permission window, so a
-# permission parked mid-run can still be answered before the run is over.
-DEFAULT_AGENT_HOST_EVENT_TIMEOUT_SECONDS = 3000.0
+# A long deadline is safe because it is not what detects a host that has gone
+# away. The run lease is 90 seconds and is checked every 5, so a host that
+# crashed, slept or lost its network is failed inside two minutes no matter how
+# far off the deadline is. The deadline exists only to bound a host that is
+# still answering and still working.
+#
+# What it must still sit inside:
+#
+#   * the worker task that drives the harness
+#     (AGENT_RUN_JOB_TIMEOUT_SECONDS). Past that, streaq cancels the job and
+#     Lemma reports the run failed -- so a deadline beyond it is one we cannot
+#     honour, and the host would keep executing a run we have given up on;
+#   * comfortably above the host's 30-minute permission window, so a permission
+#     parked mid-run can still be answered before the run is over.
+DEFAULT_AGENT_HOST_EVENT_TIMEOUT_SECONDS = 14400.0
 # Stop this far short of the credential's own expiry, so the last tool call of
 # a run is still made with a token that is valid.
 CREDENTIAL_SAFETY_MARGIN_SECONDS = 120.0
@@ -126,16 +137,24 @@ def credential_bounded_timeout(
     now: datetime,
     agent_run_id: UUID,
 ) -> tuple[float, bool]:
-    """Bound the run by the credential it is being dispatched with.
+    """Refuse to dispatch a run whose credential is already spent.
 
-    A run is no longer stuck with that credential — the consume loop renews it
-    in flight (:func:`credential_refresh_due`) — so this is the conservative
-    starting bound rather than the run's real ceiling, and it normally does
-    nothing: a fresh token outlives the configured window.
+    This used to also *shorten* the run to the credential's remaining life. That
+    made sense while the token was the run's real ceiling, and it was harmless
+    while the window was fifty minutes, because a fresh one-hour token outlived
+    it and the clamp never fired.
 
-    What it still does is refuse to dispatch at all when there is not enough
-    credential left to be worth starting, so the turn fails immediately rather
-    than a minute later for a reason nobody can see.
+    It is neither now. The consume loop renews the credential in flight
+    (:func:`credential_refresh_due`), so the token dispatched with the run is a
+    starting point rather than a limit -- and against a window measured in hours
+    a clamp to the *initial* expiry would fire on every single run, quietly
+    putting back the ceiling this was supposed to have lifted.
+
+    So the expiry no longer bounds the window. What it still does is refuse to
+    start a run there is not enough credential left to be worth starting, and
+    the run that outlives every attempt to renew is ended explicitly by
+    :func:`credential_exhausted` rather than left to discover its tools have
+    stopped working.
     """
     if credential_expires_at is None:
         # An opaque credential silently disables all three of the protections
@@ -153,18 +172,11 @@ def credential_bounded_timeout(
     usable = (
         credential_expires_at - now
     ).total_seconds() - CREDENTIAL_SAFETY_MARGIN_SECONDS
-    if usable >= configured_seconds:
-        return configured_seconds, False
     if usable < MINIMUM_RUN_SECONDS:
         raise RuntimeError(
             "The Lemma credential for this run expires too soon to dispatch it"
         )
-    logger.warning(
-        "agent.harnesses.agent_host.run_deadline_capped_by_credential.degraded",
-        agent_run_id=str(agent_run_id),
-        timeout_seconds=int(usable),
-    )
-    return usable, True
+    return configured_seconds, False
 
 
 def failure_events(

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_host_run_window.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_host_run_window.py
@@ -23,6 +23,7 @@ from app.core.infrastructure.jobs.streaq_runtime import (
 from app.modules.agent.events.handlers import _ORPHANED_RUN_CUTOFF_SECONDS
 from app.modules.agent.infrastructure.agent_host.repository_common import (
     DEFAULT_PERMISSION_COMMAND_TTL_SECONDS,
+    DEFAULT_RUN_LEASE_SECONDS,
 )
 from app.modules.agent.infrastructure.harnesses.agent_host.run_window import (
     CREDENTIAL_DEADLINE_MESSAGE,
@@ -63,6 +64,29 @@ class TestTheCeilingsAgree:
 
     def test_the_orphan_sweep_never_reaps_a_healthy_run(self) -> None:
         assert _ORPHANED_RUN_CUTOFF_SECONDS > AGENT_RUN_JOB_TIMEOUT_SECONDS
+
+    def test_a_run_may_last_hours(self) -> None:
+        """An agent host run is a person's real task, not a request.
+
+        A run doing steady work was killed at minute fifty with "run deadline
+        elapsed". The number came from a chain of ceilings whose binding link --
+        the one-hour MCP credential -- stopped binding once the harness began
+        refreshing it in flight, and the note explaining the number outlived the
+        constraint it described.
+        """
+        assert DEFAULT_AGENT_HOST_EVENT_TIMEOUT_SECONDS >= 4 * 60 * 60
+
+    def test_a_host_that_goes_away_is_caught_by_the_lease_not_the_deadline(
+        self,
+    ) -> None:
+        """Why a long deadline is safe.
+
+        The deadline does not detect a host that crashed, slept or lost its
+        network -- the lease does, and it is an order of magnitude shorter. If
+        that ever stopped being true, a dead host would sit RUNNING for hours.
+        """
+        assert DEFAULT_RUN_LEASE_SECONDS < 300
+        assert DEFAULT_RUN_LEASE_SECONDS * 10 < DEFAULT_AGENT_HOST_EVENT_TIMEOUT_SECONDS
 
     def test_a_permission_parked_mid_run_can_still_be_answered(self) -> None:
         """When the run is shorter than the host's permission window, every
@@ -128,9 +152,15 @@ class TestCredentialBoundedTimeout:
         assert seconds == DEFAULT_AGENT_HOST_EVENT_TIMEOUT_SECONDS
         assert bounded is False
 
-    def test_a_short_credential_shortens_the_run(self) -> None:
-        """The bridge sends this token verbatim for the run's whole life with no
-        refresh, so outliving it means every lemma_* call 401s in silence."""
+    def test_a_short_credential_no_longer_shortens_the_run(self) -> None:
+        """The token is renewed in flight, so its expiry is a starting point.
+
+        This used to clamp the window to whatever was left of the credential.
+        Harmless while the window was fifty minutes -- a fresh one-hour token
+        outlived it, so the clamp never fired -- and wrong against a window
+        measured in hours, where it would fire on every run and quietly put the
+        old ceiling back.
+        """
         seconds, bounded = credential_bounded_timeout(
             configured_seconds=DEFAULT_AGENT_HOST_EVENT_TIMEOUT_SECONDS,
             credential_expires_at=_now() + timedelta(minutes=20),
@@ -138,10 +168,21 @@ class TestCredentialBoundedTimeout:
             agent_run_id=uuid7(),
         )
 
-        assert bounded is True
-        assert seconds < DEFAULT_AGENT_HOST_EVENT_TIMEOUT_SECONDS
-        # Stops short of the expiry, so the last tool call still has a live token.
-        assert seconds < 20 * 60
+        assert bounded is False
+        assert seconds == DEFAULT_AGENT_HOST_EVENT_TIMEOUT_SECONDS
+
+    def test_a_fresh_credential_does_not_cap_a_multi_hour_window(self) -> None:
+        """The regression that raising the window would otherwise have hit: a
+        one-hour token against a four-hour run."""
+        seconds, bounded = credential_bounded_timeout(
+            configured_seconds=DEFAULT_AGENT_HOST_EVENT_TIMEOUT_SECONDS,
+            credential_expires_at=_now() + timedelta(hours=1),
+            now=_now(),
+            agent_run_id=uuid7(),
+        )
+
+        assert bounded is False
+        assert seconds == DEFAULT_AGENT_HOST_EVENT_TIMEOUT_SECONDS
 
     def test_an_almost_expired_credential_refuses_to_dispatch(self) -> None:
         with pytest.raises(RuntimeError, match="expires too soon"):


### PR DESCRIPTION
## What changes

An Agent Host run may now last four hours instead of fifty minutes.

## Why

A local agent working steadily on a real task was killed mid-work:

> Agent Host run deadline elapsed; the provider process was terminated

Its journal entry shows the window it was given:

| run | created | deadline | window |
|---|---|---|---|
| `01a0567a` | 06:21:07 | 07:11:08 | **50.0 min** |

So the ceiling did exactly what it was told — this was policy, not a
malfunction. **But the reason that number existed had gone away.**

The window was bounded from above by the MCP credential encrypted into
`START_RUN`: a one-hour validity which, as the comment in `streaq_runtime.py`
put it, `nothing refreshes`. Something does now — `refresh_credential` mints a
replacement and enqueues it to the host as a command, on a ten-minute margin.
Once that landed, the credential stopped being the ceiling, and the note
explaining the fifty minutes outlived the constraint it described. Every run
since has been cut short for a reason that no longer applied.

## How

The ceilings are one chain, so they move together:

| | before | after |
|---|---|---|
| `DEFAULT_AGENT_HOST_EVENT_TIMEOUT_SECONDS` | 3000 (50 min) | 14400 (4 h) |
| `AGENT_RUN_JOB_TIMEOUT_SECONDS` | 3300 (55 min) | 14700 (4 h 5 min) |
| `_ORPHANED_RUN_CUTOFF_SECONDS` | derived | derived, follows automatically |

**A second clamp had to go with them.** `credential_bounded_timeout` also
shortened the run to whatever was left of the credential at dispatch. That was
harmless while the window was fifty minutes — a fresh one-hour token outlived
it, so the clamp never fired — and against a window measured in hours it would
have fired on *every single run*, quietly putting the old ceiling back at ~58
minutes. Its own docstring had assumed exactly this ("a fresh token outlives the
configured window"), and the existing test caught it the moment the window
moved.

It now refuses to start a run whose credential is already spent, and nothing
more. A run that outlives every attempt to renew is still ended explicitly by
`credential_exhausted`, rather than left to discover its Lemma tools have
started 401ing.

The `run_deadline_capped_by_credential.degraded` event lost its only emitter and
is removed from the catalog with it.

## Why a long deadline is safe

**The deadline is not what detects a host that has gone away.** The run lease is
90 seconds and is checked every 5, so a host that crashed, slept, or lost its
network is failed within about two minutes however distant the deadline is. The
deadline only bounds a host that is still answering and still working. That is
now pinned by a test, because if it ever stopped being true a dead host would
sit `RUNNING` for hours.

The real cost is that one run holds an interactive-lane slot for its whole life.
That is affordable at the default concurrency of 50, and it is stated in the
comment rather than left to be discovered.

## How to verify

```bash
cd lemma-backend && uv run pytest app/modules/agent/tests/unit -q
make quality
```

Ran locally: 1450 agent unit tests, quality gates pass.

New and changed tests, all in `test_agent_host_run_window.py` beside the
existing ceiling invariants:

- `test_a_run_may_last_hours`
- `test_a_host_that_goes_away_is_caught_by_the_lease_not_the_deadline`
- `test_a_fresh_credential_does_not_cap_a_multi_hour_window` — the regression
  raising the window would otherwise have hit
- `test_a_short_credential_no_longer_shortens_the_run` — replaces the test that
  asserted the clamp

The pre-existing invariants still hold unchanged: the worker outlives the
advertised deadline with margin, the orphan sweep never reaps a healthy run, and
a permission parked mid-run can still be answered.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [ ] **Rollback** — revert; runs go back to being cut at fifty minutes.