### PR TITLE
Stop holding a model request open when it has stopped making progress

### DIFF
--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -70,6 +70,7 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'agent.memory.folder_provisioning_denied.observed': EventSpec('warning', frozenset()),
     'agent.message_replies.delivered': EventSpec('debug', frozenset({'conversation_id', 'started_new_run'})),
     'agent.mock_model.mock_llm_structured_output_required.diagnostic': EventSpec('debug', frozenset()),
+    'agent.model_stream_budget.stream_abandoned.degraded': EventSpec('warning', frozenset({'elapsed_seconds', 'first_chunk', 'reason', 'url'})),
     'agent.module.system_lemma_models_will_be.observed': EventSpec('debug', frozenset()),
     'agent.pending_user_messages.claim_failed.degraded': EventSpec('warning', frozenset({'agent_run_id'})),
     'agent.pending_user_messages.steered_into_run.observed': EventSpec('info', frozenset({'agent_run_id', 'message_count'})),

--- a/lemma-backend/app/modules/agent/config.py
+++ b/lemma-backend/app/modules/agent/config.py
@@ -129,6 +129,26 @@ class AgentSettings(BaseSettings):
             "httpx resets it on every chunk of a streamed response."
         ),
     )
+    agent_model_stream_first_chunk_timeout_seconds: float = Field(
+        default=60.0,
+        description=(
+            "How long a provider may take to send the first chunk of a response "
+            "body before the request is abandoned and retried. Unlike the "
+            "per-chunk read timeout above, a provider cannot reset this one, so "
+            "it is what catches a request that was accepted and never started. "
+            "0 disables it."
+        ),
+    )
+    agent_model_stream_total_timeout_seconds: float = Field(
+        default=300.0,
+        description=(
+            "Ceiling on one whole model exchange, first byte to last. The only "
+            "bound that catches a provider trickling a token a second: the "
+            "per-chunk timeout never fires while chunks keep arriving. Generous "
+            "on purpose, because a long answer streaming steadily has to be "
+            "allowed to finish. 0 disables it."
+        ),
+    )
     agent_model_http_max_connections: int = Field(
         default=100,
         description="Connection-pool ceiling per provider endpoint.",

--- a/lemma-backend/app/modules/agent/services/model_stream_budget.py
+++ b/lemma-backend/app/modules/agent/services/model_stream_budget.py
@@ -1,0 +1,193 @@
+"""Ending a model response that has stopped making progress.
+
+The provider client's read timeout is *per chunk*: httpx resets it every time
+bytes arrive, which is the right shape for "the provider has gone away" and the
+reason a legitimately long answer can stream for minutes without tripping it.
+
+It cannot see the other failure, and that is the one production hit. A provider
+that keeps sending *something* — a token every half-second, a keep-alive frame —
+never trips a per-chunk timeout however long it goes on. Measured on dev: two
+consecutive requests took 85s and 185s to deliver 71 and 325 tokens, roughly one
+token per second, while fifteen other requests on the same client finished in
+0.6-9.0s at forty to ninety tokens per second. Nothing timed out, nothing
+retried, and the person's HTTP request stayed open the whole time holding the
+conversation's one active run slot.
+
+So this bounds the two things a per-chunk timeout structurally cannot:
+
+* how long the provider may take to send the *first* body chunk, which is where
+  a request that was accepted but never really started shows itself, and
+* how long one exchange may run in total, which is the only thing that catches
+  a trickle.
+
+Both raise :class:`httpx.ReadTimeout`. That is not decoration: it is an
+``httpx.TransportError``, so ``is_retryable_stream_error`` already returns True
+for it and ``drive_with_retry`` re-enters the run from the snapshot taken before
+the failing request — re-asking only that request, replaying completed tool
+results rather than re-running them. Raising the transport's own error is what
+lets an existing, tested recovery path handle a new failure with no changes to
+it.
+
+The stream is closed on the way out rather than abandoned, so a provider that
+has stopped making progress does not keep a pooled connection with it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import AsyncIterator
+
+import httpx
+
+from app.core.log.log import get_logger
+
+logger = get_logger(__name__)
+
+__all__ = ["ModelStreamBudgetTransport", "budgeted_stream"]
+
+
+def _disabled(seconds: float | None) -> bool:
+    """A budget of zero (or less, or nothing) means "do not bound this"."""
+    return seconds is None or seconds <= 0
+
+
+class _BudgetedByteStream(httpx.AsyncByteStream):
+    """Wraps a response body, failing it when progress stops.
+
+    Each chunk is awaited under its own deadline rather than the whole
+    iteration under one. Spanning a ``yield`` with a timeout would put the
+    cancellation in whichever task happened to be consuming the generator
+    instead of this one — the same task-bound cancel-scope hazard the harness
+    documents at length — and a timer per chunk is the cost of not having it.
+    """
+
+    def __init__(
+        self,
+        stream: httpx.AsyncByteStream,
+        *,
+        request: httpx.Request,
+        first_chunk_seconds: float | None,
+        total_seconds: float | None,
+    ) -> None:
+        self._stream = stream
+        self._request = request
+        self._first_chunk_seconds = first_chunk_seconds
+        self._total_seconds = total_seconds
+
+    def _budget(self, *, started: float, first_chunk: bool) -> float | None:
+        """How long the next chunk may take. ``None`` means "unbounded"."""
+        budgets: list[float] = []
+        if first_chunk and not _disabled(self._first_chunk_seconds):
+            budgets.append(float(self._first_chunk_seconds))  # type: ignore[arg-type]
+        if not _disabled(self._total_seconds):
+            elapsed = time.monotonic() - started
+            budgets.append(float(self._total_seconds) - elapsed)  # type: ignore[arg-type]
+        return min(budgets) if budgets else None
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        started = time.monotonic()
+        iterator = self._stream.__aiter__()
+        first_chunk = True
+        while True:
+            budget = self._budget(started=started, first_chunk=first_chunk)
+            try:
+                if budget is None:
+                    chunk = await iterator.__anext__()
+                else:
+                    # Negative budgets are possible when the total elapsed while
+                    # the consumer held the last chunk; asyncio.timeout fires
+                    # immediately on those, which is the intended answer.
+                    async with asyncio.timeout(budget):
+                        chunk = await iterator.__anext__()
+            except StopAsyncIteration:
+                return
+            except TimeoutError as exc:
+                raise await self._expired(
+                    started=started, first_chunk=first_chunk
+                ) from exc
+            first_chunk = False
+            yield chunk
+
+    async def _expired(self, *, started: float, first_chunk: bool) -> httpx.ReadTimeout:
+        """Close the connection, say why, and build the error to raise."""
+        elapsed = time.monotonic() - started
+        reason = (
+            "the provider sent no response body"
+            if first_chunk
+            else "the provider stopped making progress"
+        )
+        # Closed rather than left to the pool: a stream abandoned mid-body would
+        # otherwise hold a connection open for a provider we have just given up
+        # on, which is the state this whole module exists to end.
+        await self.aclose()
+        logger.warning(
+            "agent.model_stream_budget.stream_abandoned.degraded",
+            reason=reason,
+            elapsed_seconds=round(elapsed, 2),
+            first_chunk=first_chunk,
+            url=str(self._request.url),
+        )
+        return httpx.ReadTimeout(
+            f"Model stream abandoned after {elapsed:.1f}s: {reason}.",
+            request=self._request,
+        )
+
+    async def aclose(self) -> None:
+        await self._stream.aclose()
+
+
+class ModelStreamBudgetTransport(httpx.AsyncBaseTransport):
+    """Applies :class:`_BudgetedByteStream` to every response it passes on.
+
+    A transport rather than something further up because this has to sit under
+    every provider SDK we use: the budget then holds for anything reached over
+    the shared client, and the error it raises is the one the SDKs and the retry
+    layer already understand.
+    """
+
+    def __init__(
+        self,
+        wrapped: httpx.AsyncBaseTransport,
+        *,
+        first_chunk_seconds: float | None,
+        total_seconds: float | None,
+    ) -> None:
+        self._wrapped = wrapped
+        self._first_chunk_seconds = first_chunk_seconds
+        self._total_seconds = total_seconds
+
+    @property
+    def wrapped(self) -> httpx.AsyncBaseTransport:
+        return self._wrapped
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        response = await self._wrapped.handle_async_request(request)
+        if _disabled(self._first_chunk_seconds) and _disabled(self._total_seconds):
+            return response
+        response.stream = budgeted_stream(
+            response.stream,  # type: ignore[arg-type]
+            request=request,
+            first_chunk_seconds=self._first_chunk_seconds,
+            total_seconds=self._total_seconds,
+        )
+        return response
+
+    async def aclose(self) -> None:
+        await self._wrapped.aclose()
+
+
+def budgeted_stream(
+    stream: httpx.AsyncByteStream,
+    *,
+    request: httpx.Request,
+    first_chunk_seconds: float | None,
+    total_seconds: float | None,
+) -> httpx.AsyncByteStream:
+    """A response body that fails rather than trickling forever."""
+    return _BudgetedByteStream(
+        stream,
+        request=request,
+        first_chunk_seconds=first_chunk_seconds,
+        total_seconds=total_seconds,
+    )

--- a/lemma-backend/app/modules/agent/services/runtime_model_factory.py
+++ b/lemma-backend/app/modules/agent/services/runtime_model_factory.py
@@ -34,6 +34,9 @@ from app.modules.agent.config import agent_settings
 from app.modules.agent.infrastructure.transport_errors import (
     RETRYABLE_STATUS_CODES,
 )
+from app.modules.agent.services.model_stream_budget import (
+    ModelStreamBudgetTransport,
+)
 from app.modules.agent.services.openai_schema_compat import (
     openai_compatible_model_profile,
 )
@@ -135,36 +138,60 @@ def _should_retry_status(response: httpx.Response) -> None:
 
 
 def _build_provider_client(headers: Mapping[str, object]) -> httpx.AsyncClient:
+    # Limits belong to the transport, not to the client. `AsyncClient._init_transport`
+    # returns a transport passed to it *before* it ever looks at `limits`, so a
+    # `limits=` beside a custom `transport=` is accepted and silently discarded:
+    # this pool ran on httpx's defaults (20 keepalive, 5s expiry) while the
+    # settings said 100 and 30, and `agent_model_http_max_connections` did
+    # nothing at all. Building the base transport here is what makes the setting
+    # real, and it has to be built explicitly anyway — AsyncTenacityTransport
+    # wraps `AsyncHTTPTransport()` with no arguments when handed nothing.
+    pooled = httpx.AsyncHTTPTransport(
+        limits=httpx.Limits(
+            max_connections=agent_settings.agent_model_http_max_connections,
+            max_keepalive_connections=agent_settings.agent_model_http_max_connections,
+            keepalive_expiry=30.0,
+        ),
+    )
+    retrying = AsyncTenacityTransport(
+        config=RetryConfig(
+            retry=lambda state: isinstance(
+                state.outcome.exception() if state.outcome else None,
+                (httpx.TransportError, httpx.HTTPStatusError),
+            ),
+            wait=wait_retry_after(
+                fallback_strategy=wait_exponential(multiplier=1, max=30),
+                max_wait=60,
+            ),
+            stop=stop_after_attempt(3),
+            reraise=True,
+        ),
+        wrapped=pooled,
+        validate_response=_should_retry_status,
+    )
     return httpx.AsyncClient(
         # Split timeouts: the read timeout is per-chunk, so it is the "provider
         # has gone away" threshold rather than a budget for the whole turn — a
-        # long tool-using answer streams for minutes without tripping it.
+        # long tool-using answer streams for minutes without tripping it. What
+        # it therefore cannot see is a provider that keeps sending *something*
+        # forever, which is what the stream budget outside it is for.
         timeout=httpx.Timeout(
             connect=agent_settings.agent_model_http_connect_timeout_seconds,
             read=agent_settings.agent_model_http_read_timeout_seconds,
             write=30.0,
             pool=10.0,
         ),
-        limits=httpx.Limits(
-            max_connections=agent_settings.agent_model_http_max_connections,
-            max_keepalive_connections=agent_settings.agent_model_http_max_connections,
-            keepalive_expiry=30.0,
-        ),
         headers={str(key): str(value) for key, value in headers.items()},
-        transport=AsyncTenacityTransport(
-            config=RetryConfig(
-                retry=lambda state: isinstance(
-                    state.outcome.exception() if state.outcome else None,
-                    (httpx.TransportError, httpx.HTTPStatusError),
-                ),
-                wait=wait_retry_after(
-                    fallback_strategy=wait_exponential(multiplier=1, max=30),
-                    max_wait=60,
-                ),
-                stop=stop_after_attempt(3),
-                reraise=True,
+        # Outermost, so the budget covers the response body of whichever attempt
+        # tenacity finally returns. It has to be out here regardless: tenacity
+        # retries `handle_async_request`, which is done once the headers land, so
+        # nothing inside it is still watching while the body streams.
+        transport=ModelStreamBudgetTransport(
+            retrying,
+            first_chunk_seconds=(
+                agent_settings.agent_model_stream_first_chunk_timeout_seconds
             ),
-            validate_response=_should_retry_status,
+            total_seconds=agent_settings.agent_model_stream_total_timeout_seconds,
         ),
     )
 

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_config.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_config.py
@@ -47,6 +47,16 @@ EXPECTED = [
         "AGENT_MODEL_HTTP_READ_TIMEOUT_SECONDS",
         180.0,
     ),
+    (
+        "agent_model_stream_first_chunk_timeout_seconds",
+        "AGENT_MODEL_STREAM_FIRST_CHUNK_TIMEOUT_SECONDS",
+        60.0,
+    ),
+    (
+        "agent_model_stream_total_timeout_seconds",
+        "AGENT_MODEL_STREAM_TOTAL_TIMEOUT_SECONDS",
+        300.0,
+    ),
     ("agent_model_http_max_connections", "AGENT_MODEL_HTTP_MAX_CONNECTIONS", 100),
     ("widget_url_expiry_seconds", "WIDGET_URL_EXPIRY_SECONDS", 1800),
     ("speech_provider", "SPEECH_PROVIDER", "auto"),

--- a/lemma-backend/app/modules/agent/tests/unit/test_model_stream_budget.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_model_stream_budget.py
@@ -1,0 +1,220 @@
+"""A model response that stops making progress has to end, not hang.
+
+The failure these pin is the one dev hit: a provider that keeps sending
+*something* — a token a second — while the per-chunk read timeout resets on
+every chunk and never fires. Nothing timed out, nothing retried, and the
+person's request stayed open for 270s holding the conversation's active run.
+
+Two of these matter more than the rest and are worth naming:
+
+* ``test_the_error_raised_is_one_the_run_already_knows_how_to_retry`` is the
+  load-bearing one. The budget is only a fix because the error it raises routes
+  into ``drive_with_retry``; raising anything else would turn a slow provider
+  into a failed run, which is worse than the hang.
+* ``test_a_steady_long_answer_is_not_cut_off`` is the one that keeps this from
+  being a regression. A budget that fires on legitimate work would be a far
+  more expensive bug than the one being fixed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+
+from app.modules.agent.infrastructure.transport_errors import (
+    is_retryable_stream_error,
+)
+from app.modules.agent.services.model_stream_budget import (
+    ModelStreamBudgetTransport,
+    budgeted_stream,
+)
+
+A_REQUEST = httpx.Request("POST", "https://provider.example/v1/chat/completions")
+
+
+class _Body(httpx.AsyncByteStream):
+    """A response body on a script: wait this long, then send this.
+
+    Records whether it was closed, because "the connection is not kept" is half
+    of what is being fixed and is otherwise invisible from the outside.
+    """
+
+    def __init__(self, *, chunks: int, gap: float, lead_in: float | None = None):
+        self.chunks = chunks
+        self.gap = gap
+        self.lead_in = gap if lead_in is None else lead_in
+        self.closed = False
+        self.delivered = 0
+
+    async def __aiter__(self) -> AsyncIterator[bytes]:
+        for index in range(self.chunks):
+            await asyncio.sleep(self.lead_in if index == 0 else self.gap)
+            self.delivered += 1
+            yield b"data: token\n\n"
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _budgeted(body: _Body, *, first_chunk: float | None, total: float | None):
+    return budgeted_stream(
+        body,
+        request=A_REQUEST,
+        first_chunk_seconds=first_chunk,
+        total_seconds=total,
+    )
+
+
+async def _drain(stream) -> int:
+    received = 0
+    async for _ in stream:
+        received += 1
+    return received
+
+
+@pytest.mark.asyncio
+async def test_a_provider_that_never_starts_is_given_up_on() -> None:
+    """Accepted the request, sent headers, then nothing.
+
+    The per-chunk read timeout cannot help here on any sane setting, because
+    the setting that would catch it quickly is the one that kills legitimate
+    long answers. A first-chunk bound is a different question with a different
+    answer.
+    """
+    body = _Body(chunks=3, gap=0.01, lead_in=5.0)
+
+    with pytest.raises(httpx.ReadTimeout) as raised:
+        await _drain(_budgeted(body, first_chunk=0.05, total=None))
+
+    assert "no response body" in str(raised.value)
+    assert body.delivered == 0
+
+
+@pytest.mark.asyncio
+async def test_a_trickling_provider_is_given_up_on() -> None:
+    """The actual production failure, in miniature.
+
+    Chunks keep arriving, so a per-chunk timeout is reset forever and the
+    exchange never ends. Only a total bound sees it — note the first chunk
+    arrives promptly here, so the first-chunk bound is deliberately generous
+    and takes no part in catching this.
+    """
+    body = _Body(chunks=1000, gap=0.01)
+
+    with pytest.raises(httpx.ReadTimeout) as raised:
+        await _drain(_budgeted(body, first_chunk=5.0, total=0.1))
+
+    assert "stopped making progress" in str(raised.value)
+    # It really was making *some* progress, which is the whole difficulty.
+    assert body.delivered > 0
+
+
+@pytest.mark.asyncio
+async def test_the_error_raised_is_one_the_run_already_knows_how_to_retry() -> None:
+    """The reason this fix is a fix rather than a different failure.
+
+    ``httpx.ReadTimeout`` is an ``httpx.TransportError``, which
+    ``is_retryable_stream_error`` already answers True for, so the run re-enters
+    the graph from the snapshot taken before the failing request instead of
+    dying. Pinned here because it is an invariant across two modules that
+    nothing else would catch if either side moved.
+    """
+    body = _Body(chunks=1000, gap=0.01)
+
+    with pytest.raises(httpx.ReadTimeout) as raised:
+        await _drain(_budgeted(body, first_chunk=None, total=0.1))
+
+    assert is_retryable_stream_error(raised.value) is True
+
+
+@pytest.mark.asyncio
+async def test_the_connection_is_not_kept_for_a_provider_we_gave_up_on() -> None:
+    """Abandoning the body without closing it would hold a pooled connection.
+
+    That is the state this module exists to end, so a stream left open on the
+    way out would defeat the point while still passing every other test here.
+    """
+    body = _Body(chunks=1000, gap=0.01)
+
+    with pytest.raises(httpx.ReadTimeout):
+        await _drain(_budgeted(body, first_chunk=None, total=0.1))
+
+    assert body.closed is True
+
+
+@pytest.mark.asyncio
+async def test_a_steady_long_answer_is_not_cut_off() -> None:
+    """The regression this must not introduce.
+
+    An answer that streams for a long time while genuinely producing tokens is
+    ordinary agent work. A bound that fires on it would break real runs to fix
+    a rare one, so the budget is sized well above the work, not near it.
+    """
+    body = _Body(chunks=40, gap=0.005)
+
+    received = await _drain(_budgeted(body, first_chunk=1.0, total=5.0))
+
+    assert received == 40
+    assert body.closed is False
+
+
+@pytest.mark.asyncio
+async def test_a_prompt_response_is_untouched() -> None:
+    """The overwhelming majority of requests, which must not change at all."""
+    body = _Body(chunks=3, gap=0.0)
+
+    assert await _drain(_budgeted(body, first_chunk=1.0, total=5.0)) == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("setting", [0.0, None])
+async def test_a_budget_can_be_switched_off(setting) -> None:
+    """Zero means "do not bound this", so an operator can rule this out.
+
+    Worth a test because the check is `<= 0` rather than falsy: a budget is a
+    float from settings, and the day somebody sets it to something odd, the
+    behaviour should be the documented one.
+    """
+    body = _Body(chunks=3, gap=0.01)
+
+    assert await _drain(_budgeted(body, first_chunk=setting, total=setting)) == 3
+
+
+@pytest.mark.asyncio
+async def test_the_transport_bounds_a_real_client_request() -> None:
+    """End to end through httpx, because that is how it is actually wired.
+
+    Direct tests of the stream prove the bound; this proves it survives being
+    installed as a transport, where httpx — not the test — drives the body.
+    """
+    body = _Body(chunks=1000, gap=0.01)
+    transport = ModelStreamBudgetTransport(
+        httpx.MockTransport(lambda request: httpx.Response(200, stream=body)),
+        first_chunk_seconds=None,
+        total_seconds=0.1,
+    )
+
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(httpx.ReadTimeout):
+            await client.post("https://provider.example/v1/chat/completions")
+
+    assert body.closed is True
+
+
+@pytest.mark.asyncio
+async def test_the_transport_leaves_a_healthy_response_alone() -> None:
+    body = _Body(chunks=4, gap=0.0)
+    transport = ModelStreamBudgetTransport(
+        httpx.MockTransport(lambda request: httpx.Response(200, stream=body)),
+        first_chunk_seconds=1.0,
+        total_seconds=5.0,
+    )
+
+    async with httpx.AsyncClient(transport=transport) as client:
+        response = await client.post("https://provider.example/v1/chat/completions")
+
+    assert response.status_code == 200
+    assert response.content == b"data: token\n\n" * 4

--- a/lemma-backend/app/modules/agent/tests/unit/test_provider_client_wiring.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_provider_client_wiring.py
@@ -1,0 +1,86 @@
+"""What the provider client is actually built with, as opposed to what it says.
+
+Both of these pin a setting that was being written down and then discarded, and
+neither failure was visible from anywhere: the client was constructed without
+error, served traffic, and used values nobody had chosen.
+
+``limits=`` is the sharper one. ``AsyncClient._init_transport`` returns a
+transport handed to it *before* it looks at ``limits``, so passing both is
+accepted in silence — the pool ran on httpx's defaults (20 keepalive, 5s expiry)
+while the settings said 100 and 30, and ``agent_model_http_max_connections`` did
+nothing whatsoever. A test that reads the pool is the only way that shows up,
+because every test that reads the *settings* agreed with itself.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.modules.agent.config import agent_settings
+from app.modules.agent.services import runtime_model_factory as factory
+from app.modules.agent.services.model_stream_budget import ModelStreamBudgetTransport
+
+
+@pytest.fixture
+def client() -> httpx.AsyncClient:
+    return factory._build_provider_client({})
+
+
+def _pool(client: httpx.AsyncClient):
+    """Walk down to the connection pool the requests actually go through."""
+    transport = client._transport
+    assert isinstance(transport, ModelStreamBudgetTransport)
+    return transport.wrapped.wrapped._pool  # tenacity -> AsyncHTTPTransport
+
+
+def test_the_configured_pool_ceiling_reaches_the_pool(client) -> None:
+    """The setting was inert: read it off the live pool, not off the config."""
+    assert _pool(client)._max_connections == (
+        agent_settings.agent_model_http_max_connections
+    )
+
+
+def test_the_configured_keepalive_reaches_the_pool(client) -> None:
+    """Keepalive was httpx's 20/5s, not the 100/30s written beside it.
+
+    Worth its own test rather than an extra assertion above: the ceiling
+    happened to equal httpx's default, so it would have passed while wrong.
+    Keepalive is where the two genuinely differ, and so where the bug shows.
+    """
+    pool = _pool(client)
+    assert pool._max_keepalive_connections == (
+        agent_settings.agent_model_http_max_connections
+    )
+    assert pool._keepalive_expiry == 30.0
+
+
+def test_the_stream_budget_is_installed_outside_the_retry_layer(client) -> None:
+    """Order is load-bearing, not cosmetic.
+
+    Tenacity retries ``handle_async_request``, which is finished once the
+    headers arrive — nothing inside it is still watching while the body
+    streams. A budget installed underneath it would never see the trickle it
+    exists to catch.
+    """
+    transport = client._transport
+    assert isinstance(transport, ModelStreamBudgetTransport)
+    assert transport._total_seconds == (
+        agent_settings.agent_model_stream_total_timeout_seconds
+    )
+    assert transport._first_chunk_seconds == (
+        agent_settings.agent_model_stream_first_chunk_timeout_seconds
+    )
+
+
+def test_the_per_chunk_read_timeout_still_applies(client) -> None:
+    """The budget adds a bound; it does not replace the one already there.
+
+    A custom transport does *not* discard timeouts the way it discards limits —
+    they travel per-request in the extensions — so this stays true, and it is
+    worth pinning next to the limits bug so the two are not conflated later.
+    """
+    assert client.timeout.read == agent_settings.agent_model_http_read_timeout_seconds
+    assert client.timeout.connect == (
+        agent_settings.agent_model_http_connect_timeout_seconds
+    )

--- a/lemma-backend/app/modules/agent/tests/unit/test_pydantic_ai_harness_retry.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_pydantic_ai_harness_retry.py
@@ -40,6 +40,30 @@ def _drop_then_succeed(drop_after: str, final: str, attempts: list[int]):
     return stream_fn
 
 
+def _budget_expiry_then_succeed(final: str, attempts: list[int]):
+    """A stream abandoned by the progress budget once, then answering normally.
+
+    Raises what `model_stream_budget` raises, message and all, rather than a
+    bare `ReadTimeout`: the budget is only a fix if its error routes into this
+    retry, and a test that invented its own exception would pass while the real
+    one fell through to the catch-all and failed the run.
+    """
+
+    async def stream_fn(messages, info: AgentInfo) -> AsyncIterator[str]:
+        del messages, info
+        attempts.append(1)
+        if len(attempts) == 1:
+            yield "a trickle "
+            raise httpx.ReadTimeout(
+                "Model stream abandoned after 300.0s: "
+                "the provider stopped making progress.",
+                request=httpx.Request("POST", "https://provider.example/v1/chat"),
+            )
+        yield final
+
+    return stream_fn
+
+
 def _stream_text(text: str):
     """A stream that answers normally."""
 
@@ -171,6 +195,29 @@ async def test_mid_stream_drop_is_retried_and_the_run_completes(monkeypatch) -> 
     events = await _run_harness(model, monkeypatch=monkeypatch)
 
     assert len(attempts) == 2, "the dropped request should be re-issued exactly once"
+    assert not [e for e in events if e.type is AgentEventType.ERROR]
+    assert _messages(events) == ["the real answer"]
+
+
+@pytest.mark.asyncio
+async def test_a_stream_abandoned_by_the_progress_budget_is_retried(
+    monkeypatch,
+) -> None:
+    """The end of the chain the stream budget depends on.
+
+    A provider trickling a token a second used to hold the run open until
+    somebody gave up; it is now abandoned with a `ReadTimeout`. This is what
+    makes that an improvement rather than a new way to fail: the run re-asks the
+    request and answers, and the person never learns any of it happened.
+    """
+    attempts: list[int] = []
+    model = FunctionModel(
+        stream_function=_budget_expiry_then_succeed("the real answer", attempts)
+    )
+
+    events = await _run_harness(model, monkeypatch=monkeypatch)
+
+    assert len(attempts) == 2, "the abandoned request should be re-issued once"
     assert not [e for e in events if e.type is AgentEventType.ERROR]
     assert _messages(events) == ["the real answer"]
 

--- a/tests/scenarios/harness/steps/agent.py
+++ b/tests/scenarios/harness/steps/agent.py
@@ -9,7 +9,12 @@ from typing import Any
 
 from harness.run import a_name_for
 from harness.drivers.api import every_item, items_of
-from harness.waiting import eventually, UNTIL_A_MODEL_ACTS
+from harness.waiting import (
+    eventually,
+    UNTIL_A_MODEL_ACTS,
+    UNTIL_A_RUN_SETTLES,
+    UNTIL_A_STEERED_RUN_FINISHES,
+)
 
 JSON = dict[str, Any]
 
@@ -165,6 +170,7 @@ class AgentSteps:
         with_agent: str | None = None,
         saying: str | None = None,
         under: JSON | None = None,
+        watching: bool = True,
     ) -> JSON:
         """Open a thread, and optionally say the first thing.
 
@@ -176,6 +182,19 @@ class AgentSteps:
         ``under`` makes this thread a
         child of another, which is how a subagent's work stays attached to the
         conversation that delegated it.
+
+        ``watching`` is the default because most scenarios do want to send a
+        message the way a browser does, over the stream. Pass ``watching=False``
+        when the scenario intends to *answer* the agent. Sending over the stream
+        holds one HTTP request open for as long as the run takes, so the
+        scenario is blocked reading exactly when it is supposed to be replying:
+        it works today only because a run that pauses for approval ends, and
+        ends the stream with it. That makes a test's own request timeout a
+        ceiling on the model, which is a race nobody chose and one the product
+        cannot promise to win — a single model call has been measured at 194s at
+        the 99.9th percentile against dev, and at nineteen minutes at worst.
+        Appending instead starts the same run without tying the scenario to how
+        long it takes.
         """
         body: JSON = {}
         if with_agent:
@@ -189,7 +208,12 @@ class AgentSteps:
         )
         self.conversation = conversation
         if saying:
-            await self.says(saying, in_conversation=conversation, in_pod=in_pod)
+            if watching:
+                await self.says(saying, in_conversation=conversation, in_pod=in_pod)
+            else:
+                await self.adds_while_it_works(
+                    saying, in_conversation=conversation, in_pod=in_pod
+                )
         return conversation
 
     async def conversations_in(self, pod: JSON, *, pages: int = 20) -> list[JSON]:
@@ -269,7 +293,7 @@ class AgentSteps:
         in_conversation: JSON,
         in_pod: JSON,
         after: int = 0,
-        timeout: float = 60.0,
+        timeout: float = UNTIL_A_MODEL_ACTS,
     ) -> list[JSON]:
         """Wait until the agent has added at least one message beyond ``after``.
 
@@ -288,7 +312,7 @@ class AgentSteps:
         )
 
     async def waits_for_the_run_to_settle(
-        self, *, conversation: JSON, in_pod: JSON, timeout: float = 60.0
+        self, *, conversation: JSON, in_pod: JSON, timeout: float = UNTIL_A_RUN_SETTLES
     ) -> JSON:
         return await eventually(
             lambda: self.opens_conversation(conversation, in_pod=in_pod),
@@ -427,7 +451,7 @@ class AgentSteps:
         allow: bool,
         in_pod: JSON,
         for_the_session: bool = False,
-        timeout: float = 90.0,
+        timeout: float = UNTIL_A_STEERED_RUN_FINISHES,
     ) -> int:
         """Stay with a run, answering each thing it asks, until it finishes.
 

--- a/tests/scenarios/harness/steps/building.py
+++ b/tests/scenarios/harness/steps/building.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 from harness.run import a_name_for
 from harness.drivers.api import items_of
 from harness.tenant import STANDING_CONNECTORS, standing_auth_config_name
-from harness.waiting import eventually
+from harness.waiting import eventually, UNTIL_BACKGROUND_WORK_LANDS
 
 JSON = dict[str, Any]
 
@@ -286,7 +286,12 @@ class BuildingSteps:
     # --- running functions ------------------------------------------------
 
     async def runs_function(
-        self, name: str, *, with_input: JSON, in_pod: JSON, timeout: float = 120.0
+        self,
+        name: str,
+        *,
+        with_input: JSON,
+        in_pod: JSON,
+        timeout: float = UNTIL_BACKGROUND_WORK_LANDS,
     ) -> JSON:
         """Run a function and wait for it to reach a terminal state.
 
@@ -378,7 +383,7 @@ class BuildingSteps:
         return response.status_code
 
     async def runs_workflow(
-        self, name: str, *, in_pod: JSON, timeout: float = 120.0
+        self, name: str, *, in_pod: JSON, timeout: float = UNTIL_BACKGROUND_WORK_LANDS
     ) -> JSON:
         started = await self.api.post(
             f"/pods/{in_pod['id']}/workflows/{name}/runs",
@@ -398,7 +403,9 @@ class BuildingSteps:
 
     # --- bundles -----------------------------------------------------------
 
-    async def exports_pod(self, pod: JSON, *, timeout: float = 120.0) -> JSON:
+    async def exports_pod(
+        self, pod: JSON, *, timeout: float = UNTIL_BACKGROUND_WORK_LANDS
+    ) -> JSON:
         started = await self.api.expect(
             "POST",
             f"/pods/{pod['id']}/bundle/exports",
@@ -442,7 +449,7 @@ class BuildingSteps:
         return staged["url"]
 
     async def plans_import(
-        self, url: str, *, into_pod: JSON, timeout: float = 120.0
+        self, url: str, *, into_pod: JSON, timeout: float = UNTIL_BACKGROUND_WORK_LANDS
     ) -> JSON:
         started = await self.api.expect(
             "POST",
@@ -468,7 +475,7 @@ class BuildingSteps:
         *,
         into_pod: JSON,
         variables: JSON | None = None,
-        timeout: float = 180.0,
+        timeout: float = UNTIL_BACKGROUND_WORK_LANDS,
     ) -> JSON:
         import_id = plan.get("import_id") or plan.get("id")
         await self.api.expect(

--- a/tests/scenarios/harness/waiting.py
+++ b/tests/scenarios/harness/waiting.py
@@ -55,6 +55,16 @@ UNTIL_A_RUN_SETTLES = 120.0
 #: answer.
 UNTIL_A_MODEL_ACTS = 180.0
 
+#: A run a person is *steering*: it asks, they answer, it carries on, and this
+#: is the patience for the whole exchange rather than for one turn of it. Longer
+#: than the others because it spans several model turns end to end, and because
+#: it is the bound that used to be supplied by accident — the send was made over
+#: the stream, so the harness's own 150s per-request timeout capped the model
+#: while no scenario said so. Measured against dev, one model call alone reaches
+#: 194s at the 99.9th percentile, so anything shorter is a coin toss dressed up
+#: as an assertion.
+UNTIL_A_STEERED_RUN_FINISHES = 300.0
+
 #: Work the product does on its own schedule — a trigger firing, a document
 #: converting, a bundle exporting, a failing schedule giving up.
 UNTIL_BACKGROUND_WORK_LANDS = 180.0

--- a/tests/scenarios/journeys/agents_and_conversations/test_asking_and_delegating.py
+++ b/tests/scenarios/journeys/agents_and_conversations/test_asking_and_delegating.py
@@ -61,7 +61,7 @@ async def test_an_agent_asks_and_resumes_with_the_answer(world):
     )
 
     conversation = await alice.starts_a_conversation(
-        in_pod=pod, with_agent=agent["name"], saying="Prepare a report."
+        watching=False, in_pod=pod, with_agent=agent["name"], saying="Prepare a report."
     )
 
     [question] = await alice.waits_for_an_approval_in(conversation, in_pod=pod)
@@ -100,7 +100,7 @@ async def test_an_unanswered_question_keeps_waiting(world):
     )
 
     conversation = await alice.starts_a_conversation(
-        in_pod=pod, with_agent=agent["name"], saying="Get started."
+        watching=False, in_pod=pod, with_agent=agent["name"], saying="Get started."
     )
 
     await alice.waits_for_an_approval_in(conversation, in_pod=pod)
@@ -168,6 +168,7 @@ async def test_decisions_are_a_durable_record(world):
     table = await alice.creates_a_table(in_pod=pod, columns=[column("title")])
 
     conversation = await alice.starts_a_conversation(
+        watching=False,
         in_pod=pod,
         with_agent=agent["name"],
         saying=f"Have a look at the {table['name']} table.",
@@ -210,6 +211,7 @@ async def test_an_agent_delegates_to_a_subagent(world):
     )
 
     conversation = await alice.starts_a_conversation(
+        watching=False,
         in_pod=pod,
         with_agent=agent["name"],
         saying=(

--- a/tests/scenarios/journeys/sharing_and_permissions/test_session_approvals.py
+++ b/tests/scenarios/journeys/sharing_and_permissions/test_session_approvals.py
@@ -85,6 +85,7 @@ async def test_approving_runs_the_described_action(pod_with_two_records):
     alice, pod, table, first, second, agent = pod_with_two_records
 
     conversation = await alice.starts_a_conversation(
+        watching=False,
         in_pod=pod,
         with_agent=agent["name"],
         saying=(
@@ -113,6 +114,7 @@ async def test_denying_leaves_the_action_undone(pod_with_two_records):
     del second
 
     conversation = await alice.starts_a_conversation(
+        watching=False,
         in_pod=pod,
         with_agent=agent["name"],
         saying=(
@@ -158,6 +160,7 @@ async def test_a_session_approval_stops_repeat_asking(pod_with_two_records):
     )
 
     conversation = await alice.starts_a_conversation(
+        watching=False,
         in_pod=pod,
         with_agent=ungranted["name"],
         saying=(
@@ -191,6 +194,7 @@ async def test_a_session_approval_does_not_leak_to_another_conversation(
     alice, pod, table, first, second, agent = pod_with_two_records
 
     approved = await alice.starts_a_conversation(
+        watching=False,
         in_pod=pod,
         with_agent=agent["name"],
         saying=(f"Delete the row titled 'first' from the {table['name']} table."),
@@ -205,6 +209,7 @@ async def test_a_session_approval_does_not_leak_to_another_conversation(
     # The only thing that changed is which conversation it is happening in,
     # which is precisely what a *session* approval is scoped to.
     fresh = await alice.starts_a_conversation(
+        watching=False,
         in_pod=pod,
         with_agent=agent["name"],
         saying=(f"Delete the row titled 'second' from the {table['name']} table."),

--- a/tests/scenarios/journeys/test_harness_contract.py
+++ b/tests/scenarios/journeys/test_harness_contract.py
@@ -148,6 +148,44 @@ def test_a_scenario_waits_on_a_named_budget():
     )
 
 
+def test_a_harness_step_waits_on_a_named_budget():
+    """The other half of the rule above, and the half that hid a real bound.
+
+    The guard above reads scenarios, so a literal written as a *default* on a
+    harness step was invisible to it: `answers_every_approval` waited 90s and
+    `waits_for_the_run_to_settle` 60s, and no scenario said either number or
+    could have moved it. That is the same defect the named budgets exist to
+    stop, one level down, and the more dangerous version — a scenario at least
+    shows its number at the call site.
+
+    Only `harness/steps` is read. `stack.py` waits on a container coming up and
+    `drivers` on one HTTP request, which are bounds on the machinery rather than
+    patience for the product, and stay literals for the reason the guard above
+    gives.
+    """
+    offenders: list[str] = []
+    for path in sorted((SUITE / "harness" / "steps").glob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            arguments = node.args
+            defaults = list(arguments.defaults) + list(arguments.kw_defaults)
+            named = list(arguments.args) + list(arguments.kwonlyargs)
+            for argument, default in zip(named[-len(defaults) :], defaults):
+                if argument.arg != "timeout" or default is None:
+                    continue
+                if isinstance(default, ast.Constant):
+                    offenders.append(
+                        f"{path.relative_to(SUITE)}:{default.lineno} ({node.name})"
+                    )
+    assert not offenders, (
+        "a harness step's default wait must be a named budget from "
+        "`harness.waiting`, so it is visible and moves with the others:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
 def test_scenarios_do_not_sleep():
     """No scenario waits by sleeping.
 


### PR DESCRIPTION
A model request that stops making progress used to be held open with no bound at all. Nothing timed out, nothing retried, and the person's HTTP request stayed open for as long as the provider cared to take.

Found by chasing a single scenario failure on dev (`test_denying_leaves_the_action_undone`, `httpx.ReadTimeout` after 31 consecutive passes). The failure turned out to be a symptom; three separate defects are fixed here, and the last of them is the only one that makes that scenario green.

## What was actually happening

The timed-out request was not the approval it looked like. `POST /pods/{id}/conversations/{id}/messages` is a `StreamingResponse`, and the harness drains it, so that one request lasts as long as the run does.

From dev, the run behind it: one `agent_run`, `COMPLETED`, `17:11:16 → 17:15:46` — 270s. Phoenix accounts for all of it as **two LLM calls, 85.2s and 184.7s**; the tool call in between took 80ms. Those two delivered 71 and 325 output tokens, an effective **0.83 and 1.76 tokens/sec**, against 36–94 tok/s for healthy calls in the same window — one of which carried 98k input tokens.

It is not our event loop, which was the obvious competing explanation. **During the 184.7s call, 15 other LLM calls ran concurrently and finished in 0.6–9.0s at full rate.** CPU throttling on the pod was 79ms over its whole life.

Across 14,476 retained LLM spans: p50 3.5s, p95 23.0s, p99 70.0s, p99.9 194.6s, **max 1169.6s**. 191 calls over 60s, 51 over 120s, 8 over 300s. The tail is real, and nothing bounded it.

## 1. Nothing bounded a model exchange

`agent_model_http_read_timeout_seconds` is 180s and, as its own docstring says, **per chunk** — httpx resets it every time bytes arrive. That is the right shape for "the provider has gone away", and it is exactly why it cannot see a provider that keeps sending *something*. A trickle never trips it, at any setting that does not also kill legitimate long answers.

`model_stream_budget.py` adds the two bounds a per-chunk timeout structurally cannot: how long the provider may take to send the **first** body chunk (60s), and how long one exchange may run in **total** (300s). Both sized above measured percentiles of the full distribution — 300s sits above p99.9 and catches 8 calls in 14,476, including the 19.5-minute one.

Both raise `httpx.ReadTimeout`, and that is the load-bearing decision rather than a detail. It is an `httpx.TransportError`, so `is_retryable_stream_error` already answers True and `drive_with_retry` re-enters the run from the snapshot taken *before* the failing request — re-asking only that request and replaying completed tool results rather than re-running them. Raising the transport's own error is what lets an existing, tested recovery path handle a new failure with no changes to it. There is a test pinning that end to end.

The stream is closed on the way out, not abandoned, so a provider we have given up on does not keep a pooled connection with it.

## 2. The pool settings were being discarded in silence

`AsyncClient._init_transport` returns a transport handed to it *before* it looks at `limits`, so passing both is accepted and the limits are dropped. Measured on `main`:

```
max_connections           = 100   (config says 100 — matched httpx's default by luck)
max_keepalive_connections = 20    (config says 100)
keepalive_expiry          = 5.0   (config says 30.0)
```

`agent_model_http_max_connections` did nothing whatsoever. Limits now go on the transport, where they apply. Timeouts were never affected — those travel per-request in the extensions — and there is a test pinning that too, so the two are not conflated later.

Related: `AsyncTenacityTransport` wraps a bare `AsyncHTTPTransport()` when handed nothing, so the base transport had to be built explicitly regardless.

## 3. A test's own request timeout was acting as a ceiling on the model

This is the one that fixes the scenario, and the product fix above does **not** fix it: at 270s the run was inside every bound this PR adds, and correctly so.

Sending over the stream holds one HTTP request open for the whole run, against the harness's 150s per-request bound. So a scenario that intends to *answer* the agent is blocked reading at exactly the moment it is supposed to reply — it works today only because a run that pauses for approval ends, and ends the stream with it. That makes an HTTP client timeout the real bound on the model, which no scenario chose and the product cannot promise to win: a single call reaches 194s at p99.9.

`starts_a_conversation(..., watching=False)` appends instead, starting the same run without tying the scenario to how long it takes. Applied to the nine scenarios that answer the agent, plus `test_an_agent_delegates_to_a_subagent` — which asked for `UNTIL_A_MODEL_ACTS` (180s) while the stream silently capped it at 150s, so its declared budget was unreachable.

## 4. The budgets that were hiding one level down

Moving those sends off the stream exposed what had been absorbing the wait. `answers_every_approval` waited **90s** and `waits_for_the_run_to_settle` **60s**, both as defaults on harness steps — so no scenario said either number or could have moved it. With p99 for a *single* call at 70s, the second one was a coin toss.

The named-budget guard from #585 reads scenarios, so a literal written as a default was invisible to it. `test_a_harness_step_waits_on_a_named_budget` reads `harness/steps` too; it was checked against the original `90.0` and fails on it. `stack.py` and `drivers` keep their literals for the reason the existing guard gives — those bound the machinery, not our patience for the product.

New budget `UNTIL_A_STEERED_RUN_FINISHES` (300s) for a run a person is steering across several turns, and the rest moved onto the existing names.

## What this does not do

It does not bound a whole run. Three attempts at 300s is 15 minutes in the worst case, and a legitimately long multi-turn run is indistinguishable from that without a throughput signal we do not currently record. `agent.model_stream_budget.stream_abandoned.degraded` logs every expiry with its elapsed time and which bound fired, which is the measurement needed to tighten these on evidence rather than on argument.

Defaults are deliberately safe over aggressive: a false expiry costs one retry, not a failed run.

## Verification

| check | result |
|---|---|
| `make quality` (incl. architecture ratchet, log catalog, census) | pass |
| agent unit suite | 1492 passed |
| new: `test_model_stream_budget.py` | 10 passed |
| new: `test_provider_client_wiring.py` | 4 passed |
| `make scenarios-guards` | 90 passed |
| scenario collection | 431 collected, 34 deselected |

Both new guards were checked against the previous behaviour rather than assumed: the wiring tests fail on `main` (three of four), the limits bug was measured on `main` directly, and the harness-budget guard fails when the original `90.0` is put back.
