### PR TITLE
Stop the scenario suite reporting its own noise as failures

### DIFF
--- a/tests/scenarios/harness/drivers/api.py
+++ b/tests/scenarios/harness/drivers/api.py
@@ -19,12 +19,34 @@ Two conventions worth knowing:
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any
 
 import httpx
 
 JSON = dict[str, Any]
+
+#: How many times a throttled request is sent again before giving up, and how
+#: long to wait between tries. Doubling from a fifth of a second gives about
+#: three seconds in total — long enough to ride out the bursts this suite
+#: creates, short enough that a deployment which is genuinely refusing still
+#: fails inside a scenario's own deadline rather than eating it.
+_THROTTLE_ATTEMPTS = 5
+_THROTTLE_BACKOFF_SECONDS = 0.2
+
+
+def _is_throttling(response: httpx.Response) -> bool:
+    """A 429 that means "slow down", not one that means "you are over a limit"."""
+    if response.status_code != 429:
+        return False
+    try:
+        code = str((response.json() or {}).get("code") or "")
+    except Exception:
+        # A throttle from a proxy or gateway need not answer in our JSON shape,
+        # and an unreadable body is not evidence of a deliberate refusal.
+        return True
+    return code != "USAGE_LIMIT_EXCEEDED"
 
 
 class UnexpectedResponse(AssertionError):
@@ -95,7 +117,7 @@ class ApiDriver:
         return {"Authorization": f"Bearer {self._token}"} if self._token else {}
 
     async def call(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
-        response = await self._send(method, path, **kwargs)
+        response = await self._send_through_throttling(method, path, **kwargs)
         if not self._session_ran_out(response):
             return response
         # Renew once and try again. Once, because a second 401 after a fresh
@@ -108,7 +130,33 @@ class ApiDriver:
             await self._renew()  # type: ignore[misc]
         finally:
             self._renewing = False
-        return await self._send(method, path, **kwargs)
+        return await self._send_through_throttling(method, path, **kwargs)
+
+    async def _send_through_throttling(
+        self, method: str, path: str, **kwargs: Any
+    ) -> httpx.Response:
+        """Send, and try again while the deployment is asking us to slow down.
+
+        A throttling 429 is the deployment saying "ask again shortly". It is
+        never the product being broken, and every client worth the name retries
+        it — so a scenario that reports one as a failure is reporting the
+        suite's own burstiness as a defect. This suite is a burst by nature:
+        hundreds of requests from one runner against a deployment other people
+        are also using. Three scenarios died on a 429 in a single run, and the
+        signup that seeds the whole tenant died on one in another.
+
+        Deliberately narrow, in the same way the 401 renewal below is. A spend
+        cap also answers 429, and *that* one is a promise
+        (`test_work_over_the_limit_is_refused_clearly` asserts it): a refusal
+        naming the limit it hit is an answer, not a "come back later", so it is
+        returned untouched and only an unnamed throttle is retried.
+        """
+        for attempt in range(_THROTTLE_ATTEMPTS):
+            response = await self._send(method, path, **kwargs)
+            if not _is_throttling(response) or attempt == _THROTTLE_ATTEMPTS - 1:
+                return response
+            await asyncio.sleep(_THROTTLE_BACKOFF_SECONDS * (2**attempt))
+        return response
 
     def _session_ran_out(self, response: httpx.Response) -> bool:
         """A 401 on a request that carried a token, and that we can do something about.

--- a/tests/scenarios/harness/steps/agent.py
+++ b/tests/scenarios/harness/steps/agent.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from harness.run import a_name_for
 from harness.drivers.api import every_item, items_of
-from harness.waiting import eventually
+from harness.waiting import eventually, UNTIL_A_MODEL_ACTS
 
 JSON = dict[str, Any]
 
@@ -394,13 +394,29 @@ class AgentSteps:
         return response.json() if response.content else {}
 
     async def waits_for_an_approval_in(
-        self, conversation: JSON, *, in_pod: JSON, after: int = 0, timeout: float = 60.0
+        self,
+        conversation: JSON,
+        *,
+        in_pod: JSON,
+        after: int = 0,
+        timeout: float = UNTIL_A_MODEL_ACTS,
     ) -> list[JSON]:
-        """Wait until the run has asked a person for permission."""
+        """Wait until the run has asked a person for permission.
+
+        On the model budget, not the run one. What is being waited for is a
+        model reading its instructions and *choosing* to call the question
+        tool — a queued run reaches that two turns in, and at sixty seconds
+        this reported "it never happened" three times in thirty-one runs while
+        the product was working perfectly.
+        """
         return await eventually(
             lambda: self.approvals_in(conversation, in_pod=in_pod),
             lambda requests: len(requests) > after,
-            describe=f"an approval request in conversation {conversation['id']}",
+            describe=(
+                f"an approval request in conversation {conversation['id']} — "
+                f"the agent was told to ask before acting and had "
+                f"{timeout:.0f}s to do it"
+            ),
             timeout=timeout,
         )
 

--- a/tests/scenarios/harness/waiting.py
+++ b/tests/scenarios/harness/waiting.py
@@ -28,6 +28,37 @@ T = TypeVar("T")
 DEFAULT_TIMEOUT = 20.0
 DEFAULT_INTERVAL = 0.1
 
+# The bounds, named for what is being waited on rather than written as a number
+# at each call site. Thirty-two call sites carried eight different literals, and
+# the docstring above already claimed the bound "lives in one place" — it did
+# not, so when a shared deployment was slow there was no one number to move and
+# a scenario failed on whichever literal happened to be tightest that day.
+#
+# Each is set from the slowest *healthy* observation of that kind of work, not
+# from what usually happens. Being generous costs a green run nothing: a
+# deadline is only ever reached when something has already gone wrong, so the
+# price of a larger bound is paid solely by a run that was going to fail anyway.
+# The assertion is unchanged either way — only the patience is.
+
+#: A write becoming readable: a cache invalidating, a role taking effect, a row
+#: appearing to a watcher. Fast, and slow only when something is wrong.
+UNTIL_A_CHANGE_IS_VISIBLE = 30.0
+
+#: An agent run reaching a terminal state, once it has started. Covers the queue
+#: as well as the model, because a scenario cannot see the difference.
+UNTIL_A_RUN_SETTLES = 120.0
+
+#: A real model producing a reply, or choosing to call a tool. The longest
+#: bound, and the one worth being most generous with: it is the only kind of
+#: wait whose length is decided by something outside this system, and a run that
+#: is merely queued behind another looks exactly like one that will never
+#: answer.
+UNTIL_A_MODEL_ACTS = 180.0
+
+#: Work the product does on its own schedule — a trigger firing, a document
+#: converting, a bundle exporting, a failing schedule giving up.
+UNTIL_BACKGROUND_WORK_LANDS = 180.0
+
 
 class NeverHappened(AssertionError):
     """A condition did not hold within its bound."""

--- a/tests/scenarios/journeys/agents_and_conversations/test_asking_and_delegating.py
+++ b/tests/scenarios/journeys/agents_and_conversations/test_asking_and_delegating.py
@@ -9,6 +9,7 @@ rather than disappearing into a side channel.
 from __future__ import annotations
 
 from harness import capability, covers, journey, proves, scenario
+from harness.waiting import UNTIL_A_MODEL_ACTS
 from harness.credentials import needs
 from harness.environment import MODEL_IS_REAL
 from harness.steps.datastore import column
@@ -218,7 +219,7 @@ async def test_an_agent_delegates_to_a_subagent(world):
         ),
     )
     await alice.waits_for_the_run_to_settle(
-        conversation=conversation, in_pod=pod, timeout=120.0
+        conversation=conversation, in_pod=pod, timeout=UNTIL_A_MODEL_ACTS
     )
 
     # The parent's own transcript is where a person looks, and the delegation

--- a/tests/scenarios/journeys/agents_and_conversations/test_controlling_an_agent.py
+++ b/tests/scenarios/journeys/agents_and_conversations/test_controlling_an_agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from harness import capability, covers, journey, proves, scenario
+from harness.waiting import UNTIL_A_MODEL_ACTS
 
 pytestmark = [journey("Agents and conversations"), capability("Stay in control")]
 
@@ -103,7 +104,7 @@ async def test_a_message_sent_mid_run_is_answered(pod):
     assert isinstance(added["started_new_run"], bool)
 
     await alice.waits_for_the_run_to_settle(
-        conversation=conversation, in_pod=the_pod, timeout=90.0
+        conversation=conversation, in_pod=the_pod, timeout=UNTIL_A_MODEL_ACTS
     )
     messages = await alice.messages_in(conversation, in_pod=the_pod)
 

--- a/tests/scenarios/journeys/automating_work/test_waiting_runs.py
+++ b/tests/scenarios/journeys/automating_work/test_waiting_runs.py
@@ -10,7 +10,7 @@ second time.
 from __future__ import annotations
 
 from harness import capability, covers, journey, proves, scenario
-from harness.waiting import eventually
+from harness.waiting import eventually, UNTIL_A_RUN_SETTLES
 
 pytestmark = [
     journey("Automating work"),
@@ -57,7 +57,7 @@ async def _a_waiting_run(alice, pod):
         lambda: alice.api.get(f"/pods/{pod['id']}/workflow-runs/{run['id']}"),
         lambda state: str(state.get("status")).upper() == "WAITING",
         describe="the run to stop on the person it needs",
-        timeout=60.0,
+        timeout=UNTIL_A_RUN_SETTLES,
     )
     return workflow, waiting
 
@@ -107,7 +107,7 @@ async def test_answering_resumes_the_run(world):
             str(state.get("status")).upper() in {"COMPLETED", "FAILED", "CANCELLED"}
         ),
         describe="the run to carry on once it was answered",
-        timeout=60.0,
+        timeout=UNTIL_A_RUN_SETTLES,
     )
     assert str(finished.get("status")).upper() == "COMPLETED", (
         f"the run resumed and then did not finish cleanly: {finished}"
@@ -142,7 +142,7 @@ async def test_a_repeated_answer_resumes_once(world):
             str(state.get("status")).upper() in {"COMPLETED", "FAILED", "CANCELLED"}
         ),
         describe="the run to reach a terminal state",
-        timeout=60.0,
+        timeout=UNTIL_A_RUN_SETTLES,
     )
     assert str(finished.get("status")).upper() == "COMPLETED", (
         f"submitting the same answer twice broke the run: {finished} "
@@ -176,7 +176,7 @@ async def test_cancelling_a_live_run_stops_it(world):
         lambda: alice.api.get(f"/pods/{pod['id']}/workflow-runs/{run['id']}"),
         lambda state: str(state.get("status")).upper() == "CANCELLED",
         describe="the run to report itself stopped",
-        timeout=60.0,
+        timeout=UNTIL_A_RUN_SETTLES,
     )
     assert str(stopped.get("status")).upper() == "CANCELLED", stopped
 

--- a/tests/scenarios/journeys/connectors_and_accounts/test_provider_trouble.py
+++ b/tests/scenarios/journeys/connectors_and_accounts/test_provider_trouble.py
@@ -14,6 +14,7 @@ import time
 import pytest
 
 from harness import capability, covers, journey, proves, scenario
+from harness.waiting import UNTIL_A_RUN_SETTLES
 
 pytestmark = [
     journey("Connectors and accounts"),
@@ -99,7 +100,7 @@ async def test_a_hanging_provider_is_given_up_on(connected):
                 f"{auth_config['name']}/operations/{SLOW}/execute",
                 json={"payload": {}},
             ),
-            timeout=90.0,
+            timeout=UNTIL_A_RUN_SETTLES,
         )
     except TimeoutError:  # pragma: no cover - the failure this is looking for
         raise AssertionError(

--- a/tests/scenarios/journeys/operating_a_deployment/test_usage_ledger.py
+++ b/tests/scenarios/journeys/operating_a_deployment/test_usage_ledger.py
@@ -14,7 +14,7 @@ from harness import capability, covers, journey, proves, scenario
 from harness.credentials import needs
 from harness.environment import MODEL_IS_REAL
 from harness.steps.datastore import column
-from harness.waiting import eventually
+from harness.waiting import eventually, UNTIL_A_RUN_SETTLES
 
 pytestmark = [
     journey("Operating a deployment"),
@@ -52,7 +52,7 @@ async def test_a_run_is_always_recorded(after_a_run):
         lambda: _events(alice, organization),
         bool,
         describe="the run to reach the usage ledger",
-        timeout=60.0,
+        timeout=UNTIL_A_RUN_SETTLES,
     )
 
     assert recorded, "a completed agent run left no usage record at all"
@@ -80,7 +80,7 @@ async def test_a_usage_record_is_attributed(after_a_run):
         lambda: _events(alice, organization),
         bool,
         describe="the run to reach the usage ledger",
-        timeout=60.0,
+        timeout=UNTIL_A_RUN_SETTLES,
     )
     entry = recorded[0]
 
@@ -150,7 +150,7 @@ async def test_a_failed_run_is_recorded_too(world, run):
         lambda: _events(alice, organization),
         bool,
         describe="a run that did not get what it wanted to reach the ledger",
-        timeout=60.0,
+        timeout=UNTIL_A_RUN_SETTLES,
     )
     assert recorded, (
         "a run that spent tokens and then failed left no usage record, so its "

--- a/tests/scenarios/journeys/packaging_and_reuse/test_bundles_and_apps.py
+++ b/tests/scenarios/journeys/packaging_and_reuse/test_bundles_and_apps.py
@@ -7,7 +7,7 @@ import pytest
 
 from harness import capability, covers, journey, proves, scenario
 from harness.steps.datastore import column
-from harness.waiting import eventually
+from harness.waiting import eventually, UNTIL_BACKGROUND_WORK_LANDS
 
 pytestmark = [journey("Packaging and reuse"), capability("Take a pod with you")]
 
@@ -43,7 +43,7 @@ async def test_a_pod_exports_to_a_downloadable_bundle(pod):
         ),
         lambda payload: str(payload.get("status")).upper() in TERMINAL_EXPORT,
         describe="the export to finish",
-        timeout=90.0,
+        timeout=UNTIL_BACKGROUND_WORK_LANDS,
     )
     assert str(finished["status"]).upper() == "READY", finished
     assert finished.get("download_url") or finished.get("url"), (

--- a/tests/scenarios/journeys/platform/test_agent_host_dispatch.py
+++ b/tests/scenarios/journeys/platform/test_agent_host_dispatch.py
@@ -16,7 +16,7 @@ from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 from harness import capability, covers, journey, proves, scenario
-from harness.waiting import eventually
+from harness.waiting import eventually, UNTIL_A_RUN_SETTLES
 
 pytestmark = [journey("Platform"), capability("Agent hosts")]
 
@@ -184,7 +184,7 @@ async def test_dispatched_work_is_claimed_exactly_once(world):
             first_claim,
             bool,
             describe="the paired host to be offered the dispatched run",
-            timeout=120.0,
+            timeout=UNTIL_A_RUN_SETTLES,
         )
         assert len(commands) == 1, (
             f"one message became {len(commands)} START_RUN claims on the host: "

--- a/tests/scenarios/journeys/scheduling_and_triggers/test_failing_schedules.py
+++ b/tests/scenarios/journeys/scheduling_and_triggers/test_failing_schedules.py
@@ -16,7 +16,7 @@ import pytest
 
 from harness import capability, covers, journey, proves, scenario
 from harness.steps.datastore import column
-from harness.waiting import eventually
+from harness.waiting import eventually, UNTIL_BACKGROUND_WORK_LANDS
 
 pytestmark = [
     journey("Scheduling and triggers"),
@@ -78,7 +78,7 @@ async def test_repeated_failure_stops_a_schedule(doomed):
         lambda: alice.opens_schedule(schedule, in_pod=pod),
         lambda state: state.get("is_active") is False,
         describe="the schedule to give up after a run of failures",
-        timeout=180.0,
+        timeout=UNTIL_BACKGROUND_WORK_LANDS,
     )
 
     assert stopped.get("paused_by_failures") is True, (
@@ -104,7 +104,7 @@ async def test_a_stopped_schedule_explains_itself(doomed):
         lambda: alice.opens_schedule(schedule, in_pod=pod),
         lambda state: state.get("is_active") is False,
         describe="the schedule to give up after a run of failures",
-        timeout=180.0,
+        timeout=UNTIL_BACKGROUND_WORK_LANDS,
     )
 
     # "It stopped" without "here is what went wrong" leaves a person with
@@ -146,7 +146,7 @@ async def test_a_stopped_schedule_can_be_restarted(doomed):
         lambda: alice.opens_schedule(schedule, in_pod=pod),
         lambda state: state.get("is_active") is False,
         describe="the schedule to give up after a run of failures",
-        timeout=180.0,
+        timeout=UNTIL_BACKGROUND_WORK_LANDS,
     )
 
     await alice.resumes_schedule(schedule, in_pod=pod)

--- a/tests/scenarios/journeys/scheduling_and_triggers/test_narrowing_triggers.py
+++ b/tests/scenarios/journeys/scheduling_and_triggers/test_narrowing_triggers.py
@@ -14,7 +14,7 @@ import pytest
 
 from harness import capability, covers, journey, proves, scenario
 from harness.steps.datastore import column
-from harness.waiting import eventually
+from harness.waiting import eventually, UNTIL_BACKGROUND_WORK_LANDS
 
 pytestmark = [
     journey("Scheduling and triggers"),
@@ -74,7 +74,7 @@ async def test_a_change_below_the_condition_is_skipped(watching_for_done):
         lambda: alice.opens_schedule(schedule, in_pod=pod),
         lambda state: state.get("last_fire_status") is not None,
         describe="the trigger to be recorded even though it was skipped",
-        timeout=60.0,
+        timeout=UNTIL_BACKGROUND_WORK_LANDS,
     )
 
     # Recorded at all is the first half of the promise: a trigger silently
@@ -104,7 +104,7 @@ async def test_a_change_meeting_the_condition_fires(watching_for_done):
         lambda: _runs(alice, schedule, pod),
         lambda runs: any(str(run.get("status")) in ACTED_ON for run in runs),
         describe="the trigger to fire for a row that met the condition",
-        timeout=90.0,
+        timeout=UNTIL_BACKGROUND_WORK_LANDS,
     )
     assert acted, "a matching row triggered nothing"
 
@@ -133,7 +133,7 @@ async def test_skipped_and_fired_are_distinguishable(watching_for_done):
         lambda: _runs(alice, schedule, pod),
         lambda found: any(str(run.get("status")) in ACTED_ON for run in found),
         describe="the matching trigger to produce a run",
-        timeout=90.0,
+        timeout=UNTIL_BACKGROUND_WORK_LANDS,
     )
     settled = await alice.opens_schedule(schedule, in_pod=pod)
 

--- a/tests/scenarios/journeys/scheduling_and_triggers/test_triggers.py
+++ b/tests/scenarios/journeys/scheduling_and_triggers/test_triggers.py
@@ -11,7 +11,7 @@ import pytest
 
 from harness import capability, covers, journey, proves, scenario
 from harness.steps.datastore import column
-from harness.waiting import eventually, never
+from harness.waiting import eventually, never, UNTIL_BACKGROUND_WORK_LANDS
 
 pytestmark = [
     journey("Scheduling and triggers"),
@@ -61,7 +61,7 @@ async def test_a_record_change_fires_a_schedule(watched_table):
         lambda: _runs(alice, schedule, pod),
         bool,
         describe="the datastore schedule to fire",
-        timeout=60.0,
+        timeout=UNTIL_BACKGROUND_WORK_LANDS,
     )
     assert fired, "a watched insert must produce a firing"
 

--- a/tests/scenarios/journeys/sharing_and_permissions/test_roles_and_reach.py
+++ b/tests/scenarios/journeys/sharing_and_permissions/test_roles_and_reach.py
@@ -13,7 +13,7 @@ import pytest
 
 from harness import capability, covers, journey, proves, scenario
 from harness.steps.datastore import column
-from harness.waiting import eventually
+from harness.waiting import eventually, UNTIL_A_CHANGE_IS_VISIBLE
 
 pytestmark = [
     journey("Sharing and permissions"),
@@ -94,7 +94,7 @@ async def test_a_role_grant_follows_the_role(world, a_pod_and_a_table):
             lambda person=person: _can_read(person, table, pod),
             lambda allowed: allowed,
             describe=f"{person.label} to reach the table their role grants",
-            timeout=15.0,
+            timeout=UNTIL_A_CHANGE_IS_VISIBLE,
         )
         assert reached, person.label
 
@@ -124,7 +124,7 @@ async def test_losing_a_role_takes_back_its_grant(world, a_pod_and_a_table):
         lambda: _can_read(bob, table, pod),
         lambda allowed: allowed,
         describe="bob to reach the table his role grants",
-        timeout=15.0,
+        timeout=UNTIL_A_CHANGE_IS_VISIBLE,
     )
 
     # Moved to a role that grants nothing at all, rather than to POD_VIEWER —
@@ -137,7 +137,7 @@ async def test_losing_a_role_takes_back_its_grant(world, a_pod_and_a_table):
         lambda: _can_read(bob, table, pod),
         lambda allowed: not allowed,
         describe="bob to lose what the auditor role granted",
-        timeout=15.0,
+        timeout=UNTIL_A_CHANGE_IS_VISIBLE,
     )
 
 

--- a/tests/scenarios/journeys/surfaces_and_notifications/test_email_surfaces.py
+++ b/tests/scenarios/journeys/surfaces_and_notifications/test_email_surfaces.py
@@ -28,7 +28,7 @@ import pytest
 
 from harness import capability, covers, journey, proves, scenario
 from harness.stack import inbound_email_domain, webhook_signing_secret
-from harness.waiting import eventually
+from harness.waiting import eventually, UNTIL_A_RUN_SETTLES
 
 pytestmark = [
     journey("Surfaces and notifications"),
@@ -210,7 +210,7 @@ async def test_mail_reaches_the_pod_that_owns_the_address(mailbox):
         lambda: alice.conversations_in(pod),
         bool,
         describe="the email to open a conversation in the pod that owns the address",
-        timeout=120.0,
+        timeout=UNTIL_A_RUN_SETTLES,
     )
     # The thread is created before the message is persisted onto it, so reading
     # straight away finds an empty conversation and reports a working feature as
@@ -221,7 +221,7 @@ async def test_mail_reaches_the_pod_that_owns_the_address(mailbox):
             "take a look" in str(message.get("text") or "") for message in messages
         ),
         describe="the email's words to reach the conversation it opened",
-        timeout=60.0,
+        timeout=UNTIL_A_RUN_SETTLES,
     )
     assert said, said
 

--- a/tests/scenarios/journeys/surfaces_and_notifications/test_threads_and_files.py
+++ b/tests/scenarios/journeys/surfaces_and_notifications/test_threads_and_files.py
@@ -9,7 +9,7 @@ no memory of their first. And a file sent to the bot has to reach the agent, or
 from __future__ import annotations
 
 from harness import capability, covers, journey, proves, scenario, stack_lane
-from harness.waiting import eventually
+from harness.waiting import eventually, UNTIL_A_RUN_SETTLES
 
 pytestmark = [
     journey("Surfaces and notifications"),
@@ -66,7 +66,7 @@ async def test_a_separate_chat_is_a_separate_conversation(reachable):
         reachable.conversations,
         lambda found: len(found) >= 2,
         describe="a second chat to get its own conversation",
-        timeout=60.0,
+        timeout=UNTIL_A_RUN_SETTLES,
     )
     assert len(threads) == 2, (
         f"two separate chats share one conversation, so each sees the other's "
@@ -121,7 +121,7 @@ async def test_an_attachment_reaches_the_pod(reachable):
         lambda: reachable.alice.paths_in(reachable.pod, directory=TELEGRAM_FOLDER),
         lambda found: any(path.endswith("quarter.csv") for path in found),
         describe="the attachment to reach the pod",
-        timeout=90.0,
+        timeout=UNTIL_A_RUN_SETTLES,
     )
     landed = sorted(path for path in arrived if path.endswith("quarter.csv"))[0]
 

--- a/tests/scenarios/journeys/test_harness_contract.py
+++ b/tests/scenarios/journeys/test_harness_contract.py
@@ -108,6 +108,44 @@ def test_scenarios_do_not_mock():
     )
 
 
+def test_a_scenario_waits_on_a_named_budget():
+    """No scenario invents its own deadline.
+
+    `eventually` says the bound "lives in one place. When CI is loaded and
+    everything is three times slower, one number moves." That was not true:
+    thirty-two call sites carried eight different literals, tuned one at a time
+    against whatever a shared deployment did that day, and a run failed on
+    whichever happened to be tightest. Naming them says what is being waited
+    for — a change becoming visible, a run settling, a model acting, background
+    work landing — and puts each number back in one place.
+
+    Only `eventually`'s own bound is policed. An HTTP client timeout is how long
+    one request may take, and a socket wait that proves nothing arrives is paid
+    on every green run rather than only on a failing one; neither is this kind
+    of bound, and both are still written as numbers on purpose.
+    """
+    offenders: list[str] = []
+    for path in _scenario_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = node.func.attr if isinstance(node.func, ast.Attribute) else getattr(
+                node.func, "id", ""
+            )
+            if name not in {"eventually", "waits_for_an_approval_in"}:
+                continue
+            for keyword in node.keywords:
+                if keyword.arg != "timeout":
+                    continue
+                if isinstance(keyword.value, ast.Constant):
+                    offenders.append(f"{path.relative_to(SUITE)}:{keyword.value.lineno}")
+    assert not offenders, (
+        "wait on a named budget from `harness.waiting` rather than a literal, so "
+        "one number moves when the deployment is slow:\n  " + "\n  ".join(offenders)
+    )
+
+
 def test_scenarios_do_not_sleep():
     """No scenario waits by sleeping.
 

--- a/tests/scenarios/journeys/working_with_data/test_bulk_fairness.py
+++ b/tests/scenarios/journeys/working_with_data/test_bulk_fairness.py
@@ -18,7 +18,7 @@ import pytest
 
 from harness import capability, covers, journey, proves, scenario
 from harness.run import a_name_for
-from harness.waiting import eventually
+from harness.waiting import eventually, UNTIL_BACKGROUND_WORK_LANDS
 
 pytestmark = [
     journey("Working with data"),
@@ -121,7 +121,7 @@ async def test_a_declined_upload_can_be_retried(two_pods):
         lambda: _upload(alice, busy, retried),
         lambda response: response.status_code < 400,
         describe="the staging pool to take an upload again",
-        timeout=90.0,
+        timeout=UNTIL_BACKGROUND_WORK_LANDS,
     )
 
     stored = await alice.opens_file(landed.json()["path"], in_pod=busy)

--- a/tests/scenarios/journeys/working_with_data/test_file_lifecycle.py
+++ b/tests/scenarios/journeys/working_with_data/test_file_lifecycle.py
@@ -6,7 +6,7 @@ import pytest
 
 
 from harness import capability, covers, journey, proves, scenario, stack_lane
-from harness.waiting import eventually, never
+from harness.waiting import eventually, never, UNTIL_BACKGROUND_WORK_LANDS
 
 pytestmark = [journey("Working with data"), capability("Put documents in")]
 
@@ -144,7 +144,7 @@ async def _the_promise_about_an_unreachable_extractor(alice, pod, report):
         lambda: alice.opens_file(report["path"], in_pod=pod),
         lambda f: str(f.get("status")) != "PROCESSING",
         describe=f"{report['path']} to settle out of PROCESSING",
-        timeout=60.0,
+        timeout=UNTIL_BACKGROUND_WORK_LANDS,
     )
 
     # The rest is only observable where there is no extractor to reach. This
@@ -213,7 +213,7 @@ async def test_supplied_markdown_is_used(pod_with_file):
         # the staging pool on purpose. CI shards by journey and never sees this,
         # a local run of the whole directory does, and a wait costs nothing when
         # things are fast.
-        timeout=150.0,
+        timeout=UNTIL_BACKGROUND_WORK_LANDS,
     )
     assert any(c["name"] == "document.md" for c in children), children
 


### PR DESCRIPTION
Twenty-six runs of history from release-radar, every failure classified. Setting aside the scenarios that were simply broken and have since been fixed, what remains is three sources of flakiness — and **none of them is the product**.

Ranked by how often a scenario flipped between passing and failing:

| flips | fails | runs | scenario | cause |
|---:|---:|---:|---|---|
| 5 | 3 | 31 | `test_an_unanswered_question_keeps_waiting` | model must choose a tool in 60s |
| 4 | 2 | 31 | `test_decisions_are_a_durable_record` | run must finish in 90s |
| 2 | 1 | 31 | `test_a_run_is_always_recorded` | run must settle in 60s |
| 2 | 1 | 31 | `test_a_hostile_bundle...` ×3 | **429** |
| 2 | 1 | 31 | `test_a_pod_exports_to_a_downloadable_bundle` | export in 90s |

## A throttling 429 was reported as a defect

The driver retried a 401 and nothing else, so a 429 went straight to the scenario — *"starting an import answered 429, expected 202"* took three scenarios down in one run, and the signup that seeds the whole tenant died on one in another.

This suite is a burst by nature: hundreds of requests from one runner against a deployment other people are also using. Every client worth the name retries a throttle. It now does — five tries, doubling backoff, about three seconds total.

Narrow, in the same way the 401 renewal is: a spend cap also answers 429, and *that* one is a promise `test_work_over_the_limit_is_refused_clearly` asserts. A refusal naming the limit it hit is an answer, not "come back later", so only an unnamed throttle is retried.

## Every scenario invented its own deadline

`eventually`'s docstring says the bound *"lives in one place. When CI is loaded and everything is three times slower, one number moves."* It did not — **32 call sites carried 8 different literals** (8, 15, 30, 60, 90, 120, 150, 180), each tuned once against whatever the deployment did that day, and a run failed on whichever was tightest.

They are now four budgets named for what is being waited on:

- `UNTIL_A_CHANGE_IS_VISIBLE` — a write becoming readable
- `UNTIL_A_RUN_SETTLES` — an agent run reaching a terminal state
- `UNTIL_A_MODEL_ACTS` — a real model replying or choosing a tool
- `UNTIL_BACKGROUND_WORK_LANDS` — triggers, conversions, exports, schedules giving up

**Being generous costs a green run nothing.** A deadline is only ever reached when something has already gone wrong, so a larger bound is paid solely by a run that was going to fail anyway. The assertions are unchanged — only the patience is.

Two waits are deliberately left as numbers, and the new guard says why: an httpx client timeout is how long one *request* may take, and a socket wait that proves nothing arrives is paid on every *green* run rather than only on a failing one. I converted both in the first pass and reverted them; they are the cases a blind sweep gets wrong.

## A model choosing to call a tool was on a 60-second budget

That is the one kind of wait whose length is decided outside this system, and a queued run reaches its tool call two turns in. `waits_for_an_approval_in` reported *"an approval request … never happened"* three times in thirty-one runs with the product working perfectly. It is on the model budget now, and its failure says how long the agent was given.

## Not changed, deliberately

- **`test_an_image_is_understood`** asserts a real model names a colour. It is on the right budget already; the residual variance is the model's, and weakening the assertion would buy green at the cost of the promise.
- **The standing-tenant accumulation class** (a pod list past 100, a stale pause swallowing the next message) is already fixed at the source in #560 and #575 rather than by waiting longer.

## Verification

39/39 scenarios and 128 tests against a booted stack; the coverage gate and all 89 harness guards pass. The new guard fails if a literal deadline is reintroduced — checked by putting one back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)