### PR TITLE
Make the schedule field an agent can be refused for discoverable

### DIFF
--- a/lemma-backend/app/modules/schedule/domain/schedule.py
+++ b/lemma-backend/app/modules/schedule/domain/schedule.py
@@ -30,7 +30,9 @@ class ScheduleType(str, Enum):
 #: the same thing.
 INSTRUCTION_REQUIRED = (
     "This agent has no standing instruction of its own, so a schedule that "
-    "wakes it must say what it should do when it fires."
+    "wakes it must say what it should do when it fires. Set the schedule's "
+    "`instruction` field (CLI: --instruction). No other field carries it: a "
+    "payload under a different key is dropped, not used."
 )
 
 

--- a/lemma-cli/lemma_cli/cli_app/scaffold.py
+++ b/lemma-cli/lemma_cli/cli_app/scaffold.py
@@ -109,6 +109,7 @@ FUNCTION_JSON = _fill_enums("""{
   "description": "TODO: what this function does.",
   "type": "API",         // API = sync request/response; JOB = async background run
   "visibility": "POD",   // __VISIBILITY__
+  // "config": { },      // runtime settings for this function (timeouts, memory)
   "code": { "$file": "code.py" },
   // Zero access by default. This EMPTY list means "holds nothing" — on import it
   // REPLACES the function's grants, so delete the whole "permissions" key if you
@@ -152,6 +153,11 @@ AGENT_JSON = _fill_enums("""{
   "toolsets": ["POD"],
   "visibility": "POD",   // __VISIBILITY__
   // agent_runtime omitted -> the system runtime profile (system:lemma). Add it to pin a specific model.
+  // Structured I/O. With an output_schema the agent must answer in that shape,
+  // which is what lets a workflow read named fields off its result.
+  // "input_schema": { "type": "object", "properties": { } },
+  // "output_schema": { "type": "object", "properties": { } },
+  // "metadata": { },     // free-form; yours to read, the platform ignores it
   // Zero access by default. This EMPTY list means "holds nothing" — on import it
   // REPLACES the agent's grants, so delete the whole "permissions" key if you are
   // re-authoring an agent whose live grants you want left alone.
@@ -189,6 +195,7 @@ WORKFLOW_JSON = """{
   "name": "__NAME__",
   "description": "TODO: what this workflow orchestrates.",
   "start": { "type": "MANUAL" },   // MANUAL | SCHEDULED | DATASTORE_EVENT | EVENT
+  // "mode": "DURABLE",            // how runs are executed; omit for the default
   "nodes": [
     // Entry FORM collects the run input. Node types: FORM AGENT FUNCTION DECISION LOOP WAIT_UNTIL END
     { "id": "intake", "type": "FORM", "label": "Intake",
@@ -218,6 +225,18 @@ SCHEDULE_JSON = """{
   // Exactly one target — the agent or workflow to start. It must already exist in the pod.
   "workflow_name": "__TARGET__",
   // "agent_name": "some-agent",   // ...or target an agent instead of a workflow
+  // "agent_name": "POD_DEFAULT",  // ...or the pod's own assistant, which has no name
+  // What the target should DO when this fires. There is no other field for it:
+  // a payload under any other key is not sent. Required for POD_DEFAULT, which
+  // has no standing instruction of its own to fall back on.
+  // "instruction": "Summarise yesterday's tickets and message me the list.",
+  // Decides whether to fire AT ALL, unlike "instruction", which directs the
+  // work afterwards. Optional; omit to fire every time.
+  // "filter_instruction": "Only when the row's status is 'urgent'.",
+  // "filter_output_schema": { "type": "object" },  // shape the filter must answer in
+  // WEBHOOK only — the connector account and trigger this listens on.
+  // "account_id": "TODO-connector-account-uuid",
+  // "connector_trigger_id": "TODO-connector-trigger-uuid",
   "is_active": false,               // flip to true once the target exists and you've imported it
   "visibility": "POD"
 }

--- a/lemma-cli/lemma_cli/cli_core/commands/apps.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/apps.py
@@ -26,7 +26,7 @@ from ..app_scaffold import (
 )
 from ..confirm import confirm_destructive
 from ..io import emit, to_plain
-from ..payload import read_json
+from ..payload import build_request, read_json
 from ..sdk import pod_client
 from ..state import console, fail, run_with_client, state_from_ctx
 from lemma_sdk.config import resolve_auth_url, resolve_base_url, resolve_token
@@ -245,7 +245,7 @@ def create_app(
     result = run_with_client(
         ctx,
         lambda client, s: pod_client(client, s, pod).apps.create(
-            CreateAppRequest.from_dict(payload)
+            build_request(CreateAppRequest, payload, context="app")
         ),
     )
     if result is not None:
@@ -270,7 +270,7 @@ def update_app(
     result = run_with_client(
         ctx,
         lambda client, s: pod_client(client, s, pod).apps.update(
-            app, UpdateAppRequest.from_dict(payload)
+            app, build_request(UpdateAppRequest, payload, context="app")
         ),
     )
     if result is not None:

--- a/lemma-cli/lemma_cli/cli_core/commands/connectors.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/connectors.py
@@ -11,7 +11,7 @@ from lemma_sdk.openapi_client.models.auth_config_create_schema import (
 
 from ..confirm import confirm_destructive
 from ..io import emit, list_items, to_plain
-from ..payload import read_json
+from ..payload import build_request, read_json
 from ..state import console, run_with_client, state_from_ctx
 from ..context import org_for
 
@@ -446,7 +446,7 @@ def create_account(
         lambda client, s: (
             client.connectors.accounts.create(
                 auth_config or auth_config_id or "",
-                AccountCreateSchema.from_dict(request_data),
+                build_request(AccountCreateSchema, request_data, context="account"),
             )
             if hasattr(client.connectors, "accounts")
             else client.connectors.create_account(

--- a/lemma-cli/lemma_cli/cli_core/commands/schedules.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/schedules.py
@@ -249,6 +249,27 @@ def create_schedule(
 def update_schedule(
     ctx: typer.Context,
     schedule: str = typer.Argument(...),
+    agent: str | None = typer.Option(
+        None,
+        "--agent",
+        help=(
+            "Retarget at a pod agent, by name. Pass POD_DEFAULT for the pod's "
+            "default assistant; that target requires --instruction."
+        ),
+    ),
+    workflow: str | None = typer.Option(
+        None, "--workflow", help="Retarget at a workflow, by name."
+    ),
+    instruction: str | None = typer.Option(
+        None,
+        "--instruction",
+        help=(
+            "What the target should do when this fires. Required with "
+            "--agent POD_DEFAULT. Unlike --filter, which decides whether to "
+            "fire at all, this directs the work afterwards."
+        ),
+    ),
+    filter_instruction: str | None = typer.Option(None, "--filter"),
     json_payload: str | None = typer.Option(
         None, "--data", "-d", help="Raw JSON payload."
     ),
@@ -257,13 +278,26 @@ def update_schedule(
     ),
     pod: str | None = typer.Option(None, "--pod"),
 ) -> None:
-    """Update a schedule from a JSON payload."""
-    payload = read_json(json_payload, file, required=True)
+    """Update a schedule."""
+    extra = read_json(json_payload, file, required=False)
+    flags = {
+        "agent_name": agent,
+        "workflow_name": workflow,
+        "instruction": instruction,
+        "filter_instruction": filter_instruction,
+    }
+    payload = {**extra, **{k: v for k, v in flags.items() if v is not None}}
+    if not payload:
+        fail("Nothing to update. Pass a flag, or --data/--file with a payload.")
     state = state_from_ctx(ctx)
     result = run_with_client(
         ctx,
         lambda client, s: pod_client(client, s, pod).schedules.update(
-            schedule, UpdateScheduleRequest.from_dict(payload)
+            schedule,
+            # `build_request`, not `from_dict`: the generated model drops every
+            # key it does not declare, so a hand-written payload naming the
+            # wrong field was applied as an empty update and reported success.
+            build_request(UpdateScheduleRequest, payload, context="schedule"),
         ),
     )
     if result is not None:

--- a/lemma-cli/lemma_cli/cli_core/commands/workflows.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/workflows.py
@@ -170,7 +170,7 @@ def update_workflow(
     result = run_with_client(
         ctx,
         lambda client, s: pod_client(client, s, pod).workflows.update(
-            workflow, WorkflowUpdateRequest.from_dict(payload)
+            workflow, build_request(WorkflowUpdateRequest, payload, context="workflow")
         ),
     )
     if result is not None:

--- a/lemma-cli/tests/test_commands_schedules.py
+++ b/lemma-cli/tests/test_commands_schedules.py
@@ -285,3 +285,86 @@ def test_schedules_list_json_is_untouched_by_the_target_column(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert "target" not in json.loads(result.stdout)["items"][0]
+
+
+# ---------------------------------------------------------------------------
+# update: the wake instruction, and fields that do not exist
+# ---------------------------------------------------------------------------
+
+
+def _update_capture(monkeypatch):
+    captured = {}
+
+    class FakeSchedules:
+        def update(self, schedule, request):
+            captured["schedule"] = schedule
+            captured["payload"] = request.to_dict()
+            return {"id": "sched-1", "name": schedule}
+
+    monkeypatch.setattr(
+        schedules,
+        "run_with_client",
+        _make_fake_client_and_run(FakeSchedules(), captured),
+    )
+    return captured
+
+
+def test_schedules_update_takes_the_instruction_as_a_flag(monkeypatch):
+    """Retargeting at the assistant needed a hand-written JSON body, because
+    `update` had no flags at all -- so the one field the API then demands could
+    only be supplied by someone who already knew its name."""
+    captured = _update_capture(monkeypatch)
+
+    result = runner.invoke(
+        app,
+        [
+            "--pod",
+            "pod-1",
+            "schedules",
+            "update",
+            "wellness",
+            "--agent",
+            "POD_DEFAULT",
+            "--instruction",
+            "Ask how they are doing.",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["payload"]["agent_name"] == "POD_DEFAULT"
+    assert captured["payload"]["instruction"] == "Ask how they are doing."
+
+
+def test_schedules_update_warns_on_an_unrecognized_field(monkeypatch):
+    """`create` warned and `update` did not, so a payload naming the wrong key
+    was applied as an empty update and reported success -- which reads as "the
+    field was accepted", and sent the caller looking somewhere else."""
+    captured = _update_capture(monkeypatch)
+
+    result = runner.invoke(
+        app,
+        [
+            "--pod",
+            "pod-1",
+            "schedules",
+            "update",
+            "wellness",
+            "--data",
+            '{"data": "wake up and do the thing"}',
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "data" in result.output
+    assert "instruction" not in captured["payload"]
+
+
+def test_schedules_update_refuses_to_do_nothing(monkeypatch):
+    """An update with no flags and no payload used to be a required-arg error
+    from `--data`; now that flags exist it has to say what is actually wrong."""
+    _update_capture(monkeypatch)
+
+    result = runner.invoke(app, ["--pod", "pod-1", "schedules", "update", "wellness"])
+
+    assert result.exit_code != 0
+    assert "Nothing to update" in result.output

--- a/lemma-cli/tests/test_scaffold.py
+++ b/lemma-cli/tests/test_scaffold.py
@@ -829,3 +829,75 @@ def test_schedule_scaffold_passes_the_importer_s_own_validation(tmp_path):
     }
     assert _validate_schedule_config(datastore, "nightly", str(path)) == []
     assert json.dumps(datastore)  # serializable, for good measure
+
+
+# --------------------------------------------------------------------------- #
+# scaffold <-> API drift
+# --------------------------------------------------------------------------- #
+#: Fields a scaffold deliberately does not mention, and why. Everything else on
+#: a create-request model must appear in the scaffold for its resource.
+#:
+#: This exists because `instruction` was added to schedules — required whenever
+#: the target is the pod's assistant — and the scaffold was not touched. The
+#: scaffold is what `lemma <resource> schema` prints, and it is what the CLI's
+#: own unrecognized-field warning tells you to go read. Missing from there, the
+#: field was unreachable to anyone working from the tooling: the API refused the
+#: schedule, named no field, and the reference it pointed at did not list one.
+#:
+#: Adding an entry here is a decision to leave a field undocumented. Prefer
+#: documenting it — a commented-out line in the scaffold costs nothing.
+UNDOCUMENTED_SCAFFOLD_FIELDS: dict[str, set[str]] = {
+    # Presentation only; carrying a TODO icon URL into every scaffold is noise.
+    "function": {"icon_url"},
+    "agent": {"icon_url"},
+    "workflow": {"icon_url"},
+}
+
+SCAFFOLD_REQUEST_MODELS: list[tuple[str, str, str]] = [
+    ("table", "create_table_request", "CreateTableRequest"),
+    ("function", "create_function_request", "CreateFunctionRequest"),
+    ("agent", "create_agent_request", "CreateAgentRequest"),
+    ("workflow", "workflow_create_request", "WorkflowCreateRequest"),
+    ("schedule", "create_schedule_request", "CreateScheduleRequest"),
+]
+
+
+@pytest.mark.parametrize(("resource", "module", "model"), SCAFFOLD_REQUEST_MODELS)
+def test_every_api_field_reaches_the_scaffold(resource, module, model):
+    """A field the API accepts but the scaffold never names is unreachable.
+
+    The scaffold is the canonical "what fields exist" reference — printed by
+    `lemma <resource> schema`, written by `lemma init`, and pointed at by the
+    warning the CLI emits when a payload names something unrecognized. A field
+    absent from it can only be found by guessing.
+    """
+    import importlib
+
+    import attrs
+
+    from lemma_cli.cli_app.scaffold import resource_example
+
+    request_model = getattr(
+        importlib.import_module(f"lemma_sdk.openapi_client.models.{module}"), model
+    )
+    fields = {
+        # The generated client suffixes Python keywords with `_`; the wire name
+        # (and so the name a hand-written payload uses) is the bare one.
+        field.name.rstrip("_")
+        for field in attrs.fields(request_model)
+        if field.name != "additional_properties"
+    }
+    scaffold = resource_example(resource)
+
+    undocumented = {
+        name
+        for name in fields - UNDOCUMENTED_SCAFFOLD_FIELDS.get(resource, set())
+        if name not in scaffold
+    }
+
+    assert not undocumented, (
+        f"`lemma {resource} schema` never mentions {sorted(undocumented)}, so "
+        f"nobody working from the CLI can discover {'it' if len(undocumented) == 1 else 'them'}. "
+        f"Add a line (commented out is fine) to the scaffold in cli_app/scaffold.py, "
+        f"or record a reason in UNDOCUMENTED_SCAFFOLD_FIELDS."
+    )


### PR DESCRIPTION
## What changes

`instruction` — the schedule field the API demands whenever the target is the
pod's assistant — is now reachable from the tooling: it appears in
`lemma schedules schema`, `lemma schedules update` takes it as a flag, and the
422 that requires it names it.

## Why

Seen in a real conversation: the assistant was asked to schedule a check-in,
hit `422 SCHEDULE_VALIDATION_ERROR`, and spent ~40 messages brute-force probing
field names (`input`, `data`, `prompt`, `message`) before detouring into
building a whole workflow to get around it. Every signpost it followed was
wrong, and each one on its own looks reasonable:

1. **The error names no field.** "a schedule that wakes it must say what it
   should do when it fires" — true, and unactionable.
2. **The scaffold doesn't list it.** `SCHEDULE_JSON` is what
   `lemma schedules schema` prints, what `lemma init` writes, and what the
   CLI's own unrecognized-field warning tells you to go read. It was never
   updated when `instruction` and the `POD_DEFAULT` target were added, so it
   mentioned neither.
3. **`update` had no flags**, so retargeting meant hand-writing JSON against
   that reference.
4. **`update` dropped unknown keys silently.** It built its request with
   `from_dict`, which discards every key the model doesn't declare — so a
   payload under the wrong name was applied as an empty update and **reported
   success**. That doesn't read as "wrong field"; it reads as "accepted and
   ignored", which is what sent the agent looking elsewhere.

`create` has used `build_request` and warned since it was written. `update`
never did. Four other raw-payload paths had the same gap: apps create/update,
workflow update, connector account create — all routed through `build_request`
here.

## The gate

The scaffold gap is worth preventing, not just fixing: a field can be added to a
request model, given a CLI flag, and made conditionally required without
anything noticing the reference never mentions it.

`test_every_api_field_reaches_the_scaffold` compares each create-request model
against its scaffold and fails on anything undocumented, with an explicit
`UNDOCUMENTED_SCAFFOLD_FIELDS` list for the few left out on purpose. It found
six more the moment it was written — `config` and `type` on functions,
`input_schema`, `output_schema` and `metadata` on agents, `mode` on workflows —
all now documented rather than excluded.

## Note on the sandbox CLI

The conversation that surfaced this ran against a stale sandbox: the
`E2B_WORKSPACE_TEMPLATE` pinned in dev is build `bae2e097`, created
**2026-08-25**, while `--instruction` landed on **Sep 1**. That template is
built and promoted by hand and no CI job rebuilds or drift-checks it, so its
CLI trails the API silently.

Promoting the newer build (`ce7f3914`, Sep 3) is a deployment change and not in
this PR — **and it would not have prevented this**. I booted both templates:

| | pinned (Aug 25) | newest (Sep 3) |
|---|---|---|
| `schedules create --help` has `--instruction` | ✗ | ✓ |
| `schedules update --help` has `--instruction` | ✗ | ✗ |
| `schedules schema` mentions `instruction` | ✗ | ✗ |

The blocker was on `update`, discovered via `schema`. Both were still broken on
main until this change.

## How to verify

```bash
cd lemma-cli && uv run pytest tests/test_scaffold.py tests/test_commands_schedules.py -q
```

`77 passed`. Deleting the `instruction` line from the scaffold fails
`test_every_api_field_reaches_the_scaffold`, naming the field and the file.

```bash
cd lemma-cli && uv run pytest tests/ --ignore=tests/e2e -q
```

`747 passed`.

```bash
cd lemma-backend && uv run pytest app/modules/schedule -q
```

`315 passed, 7 skipped`.

```bash
make quality
```

`✓ quality gates pass`.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no authorization change. `build_request` only warns about
      keys it was already dropping; nothing new is sent to the API.
- [x] **Rollback** — plain revert; no migration, no API or SDK surface change.

## Compatibility and rollback notes

No schema, API or SDK change. `schedules update` still accepts the same
`--data`/`--file` payloads; it now warns about keys it silently discarded before
and errors when given nothing to do, where it previously failed on a missing
required `--data`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
