### PR TITLE
WIP: Conversations more than one person and more than one agent can be in

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ read the [README](../README.md) or visit [lemma.work](https://lemma.work).
 | [Agent memory](architecture/agent-memory.md) | Where an agent's durable facts live, what is loaded into every prompt, and what bounds it |
 | [Database connection scope](design/db-connection-scope.md) | How long a pooled connection is held, the gates that keep it short, and what authorization costs |
 | [Product analytics](design/product-analytics.md) | The product-analytics plane, its event contract, origins, and the privacy boundary |
+| [Agent conversations](design/agent-conversations.md) | Proposed: one persistent conversation per agent, who a run acts as, who sees the working, and how a message finds its agent |
 
 The sandbox set breaks down further:
 [protocol](architecture/sandbox/sandbox-protocol.md) ·

--- a/docs/design/agent-conversations.md
+++ b/docs/design/agent-conversations.md
@@ -1,0 +1,376 @@
+# Agent conversations
+
+Status: the backend is built; the web workspace is not. What landed, and what
+did not, is at the end under [Where this stands](#where-this-stands).
+
+## The model
+
+A conversation with an agent is **one persistent thing per agent**, not one per
+session. You open Lemma, you are already in it, and the last thing you said is
+above the composer. You can still create more, and you can still start a new
+topic inside one — but neither is the default path, and neither is how talking
+to an agent *begins*.
+
+A conversation starts as a DM: one person, one agent. From there people and
+agents can be added to it. That single sentence is what makes the rest of this
+document necessary, because the current model has exactly one owner per
+conversation and resolves every permission question through them.
+
+Four rules follow from it:
+
+- **A run acts as the sender**, not as the conversation. Whoever typed the
+  message is the identity the agent's tools execute under.
+- **With more than one agent present, an `@mention` addresses one of them.** An
+  unaddressed message reaches a small router model that decides who — if anyone
+  — answers. Silence is the expected answer.
+- **Everyone sees the answer; only the sender sees the working.** A run's final
+  text is the conversation's; its tool calls, tool results and reasoning belong
+  to the person who triggered it.
+- **A subthread is created deliberately**, by a person branching or an agent
+  spawning. It is not one per turn.
+
+The noun stays **conversation**. `channel` is already a Slack channel
+(`external_channel_id`) and already a delivery route
+(`agent_surfaces/services/notification_channels.py`); a third meaning is not
+worth the shorter word. This document says "conversation" for the persistent
+thing, and "channel" only where it means a Slack one.
+
+## What already exists
+
+The reason this is a proposal and not a rewrite: most of the storage and all of
+the history policy already assume a long-lived conversation.
+
+`agent_conversations` already has a nullable `agent_id` (NULL is the pod's
+default assistant), a `parent_id`, a `conversation_type`, and `is_archived`. It
+also already carries the index this design needs as a *uniqueness* key:
+
+```
+ix_agent_conv_user_pod_agent_roots
+  (user_id, pod_id, COALESCE(agent_id, '00000000-…-0001'))
+  WHERE parent_id IS NULL
+```
+
+That sentinel is `DEFAULT_POD_AGENT_ID` from `app/core/authorization/delegation.py`
+— the pod assistant's id. The key for "the conversation between this person and
+this agent" is already spelled out in the schema; it is simply not unique yet.
+
+History policy already treats conversations as things that do not end.
+`app/modules/agent/services/runtime_history.py` keeps the most recent five runs
+in full, caps a conversation at sixty runs, and elides everything older to its
+first and last message with a synthetic notice in between.
+`app/modules/agent/services/context_budget.py` compacts at 80% of whatever
+window the model actually has. The docstring on the former records that the web
+UI once had *no* bound and a 400-turn conversation loaded every run it had ever
+had. The permanent conversation is already partly the operating reality; what
+changes is that it becomes the intent.
+
+Addressing exists too, for external surfaces.
+`app/modules/agent_surfaces/services/surface_routing.py` defines `_addressed()`
+as `mentioned_agent or is_thread_reply`, and group surfaces already require it.
+The second clause is the important one: a reply inside the agent's thread counts
+as addressed, so a mention is *sticky* within a subthread. Mention once, then
+talk normally. Native conversations should use the same predicate rather than
+growing a second one.
+
+Finally, the model already learns who spoke in a group. `_sender_label` in
+`app/modules/agent/infrastructure/harnesses/pydantic_ai_history.py` reads
+`sender_display_name` / `sender_email` / `sender_phone` off message metadata and
+renders it into history. The prompt half of multi-sender is solved; it is
+metadata-shaped and surface-only, which is what has to change.
+
+## Membership and access
+
+Today a conversation has one owner and the check is equality:
+
+```python
+# app/modules/agent/services/conversation_access.py
+if conversation.user_id != user_id:
+    raise ConversationNotFoundError()
+```
+
+There is no participants table anywhere in the module. Adding people starts
+here, ahead of everything else in this document.
+
+The shape:
+
+| Concern | Decision |
+| --- | --- |
+| Members | A `conversation_participants` row per person and per agent, with a role. Pod membership is not sufficient — a conversation is narrower than a pod. |
+| Access check | Membership lookup replaces the equality test. It keeps returning not-found rather than forbidden, for the reason already documented there. |
+| `conversation.user_id` | Demoted to *who opened it*. It stops being an authorization input. |
+| Agents present | Rows in the same table. This is what gives the router a roster and the mention parser a namespace. |
+
+Demoting `conversation.user_id` is the wide part of the diff. It is read as the
+acting identity in roughly twenty places outside tests — `conversation_turns`,
+`snooze_wake_service`, `queued_followup`, `message_reply_service`,
+`conversation_title_service`, `conversation_mcp_service`, the pydantic-ai
+harness. Each one has to be re-pointed at an identity that now varies per run.
+
+One layered check moves with it. `widget_controller` re-applies
+`conversation.user_id == viewer` on top of `CONVERSATION_READ` specifically
+because that permission is pod-wide and would otherwise let any pod member read
+another member's widget HTML. Under participants that becomes a membership
+test — and given the visibility rule below, probably a sender test.
+
+## Who a run acts as
+
+`RunIdentity` already carries a `user_id`
+(`app/modules/agent/services/run_identity.py`) and is documented as everything
+fixed for the whole run. That is the correct home for the acting identity. The
+move is:
+
+- `conversation.user_id` — who opened it. Provenance, not permission.
+- `RunIdentity.user_id` — who this run acts as. Every authorization context,
+  every tool grant, every RLS decision reads this.
+
+This is what makes multi-person conversations tractable at all. Grants stay per
+person; a conversation does not become a shared credential. If you cannot run a
+function, an agent you talk to cannot run it for you, and the existing
+`require_agent_actions` check on `agent.execute` keeps meaning what it means.
+
+### Runs with no sender
+
+Not every run has one. Snooze wakes, queued followups, title generation and
+scheduled runs all build their context from `conversation.user_id` today
+precisely because there is nobody typing. Under run-as-sender they need a
+recorded actor, and it should be **captured at setup time, not resolved at fire
+time** — "this schedule acts as the person who created it," written down when
+the schedule is created. Resolving it later, from membership, means the identity
+a background run holds can change when someone joins or leaves.
+
+This is the same question already open on scheduled runs, where an unattended
+run holds user-equivalent authority. This design does not answer it; it does
+make the answer apply in one more place, and it makes the actor explicit enough
+that the answer has somewhere to live.
+
+## Visibility: the answer is shared, the working is not
+
+Run-as-sender fixes what an agent may *do* on someone's behalf. It does nothing
+about what the result then shows to everyone else standing in the room. A run
+acting as A uses A's grants, and its output lands where B can read it.
+
+The rule:
+
+- **Final answer** — the run's assistant `TEXT` — belongs to the conversation.
+  Everyone present sees it.
+- **Working** — `TOOL_CALL`, `TOOL_RETURN`, `THINKING` — belongs to the sender.
+  Only they see it.
+
+`MessageKind` already draws exactly this line, so rendering needs no new
+concept: filter by kind per viewer and stop.
+
+### The unit is the run, not the message
+
+Prompt construction cannot do the same thing, and this is the constraint that
+shapes the feature.
+
+`pydantic_ai_history` is explicit that its one subtle rule is tool pairing. When
+a call has no matching return, `_build_tool_batch` does not drop it — it
+**synthesizes a failure return**, deliberately, to preserve the
+`tool_use`/`tool_result` pairing Anthropic requires. So stripping A's tool
+returns out of B's history would tell the model that A's tools *failed*. That is
+not a redaction; it is a false statement that changes what the agent does next.
+Keeping the calls and dropping only the returns is no safer, because tool
+arguments carry the sensitive query about as often as the result carries the
+sensitive answer.
+
+So a run's working is included whole or excluded whole. For B's turn, A's
+earlier runs reduce to the question and the final answer.
+
+That is the elision `runtime_history` already performs — trimming whole runs at
+a time so a tool call is never separated from its return, and reducing an old
+run to its first and last message with a notice in between. The same mechanism,
+triggered by *who is looking* rather than by age. This is the reason the rule is
+affordable.
+
+Two things fall out without extra work:
+
+- **Reasoning is already conditional.** `PendingThoughts` gates thought replay on
+  the `protocol` argument, and a caller that does not name one replays no
+  reasoning at all. The hardest part of "working" to redact is off by default.
+- **Approvals land on the right person.** `interaction_sender_matches` already
+  requires the resolver to be the same external user and fails closed when it
+  cannot tell. If working is sender-private, only the sender sees the approve
+  button — which is the correct answer and already the code's instinct.
+
+There is a second, unrelated reason to want this: other people's tool payloads
+were going to consume the context window anyway. The privacy rule and the
+context budget push in the same direction.
+
+### What it does not close
+
+**Derived answers.** "Summarise the salary table" produces a final answer that
+*is* the private data. Filtering by kind does nothing, and no plumbing will. The
+control is the prompt: an agent should know who is present and be able to
+decline to put something in a shared room. That is soft, and it should be
+described as soft.
+
+**Egress.** Once an answer leaves through a surface, that platform's membership
+decides who reads it, not ours.
+
+Both are reasons the visibility rule is a *default that prevents accidents*,
+not an access-control system. The stated policy remains that a conversation is a
+room: joining it is being trusted with what is said in it. Adding a member is a
+grant, and the product should say so.
+
+Resource rendering is not on this list. `display_resource` resolves content
+through the pod's own services under the caller's context, so pod membership and
+RLS already bound it.
+
+## Addressing
+
+Two stages, in order. The first is deterministic and the second is not, and that
+ordering is the design.
+
+**1. Explicit address.** An `@mention` of an agent present in the conversation,
+or a message inside a subthread that agent is already answering. Reuse the
+`_addressed()` predicate. An explicit mention must never reach a model to be
+interpreted.
+
+**2. The router.** Only for messages stage 1 did not claim. A small model gets
+the last message, the roster, and a short window of recent turns, and returns
+one agent or nobody.
+
+Four constraints on it:
+
+- **Ignore is the default and must be cheap.** Where people mostly talk to each
+  other, most messages are not for any agent. A model asked "who should reply?"
+  will find someone to be helpful with, so the prompt has to be biased hard
+  toward silence and the call small enough that being wrong costs nothing.
+- **Never route agent-authored messages.** Otherwise agent A posts, the router
+  sees a new message, routes to agent B, who posts, and it talks to itself. A
+  per-turn routing budget is the backstop; excluding agent authorship is the
+  fix.
+- **Skip it entirely when the answer is structural.** A DM with one agent — the
+  default, and most of them — has one candidate and every message is addressed.
+  No router call should ever be made there.
+- **It decides *who*, never *what*.** The router does not summarise, rewrite or
+  pre-answer. It picks a name or returns nothing, so a wrong decision costs one
+  skipped reply rather than a fabricated one.
+
+Choosing nobody is an ordinary outcome, and it means **no run is created at
+all**: the message is stored, everyone watching is sent it, and
+`AgentRunStartResult.agent_run_id` is null. The send endpoint answers that with
+a single `unanswered` frame and closes, rather than holding a stream open
+against a run that will never exist.
+
+## Subthreads
+
+A subthread is a deliberate branch. It is not one per agent run.
+
+A run is an execution boundary: one message in, one pass of the harness. Keying
+subthreads on run ids would produce a subthread per turn, which is not a thread.
+Runs stay what they already are — the unit history is trimmed by, whole runs at
+a time, so a tool call is never separated from its return.
+
+Branch points belong on `AgentRun.parent_run_id`, which already exists.
+
+They do **not** belong on `Conversation.parent_id`. That column already carries
+two meanings — sub-agent spawn linkage and PROJECT pinning — and the codebase
+explicitly pins the distinction between them (see the comment in
+`app/modules/agent/tools/toolset_selection.py` and the sub-agent tests). A third
+meaning on the same column is a bug nobody will be able to name.
+
+A "new topic" control inside a conversation was built and removed. It reset the
+context without ending the conversation, which sounded like the answer to the
+objection above -- and was worse than the thing it replaced. Creating a new
+conversation already gives a clean slate, says so unambiguously, and leaves the
+old one where you can find it; a hidden mode that silently drops context is a
+way to lose work by mis-clicking. Surfaces keep their own
+``dm_conversation_reset_after_hours``, which is a different question: nobody
+chooses it, so nothing is mis-clicked.
+
+## What stays unsolved
+
+**Compaction summaries become durable memory.** Today a compaction summary is a
+transient prompt artifact on a conversation that will probably be abandoned. In
+one that never ends, the summary *is* its memory of its own past. It should be a
+durable, inspectable record — something a person can read and correct — rather
+than a string regenerated inside a prompt. This is the largest piece of
+engineering in the design and it is not schema work.
+
+## Order of work
+
+1. **Participants table and the access check.** Replaces the equality test in
+   `conversation_access`. Useful on its own: it is what lets a second person see
+   a conversation at all.
+2. **Sender on messages.** A real column, not metadata. `_sender_label` already
+   knows how to render it into history; it just reads the wrong place.
+3. **Actor moves to the run.** `conversation.user_id` demotes to provenance;
+   `RunIdentity.user_id` becomes the acting identity. Wide diff, and background
+   paths need explicit actors.
+4. **Visibility.** Kind filtering in rendering, run-granular elision in history.
+   Ships with (1) — a second member without it is a leak.
+5. **Conversation resolution.** Make the existing root index unique and resolve
+   `(user_id, pod_id, agent_id)` instead of creating a new row. Existing
+   conversations are not merged: the most recently active one per key becomes
+   the persistent one, the rest stay as history.
+6. **Subthreads and "new topic."** Then retire
+   `dm_conversation_reset_after_hours` for native conversations.
+7. **The router**, behind a flag, off by default, never reached in a one-agent
+   DM.
+
+The first two are worth having even if the rest slips.
+
+## Open questions
+
+- Is the persistent conversation keyed `(user, pod, agent)` or `(pod, agent)`?
+  This document assumes the former — a DM that grows — because it is the only
+  one that starts from an existing index and does not change what a conversation
+  is on day one. The latter exists before anyone speaks, and it is a different
+  product.
+- Does a Slack channel where the agent lives *become* the Lemma conversation, or
+  sit beside it as a linked surface? Today `surface_conversation_links` creates
+  one per external thread. Under this design that is either a subthread or a
+  duplicate, and duplicate is the wrong answer.
+- What does removing a member do to history they have already read?
+
+## Where this stands
+
+Built. The tables below are the map from a rule above to the code that holds it.
+
+**Backend**
+
+| Piece | Where |
+| --- | --- |
+| Membership | `agent_conversation_participants` (migration 0025, backfilling an OWNER row per conversation), `domain/participants.py`, `infrastructure/conversation_participant_store.py` |
+| Access | `conversation_access.validate_conversation_access` — the opener, or anyone added; and an agent present in the conversation may be addressed in it |
+| Sender | `agent_messages.sender_user_id` (migration 0026), written on every user message |
+| Actor | `agent_runs.triggered_by_user_id` (migration 0027, backfilled from the conversation owner). The runner reads it off the run rather than the job payload, and it is the identity the tools, the usage reservation and the telemetry all use |
+| Visibility | Kind filtering in `ConversationViewerQueriesMixin.list_messages`; run-granular collapsing in `runtime_history.select_runtime_history` |
+| Resolution | `find_persistent_conversation` + `ConversationService.open_conversation`, behind `POST /pods/{pod_id}/conversations/open` |
+| Subthreads | `runtime_history.apply_branch_lineage`, reached by `branch_from_run_id` on a send; the branch point is `AgentRun.parent_run_id` |
+| Router | `services/agent_router.py` holds the rules, `agent_router_model.py` the model call; `TurnCoordinator._route_unaddressed` calls it on every send that named nobody. No flag: routing is how a room with several agents works |
+| API | `conversation_open_controller` — open, and list/add/remove participants |
+
+**Web workspace**
+
+| Piece | Where |
+| --- | --- |
+| Sender on a turn | `lib/assistant/turns.ts` reads `messageSenderUserId` into `ChatTurn.senderUserId` |
+| Trace suppression | Same file: another person's trace is dropped whole and the turn is marked `traceWithheld`, which renders as "Worked privately" |
+| Byline | `assistant-turn.tsx`, from the roster; never shown for your own messages |
+| Participants panel | `components/conversations/conversation-participants.tsx`, in the assistant header |
+| Sidebar grouping | `assistant-experience-sidebar.tsx` groups into Ongoing (newest per agent, the same rule the server resolves with) and Earlier |
+| `@agent` | Agent participants join the composer's mention typeahead; `lib/assistant/addressed-agent.ts` reads the mention back out of the text and the send carries it as `agent_name` |
+
+Naming an agent in a send routes that turn to it, which is why the access check
+accepts an agent that is present rather than only the conversation's own.
+
+**Not built**
+
+- **Nothing writes `parent_run_id` from the UI yet.** The API takes
+  `branch_from_run_id` and the history follows the branch; the transcript has no
+  "branch from here" affordance, so subthreads are reachable through the API
+  only.
+- **The router has never run against a real model.** The rules, the guards and
+  the wiring are tested; the model call itself has only ever been exercised
+  against doubles.
+- **`dm_conversation_reset_after_hours` is untouched**, and stays that way. It
+  answers a question native conversations do not have.
+
+Uniqueness is not enforced on the resolution key. Every account already has
+many conversations per `(user, pod, agent)`, so a unique index cannot be added
+without merging or discarding history. `find_persistent_conversation` takes the
+newest live one instead; two simultaneous first messages could leave a spare,
+which the next resolve does not pick.

--- a/docs/product/coverage.md
+++ b/docs/product/coverage.md
@@ -28,7 +28,7 @@ the module suites may cover it — but it is untested *as product*.
 
 | Surface | Exercised | Total |
 | --- | ---: | ---: |
-| OpenAPI operations | 236 | 236 |
+| OpenAPI operations | 236 | 240 |
 | Product events | 28 | 28 |
 
 ## Covered, but only in a lane that is not routinely run

--- a/lemma-backend/app/composition/conversation_participant_labels.py
+++ b/lemma-backend/app/composition/conversation_participant_labels.py
@@ -1,0 +1,42 @@
+"""Names for the people in a conversation.
+
+In the composition root because it spans two modules: the roster belongs to the
+agent module and the names belong to identity, and neither may reach into the
+other's tables. One query rather than a read per participant -- this is on the
+path that opens a conversation, and the transcript cannot attribute a turn
+until it has come back.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.identity.infrastructure.models.user_models import User
+
+
+async def read_user_labels(
+    session: AsyncSession, user_ids: list[UUID]
+) -> dict[UUID, str]:
+    """What to call each of these people: a name, or an email.
+
+    Missing ids are simply absent from the result. A caller that gets nothing
+    back decides for itself whether "Unknown" or an unlabelled row reads better
+    in its own context, which this cannot know.
+    """
+    if not user_ids:
+        return {}
+    rows = await session.execute(
+        select(User.id, User.first_name, User.last_name, User.email).where(
+            User.id.in_(user_ids)
+        )
+    )
+    labels: dict[UUID, str] = {}
+    for user_id, first_name, last_name, email in rows:
+        person = " ".join(part for part in (first_name, last_name) if part).strip()
+        label = person or (email or "")
+        if label:
+            labels[user_id] = label
+    return labels

--- a/lemma-backend/app/composition/workflow_agent.py
+++ b/lemma-backend/app/composition/workflow_agent.py
@@ -100,6 +100,10 @@ class AgentControlAdapter(AgentPort):
             conversation_id=conversation.id,
             agent_id=agent.id,
             agent_runtime=runtime,
+            # A workflow has no sender. It acts as the conversation's owner,
+            # which is the authority it already ran with before this column
+            # made that explicit.
+            triggered_by_user_id=conversation.user_id,
             metadata=metadata,
         )
         await self.conversation_repo.append_message(

--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -93,6 +93,7 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'agent.pydantic_ai_streaming.stop_check.failed': EventSpec('error', frozenset({'agent_run_id'})),
     'agent.queued_followup.start_failed.degraded': EventSpec('warning', frozenset({'agent_run_id', 'conversation_id'})),
     'agent.realtime.publishing_agent_realtime_event.diagnostic': EventSpec('debug', frozenset({'conversation_id', 'error_type'})),
+    'agent.router.decision.failed': EventSpec('error', frozenset({'pod_id'})),
     'agent.run.context_brief_unavailable.degraded': EventSpec('warning', frozenset({'agent_id', 'conversation_id'})),
     'agent.run.inline_reasoning_reclassified.diagnostic': EventSpec('debug', frozenset({'answer_survived', 'thought_count'})),
     'agent.run_event_pump.stream_ended_without_a_terminal_event.degraded': EventSpec('warning', frozenset({'agent_run_id'})),

--- a/lemma-backend/app/modules/agent/api/controllers/conversation_controller.py
+++ b/lemma-backend/app/modules/agent/api/controllers/conversation_controller.py
@@ -391,6 +391,8 @@ async def send_message(
                 content=data.content,
                 pod_id=pod_id,
                 message_metadata=data.metadata,
+                agent_name=data.agent_name,
+                branch_from_run_id=data.branch_from_run_id,
             )
 
     return await start_and_stream_run(
@@ -439,6 +441,12 @@ async def append_message(
             content=data.content,
             pod_id=pod_id,
             message_metadata=data.metadata,
+            # The same request body as the streaming send, so the same fields
+            # have to mean the same thing. Reading `content` here and ignoring
+            # `agent_name` is how a mention worked on one endpoint and vanished
+            # on the other.
+            agent_name=data.agent_name,
+            branch_from_run_id=data.branch_from_run_id,
         )
     return AgentRunStartResponse.model_validate(result)
 

--- a/lemma-backend/app/modules/agent/api/controllers/conversation_open_controller.py
+++ b/lemma-backend/app/modules/agent/api/controllers/conversation_open_controller.py
@@ -1,0 +1,141 @@
+"""Opening the conversation somebody is already having with an agent.
+
+Its own module because ``conversation_controller`` is at the architecture
+ratchet's per-file limit, and because this route answers a different question
+from the ones there: not "make me a conversation" but "take me back to mine".
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, status
+
+from app.core.api.dependencies import CurrentUser
+from app.core.authorization.dependencies import require_pod_membership
+from app.modules.agent.api.dependencies import ConversationServiceDep
+from app.modules.agent.api.schemas import (
+    AddConversationParticipantRequest,
+    ConversationParticipantListResponse,
+    ConversationParticipantResponse,
+    ConversationResponse,
+)
+
+router = APIRouter(prefix="/pods/{pod_id}/conversations", tags=["agent_conversations"])
+
+CONVERSATION_MEMBERSHIP = require_pod_membership()
+
+
+@router.post(
+    "/open",
+    response_model=ConversationResponse,
+    status_code=status.HTTP_200_OK,
+    operation_id="agent.conversation.open",
+    dependencies=[CONVERSATION_MEMBERSHIP],
+    summary="Open Pod Agent Conversation",
+    description=(
+        "Return the caller's ongoing conversation with an agent, opening one "
+        "if there is none yet. Omit agent_name for the default pod assistant. "
+        "Unlike create, calling this twice returns the same conversation: it "
+        "is where a person lands when they open the agent rather than a new "
+        "session each time. Archived, task, project and surface-bound "
+        "conversations are never returned."
+    ),
+)
+async def open_conversation(
+    pod_id: UUID,
+    user: CurrentUser,
+    service: ConversationServiceDep,
+    agent_name: str | None = None,
+) -> ConversationResponse:
+    conversation, _created = await service.open_conversation(
+        pod_id=pod_id,
+        agent_name=agent_name,
+        user_id=user.id,
+    )
+    return ConversationResponse.model_validate(conversation)
+
+
+@router.get(
+    "/{conversation_id}/participants",
+    response_model=ConversationParticipantListResponse,
+    operation_id="agent.conversation.participant.list",
+    dependencies=[CONVERSATION_MEMBERSHIP],
+    summary="List Conversation Participants",
+    description="Who is in a conversation: the people, and the agents present.",
+)
+async def list_participants(
+    pod_id: UUID,
+    conversation_id: UUID,
+    user: CurrentUser,
+    service: ConversationServiceDep,
+) -> ConversationParticipantListResponse:
+    participants = await service.list_participants(
+        conversation_id=conversation_id, user_id=user.id, pod_id=pod_id
+    )
+    return ConversationParticipantListResponse(
+        items=[
+            ConversationParticipantResponse.model_validate(participant)
+            for participant in participants
+        ]
+    )
+
+
+@router.post(
+    "/{conversation_id}/participants",
+    response_model=ConversationParticipantResponse,
+    status_code=status.HTTP_201_CREATED,
+    operation_id="agent.conversation.participant.add",
+    dependencies=[CONVERSATION_MEMBERSHIP],
+    summary="Add Conversation Participant",
+    description=(
+        "Add one person, or one agent, to a conversation. Name exactly one of "
+        "user_id or agent_name. Adding a person is a grant: every answer in "
+        "the conversation is from then on said to them. Their own working "
+        "stays private to them, and so does everyone else's."
+    ),
+)
+async def add_participant(
+    pod_id: UUID,
+    conversation_id: UUID,
+    data: AddConversationParticipantRequest,
+    user: CurrentUser,
+    service: ConversationServiceDep,
+) -> ConversationParticipantResponse:
+    participant = await service.add_participant(
+        conversation_id=conversation_id,
+        user_id=user.id,
+        pod_id=pod_id,
+        member_user_id=data.user_id,
+        agent_name=data.agent_name,
+    )
+    return ConversationParticipantResponse.model_validate(participant)
+
+
+@router.delete(
+    "/{conversation_id}/participants",
+    status_code=status.HTTP_204_NO_CONTENT,
+    operation_id="agent.conversation.participant.remove",
+    dependencies=[CONVERSATION_MEMBERSHIP],
+    summary="Remove Conversation Participant",
+    description=(
+        "Remove one person, or one agent. Name exactly one of user_id or "
+        "agent_id. The person who opened the conversation cannot be removed "
+        "from it."
+    ),
+)
+async def remove_participant(
+    pod_id: UUID,
+    conversation_id: UUID,
+    user: CurrentUser,
+    service: ConversationServiceDep,
+    user_id: UUID | None = None,
+    agent_id: UUID | None = None,
+) -> None:
+    await service.remove_participant(
+        conversation_id=conversation_id,
+        user_id=user.id,
+        pod_id=pod_id,
+        member_user_id=user_id,
+        agent_id=agent_id,
+    )

--- a/lemma-backend/app/modules/agent/api/controllers/conversation_streaming.py
+++ b/lemma-backend/app/modules/agent/api/controllers/conversation_streaming.py
@@ -58,7 +58,32 @@ async def start_and_stream_run(
         await close_subscription(type(exc), exc, exc.__traceback__)
         raise
 
+    if result.agent_run_id is None:
+        # Nobody is answering. The message is stored and everyone watching has
+        # already been sent it; there is no run to follow, so the stream says
+        # so once and ends rather than holding a connection open against a
+        # subscription that will never see a frame.
+        await close_subscription()
+
+        async def unanswered() -> AsyncGenerator[str, None]:
+            yield encode_stream_chunk(
+                event_type="unanswered",
+                data={"conversation_id": str(conversation_id)},
+            )
+
+        return StreamingResponse(unanswered(), media_type="text/event-stream")
+
     async def event_generator() -> AsyncGenerator[str, None]:
+        # Who is answering, before a single token. Everything the client shows
+        # while a turn is in flight -- the name on the bubble, "batman is
+        # typing" -- needs this, and the first frame that would otherwise carry
+        # it is the finished message. Without it a live turn is anonymous for
+        # its whole duration, which is the entire time anyone is looking at it.
+        yield encode_stream_chunk(
+            event_type="run_started",
+            data={"agent_id": str(result.agent_id) if result.agent_id else None},
+            agent_run_id=result.agent_run_id,
+        )
         try:
             async for chunk in iter_subscription(iterator, result.agent_run_id):
                 yield chunk

--- a/lemma-backend/app/modules/agent/api/schemas.py
+++ b/lemma-backend/app/modules/agent/api/schemas.py
@@ -144,6 +144,31 @@ class AgentListResponse(BaseModel):
     next_page_token: str | None = None
 
 
+class ConversationParticipantResponse(BaseModel):
+    id: UUID
+    conversation_id: UUID
+    #: Exactly one of these is set. A person row is who may read the
+    #: conversation; an agent row is the roster a mention resolves against.
+    user_id: UUID | None = None
+    agent_id: UUID | None = None
+    role: str
+    #: What to call them on screen: a name, or an email, or nothing.
+    display_name: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ConversationParticipantListResponse(BaseModel):
+    items: list[ConversationParticipantResponse]
+
+
+class AddConversationParticipantRequest(BaseModel):
+    """Add one person or one agent. Naming both, or neither, is rejected."""
+
+    user_id: UUID | None = None
+    agent_name: str | None = None
+
+
 class ConversationResponse(BaseModel):
     id: UUID
     user_id: UUID
@@ -163,6 +188,10 @@ class ConversationResponse(BaseModel):
     last_run_error: str | None = None
     last_run_finished_at: datetime | None = None
     last_run_retryable: bool = False
+    #: Everyone in it, people and agents. Carried on the conversation rather
+    #: than fetched separately because the transcript needs it to attribute a
+    #: message the moment it renders one.
+    participants: list[ConversationParticipantResponse] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
 
@@ -198,7 +227,11 @@ class ConversationListResponse(BaseModel):
 
 class AgentRunStartResponse(BaseModel):
     conversation_id: UUID
-    agent_run_id: UUID
+    #: Null when the message was stored and no agent is answering it. See
+    #: `AgentRunStartResult`.
+    agent_run_id: UUID | None = None
+    #: Which agent is answering. Null for the pod's default assistant.
+    agent_id: UUID | None = None
     started_new_run: bool
 
     model_config = ConfigDict(from_attributes=True)
@@ -209,6 +242,13 @@ class MessageResponse(BaseModel):
     conversation_id: UUID
     sequence: int
     agent_run_id: UUID | None = None
+    #: Which person wrote this, when a person did. Null on everything an agent
+    #: produced, and on user messages predating the column.
+    sender_user_id: UUID | None = None
+    #: The agent that produced it, when an agent did. Null on anything a person
+    #: wrote. A conversation can be answered by more than one agent, so this is
+    #: what lets a transcript put a name on an answer.
+    agent_id: UUID | None = None
     role: str
     kind: MessageKind
     text: str | None = None
@@ -266,6 +306,13 @@ class UpdateConversationRequest(BaseModel):
 class SendMessageRequest(BaseModel):
     content: str
     metadata: JsonObject | None = None
+    #: Address one agent for this turn, as an `@mention` does. It must already
+    #: be in the conversation: naming one that is not is refused, so a name
+    #: typed into a message cannot reach an agent nobody added.
+    agent_name: str | None = None
+    #: Branch a subthread from an earlier run. The new run sees that run and
+    #: everything leading to it, and no sibling branch sees this one.
+    branch_from_run_id: UUID | None = None
 
 
 class CreateAgentRequest(BaseModel):

--- a/lemma-backend/app/modules/agent/config.py
+++ b/lemma-backend/app/modules/agent/config.py
@@ -32,6 +32,13 @@ class AgentSettings(BaseSettings):
         extra="ignore",
     )
 
+    agent_router_model: str | None = Field(
+        default=None,
+        description=(
+            "Optional small model that decides who answers an unaddressed "
+            "message. Falls back to the system profile's default."
+        ),
+    )
     agent_run_stop_poll_interval_seconds: float = Field(
         default=1.0,
         description="Minimum interval between database polls of an agent run's stop flag.",

--- a/lemma-backend/app/modules/agent/domain/entities.py
+++ b/lemma-backend/app/modules/agent/domain/entities.py
@@ -10,6 +10,7 @@ from pydantic import Field
 
 from app.core.authorization.context import ResourceType
 from app.core.domain.entity import CreatedEntity, Entity
+from app.modules.agent.domain.participants import ConversationParticipant
 from app.modules.agent.domain.value_objects import (
     AgentRuntimeConfig,
     AgentRunStatus,
@@ -60,6 +61,13 @@ class Message(CreatedEntity):
     conversation_id: UUID
     sequence: int
     agent_run_id: UUID | None = None
+    #: The person who wrote it, when a person did. See the column comment.
+    sender_user_id: UUID | None = None
+    #: The agent that produced it, read from its run rather than stored. A
+    #: conversation can be answered by more than one agent now, so "which agent
+    #: said this" is a question the transcript has to be able to answer, and
+    #: the run is where it is recorded. None on anything a person wrote.
+    agent_id: UUID | None = None
     # An enum, like `kind`. It used to be a bare `str` while `kind` next to it
     # was an enum, so every reader had to know which of the two it was holding
     # and normalize accordingly -- and one that forgot compared `str(kind)`
@@ -82,6 +90,7 @@ class Message(CreatedEntity):
         sequence: int,
         agent_run_id: UUID | None,
         role: MessageRole | str,
+        sender_user_id: UUID | None = None,
         kind: MessageKind = MessageKind.TEXT,
         text: str | None = None,
         tool_name: str | None = None,
@@ -94,6 +103,7 @@ class Message(CreatedEntity):
             conversation_id=conversation_id,
             sequence=sequence,
             agent_run_id=agent_run_id,
+            sender_user_id=sender_user_id,
             role=MessageRole(role),
             kind=kind,
             text=text,
@@ -117,6 +127,7 @@ class Message(CreatedEntity):
             conversation_id=conversation_id,
             sequence=sequence,
             agent_run_id=agent_run_id,
+            sender_user_id=draft.sender_user_id,
             role=draft.role,
             kind=draft.kind,
             text=draft.text,
@@ -154,6 +165,18 @@ class Conversation(Entity):
     last_run_retryable: bool = False
     messages: list[Message] = Field(default_factory=list)
     agent_runs: list["AgentRun"] = Field(default_factory=list)
+    #: Loaded by `ConversationRepository.get_conversation`. Empty on an entity
+    #: nobody asked for membership on, which is why `validate_conversation_access`
+    #: still accepts the owner directly rather than relying on this alone.
+    participants: list[ConversationParticipant] = Field(default_factory=list)
+
+    def has_participant(self, user_id: UUID) -> bool:
+        return any(participant.user_id == user_id for participant in self.participants)
+
+    def has_agent_participant(self, agent_id: UUID) -> bool:
+        return any(
+            participant.agent_id == agent_id for participant in self.participants
+        )
 
     @property
     def is_pod_assistant(self) -> bool:
@@ -174,6 +197,9 @@ class AgentRun(Entity):
     conversation_id: UUID
     agent_id: UUID | None = None
     parent_run_id: UUID | None = None
+    #: Whose message started this run. See the column comment; it is what makes
+    #: a run's working attributable in a conversation with several people in it.
+    triggered_by_user_id: UUID | None = None
     status: AgentRunStatus = AgentRunStatus.RUNNING
     agent_runtime: AgentRuntimeConfig = Field(
         default_factory=lambda: AgentRuntimeConfig(profile_id="system:lemma")

--- a/lemma-backend/app/modules/agent/domain/messages.py
+++ b/lemma-backend/app/modules/agent/domain/messages.py
@@ -1,0 +1,167 @@
+"""A message, before it has a row: its role, its kind, and the draft of one.
+
+Split out of ``value_objects`` when that file reached the architecture
+ratchet's per-file limit. Everything here is still re-exported from there, so
+no import site had to move, and both names go on meaning the same thing.
+
+These four travel together: ``MessageDraft`` is built from ``MessageRole`` and
+``MessageKind`` by every ``of_*`` constructor, and ``TEXTUAL_MESSAGE_KINDS``
+is the set of kinds whose body is in ``text``.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from uuid import UUID
+
+from pydantic import BaseModel
+
+JsonValue = object
+JsonObject = dict[str, object]
+
+
+class MessageRole(str, Enum):
+    USER = "user"
+    ASSISTANT = "assistant"
+    SYSTEM = "system"
+    TOOL = "tool"
+
+
+class MessageKind(str, Enum):
+    """Discriminates the flat message body.
+
+    A message carries exactly one kind. Textual kinds use ``text``; tool kinds
+    use ``tool_name``/``tool_call_id`` plus ``tool_args`` (call) or
+    ``tool_result`` (return). There is no nested ``content`` object.
+    """
+
+    TEXT = "TEXT"
+    NOTIFICATION = "NOTIFICATION"
+    THINKING = "THINKING"
+    TOOL_CALL = "TOOL_CALL"
+    TOOL_RETURN = "TOOL_RETURN"
+
+    @classmethod
+    def _missing_(cls, value: object) -> "MessageKind | None":
+        # Case-insensitive so a lowercase kind from a harness payload or a
+        # pre-migration row still resolves to the CAPS member.
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip().upper()
+        for member in cls:
+            if member.value == normalized:
+                return member
+        return None
+
+
+#: What a run produced on the way to an answer, as opposed to the answer. In a
+#: conversation with more than one person in it these belong to whoever
+#: triggered the run: tool arguments carry the question they asked and tool
+#: results carry data their grants reached, neither of which the rest of the
+#: room is owed. The final text is the conversation's.
+WORKING_MESSAGE_KINDS = frozenset(
+    {MessageKind.THINKING, MessageKind.TOOL_CALL, MessageKind.TOOL_RETURN}
+)
+
+TEXTUAL_MESSAGE_KINDS = frozenset(
+    {MessageKind.TEXT, MessageKind.NOTIFICATION, MessageKind.THINKING}
+)
+
+
+class MessageDraft(BaseModel):
+    """Harness-produced message before durable DB id/sequence assignment.
+
+    Flat by construction: the body lives directly on the draft instead of a
+    nested ``content`` union, so there is no ``content.content`` indirection.
+    Build via the ``of_*`` constructors to keep call sites readable.
+    """
+
+    role: MessageRole
+    kind: MessageKind
+    #: Set only on messages a person wrote. Carried on the draft rather than
+    #: derived from `role` at write time, because the writer is the only layer
+    #: that knows *which* person the request came from.
+    sender_user_id: UUID | None = None
+    text: str | None = None
+    tool_name: str | None = None
+    tool_call_id: str | None = None
+    tool_args: JsonValue = None
+    tool_result: JsonValue = None
+    metadata: JsonObject | None = None
+
+    @classmethod
+    def of_text(
+        cls,
+        text: str,
+        *,
+        role: MessageRole = MessageRole.ASSISTANT,
+        sender_user_id: UUID | None = None,
+        metadata: JsonObject | None = None,
+    ) -> "MessageDraft":
+        return cls(
+            role=role,
+            kind=MessageKind.TEXT,
+            text=text,
+            sender_user_id=sender_user_id,
+            metadata=metadata,
+        )
+
+    @classmethod
+    def of_thinking(
+        cls,
+        text: str,
+        *,
+        role: MessageRole = MessageRole.ASSISTANT,
+        metadata: JsonObject | None = None,
+    ) -> "MessageDraft":
+        return cls(role=role, kind=MessageKind.THINKING, text=text, metadata=metadata)
+
+    @classmethod
+    def of_notification(
+        cls,
+        text: str,
+        *,
+        role: MessageRole = MessageRole.ASSISTANT,
+        metadata: JsonObject | None = None,
+    ) -> "MessageDraft":
+        return cls(
+            role=role, kind=MessageKind.NOTIFICATION, text=text, metadata=metadata
+        )
+
+    @classmethod
+    def of_tool_call(
+        cls,
+        *,
+        tool_name: str,
+        tool_call_id: str,
+        tool_args: JsonValue = None,
+        role: MessageRole = MessageRole.ASSISTANT,
+        metadata: JsonObject | None = None,
+    ) -> "MessageDraft":
+        return cls(
+            role=role,
+            kind=MessageKind.TOOL_CALL,
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            tool_args=tool_args,
+            metadata=metadata,
+        )
+
+    @classmethod
+    def of_tool_return(
+        cls,
+        *,
+        tool_call_id: str,
+        tool_name: str | None = None,
+        tool_result: JsonValue = None,
+        role: MessageRole = MessageRole.TOOL,
+        metadata: JsonObject | None = None,
+    ) -> "MessageDraft":
+        return cls(
+            role=role,
+            kind=MessageKind.TOOL_RETURN,
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            tool_result=tool_result,
+            metadata=metadata,
+        )

--- a/lemma-backend/app/modules/agent/domain/participants.py
+++ b/lemma-backend/app/modules/agent/domain/participants.py
@@ -1,0 +1,49 @@
+"""Who is in a conversation.
+
+A conversation used to have exactly one owner, and ``conversation.user_id``
+answered every question about who could reach it. That holds while a
+conversation is a DM and stops holding the moment a second person is in one,
+which is what this table exists for. See
+``docs/design/agent-conversations.md``.
+
+People and agents share the table. A person row is who may read the
+conversation at all; an agent row is what gives a router its roster and an
+``@mention`` its namespace. Exactly one of the two columns is set on any row,
+enforced by the database rather than trusted of callers.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from uuid import UUID
+
+from app.core.domain.entity import CreatedEntity
+
+
+class ConversationParticipantRole(str, Enum):
+    """Why this participant is here."""
+
+    #: Opened the conversation. One per conversation, and not removable -- a
+    #: person cannot be evicted from a conversation they started, so the access
+    #: check needs no separate owner clause once every row has one of these.
+    OWNER = "OWNER"
+    #: Added afterwards.
+    MEMBER = "MEMBER"
+
+
+class ConversationParticipant(CreatedEntity):
+    """One person, or one agent, in a conversation."""
+
+    conversation_id: UUID
+    user_id: UUID | None = None
+    agent_id: UUID | None = None
+    role: ConversationParticipantRole = ConversationParticipantRole.MEMBER
+    #: What to call them on screen. Resolved when the roster is read, not
+    #: stored: a name that was copied here would go stale the moment somebody
+    #: changed theirs, and a transcript that attributes a message to the wrong
+    #: name is worse than one that shows an email.
+    display_name: str | None = None
+
+    @property
+    def is_agent(self) -> bool:
+        return self.agent_id is not None

--- a/lemma-backend/app/modules/agent/domain/ports.py
+++ b/lemma-backend/app/modules/agent/domain/ports.py
@@ -81,6 +81,14 @@ class AgentRepository(Protocol):
 class ConversationRepository(Protocol):
     async def create_conversation(self, conversation: Conversation) -> Conversation: ...
 
+    async def find_persistent_conversation(
+        self,
+        *,
+        user_id: UUID,
+        pod_id: UUID,
+        agent_id: UUID | None,
+    ) -> Conversation | None: ...
+
     async def create_conversation_once(
         self,
         conversation: Conversation,
@@ -112,6 +120,7 @@ class ConversationRepository(Protocol):
         agent_id: UUID | None,
         agent_runtime: AgentRuntimeConfig,
         parent_run_id: UUID | None = None,
+        triggered_by_user_id: UUID | None = None,
         metadata: JsonObject | None = None,
     ) -> AgentRun: ...
 
@@ -149,6 +158,8 @@ class ConversationRepository(Protocol):
         self,
         *,
         conversation_id: UUID,
+        viewer_id: UUID | None = None,
+        owner_user_id: UUID | None = None,
         before_sequence: int | None = None,
         after_sequence: int | None = None,
         limit: int = 100,

--- a/lemma-backend/app/modules/agent/domain/prompts.py
+++ b/lemma-backend/app/modules/agent/domain/prompts.py
@@ -145,6 +145,36 @@ def load_toolset_fragment(toolset: AgentToolset) -> str | None:
     return _read_required_prompt(path) if path is not None else None
 
 
+def _room_section(conversation, agent) -> str | None:
+    """Who is in this conversation, and which of them this agent is.
+
+    Only rendered when somebody else is here. A one-to-one conversation needs
+    no roster, and adding one would put a section in every prompt to say that
+    the only two participants are the two already talking.
+    """
+    participants = getattr(conversation, "participants", None) or []
+    people = [p for p in participants if p.user_id is not None]
+    agents = [p for p in participants if p.agent_id is not None]
+    if len(people) + len(agents) < 2:
+        return None
+
+    lines = ["# In This Conversation"]
+    if people:
+        lines.append(
+            "People: " + ", ".join(p.display_name or "someone" for p in people)
+        )
+    if agents:
+        lines.append(
+            "Agents: " + ", ".join(p.display_name or "an agent" for p in agents)
+        )
+    lines.append(
+        f"You are {agent.name} here. Answer as yourself; the others are present "
+        "and can be addressed by name, so do not relay messages on their behalf "
+        "or answer for them."
+    )
+    return "\n".join(lines)
+
+
 def build_agent_instructions(
     *,
     agent: Agent,
@@ -235,6 +265,14 @@ def build_agent_instructions(
     context_brief = getattr(ctx, "context_brief", None)
     if isinstance(context_brief, str) and context_brief.strip():
         sections.append(context_brief.strip())
+
+    # Who else is in the room. Conversation-derived, so it cannot live in the
+    # cached brief -- and without it an agent in a shared conversation has no
+    # idea anybody else is present. One said "it's just me in here, no other
+    # agents around" while standing next to another agent and two people.
+    room = _room_section(conversation, agent)
+    if room:
+        sections.append(room)
 
     # The task list the conversation already has, if any. Without this a run
     # starts blind: the list lives in conversation metadata, and the tool return

--- a/lemma-backend/app/modules/agent/domain/value_objects.py
+++ b/lemma-backend/app/modules/agent/domain/value_objects.py
@@ -273,131 +273,15 @@ DEFAULT_HISTORY_SUMMARIZATION_KEEP_MESSAGES = 40
 DEFAULT_HISTORY_HARD_TOKEN_CEILING = 117_760
 
 
-class MessageRole(str, Enum):
-    USER = "user"
-    ASSISTANT = "assistant"
-    SYSTEM = "system"
-    TOOL = "tool"
-
-
-class MessageKind(str, Enum):
-    """Discriminates the flat message body.
-
-    A message carries exactly one kind. Textual kinds use ``text``; tool kinds
-    use ``tool_name``/``tool_call_id`` plus ``tool_args`` (call) or
-    ``tool_result`` (return). There is no nested ``content`` object.
-    """
-
-    TEXT = "TEXT"
-    NOTIFICATION = "NOTIFICATION"
-    THINKING = "THINKING"
-    TOOL_CALL = "TOOL_CALL"
-    TOOL_RETURN = "TOOL_RETURN"
-
-    @classmethod
-    def _missing_(cls, value: object) -> "MessageKind | None":
-        # Case-insensitive so a lowercase kind from a harness payload or a
-        # pre-migration row still resolves to the CAPS member.
-        if not isinstance(value, str):
-            return None
-        normalized = value.strip().upper()
-        for member in cls:
-            if member.value == normalized:
-                return member
-        return None
-
-
-TEXTUAL_MESSAGE_KINDS = frozenset(
-    {MessageKind.TEXT, MessageKind.NOTIFICATION, MessageKind.THINKING}
+# Re-exported: these moved to `domain.messages` when this file reached the
+# per-file limit, and every caller still imports them from here.
+from app.modules.agent.domain.messages import (  # noqa: E402
+    TEXTUAL_MESSAGE_KINDS as TEXTUAL_MESSAGE_KINDS,
+    WORKING_MESSAGE_KINDS as WORKING_MESSAGE_KINDS,
+    MessageDraft as MessageDraft,
+    MessageKind as MessageKind,
+    MessageRole as MessageRole,
 )
-
-
-class MessageDraft(BaseModel):
-    """Harness-produced message before durable DB id/sequence assignment.
-
-    Flat by construction: the body lives directly on the draft instead of a
-    nested ``content`` union, so there is no ``content.content`` indirection.
-    Build via the ``of_*`` constructors to keep call sites readable.
-    """
-
-    role: MessageRole
-    kind: MessageKind
-    text: str | None = None
-    tool_name: str | None = None
-    tool_call_id: str | None = None
-    tool_args: JsonValue = None
-    tool_result: JsonValue = None
-    metadata: JsonObject | None = None
-
-    @classmethod
-    def of_text(
-        cls,
-        text: str,
-        *,
-        role: MessageRole = MessageRole.ASSISTANT,
-        metadata: JsonObject | None = None,
-    ) -> "MessageDraft":
-        return cls(role=role, kind=MessageKind.TEXT, text=text, metadata=metadata)
-
-    @classmethod
-    def of_thinking(
-        cls,
-        text: str,
-        *,
-        role: MessageRole = MessageRole.ASSISTANT,
-        metadata: JsonObject | None = None,
-    ) -> "MessageDraft":
-        return cls(role=role, kind=MessageKind.THINKING, text=text, metadata=metadata)
-
-    @classmethod
-    def of_notification(
-        cls,
-        text: str,
-        *,
-        role: MessageRole = MessageRole.ASSISTANT,
-        metadata: JsonObject | None = None,
-    ) -> "MessageDraft":
-        return cls(
-            role=role, kind=MessageKind.NOTIFICATION, text=text, metadata=metadata
-        )
-
-    @classmethod
-    def of_tool_call(
-        cls,
-        *,
-        tool_name: str,
-        tool_call_id: str,
-        tool_args: JsonValue = None,
-        role: MessageRole = MessageRole.ASSISTANT,
-        metadata: JsonObject | None = None,
-    ) -> "MessageDraft":
-        return cls(
-            role=role,
-            kind=MessageKind.TOOL_CALL,
-            tool_name=tool_name,
-            tool_call_id=tool_call_id,
-            tool_args=tool_args,
-            metadata=metadata,
-        )
-
-    @classmethod
-    def of_tool_return(
-        cls,
-        *,
-        tool_call_id: str,
-        tool_name: str | None = None,
-        tool_result: JsonValue = None,
-        role: MessageRole = MessageRole.TOOL,
-        metadata: JsonObject | None = None,
-    ) -> "MessageDraft":
-        return cls(
-            role=role,
-            kind=MessageKind.TOOL_RETURN,
-            tool_name=tool_name,
-            tool_call_id=tool_call_id,
-            tool_result=tool_result,
-            metadata=metadata,
-        )
 
 
 class AgentEventType(str, Enum):
@@ -542,10 +426,19 @@ class HarnessOptions:
 
 
 class AgentRunStartResult(BaseModel):
-    """Result returned after adding a user message to a conversation."""
+    """Result returned after adding a user message to a conversation.
+
+    ``agent_run_id`` is None when the message was stored and nobody is
+    answering it -- a room with several agents in it where none was addressed
+    and the router chose silence. That is an ordinary outcome, not a failure:
+    most of what is said in a room with people in it is not for an agent.
+    """
 
     conversation_id: UUID
-    agent_run_id: UUID
+    agent_run_id: UUID | None = None
+    #: Which agent is answering, so a client can name the reply while it is
+    #: still streaming. Null for the pod's default assistant, which has no row.
+    agent_id: UUID | None = None
     started_new_run: bool
 
 

--- a/lemma-backend/app/modules/agent/infrastructure/conversation_idempotency_store.py
+++ b/lemma-backend/app/modules/agent/infrastructure/conversation_idempotency_store.py
@@ -4,6 +4,9 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.agent.domain.entities import Conversation as ConversationEntity
+from app.modules.agent.infrastructure.conversation_participant_store import (
+    ensure_owner_participant,
+)
 from app.modules.agent.infrastructure.models import ConversationModel
 
 
@@ -48,6 +51,11 @@ async def create_conversation_for_id(
         created = await session.get(ConversationModel, created_id)
         if created is None:
             raise RuntimeError("Created conversation could not be reloaded")
+        # The row's own owner, not the caller's id: this path can return a
+        # conversation somebody else reserved.
+        await ensure_owner_participant(
+            session, conversation_id=created.id, user_id=created.user_id
+        )
         return created.to_entity(), True
 
     existing = await session.get(ConversationModel, conversation.id)

--- a/lemma-backend/app/modules/agent/infrastructure/conversation_origin_store.py
+++ b/lemma-backend/app/modules/agent/infrastructure/conversation_origin_store.py
@@ -5,6 +5,9 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.modules.agent.domain.entities import Conversation as ConversationEntity
+from app.modules.agent.infrastructure.conversation_participant_store import (
+    ensure_owner_participant,
+)
 from app.modules.agent.infrastructure.models import ConversationModel
 
 
@@ -48,6 +51,11 @@ async def create_conversation_for_origin(
         created = await session.get(ConversationModel, created_id)
         if created is None:
             raise RuntimeError("Created conversation could not be reloaded")
+        # The row's own owner, not the caller's id: this path can return a
+        # conversation somebody else reserved.
+        await ensure_owner_participant(
+            session, conversation_id=created.id, user_id=created.user_id
+        )
         return created.to_entity(), True
 
     existing = await session.scalar(

--- a/lemma-backend/app/modules/agent/infrastructure/conversation_participant_store.py
+++ b/lemma-backend/app/modules/agent/infrastructure/conversation_participant_store.py
@@ -1,0 +1,209 @@
+"""Reading and writing conversation membership.
+
+Kept out of ``ConversationRepository`` for the reason its other query mixins
+are: that class is near the per-file limit, and membership is a self-contained
+question that nothing else in it needs to know the shape of.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.modules.agent.domain.participants import (
+    ConversationParticipant,
+    ConversationParticipantRole,
+)
+from app.composition.conversation_participant_labels import read_user_labels
+from app.modules.agent.infrastructure.models import AgentModel
+from app.modules.agent.infrastructure.participant_models import (
+    ConversationParticipantModel,
+)
+
+
+async def ensure_owner_participant(
+    session: AsyncSession,
+    *,
+    conversation_id: UUID,
+    user_id: UUID,
+) -> None:
+    """Record the opener's membership for a conversation that has none.
+
+    Called from every path that creates a conversation, and idempotent because
+    two of those three are ``on_conflict_do_nothing`` inserts that return an
+    existing row as readily as a new one.
+
+    ``user_id`` must be the conversation row's own ``user_id``, never the
+    caller's. On the idempotent paths the row that comes back may already
+    belong to somebody else, and writing the caller in as owner there would
+    hand them a conversation they have no claim to.
+    """
+    await session.execute(
+        insert(ConversationParticipantModel)
+        .values(
+            conversation_id=conversation_id,
+            user_id=user_id,
+            role=ConversationParticipantRole.OWNER.value,
+        )
+        .on_conflict_do_nothing(constraint="uq_conversation_participant_user")
+    )
+
+
+async def list_participants(
+    session: AsyncSession,
+    conversation_id: UUID,
+) -> list[ConversationParticipant]:
+    """Everyone in one conversation, people and agents alike, with their names.
+
+    One query with two outer joins rather than a roster and then a lookup per
+    row: this is read on every conversation open, and a transcript cannot put a
+    name on a turn until it has come back.
+    """
+    result = await session.execute(
+        select(ConversationParticipantModel, AgentModel.name)
+        .outerjoin(AgentModel, ConversationParticipantModel.agent_id == AgentModel.id)
+        .where(ConversationParticipantModel.conversation_id == conversation_id)
+        .order_by(ConversationParticipantModel.created_at)
+    )
+    rows = list(result)
+    participants: list[ConversationParticipant] = []
+    for model, agent_name in rows:
+        entity = model.to_entity()
+        entity.display_name = agent_name
+        participants.append(entity)
+    # People's names live in identity, which this module may not read directly.
+    # Resolved together afterwards rather than joined: the join would be one
+    # query, and one query that crosses a module boundary is worse than two
+    # that do not.
+    labels = await read_user_labels(
+        session,
+        [
+            participant.user_id
+            for participant in participants
+            if participant.user_id is not None
+        ],
+    )
+    for participant in participants:
+        if participant.user_id is not None:
+            participant.display_name = labels.get(participant.user_id)
+    return participants
+
+
+async def list_participants_for_conversations(
+    session: AsyncSession,
+    conversation_ids: list[UUID],
+) -> dict[UUID, list[ConversationParticipant]]:
+    """The same, for many conversations in one round trip.
+
+    A list endpoint that asked per conversation would issue one query per row,
+    which is the shape that makes a sidebar slow as somebody's history grows.
+    """
+    if not conversation_ids:
+        return {}
+    result = await session.execute(
+        select(ConversationParticipantModel)
+        .where(ConversationParticipantModel.conversation_id.in_(conversation_ids))
+        .order_by(ConversationParticipantModel.created_at)
+    )
+    grouped: dict[UUID, list[ConversationParticipant]] = {}
+    for model in result.scalars():
+        grouped.setdefault(model.conversation_id, []).append(model.to_entity())
+    return grouped
+
+
+async def add_participant(
+    session: AsyncSession,
+    *,
+    conversation_id: UUID,
+    user_id: UUID | None = None,
+    agent_id: UUID | None = None,
+    role: ConversationParticipantRole = ConversationParticipantRole.MEMBER,
+) -> ConversationParticipant:
+    """Add one person or one agent. Adding twice is not an error.
+
+    Conflict-free rather than try/except: catching the integrity error would
+    mean rolling the session back, and the session belongs to the caller's unit
+    of work, not to this function.
+    """
+    if (user_id is None) == (agent_id is None):
+        raise ValueError("a participant is exactly one of a user or an agent")
+    constraint = (
+        "uq_conversation_participant_user"
+        if user_id is not None
+        else "uq_conversation_participant_agent"
+    )
+    await session.execute(
+        insert(ConversationParticipantModel)
+        .values(
+            conversation_id=conversation_id,
+            user_id=user_id,
+            agent_id=agent_id,
+            role=role.value,
+        )
+        .on_conflict_do_nothing(constraint=constraint)
+    )
+    stored = await _find_participant(
+        session,
+        conversation_id=conversation_id,
+        user_id=user_id,
+        agent_id=agent_id,
+    )
+    if stored is None:
+        raise RuntimeError("Participant could not be read back after insert")
+    return stored.to_entity()
+
+
+async def remove_participant(
+    session: AsyncSession,
+    *,
+    conversation_id: UUID,
+    user_id: UUID | None = None,
+    agent_id: UUID | None = None,
+) -> bool:
+    """Remove one participant. Returns whether there was one to remove.
+
+    The owner is refused rather than silently skipped: a caller asking to evict
+    the person whose conversation it is has got something wrong, and returning
+    False would read as "they were not in it".
+    """
+    if (user_id is None) == (agent_id is None):
+        raise ValueError("a participant is exactly one of a user or an agent")
+    existing = await _find_participant(
+        session,
+        conversation_id=conversation_id,
+        user_id=user_id,
+        agent_id=agent_id,
+    )
+    if existing is None:
+        return False
+    if existing.role == ConversationParticipantRole.OWNER.value:
+        raise ValueError("the owner of a conversation cannot be removed from it")
+    await session.execute(
+        delete(ConversationParticipantModel).where(
+            ConversationParticipantModel.id == existing.id
+        )
+    )
+    return True
+
+
+async def _find_participant(
+    session: AsyncSession,
+    *,
+    conversation_id: UUID,
+    user_id: UUID | None,
+    agent_id: UUID | None,
+) -> ConversationParticipantModel | None:
+    subject = (
+        ConversationParticipantModel.user_id == user_id
+        if user_id is not None
+        else ConversationParticipantModel.agent_id == agent_id
+    )
+    return await session.scalar(
+        select(ConversationParticipantModel).where(
+            ConversationParticipantModel.conversation_id == conversation_id,
+            subject,
+        )
+    )

--- a/lemma-backend/app/modules/agent/infrastructure/models.py
+++ b/lemma-backend/app/modules/agent/infrastructure/models.py
@@ -13,7 +13,6 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Index,
-    Integer,
     String,
     Text,
     UniqueConstraint,
@@ -291,6 +290,14 @@ class AgentRunModel(UUIDAuditBase):
         nullable=True,
         index=True,
     )
+    #: Who this run is answering. The conversation records who opened it, which
+    #: stops being the same question once more than one person is in it: this
+    #: is whose message started the run, and therefore whose working it is.
+    triggered_by_user_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
     status: Mapped[str] = mapped_column(
         String(32),
         nullable=False,
@@ -342,6 +349,7 @@ class AgentRunModel(UUIDAuditBase):
             conversation_id=self.conversation_id,
             agent_id=self.agent_id,
             parent_run_id=self.parent_run_id,
+            triggered_by_user_id=self.triggered_by_user_id,
             status=AgentRunStatus(self.status),
             agent_runtime=AgentRuntimeConfig.model_validate(self.agent_runtime),
             started_at=self.started_at,
@@ -379,6 +387,14 @@ class MessageModel(UUIDCreatedBase):
         nullable=True,
     )
     sequence: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    #: Which person wrote this, when a person did. NULL on everything an agent
+    #: or the system produced, and on user messages predating the column.
+    #: `role` says a human spoke; this says which one, which is the question a
+    #: conversation holding more than one of them has to be able to answer.
+    sender_user_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     role: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
     kind: Mapped[str] = mapped_column(
         String(32),
@@ -414,6 +430,7 @@ class MessageModel(UUIDCreatedBase):
             conversation_id=self.conversation_id,
             sequence=self.sequence,
             agent_run_id=self.agent_run_id,
+            sender_user_id=self.sender_user_id,
             role=self.role,
             kind=MessageKind(self.kind),
             text=self.text,
@@ -504,97 +521,3 @@ class AgentFeedbackModel(UUIDAuditBase):
 
 
 AgentFeedback = AgentFeedbackModel
-
-
-class AgentConversationWaitModel(UUIDAuditBase):
-    """What a snoozed conversation is waiting on — the single source of truth.
-
-    Mirrors ``workflow_run_waits``. The partial unique index enforces at most one
-    ACTIVE wait per conversation: a turn that paused on a snooze cannot also be
-    snoozed again until it wakes, and a duplicate wake cannot create a second row.
-    """
-
-    __tablename__ = "agent_conversation_waits"
-    __table_args__ = (
-        Index(
-            "ix_agent_conversation_waits_conversation_status",
-            "conversation_id",
-            "status",
-        ),
-        Index("ix_agent_conversation_waits_external_ref", "external_ref"),
-        Index(
-            "ix_agent_conversation_waits_type_ref_status",
-            "wait_type",
-            "external_ref",
-            "status",
-        ),
-        Index(
-            "uq_agent_conversation_waits_one_active",
-            "conversation_id",
-            unique=True,
-            postgresql_where=text("status = 'ACTIVE'"),
-        ),
-    )
-
-    conversation_id: Mapped[UUID] = mapped_column(
-        ForeignKey("agent_conversations.id", ondelete="CASCADE"),
-        index=True,
-        nullable=False,
-    )
-    agent_run_id: Mapped[UUID] = mapped_column(
-        ForeignKey("agent_runs.id", ondelete="CASCADE"),
-        index=True,
-        nullable=False,
-    )
-    pod_id: Mapped[UUID] = mapped_column(
-        ForeignKey("pods.id", ondelete="CASCADE"),
-        index=True,
-        nullable=False,
-    )
-    tool_call_id: Mapped[str] = mapped_column(String(255), nullable=False)
-
-    wait_type: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
-    status: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
-
-    external_ref: Mapped[str | None] = mapped_column(String, nullable=True)
-    scheduled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
-    wake_attempts: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=0, server_default="0"
-    )
-    # See the workflow wait model: a timer fires once, so a row lock is not a
-    # claim -- it is released at commit and the next tick reclaims the row.
-    fire_lease_until: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
-
-    # Nullable to match the migration: `create` always writes a dict, but a row
-    # inserted by hand or by a future backfill must not need one.
-    spec: Mapped[dict | None] = mapped_column(JSONB, default=dict)
-    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
-
-    def to_entity(self):
-        from app.modules.agent.domain.wait import (
-            AgentConversationWaitEntity,
-            AgentWaitStatus,
-            AgentWaitType,
-        )
-
-        return AgentConversationWaitEntity(
-            id=self.id,
-            conversation_id=self.conversation_id,
-            agent_run_id=self.agent_run_id,
-            pod_id=self.pod_id,
-            tool_call_id=self.tool_call_id,
-            wait_type=AgentWaitType(self.wait_type),
-            status=AgentWaitStatus(self.status),
-            external_ref=self.external_ref,
-            scheduled_at=self.scheduled_at,
-            wake_attempts=self.wake_attempts,
-            spec=dict(self.spec or {}),
-            completed_at=self.completed_at,
-            created_at=self.created_at,
-            updated_at=self.updated_at,
-        )
-
-
-AgentConversationWait = AgentConversationWaitModel

--- a/lemma-backend/app/modules/agent/infrastructure/participant_models.py
+++ b/lemma-backend/app/modules/agent/infrastructure/participant_models.py
@@ -1,0 +1,90 @@
+"""SQLAlchemy model for conversation membership.
+
+Its own module rather than a class in ``infrastructure/models.py`` because that
+file is at the architecture ratchet's per-file limit; ``runtime_models`` is the
+existing precedent for splitting a model out of it. Registered for migrations
+in ``migrations/env.py`` alongside the others.
+
+No ORM relationship back to ``ConversationModel``: adding one would push
+that file past the same limit, and an implicit lazy load raises under async
+SQLAlchemy anyway. Membership is read through
+``conversation_participant_store`` instead, which asks for it explicitly.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import (
+    CheckConstraint,
+    ForeignKey,
+    Index,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.infrastructure.db.base import UUIDCreatedBase
+from app.modules.agent.domain.participants import (
+    ConversationParticipant as ConversationParticipantEntity,
+    ConversationParticipantRole,
+)
+
+
+class ConversationParticipantModel(UUIDCreatedBase):
+    """One person or one agent in a conversation."""
+
+    __tablename__ = "agent_conversation_participants"
+    __table_args__ = (
+        CheckConstraint(
+            "(user_id IS NULL) <> (agent_id IS NULL)",
+            name="ck_conversation_participant_exactly_one_subject",
+        ),
+        # Postgres treats NULLs as distinct in a unique index, so the person
+        # constraint does not bound how many agents a conversation may hold,
+        # and vice versa. That is why these are two constraints and not one
+        # over both columns.
+        UniqueConstraint(
+            "conversation_id", "user_id", name="uq_conversation_participant_user"
+        ),
+        UniqueConstraint(
+            "conversation_id", "agent_id", name="uq_conversation_participant_agent"
+        ),
+        # "Which conversations am I in", which is how the list endpoint will
+        # ask once it stops filtering on the owner column.
+        Index("ix_conversation_participant_user", "user_id", "conversation_id"),
+    )
+
+    conversation_id: Mapped[UUID] = mapped_column(
+        ForeignKey("agent_conversations.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    #: Set when the participant is a person; NULL when it is an agent.
+    user_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    #: Set when the participant is an agent; NULL when it is a person. CASCADE
+    #: rather than the SET NULL that ``agent_conversations.agent_id`` uses: a
+    #: conversation outlives its agent and falls back to the pod assistant, but
+    #: a membership row for an agent that no longer exists means nothing.
+    agent_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("agents.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    role: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default=ConversationParticipantRole.MEMBER.value,
+    )
+
+    def to_entity(self) -> ConversationParticipantEntity:
+        return ConversationParticipantEntity(
+            id=self.id,
+            created_at=self.created_at,
+            conversation_id=self.conversation_id,
+            user_id=self.user_id,
+            agent_id=self.agent_id,
+            role=ConversationParticipantRole(self.role),
+        )

--- a/lemma-backend/app/modules/agent/infrastructure/repositories/conversation_repository.py
+++ b/lemma-backend/app/modules/agent/infrastructure/repositories/conversation_repository.py
@@ -6,7 +6,7 @@ from collections.abc import Sequence
 from datetime import datetime, timezone
 from uuid import UUID
 
-from sqlalchemy import func, literal, literal_column, select, update
+from sqlalchemy import func, literal, literal_column, or_, select, update
 from sqlalchemy.dialects.postgresql import JSONB, array
 from sqlalchemy.orm import selectinload
 
@@ -35,6 +35,9 @@ from app.modules.agent.domain.value_objects import (
     MessageDraft,
     to_json_value,
 )
+from app.modules.agent.infrastructure.participant_models import (
+    ConversationParticipantModel,
+)
 from app.modules.agent.infrastructure.models import (
     AgentRunModel,
     ConversationModel,
@@ -42,6 +45,10 @@ from app.modules.agent.infrastructure.models import (
 )
 from app.modules.agent.infrastructure.conversation_origin_store import (
     create_conversation_for_origin,
+)
+from app.modules.agent.infrastructure.conversation_participant_store import (
+    ensure_owner_participant,
+    list_participants,
 )
 from app.modules.agent.infrastructure.conversation_run_queries import (
     ConversationRunQueriesMixin,
@@ -60,6 +67,9 @@ from app.modules.agent.infrastructure.repositories.conversation_approval_queries
 from app.modules.agent.infrastructure.repositories.conversation_opening_texts import (
     ConversationOpeningTextsMixin,
 )
+from app.modules.agent.infrastructure.repositories.conversation_viewer_queries import (
+    ConversationViewerQueriesMixin,
+)
 
 _DEFAULT_POD_AGENT_ID_SQL = literal_column(f"'{DEFAULT_POD_AGENT_ID}'::uuid")
 
@@ -68,6 +78,7 @@ class ConversationRepository(
     ConversationApprovalQueriesMixin,
     ConversationOpeningTextsMixin,
     ConversationRunQueriesMixin,
+    ConversationViewerQueriesMixin,
 ):
     """Repository for conversations, agent runs, and messages."""
 
@@ -108,6 +119,11 @@ class ConversationRepository(
         )
         self.session.add(model)
         await self.session.flush()
+        await ensure_owner_participant(
+            self.session,
+            conversation_id=model.id,
+            user_id=model.user_id,
+        )
         self.uow.collect_events(
             [
                 ConversationStartedEvent(
@@ -242,7 +258,12 @@ class ConversationRepository(
             # Seeded into __dict__ rather than assigned, so SQLAlchemy does not
             # treat this as a mutation of the relationship and try to flush it.
             model.__dict__["agent_runs"] = [latest] if latest is not None else []
-        return model.to_entity()
+        entity = model.to_entity()
+        # Always, not behind a flag: `validate_conversation_access` reads it,
+        # and a flag would mean the answer to "may this person see it" depended
+        # on what the caller happened to ask for.
+        entity.participants = await list_participants(self.session, model.id)
+        return entity
 
     async def list_conversations(
         self,
@@ -261,8 +282,25 @@ class ConversationRepository(
         # One list or the other, never both: the archive is a place you go, not
         # a tail on the end of the history. Equality rather than "not archived"
         # so the same query serves both without a second code path.
+        # Yours, or one you were added to. Owner-only was correct while a
+        # conversation had exactly one person in it, and it is what made being
+        # added to one useless: you could open it from a link and never find it
+        # again, because it was in nobody's list but the opener's.
+        #
+        # EXISTS rather than a join: a conversation has a handful of
+        # participants, the row is looked up through
+        # `ix_conversation_participant_user`, and a join would multiply the
+        # conversation rows before the limit is applied.
+        in_conversation = (
+            select(ConversationParticipantModel.id)
+            .where(
+                ConversationParticipantModel.conversation_id == ConversationModel.id,
+                ConversationParticipantModel.user_id == user_id,
+            )
+            .exists()
+        )
         stmt = select(ConversationModel).where(
-            ConversationModel.user_id == user_id,
+            or_(ConversationModel.user_id == user_id, in_conversation),
             ConversationModel.pod_id == pod_id,
             ConversationModel.is_archived.is_(archived),
         )
@@ -367,6 +405,7 @@ class ConversationRepository(
         agent_id: UUID | None,
         agent_runtime: AgentRuntimeConfig,
         parent_run_id: UUID | None = None,
+        triggered_by_user_id: UUID | None = None,
         metadata: JsonObject | None = None,
     ) -> AgentRunEntity:
         now = datetime.now(timezone.utc)
@@ -374,6 +413,7 @@ class ConversationRepository(
             conversation_id=conversation_id,
             agent_id=agent_id,
             parent_run_id=parent_run_id,
+            triggered_by_user_id=triggered_by_user_id,
             status=AgentRunStatus.RUNNING.value,
             agent_runtime=agent_runtime.model_dump(mode="json"),
             started_at=now,
@@ -420,6 +460,7 @@ class ConversationRepository(
             conversation_id=conversation.id,
             agent_run_id=agent_run_id,
             sequence=sequence,
+            sender_user_id=draft.sender_user_id,
             role=draft.role.value,
             kind=draft.kind.value,
             text=draft.text,
@@ -438,30 +479,6 @@ class ConversationRepository(
         self.session.add(model)
         await self.session.flush()
         return model.to_entity()
-
-    async def list_messages(
-        self,
-        *,
-        conversation_id: UUID,
-        before_sequence: int | None = None,
-        after_sequence: int | None = None,
-        limit: int = 100,
-    ) -> tuple[list[MessageEntity], int | None]:
-        stmt = select(MessageModel).where(
-            MessageModel.conversation_id == conversation_id
-        )
-        if before_sequence is not None:
-            stmt = stmt.where(MessageModel.sequence < before_sequence)
-        if after_sequence is not None:
-            stmt = stmt.where(MessageModel.sequence > after_sequence)
-        stmt = stmt.order_by(MessageModel.sequence.desc()).limit(limit + 1)
-        result = await self.session.execute(stmt)
-        rows = list(result.scalars())
-        has_more = len(rows) > limit
-        if has_more:
-            rows = rows[:limit]
-        next_cursor = rows[-1].sequence if has_more and rows else None
-        return [row.to_entity() for row in reversed(rows)], next_cursor
 
     async def finish_agent_run(
         self,

--- a/lemma-backend/app/modules/agent/infrastructure/repositories/conversation_viewer_queries.py
+++ b/lemma-backend/app/modules/agent/infrastructure/repositories/conversation_viewer_queries.py
@@ -1,0 +1,154 @@
+"""What one viewer may read: their conversation with an agent, and its messages.
+
+Split out of ``ConversationRepository`` for the reason its other query mixins
+were -- that class is at the architecture ratchet's per-file limit. These two
+belong together: both answer a question asked on behalf of a particular person
+rather than about the conversation in the abstract.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import func, literal_column, or_, select
+from sqlalchemy.orm import aliased
+
+from app.core.authorization.delegation import DEFAULT_POD_AGENT_ID
+from app.modules.agent.domain.entities import (
+    Conversation as ConversationEntity,
+    Message as MessageEntity,
+)
+from app.modules.agent.domain.value_objects import (
+    ConversationType,
+    MessageRole,
+    WORKING_MESSAGE_KINDS,
+)
+from app.modules.agent.infrastructure.conversation_participant_store import (
+    list_participants,
+)
+from app.modules.agent.infrastructure.models import (
+    AgentRunModel,
+    ConversationModel,
+    MessageModel,
+)
+
+_DEFAULT_POD_AGENT_ID_SQL = literal_column(f"'{DEFAULT_POD_AGENT_ID}'::uuid")
+
+#: Compared against the stored column, which holds the enum's value.
+_WORKING_KIND_VALUES = tuple(kind.value for kind in WORKING_MESSAGE_KINDS)
+
+
+class ConversationViewerQueriesMixin:
+    async def find_persistent_conversation(
+        self,
+        *,
+        user_id: UUID,
+        pod_id: UUID,
+        agent_id: UUID | None,
+    ) -> ConversationEntity | None:
+        """The conversation this person is already having with this agent.
+
+        Newest live root CHAT conversation for the key, or None when there has
+        never been one. Reads through ``ix_agent_conv_user_pod_agent_roots``,
+        whose columns are exactly this key -- the index has always described
+        this question, it was just never asked.
+
+        Deliberately not backed by a unique constraint. Every account already
+        has many rows per key, so a unique index cannot be added without
+        merging or discarding history, and neither is a migration's decision to
+        make. The cost of leaving it out is that two simultaneous first
+        messages could each create one; the consequence is a spare empty
+        conversation that the next resolve does not pick, rather than a lost or
+        mixed-up one.
+
+        TASK and PROJECT conversations are excluded on purpose. A task is a
+        unit of work that ends, and a project is a pinned group -- neither is
+        the thing somebody means by "the conversation I am having with this
+        agent".
+        """
+        agent_scope_id = func.coalesce(
+            ConversationModel.agent_id, _DEFAULT_POD_AGENT_ID_SQL
+        )
+        model = await self.session.scalar(
+            select(ConversationModel)
+            .where(
+                ConversationModel.user_id == user_id,
+                ConversationModel.pod_id == pod_id,
+                agent_scope_id == (agent_id or DEFAULT_POD_AGENT_ID),
+                ConversationModel.parent_id.is_(None),
+                ConversationModel.is_archived.is_(False),
+                ConversationModel.conversation_type == ConversationType.CHAT.value,
+                ConversationModel.origin_id.is_(None),
+            )
+            .order_by(ConversationModel.updated_at.desc(), ConversationModel.id.desc())
+            .limit(1)
+        )
+        if model is None:
+            return None
+        entity = model.to_entity()
+        entity.participants = await list_participants(self.session, model.id)
+        return entity
+
+    async def list_messages(
+        self,
+        *,
+        conversation_id: UUID,
+        viewer_id: UUID | None = None,
+        owner_user_id: UUID | None = None,
+        before_sequence: int | None = None,
+        after_sequence: int | None = None,
+        limit: int = 100,
+    ) -> tuple[list[MessageEntity], int | None]:
+        """Messages in sequence order, bounded to what this viewer may see.
+
+        ``viewer_id`` is optional because not every caller is a reader: the
+        approval scan and the runtime both need the whole log, and a filter
+        applied there would hide a pending tool call from the machinery that
+        has to resolve it. Passing None keeps the unfiltered behaviour.
+
+        The filter is in the query rather than over the result, so a page of
+        `limit` is a page of what the viewer can see. Filtering afterwards
+        would return short pages whose length leaked how much was hidden.
+        """
+        # Always joined, not only when filtering: every message has to be able
+        # to say which agent produced it, and that lives on the run.
+        run = aliased(AgentRunModel)
+        stmt = (
+            select(MessageModel, run.agent_id)
+            .outerjoin(run, MessageModel.agent_run_id == run.id)
+            .where(MessageModel.conversation_id == conversation_id)
+        )
+        if viewer_id is not None:
+            visible = [
+                MessageModel.kind.notin_(_WORKING_KIND_VALUES),
+                run.triggered_by_user_id == viewer_id,
+            ]
+            # A run with no recorded trigger predates the column, and the
+            # backfill resolved those to the owner. Anyone else asking gets the
+            # answer without the working, which is the safe direction.
+            if owner_user_id is not None and viewer_id == owner_user_id:
+                visible.append(run.triggered_by_user_id.is_(None))
+            stmt = stmt.where(or_(*visible))
+        if before_sequence is not None:
+            stmt = stmt.where(MessageModel.sequence < before_sequence)
+        if after_sequence is not None:
+            stmt = stmt.where(MessageModel.sequence > after_sequence)
+        stmt = stmt.order_by(MessageModel.sequence.desc()).limit(limit + 1)
+        result = await self.session.execute(stmt)
+        rows = list(result)
+        has_more = len(rows) > limit
+        if has_more:
+            rows = rows[:limit]
+        next_cursor = rows[-1][0].sequence if has_more and rows else None
+
+        def _entity(row) -> MessageEntity:
+            model, agent_id = row
+            entity = model.to_entity()
+            # The run's agent produced the *answer*, not the question. A user
+            # message shares the run, so taking the join's value unconditionally
+            # attributed a person's own words to whichever agent replied to them.
+            if entity.role is not MessageRole.USER:
+                entity.agent_id = agent_id
+            return entity
+
+        return [_entity(row) for row in reversed(rows)], next_cursor

--- a/lemma-backend/app/modules/agent/infrastructure/wait_models.py
+++ b/lemma-backend/app/modules/agent/infrastructure/wait_models.py
@@ -1,0 +1,120 @@
+"""SQLAlchemy model for what a snoozed conversation is waiting on.
+
+Its own module rather than a class in ``models.py`` because that file sits at
+the architecture ratchet's per-file limit and the conversation models next door
+still have columns to gain. This one moved because it is the cleanest cut: no
+``relationship()`` in either direction, so nothing else has to be told where it
+went except its two importers.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import (
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.infrastructure.db.base import UUIDAuditBase
+
+
+class AgentConversationWaitModel(UUIDAuditBase):
+    """What a snoozed conversation is waiting on — the single source of truth.
+
+    Mirrors ``workflow_run_waits``. The partial unique index enforces at most one
+    ACTIVE wait per conversation: a turn that paused on a snooze cannot also be
+    snoozed again until it wakes, and a duplicate wake cannot create a second row.
+    """
+
+    __tablename__ = "agent_conversation_waits"
+    __table_args__ = (
+        Index(
+            "ix_agent_conversation_waits_conversation_status",
+            "conversation_id",
+            "status",
+        ),
+        Index("ix_agent_conversation_waits_external_ref", "external_ref"),
+        Index(
+            "ix_agent_conversation_waits_type_ref_status",
+            "wait_type",
+            "external_ref",
+            "status",
+        ),
+        Index(
+            "uq_agent_conversation_waits_one_active",
+            "conversation_id",
+            unique=True,
+            postgresql_where=text("status = 'ACTIVE'"),
+        ),
+    )
+
+    conversation_id: Mapped[UUID] = mapped_column(
+        ForeignKey("agent_conversations.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    agent_run_id: Mapped[UUID] = mapped_column(
+        ForeignKey("agent_runs.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    pod_id: Mapped[UUID] = mapped_column(
+        ForeignKey("pods.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    tool_call_id: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    wait_type: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+    status: Mapped[str] = mapped_column(String(30), nullable=False, index=True)
+
+    external_ref: Mapped[str | None] = mapped_column(String, nullable=True)
+    scheduled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    wake_attempts: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    # See the workflow wait model: a timer fires once, so a row lock is not a
+    # claim -- it is released at commit and the next tick reclaims the row.
+    fire_lease_until: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    # Nullable to match the migration: `create` always writes a dict, but a row
+    # inserted by hand or by a future backfill must not need one.
+    spec: Mapped[dict | None] = mapped_column(JSONB, default=dict)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    def to_entity(self):
+        from app.modules.agent.domain.wait import (
+            AgentConversationWaitEntity,
+            AgentWaitStatus,
+            AgentWaitType,
+        )
+
+        return AgentConversationWaitEntity(
+            id=self.id,
+            conversation_id=self.conversation_id,
+            agent_run_id=self.agent_run_id,
+            pod_id=self.pod_id,
+            tool_call_id=self.tool_call_id,
+            wait_type=AgentWaitType(self.wait_type),
+            status=AgentWaitStatus(self.status),
+            external_ref=self.external_ref,
+            scheduled_at=self.scheduled_at,
+            wake_attempts=self.wake_attempts,
+            spec=dict(self.spec or {}),
+            completed_at=self.completed_at,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )
+
+
+AgentConversationWait = AgentConversationWaitModel

--- a/lemma-backend/app/modules/agent/infrastructure/wait_repository.py
+++ b/lemma-backend/app/modules/agent/infrastructure/wait_repository.py
@@ -17,7 +17,9 @@ from app.modules.agent.domain.wait import (
     AgentConversationWaitEntity,
     AgentWaitStatus,
 )
-from app.modules.agent.infrastructure.models import AgentConversationWaitModel
+from app.modules.agent.infrastructure.wait_models import (
+    AgentConversationWaitModel,
+)
 
 
 class AgentConversationWaitRepository:

--- a/lemma-backend/app/modules/agent/module.py
+++ b/lemma-backend/app/modules/agent/module.py
@@ -41,6 +41,9 @@ def _routers():
     from app.modules.agent.api.controllers.conversation_controller import (
         router as conversation,
     )
+    from app.modules.agent.api.controllers.conversation_open_controller import (
+        router as conversation_open,
+    )
 
     # serve_router is included before the main widget router (more specific path).
     from app.modules.agent.api.controllers.widget_controller import (
@@ -53,6 +56,9 @@ def _routers():
         agent_host,
         runtime_config,
         tool,
+        # Before the general router: `/conversations/open` must not be read as
+        # `/conversations/{conversation_id}`.
+        conversation_open,
         conversation,
         widget_serve,
         widget,

--- a/lemma-backend/app/modules/agent/services/agent_context_brief.py
+++ b/lemma-backend/app/modules/agent/services/agent_context_brief.py
@@ -68,10 +68,9 @@ _MAX_COLUMNS = 40
 # rebuild on nearly every run to protect against variation that does not exist.
 #
 # Nothing in the rendered brief is conversation-derived. The build reads the pod,
-# the user and either the pod inventory or the agent's grants; the only thing it
-# takes from the conversation is whether this is the pod default assistant, which
-# selects between those two branches -- so that boolean belongs in the key and
-# the conversation id does not.
+# the user and either the pod inventory or the agent's grants, selected by
+# whether the running agent is the pod default -- so that boolean belongs in the
+# key and the conversation id does not.
 _BriefKey = tuple[UUID, UUID, UUID, bool]
 _brief_cache: RedisJsonCache | None = None
 
@@ -143,9 +142,15 @@ class AgentContextBriefBuilder:
         toolsets: Collection[AgentToolset] = (),
     ) -> str:
         # The pod default assistant runs with the user's permissions and sees the
-        # whole pod; named agents see only what they're granted. This is the one
-        # thing the conversation contributes, so it is resolved into the key.
-        is_default = conversation.is_pod_assistant or agent.id == DEFAULT_POD_AGENT_ID
+        # whole pod; named agents see only what they're granted.
+        #
+        # The agent that is *running* decides which of the two it gets, not the
+        # conversation it is running in. These agreed while the answering agent
+        # was always the conversation's own; an `@mention` breaks that, and the
+        # conversation winning handed a named agent the pod assistant's brief --
+        # which lists the pod's agents, including itself. It read its own name
+        # there as somebody else and tried to relay the message to itself.
+        is_default = agent.id == DEFAULT_POD_AGENT_ID
         with run_phase("context_brief") as span:
             key: _BriefKey = (agent.id, pod_id, user_id, is_default)
             cached = await _get_cached_brief(key)

--- a/lemma-backend/app/modules/agent/services/agent_router.py
+++ b/lemma-backend/app/modules/agent/services/agent_router.py
@@ -1,0 +1,153 @@
+"""Which agent, if any, answers a message nobody addressed.
+
+Two stages, and the order is the design. An explicit ``@mention`` -- or a
+message inside a subthread an agent is already answering -- is settled here
+without a model ever seeing it. Only what is left over reaches one, and the
+answer it is asked for is a name, never a reply.
+
+Silence is the expected outcome. In a conversation where people mostly talk to
+each other, most messages are for nobody, and a model asked "who should reply?"
+will find somebody to be helpful with. The prompt says so, the roster is the
+only thing it may choose from, and being wrong costs one skipped reply rather
+than a fabricated one.
+
+See ``docs/design/agent-conversations.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+
+@dataclass(frozen=True, slots=True)
+class RosterAgent:
+    """One agent present in a conversation, as the router sees it."""
+
+    id: UUID
+    name: str
+
+
+@dataclass(frozen=True, slots=True)
+class InboundMessage:
+    """What is known about a message before anybody has decided who it is for."""
+
+    text: str
+    #: None when a person wrote it. Set when an agent did, which is what stops
+    #: the room from talking to itself.
+    author_agent_id: UUID | None = None
+    #: Resolved by the surface or the composer, not parsed here: the platforms
+    #: encode mentions differently and one of them already knows which.
+    mentioned_agent_id: UUID | None = None
+    #: The agent already answering the subthread this landed in, if any. A
+    #: reply inside an agent's thread is addressed to it -- mention once, then
+    #: talk normally.
+    subthread_agent_id: UUID | None = None
+
+
+def addressed_agent(message: InboundMessage, roster: list[RosterAgent]) -> UUID | None:
+    """Stage one: who this is explicitly for, without asking anybody.
+
+    A mention for an agent that is not in the conversation is not an address.
+    Resolving it anyway would let a name typed in a room reach an agent that
+    was never added to it.
+    """
+    present = {agent.id for agent in roster}
+    for candidate in (message.mentioned_agent_id, message.subthread_agent_id):
+        if candidate is not None and candidate in present:
+            return candidate
+    return None
+
+
+def routing_is_needed(message: InboundMessage, roster: list[RosterAgent]) -> bool:
+    """Whether stage two should run at all.
+
+    Three structural answers, none of which needs a model:
+
+    - **An agent wrote it.** Otherwise agent A posts, the router sees a new
+      message, routes to agent B, who posts, and it never stops. A per-turn
+      budget is a backstop; not considering agent authorship is the fix.
+    - **Nobody is there.** No candidates, no question.
+    - **Exactly one agent is there.** That is the default conversation and
+      almost all of them: one candidate means every message is addressed, and
+      paying for a model to say so on every message would be the whole cost of
+      this feature for none of its value.
+    """
+    if message.author_agent_id is not None:
+        return False
+    if len(roster) <= 1:
+        return False
+    return addressed_agent(message, roster) is None
+
+
+def sole_agent(roster: list[RosterAgent]) -> UUID | None:
+    """The one agent present, when there is exactly one."""
+    return roster[0].id if len(roster) == 1 else None
+
+
+def resolve_router_choice(name: str | None, roster: list[RosterAgent]) -> UUID | None:
+    """Turn what the model said into an agent, or into silence.
+
+    Anything unrecognised is silence. A model that answers with a name nobody
+    has, with prose, or with an apology has not chosen an agent, and the
+    failure mode worth avoiding is inventing one from a near-match.
+    """
+    if not name:
+        return None
+    wanted = name.strip().lstrip("@").casefold()
+    if wanted in {"", "none", "nobody", "no one", "null"}:
+        return None
+    for agent in roster:
+        if agent.name.casefold() == wanted:
+            return agent.id
+    return None
+
+
+def resolve_router_choices(
+    names: list[str] | None, roster: list[RosterAgent]
+) -> list[UUID]:
+    """Turn what the model said into agents, dropping anything unrecognised.
+
+    Order is kept: the model is asked to answer most-relevant first, and a
+    caller that can only dispatch one takes the head.
+    """
+    chosen: list[UUID] = []
+    for name in names or []:
+        agent_id = resolve_router_choice(name, roster)
+        if agent_id is not None and agent_id not in chosen:
+            chosen.append(agent_id)
+    return chosen
+
+
+def router_prompt(
+    message: InboundMessage,
+    roster: list[RosterAgent],
+    recent: list[str] | None = None,
+) -> str:
+    """The whole prompt. Short on purpose -- see the module docstring.
+
+    `recent` is the last few lines of the conversation, oldest first. Without
+    it every message is judged cold: "yes please" or "and the other one?" is
+    unroutable on its own and obvious in context.
+    """
+    names = ", ".join(agent.name for agent in roster)
+    context = (
+        "Recent messages, oldest first:\n" + "\n".join(recent) + "\n\n"
+        if recent
+        else ""
+    )
+    return (
+        "You route messages in a conversation that has both people and agents "
+        "in it. Name every agent that should answer, most relevant first, or "
+        "none of them.\n\n"
+        f"Agents present: {names}\n\n"
+        f"{context}"
+        f"Message to route: {message.text}\n\n"
+        "Choose an agent when the message is addressed to one of them, when it "
+        "is addressed to the room as a whole, or when it asks something an "
+        "agent here would answer. Name more than one only when the message "
+        "genuinely asks several of them for something.\n\n"
+        "Choose nobody when the message is one person talking to another -- "
+        "arranging something between themselves, replying to each other, or "
+        "chatting about anything the agents are not part of."
+    )

--- a/lemma-backend/app/modules/agent/services/agent_router_model.py
+++ b/lemma-backend/app/modules/agent/services/agent_router_model.py
@@ -1,0 +1,220 @@
+"""Asking a small model who should answer, and never letting it do more.
+
+The decision rules live in ``agent_router``; they are pure and they settle most
+messages without anything here running. This is only the leftover case: nobody
+was addressed, several agents are present, and a person wrote it.
+
+Three properties matter more than accuracy:
+
+- **It cannot answer.** The model is asked for a name and its output is matched
+  against the roster. Anything else is silence, so a wrong call costs one
+  skipped reply rather than a fabricated one.
+- **It cannot fail loudly.** A router that raises would break a message send
+  over a question whose correct default answer is "nobody". Every failure is
+  logged and returns silence.
+- **It is small and short.** One message, the roster, no history. Routing runs
+  on messages that are usually not for any agent, so it has to cost almost
+  nothing to be wrong about.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from opentelemetry import metrics
+from pydantic import BaseModel, Field
+from pydantic_ai import Agent as PydanticAIAgent, ModelSettings, UsageLimits
+
+from app.composition.agent_usage import (
+    UsageExecutionContext,
+    record_pydantic_ai_result_usage,
+    reserve_usage_for_runtime,
+)
+from app.core.log.log import get_logger
+from app.modules.agent.config import agent_settings
+from app.modules.agent.domain.value_objects import AgentRuntimeConfig
+from app.modules.agent.services.agent_router import (
+    InboundMessage,
+    RosterAgent,
+    addressed_agent,
+    resolve_router_choices,
+    router_prompt,
+    routing_is_needed,
+)
+from app.modules.agent.services.runtime_model_factory import (
+    require_pydantic_ai_model_from_runtime_profile,
+    usage_limits_for,
+)
+from app.modules.agent.services.runtime_profile_service import (
+    DEFAULT_SYSTEM_AGENT_RUNTIME_PROFILE_ID,
+    AgentRuntimeProfileService,
+)
+
+logger = get_logger(__name__)
+
+meter = metrics.get_meter(__name__)
+#: One increment per routed message, labelled with what happened to it:
+#: `addressed` (never reached a model), `skipped` (a structural guard), `agent`
+#: (a model chose one) or `silent` (a model chose nobody, or failed).
+router_counter = meter.create_counter("lemma.agent.message_routes")
+
+_ROUTER_SYSTEM_PROMPT = (
+    "You decide which agent, if any, a message is for. You never answer the "
+    "message. You reply with one agent name, or the single word NONE."
+)
+#: Enough for a reasoning model to think and then answer. It was 32 -- the
+#: length of a name -- which looked frugal and was the whole bug: a reasoning
+#: model narrates before it answers, so the cap truncated every reply mid-
+#: sentence and the name never arrived. Every message routed to nobody, and the
+#: tolerant parser below correctly read the prose as "no choice".
+_ROUTER_USAGE_LIMITS = UsageLimits(request_limit=2, output_tokens_limit=1024)
+#: `thinking=False` because routing is a lookup, not a problem: the roster is
+#: in the prompt and the answer is one of its names. Reasoning here bought
+#: nothing and cost a multiple of the latency on every unaddressed message.
+#: Silently ignored by models that always reason, which is why the structured
+#: output below is what actually guarantees a usable answer.
+_ROUTER_MODEL_SETTINGS = ModelSettings(temperature=0.0, thinking=False)
+
+
+class RouterChoice(BaseModel):
+    """The router's answer, as a field rather than as prose.
+
+    Structured output is what makes the answer separable from the thinking. A
+    model that reasons out loud still has to put its choice here, so the reply
+    cannot be lost in the narration -- which is exactly how free text failed:
+    the cap truncated every reply mid-sentence and the name never arrived.
+    """
+
+    agents: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Names of the agents who should answer, exactly as listed, most "
+            "relevant first. Empty when the message is not for any of them."
+        ),
+    )
+
+
+async def resolve_responder(
+    message: InboundMessage,
+    roster: list[RosterAgent],
+    *,
+    user_id: UUID,
+    organization_id: UUID | None,
+    pod_id: UUID,
+    recent: list[str] | None = None,
+) -> list[UUID]:
+    """Which agents answer this message, most relevant first. Empty for nobody.
+
+    Stage one first and without a model. Only what is left reaches one.
+    """
+    addressed = addressed_agent(message, roster)
+    if addressed is not None:
+        router_counter.add(1, {"outcome": "addressed"})
+        return [addressed]
+    if not routing_is_needed(message, roster):
+        router_counter.add(1, {"outcome": "skipped"})
+        return []
+
+    chosen = await _ask_model(
+        message,
+        roster,
+        user_id=user_id,
+        organization_id=organization_id,
+        pod_id=pod_id,
+        recent=recent,
+    )
+    router_counter.add(1, {"outcome": "agent" if chosen else "silent"})
+    return chosen
+
+
+async def _ask_model(
+    message: InboundMessage,
+    roster: list[RosterAgent],
+    *,
+    user_id: UUID,
+    organization_id: UUID | None,
+    pod_id: UUID,
+    recent: list[str] | None = None,
+) -> list[UUID]:
+    try:
+        resolved = await _resolve_runtime(
+            organization_id=organization_id, user_id=user_id
+        )
+        runtime_profile = resolved.public_snapshot()
+        model = require_pydantic_ai_model_from_runtime_profile(
+            runtime_profile=runtime_profile,
+            runtime_credentials=resolved.credentials or {},
+            fallback_model_name=resolved.model_name_for_harness,
+        )
+        usage_context = UsageExecutionContext(
+            user_id=user_id,
+            organization_id=organization_id,
+            pod_id=pod_id,
+            source_type="agent_router",
+        )
+        reservation = await reserve_usage_for_runtime(
+            organization_id=organization_id,
+            user_id=user_id,
+            runtime_profile=runtime_profile,
+        )
+        agent = PydanticAIAgent(
+            model,
+            system_prompt=_ROUTER_SYSTEM_PROMPT,
+            output_type=RouterChoice,
+        )
+        result = None
+        try:
+            result = await agent.run(
+                router_prompt(message, roster, recent),
+                usage_limits=usage_limits_for(model, _ROUTER_USAGE_LIMITS),
+                model_settings=_ROUTER_MODEL_SETTINGS,
+            )
+        finally:
+            # Recorded on both paths from one place. A `finally` rather than a
+            # matched pair of calls: the reservation has to be settled whatever
+            # happened, and two call sites is how one of them drifts.
+            await record_pydantic_ai_result_usage(
+                ctx=usage_context,
+                runtime_profile=runtime_profile,
+                result=result,
+                status="COMPLETED" if result is not None else "FAILED",
+                reservation=reservation,
+                metadata={"helper": "agent_router"},
+            )
+        # Still through the tolerant parser: it is what turns "NONE", an
+        # unknown name or a near-miss into silence rather than a guess.
+        return resolve_router_choices(result.output.agents, roster)
+    except RuntimeError, OSError, TimeoutError, ValueError:
+        # Silence, not an error. The correct default answer to "who should reply
+        # to this?" is nobody, so a router that cannot be reached must not stop
+        # the message reaching the people in the room. pydantic-ai raises
+        # `AgentRunError`/`UserError`, both `RuntimeError`s, and the transport
+        # failures underneath are `OSError`/`TimeoutError` -- so this covers the
+        # model being unreachable, misconfigured or over its limits.
+        #
+        # Deliberately not `Exception`: a `TypeError` here is our bug, and a
+        # router that swallows its own bugs is one that silently stops routing.
+        logger.error("agent.router.decision.failed", pod_id=pod_id, exc_info=True)
+        return []
+
+
+async def _resolve_runtime(*, organization_id: UUID | None, user_id: UUID):
+    service = AgentRuntimeProfileService()
+    try:
+        return await service.resolve(
+            runtime=AgentRuntimeConfig(
+                profile_id=DEFAULT_SYSTEM_AGENT_RUNTIME_PROFILE_ID,
+                model_name=agent_settings.agent_router_model,
+            ),
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+    except RuntimeError:
+        # Not in this deployment's catalog — the profile default will do.
+        return await service.resolve(
+            runtime=AgentRuntimeConfig(
+                profile_id=DEFAULT_SYSTEM_AGENT_RUNTIME_PROFILE_ID
+            ),
+            organization_id=organization_id,
+            user_id=user_id,
+        )

--- a/lemma-backend/app/modules/agent/services/agent_runner_service.py
+++ b/lemma-backend/app/modules/agent/services/agent_runner_service.py
@@ -23,7 +23,7 @@ from app.core.observability.telemetry import (
 from app.modules.agent.config import agent_settings
 from app.modules.agent.services.context_budget import context_budget_for
 from app.modules.agent.services.conversation_access import (
-    resolve_agent,
+    resolve_run_agent,
     validate_conversation_access,
 )
 from app.modules.agent.domain.entities import Agent, AgentRun, Conversation, Message
@@ -32,9 +32,7 @@ from app.modules.agent.domain.errors import (
 )
 from app.modules.agent.domain.value_objects import (
     AgentEvent,
-    AgentRuntimeConfig,
     AgentRunStatus,
-    ConversationType,
     HarnessKind,
     HarnessOptions,
     JsonObject,
@@ -47,15 +45,11 @@ from app.modules.agent.domain.runtime_profiles import (
 from app.modules.agent.capabilities import build_lemma_harness_tooling
 from app.modules.agent.infrastructure.harnesses.registry import HarnessRegistry
 from app.modules.agent.infrastructure.repositories import (
-    AgentRuntimeProfileRepository,
     AgentRepository,
     ConversationRepository,
 )
-from app.modules.agent.services.runtime_profile_service import (
-    AgentRuntimeProfileService,
-    ResolvedAgentRuntime,
-)
 from app.modules.agent.services.run_message_writer import RunMessageWriter
+from app.modules.agent.services.run_resolution import RunResolutionMixin
 from app.modules.agent.services.run_phase_spans import (
     observe_first_output,
     record_history_size,
@@ -87,10 +81,7 @@ from app.composition.agent_usage import (
     usage_execution_context,
 )
 from app.modules.agent.tools.context import ConversationContext
-from app.modules.agent.tools.callable_tool_factory import AgentCallableToolFactory
-from app.modules.agent.tools.final_answer import get_final_answer_tool
 from app.modules.agent.tools.tool_assembler import RunToolAssembler
-from app.core.crypto import get_secret_cipher
 
 logger = get_logger(__name__)
 
@@ -162,7 +153,7 @@ class AgentRunObserver(Protocol):
         raise NotImplementedError
 
 
-class AgentRunnerService:
+class AgentRunnerService(RunResolutionMixin):
     """Executes one persisted agent run and persists harness messages."""
 
     def __init__(
@@ -196,15 +187,23 @@ class AgentRunnerService:
             agent_run_id=agent_run_id,
             user_id=user_id,
             pod_id=pod_id,
-            agent_name=agent_name,
         )
+        # Whose grants this run holds, read off the run rather than the job
+        # payload: the row was written when the person spoke, and a reclaimed
+        # or replayed job can carry a different one. Not
+        # `conversation.user_id`, which says who opened the conversation and
+        # stops being who is speaking as soon as anybody else is in it.
+        acting_user_id = agent_run.triggered_by_user_id or user_id
         run = RunIdentity(
             conversation_id=conversation.id,
             agent_run_id=agent_run_id,
             organization_id=conversation.organization_id,
             pod_id=conversation.pod_id,
-            user_id=user_id,
-            agent_id=conversation.agent_id,
+            user_id=acting_user_id,
+            # The run's own agent. `conversation.agent_id` names the default,
+            # which is null on a conversation an addressed agent answered -- so
+            # reading it here labelled every routed answer as the pod assistant.
+            agent_id=agent_run.agent_id,
             started_at=agent_run.started_at,
         )
         if agent_run.status != AgentRunStatus.RUNNING:
@@ -223,7 +222,7 @@ class AgentRunnerService:
         try:
             resolved_runtime = await self._resolve_agent_runtime(
                 agent_run.agent_runtime,
-                user_id=user_id,
+                user_id=acting_user_id,
                 organization_id=conversation.organization_id,
             )
             harness = self.harness_registry.get(resolved_runtime.harness_kind)
@@ -235,7 +234,9 @@ class AgentRunnerService:
                 conversation=conversation,
                 agent=agent,
                 agent_run_id=agent_run_id,
-                user_id=user_id,
+                # The authority the tools execute with: what the person who
+                # spoke can reach, and nothing further.
+                user_id=acting_user_id,
                 resolved_runtime=resolved_runtime,
                 runtime_profile_snapshot=runtime_profile_snapshot,
                 runtime_credentials=runtime_credentials,
@@ -280,7 +281,7 @@ class AgentRunnerService:
                 harness_toolsets = []
             usage_reservation = await self.usage_recorder.reserve(
                 organization_id=conversation.organization_id,
-                user_id=user_id,
+                user_id=acting_user_id,  # spent against whoever asked
                 runtime_profile=runtime_profile_snapshot,
             )
             run_with_usage = run.with_runtime_profile(
@@ -321,7 +322,7 @@ class AgentRunnerService:
                 agent_id=conversation.agent_id,
                 pod_id=conversation.pod_id,
                 organization_id=conversation.organization_id,
-                user_id=user_id,
+                user_id=acting_user_id,
                 agent_name=agent.name,
                 harness_kind=resolved_runtime.harness_kind.value,
                 model_name=resolved_runtime.model_name_for_harness,
@@ -450,36 +451,6 @@ class AgentRunnerService:
             if not isinstance(exc, Exception):
                 raise
 
-    async def _resolve_agent_runtime(
-        self,
-        agent_runtime: AgentRuntimeConfig,
-        *,
-        user_id: UUID,
-        organization_id: UUID | None,
-    ) -> ResolvedAgentRuntime:
-        with run_phase("resolve_runtime"):
-            async with self.uow_factory() as uow:
-                service = AgentRuntimeProfileService(
-                    AgentRuntimeProfileRepository(
-                        uow,
-                        encryption=get_secret_cipher(),
-                    )
-                )
-                return await service.resolve(
-                    runtime=agent_runtime,
-                    organization_id=organization_id,
-                    user_id=user_id,
-                )
-
-    def _agent_with_resolved_runtime_metadata(
-        self,
-        agent: Agent,
-        *,
-        resolved_runtime: ResolvedAgentRuntime,
-    ) -> Agent:
-        del resolved_runtime
-        return agent
-
     async def _should_stop_run(self, agent_run_id: UUID) -> bool:
         async with self.uow_factory() as uow:
             agent_run = await ConversationRepository(uow).get_agent_run(agent_run_id)
@@ -525,7 +496,6 @@ class AgentRunnerService:
         agent_run_id: UUID,
         user_id: UUID,
         pod_id: UUID,
-        agent_name: str | None,
     ) -> tuple[Conversation, Agent, AgentRun, list[Message]]:
         with run_phase("load_context") as span:
             async with self.uow_factory() as uow:
@@ -538,11 +508,15 @@ class AgentRunnerService:
                     user_id=user_id,
                     pod_id=pod_id,
                 )
-                agent = await resolve_agent(
+                # Off the run, not the conversation: an addressed agent
+                # answers one turn, and the run is where that decision was
+                # recorded. The job's `agent_name` is not consulted -- it says
+                # what was asked for, and the row says what was agreed.
+                agent = await resolve_run_agent(
+                    agent_run,
                     conversation,
                     user_id=user_id,
                     agent_repository=AgentRepository(uow),
-                    agent_name=agent_name,
                 )
                 # Which runs survive the trim decides which need every message,
                 # and the trim can keep an old-but-active run while dropping
@@ -552,7 +526,12 @@ class AgentRunnerService:
                     runs, full_run_ids=runtime_full_run_ids(runs, conversation)
                 )
                 agent_run = self._find_agent_run(runs, agent_run_id)
-                messages = self._select_runtime_history(runs, conversation)
+                messages = self._select_runtime_history(
+                    runs,
+                    conversation,
+                    viewer_id=agent_run.triggered_by_user_id,
+                    current_run=agent_run,
+                )
                 record_history_size(span, runs=runs, sent=messages)
                 return conversation, agent, agent_run, messages
 
@@ -568,29 +547,13 @@ class AgentRunnerService:
         return apply_surface_history_window(runs, conversation)
 
     def _select_runtime_history(
-        self, runs: list[AgentRun], conversation: Conversation | None = None
-    ) -> list[Message]:
-        return select_runtime_history(runs, conversation)
-
-    def _resolve_output_type(
-        self, agent: Agent, conversation: Conversation
-    ) -> object | None:
-        # TASK conversations always get the final_answer tool: it drives the task
-        # lifecycle (status WAITING/COMPLETED/FAILED), not just structured output.
-        # The output *schema* is only applied when the agent configures one — see
-        # get_final_answer_tool, which uses `output: str` otherwise (no schema is
-        # pushed to the model when output_schema is absent).
-        if conversation.type == ConversationType.TASK:
-            return get_final_answer_tool(agent)
-        return None
-
-    async def _resolve_configured_accounts(
         self,
+        runs: list[AgentRun],
+        conversation: Conversation | None = None,
         *,
-        agent: Agent,
-        user_id: UUID,
-    ) -> dict[str, UUID]:
-        with run_phase("configured_accounts"):
-            return await AgentCallableToolFactory(
-                self.uow_factory
-            ).resolve_configured_accounts(agent=agent, user_id=user_id)
+        viewer_id: UUID | None = None,
+        current_run: AgentRun | None = None,
+    ) -> list[Message]:
+        return select_runtime_history(
+            runs, conversation, viewer_id=viewer_id, current_run=current_run
+        )

--- a/lemma-backend/app/modules/agent/services/conversation_access.py
+++ b/lemma-backend/app/modules/agent/services/conversation_access.py
@@ -48,14 +48,32 @@ def validate_conversation_access(
 
     Not-found rather than forbidden on purpose: a conversation in someone else's
     pod should not be distinguishable from one that does not exist.
+
+    Reachable by the person who opened it, or by anyone since added to it. The
+    two clauses are not redundant. Membership is only populated on an entity
+    somebody asked for it on, so an owner check that depended on the list would
+    lock people out of their own conversations wherever it was not loaded; and
+    the owner is not removable, so "opened it" is a standing claim rather than a
+    transitional allowance. What changes in a later step is which of the two is
+    load-bearing: once a run acts as its sender rather than as the conversation,
+    `user_id` is provenance and the membership row backfilled for it is the
+    access record.
     """
     if conversation is None:
         raise ConversationNotFoundError()
-    if conversation.user_id != user_id:
+    if conversation.user_id != user_id and not conversation.has_participant(user_id):
         raise ConversationNotFoundError()
     if conversation.pod_id != pod_id:
         raise ConversationNotFoundError()
-    if agent_id is not None and conversation.agent_id != agent_id:
+    if (
+        agent_id is not None
+        and conversation.agent_id != agent_id
+        and not conversation.has_agent_participant(agent_id)
+    ):
+        # A conversation's own `agent_id` is the one that answers by default.
+        # An agent added to the conversation may also be addressed in it, which
+        # is what an `@mention` does -- so being present is as good a claim as
+        # being the default, and nothing else is.
         raise ConversationNotFoundError()
 
 
@@ -93,6 +111,36 @@ async def resolve_agent(
     if agent_name is not None and agent.name != agent_name:
         raise AgentNotFoundError(agent_name)
     return agent
+
+
+async def resolve_run_agent(
+    agent_run: object,
+    conversation: Conversation,
+    *,
+    user_id: UUID,
+    agent_repository: object,
+) -> Agent:
+    """The agent that answers one run.
+
+    The conversation names a default. A run may name a different one, because
+    an `@mention` addresses an agent for a single turn -- and the run is where
+    that decision was recorded, so the run is what has to be read back.
+
+    `resolve_agent` cannot answer this: given a name it *asserts* the
+    conversation's own agent matches, which is the right check for "am I
+    talking to who I think" and the wrong one for "who is answering this turn".
+    """
+    run_agent_id = getattr(agent_run, "agent_id", None)
+    if run_agent_id is not None and run_agent_id != conversation.agent_id:
+        agent = await agent_repository.get(run_agent_id)  # type: ignore[attr-defined]
+        if agent is None:
+            raise AgentNotFoundError(str(run_agent_id))
+        return agent
+    return await resolve_agent(
+        conversation,
+        user_id=user_id,
+        agent_repository=agent_repository,
+    )
 
 
 async def resolve_agent_for_path(

--- a/lemma-backend/app/modules/agent/services/conversation_queries.py
+++ b/lemma-backend/app/modules/agent/services/conversation_queries.py
@@ -173,6 +173,8 @@ class ConversationQueries:
         )
         return await self.conversation_repository.list_messages(
             conversation_id=conversation_id,
+            viewer_id=user_id,
+            owner_user_id=conversation.user_id,
             before_sequence=before_sequence,
             after_sequence=after_sequence,
             limit=limit,

--- a/lemma-backend/app/modules/agent/services/conversation_retry_service.py
+++ b/lemma-backend/app/modules/agent/services/conversation_retry_service.py
@@ -73,6 +73,7 @@ class ConversationRetryService(ConversationService):
             conversation_id=conversation.id,
             agent_id=conversation.agent_id,
             agent_runtime=failed_run.agent_runtime,
+            triggered_by_user_id=user_id,
             metadata={
                 "source": "manual_retry",
                 "retried_agent_run_id": str(failed_run.id),

--- a/lemma-backend/app/modules/agent/services/conversation_service.py
+++ b/lemma-backend/app/modules/agent/services/conversation_service.py
@@ -14,8 +14,15 @@ from app.modules.agent.services.conversation_resume_return import (
     ResumeToolReturnBuilder,
 )
 from app.modules.agent.domain.sentinels import UNSET, UnsetType
+from app.core.authorization.dependencies import assert_pod_membership
+from app.core.authorization.factory import create_authorization_data_service
 from app.core.authorization.permissions import Permissions
 from app.core.infrastructure.db.uow import SqlAlchemyUnitOfWork
+from app.modules.agent.domain.participants import ConversationParticipant
+from app.modules.agent.infrastructure.conversation_participant_store import (
+    add_participant as add_conversation_participant,
+    remove_participant as remove_conversation_participant,
+)
 from app.modules.agent.services.conversation_access import (
     authorized_conversation,
     resolve_expected_agent_id,
@@ -32,6 +39,7 @@ from app.modules.agent.domain.entities import (
 )
 from app.modules.agent.domain.errors import (
     ConversationNotFoundError,
+    ConversationValidationError,
 )
 from app.modules.agent.domain.ports import (
     AgentRepository,
@@ -164,6 +172,129 @@ class ConversationService:
         )
         await self._apply_inherited_cwd(conversation, parent_id=parent_id)
         return await self.conversation_repository.create_conversation(conversation)
+
+    async def open_conversation(
+        self,
+        *,
+        pod_id: UUID,
+        agent_name: str | None,
+        user_id: UUID,
+    ) -> tuple[Conversation, bool]:
+        """The conversation this person is having with this agent.
+
+        Returns it with whether it had to be opened. This is what "talking to
+        an agent" resolves to: one persistent conversation per agent rather
+        than a new one per session, so the last thing said is still there.
+        Explicitly creating another is still possible and still
+        `create_conversation` -- this is only what happens when nobody said
+        which one they meant.
+
+        The permission check is `create_conversation`'s, reached on the create
+        branch. Resolving is a read of the caller's own conversations, and the
+        row it returns is one they already own.
+        """
+        agent = (
+            await resolve_agent_for_path(
+                self.agent_repository, pod_id=pod_id, agent_name=agent_name
+            )
+            if agent_name is not None
+            else None
+        )
+        existing = await self.conversation_repository.find_persistent_conversation(
+            user_id=user_id,
+            pod_id=pod_id,
+            agent_id=agent.id if agent else None,
+        )
+        if existing is not None:
+            return existing, False
+        created = await self.create_conversation(
+            pod_id=pod_id,
+            agent_name=agent_name,
+            user_id=user_id,
+        )
+        return created, True
+
+    async def list_participants(
+        self,
+        *,
+        conversation_id: UUID,
+        user_id: UUID,
+        pod_id: UUID,
+    ) -> list[ConversationParticipant]:
+        """Who is in this conversation. Members only -- asking is reading it."""
+        conversation = await self.conversation_repository.get_conversation(
+            conversation_id
+        )
+        validate_conversation_access(conversation, user_id=user_id, pod_id=pod_id)
+        return conversation.participants
+
+    async def add_participant(
+        self,
+        *,
+        conversation_id: UUID,
+        user_id: UUID,
+        pod_id: UUID,
+        member_user_id: UUID | None = None,
+        agent_name: str | None = None,
+    ) -> ConversationParticipant:
+        """Add one person or one agent to a conversation.
+
+        Adding somebody is a grant. Their own working stays theirs, but every
+        answer in the conversation is now said to them -- including answers
+        produced from data they could not have reached themselves.
+        """
+        conversation = await self.conversation_repository.get_conversation(
+            conversation_id
+        )
+        validate_conversation_access(conversation, user_id=user_id, pod_id=pod_id)
+        agent = (
+            await resolve_agent_for_path(
+                self.agent_repository, pod_id=pod_id, agent_name=agent_name
+            )
+            if agent_name is not None
+            else None
+        )
+        if (member_user_id is None) == (agent is None):
+            raise ConversationValidationError(
+                "Name exactly one of user_id or agent_name"
+            )
+        if member_user_id is not None:
+            # Membership of a conversation cannot exceed membership of the pod
+            # it lives in: a conversation is narrower than a pod, never wider.
+            # Built for the person being added, not the caller -- the question
+            # is whether *they* belong here.
+            member_ctx = await create_authorization_data_service(
+                self.uow
+            ).build_user_context(user_id=member_user_id, pod_id=pod_id)
+            assert_pod_membership(member_ctx, "be added to a conversation in this pod")
+        return await add_conversation_participant(
+            self.uow.session,
+            conversation_id=conversation_id,
+            user_id=member_user_id,
+            agent_id=agent.id if agent else None,
+        )
+
+    async def remove_participant(
+        self,
+        *,
+        conversation_id: UUID,
+        user_id: UUID,
+        pod_id: UUID,
+        member_user_id: UUID | None = None,
+        agent_id: UUID | None = None,
+    ) -> bool:
+        conversation = await self.conversation_repository.get_conversation(
+            conversation_id
+        )
+        validate_conversation_access(conversation, user_id=user_id, pod_id=pod_id)
+        if (member_user_id is None) == (agent_id is None):
+            raise ConversationValidationError("Name exactly one of user_id or agent_id")
+        return await remove_conversation_participant(
+            self.uow.session,
+            conversation_id=conversation_id,
+            user_id=member_user_id,
+            agent_id=agent_id,
+        )
 
     async def _apply_inherited_cwd(
         self,
@@ -376,6 +507,7 @@ class ConversationService:
         pod_id: UUID,
         agent_name: str | None = None,
         message_metadata: dict[str, object] | None = None,
+        branch_from_run_id: UUID | None = None,
         require_execute_grant: bool = True,
     ) -> AgentRunStartResult:
         conversation = await self._get_or_create_conversation_for_message(
@@ -414,6 +546,7 @@ class ConversationService:
             content=content,
             agent_name=agent_name,
             message_metadata=message_metadata,
+            branch_from_run_id=branch_from_run_id,
         )
 
     async def _get_or_create_conversation_for_message(

--- a/lemma-backend/app/modules/agent/services/conversation_turns.py
+++ b/lemma-backend/app/modules/agent/services/conversation_turns.py
@@ -40,13 +40,16 @@ from app.modules.agent.infrastructure.wait_repository import (
     AgentConversationWaitRepository,
 )
 from app.modules.agent.services.conversation_access import (
+    POD_ASSISTANT_AGENT_ID,
     require_agent_action,
     resolve_agent,
+    resolve_agent_for_path,
     resolve_expected_agent_id,
     validate_conversation_access,
 )
 from app.modules.agent.services.conversation_approvals import ApprovalCoordinator
 from app.modules.agent.services.pause_resume import PauseResume
+from app.modules.agent.services.turn_routing import UNROUTED, TurnRoutingMixin
 from app.modules.agent.services.pod_runtime_defaults import (
     default_agent_runtime_for_pod,
 )
@@ -65,7 +68,7 @@ from app.modules.agent.tools.snooze.models import (
 logger = get_logger(__name__)
 
 
-class TurnCoordinator:
+class TurnCoordinator(TurnRoutingMixin):
     """Starts the run that answers a message, and stops the one in flight."""
 
     def __init__(
@@ -93,6 +96,7 @@ class TurnCoordinator:
         content: str,
         agent_name: str | None,
         message_metadata: dict[str, object] | None,
+        branch_from_run_id: UUID | None = None,
     ) -> AgentRunStartResult:
         """Append the message and return the run that will answer it.
 
@@ -101,11 +105,47 @@ class TurnCoordinator:
         """
         # Resolve the agent (a read) before taking the conversation lock, so the
         # FOR UPDATE span covers only the active-run check + run/message writes.
+        # `agent_name` names an agent for this turn: the conversation's own
+        # agent answers when nobody says otherwise, and an agent added to the
+        # conversation answers when somebody addresses it. The access check the
+        # caller already ran has refused a name that is neither.
         agent = await resolve_agent(
             conversation,
             user_id=user_id,
             agent_repository=self.agent_repository,
         )
+
+        # Nobody named an agent, and the room holds more than one. Ask who this
+        # is for -- and accept "nobody" as an answer, because in a room with
+        # people in it most of what is said is not for an agent.
+        answering_agent = agent
+        answered_by_name = agent_name
+        if agent_name is not None and agent_name != agent.name:
+            # Addressed somebody other than the conversation's own agent. The
+            # access check the caller already ran refused a name that is not
+            # present, so this only resolves one that is.
+            answering_agent = await resolve_agent_for_path(
+                self.agent_repository,
+                pod_id=conversation.pod_id,
+                agent_name=agent_name,
+            )
+        if agent_name is None:
+            routed = await self._route_unaddressed(
+                conversation,
+                content=content,
+                user_id=user_id,
+                pod_id=pod_id,
+            )
+            if routed is not UNROUTED:
+                if routed is None:
+                    return await self._store_without_answering(
+                        conversation,
+                        content=content,
+                        user_id=user_id,
+                        message_metadata=message_metadata,
+                    )
+                answering_agent = routed
+                answered_by_name = routed.name
 
         await self.conversation_repository.lock_conversation(conversation.id)
         active_run = await self.conversation_repository.get_active_agent_run_for_update(
@@ -129,7 +169,7 @@ class TurnCoordinator:
             )
             selected_agent_runtime = (
                 conversation.agent_runtime
-                or agent.agent_runtime
+                or answering_agent.agent_runtime
                 or await default_agent_runtime_for_pod(
                     self.uow, pod_id=conversation.pod_id
                 )
@@ -141,8 +181,25 @@ class TurnCoordinator:
             )
             active_run = await self.conversation_repository.create_agent_run(
                 conversation_id=conversation.id,
-                agent_id=conversation.agent_id,
+                # The agent answering this turn: the conversation's own, unless
+                # somebody addressed another one present in it.
+                #
+                # The pod assistant has no row of its own -- `resolve_agent`
+                # synthesises it with a sentinel id -- and this column carries a
+                # foreign key. So an addressed agent is written only when it is
+                # a real one; naming the pod default lands back on NULL, which
+                # is already how a conversation says "the pod assistant".
+                agent_id=(
+                    None
+                    if answering_agent.id == POD_ASSISTANT_AGENT_ID
+                    else answering_agent.id
+                ),
                 agent_runtime=selected_agent_runtime,
+                triggered_by_user_id=user_id,
+                # Where this carried on from. Only set when a person picked an
+                # earlier run to branch at; a run with no parent is on the
+                # trunk and sees the whole conversation.
+                parent_run_id=branch_from_run_id,
                 metadata={"source": "user_message"},
             )
 
@@ -162,6 +219,7 @@ class TurnCoordinator:
             draft=MessageDraft.of_text(
                 content,
                 role=MessageRole.USER,
+                sender_user_id=user_id,
                 metadata=metadata,
             ),
         )
@@ -174,7 +232,7 @@ class TurnCoordinator:
                         agent_run_id=active_run.id,
                         user_id=user_id,
                         pod_id=pod_id,
-                        agent_name=agent_name,
+                        agent_name=answered_by_name,
                     )
                 ]
             )
@@ -200,6 +258,7 @@ class TurnCoordinator:
         return AgentRunStartResult(
             conversation_id=conversation.id,
             agent_run_id=active_run.id,
+            agent_id=active_run.agent_id,
             started_new_run=started_new_run,
         )
 
@@ -283,6 +342,8 @@ class TurnCoordinator:
             conversation_id=conversation.id,
             agent_id=conversation.agent_id,
             agent_runtime=agent_runtime,
+            # The queued messages are the owner's; nothing else queued them.
+            triggered_by_user_id=conversation.user_id,
             metadata={
                 "source": "queued_messages",
                 "queued_behind_agent_run_id": str(completed_run_id),

--- a/lemma-backend/app/modules/agent/services/due_snooze_claimer.py
+++ b/lemma-backend/app/modules/agent/services/due_snooze_claimer.py
@@ -13,7 +13,9 @@ from app.core.domain.timers import (
     lease_expiry,
     lease_is_free,
 )
-from app.modules.agent.infrastructure.models import AgentConversationWaitModel
+from app.modules.agent.infrastructure.wait_models import (
+    AgentConversationWaitModel,
+)
 
 SNOOZE_WAKE_SOURCE = "agent_snooze"
 

--- a/lemma-backend/app/modules/agent/services/pause_resume.py
+++ b/lemma-backend/app/modules/agent/services/pause_resume.py
@@ -174,6 +174,8 @@ class PauseResume:
             conversation_id=conversation.id,
             agent_id=conversation.agent_id,
             agent_runtime=selected_agent_runtime,
+            # Whoever answered the pause, not whoever opened the conversation.
+            triggered_by_user_id=user_id,
             metadata={"source": source, "resumed_tool_call_id": resumed_tool_call_id},
         )
         self.uow.collect_events(

--- a/lemma-backend/app/modules/agent/services/run_event_pump.py
+++ b/lemma-backend/app/modules/agent/services/run_event_pump.py
@@ -119,6 +119,10 @@ class RunEventPump:
                 agent_run_id=run.agent_run_id,
                 data=event.data,
             )
+            # Read back from the run rather than stored on the row: the message
+            # table has no agent column, and the frame needs one so the
+            # transcript can name whoever is speaking as it arrives.
+            saved_message.agent_id = run.agent_id
             await publish_conversation_event(
                 run.conversation_id,
                 message_payload(run.agent_run_id, message_to_payload(saved_message)),

--- a/lemma-backend/app/modules/agent/services/run_resolution.py
+++ b/lemma-backend/app/modules/agent/services/run_resolution.py
@@ -1,0 +1,87 @@
+"""Resolving what a run needs before it can start.
+
+Four lookups the runner performs once per run: the runtime profile behind the
+conversation's configured model, the output type a TASK conversation forces,
+and the connector accounts the agent is configured against.
+
+A mixin rather than module functions because they are monkeypatched on the
+instance in tests and read ``self.uow_factory``; moved out of
+``agent_runner_service`` because that file is at the architecture ratchet's
+per-file limit.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.core.crypto import get_secret_cipher
+from app.modules.agent.services.run_phase_spans import run_phase
+from app.modules.agent.domain.entities import Agent, Conversation
+from app.modules.agent.domain.value_objects import (
+    AgentRuntimeConfig,
+    ConversationType,
+)
+from app.modules.agent.infrastructure.repositories import (
+    AgentRuntimeProfileRepository,
+)
+from app.modules.agent.services.runtime_profile_service import (
+    AgentRuntimeProfileService,
+    ResolvedAgentRuntime,
+)
+from app.modules.agent.tools.callable_tool_factory import AgentCallableToolFactory
+from app.modules.agent.tools.final_answer import get_final_answer_tool
+
+
+class RunResolutionMixin:
+    async def _resolve_agent_runtime(
+        self,
+        agent_runtime: AgentRuntimeConfig,
+        *,
+        user_id: UUID,
+        organization_id: UUID | None,
+    ) -> ResolvedAgentRuntime:
+        with run_phase("resolve_runtime"):
+            async with self.uow_factory() as uow:
+                service = AgentRuntimeProfileService(
+                    AgentRuntimeProfileRepository(
+                        uow,
+                        encryption=get_secret_cipher(),
+                    )
+                )
+                return await service.resolve(
+                    runtime=agent_runtime,
+                    organization_id=organization_id,
+                    user_id=user_id,
+                )
+
+    def _agent_with_resolved_runtime_metadata(
+        self,
+        agent: Agent,
+        *,
+        resolved_runtime: ResolvedAgentRuntime,
+    ) -> Agent:
+        del resolved_runtime
+        return agent
+
+    def _resolve_output_type(
+        self, agent: Agent, conversation: Conversation
+    ) -> object | None:
+        # TASK conversations always get the final_answer tool: it drives the task
+        # lifecycle (status WAITING/COMPLETED/FAILED), not just structured output.
+        # The output *schema* is only applied when the agent configures one — see
+        # get_final_answer_tool, which uses `output: str` otherwise (no schema is
+        # pushed to the model when output_schema is absent).
+        if conversation.type == ConversationType.TASK:
+            return get_final_answer_tool(agent)
+        return None
+
+    async def _resolve_configured_accounts(
+        self,
+        *,
+        agent: Agent,
+        user_id: UUID,
+    ) -> dict[str, UUID]:
+        with run_phase("configured_accounts"):
+            return await AgentCallableToolFactory(
+                self.uow_factory
+            ).resolve_configured_accounts(agent=agent, user_id=user_id)

--- a/lemma-backend/app/modules/agent/services/runtime_history.py
+++ b/lemma-backend/app/modules/agent/services/runtime_history.py
@@ -183,31 +183,199 @@ def _dropped_runs_notice(run: AgentRun, dropped: int) -> Message:
     )
 
 
+def apply_branch_lineage(
+    runs: list[AgentRun], current_run: AgentRun | None
+) -> list[AgentRun]:
+    """Keep only the runs on this run's branch.
+
+    A subthread is a deliberate branch: somebody picked an earlier run and
+    carried on from there, which ``AgentRun.parent_run_id`` records. Two
+    branches off the same point are separate conversations about the same
+    starting position, and each has to be able to not know about the other --
+    otherwise branching is just a second way of writing in the same place.
+
+    A run with no parent is on the trunk and sees everything, which is every
+    run there has ever been until somebody branches. That is why this is a
+    no-op by default rather than a mode.
+
+    Kept: the run's ancestors, and the trunk up to the point it left. Excluded:
+    every sibling branch, and anything descended from one.
+    """
+    if current_run is None or current_run.parent_run_id is None:
+        return runs
+    by_id = {run.id: run for run in runs}
+    lineage: list[AgentRun] = []
+    walker: AgentRun | None = current_run
+    seen: set[UUID] = set()
+    while walker is not None and walker.id not in seen:
+        seen.add(walker.id)
+        lineage.append(walker)
+        parent_id = walker.parent_run_id
+        walker = by_id.get(parent_id) if parent_id is not None else None
+    root = lineage[-1]
+    return [
+        run
+        for run in runs
+        if run.id in seen
+        or (run.parent_run_id is None and run.started_at <= root.started_at)
+    ]
+
+
+def _belongs_to_someone_else(
+    run: AgentRun,
+    *,
+    viewer_id: UUID | None,
+    owner_id: UUID | None,
+) -> bool:
+    """Is this run somebody else's working, from this run's point of view?
+
+    A run with no recorded trigger predates the column, and the backfill
+    resolved those to the conversation's owner -- so the same rule is applied
+    here as in `ConversationRepository.list_messages`, and the model is shown
+    what the person reading over its shoulder is shown.
+
+    `viewer_id` of None means nobody asked, which is every single-person
+    conversation and every caller that predates this. Nothing is withheld then.
+    """
+    if viewer_id is None:
+        return False
+    trigger = run.triggered_by_user_id or owner_id
+    return trigger is not None and trigger != viewer_id
+
+
 def select_runtime_history(
-    runs: list[AgentRun], conversation: Conversation | None = None
+    runs: list[AgentRun],
+    conversation: Conversation | None = None,
+    *,
+    viewer_id: UUID | None = None,
+    current_run: AgentRun | None = None,
 ) -> list[Message]:
+    """The history for one run, bounded by age, by count, and by whose it is.
+
+    `viewer_id` is who the run acts for. Another person's run is collapsed to
+    its question and its answer however recent it is: the tool arguments carry
+    what they asked and the tool results carry data their grants reached, and
+    replaying either into this run would hand it both. `_collapsed_run` already
+    produces exactly that shape for old runs, so this is the same reduction on
+    a different trigger.
+    """
     # Surface (Slack/Telegram/WhatsApp/…) conversations bound how much prior
     # history reaches the model by age + count. Trim at run granularity first
     # so tool-call/tool-return pairs (which live within a run) stay intact.
+    # Branch first, then the windows: the branch decides which runs are even in
+    # this conversation's line, and the caps bound what is left of it.
+    runs = apply_branch_lineage(runs, current_run)
     original_count = len(runs)
     runs = apply_surface_history_window(runs, conversation)
     prefix: list[Message] = []
     if runs and len(runs) < original_count:
         prefix = [_dropped_runs_notice(runs[0], original_count - len(runs))]
-    if len(runs) <= FULL_HISTORY_AGENT_RUN_COUNT:
-        return prefix + [message for run in runs for message in run.ordered_messages()]
 
-    recent_run_ids = {run.id for run in runs[-FULL_HISTORY_AGENT_RUN_COUNT:]}
+    owner_id = conversation.user_id if conversation is not None else None
+    # Whose words are whose. A conversation can be answered by several agents,
+    # and each of them has to read the others as other people.
+    names = _agent_names(conversation)
+    own_agent_id = getattr(current_run, "agent_id", None) if current_run else None
+    # Every run when there are few enough of them: the count cap is what
+    # elides, and below it nothing is old enough to lose anything to age.
+    recent_run_ids = (
+        {run.id for run in runs[-FULL_HISTORY_AGENT_RUN_COUNT:]}
+        if len(runs) > FULL_HISTORY_AGENT_RUN_COUNT
+        else {run.id for run in runs}
+    )
     selected: list[Message] = []
     for run in runs:
         messages = run.ordered_messages()
-        if not messages:
-            continue
-        if run.id in recent_run_ids or run.message_count <= 2:
-            selected.extend(messages)
-            continue
-        selected.extend(_collapsed_run(run, messages))
+        if messages:
+            selected.extend(
+                _messages_for_run(
+                    run,
+                    messages,
+                    viewer_id=viewer_id,
+                    owner_id=owner_id,
+                    own_agent_id=own_agent_id,
+                    names=names,
+                    carried_whole=run.id in recent_run_ids,
+                )
+            )
     return prefix + selected
+
+
+def _messages_for_run(
+    run: AgentRun,
+    messages: list[Message],
+    *,
+    viewer_id: UUID | None,
+    owner_id: UUID | None,
+    own_agent_id: UUID | None,
+    names: dict[UUID, str],
+    carried_whole: bool,
+) -> list[Message]:
+    """How much of one run reaches the prompt, and in whose voice.
+
+    Ordered by what each rule protects. Somebody else's working is withheld
+    before anything else, because recency would otherwise wave it through.
+    Another agent's speech is attributed next, because replaying it as this
+    agent's own is how an agent loses track of who it is. What survives both is
+    then bounded by age and size.
+    """
+    if _belongs_to_someone_else(run, viewer_id=viewer_id, owner_id=owner_id):
+        return _collapsed_run(run, messages)
+    speaker = names.get(run.agent_id) if run.agent_id != own_agent_id else None
+    if speaker:
+        return _attributed_to_another_agent(run, messages, speaker)
+    if carried_whole or run.message_count <= 2:
+        return messages
+    return _collapsed_run(run, messages)
+
+
+def _agent_names(conversation: Conversation | None) -> dict[UUID, str]:
+    """Which agent is called what, from the conversation's own roster."""
+    participants = getattr(conversation, "participants", None) or []
+    return {
+        participant.agent_id: participant.display_name
+        for participant in participants
+        if participant.agent_id is not None and participant.display_name
+    }
+
+
+def _attributed_to_another_agent(
+    run: AgentRun, messages: list[Message], name: str
+) -> list[Message]:
+    """Another agent's turn, rewritten as something that was said to this one.
+
+    Replaying it unchanged is what made a named agent lose track of who it is:
+    every assistant message in a conversation was handed to the model as its
+    own prior words, so an agent answering after another one read that agent's
+    replies as its own and answered as them. One insisted it was Robin while
+    running as Batman, in a conversation where Robin had spoken first.
+
+    So the other agent's speech becomes reported speech -- a user-role line
+    naming who said it -- and its working is dropped. Dropping the working
+    whole is the same rule elision follows: a tool call without its return is
+    worse than neither.
+    """
+    kept: list[Message] = []
+    for message in messages:
+        if message.role is MessageRole.USER:
+            kept.append(message)
+            continue
+        if message.kind is not MessageKind.TEXT or not message.text:
+            continue
+        kept.append(
+            Message(
+                id=message.id,
+                conversation_id=message.conversation_id,
+                sequence=message.sequence,
+                agent_run_id=run.id,
+                role=MessageRole.USER.value,
+                kind=MessageKind.TEXT,
+                text=f"{name} said: {message.text}",
+                created_at=message.created_at,
+                metadata={"synthetic": True, "spoken_by_agent": name},
+            )
+        )
+    return kept
 
 
 def _collapsed_run(run: AgentRun, messages: list[Message]) -> list[Message]:

--- a/lemma-backend/app/modules/agent/services/serialization.py
+++ b/lemma-backend/app/modules/agent/services/serialization.py
@@ -12,6 +12,13 @@ def message_to_payload(message: Message) -> JsonObject:
         "conversation_id": str(message.conversation_id),
         "sequence": message.sequence,
         "agent_run_id": str(message.agent_run_id) if message.agent_run_id else None,
+        # Identity travels on the live frame, not only on the refetch. Without
+        # these a streamed message arrives anonymous and the transcript labels
+        # it with the default agent until something refetches it.
+        "sender_user_id": (
+            str(message.sender_user_id) if message.sender_user_id else None
+        ),
+        "agent_id": str(message.agent_id) if message.agent_id else None,
         "role": message.role,
         "kind": message.kind.value,
         "text": message.text,

--- a/lemma-backend/app/modules/agent/services/snooze_wake_service.py
+++ b/lemma-backend/app/modules/agent/services/snooze_wake_service.py
@@ -66,7 +66,19 @@ class SnoozeWakeService:
         claimed.complete(reason)
         await self.waits.update(claimed)
 
-        ctx = await self._context_for(conversation.user_id, claimed.pod_id)
+        # A wake has no sender, so it acts as whoever set the snooze -- which
+        # is the trigger of the run that called the tool, recorded at that
+        # moment. Resolving it from the conversation instead would mean the
+        # authority a sleeping run wakes with could change when somebody joins
+        # or leaves. The owner remains the answer for runs predating the column.
+        paused_run = await self.conversations.get_agent_run(claimed.agent_run_id)
+        acting_user_id = (
+            paused_run.triggered_by_user_id
+            if paused_run is not None and paused_run.triggered_by_user_id is not None
+            else conversation.user_id
+        )
+
+        ctx = await self._context_for(acting_user_id, claimed.pod_id)
         token = set_current_context(ctx)
         try:
             service = self._conversation_service()
@@ -81,7 +93,7 @@ class SnoozeWakeService:
                 conversation=conversation,
                 paused_run_id=claimed.agent_run_id,
                 resumed_tool_call_id=claimed.tool_call_id,
-                user_id=conversation.user_id,
+                user_id=acting_user_id,
                 pod_id=claimed.pod_id,
                 agent_name=None,
                 source="snooze_resume",

--- a/lemma-backend/app/modules/agent/services/turn_routing.py
+++ b/lemma-backend/app/modules/agent/services/turn_routing.py
@@ -1,0 +1,141 @@
+"""Who answers a message nobody addressed, and what happens when nobody does.
+
+Split from ``conversation_turns`` because that file is at the architecture
+ratchet's per-file limit, and because these two are one question: the routing
+decision and the path it takes when the answer is "nobody". The rest of the
+coordinator is about running a turn, which is a different subject.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from app.modules.agent.domain.entities import Agent, Conversation
+from app.modules.agent.domain.value_objects import (
+    AgentRunStartResult,
+    MessageDraft,
+    MessageKind,
+    MessageRole,
+)
+from app.modules.agent.services.agent_router import (
+    InboundMessage,
+    RosterAgent,
+    routing_is_needed,
+)
+from app.modules.agent.services.realtime import (
+    input_added_payload,
+    publish_conversation_event,
+)
+from app.modules.agent.services.serialization import message_to_payload
+
+#: How much of the conversation the router is shown. Enough to resolve a reply
+#: or a follow-up, short enough that routing stays cheap on every message.
+_ROUTER_CONTEXT_MESSAGES = 6
+
+#: "The question does not arise" -- distinct from None, which is a router that
+#: was asked and chose nobody. Without a third value the two collapse, and a
+#: one-agent conversation would fall into the silence path on every message.
+UNROUTED = object()
+
+
+class TurnRoutingMixin:
+    async def _route_unaddressed(
+        self,
+        conversation: Conversation,
+        *,
+        content: str,
+        user_id: UUID,
+        pod_id: UUID,
+    ) -> Agent | None | object:
+        """Who answers a message nobody addressed.
+
+        Three answers, and they are all different: ``UNROUTED`` means the
+        question does not arise and the conversation's own agent answers as it
+        always has; an agent means route to that one; None means nobody
+        answers and the message is simply stored.
+
+        Only rooms with more than one agent in them ever reach a model. That is
+        what `routing_is_needed` decides, and it is why the default
+        conversation -- one person, one agent -- costs nothing.
+        """
+        roster = [
+            RosterAgent(id=participant.agent_id, name=participant.display_name or "")
+            for participant in conversation.participants
+            if participant.agent_id is not None
+        ]
+        message = InboundMessage(text=content)
+        if not routing_is_needed(message, roster):
+            return UNROUTED
+        # Imported here, not at module load: it pulls in pydantic-ai, and this
+        # module is on the API's import path. The structural check above is what
+        # makes that affordable -- most conversations never reach this line.
+        from app.modules.agent.services.agent_router_model import resolve_responder
+
+        # The last few lines, oldest first. Without them every message is
+        # judged cold, and "yes please" or "and the other one?" is unroutable
+        # on its own while being obvious in context.
+        recent, _ = await self.conversation_repository.list_messages(
+            conversation_id=conversation.id,
+            limit=_ROUTER_CONTEXT_MESSAGES,
+        )
+        chosen_ids = await resolve_responder(
+            message,
+            roster,
+            user_id=user_id,
+            organization_id=conversation.organization_id,
+            pod_id=pod_id,
+            recent=[
+                f"{item.role.value}: {item.text}"
+                for item in recent
+                if item.text and item.kind is MessageKind.TEXT
+            ],
+        )
+        if not chosen_ids:
+            return None
+        # One run per conversation is a database invariant
+        # (`uq_agent_active_run_per_conversation`), so however many the router
+        # names, one of them answers now. They come back most-relevant first.
+        chosen = await self.agent_repository.get(chosen_ids[0])
+        # The roster came from the conversation's own rows, so a missing agent
+        # here means it was deleted between the two reads. Falling back to the
+        # conversation's agent is better than dropping the message.
+        return chosen if chosen is not None else UNROUTED
+
+    async def _store_without_answering(
+        self,
+        conversation: Conversation,
+        *,
+        content: str,
+        user_id: UUID,
+        message_metadata: dict[str, object] | None,
+    ) -> AgentRunStartResult:
+        """Keep the message; start no run.
+
+        The ordinary outcome of talking to a person in a room an agent happens
+        to be in. The message is stored, published to everyone watching, and
+        nothing answers -- so there is no run, and the result says so.
+        """
+        saved = await self.conversation_repository.append_message(
+            conversation_id=conversation.id,
+            agent_run_id=None,
+            draft=MessageDraft.of_text(
+                content,
+                role=MessageRole.USER,
+                sender_user_id=user_id,
+                metadata={**(message_metadata or {}), "answered_by_agent": False},
+            ),
+        )
+        await self.uow.commit()
+
+        async def _publish() -> None:
+            await publish_conversation_event(
+                conversation.id,
+                input_added_payload(None, message_to_payload(saved)),
+            )
+
+        self.uow.after_commit(_publish)
+        return AgentRunStartResult(
+            conversation_id=conversation.id,
+            agent_run_id=None,
+            started_new_run=False,
+        )

--- a/lemma-backend/app/modules/agent/tests/e2e/test_conversation_addressing_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_conversation_addressing_e2e.py
@@ -1,0 +1,141 @@
+"""Addressing an agent in a conversation, against a real database.
+
+`@mention` routing has one rule that only shows up end-to-end: the agent it
+names is not the conversation's own, so every access check between the request
+and the run has to accept an agent that is merely *present*. Any one of them
+refusing turns a mention into a message that vanishes -- which is exactly how
+this shipped broken.
+
+The negative case matters as much: naming an agent nobody added must be refused,
+or a name typed into a room reaches an agent that was never in it.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+
+from app.core.infrastructure.db.session import async_session_maker
+from app.core.infrastructure.db.uow_factory import create_uow_from_session_maker
+from app.modules.agent.infrastructure.repositories import ConversationRepository
+
+pytestmark = pytest.mark.e2e
+
+
+async def _create_pod(authenticated_client, fixed_test_org) -> str:
+    response = await authenticated_client.post(
+        "/pods",
+        json={
+            "name": f"Addressing Pod {uuid4().hex[:8]}",
+            "description": "Agent addressing E2E pod",
+            "organization_id": fixed_test_org["id"],
+            "type": "HYBRID",
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+async def _create_agent(authenticated_client, pod_id: str, name: str) -> dict:
+    response = await authenticated_client.post(
+        f"/pods/{pod_id}/agents",
+        json={
+            "name": name,
+            "instruction": "You are a test agent. Reply with one short line.",
+        },
+    )
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+async def _create_conversation(authenticated_client, pod_id: str) -> str:
+    """A conversation on the pod's default assistant, not on the named agent."""
+    response = await authenticated_client.post(
+        f"/pods/{pod_id}/conversations",
+        json={"agent_runtime": {"profile_id": "system:lemma"}},
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+class TestListingWhatYouAreIn:
+    async def test_a_conversation_you_were_added_to_appears_in_your_list(
+        self, authenticated_client, fixed_test_org
+    ) -> None:
+        """Owner-only listing is what made being added to a conversation
+        useless: you could open it from a link and never find it again."""
+        pod_id = await _create_pod(authenticated_client, fixed_test_org)
+        conversation_id = await _create_conversation(authenticated_client, pod_id)
+
+        listed = await authenticated_client.get(f"/pods/{pod_id}/conversations")
+        assert listed.status_code == 200, listed.text
+        # The opener sees it because they own it; the participant row backfilled
+        # for them means the same query finds it either way.
+        assert conversation_id in {item["id"] for item in listed.json()["items"]}
+
+    async def test_an_agent_participant_does_not_put_it_in_somebody_elses_list(
+        self, authenticated_client, fixed_test_org
+    ) -> None:
+        """Agents share the participants table with people. Matching on the
+        table rather than on `user_id` would list a conversation for everyone
+        the moment an agent joined it."""
+        pod_id = await _create_pod(authenticated_client, fixed_test_org)
+        await _create_agent(authenticated_client, pod_id, "scout")
+        conversation_id = await _create_conversation(authenticated_client, pod_id)
+        added = await authenticated_client.post(
+            f"/pods/{pod_id}/conversations/{conversation_id}/participants",
+            json={"agent_name": "scout"},
+        )
+        assert added.status_code in (200, 201), added.text
+
+        listed = await authenticated_client.get(f"/pods/{pod_id}/conversations")
+
+        ids = [item["id"] for item in listed.json()["items"]]
+        assert ids.count(conversation_id) == 1, "an agent must not duplicate the row"
+
+
+class TestAddressingAnAgent:
+    async def test_an_agent_in_the_conversation_can_be_addressed(
+        self, authenticated_client, fixed_test_org
+    ) -> None:
+        pod_id = await _create_pod(authenticated_client, fixed_test_org)
+        agent = await _create_agent(authenticated_client, pod_id, "batman")
+        conversation_id = await _create_conversation(authenticated_client, pod_id)
+
+        added = await authenticated_client.post(
+            f"/pods/{pod_id}/conversations/{conversation_id}/participants",
+            json={"agent_name": "batman"},
+        )
+        assert added.status_code in (200, 201), added.text
+
+        response = await authenticated_client.post(
+            f"/pods/{pod_id}/conversations/{conversation_id}/messages/append",
+            json={"content": "@batman hi", "agent_name": "batman"},
+        )
+
+        # The message must land, and it must land on *batman* -- a 200 alone
+        # proves nothing, because the pod's default assistant answering is also
+        # a 200. That weaker assertion is what let this ship broken.
+        assert response.status_code == 200, response.text
+        run_id = response.json()["agent_run_id"]
+        assert run_id, response.text
+
+        async with create_uow_from_session_maker(async_session_maker) as uow:
+            run = await ConversationRepository(uow).get_agent_run(UUID(run_id))
+        assert run is not None
+        assert str(run.agent_id) == agent["id"]
+
+    async def test_an_agent_that_was_never_added_is_refused(
+        self, authenticated_client, fixed_test_org
+    ) -> None:
+        pod_id = await _create_pod(authenticated_client, fixed_test_org)
+        await _create_agent(authenticated_client, pod_id, "joker")
+        conversation_id = await _create_conversation(authenticated_client, pod_id)
+
+        response = await authenticated_client.post(
+            f"/pods/{pod_id}/conversations/{conversation_id}/messages/append",
+            json={"content": "@joker hi", "agent_name": "joker"},
+        )
+
+        assert response.status_code == 404, response.text

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_config.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_config.py
@@ -9,6 +9,7 @@ from app.modules.agent.config import AgentSettings
 pytestmark = pytest.mark.unit
 
 EXPECTED = [
+    ("agent_router_model", "AGENT_ROUTER_MODEL", None),
     (
         "agent_run_stop_poll_interval_seconds",
         "AGENT_RUN_STOP_POLL_INTERVAL_SECONDS",

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_context_brief.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_context_brief.py
@@ -9,6 +9,8 @@ opening any UoW.
 from types import SimpleNamespace
 from uuid import uuid4
 
+from app.core.authorization.delegation import DEFAULT_POD_AGENT_ID
+
 import pytest
 
 from app.modules.agent.domain.value_objects import AgentToolset
@@ -170,6 +172,11 @@ def _named_agent():
     return SimpleNamespace(id=uuid4(), name="agent", description=None)
 
 
+def _pod_assistant():
+    """The pod default, which is identified by its sentinel id and nothing else."""
+    return SimpleNamespace(id=DEFAULT_POD_AGENT_ID, name="assistant", description=None)
+
+
 def _conversation(is_pod_assistant: bool):
     return SimpleNamespace(id=uuid4(), is_pod_assistant=is_pod_assistant)
 
@@ -192,8 +199,12 @@ async def test_default_assistant_brief_never_overlaps_uows(stubbed):
     factory = RecordingUoWFactory()
     builder = AgentContextBriefBuilder(factory)
     await builder.build(
-        agent=_named_agent(),
-        conversation=_conversation(True),  # pod assistant -> full inventory path
+        # The *agent* selects the inventory path. It used to be the
+        # conversation, which is how a named agent answering an `@mention` in a
+        # pod-default conversation was handed the pod assistant's brief -- one
+        # that lists the pod's agents, itself included.
+        agent=_pod_assistant(),
+        conversation=_conversation(True),
         user_id=uuid4(),
         pod_id=uuid4(),
     )
@@ -251,12 +262,16 @@ async def test_a_new_conversation_reuses_the_cached_brief(stubbed, monkeypatch):
 
 
 async def test_the_two_brief_shapes_never_share_a_cache_entry(stubbed, monkeypatch):
-    """The correctness guard on dropping the conversation id.
+    """The correctness guard on the cache key.
 
-    Whether the conversation is the pod default assistant selects between the
-    full pod inventory and the agent's own grants -- two different briefs from
-    the same agent, pod and user. That is the one thing the conversation
-    contributes, so it has to stay in the key.
+    The pod assistant sees the full pod inventory; a named agent sees only its
+    own grants. Two different briefs, and the agent is what tells them apart --
+    so two agents in the *same* conversation must not be served each other's.
+
+    This used to turn on the conversation instead. That is what let a named
+    agent answering an `@mention` in a pod-default conversation be handed the
+    inventory brief, read its own name in the agent list, and try to relay the
+    message to itself.
     """
     monkeypatch.setattr(
         brief_mod.agent_settings, "agent_context_brief_cache_ttl_seconds", 60
@@ -266,12 +281,13 @@ async def test_the_two_brief_shapes_never_share_a_cache_entry(stubbed, monkeypat
     agent = _named_agent()
     uid, pid = uuid4(), uuid4()
 
+    conversation = _conversation(True)
     granted = await builder.build(
-        agent=agent, conversation=_conversation(False), user_id=uid, pod_id=pid
+        agent=agent, conversation=conversation, user_id=uid, pod_id=pid
     )
     opened_after_first = factory.opened
     inventory = await builder.build(
-        agent=agent, conversation=_conversation(True), user_id=uid, pod_id=pid
+        agent=_pod_assistant(), conversation=conversation, user_id=uid, pod_id=pid
     )
 
     assert factory.opened > opened_after_first  # rebuilt, not served the other

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_router.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_router.py
@@ -1,0 +1,445 @@
+"""Who answers a message nobody addressed.
+
+The value here is in what never reaches a model: an explicit mention, a reply
+in an agent's own subthread, an agent's own message, and the one-agent case.
+Those are the guards, and they are what these pin.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+from app.modules.agent.services.agent_router import (
+    InboundMessage,
+    RosterAgent,
+    addressed_agent,
+    resolve_router_choice,
+    routing_is_needed,
+    sole_agent,
+)
+
+
+def _roster(*names: str) -> list[RosterAgent]:
+    return [RosterAgent(id=uuid4(), name=name) for name in names]
+
+
+def test_a_mention_is_settled_without_a_model():
+    roster = _roster("scout", "archivist")
+    message = InboundMessage(text="do the thing", mentioned_agent_id=roster[1].id)
+
+    assert addressed_agent(message, roster) == roster[1].id
+    assert routing_is_needed(message, roster) is False
+
+
+def test_a_reply_in_an_agents_subthread_counts_as_addressed():
+    """Mention once, then talk normally."""
+    roster = _roster("scout", "archivist")
+    message = InboundMessage(text="and the other one?", subthread_agent_id=roster[0].id)
+
+    assert addressed_agent(message, roster) == roster[0].id
+
+
+def test_a_mention_of_an_agent_who_is_not_here_addresses_nobody():
+    """Otherwise a name typed in a room reaches an agent never added to it."""
+    roster = _roster("scout")
+    message = InboundMessage(text="@archivist help", mentioned_agent_id=uuid4())
+
+    assert addressed_agent(message, roster) is None
+
+
+def test_an_agents_own_message_is_never_routed():
+    """Agent A posts, the router routes to B, B posts, forever."""
+    roster = _roster("scout", "archivist")
+    message = InboundMessage(text="here is the answer", author_agent_id=roster[0].id)
+
+    assert routing_is_needed(message, roster) is False
+
+
+def test_one_agent_never_reaches_the_router():
+    """The default conversation, and almost all of them."""
+    roster = _roster("scout")
+    message = InboundMessage(text="anything")
+
+    assert routing_is_needed(message, roster) is False
+    assert sole_agent(roster) == roster[0].id
+
+
+def test_an_unaddressed_message_with_several_agents_does_reach_it():
+    roster = _roster("scout", "archivist")
+
+    assert routing_is_needed(InboundMessage(text="who knows this?"), roster) is True
+
+
+def test_the_model_choosing_nobody_is_silence():
+    roster = _roster("scout", "archivist")
+
+    for answer in ["NONE", "none", "nobody", "", None, "  "]:
+        assert resolve_router_choice(answer, roster) is None
+
+
+def test_an_unrecognised_answer_is_silence_not_a_guess():
+    """A near-match is the failure worth avoiding: it invents an addressee."""
+    roster = _roster("scout", "archivist")
+
+    assert resolve_router_choice("scou", roster) is None
+    assert resolve_router_choice("I think scout should take this", roster) is None
+    assert resolve_router_choice("archivist", roster) == roster[1].id
+    assert resolve_router_choice("@Scout", roster) == roster[0].id
+
+
+# --- composition -------------------------------------------------------------
+
+
+async def test_an_addressed_message_never_reaches_a_model(monkeypatch):
+    import app.modules.agent.services.agent_router_model as router_model
+
+    called = False
+
+    async def _never(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        return None
+
+    monkeypatch.setattr(router_model, "_ask_model", _never)
+    roster = _roster("scout", "archivist")
+    message = InboundMessage(text="go", mentioned_agent_id=roster[1].id)
+
+    chosen = await router_model.resolve_responder(
+        message, roster, user_id=uuid4(), organization_id=None, pod_id=uuid4()
+    )
+
+    assert chosen == [roster[1].id]
+    assert called is False
+
+
+async def test_a_router_failure_is_silence(monkeypatch):
+    """A router that cannot be reached must not stop the message reaching the
+    people in the room."""
+    import app.modules.agent.services.agent_router_model as router_model
+
+    async def _explode(**_kwargs):
+        raise RuntimeError("no model here")
+
+    monkeypatch.setattr(router_model, "_resolve_runtime", _explode)
+
+    chosen = await router_model.resolve_responder(
+        InboundMessage(text="who knows this?"),
+        _roster("scout", "archivist"),
+        user_id=uuid4(),
+        organization_id=None,
+        pod_id=uuid4(),
+    )
+
+    assert chosen == []
+
+
+# --- the send path actually asks ---------------------------------------------
+
+
+def _turn_coordinator():
+    from app.modules.agent.services.conversation_turns import TurnCoordinator
+
+    # The router is shown the last few messages, so the repository has to be
+    # able to hand them over even when a test does not care what they are.
+    conversations = SimpleNamespace(list_messages=AsyncMock(return_value=([], None)))
+    return TurnCoordinator(
+        SimpleNamespace(), conversations, SimpleNamespace(), None, None, None
+    )
+
+
+def _conversation_with_agents(*agent_ids):
+    from app.modules.agent.domain.entities import Conversation
+    from app.modules.agent.domain.participants import ConversationParticipant
+
+    conversation = Conversation(user_id=uuid4(), pod_id=uuid4())
+    conversation.participants = [
+        ConversationParticipant(conversation_id=conversation.id, agent_id=agent_id)
+        for agent_id in agent_ids
+    ]
+    return conversation
+
+
+async def test_the_send_path_skips_the_router_for_one_agent():
+    """The rule is pinned above; this pins that the send path applies it.
+    Paying for a model to say "the only agent here" on every message would be
+    the whole cost of the feature for none of its value."""
+    from app.modules.agent.services.turn_routing import UNROUTED
+
+    conversation = _conversation_with_agents(uuid4())
+    routed = await _turn_coordinator()._route_unaddressed(
+        conversation,
+        content="hi",
+        user_id=conversation.user_id,
+        pod_id=conversation.pod_id,
+    )
+    assert routed is UNROUTED
+
+
+async def test_two_agents_ask_and_silence_is_an_answer(monkeypatch):
+    """Silence is distinct from "the question does not arise": one stores the
+    message with no run, the other lets the conversation's own agent reply."""
+    import app.modules.agent.services.agent_router_model as router_model
+
+    async def _silent(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr(router_model, "resolve_responder", _silent)
+    conversation = _conversation_with_agents(uuid4(), uuid4())
+    routed = await _turn_coordinator()._route_unaddressed(
+        conversation,
+        content="anyone?",
+        user_id=conversation.user_id,
+        pod_id=conversation.pod_id,
+    )
+    assert routed is None
+
+
+async def test_a_chosen_agent_is_returned_whole(monkeypatch):
+    import app.modules.agent.services.agent_router_model as router_model
+
+    chosen_id = uuid4()
+    chosen = SimpleNamespace(id=chosen_id, name="scout", agent_runtime=None)
+
+    async def _chose(*_args, **_kwargs):
+        return [chosen_id]
+
+    monkeypatch.setattr(router_model, "resolve_responder", _chose)
+    coordinator = _turn_coordinator()
+    coordinator.agent_repository = SimpleNamespace(get=AsyncMock(return_value=chosen))
+    conversation = _conversation_with_agents(chosen_id, uuid4())
+
+    routed = await coordinator._route_unaddressed(
+        conversation,
+        content="anyone?",
+        user_id=conversation.user_id,
+        pod_id=conversation.pod_id,
+    )
+
+    assert routed is chosen
+
+
+async def test_an_agent_deleted_mid_flight_falls_back(monkeypatch):
+    """The roster came from the conversation's own rows, so a miss here means
+    the agent was deleted between two reads. Dropping the message would be
+    worse than letting the conversation's own agent answer."""
+    import app.modules.agent.services.agent_router_model as router_model
+    from app.modules.agent.services.turn_routing import UNROUTED
+
+    async def _chose(*_args, **_kwargs):
+        return [uuid4()]
+
+    monkeypatch.setattr(router_model, "resolve_responder", _chose)
+    coordinator = _turn_coordinator()
+    coordinator.agent_repository = SimpleNamespace(get=AsyncMock(return_value=None))
+    conversation = _conversation_with_agents(uuid4(), uuid4())
+
+    routed = await coordinator._route_unaddressed(
+        conversation,
+        content="anyone?",
+        user_id=conversation.user_id,
+        pod_id=conversation.pod_id,
+    )
+
+    assert routed is UNROUTED
+
+
+# --- an addressed agent gets its own brief -----------------------------------
+
+
+async def test_a_named_agent_never_gets_the_pod_assistants_brief(monkeypatch):
+    """Which brief an agent gets is decided by the agent that is running, not
+    by the conversation it runs in.
+
+    An `@mention` puts a named agent in a conversation whose own agent is the
+    pod assistant. While the conversation decided, that agent was handed the
+    pod-inventory brief -- which lists the pod's agents, itself included -- so
+    it read its own name as somebody else and relayed the message on instead of
+    answering it.
+    """
+    from app.modules.agent.domain.entities import Agent, Conversation
+    from app.modules.agent.services.agent_context_brief import (
+        AgentContextBriefBuilder,
+    )
+    import app.modules.agent.services.agent_context_brief as brief_module
+
+    chosen: list[str] = []
+
+    async def _inventory(self, **_kwargs):
+        chosen.append("pod_inventory")
+        return []
+
+    async def _granted(self, **_kwargs):
+        chosen.append("granted_resources")
+        return []
+
+    monkeypatch.setattr(AgentContextBriefBuilder, "_pod_inventory", _inventory)
+    monkeypatch.setattr(AgentContextBriefBuilder, "_granted_resources", _granted)
+    # The cache is keyed on the same boolean, so leave it out of the question.
+    monkeypatch.setattr(brief_module, "_get_cached_brief", AsyncMock(return_value=None))
+    monkeypatch.setattr(brief_module, "_set_cached_brief", AsyncMock())
+
+    class _Repo:
+        def __init__(self, _uow):
+            pass
+
+        async def get_pod_name(self, _pod_id):
+            return "Test Pod"
+
+        async def get_user_profile(self, _user_id):
+            return SimpleNamespace(
+                email="tester@example.com",
+                display_name="Tester",
+                first_name="Tester",
+                last_name=None,
+                timezone=None,
+            )
+
+    monkeypatch.setattr(brief_module, "AgentContextBriefRepository", _Repo)
+
+    class _Uow:
+        async def __aenter__(self):
+            return SimpleNamespace()
+
+        async def __aexit__(self, *_exc):
+            return False
+
+    # A pod-default conversation answered by a *named* agent -- the shape an
+    # `@mention` creates.
+    conversation = Conversation(user_id=uuid4(), pod_id=uuid4())
+    assert conversation.is_pod_assistant
+    named = Agent(
+        id=uuid4(),
+        pod_id=conversation.pod_id,
+        user_id=conversation.user_id,
+        name="batman",
+        instruction="You are batman.",
+    )
+
+    await AgentContextBriefBuilder(lambda: _Uow()).build(
+        agent=named,
+        conversation=conversation,
+        user_id=conversation.user_id,
+        pod_id=conversation.pod_id,
+    )
+
+    assert chosen == ["granted_resources"], chosen
+
+
+# --- the answer must be separable from the thinking --------------------------
+
+
+async def test_the_router_asks_for_a_structured_choice(monkeypatch):
+    """The choice comes back in a field, never as prose.
+
+    This shipped asking for free text with a 32-token cap, which looked frugal
+    and was the whole bug: a reasoning model narrates before it answers, so
+    every reply was truncated mid-sentence and the name never arrived. The
+    tolerant parser then correctly read the prose as "no choice", and every
+    message routed to nobody.
+    """
+    import app.modules.agent.services.agent_router_model as router_model
+
+    captured: dict[str, object] = {}
+
+    class _FakeAgent:
+        def __init__(self, _model, *, system_prompt, output_type):
+            captured["output_type"] = output_type
+            captured["system_prompt"] = system_prompt
+
+        async def run(self, _prompt, **_kwargs):
+            return SimpleNamespace(
+                output=router_model.RouterChoice(agents=["archivist"]), usage=None
+            )
+
+    monkeypatch.setattr(router_model, "PydanticAIAgent", _FakeAgent)
+    monkeypatch.setattr(
+        router_model,
+        "_resolve_runtime",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                public_snapshot=lambda: {},
+                credentials={},
+                model_name_for_harness="test-model",
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        router_model,
+        "require_pydantic_ai_model_from_runtime_profile",
+        lambda **_kwargs: object(),
+    )
+    monkeypatch.setattr(router_model, "usage_limits_for", lambda *_a, **_k: None)
+    monkeypatch.setattr(router_model, "reserve_usage_for_runtime", AsyncMock())
+    monkeypatch.setattr(router_model, "record_pydantic_ai_result_usage", AsyncMock())
+
+    roster = _roster("scout", "archivist")
+    chosen = await router_model.resolve_responder(
+        InboundMessage(text="who knows this?"),
+        roster,
+        user_id=uuid4(),
+        organization_id=None,
+        pod_id=uuid4(),
+    )
+
+    assert captured["output_type"] is router_model.RouterChoice
+    assert chosen == [roster[1].id]
+
+
+def test_the_output_budget_leaves_room_to_think():
+    """A cap sized to a name truncates a model that reasons before answering."""
+    import app.modules.agent.services.agent_router_model as router_model
+
+    assert router_model._ROUTER_USAGE_LIMITS.output_tokens_limit >= 256
+
+
+# --- an agent knows who else is in the room ----------------------------------
+
+
+def _participant(*, user_id=None, agent_id=None, name=None):
+    from app.modules.agent.domain.participants import ConversationParticipant
+
+    return ConversationParticipant(
+        conversation_id=uuid4(),
+        user_id=user_id,
+        agent_id=agent_id,
+        display_name=name,
+    )
+
+
+def test_a_shared_conversation_tells_an_agent_who_is_present():
+    """Without this an agent in a shared conversation is blind to the room.
+    One replied "it's just me in here, no other agents around" while standing
+    next to another agent and two people."""
+    from app.modules.agent.domain.prompts import _room_section
+
+    conversation = SimpleNamespace(
+        participants=[
+            _participant(user_id=uuid4(), name="Deepak"),
+            _participant(user_id=uuid4(), name="Sam"),
+            _participant(agent_id=uuid4(), name="batman"),
+            _participant(agent_id=uuid4(), name="robin"),
+        ]
+    )
+
+    section = _room_section(conversation, SimpleNamespace(name="robin"))
+
+    assert section is not None
+    assert "Deepak" in section and "Sam" in section
+    assert "batman" in section and "robin" in section
+    assert "You are robin here" in section
+    # The behaviour that made this necessary: relaying instead of answering.
+    assert "do not relay" in section
+
+
+def test_a_one_to_one_conversation_gets_no_roster():
+    """A section saying the only two participants are the two already talking
+    is noise in every prompt of every ordinary conversation."""
+    from app.modules.agent.domain.prompts import _room_section
+
+    conversation = SimpleNamespace(
+        participants=[_participant(user_id=uuid4(), name="Deepak")]
+    )
+
+    assert _room_section(conversation, SimpleNamespace(name="Lem")) is None

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_runner_service.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_runner_service.py
@@ -195,6 +195,11 @@ async def test_execute_re_raises_cancelled_error(monkeypatch) -> None:
     agent_run = SimpleNamespace(
         started_at=None,
         status=AgentRunStatus.RUNNING,
+        # Whose grants the run holds, and which agent answers. The runner reads
+        # both off the run rather than off the job payload or the conversation,
+        # so a double without them is not a run.
+        triggered_by_user_id=None,
+        agent_id=None,
         agent_runtime=None,
         error=None,
     )

--- a/lemma-backend/app/modules/agent/tests/unit/test_conversation_controller.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_conversation_controller.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException
 from starlette.datastructures import QueryParams
 
 from app.modules.agent.api.controllers import conversation_controller
+from app.modules.agent.api.schemas import SendMessageRequest
 from app.modules.agent.api.controllers.conversation_controller import (
     _parse_metadata_filters,
     append_message,
@@ -267,7 +268,7 @@ async def test_send_message_starts_run_before_stream_body_is_consumed(
     response = await send_message(
         pod_id=uuid4(),
         conversation_id=result.conversation_id,
-        data=SimpleNamespace(content="say ok", metadata=None),
+        data=SendMessageRequest(content="say ok"),
         user=SimpleNamespace(id=uuid4()),
         channel_service=channel_service,
         request=SimpleNamespace(),
@@ -335,7 +336,7 @@ async def test_append_message_returns_typed_response_without_streaming(
     response = await append_message(
         pod_id=uuid4(),
         conversation_id=result.conversation_id,
-        data=SimpleNamespace(content="say ok", metadata=None),
+        data=SendMessageRequest(content="say ok"),
         user=SimpleNamespace(id=uuid4()),
         request=SimpleNamespace(),
         uow_factory=uow_factory,
@@ -368,7 +369,7 @@ async def test_append_message_reports_joining_an_active_run(monkeypatch) -> None
     response = await append_message(
         pod_id=uuid4(),
         conversation_id=result.conversation_id,
-        data=SimpleNamespace(content="steer this run", metadata=None),
+        data=SendMessageRequest(content="steer this run"),
         user=SimpleNamespace(id=uuid4()),
         request=SimpleNamespace(),
         uow_factory=uow_factory,
@@ -488,16 +489,24 @@ async def test_send_message_encodes_a_dead_subscription_as_stream_error(
     response = await send_message(
         pod_id=uuid4(),
         conversation_id=result.conversation_id,
-        data=SimpleNamespace(content="say ok", metadata=None),
+        data=SendMessageRequest(content="say ok"),
         user=SimpleNamespace(id=uuid4()),
         channel_service=channel_service,
         request=SimpleNamespace(),
         uow_factory=uow_factory,
     )
     chunks = [chunk async for chunk in response.body_iterator]
-    payload = json.loads(chunks[0].removeprefix("data: ").strip())
+    frames = [json.loads(chunk.removeprefix("data: ").strip()) for chunk in chunks]
 
-    assert payload == {
+    # The stream opens by naming who is answering, before any token, so a live
+    # turn is attributable for its whole duration rather than only once it
+    # finishes. Everything else follows it.
+    assert frames[0] == {
+        "type": "run_started",
+        "data": {"agent_id": None},
+        "agent_run_id": str(result.agent_run_id),
+    }
+    assert frames[1] == {
         "type": "stream_error",
         "data": "Realtime stream interrupted. Reconnect to continue.",
         "agent_run_id": str(result.agent_run_id),
@@ -526,7 +535,7 @@ async def test_send_message_raises_usage_limit_before_stream_starts(
         await send_message(
             pod_id=uuid4(),
             conversation_id=uuid4(),
-            data=SimpleNamespace(content="say ok", metadata=None),
+            data=SendMessageRequest(content="say ok"),
             user=SimpleNamespace(id=uuid4()),
             channel_service=channel_service,
             request=SimpleNamespace(),
@@ -557,7 +566,7 @@ async def test_send_message_cancellation_releases_pubsub_subscription(
         await send_message(
             pod_id=uuid4(),
             conversation_id=uuid4(),
-            data=SimpleNamespace(content="say ok", metadata=None),
+            data=SendMessageRequest(content="say ok"),
             user=SimpleNamespace(id=uuid4()),
             channel_service=channel_service,
             request=SimpleNamespace(),

--- a/lemma-backend/app/modules/agent/tests/unit/test_conversation_participants.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_conversation_participants.py
@@ -1,0 +1,183 @@
+"""Who may reach a conversation once it can hold more than one person.
+
+The access rule is the behaviour change: it used to be equality against
+`conversation.user_id`, and it is now that or membership. These pin both halves
+plus the cases that would quietly widen it.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from app.modules.agent.domain.entities import Conversation
+from app.modules.agent.domain.errors import ConversationNotFoundError
+from app.modules.agent.domain.participants import (
+    ConversationParticipant,
+    ConversationParticipantRole,
+)
+from app.modules.agent.infrastructure.conversation_participant_store import (
+    add_participant,
+    remove_participant,
+)
+from app.modules.agent.infrastructure.participant_models import (
+    ConversationParticipantModel,
+)
+from app.modules.agent.services.conversation_access import (
+    validate_conversation_access,
+)
+from app.modules.test_support.mappers import configure_test_mappers
+
+# Constructing a participant model configures the mappers, and a partial model
+# graph fails to resolve its relationship targets by name — so without this the
+# file passes in a suite and fails on its own.
+configure_test_mappers()
+
+
+def _conversation(**kwargs) -> Conversation:
+    return Conversation(user_id=uuid4(), pod_id=uuid4(), **kwargs)
+
+
+def test_owner_reaches_their_own_conversation():
+    conversation = _conversation()
+    validate_conversation_access(
+        conversation, user_id=conversation.user_id, pod_id=conversation.pod_id
+    )
+
+
+def test_stranger_does_not():
+    conversation = _conversation()
+    with pytest.raises(ConversationNotFoundError):
+        validate_conversation_access(
+            conversation, user_id=uuid4(), pod_id=conversation.pod_id
+        )
+
+
+def test_added_member_reaches_it():
+    conversation = _conversation()
+    member_id = uuid4()
+    conversation.participants = [
+        ConversationParticipant(conversation_id=conversation.id, user_id=member_id)
+    ]
+    validate_conversation_access(
+        conversation, user_id=member_id, pod_id=conversation.pod_id
+    )
+
+
+def test_membership_does_not_cross_pods():
+    """Membership widens *who*, never *where*. A member reaching in from the
+    wrong pod is still nothing, or a conversation would be readable through any
+    pod its member happens to belong to."""
+    conversation = _conversation()
+    member_id = uuid4()
+    conversation.participants = [
+        ConversationParticipant(conversation_id=conversation.id, user_id=member_id)
+    ]
+    with pytest.raises(ConversationNotFoundError):
+        validate_conversation_access(conversation, user_id=member_id, pod_id=uuid4())
+
+
+def test_an_agent_participant_grants_nobody_access():
+    """Agent rows share the table, and their `user_id` is NULL. A membership
+    test written as "is there a row for you" would match every person against
+    every agent row if it ever saw a null id on both sides."""
+    conversation = _conversation()
+    conversation.participants = [
+        ConversationParticipant(conversation_id=conversation.id, agent_id=uuid4())
+    ]
+    assert conversation.has_participant(uuid4()) is False
+    with pytest.raises(ConversationNotFoundError):
+        validate_conversation_access(
+            conversation, user_id=uuid4(), pod_id=conversation.pod_id
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"user_id": uuid4(), "agent_id": uuid4()},
+    ],
+    ids=["neither", "both"],
+)
+async def test_a_participant_is_exactly_one_subject(kwargs):
+    """Rejected before the session is touched, which is why None works here."""
+    with pytest.raises(ValueError):
+        await add_participant(None, conversation_id=uuid4(), **kwargs)
+    with pytest.raises(ValueError):
+        await remove_participant(None, conversation_id=uuid4(), **kwargs)
+
+
+class _SessionHolding:
+    def __init__(self, model):
+        self._model = model
+
+    async def scalar(self, _statement):
+        return self._model
+
+
+async def test_the_owner_cannot_be_removed():
+    conversation_id, owner_id = uuid4(), uuid4()
+    session = _SessionHolding(
+        ConversationParticipantModel(
+            id=uuid4(),
+            conversation_id=conversation_id,
+            user_id=owner_id,
+            role=ConversationParticipantRole.OWNER.value,
+        )
+    )
+    with pytest.raises(ValueError):
+        await remove_participant(
+            session, conversation_id=conversation_id, user_id=owner_id
+        )
+
+
+class _SessionHoldingNothing:
+    async def scalar(self, _statement):
+        return None
+
+
+async def test_removing_somebody_who_is_not_there_is_not_an_error():
+    assert (
+        await remove_participant(
+            _SessionHoldingNothing(), conversation_id=uuid4(), user_id=uuid4()
+        )
+        is False
+    )
+
+
+# --- addressing an agent present in the conversation -------------------------
+
+
+def test_an_agent_added_to_the_conversation_may_be_addressed():
+    """An `@mention` names an agent for one turn. Being present in the
+    conversation is as good a claim to answer as being its default agent."""
+    conversation = _conversation(agent_id=uuid4())
+    guest_agent_id = uuid4()
+    conversation.participants = [
+        ConversationParticipant(
+            conversation_id=conversation.id, agent_id=guest_agent_id
+        )
+    ]
+
+    validate_conversation_access(
+        conversation,
+        user_id=conversation.user_id,
+        pod_id=conversation.pod_id,
+        agent_id=guest_agent_id,
+    )
+
+
+def test_an_agent_that_is_not_here_may_not_be_addressed():
+    """Otherwise a name typed into a conversation reaches an agent nobody
+    added to it, with that conversation's history."""
+    conversation = _conversation(agent_id=uuid4())
+
+    with pytest.raises(ConversationNotFoundError):
+        validate_conversation_access(
+            conversation,
+            user_id=conversation.user_id,
+            pod_id=conversation.pod_id,
+            agent_id=uuid4(),
+        )

--- a/lemma-backend/app/modules/agent/tests/unit/test_conversation_read_narrowing.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_conversation_read_narrowing.py
@@ -36,6 +36,11 @@ class _Result:
     def scalars(self):
         return iter(self._rows)
 
+    def __iter__(self):
+        # A real Result iterates its rows, and a caller selecting several
+        # columns reads it that way rather than through `scalars`.
+        return iter(self._rows)
+
     def one(self):
         return self._rows[0]
 

--- a/lemma-backend/app/modules/agent/tests/unit/test_conversation_retry.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_conversation_retry.py
@@ -130,6 +130,9 @@ async def test_retry_failed_run_reuses_runtime_without_appending_message(
         conversation_id=conversation.id,
         agent_id=conversation.agent_id,
         agent_runtime=failed_run.agent_runtime,
+        # The person retrying, which is who the run acts as -- not the owner
+        # of the conversation, though here they are the same person.
+        triggered_by_user_id=conversation.user_id,
         metadata={
             "source": "manual_retry",
             "retried_agent_run_id": str(failed_run.id),

--- a/lemma-backend/app/modules/agent/tests/unit/test_conversation_visibility.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_conversation_visibility.py
@@ -1,0 +1,311 @@
+"""What one person's run may see of another's, in a shared conversation.
+
+The rule is that the answer belongs to the conversation and the working
+belongs to whoever triggered the run. These pin the prompt half: another
+person's run reaches the model as its question and its answer, never as its
+tool arguments or its tool results.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from uuid import UUID, uuid4
+
+from app.modules.agent.domain.entities import (
+    AgentRun,
+    AgentRuntimeConfig,
+    Message,
+    MessageKind,
+    MessageRole,
+)
+from app.modules.agent.services.runtime_history import select_runtime_history
+
+_BASE = datetime.now(timezone.utc) - timedelta(hours=1)
+
+
+def _run(
+    conversation_id: UUID,
+    *,
+    index: int,
+    triggered_by: UUID | None,
+    secret: str = "s3cret",
+) -> AgentRun:
+    """One run: a question, a tool call, its result, and an answer."""
+    run_id = uuid4()
+    base = index * 1000
+    return AgentRun(
+        id=run_id,
+        conversation_id=conversation_id,
+        triggered_by_user_id=triggered_by,
+        agent_runtime=AgentRuntimeConfig(profile_id="system:lemma"),
+        started_at=_BASE + timedelta(minutes=index),
+        messages=[
+            Message(
+                conversation_id=conversation_id,
+                sequence=base,
+                agent_run_id=run_id,
+                role=MessageRole.USER,
+                kind=MessageKind.TEXT,
+                text=f"question {index}",
+            ),
+            Message(
+                conversation_id=conversation_id,
+                sequence=base + 1,
+                agent_run_id=run_id,
+                role=MessageRole.ASSISTANT,
+                kind=MessageKind.TOOL_CALL,
+                tool_name="query_table",
+                tool_call_id=f"tc_{index}",
+                tool_args={"where": secret},
+            ),
+            Message(
+                conversation_id=conversation_id,
+                sequence=base + 2,
+                agent_run_id=run_id,
+                role=MessageRole.TOOL,
+                kind=MessageKind.TOOL_RETURN,
+                tool_name="query_table",
+                tool_call_id=f"tc_{index}",
+                tool_result={"rows": [secret]},
+            ),
+            Message(
+                conversation_id=conversation_id,
+                sequence=base + 3,
+                agent_run_id=run_id,
+                role=MessageRole.ASSISTANT,
+                kind=MessageKind.TEXT,
+                text=f"answer {index}",
+            ),
+        ],
+    )
+
+
+def _conversation(owner_id: UUID):
+    return SimpleNamespace(
+        id=uuid4(), user_id=owner_id, metadata={}, is_pod_assistant=False
+    )
+
+
+def _kinds(messages: list[Message]) -> set[MessageKind]:
+    return {message.kind for message in messages}
+
+
+def test_another_persons_working_never_reaches_the_model():
+    owner_id, other_id = uuid4(), uuid4()
+    conversation = _conversation(owner_id)
+    runs = [_run(conversation.id, index=0, triggered_by=other_id)]
+
+    selected = select_runtime_history(runs, conversation, viewer_id=owner_id)
+
+    texts = " ".join(message.text or "" for message in selected)
+    assert "question 0" in texts
+    assert "answer 0" in texts
+    assert MessageKind.TOOL_CALL not in _kinds(selected)
+    assert MessageKind.TOOL_RETURN not in _kinds(selected)
+    assert "s3cret" not in str([m.model_dump() for m in selected])
+
+
+def test_your_own_recent_run_is_carried_whole():
+    owner_id = uuid4()
+    conversation = _conversation(owner_id)
+    runs = [_run(conversation.id, index=0, triggered_by=owner_id)]
+
+    selected = select_runtime_history(runs, conversation, viewer_id=owner_id)
+
+    assert MessageKind.TOOL_CALL in _kinds(selected)
+    assert MessageKind.TOOL_RETURN in _kinds(selected)
+
+
+def test_a_run_with_no_trigger_belongs_to_the_owner():
+    """Runs predating the column were backfilled to the owner; the same rule is
+    applied here so the prompt and the transcript agree about whose they are."""
+    owner_id, other_id = uuid4(), uuid4()
+    conversation = _conversation(owner_id)
+    runs = [_run(conversation.id, index=0, triggered_by=None)]
+
+    assert MessageKind.TOOL_CALL in _kinds(
+        select_runtime_history(runs, conversation, viewer_id=owner_id)
+    )
+    assert MessageKind.TOOL_CALL not in _kinds(
+        select_runtime_history(runs, conversation, viewer_id=other_id)
+    )
+
+
+def test_naming_no_viewer_withholds_nothing():
+    """Every caller that predates this, and every single-person conversation."""
+    conversation = _conversation(uuid4())
+    runs = [_run(conversation.id, index=0, triggered_by=uuid4())]
+
+    assert MessageKind.TOOL_RETURN in _kinds(select_runtime_history(runs, conversation))
+
+
+def test_recency_does_not_override_ownership():
+    """The most recent run is normally carried whole. Being recent is not a
+    reason to hand somebody else's tool results to this run."""
+    owner_id, other_id = uuid4(), uuid4()
+    conversation = _conversation(owner_id)
+    runs = [
+        _run(conversation.id, index=0, triggered_by=owner_id),
+        _run(conversation.id, index=1, triggered_by=other_id),
+    ]
+
+    selected = select_runtime_history(runs, conversation, viewer_id=owner_id)
+    latest = [m for m in selected if m.sequence >= 1000]
+
+    assert MessageKind.TOOL_RETURN not in _kinds(latest)
+    assert any("answer 1" in (m.text or "") for m in latest)
+
+
+# --- who a run acts as ------------------------------------------------------
+
+
+def test_the_run_decides_the_actor_not_the_job_payload():
+    """`RunIdentity.user_id` is read off the run, so a job whose payload named
+    the conversation's owner cannot widen a run started by somebody else."""
+    from app.modules.agent.services.run_identity import RunIdentity
+
+    owner_id, sender_id = uuid4(), uuid4()
+    conversation = _conversation(owner_id)
+    run = _run(conversation.id, index=0, triggered_by=sender_id)
+
+    acting_user_id = run.triggered_by_user_id or owner_id
+    identity = RunIdentity(
+        conversation_id=conversation.id,
+        agent_run_id=run.id,
+        pod_id=uuid4(),
+        user_id=acting_user_id,
+    )
+
+    assert identity.user_id == sender_id
+    assert identity.user_id != owner_id
+
+
+def test_a_run_with_no_trigger_falls_back_to_the_payload():
+    """Runs created before the column carry None, and the owner-derived value
+    the caller passes stands in -- the same answer the backfill wrote."""
+    owner_id = uuid4()
+    conversation = _conversation(owner_id)
+    run = _run(conversation.id, index=0, triggered_by=None)
+
+    assert (run.triggered_by_user_id or owner_id) == owner_id
+
+
+# --- subthread branches ------------------------------------------------------
+
+
+def _branch(parent: object, conversation_id, *, index: int, triggered_by):
+    run = _run(conversation_id, index=index, triggered_by=triggered_by)
+    run.parent_run_id = parent.id
+    return run
+
+
+def test_a_branch_does_not_see_its_siblings():
+    """Two branches off one point are separate conversations about the same
+    starting position. If each could read the other, branching would just be a
+    second way of writing in the same place."""
+    from app.modules.agent.services.runtime_history import apply_branch_lineage
+
+    owner = uuid4()
+    conversation = _conversation(owner)
+    trunk = _run(conversation.id, index=0, triggered_by=owner)
+    left = _branch(trunk, conversation.id, index=1, triggered_by=owner)
+    right = _branch(trunk, conversation.id, index=2, triggered_by=owner)
+
+    kept = apply_branch_lineage([trunk, left, right], right)
+
+    assert [run.id for run in kept] == [trunk.id, right.id]
+
+
+def test_a_trunk_run_still_sees_everything():
+    """The default, and every conversation nobody has branched."""
+    from app.modules.agent.services.runtime_history import apply_branch_lineage
+
+    owner = uuid4()
+    conversation = _conversation(owner)
+    runs = [
+        _run(conversation.id, index=0, triggered_by=owner),
+        _run(conversation.id, index=1, triggered_by=owner),
+    ]
+
+    assert apply_branch_lineage(runs, runs[-1]) == runs
+
+
+def test_a_branch_keeps_the_trunk_it_left_from():
+    from app.modules.agent.services.runtime_history import apply_branch_lineage
+
+    owner = uuid4()
+    conversation = _conversation(owner)
+    first = _run(conversation.id, index=0, triggered_by=owner)
+    second = _run(conversation.id, index=1, triggered_by=owner)
+    later = _run(conversation.id, index=3, triggered_by=owner)
+    branch = _branch(second, conversation.id, index=2, triggered_by=owner)
+
+    kept = apply_branch_lineage([first, second, branch, later], branch)
+
+    # Everything up to the point it left, and not the trunk that carried on
+    # without it.
+    assert [run.id for run in kept] == [first.id, second.id, branch.id]
+
+
+# --- one agent must not read another's words as its own ----------------------
+
+
+def _agent_conversation(owner_id, *agents):
+    """A conversation whose roster names each agent."""
+    from app.modules.agent.domain.participants import ConversationParticipant
+
+    conversation = _conversation(owner_id)
+    conversation.participants = [
+        ConversationParticipant(
+            conversation_id=conversation.id, agent_id=agent_id, display_name=name
+        )
+        for agent_id, name in agents
+    ]
+    return conversation
+
+
+def test_another_agents_reply_arrives_as_reported_speech():
+    """The bug this exists for: every assistant message used to be replayed as
+    the running model's own prior words, so an agent answering after another
+    one read that agent's replies as its own. Batman insisted it was Robin."""
+    batman_id, robin_id = uuid4(), uuid4()
+    owner = uuid4()
+    conversation = _agent_conversation(
+        owner, (batman_id, "batman"), (robin_id, "robin")
+    )
+
+    robin_run = _run(conversation.id, index=0, triggered_by=owner)
+    robin_run.agent_id = robin_id
+    batman_run = _run(conversation.id, index=1, triggered_by=owner)
+    batman_run.agent_id = batman_id
+
+    selected = select_runtime_history(
+        [robin_run, batman_run], conversation, viewer_id=owner, current_run=batman_run
+    )
+
+    spoken = [m for m in selected if (m.text or "").startswith("robin said:")]
+    assert spoken, "robin's reply must be attributed, not replayed as batman's own"
+    # And it must not still be sitting there as an assistant turn.
+    assert not any(
+        m.role is MessageRole.ASSISTANT and (m.text or "").startswith("answer 0")
+        for m in selected
+    )
+
+
+def test_an_agents_own_turn_is_left_alone():
+    """Its own history is its own; attributing it would make the agent read its
+    own words as somebody else's."""
+    batman_id = uuid4()
+    owner = uuid4()
+    conversation = _agent_conversation(owner, (batman_id, "batman"))
+
+    own = _run(conversation.id, index=0, triggered_by=owner)
+    own.agent_id = batman_id
+
+    selected = select_runtime_history(
+        [own], conversation, viewer_id=owner, current_run=own
+    )
+
+    assert any(m.role is MessageRole.ASSISTANT for m in selected)
+    assert not any((m.text or "").startswith("batman said:") for m in selected)

--- a/lemma-backend/app/modules/agent/tests/unit/test_message_sender.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_message_sender.py
@@ -1,0 +1,49 @@
+"""Which person a message came from, carried from the draft to the row.
+
+`role` says a human spoke. These pin that the *which one* survives the trip,
+and that nothing else acquires an author on the way.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from app.modules.agent.domain.entities import Message
+from app.modules.agent.domain.value_objects import (
+    MessageDraft,
+    MessageKind,
+    MessageRole,
+)
+
+
+def test_a_user_draft_carries_its_sender_into_the_message():
+    sender_id = uuid4()
+    draft = MessageDraft.of_text(
+        "hello", role=MessageRole.USER, sender_user_id=sender_id
+    )
+    message = Message.from_draft(
+        draft, conversation_id=uuid4(), sequence=0, agent_run_id=uuid4()
+    )
+    assert message.sender_user_id == sender_id
+
+
+def test_an_assistant_draft_has_no_sender():
+    """Nothing derives a sender from `role`, so an agent's own text stays
+    unattributed rather than inheriting whoever prompted it."""
+    draft = MessageDraft.of_text("the answer")
+    message = Message.from_draft(
+        draft, conversation_id=uuid4(), sequence=1, agent_run_id=uuid4()
+    )
+    assert message.role is MessageRole.ASSISTANT
+    assert message.sender_user_id is None
+
+
+def test_tool_drafts_have_no_sender():
+    draft = MessageDraft.of_tool_call(
+        tool_name="read_file", tool_call_id="tc_1", tool_args={"path": "a"}
+    )
+    message = Message.from_draft(
+        draft, conversation_id=uuid4(), sequence=2, agent_run_id=uuid4()
+    )
+    assert message.kind is MessageKind.TOOL_CALL
+    assert message.sender_user_id is None

--- a/lemma-backend/app/modules/agent/tests/unit/test_runtime_history_bounded_load.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_runtime_history_bounded_load.py
@@ -133,7 +133,12 @@ def _fingerprint(messages: list[Message]) -> list[tuple]:
 
 def _surface_conversation():
     return SimpleNamespace(
-        id=uuid4(), metadata={"surface_platform": "slack"}, is_pod_assistant=False
+        id=uuid4(),
+        # Every conversation has an owner, and the history builder reads it to
+        # decide whose working an untriggered run is.
+        user_id=uuid4(),
+        metadata={"surface_platform": "slack"},
+        is_pod_assistant=False,
     )
 
 

--- a/lemma-backend/app/modules/agent/tests/unit/test_widget_controller.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_widget_controller.py
@@ -13,6 +13,7 @@ from fastapi import HTTPException
 import app.modules.agent.api.controllers.widget_controller as ctrl
 from app.core.domain.errors import DomainError
 from app.core.ports.widget_content import WidgetArtifact
+from app.modules.agent.domain.entities import Conversation
 from app.modules.agent.services.widget_token import verify_widget_token
 
 
@@ -46,11 +47,16 @@ def _fake_conv_service(owner_id, pod_id):
     method that no longer existed — the double answered for the thing under
     test. The controller calls the real `validate_conversation_access` now, so
     the check this exercises is the shipped one.
+
+    The real entity rather than a stand-in with the three fields the check
+    happened to read, for the same reason: a stand-in goes stale the moment the
+    check consults something new, and it fails as an AttributeError rather than
+    as the refusal the test is asserting.
     """
 
     class _Repo:
         async def get_conversation(self, conversation_id, **_kw):
-            return SimpleNamespace(user_id=owner_id, pod_id=pod_id, agent_id=None)
+            return Conversation(user_id=owner_id, pod_id=pod_id, agent_id=None)
 
     class _Svc:
         conversation_repository = _Repo()

--- a/lemma-backend/docs/contracts/agent.md
+++ b/lemma-backend/docs/contracts/agent.md
@@ -18,6 +18,10 @@ The table below is generated from the committed OpenAPI specification by `script
 | `agent.conversation.message.append` | POST | `/pods/{pod_id}/conversations/{conversation_id}/messages/append` | Append Pod Conversation Message |
 | `agent.conversation.message.list` | GET | `/pods/{pod_id}/conversations/{conversation_id}/messages` | List Pod Conversation Messages |
 | `agent.conversation.message.send` | POST | `/pods/{pod_id}/conversations/{conversation_id}/messages` | Send Pod Conversation Message |
+| `agent.conversation.open` | POST | `/pods/{pod_id}/conversations/open` | Open Pod Agent Conversation |
+| `agent.conversation.participant.add` | POST | `/pods/{pod_id}/conversations/{conversation_id}/participants` | Add Conversation Participant |
+| `agent.conversation.participant.list` | GET | `/pods/{pod_id}/conversations/{conversation_id}/participants` | List Conversation Participants |
+| `agent.conversation.participant.remove` | DELETE | `/pods/{pod_id}/conversations/{conversation_id}/participants` | Remove Conversation Participant |
 | `agent.conversation.retry` | POST | `/pods/{pod_id}/conversations/{conversation_id}/retry` | Retry Failed Pod Conversation Run |
 | `agent.conversation.stop` | POST | `/pods/{pod_id}/conversations/{conversation_id}/stop` | Stop Pod Conversation |
 | `agent.conversation.stream` | GET | `/pods/{pod_id}/conversations/{conversation_id}/stream` | Stream Pod Conversation |

--- a/lemma-backend/docs/modules/route-inventory.md
+++ b/lemma-backend/docs/modules/route-inventory.md
@@ -10,6 +10,7 @@ run `uv run python scripts/generate_route_inventory.py`.
 | DELETE | `/me/runtime/agent-hosts/{host_id}` | `agent.host.revoke` | Revoke Agent Host |
 | DELETE | `/organizations/{org_id}/agent-runtime/profiles/{profile_id}` | `agent.runtime.profiles.archive` | Archive Agent Runtime Profile |
 | DELETE | `/pods/{pod_id}/agents/{agent_name}` | `agent.delete` | Delete Agent |
+| DELETE | `/pods/{pod_id}/conversations/{conversation_id}/participants` | `agent.conversation.participant.remove` | Remove Conversation Participant |
 | GET | `/me/runtime/agent-hosts` | `agent.host.list` | List Agent Hosts |
 | GET | `/me/runtime/agent-hosts/{host_id}/harnesses` | `agent.host.harnesses.list` | List Agent Host Harnesses |
 | GET | `/organizations/{org_id}/agent-runtime/profiles` | `agent.runtime.profiles.list` | List Available Agent Runtime Profiles |
@@ -21,6 +22,7 @@ run `uv run python scripts/generate_route_inventory.py`.
 | GET | `/pods/{pod_id}/conversations/{conversation_id}` | `agent.conversation.get` | Get Pod Conversation |
 | GET | `/pods/{pod_id}/conversations/{conversation_id}/approvals` | `agent.conversation.approval.list` | List Agent Run Approvals |
 | GET | `/pods/{pod_id}/conversations/{conversation_id}/messages` | `agent.conversation.message.list` | List Pod Conversation Messages |
+| GET | `/pods/{pod_id}/conversations/{conversation_id}/participants` | `agent.conversation.participant.list` | List Conversation Participants |
 | GET | `/pods/{pod_id}/conversations/{conversation_id}/stream` | `agent.conversation.stream` | Stream Pod Conversation |
 | PATCH | `/organizations/{org_id}/agent-runtime/profiles/{profile_id}` | `agent.runtime.profiles.update` | Update Agent Runtime Profile |
 | PATCH | `/pods/{pod_id}/agents/{agent_name}` | `agent.update` | Update Agent |
@@ -34,9 +36,11 @@ run `uv run python scripts/generate_route_inventory.py`.
 | POST | `/organizations/{org_id}/agent-runtime/profiles/{profile_id}:restore` | `agent.runtime.profiles.restore` | Restore Agent Runtime Profile |
 | POST | `/pods/{pod_id}/agents` | `agent.create` | Create Agent |
 | POST | `/pods/{pod_id}/conversations` | `agent.conversation.create` | Create Pod Agent Conversation |
+| POST | `/pods/{pod_id}/conversations/open` | `agent.conversation.open` | Open Pod Agent Conversation |
 | POST | `/pods/{pod_id}/conversations/{conversation_id}/approvals/{approval_id}/decision` | `agent.conversation.approval.resolve` | Resolve User Approval |
 | POST | `/pods/{pod_id}/conversations/{conversation_id}/messages` | `agent.conversation.message.send` | Send Pod Conversation Message |
 | POST | `/pods/{pod_id}/conversations/{conversation_id}/messages/append` | `agent.conversation.message.append` | Append Pod Conversation Message |
+| POST | `/pods/{pod_id}/conversations/{conversation_id}/participants` | `agent.conversation.participant.add` | Add Conversation Participant |
 | POST | `/pods/{pod_id}/conversations/{conversation_id}/retry` | `agent.conversation.retry` | Retry Failed Pod Conversation Run |
 | POST | `/pods/{pod_id}/conversations/{conversation_id}/stop` | `agent.conversation.stop` | Stop Pod Conversation |
 | POST | `/pods/{pod_id}/widgets/{conversation_id}/{tool_call_id}/embed-token` | `widget.embed_token` | Mint Widget Embed URL |

--- a/lemma-backend/migrations/env.py
+++ b/lemma-backend/migrations/env.py
@@ -31,6 +31,12 @@ from app.modules.agent.infrastructure import models as agent_models  # noqa: F40
 from app.modules.agent.infrastructure import (  # noqa: F401
     runtime_models as agent_runtime_models,
 )
+from app.modules.agent.infrastructure import (  # noqa: F401
+    participant_models as agent_participant_models,
+)
+from app.modules.agent.infrastructure import (  # noqa: F401
+    wait_models as agent_wait_models,
+)
 
 # Trigger
 from app.modules.schedule.infrastructure import models as trigger_models  # noqa: F401

--- a/lemma-backend/migrations/versions/2026-08-31_conversation_participants_0025.py
+++ b/lemma-backend/migrations/versions/2026-08-31_conversation_participants_0025.py
@@ -1,0 +1,98 @@
+"""Let a conversation hold more than one person.
+
+``agent_conversations.user_id`` was the whole access model: one owner, and
+``validate_conversation_access`` compared against it. That is the right model
+for a DM and has no answer at all for a second person, which is what this table
+adds. See ``docs/design/agent-conversations.md``.
+
+People and agents share the table. A person row is who may read the
+conversation; an agent row is the roster an ``@mention`` resolves against and a
+router chooses from. Exactly one of the two columns is set per row, and the
+check constraint enforces that rather than trusting the three code paths that
+create conversations to agree.
+
+The two unique constraints are separate on purpose. Postgres treats NULLs as
+distinct in a unique index, so one constraint over both columns would not stop
+a person being added twice, while the pair does -- and neither bounds how many
+agents a conversation may hold.
+
+Every existing conversation is backfilled with an OWNER row for the user_id it
+already had, so membership is complete from the first deploy rather than only
+for conversations created after it. Until a run acts as its sender rather than
+as its conversation, the access check still accepts the owner column directly;
+this backfill is what lets that clause be removed later without locking anybody
+out of their own history.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0025_conversation_participants"
+down_revision = "0024_drop_surface_schedule_id"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_conversation_participants",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("conversation_id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=True),
+        sa.Column("agent_id", sa.Uuid(), nullable=True),
+        sa.Column("role", sa.String(length=32), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["conversation_id"], ["agent_conversations.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["agent_id"], ["agents.id"], ondelete="CASCADE"),
+        sa.CheckConstraint(
+            "(user_id IS NULL) <> (agent_id IS NULL)",
+            name="ck_conversation_participant_exactly_one_subject",
+        ),
+        sa.UniqueConstraint(
+            "conversation_id", "user_id", name="uq_conversation_participant_user"
+        ),
+        sa.UniqueConstraint(
+            "conversation_id", "agent_id", name="uq_conversation_participant_agent"
+        ),
+    )
+    op.create_index(
+        "ix_agent_conversation_participants_conversation_id",
+        "agent_conversation_participants",
+        ["conversation_id"],
+    )
+    op.create_index(
+        "ix_conversation_participant_user",
+        "agent_conversation_participants",
+        ["user_id", "conversation_id"],
+    )
+    op.execute(
+        """
+        INSERT INTO agent_conversation_participants
+            (id, created_at, conversation_id, user_id, agent_id, role)
+        SELECT
+            gen_random_uuid(),
+            c.created_at,
+            c.id,
+            c.user_id,
+            NULL,
+            'OWNER'
+        FROM agent_conversations AS c
+        ON CONFLICT ON CONSTRAINT uq_conversation_participant_user DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_conversation_participant_user",
+        table_name="agent_conversation_participants",
+    )
+    op.drop_index(
+        "ix_agent_conversation_participants_conversation_id",
+        table_name="agent_conversation_participants",
+    )
+    op.drop_table("agent_conversation_participants")

--- a/lemma-backend/migrations/versions/2026-08-31_message_sender_0026.py
+++ b/lemma-backend/migrations/versions/2026-08-31_message_sender_0026.py
@@ -1,0 +1,49 @@
+"""Record which person wrote a message.
+
+``role`` said a human spoke; nothing said which one. That was answerable by
+inference while a conversation had exactly one person in it -- every user
+message was the owner's -- and stops being answerable the moment a second
+person is in one. See ``docs/design/agent-conversations.md``.
+
+Nullable with no backfill, deliberately. Every existing user message belongs to
+the conversation's owner, so a backfill would be derivable rather than
+informative, and it would write the owner's id onto surface messages that came
+from somebody who has no account here at all. NULL reads as "before we
+recorded this", which is true, and the owner column still answers for those
+rows.
+
+``ON DELETE SET NULL`` rather than CASCADE: a message is part of the
+conversation's record and does not stop existing because its author's account
+did.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0026_message_sender"
+down_revision = "0025_conversation_participants"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_messages",
+        sa.Column("sender_user_id", sa.Uuid(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_agent_messages_sender_user_id",
+        "agent_messages",
+        "users",
+        ["sender_user_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "fk_agent_messages_sender_user_id", "agent_messages", type_="foreignkey"
+    )
+    op.drop_column("agent_messages", "sender_user_id")

--- a/lemma-backend/migrations/versions/2026-08-31_run_triggered_by_0027.py
+++ b/lemma-backend/migrations/versions/2026-08-31_run_triggered_by_0027.py
@@ -1,0 +1,64 @@
+"""Record whose message started a run.
+
+A run belonged to its conversation, and the conversation belonged to one
+person, so "whose run is this" never had to be asked. It has to be asked the
+moment a conversation holds more than one person, for two reasons that arrive
+together: the working a run produces is shown only to whoever triggered it, and
+the run itself will act with that person's grants rather than the
+conversation's. See ``docs/design/agent-conversations.md``.
+
+Backfilled from ``agent_conversations.user_id``. Unlike the message sender
+column, this backfill is informative rather than circular: every run that
+exists today was started by the only person who could reach the conversation,
+so the value is known rather than assumed, and leaving it NULL would make every
+historical run's working invisible to the person whose working it is.
+
+``ON DELETE SET NULL``: a run is part of the record and outlives the account
+that started it.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0027_run_triggered_by"
+down_revision = "0026_message_sender"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_runs",
+        sa.Column("triggered_by_user_id", sa.Uuid(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_agent_runs_triggered_by_user_id",
+        "agent_runs",
+        "users",
+        ["triggered_by_user_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        "ix_agent_runs_triggered_by_user_id",
+        "agent_runs",
+        ["triggered_by_user_id"],
+    )
+    op.execute(
+        """
+        UPDATE agent_runs AS r
+        SET triggered_by_user_id = c.user_id
+        FROM agent_conversations AS c
+        WHERE c.id = r.conversation_id
+          AND r.triggered_by_user_id IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agent_runs_triggered_by_user_id", table_name="agent_runs")
+    op.drop_constraint(
+        "fk_agent_runs_triggered_by_user_id", "agent_runs", type_="foreignkey"
+    )
+    op.drop_column("agent_runs", "triggered_by_user_id")

--- a/lemma-frontend/components/ai/ai-assistant-context.tsx
+++ b/lemma-frontend/components/ai/ai-assistant-context.tsx
@@ -41,6 +41,8 @@ type SendMessageOptions = {
     metadata?: Record<string, unknown> | null;
     conversationMetadata?: Record<string, unknown> | null;
     title?: string | null;
+    /** Address one agent for this turn; it must be in the conversation. */
+    agentName?: string | null;
 };
 
 export type Message = SdkAssistantRenderableMessage;
@@ -618,6 +620,7 @@ export function AIAssistantProvider({
                         ...options.metadata,
                 }
                     : undefined,
+                agentName: options?.agentName,
             });
         } catch (error) {
             throw error;

--- a/lemma-frontend/components/ai/pod-assistant.tsx
+++ b/lemma-frontend/components/ai/pod-assistant.tsx
@@ -33,6 +33,10 @@ import {
   type AssistantPresentation,
 } from "@/components/pod/pod-layout-context";
 import { useDatastoreFiles, useTables } from "@/lib/hooks/use-datastores";
+import { ConversationParticipants } from "@/components/conversations/conversation-participants";
+import { useConversationParticipants } from "@/lib/hooks/use-assistants";
+import { useProfile } from "@/lib/hooks/use-user";
+import { formatAgentName } from "@/lib/utils/agents";
 import { cn } from "@/lib/utils";
 import { getConversationStatusView, type ConversationStatusView } from "@/lib/utils/conversations";
 import { useAIAssistant, useAIAssistantTranscript } from "./ai-assistant-context";
@@ -271,6 +275,15 @@ function PodAssistantSurface({
   // Subscribed separately from the rest of the assistant: this is the surface
   // that draws the transcript, so it is the one that should re-render per flush.
   const transcript = useAIAssistantTranscript();
+  // Who is reading, so a transcript with more than one person in it can
+  // attribute a turn and keep somebody else's working out of it.
+  const { data: profile } = useProfile();
+  // The roster, for attributing a turn to whoever sent it. Only fetched for the
+  // conversation actually open.
+  const { data: participants } = useConversationParticipants(
+    assistant.conversationPodId,
+    assistant.openedConversationId,
+  );
   // Rebuilt only when one of the two contexts it reads changes, never merely
   // because this component rendered. Both context values are memoized by the
   // provider, so on a keystroke — which re-renders this surface whenever a
@@ -291,6 +304,17 @@ function PodAssistantSurface({
     }));
 
     const seenFiles = new Set<string>();
+    const agentMentions = (participants ?? [])
+      .filter((participant) => !!participant.agent_id && !!participant.display_name)
+      .map((participant) => ({
+        id: `agent:${participant.agent_id}`,
+        kind: "agent" as const,
+        label: formatAgentName(participant.display_name as string),
+        // The same token the send resolves against, so what the composer
+        // inserts and what the server reads are one string.
+        insertText: `@${participant.display_name}`,
+        detail: "Agent in this conversation",
+      }));
     const fileMentions = (filesData?.items ?? [])
       .map(getFileMentionPath)
       .filter((path) => {
@@ -306,13 +330,23 @@ function PodAssistantSurface({
         detail: path,
       }));
 
-    return [...tableMentions, ...fileMentions];
-  }, [filesData, tablesData?.items]);
+    // Agents first: in a conversation with several of them, who answers is
+    // the question being asked, and a table is not competing for that slot.
+    return [...agentMentions, ...tableMentions, ...fileMentions];
+  }, [filesData, tablesData?.items, participants]);
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-3">
       <AssistantExperienceView
         controller={controller}
+        viewerId={profile?.id ?? null}
+        participants={participants ?? []}
+        participantsControl={(
+          <ConversationParticipants
+            podId={assistant.conversationPodId}
+            conversationId={assistant.openedConversationId}
+          />
+        )}
         title={title}
         subtitle={subtitle}
         placeholder={placeholder}

--- a/lemma-frontend/components/conversations/conversation-participants.tsx
+++ b/lemma-frontend/components/conversations/conversation-participants.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Users } from '@/components/ui/icons';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from '@/components/ui/popover';
+import {
+    useAddConversationParticipant,
+    useConversationParticipants,
+    useRemoveConversationParticipant,
+} from '@/lib/hooks/use-assistants';
+import { usePodMembers } from '@/lib/hooks/use-pod-members';
+import { useAgents } from '@/lib/hooks/use-agents';
+import { formatAgentName } from '@/lib/utils/agents';
+
+/**
+ * Who is in a conversation, and how somebody else gets in.
+ *
+ * Adding a person is a grant, not an invitation: from then on every answer in
+ * the conversation is said to them, including answers produced from data they
+ * could not have reached themselves. Their own working stays theirs — the
+ * transcript withholds it — and so does everyone else's. The copy says so,
+ * because a roster that reads like a share sheet invites the wrong assumption.
+ */
+export function ConversationParticipants({
+    podId,
+    conversationId,
+}: {
+    podId: string | null | undefined;
+    conversationId: string | null | undefined;
+}) {
+    const [open, setOpen] = useState(false);
+    const { data: participants } = useConversationParticipants(podId, conversationId);
+    const { data: members } = usePodMembers(podId || '');
+    const { data: agents } = useAgents(podId || undefined);
+    const addParticipant = useAddConversationParticipant(podId);
+    const removeParticipant = useRemoveConversationParticipant(podId);
+
+    const people = useMemo(
+        () => (participants ?? []).filter((participant) => !!participant.user_id),
+        [participants],
+    );
+    const presentAgents = useMemo(
+        () => (participants ?? []).filter((participant) => !!participant.agent_id),
+        [participants],
+    );
+    const presentUserIds = useMemo(
+        () => new Set(people.map((participant) => participant.user_id)),
+        [people],
+    );
+    const presentAgentIds = useMemo(
+        () => new Set(presentAgents.map((participant) => participant.agent_id)),
+        [presentAgents],
+    );
+
+    // Only what can actually be added: a pod member already here is not a
+    // choice, and offering them means the first thing the control does is fail.
+    const addablePeople = (members?.items ?? []).filter(
+        (member) => !presentUserIds.has(member.user_id),
+    );
+    const addableAgents = (agents?.items ?? []).filter(
+        (agent) => !presentAgentIds.has(agent.id),
+    );
+
+    if (!podId || !conversationId) return null;
+
+    const add = async (subject: { user_id?: string; agent_name?: string }) => {
+        try {
+            await addParticipant.mutateAsync({ conversationId, ...subject });
+        } catch {
+            toast.error('Could not add them to this conversation');
+        }
+    };
+
+    const remove = async (subject: { user_id?: string; agent_id?: string }) => {
+        try {
+            await removeParticipant.mutateAsync({ conversationId, ...subject });
+        } catch {
+            // The owner is refused by the server rather than hidden here: the
+            // rule belongs in one place, and a button that silently does
+            // nothing is worse than one that says why.
+            toast.error('The person who opened this conversation cannot be removed');
+        }
+    };
+
+    const count = (participants ?? []).length;
+
+    return (
+        <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+                <Button variant="quiet" size="xs" title="Who is in this conversation">
+                    <Users className="h-3.5 w-3.5" />
+                    {count > 1 ? count : null}
+                </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-72 p-0">
+                <div className="border-b border-[var(--border-subtle)] px-3 py-2">
+                    <div className="text-sm text-[var(--text-primary)]">In this conversation</div>
+                    <p className="mt-0.5 text-xs text-[var(--text-secondary)]">
+                        Everyone here sees the answers. Each person&rsquo;s own tool
+                        calls and thinking stay private to them.
+                    </p>
+                </div>
+                <ul className="max-h-56 overflow-y-auto py-1">
+                    {(participants ?? []).map((participant) => (
+                        <li
+                            key={participant.user_id ?? participant.agent_id}
+                            className="flex items-center justify-between gap-2 px-3 py-1.5"
+                        >
+                            <span className="min-w-0 truncate text-sm text-[var(--text-primary)]">
+                                {participant.display_name
+                                    ?? (participant.agent_id ? 'Agent' : 'Someone')}
+                            </span>
+                            <span className="flex shrink-0 items-center gap-2">
+                                {participant.role === 'OWNER' ? (
+                                    <span className="text-xs text-[var(--text-tertiary)]">opened it</span>
+                                ) : (
+                                    <Button
+                                        variant="quiet"
+                                        size="xs"
+                                        onClick={() => void remove({
+                                            user_id: participant.user_id ?? undefined,
+                                            agent_id: participant.agent_id ?? undefined,
+                                        })}
+                                    >
+                                        Remove
+                                    </Button>
+                                )}
+                            </span>
+                        </li>
+                    ))}
+                </ul>
+                {addablePeople.length > 0 || addableAgents.length > 0 ? (
+                    <div className="border-t border-[var(--border-subtle)] py-1">
+                        {addablePeople.map((member) => (
+                            <Button
+                                key={member.user_id}
+                                variant="quiet"
+                                size="xs"
+                                className="w-full justify-start"
+                                onClick={() => void add({ user_id: member.user_id })}
+                            >
+                                Add {member.user_name || member.user_email}
+                            </Button>
+                        ))}
+                        {addableAgents.map((agent) => (
+                            <Button
+                                key={agent.id}
+                                variant="quiet"
+                                size="xs"
+                                className="w-full justify-start"
+                                onClick={() => void add({ agent_name: agent.name })}
+                            >
+                                Add {formatAgentName(agent.name)}
+                            </Button>
+                        ))}
+                    </div>
+                ) : null}
+            </PopoverContent>
+        </Popover>
+    );
+}

--- a/lemma-frontend/components/lemma/assistant/assistant-avatar.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-avatar.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * The face beside a message.
+ *
+ * Initials on a colour derived from the id, because nobody in a pod has
+ * uploaded a picture and a row of identical grey circles distinguishes nothing.
+ * Deriving the colour from the id rather than the name keeps it stable when
+ * somebody is renamed, and keeps two people called Deepak apart.
+ */
+
+/**
+ * Eight colours, defined in CSS rather than computed here.
+ *
+ * A hue could be derived and set inline, and that is what this did first --
+ * but per-person colour is data, not runtime geometry, and inline styles are
+ * where a design system quietly stops applying. The palette lives with the
+ * rest of the tokens; this only chooses which of them.
+ */
+const SWATCHES = 8;
+
+function swatchFor(seed: string): number {
+  let hash = 0;
+  for (let index = 0; index < seed.length; index += 1) {
+    hash = (hash * 31 + seed.charCodeAt(index)) | 0;
+  }
+  return Math.abs(hash) % SWATCHES;
+}
+
+/** One letter, or two from a two-word name. Never more — it stops being a face. */
+function initialsFor(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "?";
+  if (words.length === 1) return words[0].slice(0, 1).toUpperCase();
+  return (words[0][0] + words[words.length - 1][0]).toUpperCase();
+}
+
+export function AssistantAvatar({
+  name,
+  seed,
+  imageUrl,
+  className,
+}: {
+  name: string;
+  /** Stable identity — a user or agent id. Falls back to the name. */
+  seed?: string | null;
+  imageUrl?: string | null;
+  className?: string;
+}) {
+  const swatch = swatchFor(seed || name);
+  return (
+    <span
+      className={cn("lchat-avatar", `lchat-avatar-c${swatch}`, className)}
+      aria-hidden="true"
+    >
+      {imageUrl ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={imageUrl} alt="" className="lchat-avatar-image" />
+      ) : (
+        initialsFor(name)
+      )}
+    </span>
+  );
+}

--- a/lemma-frontend/components/lemma/assistant/assistant-experience-composer.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-experience-composer.tsx
@@ -4,6 +4,7 @@ import type { ChangeEvent, KeyboardEvent, ReactNode, RefObject } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
+  Bot,
   Table,
   FileText,
 } from "@/components/ui/icons";
@@ -39,6 +40,12 @@ export interface AssistantExperienceComposerBodyProps {
   hasPendingFileUploads: boolean;
   runtimeLabel: string | null;
   composerModelControl: ReactNode;
+  /**
+   * Who is in the conversation. Rendered here rather than in the header because
+   * the header is optional -- the pod conversation route turns it off -- and a
+   * control that only exists on some surfaces is one nobody can find.
+   */
+  participantsControl?: ReactNode;
   onUploadSelection: (files: FileList | null) => void;
   onDraftChange: (event: ChangeEvent<HTMLTextAreaElement>) => void;
   onKeyDown: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
@@ -60,6 +67,7 @@ export function AssistantExperienceComposerBody({
   isConversationBusy,
   hasPendingFileUploads,
   runtimeLabel,
+  participantsControl,
   composerModelControl,
   onUploadSelection,
   onDraftChange,
@@ -83,7 +91,11 @@ export function AssistantExperienceComposerBody({
               className="lemma-assistant-resource-mention-button flex w-full min-w-0 items-center gap-2 rounded-md px-2 py-2 text-left text-sm transition-colors hover:bg-[var(--row-bg)]"
             >
               <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-[var(--row-border)] bg-[var(--card-bg)] text-[var(--text-tertiary)]">
-                {mention.kind === "table" ? <Table className="h-3.5 w-3.5" /> : <FileText className="h-3.5 w-3.5" />}
+                {mention.kind === "agent"
+                  ? <Bot className="h-3.5 w-3.5" />
+                  : mention.kind === "table"
+                    ? <Table className="h-3.5 w-3.5" />
+                    : <FileText className="h-3.5 w-3.5" />}
               </span>
               <span className="min-w-0 flex-1">
                 <span className="block truncate font-medium text-[var(--text-primary)]">{mention.label}</span>
@@ -123,9 +135,14 @@ export function AssistantExperienceComposerBody({
         isAttaching={controller.isUploadingFiles}
         density={density === 'compact' ? 'tight' : 'roomy'}
         className={cn(radius === 'none' && 'rounded-none')}
-        controls={composerModelControl ?? (runtimeLabel ? (
-          <span className="truncate px-2 py-1 text-xs text-[var(--text-secondary)]">{runtimeLabel}</span>
-        ) : null)}
+        controls={(
+          <>
+            {participantsControl}
+            {composerModelControl ?? (runtimeLabel ? (
+              <span className="truncate px-2 py-1 text-xs text-[var(--text-secondary)]">{runtimeLabel}</span>
+            ) : null)}
+          </>
+        )}
       />
     </div>
   );

--- a/lemma-frontend/components/lemma/assistant/assistant-experience-conversation.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-experience-conversation.tsx
@@ -74,6 +74,10 @@ export interface AssistantExperienceConversationProps {
   onNavigateResource?: (resourceType: string, resourceId: string, meta?: Record<string, unknown>) => void;
   renderMessageContent: (args: AssistantMessageRenderArgs) => ReactNode;
   renderToolInvocation?: (args: AssistantToolRenderArgs) => ReactNode;
+  /** What to call whoever sent a turn. Absent in a one-person conversation. */
+  resolveSenderName?: (userId: string) => string | null;
+  /** What to call the agent that answered. Absent when only one could have. */
+  resolveAgentName?: (agentId: string) => string | null;
   showAssistantErrorInTranscript: boolean;
   assistantErrorTitle: string;
   assistantErrorDetails: string;
@@ -119,6 +123,8 @@ export const AssistantExperienceConversation = memo(function AssistantExperience
   onNavigateResource,
   renderMessageContent,
   renderToolInvocation,
+  resolveSenderName,
+  resolveAgentName,
   showAssistantErrorInTranscript,
   assistantErrorTitle,
   assistantErrorDetails,
@@ -218,6 +224,8 @@ export const AssistantExperienceConversation = memo(function AssistantExperience
               onResolveUserApproval={onResolveUserApproval}
               renderMessageContent={renderMessageContent}
               renderToolInvocation={renderToolInvocation}
+              resolveSenderName={resolveSenderName}
+              resolveAgentName={resolveAgentName}
             />
           </Fragment>
         );

--- a/lemma-frontend/components/lemma/assistant/assistant-experience-sidebar.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-experience-sidebar.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { Fragment, useMemo, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import type {
   AssistantControllerView,
+  AssistantConversationListItem,
   AssistantConversationRenderArgs,
   LemmaAssistantAppearance,
   LemmaAssistantRadius,
@@ -17,6 +18,40 @@ import {
   assistantRadiusClassName,
   assistantSidebarClassName,
 } from "./assistant-experience-helpers";
+
+/**
+ * Two groups, never more: the conversation you are having with each agent, and
+ * everything else.
+ *
+ * "Ongoing" is the newest live conversation per agent — the same rule the
+ * server resolves with, so the row at the top of this list is the one a bare
+ * "talk to this agent" lands in. Everything else is history, in the order it
+ * already came in.
+ *
+ * Both groups' labels are hidden while there is nothing to distinguish, so a
+ * person with three conversations and one agent still sees a plain list.
+ */
+function groupConversations(conversations: AssistantConversationListItem[]) {
+  const ongoing: AssistantConversationListItem[] = [];
+  const earlier: AssistantConversationListItem[] = [];
+  const seenAgents = new Set<string>();
+  for (const conversation of conversations) {
+    // Null agent_id is the pod assistant, which is one agent, not "no agent" —
+    // so it gets its own slot rather than sharing one with every named agent.
+    const key = conversation.agent_id ?? "__pod_default__";
+    if (seenAgents.has(key)) {
+      earlier.push(conversation);
+      continue;
+    }
+    seenAgents.add(key);
+    ongoing.push(conversation);
+  }
+  const showLabel = earlier.length > 0;
+  return [
+    { label: "Ongoing", showLabel, conversations: ongoing },
+    { label: "Earlier", showLabel, conversations: earlier },
+  ].filter((group) => group.conversations.length > 0);
+}
 
 export interface AssistantExperienceSidebarProps {
   controller: AssistantControllerView;
@@ -33,6 +68,10 @@ export function AssistantExperienceSidebar({
   showNewConversationButton,
   renderConversationLabel,
 }: AssistantExperienceSidebarProps) {
+  const groups = useMemo(
+    () => groupConversations(controller.conversations),
+    [controller.conversations],
+  );
   return (
     <aside className={assistantSidebarClassName(appearance)}>
       <div className="border-b border-[color:color-mix(in_srgb,var(--border-subtle)_60%,transparent)] px-4 py-3">
@@ -57,7 +96,12 @@ export function AssistantExperienceSidebar({
         </div>
       </div>
       <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-3">
-        {controller.conversations.map((conversation) => {
+        {groups.map((group) => (
+          <Fragment key={group.label}>
+            {group.showLabel ? (
+              <div className="px-1 pt-2 text-xs text-[var(--text-tertiary)]">{group.label}</div>
+            ) : null}
+            {group.conversations.map((conversation) => {
           const isActive = conversation.id === controller.activeConversationId;
           return (
             <button
@@ -83,6 +127,8 @@ export function AssistantExperienceSidebar({
             </button>
           );
         })}
+          </Fragment>
+        ))}
       </div>
     </aside>
   );

--- a/lemma-frontend/components/lemma/assistant/assistant-experience.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-experience.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useState,
   type KeyboardEvent,
+  type ReactNode,
 } from "react";
 import type {
   AgentRuntimeConfig,
@@ -27,6 +28,7 @@ import {
 } from "lemma-sdk";
 // Rows → turns: the conversation-shaped model (ask, work pill, speech,
 // artifacts, interaction cards) the transcript renders.
+import { addressedAgentName } from "@/lib/assistant/addressed-agent";
 import { buildChatTurns, interactionAnchorId } from "@/lib/assistant/turns";
 import { toast } from "sonner";
 import { thisComputer } from "@/lib/desktop/this-computer";
@@ -41,6 +43,7 @@ import type {
 import type {
   AssistantControllerView,
   AssistantExperienceCustomizationProps,
+  AssistantParticipant,
   AssistantResourceMention,
   LemmaAssistantAppearance,
   LemmaAssistantDensity,
@@ -175,6 +178,23 @@ export interface AssistantExperienceViewProps extends AssistantExperienceCustomi
   showHeader?: boolean;
   showModelPicker?: boolean;
   showNewConversationButton?: boolean;
+  /**
+   * Who is reading. Passed in rather than fetched: this view is used by the pod
+   * assistant, the agent test panel and the flow run inspector, and only the
+   * first of those is a conversation somebody else can be in.
+   *
+   * Omitting it withholds nothing, which is the correct default for a
+   * transcript nobody else can see.
+   */
+  viewerId?: string | null;
+  /**
+   * Everyone in the conversation. Only used to put a name on somebody else's
+   * turn, so an empty list simply means no bylines — which is right for the
+   * conversations that have only ever had one person in them.
+   */
+  participants?: AssistantParticipant[];
+  /** Rendered in the composer's control row. See the composer prop. */
+  participantsControl?: ReactNode;
   onNavigateResource?: (resourceType: string, resourceId: string, meta?: Record<string, unknown>) => void;
 }
 
@@ -197,6 +217,9 @@ export function AssistantExperienceView({
   draft: controlledDraft,
   onDraftChange,
   showConversationList = false,
+  viewerId = null,
+  participants,
+  participantsControl,
   appearance = "default",
   density = "comfortable",
   chromeStyle,
@@ -358,12 +381,50 @@ export function AssistantExperienceView({
   }, [draft, resizeComposer]);
 
   const displayMessageRows = useMemo(() => buildDisplayMessageRows(controllerMessages), [controllerMessages]);
+  // Built once per roster rather than scanned per turn: a long transcript
+  // renders every turn and each one would otherwise walk the whole list.
+  const senderNames = useMemo(() => {
+    const names = new Map<string, string>();
+    for (const participant of participants ?? []) {
+      if (participant.user_id && participant.display_name) {
+        names.set(participant.user_id, participant.display_name);
+      }
+    }
+    return names;
+  }, [participants]);
+  const agentNamesById = useMemo(() => {
+    const names = new Map<string, string>();
+    for (const participant of participants ?? []) {
+      if (participant.agent_id && participant.display_name) {
+        names.set(participant.agent_id, participant.display_name);
+      }
+    }
+    return names;
+  }, [participants]);
+  // Every turn is labelled once the room holds more than one voice -- two
+  // people, or an agent that is not the only one who could have answered.
+  // Below that there is nothing to disambiguate and a name on every bubble is
+  // just noise, which is why a plain one-to-one chat is left alone.
+  const named = senderNames.size > 1 || agentNamesById.size > 1;
+  const resolveSenderName = useMemo(
+    () => (named
+      ? (userId: string) => senderNames.get(userId) ?? null
+      : undefined),
+    [named, senderNames],
+  );
+  const resolveAgentName = useMemo(
+    () => (named
+      ? (agentId: string) => agentNamesById.get(agentId) ?? null
+      : undefined),
+    [named, agentNamesById],
+  );
 
   const displayResourcePodId = currentPodIdFromBrowserPath();
   const chatTurns = useMemo(
     () => buildChatTurns({
       rows: displayMessageRows,
       messages: controllerMessages,
+      viewerId,
       // A send in flight counts as live, not just a run the server has already
       // confirmed. The turn goes on screen the moment you press enter, but the
       // conversation is not reported RUNNING for a few hundred milliseconds
@@ -376,7 +437,7 @@ export function AssistantExperienceView({
       podId: displayResourcePodId,
       conversationId: activeConversationId,
     }),
-    [displayMessageRows, controllerMessages, isConversationBusy, displayResourcePodId, activeConversationId],
+    [displayMessageRows, controllerMessages, isConversationBusy, displayResourcePodId, activeConversationId, viewerId],
   );
   const currentRunLatestUserIndex = latestUserIndex(controllerMessages);
   const activePendingApprovalInvocation = findPendingUserApprovalInvocation(displayMessageRows, currentRunLatestUserIndex);
@@ -467,6 +528,15 @@ export function AssistantExperienceView({
     : null;
   const liveRunStatus = statusPlacement === "inline" ? runStatusModel : null;
 
+  // The agents in the room, by the name an `@mention` would use. Rebuilt only
+  // when the roster changes, not per keystroke.
+  const agentNames = useMemo(
+    () => (participants ?? [])
+      .filter((participant) => participant.agent_id && participant.display_name)
+      .map((participant) => participant.display_name as string),
+    [participants],
+  );
+
   const handleSubmit = useCallback(async () => {
     if ((!draft.trim() && !hasPendingFileUploads) || interactionPending) return;
     const message = draft.trim();
@@ -476,8 +546,17 @@ export function AssistantExperienceView({
     // rather than starting a second one. Otherwise identical to a send —
     // attachments included, because the two go to the same endpoint shape and a
     // dropped file with no explanation is worse than either outcome.
-    await (isConversationBusy ? steerMessage(message) : sendMessage(message));
-  }, [draft, hasPendingFileUploads, isConversationBusy, interactionPending, scrollToBottom, sendMessage, steerMessage, setDraft]);
+    if (isConversationBusy) {
+      // A steer joins the run already going, so it never picks a new responder.
+      await steerMessage(message);
+      return;
+    }
+    // `@name` in the text is what routes the turn. Read here rather than on the
+    // server: the composer already knows who is in the room, and a name the
+    // server had to guess at could reach an agent nobody added.
+    const addressed = addressedAgentName(message, agentNames);
+    await sendMessage(message, addressed ? { agentName: addressed } : undefined);
+  }, [draft, hasPendingFileUploads, isConversationBusy, interactionPending, scrollToBottom, sendMessage, steerMessage, setDraft, agentNames]);
 
   // Only the empty state offers suggestions, and it renders under
   // `showEmptyState={isConversationEmpty}` — which requires nothing to be
@@ -735,6 +814,8 @@ export function AssistantExperienceView({
             onNavigateResource={onNavigateResource}
             renderMessageContent={renderMessageContent}
             renderToolInvocation={renderToolInvocation}
+            resolveSenderName={resolveSenderName}
+            resolveAgentName={resolveAgentName}
             showAssistantErrorInTranscript={showAssistantErrorInTranscript}
             assistantErrorTitle={assistantErrorTitle}
             assistantErrorDetails={assistantErrorDetails}
@@ -773,6 +854,7 @@ export function AssistantExperienceView({
           hasPendingFileUploads={hasPendingFileUploads}
           runtimeLabel={runtimeLabel}
           composerModelControl={composerModelControl}
+          participantsControl={participantsControl}
           onUploadSelection={(files) => { void handleUploadSelection(files); }}
           onDraftChange={(event) => {
             setDraft(event.target.value);

--- a/lemma-frontend/components/lemma/assistant/assistant-turn.tsx
+++ b/lemma-frontend/components/lemma/assistant/assistant-turn.tsx
@@ -29,6 +29,8 @@ import {
   type AssistantRenderableMessage,
 } from "lemma-sdk";
 import { cn } from "@/lib/utils";
+import { DEFAULT_RESPONDER_NAME } from "@/lib/utils/agents";
+import { AssistantAvatar } from "./assistant-avatar";
 import { Check, ChevronDown, Copy } from "@/components/ui/icons";
 import { InlineLoader } from "@/components/brand/loader";
 import { getLemmaClient } from "@/lib/sdk/lemma-client";
@@ -496,6 +498,13 @@ export interface AssistantTurnViewProps {
   onResolveUserApproval?: (approvalId: string, decision: UserApprovalDecision, response?: Record<string, unknown> | null) => Promise<void>;
   renderMessageContent: (args: AssistantMessageRenderArgs) => ReactNode;
   renderToolInvocation?: (args: AssistantToolRenderArgs) => ReactNode;
+  /**
+   * What to call the person who sent a turn. Absent while the conversation
+   * holds one voice, which is what keeps a plain one-to-one chat unlabelled.
+   */
+  resolveSenderName?: (userId: string) => string | null;
+  /** What to call the agent that answered a turn. Absent for the same reason. */
+  resolveAgentName?: (agentId: string) => string | null;
 }
 
 // Memoized against the turn fingerprint: `buildChatTurns` rebuilds every turn
@@ -511,8 +520,33 @@ export const AssistantTurnView = memo(function AssistantTurnView({
   onResolveUserApproval,
   renderMessageContent,
   renderToolInvocation,
+  resolveSenderName,
+  resolveAgentName,
 }: AssistantTurnViewProps) {
   const userTimestamp = turn.userMessage?.createdAt ? formatTimeStamp(turn.userMessage.createdAt.getTime()) : null;
+  // Everybody's own name, including the reader's. It was "You" for your own
+  // messages, which is how a messenger does it and was wrong here: with two
+  // windows open it is genuinely ambiguous whose "You" you are looking at, and
+  // a name is never ambiguous. Slack shows you your own name for this reason.
+  //
+  // Both resolvers are absent while the conversation holds a single voice, so
+  // a plain one-to-one chat renders exactly as it did.
+  const senderName = turn.senderUserId && resolveSenderName
+    ? resolveSenderName(turn.senderUserId)
+    : null;
+  // The pod assistant has no agent row, so a turn it answered carries no id,
+  // and the fallback names it rather than leaving a blank where every other
+  // turn has a name.
+  //
+  // But not while the turn is still streaming and unattributed: the bubble is
+  // built client-side from token deltas, before any frame says who is
+  // answering, so falling back there labelled every live reply as the default
+  // agent — batman's answers included. No name for a moment is honest; the
+  // wrong name is not.
+  const agentUnknownWhileLive = turn.isLive && !turn.agentId;
+  const agentName = resolveAgentName && turn.items.length > 0 && !agentUnknownWhileLive
+    ? (turn.agentId ? resolveAgentName(turn.agentId) : DEFAULT_RESPONDER_NAME)
+    : null;
   const showStatusPill = turn.isLive || turn.trace.length > 0;
   // The assistant's stamp rides under the turn's last beat, not every bubble.
   const assistantStamp = !turn.isLive && turn.items.length > 0 ? formatTimeStamp(turn.endedAtMs) : null;
@@ -572,6 +606,12 @@ export const AssistantTurnView = memo(function AssistantTurnView({
     >
       {turn.userMessage && turn.userMessage.content.trim() ? (
         <div className="lchat-user">
+          {senderName ? (
+            <div className="lchat-user-sender">
+              <AssistantAvatar name={senderName} seed={turn.senderUserId} />
+              <span>{senderName}</span>
+            </div>
+          ) : null}
           <div className="lchat-bubble lchat-bubble-user group relative">
             {speechContent(turn.userMessage.content, turn.userMessage, "user", turn.userMessage.id)}
             <HoverCopyButton text={turn.userMessage.content} side="left" />
@@ -586,7 +626,37 @@ export const AssistantTurnView = memo(function AssistantTurnView({
           Live: it is the typing indicator — it rides the frontier, after the
           newest beat, so "what it is doing right now" is never stranded above
           the bubbles it is producing. */}
+      {agentName ? (
+        <div className="lchat-agent-sender">
+          <AssistantAvatar name={agentName} seed={turn.agentId} />
+          <span>{agentName}</span>
+        </div>
+      ) : null}
+
+      {/* In flight and nothing said yet. A blank turn cannot be told apart
+          from a dead one, and the status pill only appears once there is work
+          to describe. */}
+      {turn.isLive && turn.items.length === 0 ? (
+        <div className="lchat-typing" aria-label="typing">
+          <span /><span /><span />
+        </div>
+      ) : null}
+
+      {/* Delivered, and nobody picked it up. Said plainly: an unanswered turn
+          and a broken one look the same otherwise, and the reader cannot tell
+          which they are looking at. */}
+      {turn.unanswered ? (
+        <div className="lchat-unanswered">No agent replied to this</div>
+      ) : null}
+
       {!turn.isLive ? statusPill : null}
+
+      {/* Something happened here that this reader may not see. Said plainly,
+          rather than leaving a turn that jumps from a question to an answer
+          with no sign that any work was done in between. */}
+      {turn.traceWithheld ? (
+        <div className="lchat-trace-withheld">Worked privately</div>
+      ) : null}
 
       {turn.items.map((item) => {
         if (item.kind === "notice") {

--- a/lemma-frontend/components/lemma/assistant/assistant-types.ts
+++ b/lemma-frontend/components/lemma/assistant/assistant-types.ts
@@ -12,12 +12,26 @@ export type LemmaAssistantAppearance = "default" | "minimal" | "borderless" | "c
 export type LemmaAssistantDensity = "compact" | "comfortable" | "spacious";
 export type LemmaAssistantRadius = "none" | "sm" | "md" | "lg" | "xl";
 
+/**
+ * One participant, as the transcript needs them: an id to match a turn's sender
+ * against, and something to call them. Structural rather than the SDK's
+ * response type, so this view can be handed a roster from anywhere.
+ */
+export interface AssistantParticipant {
+  user_id?: string | null;
+  agent_id?: string | null;
+  display_name?: string | null;
+  role?: string;
+}
+
 export interface AssistantConversationListItem {
   id: string;
   title?: string | null;
   status?: string | null;
   updated_at?: string | null;
   created_at?: string | null;
+  /** Null is the pod's default assistant, which has no agent row of its own. */
+  agent_id?: string | null;
 }
 
 export interface AssistantControllerView {
@@ -48,7 +62,7 @@ export interface AssistantControllerView {
   completedActions: AssistantAction[];
   streamingTool?: AssistantStreamingTool | null;
   selectConversation(conversationId: string | null): void;
-  sendMessage(content: string, options?: { forceNewConversation?: boolean }): Promise<void>;
+  sendMessage(content: string, options?: { forceNewConversation?: boolean; agentName?: string | null }): Promise<void>;
   /** Append a follow-up to a conversation that already has a run in flight. */
   steerMessage(content: string): Promise<void>;
   retryFailedMessage?(): Promise<void>;
@@ -95,7 +109,11 @@ export interface EmptyStateSuggestion {
 
 export interface AssistantResourceMention {
   id: string;
-  kind: "file" | "table";
+  /**
+   * An agent is not a resource, but it is mentioned the same way, and one
+   * typeahead is what makes `@` mean one thing in the composer rather than two.
+   */
+  kind: "file" | "table" | "agent";
   label: string;
   insertText: string;
   detail?: string;

--- a/lemma-frontend/lib/assistant/__tests__/addressed-agent.test.ts
+++ b/lemma-frontend/lib/assistant/__tests__/addressed-agent.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { addressedAgentName } from "../addressed-agent";
+
+describe("addressedAgentName", () => {
+  it("finds a mention anywhere in the message, not only at the start", () => {
+    expect(addressedAgentName("can you ask @batman about this", ["batman"]))
+      .toBe("batman");
+  });
+
+  it("ignores a name that is not mentioned with @", () => {
+    // The case that made this necessary: "what's up batman" is prose, and
+    // routing on it would hand a turn to an agent nobody addressed.
+    expect(addressedAgentName("what's up batman", ["batman"])).toBeNull();
+  });
+
+  it("prefers the longest matching name", () => {
+    // Otherwise `@ops-lead` is unreachable whenever `@ops` also exists.
+    expect(addressedAgentName("@ops-lead please look", ["ops", "ops-lead"]))
+      .toBe("ops-lead");
+  });
+
+  it("does not match a prefix of a longer name", () => {
+    expect(addressedAgentName("@batman hi", ["bat"])).toBeNull();
+  });
+
+  it("is case-insensitive but answers with the roster's spelling", () => {
+    expect(addressedAgentName("@BatMan hi", ["batman"])).toBe("batman");
+  });
+
+  it("returns null when nobody is in the room", () => {
+    expect(addressedAgentName("@batman hi", [])).toBeNull();
+  });
+});

--- a/lemma-frontend/lib/assistant/addressed-agent.ts
+++ b/lemma-frontend/lib/assistant/addressed-agent.ts
@@ -1,0 +1,42 @@
+/**
+ * Which agent a message addresses.
+ *
+ * The composer inserts `@Name` as plain text, the same as a table or file
+ * mention. This reads it back out so the send can name the agent, because the
+ * text alone routes nothing — the server needs the name in the request, and it
+ * refuses one that is not already in the conversation.
+ *
+ * Pure and framework-free so the matching rules are testable without rendering.
+ */
+
+/** Longest name first: with both `@ops` and `@ops-lead` present, `@ops-lead`
+ *  must win, or the longer name is unreachable. */
+function byLengthDescending(a: string, b: string): number {
+  return b.length - a.length;
+}
+
+function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * The first agent from `names` that the text mentions, or null.
+ *
+ * Case-insensitive, and anywhere in the message rather than only at the start —
+ * "can you ask @batman about this" addresses batman as plainly as leading with
+ * the name. The mention has to end at a word boundary so `@bat` does not match
+ * `@batman`.
+ */
+export function addressedAgentName(
+  text: string,
+  names: readonly string[],
+): string | null {
+  const trimmed = text.trim();
+  if (!trimmed.includes("@")) return null;
+  for (const name of [...names].sort(byLengthDescending)) {
+    if (!name) continue;
+    const pattern = new RegExp(`@${escapeForRegExp(name)}(?![\\w-])`, "i");
+    if (pattern.test(trimmed)) return name;
+  }
+  return null;
+}

--- a/lemma-frontend/lib/assistant/turns.ts
+++ b/lemma-frontend/lib/assistant/turns.ts
@@ -33,6 +33,8 @@ import {
   formatDurationCompact,
   isFinalResultToolName,
   isRenderableUserInteractionInvocation,
+  messageAgentId,
+  messageSenderUserId,
   messageTextContent,
   messageTimeMs,
   normalizeAgentToolName,
@@ -129,6 +131,28 @@ export interface ChatTurn {
   failedCount: number;
   isLive: boolean;
   hasPendingInteraction: boolean;
+  /** Who sent the turn. Null for anything an agent or the system started. */
+  senderUserId: string | null;
+  /**
+   * Which agent answered the turn. Null until the first assistant message
+   * arrives, and on a turn nothing answered. A conversation can hold several
+   * agents, so an answer that does not say which one produced it is one the
+   * reader cannot attribute.
+   */
+  agentId: string | null;
+  /**
+   * The message was delivered and no agent picked it up — a room where nobody
+   * was addressed and the router chose silence. Shown, because a turn that
+   * simply stops looks identical to one that broke.
+   */
+  unanswered: boolean;
+  /**
+   * True when this turn's working was withheld because somebody else sent it.
+   * Distinct from a turn that simply did no work: one has nothing to show, the
+   * other has something the reader may not see, and the UI says so rather than
+   * rendering an inexplicably empty turn.
+   */
+  traceWithheld: boolean;
 }
 
 // --- classification tables --------------------------------------------------
@@ -266,6 +290,16 @@ export interface BuildChatTurnsOptions {
   isRunActive: boolean;
   podId: string | null;
   conversationId: string | null;
+  /**
+   * Who is reading. In a conversation with more than one person in it, a turn's
+   * trace — its tool calls, its results, its thinking — belongs to whoever sent
+   * the turn, not to the room: tool arguments carry what they asked and tool
+   * results carry data their grants reached. The answer is everyone's.
+   *
+   * Null or undefined withholds nothing, which is every conversation that has
+   * only ever had one person in it.
+   */
+  viewerId?: string | null;
 }
 
 interface MutableTurn extends ChatTurn {
@@ -308,6 +342,15 @@ function turnIdForUserMessage(
   return unique(`turn-${inheritedId ?? messageId}`);
 }
 
+/** Whether the server stored this message with nobody answering it. */
+function wentUnanswered(message: AssistantRenderableMessage): boolean {
+  const metadata = (message.metadata ?? message.message_metadata) as
+    | Record<string, unknown>
+    | null
+    | undefined;
+  return metadata?.answered_by_agent === false;
+}
+
 function newTurn(id: string, userMessage: AssistantRenderableMessage | null): MutableTurn {
   return {
     id,
@@ -324,6 +367,10 @@ function newTurn(id: string, userMessage: AssistantRenderableMessage | null): Mu
     failedCount: 0,
     isLive: false,
     hasPendingInteraction: false,
+    senderUserId: userMessage ? messageSenderUserId(userMessage) : null,
+    agentId: null,
+    unanswered: userMessage ? wentUnanswered(userMessage) : false,
+    traceWithheld: false,
     artifactByPath: new Map(),
     resourceIds: new Set(),
   };
@@ -335,6 +382,7 @@ export function buildChatTurns({
   isRunActive,
   podId,
   conversationId,
+  viewerId,
 }: BuildChatTurnsOptions): ChatTurn[] {
   const turns: MutableTurn[] = [];
   let current: MutableTurn | null = null;
@@ -548,6 +596,13 @@ export function buildChatTurns({
     const isLastRow = rowIndex === lastRowIndex;
     const turn = ensureTurn(`turn-${row.id || rowIndex}`);
 
+    // The first assistant message to carry one names the turn's agent. Later
+    // ones cannot change it: a turn is answered by one agent, and letting a
+    // trailing message overwrite it would relabel a turn mid-render.
+    if (turn.agentId === null) {
+      turn.agentId = messageAgentId(message);
+    }
+
     // A clustered row's own timestamp is its newest message's; the turn's span
     // is the span of the row's source messages.
     for (const sourceIndex of row.sourceIndexes) {
@@ -667,6 +722,21 @@ export function buildChatTurns({
     }
   }
 
+  // Somebody else's working. Applied here rather than while collecting, so the
+  // counts stay true to what the run did — the pill says "worked for 9m" about
+  // work that happened, and hiding the steps must not rewrite the history.
+  // Dropped whole: a trace half-shown is a tool call whose result is missing,
+  // which reads as a failure rather than as a redaction.
+  if (viewerId) {
+    for (const turn of turns) {
+      if (turn.senderUserId && turn.senderUserId !== viewerId && turn.trace.length > 0) {
+        turn.trace = [];
+        turn.subagentParts = [];
+        turn.traceWithheld = true;
+      }
+    }
+  }
+
   // Nothing to say and nothing to show: drop. (Empty turns are how stray
   // whitespace-only messages used to render as sliver bubbles.)
   const visibleTurns = turns.filter((turn) => (
@@ -783,6 +853,12 @@ export function chatTurnFingerprint(turn: ChatTurn): string {
     turn.thinkingCount,
     turn.failedCount,
     turn.hasPendingInteraction ? 1 : 0,
+    // Both, because the turn re-renders when either changes: the byline is
+    // keyed off the sender, and the withheld notice replaces the trace pill.
+    turn.senderUserId ?? "",
+    turn.agentId ?? "",
+    turn.unanswered ? 1 : 0,
+    turn.traceWithheld ? 1 : 0,
     turn.userMessage?.id ?? "",
     items,
     trace,

--- a/lemma-frontend/lib/hooks/use-assistants.ts
+++ b/lemma-frontend/lib/hooks/use-assistants.ts
@@ -152,6 +152,62 @@ export function useConversations(podId: string, assistantName: string, params?: 
     });
 }
 
+/**
+ * Everyone in a conversation: the people, and the agents present.
+ *
+ * Read on open rather than folded into the conversation query, because the
+ * transcript needs it to attribute a turn and the conversation list does not.
+ */
+export function useConversationParticipants(
+    podId: string | null | undefined,
+    conversationId: string | null | undefined,
+) {
+    return useQuery({
+        queryKey: ['conversation-participants', podId, conversationId],
+        queryFn: () => getLemmaClient(podId || undefined).conversations.listParticipants(
+            conversationId as string,
+            { pod_id: podId ?? undefined },
+        ),
+        enabled: !!podId && !!conversationId,
+    });
+}
+
+export function useAddConversationParticipant(podId: string | null | undefined) {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: ({ conversationId, ...subject }: {
+            conversationId: string;
+            user_id?: string | null;
+            agent_name?: string | null;
+        }) => getLemmaClient(podId || undefined).conversations.addParticipant(
+            conversationId, subject, { pod_id: podId ?? undefined },
+        ),
+        onSuccess: (_result, variables) => {
+            queryClient.invalidateQueries({
+                queryKey: ['conversation-participants', podId, variables.conversationId],
+            });
+        },
+    });
+}
+
+export function useRemoveConversationParticipant(podId: string | null | undefined) {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: ({ conversationId, ...subject }: {
+            conversationId: string;
+            user_id?: string | null;
+            agent_id?: string | null;
+        }) => getLemmaClient(podId || undefined).conversations.removeParticipant(
+            conversationId, subject, { pod_id: podId ?? undefined },
+        ),
+        onSuccess: (_result, variables) => {
+            queryClient.invalidateQueries({
+                queryKey: ['conversation-participants', podId, variables.conversationId],
+            });
+        },
+    });
+}
+
 export function useScopedConversations(
     scope: ConversationScope,
     params?: { limit?: number; cursor?: string; enabled?: boolean; archived?: boolean },

--- a/lemma-frontend/public/openapi.json
+++ b/lemma-frontend/public/openapi.json
@@ -276,6 +276,36 @@
         "title": "AddColumnRequest",
         "type": "object"
       },
+      "AddConversationParticipantRequest": {
+        "description": "Add one person or one agent. Naming both, or neither, is rejected.",
+        "properties": {
+          "agent_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "title": "AddConversationParticipantRequest",
+        "type": "object"
+      },
       "AgentActionResponse": {
         "properties": {
           "agent_runtime": {
@@ -1741,10 +1771,29 @@
       },
       "AgentRunStartResponse": {
         "properties": {
+          "agent_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id"
+          },
           "agent_run_id": {
-            "format": "uuid",
-            "title": "Agent Run Id",
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Run Id"
           },
           "conversation_id": {
             "format": "uuid",
@@ -1758,7 +1807,6 @@
         },
         "required": [
           "conversation_id",
-          "agent_run_id",
           "started_new_run"
         ],
         "title": "AgentRunStartResponse",
@@ -4047,6 +4095,82 @@
         "title": "ConversationListResponse",
         "type": "object"
       },
+      "ConversationParticipantListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ConversationParticipantResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "ConversationParticipantListResponse",
+        "type": "object"
+      },
+      "ConversationParticipantResponse": {
+        "properties": {
+          "agent_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id"
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "title": "Conversation Id",
+            "type": "string"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": [
+          "id",
+          "conversation_id",
+          "role"
+        ],
+        "title": "ConversationParticipantResponse",
+        "type": "object"
+      },
       "ConversationResponse": {
         "properties": {
           "agent_id": {
@@ -4179,6 +4303,13 @@
               }
             ],
             "title": "Parent Id"
+          },
+          "participants": {
+            "items": {
+              "$ref": "#/components/schemas/ConversationParticipantResponse"
+            },
+            "title": "Participants",
+            "type": "array"
           },
           "pod_cwd": {
             "description": "The conversation's working directory in pod files. Anything a person attaches here is what the agent finds by a bare filename, because this is the directory its pod tools resolve against.",
@@ -8635,6 +8766,18 @@
       },
       "MessageResponse": {
         "properties": {
+          "agent_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id"
+          },
           "agent_run_id": {
             "anyOf": [
               {
@@ -8680,6 +8823,18 @@
           "role": {
             "title": "Role",
             "type": "string"
+          },
+          "sender_user_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sender User Id"
           },
           "sequence": {
             "title": "Sequence",
@@ -12683,6 +12838,29 @@
       },
       "SendMessageRequest": {
         "properties": {
+          "agent_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
+          },
+          "branch_from_run_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Branch From Run Id"
+          },
           "content": {
             "title": "Content",
             "type": "string"
@@ -23814,6 +23992,76 @@
         }
       }
     },
+    "/pods/{pod_id}/conversations/open": {
+      "post": {
+        "description": "Return the caller's ongoing conversation with an agent, opening one if there is none yet. Omit agent_name for the default pod assistant. Unlike create, calling this twice returns the same conversation: it is where a person lands when they open the agent rather than a new session each time. Archived, task, project and surface-bound conversations are never returned.",
+        "operationId": "agent.conversation.open",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pod_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Pod Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "agent_name",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Open Pod Agent Conversation",
+        "tags": [
+          "agent_conversations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "agent.conversation"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "agent.conversation",
+          "result": "entity",
+          "verb": "open"
+        }
+      }
+    },
     "/pods/{pod_id}/conversations/{conversation_id}": {
       "get": {
         "description": "Get a single pod-scoped assistant or agent conversation by id.",
@@ -24370,6 +24618,228 @@
           "resource": "agent.conversation.message",
           "result": "entity",
           "verb": "append"
+        }
+      }
+    },
+    "/pods/{pod_id}/conversations/{conversation_id}/participants": {
+      "delete": {
+        "description": "Remove one person, or one agent. Name exactly one of user_id or agent_id. The person who opened the conversation cannot be removed from it.",
+        "operationId": "agent.conversation.participant.remove",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pod_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Pod Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Conversation Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "user_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "agent_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Remove Conversation Participant",
+        "tags": [
+          "agent_conversations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "agent.conversation.participant"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "agent.conversation.participant",
+          "result": "void",
+          "verb": "remove"
+        }
+      },
+      "get": {
+        "description": "Who is in a conversation: the people, and the agents present.",
+        "operationId": "agent.conversation.participant.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pod_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Pod Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Conversation Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationParticipantListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Conversation Participants",
+        "tags": [
+          "agent_conversations"
+        ],
+        "x-lemma": {
+          "kind": "query",
+          "paginates": false,
+          "resource": "agent.conversation.participant",
+          "result": "collection",
+          "verb": "list"
+        }
+      },
+      "post": {
+        "description": "Add one person, or one agent, to a conversation. Name exactly one of user_id or agent_name. Adding a person is a grant: every answer in the conversation is from then on said to them. Their own working stays private to them, and so does everyone else's.",
+        "operationId": "agent.conversation.participant.add",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pod_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Pod Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Conversation Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddConversationParticipantRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationParticipantResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Add Conversation Participant",
+        "tags": [
+          "agent_conversations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "agent.conversation.participant"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "agent.conversation.participant",
+          "result": "entity",
+          "verb": "add"
         }
       }
     },

--- a/lemma-frontend/styles/features/assistant-chat.css
+++ b/lemma-frontend/styles/features/assistant-chat.css
@@ -62,6 +62,120 @@
     padding-left: var(--space-1);
 }
 
+/* Who is speaking, in a room with more than one voice in it. Above the bubble
+   and aligned with it, the way a group thread names a speaker. Both are absent
+   in a plain one-to-one chat, so that case looks exactly as it did.
+
+   The two differ only in which edge they hang from: a person's message is
+   right-aligned and an agent's is left, and a label that did not follow its
+   bubble would read as belonging to the turn above. */
+.lchat-user-sender,
+.lchat-agent-sender {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    color: var(--text-tertiary);
+    font-size: var(--text-xs);
+}
+
+.lchat-user-sender {
+    padding-right: var(--space-1);
+    /* The face follows the bubble to the right edge, so name and avatar read
+       as one label rather than as two things at opposite ends of the row. */
+    flex-direction: row-reverse;
+}
+
+/* A face beside a name. Small enough to sit on the byline's own line rather
+   than claim a column, which is what keeps the bubble layout intact. */
+.lchat-avatar {
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    width: var(--space-5);
+    height: var(--space-5);
+    border-radius: var(--radius-full);
+    overflow: hidden;
+    color: var(--text-on-brand);
+    font-size: var(--text-2xs);
+    letter-spacing: 0.02em;
+}
+
+/* Eight swatches, one lightness, so a room of faces reads as one set and none
+   of them shouts. Chosen from an id so it survives a rename. */
+.lchat-avatar-c0 { background-color: hsl(212 58% 42%); }
+.lchat-avatar-c1 { background-color: hsl(340 58% 42%); }
+.lchat-avatar-c2 { background-color: hsl(152 58% 42%); }
+.lchat-avatar-c3 { background-color: hsl(32 58% 42%); }
+.lchat-avatar-c4 { background-color: hsl(268 58% 42%); }
+.lchat-avatar-c5 { background-color: hsl(190 58% 42%); }
+.lchat-avatar-c6 { background-color: hsl(8 58% 42%); }
+.lchat-avatar-c7 { background-color: hsl(96 58% 42%); }
+
+.lchat-avatar-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+/* Three dots while a turn is in flight and has said nothing yet. The pill that
+   follows says what it is doing; this says only that somebody is there, which
+   is the whole job -- a reader watching a blank turn cannot tell a slow answer
+   from a dead one. */
+.lchat-typing {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-2) var(--space-3);
+}
+
+.lchat-typing span {
+    width: var(--space-1-5);
+    height: var(--space-1-5);
+    border-radius: var(--radius-full);
+    background-color: var(--text-tertiary);
+    animation: lchat-typing-bounce 1.2s var(--ease-standard) infinite;
+}
+
+.lchat-typing span:nth-child(2) { animation-delay: 0.15s; }
+.lchat-typing span:nth-child(3) { animation-delay: 0.3s; }
+
+@keyframes lchat-typing-bounce {
+    0%, 60%, 100% { opacity: 0.3; transform: translateY(0); }
+    30% { opacity: 1; transform: translateY(-25%); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    /* The dots still say "someone is there"; they simply stop moving. */
+    .lchat-typing span { animation: none; opacity: 0.6; }
+}
+
+.lchat-agent-sender {
+    align-self: flex-start;
+    padding-left: var(--space-1);
+    margin-bottom: var(--space-1);
+}
+
+/* The message landed and nobody answered it. Quiet, and on the reader's side
+   rather than the agents' -- it is a fact about their message, not a reply. */
+.lchat-unanswered {
+    align-self: flex-end;
+    padding-right: var(--space-1);
+    color: var(--text-tertiary);
+    font-size: var(--text-xs);
+    font-style: italic;
+}
+
+/* Work was done here that this reader may not see. Deliberately quieter than
+   the status pill it stands in for: it is a fact about the turn, not something
+   to open. */
+.lchat-trace-withheld {
+    align-self: flex-start;
+    color: var(--text-tertiary);
+    font-size: var(--text-xs);
+    font-style: italic;
+}
+
 /* --- day separators ---------------------------------------------------------- */
 
 /* A bare stamp, centred — no rules on either side. */

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -13,4 +13,4 @@ SDK and the server it is talking to.
 from __future__ import annotations
 
 API_VERSION = "0.7.1"
-SPEC_SHA256 = "e8d9602aba5ff8debbdbb78259c61352334e444bb74ee96cb44754fbd59b10ed"
+SPEC_SHA256 = "b604a98ec86f3994a81896000c5cca4cfa770329bbbea77ef3938e1b422cf7c8"

--- a/lemma-python/lemma_sdk/openapi_client/api/agent_conversations/agent_conversation_open.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/agent_conversations/agent_conversation_open.py
@@ -1,0 +1,208 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.conversation_response import ConversationResponse
+from ...models.error_response import ErrorResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    pod_id: UUID,
+    *,
+    agent_name: None | str | Unset = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    json_agent_name: None | str | Unset
+    if isinstance(agent_name, Unset):
+        json_agent_name = UNSET
+    else:
+        json_agent_name = agent_name
+    params["agent_name"] = json_agent_name
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/pods/{pod_id}/conversations/open".format(
+            pod_id=quote(str(pod_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ConversationResponse | ErrorResponse | None:
+    if response.status_code == 200:
+        response_200 = ConversationResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = ErrorResponse.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ConversationResponse | ErrorResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    pod_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    agent_name: None | str | Unset = UNSET,
+) -> Response[ConversationResponse | ErrorResponse]:
+    """Open Pod Agent Conversation
+
+     Return the caller's ongoing conversation with an agent, opening one if there is none yet. Omit
+    agent_name for the default pod assistant. Unlike create, calling this twice returns the same
+    conversation: it is where a person lands when they open the agent rather than a new session each
+    time. Archived, task, project and surface-bound conversations are never returned.
+
+    Args:
+        pod_id (UUID):
+        agent_name (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ConversationResponse | ErrorResponse]
+    """
+
+    kwargs = _get_kwargs(
+        pod_id=pod_id,
+        agent_name=agent_name,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    pod_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    agent_name: None | str | Unset = UNSET,
+) -> ConversationResponse | ErrorResponse | None:
+    """Open Pod Agent Conversation
+
+     Return the caller's ongoing conversation with an agent, opening one if there is none yet. Omit
+    agent_name for the default pod assistant. Unlike create, calling this twice returns the same
+    conversation: it is where a person lands when they open the agent rather than a new session each
+    time. Archived, task, project and surface-bound conversations are never returned.
+
+    Args:
+        pod_id (UUID):
+        agent_name (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ConversationResponse | ErrorResponse
+    """
+
+    return sync_detailed(
+        pod_id=pod_id,
+        client=client,
+        agent_name=agent_name,
+    ).parsed
+
+
+async def asyncio_detailed(
+    pod_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    agent_name: None | str | Unset = UNSET,
+) -> Response[ConversationResponse | ErrorResponse]:
+    """Open Pod Agent Conversation
+
+     Return the caller's ongoing conversation with an agent, opening one if there is none yet. Omit
+    agent_name for the default pod assistant. Unlike create, calling this twice returns the same
+    conversation: it is where a person lands when they open the agent rather than a new session each
+    time. Archived, task, project and surface-bound conversations are never returned.
+
+    Args:
+        pod_id (UUID):
+        agent_name (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ConversationResponse | ErrorResponse]
+    """
+
+    kwargs = _get_kwargs(
+        pod_id=pod_id,
+        agent_name=agent_name,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    pod_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    agent_name: None | str | Unset = UNSET,
+) -> ConversationResponse | ErrorResponse | None:
+    """Open Pod Agent Conversation
+
+     Return the caller's ongoing conversation with an agent, opening one if there is none yet. Omit
+    agent_name for the default pod assistant. Unlike create, calling this twice returns the same
+    conversation: it is where a person lands when they open the agent rather than a new session each
+    time. Archived, task, project and surface-bound conversations are never returned.
+
+    Args:
+        pod_id (UUID):
+        agent_name (None | str | Unset):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ConversationResponse | ErrorResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            pod_id=pod_id,
+            client=client,
+            agent_name=agent_name,
+        )
+    ).parsed

--- a/lemma-python/lemma_sdk/openapi_client/api/agent_conversations/agent_conversation_participant_add.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/agent_conversations/agent_conversation_participant_add.py
@@ -1,0 +1,219 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.add_conversation_participant_request import (
+    AddConversationParticipantRequest,
+)
+from ...models.conversation_participant_response import ConversationParticipantResponse
+from ...models.error_response import ErrorResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    pod_id: UUID,
+    conversation_id: UUID,
+    *,
+    body: AddConversationParticipantRequest,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/pods/{pod_id}/conversations/{conversation_id}/participants".format(
+            pod_id=quote(str(pod_id), safe=""),
+            conversation_id=quote(str(conversation_id), safe=""),
+        ),
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ConversationParticipantResponse | ErrorResponse | None:
+    if response.status_code == 201:
+        response_201 = ConversationParticipantResponse.from_dict(response.json())
+
+        return response_201
+
+    if response.status_code == 422:
+        response_422 = ErrorResponse.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ConversationParticipantResponse | ErrorResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    pod_id: UUID,
+    conversation_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: AddConversationParticipantRequest,
+) -> Response[ConversationParticipantResponse | ErrorResponse]:
+    """Add Conversation Participant
+
+     Add one person, or one agent, to a conversation. Name exactly one of user_id or agent_name. Adding a
+    person is a grant: every answer in the conversation is from then on said to them. Their own working
+    stays private to them, and so does everyone else's.
+
+    Args:
+        pod_id (UUID):
+        conversation_id (UUID):
+        body (AddConversationParticipantRequest): Add one person or one agent. Naming both, or
+            neither, is rejected.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ConversationParticipantResponse | ErrorResponse]
+    """
+
+    kwargs = _get_kwargs(
+        pod_id=pod_id,
+        conversation_id=conversation_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    pod_id: UUID,
+    conversation_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: AddConversationParticipantRequest,
+) -> ConversationParticipantResponse | ErrorResponse | None:
+    """Add Conversation Participant
+
+     Add one person, or one agent, to a conversation. Name exactly one of user_id or agent_name. Adding a
+    person is a grant: every answer in the conversation is from then on said to them. Their own working
+    stays private to them, and so does everyone else's.
+
+    Args:
+        pod_id (UUID):
+        conversation_id (UUID):
+        body (AddConversationParticipantRequest): Add one person or one agent. Naming both, or
+            neither, is rejected.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ConversationParticipantResponse | ErrorResponse
+    """
+
+    return sync_detailed(
+        pod_id=pod_id,
+        conversation_id=conversation_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    pod_id: UUID,
+    conversation_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: AddConversationParticipantRequest,
+) -> Response[ConversationParticipantResponse | ErrorResponse]:
+    """Add Conversation Participant
+
+     Add one person, or one agent, to a conversation. Name exactly one of user_id or agent_name. Adding a
+    person is a grant: every answer in the conversation is from then on said to them. Their own working
+    stays private to them, and so does everyone else's.
+
+    Args:
+        pod_id (UUID):
+        conversation_id (UUID):
+        body (AddConversationParticipantRequest): Add one person or one agent. Naming both, or
+            neither, is rejected.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ConversationParticipantResponse | ErrorResponse]
+    """
+
+    kwargs = _get_kwargs(
+        pod_id=pod_id,
+        conversation_id=conversation_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    pod_id: UUID,
+    conversation_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    body: AddConversationParticipantRequest,
+) -> ConversationParticipantResponse | ErrorResponse | None:
+    """Add Conversation Participant
+
+     Add one person, or one agent, to a conversation. Name exactly one of user_id or agent_name. Adding a
+    person is a grant: every answer in the conversation is from then on said to them. Their own working
+    stays private to them, and so does everyone else's.
+
+    Args:
+        pod_id (UUID):
+        conversation_id (UUID):
+        body (AddConversationParticipantRequest): Add one person or one agent. Naming both, or
+            neither, is rejected.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ConversationParticipantResponse | ErrorResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            pod_id=pod_id,
+            conversation_id=conversation_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/lemma-python/lemma_sdk/openapi_client/api/agent_conversations/agent_conversation_participant_list.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/agent_conversations/agent_conversation_participant_list.py
@@ -1,0 +1,186 @@
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.conversation_participant_list_response import (
+    ConversationParticipantListResponse,
+)
+from ...models.error_response import ErrorResponse
+from ...types import Response
+
+
+def _get_kwargs(
+    pod_id: UUID,
+    conversation_id: UUID,
+) -> dict[str, Any]:
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/pods/{pod_id}/conversations/{conversation_id}/participants".format(
+            pod_id=quote(str(pod_id), safe=""),
+            conversation_id=quote(str(conversation_id), safe=""),
+        ),
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> ConversationParticipantListResponse | ErrorResponse | None:
+    if response.status_code == 200:
+        response_200 = ConversationParticipantListResponse.from_dict(response.json())
+
+        return response_200
+
+    if response.status_code == 422:
+        response_422 = ErrorResponse.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[ConversationParticipantListResponse | ErrorResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    pod_id: UUID,
+    conversation_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[ConversationParticipantListResponse | ErrorResponse]:
+    """List Conversation Participants
+
+     Who is in a conversation: the people, and the agents present.
+
+    Args:
+        pod_id (UUID):
+        conversation_id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ConversationParticipantListResponse | ErrorResponse]
+    """
+
+    kwargs = _get_kwargs(
+        pod_id=pod_id,
+        conversation_id=conversation_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    pod_id: UUID,
+    conversation_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> ConversationParticipantListResponse | ErrorResponse | None:
+    """List Conversation Participants
+
+     Who is in a conversation: the people, and the agents present.
+
+    Args:
+        pod_id (UUID):
+        conversation_id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ConversationParticipantListResponse | ErrorResponse
+    """
+
+    return sync_detailed(
+        pod_id=pod_id,
+        conversation_id=conversation_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    pod_id: UUID,
+    conversation_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> Response[ConversationParticipantListResponse | ErrorResponse]:
+    """List Conversation Participants
+
+     Who is in a conversation: the people, and the agents present.
+
+    Args:
+        pod_id (UUID):
+        conversation_id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[ConversationParticipantListResponse | ErrorResponse]
+    """
+
+    kwargs = _get_kwargs(
+        pod_id=pod_id,
+        conversation_id=conversation_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    pod_id: UUID,
+    conversation_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+) -> ConversationParticipantListResponse | ErrorResponse | None:
+    """List Conversation Participants
+
+     Who is in a conversation: the people, and the agents present.
+
+    Args:
+        pod_id (UUID):
+        conversation_id (UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        ConversationParticipantListResponse | ErrorResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            pod_id=pod_id,
+            conversation_id=conversation_id,
+            client=client,
+        )
+    ).parsed

--- a/lemma-python/lemma_sdk/openapi_client/api/agent_conversations/agent_conversation_participant_remove.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/agent_conversations/agent_conversation_participant_remove.py
@@ -1,0 +1,236 @@
+from http import HTTPStatus
+from typing import Any, cast
+from urllib.parse import quote
+from uuid import UUID
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.error_response import ErrorResponse
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    pod_id: UUID,
+    conversation_id: UUID,
+    *,
+    user_id: None | Unset | UUID = UNSET,
+    agent_id: None | Unset | UUID = UNSET,
+) -> dict[str, Any]:
+
+    params: dict[str, Any] = {}
+
+    json_user_id: None | str | Unset
+    if isinstance(user_id, Unset):
+        json_user_id = UNSET
+    elif isinstance(user_id, UUID):
+        json_user_id = str(user_id)
+    else:
+        json_user_id = user_id
+    params["user_id"] = json_user_id
+
+    json_agent_id: None | str | Unset
+    if isinstance(agent_id, Unset):
+        json_agent_id = UNSET
+    elif isinstance(agent_id, UUID):
+        json_agent_id = str(agent_id)
+    else:
+        json_agent_id = agent_id
+    params["agent_id"] = json_agent_id
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": "/pods/{pod_id}/conversations/{conversation_id}/participants".format(
+            pod_id=quote(str(pod_id), safe=""),
+            conversation_id=quote(str(conversation_id), safe=""),
+        ),
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | ErrorResponse | None:
+    if response.status_code == 204:
+        response_204 = cast(Any, None)
+        return response_204
+
+    if response.status_code == 422:
+        response_422 = ErrorResponse.from_dict(response.json())
+
+        return response_422
+
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | ErrorResponse]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    pod_id: UUID,
+    conversation_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    user_id: None | Unset | UUID = UNSET,
+    agent_id: None | Unset | UUID = UNSET,
+) -> Response[Any | ErrorResponse]:
+    """Remove Conversation Participant
+
+     Remove one person, or one agent. Name exactly one of user_id or agent_id. The person who opened the
+    conversation cannot be removed from it.
+
+    Args:
+        pod_id (UUID):
+        conversation_id (UUID):
+        user_id (None | Unset | UUID):
+        agent_id (None | Unset | UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | ErrorResponse]
+    """
+
+    kwargs = _get_kwargs(
+        pod_id=pod_id,
+        conversation_id=conversation_id,
+        user_id=user_id,
+        agent_id=agent_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    pod_id: UUID,
+    conversation_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    user_id: None | Unset | UUID = UNSET,
+    agent_id: None | Unset | UUID = UNSET,
+) -> Any | ErrorResponse | None:
+    """Remove Conversation Participant
+
+     Remove one person, or one agent. Name exactly one of user_id or agent_id. The person who opened the
+    conversation cannot be removed from it.
+
+    Args:
+        pod_id (UUID):
+        conversation_id (UUID):
+        user_id (None | Unset | UUID):
+        agent_id (None | Unset | UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | ErrorResponse
+    """
+
+    return sync_detailed(
+        pod_id=pod_id,
+        conversation_id=conversation_id,
+        client=client,
+        user_id=user_id,
+        agent_id=agent_id,
+    ).parsed
+
+
+async def asyncio_detailed(
+    pod_id: UUID,
+    conversation_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    user_id: None | Unset | UUID = UNSET,
+    agent_id: None | Unset | UUID = UNSET,
+) -> Response[Any | ErrorResponse]:
+    """Remove Conversation Participant
+
+     Remove one person, or one agent. Name exactly one of user_id or agent_id. The person who opened the
+    conversation cannot be removed from it.
+
+    Args:
+        pod_id (UUID):
+        conversation_id (UUID):
+        user_id (None | Unset | UUID):
+        agent_id (None | Unset | UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any | ErrorResponse]
+    """
+
+    kwargs = _get_kwargs(
+        pod_id=pod_id,
+        conversation_id=conversation_id,
+        user_id=user_id,
+        agent_id=agent_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    pod_id: UUID,
+    conversation_id: UUID,
+    *,
+    client: AuthenticatedClient | Client,
+    user_id: None | Unset | UUID = UNSET,
+    agent_id: None | Unset | UUID = UNSET,
+) -> Any | ErrorResponse | None:
+    """Remove Conversation Participant
+
+     Remove one person, or one agent. Name exactly one of user_id or agent_id. The person who opened the
+    conversation cannot be removed from it.
+
+    Args:
+        pod_id (UUID):
+        conversation_id (UUID):
+        user_id (None | Unset | UUID):
+        agent_id (None | Unset | UUID):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Any | ErrorResponse
+    """
+
+    return (
+        await asyncio_detailed(
+            pod_id=pod_id,
+            conversation_id=conversation_id,
+            client=client,
+            user_id=user_id,
+            agent_id=agent_id,
+        )
+    ).parsed

--- a/lemma-python/lemma_sdk/openapi_client/models/__init__.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/__init__.py
@@ -16,6 +16,7 @@ _NAME_TO_MODULE = {
     'AccountResponseSchema': 'account_response_schema',
     'AccountResponseSchemaPreferencesType0': 'account_response_schema_preferences_type_0',
     'AddColumnRequest': 'add_column_request',
+    'AddConversationParticipantRequest': 'add_conversation_participant_request',
     'AgentActionResponse': 'agent_action_response',
     'AgentActionResponseInputSchemaType0': 'agent_action_response_input_schema_type_0',
     'AgentActionResponseMetadataType0': 'agent_action_response_metadata_type_0',
@@ -144,6 +145,8 @@ _NAME_TO_MODULE = {
     'ConnectorSkillResponse': 'connector_skill_response',
     'ConnectorStatusResponse': 'connector_status_response',
     'ConversationListResponse': 'conversation_list_response',
+    'ConversationParticipantListResponse': 'conversation_participant_list_response',
+    'ConversationParticipantResponse': 'conversation_participant_response',
     'ConversationResponse': 'conversation_response',
     'ConversationResponseMetadataType0': 'conversation_response_metadata_type_0',
     'ConversationStatus': 'conversation_status',
@@ -534,6 +537,7 @@ if TYPE_CHECKING:
     from .account_response_schema import AccountResponseSchema
     from .account_response_schema_preferences_type_0 import AccountResponseSchemaPreferencesType0
     from .add_column_request import AddColumnRequest
+    from .add_conversation_participant_request import AddConversationParticipantRequest
     from .agent_action_response import AgentActionResponse
     from .agent_action_response_input_schema_type_0 import AgentActionResponseInputSchemaType0
     from .agent_action_response_metadata_type_0 import AgentActionResponseMetadataType0
@@ -662,6 +666,8 @@ if TYPE_CHECKING:
     from .connector_skill_response import ConnectorSkillResponse
     from .connector_status_response import ConnectorStatusResponse
     from .conversation_list_response import ConversationListResponse
+    from .conversation_participant_list_response import ConversationParticipantListResponse
+    from .conversation_participant_response import ConversationParticipantResponse
     from .conversation_response import ConversationResponse
     from .conversation_response_metadata_type_0 import ConversationResponseMetadataType0
     from .conversation_status import ConversationStatus
@@ -1065,6 +1071,7 @@ __all__ = [
     'AccountResponseSchema',
     'AccountResponseSchemaPreferencesType0',
     'AddColumnRequest',
+    'AddConversationParticipantRequest',
     'AgentActionResponse',
     'AgentActionResponseInputSchemaType0',
     'AgentActionResponseMetadataType0',
@@ -1193,6 +1200,8 @@ __all__ = [
     'ConnectorSkillResponse',
     'ConnectorStatusResponse',
     'ConversationListResponse',
+    'ConversationParticipantListResponse',
+    'ConversationParticipantResponse',
     'ConversationResponse',
     'ConversationResponseMetadataType0',
     'ConversationStatus',

--- a/lemma-python/lemma_sdk/openapi_client/models/add_conversation_participant_request.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/add_conversation_participant_request.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+from uuid import UUID
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="AddConversationParticipantRequest")
+
+
+@_attrs_define
+class AddConversationParticipantRequest:
+    """Add one person or one agent. Naming both, or neither, is rejected.
+
+    Attributes:
+        agent_name (None | str | Unset):
+        user_id (None | Unset | UUID):
+    """
+
+    agent_name: None | str | Unset = UNSET
+    user_id: None | Unset | UUID = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        agent_name: None | str | Unset
+        if isinstance(self.agent_name, Unset):
+            agent_name = UNSET
+        else:
+            agent_name = self.agent_name
+
+        user_id: None | str | Unset
+        if isinstance(self.user_id, Unset):
+            user_id = UNSET
+        elif isinstance(self.user_id, UUID):
+            user_id = str(self.user_id)
+        else:
+            user_id = self.user_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if agent_name is not UNSET:
+            field_dict["agent_name"] = agent_name
+        if user_id is not UNSET:
+            field_dict["user_id"] = user_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+
+        def _parse_agent_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        agent_name = _parse_agent_name(d.pop("agent_name", UNSET))
+
+        def _parse_user_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                user_id_type_0 = UUID(data)
+
+                return user_id_type_0
+            except TypeError, ValueError, AttributeError, KeyError:
+                pass
+            return cast(None | Unset | UUID, data)
+
+        user_id = _parse_user_id(d.pop("user_id", UNSET))
+
+        add_conversation_participant_request = cls(
+            agent_name=agent_name,
+            user_id=user_id,
+        )
+
+        add_conversation_participant_request.additional_properties = d
+        return add_conversation_participant_request
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/lemma-python/lemma_sdk/openapi_client/models/conversation_participant_list_response.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/conversation_participant_list_response.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+if TYPE_CHECKING:
+    from ..models.conversation_participant_response import (
+        ConversationParticipantResponse,
+    )
+
+
+T = TypeVar("T", bound="ConversationParticipantListResponse")
+
+
+@_attrs_define
+class ConversationParticipantListResponse:
+    """
+    Attributes:
+        items (list[ConversationParticipantResponse]):
+    """
+
+    items: list[ConversationParticipantResponse]
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        items = []
+        for items_item_data in self.items:
+            items_item = items_item_data.to_dict()
+            items.append(items_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "items": items,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.conversation_participant_response import (
+            ConversationParticipantResponse,
+        )
+
+        d = dict(src_dict)
+        items = []
+        _items = d.pop("items")
+        for items_item_data in _items:
+            items_item = ConversationParticipantResponse.from_dict(items_item_data)
+
+            items.append(items_item)
+
+        conversation_participant_list_response = cls(
+            items=items,
+        )
+
+        conversation_participant_list_response.additional_properties = d
+        return conversation_participant_list_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/lemma-python/lemma_sdk/openapi_client/models/conversation_participant_response.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/conversation_participant_response.py
@@ -9,29 +9,35 @@ from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-T = TypeVar("T", bound="AgentRunStartResponse")
+T = TypeVar("T", bound="ConversationParticipantResponse")
 
 
 @_attrs_define
-class AgentRunStartResponse:
+class ConversationParticipantResponse:
     """
     Attributes:
         conversation_id (UUID):
-        started_new_run (bool):
+        id (UUID):
+        role (str):
         agent_id (None | Unset | UUID):
-        agent_run_id (None | Unset | UUID):
+        display_name (None | str | Unset):
+        user_id (None | Unset | UUID):
     """
 
     conversation_id: UUID
-    started_new_run: bool
+    id: UUID
+    role: str
     agent_id: None | Unset | UUID = UNSET
-    agent_run_id: None | Unset | UUID = UNSET
+    display_name: None | str | Unset = UNSET
+    user_id: None | Unset | UUID = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         conversation_id = str(self.conversation_id)
 
-        started_new_run = self.started_new_run
+        id = str(self.id)
+
+        role = self.role
 
         agent_id: None | str | Unset
         if isinstance(self.agent_id, Unset):
@@ -41,26 +47,35 @@ class AgentRunStartResponse:
         else:
             agent_id = self.agent_id
 
-        agent_run_id: None | str | Unset
-        if isinstance(self.agent_run_id, Unset):
-            agent_run_id = UNSET
-        elif isinstance(self.agent_run_id, UUID):
-            agent_run_id = str(self.agent_run_id)
+        display_name: None | str | Unset
+        if isinstance(self.display_name, Unset):
+            display_name = UNSET
         else:
-            agent_run_id = self.agent_run_id
+            display_name = self.display_name
+
+        user_id: None | str | Unset
+        if isinstance(self.user_id, Unset):
+            user_id = UNSET
+        elif isinstance(self.user_id, UUID):
+            user_id = str(self.user_id)
+        else:
+            user_id = self.user_id
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
                 "conversation_id": conversation_id,
-                "started_new_run": started_new_run,
+                "id": id,
+                "role": role,
             }
         )
         if agent_id is not UNSET:
             field_dict["agent_id"] = agent_id
-        if agent_run_id is not UNSET:
-            field_dict["agent_run_id"] = agent_run_id
+        if display_name is not UNSET:
+            field_dict["display_name"] = display_name
+        if user_id is not UNSET:
+            field_dict["user_id"] = user_id
 
         return field_dict
 
@@ -69,7 +84,9 @@ class AgentRunStartResponse:
         d = dict(src_dict)
         conversation_id = UUID(d.pop("conversation_id"))
 
-        started_new_run = d.pop("started_new_run")
+        id = UUID(d.pop("id"))
+
+        role = d.pop("role")
 
         def _parse_agent_id(data: object) -> None | Unset | UUID:
             if data is None:
@@ -88,7 +105,16 @@ class AgentRunStartResponse:
 
         agent_id = _parse_agent_id(d.pop("agent_id", UNSET))
 
-        def _parse_agent_run_id(data: object) -> None | Unset | UUID:
+        def _parse_display_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        display_name = _parse_display_name(d.pop("display_name", UNSET))
+
+        def _parse_user_id(data: object) -> None | Unset | UUID:
             if data is None:
                 return data
             if isinstance(data, Unset):
@@ -96,24 +122,26 @@ class AgentRunStartResponse:
             try:
                 if not isinstance(data, str):
                     raise TypeError()
-                agent_run_id_type_0 = UUID(data)
+                user_id_type_0 = UUID(data)
 
-                return agent_run_id_type_0
+                return user_id_type_0
             except TypeError, ValueError, AttributeError, KeyError:
                 pass
             return cast(None | Unset | UUID, data)
 
-        agent_run_id = _parse_agent_run_id(d.pop("agent_run_id", UNSET))
+        user_id = _parse_user_id(d.pop("user_id", UNSET))
 
-        agent_run_start_response = cls(
+        conversation_participant_response = cls(
             conversation_id=conversation_id,
-            started_new_run=started_new_run,
+            id=id,
+            role=role,
             agent_id=agent_id,
-            agent_run_id=agent_run_id,
+            display_name=display_name,
+            user_id=user_id,
         )
 
-        agent_run_start_response.additional_properties = d
-        return agent_run_start_response
+        conversation_participant_response.additional_properties = d
+        return conversation_participant_response
 
     @property
     def additional_keys(self) -> list[str]:

--- a/lemma-python/lemma_sdk/openapi_client/models/conversation_response.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/conversation_response.py
@@ -16,6 +16,9 @@ from ..types import UNSET, Unset
 
 if TYPE_CHECKING:
     from ..models.agent_runtime_config import AgentRuntimeConfig
+    from ..models.conversation_participant_response import (
+        ConversationParticipantResponse,
+    )
     from ..models.conversation_response_metadata_type_0 import (
         ConversationResponseMetadataType0,
     )
@@ -47,6 +50,7 @@ class ConversationResponse:
         organization_id (None | Unset | UUID):
         output (Any | None | Unset):
         parent_id (None | Unset | UUID):
+        participants (list[ConversationParticipantResponse] | Unset):
         status (ConversationStatus | None | Unset):
         title (None | str | Unset):
         type_ (ConversationType | Unset): User-visible conversation behavior.
@@ -70,6 +74,7 @@ class ConversationResponse:
     organization_id: None | Unset | UUID = UNSET
     output: Any | None | Unset = UNSET
     parent_id: None | Unset | UUID = UNSET
+    participants: list[ConversationParticipantResponse] | Unset = UNSET
     status: ConversationStatus | None | Unset = UNSET
     title: None | str | Unset = UNSET
     type_: ConversationType | Unset = UNSET
@@ -171,6 +176,13 @@ class ConversationResponse:
         else:
             parent_id = self.parent_id
 
+        participants: list[dict[str, Any]] | Unset = UNSET
+        if not isinstance(self.participants, Unset):
+            participants = []
+            for participants_item_data in self.participants:
+                participants_item = participants_item_data.to_dict()
+                participants.append(participants_item)
+
         status: None | str | Unset
         if isinstance(self.status, Unset):
             status = UNSET
@@ -225,6 +237,8 @@ class ConversationResponse:
             field_dict["output"] = output
         if parent_id is not UNSET:
             field_dict["parent_id"] = parent_id
+        if participants is not UNSET:
+            field_dict["participants"] = participants
         if status is not UNSET:
             field_dict["status"] = status
         if title is not UNSET:
@@ -237,6 +251,9 @@ class ConversationResponse:
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
         from ..models.agent_runtime_config import AgentRuntimeConfig
+        from ..models.conversation_participant_response import (
+            ConversationParticipantResponse,
+        )
         from ..models.conversation_response_metadata_type_0 import (
             ConversationResponseMetadataType0,
         )
@@ -410,6 +427,17 @@ class ConversationResponse:
 
         parent_id = _parse_parent_id(d.pop("parent_id", UNSET))
 
+        _participants = d.pop("participants", UNSET)
+        participants: list[ConversationParticipantResponse] | Unset = UNSET
+        if _participants is not UNSET:
+            participants = []
+            for participants_item_data in _participants:
+                participants_item = ConversationParticipantResponse.from_dict(
+                    participants_item_data
+                )
+
+                participants.append(participants_item)
+
         def _parse_status(data: object) -> ConversationStatus | None | Unset:
             if data is None:
                 return data
@@ -462,6 +490,7 @@ class ConversationResponse:
             organization_id=organization_id,
             output=output,
             parent_id=parent_id,
+            participants=participants,
             status=status,
             title=title,
             type_=type_,

--- a/lemma-python/lemma_sdk/openapi_client/models/message_response.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/message_response.py
@@ -33,8 +33,10 @@ class MessageResponse:
             ``tool_result`` (return). There is no nested ``content`` object.
         role (str):
         sequence (int):
+        agent_id (None | Unset | UUID):
         agent_run_id (None | Unset | UUID):
         metadata (MessageResponseMetadataType0 | None | Unset):
+        sender_user_id (None | Unset | UUID):
         text (None | str | Unset):
         tool_args (Any | None | Unset):
         tool_call_id (None | str | Unset):
@@ -48,8 +50,10 @@ class MessageResponse:
     kind: MessageKind
     role: str
     sequence: int
+    agent_id: None | Unset | UUID = UNSET
     agent_run_id: None | Unset | UUID = UNSET
     metadata: MessageResponseMetadataType0 | None | Unset = UNSET
+    sender_user_id: None | Unset | UUID = UNSET
     text: None | str | Unset = UNSET
     tool_args: Any | None | Unset = UNSET
     tool_call_id: None | str | Unset = UNSET
@@ -74,6 +78,14 @@ class MessageResponse:
 
         sequence = self.sequence
 
+        agent_id: None | str | Unset
+        if isinstance(self.agent_id, Unset):
+            agent_id = UNSET
+        elif isinstance(self.agent_id, UUID):
+            agent_id = str(self.agent_id)
+        else:
+            agent_id = self.agent_id
+
         agent_run_id: None | str | Unset
         if isinstance(self.agent_run_id, Unset):
             agent_run_id = UNSET
@@ -89,6 +101,14 @@ class MessageResponse:
             metadata = self.metadata.to_dict()
         else:
             metadata = self.metadata
+
+        sender_user_id: None | str | Unset
+        if isinstance(self.sender_user_id, Unset):
+            sender_user_id = UNSET
+        elif isinstance(self.sender_user_id, UUID):
+            sender_user_id = str(self.sender_user_id)
+        else:
+            sender_user_id = self.sender_user_id
 
         text: None | str | Unset
         if isinstance(self.text, Unset):
@@ -132,10 +152,14 @@ class MessageResponse:
                 "sequence": sequence,
             }
         )
+        if agent_id is not UNSET:
+            field_dict["agent_id"] = agent_id
         if agent_run_id is not UNSET:
             field_dict["agent_run_id"] = agent_run_id
         if metadata is not UNSET:
             field_dict["metadata"] = metadata
+        if sender_user_id is not UNSET:
+            field_dict["sender_user_id"] = sender_user_id
         if text is not UNSET:
             field_dict["text"] = text
         if tool_args is not UNSET:
@@ -167,6 +191,23 @@ class MessageResponse:
         role = d.pop("role")
 
         sequence = d.pop("sequence")
+
+        def _parse_agent_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                agent_id_type_0 = UUID(data)
+
+                return agent_id_type_0
+            except TypeError, ValueError, AttributeError, KeyError:
+                pass
+            return cast(None | Unset | UUID, data)
+
+        agent_id = _parse_agent_id(d.pop("agent_id", UNSET))
 
         def _parse_agent_run_id(data: object) -> None | Unset | UUID:
             if data is None:
@@ -203,6 +244,23 @@ class MessageResponse:
             return cast(MessageResponseMetadataType0 | None | Unset, data)
 
         metadata = _parse_metadata(d.pop("metadata", UNSET))
+
+        def _parse_sender_user_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                sender_user_id_type_0 = UUID(data)
+
+                return sender_user_id_type_0
+            except TypeError, ValueError, AttributeError, KeyError:
+                pass
+            return cast(None | Unset | UUID, data)
+
+        sender_user_id = _parse_sender_user_id(d.pop("sender_user_id", UNSET))
 
         def _parse_text(data: object) -> None | str | Unset:
             if data is None:
@@ -256,8 +314,10 @@ class MessageResponse:
             kind=kind,
             role=role,
             sequence=sequence,
+            agent_id=agent_id,
             agent_run_id=agent_run_id,
             metadata=metadata,
+            sender_user_id=sender_user_id,
             text=text,
             tool_args=tool_args,
             tool_call_id=tool_call_id,

--- a/lemma-python/lemma_sdk/openapi_client/models/send_message_request.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/send_message_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, TypeVar, cast
+from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -22,10 +23,14 @@ class SendMessageRequest:
     """
     Attributes:
         content (str):
+        agent_name (None | str | Unset):
+        branch_from_run_id (None | Unset | UUID):
         metadata (None | SendMessageRequestMetadataType0 | Unset):
     """
 
     content: str
+    agent_name: None | str | Unset = UNSET
+    branch_from_run_id: None | Unset | UUID = UNSET
     metadata: None | SendMessageRequestMetadataType0 | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
@@ -35,6 +40,20 @@ class SendMessageRequest:
         )
 
         content = self.content
+
+        agent_name: None | str | Unset
+        if isinstance(self.agent_name, Unset):
+            agent_name = UNSET
+        else:
+            agent_name = self.agent_name
+
+        branch_from_run_id: None | str | Unset
+        if isinstance(self.branch_from_run_id, Unset):
+            branch_from_run_id = UNSET
+        elif isinstance(self.branch_from_run_id, UUID):
+            branch_from_run_id = str(self.branch_from_run_id)
+        else:
+            branch_from_run_id = self.branch_from_run_id
 
         metadata: dict[str, Any] | None | Unset
         if isinstance(self.metadata, Unset):
@@ -51,6 +70,10 @@ class SendMessageRequest:
                 "content": content,
             }
         )
+        if agent_name is not UNSET:
+            field_dict["agent_name"] = agent_name
+        if branch_from_run_id is not UNSET:
+            field_dict["branch_from_run_id"] = branch_from_run_id
         if metadata is not UNSET:
             field_dict["metadata"] = metadata
 
@@ -64,6 +87,34 @@ class SendMessageRequest:
 
         d = dict(src_dict)
         content = d.pop("content")
+
+        def _parse_agent_name(data: object) -> None | str | Unset:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(None | str | Unset, data)
+
+        agent_name = _parse_agent_name(d.pop("agent_name", UNSET))
+
+        def _parse_branch_from_run_id(data: object) -> None | Unset | UUID:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                branch_from_run_id_type_0 = UUID(data)
+
+                return branch_from_run_id_type_0
+            except TypeError, ValueError, AttributeError, KeyError:
+                pass
+            return cast(None | Unset | UUID, data)
+
+        branch_from_run_id = _parse_branch_from_run_id(
+            d.pop("branch_from_run_id", UNSET)
+        )
 
         def _parse_metadata(
             data: object,
@@ -86,6 +137,8 @@ class SendMessageRequest:
 
         send_message_request = cls(
             content=content,
+            agent_name=agent_name,
+            branch_from_run_id=branch_from_run_id,
             metadata=metadata,
         )
 

--- a/lemma-python/lemma_sdk/openapi_spec.json
+++ b/lemma-python/lemma_sdk/openapi_spec.json
@@ -276,6 +276,36 @@
         "title": "AddColumnRequest",
         "type": "object"
       },
+      "AddConversationParticipantRequest": {
+        "description": "Add one person or one agent. Naming both, or neither, is rejected.",
+        "properties": {
+          "agent_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "title": "AddConversationParticipantRequest",
+        "type": "object"
+      },
       "AgentActionResponse": {
         "properties": {
           "agent_runtime": {
@@ -1741,10 +1771,29 @@
       },
       "AgentRunStartResponse": {
         "properties": {
+          "agent_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id"
+          },
           "agent_run_id": {
-            "format": "uuid",
-            "title": "Agent Run Id",
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Run Id"
           },
           "conversation_id": {
             "format": "uuid",
@@ -1758,7 +1807,6 @@
         },
         "required": [
           "conversation_id",
-          "agent_run_id",
           "started_new_run"
         ],
         "title": "AgentRunStartResponse",
@@ -4047,6 +4095,82 @@
         "title": "ConversationListResponse",
         "type": "object"
       },
+      "ConversationParticipantListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ConversationParticipantResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "ConversationParticipantListResponse",
+        "type": "object"
+      },
+      "ConversationParticipantResponse": {
+        "properties": {
+          "agent_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id"
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "title": "Conversation Id",
+            "type": "string"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": [
+          "id",
+          "conversation_id",
+          "role"
+        ],
+        "title": "ConversationParticipantResponse",
+        "type": "object"
+      },
       "ConversationResponse": {
         "properties": {
           "agent_id": {
@@ -4179,6 +4303,13 @@
               }
             ],
             "title": "Parent Id"
+          },
+          "participants": {
+            "items": {
+              "$ref": "#/components/schemas/ConversationParticipantResponse"
+            },
+            "title": "Participants",
+            "type": "array"
           },
           "pod_cwd": {
             "description": "The conversation's working directory in pod files. Anything a person attaches here is what the agent finds by a bare filename, because this is the directory its pod tools resolve against.",
@@ -8635,6 +8766,18 @@
       },
       "MessageResponse": {
         "properties": {
+          "agent_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id"
+          },
           "agent_run_id": {
             "anyOf": [
               {
@@ -8680,6 +8823,18 @@
           "role": {
             "title": "Role",
             "type": "string"
+          },
+          "sender_user_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sender User Id"
           },
           "sequence": {
             "title": "Sequence",
@@ -12683,6 +12838,29 @@
       },
       "SendMessageRequest": {
         "properties": {
+          "agent_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
+          },
+          "branch_from_run_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Branch From Run Id"
+          },
           "content": {
             "title": "Content",
             "type": "string"
@@ -23814,6 +23992,76 @@
         }
       }
     },
+    "/pods/{pod_id}/conversations/open": {
+      "post": {
+        "description": "Return the caller's ongoing conversation with an agent, opening one if there is none yet. Omit agent_name for the default pod assistant. Unlike create, calling this twice returns the same conversation: it is where a person lands when they open the agent rather than a new session each time. Archived, task, project and surface-bound conversations are never returned.",
+        "operationId": "agent.conversation.open",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pod_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Pod Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "agent_name",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Open Pod Agent Conversation",
+        "tags": [
+          "agent_conversations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "agent.conversation"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "agent.conversation",
+          "result": "entity",
+          "verb": "open"
+        }
+      }
+    },
     "/pods/{pod_id}/conversations/{conversation_id}": {
       "get": {
         "description": "Get a single pod-scoped assistant or agent conversation by id.",
@@ -24370,6 +24618,228 @@
           "resource": "agent.conversation.message",
           "result": "entity",
           "verb": "append"
+        }
+      }
+    },
+    "/pods/{pod_id}/conversations/{conversation_id}/participants": {
+      "delete": {
+        "description": "Remove one person, or one agent. Name exactly one of user_id or agent_id. The person who opened the conversation cannot be removed from it.",
+        "operationId": "agent.conversation.participant.remove",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pod_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Pod Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Conversation Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "user_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "agent_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Remove Conversation Participant",
+        "tags": [
+          "agent_conversations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "agent.conversation.participant"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "agent.conversation.participant",
+          "result": "void",
+          "verb": "remove"
+        }
+      },
+      "get": {
+        "description": "Who is in a conversation: the people, and the agents present.",
+        "operationId": "agent.conversation.participant.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pod_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Pod Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Conversation Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationParticipantListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Conversation Participants",
+        "tags": [
+          "agent_conversations"
+        ],
+        "x-lemma": {
+          "kind": "query",
+          "paginates": false,
+          "resource": "agent.conversation.participant",
+          "result": "collection",
+          "verb": "list"
+        }
+      },
+      "post": {
+        "description": "Add one person, or one agent, to a conversation. Name exactly one of user_id or agent_name. Adding a person is a grant: every answer in the conversation is from then on said to them. Their own working stays private to them, and so does everyone else's.",
+        "operationId": "agent.conversation.participant.add",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pod_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Pod Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Conversation Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddConversationParticipantRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationParticipantResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Add Conversation Participant",
+        "tags": [
+          "agent_conversations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "agent.conversation.participant"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "agent.conversation.participant",
+          "result": "entity",
+          "verb": "add"
         }
       }
     },

--- a/lemma-typescript/public/lemma-client.js
+++ b/lemma-typescript/public/lemma-client.js
@@ -11499,6 +11499,54 @@ var LemmaClient = (() => {
       const podId = this.requirePodId(options.pod_id);
       return this.http.request("GET", `/pods/${podId}/conversations/${conversationId}`).then(normalizeConversation);
     }
+    /** Everyone in a conversation: the people, and the agents present. */
+    listParticipants(conversationId, options = {}) {
+      const podId = this.requirePodId(options.pod_id);
+      return this.http.request(
+        "GET",
+        `/pods/${podId}/conversations/${conversationId}/participants`
+      ).then((response) => {
+        var _a;
+        return (_a = response == null ? void 0 : response.items) != null ? _a : [];
+      });
+    }
+    /**
+     * Add one person, or one agent. Name exactly one of them.
+     *
+     * Adding a person is a grant: every answer in the conversation is from then
+     * on said to them. Their own working stays private to them, and so does
+     * everyone else's.
+     */
+    addParticipant(conversationId, subject, options = {}) {
+      const podId = this.requirePodId(options.pod_id);
+      return this.http.request(
+        "POST",
+        `/pods/${podId}/conversations/${conversationId}/participants`,
+        { body: subject }
+      );
+    }
+    /** Remove one person or one agent. The person who opened it cannot be removed. */
+    removeParticipant(conversationId, subject, options = {}) {
+      const podId = this.requirePodId(options.pod_id);
+      return this.http.request(
+        "DELETE",
+        `/pods/${podId}/conversations/${conversationId}/participants`,
+        { params: { user_id: subject.user_id, agent_id: subject.agent_id } }
+      );
+    }
+    /**
+     * The conversation this person is already having with an agent, opening one
+     * if there is none. Calling it twice returns the same conversation.
+     */
+    open(options = {}) {
+      var _a;
+      const podId = this.requirePodId(options.pod_id);
+      return this.http.request(
+        "POST",
+        `/pods/${podId}/conversations/open`,
+        { params: { agent_name: (_a = options.agent_name) != null ? _a : void 0 } }
+      ).then(normalizeConversation);
+    }
     async update(conversationId, payload, options = {}) {
       const podId = this.requirePodId(options.pod_id);
       const { harness_kind, model, model_name, profile_id, ...requestBody } = payload;

--- a/lemma-typescript/public/lemma-ui.js
+++ b/lemma-typescript/public/lemma-ui.js
@@ -199,6 +199,11 @@ var LemmaUI = (() => {
       conversation_id: typeof value.conversation_id === "string" ? value.conversation_id : void 0,
       sequence: typeof value.sequence === "number" ? value.sequence : void 0,
       agent_run_id: typeof value.agent_run_id === "string" ? value.agent_run_id : null,
+      // Who is speaking. Dropped here, a streamed message arrives anonymous and
+      // the transcript cannot attribute it until something refetches — which is
+      // how every live reply was labelled with the default agent's name.
+      sender_user_id: typeof value.sender_user_id === "string" ? value.sender_user_id : null,
+      agent_id: typeof value.agent_id === "string" ? value.agent_id : null,
       metadata: isRecord2(value.metadata) ? value.metadata : null
     };
     return message;

--- a/lemma-typescript/src/__tests__/message-identity-survives-transport.test.ts
+++ b/lemma-typescript/src/__tests__/message-identity-survives-transport.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Who said a message must survive every hop it takes.
+ *
+ * A message reaches the transcript by two different routes — the REST read and
+ * the realtime frame — and each is normalised by its own hand-written mapping
+ * that names every field it copies. Identity was added to the schema and left
+ * out of those mappings four separate times: the API response, the SDK's
+ * renderable type, the controller's mapping, and the stream normaliser. Every
+ * time, the symptom was the same: replies from a named agent showed the default
+ * agent's name, and only corrected themselves on a refetch.
+ *
+ * These pin both routes, so the next field added to the schema fails here
+ * rather than in a transcript.
+ */
+import { describe, expect, it } from "vitest";
+
+import { parseAssistantStreamEvent } from "../assistant-events.js";
+
+/** Every field that answers "who is this from". */
+const IDENTITY_FIELDS = ["sender_user_id", "agent_id", "agent_run_id"] as const;
+
+function frame(overrides: Record<string, unknown> = {}) {
+  return {
+    type: "message",
+    data: {
+      id: "msg_1",
+      role: "assistant",
+      kind: "TEXT",
+      text: "hello",
+      created_at: new Date().toISOString(),
+      conversation_id: "conv_1",
+      sequence: 3,
+      agent_run_id: "run_1",
+      sender_user_id: "user_1",
+      agent_id: "agent_1",
+      ...overrides,
+    },
+  };
+}
+
+describe("a streamed message keeps its identity", () => {
+  it("carries every identity field through the stream normaliser", () => {
+    const parsed = parseAssistantStreamEvent(frame());
+    const message = parsed?.message;
+
+    expect(message).toBeTruthy();
+    for (const field of IDENTITY_FIELDS) {
+      expect(
+        (message as Record<string, unknown>)[field],
+        `${field} was dropped in transit, so the transcript cannot attribute this message`,
+      ).toBeTruthy();
+    }
+  });
+
+  it("reports null rather than undefined when a field is genuinely absent", () => {
+    // An agent's own message has no sender; a person's has no agent. Both are
+    // real states, and neither should look like a field that went missing.
+    const parsed = parseAssistantStreamEvent(
+      frame({ sender_user_id: undefined, agent_id: undefined }),
+    );
+
+    expect(parsed?.message?.sender_user_id).toBeNull();
+    expect(parsed?.message?.agent_id).toBeNull();
+  });
+});

--- a/lemma-typescript/src/assistant-events.ts
+++ b/lemma-typescript/src/assistant-events.ts
@@ -77,6 +77,11 @@ function toConversationMessage(value: unknown): ConversationMessage | undefined 
     conversation_id: typeof value.conversation_id === "string" ? value.conversation_id : undefined,
     sequence: typeof value.sequence === "number" ? value.sequence : undefined,
     agent_run_id: typeof value.agent_run_id === "string" ? value.agent_run_id : null,
+    // Who is speaking. Dropped here, a streamed message arrives anonymous and
+    // the transcript cannot attribute it until something refetches — which is
+    // how every live reply was labelled with the default agent's name.
+    sender_user_id: typeof value.sender_user_id === "string" ? value.sender_user_id : null,
+    agent_id: typeof value.agent_id === "string" ? value.agent_id : null,
     metadata: isRecord(value.metadata) ? value.metadata : null,
   };
 

--- a/lemma-typescript/src/core/agent/display.ts
+++ b/lemma-typescript/src/core/agent/display.ts
@@ -188,6 +188,20 @@ function messageAgentRunId(message: AssistantRenderableMessage): string | null {
   return typeof agentRunId === "string" && agentRunId.trim() ? agentRunId : null;
 }
 
+/** Who wrote a message, reading either casing the transports use. */
+export function messageSenderUserId(message: AssistantRenderableMessage): string | null {
+  const record = messageRecord(message);
+  const sender = record.sender_user_id ?? record.senderUserId;
+  return typeof sender === "string" && sender.trim() ? sender : null;
+}
+
+/** Which agent produced a message, reading either casing the transports use. */
+export function messageAgentId(message: AssistantRenderableMessage): string | null {
+  const record = messageRecord(message);
+  const agentId = record.agent_id ?? record.agentId;
+  return typeof agentId === "string" && agentId.trim() ? agentId : null;
+}
+
 function messageFlag(message: AssistantRenderableMessage, snakeKey: string, camelKey: string): boolean {
   const content = contentRecord(message);
   const metadata = metadataRecord(message);

--- a/lemma-typescript/src/core/agent/renderable.ts
+++ b/lemma-typescript/src/core/agent/renderable.ts
@@ -52,6 +52,19 @@ export interface AssistantRenderableMessage {
   optimistic_id?: string;
   sequence?: number;
   agent_run_id?: string | null;
+  /**
+   * Which person wrote it. Null on everything an agent produced, and on user
+   * messages that predate the column. `role` says a human spoke; this says
+   * which one, which is what a conversation with several people in it needs to
+   * put a name on a turn.
+   */
+  sender_user_id?: string | null;
+  /**
+   * Which agent produced it. Null on anything a person wrote. A conversation
+   * can be answered by more than one agent, so an answer that does not say
+   * which one is an answer nobody can attribute.
+   */
+  agent_id?: string | null;
   metadata?: Record<string, unknown> | null;
   message_metadata?: Record<string, unknown> | null;
   /** Flat message fields, passed through so consumers can inspect the raw kind. */

--- a/lemma-typescript/src/index.ts
+++ b/lemma-typescript/src/index.ts
@@ -97,6 +97,8 @@ export {
   contentRecord,
   metadataRecord,
   messageAgentRunId,
+  messageSenderUserId,
+  messageAgentId,
   messageFlag,
   isFinalAnswerMessage,
   isIntermediateAssistantMessage,

--- a/lemma-typescript/src/namespaces/conversations.ts
+++ b/lemma-typescript/src/namespaces/conversations.ts
@@ -5,6 +5,7 @@ import type { AgentRuntimeProfileListResponse } from "../openapi_client/models/A
 import type { AgentRuntimeProfileResponse } from "../openapi_client/models/AgentRuntimeProfileResponse.js";
 import type { AgentRunStartResponse } from "../openapi_client/models/AgentRunStartResponse.js";
 import type { ConversationListResponse } from "../openapi_client/models/ConversationListResponse.js";
+import type { ConversationParticipantResponse as ConversationParticipant } from "../openapi_client/models/ConversationParticipantResponse.js";
 import type { ConversationType } from "../openapi_client/models/ConversationType.js";
 import type { CreateConversationRequest } from "../openapi_client/models/CreateConversationRequest.js";
 import type { HarnessKind } from "../openapi_client/models/HarnessKind.js";
@@ -266,6 +267,67 @@ export class ConversationsNamespace {
     const podId = this.requirePodId(options.pod_id);
     return this.http.request<Conversation>("GET", `/pods/${podId}/conversations/${conversationId}`)
       .then(normalizeConversation);
+  }
+
+  /** Everyone in a conversation: the people, and the agents present. */
+  listParticipants(
+    conversationId: string,
+    options: { pod_id?: string | null } = {},
+  ): Promise<ConversationParticipant[]> {
+    const podId = this.requirePodId(options.pod_id);
+    return this.http.request<{ items?: ConversationParticipant[] }>(
+      "GET",
+      `/pods/${podId}/conversations/${conversationId}/participants`,
+    ).then((response) => response?.items ?? []);
+  }
+
+  /**
+   * Add one person, or one agent. Name exactly one of them.
+   *
+   * Adding a person is a grant: every answer in the conversation is from then
+   * on said to them. Their own working stays private to them, and so does
+   * everyone else's.
+   */
+  addParticipant(
+    conversationId: string,
+    subject: { user_id?: string | null; agent_name?: string | null },
+    options: { pod_id?: string | null } = {},
+  ): Promise<ConversationParticipant> {
+    const podId = this.requirePodId(options.pod_id);
+    return this.http.request<ConversationParticipant>(
+      "POST",
+      `/pods/${podId}/conversations/${conversationId}/participants`,
+      { body: subject },
+    );
+  }
+
+  /** Remove one person or one agent. The person who opened it cannot be removed. */
+  removeParticipant(
+    conversationId: string,
+    subject: { user_id?: string | null; agent_id?: string | null },
+    options: { pod_id?: string | null } = {},
+  ): Promise<void> {
+    const podId = this.requirePodId(options.pod_id);
+    return this.http.request<void>(
+      "DELETE",
+      `/pods/${podId}/conversations/${conversationId}/participants`,
+      { params: { user_id: subject.user_id, agent_id: subject.agent_id } },
+    );
+  }
+
+  /**
+   * The conversation this person is already having with an agent, opening one
+   * if there is none. Calling it twice returns the same conversation.
+   */
+  open(
+    options: { pod_id?: string | null; agent_name?: string | null } = {},
+  ): Promise<Conversation> {
+    const podId = this.requirePodId(options.pod_id);
+    return this.http.request<Conversation>(
+      "POST",
+      `/pods/${podId}/conversations/open`,
+      { params: { agent_name: options.agent_name ?? undefined } },
+    ).then(normalizeConversation);
   }
 
   async update(

--- a/lemma-typescript/src/openapi_client/index.ts
+++ b/lemma-typescript/src/openapi_client/index.ts
@@ -11,6 +11,7 @@ export type { AccountCreateSchema } from './models/AccountCreateSchema.js';
 export type { AccountListResponseSchema } from './models/AccountListResponseSchema.js';
 export type { AccountResponseSchema } from './models/AccountResponseSchema.js';
 export type { AddColumnRequest } from './models/AddColumnRequest.js';
+export type { AddConversationParticipantRequest } from './models/AddConversationParticipantRequest.js';
 export type { AgentActionResponse } from './models/AgentActionResponse.js';
 export type { AgentDetailResponse } from './models/AgentDetailResponse.js';
 export type { AgentHostCapacity } from './models/AgentHostCapacity.js';
@@ -100,6 +101,8 @@ export type { ConnectorStatusResponse } from './models/ConnectorStatusResponse.j
 export type { ConnectRequestInitiateSchema } from './models/ConnectRequestInitiateSchema.js';
 export type { ConnectRequestResponseSchema } from './models/ConnectRequestResponseSchema.js';
 export type { ConversationListResponse } from './models/ConversationListResponse.js';
+export type { ConversationParticipantListResponse } from './models/ConversationParticipantListResponse.js';
+export type { ConversationParticipantResponse } from './models/ConversationParticipantResponse.js';
 export type { ConversationResponse } from './models/ConversationResponse.js';
 export { ConversationStatus } from './models/ConversationStatus.js';
 export { ConversationType } from './models/ConversationType.js';

--- a/lemma-typescript/src/openapi_client/models/AddConversationParticipantRequest.ts
+++ b/lemma-typescript/src/openapi_client/models/AddConversationParticipantRequest.ts
@@ -2,9 +2,10 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type SendMessageRequest = {
+/**
+ * Add one person or one agent. Naming both, or neither, is rejected.
+ */
+export type AddConversationParticipantRequest = {
     agent_name?: (string | null);
-    branch_from_run_id?: (string | null);
-    content: string;
-    metadata?: (Record<string, any> | null);
+    user_id?: (string | null);
 };

--- a/lemma-typescript/src/openapi_client/models/ConversationParticipantListResponse.ts
+++ b/lemma-typescript/src/openapi_client/models/ConversationParticipantListResponse.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do not edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ConversationParticipantResponse } from './ConversationParticipantResponse.js';
+export type ConversationParticipantListResponse = {
+    items: Array<ConversationParticipantResponse>;
+};

--- a/lemma-typescript/src/openapi_client/models/ConversationParticipantResponse.ts
+++ b/lemma-typescript/src/openapi_client/models/ConversationParticipantResponse.ts
@@ -2,9 +2,11 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type AgentRunStartResponse = {
+export type ConversationParticipantResponse = {
     agent_id?: (string | null);
-    agent_run_id?: (string | null);
     conversation_id: string;
-    started_new_run: boolean;
+    display_name?: (string | null);
+    id: string;
+    role: string;
+    user_id?: (string | null);
 };

--- a/lemma-typescript/src/openapi_client/models/ConversationResponse.ts
+++ b/lemma-typescript/src/openapi_client/models/ConversationResponse.ts
@@ -4,6 +4,7 @@
 /* eslint-disable */
 import type { AgentRunStatus } from './AgentRunStatus.js';
 import type { AgentRuntimeConfig } from './AgentRuntimeConfig.js';
+import type { ConversationParticipantResponse } from './ConversationParticipantResponse.js';
 import type { ConversationStatus } from './ConversationStatus.js';
 import type { ConversationType } from './ConversationType.js';
 export type ConversationResponse = {
@@ -21,6 +22,7 @@ export type ConversationResponse = {
     organization_id?: (string | null);
     output?: null;
     parent_id?: (string | null);
+    participants?: Array<ConversationParticipantResponse>;
     /**
      * The conversation's working directory in pod files. Anything a person attaches here is what the agent finds by a bare filename, because this is the directory its pod tools resolve against.
      */

--- a/lemma-typescript/src/openapi_client/models/MessageResponse.ts
+++ b/lemma-typescript/src/openapi_client/models/MessageResponse.ts
@@ -4,12 +4,14 @@
 /* eslint-disable */
 import type { MessageKind } from './MessageKind.js';
 export type MessageResponse = {
+    agent_id?: (string | null);
     conversation_id: string;
     created_at: string;
     id: string;
     kind: MessageKind;
     metadata?: (Record<string, any> | null);
     role: string;
+    sender_user_id?: (string | null);
     sequence: number;
     text?: (string | null);
     tool_args?: null;

--- a/lemma-typescript/src/openapi_client/services/AgentConversationsService.ts
+++ b/lemma-typescript/src/openapi_client/services/AgentConversationsService.ts
@@ -2,9 +2,12 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type { AddConversationParticipantRequest } from '../models/AddConversationParticipantRequest.js';
 import type { AgentRunStartResponse } from '../models/AgentRunStartResponse.js';
 import type { ApprovalDecisionResponse } from '../models/ApprovalDecisionResponse.js';
 import type { ConversationListResponse } from '../models/ConversationListResponse.js';
+import type { ConversationParticipantListResponse } from '../models/ConversationParticipantListResponse.js';
+import type { ConversationParticipantResponse } from '../models/ConversationParticipantResponse.js';
 import type { ConversationResponse } from '../models/ConversationResponse.js';
 import type { ConversationStatus } from '../models/ConversationStatus.js';
 import type { ConversationType } from '../models/ConversationType.js';
@@ -82,6 +85,32 @@ export class AgentConversationsService {
             },
             body: requestBody,
             mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Open Pod Agent Conversation
+     * Return the caller's ongoing conversation with an agent, opening one if there is none yet. Omit agent_name for the default pod assistant. Unlike create, calling this twice returns the same conversation: it is where a person lands when they open the agent rather than a new session each time. Archived, task, project and surface-bound conversations are never returned.
+     * @param podId
+     * @param agentName
+     * @returns ConversationResponse Successful Response
+     * @throws ApiError
+     */
+    public static agentConversationOpen(
+        podId: string,
+        agentName?: (string | null),
+    ): CancelablePromise<ConversationResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/pods/{pod_id}/conversations/open',
+            path: {
+                'pod_id': podId,
+            },
+            query: {
+                'agent_name': agentName === null ? 'POD_DEFAULT' : agentName,
+            },
             errors: {
                 422: `Validation Error`,
             },
@@ -287,6 +316,90 @@ export class AgentConversationsService {
                 404: `Conversation was not found or is not visible`,
                 422: `Validation Error`,
                 429: `The account usage limit was exceeded`,
+            },
+        });
+    }
+    /**
+     * Remove Conversation Participant
+     * Remove one person, or one agent. Name exactly one of user_id or agent_id. The person who opened the conversation cannot be removed from it.
+     * @param podId
+     * @param conversationId
+     * @param userId
+     * @param agentId
+     * @returns void
+     * @throws ApiError
+     */
+    public static agentConversationParticipantRemove(
+        podId: string,
+        conversationId: string,
+        userId?: (string | null),
+        agentId?: (string | null),
+    ): CancelablePromise<void> {
+        return __request(OpenAPI, {
+            method: 'DELETE',
+            url: '/pods/{pod_id}/conversations/{conversation_id}/participants',
+            path: {
+                'pod_id': podId,
+                'conversation_id': conversationId,
+            },
+            query: {
+                'user_id': userId,
+                'agent_id': agentId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * List Conversation Participants
+     * Who is in a conversation: the people, and the agents present.
+     * @param podId
+     * @param conversationId
+     * @returns ConversationParticipantListResponse Successful Response
+     * @throws ApiError
+     */
+    public static agentConversationParticipantList(
+        podId: string,
+        conversationId: string,
+    ): CancelablePromise<ConversationParticipantListResponse> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/pods/{pod_id}/conversations/{conversation_id}/participants',
+            path: {
+                'pod_id': podId,
+                'conversation_id': conversationId,
+            },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Add Conversation Participant
+     * Add one person, or one agent, to a conversation. Name exactly one of user_id or agent_name. Adding a person is a grant: every answer in the conversation is from then on said to them. Their own working stays private to them, and so does everyone else's.
+     * @param podId
+     * @param conversationId
+     * @param requestBody
+     * @returns ConversationParticipantResponse Successful Response
+     * @throws ApiError
+     */
+    public static agentConversationParticipantAdd(
+        podId: string,
+        conversationId: string,
+        requestBody: AddConversationParticipantRequest,
+    ): CancelablePromise<ConversationParticipantResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/pods/{pod_id}/conversations/{conversation_id}/participants',
+            path: {
+                'pod_id': podId,
+                'conversation_id': conversationId,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+            errors: {
+                422: `Validation Error`,
             },
         });
     }

--- a/lemma-typescript/src/openapi_spec.json
+++ b/lemma-typescript/src/openapi_spec.json
@@ -276,6 +276,36 @@
         "title": "AddColumnRequest",
         "type": "object"
       },
+      "AddConversationParticipantRequest": {
+        "description": "Add one person or one agent. Naming both, or neither, is rejected.",
+        "properties": {
+          "agent_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "title": "AddConversationParticipantRequest",
+        "type": "object"
+      },
       "AgentActionResponse": {
         "properties": {
           "agent_runtime": {
@@ -1741,10 +1771,29 @@
       },
       "AgentRunStartResponse": {
         "properties": {
+          "agent_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id"
+          },
           "agent_run_id": {
-            "format": "uuid",
-            "title": "Agent Run Id",
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Run Id"
           },
           "conversation_id": {
             "format": "uuid",
@@ -1758,7 +1807,6 @@
         },
         "required": [
           "conversation_id",
-          "agent_run_id",
           "started_new_run"
         ],
         "title": "AgentRunStartResponse",
@@ -4047,6 +4095,82 @@
         "title": "ConversationListResponse",
         "type": "object"
       },
+      "ConversationParticipantListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/ConversationParticipantResponse"
+            },
+            "title": "Items",
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "title": "ConversationParticipantListResponse",
+        "type": "object"
+      },
+      "ConversationParticipantResponse": {
+        "properties": {
+          "agent_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id"
+          },
+          "conversation_id": {
+            "format": "uuid",
+            "title": "Conversation Id",
+            "type": "string"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": [
+          "id",
+          "conversation_id",
+          "role"
+        ],
+        "title": "ConversationParticipantResponse",
+        "type": "object"
+      },
       "ConversationResponse": {
         "properties": {
           "agent_id": {
@@ -4179,6 +4303,13 @@
               }
             ],
             "title": "Parent Id"
+          },
+          "participants": {
+            "items": {
+              "$ref": "#/components/schemas/ConversationParticipantResponse"
+            },
+            "title": "Participants",
+            "type": "array"
           },
           "pod_cwd": {
             "description": "The conversation's working directory in pod files. Anything a person attaches here is what the agent finds by a bare filename, because this is the directory its pod tools resolve against.",
@@ -8635,6 +8766,18 @@
       },
       "MessageResponse": {
         "properties": {
+          "agent_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id"
+          },
           "agent_run_id": {
             "anyOf": [
               {
@@ -8680,6 +8823,18 @@
           "role": {
             "title": "Role",
             "type": "string"
+          },
+          "sender_user_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sender User Id"
           },
           "sequence": {
             "title": "Sequence",
@@ -12683,6 +12838,29 @@
       },
       "SendMessageRequest": {
         "properties": {
+          "agent_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
+          },
+          "branch_from_run_id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Branch From Run Id"
+          },
           "content": {
             "title": "Content",
             "type": "string"
@@ -23814,6 +23992,76 @@
         }
       }
     },
+    "/pods/{pod_id}/conversations/open": {
+      "post": {
+        "description": "Return the caller's ongoing conversation with an agent, opening one if there is none yet. Omit agent_name for the default pod assistant. Unlike create, calling this twice returns the same conversation: it is where a person lands when they open the agent rather than a new session each time. Archived, task, project and surface-bound conversations are never returned.",
+        "operationId": "agent.conversation.open",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pod_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Pod Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "agent_name",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Open Pod Agent Conversation",
+        "tags": [
+          "agent_conversations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "agent.conversation"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "agent.conversation",
+          "result": "entity",
+          "verb": "open"
+        }
+      }
+    },
     "/pods/{pod_id}/conversations/{conversation_id}": {
       "get": {
         "description": "Get a single pod-scoped assistant or agent conversation by id.",
@@ -24370,6 +24618,228 @@
           "resource": "agent.conversation.message",
           "result": "entity",
           "verb": "append"
+        }
+      }
+    },
+    "/pods/{pod_id}/conversations/{conversation_id}/participants": {
+      "delete": {
+        "description": "Remove one person, or one agent. Name exactly one of user_id or agent_id. The person who opened the conversation cannot be removed from it.",
+        "operationId": "agent.conversation.participant.remove",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pod_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Pod Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Conversation Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "user_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "User Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "agent_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "uuid",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Agent Id"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Remove Conversation Participant",
+        "tags": [
+          "agent_conversations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "agent.conversation.participant"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "agent.conversation.participant",
+          "result": "void",
+          "verb": "remove"
+        }
+      },
+      "get": {
+        "description": "Who is in a conversation: the people, and the agents present.",
+        "operationId": "agent.conversation.participant.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pod_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Pod Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Conversation Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationParticipantListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Conversation Participants",
+        "tags": [
+          "agent_conversations"
+        ],
+        "x-lemma": {
+          "kind": "query",
+          "paginates": false,
+          "resource": "agent.conversation.participant",
+          "result": "collection",
+          "verb": "list"
+        }
+      },
+      "post": {
+        "description": "Add one person, or one agent, to a conversation. Name exactly one of user_id or agent_name. Adding a person is a grant: every answer in the conversation is from then on said to them. Their own working stays private to them, and so does everyone else's.",
+        "operationId": "agent.conversation.participant.add",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "pod_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Pod Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "conversation_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Conversation Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddConversationParticipantRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationParticipantResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Add Conversation Participant",
+        "tags": [
+          "agent_conversations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "agent.conversation.participant"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "agent.conversation.participant",
+          "result": "entity",
+          "verb": "add"
         }
       }
     },

--- a/lemma-typescript/src/react/useAssistantController.ts
+++ b/lemma-typescript/src/react/useAssistantController.ts
@@ -84,6 +84,10 @@ export interface SendAssistantControllerMessageOptions {
   metadata?: Record<string, unknown> | null;
   conversationMetadata?: Record<string, unknown> | null;
   instructions?: string | null;
+  /**
+   * Address one agent for this turn. It must already be in the conversation.
+   */
+  agentName?: string | null;
 }
 
 export type AssistantUserApprovalDecision = "APPROVE_ONCE" | "APPROVE_FOR_SESSION" | "DENY";
@@ -550,6 +554,8 @@ function mapConversationMessage(
     optimistic_id: msg.optimistic_id,
     sequence: msg.sequence,
     agent_run_id: msg.agent_run_id,
+    sender_user_id: msg.sender_user_id ?? null,
+    agent_id: msg.agent_id ?? null,
     metadata: msg.metadata ?? null,
     message_metadata: (msg.message_metadata as Record<string, unknown> | undefined) ?? null,
     kind: msg.kind,
@@ -1876,6 +1882,7 @@ export function useAssistantController({
               })),
             }
           : options.metadata ?? undefined,
+        agentName: options.agentName,
       });
       touchConversation(finalConversationId, { updated_at: new Date().toISOString() });
     } catch (err) {

--- a/lemma-typescript/src/react/useAssistantSession.ts
+++ b/lemma-typescript/src/react/useAssistantSession.ts
@@ -88,6 +88,16 @@ export interface SendAssistantMessageOptions {
    * created — the session's own copy is a render behind at that point.
    */
   knownConversation?: Conversation | null;
+  /**
+   * Address one agent for this turn, as an `@mention` does. It must already be
+   * in the conversation; the server refuses a name that is not.
+   */
+  agentName?: string | null;
+  /**
+   * Branch a subthread from an earlier run. The new run sees that run and
+   * everything leading to it, and no sibling branch sees this one.
+   */
+  branchFromRunId?: string | null;
 }
 
 export interface ResumeAssistantOptions {
@@ -1076,7 +1086,12 @@ export function useAssistantSession(options: UseAssistantSessionOptions): UseAss
 
       const stream = await scopedClient.conversations.sendMessageStream(
         resolvedConversationId,
-        { content, metadata: input.metadata ?? undefined },
+        {
+          content,
+          metadata: input.metadata ?? undefined,
+          agent_name: input.agentName ?? undefined,
+          branch_from_run_id: input.branchFromRunId ?? undefined,
+        },
         {
           pod_id: scope.podId ?? undefined,
           signal: controller.signal,

--- a/lemma-typescript/src/types.ts
+++ b/lemma-typescript/src/types.ts
@@ -5,6 +5,7 @@ import type {
   AgentRuntimeProfileListResponse,
   AgentRuntimeProfileResponse,
   ColumnSchema,
+  ConversationParticipantResponse,
   ConversationResponse as GeneratedConversationResponse,
   CreateAgentRequest,
   DatastoreQueryResponse,
@@ -143,10 +144,15 @@ export interface ConversationMessageResponse {
   conversation_id?: string;
   sequence?: number;
   agent_run_id?: string | null;
+  /** Which person wrote it, when a person did. Null for anything an agent produced. */
+  sender_user_id?: string | null;
+  /** Which agent produced it. Null on anything a person wrote. */
+  agent_id?: string | null;
   metadata?: Record<string, unknown> | null;
 }
 
 export type ConversationMessage = ConversationMessageResponse;
+export type ConversationParticipant = ConversationParticipantResponse;
 
 export type FunctionRun = FunctionRunResponse;
 export type FunctionRunSummary = FunctionRunSummaryResponse;


### PR DESCRIPTION
**WIP — not for review yet.** Working end to end locally; the open questions below want deciding before this is finishable.

Makes a conversation something more than one person and more than one agent can be in, and makes the transcript able to say who said what. Design and reasoning: [`docs/design/agent-conversations.md`](docs/design/agent-conversations.md).

## What changes

- **Membership.** `agent_conversation_participants` holds people and agents; access is "opened it, or was added". Migration 0025 backfills an OWNER row for every existing conversation. Listing returns conversations you were added to, not only ones you opened.
- **Attribution.** Messages record which person wrote them and which agent produced them; runs record whose message started them.
- **Visibility.** The final answer belongs to the conversation; tool calls, results and reasoning belong to whoever triggered the run. Enforced in the transcript query *and* in prompt construction — another person's run reaches the model as its question and its answer.
- **Acting identity.** A run acts as its sender, read off the run rather than the job payload. Tools, usage and telemetry all follow it. Background runs get an actor recorded at setup time.
- **Addressing.** `@name` routes a turn to an agent present in the conversation. The run records which agent answers and the runner reads it back.
- **Routing.** A message nobody addressed goes to a small model that names an agent or nobody. Nobody means no run at all.
- **Persistent conversation.** `POST /conversations/open` resolves the conversation you are already having with an agent.
- **Transcript.** Names, avatars, a typing indicator, a participants panel, `@agent` in the composer, Ongoing/Earlier grouping.

## One pattern worth naming

Three bugs had one shape: **assumptions that hold only while a conversation has exactly one agent.** The runner resolved the agent from the conversation; the context brief chose its shape from the conversation; history replayed every assistant message as one voice. Each was correct before, and each produced an agent that did not know who it was.

A fourth had a different shape and recurred four times: identity added to the schema and forgotten in a hand-written field-by-field mapping. Symptom each time — a named agent's reply showing the default agent's name. `message-identity-survives-transport.test.ts` pins the two transport hops; it will not catch a *new* field forgotten the same way.

## Open questions

- **Several agents cannot answer at once.** `uq_agent_active_run_per_conversation` allows one active run per conversation. The router names an array; only the first answers. Lifting that index is a real concurrency decision, not a tweak.
- **Visibility is a default, not access control.** A derived answer ("summarise the salary table") still reaches the room. The stated policy is that a conversation is a room; worth confirming.
- **Resolution has no unique index.** Every account already has many conversations per key, so one cannot be added without merging or discarding history. Newest live wins; a race leaves a spare.
- **Subthread branching has no UI.** `branch_from_run_id` and the lineage filter work; nothing in the transcript offers "branch from here".
- The branch also carries **uncommitted work that predates this session** in the same feature area.

## Verification

`make quality` and `npm run check` pass. 1501 backend unit tests, 165/166 agent e2e, 261 SDK tests, 154 frontend tests.

One pre-existing e2e failure, **not from this branch**: `test_compaction_bounds_a_history_built_from_real_tool_output` asserts `204518 <= 40000`. It fails identically with this work stashed — a compaction ceiling regression worth its own issue.

Not verified: I could not sign in, so the visual result is unchecked beyond types, lint and the design audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
