### PR TITLE
Apply the history processors the way a run applies them

### DIFF
--- a/lemma-backend/app/modules/agent/tests/e2e/test_long_running_and_research_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_long_running_and_research_e2e.py
@@ -856,9 +856,19 @@ async def test_compaction_bounds_a_history_built_from_real_tool_output(
         ),
         summarization_model=None,
     )
-    guard = processors[-1]
-
-    compacted = await guard(history)
+    # Applied the way a run applies them: every processor, in order.
+    #
+    # This used to reach for `processors[-1]` and call it "the guard". That was
+    # true when it was written and stopped being true when a processor was
+    # appended after the ceiling guard to fix the leading message's role -- so
+    # the test called *that* one, which never trims, measured the history
+    # unchanged at 204,518 tokens, and reported a compaction failure that was
+    # nothing of the sort. Production was never affected; it runs the whole
+    # chain. Running the whole chain here too means the test cannot be wrong
+    # about the order again.
+    compacted: list[object] = list(history)
+    for processor in processors:
+        compacted = await processor(compacted)
 
     assert count_model_message_tokens(compacted) <= ceiling
     assert compacted[-1] is history[-1], "the most recent turn must survive"


### PR DESCRIPTION
## What changes

The compaction e2e applies every history processor in order, as a run does,
instead of calling whichever one happens to be last.

## Why

The protected suite — the gate that has to pass before a release can be cut —
failed on the 0.7.2 release commit:

```
test_compaction_bounds_a_history_built_from_real_tool_output
AssertionError: assert 204518 <= 40000
```

**Nothing is wrong with compaction.** The test reached for `processors[-1]` and
called it "the guard". That was true when it was written. A processor was later
appended *after* the ceiling guard — the one that guarantees the history opens
with a role the provider will accept — so `[-1]` silently became that one. It
never trims, so the test measured the history unchanged and reported a
compaction failure that was nothing of the sort.

Measured directly on the same history the test builds:

| | tokens |
|---|---|
| raw history | 204,518 |
| `processors[-1]` alone — what the test did | 204,518 (untouched) |
| **the full chain, production order** | **34,145** ✓ |

with the guard logging `token_ceiling_enforced.degraded` (`dropped_count: 49`),
the most recent turn preserved, and no tool result left without its call.

## How

The test builds the processors and runs all of them, in order. That is both the
stronger assertion — it is what actually happens on a request — and one that
cannot go stale the same way, because it makes no claim about which position the
guard occupies. A guard that stopped trimming still fails it, which is the point
of the test.

One sibling in `test_history_compaction.py` had already been quietly adjusted to
`[-2]` when that processor was appended. That is the same hazard, and the reason
to stop indexing rather than to re-index.

## How to verify

The e2e itself needs a real container for its build-log output. The processor
behaviour it asserts was reproduced directly against the same fabricated
history, and every assertion in the test passes:

```
ALL ASSERTIONS PASS  tokens: 34145
```

`make quality` passes. The real proof is the protected suite on this commit,
which is also what unblocks the 0.7.2 release.

## Checklist

- [x] Tests cover the behavioral change — this *is* the test fix
- [x] Lint, typecheck, and architecture gates pass locally
- [ ] **Rollback** — revert; the protected suite goes back to failing on a
      correct implementation.