### PR TITLE
A unit test can no longer reach production, and --output json answers with JSON

### DIFF
--- a/lemma-cli/lemma_cli/cli_core/app.py
+++ b/lemma-cli/lemma_cli/cli_core/app.py
@@ -335,6 +335,7 @@ def init(
 
 @app.command("schema")
 def schema_cmd(
+    ctx: typer.Context,
     resource: str = typer.Argument(
         ..., help="pod, table, function, agent, workflow, schedule, or surface."
     ),
@@ -344,7 +345,7 @@ def schema_cmd(
     (and the same as the per-resource `lemma <resource> schema`)."""
     from .commands._authoring import print_resource_schema
 
-    print_resource_schema(resource)
+    print_resource_schema(ctx, resource)
 
 
 @app.command("version")

--- a/lemma-cli/lemma_cli/cli_core/commands/_authoring.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/_authoring.py
@@ -12,7 +12,8 @@ from pathlib import Path
 
 import typer
 
-from ..state import console
+from ..io import emit
+from ..state import console, state_from_ctx
 
 
 def grant_resource(
@@ -42,11 +43,29 @@ def grant_resource(
     console.print("[dim]next:[/dim] `lemma pods import .` to apply")
 
 
-def print_resource_schema(resource_type: str) -> None:
-    """Print the JSONC scaffold/example for a resource type (same shape `init` writes)."""
+def print_resource_schema(ctx: typer.Context, resource_type: str) -> None:
+    """Print the JSONC scaffold/example for a resource type (same shape `init` writes).
+
+    The scaffold is JSON *with comments* — that is the point of it, and it is
+    what `init` writes to a file. But it is not parseable JSON, so under
+    `--output json` this was handing a `| jq` a syntax error on every one of
+    the resource types. In that mode the template travels as a string value
+    instead, which keeps the comments and satisfies the promise.
+
+    The context is passed rather than fetched: typer vendors its own click, so
+    a top-level `click.get_current_context()` looks at a different context
+    stack and answers `None` — the same vendoring that makes a `TyperGroup`
+    fail an `isinstance(cmd, click.Group)` check.
+    """
     from ...cli_app.scaffold import ScaffoldError, resource_example
 
     try:
-        typer.echo(resource_example(resource_type))
+        example = resource_example(resource_type)
     except ScaffoldError as exc:
         raise typer.BadParameter(str(exc)) from exc
+
+    state = state_from_ctx(ctx)
+    if state.output == "json":
+        emit(state, {"resource_type": resource_type, "template": example})
+        return
+    typer.echo(example)

--- a/lemma-cli/lemma_cli/cli_core/commands/agents.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/agents.py
@@ -278,11 +278,11 @@ def grant_agent(
 
 
 @app.command("schema")
-def schema_agent() -> None:
+def schema_agent(ctx: typer.Context) -> None:
     """Print the JSONC example/shape for an agent bundle file."""
     from ._authoring import print_resource_schema
 
-    print_resource_schema("agent")
+    print_resource_schema(ctx, "agent")
 
 
 @app.command("delete")

--- a/lemma-cli/lemma_cli/cli_core/commands/data.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/data.py
@@ -51,11 +51,11 @@ def init_table(
 
 
 @tables_app.command("schema")
-def schema_table() -> None:
+def schema_table(ctx: typer.Context) -> None:
     """Print the JSONC example/shape for a table bundle file."""
     from ._authoring import print_resource_schema
 
-    print_resource_schema("table")
+    print_resource_schema(ctx, "table")
 
 
 @tables_app.command("list")

--- a/lemma-cli/lemma_cli/cli_core/commands/functions.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/functions.py
@@ -295,11 +295,11 @@ def grant_function(
 
 
 @app.command("schema")
-def schema_function() -> None:
+def schema_function(ctx: typer.Context) -> None:
     """Print the JSONC example/shape for a function bundle file."""
     from ._authoring import print_resource_schema
 
-    print_resource_schema("function")
+    print_resource_schema(ctx, "function")
 
 
 @app.command("run")

--- a/lemma-cli/lemma_cli/cli_core/commands/pods.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/pods.py
@@ -747,6 +747,16 @@ def doctor_pod(
         return
     report = to_plain(result)
     errors, warnings = report["errors"], report["warnings"]
+    state = state_from_ctx(ctx)
+    if state.output == "json":
+        # The report was always built; only the human rendering existed, so
+        # `--output json` printed prose on the stream it promises is parseable
+        # and never handed over the findings at all. The exit code is part of
+        # the answer, so it is decided the same way in both modes.
+        emit(state, report)
+        if errors:
+            raise typer.Exit(1)
+        return
     for msg in errors:
         console.print(f"[red]error[/red]  {msg}")
     for msg in warnings:

--- a/lemma-cli/lemma_cli/cli_core/commands/schedules.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/schedules.py
@@ -40,11 +40,11 @@ def init_schedule(
 
 
 @app.command("schema")
-def schema_schedule() -> None:
+def schema_schedule(ctx: typer.Context) -> None:
     """Print the JSONC example/shape for a schedule bundle file."""
     from ._authoring import print_resource_schema
 
-    print_resource_schema("schedule")
+    print_resource_schema(ctx, "schedule")
 
 
 def _normalize_datastore_operations(values: list[str]) -> list[str]:

--- a/lemma-cli/lemma_cli/cli_core/commands/surfaces.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/surfaces.py
@@ -44,11 +44,11 @@ def init_surface(
 
 
 @app.command("schema")
-def schema_surface() -> None:
+def schema_surface(ctx: typer.Context) -> None:
     """Print the JSONC example/shape for a surface bundle file."""
     from ._authoring import print_resource_schema
 
-    print_resource_schema("surface")
+    print_resource_schema(ctx, "surface")
 
 
 def _clean_payload(payload: dict[str, Any]) -> dict[str, Any]:

--- a/lemma-cli/lemma_cli/cli_core/commands/workflows.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/workflows.py
@@ -142,11 +142,11 @@ def create_workflow(
 
 
 @app.command("schema")
-def schema_workflow() -> None:
+def schema_workflow(ctx: typer.Context) -> None:
     """Print the JSONC example/shape for a workflow bundle file."""
     from ._authoring import print_resource_schema
 
-    print_resource_schema("workflow")
+    print_resource_schema(ctx, "workflow")
 
 
 @app.command("update")

--- a/lemma-cli/tests/conftest.py
+++ b/lemma-cli/tests/conftest.py
@@ -31,6 +31,79 @@ def _isolate_developer_config(tmp_path, monkeypatch):
         monkeypatch.delenv(name, raising=False)
 
 
+_LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1", "0.0.0.0", "", None}
+
+
+def _is_local(address: object) -> bool:
+    if isinstance(address, (str, bytes)):  # AF_UNIX path
+        return True
+    if isinstance(address, tuple) and address:
+        host = address[0]
+        if host in _LOCAL_HOSTS:
+            return True
+        return isinstance(host, str) and (
+            host.startswith("127.") or host.endswith(".localhost")
+        )
+    return False
+
+
+@pytest.fixture(autouse=True)
+def _no_outbound_network(request, monkeypatch):
+    """No unit test may open a socket to anything but this machine.
+
+    `_isolate_developer_config` keeps the developer's *config* out, and that
+    turned out to be the dangerous half of the job: with no config and no
+    LEMMA_* left, `resolve_base_url()` falls through to `DEFAULT_BASE_URL`,
+    which is `https://api.lemma.work`. **Production is the fallback.** So any
+    test that reaches an unstubbed code path does not fail — it quietly calls
+    the live service, and the more isolated the test, the more certainly it
+    talks to prod rather than to anything local.
+
+    That is not hypothetical. A test that walked every command in the app
+    reached `auth login`, which does not go through the stubbed
+    `run_with_client`: it fetched `/auth/cli/info` from production, opened a
+    real browser, and polled for the full `LOGIN_WAIT_SECONDS` of 300.
+
+    Local addresses stay allowed so a test may still stand up its own server.
+    `webbrowser.open` is stopped for the same reason: a test suite must not
+    take over the screen.
+    """
+    if request.node.get_closest_marker("e2e"):
+        return
+
+    import socket
+    import webbrowser
+
+    real_connect = socket.socket.connect
+    real_create = socket.create_connection
+
+    def guard(address: object) -> None:
+        if not _is_local(address):
+            raise AssertionError(
+                f"a unit test tried to reach {address!r}. Nothing outside this "
+                "machine is reachable from the unit lane — with no config and "
+                "no LEMMA_* set, an unstubbed CLI path resolves to "
+                "https://api.lemma.work, so this would have hit production. "
+                "Stub the call, or mark the test `e2e`."
+            )
+
+    def connect(self, address, *args, **kwargs):
+        guard(address)
+        return real_connect(self, address, *args, **kwargs)
+
+    def create_connection(address, *args, **kwargs):
+        guard(address)
+        return real_create(address, *args, **kwargs)
+
+    monkeypatch.setattr(socket.socket, "connect", connect)
+    monkeypatch.setattr(socket, "create_connection", create_connection)
+    monkeypatch.setattr(
+        webbrowser,
+        "open",
+        lambda *a, **k: pytest.fail("a unit test tried to open a browser"),
+    )
+
+
 @pytest.fixture
 def runner():
     return CliRunner()

--- a/lemma-cli/tests/test_json_output_contract.py
+++ b/lemma-cli/tests/test_json_output_contract.py
@@ -1,0 +1,287 @@
+"""`--output json` promises a parseable stream; this walks the real app.
+
+`telemetry.py` states the discipline — "stderr, never stdout: `--output json`
+promises a parseable stream" — and `fail()` funnels every runtime error to
+`err_console` for exactly that reason. What no test covered was the *success*
+path: a command that renders its result with `console.print` instead of
+`emit()` puts prose on stdout in JSON mode, and nothing noticed.
+
+Two commands were doing it when this test was written, and they failed in
+different ways:
+
+* the seven `<resource> schema` commands (fourteen, counting the singular and
+  plural aliases) printed a JSONC template — JSON *with comments*, which is the
+  point of a scaffold and is not parseable. `| jq` got a syntax error.
+* `pod doctor` printed its findings as prose and never emitted the report at
+  all. Not a diagnostic leaking into stdout: `--output json` returned no
+  machine-readable answer whatsoever, having already built one.
+
+**What this covers, honestly.** Commands are invoked against a permissive stub
+client, so the ones reachable without real input are the ones checked — 91 to
+93 of 353 leaf commands, the exact number depending on what else ran first. The rest exit 2 on a usage error
+because they need a file, a JSON body, or a name that cannot be invented, and
+that is correct behaviour rather than a gap this test should paper over. So
+this asserts the contract for every command it can *reach*, and separately
+asserts the reach itself has not collapsed — a change that made every command
+exit 2 would otherwise turn this green while checking nothing.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import json
+import pkgutil
+import tempfile
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import typer.main
+from typer.testing import CliRunner
+
+import lemma_cli.cli_core.commands as commands_pkg
+from lemma_cli.app import LAZY_GROUPS, app
+
+pytestmark = pytest.mark.unit
+
+UUID = "11111111-1111-1111-1111-111111111111"
+
+#: A floor against collapse, deliberately below the observed range rather than
+#: equal to it: the walk reaches 93 commands when this file runs alone and 91
+#: in the full suite, so something earlier in a session shifts two of them.
+#: The number's job is to catch the walk reaching *nothing* — a change that
+#: made every command exit early would otherwise leave the contract test above
+#: passing while asserting on an empty set. It is not a claim about the exact
+#: count, and raising it to the observed maximum only makes the suite fail.
+MINIMUM_COMMANDS_REACHED = 85
+
+#: Seconds any one command may take before this test calls it a hang. Generous:
+#: the whole walk runs in about four seconds, so this only fires on a command
+#: that never returns.
+COMMAND_DEADLINE_SECONDS = 20.0
+
+#: command path -> why invoking it here would do something other than print.
+#: These do not go through `run_with_client`, so stubbing it does not reach
+#: them; they open a browser, take over the terminal, or talk to the auth
+#: server directly. `auth login` is the reason this list exists: walking it
+#: fetched `/auth/cli/info` from `DEFAULT_BASE_URL` -- production -- opened a
+#: real browser, and polled for the full 300s login wait.
+NOT_INVOCABLE = {
+    "auth login": "browser login: fetches /auth/cli/info, opens a browser, polls",
+    "auth logout": "revokes the session it finds, which under HOME isolation is nobody's",
+    "tui": "the full-screen terminal UI; it takes the terminal and does not return",
+}
+
+
+def _commands() -> dict[str, object]:
+    """Every leaf command in the app.
+
+    These come from `lemma_cli.app`, the console-script entry point, rather
+    than from `cli_core.app` underneath it. The two share one `LAZY_GROUPS`
+    dict and the entry point `setdefault`s the `tui` group into it, so
+    importing the lower module walks 352 commands when this file runs alone
+    and 353 when some earlier test happened to import the entry point first.
+    The extra one is `tui`, which takes the terminal and never returns: the
+    suite hung on exactly that, with no indication of which command did it.
+
+    Groups are found by duck typing rather than `isinstance(cmd, click.Group)`:
+    typer vendors its own click, so a `TyperGroup` is not an instance of the
+    top-level `click.Group` and a nested sub-app reads as a leaf. (That same
+    vendoring is why `print_resource_schema` takes a `ctx` instead of calling
+    `click.get_current_context()`, which answers `None` from here.)
+    """
+    found: dict[str, object] = {}
+
+    def walk(command: object, path: list[str]) -> None:
+        children = getattr(command, "commands", None)
+        if children:
+            for name, child in children.items():
+                walk(child, [*path, name])
+            return
+        found[" ".join(path)] = command
+
+    for group_name, (module, attr, *_rest) in LAZY_GROUPS.items():
+        sub_app = getattr(importlib.import_module(module), attr)
+        walk(typer.main.get_command(sub_app), [group_name])
+    return found
+
+
+class _Stub:
+    """Stands in for the SDK client: any attribute or call, and dict-shaped.
+
+    `to_dict` and `get` are answered concretely because `io.to_plain` and
+    `io.list_items` duck-type on them — a stub that returned itself from
+    `to_dict()` would recurse forever instead of rendering.
+    """
+
+    def __getattr__(self, name: str) -> object:
+        if name == "to_dict":
+            return lambda: {"items": [], "id": UUID, "name": "x"}
+        if name == "get":
+            return lambda key, default=None: default
+        if name in {"value", "_asdict"}:
+            raise AttributeError(name)
+        return _Stub()
+
+    def __call__(self, *args: object, **kwargs: object) -> "_Stub":
+        return _Stub()
+
+    def __len__(self) -> int:
+        return 0
+
+    def __iter__(self):
+        return iter(())
+
+    def __bool__(self) -> bool:
+        return True
+
+    def __str__(self) -> str:
+        return "x"
+
+
+def _json_state() -> SimpleNamespace:
+    return SimpleNamespace(
+        config={
+            "defaults": {"org_id": "org-1", "pod_id": UUID},
+            "_runtime": {"pod": UUID},
+            "servers": {},
+        },
+        output="json",
+        full=False,
+    )
+
+
+def _command_modules() -> list[object]:
+    root = Path(commands_pkg.__file__).parent
+    return [
+        importlib.import_module(f"lemma_cli.cli_core.commands.{info.name}")
+        for info in pkgutil.iter_modules([str(root)])
+    ]
+
+
+def _invoke_within_deadline(runner: CliRunner, argv: list[str]):
+    """Run one command, or return `None` if it does not finish in time.
+
+    A daemon thread rather than `signal.alarm`: this suite also runs on
+    Windows, where there is no SIGALRM. A command that never returns leaks its
+    thread, which is why the caller reports it and the fix is to name it in
+    `NOT_INVOCABLE` rather than to raise this deadline.
+
+    Without this, an interactive command turns the whole suite into a silent
+    hang with no indication of which command did it -- `tui` did exactly that,
+    and finding it took a traced run.
+    """
+    box: list[object] = []
+
+    def call() -> None:
+        box.append(runner.invoke(app, argv, catch_exceptions=True))
+
+    thread = threading.Thread(target=call, daemon=True)
+    thread.start()
+    thread.join(COMMAND_DEADLINE_SECONDS)
+    return box[0] if box else None
+
+
+def _run_every_command() -> tuple[list[tuple[str, str]], list[str], int]:
+    """Invoke each leaf command under `--output json`.
+
+    Returns the ones that wrote non-JSON to stdout, the ones that never
+    returned, and how many were reached.
+    """
+    runner = CliRunner()
+    modules = _command_modules()
+    # An isolated cwd, because this *runs* the commands: `pod init` and its
+    # siblings scaffold a bundle into the working directory, and walking them
+    # from the checkout left a stray `lemma-cli/x/` tree behind -- named after
+    # the stub, which is how it was noticed.
+    with tempfile.TemporaryDirectory() as tmp, contextlib.chdir(tmp):
+        return _walk(runner, modules)
+
+
+def _walk(runner: CliRunner, modules: list[object]):
+    def stub_run(ctx: object, fn) -> object:
+        return fn(_Stub(), _json_state())
+
+    offenders: list[tuple[str, str]] = []
+    hung: list[str] = []
+    reached = 0
+    for name, command in sorted(_commands().items()):
+        if name in NOT_INVOCABLE:
+            continue
+        argv = name.split() + ["--output", "json"]
+        for param in command.params:
+            if not param.required:
+                continue
+            if param.__class__.__name__ == "Argument":
+                argv.append(UUID)
+            elif param.opts:
+                argv += [param.opts[0], UUID]
+
+        with contextlib.ExitStack() as stack:
+            for module in modules:
+                if hasattr(module, "run_with_client"):
+                    stack.enter_context(_patched(module, stub_run))
+            result = _invoke_within_deadline(runner, argv)
+
+        if result is None:
+            hung.append(name)
+            continue
+        if result.exit_code != 0:
+            continue
+        reached += 1
+        stdout = result.stdout.strip()
+        if not stdout:
+            continue
+        try:
+            json.loads(stdout)
+        except ValueError:
+            offenders.append((name, stdout.splitlines()[0][:70]))
+    return offenders, hung, reached
+
+
+@contextlib.contextmanager
+def _patched(module: object, replacement) -> object:
+    original = module.run_with_client
+    module.run_with_client = replacement
+    try:
+        yield
+    finally:
+        module.run_with_client = original
+
+
+def test_no_command_writes_non_json_to_stdout_in_json_mode():
+    offenders, _hung, _reached = _run_every_command()
+    rendered = "\n".join(f"  {name}: {first!r}" for name, first in offenders)
+    assert offenders == [], (
+        "these commands wrote something other than JSON to stdout under "
+        f"--output json:\n{rendered}\n"
+        "Render the result through `emit(state, ...)`, and send progress, "
+        "warnings and advisories to `err_console` instead of `console`."
+    )
+
+
+def test_the_walk_still_reaches_the_commands_it_claims_to():
+    """A gate nothing reaches is a gate that passes for the wrong reason."""
+    _offenders, hung, reached = _run_every_command()
+    assert hung == [], (
+        f"{hung} did not return within {COMMAND_DEADLINE_SECONDS}s. A command "
+        "that takes the terminal or polls forever cannot be walked here — add "
+        "it to NOT_INVOCABLE with the reason."
+    )
+    assert reached >= MINIMUM_COMMANDS_REACHED, (
+        f"only {reached} commands ran to completion under the stub, down from "
+        f"{MINIMUM_COMMANDS_REACHED}. Something made commands exit early, so "
+        "the JSON contract above is being asserted against fewer of them than "
+        "before — find out what, rather than lowering this number."
+    )
+
+
+def test_the_not_invocable_list_has_not_outlived_its_commands():
+    """An exemption for a command that no longer exists is how a guard rots
+    into a list of names nobody checks."""
+    stale = sorted(set(NOT_INVOCABLE) - set(_commands()))
+    assert stale == [], (
+        f"{stale} are exempted but no longer exist. Drop them from NOT_INVOCABLE."
+    )

--- a/lemma-cli/tests/test_list_limit_convention.py
+++ b/lemma-cli/tests/test_list_limit_convention.py
@@ -17,7 +17,7 @@ import importlib
 import pytest
 import typer.main
 
-from lemma_cli.cli_core.app import LAZY_GROUPS
+from lemma_cli.app import LAZY_GROUPS
 
 pytestmark = pytest.mark.unit
 
@@ -35,6 +35,13 @@ COMPLETE_SET_LISTINGS = {
 
 def _commands() -> dict[str, set[str]]:
     """Every leaf command in the app, mapped to the option strings it declares.
+
+    `LAZY_GROUPS` comes from `lemma_cli.app`, the console-script entry point,
+    rather than from `cli_core.app` underneath it. The two share one dict and
+    the entry point `setdefault`s the `tui` group into it, so importing the
+    lower module walks 352 commands alone and 353 when an earlier test
+    imported the entry point first — what this guard checked depended on test
+    ordering.
 
     Groups are found by duck typing rather than `isinstance(cmd, click.Group)`:
     typer vendors its own click, so a `TyperGroup` is not an instance of the

--- a/lemma-python/tests/conftest.py
+++ b/lemma-python/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 import sys
 from pathlib import Path
 
@@ -7,3 +8,65 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+_LOCAL_HOSTS = {"localhost", "127.0.0.1", "::1", "0.0.0.0", "", None}
+
+
+def _is_local(address: object) -> bool:
+    if isinstance(address, (str, bytes)):  # AF_UNIX path
+        return True
+    if isinstance(address, tuple) and address:
+        host = address[0]
+        if host in _LOCAL_HOSTS:
+            return True
+        return isinstance(host, str) and (
+            host.startswith("127.") or host.endswith(".localhost")
+        )
+    return False
+
+
+@pytest.fixture(autouse=True)
+def _no_outbound_network(request, monkeypatch):
+    """No unit test may open a socket to anything but this machine.
+
+    `resolve_base_url()` falls through to `DEFAULT_BASE_URL`, which is
+    `https://api.lemma.work`. A test that builds a client without pinning a URL
+    therefore points at **production**, and one that gets far enough to send a
+    request calls the live service rather than failing.
+
+    Nothing in this suite does that today -- this was added after the same hole
+    was found in the CLI's, where a test that walked every command reached
+    `auth login`, fetched `/auth/cli/info` from production, opened a browser
+    and polled for the full 300-second login wait. The guard is here so the
+    next test cannot repeat it.
+
+    Local addresses stay allowed so a test may still stand up its own server.
+    """
+    if request.node.get_closest_marker("integration"):
+        return
+
+    import socket
+
+    real_connect = socket.socket.connect
+    real_create = socket.create_connection
+
+    def guard(address: object) -> None:
+        if not _is_local(address):
+            raise AssertionError(
+                f"a unit test tried to reach {address!r}. Nothing outside this "
+                "machine is reachable from the unit lane -- an SDK client with "
+                "no base_url resolves to https://api.lemma.work, so this would "
+                "have hit production. Pin a local URL, or stub the transport."
+            )
+
+    def connect(self, address, *args, **kwargs):
+        guard(address)
+        return real_connect(self, address, *args, **kwargs)
+
+    def create_connection(address, *args, **kwargs):
+        guard(address)
+        return real_create(address, *args, **kwargs)
+
+    monkeypatch.setattr(socket.socket, "connect", connect)
+    monkeypatch.setattr(socket, "create_connection", create_connection)


### PR DESCRIPTION
## What changes

Three things, found in that order because each one uncovered the next:

1. **Unit tests can no longer reach the network.** A guard in both
   `lemma-cli/tests/conftest.py` and `lemma-python/tests/conftest.py`.
2. **`--output json` now returns JSON** from the fourteen `<resource> schema`
   commands and from `pod doctor`.
3. **A gate that walks every command under `--output json`** and holds it to the
   promise.

## Why

### The CLI test suite could call production, and isolation made that *more* likely

`lemma-cli/tests/conftest.py` already isolated `HOME` and cleared `LEMMA_*`, with
a good reason: a developer's own config must not steer a test. That turned out to
be the dangerous half of the job. With no config and no environment left,
`resolve_base_url()` falls through to `DEFAULT_BASE_URL` — `https://api.lemma.work`.

**The better isolated the test, the more certainly it talks to production.**
Nothing stopped a socket.

This was not theoretical. A test that walked every command reached `auth login`,
which does not go through the stubbed `run_with_client`: it fetched
`/auth/cli/info` from production, opened a real browser, and polled for the full
300-second `LOGIN_WAIT_SECONDS`. That test is in this PR; the guard is what makes
it safe to have.

The guard refuses any connection to an address that is not this machine and stops
`webbrowser.open`. Local addresses stay allowed so a test may still stand up its
own server. `e2e`-marked tests are exempt, and every file under `tests/e2e/`
carries the marker (only `__init__.py` and `helpers.py` do not, and they hold no
tests).

**Running the whole suite behind the guard is the audit.** 774 passed — nothing
else in the CLI suite was reaching out. `lemma-python/tests` had *no* isolation at
all, neither HOME nor network, and shares the same production default; its 115
tests pass unchanged with the guard, so nothing there calls out today either. The
guard is what keeps that true.

Both guards are verified by watching them fire — a connect to `api.lemma.work`
raises, a connect to `127.0.0.1` is still refused by the OS rather than the guard.

### Two commands broke the `--output json` promise

`telemetry.py` states the rule and `fail()` follows it for errors. The success
path had no equivalent, and the two failures were not the same shape:

| command | what `--output json` did |
|---|---|
| `<resource> schema` ×14 | printed JSONC — JSON *with comments* — so `\| jq` got a syntax error |
| `pod doctor` | printed prose and emitted **nothing**, having already built the report |

`pod doctor` is the interesting one: the cheap fix for "diagnostics on stdout"
(redirect the stdout console to stderr in JSON mode) would have turned polluted
output into *no* output. The report existed and was discarded; now it is emitted,
and the exit code is still decided the same way in both modes.

`print_resource_schema` takes a `ctx` rather than calling
`click.get_current_context()` — the first thing tried, which returns `None`
because typer vendors its own click and the top-level module looks at a different
context stack. Same vendoring that makes a `TyperGroup` fail
`isinstance(cmd, click.Group)`, which `test_list_limit_convention` already
documents.

### What the gate covers, and what it does not

Commands run against a permissive stub, so the ones reachable without real input
are the ones checked: **91 to 93 of 353 leaf commands**. The rest exit 2 on a
usage error because they need a file, a JSON body, or a name that cannot be
invented — correct behaviour, not a gap to paper over.

So the contract is asserted for every command it can *reach*, and the reach is
asserted separately: a change that made every command exit early would otherwise
leave the contract test passing against an empty set. That floor is set **below**
the observed range rather than equal to it. The exact count is 93 alone and 91 in
the full suite — something earlier in a session shifts two of them, and I did not
track down which. The floor's job is to catch collapse, and pinning it to the
maximum would only make the suite fail.

Three defects in the walk itself had to be fixed first, each a cost of this kind
of test worth naming:

- **it reached production** — interactive commands are now named in
  `NOT_INVOCABLE`, with a two-way check so an exemption cannot outlive its command
- **it hung the suite with no clue which command did it** (`tui` takes the
  terminal and never returns) — each command now runs under a deadline so a hang
  fails by name. A daemon thread rather than `signal.alarm`, because this suite
  also runs on Windows.
- **it wrote to the checkout** — `pod init` scaffolds into the working directory
  and left a stray `lemma-cli/x/` tree. It now runs in a temporary directory.

`tui` also exposed an ordering bug in an existing test. `lemma_cli.app` is the
console-script entry point and `setdefault`s the `tui` group into the *same*
`LAZY_GROUPS` dict `cli_core.app` owns, so importing only `cli_core.app` walks 352
commands alone and 353 when something imported the entry point first — meaning
what `test_list_limit_convention` checked depended on test ordering. Both walkers
now import it explicitly.

## How to verify

The gate must fail against the old behaviour before it passes:

```bash
cd lemma-cli
git stash push lemma_cli/cli_core/commands/_authoring.py lemma_cli/cli_core/commands/pods.py \
  lemma_cli/cli_core/commands/agents.py lemma_cli/cli_core/commands/data.py \
  lemma_cli/cli_core/commands/functions.py lemma_cli/cli_core/commands/schedules.py \
  lemma_cli/cli_core/commands/workflows.py lemma_cli/cli_core/commands/surfaces.py \
  lemma_cli/cli_core/app.py
uv run pytest tests/test_json_output_contract.py -q
git stash pop
```

Before: `test_no_command_writes_non_json_to_stdout_in_json_mode` fails, naming
all fourteen `schema` commands and `pod doctor`. After: 3 passed.

The network guard, likewise — a scratch test asserting `socket.create_connection(("api.lemma.work", 443))`
raises `AssertionError` and `("127.0.0.1", 1)` still raises `OSError`, in both
suites: 2 passed each.

```bash
make quality
(cd lemma-cli && uv run pytest tests -q -m "not e2e")
(cd lemma-python && uv run pytest tests -q)
```

`✓ quality gates pass` · CLI `774 passed, 18 deselected in 11.12s` ·
SDK `115 passed, 1 skipped`.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — this removes an outbound path from the test suites rather
      than adding one; no new secret in a log, response, or queued payload

No migration, no API surface change.

## Compatibility and rollback notes

`<resource> schema --output json` changes shape, from raw JSONC to
`{"resource_type": ..., "template": ...}`. Nothing could have been consuming the
old form successfully — it was not parseable JSON. Pretty mode is unchanged, so
`lemma workflow schema > workflow.jsonc` still writes what it always did.

`pod doctor --output json` gains output where it previously had none, and keeps
its exit codes.

Rollback is a straight revert of any of the three commits independently.
