### PR TITLE
The run sweep stops racing its own dispatch, and e2e teardown stops cancelling the lifespan it closes

### DIFF
--- a/desktop/locald/src/agent_host.rs
+++ b/desktop/locald/src/agent_host.rs
@@ -484,11 +484,19 @@ impl AgentHostSupervisor {
     /// Failing to record is not failing to start. The sidecar is up either
     /// way; all that is lost is the next daemon's ability to reclaim it, which
     /// is where this started.
+    ///
+    /// `settled_process_identity` rather than a bare `process_identity`, and
+    /// for the reason this record exists at all: a child that has forked but
+    /// not yet finished `exec` still reports its parent's binary, so recording
+    /// the moment `spawn` returns writes down the wrong executable -- and a
+    /// record whose executable does not match is one `reclaim_leftover`
+    /// declines to signal. The window is small and entirely load-dependent,
+    /// which is the worst size for it to be.
     fn record_running(&self, child: &mut Child) {
         let Some(installation_id) = self.installation_id.clone() else {
             return;
         };
-        let Ok(identity) = crate::host_process::process_identity(child.id()) else {
+        let Ok(identity) = crate::host_process::settled_process_identity(child) else {
             return;
         };
         let record = AgentHostRecord {

--- a/desktop/locald/src/host_process.rs
+++ b/desktop/locald/src/host_process.rs
@@ -1816,12 +1816,17 @@ pub(crate) fn process_identity(pid: u32) -> io::Result<ProcessIdentity> {
 /// still cost the whole settle budget before reporting the one thing worth
 /// knowing about it — that it had already died, and with what status.
 #[cfg(unix)]
-fn settled_process_identity(child: &mut Child) -> io::Result<ProcessIdentity> {
+pub(crate) fn settled_process_identity(child: &mut Child) -> io::Result<ProcessIdentity> {
     let pid = child.id().to_string();
+    // Read once, outside the loop: it cannot change, and it is a syscall.
+    let own_image = std::env::current_exe().ok();
     let deadline = Instant::now() + IDENTITY_SETTLE_TIMEOUT;
     loop {
-        if let Some(identity) = query_process_identity(&pid)? {
-            return Ok(identity);
+        match query_process_identity(&pid)? {
+            Some(identity) if !names_our_own_image(&identity, own_image.as_deref()) => {
+                return Ok(identity);
+            }
+            _ => {}
         }
         if child.try_wait()?.is_some() {
             return Err(io::Error::new(
@@ -1839,10 +1844,34 @@ fn settled_process_identity(child: &mut Child) -> io::Result<ProcessIdentity> {
     }
 }
 
+/// Whether a just-spawned child is still reporting *this* process's binary.
+///
+/// Between `fork` and `exec` a child is a copy of its parent, so on Linux
+/// `/proc/<pid>/exe` names this daemon rather than the binary the child was
+/// spawned to run -- there is no bracketed placeholder to give the window away,
+/// only a plausible path that happens to be the wrong one. An identity read
+/// there records the wrong executable, and the reclaim path declines to signal
+/// a record whose executable no longer matches. So the leftover that record was
+/// written to catch survives every future launch: exactly the failure the
+/// ownership record exists to prevent, reached through the moment it is
+/// written. It is how
+/// `a_sidecar_that_outlived_its_daemon_is_reclaimed_before_the_next_spawn`
+/// fails on a loaded Linux runner -- the leftover is never signalled and the
+/// test waits out the full `sleep 30`.
+///
+/// This is the Linux counterpart of the `(sh)` that `ps` reports on macOS: both
+/// mean "not settled yet", and both are waited out rather than recorded. A
+/// daemon that genuinely spawned a copy of itself would wait out the whole
+/// settle budget and then record anyway -- slower, and still correct.
+#[cfg(unix)]
+fn names_our_own_image(identity: &ProcessIdentity, own_image: Option<&Path>) -> bool {
+    own_image.is_some_and(|own| Path::new(identity.executable.as_str()) == own)
+}
+
 /// Windows names a process's image at creation, so there is no window to wait
 /// out and nothing a live child can report that a query would miss.
 #[cfg(windows)]
-fn settled_process_identity(child: &mut Child) -> io::Result<ProcessIdentity> {
+pub(crate) fn settled_process_identity(child: &mut Child) -> io::Result<ProcessIdentity> {
     process_identity(child.id())
 }
 

--- a/lemma-backend/app/core/tests/e2e/test_connection_scope_flows_e2e.py
+++ b/lemma-backend/app/core/tests/e2e/test_connection_scope_flows_e2e.py
@@ -41,6 +41,7 @@ db_manager = e2e_fixtures.db_manager
 test_app = e2e_fixtures.test_app
 db_session = e2e_fixtures.db_session
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org

--- a/lemma-backend/app/core/tests/e2e/test_pod_delivery_marker_e2e.py
+++ b/lemma-backend/app/core/tests/e2e/test_pod_delivery_marker_e2e.py
@@ -49,6 +49,7 @@ sandbox_reachable_backend = e2e_fixtures.sandbox_reachable_backend
 worker = e2e_fixtures.worker
 test_app = e2e_fixtures.test_app
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org

--- a/lemma-backend/app/modules/agent/tests/e2e/conftest.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/conftest.py
@@ -25,6 +25,7 @@ db_manager = e2e_fixtures.db_manager
 test_app = e2e_fixtures.test_app
 db_session = e2e_fixtures.db_session
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/conftest.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/conftest.py
@@ -39,6 +39,7 @@ e2e_settings = e2e_fixtures.e2e_settings
 db_manager = e2e_fixtures.db_manager
 test_app = e2e_fixtures.test_app
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org
@@ -241,6 +242,7 @@ __all__ = [
     "async_client",
     "db_manager",
     "db_session",
+    "e2e_process_clients",
     "e2e_settings",
     "fake_composio_email",
     "fake_composio_server",

--- a/lemma-backend/app/modules/apps/tests/e2e/conftest.py
+++ b/lemma-backend/app/modules/apps/tests/e2e/conftest.py
@@ -19,6 +19,7 @@ db_manager = e2e_fixtures.db_manager
 test_app = e2e_fixtures.test_app
 db_session = e2e_fixtures.db_session
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org

--- a/lemma-backend/app/modules/connectors/tests/e2e/conftest.py
+++ b/lemma-backend/app/modules/connectors/tests/e2e/conftest.py
@@ -19,6 +19,7 @@ db_manager = e2e_fixtures.db_manager
 test_app = e2e_fixtures.test_app
 db_session = e2e_fixtures.db_session
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org

--- a/lemma-backend/app/modules/datastore/tests/e2e/conftest.py
+++ b/lemma-backend/app/modules/datastore/tests/e2e/conftest.py
@@ -78,6 +78,7 @@ db_manager = e2e_fixtures.db_manager
 test_app = e2e_fixtures.test_app
 db_session = e2e_fixtures.db_session
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org
@@ -274,6 +275,7 @@ __all__ = [
     "authenticated_client",
     "db_manager",
     "db_session",
+    "e2e_process_clients",
     "document_worker",
     "e2e_settings",
     "fixed_test_org",

--- a/lemma-backend/app/modules/function/application/runtime_policy.py
+++ b/lemma-backend/app/modules/function/application/runtime_policy.py
@@ -1,3 +1,19 @@
 """Fixed cross-component policy for function execution protocol v2."""
 
 FUNCTION_JOB_CALLBACK_GRACE_SECONDS = 60
+
+#: How long an asynchronous run must have sat PENDING before the recovery sweep
+#: (``reconcile_function_runs``, once a minute) may treat it as unqueued.
+#:
+#: One sweep interval, and the floor is the point rather than a tuning knob.
+#: Queue publication happens after the unit of work that writes ``job_id``
+#: commits, so *every* asynchronous run is briefly PENDING-and-unqueued on the
+#: ordinary path -- indistinguishable, to a sweep with no floor, from one whose
+#: publication was genuinely lost. Republishing such a run looks free because
+#: Streaq deduplicates the deterministic task identity, but deduplication only
+#: protects the *publication*: nothing stops the worker that consumes the copy
+#: from winning the PENDING -> RUNNING transition away from a caller that was
+#: dispatching the same run in-process, which then goes on waiting for an
+#: outcome it no longer owns. A run that has not survived a full sweep interval
+#: has not lost anything yet, so it is left alone.
+FUNCTION_RUN_REPUBLISH_MIN_AGE_SECONDS = 60

--- a/lemma-backend/app/modules/function/events/handlers.py
+++ b/lemma-backend/app/modules/function/events/handlers.py
@@ -44,6 +44,7 @@ from app.modules.function.infrastructure.execution_repository import (
 )
 from app.modules.function.application.runtime_policy import (
     FUNCTION_JOB_CALLBACK_GRACE_SECONDS,
+    FUNCTION_RUN_REPUBLISH_MIN_AGE_SECONDS,
 )
 from app.core.log.log import get_logger
 
@@ -119,6 +120,7 @@ async def _reconcile_unqueued_function_runs(
     async with uow_factory() as uow:
         run_ids = await FunctionRunRepository(uow).list_pending_async_runs(
             now=now,
+            min_age_seconds=FUNCTION_RUN_REPUBLISH_MIN_AGE_SECONDS,
             limit=limit,
         )
 

--- a/lemma-backend/app/modules/function/infrastructure/repositories.py
+++ b/lemma-backend/app/modules/function/infrastructure/repositories.py
@@ -528,16 +528,16 @@ class FunctionRunRepository(FunctionRunRepositoryPort):
         return int(getattr(result, "rowcount", 0) or 0)
 
     async def list_pending_async_runs(
-        self,
-        *,
-        now: datetime,
-        limit: int = 100,
+        self, *, now: datetime, min_age_seconds: int, limit: int = 100
     ) -> list[UUID]:
-        """Return asynchronous runs still waiting for their one execution.
+        """Return asynchronous runs whose one execution was never queued.
 
-        ``job_id`` is the durable asynchronous-dispatch intent. Queue publication
-        happens after this UoW closes; republishing a queued run is safe because
-        Streaq atomically deduplicates the deterministic task identity.
+        ``job_id`` is the durable asynchronous-dispatch intent, and publication
+        follows the unit of work that sets it -- so every asynchronous run is
+        briefly PENDING-and-unqueued even when nothing went wrong. Republishing
+        one is harmless (Streaq deduplicates the deterministic task identity)
+        but claiming one is not, which is what ``min_age_seconds`` is for; the
+        argument for its value lives on the constant it is passed from.
         """
 
         statement = (
@@ -547,6 +547,7 @@ class FunctionRunRepository(FunctionRunRepositoryPort):
                 FunctionRunModel.job_id.is_not(None),
                 FunctionRunModel.deadline_at.is_not(None),
                 FunctionRunModel.deadline_at > now,
+                FunctionRunModel.created_at <= now - timedelta(seconds=min_age_seconds),
             )
             .order_by(FunctionRunModel.created_at, FunctionRunModel.id)
             .limit(limit)

--- a/lemma-backend/app/modules/function/tests/e2e/conftest.py
+++ b/lemma-backend/app/modules/function/tests/e2e/conftest.py
@@ -30,6 +30,7 @@ worker = e2e_fixtures.worker
 db_manager = e2e_fixtures.db_manager
 test_app = e2e_fixtures.test_app
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org
@@ -62,6 +63,7 @@ __all__ = [
     "configure_workspace_api_url",
     "db_manager",
     "db_session",
+    "e2e_process_clients",
     "e2e_settings",
     "fixed_test_org",
     "fixed_test_user",

--- a/lemma-backend/app/modules/function/tests/e2e/test_function_execution_repository_concurrency.py
+++ b/lemma-backend/app/modules/function/tests/e2e/test_function_execution_repository_concurrency.py
@@ -7,6 +7,9 @@ from uuid import UUID, uuid7
 import pytest
 
 from app.core.infrastructure.db.uow_factory import SessionUnitOfWorkFactory
+from app.modules.function.application.runtime_policy import (
+    FUNCTION_RUN_REPUBLISH_MIN_AGE_SECONDS,
+)
 from app.modules.function.application.function_session_token_cache import (
     FunctionSessionTokenKey,
 )
@@ -325,3 +328,51 @@ async def test_running_job_receives_callback_grace_before_reconciliation(
             )
             == 1
         )
+
+
+async def test_a_freshly_created_async_run_is_not_republished_as_unqueued(
+    db_manager,
+    test_pod,
+    fixed_test_user,
+) -> None:
+    """The recovery sweep must not compete with a dispatch already under way.
+
+    Queue publication happens after the creating unit of work closes, so every
+    asynchronous run spends a moment PENDING with a ``job_id`` and no queue
+    entry -- indistinguishable, to a sweep with no age floor, from one whose
+    publication was lost. Picking such a run up starts a second dispatcher for
+    it, and only one of the two can win the PENDING -> RUNNING transition; the
+    loser goes on waiting for a run it no longer owns. That is what made
+    ``test_api_and_job_execute_through_one_per_pod_docker_sandbox`` fail
+    intermittently against the session-scoped worker.
+    """
+
+    pod_id = UUID(test_pod["id"])
+    user_id = UUID(fixed_test_user["id"])
+    now = datetime.now(timezone.utc)
+    async with db_manager.session_factory() as session:
+        run_id = await _seed_run(
+            session,
+            pod_id=pod_id,
+            user_id=user_id,
+            # Well past the age floor, so pushing ``now`` beyond that floor in
+            # the second assertion does not also expire the run and take it out
+            # of the result for the wrong reason.
+            deadline_at=now + timedelta(minutes=10),
+            job=True,
+        )
+
+    factory = SessionUnitOfWorkFactory(db_manager.session_factory)
+    async with factory() as uow:
+        assert (
+            await FunctionRunRepository(uow).list_pending_async_runs(
+                now=now,
+                min_age_seconds=FUNCTION_RUN_REPUBLISH_MIN_AGE_SECONDS,
+            )
+            == []
+        )
+    async with factory() as uow:
+        assert await FunctionRunRepository(uow).list_pending_async_runs(
+            now=now + timedelta(seconds=FUNCTION_RUN_REPUBLISH_MIN_AGE_SECONDS + 1),
+            min_age_seconds=FUNCTION_RUN_REPUBLISH_MIN_AGE_SECONDS,
+        ) == [run_id]

--- a/lemma-backend/app/modules/function/tests/e2e/test_function_execution_repository_concurrency.py
+++ b/lemma-backend/app/modules/function/tests/e2e/test_function_execution_repository_concurrency.py
@@ -349,30 +349,41 @@ async def test_a_freshly_created_async_run_is_not_republished_as_unqueued(
 
     pod_id = UUID(test_pod["id"])
     user_id = UUID(fixed_test_user["id"])
-    now = datetime.now(timezone.utc)
     async with db_manager.session_factory() as session:
         run_id = await _seed_run(
             session,
             pod_id=pod_id,
             user_id=user_id,
-            # Well past the age floor, so pushing ``now`` beyond that floor in
-            # the second assertion does not also expire the run and take it out
-            # of the result for the wrong reason.
-            deadline_at=now + timedelta(minutes=10),
+            # Well past the age floor, so advancing the clock past that floor
+            # below does not also expire the run and take it out of the result
+            # for the wrong reason.
+            deadline_at=datetime.now(timezone.utc) + timedelta(minutes=10),
             job=True,
         )
+        # Both assertions are anchored on the row's own ``created_at`` rather
+        # than on a clock read before seeding. ``created_at`` is assigned at
+        # flush, so a wall-clock anchor is only correct while seeding stays
+        # faster than the margin the second assertion leaves -- and this is the
+        # first database touch in the test, so on a loaded runner it is the
+        # slowest. Anchoring here removes the margin instead of widening it,
+        # and lands the second query exactly on the ``<=`` boundary, which is
+        # the edge worth asserting.
+        seeded = await session.get(FunctionRunModel, run_id)
+        assert seeded is not None
+        created_at = seeded.created_at
 
+    floor = timedelta(seconds=FUNCTION_RUN_REPUBLISH_MIN_AGE_SECONDS)
     factory = SessionUnitOfWorkFactory(db_manager.session_factory)
     async with factory() as uow:
         assert (
             await FunctionRunRepository(uow).list_pending_async_runs(
-                now=now,
+                now=created_at,
                 min_age_seconds=FUNCTION_RUN_REPUBLISH_MIN_AGE_SECONDS,
             )
             == []
         )
     async with factory() as uow:
         assert await FunctionRunRepository(uow).list_pending_async_runs(
-            now=now + timedelta(seconds=FUNCTION_RUN_REPUBLISH_MIN_AGE_SECONDS + 1),
+            now=created_at + floor,
             min_age_seconds=FUNCTION_RUN_REPUBLISH_MIN_AGE_SECONDS,
         ) == [run_id]

--- a/lemma-backend/app/modules/function/tests/perf/conftest.py
+++ b/lemma-backend/app/modules/function/tests/perf/conftest.py
@@ -47,6 +47,7 @@ e2e_settings = e2e_fixtures.e2e_settings
 db_manager = e2e_fixtures.db_manager
 db_session = e2e_fixtures.db_session
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org
@@ -607,6 +608,7 @@ async def _static_url(url: str) -> AsyncIterator[str]:
 
 
 __all__ = [
+    "e2e_process_clients",
     "authenticated_client",
     "backend_server",
     "db_manager",

--- a/lemma-backend/app/modules/function/tests/unit/test_function_event_handlers.py
+++ b/lemma-backend/app/modules/function/tests/unit/test_function_event_handlers.py
@@ -14,6 +14,9 @@ from app.modules.function.config import function_settings
 from app.core.infrastructure.jobs.streaq_runtime import streaq_worker
 from app.modules.function.api import dependencies
 from app.modules.function.events import handlers
+from app.modules.function.application.runtime_policy import (
+    FUNCTION_RUN_REPUBLISH_MIN_AGE_SECONDS,
+)
 from app.modules.function.domain.errors import FunctionRunQueueUnavailable
 from app.modules.function.domain.identities import function_run_job_id
 from app.modules.function.infrastructure.function_run_queue import (
@@ -68,9 +71,12 @@ async def test_reconcile_does_not_hold_db_connection_during_queue_io(
         def __init__(self, uow):
             assert uow == "uow"
 
-        async def list_pending_async_runs(self, *, now, limit):
+        async def list_pending_async_runs(self, *, now, min_age_seconds, limit):
             assert state["open"] is True
             assert limit == 100
+            # The sweep is recovery, not a second dispatcher: it must always
+            # ask for an age floor, never for every unqueued run it can see.
+            assert min_age_seconds == FUNCTION_RUN_REPUBLISH_MIN_AGE_SECONDS
             return [run_id]
 
     class _Queue:

--- a/lemma-backend/app/modules/icon/tests/e2e/conftest.py
+++ b/lemma-backend/app/modules/icon/tests/e2e/conftest.py
@@ -19,6 +19,7 @@ db_manager = e2e_fixtures.db_manager
 test_app = e2e_fixtures.test_app
 db_session = e2e_fixtures.db_session
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org

--- a/lemma-backend/app/modules/identity/tests/e2e/conftest.py
+++ b/lemma-backend/app/modules/identity/tests/e2e/conftest.py
@@ -28,6 +28,7 @@ db_manager = e2e_fixtures.db_manager
 test_app = e2e_fixtures.test_app
 db_session = e2e_fixtures.db_session
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org
@@ -74,6 +75,7 @@ __all__ = [
     "authenticated_client",
     "db_manager",
     "db_session",
+    "e2e_process_clients",
     "e2e_settings",
     "fixed_test_org",
     "fixed_test_user",

--- a/lemma-backend/app/modules/pod/tests/e2e/conftest.py
+++ b/lemma-backend/app/modules/pod/tests/e2e/conftest.py
@@ -20,6 +20,7 @@ db_manager = e2e_fixtures.db_manager
 test_app = e2e_fixtures.test_app
 db_session = e2e_fixtures.db_session
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org
@@ -32,6 +33,7 @@ __all__ = [
     "authenticated_client",
     "db_manager",
     "db_session",
+    "e2e_process_clients",
     "e2e_settings",
     "fixed_test_org",
     "fixed_test_user",

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/conftest.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/conftest.py
@@ -46,6 +46,7 @@ worker = e2e_fixtures.worker
 db_manager = e2e_fixtures.db_manager
 test_app = e2e_fixtures.test_app
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org
@@ -89,6 +90,7 @@ __all__ = [
     "configure_workspace_api_url",
     "db_manager",
     "db_session",
+    "e2e_process_clients",
     "e2e_settings",
     "fixed_test_org",
     "fixed_test_user",

--- a/lemma-backend/app/modules/schedule/tests/e2e/conftest.py
+++ b/lemma-backend/app/modules/schedule/tests/e2e/conftest.py
@@ -21,6 +21,7 @@ db_manager = e2e_fixtures.db_manager
 test_app = e2e_fixtures.test_app
 db_session = e2e_fixtures.db_session
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org
@@ -61,6 +62,7 @@ __all__ = [
     "authenticated_client",
     "db_manager",
     "db_session",
+    "e2e_process_clients",
     "e2e_settings",
     "fixed_test_org",
     "fixed_test_user",

--- a/lemma-backend/app/modules/test_support/e2e/fixtures.py
+++ b/lemma-backend/app/modules/test_support/e2e/fixtures.py
@@ -19,6 +19,7 @@ db_manager = e2e_base.db_manager
 test_app = e2e_base.test_app
 db_session = e2e_base.db_session
 async_client = e2e_base.async_client
+e2e_process_clients = e2e_base.e2e_process_clients
 fixed_test_user = e2e_base.fixed_test_user
 authenticated_client = e2e_base.authenticated_client
 fixed_test_org = e2e_base.fixed_test_org
@@ -29,6 +30,7 @@ __all__ = [
     "async_client",
     "db_manager",
     "db_session",
+    "e2e_process_clients",
     "e2e_settings",
     "fixed_test_org",
     "fixed_test_user",

--- a/lemma-backend/app/modules/test_support/e2e/runtime.py
+++ b/lemma-backend/app/modules/test_support/e2e/runtime.py
@@ -433,9 +433,16 @@ def function_image(e2e_settings) -> Generator[str, None, None]:
 
 
 @pytest_asyncio.fixture(scope="function")
-async def backend_server(test_app) -> AsyncGenerator[dict[str, str], None]:
+async def backend_server(
+    test_app, e2e_process_clients
+) -> AsyncGenerator[dict[str, str], None]:
     """Run a real backend HTTP server for Docker workspace callbacks."""
 
+    # `e2e_process_clients` is not used here -- it is requested so that pytest
+    # finalises it after this fixture, which is what keeps the per-test client
+    # shutdown from cancelling the lifespan this server is still running. Its
+    # docstring has the whole story.
+    del e2e_process_clients
     # The production worker used by queued-function E2E is session-scoped and
     # captures its explicitly configured callback URL at startup. Rebind the
     # function-scoped backend to that stable port instead of silently relying on

--- a/lemma-backend/app/modules/test_support/e2e_base.py
+++ b/lemma-backend/app/modules/test_support/e2e_base.py
@@ -217,9 +217,21 @@ async def _close_e2e_process_clients() -> None:
 
     ``httpx.ASGITransport`` intentionally does not run the application's
     lifespan. E2E requests can therefore initialize the same lazy singletons as
-    production without invoking their production shutdown hooks. Keep this
-    cleanup on the pytest async loop and call it from the canonical client
-    fixture after all dependent request fixtures have unwound.
+    production without invoking their production shutdown hooks.
+
+    Call it only through the ``e2e_process_clients`` fixture, which exists to
+    put it after every fixture that could still be using one of these -- see
+    that fixture for what goes wrong when it runs earlier.
+
+    The message bus is deliberately not in the list, and nothing else in the
+    harness closes it either. It is the one process-wide client an E2E request
+    cannot open: ``SqlAlchemyUnitOfWork`` stages domain events in the outbox
+    and a separate dispatcher publishes them, so no request path ever reaches
+    ``FastStreamRedisMessageBus._get_broker``. The only connect in this process
+    is ``app/app.py``'s lifespan, which closes it in the same ``finally``.
+    Measured rather than assumed: ``_get_broker`` is called 0 times across the
+    112 tests of ``app/modules/pod/tests/e2e``, and exactly as many times as
+    ``close`` on a suite that runs ``backend_server``.
     """
 
     from app.core.infrastructure.cache.redis_json_cache import close_redis_json_caches
@@ -738,34 +750,6 @@ def e2e_settings(test_database_url, test_redis_url, supertokens_container, worke
     return settings
 
 
-@pytest_asyncio.fixture(scope="session", autouse=True)
-async def cleanup_workspace_containers_session():
-    yield
-    # The message bus is a process-wide singleton with no per-test subscribe
-    # state (it's publish-only; the real FastStream consumers run in the
-    # separate streaq worker subprocess, unaffected by this connection's
-    # lifecycle) -- close it once per xdist worker here instead of
-    # reconnecting it on every single test's teardown via
-    # _close_e2e_process_clients.
-    from app.core.infrastructure.events.message_bus import close_message_bus
-
-    await _run_cleanup_step("close_message_bus", close_message_bus)
-    # Close exactly the contexts created by this pytest process. Broad sweeps
-    # by the shared label are unsafe even in a serial session because another
-    # independently invoked pytest process may be running at the same time.
-    _close_shared_contexts()
-
-
-@pytest_asyncio.fixture(scope="function", autouse=True)
-async def cleanup_workspace_containers_function():
-    yield
-    # Per-test: only reap this test's sandbox pods. Sweeping all lemma.e2e
-    # containers here would kill the shared session testcontainers and break every
-    # subsequent test.
-    _cleanup_e2e_workspace_containers(sandboxes_only=True)
-    await _close_e2e_process_clients()
-
-
 def _import_e2e_models() -> None:
     """Populate shared SQLAlchemy metadata before schema creation.
 
@@ -1179,17 +1163,52 @@ async def db_session(db_manager) -> AsyncGenerator:
 
 
 @pytest_asyncio.fixture(scope="function")
-async def async_client(test_app) -> AsyncGenerator["AsyncClient", None]:
+async def e2e_process_clients() -> AsyncGenerator[None, None]:
+    """Own the shutdown of the process-wide clients a test may have opened.
+
+    A fixture rather than a `finally` inside `async_client`, because *when*
+    this runs is the whole point and only a dependency edge can state it.
+    Every fixture that can leave one of these singletons open depends on this
+    one, so pytest sets it up first and finalises it last -- after all of them.
+
+    It has to be last because the singletons are not all opened the same way.
+    `async_client` opens them lazily, one HTTPX ASGI request at a time, on the
+    pytest loop. `backend_server` opens them inside the application's own
+    lifespan, running on uvicorn's lifespan task -- and some carry an anyio
+    cancel scope bound to whichever task entered it. Closing the streaq queue
+    from the wrong task cancels that scope's *host*, which is uvicorn's
+    lifespan task parked in `receive()`: the application shutdown then unwinds
+    mid-cancellation, stops partway through `app/app.py`'s core closers, and
+    prints a cancel-scope `RuntimeError` from the MCP session manager's task
+    group on the way out. Green, loud, and directly under whatever else that
+    test printed -- which is how it was once read as the cause of an unrelated
+    failure.
+
+    The noise was the visible half. The closers that never ran were the other
+    one: every test with a `backend_server` leaked the redis connection and
+    socket that `close_redis_json_caches` was cancelled in the middle of, and
+    reported them as `ResourceWarning`s nobody connected to this.
+
+    Ordered after the server, the application's own lifespan closes what it
+    opened, on the task that opened it, and this is left with nothing to do.
+    """
+
+    yield
+    await _close_e2e_process_clients()
+
+
+@pytest_asyncio.fixture(scope="function")
+async def async_client(
+    test_app, e2e_process_clients
+) -> AsyncGenerator["AsyncClient", None]:
     from httpx import ASGITransport, AsyncClient
 
+    del e2e_process_clients  # ordering only; see the fixture's docstring
     async with AsyncClient(
         transport=ASGITransport(app=test_app),
         base_url="http://testserver",
     ) as client:
-        try:
-            yield client
-        finally:
-            await _close_e2e_process_clients()
+        yield client
 
 
 @pytest_asyncio.fixture(scope="function")

--- a/lemma-backend/app/modules/test_support/perf/conftest.py
+++ b/lemma-backend/app/modules/test_support/perf/conftest.py
@@ -27,6 +27,7 @@ db_manager = e2e_fixtures.db_manager
 test_app = e2e_fixtures.test_app
 db_session = e2e_fixtures.db_session
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org

--- a/lemma-backend/app/modules/usage/tests/e2e/conftest.py
+++ b/lemma-backend/app/modules/usage/tests/e2e/conftest.py
@@ -13,6 +13,7 @@ db_manager = e2e_fixtures.db_manager
 __all__ = [
     "test_app",
     "async_client",
+    "e2e_process_clients",
     "fixed_test_user",
     "authenticated_client",
     "fixed_test_org",
@@ -27,6 +28,7 @@ __all__ = [
 
 test_app = e2e_fixtures.test_app
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org

--- a/lemma-backend/app/modules/workflow/tests/e2e/conftest.py
+++ b/lemma-backend/app/modules/workflow/tests/e2e/conftest.py
@@ -28,6 +28,7 @@ db_manager = e2e_fixtures.db_manager
 test_app = e2e_fixtures.test_app
 db_session = e2e_fixtures.db_session
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org
@@ -42,6 +43,7 @@ __all__ = [
     "configure_workspace_api_url",
     "db_manager",
     "db_session",
+    "e2e_process_clients",
     "e2e_settings",
     "fixed_test_org",
     "fixed_test_user",

--- a/lemma-backend/app/modules/workspace/tests/e2e/conftest.py
+++ b/lemma-backend/app/modules/workspace/tests/e2e/conftest.py
@@ -27,6 +27,7 @@ db_manager = e2e_fixtures.db_manager
 test_app = e2e_fixtures.test_app
 db_session = e2e_fixtures.db_session
 async_client = e2e_fixtures.async_client
+e2e_process_clients = e2e_fixtures.e2e_process_clients
 fixed_test_user = e2e_fixtures.fixed_test_user
 authenticated_client = e2e_fixtures.authenticated_client
 fixed_test_org = e2e_fixtures.fixed_test_org

--- a/scripts/check_client_structure.py
+++ b/scripts/check_client_structure.py
@@ -18,14 +18,14 @@ pointed at the client tree, and deliberately only the part of it that transfers:
 * **untyped escapes** -- same rule, `Any` and bare containers in annotations.
 
 What is left behind, so that its absence is a decision rather than an omission:
-`forbidden_imports`, `composition_deep_imports`, `core_module_imports` and
-`module_cycles` all encode the backend's modular-monolith layering -- a module
-may only be reached through its published contracts, and `app/core` may not
-depend on a module. The clients have no such architecture to protect. A CLI is
-a command tree over an SDK, and `lemma_cli.cli_core.commands.pods` importing
-`lemma_cli.cli_core.io` is the design, not a breach of it. Applying the rule
-here would have produced a large baseline of violations that nobody intends to
-ever fix, which is the fastest way to teach people that a gate means nothing.
+`forbidden_imports`, `core_module_imports` and `module_cycles` all encode the
+backend's modular-monolith layering -- a module may only be reached through its
+published contracts, and `app/core` may not depend on a module. The clients
+have no such architecture to protect. A CLI is a command tree over an SDK, and
+`lemma_cli.cli_core.commands.pods` importing `lemma_cli.cli_core.io` is the
+design, not a breach of it. Applying the rule here would have produced a large
+baseline of violations that nobody intends to ever fix, which is the fastest
+way to teach people that a gate means nothing.
 
 Written as a sibling rather than by parameterising the backend's checker: the
 thresholds and the counting rules are shared, but the *inputs* are not. The

--- a/scripts/run_codeql.sh
+++ b/scripts/run_codeql.sh
@@ -26,6 +26,8 @@ usage: run_codeql.sh [--language python|javascript-typescript] [--all] [--base <
   --base      Diff against this ref (default: origin/main, or $CODEQL_DIFF_BASE).
 
 Results are cached under .codeql/; delete that directory to force a rebuild.
+The evaluator is given half of physical memory, clamped to 4-16 GB; set
+$CODEQL_RAM_MB to override.
 USAGE
 }
 
@@ -56,6 +58,46 @@ if [[ -z "$languages" ]]; then
   languages="python javascript-typescript"
 fi
 
+# CodeQL picks its own memory budget, and the choice does not scale with the
+# machine: on macOS it settles on a Java heap of 1084 MiB no matter how much is
+# free, and `Classes/ConflictingAttributesInBaseClasses.ql` exhausts that on
+# this database. The run then dies with exit 99 after eight to ten minutes of
+# evaluation -- which reads like a broken query rather than a budget, and costs
+# the whole analysis every time. So say what the budget is instead of accepting
+# a default that cannot finish.
+#
+# `CODEQL_RAM_MB` overrides it. CI does not use this script (the security
+# workflow runs `github/codeql-action`, which sizes itself from the runner), so
+# this is a laptop-facing number.
+detect_total_ram_mb() {
+  local total_bytes total_kb
+  if total_bytes="$(sysctl -n hw.memsize 2>/dev/null)" &&
+    [[ "$total_bytes" =~ ^[0-9]+$ ]]; then
+    echo "$((total_bytes / 1048576))"
+    return
+  fi
+  if [[ -r /proc/meminfo ]]; then
+    total_kb="$(awk '/^MemTotal:/ {print $2; exit}' /proc/meminfo)"
+    if [[ "$total_kb" =~ ^[0-9]+$ ]]; then
+      echo "$((total_kb / 1024))"
+      return
+    fi
+  fi
+  echo 0
+}
+
+ram_mb="${CODEQL_RAM_MB:-}"
+if [[ -z "$ram_mb" ]]; then
+  ram_mb="$(($(detect_total_ram_mb) / 2))"
+  # Floor: comfortably above the ~1 GB default that failed, so a small machine
+  # still gets a budget rather than the one that cannot finish. Ceiling: past
+  # this the analysis gains nothing here and the rest of the machine loses a
+  # lot. A box that reports no memory at all lands on the floor, which is the
+  # safe end to be wrong on.
+  if ((ram_mb < 4096)); then ram_mb=4096; fi
+  if ((ram_mb > 16384)); then ram_mb=16384; fi
+fi
+
 changed_files="$db_root/changed-files.txt"
 mkdir -p "$db_root"
 if [[ "$scope" == "diff" ]]; then
@@ -71,7 +113,22 @@ if [[ "$scope" == "diff" ]]; then
   git -C "$repo_root" diff -U0 --diff-filter=d "$base_ref...HEAD" \
     | awk '/^\+\+\+ b\//{f=substr($0,7)} /^@@/{split($3,a,","); s=substr(a[1],2)+0; n=(a[2]==""?1:a[2]+0); if(n>0) print f":"s"-"(s+n-1)}' \
     > "$changed_files"
-  echo "Scope: $(cut -d: -f1 "$changed_files" | sort -u | wc -l | tr -d ' ') file(s) changed against $base_ref"
+  changed_count="$(cut -d: -f1 "$changed_files" | sort -u | wc -l | tr -d ' ')"
+  echo "Scope: $changed_count file(s) changed against $base_ref"
+  # The scope is a three-dot diff, which cannot see uncommitted or unstaged
+  # work. Analysing anyway spends ten minutes to report nothing and then says
+  # it passed -- a green that means "your change was never looked at". Say so
+  # and stop, which is both honest and ten minutes faster.
+  if [[ "$changed_count" == "0" ]]; then
+    cat >&2 <<NOTHING
+Nothing to analyse: no committed change against $base_ref.
+
+  This scope is the diff $base_ref...HEAD, so work that is only in the working
+  tree or the index is invisible to it. Commit first, or pass --all to analyse
+  the whole repository.
+NOTHING
+    exit 0
+  fi
 else
   : > "$changed_files"
   echo "Scope: the whole repository"
@@ -116,11 +173,12 @@ for language in $languages; do
   suite_language="$language"
   [[ "$language" == "javascript-typescript" ]] && suite_language="javascript"
 
-  echo "==> Analysing $language with security-and-quality"
+  echo "==> Analysing $language with security-and-quality (${ram_mb} MB)"
   codeql database analyze "$db" \
     "codeql/${suite_language}-queries:codeql-suites/${suite_language}-security-and-quality.qls" \
     --format=sarif-latest \
     --output="$sarif" \
+    --ram="$ram_mb" \
     --download >/dev/null
 
   python3 "$repo_root/scripts/summarize_codeql.py" \


### PR DESCRIPTION
## What changes

Five defects found while chasing one intermittent CI failure. The first three
share a blast radius — a required e2e shard failing for reasons unrelated to the
code under test — and the last two are what the chase ran into: a second CI job
failing the same way, and the local gate that was supposed to catch either.

1. **`reconcile_function_runs` stops claiming runs nobody lost.** The
   once-a-minute sweep that recovers asynchronous function runs whose queue
   publication failed now ignores runs younger than one sweep interval.
2. **E2E teardown stops cancelling the lifespan it is closing.** The per-test
   shutdown of the process-wide clients moves out of `async_client`'s `finally`
   into its own fixture, which both `async_client` and `backend_server` depend
   on.
3. **Two autouse fixtures that never ran are deleted**, and the one live step
   inside them gets a documented answer.
4. **The Agent Host records its sidecar's identity only once that sidecar has
   `exec`'d**, so the reclaim path can recognise a leftover it wrote down.
5. **`make check` can finish its CodeQL stage**, and stops reporting success
   when it looked at nothing.

---

## Why 1 — the sandbox shard's flake

`test_api_and_job_execute_through_one_per_pod_docker_sandbox` failed
intermittently in `lemma-backend e2e (sandbox)`. That shard sits behind
`Backend E2E passed`, which is required, so it blocked unrelated merges.

**The reported symptom was the wrong one.** The visible error was a cancel-scope
`RuntimeError` in teardown. That block prints on every e2e run in the shard,
passing ones included — it is defect 2, and it merely sat next to the failure.
The actual failure is 500 lines earlier:

```
test_function_sandbox_execution_e2e.py:279: in _wait_for_terminal
Failed: Timed out waiting for function run 01a077e9-… terminal.
Last value: <FunctionRunModel object at 0x…>
```

A 45-second wait for a JOB run to settle, with the row still non-terminal.

**What actually happens.** The test writes its JOB run row directly: `PENDING`,
`job_id` set, `deadline_at` in the future — which is, by construction, the row
shape production writes before publishing to the queue. It then dispatches that
run in-process. Meanwhile the session-scoped production worker is up (started by
the worker-driven tests earlier in the same shard) and its
`reconcile_function_runs` cron fires every minute. When a tick lands in the
one-to-two-second window between the row's commit and the test's own dispatch,
the sweep republishes the run, the worker consumes it, and the worker — not the
test — wins the `PENDING -> RUNNING` transition.

The test's own `dispatcher.execute` then returns early at `_resolve_dispatch`
(`run.status != PENDING`), which is why the failing run's captured output has an
`endpoint_acquired` line for the `SYNCHRONOUS` dispatch and none at all for the
`ASYNCHRONOUS` one. From there the run's settlement belongs to the worker, and
if its invocation comes back `InvocationOutcomeUnconfirmed` — a half-started
sandbox answering 5xx, which is what a cold one-per-pod container does while the
test's API run is still bringing it up on a four-vCPU runner — the dispatcher
deliberately leaves the run `RUNNING` for the deadline reconciler at
`deadline_at + 60s`. That is 240 seconds. The test waits 45.

Corroborating the window: the failing run's rows were committed at 18:10:00.0x,
within one second of a minute boundary. A 1-in-60 coincidence, or the mechanism.

**Why the fix is not test-shaped.** `list_pending_async_runs` had no notion of
age, and publication happens *after* the unit of work that writes `job_id`
commits — so every asynchronous run in production is briefly
PENDING-and-unqueued on the ordinary path, and the sweep picked those up too.
The old docstring argued this away with Streaq's deterministic-identity
deduplication, but deduplication only protects the *publication*. It does
nothing about ownership: whichever caller loses the `PENDING -> RUNNING` race
goes on waiting for an outcome it no longer owns, and `execute_run_by_id`
dispatches in-process rather than publishing, so this is reachable outside
tests. An age floor makes the sweep the recovery mechanism it claims to be, and
stops it re-publishing every in-flight run once a minute.

Worst-case recovery for a genuinely lost run goes from 60s to 120s, against a
600s job deadline.

No sleep, no retry, no `pytest.mark.flaky`, no widened `except`; the test's
45-second budget is unchanged.

## Why 2 — the teardown noise that misdirected the diagnosis

Every e2e test using `backend_server` printed this at teardown, on green runs as
well as red:

```
ERROR:      + Exception Group Traceback (most recent call last):
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
    |   File "app/app.py", line 220, in lifespan
    |   File "uvicorn/lifespan/on.py", line 137, in receive
    | asyncio.exceptions.CancelledError: Cancelled via cancel scope <id> by <Task
    |   …async_finalizer() running at pytest_asyncio/plugin.py:416>
    | RuntimeError: Attempted to exit a cancel scope that isn't the current tasks's current cancel scope
```

**The owner of the scope.** Instrumenting
`anyio._backends._asyncio.CancelScope.cancel` to dump a stack on every call
names it exactly:

```
async_finalizer (pytest_asyncio/plugin.py:416)
  e2e_base.py:1192  async_client  -> _close_e2e_process_clients()
  e2e_base.py:253                 -> _run_cleanup_step("close_streaq_job_queue", …)
  streaq_job_queue.py:156         -> lane_stack.aclose()
  streaq/worker.py:368            -> AsyncExitStack.__aexit__  -> CancelScope.cancel()
```

The streaq queue is a process-wide singleton. With a `backend_server` up it was
opened by `app/app.py`'s lifespan — on **uvicorn's lifespan task** — and the
anyio cancel scope inside it is bound to whichever task entered it. Closing it
from the fixture finalizer cancels that scope's *host*: uvicorn's lifespan task,
parked in `receive()`.

It is an ordering fault. `backend_server` is set up before `async_client` and
therefore torn down *after* it, so the client's cleanup ran while the server was
still serving the lifespan that owned the same singletons.

**Not only noise.** The cancellation lands inside `app/app.py:273 await
close_redis_json_caches()`, so every core closer after that line — redis
clients, the engine, the channel service, the datastore engine, telemetry —
never ran. Each such test leaked a redis connection and its socket, reported as
`ResourceWarning`s nobody had connected to this.

Same command, same two tests, before and after:

| | before | after |
|---|---:|---:|
| cancel-scope `RuntimeError` | 4 | 0 |
| `Cancelled via cancel scope` | 4 | 0 |
| `ResourceWarning` | 14 | 0 |

**Why a fixture and not a `finally`.** *When* the cleanup runs is the whole
point, and a dependency edge is the only thing that states it: pytest sets a
dependency up first and finalises it last. Ordered after the server, the
application's own lifespan closes what it opened, on the task that opened it,
and the fixture is left with nothing to do. Nothing is silenced — no broad
`except`, no `contextlib.suppress`, no log filter.

The fixture must be visible wherever `async_client` or `backend_server` is, so
it is exported alongside them: `e2e/fixtures.py`, twelve module e2e conftests,
two perf conftests, and the two `app/core/tests/e2e` modules that bind the
fixture set themselves.

## Why 3 — cleanup that reads as live and is not

`e2e_base.py` is not a pytest plugin; its fixtures reach tests only because each
module's `tests/e2e/conftest.py` rebinds them by name. Neither
`cleanup_workspace_containers_session` nor `cleanup_workspace_containers_function`
is rebound anywhere, so `autouse` had nothing to attach to:

```bash
cd lemma-backend && uv run pytest \
  app/modules/function/tests/e2e/test_function_execution_repository_concurrency.py \
  --fixtures -q | grep cleanup_workspace_containers   # prints nothing
```

They cost nothing at runtime and read as live cleanup — a reader tracing
teardown ordering will believe the function-scoped one runs last, which is the
opposite of true, and is exactly the detour that cost time on defect 2. Their
container reaping already lives in the root `conftest.py` as a
`pytest_runtest_teardown` hook and `pytest_sessionfinish`.

The one step the root conftest did **not** pick up is `close_message_bus`, and
it turns out to need no home. `SqlAlchemyUnitOfWork` stages domain events in the
outbox and a separate dispatcher publishes them (`set_message_bus` is a
documented no-op), so no request path reaches
`FastStreamRedisMessageBus._get_broker`; the only connect in the pytest process
is `app/app.py`'s lifespan, which closes it in the same `finally`. Measured, not
assumed — a probe counting `_get_broker` and `close`:

| suite | `_get_broker` | `close` | bus at session end |
|---|---:|---:|---|
| `pod` e2e, 112 tests, no `backend_server` | 0 | 0 | never connected |
| sandbox execution, 2 tests, `backend_server` | 2 | 2 | closed, singleton reset |

That is recorded on `_close_e2e_process_clients`, where someone asking "what
closes this in e2e?" will look. The deleted fixture's own comment called the bus
"publish-only" in tests; it is not published to at all, because the outbox sits
in front of it.

Also here: `scripts/check_client_structure.py` loses a docstring reference to
`composition_deep_imports`, a metric deleted in #640.

## Why 4 — the Agent Host never reclaims its leftover

`Desktop contracts` fails intermittently on
`a_sidecar_that_outlived_its_daemon_is_reclaimed_before_the_next_spawn`, and
the timing names the cause. The leftover it spawns is `/bin/sleep 30`, and the
failing binary is timed at **30.01s** while its siblings finish in 0.25s and
0.00s: the child was not too short-lived to reclaim, it ran to completion
untouched. `ExitStatus(unix_wait_status(0))` is `sleep` finishing normally, and
`reaper.join()` waiting all thirty seconds for it.

`record_running` read the ownership identity the instant `spawn` returned.
Between `fork` and `exec` a child is a copy of its parent, so on Linux
`/proc/<pid>/exe` names *this daemon* rather than the binary the child was
spawned to run. `reclaim_leftover` later reads the real path, sees the
executables differ, and declines to signal. `start_identity` cannot drift for a
live process, so the executable is the only field that can have differed.

The file's own docstring predicted it: "a record written mid-exec names the
pre-exec binary. That record then fails to match later, and a ledger entry that
fails to match is one this daemon declines to signal -- the safe direction".
Safe, and in this case also inert: the leftover survives every future launch,
keeps the lock on its data directory, and every launch afterwards can only log
`another Agent Host is already serving`. That is the P0 the ownership record
exists to prevent, reached through the moment it is written.

`settled_process_identity` now treats "still reporting our own image" as
not-settled and keeps polling -- the Linux counterpart of the `(sh)` placeholder
`ps` reports on macOS, which that loop already waits out -- and `record_running`
calls it instead of the bare `process_identity`, which is what holding a
`&mut Child` was for. The generic process ledger already called it, so both
ownership records are covered without a signature change.

The assertion is untouched. It still requires `status.signal().is_some()`, so it
still fails if reclaim does not kill.

## How to verify

The reconciler race was reproduced deterministically by firing
`_reconcile_unqueued_function_runs` by hand at the moment the cron would, in a
throwaway copy of the failing test with the session worker up. Before the
change it reported `published=1` and the test's own dispatch came back
`RUNNING` without ever acquiring an endpoint — the CI shape exactly. After,
`published=0` and the test owns its run.

```bash
make quality
make -C lemma-backend test-unit
make -C lemma-backend test-e2e-shard-ci SHARD=sandbox
(cd lemma-backend && uv run pytest app/modules/pod/tests/e2e -q)
(cd lemma-backend && uv run pytest app/modules/function/tests/e2e/test_function_sandbox_execution_e2e.py \
   -m "e2e and not slow and not provider and not local_cli and not indexing and not protected" -s -q)
make desktop-test && make desktop-lint
(cd desktop && cargo fmt --all -- --check)
(cd desktop && cargo test -p lemma-locald --lib agent_host -- --test-threads=1)   # x5
```

The Agent Host failure is Linux-only -- macOS goes through the `ps`/`(sh)` path
that already waits the window out -- so the local runs show only that nothing
broke. CI is what exercises the fix.

`-s` matters for the last one: without it pytest prints captured teardown output
only for *failing* tests, which is why the cancel-scope block was invisible on
green runs and surfaced exactly once, next to an unrelated failure.

## Checklist

- [x] Tests cover the behavioral change — for the age floor
      (`test_a_freshly_created_async_run_is_not_republished_as_unqueued`, plus
      the reconciler unit test now asserting the floor is always passed).
      Deliberately not for the teardown fix: the only honest assertion is "this
      run printed no cancel-scope traceback and no `ResourceWarning`", which
      needs a subprocess pytest run to observe. The before/after counts above
      are that check, run by hand.
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

No migration, no API surface, no schema change. `ix_function_runs_pending_async`
is already `(created_at, id)` under the same partial predicate, so the new
`created_at` bound is served by the existing index. Everything else is test
harness. Revert is a plain revert: the sweep goes back to picking up runs of any
age, and the deleted fixtures never executed, so restoring them changes nothing
that ran.
