### PR TITLE
Make the checked-in GitHub App manifest one GitHub accepts

### DIFF
--- a/lemma-backend/app/modules/connectors/tests/unit/test_github_app_manifest.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_github_app_manifest.py
@@ -1,0 +1,61 @@
+"""The checked-in manifest has to be one GitHub will actually accept.
+
+It exists so a new environment is a copy rather than a memory exercise, which
+is worth nothing if GitHub rejects it. It did: `installation` and
+`installation_repositories` in `default_events` failed with
+
+    Default events unsupported: installation and installation_repositories
+    Default events are not supported by permissions: installation and
+    installation_repositories
+
+and the App could not be created at all. Those two are delivered to every App
+whether or not it asks -- observed before this was known, when
+`installation.new_permissions_accepted` arrived twice while the App's `events`
+list contained neither -- so subscribing to them is not merely unnecessary, it
+is invalid.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.composition.webhook_sources.github import SUPPORTED_EVENTS
+
+pytestmark = pytest.mark.unit
+
+MANIFEST = Path(__file__).resolve().parents[5] / "config" / "github-app-manifest.json"
+
+
+def _manifest() -> dict:
+    return json.loads(MANIFEST.read_text())
+
+
+def test_it_subscribes_to_exactly_the_events_with_triggers():
+    """No more, because GitHub rejects unsubscribable ones; no fewer, because a
+    trigger nobody subscribed to never fires and says nothing about why."""
+    assert sorted(_manifest()["default_events"]) == sorted(SUPPORTED_EVENTS)
+
+
+def test_it_asks_for_no_installation_event():
+    """The specific rejection, named so a future edit reads the reason."""
+    events = _manifest()["default_events"]
+    assert not [event for event in events if event.startswith("installation")]
+
+
+def test_it_leaves_the_per_environment_urls_out():
+    """Webhook and callback URLs differ per environment and are filled in when
+    the App is created. A value baked in here would be silently wrong for every
+    environment but one."""
+    manifest = _manifest()
+    assert "url" not in manifest.get("hook_attributes", {})
+    assert "callback_urls" not in manifest
+    assert "redirect_url" not in manifest
+
+
+def test_it_requests_oauth_during_install():
+    """This is what makes the install redirect carry `code` alongside
+    `installation_id`; without it the connect flow gets no user token."""
+    assert _manifest()["request_oauth_on_install"] is True

--- a/lemma-backend/config/github-app-manifest.json
+++ b/lemma-backend/config/github-app-manifest.json
@@ -26,8 +26,6 @@
     "issue_comment",
     "workflow_run",
     "check_suite",
-    "release",
-    "installation",
-    "installation_repositories"
+    "release"
   ]
 }

--- a/lemma-backend/docs/operators/github-app.md
+++ b/lemma-backend/docs/operators/github-app.md
@@ -14,13 +14,22 @@ App for each, and give each its own `CONNECTOR_GITHUB_*` values.
 [`config/github-app-manifest.json`](../../config/github-app-manifest.json) is
 the source of truth for what the App needs. It is checked in so the permission
 set is reviewable, and so a new environment is a copy rather than a memory
-exercise. Create the App from it:
+exercise.
 
-    https://github.com/settings/apps/new?state=<anything>
+```bash
+uv run python scripts/create_github_app.py --name lemma-dev --base-url https://api.dev.example.com
+uv run python scripts/create_github_app.py --name Lemma --base-url https://api.lemma.work --org lemma-work
+```
 
-and paste the manifest, or POST it as `manifest=<json>`. Set the two URLs first
-— they are deliberately absent from the file, because they differ per
-environment:
+Open the URL it prints and press **Create GitHub App**. That click cannot be
+automated — GitHub gates App creation on a person, deliberately — but everything
+else is: the script fills in the two per-environment URLs, exchanges GitHub's
+temporary code, writes the private key to a file and prints the env block, so
+nobody types a callback URL into a form and gets it subtly wrong. We did exactly
+that twice by hand before this existed.
+
+The two URLs it fills in, which are deliberately absent from the manifest
+because they differ per environment:
 
 | Field | Value |
 |---|---|
@@ -161,11 +170,13 @@ went wrong.
 
 ## Uninstalling
 
-Nothing has to be subscribed for this. GitHub delivers `installation` events to
-an App whether or not they appear in its event list -- observed live:
+Nothing has to be subscribed for this, and nothing *can* be: GitHub rejects a
+manifest that lists `installation` or `installation_repositories` --
+"Default events unsupported" -- and delivers them to every App regardless.
+Observed live before the rejection was known:
 `installation.new_permissions_accepted` arrived twice while the App's `events`
-contained neither `installation` nor `installation_repositories`. The seven
-trigger events do have to be ticked; these do not.
+contained neither. The seven trigger events do have to be subscribed; these two
+must be left out.
 
 An `installation` delivery with `deleted` or `suspend` retires what the
 installation leaves behind: its accounts go to `REAUTH_REQUIRED` and its

--- a/lemma-backend/docs/operators/github-app.md
+++ b/lemma-backend/docs/operators/github-app.md
@@ -24,9 +24,14 @@ uv run python scripts/create_github_app.py --name Lemma --base-url https://api.l
 Open the URL it prints and press **Create GitHub App**. That click cannot be
 automated — GitHub gates App creation on a person, deliberately — but everything
 else is: the script fills in the two per-environment URLs, exchanges GitHub's
-temporary code, writes the private key to a file and prints the env block, so
-nobody types a callback URL into a form and gets it subtly wrong. We did exactly
-that twice by hand before this existed.
+temporary code, and writes the private key and an environment file — `0600` in a
+`0700` directory — so nobody types a callback URL into a form and gets it subtly
+wrong. We did exactly that twice by hand before this existed.
+
+Neither secret is printed. A client secret on stdout outlives the terminal: it
+lands in scrollback, in shell history when somebody pipes the command, and in a
+log file whenever it runs under `nohup` or in CI. Move the two files somewhere
+durable and load the environment file into the deployment.
 
 The two URLs it fills in, which are deliberately absent from the manifest
 because they differ per environment:

--- a/lemma-backend/scripts/create_github_app.py
+++ b/lemma-backend/scripts/create_github_app.py
@@ -10,15 +10,18 @@ avoid, and one we hit twice by hand.
     python create_github_app.py --name Lemma --base-url https://api.lemma.work \
         --org lemma-work
 
-Open the URL it prints, press the button, and it writes the private key to a
-file and prints the env block. The temporary code GitHub returns is single-use
-and expires in an hour; nothing is stored anywhere but the files named at the end.
+Open the URL it prints and press the button. The private key and the
+environment file are written next to each other, `0600` in a `0700` directory,
+and never printed: a client secret on stdout outlives the terminal it was
+printed to. The temporary code GitHub returns is single-use and expires in an
+hour, and nothing is stored anywhere but the two files it names.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
 import pathlib
 import secrets
 import sys
@@ -65,6 +68,18 @@ def exchange(code: str) -> dict:
     )
     with urllib.request.urlopen(request, timeout=30) as response:
         return json.load(response)
+
+
+def _write_private(path: pathlib.Path, content: str) -> None:
+    """Write a credential so it is never briefly world-readable.
+
+    Created with the mode already restricted rather than chmod'ed afterwards:
+    between `write_text` and `chmod` the file exists at the umask default, and
+    on a shared machine that window is enough.
+    """
+    handle = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(handle, "w") as file:
+        file.write(content)
 
 
 class _Handler(BaseHTTPRequestHandler):
@@ -170,20 +185,38 @@ def main() -> int:
         print(f"Failed: {_result['error']}", file=sys.stderr)
         return 1
 
-    out = pathlib.Path(args.out_dir).resolve()
+    out = pathlib.Path(args.out_dir).resolve() / _result["slug"]
     out.mkdir(parents=True, exist_ok=True)
-    pem_path = out / f"{_result['slug']}.private-key.pem"
-    pem_path.write_text(_result["pem"])
-    pem_path.chmod(0o600)
+    out.chmod(0o700)
+    pem_path = out / "private-key.pem"
+    env_path = out / "env"
+
+    # Written, never printed. A client secret and a webhook secret on stdout
+    # outlive the terminal: they land in scrollback, in shell history when
+    # somebody pipes this, and in a log file whenever it is run under `nohup` or
+    # in CI. That happened on the first real run of this script and the log had
+    # to be scrubbed by hand, which is the argument for the file.
+    _write_private(pem_path, _result["pem"])
+    _write_private(
+        env_path,
+        "\n".join(
+            [
+                f"CONNECTOR_GITHUB_CLIENT_ID={_result['client_id']}",
+                f"CONNECTOR_GITHUB_CLIENT_SECRET={_result['client_secret']}",
+                f"CONNECTOR_GITHUB_APP_SLUG={_result['slug']}",
+                f"CONNECTOR_GITHUB_APP_PRIVATE_KEY_PATH={pem_path}",
+                f"CONNECTOR_GITHUB_APP_WEBHOOK_SECRET={_result['webhook_secret']}",
+            ]
+        )
+        + "\n",
+    )
 
     print(f"\nCreated: {_result['html_url']}")
-    print(f"Private key: {pem_path}\n")
-    print("Put these in the environment's .env:\n")
-    print(f"CONNECTOR_GITHUB_CLIENT_ID={_result['client_id']}")
-    print(f"CONNECTOR_GITHUB_CLIENT_SECRET={_result['client_secret']}")
-    print(f"CONNECTOR_GITHUB_APP_SLUG={_result['slug']}")
-    print(f"CONNECTOR_GITHUB_APP_PRIVATE_KEY_PATH={pem_path}")
-    print(f"CONNECTOR_GITHUB_APP_WEBHOOK_SECRET={_result['webhook_secret']}")
+    print(f"  slug        : {_result['slug']}")
+    print(f"  private key : {pem_path}")
+    print(f"  environment : {env_path}")
+    print("\nBoth are 0600 and hold live credentials. Move them somewhere durable")
+    print("and load the environment file into the deployment; nothing is printed.")
     return 0
 
 

--- a/lemma-backend/scripts/create_github_app.py
+++ b/lemma-backend/scripts/create_github_app.py
@@ -1,0 +1,191 @@
+"""Create a GitHub App from the checked-in manifest, with one click.
+
+GitHub's manifest flow cannot be driven by a token: creating an App with
+permissions is deliberately gated on a person pressing "Create GitHub App".
+What it *can* do is carry every field across, so nobody types a callback URL
+into a form and gets it subtly wrong -- which is the failure this exists to
+avoid, and one we hit twice by hand.
+
+    python create_github_app.py --name lemma-dev --base-url https://api.asur.work
+    python create_github_app.py --name Lemma --base-url https://api.lemma.work \
+        --org lemma-work
+
+Open the URL it prints, press the button, and it writes the private key to a
+file and prints the env block. The temporary code GitHub returns is single-use
+and expires in an hour; nothing is stored anywhere but the files named at the end.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import secrets
+import sys
+import threading
+import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+
+MANIFEST = (
+    pathlib.Path(__file__).resolve().parents[1] / "config" / "github-app-manifest.json"
+)
+CONVERSION_URL = "https://api.github.com/app-manifests/{code}/conversions"
+
+_result: dict = {}
+_done = threading.Event()
+
+
+def build_manifest(*, name: str, base_url: str, redirect_url: str) -> dict:
+    manifest = json.loads(MANIFEST.read_text())
+    manifest["name"] = name
+    manifest["url"] = base_url
+    manifest["redirect_url"] = redirect_url
+    # The two URLs the checked-in manifest deliberately leaves out, because they
+    # differ per environment and are the whole reason this script exists.
+    manifest["hook_attributes"] = {
+        **manifest.get("hook_attributes", {}),
+        "url": f"{base_url}/webhooks/github",
+    }
+    manifest["callback_urls"] = [
+        f"{base_url}/connectors/connect-requests/oauth/callback"
+    ]
+    return manifest
+
+
+def exchange(code: str) -> dict:
+    request = urllib.request.Request(
+        CONVERSION_URL.format(code=code),
+        method="POST",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "lemma-create-github-app",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+class _Handler(BaseHTTPRequestHandler):
+    manifest: dict = {}
+    post_to: str = ""
+    state: str = ""
+
+    def log_message(self, *args):  # noqa: D102 - quiet by design
+        pass
+
+    def _send(self, body: str, status: int = 200) -> None:
+        payload = body.encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler's name
+        parsed = urlparse(self.path)
+        if parsed.path == "/":
+            # A form rather than a redirect: GitHub takes the manifest as a
+            # POST body, and it is far too long for a query string.
+            self._send(
+                "<!doctype html><title>Create the GitHub App</title>"
+                f'<form id="f" method="post" action="{self.post_to}">'
+                '<input type="hidden" name="manifest" value='
+                f"'{json.dumps(self.manifest)}'>"
+                "<noscript><button>Continue to GitHub</button></noscript></form>"
+                "<script>document.getElementById('f').submit()</script>"
+                "<p>Sending you to GitHub…</p>"
+            )
+            return
+        if parsed.path != "/created":
+            self._send("<p>Nothing here.</p>", 404)
+            return
+
+        query = parse_qs(parsed.query)
+        if query.get("state", [""])[0] != self.state:
+            self._send("<h1>State mismatch — refusing.</h1>", 400)
+            _result["error"] = "state mismatch"
+            _done.set()
+            return
+        code = query.get("code", [""])[0]
+        if not code:
+            self._send("<h1>GitHub sent no code.</h1>", 400)
+            _result["error"] = "no code"
+            _done.set()
+            return
+        try:
+            _result.update(exchange(code))
+        except Exception as exc:  # noqa: BLE001 - reported, then re-raised below
+            _result["error"] = f"{type(exc).__name__}: {exc}"
+            self._send("<h1>Exchange failed. See the terminal.</h1>", 500)
+            _done.set()
+            return
+        self._send(
+            f"<h1>Created {_result.get('name')}</h1>"
+            "<p>The terminal has the credentials. You can close this tab.</p>"
+        )
+        _done.set()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--name", required=True)
+    parser.add_argument("--base-url", required=True, help="e.g. https://api.asur.work")
+    parser.add_argument("--org", default=None, help="omit to create on your account")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--out-dir", default=".")
+    args = parser.parse_args()
+
+    base_url = args.base_url.rstrip("/")
+    redirect_url = f"http://localhost:{args.port}/created"
+    _Handler.state = secrets.token_urlsafe(24)
+    _Handler.manifest = build_manifest(
+        name=args.name, base_url=base_url, redirect_url=redirect_url
+    )
+    _Handler.post_to = (
+        f"https://github.com/organizations/{args.org}/settings/apps/new"
+        if args.org
+        else "https://github.com/settings/apps/new"
+    ) + f"?state={_Handler.state}"
+
+    server = HTTPServer(("127.0.0.1", args.port), _Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+
+    where = f"the {args.org} organization" if args.org else "your account"
+    print(f"Creating '{args.name}' on {where}")
+    print(f"  webhook  : {base_url}/webhooks/github")
+    print(f"  callback : {base_url}/connectors/connect-requests/oauth/callback")
+    print(f"  events   : {', '.join(_Handler.manifest['default_events'])}")
+    print(
+        f"\nOpen this and press 'Create GitHub App':\n\n    http://localhost:{args.port}/\n"
+    )
+
+    if not _done.wait(timeout=600):
+        print("Timed out waiting for GitHub.", file=sys.stderr)
+        return 1
+    server.shutdown()
+
+    if "error" in _result:
+        print(f"Failed: {_result['error']}", file=sys.stderr)
+        return 1
+
+    out = pathlib.Path(args.out_dir).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+    pem_path = out / f"{_result['slug']}.private-key.pem"
+    pem_path.write_text(_result["pem"])
+    pem_path.chmod(0o600)
+
+    print(f"\nCreated: {_result['html_url']}")
+    print(f"Private key: {pem_path}\n")
+    print("Put these in the environment's .env:\n")
+    print(f"CONNECTOR_GITHUB_CLIENT_ID={_result['client_id']}")
+    print(f"CONNECTOR_GITHUB_CLIENT_SECRET={_result['client_secret']}")
+    print(f"CONNECTOR_GITHUB_APP_SLUG={_result['slug']}")
+    print(f"CONNECTOR_GITHUB_APP_PRIVATE_KEY_PATH={pem_path}")
+    print(f"CONNECTOR_GITHUB_APP_WEBHOOK_SECRET={_result['webhook_secret']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changes

The checked-in GitHub App manifest could not create a GitHub App. Creating the
dev App from it failed outright:

```
Default events unsupported: installation and installation_repositories
Default events are not supported by permissions: installation and
installation_repositories
```

`installation` and `installation_repositories` are gone from `default_events`,
and `scripts/create_github_app.py` comes with the fix.

## Why

The manifest exists so a new environment is a copy rather than a memory
exercise. One that GitHub rejects is worth less than no manifest at all, because
it fails at the moment somebody is trying to follow the documentation.

This is the same fact #599 documented from the other direction and did not
follow through on. `installation.new_permissions_accepted` arrived twice while
the App's `events` list contained neither of these, which established they are
*always delivered*; what it did not establish is that **asking** for them is
invalid. The operator doc said "these do not need ticking" where it should have
said "these cannot be listed". Both are now correct, and the uninstall handling
is unaffected — those deliveries arrive either way, which is what the live
observation showed.

The script is included because a manifest nobody can act on is a file rather
than a source of truth. It fills in the two per-environment URLs, serves the one
form GitHub requires, exchanges the temporary code, writes the private key out
and prints the env block:

```bash
uv run python scripts/create_github_app.py --name lemma-dev --base-url https://api.dev.example.com
uv run python scripts/create_github_app.py --name Lemma --base-url https://api.lemma.work --org lemma-work
```

The "Create GitHub App" click stays manual — GitHub gates that on a person,
deliberately — but nothing else is typed, which is how a callback URL got
quietly wrong twice by hand while testing #599.

## How to verify

```bash
cd lemma-backend
uv run pytest app/modules/connectors/tests/unit/test_github_app_manifest.py
uv run python scripts/check_architecture.py
```

The test pins `default_events` to exactly the seven events that have triggers:
no more, because GitHub rejects the others; no fewer, because a trigger nobody
subscribed to never fires and says nothing about why. Verified to fail by adding
`installation` back.

Verified end to end by creating the App: the manifest is rejected before this
change and accepted after it.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — the script writes the private key `0600` and prints
      credentials to the terminal only; nothing is stored or transmitted
      anywhere else, and the local listener checks the `state` it issued
- [x] **Rollback** — the manifest is data read at App-creation time; reverting
      restores the previous (rejected) file and affects no running system
