### PR TITLE
0.8.0 API surface: one spelling for an organization, a collection, and an action

### DIFF
--- a/desktop/agent-host/src/api.rs
+++ b/desktop/agent-host/src/api.rs
@@ -160,7 +160,7 @@ impl TargetClient {
             .timeout(std::time::Duration::from_secs(30))
             .user_agent(format!("lemma-agent-host/{}", crate::HOST_RELEASE))
             .build()?;
-        let endpoint = endpoint(&base_url, "agent-host/pairings:complete")?;
+        let endpoint = endpoint(&base_url, "agent-host/pairings/complete")?;
         let response = client.post(endpoint).json(&request).send().await?;
         let response: PairingCompleteResponse = decode(response).await?;
         anyhow::ensure!(
@@ -217,7 +217,7 @@ impl TargetClient {
 
     pub async fn append_events(&self, batch: &EventBatch) -> Result<EventAck, ApiError> {
         let response = self
-            .authenticated(Method::POST, "agent-host/events:append", Some(batch))
+            .authenticated(Method::POST, "agent-host/events/append", Some(batch))
             .await?;
         decode(response).await
     }

--- a/desktop/agent-host/src/runtime.rs
+++ b/desktop/agent-host/src/runtime.rs
@@ -2759,7 +2759,7 @@ mod target_worker_tests {
         async fn with_manifest(manifest: AdapterManifest) -> Self {
             let stub = Arc::<StubState>::default();
             let app = Router::new()
-                .route("/agent-host/events:append", post(append_events))
+                .route("/agent-host/events/append", post(append_events))
                 .route("/agent-host/poll", post(poll))
                 .with_state(Arc::clone(&stub));
             let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/desktop/agent-host/tests/http_control_e2e.rs
+++ b/desktop/agent-host/tests/http_control_e2e.rs
@@ -116,10 +116,10 @@ async fn pairing_and_all_control_endpoints_interoperate() {
         reject_next_authenticated: Arc::new(AtomicBool::new(false)),
     };
     let app = Router::new()
-        .route("/agent-host/pairings:complete", post(pairing))
+        .route("/agent-host/pairings/complete", post(pairing))
         .route("/agent-host/poll", post(poll))
         .route("/agent-host/harnesses", put(publish))
-        .route("/agent-host/events:append", post(append_events))
+        .route("/agent-host/events/append", post(append_events))
         .route("/agent-host/revoke", post(revoke))
         .with_state(state.clone());
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/desktop/agent-host/tests/latency_bench.rs
+++ b/desktop/agent-host/tests/latency_bench.rs
@@ -306,7 +306,7 @@ async fn append_events(
         {
             state.mark("terminal reached Lemma");
         }
-        state.mark(format!("events:append batch of {}", batch.events.len()));
+        state.mark(format!("events/append batch of {}", batch.events.len()));
         events.extend(batch.events);
     }
     Ok(Json(response))
@@ -337,10 +337,10 @@ impl Bench {
             checkpoint_states: Arc::new(Mutex::new(std::collections::HashMap::new())),
         };
         let app = Router::new()
-            .route("/agent-host/pairings:complete", post(pairing))
+            .route("/agent-host/pairings/complete", post(pairing))
             .route("/agent-host/harnesses", put(publish))
             .route("/agent-host/poll", post(poll))
-            .route("/agent-host/events:append", post(append_events))
+            .route("/agent-host/events/append", post(append_events))
             .with_state(state.clone());
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
@@ -483,7 +483,7 @@ async fn measure(mode: Mode, harness: &str, prompt: &str) {
     }
     let appends = hops
         .iter()
-        .filter(|hop| hop.what.starts_with("events:append"))
+        .filter(|hop| hop.what.starts_with("events/append"))
         .map(|hop| hop.at)
         .collect::<Vec<_>>();
     let batches = appends.len();

--- a/desktop/agent-host/tests/real_harness_e2e.rs
+++ b/desktop/agent-host/tests/real_harness_e2e.rs
@@ -818,10 +818,10 @@ async fn run_through_paired_agent_host(source_paths: &HostPaths, agent: &str) {
         events: Arc::new(Mutex::new(Vec::new())),
     };
     let app = Router::new()
-        .route("/agent-host/pairings:complete", post(pairing))
+        .route("/agent-host/pairings/complete", post(pairing))
         .route("/agent-host/harnesses", put(publish))
         .route("/agent-host/poll", post(poll))
-        .route("/agent-host/events:append", post(append_events))
+        .route("/agent-host/events/append", post(append_events))
         .with_state(state.clone());
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let address = listener.local_addr().unwrap();

--- a/desktop/agent-host/tests/support/mod.rs
+++ b/desktop/agent-host/tests/support/mod.rs
@@ -716,10 +716,10 @@ impl ControlPlane {
             host_log: Arc::new(Mutex::new(None)),
         };
         let app = Router::new()
-            .route("/agent-host/pairings:complete", post(pairing))
+            .route("/agent-host/pairings/complete", post(pairing))
             .route("/agent-host/harnesses", put(publish))
             .route("/agent-host/poll", post(poll))
-            .route("/agent-host/events:append", post(append_events))
+            .route("/agent-host/events/append", post(append_events))
             .with_state(state.clone());
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();

--- a/lemma-backend/app/core/security.py
+++ b/lemma-backend/app/core/security.py
@@ -194,7 +194,7 @@ EXCLUDED_PATHS = (
     "/agent-runtime/conversations/",  # conversation-scoped MCP routes validate their own token
     # A paired computer has no user session and never will: it authenticates
     # with its own host secret, which `_authenticated_host` checks on every one
-    # of these routes, and `pairings:complete` is authenticated by the one-time
+    # of these routes, and `pairings/complete` is authenticated by the one-time
     # pairing code it consumes. Requiring a session here 401s the only caller
     # these routes have. The user-facing host routes are under `/me/runtime/...`
     # and stay session-protected.

--- a/lemma-backend/app/core/tests/e2e/test_connection_scope_flows_e2e.py
+++ b/lemma-backend/app/core/tests/e2e/test_connection_scope_flows_e2e.py
@@ -89,7 +89,7 @@ async def test_listing_pods_holds_no_connection_across_slow_work(
     await _create_pod(authenticated_client, fixed_test_org["id"])
     org_id = fixed_test_org["id"]
     async with scoped_connection_guard():
-        response = await authenticated_client.get(f"/pods/organization/{org_id}")
+        response = await authenticated_client.get(f"/organizations/{org_id}/pods")
     assert response.status_code == 200, response.text
 
 

--- a/lemma-backend/app/modules/agent/api/controllers/agent_host_controller.py
+++ b/lemma-backend/app/modules/agent/api/controllers/agent_host_controller.py
@@ -247,10 +247,20 @@ async def list_agent_host_harnesses(
     )
 
 
+# The colon spelling is what every already-paired host calls, and the
+# desktop app has no auto-updater: an installed host keeps whatever path it
+# shipped with until someone reinstalls it. Same function, so the two cannot
+# drift; hidden from the schema, so the surface is the slash spelling only.
+# Removable once a host that predates the rename can no longer reach us.
+@router.post(
+    "/agent-host/pairings/complete",
+    response_model=AgentHostPairingCompleted,
+    operation_id="agent.host.pairing.complete",
+)
 @router.post(
     "/agent-host/pairings:complete",
     response_model=AgentHostPairingCompleted,
-    operation_id="agent.host.pairing.complete",
+    include_in_schema=False,
 )
 async def complete_agent_host_pairing(
     request: AgentHostPairingComplete,
@@ -528,10 +538,17 @@ async def _await_commands(
                     await waiting
 
 
+# Colon spelling retained for already-paired hosts; see the note on
+# `/agent-host/pairings/complete`.
+@router.post(
+    "/agent-host/events/append",
+    response_model=AgentHostEventAck,
+    operation_id="agent.host.events.append",
+)
 @router.post(
     "/agent-host/events:append",
     response_model=AgentHostEventAck,
-    operation_id="agent.host.events.append",
+    include_in_schema=False,
 )
 async def append_agent_host_events(
     request: AgentHostEventBatch,

--- a/lemma-backend/app/modules/agent/api/controllers/runtime_config_controller.py
+++ b/lemma-backend/app/modules/agent/api/controllers/runtime_config_controller.py
@@ -47,7 +47,7 @@ router = APIRouter(tags=["agent_runtime"])
 
 async def _ensure_org_member(
     *,
-    org_id: UUID,
+    organization_id: UUID,
     user: CurrentUser,
     uow: UoWDep,
 ) -> None:
@@ -58,7 +58,9 @@ async def _ensure_org_member(
     # where it applies rather than compiled into the read, so a second caller
     # wanting a narrower rule does not have to publish a second query.
     if (
-        await organization_member_role(uow, user_id=user.id, organization_id=org_id)
+        await organization_member_role(
+            uow, user_id=user.id, organization_id=organization_id
+        )
         is None
     ):
         raise HTTPException(
@@ -98,7 +100,7 @@ def _is_own_machine_profile(data: CreateAgentRuntimeProfileRequest) -> bool:
 async def _require_profile_editor(
     *,
     profile,
-    org_id: UUID,
+    organization_id: UUID,
     user: CurrentUser,
     ctx: OrgContextDep,
 ) -> None:
@@ -111,14 +113,14 @@ async def _require_profile_editor(
     """
     if profile.scope is RuntimeProfileScope.PERSONAL and profile.user_id == user.id:
         return
-    await ctx.require(Permissions.ORG_UPDATE, ResourceRef.organization(org_id))
+    await ctx.require(Permissions.ORG_UPDATE, ResourceRef.organization(organization_id))
 
 
 async def _load_profile_or_404(
     service: AgentRuntimeProfileService,
     *,
     profile_id: str,
-    org_id: UUID,
+    organization_id: UUID,
     user: CurrentUser,
 ):
     if service.repository is None:
@@ -128,7 +130,7 @@ async def _load_profile_or_404(
         )
     profile = await service.repository.get_visible_by_id(
         profile_id=profile_id,
-        organization_id=org_id,
+        organization_id=organization_id,
         user_id=user.id,
         # An archived profile must still be addressable, or it could never be
         # restored or renamed out of a name collision.
@@ -153,23 +155,23 @@ def _runtime_profile_service(uow: UoWDep) -> AgentRuntimeProfileService:
 
 
 @router.get(
-    "/organizations/{org_id}/agent-runtime/profiles",
+    "/organizations/{organization_id}/agent-runtime/profiles",
     response_model=AgentRuntimeProfileListResponse,
     operation_id="agent.runtime.profiles.list",
     summary="List Available Agent Runtime Profiles",
 )
 async def list_available_runtime_profiles(
-    org_id: UUID,
+    organization_id: UUID,
     user: CurrentUser,
     uow: UoWDep,
     include_disabled: bool = False,
 ) -> AgentRuntimeProfileListResponse:
-    await _ensure_org_member(org_id=org_id, user=user, uow=uow)
+    await _ensure_org_member(organization_id=organization_id, user=user, uow=uow)
     service = _runtime_profile_service(uow)
     # Archived profiles are excluded by default: this listing is also the chat
     # model catalog, and a retired model must not stay pickable.
     entries = await service.list_profiles_with_availability(
-        organization_id=org_id,
+        organization_id=organization_id,
         user_id=user.id,
         include_disabled=include_disabled,
     )
@@ -184,14 +186,14 @@ async def list_available_runtime_profiles(
 
 
 @router.post(
-    "/organizations/{org_id}/agent-runtime/profiles",
+    "/organizations/{organization_id}/agent-runtime/profiles",
     response_model=AgentRuntimeProfileResponse,
     status_code=status.HTTP_201_CREATED,
     operation_id="agent.runtime.profiles.create",
     summary="Create Agent Runtime Profile",
 )
 async def create_runtime_profile(
-    org_id: UUID,
+    organization_id: UUID,
     data: CreateAgentRuntimeProfileRequest,
     user: CurrentUser,
     uow: UoWDep,
@@ -204,14 +206,16 @@ async def create_runtime_profile(
     # nothing, and gating it here meant a member could see the models page from
     # their pod without being able to add the machine sitting in front of them.
     if _is_own_machine_profile(data):
-        await _ensure_org_member(org_id=org_id, user=user, uow=uow)
+        await _ensure_org_member(organization_id=organization_id, user=user, uow=uow)
     else:
-        await ctx.require(Permissions.ORG_UPDATE, ResourceRef.organization(org_id))
+        await ctx.require(
+            Permissions.ORG_UPDATE, ResourceRef.organization(organization_id)
+        )
     service = _runtime_profile_service(uow)
     try:
         if isinstance(data, CreateAgentHostRuntimeProfileRequest):
             profile = await service.create_agent_host_profile(
-                organization_id=org_id,
+                organization_id=organization_id,
                 user_id=user.id,
                 harness_id=data.harness_id,
                 name=data.name,
@@ -222,7 +226,7 @@ async def create_runtime_profile(
             )
         elif isinstance(data, CreateOpenAICompatibleRuntimeProfileRequest):
             profile = await service.create_openai_compatible_profile(
-                organization_id=org_id,
+                organization_id=organization_id,
                 name=data.name,
                 base_url=data.base_url,
                 api_key=data.api_key,
@@ -234,7 +238,7 @@ async def create_runtime_profile(
             )
         elif isinstance(data, CreateAnthropicCompatibleRuntimeProfileRequest):
             profile = await service.create_anthropic_compatible_profile(
-                organization_id=org_id,
+                organization_id=organization_id,
                 name=data.name,
                 api_key=data.api_key,
                 base_url=data.base_url,
@@ -260,13 +264,13 @@ async def create_runtime_profile(
 
 
 @router.get(
-    "/organizations/{org_id}/agent-runtime/profiles/{profile_id}",
+    "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}",
     response_model=AgentRuntimeProfileDetailResponse,
     operation_id="agent.runtime.profiles.get",
     summary="Get Agent Runtime Profile",
 )
 async def get_runtime_profile(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     user: CurrentUser,
     uow: UoWDep,
@@ -276,9 +280,11 @@ async def get_runtime_profile(
     # harness profile this returns another member's machine's configuration.
     service = _runtime_profile_service(uow)
     profile = await _load_profile_or_404(
-        service, profile_id=profile_id, org_id=org_id, user=user
+        service, profile_id=profile_id, organization_id=organization_id, user=user
     )
-    await _require_profile_editor(profile=profile, org_id=org_id, user=user, ctx=ctx)
+    await _require_profile_editor(
+        profile=profile, organization_id=organization_id, user=user, ctx=ctx
+    )
 
     harness = None
     host_status = None
@@ -303,13 +309,13 @@ async def get_runtime_profile(
 
 
 @router.patch(
-    "/organizations/{org_id}/agent-runtime/profiles/{profile_id}",
+    "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}",
     response_model=AgentRuntimeProfileResponse,
     operation_id="agent.runtime.profiles.update",
     summary="Update Agent Runtime Profile",
 )
 async def update_runtime_profile(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     data: UpdateAgentRuntimeProfileRequest,
     user: CurrentUser,
@@ -318,9 +324,11 @@ async def update_runtime_profile(
 ) -> AgentRuntimeProfileResponse:
     service = _runtime_profile_service(uow)
     profile = await _load_profile_or_404(
-        service, profile_id=profile_id, org_id=org_id, user=user
+        service, profile_id=profile_id, organization_id=organization_id, user=user
     )
-    await _require_profile_editor(profile=profile, org_id=org_id, user=user, ctx=ctx)
+    await _require_profile_editor(
+        profile=profile, organization_id=organization_id, user=user, ctx=ctx
+    )
     editor = AgentRuntimeProfileEditor(service)
 
     # Only fields the caller actually sent are forwarded. Everything else stays
@@ -331,7 +339,7 @@ async def update_runtime_profile(
     changes = {field: getattr(data, field) for field in supplied}
     common = {
         "profile_id": profile_id,
-        "organization_id": org_id,
+        "organization_id": organization_id,
         "user_id": user.id,
     }
     try:
@@ -361,13 +369,13 @@ async def update_runtime_profile(
 
 
 @router.delete(
-    "/organizations/{org_id}/agent-runtime/profiles/{profile_id}",
+    "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     operation_id="agent.runtime.profiles.archive",
     summary="Archive Agent Runtime Profile",
 )
 async def archive_runtime_profile(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     user: CurrentUser,
     uow: UoWDep,
@@ -378,13 +386,15 @@ async def archive_runtime_profile(
     # break dispatch idempotency for an in-flight run.
     service = _runtime_profile_service(uow)
     profile = await _load_profile_or_404(
-        service, profile_id=profile_id, org_id=org_id, user=user
+        service, profile_id=profile_id, organization_id=organization_id, user=user
     )
-    await _require_profile_editor(profile=profile, org_id=org_id, user=user, ctx=ctx)
+    await _require_profile_editor(
+        profile=profile, organization_id=organization_id, user=user, ctx=ctx
+    )
     try:
         await AgentRuntimeProfileEditor(service).archive_profile(
             profile_id=profile_id,
-            organization_id=org_id,
+            organization_id=organization_id,
             user_id=user.id,
         )
     except ValueError as exc:
@@ -396,13 +406,13 @@ async def archive_runtime_profile(
 
 
 @router.post(
-    "/organizations/{org_id}/agent-runtime/profiles/{profile_id}:restore",
+    "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}/restore",
     response_model=AgentRuntimeProfileResponse,
     operation_id="agent.runtime.profiles.restore",
     summary="Restore Agent Runtime Profile",
 )
 async def restore_runtime_profile(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     user: CurrentUser,
     uow: UoWDep,
@@ -410,13 +420,15 @@ async def restore_runtime_profile(
 ) -> AgentRuntimeProfileResponse:
     service = _runtime_profile_service(uow)
     profile = await _load_profile_or_404(
-        service, profile_id=profile_id, org_id=org_id, user=user
+        service, profile_id=profile_id, organization_id=organization_id, user=user
     )
-    await _require_profile_editor(profile=profile, org_id=org_id, user=user, ctx=ctx)
+    await _require_profile_editor(
+        profile=profile, organization_id=organization_id, user=user, ctx=ctx
+    )
     try:
         restored = await AgentRuntimeProfileEditor(service).restore_profile(
             profile_id=profile_id,
-            organization_id=org_id,
+            organization_id=organization_id,
             user_id=user.id,
         )
     except ValueError as exc:

--- a/lemma-backend/app/modules/agent/tests/e2e/agent_host_helpers.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/agent_host_helpers.py
@@ -53,7 +53,7 @@ async def pair(
     assert minted.status_code == status.HTTP_200_OK, minted.text
 
     completed = await async_client.post(
-        "/agent-host/pairings:complete",
+        "/agent-host/pairings/complete",
         json={
             "pairing_code": minted.json()["pairing_code"],
             "display_name": display_name,

--- a/lemma-backend/app/modules/agent/tests/e2e/test_agent_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_agent_e2e.py
@@ -2854,7 +2854,7 @@ class TestAgentRuntimeConfigApis:
 
         # Restore: back to ACTIVE, and back in the default listing.
         restored = await authenticated_client.post(
-            f"/organizations/{org_id}/agent-runtime/profiles/{profile_id}:restore",
+            f"/organizations/{org_id}/agent-runtime/profiles/{profile_id}/restore",
         )
         assert restored.status_code == status.HTTP_200_OK, restored.text
         restored_payload = restored.json()
@@ -2870,7 +2870,7 @@ class TestAgentRuntimeConfigApis:
 
         # Restoring an already-active profile is idempotent too.
         restored_again = await authenticated_client.post(
-            f"/organizations/{org_id}/agent-runtime/profiles/{profile_id}:restore",
+            f"/organizations/{org_id}/agent-runtime/profiles/{profile_id}/restore",
         )
         assert restored_again.status_code == status.HTTP_200_OK, restored_again.text
         assert restored_again.json()["status"] == "ACTIVE"
@@ -3134,7 +3134,7 @@ class TestAgentOpenApi:
         assert profile_path["delete"]["operationId"] == "agent.runtime.profiles.archive"
         assert (
             paths[
-                "/organizations/{org_id}/agent-runtime/profiles/{profile_id}:restore"
+                "/organizations/{org_id}/agent-runtime/profiles/{profile_id}/restore"
             ]["post"]["operationId"]
             == "agent.runtime.profiles.restore"
         )

--- a/lemma-backend/app/modules/agent/tests/e2e/test_agent_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_agent_e2e.py
@@ -3042,7 +3042,7 @@ class TestAgentOpenApi:
         schemas = openapi["components"]["schemas"]
 
         assert "/pods/{pod_id}/conversations" in paths
-        assert "/organizations/{org_id}/agent-runtime/profiles" in paths
+        assert "/organizations/{organization_id}/agent-runtime/profiles" in paths
         assert "/me/runtime/agent-hosts/{host_id}/harnesses" in paths
         assert "/agent-runtime/profiles" not in paths
         assert "/agent-runtime/default" not in paths
@@ -3095,20 +3095,20 @@ class TestAgentOpenApi:
             == "agent.host.harnesses.list"
         )
         assert (
-            paths["/organizations/{org_id}/agent-runtime/profiles"]["get"][
+            paths["/organizations/{organization_id}/agent-runtime/profiles"]["get"][
                 "operationId"
             ]
             == "agent.runtime.profiles.list"
         )
         assert (
-            paths["/organizations/{org_id}/agent-runtime/profiles"]["post"][
+            paths["/organizations/{organization_id}/agent-runtime/profiles"]["post"][
                 "operationId"
             ]
             == "agent.runtime.profiles.create"
         )
-        create_profile_schema = paths["/organizations/{org_id}/agent-runtime/profiles"][
-            "post"
-        ]["requestBody"]["content"]["application/json"]["schema"]
+        create_profile_schema = paths[
+            "/organizations/{organization_id}/agent-runtime/profiles"
+        ]["post"]["requestBody"]["content"]["application/json"]["schema"]
         assert create_profile_schema["discriminator"]["propertyName"] == "source"
         assert set(create_profile_schema["discriminator"]["mapping"]) == {
             "AGENT_HOST",
@@ -3127,14 +3127,14 @@ class TestAgentOpenApi:
         )
 
         profile_path = paths[
-            "/organizations/{org_id}/agent-runtime/profiles/{profile_id}"
+            "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}"
         ]
         assert profile_path["get"]["operationId"] == "agent.runtime.profiles.get"
         assert profile_path["patch"]["operationId"] == "agent.runtime.profiles.update"
         assert profile_path["delete"]["operationId"] == "agent.runtime.profiles.archive"
         assert (
             paths[
-                "/organizations/{org_id}/agent-runtime/profiles/{profile_id}/restore"
+                "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}/restore"
             ]["post"]["operationId"]
             == "agent.runtime.profiles.restore"
         )

--- a/lemma-backend/app/modules/agent/tests/e2e/test_agent_hermetic_journeys_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_agent_hermetic_journeys_e2e.py
@@ -2353,7 +2353,7 @@ async def test_public_runtime_profile_edit_archive_and_restore(
     )
     assert archived_item["status"] == "DISABLED"
 
-    restored = await authenticated_client.post(f"{base}/{profile_id}:restore")
+    restored = await authenticated_client.post(f"{base}/{profile_id}/restore")
     assert restored.status_code == status.HTTP_200_OK, restored.text
     assert restored.json()["status"] == "ACTIVE"
     # Archiving is reversible without re-entering the credential.

--- a/lemma-backend/app/modules/agent/tests/e2e/test_agent_host_transport_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_agent_host_transport_e2e.py
@@ -7,7 +7,7 @@ that gap, each hiding the next:
 * the global `verify_auth` dependency has an allowlist and `/agent-host` was not
   on it, so every one of these routes 401'd - a paired computer has no user
   session and never will;
-* `pairings:complete` is the one route whose credential *is* its body, and
+* `pairings/complete` is the one route whose credential *is* its body, and
   nothing checked that it works without a session;
 * the idle poll called `asyncio.wait_for(anext(...))`, whose timeout cancels and
   closes the async generator, so the second idle round raised
@@ -129,12 +129,44 @@ async def test_a_pairing_code_is_single_use(authenticated_client, async_client):
         "hello": hello(),
     }
 
-    first = await async_client.post("/agent-host/pairings:complete", json=body)
+    first = await async_client.post("/agent-host/pairings/complete", json=body)
     assert first.status_code == status.HTTP_200_OK, first.text
 
-    replayed = await async_client.post("/agent-host/pairings:complete", json=body)
+    replayed = await async_client.post("/agent-host/pairings/complete", json=body)
     assert replayed.status_code != status.HTTP_200_OK
     assert first.json()["host_secret"] not in replayed.text
+
+
+@pytest.mark.asyncio
+async def test_the_colon_spelling_still_reaches_the_same_handler(
+    authenticated_client, async_client
+):
+    """An already-paired host keeps working after the slash rename.
+
+    `:complete` and `:append` were the shipped spelling, and the desktop app
+    has no auto-updater — an installed host keeps calling whatever it was built
+    with. Both spellings are the same function, so this asserts routing, not
+    behaviour: reaching the handler at all is the whole claim.
+    """
+    minted = await authenticated_client.post(
+        "/me/runtime/agent-host-pairings",
+        json={"display_name": "e2e legacy path", "organization_id": None},
+    )
+    paired = await async_client.post(
+        "/agent-host/pairings:complete",
+        json={
+            "pairing_code": minted.json()["pairing_code"],
+            "display_name": "e2e legacy path",
+            "hello": hello(),
+        },
+    )
+    assert paired.status_code == status.HTTP_200_OK, paired.text
+
+    # The events route is host-authenticated, so an unauthenticated call must
+    # be rejected by the handler rather than by the router. A 404 would mean
+    # the alias is not registered at all, which is the failure this guards.
+    appended = await async_client.post("/agent-host/events:append", json={})
+    assert appended.status_code != status.HTTP_404_NOT_FOUND, appended.text
 
 
 @pytest.mark.asyncio

--- a/lemma-backend/app/modules/identity/api/controllers/organization_controller.py
+++ b/lemma-backend/app/modules/identity/api/controllers/organization_controller.py
@@ -174,7 +174,7 @@ async def check_slug_availability(
 
 
 @router.post(
-    "/{org_id}/join",
+    "/{organization_id}/join",
     status_code=status.HTTP_200_OK,
     operation_id="org.join_auto_join",
     dependencies=[
@@ -186,19 +186,19 @@ async def check_slug_availability(
 )
 async def join_auto_join_organization(
     request: Request,
-    org_id: UUID,
+    organization_id: UUID,
     org_service: OrganizationServiceDep,
     uow: UoWDep,
 ) -> OrganizationResponse:
     """Join an organization that allows automatic joining for the user's email domain."""
     user: UserEntity = request.state.user
     organization = await org_service.join_auto_join_organization(
-        organization_id=org_id,
+        organization_id=organization_id,
         user_id=user.id,
     )
     await _sync_org_role_assignment(
         uow,
-        organization_id=org_id,
+        organization_id=organization_id,
         user_id=user.id,
         role=OrganizationRole.ORG_MEMBER,
         assigned_by_user_id=user.id,
@@ -243,7 +243,7 @@ async def list_my_invitations(
 
 
 @router.get(
-    "/{org_id}",
+    "/{organization_id}",
     status_code=status.HTTP_200_OK,
     operation_id="org.get",
     summary="Get Organization",
@@ -252,13 +252,13 @@ async def list_my_invitations(
 )
 async def get_organization(
     request: Request,
-    org_id: UUID,
+    organization_id: UUID,
     org_service: OrganizationServiceDep,
 ) -> OrganizationResponse:
     """Get organization details."""
     user: UserEntity = request.state.user
     organization = await org_service.get_organization(
-        org_id=org_id,
+        organization_id=organization_id,
         requester_user_id=user.id,
     )
 
@@ -266,7 +266,7 @@ async def get_organization(
 
 
 @router.patch(
-    "/{org_id}",
+    "/{organization_id}",
     status_code=status.HTTP_200_OK,
     operation_id="org.update",
     dependencies=[reject_delegated_workload_anywhere("change organization settings")],
@@ -276,14 +276,14 @@ async def get_organization(
 )
 async def update_organization(
     request: Request,
-    org_id: UUID,
+    organization_id: UUID,
     data: OrganizationUpdateRequest,
     org_service: OrganizationServiceDep,
 ) -> OrganizationResponse:
     """Update an organization (owner only)."""
     user: UserEntity = request.state.user
     organization = await org_service.update_organization(
-        org_id=org_id,
+        organization_id=organization_id,
         requester_user_id=user.id,
         name=data.name,
         join_policy=data.join_policy,
@@ -293,7 +293,7 @@ async def update_organization(
 
 
 @router.get(
-    "/{org_id}/members",
+    "/{organization_id}/members",
     status_code=status.HTTP_200_OK,
     operation_id="org.member.list",
     summary="List Organization Members",
@@ -302,7 +302,7 @@ async def update_organization(
 )
 async def list_members(
     request: Request,
-    org_id: UUID,
+    organization_id: UUID,
     org_service: OrganizationServiceDep,
     limit: int = 100,
     page_token: str | None = None,
@@ -312,7 +312,7 @@ async def list_members(
 
     user: UserEntity = request.state.user
     members, next_cursor = await org_service.list_organization_members(
-        organization_id=org_id,
+        organization_id=organization_id,
         requester_user_id=user.id,
         limit=limit,
         cursor=page_token,
@@ -326,7 +326,7 @@ async def list_members(
 
 
 @router.post(
-    "/{org_id}/invitations",
+    "/{organization_id}/invitations",
     status_code=status.HTTP_201_CREATED,
     operation_id="org.invitation.invite",
     dependencies=[
@@ -338,7 +338,7 @@ async def list_members(
 )
 async def invite_member(
     request: Request,
-    org_id: UUID,
+    organization_id: UUID,
     data: OrganizationInvitationRequest,
     org_service: OrganizationServiceDep,
 ) -> OrganizationInvitationResponse:
@@ -346,7 +346,7 @@ async def invite_member(
     user: UserEntity = request.state.user
     entity = OrganizationInvitationEntity(
         email=data.email,
-        organization_id=org_id,
+        organization_id=organization_id,
         role=data.role,
         pod_id=data.pod_id,
         pod_role=data.pod_role,
@@ -362,7 +362,7 @@ async def invite_member(
 
 
 @router.get(
-    "/{org_id}/invitations",
+    "/{organization_id}/invitations",
     status_code=status.HTTP_200_OK,
     operation_id="org.invitation.list",
     summary="List Organization Invitations",
@@ -371,7 +371,7 @@ async def invite_member(
 )
 async def list_invitations(
     request: Request,
-    org_id: UUID,
+    organization_id: UUID,
     org_service: OrganizationServiceDep,
     status: OrganizationInvitationStatus = OrganizationInvitationStatus.PENDING,
     limit: int = 100,
@@ -382,7 +382,7 @@ async def list_invitations(
 
     user: UserEntity = request.state.user
     invitations, next_cursor = await org_service.list_invitations(
-        organization_id=org_id,
+        organization_id=organization_id,
         requester_user_id=user.id,
         status=status,
         limit=limit,
@@ -491,7 +491,7 @@ async def revoke_invitation(
 
 
 @router.patch(
-    "/{org_id}/members/{member_id}/role",
+    "/{organization_id}/members/{member_id}/role",
     status_code=status.HTTP_200_OK,
     operation_id="org.member.update_role",
     dependencies=[
@@ -503,7 +503,7 @@ async def revoke_invitation(
 )
 async def update_member_role(
     request: Request,
-    org_id: UUID,
+    organization_id: UUID,
     member_id: UUID,
     data: UpdateMemberRoleRequest,
     org_service: OrganizationServiceDep,
@@ -515,10 +515,10 @@ async def update_member_role(
         member_id=member_id,
         new_role=data.role,
         requester_user_id=user.id,
-        organization_id=org_id,
+        organization_id=organization_id,
     )
     await AuthorizationDataService(uow.session).assign_roles(
-        organization_id=org_id,
+        organization_id=organization_id,
         pod_id=None,
         principal_type="ORG_MEMBER",
         principal_id=member_id,
@@ -557,7 +557,7 @@ async def _sync_org_role_assignment(
 
 
 @router.delete(
-    "/{org_id}/members/{member_id}",
+    "/{organization_id}/members/{member_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     operation_id="org.member.remove",
     dependencies=[reject_delegated_workload_anywhere("remove organization members")],
@@ -566,7 +566,7 @@ async def _sync_org_role_assignment(
 )
 async def remove_member(
     request: Request,
-    org_id: UUID,
+    organization_id: UUID,
     member_id: UUID,
     org_service: OrganizationServiceDep,
     uow: UoWDep,
@@ -582,7 +582,7 @@ async def remove_member(
     await org_service.remove_member(
         member_id=member_id,
         requester_user_id=user.id,
-        organization_id=org_id,
+        organization_id=organization_id,
     )
     if targets is not None:
         await authz.purge_member_authorization(targets)

--- a/lemma-backend/app/modules/identity/api/controllers/organization_controller.py
+++ b/lemma-backend/app/modules/identity/api/controllers/organization_controller.py
@@ -258,7 +258,8 @@ async def get_organization(
     """Get organization details."""
     user: UserEntity = request.state.user
     organization = await org_service.get_organization(
-        organization_id=organization_id,
+        # The service's parameter is `org_id`; only the wire renamed.
+        org_id=organization_id,
         requester_user_id=user.id,
     )
 
@@ -283,7 +284,8 @@ async def update_organization(
     """Update an organization (owner only)."""
     user: UserEntity = request.state.user
     organization = await org_service.update_organization(
-        organization_id=organization_id,
+        # The service's parameter is `org_id`; only the wire renamed.
+        org_id=organization_id,
         requester_user_id=user.id,
         name=data.name,
         join_policy=data.join_policy,

--- a/lemma-backend/app/modules/identity/api/controllers/organization_navigation_controller.py
+++ b/lemma-backend/app/modules/identity/api/controllers/organization_navigation_controller.py
@@ -80,7 +80,7 @@ async def get_navigation(request: Request, uow: UoWDep) -> NavigationResponse:
 
 
 @router.get(
-    "/{org_id}/home",
+    "/{organization_id}/home",
     status_code=status.HTTP_200_OK,
     operation_id="org.home",
     summary="Get Organization Home",
@@ -92,7 +92,7 @@ async def get_navigation(request: Request, uow: UoWDep) -> NavigationResponse:
     response_model=OrganizationHomeResponse,
 )
 async def get_organization_home(
-    request: Request, org_id: UUID, uow: UoWDep
+    request: Request, organization_id: UUID, uow: UoWDep
 ) -> OrganizationHomeResponse:
     """One organization in detail, cached per (organization, user).
 
@@ -108,12 +108,14 @@ async def get_organization_home(
     listing to another.
     """
     user: UserEntity = request.state.user
-    cached = await get_cached_organization_home(organization_id=org_id, user_id=user.id)
+    cached = await get_cached_organization_home(
+        organization_id=organization_id, user_id=user.id
+    )
     if cached is not None:
         return OrganizationHomeResponse.model_validate(cached)
 
     home = await load_organization_home(
-        session=uow.session, user_id=user.id, organization_id=org_id
+        session=uow.session, user_id=user.id, organization_id=organization_id
     )
     if home is None:
         raise HTTPException(
@@ -156,7 +158,7 @@ async def get_organization_home(
         ],
     )
     await set_cached_organization_home(
-        organization_id=org_id,
+        organization_id=organization_id,
         user_id=user.id,
         payload=response.model_dump(mode="json"),
     )

--- a/lemma-backend/app/modules/identity/api/schemas/organization_schemas.py
+++ b/lemma-backend/app/modules/identity/api/schemas/organization_schemas.py
@@ -170,7 +170,7 @@ class NavigationPodResponse(BaseSchema):
     columns cost nothing to return: they ride along in the query that found the
     pod, so the response grows with the number of pods and not with what is
     inside them. Apps, agents and roles are the other side of that line, and
-    live on ``/organizations/{org_id}/home``.
+    live on ``/organizations/{organization_id}/home``.
     """
 
     id: UUID

--- a/lemma-backend/app/modules/identity/module.py
+++ b/lemma-backend/app/modules/identity/module.py
@@ -22,8 +22,8 @@ def _routers():
     )
 
     # Navigation first: its ``/navigation`` is a literal path that would
-    # otherwise be captured by ``/{org_id}`` in the organization router, which
-    # FastAPI matches in registration order.
+    # otherwise be captured by ``/{organization_id}`` in the organization
+    # router, which FastAPI matches in registration order.
     return [
         user,
         organization_navigation,

--- a/lemma-backend/app/modules/identity/tests/e2e/test_organization_navigation_e2e.py
+++ b/lemma-backend/app/modules/identity/tests/e2e/test_organization_navigation_e2e.py
@@ -424,7 +424,7 @@ async def test_a_realistic_multi_org_workspace_stays_fast(
         response = await authenticated_client.get("/organizations")
         assert response.status_code == status.HTTP_200_OK, response.text
         for org_id in org_ids:
-            response = await authenticated_client.get(f"/pods/organization/{org_id}")
+            response = await authenticated_client.get(f"/organizations/{org_id}/pods")
             assert response.status_code == status.HTTP_200_OK, response.text
         return response
 
@@ -448,7 +448,7 @@ async def test_a_realistic_multi_org_workspace_stays_fast(
             f"\n  {'route':44} {'cold':>9} {'p50':>9} {'p95':>9}"
             f"\n  {'GET /organizations/navigation':44} {navigation_cold:7.1f}ms {navigation_p50:7.1f}ms {navigation_p95:7.1f}ms"
             f"\n  {'GET /organizations/{id}/home':44} {home_cold:7.1f}ms {home_p50:7.1f}ms {home_p95:7.1f}ms"
-            f"\n  {'was: /organizations + 5x /pods/organization':44} {'':9} {legacy_p50:7.1f}ms {legacy_p95:7.1f}ms"
+            f"\n  {'was: /organizations + 5x .../pods':44} {'':9} {legacy_p50:7.1f}ms {legacy_p95:7.1f}ms"
             f"\n  → the sidebar costs {legacy_p50 / navigation_p50:.1f}x less than the fan-out it replaces"
             f"\n  → home's p50 is a cache hit; {home_cold:.1f}ms is what building it costs"
         )

--- a/lemma-backend/app/modules/pod/api/controllers/pod_controller.py
+++ b/lemma-backend/app/modules/pod/api/controllers/pod_controller.py
@@ -29,6 +29,16 @@ from app.modules.pod.domain.pod_entities import (
 
 router = APIRouter(prefix="/pods", tags=["Pods"], redirect_slashes=False)
 
+# Pods are an organization-scoped collection, so they hang off the
+# organization the way connectors and usage already do. Its own router,
+# because the collection path is not under `/pods` -- the same shape
+# `connector_operation_controller` uses for its org-scoped prefix.
+organization_router = APIRouter(
+    prefix="/organizations/{organization_id}/pods",
+    tags=["Pods"],
+    redirect_slashes=False,
+)
+
 
 @router.post(
     "",
@@ -122,11 +132,11 @@ async def delete_pod(
     await pod_service.delete_pod(pod_id, user.id)
 
 
-@router.get(
-    "/organization/{organization_id}",
+@organization_router.get(
+    "",
     status_code=status.HTTP_200_OK,
     operation_id="pod.list",
-    summary="List PodS by Organization",
+    summary="List Pods by Organization",
     description="List all pods in an organization",
     response_model=PodListResponse,
 )

--- a/lemma-backend/app/modules/pod/module.py
+++ b/lemma-backend/app/modules/pod/module.py
@@ -4,7 +4,10 @@ from app.core.registry import LemmaModule
 
 
 def _routers():
-    from app.modules.pod.api.controllers.pod_controller import router as pod
+    from app.modules.pod.api.controllers.pod_controller import (
+        router as pod,
+        organization_router as pod_by_organization,
+    )
     from app.modules.pod.api.controllers.pod_member_controller import router as member
     from app.modules.pod.api.controllers.pod_permission_controller import (
         router as permission,
@@ -22,6 +25,7 @@ def _routers():
 
     return [
         pod,
+        pod_by_organization,
         member,
         permission,
         resource_access,

--- a/lemma-backend/app/modules/pod/tests/e2e/test_pod_controller.py
+++ b/lemma-backend/app/modules/pod/tests/e2e/test_pod_controller.py
@@ -36,7 +36,7 @@ async def test_pod_workflow(authenticated_client, fixed_test_org):
     # 3. List Pods
     # Note: API requires organization ID to list pods
     response = await authenticated_client.get(
-        f"/pods/organization/{org_id}", follow_redirects=True
+        f"/organizations/{org_id}/pods", follow_redirects=True
     )
 
     assert response.status_code == 200
@@ -92,7 +92,7 @@ async def test_pod_workflow(authenticated_client, fixed_test_org):
     assert response.status_code == 404
 
     response = await authenticated_client.get(
-        f"/pods/organization/{org_id}",
+        f"/organizations/{org_id}/pods",
         follow_redirects=True,
     )
     assert response.status_code == 200
@@ -106,7 +106,7 @@ async def test_list_pods_by_organization(authenticated_client, fixed_test_org):
     pod = await _create_pod(authenticated_client, org_id, name="E2E List Pod")
 
     response = await authenticated_client.get(
-        f"/pods/organization/{org_id}",
+        f"/organizations/{org_id}/pods",
         follow_redirects=True,
     )
 
@@ -127,7 +127,7 @@ async def test_list_pods_by_organization_uses_last_returned_id_as_next_page_toke
     await _create_pod(authenticated_client, org_id, name="Cursor Pod C")
 
     first_page = await authenticated_client.get(
-        f"/pods/organization/{org_id}",
+        f"/organizations/{org_id}/pods",
         params={"limit": 2},
         follow_redirects=True,
     )
@@ -138,7 +138,7 @@ async def test_list_pods_by_organization_uses_last_returned_id_as_next_page_toke
     assert first_payload["next_page_token"] == first_payload["items"][-1]["id"]
 
     second_page = await authenticated_client.get(
-        f"/pods/organization/{org_id}",
+        f"/organizations/{org_id}/pods",
         params={"limit": 2, "page_token": first_payload["next_page_token"]},
         follow_redirects=True,
     )
@@ -200,7 +200,7 @@ async def _assert_pod_fully_gone(client: AsyncClient, org_id: str, pod_id: str, 
     assert detail.status_code == 404, detail.text
 
     listing = await client.get(
-        f"/pods/organization/{org_id}", follow_redirects=True, **kw
+        f"/organizations/{org_id}/pods", follow_redirects=True, **kw
     )
     assert listing.status_code == 200, listing.text
     assert all(item["id"] != pod_id for item in listing.json().get("items", []))
@@ -260,7 +260,7 @@ async def test_org_owner_can_delete_pod_they_do_not_belong_to(
 
     # The org owner sees it in the list and can delete it.
     listing = await authenticated_client.get(
-        f"/pods/organization/{org_id}", follow_redirects=True
+        f"/organizations/{org_id}/pods", follow_redirects=True
     )
     assert any(item["id"] == pod_id for item in listing.json().get("items", []))
 
@@ -317,7 +317,7 @@ async def test_deleted_pod_name_can_be_reused(authenticated_client, fixed_test_o
     assert second_pod["id"] != first_pod["id"]
 
     deleted_pod_response = await authenticated_client.get(
-        f"/pods/organization/{org_id}",
+        f"/organizations/{org_id}/pods",
         follow_redirects=True,
     )
     assert deleted_pod_response.status_code == 200
@@ -435,7 +435,7 @@ async def test_list_pods_by_organization_only_returns_member_pods(
     assert accept_response.status_code == 200, accept_response.text
 
     response = await async_client.get(
-        f"/pods/organization/{org_id}",
+        f"/organizations/{org_id}/pods",
         headers={"Authorization": f"Bearer {outsider_token}"},
         follow_redirects=True,
     )

--- a/lemma-backend/app/modules/pod/tests/e2e/test_pod_join_request_controller_e2e.py
+++ b/lemma-backend/app/modules/pod/tests/e2e/test_pod_join_request_controller_e2e.py
@@ -101,7 +101,7 @@ async def test_pod_join_request_lifecycle(
     assert self_member_after.json()["user_id"] == outsider_id
 
     visible_pods_response = await async_client.get(
-        f"/pods/organization/{org_id}",
+        f"/organizations/{org_id}/pods",
         headers={"Authorization": f"Bearer {outsider_token}"},
     )
     assert visible_pods_response.status_code == 200, visible_pods_response.text
@@ -235,7 +235,7 @@ async def test_request_join_auto_approves_when_policy_allows(
 
     # The user is now a real pod member (auto-added to the org too).
     visible_pods = await async_client.get(
-        f"/pods/organization/{org_id}", headers=outsider_headers
+        f"/organizations/{org_id}/pods", headers=outsider_headers
     )
     assert visible_pods.status_code == 200, visible_pods.text
     assert any(

--- a/lemma-backend/app/modules/pod/tests/e2e/test_pod_list_query_budget_e2e.py
+++ b/lemma-backend/app/modules/pod/tests/e2e/test_pod_list_query_budget_e2e.py
@@ -45,13 +45,13 @@ async def test_pod_list_query_count_does_not_grow_with_pod_count(
 
     await _create_pods(authenticated_client, org_id, 2)
     with counted_queries() as small:
-        first = await authenticated_client.get(f"/pods/organization/{org_id}")
+        first = await authenticated_client.get(f"/organizations/{org_id}/pods")
     assert first.status_code == status.HTTP_200_OK, first.text
     assert len(first.json()["items"]) == 2
 
     await _create_pods(authenticated_client, org_id, 8)
     with counted_queries() as large:
-        second = await authenticated_client.get(f"/pods/organization/{org_id}")
+        second = await authenticated_client.get(f"/organizations/{org_id}/pods")
     assert second.status_code == status.HTTP_200_OK, second.text
     assert len(second.json()["items"]) == 10
 
@@ -87,7 +87,7 @@ async def test_pod_list_stays_within_its_query_budget(
     await _create_pods(authenticated_client, org_id, pod_count)
 
     with counted_queries() as statements:
-        response = await authenticated_client.get(f"/pods/organization/{org_id}")
+        response = await authenticated_client.get(f"/organizations/{org_id}/pods")
     assert response.status_code == status.HTTP_200_OK, response.text
 
     budget = 4
@@ -141,14 +141,14 @@ async def test_request_cost_decomposition_is_reported(
 
     health = await measure("/health")
     orgs = await measure("/organizations")
-    pods = await measure(f"/pods/organization/{org_id}")
+    pods = await measure(f"/organizations/{org_id}/pods")
 
     with capsys.disabled():
         print("\n  route                       p50      p95   queries")
         for label, (p50, p95, queries) in (
             ("/health (no auth, no db)", health),
             ("/organizations (auth)", orgs),
-            ("/pods/organization (10 pods)", pods),
+            ("/organizations/{id}/pods (10 pods)", pods),
         ):
             print(f"  {label:26} {p50:6.1f}ms {p95:6.1f}ms  {queries:3d}")
         print(

--- a/lemma-backend/app/modules/test_support/perf/test_list_api_latency_benchmark.py
+++ b/lemma-backend/app/modules/test_support/perf/test_list_api_latency_benchmark.py
@@ -469,7 +469,7 @@ ENDPOINTS = [
         "pod",
         max_limit=1000,
     ),
-    Endpoint("org_pods", "/pods/organization/{scope}", _seed_pods, _stmt_pods, "org"),
+    Endpoint("org_pods", "/organizations/{scope}/pods", _seed_pods, _stmt_pods, "org"),
 ]
 
 

--- a/lemma-backend/docs/contracts/agent.md
+++ b/lemma-backend/docs/contracts/agent.md
@@ -25,11 +25,11 @@ The table below is generated from the committed OpenAPI specification by `script
 | `agent.create` | POST | `/pods/{pod_id}/agents` | Create Agent |
 | `agent.delete` | DELETE | `/pods/{pod_id}/agents/{agent_name}` | Delete Agent |
 | `agent.get` | GET | `/pods/{pod_id}/agents/{agent_name}` | Get Agent |
-| `agent.host.events.append` | POST | `/agent-host/events:append` | Append Agent Host Events |
+| `agent.host.events.append` | POST | `/agent-host/events/append` | Append Agent Host Events |
 | `agent.host.harnesses.list` | GET | `/me/runtime/agent-hosts/{host_id}/harnesses` | List Agent Host Harnesses |
 | `agent.host.harnesses.publish` | PUT | `/agent-host/harnesses` | Publish Agent Host Harnesses |
 | `agent.host.list` | GET | `/me/runtime/agent-hosts` | List Agent Hosts |
-| `agent.host.pairing.complete` | POST | `/agent-host/pairings:complete` | Complete Agent Host Pairing |
+| `agent.host.pairing.complete` | POST | `/agent-host/pairings/complete` | Complete Agent Host Pairing |
 | `agent.host.pairing.create` | POST | `/me/runtime/agent-host-pairings` | Create Agent Host Pairing |
 | `agent.host.poll` | POST | `/agent-host/poll` | Poll Agent Host Commands |
 | `agent.host.revoke` | DELETE | `/me/runtime/agent-hosts/{host_id}` | Revoke Agent Host |
@@ -37,12 +37,12 @@ The table below is generated from the committed OpenAPI specification by `script
 | `agent.list` | GET | `/pods/{pod_id}/agents` | List Agents |
 | `agent.permissions.get` | GET | `/pods/{pod_id}/agents/{agent_name}/permissions` | Get Agent Resource Permissions |
 | `agent.permissions.replace` | PUT | `/pods/{pod_id}/agents/{agent_name}/permissions` | Replace Agent Resource Permissions |
-| `agent.runtime.profiles.archive` | DELETE | `/organizations/{org_id}/agent-runtime/profiles/{profile_id}` | Archive Agent Runtime Profile |
-| `agent.runtime.profiles.create` | POST | `/organizations/{org_id}/agent-runtime/profiles` | Create Agent Runtime Profile |
-| `agent.runtime.profiles.get` | GET | `/organizations/{org_id}/agent-runtime/profiles/{profile_id}` | Get Agent Runtime Profile |
-| `agent.runtime.profiles.list` | GET | `/organizations/{org_id}/agent-runtime/profiles` | List Available Agent Runtime Profiles |
-| `agent.runtime.profiles.restore` | POST | `/organizations/{org_id}/agent-runtime/profiles/{profile_id}:restore` | Restore Agent Runtime Profile |
-| `agent.runtime.profiles.update` | PATCH | `/organizations/{org_id}/agent-runtime/profiles/{profile_id}` | Update Agent Runtime Profile |
+| `agent.runtime.profiles.archive` | DELETE | `/organizations/{organization_id}/agent-runtime/profiles/{profile_id}` | Archive Agent Runtime Profile |
+| `agent.runtime.profiles.create` | POST | `/organizations/{organization_id}/agent-runtime/profiles` | Create Agent Runtime Profile |
+| `agent.runtime.profiles.get` | GET | `/organizations/{organization_id}/agent-runtime/profiles/{profile_id}` | Get Agent Runtime Profile |
+| `agent.runtime.profiles.list` | GET | `/organizations/{organization_id}/agent-runtime/profiles` | List Available Agent Runtime Profiles |
+| `agent.runtime.profiles.restore` | POST | `/organizations/{organization_id}/agent-runtime/profiles/{profile_id}/restore` | Restore Agent Runtime Profile |
+| `agent.runtime.profiles.update` | PATCH | `/organizations/{organization_id}/agent-runtime/profiles/{profile_id}` | Update Agent Runtime Profile |
 | `agent.tool.report_feedback` | POST | `/tools/report-feedback` | Agent Report Feedback |
 | `agent.tool.web_search` | POST | `/tools/web-search` | Agent Web Search |
 | `agent.update` | PATCH | `/pods/{pod_id}/agents/{agent_name}` | Update Agent |

--- a/lemma-backend/docs/contracts/identity.md
+++ b/lemma-backend/docs/contracts/identity.md
@@ -12,23 +12,23 @@ The table below is generated from the committed OpenAPI specification by `script
 | --- | --- | --- | --- |
 | `auth.verify_token` | GET | `/auth/verify-token` | Verify access token |
 | `org.create` | POST | `/organizations` | Create Organization |
-| `org.get` | GET | `/organizations/{org_id}` | Get Organization |
-| `org.home` | GET | `/organizations/{org_id}/home` | Get Organization Home |
+| `org.get` | GET | `/organizations/{organization_id}` | Get Organization |
+| `org.home` | GET | `/organizations/{organization_id}/home` | Get Organization Home |
 | `org.invitation.accept` | POST | `/organizations/invitations/{invitation_id}/accept` | Accept Invitation |
 | `org.invitation.get` | GET | `/organizations/invitations/{invitation_id}` | Get Organization Invitation |
-| `org.invitation.invite` | POST | `/organizations/{org_id}/invitations` | Invite Member |
-| `org.invitation.list` | GET | `/organizations/{org_id}/invitations` | List Organization Invitations |
+| `org.invitation.invite` | POST | `/organizations/{organization_id}/invitations` | Invite Member |
+| `org.invitation.list` | GET | `/organizations/{organization_id}/invitations` | List Organization Invitations |
 | `org.invitation.list_mine` | GET | `/organizations/invitations` | List My Invitations |
 | `org.invitation.revoke` | DELETE | `/organizations/invitations/{invitation_id}` | Revoke Invitation |
-| `org.join_auto_join` | POST | `/organizations/{org_id}/join` | Join Auto-Join Organization |
+| `org.join_auto_join` | POST | `/organizations/{organization_id}/join` | Join Auto-Join Organization |
 | `org.list` | GET | `/organizations` | List My Organizations |
-| `org.member.list` | GET | `/organizations/{org_id}/members` | List Organization Members |
-| `org.member.remove` | DELETE | `/organizations/{org_id}/members/{member_id}` | Remove Member |
-| `org.member.update_role` | PATCH | `/organizations/{org_id}/members/{member_id}/role` | Update Member Role |
+| `org.member.list` | GET | `/organizations/{organization_id}/members` | List Organization Members |
+| `org.member.remove` | DELETE | `/organizations/{organization_id}/members/{member_id}` | Remove Member |
+| `org.member.update_role` | PATCH | `/organizations/{organization_id}/members/{member_id}/role` | Update Member Role |
 | `org.navigation` | GET | `/organizations/navigation` | List Organizations And Their Pods |
 | `org.slug_availability` | GET | `/organizations/slug-availability` | Check Organization Slug Availability |
 | `org.suggested` | GET | `/organizations/suggested` | Get Suggested Organizations |
-| `org.update` | PATCH | `/organizations/{org_id}` | Update Organization |
+| `org.update` | PATCH | `/organizations/{organization_id}` | Update Organization |
 | `user.current.get` | GET | `/users/me` | Get Current User |
 | `user.profile.get` | GET | `/users/me/profile` | Get User Profile |
 | `user.profile.upsert` | POST | `/users/me/profile` | Create or Update Profile |

--- a/lemma-backend/docs/contracts/pod.md
+++ b/lemma-backend/docs/contracts/pod.md
@@ -18,7 +18,7 @@ The table below is generated from the committed OpenAPI specification by `script
 | `pod.join_request.create` | POST | `/pods/{pod_id}/join-requests` | Create Pod Join Request |
 | `pod.join_request.list` | GET | `/pods/{pod_id}/join-requests` | List Pod Join Requests |
 | `pod.join_request.me` | GET | `/pods/{pod_id}/join-requests/me` | Get My Pod Join Request |
-| `pod.list` | GET | `/pods/organization/{organization_id}` | List PodS by Organization |
+| `pod.list` | GET | `/organizations/{organization_id}/pods` | List Pods by Organization |
 | `pod.member.add` | POST | `/pods/{pod_id}/members` | Add Pod Member |
 | `pod.member.get` | GET | `/pods/{pod_id}/members/{pod_member_id}` | Get Pod Member |
 | `pod.member.list` | GET | `/pods/{pod_id}/members` | List Pod Members |

--- a/lemma-backend/docs/modules/route-inventory.md
+++ b/lemma-backend/docs/modules/route-inventory.md
@@ -8,12 +8,12 @@ run `uv run python scripts/generate_route_inventory.py`.
 | Method | Path | Operation ID | Summary |
 | --- | --- | --- | --- |
 | DELETE | `/me/runtime/agent-hosts/{host_id}` | `agent.host.revoke` | Revoke Agent Host |
-| DELETE | `/organizations/{org_id}/agent-runtime/profiles/{profile_id}` | `agent.runtime.profiles.archive` | Archive Agent Runtime Profile |
+| DELETE | `/organizations/{organization_id}/agent-runtime/profiles/{profile_id}` | `agent.runtime.profiles.archive` | Archive Agent Runtime Profile |
 | DELETE | `/pods/{pod_id}/agents/{agent_name}` | `agent.delete` | Delete Agent |
 | GET | `/me/runtime/agent-hosts` | `agent.host.list` | List Agent Hosts |
 | GET | `/me/runtime/agent-hosts/{host_id}/harnesses` | `agent.host.harnesses.list` | List Agent Host Harnesses |
-| GET | `/organizations/{org_id}/agent-runtime/profiles` | `agent.runtime.profiles.list` | List Available Agent Runtime Profiles |
-| GET | `/organizations/{org_id}/agent-runtime/profiles/{profile_id}` | `agent.runtime.profiles.get` | Get Agent Runtime Profile |
+| GET | `/organizations/{organization_id}/agent-runtime/profiles` | `agent.runtime.profiles.list` | List Available Agent Runtime Profiles |
+| GET | `/organizations/{organization_id}/agent-runtime/profiles/{profile_id}` | `agent.runtime.profiles.get` | Get Agent Runtime Profile |
 | GET | `/pods/{pod_id}/agents` | `agent.list` | List Agents |
 | GET | `/pods/{pod_id}/agents/{agent_name}` | `agent.get` | Get Agent |
 | GET | `/pods/{pod_id}/agents/{agent_name}/permissions` | `agent.permissions.get` | Get Agent Resource Permissions |
@@ -22,16 +22,16 @@ run `uv run python scripts/generate_route_inventory.py`.
 | GET | `/pods/{pod_id}/conversations/{conversation_id}/approvals` | `agent.conversation.approval.list` | List Agent Run Approvals |
 | GET | `/pods/{pod_id}/conversations/{conversation_id}/messages` | `agent.conversation.message.list` | List Pod Conversation Messages |
 | GET | `/pods/{pod_id}/conversations/{conversation_id}/stream` | `agent.conversation.stream` | Stream Pod Conversation |
-| PATCH | `/organizations/{org_id}/agent-runtime/profiles/{profile_id}` | `agent.runtime.profiles.update` | Update Agent Runtime Profile |
+| PATCH | `/organizations/{organization_id}/agent-runtime/profiles/{profile_id}` | `agent.runtime.profiles.update` | Update Agent Runtime Profile |
 | PATCH | `/pods/{pod_id}/agents/{agent_name}` | `agent.update` | Update Agent |
 | PATCH | `/pods/{pod_id}/conversations/{conversation_id}` | `agent.conversation.update` | Update Pod Conversation |
-| POST | `/agent-host/events:append` | `agent.host.events.append` | Append Agent Host Events |
-| POST | `/agent-host/pairings:complete` | `agent.host.pairing.complete` | Complete Agent Host Pairing |
+| POST | `/agent-host/events/append` | `agent.host.events.append` | Append Agent Host Events |
+| POST | `/agent-host/pairings/complete` | `agent.host.pairing.complete` | Complete Agent Host Pairing |
 | POST | `/agent-host/poll` | `agent.host.poll` | Poll Agent Host Commands |
 | POST | `/agent-host/revoke` | `agent.host.self_revoke` | Self Revoke Agent Host |
 | POST | `/me/runtime/agent-host-pairings` | `agent.host.pairing.create` | Create Agent Host Pairing |
-| POST | `/organizations/{org_id}/agent-runtime/profiles` | `agent.runtime.profiles.create` | Create Agent Runtime Profile |
-| POST | `/organizations/{org_id}/agent-runtime/profiles/{profile_id}:restore` | `agent.runtime.profiles.restore` | Restore Agent Runtime Profile |
+| POST | `/organizations/{organization_id}/agent-runtime/profiles` | `agent.runtime.profiles.create` | Create Agent Runtime Profile |
+| POST | `/organizations/{organization_id}/agent-runtime/profiles/{profile_id}/restore` | `agent.runtime.profiles.restore` | Restore Agent Runtime Profile |
 | POST | `/pods/{pod_id}/agents` | `agent.create` | Create Agent |
 | POST | `/pods/{pod_id}/conversations` | `agent.conversation.create` | Create Pod Agent Conversation |
 | POST | `/pods/{pod_id}/conversations/{conversation_id}/approvals/{approval_id}/decision` | `agent.conversation.approval.resolve` | Resolve User Approval |
@@ -187,7 +187,7 @@ run `uv run python scripts/generate_route_inventory.py`.
 | Method | Path | Operation ID | Summary |
 | --- | --- | --- | --- |
 | DELETE | `/organizations/invitations/{invitation_id}` | `org.invitation.revoke` | Revoke Invitation |
-| DELETE | `/organizations/{org_id}/members/{member_id}` | `org.member.remove` | Remove Member |
+| DELETE | `/organizations/{organization_id}/members/{member_id}` | `org.member.remove` | Remove Member |
 | GET | `/auth/verify-token` | `auth.verify_token` | Verify access token |
 | GET | `/organizations` | `org.list` | List My Organizations |
 | GET | `/organizations/invitations` | `org.invitation.list_mine` | List My Invitations |
@@ -195,18 +195,18 @@ run `uv run python scripts/generate_route_inventory.py`.
 | GET | `/organizations/navigation` | `org.navigation` | List Organizations And Their Pods |
 | GET | `/organizations/slug-availability` | `org.slug_availability` | Check Organization Slug Availability |
 | GET | `/organizations/suggested` | `org.suggested` | Get Suggested Organizations |
-| GET | `/organizations/{org_id}` | `org.get` | Get Organization |
-| GET | `/organizations/{org_id}/home` | `org.home` | Get Organization Home |
-| GET | `/organizations/{org_id}/invitations` | `org.invitation.list` | List Organization Invitations |
-| GET | `/organizations/{org_id}/members` | `org.member.list` | List Organization Members |
+| GET | `/organizations/{organization_id}` | `org.get` | Get Organization |
+| GET | `/organizations/{organization_id}/home` | `org.home` | Get Organization Home |
+| GET | `/organizations/{organization_id}/invitations` | `org.invitation.list` | List Organization Invitations |
+| GET | `/organizations/{organization_id}/members` | `org.member.list` | List Organization Members |
 | GET | `/users/me` | `user.current.get` | Get Current User |
 | GET | `/users/me/profile` | `user.profile.get` | Get User Profile |
-| PATCH | `/organizations/{org_id}` | `org.update` | Update Organization |
-| PATCH | `/organizations/{org_id}/members/{member_id}/role` | `org.member.update_role` | Update Member Role |
+| PATCH | `/organizations/{organization_id}` | `org.update` | Update Organization |
+| PATCH | `/organizations/{organization_id}/members/{member_id}/role` | `org.member.update_role` | Update Member Role |
 | POST | `/organizations` | `org.create` | Create Organization |
 | POST | `/organizations/invitations/{invitation_id}/accept` | `org.invitation.accept` | Accept Invitation |
-| POST | `/organizations/{org_id}/invitations` | `org.invitation.invite` | Invite Member |
-| POST | `/organizations/{org_id}/join` | `org.join_auto_join` | Join Auto-Join Organization |
+| POST | `/organizations/{organization_id}/invitations` | `org.invitation.invite` | Invite Member |
+| POST | `/organizations/{organization_id}/join` | `org.join_auto_join` | Join Auto-Join Organization |
 | POST | `/users/me/profile` | `user.profile.upsert` | Create or Update Profile |
 
 ## pod
@@ -217,7 +217,7 @@ run `uv run python scripts/generate_route_inventory.py`.
 | DELETE | `/pods/{pod_id}/members/{pod_member_id}` | `pod.member.remove` | Remove Pod Member |
 | DELETE | `/pods/{pod_id}/resources/{resource_type}/{resource_name}/access/grantees/{grantee_type}/{grantee_id}` | `pod.resource_access.grant.delete` | Delete Resource Access Grant |
 | DELETE | `/pods/{pod_id}/roles/{role_name}` | `pod.roles.delete` | Delete Pod Role |
-| GET | `/pods/organization/{organization_id}` | `pod.list` | List PodS by Organization |
+| GET | `/organizations/{organization_id}/pods` | `pod.list` | List Pods by Organization |
 | GET | `/pods/{pod_id}` | `pod.get` | Get Pod |
 | GET | `/pods/{pod_id}/join-requests` | `pod.join_request.list` | List Pod Join Requests |
 | GET | `/pods/{pod_id}/join-requests/me` | `pod.join_request.me` | Get My Pod Join Request |

--- a/lemma-frontend/public/openapi.json
+++ b/lemma-frontend/public/openapi.json
@@ -8931,7 +8931,7 @@
         "type": "object"
       },
       "NavigationPodResponse": {
-        "description": "A pod as a listing entry — enough to draw it, label it, and link to it.\n\nThe line this payload holds is scalars yes, collections no. A pod's own\ncolumns cost nothing to return: they ride along in the query that found the\npod, so the response grows with the number of pods and not with what is\ninside them. Apps, agents and roles are the other side of that line, and\nlive on ``/organizations/{org_id}/home``.",
+        "description": "A pod as a listing entry — enough to draw it, label it, and link to it.\n\nThe line this payload holds is scalars yes, collections no. A pod's own\ncolumns cost nothing to return: they ride along in the query that found the\npod, so the response grows with the number of pods and not with what is\ninside them. Apps, agents and roles are the other side of that line, and\nlive on ``/organizations/{organization_id}/home``.",
         "properties": {
           "description": {
             "anyOf": [
@@ -17836,7 +17836,7 @@
   },
   "openapi": "3.1.0",
   "paths": {
-    "/agent-host/events:append": {
+    "/agent-host/events/append": {
       "post": {
         "description": "Append one ordered batch to the run's stream.\n\nThere is no second lane to publish on: every event type travels the one\nordered stream, and the ack watermark is the stream's last entry.",
         "operationId": "agent.host.events.append",
@@ -17976,7 +17976,7 @@
         }
       }
     },
-    "/agent-host/pairings:complete": {
+    "/agent-host/pairings/complete": {
       "post": {
         "description": "Consume a pairing code and issue the host secret, shown exactly once.",
         "operationId": "agent.host.pairing.complete",
@@ -19176,18 +19176,18 @@
         }
       }
     },
-    "/organizations/{org_id}": {
+    "/organizations/{organization_id}": {
       "get": {
         "description": "Get organization details",
         "operationId": "org.get",
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           }
@@ -19232,11 +19232,11 @@
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           }
@@ -19289,17 +19289,17 @@
         }
       }
     },
-    "/organizations/{org_id}/agent-runtime/profiles": {
+    "/organizations/{organization_id}/agent-runtime/profiles": {
       "get": {
         "operationId": "agent.runtime.profiles.list",
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           },
@@ -19353,11 +19353,11 @@
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           }
@@ -19429,17 +19429,17 @@
         }
       }
     },
-    "/organizations/{org_id}/agent-runtime/profiles/{profile_id}": {
+    "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}": {
       "delete": {
         "operationId": "agent.runtime.profiles.archive",
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           },
@@ -19488,11 +19488,11 @@
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           },
@@ -19545,11 +19545,11 @@
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           },
@@ -19630,17 +19630,17 @@
         }
       }
     },
-    "/organizations/{org_id}/agent-runtime/profiles/{profile_id}:restore": {
+    "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}/restore": {
       "post": {
         "operationId": "agent.runtime.profiles.restore",
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           },
@@ -19689,467 +19689,6 @@
           "resource": "agent.runtime.profiles",
           "result": "entity",
           "verb": "restore"
-        }
-      }
-    },
-    "/organizations/{org_id}/home": {
-      "get": {
-        "description": "One organization's landing page: every pod the current user can see, with its apps, its agents, and the user's roles in that pod. Replaces fetching apps and agents per pod. Cached briefly per user.",
-        "operationId": "org.home",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationHomeResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Organization Home",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "kind": "query",
-          "paginates": false,
-          "resource": "org",
-          "result": "entity",
-          "verb": "home"
-        }
-      }
-    },
-    "/organizations/{org_id}/invitations": {
-      "get": {
-        "description": "Get all pending invitations for an organization",
-        "operationId": "org.invitation.list",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/OrganizationInvitationStatus",
-              "default": "PENDING"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 100,
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "page_token",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Page Token"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationInvitationListResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "List Organization Invitations",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "kind": "query",
-          "paginates": true,
-          "resource": "org.invitation",
-          "result": "collection",
-          "verb": "list"
-        }
-      },
-      "post": {
-        "description": "Invite a user to join the organization",
-        "operationId": "org.invitation.invite",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OrganizationInvitationRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationInvitationResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Invite Member",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "invalidates": [
-            "org.invitation"
-          ],
-          "kind": "mutation",
-          "paginates": false,
-          "resource": "org.invitation",
-          "result": "entity",
-          "verb": "invite"
-        }
-      }
-    },
-    "/organizations/{org_id}/join": {
-      "post": {
-        "description": "Join an organization when the current user's email domain is allowed to auto-join",
-        "operationId": "org.join_auto_join",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Join Auto-Join Organization",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "invalidates": [
-            "org"
-          ],
-          "kind": "mutation",
-          "paginates": false,
-          "resource": "org",
-          "result": "entity",
-          "verb": "join_auto_join"
-        }
-      }
-    },
-    "/organizations/{org_id}/members": {
-      "get": {
-        "description": "Get all members of an organization",
-        "operationId": "org.member.list",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 100,
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "page_token",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Page Token"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationMemberListResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "List Organization Members",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "kind": "query",
-          "paginates": true,
-          "resource": "org.member",
-          "result": "collection",
-          "verb": "list"
-        }
-      }
-    },
-    "/organizations/{org_id}/members/{member_id}": {
-      "delete": {
-        "description": "Remove a member from the organization",
-        "operationId": "org.member.remove",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "member_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Member Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Remove Member",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "invalidates": [
-            "org.member"
-          ],
-          "kind": "mutation",
-          "paginates": false,
-          "resource": "org.member",
-          "result": "void",
-          "verb": "remove"
-        }
-      }
-    },
-    "/organizations/{org_id}/members/{member_id}/role": {
-      "patch": {
-        "description": "Update a member's role in the organization",
-        "operationId": "org.member.update_role",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "member_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Member Id",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateMemberRoleRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationMemberResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Update Member Role",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "invalidates": [
-            "org.member"
-          ],
-          "kind": "mutation",
-          "paginates": false,
-          "resource": "org.member",
-          "result": "entity",
-          "verb": "update_role"
         }
       }
     },
@@ -21553,6 +21092,544 @@
         }
       }
     },
+    "/organizations/{organization_id}/home": {
+      "get": {
+        "description": "One organization's landing page: every pod the current user can see, with its apps, its agents, and the user's roles in that pod. Replaces fetching apps and agents per pod. Cached briefly per user.",
+        "operationId": "org.home",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationHomeResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Organization Home",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "kind": "query",
+          "paginates": false,
+          "resource": "org",
+          "result": "entity",
+          "verb": "home"
+        }
+      }
+    },
+    "/organizations/{organization_id}/invitations": {
+      "get": {
+        "description": "Get all pending invitations for an organization",
+        "operationId": "org.invitation.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrganizationInvitationStatus",
+              "default": "PENDING"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationInvitationListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Organization Invitations",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "kind": "query",
+          "paginates": true,
+          "resource": "org.invitation",
+          "result": "collection",
+          "verb": "list"
+        }
+      },
+      "post": {
+        "description": "Invite a user to join the organization",
+        "operationId": "org.invitation.invite",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationInvitationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationInvitationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Invite Member",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "org.invitation"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "org.invitation",
+          "result": "entity",
+          "verb": "invite"
+        }
+      }
+    },
+    "/organizations/{organization_id}/join": {
+      "post": {
+        "description": "Join an organization when the current user's email domain is allowed to auto-join",
+        "operationId": "org.join_auto_join",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Join Auto-Join Organization",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "org"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "org",
+          "result": "entity",
+          "verb": "join_auto_join"
+        }
+      }
+    },
+    "/organizations/{organization_id}/members": {
+      "get": {
+        "description": "Get all members of an organization",
+        "operationId": "org.member.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationMemberListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Organization Members",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "kind": "query",
+          "paginates": true,
+          "resource": "org.member",
+          "result": "collection",
+          "verb": "list"
+        }
+      }
+    },
+    "/organizations/{organization_id}/members/{member_id}": {
+      "delete": {
+        "description": "Remove a member from the organization",
+        "operationId": "org.member.remove",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "member_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Member Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Remove Member",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "org.member"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "org.member",
+          "result": "void",
+          "verb": "remove"
+        }
+      }
+    },
+    "/organizations/{organization_id}/members/{member_id}/role": {
+      "patch": {
+        "description": "Update a member's role in the organization",
+        "operationId": "org.member.update_role",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "member_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Member Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMemberRoleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationMemberResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Member Role",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "org.member"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "org.member",
+          "result": "entity",
+          "verb": "update_role"
+        }
+      }
+    },
+    "/organizations/{organization_id}/pods": {
+      "get": {
+        "description": "List all pods in an organization",
+        "operationId": "pod.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PodListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Pods by Organization",
+        "tags": [
+          "Pods"
+        ],
+        "x-lemma": {
+          "kind": "query",
+          "paginates": true,
+          "resource": "pod",
+          "result": "collection",
+          "verb": "list"
+        }
+      }
+    },
     "/pods": {
       "post": {
         "description": "Create a new pod",
@@ -21647,83 +21724,6 @@
           "resource": "pod.bundle",
           "result": "entity",
           "verb": "download"
-        }
-      }
-    },
-    "/pods/organization/{organization_id}": {
-      "get": {
-        "description": "List all pods in an organization",
-        "operationId": "pod.list",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organization_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Organization Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 100,
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "page_token",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Page Token"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PodListResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "List PodS by Organization",
-        "tags": [
-          "Pods"
-        ],
-        "x-lemma": {
-          "kind": "query",
-          "paginates": true,
-          "resource": "pod",
-          "result": "collection",
-          "verb": "list"
         }
       }
     },

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -13,4 +13,4 @@ SDK and the server it is talking to.
 from __future__ import annotations
 
 API_VERSION = "0.7.2"
-SPEC_SHA256 = "d95f65b02cadaadce2573bfbc69655528e6bd4a8557aa3c20c328654f0799f22"
+SPEC_SHA256 = "cda392a37896694bdd99f226c92232229880f9accb3fbfd6279dfb6390e55aa1"

--- a/lemma-python/lemma_sdk/openapi_client/api/agent_host/agent_host_events_append.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/agent_host/agent_host_events_append.py
@@ -22,7 +22,7 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "post",
-        "url": "/agent-host/events:append",
+        "url": "/agent-host/events/append",
     }
 
     _kwargs["json"] = body.to_dict()

--- a/lemma-python/lemma_sdk/openapi_client/api/agent_host/agent_host_pairing_complete.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/agent_host/agent_host_pairing_complete.py
@@ -19,7 +19,7 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "post",
-        "url": "/agent-host/pairings:complete",
+        "url": "/agent-host/pairings/complete",
     }
 
     _kwargs["json"] = body.to_dict()

--- a/lemma-python/lemma_sdk/openapi_client/api/agent_runtime/agent_runtime_profiles_archive.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/agent_runtime/agent_runtime_profiles_archive.py
@@ -12,14 +12,14 @@ from ...types import Response
 
 
 def _get_kwargs(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
 ) -> dict[str, Any]:
 
     _kwargs: dict[str, Any] = {
         "method": "delete",
-        "url": "/organizations/{org_id}/agent-runtime/profiles/{profile_id}".format(
-            org_id=quote(str(org_id), safe=""),
+        "url": "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}".format(
+            organization_id=quote(str(organization_id), safe=""),
             profile_id=quote(str(profile_id), safe=""),
         ),
     }
@@ -57,7 +57,7 @@ def _build_response(
 
 
 def sync_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     *,
     client: AuthenticatedClient | Client,
@@ -65,7 +65,7 @@ def sync_detailed(
     """Archive Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         profile_id (str):
 
     Raises:
@@ -77,7 +77,7 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         profile_id=profile_id,
     )
 
@@ -89,7 +89,7 @@ def sync_detailed(
 
 
 def sync(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     *,
     client: AuthenticatedClient | Client,
@@ -97,7 +97,7 @@ def sync(
     """Archive Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         profile_id (str):
 
     Raises:
@@ -109,14 +109,14 @@ def sync(
     """
 
     return sync_detailed(
-        org_id=org_id,
+        organization_id=organization_id,
         profile_id=profile_id,
         client=client,
     ).parsed
 
 
 async def asyncio_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     *,
     client: AuthenticatedClient | Client,
@@ -124,7 +124,7 @@ async def asyncio_detailed(
     """Archive Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         profile_id (str):
 
     Raises:
@@ -136,7 +136,7 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         profile_id=profile_id,
     )
 
@@ -146,7 +146,7 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     *,
     client: AuthenticatedClient | Client,
@@ -154,7 +154,7 @@ async def asyncio(
     """Archive Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         profile_id (str):
 
     Raises:
@@ -167,7 +167,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            org_id=org_id,
+            organization_id=organization_id,
             profile_id=profile_id,
             client=client,
         )

--- a/lemma-python/lemma_sdk/openapi_client/api/agent_runtime/agent_runtime_profiles_create.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/agent_runtime/agent_runtime_profiles_create.py
@@ -22,7 +22,7 @@ from ...types import Response
 
 
 def _get_kwargs(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     body: CreateAgentHostRuntimeProfileRequest
     | CreateAnthropicCompatibleRuntimeProfileRequest
@@ -32,8 +32,8 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "post",
-        "url": "/organizations/{org_id}/agent-runtime/profiles".format(
-            org_id=quote(str(org_id), safe=""),
+        "url": "/organizations/{organization_id}/agent-runtime/profiles".format(
+            organization_id=quote(str(organization_id), safe=""),
         ),
     }
 
@@ -81,7 +81,7 @@ def _build_response(
 
 
 def sync_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     body: CreateAgentHostRuntimeProfileRequest
@@ -91,7 +91,7 @@ def sync_detailed(
     """Create Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         body (CreateAgentHostRuntimeProfileRequest |
             CreateAnthropicCompatibleRuntimeProfileRequest |
             CreateOpenAICompatibleRuntimeProfileRequest):
@@ -105,7 +105,7 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         body=body,
     )
 
@@ -117,7 +117,7 @@ def sync_detailed(
 
 
 def sync(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     body: CreateAgentHostRuntimeProfileRequest
@@ -127,7 +127,7 @@ def sync(
     """Create Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         body (CreateAgentHostRuntimeProfileRequest |
             CreateAnthropicCompatibleRuntimeProfileRequest |
             CreateOpenAICompatibleRuntimeProfileRequest):
@@ -141,14 +141,14 @@ def sync(
     """
 
     return sync_detailed(
-        org_id=org_id,
+        organization_id=organization_id,
         client=client,
         body=body,
     ).parsed
 
 
 async def asyncio_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     body: CreateAgentHostRuntimeProfileRequest
@@ -158,7 +158,7 @@ async def asyncio_detailed(
     """Create Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         body (CreateAgentHostRuntimeProfileRequest |
             CreateAnthropicCompatibleRuntimeProfileRequest |
             CreateOpenAICompatibleRuntimeProfileRequest):
@@ -172,7 +172,7 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         body=body,
     )
 
@@ -182,7 +182,7 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     body: CreateAgentHostRuntimeProfileRequest
@@ -192,7 +192,7 @@ async def asyncio(
     """Create Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         body (CreateAgentHostRuntimeProfileRequest |
             CreateAnthropicCompatibleRuntimeProfileRequest |
             CreateOpenAICompatibleRuntimeProfileRequest):
@@ -207,7 +207,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            org_id=org_id,
+            organization_id=organization_id,
             client=client,
             body=body,
         )

--- a/lemma-python/lemma_sdk/openapi_client/api/agent_runtime/agent_runtime_profiles_get.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/agent_runtime/agent_runtime_profiles_get.py
@@ -15,14 +15,14 @@ from ...types import Response
 
 
 def _get_kwargs(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
 ) -> dict[str, Any]:
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/organizations/{org_id}/agent-runtime/profiles/{profile_id}".format(
-            org_id=quote(str(org_id), safe=""),
+        "url": "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}".format(
+            organization_id=quote(str(organization_id), safe=""),
             profile_id=quote(str(profile_id), safe=""),
         ),
     }
@@ -61,7 +61,7 @@ def _build_response(
 
 
 def sync_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     *,
     client: AuthenticatedClient | Client,
@@ -69,7 +69,7 @@ def sync_detailed(
     """Get Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         profile_id (str):
 
     Raises:
@@ -81,7 +81,7 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         profile_id=profile_id,
     )
 
@@ -93,7 +93,7 @@ def sync_detailed(
 
 
 def sync(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     *,
     client: AuthenticatedClient | Client,
@@ -101,7 +101,7 @@ def sync(
     """Get Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         profile_id (str):
 
     Raises:
@@ -113,14 +113,14 @@ def sync(
     """
 
     return sync_detailed(
-        org_id=org_id,
+        organization_id=organization_id,
         profile_id=profile_id,
         client=client,
     ).parsed
 
 
 async def asyncio_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     *,
     client: AuthenticatedClient | Client,
@@ -128,7 +128,7 @@ async def asyncio_detailed(
     """Get Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         profile_id (str):
 
     Raises:
@@ -140,7 +140,7 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         profile_id=profile_id,
     )
 
@@ -150,7 +150,7 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     *,
     client: AuthenticatedClient | Client,
@@ -158,7 +158,7 @@ async def asyncio(
     """Get Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         profile_id (str):
 
     Raises:
@@ -171,7 +171,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            org_id=org_id,
+            organization_id=organization_id,
             profile_id=profile_id,
             client=client,
         )

--- a/lemma-python/lemma_sdk/openapi_client/api/agent_runtime/agent_runtime_profiles_list.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/agent_runtime/agent_runtime_profiles_list.py
@@ -15,7 +15,7 @@ from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     include_disabled: bool | Unset = False,
 ) -> dict[str, Any]:
@@ -28,8 +28,8 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/organizations/{org_id}/agent-runtime/profiles".format(
-            org_id=quote(str(org_id), safe=""),
+        "url": "/organizations/{organization_id}/agent-runtime/profiles".format(
+            organization_id=quote(str(organization_id), safe=""),
         ),
         "params": params,
     }
@@ -68,7 +68,7 @@ def _build_response(
 
 
 def sync_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     include_disabled: bool | Unset = False,
@@ -76,7 +76,7 @@ def sync_detailed(
     """List Available Agent Runtime Profiles
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         include_disabled (bool | Unset):  Default: False.
 
     Raises:
@@ -88,7 +88,7 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         include_disabled=include_disabled,
     )
 
@@ -100,7 +100,7 @@ def sync_detailed(
 
 
 def sync(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     include_disabled: bool | Unset = False,
@@ -108,7 +108,7 @@ def sync(
     """List Available Agent Runtime Profiles
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         include_disabled (bool | Unset):  Default: False.
 
     Raises:
@@ -120,14 +120,14 @@ def sync(
     """
 
     return sync_detailed(
-        org_id=org_id,
+        organization_id=organization_id,
         client=client,
         include_disabled=include_disabled,
     ).parsed
 
 
 async def asyncio_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     include_disabled: bool | Unset = False,
@@ -135,7 +135,7 @@ async def asyncio_detailed(
     """List Available Agent Runtime Profiles
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         include_disabled (bool | Unset):  Default: False.
 
     Raises:
@@ -147,7 +147,7 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         include_disabled=include_disabled,
     )
 
@@ -157,7 +157,7 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     include_disabled: bool | Unset = False,
@@ -165,7 +165,7 @@ async def asyncio(
     """List Available Agent Runtime Profiles
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         include_disabled (bool | Unset):  Default: False.
 
     Raises:
@@ -178,7 +178,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            org_id=org_id,
+            organization_id=organization_id,
             client=client,
             include_disabled=include_disabled,
         )

--- a/lemma-python/lemma_sdk/openapi_client/api/agent_runtime/agent_runtime_profiles_restore.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/agent_runtime/agent_runtime_profiles_restore.py
@@ -13,14 +13,14 @@ from ...types import Response
 
 
 def _get_kwargs(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
 ) -> dict[str, Any]:
 
     _kwargs: dict[str, Any] = {
         "method": "post",
-        "url": "/organizations/{org_id}/agent-runtime/profiles/{profile_id}:restore".format(
-            org_id=quote(str(org_id), safe=""),
+        "url": "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}/restore".format(
+            organization_id=quote(str(organization_id), safe=""),
             profile_id=quote(str(profile_id), safe=""),
         ),
     }
@@ -59,7 +59,7 @@ def _build_response(
 
 
 def sync_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     *,
     client: AuthenticatedClient | Client,
@@ -67,7 +67,7 @@ def sync_detailed(
     """Restore Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         profile_id (str):
 
     Raises:
@@ -79,7 +79,7 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         profile_id=profile_id,
     )
 
@@ -91,7 +91,7 @@ def sync_detailed(
 
 
 def sync(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     *,
     client: AuthenticatedClient | Client,
@@ -99,7 +99,7 @@ def sync(
     """Restore Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         profile_id (str):
 
     Raises:
@@ -111,14 +111,14 @@ def sync(
     """
 
     return sync_detailed(
-        org_id=org_id,
+        organization_id=organization_id,
         profile_id=profile_id,
         client=client,
     ).parsed
 
 
 async def asyncio_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     *,
     client: AuthenticatedClient | Client,
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     """Restore Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         profile_id (str):
 
     Raises:
@@ -138,7 +138,7 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         profile_id=profile_id,
     )
 
@@ -148,7 +148,7 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     *,
     client: AuthenticatedClient | Client,
@@ -156,7 +156,7 @@ async def asyncio(
     """Restore Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         profile_id (str):
 
     Raises:
@@ -169,7 +169,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            org_id=org_id,
+            organization_id=organization_id,
             profile_id=profile_id,
             client=client,
         )

--- a/lemma-python/lemma_sdk/openapi_client/api/agent_runtime/agent_runtime_profiles_update.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/agent_runtime/agent_runtime_profiles_update.py
@@ -22,7 +22,7 @@ from ...types import Response
 
 
 def _get_kwargs(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     *,
     body: UpdateAgentHostRuntimeProfileRequest
@@ -33,8 +33,8 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "patch",
-        "url": "/organizations/{org_id}/agent-runtime/profiles/{profile_id}".format(
-            org_id=quote(str(org_id), safe=""),
+        "url": "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}".format(
+            organization_id=quote(str(organization_id), safe=""),
             profile_id=quote(str(profile_id), safe=""),
         ),
     }
@@ -83,7 +83,7 @@ def _build_response(
 
 
 def sync_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     *,
     client: AuthenticatedClient | Client,
@@ -94,7 +94,7 @@ def sync_detailed(
     """Update Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         profile_id (str):
         body (UpdateAgentHostRuntimeProfileRequest |
             UpdateAnthropicCompatibleRuntimeProfileRequest |
@@ -109,7 +109,7 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         profile_id=profile_id,
         body=body,
     )
@@ -122,7 +122,7 @@ def sync_detailed(
 
 
 def sync(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     *,
     client: AuthenticatedClient | Client,
@@ -133,7 +133,7 @@ def sync(
     """Update Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         profile_id (str):
         body (UpdateAgentHostRuntimeProfileRequest |
             UpdateAnthropicCompatibleRuntimeProfileRequest |
@@ -148,7 +148,7 @@ def sync(
     """
 
     return sync_detailed(
-        org_id=org_id,
+        organization_id=organization_id,
         profile_id=profile_id,
         client=client,
         body=body,
@@ -156,7 +156,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     *,
     client: AuthenticatedClient | Client,
@@ -167,7 +167,7 @@ async def asyncio_detailed(
     """Update Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         profile_id (str):
         body (UpdateAgentHostRuntimeProfileRequest |
             UpdateAnthropicCompatibleRuntimeProfileRequest |
@@ -182,7 +182,7 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         profile_id=profile_id,
         body=body,
     )
@@ -193,7 +193,7 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    org_id: UUID,
+    organization_id: UUID,
     profile_id: str,
     *,
     client: AuthenticatedClient | Client,
@@ -204,7 +204,7 @@ async def asyncio(
     """Update Agent Runtime Profile
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         profile_id (str):
         body (UpdateAgentHostRuntimeProfileRequest |
             UpdateAnthropicCompatibleRuntimeProfileRequest |
@@ -220,7 +220,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            org_id=org_id,
+            organization_id=organization_id,
             profile_id=profile_id,
             client=client,
             body=body,

--- a/lemma-python/lemma_sdk/openapi_client/api/organizations/org_get.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/organizations/org_get.py
@@ -13,13 +13,13 @@ from ...types import Response
 
 
 def _get_kwargs(
-    org_id: UUID,
+    organization_id: UUID,
 ) -> dict[str, Any]:
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/organizations/{org_id}".format(
-            org_id=quote(str(org_id), safe=""),
+        "url": "/organizations/{organization_id}".format(
+            organization_id=quote(str(organization_id), safe=""),
         ),
     }
 
@@ -57,7 +57,7 @@ def _build_response(
 
 
 def sync_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
 ) -> Response[ErrorResponse | OrganizationResponse]:
@@ -66,7 +66,7 @@ def sync_detailed(
      Get organization details
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -77,7 +77,7 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -88,7 +88,7 @@ def sync_detailed(
 
 
 def sync(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
 ) -> ErrorResponse | OrganizationResponse | None:
@@ -97,7 +97,7 @@ def sync(
      Get organization details
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -108,13 +108,13 @@ def sync(
     """
 
     return sync_detailed(
-        org_id=org_id,
+        organization_id=organization_id,
         client=client,
     ).parsed
 
 
 async def asyncio_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
 ) -> Response[ErrorResponse | OrganizationResponse]:
@@ -123,7 +123,7 @@ async def asyncio_detailed(
      Get organization details
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -134,7 +134,7 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -143,7 +143,7 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
 ) -> ErrorResponse | OrganizationResponse | None:
@@ -152,7 +152,7 @@ async def asyncio(
      Get organization details
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -164,7 +164,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            org_id=org_id,
+            organization_id=organization_id,
             client=client,
         )
     ).parsed

--- a/lemma-python/lemma_sdk/openapi_client/api/organizations/org_home.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/organizations/org_home.py
@@ -13,13 +13,13 @@ from ...types import Response
 
 
 def _get_kwargs(
-    org_id: UUID,
+    organization_id: UUID,
 ) -> dict[str, Any]:
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/organizations/{org_id}/home".format(
-            org_id=quote(str(org_id), safe=""),
+        "url": "/organizations/{organization_id}/home".format(
+            organization_id=quote(str(organization_id), safe=""),
         ),
     }
 
@@ -57,7 +57,7 @@ def _build_response(
 
 
 def sync_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
 ) -> Response[ErrorResponse | OrganizationHomeResponse]:
@@ -67,7 +67,7 @@ def sync_detailed(
     the user's roles in that pod. Replaces fetching apps and agents per pod. Cached briefly per user.
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -78,7 +78,7 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -89,7 +89,7 @@ def sync_detailed(
 
 
 def sync(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
 ) -> ErrorResponse | OrganizationHomeResponse | None:
@@ -99,7 +99,7 @@ def sync(
     the user's roles in that pod. Replaces fetching apps and agents per pod. Cached briefly per user.
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -110,13 +110,13 @@ def sync(
     """
 
     return sync_detailed(
-        org_id=org_id,
+        organization_id=organization_id,
         client=client,
     ).parsed
 
 
 async def asyncio_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
 ) -> Response[ErrorResponse | OrganizationHomeResponse]:
@@ -126,7 +126,7 @@ async def asyncio_detailed(
     the user's roles in that pod. Replaces fetching apps and agents per pod. Cached briefly per user.
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -137,7 +137,7 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -146,7 +146,7 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
 ) -> ErrorResponse | OrganizationHomeResponse | None:
@@ -156,7 +156,7 @@ async def asyncio(
     the user's roles in that pod. Replaces fetching apps and agents per pod. Cached briefly per user.
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -168,7 +168,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            org_id=org_id,
+            organization_id=organization_id,
             client=client,
         )
     ).parsed

--- a/lemma-python/lemma_sdk/openapi_client/api/organizations/org_invitation_invite.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/organizations/org_invitation_invite.py
@@ -14,7 +14,7 @@ from ...types import Response
 
 
 def _get_kwargs(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     body: OrganizationInvitationRequest,
 ) -> dict[str, Any]:
@@ -22,8 +22,8 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "post",
-        "url": "/organizations/{org_id}/invitations".format(
-            org_id=quote(str(org_id), safe=""),
+        "url": "/organizations/{organization_id}/invitations".format(
+            organization_id=quote(str(organization_id), safe=""),
         ),
     }
 
@@ -66,7 +66,7 @@ def _build_response(
 
 
 def sync_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     body: OrganizationInvitationRequest,
@@ -76,7 +76,7 @@ def sync_detailed(
      Invite a user to join the organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         body (OrganizationInvitationRequest): Organization invitation request schema.
 
     Raises:
@@ -88,7 +88,7 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         body=body,
     )
 
@@ -100,7 +100,7 @@ def sync_detailed(
 
 
 def sync(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     body: OrganizationInvitationRequest,
@@ -110,7 +110,7 @@ def sync(
      Invite a user to join the organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         body (OrganizationInvitationRequest): Organization invitation request schema.
 
     Raises:
@@ -122,14 +122,14 @@ def sync(
     """
 
     return sync_detailed(
-        org_id=org_id,
+        organization_id=organization_id,
         client=client,
         body=body,
     ).parsed
 
 
 async def asyncio_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     body: OrganizationInvitationRequest,
@@ -139,7 +139,7 @@ async def asyncio_detailed(
      Invite a user to join the organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         body (OrganizationInvitationRequest): Organization invitation request schema.
 
     Raises:
@@ -151,7 +151,7 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         body=body,
     )
 
@@ -161,7 +161,7 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     body: OrganizationInvitationRequest,
@@ -171,7 +171,7 @@ async def asyncio(
      Invite a user to join the organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         body (OrganizationInvitationRequest): Organization invitation request schema.
 
     Raises:
@@ -184,7 +184,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            org_id=org_id,
+            organization_id=organization_id,
             client=client,
             body=body,
         )

--- a/lemma-python/lemma_sdk/openapi_client/api/organizations/org_invitation_list.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/organizations/org_invitation_list.py
@@ -16,7 +16,7 @@ from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     status: OrganizationInvitationStatus | Unset = UNSET,
     limit: int | Unset = 100,
@@ -44,8 +44,8 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/organizations/{org_id}/invitations".format(
-            org_id=quote(str(org_id), safe=""),
+        "url": "/organizations/{organization_id}/invitations".format(
+            organization_id=quote(str(organization_id), safe=""),
         ),
         "params": params,
     }
@@ -84,7 +84,7 @@ def _build_response(
 
 
 def sync_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     status: OrganizationInvitationStatus | Unset = UNSET,
@@ -96,7 +96,7 @@ def sync_detailed(
      Get all pending invitations for an organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         status (OrganizationInvitationStatus | Unset): Statuses for organization invitations.
         limit (int | Unset):  Default: 100.
         page_token (None | str | Unset):
@@ -110,7 +110,7 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         status=status,
         limit=limit,
         page_token=page_token,
@@ -124,7 +124,7 @@ def sync_detailed(
 
 
 def sync(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     status: OrganizationInvitationStatus | Unset = UNSET,
@@ -136,7 +136,7 @@ def sync(
      Get all pending invitations for an organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         status (OrganizationInvitationStatus | Unset): Statuses for organization invitations.
         limit (int | Unset):  Default: 100.
         page_token (None | str | Unset):
@@ -150,7 +150,7 @@ def sync(
     """
 
     return sync_detailed(
-        org_id=org_id,
+        organization_id=organization_id,
         client=client,
         status=status,
         limit=limit,
@@ -159,7 +159,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     status: OrganizationInvitationStatus | Unset = UNSET,
@@ -171,7 +171,7 @@ async def asyncio_detailed(
      Get all pending invitations for an organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         status (OrganizationInvitationStatus | Unset): Statuses for organization invitations.
         limit (int | Unset):  Default: 100.
         page_token (None | str | Unset):
@@ -185,7 +185,7 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         status=status,
         limit=limit,
         page_token=page_token,
@@ -197,7 +197,7 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     status: OrganizationInvitationStatus | Unset = UNSET,
@@ -209,7 +209,7 @@ async def asyncio(
      Get all pending invitations for an organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         status (OrganizationInvitationStatus | Unset): Statuses for organization invitations.
         limit (int | Unset):  Default: 100.
         page_token (None | str | Unset):
@@ -224,7 +224,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            org_id=org_id,
+            organization_id=organization_id,
             client=client,
             status=status,
             limit=limit,

--- a/lemma-python/lemma_sdk/openapi_client/api/organizations/org_join_auto_join.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/organizations/org_join_auto_join.py
@@ -13,13 +13,13 @@ from ...types import Response
 
 
 def _get_kwargs(
-    org_id: UUID,
+    organization_id: UUID,
 ) -> dict[str, Any]:
 
     _kwargs: dict[str, Any] = {
         "method": "post",
-        "url": "/organizations/{org_id}/join".format(
-            org_id=quote(str(org_id), safe=""),
+        "url": "/organizations/{organization_id}/join".format(
+            organization_id=quote(str(organization_id), safe=""),
         ),
     }
 
@@ -57,7 +57,7 @@ def _build_response(
 
 
 def sync_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
 ) -> Response[ErrorResponse | OrganizationResponse]:
@@ -66,7 +66,7 @@ def sync_detailed(
      Join an organization when the current user's email domain is allowed to auto-join
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -77,7 +77,7 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
     )
 
     response = client.get_httpx_client().request(
@@ -88,7 +88,7 @@ def sync_detailed(
 
 
 def sync(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
 ) -> ErrorResponse | OrganizationResponse | None:
@@ -97,7 +97,7 @@ def sync(
      Join an organization when the current user's email domain is allowed to auto-join
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -108,13 +108,13 @@ def sync(
     """
 
     return sync_detailed(
-        org_id=org_id,
+        organization_id=organization_id,
         client=client,
     ).parsed
 
 
 async def asyncio_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
 ) -> Response[ErrorResponse | OrganizationResponse]:
@@ -123,7 +123,7 @@ async def asyncio_detailed(
      Join an organization when the current user's email domain is allowed to auto-join
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -134,7 +134,7 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
     )
 
     response = await client.get_async_httpx_client().request(**kwargs)
@@ -143,7 +143,7 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
 ) -> ErrorResponse | OrganizationResponse | None:
@@ -152,7 +152,7 @@ async def asyncio(
      Join an organization when the current user's email domain is allowed to auto-join
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
@@ -164,7 +164,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            org_id=org_id,
+            organization_id=organization_id,
             client=client,
         )
     ).parsed

--- a/lemma-python/lemma_sdk/openapi_client/api/organizations/org_member_list.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/organizations/org_member_list.py
@@ -13,7 +13,7 @@ from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     limit: int | Unset = 100,
     page_token: None | str | Unset = UNSET,
@@ -34,8 +34,8 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/organizations/{org_id}/members".format(
-            org_id=quote(str(org_id), safe=""),
+        "url": "/organizations/{organization_id}/members".format(
+            organization_id=quote(str(organization_id), safe=""),
         ),
         "params": params,
     }
@@ -74,7 +74,7 @@ def _build_response(
 
 
 def sync_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     limit: int | Unset = 100,
@@ -85,7 +85,7 @@ def sync_detailed(
      Get all members of an organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         limit (int | Unset):  Default: 100.
         page_token (None | str | Unset):
 
@@ -98,7 +98,7 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         limit=limit,
         page_token=page_token,
     )
@@ -111,7 +111,7 @@ def sync_detailed(
 
 
 def sync(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     limit: int | Unset = 100,
@@ -122,7 +122,7 @@ def sync(
      Get all members of an organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         limit (int | Unset):  Default: 100.
         page_token (None | str | Unset):
 
@@ -135,7 +135,7 @@ def sync(
     """
 
     return sync_detailed(
-        org_id=org_id,
+        organization_id=organization_id,
         client=client,
         limit=limit,
         page_token=page_token,
@@ -143,7 +143,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     limit: int | Unset = 100,
@@ -154,7 +154,7 @@ async def asyncio_detailed(
      Get all members of an organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         limit (int | Unset):  Default: 100.
         page_token (None | str | Unset):
 
@@ -167,7 +167,7 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         limit=limit,
         page_token=page_token,
     )
@@ -178,7 +178,7 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     limit: int | Unset = 100,
@@ -189,7 +189,7 @@ async def asyncio(
      Get all members of an organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         limit (int | Unset):  Default: 100.
         page_token (None | str | Unset):
 
@@ -203,7 +203,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            org_id=org_id,
+            organization_id=organization_id,
             client=client,
             limit=limit,
             page_token=page_token,

--- a/lemma-python/lemma_sdk/openapi_client/api/organizations/org_member_remove.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/organizations/org_member_remove.py
@@ -12,14 +12,14 @@ from ...types import Response
 
 
 def _get_kwargs(
-    org_id: UUID,
+    organization_id: UUID,
     member_id: UUID,
 ) -> dict[str, Any]:
 
     _kwargs: dict[str, Any] = {
         "method": "delete",
-        "url": "/organizations/{org_id}/members/{member_id}".format(
-            org_id=quote(str(org_id), safe=""),
+        "url": "/organizations/{organization_id}/members/{member_id}".format(
+            organization_id=quote(str(organization_id), safe=""),
             member_id=quote(str(member_id), safe=""),
         ),
     }
@@ -57,7 +57,7 @@ def _build_response(
 
 
 def sync_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     member_id: UUID,
     *,
     client: AuthenticatedClient | Client,
@@ -67,7 +67,7 @@ def sync_detailed(
      Remove a member from the organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         member_id (UUID):
 
     Raises:
@@ -79,7 +79,7 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         member_id=member_id,
     )
 
@@ -91,7 +91,7 @@ def sync_detailed(
 
 
 def sync(
-    org_id: UUID,
+    organization_id: UUID,
     member_id: UUID,
     *,
     client: AuthenticatedClient | Client,
@@ -101,7 +101,7 @@ def sync(
      Remove a member from the organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         member_id (UUID):
 
     Raises:
@@ -113,14 +113,14 @@ def sync(
     """
 
     return sync_detailed(
-        org_id=org_id,
+        organization_id=organization_id,
         member_id=member_id,
         client=client,
     ).parsed
 
 
 async def asyncio_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     member_id: UUID,
     *,
     client: AuthenticatedClient | Client,
@@ -130,7 +130,7 @@ async def asyncio_detailed(
      Remove a member from the organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         member_id (UUID):
 
     Raises:
@@ -142,7 +142,7 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         member_id=member_id,
     )
 
@@ -152,7 +152,7 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    org_id: UUID,
+    organization_id: UUID,
     member_id: UUID,
     *,
     client: AuthenticatedClient | Client,
@@ -162,7 +162,7 @@ async def asyncio(
      Remove a member from the organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         member_id (UUID):
 
     Raises:
@@ -175,7 +175,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            org_id=org_id,
+            organization_id=organization_id,
             member_id=member_id,
             client=client,
         )

--- a/lemma-python/lemma_sdk/openapi_client/api/organizations/org_member_update_role.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/organizations/org_member_update_role.py
@@ -14,7 +14,7 @@ from ...types import Response
 
 
 def _get_kwargs(
-    org_id: UUID,
+    organization_id: UUID,
     member_id: UUID,
     *,
     body: UpdateMemberRoleRequest,
@@ -23,8 +23,8 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "patch",
-        "url": "/organizations/{org_id}/members/{member_id}/role".format(
-            org_id=quote(str(org_id), safe=""),
+        "url": "/organizations/{organization_id}/members/{member_id}/role".format(
+            organization_id=quote(str(organization_id), safe=""),
             member_id=quote(str(member_id), safe=""),
         ),
     }
@@ -68,7 +68,7 @@ def _build_response(
 
 
 def sync_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     member_id: UUID,
     *,
     client: AuthenticatedClient | Client,
@@ -79,7 +79,7 @@ def sync_detailed(
      Update a member's role in the organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         member_id (UUID):
         body (UpdateMemberRoleRequest): Update member role request schema.
 
@@ -92,7 +92,7 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         member_id=member_id,
         body=body,
     )
@@ -105,7 +105,7 @@ def sync_detailed(
 
 
 def sync(
-    org_id: UUID,
+    organization_id: UUID,
     member_id: UUID,
     *,
     client: AuthenticatedClient | Client,
@@ -116,7 +116,7 @@ def sync(
      Update a member's role in the organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         member_id (UUID):
         body (UpdateMemberRoleRequest): Update member role request schema.
 
@@ -129,7 +129,7 @@ def sync(
     """
 
     return sync_detailed(
-        org_id=org_id,
+        organization_id=organization_id,
         member_id=member_id,
         client=client,
         body=body,
@@ -137,7 +137,7 @@ def sync(
 
 
 async def asyncio_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     member_id: UUID,
     *,
     client: AuthenticatedClient | Client,
@@ -148,7 +148,7 @@ async def asyncio_detailed(
      Update a member's role in the organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         member_id (UUID):
         body (UpdateMemberRoleRequest): Update member role request schema.
 
@@ -161,7 +161,7 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         member_id=member_id,
         body=body,
     )
@@ -172,7 +172,7 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    org_id: UUID,
+    organization_id: UUID,
     member_id: UUID,
     *,
     client: AuthenticatedClient | Client,
@@ -183,7 +183,7 @@ async def asyncio(
      Update a member's role in the organization
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         member_id (UUID):
         body (UpdateMemberRoleRequest): Update member role request schema.
 
@@ -197,7 +197,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            org_id=org_id,
+            organization_id=organization_id,
             member_id=member_id,
             client=client,
             body=body,

--- a/lemma-python/lemma_sdk/openapi_client/api/organizations/org_update.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/organizations/org_update.py
@@ -14,7 +14,7 @@ from ...types import Response
 
 
 def _get_kwargs(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     body: OrganizationUpdateRequest,
 ) -> dict[str, Any]:
@@ -22,8 +22,8 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "patch",
-        "url": "/organizations/{org_id}".format(
-            org_id=quote(str(org_id), safe=""),
+        "url": "/organizations/{organization_id}".format(
+            organization_id=quote(str(organization_id), safe=""),
         ),
     }
 
@@ -66,7 +66,7 @@ def _build_response(
 
 
 def sync_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     body: OrganizationUpdateRequest,
@@ -76,7 +76,7 @@ def sync_detailed(
      Update an organization's name or join policy (owner only)
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         body (OrganizationUpdateRequest): Organization update request schema (owner-only).
 
     Raises:
@@ -88,7 +88,7 @@ def sync_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         body=body,
     )
 
@@ -100,7 +100,7 @@ def sync_detailed(
 
 
 def sync(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     body: OrganizationUpdateRequest,
@@ -110,7 +110,7 @@ def sync(
      Update an organization's name or join policy (owner only)
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         body (OrganizationUpdateRequest): Organization update request schema (owner-only).
 
     Raises:
@@ -122,14 +122,14 @@ def sync(
     """
 
     return sync_detailed(
-        org_id=org_id,
+        organization_id=organization_id,
         client=client,
         body=body,
     ).parsed
 
 
 async def asyncio_detailed(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     body: OrganizationUpdateRequest,
@@ -139,7 +139,7 @@ async def asyncio_detailed(
      Update an organization's name or join policy (owner only)
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         body (OrganizationUpdateRequest): Organization update request schema (owner-only).
 
     Raises:
@@ -151,7 +151,7 @@ async def asyncio_detailed(
     """
 
     kwargs = _get_kwargs(
-        org_id=org_id,
+        organization_id=organization_id,
         body=body,
     )
 
@@ -161,7 +161,7 @@ async def asyncio_detailed(
 
 
 async def asyncio(
-    org_id: UUID,
+    organization_id: UUID,
     *,
     client: AuthenticatedClient | Client,
     body: OrganizationUpdateRequest,
@@ -171,7 +171,7 @@ async def asyncio(
      Update an organization's name or join policy (owner only)
 
     Args:
-        org_id (UUID):
+        organization_id (UUID):
         body (OrganizationUpdateRequest): Organization update request schema (owner-only).
 
     Raises:
@@ -184,7 +184,7 @@ async def asyncio(
 
     return (
         await asyncio_detailed(
-            org_id=org_id,
+            organization_id=organization_id,
             client=client,
             body=body,
         )

--- a/lemma-python/lemma_sdk/openapi_client/api/pods/pod_list.py
+++ b/lemma-python/lemma_sdk/openapi_client/api/pods/pod_list.py
@@ -34,7 +34,7 @@ def _get_kwargs(
 
     _kwargs: dict[str, Any] = {
         "method": "get",
-        "url": "/pods/organization/{organization_id}".format(
+        "url": "/organizations/{organization_id}/pods".format(
             organization_id=quote(str(organization_id), safe=""),
         ),
         "params": params,
@@ -80,7 +80,7 @@ def sync_detailed(
     limit: int | Unset = 100,
     page_token: None | str | Unset = UNSET,
 ) -> Response[ErrorResponse | PodListResponse]:
-    """List PodS by Organization
+    """List Pods by Organization
 
      List all pods in an organization
 
@@ -117,7 +117,7 @@ def sync(
     limit: int | Unset = 100,
     page_token: None | str | Unset = UNSET,
 ) -> ErrorResponse | PodListResponse | None:
-    """List PodS by Organization
+    """List Pods by Organization
 
      List all pods in an organization
 
@@ -149,7 +149,7 @@ async def asyncio_detailed(
     limit: int | Unset = 100,
     page_token: None | str | Unset = UNSET,
 ) -> Response[ErrorResponse | PodListResponse]:
-    """List PodS by Organization
+    """List Pods by Organization
 
      List all pods in an organization
 
@@ -184,7 +184,7 @@ async def asyncio(
     limit: int | Unset = 100,
     page_token: None | str | Unset = UNSET,
 ) -> ErrorResponse | PodListResponse | None:
-    """List PodS by Organization
+    """List Pods by Organization
 
      List all pods in an organization
 

--- a/lemma-python/lemma_sdk/openapi_client/models/navigation_pod_response.py
+++ b/lemma-python/lemma_sdk/openapi_client/models/navigation_pod_response.py
@@ -22,7 +22,7 @@ class NavigationPodResponse:
     columns cost nothing to return: they ride along in the query that found the
     pod, so the response grows with the number of pods and not with what is
     inside them. Apps, agents and roles are the other side of that line, and
-    live on ``/organizations/{org_id}/home``.
+    live on ``/organizations/{organization_id}/home``.
 
         Attributes:
             id (UUID):

--- a/lemma-python/lemma_sdk/openapi_spec.json
+++ b/lemma-python/lemma_sdk/openapi_spec.json
@@ -8931,7 +8931,7 @@
         "type": "object"
       },
       "NavigationPodResponse": {
-        "description": "A pod as a listing entry \u2014 enough to draw it, label it, and link to it.\n\nThe line this payload holds is scalars yes, collections no. A pod's own\ncolumns cost nothing to return: they ride along in the query that found the\npod, so the response grows with the number of pods and not with what is\ninside them. Apps, agents and roles are the other side of that line, and\nlive on ``/organizations/{org_id}/home``.",
+        "description": "A pod as a listing entry \u2014 enough to draw it, label it, and link to it.\n\nThe line this payload holds is scalars yes, collections no. A pod's own\ncolumns cost nothing to return: they ride along in the query that found the\npod, so the response grows with the number of pods and not with what is\ninside them. Apps, agents and roles are the other side of that line, and\nlive on ``/organizations/{organization_id}/home``.",
         "properties": {
           "description": {
             "anyOf": [
@@ -17836,7 +17836,7 @@
   },
   "openapi": "3.1.0",
   "paths": {
-    "/agent-host/events:append": {
+    "/agent-host/events/append": {
       "post": {
         "description": "Append one ordered batch to the run's stream.\n\nThere is no second lane to publish on: every event type travels the one\nordered stream, and the ack watermark is the stream's last entry.",
         "operationId": "agent.host.events.append",
@@ -17976,7 +17976,7 @@
         }
       }
     },
-    "/agent-host/pairings:complete": {
+    "/agent-host/pairings/complete": {
       "post": {
         "description": "Consume a pairing code and issue the host secret, shown exactly once.",
         "operationId": "agent.host.pairing.complete",
@@ -19176,18 +19176,18 @@
         }
       }
     },
-    "/organizations/{org_id}": {
+    "/organizations/{organization_id}": {
       "get": {
         "description": "Get organization details",
         "operationId": "org.get",
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           }
@@ -19232,11 +19232,11 @@
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           }
@@ -19289,17 +19289,17 @@
         }
       }
     },
-    "/organizations/{org_id}/agent-runtime/profiles": {
+    "/organizations/{organization_id}/agent-runtime/profiles": {
       "get": {
         "operationId": "agent.runtime.profiles.list",
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           },
@@ -19353,11 +19353,11 @@
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           }
@@ -19429,17 +19429,17 @@
         }
       }
     },
-    "/organizations/{org_id}/agent-runtime/profiles/{profile_id}": {
+    "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}": {
       "delete": {
         "operationId": "agent.runtime.profiles.archive",
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           },
@@ -19488,11 +19488,11 @@
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           },
@@ -19545,11 +19545,11 @@
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           },
@@ -19630,17 +19630,17 @@
         }
       }
     },
-    "/organizations/{org_id}/agent-runtime/profiles/{profile_id}:restore": {
+    "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}/restore": {
       "post": {
         "operationId": "agent.runtime.profiles.restore",
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           },
@@ -19689,467 +19689,6 @@
           "resource": "agent.runtime.profiles",
           "result": "entity",
           "verb": "restore"
-        }
-      }
-    },
-    "/organizations/{org_id}/home": {
-      "get": {
-        "description": "One organization's landing page: every pod the current user can see, with its apps, its agents, and the user's roles in that pod. Replaces fetching apps and agents per pod. Cached briefly per user.",
-        "operationId": "org.home",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationHomeResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Organization Home",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "kind": "query",
-          "paginates": false,
-          "resource": "org",
-          "result": "entity",
-          "verb": "home"
-        }
-      }
-    },
-    "/organizations/{org_id}/invitations": {
-      "get": {
-        "description": "Get all pending invitations for an organization",
-        "operationId": "org.invitation.list",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/OrganizationInvitationStatus",
-              "default": "PENDING"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 100,
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "page_token",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Page Token"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationInvitationListResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "List Organization Invitations",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "kind": "query",
-          "paginates": true,
-          "resource": "org.invitation",
-          "result": "collection",
-          "verb": "list"
-        }
-      },
-      "post": {
-        "description": "Invite a user to join the organization",
-        "operationId": "org.invitation.invite",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OrganizationInvitationRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationInvitationResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Invite Member",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "invalidates": [
-            "org.invitation"
-          ],
-          "kind": "mutation",
-          "paginates": false,
-          "resource": "org.invitation",
-          "result": "entity",
-          "verb": "invite"
-        }
-      }
-    },
-    "/organizations/{org_id}/join": {
-      "post": {
-        "description": "Join an organization when the current user's email domain is allowed to auto-join",
-        "operationId": "org.join_auto_join",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Join Auto-Join Organization",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "invalidates": [
-            "org"
-          ],
-          "kind": "mutation",
-          "paginates": false,
-          "resource": "org",
-          "result": "entity",
-          "verb": "join_auto_join"
-        }
-      }
-    },
-    "/organizations/{org_id}/members": {
-      "get": {
-        "description": "Get all members of an organization",
-        "operationId": "org.member.list",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 100,
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "page_token",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Page Token"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationMemberListResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "List Organization Members",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "kind": "query",
-          "paginates": true,
-          "resource": "org.member",
-          "result": "collection",
-          "verb": "list"
-        }
-      }
-    },
-    "/organizations/{org_id}/members/{member_id}": {
-      "delete": {
-        "description": "Remove a member from the organization",
-        "operationId": "org.member.remove",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "member_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Member Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Remove Member",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "invalidates": [
-            "org.member"
-          ],
-          "kind": "mutation",
-          "paginates": false,
-          "resource": "org.member",
-          "result": "void",
-          "verb": "remove"
-        }
-      }
-    },
-    "/organizations/{org_id}/members/{member_id}/role": {
-      "patch": {
-        "description": "Update a member's role in the organization",
-        "operationId": "org.member.update_role",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "member_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Member Id",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateMemberRoleRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationMemberResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Update Member Role",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "invalidates": [
-            "org.member"
-          ],
-          "kind": "mutation",
-          "paginates": false,
-          "resource": "org.member",
-          "result": "entity",
-          "verb": "update_role"
         }
       }
     },
@@ -21553,6 +21092,544 @@
         }
       }
     },
+    "/organizations/{organization_id}/home": {
+      "get": {
+        "description": "One organization's landing page: every pod the current user can see, with its apps, its agents, and the user's roles in that pod. Replaces fetching apps and agents per pod. Cached briefly per user.",
+        "operationId": "org.home",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationHomeResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Organization Home",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "kind": "query",
+          "paginates": false,
+          "resource": "org",
+          "result": "entity",
+          "verb": "home"
+        }
+      }
+    },
+    "/organizations/{organization_id}/invitations": {
+      "get": {
+        "description": "Get all pending invitations for an organization",
+        "operationId": "org.invitation.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrganizationInvitationStatus",
+              "default": "PENDING"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationInvitationListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Organization Invitations",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "kind": "query",
+          "paginates": true,
+          "resource": "org.invitation",
+          "result": "collection",
+          "verb": "list"
+        }
+      },
+      "post": {
+        "description": "Invite a user to join the organization",
+        "operationId": "org.invitation.invite",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationInvitationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationInvitationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Invite Member",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "org.invitation"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "org.invitation",
+          "result": "entity",
+          "verb": "invite"
+        }
+      }
+    },
+    "/organizations/{organization_id}/join": {
+      "post": {
+        "description": "Join an organization when the current user's email domain is allowed to auto-join",
+        "operationId": "org.join_auto_join",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Join Auto-Join Organization",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "org"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "org",
+          "result": "entity",
+          "verb": "join_auto_join"
+        }
+      }
+    },
+    "/organizations/{organization_id}/members": {
+      "get": {
+        "description": "Get all members of an organization",
+        "operationId": "org.member.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationMemberListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Organization Members",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "kind": "query",
+          "paginates": true,
+          "resource": "org.member",
+          "result": "collection",
+          "verb": "list"
+        }
+      }
+    },
+    "/organizations/{organization_id}/members/{member_id}": {
+      "delete": {
+        "description": "Remove a member from the organization",
+        "operationId": "org.member.remove",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "member_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Member Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Remove Member",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "org.member"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "org.member",
+          "result": "void",
+          "verb": "remove"
+        }
+      }
+    },
+    "/organizations/{organization_id}/members/{member_id}/role": {
+      "patch": {
+        "description": "Update a member's role in the organization",
+        "operationId": "org.member.update_role",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "member_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Member Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMemberRoleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationMemberResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Member Role",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "org.member"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "org.member",
+          "result": "entity",
+          "verb": "update_role"
+        }
+      }
+    },
+    "/organizations/{organization_id}/pods": {
+      "get": {
+        "description": "List all pods in an organization",
+        "operationId": "pod.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PodListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Pods by Organization",
+        "tags": [
+          "Pods"
+        ],
+        "x-lemma": {
+          "kind": "query",
+          "paginates": true,
+          "resource": "pod",
+          "result": "collection",
+          "verb": "list"
+        }
+      }
+    },
     "/pods": {
       "post": {
         "description": "Create a new pod",
@@ -21647,83 +21724,6 @@
           "resource": "pod.bundle",
           "result": "entity",
           "verb": "download"
-        }
-      }
-    },
-    "/pods/organization/{organization_id}": {
-      "get": {
-        "description": "List all pods in an organization",
-        "operationId": "pod.list",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organization_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Organization Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 100,
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "page_token",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Page Token"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PodListResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "List PodS by Organization",
-        "tags": [
-          "Pods"
-        ],
-        "x-lemma": {
-          "kind": "query",
-          "paginates": true,
-          "resource": "pod",
-          "result": "collection",
-          "verb": "list"
         }
       }
     },

--- a/lemma-typescript/public/lemma-client.js
+++ b/lemma-typescript/public/lemma-client.js
@@ -10734,7 +10734,7 @@ var LemmaClient = (() => {
     static agentHostEventsAppend(requestBody, authorization) {
       return request(OpenAPI, {
         method: "POST",
-        url: "/agent-host/events:append",
+        url: "/agent-host/events/append",
         headers: {
           "authorization": authorization
         },
@@ -10777,7 +10777,7 @@ var LemmaClient = (() => {
     static agentHostPairingComplete(requestBody) {
       return request(OpenAPI, {
         method: "POST",
-        url: "/agent-host/pairings:complete",
+        url: "/agent-host/pairings/complete",
         body: requestBody,
         mediaType: "application/json",
         errors: {
@@ -10925,17 +10925,17 @@ var LemmaClient = (() => {
   var AgentRuntimeService = class {
     /**
      * List Available Agent Runtime Profiles
-     * @param orgId
+     * @param organizationId
      * @param includeDisabled
      * @returns AgentRuntimeProfileListResponse Successful Response
      * @throws ApiError
      */
-    static agentRuntimeProfilesList(orgId, includeDisabled = false) {
+    static agentRuntimeProfilesList(organizationId, includeDisabled = false) {
       return request(OpenAPI, {
         method: "GET",
-        url: "/organizations/{org_id}/agent-runtime/profiles",
+        url: "/organizations/{organization_id}/agent-runtime/profiles",
         path: {
-          "org_id": orgId
+          "organization_id": organizationId
         },
         query: {
           "include_disabled": includeDisabled
@@ -10947,17 +10947,17 @@ var LemmaClient = (() => {
     }
     /**
      * Create Agent Runtime Profile
-     * @param orgId
+     * @param organizationId
      * @param requestBody
      * @returns AgentRuntimeProfileResponse Successful Response
      * @throws ApiError
      */
-    static agentRuntimeProfilesCreate(orgId, requestBody) {
+    static agentRuntimeProfilesCreate(organizationId, requestBody) {
       return request(OpenAPI, {
         method: "POST",
-        url: "/organizations/{org_id}/agent-runtime/profiles",
+        url: "/organizations/{organization_id}/agent-runtime/profiles",
         path: {
-          "org_id": orgId
+          "organization_id": organizationId
         },
         body: requestBody,
         mediaType: "application/json",
@@ -10968,17 +10968,17 @@ var LemmaClient = (() => {
     }
     /**
      * Archive Agent Runtime Profile
-     * @param orgId
+     * @param organizationId
      * @param profileId
      * @returns void
      * @throws ApiError
      */
-    static agentRuntimeProfilesArchive(orgId, profileId) {
+    static agentRuntimeProfilesArchive(organizationId, profileId) {
       return request(OpenAPI, {
         method: "DELETE",
-        url: "/organizations/{org_id}/agent-runtime/profiles/{profile_id}",
+        url: "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}",
         path: {
-          "org_id": orgId,
+          "organization_id": organizationId,
           "profile_id": profileId
         },
         errors: {
@@ -10988,17 +10988,17 @@ var LemmaClient = (() => {
     }
     /**
      * Get Agent Runtime Profile
-     * @param orgId
+     * @param organizationId
      * @param profileId
      * @returns AgentRuntimeProfileDetailResponse Successful Response
      * @throws ApiError
      */
-    static agentRuntimeProfilesGet(orgId, profileId) {
+    static agentRuntimeProfilesGet(organizationId, profileId) {
       return request(OpenAPI, {
         method: "GET",
-        url: "/organizations/{org_id}/agent-runtime/profiles/{profile_id}",
+        url: "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}",
         path: {
-          "org_id": orgId,
+          "organization_id": organizationId,
           "profile_id": profileId
         },
         errors: {
@@ -11008,18 +11008,18 @@ var LemmaClient = (() => {
     }
     /**
      * Update Agent Runtime Profile
-     * @param orgId
+     * @param organizationId
      * @param profileId
      * @param requestBody
      * @returns AgentRuntimeProfileResponse Successful Response
      * @throws ApiError
      */
-    static agentRuntimeProfilesUpdate(orgId, profileId, requestBody) {
+    static agentRuntimeProfilesUpdate(organizationId, profileId, requestBody) {
       return request(OpenAPI, {
         method: "PATCH",
-        url: "/organizations/{org_id}/agent-runtime/profiles/{profile_id}",
+        url: "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}",
         path: {
-          "org_id": orgId,
+          "organization_id": organizationId,
           "profile_id": profileId
         },
         body: requestBody,
@@ -11031,17 +11031,17 @@ var LemmaClient = (() => {
     }
     /**
      * Restore Agent Runtime Profile
-     * @param orgId
+     * @param organizationId
      * @param profileId
      * @returns AgentRuntimeProfileResponse Successful Response
      * @throws ApiError
      */
-    static agentRuntimeProfilesRestore(orgId, profileId) {
+    static agentRuntimeProfilesRestore(organizationId, profileId) {
       return request(OpenAPI, {
         method: "POST",
-        url: "/organizations/{org_id}/agent-runtime/profiles/{profile_id}:restore",
+        url: "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}/restore",
         path: {
-          "org_id": orgId,
+          "organization_id": organizationId,
           "profile_id": profileId
         },
         errors: {
@@ -13765,16 +13765,16 @@ var LemmaClient = (() => {
     /**
      * Get Organization
      * Get organization details
-     * @param orgId
+     * @param organizationId
      * @returns OrganizationResponse Successful Response
      * @throws ApiError
      */
-    static orgGet(orgId) {
+    static orgGet(organizationId) {
       return request(OpenAPI, {
         method: "GET",
-        url: "/organizations/{org_id}",
+        url: "/organizations/{organization_id}",
         path: {
-          "org_id": orgId
+          "organization_id": organizationId
         },
         errors: {
           422: `Validation Error`
@@ -13784,17 +13784,17 @@ var LemmaClient = (() => {
     /**
      * Update Organization
      * Update an organization's name or join policy (owner only)
-     * @param orgId
+     * @param organizationId
      * @param requestBody
      * @returns OrganizationResponse Successful Response
      * @throws ApiError
      */
-    static orgUpdate(orgId, requestBody) {
+    static orgUpdate(organizationId, requestBody) {
       return request(OpenAPI, {
         method: "PATCH",
-        url: "/organizations/{org_id}",
+        url: "/organizations/{organization_id}",
         path: {
-          "org_id": orgId
+          "organization_id": organizationId
         },
         body: requestBody,
         mediaType: "application/json",
@@ -13806,16 +13806,16 @@ var LemmaClient = (() => {
     /**
      * Get Organization Home
      * One organization's landing page: every pod the current user can see, with its apps, its agents, and the user's roles in that pod. Replaces fetching apps and agents per pod. Cached briefly per user.
-     * @param orgId
+     * @param organizationId
      * @returns OrganizationHomeResponse Successful Response
      * @throws ApiError
      */
-    static orgHome(orgId) {
+    static orgHome(organizationId) {
       return request(OpenAPI, {
         method: "GET",
-        url: "/organizations/{org_id}/home",
+        url: "/organizations/{organization_id}/home",
         path: {
-          "org_id": orgId
+          "organization_id": organizationId
         },
         errors: {
           422: `Validation Error`
@@ -13825,19 +13825,19 @@ var LemmaClient = (() => {
     /**
      * List Organization Invitations
      * Get all pending invitations for an organization
-     * @param orgId
+     * @param organizationId
      * @param status
      * @param limit
      * @param pageToken
      * @returns OrganizationInvitationListResponse Successful Response
      * @throws ApiError
      */
-    static orgInvitationList(orgId, status = "PENDING" /* PENDING */, limit = 100, pageToken) {
+    static orgInvitationList(organizationId, status = "PENDING" /* PENDING */, limit = 100, pageToken) {
       return request(OpenAPI, {
         method: "GET",
-        url: "/organizations/{org_id}/invitations",
+        url: "/organizations/{organization_id}/invitations",
         path: {
-          "org_id": orgId
+          "organization_id": organizationId
         },
         query: {
           "status": status,
@@ -13852,17 +13852,17 @@ var LemmaClient = (() => {
     /**
      * Invite Member
      * Invite a user to join the organization
-     * @param orgId
+     * @param organizationId
      * @param requestBody
      * @returns OrganizationInvitationResponse Successful Response
      * @throws ApiError
      */
-    static orgInvitationInvite(orgId, requestBody) {
+    static orgInvitationInvite(organizationId, requestBody) {
       return request(OpenAPI, {
         method: "POST",
-        url: "/organizations/{org_id}/invitations",
+        url: "/organizations/{organization_id}/invitations",
         path: {
-          "org_id": orgId
+          "organization_id": organizationId
         },
         body: requestBody,
         mediaType: "application/json",
@@ -13874,16 +13874,16 @@ var LemmaClient = (() => {
     /**
      * Join Auto-Join Organization
      * Join an organization when the current user's email domain is allowed to auto-join
-     * @param orgId
+     * @param organizationId
      * @returns OrganizationResponse Successful Response
      * @throws ApiError
      */
-    static orgJoinAutoJoin(orgId) {
+    static orgJoinAutoJoin(organizationId) {
       return request(OpenAPI, {
         method: "POST",
-        url: "/organizations/{org_id}/join",
+        url: "/organizations/{organization_id}/join",
         path: {
-          "org_id": orgId
+          "organization_id": organizationId
         },
         errors: {
           422: `Validation Error`
@@ -13893,18 +13893,18 @@ var LemmaClient = (() => {
     /**
      * List Organization Members
      * Get all members of an organization
-     * @param orgId
+     * @param organizationId
      * @param limit
      * @param pageToken
      * @returns OrganizationMemberListResponse Successful Response
      * @throws ApiError
      */
-    static orgMemberList(orgId, limit = 100, pageToken) {
+    static orgMemberList(organizationId, limit = 100, pageToken) {
       return request(OpenAPI, {
         method: "GET",
-        url: "/organizations/{org_id}/members",
+        url: "/organizations/{organization_id}/members",
         path: {
-          "org_id": orgId
+          "organization_id": organizationId
         },
         query: {
           "limit": limit,
@@ -13918,17 +13918,17 @@ var LemmaClient = (() => {
     /**
      * Remove Member
      * Remove a member from the organization
-     * @param orgId
+     * @param organizationId
      * @param memberId
      * @returns void
      * @throws ApiError
      */
-    static orgMemberRemove(orgId, memberId) {
+    static orgMemberRemove(organizationId, memberId) {
       return request(OpenAPI, {
         method: "DELETE",
-        url: "/organizations/{org_id}/members/{member_id}",
+        url: "/organizations/{organization_id}/members/{member_id}",
         path: {
-          "org_id": orgId,
+          "organization_id": organizationId,
           "member_id": memberId
         },
         errors: {
@@ -13939,18 +13939,18 @@ var LemmaClient = (() => {
     /**
      * Update Member Role
      * Update a member's role in the organization
-     * @param orgId
+     * @param organizationId
      * @param memberId
      * @param requestBody
      * @returns OrganizationMemberResponse Successful Response
      * @throws ApiError
      */
-    static orgMemberUpdateRole(orgId, memberId, requestBody) {
+    static orgMemberUpdateRole(organizationId, memberId, requestBody) {
       return request(OpenAPI, {
         method: "PATCH",
-        url: "/organizations/{org_id}/members/{member_id}/role",
+        url: "/organizations/{organization_id}/members/{member_id}/role",
         path: {
-          "org_id": orgId,
+          "organization_id": organizationId,
           "member_id": memberId
         },
         body: requestBody,
@@ -14453,6 +14453,31 @@ var LemmaClient = (() => {
   // src/openapi_client/services/PodsService.ts
   var PodsService = class {
     /**
+     * List Pods by Organization
+     * List all pods in an organization
+     * @param organizationId
+     * @param limit
+     * @param pageToken
+     * @returns PodListResponse Successful Response
+     * @throws ApiError
+     */
+    static podList(organizationId, limit = 100, pageToken) {
+      return request(OpenAPI, {
+        method: "GET",
+        url: "/organizations/{organization_id}/pods",
+        path: {
+          "organization_id": organizationId
+        },
+        query: {
+          "limit": limit,
+          "page_token": pageToken
+        },
+        errors: {
+          422: `Validation Error`
+        }
+      });
+    }
+    /**
      * Create Pod
      * Create a new pod
      * @param requestBody
@@ -14465,31 +14490,6 @@ var LemmaClient = (() => {
         url: "/pods",
         body: requestBody,
         mediaType: "application/json",
-        errors: {
-          422: `Validation Error`
-        }
-      });
-    }
-    /**
-     * List PodS by Organization
-     * List all pods in an organization
-     * @param organizationId
-     * @param limit
-     * @param pageToken
-     * @returns PodListResponse Successful Response
-     * @throws ApiError
-     */
-    static podList(organizationId, limit = 100, pageToken) {
-      return request(OpenAPI, {
-        method: "GET",
-        url: "/pods/organization/{organization_id}",
-        path: {
-          "organization_id": organizationId
-        },
-        query: {
-          "limit": limit,
-          "page_token": pageToken
-        },
         errors: {
           422: `Validation Error`
         }

--- a/lemma-typescript/src/namespaces/agent-host.ts
+++ b/lemma-typescript/src/namespaces/agent-host.ts
@@ -10,7 +10,7 @@ import { AgentHostService } from "../openapi_client/services/AgentHostService.js
  * Manage the caller's paired Agent Hosts.
  *
  * Only the user-authenticated management half of `/agent-host` lives here. The
- * host-authenticated half (poll, events:append, harness publish, pairing
+ * host-authenticated half (poll, events/append, harness publish, pairing
  * completion) is spoken by the Agent Host binary with its own host secret, not
  * by a browser session, so it stays off this namespace.
  */

--- a/lemma-typescript/src/openapi_client/models/NavigationPodResponse.ts
+++ b/lemma-typescript/src/openapi_client/models/NavigationPodResponse.ts
@@ -9,7 +9,7 @@
  * columns cost nothing to return: they ride along in the query that found the
  * pod, so the response grows with the number of pods and not with what is
  * inside them. Apps, agents and roles are the other side of that line, and
- * live on ``/organizations/{org_id}/home``.
+ * live on ``/organizations/{organization_id}/home``.
  */
 export type NavigationPodResponse = {
     description?: (string | null);

--- a/lemma-typescript/src/openapi_client/services/AgentHostService.ts
+++ b/lemma-typescript/src/openapi_client/services/AgentHostService.ts
@@ -36,7 +36,7 @@ export class AgentHostService {
     ): CancelablePromise<AgentHostEventAck> {
         return __request(OpenAPI, {
             method: 'POST',
-            url: '/agent-host/events:append',
+            url: '/agent-host/events/append',
             headers: {
                 'authorization': authorization,
             },
@@ -84,7 +84,7 @@ export class AgentHostService {
     ): CancelablePromise<AgentHostPairingCompleted> {
         return __request(OpenAPI, {
             method: 'POST',
-            url: '/agent-host/pairings:complete',
+            url: '/agent-host/pairings/complete',
             body: requestBody,
             mediaType: 'application/json',
             errors: {

--- a/lemma-typescript/src/openapi_client/services/AgentRuntimeService.ts
+++ b/lemma-typescript/src/openapi_client/services/AgentRuntimeService.ts
@@ -17,20 +17,20 @@ import { request as __request } from '../core/request.js';
 export class AgentRuntimeService {
     /**
      * List Available Agent Runtime Profiles
-     * @param orgId
+     * @param organizationId
      * @param includeDisabled
      * @returns AgentRuntimeProfileListResponse Successful Response
      * @throws ApiError
      */
     public static agentRuntimeProfilesList(
-        orgId: string,
+        organizationId: string,
         includeDisabled: boolean = false,
     ): CancelablePromise<AgentRuntimeProfileListResponse> {
         return __request(OpenAPI, {
             method: 'GET',
-            url: '/organizations/{org_id}/agent-runtime/profiles',
+            url: '/organizations/{organization_id}/agent-runtime/profiles',
             path: {
-                'org_id': orgId,
+                'organization_id': organizationId,
             },
             query: {
                 'include_disabled': includeDisabled,
@@ -42,20 +42,20 @@ export class AgentRuntimeService {
     }
     /**
      * Create Agent Runtime Profile
-     * @param orgId
+     * @param organizationId
      * @param requestBody
      * @returns AgentRuntimeProfileResponse Successful Response
      * @throws ApiError
      */
     public static agentRuntimeProfilesCreate(
-        orgId: string,
+        organizationId: string,
         requestBody: (CreateAgentHostRuntimeProfileRequest | CreateOpenAICompatibleRuntimeProfileRequest | CreateAnthropicCompatibleRuntimeProfileRequest),
     ): CancelablePromise<AgentRuntimeProfileResponse> {
         return __request(OpenAPI, {
             method: 'POST',
-            url: '/organizations/{org_id}/agent-runtime/profiles',
+            url: '/organizations/{organization_id}/agent-runtime/profiles',
             path: {
-                'org_id': orgId,
+                'organization_id': organizationId,
             },
             body: requestBody,
             mediaType: 'application/json',
@@ -66,20 +66,20 @@ export class AgentRuntimeService {
     }
     /**
      * Archive Agent Runtime Profile
-     * @param orgId
+     * @param organizationId
      * @param profileId
      * @returns void
      * @throws ApiError
      */
     public static agentRuntimeProfilesArchive(
-        orgId: string,
+        organizationId: string,
         profileId: string,
     ): CancelablePromise<void> {
         return __request(OpenAPI, {
             method: 'DELETE',
-            url: '/organizations/{org_id}/agent-runtime/profiles/{profile_id}',
+            url: '/organizations/{organization_id}/agent-runtime/profiles/{profile_id}',
             path: {
-                'org_id': orgId,
+                'organization_id': organizationId,
                 'profile_id': profileId,
             },
             errors: {
@@ -89,20 +89,20 @@ export class AgentRuntimeService {
     }
     /**
      * Get Agent Runtime Profile
-     * @param orgId
+     * @param organizationId
      * @param profileId
      * @returns AgentRuntimeProfileDetailResponse Successful Response
      * @throws ApiError
      */
     public static agentRuntimeProfilesGet(
-        orgId: string,
+        organizationId: string,
         profileId: string,
     ): CancelablePromise<AgentRuntimeProfileDetailResponse> {
         return __request(OpenAPI, {
             method: 'GET',
-            url: '/organizations/{org_id}/agent-runtime/profiles/{profile_id}',
+            url: '/organizations/{organization_id}/agent-runtime/profiles/{profile_id}',
             path: {
-                'org_id': orgId,
+                'organization_id': organizationId,
                 'profile_id': profileId,
             },
             errors: {
@@ -112,22 +112,22 @@ export class AgentRuntimeService {
     }
     /**
      * Update Agent Runtime Profile
-     * @param orgId
+     * @param organizationId
      * @param profileId
      * @param requestBody
      * @returns AgentRuntimeProfileResponse Successful Response
      * @throws ApiError
      */
     public static agentRuntimeProfilesUpdate(
-        orgId: string,
+        organizationId: string,
         profileId: string,
         requestBody: (UpdateAgentHostRuntimeProfileRequest | UpdateOpenAICompatibleRuntimeProfileRequest | UpdateAnthropicCompatibleRuntimeProfileRequest),
     ): CancelablePromise<AgentRuntimeProfileResponse> {
         return __request(OpenAPI, {
             method: 'PATCH',
-            url: '/organizations/{org_id}/agent-runtime/profiles/{profile_id}',
+            url: '/organizations/{organization_id}/agent-runtime/profiles/{profile_id}',
             path: {
-                'org_id': orgId,
+                'organization_id': organizationId,
                 'profile_id': profileId,
             },
             body: requestBody,
@@ -139,20 +139,20 @@ export class AgentRuntimeService {
     }
     /**
      * Restore Agent Runtime Profile
-     * @param orgId
+     * @param organizationId
      * @param profileId
      * @returns AgentRuntimeProfileResponse Successful Response
      * @throws ApiError
      */
     public static agentRuntimeProfilesRestore(
-        orgId: string,
+        organizationId: string,
         profileId: string,
     ): CancelablePromise<AgentRuntimeProfileResponse> {
         return __request(OpenAPI, {
             method: 'POST',
-            url: '/organizations/{org_id}/agent-runtime/profiles/{profile_id}:restore',
+            url: '/organizations/{organization_id}/agent-runtime/profiles/{profile_id}/restore',
             path: {
-                'org_id': orgId,
+                'organization_id': organizationId,
                 'profile_id': profileId,
             },
             errors: {

--- a/lemma-typescript/src/openapi_client/services/OrganizationsService.ts
+++ b/lemma-typescript/src/openapi_client/services/OrganizationsService.ts
@@ -218,18 +218,18 @@ export class OrganizationsService {
     /**
      * Get Organization
      * Get organization details
-     * @param orgId
+     * @param organizationId
      * @returns OrganizationResponse Successful Response
      * @throws ApiError
      */
     public static orgGet(
-        orgId: string,
+        organizationId: string,
     ): CancelablePromise<OrganizationResponse> {
         return __request(OpenAPI, {
             method: 'GET',
-            url: '/organizations/{org_id}',
+            url: '/organizations/{organization_id}',
             path: {
-                'org_id': orgId,
+                'organization_id': organizationId,
             },
             errors: {
                 422: `Validation Error`,
@@ -239,20 +239,20 @@ export class OrganizationsService {
     /**
      * Update Organization
      * Update an organization's name or join policy (owner only)
-     * @param orgId
+     * @param organizationId
      * @param requestBody
      * @returns OrganizationResponse Successful Response
      * @throws ApiError
      */
     public static orgUpdate(
-        orgId: string,
+        organizationId: string,
         requestBody: OrganizationUpdateRequest,
     ): CancelablePromise<OrganizationResponse> {
         return __request(OpenAPI, {
             method: 'PATCH',
-            url: '/organizations/{org_id}',
+            url: '/organizations/{organization_id}',
             path: {
-                'org_id': orgId,
+                'organization_id': organizationId,
             },
             body: requestBody,
             mediaType: 'application/json',
@@ -264,18 +264,18 @@ export class OrganizationsService {
     /**
      * Get Organization Home
      * One organization's landing page: every pod the current user can see, with its apps, its agents, and the user's roles in that pod. Replaces fetching apps and agents per pod. Cached briefly per user.
-     * @param orgId
+     * @param organizationId
      * @returns OrganizationHomeResponse Successful Response
      * @throws ApiError
      */
     public static orgHome(
-        orgId: string,
+        organizationId: string,
     ): CancelablePromise<OrganizationHomeResponse> {
         return __request(OpenAPI, {
             method: 'GET',
-            url: '/organizations/{org_id}/home',
+            url: '/organizations/{organization_id}/home',
             path: {
-                'org_id': orgId,
+                'organization_id': organizationId,
             },
             errors: {
                 422: `Validation Error`,
@@ -285,7 +285,7 @@ export class OrganizationsService {
     /**
      * List Organization Invitations
      * Get all pending invitations for an organization
-     * @param orgId
+     * @param organizationId
      * @param status
      * @param limit
      * @param pageToken
@@ -293,16 +293,16 @@ export class OrganizationsService {
      * @throws ApiError
      */
     public static orgInvitationList(
-        orgId: string,
+        organizationId: string,
         status: OrganizationInvitationStatus = OrganizationInvitationStatus.PENDING,
         limit: number = 100,
         pageToken?: (string | null),
     ): CancelablePromise<OrganizationInvitationListResponse> {
         return __request(OpenAPI, {
             method: 'GET',
-            url: '/organizations/{org_id}/invitations',
+            url: '/organizations/{organization_id}/invitations',
             path: {
-                'org_id': orgId,
+                'organization_id': organizationId,
             },
             query: {
                 'status': status,
@@ -317,20 +317,20 @@ export class OrganizationsService {
     /**
      * Invite Member
      * Invite a user to join the organization
-     * @param orgId
+     * @param organizationId
      * @param requestBody
      * @returns OrganizationInvitationResponse Successful Response
      * @throws ApiError
      */
     public static orgInvitationInvite(
-        orgId: string,
+        organizationId: string,
         requestBody: OrganizationInvitationRequest,
     ): CancelablePromise<OrganizationInvitationResponse> {
         return __request(OpenAPI, {
             method: 'POST',
-            url: '/organizations/{org_id}/invitations',
+            url: '/organizations/{organization_id}/invitations',
             path: {
-                'org_id': orgId,
+                'organization_id': organizationId,
             },
             body: requestBody,
             mediaType: 'application/json',
@@ -342,18 +342,18 @@ export class OrganizationsService {
     /**
      * Join Auto-Join Organization
      * Join an organization when the current user's email domain is allowed to auto-join
-     * @param orgId
+     * @param organizationId
      * @returns OrganizationResponse Successful Response
      * @throws ApiError
      */
     public static orgJoinAutoJoin(
-        orgId: string,
+        organizationId: string,
     ): CancelablePromise<OrganizationResponse> {
         return __request(OpenAPI, {
             method: 'POST',
-            url: '/organizations/{org_id}/join',
+            url: '/organizations/{organization_id}/join',
             path: {
-                'org_id': orgId,
+                'organization_id': organizationId,
             },
             errors: {
                 422: `Validation Error`,
@@ -363,22 +363,22 @@ export class OrganizationsService {
     /**
      * List Organization Members
      * Get all members of an organization
-     * @param orgId
+     * @param organizationId
      * @param limit
      * @param pageToken
      * @returns OrganizationMemberListResponse Successful Response
      * @throws ApiError
      */
     public static orgMemberList(
-        orgId: string,
+        organizationId: string,
         limit: number = 100,
         pageToken?: (string | null),
     ): CancelablePromise<OrganizationMemberListResponse> {
         return __request(OpenAPI, {
             method: 'GET',
-            url: '/organizations/{org_id}/members',
+            url: '/organizations/{organization_id}/members',
             path: {
-                'org_id': orgId,
+                'organization_id': organizationId,
             },
             query: {
                 'limit': limit,
@@ -392,20 +392,20 @@ export class OrganizationsService {
     /**
      * Remove Member
      * Remove a member from the organization
-     * @param orgId
+     * @param organizationId
      * @param memberId
      * @returns void
      * @throws ApiError
      */
     public static orgMemberRemove(
-        orgId: string,
+        organizationId: string,
         memberId: string,
     ): CancelablePromise<void> {
         return __request(OpenAPI, {
             method: 'DELETE',
-            url: '/organizations/{org_id}/members/{member_id}',
+            url: '/organizations/{organization_id}/members/{member_id}',
             path: {
-                'org_id': orgId,
+                'organization_id': organizationId,
                 'member_id': memberId,
             },
             errors: {
@@ -416,22 +416,22 @@ export class OrganizationsService {
     /**
      * Update Member Role
      * Update a member's role in the organization
-     * @param orgId
+     * @param organizationId
      * @param memberId
      * @param requestBody
      * @returns OrganizationMemberResponse Successful Response
      * @throws ApiError
      */
     public static orgMemberUpdateRole(
-        orgId: string,
+        organizationId: string,
         memberId: string,
         requestBody: UpdateMemberRoleRequest,
     ): CancelablePromise<OrganizationMemberResponse> {
         return __request(OpenAPI, {
             method: 'PATCH',
-            url: '/organizations/{org_id}/members/{member_id}/role',
+            url: '/organizations/{organization_id}/members/{member_id}/role',
             path: {
-                'org_id': orgId,
+                'organization_id': organizationId,
                 'member_id': memberId,
             },
             body: requestBody,

--- a/lemma-typescript/src/openapi_client/services/PodsService.ts
+++ b/lemma-typescript/src/openapi_client/services/PodsService.ts
@@ -12,27 +12,7 @@ import { OpenAPI } from '../core/OpenAPI.js';
 import { request as __request } from '../core/request.js';
 export class PodsService {
     /**
-     * Create Pod
-     * Create a new pod
-     * @param requestBody
-     * @returns PodResponse Successful Response
-     * @throws ApiError
-     */
-    public static podCreate(
-        requestBody: PodCreateRequest,
-    ): CancelablePromise<PodResponse> {
-        return __request(OpenAPI, {
-            method: 'POST',
-            url: '/pods',
-            body: requestBody,
-            mediaType: 'application/json',
-            errors: {
-                422: `Validation Error`,
-            },
-        });
-    }
-    /**
-     * List PodS by Organization
+     * List Pods by Organization
      * List all pods in an organization
      * @param organizationId
      * @param limit
@@ -47,7 +27,7 @@ export class PodsService {
     ): CancelablePromise<PodListResponse> {
         return __request(OpenAPI, {
             method: 'GET',
-            url: '/pods/organization/{organization_id}',
+            url: '/organizations/{organization_id}/pods',
             path: {
                 'organization_id': organizationId,
             },
@@ -55,6 +35,26 @@ export class PodsService {
                 'limit': limit,
                 'page_token': pageToken,
             },
+            errors: {
+                422: `Validation Error`,
+            },
+        });
+    }
+    /**
+     * Create Pod
+     * Create a new pod
+     * @param requestBody
+     * @returns PodResponse Successful Response
+     * @throws ApiError
+     */
+    public static podCreate(
+        requestBody: PodCreateRequest,
+    ): CancelablePromise<PodResponse> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/pods',
+            body: requestBody,
+            mediaType: 'application/json',
             errors: {
                 422: `Validation Error`,
             },

--- a/lemma-typescript/src/openapi_spec.json
+++ b/lemma-typescript/src/openapi_spec.json
@@ -8931,7 +8931,7 @@
         "type": "object"
       },
       "NavigationPodResponse": {
-        "description": "A pod as a listing entry \u2014 enough to draw it, label it, and link to it.\n\nThe line this payload holds is scalars yes, collections no. A pod's own\ncolumns cost nothing to return: they ride along in the query that found the\npod, so the response grows with the number of pods and not with what is\ninside them. Apps, agents and roles are the other side of that line, and\nlive on ``/organizations/{org_id}/home``.",
+        "description": "A pod as a listing entry \u2014 enough to draw it, label it, and link to it.\n\nThe line this payload holds is scalars yes, collections no. A pod's own\ncolumns cost nothing to return: they ride along in the query that found the\npod, so the response grows with the number of pods and not with what is\ninside them. Apps, agents and roles are the other side of that line, and\nlive on ``/organizations/{organization_id}/home``.",
         "properties": {
           "description": {
             "anyOf": [
@@ -17836,7 +17836,7 @@
   },
   "openapi": "3.1.0",
   "paths": {
-    "/agent-host/events:append": {
+    "/agent-host/events/append": {
       "post": {
         "description": "Append one ordered batch to the run's stream.\n\nThere is no second lane to publish on: every event type travels the one\nordered stream, and the ack watermark is the stream's last entry.",
         "operationId": "agent.host.events.append",
@@ -17976,7 +17976,7 @@
         }
       }
     },
-    "/agent-host/pairings:complete": {
+    "/agent-host/pairings/complete": {
       "post": {
         "description": "Consume a pairing code and issue the host secret, shown exactly once.",
         "operationId": "agent.host.pairing.complete",
@@ -19176,18 +19176,18 @@
         }
       }
     },
-    "/organizations/{org_id}": {
+    "/organizations/{organization_id}": {
       "get": {
         "description": "Get organization details",
         "operationId": "org.get",
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           }
@@ -19232,11 +19232,11 @@
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           }
@@ -19289,17 +19289,17 @@
         }
       }
     },
-    "/organizations/{org_id}/agent-runtime/profiles": {
+    "/organizations/{organization_id}/agent-runtime/profiles": {
       "get": {
         "operationId": "agent.runtime.profiles.list",
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           },
@@ -19353,11 +19353,11 @@
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           }
@@ -19429,17 +19429,17 @@
         }
       }
     },
-    "/organizations/{org_id}/agent-runtime/profiles/{profile_id}": {
+    "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}": {
       "delete": {
         "operationId": "agent.runtime.profiles.archive",
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           },
@@ -19488,11 +19488,11 @@
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           },
@@ -19545,11 +19545,11 @@
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           },
@@ -19630,17 +19630,17 @@
         }
       }
     },
-    "/organizations/{org_id}/agent-runtime/profiles/{profile_id}:restore": {
+    "/organizations/{organization_id}/agent-runtime/profiles/{profile_id}/restore": {
       "post": {
         "operationId": "agent.runtime.profiles.restore",
         "parameters": [
           {
             "in": "path",
-            "name": "org_id",
+            "name": "organization_id",
             "required": true,
             "schema": {
               "format": "uuid",
-              "title": "Org Id",
+              "title": "Organization Id",
               "type": "string"
             }
           },
@@ -19689,467 +19689,6 @@
           "resource": "agent.runtime.profiles",
           "result": "entity",
           "verb": "restore"
-        }
-      }
-    },
-    "/organizations/{org_id}/home": {
-      "get": {
-        "description": "One organization's landing page: every pod the current user can see, with its apps, its agents, and the user's roles in that pod. Replaces fetching apps and agents per pod. Cached briefly per user.",
-        "operationId": "org.home",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationHomeResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Get Organization Home",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "kind": "query",
-          "paginates": false,
-          "resource": "org",
-          "result": "entity",
-          "verb": "home"
-        }
-      }
-    },
-    "/organizations/{org_id}/invitations": {
-      "get": {
-        "description": "Get all pending invitations for an organization",
-        "operationId": "org.invitation.list",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "$ref": "#/components/schemas/OrganizationInvitationStatus",
-              "default": "PENDING"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 100,
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "page_token",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Page Token"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationInvitationListResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "List Organization Invitations",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "kind": "query",
-          "paginates": true,
-          "resource": "org.invitation",
-          "result": "collection",
-          "verb": "list"
-        }
-      },
-      "post": {
-        "description": "Invite a user to join the organization",
-        "operationId": "org.invitation.invite",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/OrganizationInvitationRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationInvitationResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Invite Member",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "invalidates": [
-            "org.invitation"
-          ],
-          "kind": "mutation",
-          "paginates": false,
-          "resource": "org.invitation",
-          "result": "entity",
-          "verb": "invite"
-        }
-      }
-    },
-    "/organizations/{org_id}/join": {
-      "post": {
-        "description": "Join an organization when the current user's email domain is allowed to auto-join",
-        "operationId": "org.join_auto_join",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Join Auto-Join Organization",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "invalidates": [
-            "org"
-          ],
-          "kind": "mutation",
-          "paginates": false,
-          "resource": "org",
-          "result": "entity",
-          "verb": "join_auto_join"
-        }
-      }
-    },
-    "/organizations/{org_id}/members": {
-      "get": {
-        "description": "Get all members of an organization",
-        "operationId": "org.member.list",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 100,
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "page_token",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Page Token"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationMemberListResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "List Organization Members",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "kind": "query",
-          "paginates": true,
-          "resource": "org.member",
-          "result": "collection",
-          "verb": "list"
-        }
-      }
-    },
-    "/organizations/{org_id}/members/{member_id}": {
-      "delete": {
-        "description": "Remove a member from the organization",
-        "operationId": "org.member.remove",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "member_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Member Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Remove Member",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "invalidates": [
-            "org.member"
-          ],
-          "kind": "mutation",
-          "paginates": false,
-          "resource": "org.member",
-          "result": "void",
-          "verb": "remove"
-        }
-      }
-    },
-    "/organizations/{org_id}/members/{member_id}/role": {
-      "patch": {
-        "description": "Update a member's role in the organization",
-        "operationId": "org.member.update_role",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "org_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Org Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "path",
-            "name": "member_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Member Id",
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UpdateMemberRoleRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/OrganizationMemberResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "Update Member Role",
-        "tags": [
-          "Organizations"
-        ],
-        "x-lemma": {
-          "invalidates": [
-            "org.member"
-          ],
-          "kind": "mutation",
-          "paginates": false,
-          "resource": "org.member",
-          "result": "entity",
-          "verb": "update_role"
         }
       }
     },
@@ -21553,6 +21092,544 @@
         }
       }
     },
+    "/organizations/{organization_id}/home": {
+      "get": {
+        "description": "One organization's landing page: every pod the current user can see, with its apps, its agents, and the user's roles in that pod. Replaces fetching apps and agents per pod. Cached briefly per user.",
+        "operationId": "org.home",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationHomeResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Organization Home",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "kind": "query",
+          "paginates": false,
+          "resource": "org",
+          "result": "entity",
+          "verb": "home"
+        }
+      }
+    },
+    "/organizations/{organization_id}/invitations": {
+      "get": {
+        "description": "Get all pending invitations for an organization",
+        "operationId": "org.invitation.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/OrganizationInvitationStatus",
+              "default": "PENDING"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationInvitationListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Organization Invitations",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "kind": "query",
+          "paginates": true,
+          "resource": "org.invitation",
+          "result": "collection",
+          "verb": "list"
+        }
+      },
+      "post": {
+        "description": "Invite a user to join the organization",
+        "operationId": "org.invitation.invite",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrganizationInvitationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationInvitationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Invite Member",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "org.invitation"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "org.invitation",
+          "result": "entity",
+          "verb": "invite"
+        }
+      }
+    },
+    "/organizations/{organization_id}/join": {
+      "post": {
+        "description": "Join an organization when the current user's email domain is allowed to auto-join",
+        "operationId": "org.join_auto_join",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Join Auto-Join Organization",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "org"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "org",
+          "result": "entity",
+          "verb": "join_auto_join"
+        }
+      }
+    },
+    "/organizations/{organization_id}/members": {
+      "get": {
+        "description": "Get all members of an organization",
+        "operationId": "org.member.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationMemberListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Organization Members",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "kind": "query",
+          "paginates": true,
+          "resource": "org.member",
+          "result": "collection",
+          "verb": "list"
+        }
+      }
+    },
+    "/organizations/{organization_id}/members/{member_id}": {
+      "delete": {
+        "description": "Remove a member from the organization",
+        "operationId": "org.member.remove",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "member_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Member Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Remove Member",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "org.member"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "org.member",
+          "result": "void",
+          "verb": "remove"
+        }
+      }
+    },
+    "/organizations/{organization_id}/members/{member_id}/role": {
+      "patch": {
+        "description": "Update a member's role in the organization",
+        "operationId": "org.member.update_role",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "member_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Member Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateMemberRoleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationMemberResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Member Role",
+        "tags": [
+          "Organizations"
+        ],
+        "x-lemma": {
+          "invalidates": [
+            "org.member"
+          ],
+          "kind": "mutation",
+          "paginates": false,
+          "resource": "org.member",
+          "result": "entity",
+          "verb": "update_role"
+        }
+      }
+    },
+    "/organizations/{organization_id}/pods": {
+      "get": {
+        "description": "List all pods in an organization",
+        "operationId": "pod.list",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "organization_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Organization Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Token"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PodListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Pods by Organization",
+        "tags": [
+          "Pods"
+        ],
+        "x-lemma": {
+          "kind": "query",
+          "paginates": true,
+          "resource": "pod",
+          "result": "collection",
+          "verb": "list"
+        }
+      }
+    },
     "/pods": {
       "post": {
         "description": "Create a new pod",
@@ -21647,83 +21724,6 @@
           "resource": "pod.bundle",
           "result": "entity",
           "verb": "download"
-        }
-      }
-    },
-    "/pods/organization/{organization_id}": {
-      "get": {
-        "description": "List all pods in an organization",
-        "operationId": "pod.list",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "organization_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Organization Id",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "required": false,
-            "schema": {
-              "default": 100,
-              "title": "Limit",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "page_token",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Page Token"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PodListResponse"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorResponse"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "summary": "List PodS by Organization",
-        "tags": [
-          "Pods"
-        ],
-        "x-lemma": {
-          "kind": "query",
-          "paginates": true,
-          "resource": "pod",
-          "result": "collection",
-          "verb": "list"
         }
       }
     },

--- a/tests/scenarios/harness/steps/pod.py
+++ b/tests/scenarios/harness/steps/pod.py
@@ -114,7 +114,7 @@ class PodSteps:
         """
         return await every_item(
             lambda params: self.api.get(
-                f"/pods/organization/{organization['id']}", params=params
+                f"/organizations/{organization['id']}/pods", params=params
             ),
             pages=pages,
         )

--- a/tests/scenarios/journeys/agents_and_conversations/test_runtime_profiles.py
+++ b/tests/scenarios/journeys/agents_and_conversations/test_runtime_profiles.py
@@ -125,7 +125,7 @@ async def test_a_provider_can_be_archived_and_restored(org, run):
     archived = await alice.opens_runtime_profile(profile_id, in_organization=organization)
     assert str(archived["status"]).upper() != "ACTIVE", archived
 
-    await alice.api.post(f"{base}:restore")
+    await alice.api.post(f"{base}/restore")
     restored = await alice.opens_runtime_profile(profile_id, in_organization=organization)
     assert str(restored["status"]).upper() == "ACTIVE", restored
 

--- a/tests/scenarios/journeys/platform/test_agent_host_dispatch.py
+++ b/tests/scenarios/journeys/platform/test_agent_host_dispatch.py
@@ -69,7 +69,7 @@ async def _pair_and_publish(alice) -> str:
     )
     completed = await alice.api.call(
         "POST",
-        "/agent-host/pairings:complete",
+        "/agent-host/pairings/complete",
         json={
             "pairing_code": pairing["pairing_code"],
             "display_name": "Scenario laptop",

--- a/tests/scenarios/journeys/platform/test_platform_services.py
+++ b/tests/scenarios/journeys/platform/test_platform_services.py
@@ -133,7 +133,7 @@ async def test_an_unpaired_host_is_refused(world):
     anonymous = await world.new_person("anonymous", sign_up=False)
 
     polled = await anonymous.api.call("POST", "/agent-host/poll", json={})
-    appended = await anonymous.api.call("POST", "/agent-host/events:append", json={})
+    appended = await anonymous.api.call("POST", "/agent-host/events/append", json={})
 
     assert polled.status_code >= 400, polled.status_code
     assert appended.status_code >= 400, appended.status_code
@@ -240,7 +240,7 @@ async def test_an_unpaired_host_cannot_claim_anything(world):
 
     completed = await anonymous.api.call(
         "POST",
-        "/agent-host/pairings:complete",
+        "/agent-host/pairings/complete",
         json={"pairing_code": "not-a-code", "display_name": "Someone's laptop"},
     )
     published = await anonymous.api.call(

--- a/tests/scenarios/journeys/test_harness_contract.py
+++ b/tests/scenarios/journeys/test_harness_contract.py
@@ -833,7 +833,7 @@ def test_every_journey_runs_in_ci():
 #: Taken from the controllers: ``limit`` defaults to 100 on each of these and
 #: the response carries ``next_page_token``.
 PAGES_ARE_REAL = {
-    "/pods/organization/*",
+    "/organizations/*/pods",
     "/pods/*/conversations",
     "/pods/*/datastore/files",
     "/pods/*/agents",


### PR DESCRIPTION
## What changes

Three API-surface inconsistencies, fixed for 0.8.0. **Breaking**, deliberately.

| | before | after | ops |
|---|---|---|---|
| path parameter | `/organizations/{org_id}/…` | `/organizations/{organization_id}/…` | 14 |
| pods collection | `GET /pods/organization/{organization_id}` | `GET /organizations/{organization_id}/pods` | 1 |
| action spelling | `…:append`, `…:complete`, `…:restore` | `…/append`, `…/complete`, `…/restore` | 3 |

175 paths before, 175 after; 13 renamed. **Zero operation IDs change.**

## Why

Each of the three had a majority already doing the right thing, and a minority
that only differed because of the order the modules were written in.

- **`{organization_id}`** is what usage and connectors already say. Identity and
  agent said `{org_id}`. The `org_id` names in the SDK, CLI and frontend are a
  *different* concept — client/session state, `LEMMA_ORG_ID`, `Lemma.for_org()` —
  and are untouched.
- **Pods** were the only org-scoped collection not nested under `/organizations/`.
- **Slash-verbs** outnumbered colon-verbs 20 to 3.
  `/pods/{pod_id}/conversations/{conversation_id}/messages/append` and
  `/agent-host/events:append` were the same verb spelled two ways.

### Two things turned out differently than expected

**Operation IDs do not move.** They are written out in each route decorator, not
derived from the path. So the `**Contracts:**` references in
`docs/product/journeys/*.md` and the `@proves`/`@covers` decorators under
`tests/scenarios/` need no sweep at all — the spec diff shows 13 paths renamed
and zero operationIds added or removed.

**Two of the three colon routes could not simply move.**
`/agent-host/pairings:complete` and `/agent-host/events:append` are hard-coded in
the Rust host at `desktop/agent-host/src/api.rs`, which pairs against a
user-supplied server — and the desktop app has no auto-updater. An installed host
keeps calling whatever path it shipped with until someone reinstalls it. Renaming
these outright strands every paired computer already in the field.

So both colon paths stay as `include_in_schema=False` aliases stacked on the
**same handler function**. There is no second implementation, so there is nothing
to drift. The published surface is the slash spelling alone, the Rust client now
sends it, and the aliases come out once a host predating the rename can no longer
reach us. `core/security.py`'s unauthenticated-route allowlist needed no change —
it matches the `/agent-host/` prefix, which both spellings share.

`test_agent_host_transport_e2e.py` covers the aliases. That file exists because
three bugs once shipped behind the absence of any real HTTP test of
`/agent-host/*`; an alias nothing exercises would be that gap again. The events
assertion is `!= 404`, not `== 200`: the route is host-authenticated, so being
*rejected by the handler* is the proof the router found it.

### Why nothing hand-written broke

Both bespoke SDK layers call the generated clients **positionally** —
`lemma_sdk/resources/orgs.py:49` is `self._call(org_get, as_uuid(org_id))`,
`lemma-typescript/src/namespaces/agent-runtime.ts:69` is
`AgentRuntimeProfilesList(orgId, …)`. A path-parameter rename reaches the
generated signature and stops. That is why a 14-operation rename typechecks clean
across `lemma-typescript` and the frontend without one call site moving.

## How to verify

```bash
make quality
make -C lemma-backend test-unit
make -C lemma-backend test-e2e-shard E2E_WORKERS=1 \
  E2E_ARGS="app/modules/agent/tests/e2e/test_agent_host_transport_e2e.py app/modules/pod/tests/e2e/test_pod_controller.py app/core/tests/e2e/test_connection_scope_flows_e2e.py"
make -C lemma-backend test-e2e-shard E2E_WORKERS=1 \
  E2E_ARGS="app/modules/pod/tests/e2e/test_pod_join_request_controller_e2e.py app/modules/identity/tests/e2e/test_organization_navigation_e2e.py app/modules/pod/tests/e2e/test_pod_list_query_budget_e2e.py"
(cd lemma-python && uv run pytest tests -q)
(cd lemma-cli && uv run pytest tests -q -m "not e2e")
(cd lemma-typescript && npx tsc --noEmit -p tsconfig.json && npx vitest run)
(cd lemma-frontend && npm ci && npx tsc --noEmit)
(cd desktop && cargo check -p lemma-agent-host --tests)
```

Results: `✓ quality gates pass` · unit `7222 passed, 76 skipped` · e2e `36 passed`
and `13 passed` and `1 passed` · SDK `115 passed, 1 skipped` · CLI `771 passed` ·
TS `tsc` clean, `291 passed` · frontend `tsc` clean · `cargo check` clean.

Codegen drift, re-run exactly as CI does — all three clean:

```bash
(cd lemma-python && OPENAPI_FILE=lemma_sdk/openapi_spec.json bash scripts/generate_openapi_client.sh)
git diff --exit-code -- lemma-python/lemma_sdk/openapi_client lemma-python/lemma_sdk/_spec_info.py
(cd lemma-typescript && OPENAPI_FILE=../lemma-python/lemma_sdk/openapi_spec.json bash scripts/generate_openapi_client.sh && node scripts/generate_l2.mjs)
git diff --exit-code -- lemma-typescript/src/openapi_client lemma-typescript/src/openapi_spec.json lemma-typescript/src/react/generated
node lemma-frontend/scripts/sync-openapi-spec.mjs --check
```

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **API surface** — OpenAPI spec regenerated, both SDKs regenerated, all committed
- [x] **Compatibility** — breaking; migration notes below
- [x] **Security** — no new secret path; the `/agent-host/` auth allowlist is a
      prefix match and covers both spellings, verified by the e2e transport suite

No migration. No new secret in a log, response, or queued payload.

## Compatibility and rollback notes

**Breaking for direct HTTP callers.** Anyone constructing these URLs by hand must
update. Callers on either generated SDK need only the 0.8.0 client — no source
change, because every path parameter is positional.

**Not breaking for paired computers.** The two `/agent-host/` colon paths keep
working via the hidden aliases, which is the whole reason they are there.

**Versions are unchanged here.** All 12 components move to 0.8.0 at release;
`check_version_consistency.py` runs against the tag, not per-PR.

**Rollback** is a straight revert. The aliases mean a revert cannot strand a host
either — a host that has updated to the slash path would break, but only desktop
builds cut after this merge can be in that state.
