### PR TITLE
Set every component to 0.7.2 for release

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2580,7 +2580,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lemma-agent-host"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2613,7 +2613,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-desktop"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "base64 0.22.1",
  "interprocess",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-guestd"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "libc",
  "serde",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-locald"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "base64 0.22.1",
  "getrandom 0.3.4",
@@ -2672,7 +2672,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-runtime"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -2680,7 +2680,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-runtime-manager"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "getrandom 0.3.4",
  "libc",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -43,7 +43,7 @@ default-members = ["."]
 [workspace.package]
 # One version for six crates. Release used to rewrite desktop/Cargo.toml alone,
 # so the moment the other five moved in here they would have drifted silently.
-version = "0.7.1"
+version = "0.7.2"
 
 [workspace.dependencies]
 # Hoisted because feature unification makes the *emergent* feature set of a

--- a/desktop/runtime/lemma-local.json
+++ b/desktop/runtime/lemma-local.json
@@ -11,7 +11,7 @@
       "format": "zip",
       "platform": "macos",
       "architecture": "aarch64",
-      "runtime_version": "0.7.1"
+      "runtime_version": "0.7.2"
     },
     "x86_64-pc-windows-msvc": {
       "url": "https://downloads.example.invalid/lemma-host-pack.zip",
@@ -21,7 +21,7 @@
       "format": "zip",
       "platform": "windows",
       "architecture": "x86_64",
-      "runtime_version": "0.7.1"
+      "runtime_version": "0.7.2"
     }
   },
   "guest_runtimes": {
@@ -33,7 +33,7 @@
       "format": "zip",
       "platform": "linux",
       "architecture": "aarch64",
-      "runtime_version": "0.7.1"
+      "runtime_version": "0.7.2"
     },
     "windows-x86_64": {
       "url": "https://downloads.example.invalid/lemma-guest-runtime.zip",
@@ -43,7 +43,7 @@
       "format": "zip",
       "platform": "linux",
       "architecture": "x86_64",
-      "runtime_version": "0.7.1"
+      "runtime_version": "0.7.2"
     }
   }
 }

--- a/desktop/runtime/lemma-local.json
+++ b/desktop/runtime/lemma-local.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "0.7.1",
+  "version": "0.7.2",
   "artifact_source": "ci-build-check",
   "host_packs": {
     "aarch64-apple-darwin": {

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Lemma",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "identifier": "work.lemma.desktop",
   "build": {
     "frontendDist": "ui"

--- a/lemma-backend/app/version.py
+++ b/lemma-backend/app/version.py
@@ -29,4 +29,4 @@ Use a normal MAJOR.MINOR.PATCH string.
 
 from __future__ import annotations
 
-API_VERSION = "0.7.1"
+API_VERSION = "0.7.2"

--- a/lemma-backend/sandbox-images/templates/function-python/uv.lock
+++ b/lemma-backend/sandbox-images/templates/function-python/uv.lock
@@ -168,7 +168,7 @@ requires-dist = [
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.1"
+version = "0.7.2"
 source = { directory = "../../../../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/lemma-backend/sandbox-images/templates/workspace-python/uv.lock
+++ b/lemma-backend/sandbox-images/templates/workspace-python/uv.lock
@@ -645,7 +645,7 @@ source = { directory = "../../../../lemma-pod-bundle" }
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.1"
+version = "0.7.2"
 source = { directory = "../../../../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/lemma-backend/uv.lock
+++ b/lemma-backend/uv.lock
@@ -2036,7 +2036,7 @@ source = { editable = "../lemma-pod-bundle" }
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/lemma-cli/lemma_cli/__init__.py
+++ b/lemma-cli/lemma_cli/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 __all__ = ["__version__"]
 
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 if sys.platform == "win32":
     for _stream in (sys.stdout, sys.stderr):

--- a/lemma-cli/pyproject.toml
+++ b/lemma-cli/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
   # >= the version that has the endpoints the current commands use, so a fresh
   # `uv tool install` upgrades an already-installed older lemma-sdk. The release
   # workflow rewrites this to the release version on every tagged build.
-  "lemma-sdk>=0.7.1",
+  "lemma-sdk>=0.7.2",
   "click>=8.3.0",
   "typer>=0.12.5",
   "rich>=13.9.4",

--- a/lemma-cli/uv.lock
+++ b/lemma-cli/uv.lock
@@ -319,7 +319,7 @@ source = { directory = "../lemma-pod-bundle" }
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.1"
+version = "0.7.2"
 source = { directory = "../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/lemma-frontend/content/changelog/0-7-2.mdx
+++ b/lemma-frontend/content/changelog/0-7-2.mdx
@@ -1,0 +1,94 @@
+---
+title: 0.7.2
+description: Desktop updates itself, agent runs last hours instead of fifty minutes, and a conversation stops being something you wait on.
+published: 2026-09-01
+tags:
+  - release
+---
+
+## Desktop can update itself
+
+0.7.1 shipped an auto-updater and a signing key. What it did not have was a
+feed a pre-release build could follow, or a version it could compare — every
+nightly called itself the same number, so the updater asked whether 0.7.1 was
+newer than 0.7.1 and was always told no. The update path only ever ran on
+release day, which is the worst day to discover it.
+
+Nightlies now follow a feed of their own at an address that does not move, and
+carry an ordered version, so the update they offer is the one after the one you
+have. That means the path a real release takes is exercised every night rather
+than once a version.
+
+Two things behind it were worth fixing on their own. The version a build stamps
+lives in three places, and stamping only two of them produced an install that
+met its own runtime and refused it — so the build now fails if those numbers
+disagree, naming both, instead of signing and publishing something that cannot
+start. And every installed runtime used to be kept forever: 1.7 GiB per version,
+in Application Support, discovered from a full disk. An install now keeps the
+release it is running and the one before it, which is enough to step back
+without downloading it all again.
+
+## An agent run can take as long as the work does
+
+A local agent working steadily on a real task was stopped at minute fifty:
+`Agent Host run deadline elapsed`. The number came from the credential the run
+was dispatched with, which expired in an hour and which nothing renewed. Something
+renews it now, and has for a while — but the ceiling stayed behind, and every run
+since had been cut short for a reason that no longer applied.
+
+Runs may now last four hours. A host that crashes, sleeps or loses its network
+is still failed within about two minutes, because that was never the deadline's
+job: the run lease notices, and it is ninety seconds long.
+
+An Agent Host that outlived the app that started it used to hold its workspace
+lock forever, so every later launch found local agents unreachable and said only
+"Fetch is aborted". A leftover is now reclaimed before the next one starts.
+
+## Conversations you can keep talking to
+
+A running conversation accepts a follow-up message instead of making you wait
+for the turn to end. A stopped run is one you can carry on from. An interrupted
+run resumes from the queue rather than waiting for a sweep, and one busy
+conversation no longer freezes the rest of the pod.
+
+Around that: sub-agents appear as chips with tabs that name themselves,
+approvals show the one that is actually pending and look approved the moment you
+approve them, and a message typed past a card is treated as a message rather
+than as that card's answer.
+
+## Documents, files and apps
+
+A `.docx` renders as the document it is instead of a parser error. A shared file
+renders the way the workspace renders it, rather than redirecting past it. An
+image somebody sends is one the agent can open. A published app can be added to
+a home screen, and an app an agent has just built opens instead of reporting
+itself unavailable.
+
+A link inside an app that points at one of your pod files used to end on a raw
+JSON error in a window with no way back. It now lands on a page that says what
+happened and offers to open the file in your workspace.
+
+## Pods, exports and surfaces
+
+Pods can be renamed, and conversations can be named, archived and pinned.
+
+Pod export stopped leaving files behind. It had been reading a preview of the
+file tree — capped at three entries per directory — and treating it as the
+pod's contents, so a migration of 266 files exported 104 of them and reported
+success. Skills were dropped from every bundle. Both are fixed, the caps that
+remain say what they skipped, and a bundle this version writes can be imported
+by it.
+
+Surfaces now share one delivery seam, so email stops being the exception, and
+each agent can have its own Slack bot instead of the second one being
+unreachable.
+
+## Faster, and quieter about it
+
+Cold start is about seven seconds shorter: the window sizes itself correctly,
+the Continue screen stops being in the way, and the backend spends less time
+importing things it does not need yet.
+
+Failures that nobody was watching now reach Slack, a backend whose worker has
+died reports itself unready instead of healthy, and the scenario suite stopped
+reporting its own noise as failures.

--- a/lemma-frontend/public/openapi.json
+++ b/lemma-frontend/public/openapi.json
@@ -17631,7 +17631,7 @@
   "info": {
     "description": "Authentication API with JWT, user management, and OAuth support",
     "title": "Lemma Backend",
-    "version": "0.7.1"
+    "version": "0.7.2"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -13,4 +13,4 @@ SDK and the server it is talking to.
 from __future__ import annotations
 
 API_VERSION = "0.7.2"
-SPEC_SHA256 = "e8d9602aba5ff8debbdbb78259c61352334e444bb74ee96cb44754fbd59b10ed"
+SPEC_SHA256 = "ebfd2d581a992aac3986f399bfdd076777560feb3a81778d91bb52030911b895"

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -12,5 +12,5 @@ SDK and the server it is talking to.
 
 from __future__ import annotations
 
-API_VERSION = "0.7.1"
+API_VERSION = "0.7.2"
 SPEC_SHA256 = "e8d9602aba5ff8debbdbb78259c61352334e444bb74ee96cb44754fbd59b10ed"

--- a/lemma-python/lemma_sdk/openapi_spec.json
+++ b/lemma-python/lemma_sdk/openapi_spec.json
@@ -17631,7 +17631,7 @@
   "info": {
     "description": "Authentication API with JWT, user management, and OAuth support",
     "title": "Lemma Backend",
-    "version": "0.7.1"
+    "version": "0.7.2"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/lemma-python/pyproject.toml
+++ b/lemma-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-sdk"
-version = "0.7.1"
+version = "0.7.2"
 description = "Python SDK for Lemma"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/lemma-python/uv.lock
+++ b/lemma-python/uv.lock
@@ -130,7 +130,7 @@ wheels = [
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },

--- a/lemma-typescript/package-lock.json
+++ b/lemma-typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemma-sdk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lemma-sdk",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "Apache-2.0",
       "dependencies": {
         "supertokens-web-js": "^0.16.0"

--- a/lemma-typescript/package.json
+++ b/lemma-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemma-sdk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "engines": {
     "node": ">=24 <25"
   },

--- a/lemma-typescript/public/lemma-client.js
+++ b/lemma-typescript/public/lemma-client.js
@@ -9877,7 +9877,7 @@ var LemmaClient = (() => {
   }
 
   // src/version.ts
-  var SDK_VERSION = "0.7.1";
+  var SDK_VERSION = "0.7.2";
   var CLIENT_HEADER_NAME = "X-Lemma-Client";
   var APP_HEADER_NAME = "X-Lemma-App";
   var KNOWN_CLIENTS = [
@@ -10304,7 +10304,7 @@ var LemmaClient = (() => {
   // src/openapi_client/core/OpenAPI.ts
   var OpenAPI = {
     BASE: "",
-    VERSION: "0.7.1",
+    VERSION: "0.7.2",
     WITH_CREDENTIALS: false,
     CREDENTIALS: "include",
     TOKEN: void 0,

--- a/lemma-typescript/src/openapi_client/core/OpenAPI.ts
+++ b/lemma-typescript/src/openapi_client/core/OpenAPI.ts
@@ -21,7 +21,7 @@ export type OpenAPIConfig = {
 
 export const OpenAPI: OpenAPIConfig = {
     BASE: '',
-    VERSION: '0.7.1',
+    VERSION: '0.7.2',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',
     TOKEN: undefined,

--- a/lemma-typescript/src/openapi_spec.json
+++ b/lemma-typescript/src/openapi_spec.json
@@ -17631,7 +17631,7 @@
   "info": {
     "description": "Authentication API with JWT, user management, and OAuth support",
     "title": "Lemma Backend",
-    "version": "0.7.1"
+    "version": "0.7.2"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/lemma-typescript/src/version.ts
+++ b/lemma-typescript/src/version.ts
@@ -1,6 +1,6 @@
 // Keep SDK_VERSION in sync with package.json "version". The CI codegen/drift
 // gate (workstream A) asserts they match so this can't silently drift.
-export const SDK_VERSION = "0.7.1";
+export const SDK_VERSION = "0.7.2";
 
 /** Sent as `X-Lemma-Client` when it will not add an otherwise avoidable browser
  *  preflight, so the backend can log which client + version hit an endpoint. */


### PR DESCRIPTION
## What changes

Every Lemma-owned component now declares `0.7.2`, so the release can be cut.

## Why

`scripts/check_version_consistency.py` is deliberately a **release** gate, not a
per-PR one — components may drift while work is in flight, and must agree at the
moment something is published. The release workflows run it against the tag
before publishing anything, so this has to land first.

## What moved

All twelve declared versions, together:

- `lemma-backend/app/version.py` (API_VERSION)
- `lemma-python`: package, `_spec_info.API_VERSION`, bundled `openapi_spec.json`
- `lemma-typescript`: package, `SDK_VERSION`, generated client `VERSION`, bundled spec
- `lemma-cli`: package version and its `lemma-sdk>=` floor
- `desktop/tauri.conf.json`, `desktop/Cargo.toml` (`[workspace.package]`)
- `desktop/runtime/lemma-local.json`

That last one is not cosmetic. The app refuses to install a runtime whose
version disagrees with its own — the failure we hit on a nightly last week — so
a stale number there is a build that cannot finish first launch.

Two lockfiles move with them:

- `desktop/Cargo.lock` records each workspace member's version, and CI builds
  with `--locked`; leaving it behind fails every desktop job rather than
  drifting quietly.
- `lemma-backend/uv.lock` follows the `lemma-sdk` version.

## How to verify

```bash
python scripts/check_version_consistency.py --expect 0.7.2
make quality
make desktop-test && make desktop-lint
cd lemma-cli && uv run pytest tests -q
```

Ran locally, all green:

- `All 12 components declare 0.7.2.`
- quality gates pass (including OpenAPI spec freshness)
- desktop: 152 + 125 + 174 tests, clippy clean
- `cargo test -p lemma-locald -p lemma-guestd --locked` passes against the
  refreshed lock
- lemma-cli: 632 tests

## Checklist

- [x] Lint, typecheck, and architecture gates pass locally
- [ ] **Tests** — no behavioral change; the version gate is the test
- [ ] **Rollback** — revert. Nothing depends on 0.7.2 until the tag is pushed.