### PR TITLE
`lemma_sdk.config` says which of its names are promises

### DIFF
--- a/lemma-python/lemma_sdk/config.py
+++ b/lemma-python/lemma_sdk/config.py
@@ -15,11 +15,11 @@ DEFAULT_AUTH_URL = "https://lemma.work/auth"
 DEFAULT_CONFIG_PATH = Path.home() / ".lemma" / "config.json"
 DEFAULT_SERVER_NAME = "lemma-cloud"
 ENV_SERVER_NAME = "env"
-LOCAL_SERVER_NAME = "local"
+_LOCAL_SERVER_NAME = "local"
 
 
 @dataclass(frozen=True)
-class CliRuntimeSettings:
+class _CliRuntimeSettings:
     base_url: str = DEFAULT_BASE_URL
     auth_url: str = DEFAULT_AUTH_URL
     token: str | None = None
@@ -28,7 +28,7 @@ class CliRuntimeSettings:
     config_file: Path = DEFAULT_CONFIG_PATH
 
     @classmethod
-    def from_env(cls, config_file: str | None = None) -> "CliRuntimeSettings":
+    def from_env(cls, config_file: str | None = None) -> "_CliRuntimeSettings":
         env_config_file = Path(
             config_file or os.getenv("LEMMA_CONFIG_FILE") or DEFAULT_CONFIG_PATH
         )
@@ -47,11 +47,7 @@ class CliRuntimeSettings:
         )
 
 
-def config_path_from_arg(config_file: str | None = None) -> Path:
-    return CliRuntimeSettings.from_env(config_file).config_file
-
-
-def load_json(raw: str) -> Any:
+def _load_json(raw: str) -> Any:
     try:
         return json.loads(raw)
     except json.JSONDecodeError as exc:
@@ -106,7 +102,7 @@ def _fresh_root_config() -> dict[str, Any]:
 def load_config(path: Path) -> dict[str, Any]:
     if not path.exists():
         return _fresh_root_config()
-    data = load_json(path.read_text(encoding="utf-8"))
+    data = _load_json(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise ValueError(f"Invalid config file at {path}: expected object")
     data = _migrate_legacy_config(data)
@@ -225,8 +221,8 @@ def get_server_config(root_config: dict[str, Any], server: str) -> dict[str, Any
     if not isinstance(server_config, dict):
         raise ValueError(f"Invalid config file: server {normalized!r} must be object")
     servers[normalized] = _ensure_server_shape(server_config)
-    if normalized == LOCAL_SERVER_NAME:
-        discovered = discover_local_server_config()
+    if normalized == _LOCAL_SERVER_NAME:
+        discovered = _discover_local_server_config()
         if discovered is not None:
             # Desktop owns this endpoint contract. Refresh it on every load so
             # a safe port rotation cannot leave an older CLI registration
@@ -241,7 +237,7 @@ def get_server_config(root_config: dict[str, Any], server: str) -> dict[str, Any
     return servers[normalized]
 
 
-def discover_local_server_config() -> dict[str, Any] | None:
+def _discover_local_server_config() -> dict[str, Any] | None:
     """Read the Desktop-owned endpoint state without assuming fixed ports."""
     root_override = os.getenv("LEMMA_LOCALD_ROOT")
     if root_override:
@@ -401,7 +397,7 @@ def mask_token(token: str | None) -> str | None:
     return f"{token[:4]}...{token[-4:]}"
 
 
-def get_config_default(config: dict[str, Any], key: str) -> str | None:
+def _get_config_default(config: dict[str, Any], key: str) -> str | None:
     defaults = config.get("defaults") or {}
     value = defaults.get(key)
     if isinstance(value, str) and value:
@@ -409,7 +405,7 @@ def get_config_default(config: dict[str, Any], key: str) -> str | None:
     return None
 
 
-def resolve_config_default(
+def _resolve_config_default(
     *,
     explicit: str | None = None,
     env_keys: tuple[str, ...] = (),
@@ -422,14 +418,14 @@ def resolve_config_default(
         env_value = os.getenv(env_key)
         if env_value:
             return env_value
-    return get_config_default(config or {}, config_key)
+    return _get_config_default(config or {}, config_key)
 
 
 def resolve_org_id(
     explicit: str | None = None,
     config: dict[str, Any] | None = None,
 ) -> str | None:
-    return resolve_config_default(
+    return _resolve_config_default(
         explicit=explicit,
         env_keys=("LEMMA_ORG_ID",),
         config=config,
@@ -441,7 +437,7 @@ def resolve_pod_id(
     explicit: str | None = None,
     config: dict[str, Any] | None = None,
 ) -> str | None:
-    return resolve_config_default(
+    return _resolve_config_default(
         explicit=explicit,
         env_keys=("LEMMA_POD_ID",),
         config=config,
@@ -449,7 +445,7 @@ def resolve_pod_id(
     )
 
 
-def get_auth_session(config: dict[str, Any]) -> dict[str, Any] | None:
+def _get_auth_session(config: dict[str, Any]) -> dict[str, Any] | None:
     auth = config.get("auth")
     if isinstance(auth, dict):
         return auth
@@ -457,7 +453,7 @@ def get_auth_session(config: dict[str, Any]) -> dict[str, Any] | None:
 
 
 def get_access_token_from_config(config: dict[str, Any]) -> str | None:
-    auth = get_auth_session(config)
+    auth = _get_auth_session(config)
     if auth:
         token = auth.get("access_token")
         if isinstance(token, str) and token:
@@ -469,7 +465,7 @@ def get_access_token_from_config(config: dict[str, Any]) -> str | None:
 
 
 def get_refresh_token_from_config(config: dict[str, Any]) -> str | None:
-    auth = get_auth_session(config)
+    auth = _get_auth_session(config)
     if auth:
         token = auth.get("refresh_token")
         if isinstance(token, str) and token:
@@ -520,7 +516,7 @@ def resolve_auth_url(
         )
     ):
         raise ValueError(str(config["_local_discovery_error"]))
-    auth = get_auth_session(config or {})
+    auth = _get_auth_session(config or {})
     return (
         explicit
         or (auth or {}).get("auth_url")
@@ -536,7 +532,7 @@ def resolve_token(
     *,
     use_env: bool = True,
 ) -> str:
-    settings = CliRuntimeSettings.from_env()
+    settings = _CliRuntimeSettings.from_env()
     token = (
         explicit
         or (settings.token if use_env else None)
@@ -550,11 +546,7 @@ def resolve_token(
 
 
 def resolve_verify_ssl(no_verify_ssl: bool = False) -> bool:
-    return not no_verify_ssl and CliRuntimeSettings.from_env().verify_ssl
-
-
-def should_use_managed_auth(explicit_token: str | None = None) -> bool:
-    return not explicit_token and not CliRuntimeSettings.from_env().token
+    return not no_verify_ssl and _CliRuntimeSettings.from_env().verify_ssl
 
 
 def upsert_auth_session(
@@ -575,38 +567,40 @@ def clear_auth_session(config: dict[str, Any]) -> dict[str, Any]:
     return next_config
 
 
-def resolve_sdk_token(token: str | None = None, config_path: Path | None = None) -> str:
-    settings = CliRuntimeSettings.from_env(str(config_path) if config_path else None)
-    if token:
-        return token
-    if settings.token:
-        return settings.token
-    root_config, server = normalize_server_config(
-        load_config(config_path or DEFAULT_CONFIG_PATH)
-    )
-    config = get_server_config(root_config, server)
-    resolved = get_access_token_from_config(config)
-    if not resolved:
-        raise ValueError(
-            "Missing token. Set LEMMA_TOKEN, run `lemma auth login`, or pass token explicitly."
-        )
-    return resolved
-
-
-def resolve_sdk_base_url(
-    api_url: str | None = None, config_path: Path | None = None
-) -> str:
-    settings = CliRuntimeSettings.from_env(str(config_path) if config_path else None)
-    if api_url:
-        return api_url.rstrip("/")
-    env_value = os.getenv("LEMMA_BASE_URL")
-    if env_value:
-        return env_value.rstrip("/")
-    root_config, server = normalize_server_config(
-        load_config(config_path or DEFAULT_CONFIG_PATH)
-    )
-    config = get_server_config(root_config, server)
-    return (
-        (config.get("base_url") if isinstance(config, dict) else None)
-        or settings.base_url
-    ).rstrip("/")
+#: The config surface, stated rather than inferred. Without this, a name
+#: became public by being defined at module scope and stayed public because
+#: nobody could tell whether anything imported it: four functions here had no
+#: caller at all, and seven more were implementation that only this module
+#: used. In a `py.typed` package that is a promise nobody meant to make.
+#:
+#: Every name below has a consumer -- the SDK's own `settings.py`, the CLI,
+#: or a test asserting on a documented default. Adding one means deciding to,
+#: which is the point.
+__all__ = [
+    "DEFAULT_AUTH_URL",
+    "DEFAULT_BASE_URL",
+    "DEFAULT_CONFIG_PATH",
+    "DEFAULT_SERVER_NAME",
+    "ENV_SERVER_NAME",
+    "build_env_server_config",
+    "clear_auth_session",
+    "config_lock",
+    "get_access_token_from_config",
+    "get_refresh_token_from_config",
+    "get_server_config",
+    "load_config",
+    "mask_token",
+    "normalize_server_config",
+    "normalize_server_name",
+    "put_server_config",
+    "resolve_auth_url",
+    "resolve_base_url",
+    "resolve_org_id",
+    "resolve_pod_id",
+    "resolve_token",
+    "resolve_verify_ssl",
+    "save_config",
+    "server_names",
+    "should_use_env_server",
+    "upsert_auth_session",
+]

--- a/lemma-python/tests/test_config_surface.py
+++ b/lemma-python/tests/test_config_surface.py
@@ -1,0 +1,86 @@
+"""What `lemma_sdk.config` promises, and the one thing another repo scrapes.
+
+`config.py` is in a published `py.typed` package, so every module-scope name it
+defines is a promise. Nothing declared which promises were meant: four functions
+had no caller anywhere, and seven more were implementation only this module used.
+They were public because they were defined, and stayed public because nobody
+could tell the difference.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import lemma_sdk.config as config
+
+_CONFIG_SOURCE = Path(config.__file__)
+
+
+def _module_scope_public_names() -> set[str]:
+    tree = ast.parse(_CONFIG_SOURCE.read_text(encoding="utf-8"))
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.ClassDef)):
+            if not node.name.startswith("_"):
+                names.add(node.name)
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Name)
+                    and not target.id.startswith("_")
+                    and target.id.isupper()
+                ):
+                    names.add(target.id)
+    return names
+
+
+def test_every_public_name_is_one_the_module_meant_to_publish():
+    """`__all__` and the module's actual public names agree.
+
+    Both directions on purpose. A name missing from `__all__` is a promise made
+    by accident; a name in `__all__` that no longer exists is a promise this
+    package cannot keep, and `from lemma_sdk.config import *` would raise on it.
+    """
+    declared = set(config.__all__)
+    actual = _module_scope_public_names()
+
+    assert actual - declared == set(), (
+        f"public but undeclared: {sorted(actual - declared)}. Add it to "
+        "__all__ if it is API, or prefix it with an underscore if it is not."
+    )
+    assert declared - actual == set(), (
+        f"declared but missing: {sorted(declared - actual)}. `import *` would "
+        "raise on these."
+    )
+
+
+def test_desktop_local_bases_stay_where_this_script_can_find_them():
+    """`scripts/check_local_domain_consistency.py` reads this by name, from text.
+
+    It has to. CI runs that script with whatever `python` the runner provides,
+    and this module is 3.14 source using PEP 758 `except A, B:` — an old
+    interpreter can neither import it nor `ast.parse` it. So the coupling is a
+    regex over source, and the rename that breaks it would otherwise surface as
+    "the check is broken" in a repo-level script rather than here, where the
+    rename happened.
+
+    The private name is deliberate: these bases are not API. What this asserts is
+    only that they keep the name and shape that consumer matches on.
+    """
+    source = _CONFIG_SOURCE.read_text(encoding="utf-8")
+
+    assert hasattr(config, "_DESKTOP_LOCAL_BASES"), (
+        "`_DESKTOP_LOCAL_BASES` is gone. `scripts/check_local_domain_consistency.py` "
+        "reads it by name to check the Rust shell, the Tauri capability file and "
+        "this SDK agree on which domains are desktop-local. Update that script in "
+        "the same change."
+    )
+    assert re.search(r"_DESKTOP_LOCAL_BASES\s*=\s*[\(\[{]([^)\]}]*)[\)\]}]", source), (
+        "`_DESKTOP_LOCAL_BASES` is no longer a literal container of strings. "
+        "`scripts/check_local_domain_consistency.py` matches it with a regex "
+        "because it cannot import this module; building it dynamically would "
+        "leave that check silently reading nothing."
+    )
+    assert all(isinstance(base, str) for base in config._DESKTOP_LOCAL_BASES)

--- a/lemma-python/tests/test_desktop_discovery.py
+++ b/lemma-python/tests/test_desktop_discovery.py
@@ -21,7 +21,7 @@ import pytest
 from lemma_sdk.config import (
     _DESKTOP_LOCAL_BASES,
     _valid_desktop_endpoint,
-    discover_local_server_config,
+    _discover_local_server_config,
 )
 
 
@@ -76,7 +76,7 @@ def test_discovery_reads_the_addresses_locald_wrote(tmp_path, monkeypatch):
         )
         monkeypatch.setenv("LEMMA_LOCALD_ROOT", str(root))
 
-        found = discover_local_server_config()
+        found = _discover_local_server_config()
 
         assert found is not None, f"an install on {base} was not discovered"
         assert found["base_url"] == f"http://app.{base}:52414"
@@ -103,4 +103,4 @@ def test_a_state_file_naming_a_host_we_do_not_serve_is_not_discovered(
     )
     monkeypatch.setenv("LEMMA_LOCALD_ROOT", str(tmp_path))
 
-    assert discover_local_server_config() is None
+    assert _discover_local_server_config() is None

--- a/scripts/check_local_domain_consistency.py
+++ b/scripts/check_local_domain_consistency.py
@@ -70,10 +70,36 @@ def capability_bases() -> set[str]:
 
 
 def sdk_bases() -> set[str]:
+    """The domains the SDK treats as a desktop-local server.
+
+    Read out of the file's text rather than imported, and that is not laziness:
+    CI runs this script with whatever `python` the runner provides -- see
+    `check_script_portability.py` -- while `lemma_sdk/config.py` is 3.14 source
+    using PEP 758 `except A, B:`. An old interpreter cannot import it and cannot
+    even `ast.parse` it.
+
+    So the coupling is to a private name in another package's source, which is
+    as fragile as it sounds. Two things make it survivable: the match spans any
+    bracket style and any number of lines, so reformatting does not break it;
+    and `test_desktop_local_bases_stay_where_this_script_can_find_them` in
+    lemma-python fails on the SDK side if the constant is renamed or moved,
+    naming this script.
+    """
+    if not SDK.exists():
+        raise SystemExit(
+            "{} is gone. This check reads `_DESKTOP_LOCAL_BASES` out of it; "
+            "point SDK at the new home rather than deleting the check.".format(SDK)
+        )
     text = SDK.read_text(encoding="utf-8")
-    match = re.search(r"_DESKTOP_LOCAL_BASES = \(([^)]*)\)", text)
+    match = re.search(r"_DESKTOP_LOCAL_BASES\s*=\s*[\(\[{]([^)\]}]*)[\)\]}]", text)
     if not match:
-        raise SystemExit(f"_DESKTOP_LOCAL_BASES not found in {SDK}")
+        raise SystemExit(
+            "`_DESKTOP_LOCAL_BASES` not found in {}. That is this check being "
+            "broken, not the domains disagreeing: it reads the constant out of "
+            "the SDK's source because CI runs this script on an interpreter too "
+            "old to import 3.14 syntax. If the constant moved or was renamed, "
+            "update this function.".format(SDK)
+        )
     return set(re.findall(r'"([^"]+)"', match.group(1)))
 
 


### PR DESCRIPTION
## What changes

`lemma_sdk/config.py` is in a published `py.typed` package, so every module-scope
name it defines is API. Nothing declared which ones were meant to be.

| | |
|---|---|
| deleted — no caller anywhere | `config_path_from_arg`, `should_use_managed_auth`, `resolve_sdk_token`, `resolve_sdk_base_url` |
| made private — used only inside this module | `CliRuntimeSettings`, `LOCAL_SERVER_NAME`, `get_auth_session`, `get_config_default`, `load_json`, `resolve_config_default`, `discover_local_server_config` |
| declared in `__all__` | the **26** that have a consumer |

## Why

The four deleted functions each occurred **exactly once** in the whole
repository, at their own `def`. The seven private ones had no consumer outside
`config.py`. They were public because they were defined, and stayed public
because nobody could tell the difference.

`__all__` now names the 26 with a real consumer — the SDK's own `settings.py`
(exactly 10, through one import), the CLI (22), or a test asserting a documented
default. `test_every_public_name_is_one_the_module_meant_to_publish` fails in
**both** directions: a name missing from `__all__` is a promise made by accident,
and a name in `__all__` that no longer exists is one `import *` would raise on.

### `CliRuntimeSettings` is not dead

An earlier note of mine had it in the dead set. It is live at two call sites,
inside `resolve_token` and `resolve_verify_ssl` — and the second is one of the ten
names the SDK itself imports. Deleting it would have broken the SDK's own auth
path. It is private now, not gone.

### The plan's other half is deliberately not done

The plan called for moving the CLI-only state into `lemma_cli`. Measured, that is
12 of 33 names — and they are the **writers** of `~/.lemma/config.json`
(`save_config`, `put_server_config`, `upsert_auth_session`, `clear_auth_session`,
`config_lock`) while the SDK keeps the readers.

Splitting the reader and the writer of one file across two packages is worse than
one package holding both. That file is a shared contract, and the SDK is where
both consumers can reach it. What was actually wrong was not where the code lived
— it was that all of it was public.

### The script that reaches past the public API

`scripts/check_local_domain_consistency.py` scrapes `_DESKTOP_LOCAL_BASES` out of
this file's *text*. It still does, and now says why: CI runs that script with
whatever `python` the runner provides — see `check_script_portability.py`, which
exists because one unparenthesised `except` once stopped every Windows host pack
building — while this module is 3.14 source using PEP 758 `except A, B:`. An old
interpreter can neither import it nor `ast.parse` it.

Two changes make that survivable:

- the match spans any bracket style across any number of lines, so reformatting
  cannot break it, and a miss now reports *"this check is broken, not the domains
  disagreeing"* rather than a bare exit;
- **`test_desktop_local_bases_stay_where_this_script_can_find_them`** fails on the
  SDK side if the constant is renamed or stops being a literal container, naming
  the script. The break surfaces where the rename happened, not in a repo-level
  script nobody is reading.

## How to verify

```bash
(cd lemma-python && uv run pytest tests -q)
(cd lemma-cli && uv run pytest tests -q -m "not e2e")
make quality
python3 scripts/check_local_domain_consistency.py
```

SDK **117 passed** · CLI **777 passed** · `✓ quality gates pass` ·
*"Local domain lists agree on ['127.0.0.1.sslip.io', 'lemma.localhost']"*.

Both new tests were watched failing — rename `_DESKTOP_LOCAL_BASES` and the
SDK-side test fires with the script's name in the message; add a public function
and the surface test names it.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Compatibility** — breaking for anyone importing the eleven names below;
      notes follow

No migration, no API surface change to the HTTP API, no new secret path.

## Compatibility and rollback notes

**Breaking only for a direct importer of a name with no caller in this
repository.** Four are deleted and seven are renamed with a leading underscore.
None is referenced by the SDK, the CLI, the backend, the desktop app, the docs or
any test — verified name by name with `git grep -w`. 0.8.0 is the release for it.

Net 612 lines to 606: 43 lines of dead code out, and the `__all__` block that
replaces guessing about the rest.

Straight revert if needed.
