### PR TITLE
A resource type can no longer opt out of the cross-pod clamp by being forgotten

### DIFF
--- a/lemma-backend/app/core/authorization/resource_tables.py
+++ b/lemma-backend/app/core/authorization/resource_tables.py
@@ -1,0 +1,197 @@
+"""Which pod a resource belongs to, and which resources have no pod at all.
+
+`Authorizer.authorize` confines a pod's default agent to the pod it was invoked
+in by comparing the resource's pod against the context's. That comparison needs
+the resource's pod, and this is what supplies it.
+
+Its own module, not because `service.py` was long, but because the thing that
+makes this safe is a *check over the whole set* — and a set worth checking is a
+set worth naming. `assert_every_resource_type_is_classified` runs at import: a
+`ResourceType` in none of the four groups below stops the process rather than
+quietly opting itself out of the clamp, which is what used to happen.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy.orm import InstrumentedAttribute
+
+from app.core.authorization.context import ResourceRef, ResourceType
+from app.modules.agent.infrastructure.models import AgentModel, ConversationModel
+from app.modules.apps.infrastructure.models import AppModel
+from app.modules.datastore.infrastructure.models import DatastoreFile, DatastoreTable
+from app.modules.function.infrastructure.models import FunctionModel
+from app.modules.schedule.infrastructure.models.schedule import Schedule
+from app.modules.workflow.infrastructure.models import WorkflowModel
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceTable:
+    """The columns a resource type is hydrated from.
+
+    Named fields rather than the 5-tuple this replaced, whose first element was
+    the model and was never read — the caller unpacked it as `_model`.
+    """
+
+    id_column: InstrumentedAttribute
+    pod_column: InstrumentedAttribute
+    owner_column: InstrumentedAttribute
+    #: ``None`` for a table with no visibility column; the caller treats such a
+    #: resource as PERSONAL.
+    visibility_column: InstrumentedAttribute | None
+    #: Set only for the hierarchical datastore types, whose grants cascade to
+    #: descendants by path. Naming it here keeps this module the only place in
+    #: `app/core` that reaches for a datastore column.
+    path_column: InstrumentedAttribute | None = None
+
+
+def _table(
+    id_column, pod_column, owner_column, visibility_column=None, path_column=None
+) -> ResourceTable:
+    return ResourceTable(
+        id_column, pod_column, owner_column, visibility_column, path_column
+    )
+
+
+#: Where a resource type learns which pod and owner it belongs to.
+#:
+#: A dict rather than an `if` ladder, and module-level rather than rebuilt per
+#: call, so that the set of types it covers can be *checked* — see
+#: `assert_every_resource_type_is_classified` below.
+#:
+#: Two readers, which is the other reason it is a table. `Authorizer` hydrates a
+#: resource from it, and `get_resource_creator` reads `owner_column` from it;
+#: that used to be a second `if` ladder over the same types, with its own
+#: `else: return None`, free to drift from this one.
+#:
+#: `FOLDER`/`DOCUMENT` carry rows for the owner lookup, but hydration never
+#: reaches them: `_hydrate_datastore_file` intercepts both several lines
+#: earlier, because a datastore file also needs the path its folder grants
+#: cascade on.
+RESOURCE_TABLES: dict[ResourceType, ResourceTable] = {
+    ResourceType.AGENT: _table(
+        AgentModel.id,
+        AgentModel.pod_id,
+        AgentModel.user_id,
+        AgentModel.visibility,
+    ),
+    ResourceType.FUNCTION: _table(
+        FunctionModel.id,
+        FunctionModel.pod_id,
+        FunctionModel.user_id,
+        FunctionModel.visibility,
+    ),
+    ResourceType.CONVERSATION: _table(
+        ConversationModel.id,
+        ConversationModel.pod_id,
+        ConversationModel.user_id,
+        None,
+    ),
+    ResourceType.DATASTORE_TABLE: _table(
+        DatastoreTable.id,
+        DatastoreTable.pod_id,
+        DatastoreTable.user_id,
+        DatastoreTable.visibility,
+    ),
+    ResourceType.APP: _table(
+        AppModel.id,
+        AppModel.pod_id,
+        AppModel.user_id,
+        AppModel.visibility,
+    ),
+    ResourceType.WORKFLOW: _table(
+        WorkflowModel.id,
+        WorkflowModel.pod_id,
+        WorkflowModel.user_id,
+        WorkflowModel.visibility,
+    ),
+    ResourceType.FOLDER: _table(
+        DatastoreFile.id,
+        DatastoreFile.pod_id,
+        DatastoreFile.owner_user_id,
+        DatastoreFile.visibility,
+        DatastoreFile.path,
+    ),
+    ResourceType.DOCUMENT: _table(
+        DatastoreFile.id,
+        DatastoreFile.pod_id,
+        DatastoreFile.owner_user_id,
+        DatastoreFile.visibility,
+        DatastoreFile.path,
+    ),
+    ResourceType.SCHEDULE: _table(
+        Schedule.id,
+        Schedule.pod_id,
+        Schedule.user_id,
+        Schedule.visibility,
+    ),
+}
+
+#: Types hydrated by a method of their own rather than by a table lookup.
+HYDRATED_BY_METHOD = frozenset(
+    {
+        # Its own id is its pod.
+        ResourceType.POD,
+        # These also have rows above, for the owner lookup; hydration takes
+        # the method because it needs the path as well.
+        ResourceType.FOLDER,
+        ResourceType.DOCUMENT,
+        # Org-scoped tables with no pod column; see the methods for why that is
+        # the right answer rather than a gap.
+        ResourceType.CONNECTOR,
+        ResourceType.CONNECTOR_ACCOUNT,
+        ResourceType.CONNECTOR_AUTH_CONFIG,
+    }
+)
+
+#: Types that do not belong to a pod, so the cross-pod clamp has nothing to
+#: compare and its absence is a decision rather than an omission. A delegated
+#: pod agent is refused an org-scoped action before hydration is reached at all,
+#: by `_is_pod_scoped_permission`.
+NOT_POD_SCOPED = frozenset({ResourceType.ORGANIZATION, ResourceType.ROLE})
+
+#: Pod-scoped types for which nothing builds a `ResourceRef` today. They exist
+#: as permission ids and grant targets, and never reach `authorize` as a
+#: resource. Listed rather than left out: the moment something does build one,
+#: `pod_is_unknowable` denies instead of waving it through, and the fix is to
+#: give the type a row above.
+NO_REFS_CONSTRUCTED = frozenset(
+    {ResourceType.POD_MEMBER, ResourceType.DATASTORE_RECORD}
+)
+
+
+def assert_every_resource_type_is_classified() -> None:
+    """Refuse to import if a `ResourceType` is in none of the sets above.
+
+    The cross-pod clamp in `Authorizer.authorize` only fires when a resource's
+    pod is known, so a type nobody classified was a type the clamp silently
+    skipped. Adding one to `ResourceType` used to be enough to opt it out; now
+    it fails here, at import, with the name of the type.
+    """
+    classified = (
+        set(RESOURCE_TABLES) | HYDRATED_BY_METHOD | NOT_POD_SCOPED | NO_REFS_CONSTRUCTED
+    )
+    missing = set(ResourceType) - classified
+    if missing:
+        raise RuntimeError(
+            "ResourceType(s) not classified for authorization hydration: "
+            + ", ".join(sorted(t.name for t in missing))
+            + ". Add a row to _RESOURCE_TABLES, or name the type in one of "
+            "HYDRATED_BY_METHOD / NOT_POD_SCOPED / NO_REFS_CONSTRUCTED."
+        )
+
+
+assert_every_resource_type_is_classified()
+
+
+def pod_is_unknowable(resource: ResourceRef) -> bool:
+    """Should a pod-scoped check refuse this resource for want of a pod?
+
+    True when the resource belongs to a pod in principle but hydration could not
+    say which. False for types that have no pod at all, whose exemption is
+    recorded in `NOT_POD_SCOPED`.
+    """
+    if resource.resource_type in NOT_POD_SCOPED:
+        return False
+    return resource.pod_id is None

--- a/lemma-backend/app/core/authorization/service.py
+++ b/lemma-backend/app/core/authorization/service.py
@@ -59,13 +59,10 @@ from app.core.authorization.permissions import (
 from app.core.authorization.resource_actions import owner_actions_for_resource
 from app.core.authorization.workload_authority import authorize_delegated_workload
 from app.core.authorization.resource_names import resolve_resource_id_by_name
-from app.modules.datastore.infrastructure.models.datastore_models import (
-    DatastoreFile,
-    DatastoreTable,
+from app.core.authorization.resource_tables import (
+    RESOURCE_TABLES,
+    pod_is_unknowable,
 )
-from app.modules.agent.infrastructure.models import AgentModel, ConversationModel
-from app.modules.apps.infrastructure.models import AppModel
-from app.modules.function.infrastructure.models import FunctionModel
 from app.modules.identity.infrastructure.models.organization_models import (
     OrganizationMember,
 )
@@ -76,8 +73,6 @@ from app.modules.pod.domain.visibility import (
     normalize_role_name,
 )
 from app.modules.pod.infrastructure.models.pod_models import Pod, PodMember
-from app.modules.schedule.infrastructure.models.schedule import Schedule
-from app.modules.workflow.infrastructure.models import WorkflowModel
 
 
 async def _session_approval(
@@ -394,30 +389,10 @@ class AuthorizationDataService:
         resource_type: ResourceType,
         resource_id: UUID,
     ) -> UUID | None:
-        if resource_type == ResourceType.AGENT:
-            stmt = select(AgentModel.user_id).where(AgentModel.id == resource_id)
-        elif resource_type == ResourceType.FUNCTION:
-            stmt = select(FunctionModel.user_id).where(FunctionModel.id == resource_id)
-        elif resource_type == ResourceType.APP:
-            stmt = select(AppModel.user_id).where(AppModel.id == resource_id)
-        elif resource_type == ResourceType.DOCUMENT:
-            stmt = select(DatastoreFile.owner_user_id).where(
-                DatastoreFile.id == resource_id
-            )
-        elif resource_type == ResourceType.FOLDER:
-            stmt = select(DatastoreFile.owner_user_id).where(
-                DatastoreFile.id == resource_id
-            )
-        elif resource_type == ResourceType.DATASTORE_TABLE:
-            stmt = select(DatastoreTable.user_id).where(
-                DatastoreTable.id == resource_id
-            )
-        elif resource_type == ResourceType.WORKFLOW:
-            stmt = select(WorkflowModel.user_id).where(WorkflowModel.id == resource_id)
-        elif resource_type == ResourceType.SCHEDULE:
-            stmt = select(Schedule.user_id).where(Schedule.id == resource_id)
-        else:
+        table = RESOURCE_TABLES.get(resource_type)
+        if table is None:
             return None
+        stmt = select(table.owner_column).where(table.id_column == resource_id)
         return (await self.session.execute(stmt)).scalar_one_or_none()
 
     async def assign_roles(
@@ -1133,137 +1108,9 @@ class AuthorizationDataService:
         await self._invalidate_snapshots_after_commit(user_id=targets.user_id)
 
 
-#: Where a resource type learns which pod and owner it belongs to:
-#: ``(model, id_column, pod_column, owner_column, visibility_column)``, with a
-#: ``None`` visibility column for a table that has none.
-#:
-#: A dict rather than an `if` ladder, and module-level rather than rebuilt per
-#: call, so that the set of types it covers can be *checked* — see
-#: `_assert_every_resource_type_is_classified` below. `FOLDER`/`DOCUMENT` are
-#: absent on purpose: they are hydrated by `_hydrate_datastore_file`, which also
-#: fetches the path the folder-grant cascade matches on, and entries for them
-#: here were unreachable.
-_RESOURCE_TABLES: dict[ResourceType, tuple] = {
-    ResourceType.AGENT: (
-        AgentModel,
-        AgentModel.id,
-        AgentModel.pod_id,
-        AgentModel.user_id,
-        AgentModel.visibility,
-    ),
-    ResourceType.FUNCTION: (
-        FunctionModel,
-        FunctionModel.id,
-        FunctionModel.pod_id,
-        FunctionModel.user_id,
-        FunctionModel.visibility,
-    ),
-    ResourceType.CONVERSATION: (
-        ConversationModel,
-        ConversationModel.id,
-        ConversationModel.pod_id,
-        ConversationModel.user_id,
-        None,
-    ),
-    ResourceType.DATASTORE_TABLE: (
-        DatastoreTable,
-        DatastoreTable.id,
-        DatastoreTable.pod_id,
-        DatastoreTable.user_id,
-        DatastoreTable.visibility,
-    ),
-    ResourceType.APP: (
-        AppModel,
-        AppModel.id,
-        AppModel.pod_id,
-        AppModel.user_id,
-        AppModel.visibility,
-    ),
-    ResourceType.WORKFLOW: (
-        WorkflowModel,
-        WorkflowModel.id,
-        WorkflowModel.pod_id,
-        WorkflowModel.user_id,
-        WorkflowModel.visibility,
-    ),
-    ResourceType.SCHEDULE: (
-        Schedule,
-        Schedule.id,
-        Schedule.pod_id,
-        Schedule.user_id,
-        Schedule.visibility,
-    ),
-}
-
-#: Types hydrated by a method of their own rather than by a table lookup.
-_HYDRATED_BY_METHOD = frozenset(
-    {
-        # Its own id is its pod.
-        ResourceType.POD,
-        # Also fetch the stored path, for the folder-grant cascade.
-        ResourceType.FOLDER,
-        ResourceType.DOCUMENT,
-        # Org-scoped tables with no pod column; see the methods for why that is
-        # the right answer rather than a gap.
-        ResourceType.CONNECTOR,
-        ResourceType.CONNECTOR_ACCOUNT,
-        ResourceType.CONNECTOR_AUTH_CONFIG,
-    }
-)
-
-#: Types that do not belong to a pod, so the cross-pod clamp has nothing to
-#: compare and its absence is a decision rather than an omission. A delegated
-#: pod agent is refused an org-scoped action before hydration is reached at all,
-#: by `_is_pod_scoped_permission`.
-_NOT_POD_SCOPED = frozenset({ResourceType.ORGANIZATION, ResourceType.ROLE})
-
-#: Pod-scoped types for which nothing builds a `ResourceRef` today. They exist
-#: as permission ids and grant targets, and never reach `authorize` as a
-#: resource. Listed rather than left out: the moment something does build one,
-#: `_pod_is_unknowable` denies instead of waving it through, and the fix is to
-#: give the type a row above.
-_NO_REFS_CONSTRUCTED = frozenset(
-    {ResourceType.POD_MEMBER, ResourceType.DATASTORE_RECORD}
-)
-
-
-def _assert_every_resource_type_is_classified() -> None:
-    """Refuse to import if a `ResourceType` is in none of the sets above.
-
-    The cross-pod clamp in `Authorizer.authorize` only fires when a resource's
-    pod is known, so a type nobody classified was a type the clamp silently
-    skipped. Adding one to `ResourceType` used to be enough to opt it out; now
-    it fails here, at import, with the name of the type.
-    """
-    classified = (
-        set(_RESOURCE_TABLES)
-        | _HYDRATED_BY_METHOD
-        | _NOT_POD_SCOPED
-        | _NO_REFS_CONSTRUCTED
-    )
-    missing = set(ResourceType) - classified
-    if missing:
-        raise RuntimeError(
-            "ResourceType(s) not classified for authorization hydration: "
-            + ", ".join(sorted(t.name for t in missing))
-            + ". Add a row to _RESOURCE_TABLES, or name the type in one of "
-            "_HYDRATED_BY_METHOD / _NOT_POD_SCOPED / _NO_REFS_CONSTRUCTED."
-        )
-
-
-_assert_every_resource_type_is_classified()
-
-
-def _pod_is_unknowable(resource: ResourceRef) -> bool:
-    """Should a pod-scoped check refuse this resource for want of a pod?
-
-    True when the resource belongs to a pod in principle but hydration could not
-    say which. False for types that have no pod at all, whose exemption is
-    recorded in `_NOT_POD_SCOPED`.
-    """
-    if resource.resource_type in _NOT_POD_SCOPED:
-        return False
-    return resource.pod_id is None
+#: Datastore's file columns, via the one table that names them. `FOLDER` and
+#: `DOCUMENT` share a row, so either serves.
+_FILES = RESOURCE_TABLES[ResourceType.FOLDER]
 
 
 class Authorizer:
@@ -1373,7 +1220,7 @@ class Authorizer:
             # omission. `_pod_is_unknowable` exempts the types that genuinely
             # have no pod, and `_assert_every_resource_type_is_classified`
             # makes staying silent about a new one impossible.
-            else _pod_is_unknowable(hydrated)
+            else pod_is_unknowable(hydrated)
         ):
             return AuthorizationDecision(
                 False, "DELEGATED_POD_SCOPE_ONLY", permission_id, hydrated
@@ -1699,24 +1546,25 @@ class Authorizer:
             return await self._hydrate_connector_account(resource)
         if resource.resource_type == ResourceType.CONNECTOR_AUTH_CONFIG:
             return await self._hydrate_connector_auth_config(resource)
-        columns = _RESOURCE_TABLES.get(resource.resource_type)
-        if columns is None:
+        table = RESOURCE_TABLES.get(resource.resource_type)
+        if table is None:
             # Not a silent pass-through: every type is classified below, and
             # `_assert_every_resource_type_is_classified` refuses to import this
             # module if one is not. Reaching here means a type is registered as
             # unroutable and something built a ref for it anyway.
             return resource
-        _model, id_col, pod_col, owner_col, visibility_col = columns
-        if visibility_col is None:
-            stmt = select(pod_col, owner_col).where(id_col == resource.resource_id)
-        else:
-            stmt = select(pod_col, owner_col, visibility_col).where(
-                id_col == resource.resource_id
+        if table.visibility_column is None:
+            stmt = select(table.pod_column, table.owner_column).where(
+                table.id_column == resource.resource_id
             )
+        else:
+            stmt = select(
+                table.pod_column, table.owner_column, table.visibility_column
+            ).where(table.id_column == resource.resource_id)
         row = (await self.session.execute(stmt)).first()
         if row is None:
             return resource
-        if visibility_col is None:
+        if table.visibility_column is None:
             visibility = ResourceVisibility.PERSONAL
         else:
             visibility = self._normalize_visibility(row[2])
@@ -1741,11 +1589,11 @@ class Authorizer:
             return resource
 
         stmt = select(
-            DatastoreFile.pod_id,
-            DatastoreFile.owner_user_id,
-            DatastoreFile.visibility,
-            DatastoreFile.path,
-        ).where(DatastoreFile.id == resource.resource_id)
+            _FILES.pod_column,
+            _FILES.owner_column,
+            _FILES.visibility_column,
+            _FILES.path_column,
+        ).where(_FILES.id_column == resource.resource_id)
         row = (await self.session.execute(stmt)).first()
         if row is None:
             return resource
@@ -1962,9 +1810,9 @@ class Authorizer:
         cached = self._folder_ids_by_paths.get(key)
         if cached is not None:
             return cached
-        stmt = select(DatastoreFile.id).where(
-            DatastoreFile.pod_id == pod_id,
-            DatastoreFile.path.in_(candidate_paths),
+        stmt = select(_FILES.id_column).where(
+            _FILES.pod_column == pod_id,
+            _FILES.path_column.in_(candidate_paths),
         )
         resolved = list((await self.session.execute(stmt)).scalars().all())
         self._folder_ids_by_paths[key] = resolved

--- a/lemma-backend/app/core/authorization/service.py
+++ b/lemma-backend/app/core/authorization/service.py
@@ -1133,6 +1133,139 @@ class AuthorizationDataService:
         await self._invalidate_snapshots_after_commit(user_id=targets.user_id)
 
 
+#: Where a resource type learns which pod and owner it belongs to:
+#: ``(model, id_column, pod_column, owner_column, visibility_column)``, with a
+#: ``None`` visibility column for a table that has none.
+#:
+#: A dict rather than an `if` ladder, and module-level rather than rebuilt per
+#: call, so that the set of types it covers can be *checked* — see
+#: `_assert_every_resource_type_is_classified` below. `FOLDER`/`DOCUMENT` are
+#: absent on purpose: they are hydrated by `_hydrate_datastore_file`, which also
+#: fetches the path the folder-grant cascade matches on, and entries for them
+#: here were unreachable.
+_RESOURCE_TABLES: dict[ResourceType, tuple] = {
+    ResourceType.AGENT: (
+        AgentModel,
+        AgentModel.id,
+        AgentModel.pod_id,
+        AgentModel.user_id,
+        AgentModel.visibility,
+    ),
+    ResourceType.FUNCTION: (
+        FunctionModel,
+        FunctionModel.id,
+        FunctionModel.pod_id,
+        FunctionModel.user_id,
+        FunctionModel.visibility,
+    ),
+    ResourceType.CONVERSATION: (
+        ConversationModel,
+        ConversationModel.id,
+        ConversationModel.pod_id,
+        ConversationModel.user_id,
+        None,
+    ),
+    ResourceType.DATASTORE_TABLE: (
+        DatastoreTable,
+        DatastoreTable.id,
+        DatastoreTable.pod_id,
+        DatastoreTable.user_id,
+        DatastoreTable.visibility,
+    ),
+    ResourceType.APP: (
+        AppModel,
+        AppModel.id,
+        AppModel.pod_id,
+        AppModel.user_id,
+        AppModel.visibility,
+    ),
+    ResourceType.WORKFLOW: (
+        WorkflowModel,
+        WorkflowModel.id,
+        WorkflowModel.pod_id,
+        WorkflowModel.user_id,
+        WorkflowModel.visibility,
+    ),
+    ResourceType.SCHEDULE: (
+        Schedule,
+        Schedule.id,
+        Schedule.pod_id,
+        Schedule.user_id,
+        Schedule.visibility,
+    ),
+}
+
+#: Types hydrated by a method of their own rather than by a table lookup.
+_HYDRATED_BY_METHOD = frozenset(
+    {
+        # Its own id is its pod.
+        ResourceType.POD,
+        # Also fetch the stored path, for the folder-grant cascade.
+        ResourceType.FOLDER,
+        ResourceType.DOCUMENT,
+        # Org-scoped tables with no pod column; see the methods for why that is
+        # the right answer rather than a gap.
+        ResourceType.CONNECTOR,
+        ResourceType.CONNECTOR_ACCOUNT,
+        ResourceType.CONNECTOR_AUTH_CONFIG,
+    }
+)
+
+#: Types that do not belong to a pod, so the cross-pod clamp has nothing to
+#: compare and its absence is a decision rather than an omission. A delegated
+#: pod agent is refused an org-scoped action before hydration is reached at all,
+#: by `_is_pod_scoped_permission`.
+_NOT_POD_SCOPED = frozenset({ResourceType.ORGANIZATION, ResourceType.ROLE})
+
+#: Pod-scoped types for which nothing builds a `ResourceRef` today. They exist
+#: as permission ids and grant targets, and never reach `authorize` as a
+#: resource. Listed rather than left out: the moment something does build one,
+#: `_pod_is_unknowable` denies instead of waving it through, and the fix is to
+#: give the type a row above.
+_NO_REFS_CONSTRUCTED = frozenset(
+    {ResourceType.POD_MEMBER, ResourceType.DATASTORE_RECORD}
+)
+
+
+def _assert_every_resource_type_is_classified() -> None:
+    """Refuse to import if a `ResourceType` is in none of the sets above.
+
+    The cross-pod clamp in `Authorizer.authorize` only fires when a resource's
+    pod is known, so a type nobody classified was a type the clamp silently
+    skipped. Adding one to `ResourceType` used to be enough to opt it out; now
+    it fails here, at import, with the name of the type.
+    """
+    classified = (
+        set(_RESOURCE_TABLES)
+        | _HYDRATED_BY_METHOD
+        | _NOT_POD_SCOPED
+        | _NO_REFS_CONSTRUCTED
+    )
+    missing = set(ResourceType) - classified
+    if missing:
+        raise RuntimeError(
+            "ResourceType(s) not classified for authorization hydration: "
+            + ", ".join(sorted(t.name for t in missing))
+            + ". Add a row to _RESOURCE_TABLES, or name the type in one of "
+            "_HYDRATED_BY_METHOD / _NOT_POD_SCOPED / _NO_REFS_CONSTRUCTED."
+        )
+
+
+_assert_every_resource_type_is_classified()
+
+
+def _pod_is_unknowable(resource: ResourceRef) -> bool:
+    """Should a pod-scoped check refuse this resource for want of a pod?
+
+    True when the resource belongs to a pod in principle but hydration could not
+    say which. False for types that have no pod at all, whose exemption is
+    recorded in `_NOT_POD_SCOPED`.
+    """
+    if resource.resource_type in _NOT_POD_SCOPED:
+        return False
+    return resource.pod_id is None
+
+
 class Authorizer:
     def __init__(self, session: AsyncSession):
         self.session = session
@@ -1229,10 +1362,18 @@ class Authorizer:
             )
 
         hydrated = await self._hydrate_resource(resource)
-        if (
-            clamp_to_pod
-            and hydrated.pod_id is not None
-            and hydrated.pod_id != ctx.pod_id
+        if clamp_to_pod and (
+            hydrated.pod_id != ctx.pod_id
+            if hydrated.pod_id is not None
+            # A pod-scoped resource whose pod could not be established is
+            # refused rather than waved through. This used to read
+            # `pod_id is not None and pod_id != ctx.pod_id`, so a type
+            # hydration did not know skipped the clamp entirely — the guard
+            # confining a pod's default agent to its own pod was opt-out by
+            # omission. `_pod_is_unknowable` exempts the types that genuinely
+            # have no pod, and `_assert_every_resource_type_is_classified`
+            # makes staying silent about a new one impossible.
+            else _pod_is_unknowable(hydrated)
         ):
             return AuthorizationDecision(
                 False, "DELEGATED_POD_SCOPE_ONLY", permission_id, hydrated
@@ -1538,6 +1679,18 @@ class Authorizer:
             return resource
         # Folder/document hydration also fetches the row's path so folder grants
         # can cascade to descendants in the matcher.
+        if resource.resource_type is ResourceType.POD:
+            # A pod's own id is the pod it belongs to, so this needs no table.
+            # Every caller happens to pass `pod_id` today; deriving it here is
+            # what stops the clamp depending on that continuing to be true.
+            return ResourceRef(
+                resource_type=resource.resource_type,
+                resource_id=resource.resource_id,
+                organization_id=resource.organization_id,
+                pod_id=resource.pod_id or resource.resource_id,
+                owner_user_id=resource.owner_user_id,
+                visibility=resource.visibility,
+            )
         if resource.resource_type in (ResourceType.FOLDER, ResourceType.DOCUMENT):
             return await self._hydrate_datastore_file(resource)
         if resource.resource_type == ResourceType.CONNECTOR:
@@ -1546,76 +1699,14 @@ class Authorizer:
             return await self._hydrate_connector_account(resource)
         if resource.resource_type == ResourceType.CONNECTOR_AUTH_CONFIG:
             return await self._hydrate_connector_auth_config(resource)
-        mapping = {
-            ResourceType.AGENT: (
-                AgentModel,
-                AgentModel.id,
-                AgentModel.pod_id,
-                AgentModel.user_id,
-                AgentModel.visibility,
-            ),
-            ResourceType.FUNCTION: (
-                FunctionModel,
-                FunctionModel.id,
-                FunctionModel.pod_id,
-                FunctionModel.user_id,
-                FunctionModel.visibility,
-            ),
-            ResourceType.CONVERSATION: (
-                ConversationModel,
-                ConversationModel.id,
-                ConversationModel.pod_id,
-                ConversationModel.user_id,
-                None,
-            ),
-            ResourceType.DATASTORE_TABLE: (
-                DatastoreTable,
-                DatastoreTable.id,
-                DatastoreTable.pod_id,
-                DatastoreTable.user_id,
-                DatastoreTable.visibility,
-            ),
-            ResourceType.FOLDER: (
-                DatastoreFile,
-                DatastoreFile.id,
-                DatastoreFile.pod_id,
-                DatastoreFile.owner_user_id,
-                DatastoreFile.visibility,
-            ),
-            ResourceType.DOCUMENT: (
-                DatastoreFile,
-                DatastoreFile.id,
-                DatastoreFile.pod_id,
-                DatastoreFile.owner_user_id,
-                DatastoreFile.visibility,
-            ),
-            ResourceType.APP: (
-                AppModel,
-                AppModel.id,
-                AppModel.pod_id,
-                AppModel.user_id,
-                AppModel.visibility,
-            ),
-            ResourceType.WORKFLOW: (
-                WorkflowModel,
-                WorkflowModel.id,
-                WorkflowModel.pod_id,
-                WorkflowModel.user_id,
-                WorkflowModel.visibility,
-            ),
-            ResourceType.SCHEDULE: (
-                Schedule,
-                Schedule.id,
-                Schedule.pod_id,
-                Schedule.user_id,
-                Schedule.visibility,
-            ),
-        }
-        if resource.resource_type not in mapping:
+        columns = _RESOURCE_TABLES.get(resource.resource_type)
+        if columns is None:
+            # Not a silent pass-through: every type is classified below, and
+            # `_assert_every_resource_type_is_classified` refuses to import this
+            # module if one is not. Reaching here means a type is registered as
+            # unroutable and something built a ref for it anyway.
             return resource
-        _model, id_col, pod_col, owner_col, visibility_col = mapping[
-            resource.resource_type
-        ]
+        _model, id_col, pod_col, owner_col, visibility_col = columns
         if visibility_col is None:
             stmt = select(pod_col, owner_col).where(id_col == resource.resource_id)
         else:

--- a/lemma-backend/app/core/authorization/tests/unit/test_resource_hydration.py
+++ b/lemma-backend/app/core/authorization/tests/unit/test_resource_hydration.py
@@ -93,20 +93,24 @@ LEARNS_ORG_ONLY = {
     ResourceType.CONNECTOR_AUTH_CONFIG: "org_scoped",
 }
 
+#: A pod's own id *is* its pod, so this one needs no table. Every caller passes
+#: `pod_id` today, which is why the clamp worked; deriving it here is what stops
+#: the clamp depending on that continuing to be true.
+LEARNS_POD_WITHOUT_A_QUERY = {ResourceType.POD}
+
 #: Types hydration does not look up at all.
 #:
-#: `CONNECTOR` is deliberate — its hydrator returns early when there is no pod,
-#: and says why in prose. The other five are simply absent from the literal
-#: mapping, and nothing anywhere records that as a decision. `ORGANIZATION` and
-#: `ROLE` are org-scoped, so a pod-default agent is already refused earlier by
-#: `_is_pod_scoped_permission`. That leaves **POD, POD_MEMBER and
-#: DATASTORE_RECORD**: pod-scoped resources, reachable by a pod-default agent,
-#: for which the cross-pod clamp does not run.
+#: `CONNECTOR` is deliberate — its hydrator returns early without a pod, and
+#: says why in prose. `ORGANIZATION` and `ROLE` have no pod: a pod-default agent
+#: is refused an org-scoped action earlier, by `_is_pod_scoped_permission`.
+#: `POD_MEMBER` and `DATASTORE_RECORD` are pod-scoped but nothing in production
+#: builds a `ResourceRef` for either — they exist as permission ids and grant
+#: targets only. They are named in `_NO_REFS_CONSTRUCTED` so that if something
+#: ever does build one, the clamp denies instead of waving it through.
 NO_LOOKUP = {
     ResourceType.CONNECTOR,
     ResourceType.ORGANIZATION,
     ResourceType.ROLE,
-    ResourceType.POD,
     ResourceType.POD_MEMBER,
     ResourceType.DATASTORE_RECORD,
 }
@@ -117,13 +121,15 @@ def test_every_resource_type_is_accounted_for():
 
     Without it, adding a type silently opts it out of the cross-pod clamp.
     """
-    covered = set(LEARNS_POD) | set(LEARNS_ORG_ONLY) | NO_LOOKUP
+    covered = (
+        set(LEARNS_POD) | set(LEARNS_ORG_ONLY) | NO_LOOKUP | LEARNS_POD_WITHOUT_A_QUERY
+    )
     assert covered == set(ResourceType), (
         f"a ResourceType is in no set: {set(ResourceType) - covered}"
     )
-    assert len(LEARNS_POD) + len(LEARNS_ORG_ONLY) + len(NO_LOOKUP) == len(
-        set(ResourceType)
-    ), "a ResourceType is in more than one set"
+    assert len(LEARNS_POD) + len(LEARNS_ORG_ONLY) + len(NO_LOOKUP) + len(
+        LEARNS_POD_WITHOUT_A_QUERY
+    ) == len(set(ResourceType)), "a ResourceType is in more than one set"
 
 
 @pytest.mark.asyncio
@@ -221,3 +227,70 @@ async def test_a_row_that_is_gone_leaves_the_ref_alone():
 
     assert session.queries == 1
     assert hydrated.pod_id is None
+
+
+@pytest.mark.asyncio
+async def test_a_pod_ref_learns_its_pod_from_its_own_id():
+    """The caller does not have to remember to pass `pod_id`."""
+    session = _RecordingSession(ROWS["generic"])
+    service = Authorizer(session)
+    pod_id = uuid4()
+
+    hydrated = await service._hydrate_resource(
+        ResourceRef(resource_type=ResourceType.POD, resource_id=pod_id)
+    )
+
+    assert session.queries == 0
+    assert hydrated.pod_id == pod_id
+
+
+def test_the_registry_refuses_a_resource_type_nobody_classified():
+    """The check that runs at import, exercised.
+
+    Adding a member to `ResourceType` used to be enough to opt it out of the
+    cross-pod clamp, silently. Now it fails loudly, naming the type.
+    """
+    from app.core.authorization import service as authorization_service
+
+    original = authorization_service._NOT_POD_SCOPED
+    try:
+        authorization_service._NOT_POD_SCOPED = frozenset()
+        with pytest.raises(RuntimeError, match="ORGANIZATION|ROLE"):
+            authorization_service._assert_every_resource_type_is_classified()
+    finally:
+        authorization_service._NOT_POD_SCOPED = original
+
+    # And passes as shipped.
+    authorization_service._assert_every_resource_type_is_classified()
+
+
+@pytest.mark.parametrize(
+    ("resource_type", "expected", "why"),
+    [
+        (ResourceType.AGENT, True, "pod-scoped and its pod was not established"),
+        (ResourceType.ORGANIZATION, False, "has no pod to be outside of"),
+        (ResourceType.ROLE, False, "has no pod to be outside of"),
+        (
+            ResourceType.POD_MEMBER,
+            True,
+            "pod-scoped; nothing builds a ref today, and if it does it is refused",
+        ),
+    ],
+    ids=lambda v: str(v)[:40],
+)
+def test_which_resources_a_pod_scoped_check_refuses_for_want_of_a_pod(
+    resource_type, expected, why
+):
+    from app.core.authorization.service import _pod_is_unknowable
+
+    ref = ResourceRef(resource_type=resource_type, resource_id=uuid4())
+    assert _pod_is_unknowable(ref) is expected, why
+
+
+def test_a_resource_that_knows_its_pod_is_never_refused_for_want_of_one():
+    from app.core.authorization.service import _pod_is_unknowable
+
+    ref = ResourceRef(
+        resource_type=ResourceType.AGENT, resource_id=uuid4(), pod_id=uuid4()
+    )
+    assert _pod_is_unknowable(ref) is False

--- a/lemma-backend/app/core/authorization/tests/unit/test_resource_hydration.py
+++ b/lemma-backend/app/core/authorization/tests/unit/test_resource_hydration.py
@@ -250,18 +250,18 @@ def test_the_registry_refuses_a_resource_type_nobody_classified():
     Adding a member to `ResourceType` used to be enough to opt it out of the
     cross-pod clamp, silently. Now it fails loudly, naming the type.
     """
-    from app.core.authorization import service as authorization_service
+    from app.core.authorization import resource_tables
 
-    original = authorization_service._NOT_POD_SCOPED
+    original = resource_tables.NOT_POD_SCOPED
     try:
-        authorization_service._NOT_POD_SCOPED = frozenset()
+        resource_tables.NOT_POD_SCOPED = frozenset()
         with pytest.raises(RuntimeError, match="ORGANIZATION|ROLE"):
-            authorization_service._assert_every_resource_type_is_classified()
+            resource_tables.assert_every_resource_type_is_classified()
     finally:
-        authorization_service._NOT_POD_SCOPED = original
+        resource_tables.NOT_POD_SCOPED = original
 
     # And passes as shipped.
-    authorization_service._assert_every_resource_type_is_classified()
+    resource_tables.assert_every_resource_type_is_classified()
 
 
 @pytest.mark.parametrize(
@@ -281,16 +281,16 @@ def test_the_registry_refuses_a_resource_type_nobody_classified():
 def test_which_resources_a_pod_scoped_check_refuses_for_want_of_a_pod(
     resource_type, expected, why
 ):
-    from app.core.authorization.service import _pod_is_unknowable
+    from app.core.authorization.resource_tables import pod_is_unknowable
 
     ref = ResourceRef(resource_type=resource_type, resource_id=uuid4())
-    assert _pod_is_unknowable(ref) is expected, why
+    assert pod_is_unknowable(ref) is expected, why
 
 
 def test_a_resource_that_knows_its_pod_is_never_refused_for_want_of_one():
-    from app.core.authorization.service import _pod_is_unknowable
+    from app.core.authorization.resource_tables import pod_is_unknowable
 
     ref = ResourceRef(
         resource_type=ResourceType.AGENT, resource_id=uuid4(), pod_id=uuid4()
     )
-    assert _pod_is_unknowable(ref) is False
+    assert pod_is_unknowable(ref) is False

--- a/lemma-backend/app/core/authorization/tests/unit/test_resource_hydration.py
+++ b/lemma-backend/app/core/authorization/tests/unit/test_resource_hydration.py
@@ -1,0 +1,223 @@
+"""What hydration fills in, for every resource type there is.
+
+Hydration exists to answer one question the caller usually cannot: which pod
+does this resource belong to. The answer gates the cross-pod clamp in
+`authorize`, which is what confines a pod's default agent -- the most common
+actor in the product -- to the pod it was invoked in:
+
+    if clamp_to_pod and hydrated.pod_id is not None and hydrated.pod_id != ctx.pod_id:
+        deny
+
+That `is not None` is load-bearing in the wrong direction. A resource type
+hydration does not know returns unchanged, `pod_id` stays `None`, and the clamp
+is skipped rather than enforced. So "which types does hydration know" is a
+security property, and until this file there was no test of it at all.
+
+These are characterization tests: they record what the code does today, so the
+registry that replaces the literal mapping can be shown to preserve it.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from app.core.authorization.context import (
+    ResourceRef,
+    ResourceType,
+    ResourceVisibility,
+)
+from app.core.authorization.service import Authorizer
+
+pytestmark = pytest.mark.unit
+
+
+class _Result:
+    def __init__(self, row):
+        self._row = row
+
+    def first(self):
+        return self._row
+
+
+class _RecordingSession:
+    """A session that answers every query with one row and counts the asking."""
+
+    def __init__(self, row=None):
+        self.queries = 0
+        self._row = row
+
+    async def execute(self, _stmt):
+        self.queries += 1
+        return _Result(self._row)
+
+
+POD_ID = uuid4()
+OWNER_ID = uuid4()
+ORG_ID = uuid4()
+
+#: What each hydrator's `select` returns, per type. Four different shapes, which
+#: is itself why the mapping is easy to get wrong.
+ROWS = {
+    #: `select(pod_col, owner_col, visibility_col)`
+    "generic": (POD_ID, OWNER_ID, "POD"),
+    #: CONVERSATION has no visibility column, so the statement is two-wide.
+    "no_visibility": (POD_ID, OWNER_ID),
+    #: FOLDER/DOCUMENT also fetch the path, for the folder-grant cascade.
+    "datastore_file": (POD_ID, OWNER_ID, "POD", "/some/path"),
+    #: The connector tables are keyed by organization, not pod.
+    "org_scoped": (ORG_ID, OWNER_ID),
+}
+
+#: Types whose hydrator resolves a **pod** — the ones the cross-pod clamp works for.
+LEARNS_POD = {
+    ResourceType.AGENT: "generic",
+    ResourceType.FUNCTION: "generic",
+    ResourceType.DATASTORE_TABLE: "generic",
+    ResourceType.APP: "generic",
+    ResourceType.WORKFLOW: "generic",
+    ResourceType.SCHEDULE: "generic",
+    ResourceType.CONVERSATION: "no_visibility",
+    ResourceType.FOLDER: "datastore_file",
+    ResourceType.DOCUMENT: "datastore_file",
+}
+
+#: Types whose hydrator reads a row but resolves only an **organization**. The
+#: connector tables have no pod column, so `pod_id` is passed through untouched
+#: and the cross-pod clamp has nothing to compare. Deliberate: a connector is an
+#: org-wide capability and the real boundary is the connected *account*,
+#: enforced in `account_resolution_service`.
+LEARNS_ORG_ONLY = {
+    ResourceType.CONNECTOR_ACCOUNT: "org_scoped",
+    ResourceType.CONNECTOR_AUTH_CONFIG: "org_scoped",
+}
+
+#: Types hydration does not look up at all.
+#:
+#: `CONNECTOR` is deliberate — its hydrator returns early when there is no pod,
+#: and says why in prose. The other five are simply absent from the literal
+#: mapping, and nothing anywhere records that as a decision. `ORGANIZATION` and
+#: `ROLE` are org-scoped, so a pod-default agent is already refused earlier by
+#: `_is_pod_scoped_permission`. That leaves **POD, POD_MEMBER and
+#: DATASTORE_RECORD**: pod-scoped resources, reachable by a pod-default agent,
+#: for which the cross-pod clamp does not run.
+NO_LOOKUP = {
+    ResourceType.CONNECTOR,
+    ResourceType.ORGANIZATION,
+    ResourceType.ROLE,
+    ResourceType.POD,
+    ResourceType.POD_MEMBER,
+    ResourceType.DATASTORE_RECORD,
+}
+
+
+def test_every_resource_type_is_accounted_for():
+    """A new `ResourceType` lands in neither set, and this is where it shows up.
+
+    Without it, adding a type silently opts it out of the cross-pod clamp.
+    """
+    covered = set(LEARNS_POD) | set(LEARNS_ORG_ONLY) | NO_LOOKUP
+    assert covered == set(ResourceType), (
+        f"a ResourceType is in no set: {set(ResourceType) - covered}"
+    )
+    assert len(LEARNS_POD) + len(LEARNS_ORG_ONLY) + len(NO_LOOKUP) == len(
+        set(ResourceType)
+    ), "a ResourceType is in more than one set"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "resource_type", sorted(LEARNS_POD, key=lambda t: t.name), ids=lambda t: t.name
+)
+async def test_a_pod_scoped_type_learns_its_pod_from_the_row(resource_type):
+    session = _RecordingSession(ROWS[LEARNS_POD[resource_type]])
+    service = Authorizer(session)
+
+    hydrated = await service._hydrate_resource(
+        ResourceRef(resource_type=resource_type, resource_id=uuid4())
+    )
+
+    assert session.queries == 1, "hydration did not ask the database"
+    assert hydrated.pod_id == POD_ID
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "resource_type",
+    sorted(LEARNS_ORG_ONLY, key=lambda t: t.name),
+    ids=lambda t: t.name,
+)
+async def test_an_org_scoped_type_learns_an_org_and_no_pod(resource_type):
+    session = _RecordingSession(ROWS[LEARNS_ORG_ONLY[resource_type]])
+    service = Authorizer(session)
+
+    hydrated = await service._hydrate_resource(
+        ResourceRef(resource_type=resource_type, resource_id=uuid4())
+    )
+
+    assert session.queries == 1
+    assert hydrated.organization_id == ORG_ID
+    assert hydrated.pod_id is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "resource_type", sorted(NO_LOOKUP, key=lambda t: t.name), ids=lambda t: t.name
+)
+async def test_a_type_with_no_lookup_keeps_a_null_pod_and_skips_the_clamp(
+    resource_type,
+):
+    """The behaviour this file exists to record.
+
+    No query, no `pod_id`, and therefore no cross-pod check on the caller's
+    side, because that check is guarded by `hydrated.pod_id is not None`.
+    """
+    session = _RecordingSession(ROWS["generic"])
+    service = Authorizer(session)
+
+    hydrated = await service._hydrate_resource(
+        ResourceRef(resource_type=resource_type, resource_id=uuid4())
+    )
+
+    assert session.queries == 0
+    assert hydrated.pod_id is None
+
+
+@pytest.mark.asyncio
+async def test_a_ref_that_already_knows_its_visibility_is_not_re_read():
+    """The caller has done the work; hydration is a lookup, not a refresh."""
+    session = _RecordingSession(ROWS["generic"])
+    service = Authorizer(session)
+    ref = ResourceRef(
+        resource_type=ResourceType.AGENT,
+        resource_id=uuid4(),
+        visibility=ResourceVisibility.POD,
+    )
+
+    assert await service._hydrate_resource(ref) is ref
+    assert session.queries == 0
+
+
+@pytest.mark.asyncio
+async def test_a_ref_with_no_id_has_nothing_to_look_up():
+    session = _RecordingSession(ROWS["generic"])
+    service = Authorizer(session)
+    ref = ResourceRef(resource_type=ResourceType.AGENT, pod_id=uuid4())
+
+    assert await service._hydrate_resource(ref) is ref
+    assert session.queries == 0
+
+
+@pytest.mark.asyncio
+async def test_a_row_that_is_gone_leaves_the_ref_alone():
+    """A deleted resource hydrates to nothing, so the clamp is skipped for it too."""
+    session = _RecordingSession(None)
+    service = Authorizer(session)
+
+    hydrated = await service._hydrate_resource(
+        ResourceRef(resource_type=ResourceType.AGENT, resource_id=uuid4())
+    )
+
+    assert session.queries == 1
+    assert hydrated.pod_id is None

--- a/lemma-backend/app/modules/agent_surfaces/tests/unit/test_notification_egress.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/unit/test_notification_egress.py
@@ -739,7 +739,8 @@ async def test_the_recipients_own_preference_no_longer_steers_delivery():
     # Autospecced against the Protocol: reading a method it no longer declares
     # raises, so this is what proves the lookup is gone rather than just unused.
     with pytest.raises(AttributeError):
-        service.membership.get_user_default_surface_ids
+        # The expression is the assertion: the attribute must not exist.
+        service.membership.get_user_default_surface_ids  # noqa: B018
 
     channels, _ = await service.resolve_channels(
         pod_id=pod_id, recipient_user_id=uuid4(), actor_agent_id=None

--- a/lemma-backend/pyproject.toml
+++ b/lemma-backend/pyproject.toml
@@ -204,6 +204,16 @@ lemma-sdk = { path = "../lemma-python", editable = true }
 [tool.ruff.lint]
 select = [
     "F",     # pyflakes
+    # `B015`/`B018` only, not the whole bugbear family: they are the rule
+    # CodeQL's `py/ineffectual-statement` is trying to be, and unlike it they
+    # know that a lone `...` is a `Protocol`/`@overload` stub body rather than a
+    # statement someone forgot to finish. That query has been open against
+    # github/codeql as a labelled false positive since 2022 (issue 11351), and
+    # GitHub Code Quality runs its own workflow with a fixed query list, so
+    # `.github/codeql-config.yml` cannot filter it. Catching the real cases here
+    # instead means they are caught locally, in `make quality`, before a PR.
+    "B015",  # useless comparison
+    "B018",  # useless expression
     "E4",    # imports
     "E7",    # statement-level errors
     "E9",    # runtime errors


### PR DESCRIPTION
## What changes

The cross-pod clamp that confines a pod's default agent to the pod it was invoked in
read:

```python
if clamp_to_pod and hydrated.pod_id is not None and hydrated.pod_id != ctx.pod_id:
    deny
```

`is not None` was load-bearing in the wrong direction. `_hydrate_resource` ended in
`if resource.resource_type not in mapping: return resource`, so a resource type the
mapping did not cover came back with no pod and the clamp was **skipped** rather than
enforced. Adding a member to `ResourceType` was enough to opt it out, and nothing
recorded which types were exempt on purpose.

Now: every `ResourceType` is classified into one of four named groups, a check at
**import** refuses to load the module if one is in none of them, and a pod-scoped
resource whose pod could not be established is **refused** instead of waved through.

## Why

Not because it was exploitable — see below — but because the guard worked only by
everyone remembering a field, with nothing enforcing it, and the failure mode of
forgetting was silent and security-relevant.

## Not a live vulnerability, and the PR should say so

I checked before building on it. **Nothing in production constructs a `ResourceRef` for
`POD_MEMBER`, `DATASTORE_RECORD` or `ROLE`** — they exist as permission ids and grant
targets and never reach `authorize` as a resource. Every `POD` ref comes from
`ResourceRef.pod()`, which sets `pod_id`. `ORGANIZATION` and `ROLE` are org-scoped and a
delegated pod agent is refused earlier by `_is_pod_scoped_permission`. So the clamp does
compare today; this closes a latent hole, not an open one.

## How to verify

```bash
cd lemma-backend && uv run pytest app/core/authorization -q
cd lemma-backend && uv run python scripts/check_architecture.py
make quality
```

95 authorization tests pass. The architecture ratchet passes with no bucket grown.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **API surface** — no API change
- [x] **Security** — this *is* the security change; the clamp moves from fail-open to
      fail-closed and the exempt set becomes explicit and checked
- [x] **Rollback** — revertible as a unit; no migrations, no data changes

## What a reviewer should look at

**The characterization tests came first, deliberately** (commit 1 of 4), and they earned
themselves: they failed the moment `POD` changed category, which is exactly what they
were written to catch. They record, for all 17 types, whether hydration reads a row,
what it resolves, and whether a pod comes back — four different row shapes turned up in
the writing, which is its own argument that a hand-maintained mapping was the wrong
mechanism.

**Extracting the registry exposed a second `if` ladder over the same types.**
`get_resource_creator` mapped each type to its owner column and ended in its own
`else: return None` — the same fail-open shape, free to drift from the mapping hydration
used. Both read one table now.

**`app/core` reaches modules less, not more**: `core_module_imports` goes 40 → 38, because
unifying the ladders removed six model imports from `service.py` against one new import
site. `resource_tables.py` is now the only place in `app/core` that names a datastore
column, which is why `path_column` is on the table.

**Dead rows removed**: the old mapping's `FOLDER`/`DOCUMENT` entries were unreachable —
`_hydrate_datastore_file` intercepts both several lines earlier. They are back in the
table for the *owner* lookup, with a comment saying why hydration still never reads them.

**One unrelated commit rides along** (`B015`/`B018`), and it is here because it came out
of the CodeQL comments on #612. GitHub Code Quality flags `...` in `Protocol` stubs as
"statement has no effect" — a false positive open against github/codeql since 2022, and
one our `.github/codeql-config.yml` cannot filter because Code Quality runs its own
workflow with a fixed query list. ruff's equivalents know what a stub is: across the whole
backend they report exactly one finding, in a test whose expression *is* its assertion.
Happy to split it out if you would rather.
