### PR TITLE
The falsy guard that named the pod's agent, on the side that still had one

### DIFF
--- a/lemma-frontend/components/surfaces/surface-connect-step.tsx
+++ b/lemma-frontend/components/surfaces/surface-connect-step.tsx
@@ -10,6 +10,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { credentialSchema, type CatalogSurface } from '@/lib/surfaces/catalog';
 import type { SurfacePlatformDefinition } from '@/lib/surfaces/registry';
 import type { Account } from '@/lib/types';
+import { isPodDefaultAgentName } from '@/lib/utils/agents';
 import { cn } from '@/lib/utils';
 
 export type CredentialValues = Record<string, unknown>;
@@ -47,6 +48,12 @@ export function SurfaceConnectStep({
 }) {
     const schema = credentialSchema(catalog);
     const journey = definition.journey;
+    // The row name, not a label: a surface bound to the pod's own agent reports
+    // `agent_name: "pod_default"`, and this value is both shown as prose and
+    // sent as the name of the Slack app the person is about to create. `null`
+    // is what the copy below already means by "the pod's own bot", so the one
+    // identifier resolves to it rather than reaching a workspace.
+    const named = agentName && !isPodDefaultAgentName(agentName) ? agentName : null;
 
     if (journey && schema) {
         return (
@@ -151,13 +158,13 @@ export function SurfaceConnectStep({
             {definition.platform === 'SLACK' ? (
                 <div className="border-t border-[var(--border-subtle)] pt-3">
                     <p className="mb-2 text-xs leading-5 text-[var(--text-secondary)]">
-                        {agentName
-                            ? `Or give ${agentName} a bot of its own — your workspace, your app, answering as ${agentName} and nobody else.`
+                        {named
+                            ? `Or give ${named} a bot of its own — your workspace, your app, answering as ${named} and nobody else.`
                             : 'Or run Lemma under your own name in Slack — your workspace, your app, your bot’s name and icon.'}
                     </p>
                     <CreateSlackAppButton
-                        agentName={agentName}
-                        label={agentName ? `Make ${agentName}’s Slack app` : undefined}
+                        agentName={named}
+                        label={named ? `Make ${named}’s Slack app` : undefined}
                     />
                     {/* The step after the button, which it cannot take for you:
                         Slack has no API that hands a third party another app's

--- a/lemma-frontend/lib/surfaces/__tests__/registry.test.ts
+++ b/lemma-frontend/lib/surfaces/__tests__/registry.test.ts
@@ -5,6 +5,8 @@ import {
     getSurfaceDefinition,
     SURFACE_PLATFORM_ORDER,
 } from '@/lib/surfaces/registry';
+import { POD_DEFAULT_AGENT_SELECTOR } from 'lemma-sdk';
+
 import { DEFAULT_RESPONDER_NAME } from '@/lib/utils/agents';
 
 describe('surface registry', () => {
@@ -75,5 +77,18 @@ describe('surface registry', () => {
     it('names the agent in second-person copy, and the default responder otherwise', () => {
         expect(forAgent('Make {agent} reachable', 'Ops')).toBe('Make Ops reachable');
         expect(forAgent('Make {agent} reachable', null)).toBe(`Make ${DEFAULT_RESPONDER_NAME} reachable`);
+    });
+
+    it('calls the pod assistant Lem when the surface arrives carrying its row name', () => {
+        // `null` was the pod default only while it had no row. It has one now,
+        // and `GET /surfaces` reports `agent_name` from that row -- so the
+        // truthy string `pod_default` walks straight past `agentName || ...`
+        // and onto the screen. The same falsy guard, at the same cost, as the
+        // five backend sites #609 fixed.
+        for (const stored of ['pod_default', POD_DEFAULT_AGENT_SELECTOR]) {
+            expect(forAgent('Make {agent} reachable', stored)).toBe(
+                `Make ${DEFAULT_RESPONDER_NAME} reachable`,
+            );
+        }
     });
 });

--- a/lemma-frontend/lib/surfaces/registry.ts
+++ b/lemma-frontend/lib/surfaces/registry.ts
@@ -1,7 +1,7 @@
 import { Mail, type LemmaIcon } from '@/components/ui/icons';
 
 import type { SurfacePlatformValue } from '@/lib/hooks/use-pod-surfaces';
-import { DEFAULT_RESPONDER_NAME } from '@/lib/utils/agents';
+import { DEFAULT_RESPONDER_NAME, isPodDefaultAgentName } from '@/lib/utils/agents';
 
 /**
  * What each surface platform needs from the setup UI, in one place.
@@ -272,7 +272,22 @@ export function getSurfaceDefinition(
     return BY_PLATFORM.get(platform.toUpperCase()) ?? null;
 }
 
-/** Substitutes the agent's name into registry copy. `null` = the pod default. */
+/**
+ * Substitutes the agent's name into registry copy. `null` = the pod default.
+ *
+ * Not `agentName || DEFAULT_RESPONDER_NAME`. `null` was the pod assistant only
+ * while it had no row of its own; it has one now, `GET /surfaces` reports
+ * `agent_name` from that row, and `pod_default` is not falsy — so the guard
+ * stopped firing for the single case it was written for and put an internal
+ * identifier in front of a person. The backend fixed the same expression at
+ * five sites; this is the display site it does not reach.
+ *
+ * Only that one name is mapped. Every other agent keeps the name its author
+ * typed, because this copy also names the Slack app a person is about to
+ * create, and rewriting that is not this function's decision to make.
+ */
 export function forAgent(copy: string, agentName: string | null): string {
-    return copy.replaceAll('{agent}', agentName || DEFAULT_RESPONDER_NAME);
+    const named
+        = agentName && !isPodDefaultAgentName(agentName) ? agentName : DEFAULT_RESPONDER_NAME;
+    return copy.replaceAll('{agent}', named);
 }


### PR DESCRIPTION
## What changes

Surface setup copy stops calling the pod's own agent `pod_default`, and stops
handing Slack a manifest for an app of that name.

## Why

#609 fixed `agent_name or "Lemma"` at five backend sites. The expression was
written when the pod's assistant had no row at all, so the null did the work;
the moment it got a row the guard stopped firing, because `pod_default` is not
falsy. That PR deliberately left the frontend alone, on the grounds that
`formatAgentName()` already maps the name at every display site.

`forAgent()` is a display site it does not reach, and it is the same
expression:

```ts
copy.replaceAll('{agent}', agentName || DEFAULT_RESPONDER_NAME)
```

`GET /surfaces` reports `agent_name` from the agent's row — `agent_name_for_id`
returns the row name, and a surface bound to the pod's own agent carries that
agent's real id, which is exactly why #609 needed an `is_pod_default` branch
rather than a null check. So `forAgent` receives the string `pod_default` and
substitutes it verbatim:

> Or give **pod_default** a bot of its own — your workspace, your app,
> answering as **pod_default** and nobody else.

**One place is worse than prose.** `surface-connect-step.tsx` passes the same
value to `CreateSlackAppButton`, which calls `agent.surface.slack_manifest`,
whose `agent_name` parameter *names the app the manifest creates*. A person
setting up Slack for the pod's own agent was handed a manifest for an app
called `pod_default` — and Slack keeps that name, in their workspace, after
the bug is gone.

`forAgent` also backs `stepPromise` and `SurfaceIdentityStep`, so the fix
covers those without touching them.

## What is deliberately *not* changed

**Only the one name is mapped**, through the `isPodDefaultAgentName` predicate
the frontend already had — not `formatAgentName`, which would also
`humanizeName` every other agent (`customer-support_bot` → "Customer support
bot"). That may well be an improvement, but this copy names an app somebody is
about to create, so rewriting what its author typed is a separate decision from
fixing a leak.

**The wire values are untouched.** `default_agent_name` on surface create and
update still sends the stored name. That is the same display-only / row-value
line `agent_display_name()` draws on the backend, and crossing it would break
the lookup rather than a label.

A sweep for the same shape found no other instance: the only other
`|| DEFAULT_RESPONDER_NAME` in the tree was this one, and `agent-home.tsx`
matches on stored names on purpose (its comment says so).

## How to verify

The test was written to fail first, and did:

```
AssertionError: expected 'Make pod_default reachable' to be 'Make Lem reachable'
```

```bash
cd lemma-typescript && npm ci && npm run build
cd ../lemma-frontend && npm ci
npx vitest run lib/surfaces/__tests__/registry.test.ts
npx vitest run
npm run check
```

`9 passed` for the registry suite, **1244 passed (114 files)** for the whole
frontend suite, and `npm run check` green — eslint, tsc, the design audit
(`productStrict=0`), education anchors, and `public/openapi.json is current`.
The SDK bundle rebuild is byte-identical; `git status` shows only the three
source files.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload; no
      authorization input changes, and the values used for lookups are
      deliberately left as the stored names
- [x] **Rollback** — pure revert, frontend-only, no migration and no API change

## Compatibility and rollback notes

Frontend display only. No migration, no API or SDK surface change, nothing
persisted differently. An app somebody already created as `pod_default` keeps
that name — Slack owns it — and has to be renamed in Slack.

Straight revert if needed.
