### PR TITLE
Three ecosystems, three incompatibilities, one red monthly dependency PR each

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,14 +10,32 @@ version: 2
 # and the security group had nowhere to go, which is how 28 alerts accumulated
 # under a config that reads as correct.
 updates:
+  # Every directory with a `uv.lock`, which is the list `lint-lockfiles`
+  # gates on -- and it has to be, for two separate reasons.
+  #
+  # The sandbox image templates depend on `lemma-cli`, `lemma-pod-bundle` and
+  # `lemma-python` by path, and uv records a path dependency's own dependency
+  # specifiers inside the dependant's lock. So bumping a *dev* pin in
+  # `lemma-python` -- ruff, say, which no image installs -- leaves both
+  # templates' locks stale. Their Dockerfiles run `uv sync --locked`, so that
+  # is not a warning, it fails the image build; the monthly group PR died there
+  # while the lock it needed was in a directory Dependabot did not own.
+  #
+  # `tests/scenarios` has no path dependency and cannot go stale that way. It
+  # is here for the other reason: a directory Dependabot does not read is a
+  # directory a security advisory has no way to reach, which is the failure the
+  # note above about the open-PR limit describes.
   - package-ecosystem: uv
     directories:
       - /lemma-backend
       - /lemma-backend/lemma-connectors
+      - /lemma-backend/sandbox-images/templates/function-python
+      - /lemma-backend/sandbox-images/templates/workspace-python
       - /lemma-cli
       - /lemma-pod-bundle
       - /lemma-python
       - /lemma-stack
+      - /tests/scenarios
     schedule:
       interval: monthly
       time: "04:00"

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2616,6 +2616,7 @@ name = "lemma-desktop"
 version = "0.7.2"
 dependencies = [
  "base64 0.22.1",
+ "hex",
  "interprocess",
  "libc",
  "objc2",
@@ -2653,6 +2654,7 @@ version = "0.7.2"
 dependencies = [
  "base64 0.22.1",
  "getrandom 0.3.4",
+ "hex",
  "hyper 0.14.32",
  "if-addrs",
  "interprocess",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -89,6 +89,7 @@ tauri-plugin-updater = "2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 interprocess = "2.4"
+hex = "0.4"
 reqwest = { workspace = true }
 sha2 = { workspace = true }
 zip = { version = "=8.6.0", default-features = false, features = ["deflate"] }

--- a/desktop/locald/Cargo.toml
+++ b/desktop/locald/Cargo.toml
@@ -8,6 +8,7 @@ license = "AGPL-3.0-or-later"
 [dependencies]
 base64 = "0.22"
 getrandom = "0.3"
+hex = "0.4"
 hyper = { version = "0.14", features = ["client", "http1", "server", "stream", "tcp"] }
 if-addrs = "0.13"
 interprocess = "2.4"

--- a/desktop/locald/src/native_host_pack.rs
+++ b/desktop/locald/src/native_host_pack.rs
@@ -987,7 +987,7 @@ fn setup_stamp(parts: &[&str]) -> String {
         // same, and two different states would share a stamp.
         hasher.update([0u8]);
     }
-    format!("{:x}", hasher.finalize())
+    hex::encode(hasher.finalize())
 }
 
 /// A fingerprint of the migration revisions a pack carries.
@@ -1013,7 +1013,7 @@ fn migrations_fingerprint(backend_dir: &Path) -> String {
         hasher.update(name.as_bytes());
         hasher.update([0u8]);
     }
-    format!("{:x}", hasher.finalize())
+    hex::encode(hasher.finalize())
 }
 
 fn random_hex(byte_count: usize) -> io::Result<String> {

--- a/desktop/src/artifact_install.rs
+++ b/desktop/src/artifact_install.rs
@@ -709,7 +709,7 @@ fn download_artifact(
             "artifact download ended early and can be resumed",
         ));
     }
-    if downloaded != artifact.size || format!("{:x}", digest.finalize()) != artifact.sha256 {
+    if downloaded != artifact.size || hex::encode(digest.finalize()) != artifact.sha256 {
         let _ = fs::remove_file(&partial);
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -821,7 +821,7 @@ fn copy_artifact_file(
         }
     }
     output.sync_all()?;
-    if downloaded != artifact.size || format!("{:x}", digest.finalize()) != artifact.sha256 {
+    if downloaded != artifact.size || hex::encode(digest.finalize()) != artifact.sha256 {
         let _ = fs::remove_file(&partial);
         return Err(invalid(
             "local artifact SHA-256 did not match the test manifest",
@@ -887,7 +887,7 @@ fn file_sha256(path: &Path) -> io::Result<String> {
         }
         digest.update(&buffer[..count]);
     }
-    Ok(format!("{:x}", digest.finalize()))
+    Ok(hex::encode(digest.finalize()))
 }
 
 fn hash_prefix(path: &Path, bytes: u64, digest: &mut Sha256) -> io::Result<()> {
@@ -1712,7 +1712,7 @@ mod tests {
         hasher.update(bytes);
         serde_json::json!({
             "url": reqwest::Url::from_file_path(path).unwrap().to_string(),
-            "sha256": format!("{:x}", hasher.finalize()),
+            "sha256": hex::encode(hasher.finalize()),
             "size": bytes.len() as u64,
             "expanded_size": expanded,
             "format": "zip",

--- a/lemma-backend/app/core/infrastructure/events/tests/unit/test_stream_subscriber_contract.py
+++ b/lemma-backend/app/core/infrastructure/events/tests/unit/test_stream_subscriber_contract.py
@@ -90,8 +90,10 @@ def test_the_gate_actually_fails_on_a_typed_subscriber():
     )
 
     assert _offenders([typed]) == [
-        "app.example.handle_surface_webhook on 'surface_events'/"
-        "'surface-webhook-events' declares `event: SurfaceWebhookReceivedEvent`"
+        (
+            "app.example.handle_surface_webhook on 'surface_events'/"
+            "'surface-webhook-events' declares `event: SurfaceWebhookReceivedEvent`"
+        )
     ]
 
 

--- a/lemma-backend/app/core/widget_html_validation.py
+++ b/lemma-backend/app/core/widget_html_validation.py
@@ -26,8 +26,10 @@ _LINT_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
         re.compile(
             r"@lemma/pod-client|\bLemmaPodClient\b|\bcreateIframeTokenProvider\b"
         ),
-        "Uses the retired `@lemma/pod-client` SDK. Load `/public/sdk/lemma-client.js` and use "
-        "`new window.LemmaClient.LemmaClient()` instead.",
+        (
+            "Uses the retired `@lemma/pod-client` SDK. Load `/public/sdk/lemma-client.js` and use "
+            "`new window.LemmaClient.LemmaClient()` instead."
+        ),
     ),
     (
         re.compile(
@@ -41,24 +43,30 @@ _LINT_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
             r"\bsrc\s*=\s*['\"]https?://[^'\"]*/public/sdk/lemma-client\.js['\"]",
             re.IGNORECASE,
         ),
-        "Hardcodes an absolute host for the SDK script. Build the URL from "
-        "`window.__LEMMA_CONFIG__.apiUrl` (the API origin) and load it in a dynamically "
-        "created `<script>` that boots in `onload` — never the app's own subdomain.",
+        (
+            "Hardcodes an absolute host for the SDK script. Build the URL from "
+            "`window.__LEMMA_CONFIG__.apiUrl` (the API origin) and load it in a dynamically "
+            "created `<script>` that boots in `onload` — never the app's own subdomain."
+        ),
     ),
     (
         re.compile(
             r"\bsrc\s*=\s*['\"]/(?:public/sdk|sdk)/lemma-(?:client|ui)\.js['\"]",
             re.IGNORECASE,
         ),
-        "Loads an SDK bundle (`lemma-client.js` / `lemma-ui.js`) with a relative "
-        "`/public/sdk/...` src, which 404s on app subdomains (only the API origin serves "
-        "the SDK). Build the URL from `window.__LEMMA_CONFIG__.apiUrl` and boot in the "
-        "script's `onload` — see the `lemma-widget` skill's \"Loading the SDK\".",
+        (
+            "Loads an SDK bundle (`lemma-client.js` / `lemma-ui.js`) with a relative "
+            "`/public/sdk/...` src, which 404s on app subdomains (only the API origin serves "
+            "the SDK). Build the URL from `window.__LEMMA_CONFIG__.apiUrl` and boot in the "
+            "script's `onload` — see the `lemma-widget` skill's \"Loading the SDK\"."
+        ),
     ),
     (
         re.compile(r"new\s+window\.LemmaClient\s*\("),
-        "`new window.LemmaClient(...)` references the namespace object, not the constructor — "
-        "use `new window.LemmaClient.LemmaClient()`.",
+        (
+            "`new window.LemmaClient(...)` references the namespace object, not the constructor — "
+            "use `new window.LemmaClient.LemmaClient()`."
+        ),
     ),
 )
 
@@ -260,15 +268,19 @@ def validate_widget_html(html: str) -> list[str]:
 
     if not _ELEMENT_TAG.search(content):
         return [
-            "Widget content must be an HTML fragment — no element tag found. "
-            "Pass raw markup, not base64 or any other encoded form."
+            (
+                "Widget content must be an HTML fragment — no element tag found. "
+                "Pass raw markup, not base64 or any other encoded form."
+            )
         ]
 
     if _SVG_ROOT.match(_without_leading_comments(content)):
         return [
-            "Widget content must be an HTML fragment, not a standalone SVG. "
-            "Upload the image with `lemma files upload` and show it with "
-            'display_resource(type="FILE", path=...).'
+            (
+                "Widget content must be an HTML fragment, not a standalone SVG. "
+                "Upload the image with `lemma files upload` and show it with "
+                'display_resource(type="FILE", path=...).'
+            )
         ]
 
     errors = list(lint_app_html(content))

--- a/lemma-backend/app/modules/agent/infrastructure/agent_host/recovery.py
+++ b/lemma-backend/app/modules/agent/infrastructure/agent_host/recovery.py
@@ -345,6 +345,8 @@ def _unaccepted_timeout(
     return (
         AgentHostRunState.DISPATCH_UNKNOWN,
         "HOST_ACCEPTANCE_UNKNOWN",
-        "The run was delivered to Agent Host, but acceptance could not be "
-        "confirmed; Lemma did not start a fallback",
+        (
+            "The run was delivered to Agent Host, but acceptance could not be "
+            "confirmed; Lemma did not start a fallback"
+        ),
     )

--- a/lemma-backend/app/modules/agent/services/agent_context_brief.py
+++ b/lemma-backend/app/modules/agent/services/agent_context_brief.py
@@ -314,9 +314,11 @@ class AgentContextBriefBuilder:
             if not rows:
                 return [
                     "\n## Granted Resources",
-                    "- (none) — you have no resource grants yet. If a tool returns "
-                    "a permission error (403), call request_approval so the user "
-                    "can grant access or run it for you.",
+                    (
+                        "- (none) — you have no resource grants yet. If a tool returns "
+                        "a permission error (403), call request_approval so the user "
+                        "can grant access or run it for you."
+                    ),
                 ]
 
             refs: list[tuple[ResourceType, UUID]] = []
@@ -361,10 +363,12 @@ class AgentContextBriefBuilder:
 
         lines = [
             "\n## Granted Resources",
-            "These are pre-authorized for you — read, query, and act on them "
-            "directly without asking for approval. Only call request_approval if a "
-            "tool returns a permission error (403), or for an explicitly "
-            "destructive action.",
+            (
+                "These are pre-authorized for you — read, query, and act on them "
+                "directly without asking for approval. Only call request_approval if a "
+                "tool returns a permission error (403), or for an explicitly "
+                "destructive action."
+            ),
         ]
         granted = list(perms_by_ref.items())
         # Truncating a section headed "These are pre-authorized for you" without
@@ -403,8 +407,10 @@ def _more_note(shown: int, total: object, noun: str) -> list[str]:
     if not isinstance(total, int) or total <= shown:
         return []
     return [
-        f"- … and {total - shown} more {noun} not listed here "
-        f"(showing {shown}). Use your tools to list them all."
+        (
+            f"- … and {total - shown} more {noun} not listed here "
+            f"(showing {shown}). Use your tools to list them all."
+        )
     ]
 
 

--- a/lemma-backend/app/modules/agent/tests/e2e/test_agent_hermetic_journeys_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_agent_hermetic_journeys_e2e.py
@@ -1478,8 +1478,10 @@ async def test_scripted_write_todos_normalizes_malformed_and_duplicate_checkbox_
             "write_todos",
             {
                 "todos": [
-                    "<todos><item>Draft the proposal</item>"
-                    "<item>Send the invoice - done</item></todos>"
+                    (
+                        "<todos><item>Draft the proposal</item>"
+                        "<item>Send the invoice - done</item></todos>"
+                    )
                 ]
             },
             tool_call_id="todo-flattened-plan-1",

--- a/lemma-backend/app/modules/agent/tests/unit/test_capabilities.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_capabilities.py
@@ -410,9 +410,11 @@ async def test_write_todos_merges_lines_and_flips_status(monkeypatch):
         "write_todos",
         {
             "todos": [
-                "- [x] Research</td>\n"
-                "<item>- [x] Build deck</item></item>\n"
-                "<item>- [ ] Upload</item>\n</todos>"
+                (
+                    "- [x] Research</td>\n"
+                    "<item>- [x] Build deck</item></item>\n"
+                    "<item>- [ ] Upload</item>\n</todos>"
+                )
             ]
         },
     )
@@ -427,11 +429,13 @@ async def test_write_todos_merges_lines_and_flips_status(monkeypatch):
         "write_todos",
         {
             "todos": [
-                "RESEARCH DONE</item>\n"
-                "<item>DECK DONE</item>\n"
-                "<item>WRITE HTML DONE</item>\n"
-                "<item>RENDER PDF DONE</item>\n"
-                "<item>UPLOAD DONE"
+                (
+                    "RESEARCH DONE</item>\n"
+                    "<item>DECK DONE</item>\n"
+                    "<item>WRITE HTML DONE</item>\n"
+                    "<item>RENDER PDF DONE</item>\n"
+                    "<item>UPLOAD DONE"
+                )
             ]
         },
     )

--- a/lemma-backend/app/modules/agent/tests/unit/test_shared_files_prompt_block.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_shared_files_prompt_block.py
@@ -70,8 +70,10 @@ def test_other_attachments_survive_alongside_a_voice_note():
 def test_plain_files_are_unchanged_without_voice_metadata():
     blocks = _shared_files_blocks({"ingested_files": ["/me/slack/report.csv"]}, "SLACK")
     assert blocks == [
-        "The user shared files; they are saved in the pod datastore at:\n"
-        "- /me/slack/report.csv"
+        (
+            "The user shared files; they are saved in the pod datastore at:\n"
+            "- /me/slack/report.csv"
+        )
     ]
 
 

--- a/lemma-backend/app/modules/agent/tests/unit/test_speech_tools.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_speech_tools.py
@@ -386,8 +386,10 @@ async def test_transcribe_asks_for_multilingual_by_default(monkeypatch):
         [
             (
                 200,
-                b'{"results": {"channels": [{"alternatives": '
-                b'[{"transcript": "kal meeting hai"}]}]}, "metadata": {}}',
+                (
+                    b'{"results": {"channels": [{"alternatives": '
+                    b'[{"transcript": "kal meeting hai"}]}]}, "metadata": {}}'
+                ),
             )
         ],
     )

--- a/lemma-backend/app/modules/agent_surfaces/domain/setup_actions.py
+++ b/lemma-backend/app/modules/agent_surfaces/domain/setup_actions.py
@@ -139,10 +139,14 @@ def build_surface_setup_actions(
                     SurfaceSetupActionField(label="Request URL", value=webhook_url)
                 ],
                 steps=[
-                    "Messages not arriving? Open your app on api.slack.com and "
-                    "check ‘Event Subscriptions’ shows this URL as Verified.",
-                    "If you changed anything, Slack may ask you to reinstall the "
-                    "app to your workspace.",
+                    (
+                        "Messages not arriving? Open your app on api.slack.com and "
+                        "check ‘Event Subscriptions’ shows this URL as Verified."
+                    ),
+                    (
+                        "If you changed anything, Slack may ask you to reinstall the "
+                        "app to your workspace."
+                    ),
                 ],
             )
         )

--- a/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/adapter.py
+++ b/lemma-backend/app/modules/agent_surfaces/platforms/whatsapp/adapter.py
@@ -174,8 +174,10 @@ class WhatsAppSurfaceAdapter(BaseSurfaceAdapter):
         number = f"+{digits}"
         profile_url = f"{settings.frontend_url.rstrip('/')}/profile"
         return (
-            f"I don't recognise {number}. Add it as the mobile number on your "
-            f"Lemma profile and I'll know it's you: {profile_url}",
+            (
+                f"I don't recognise {number}. Add it as the mobile number on your "
+                f"Lemma profile and I'll know it's you: {profile_url}"
+            ),
             {},
         )
 

--- a/lemma-backend/app/modules/agent_surfaces/tests/e2e/mock_infrastructure.py
+++ b/lemma-backend/app/modules/agent_surfaces/tests/e2e/mock_infrastructure.py
@@ -551,16 +551,20 @@ class FakeSlackServer:
 _AAD_ERROR_RESPONSES: dict[str, tuple[str, str]] = {
     "AADSTS65001": (
         "invalid_grant",
-        "AADSTS65001: The user or administrator has not consented to use the "
-        "application with ID 'fake-teams-app-id'. Send an interactive "
-        "authorization request for this user and resource.",
+        (
+            "AADSTS65001: The user or administrator has not consented to use the "
+            "application with ID 'fake-teams-app-id'. Send an interactive "
+            "authorization request for this user and resource."
+        ),
     ),
     "AADSTS700016": (
         "unauthorized_client",
-        "AADSTS700016: Application with identifier 'fake-teams-app-id' was "
-        "not found in the directory 'fake-teams-tenant'. This can happen if "
-        "the application has not been installed by the administrator of the "
-        "tenant.",
+        (
+            "AADSTS700016: Application with identifier 'fake-teams-app-id' was "
+            "not found in the directory 'fake-teams-tenant'. This can happen if "
+            "the application has not been installed by the administrator of the "
+            "tenant."
+        ),
     ),
 }
 

--- a/lemma-backend/app/modules/datastore/infrastructure/record_bulk_delete.py
+++ b/lemma-backend/app/modules/datastore/infrastructure/record_bulk_delete.py
@@ -87,8 +87,10 @@ def prepare_bulk_deletes(
         prepared.append(
             (
                 record_id,
-                f'DELETE FROM "{ctx.schema_name}"."{ctx.table_name}" '
-                f"WHERE {' AND '.join(where_clauses)} RETURNING *",
+                (
+                    f'DELETE FROM "{ctx.schema_name}"."{ctx.table_name}" '
+                    f"WHERE {' AND '.join(where_clauses)} RETURNING *"
+                ),
                 params,
             )
         )

--- a/lemma-backend/app/modules/datastore/infrastructure/record_update_sql.py
+++ b/lemma-backend/app/modules/datastore/infrastructure/record_update_sql.py
@@ -129,8 +129,10 @@ def bulk_returning_statement(
         tuples.append(f"({', '.join(placeholders)})")
 
     return (
-        f'INSERT INTO "{ctx.schema_name}"."{ctx.table_name}" ({columns_sql}) '
-        f"VALUES {', '.join(tuples)}{conflict_sql} RETURNING *",
+        (
+            f'INSERT INTO "{ctx.schema_name}"."{ctx.table_name}" ({columns_sql}) '
+            f"VALUES {', '.join(tuples)}{conflict_sql} RETURNING *"
+        ),
         params,
     )
 
@@ -174,10 +176,12 @@ def build_update_statement(
     alias = previous_image_alias(ctx)
     primary_key = ctx.primary_key_column
     return (
-        f"UPDATE {table} AS t SET {sets} "
-        f"FROM (SELECT * FROM {table} WHERE {where_sql} FOR UPDATE) AS prev "
-        f'WHERE t."{primary_key}" = prev."{primary_key}" '
-        f'RETURNING t.*, to_jsonb(prev)::text AS "{alias}"',
+        (
+            f"UPDATE {table} AS t SET {sets} "
+            f"FROM (SELECT * FROM {table} WHERE {where_sql} FOR UPDATE) AS prev "
+            f'WHERE t."{primary_key}" = prev."{primary_key}" '
+            f'RETURNING t.*, to_jsonb(prev)::text AS "{alias}"'
+        ),
         alias,
     )
 

--- a/lemma-backend/app/modules/datastore/tests/unit/test_sql_introspection.py
+++ b/lemma-backend/app/modules/datastore/tests/unit/test_sql_introspection.py
@@ -112,21 +112,29 @@ class TestSetConfigIsRejected:
         "query",
         [
             # The reported exploit, verbatim in shape.
-            "WITH escalate AS MATERIALIZED ("
-            "SELECT set_config('app.current_user_is_pod_admin','true','true')"
-            ") SELECT t.* FROM escalate, expenses t",
+            (
+                "WITH escalate AS MATERIALIZED ("
+                "SELECT set_config('app.current_user_is_pod_admin','true','true')"
+                ") SELECT t.* FROM escalate, expenses t"
+            ),
             # Impersonating another user rather than escalating.
-            "WITH s AS MATERIALIZED ("
-            "SELECT set_config('app.current_user_id','00000000-0000-0000-0000-000000000001','true')"
-            ") SELECT t.* FROM s, expenses t",
+            (
+                "WITH s AS MATERIALIZED ("
+                "SELECT set_config('app.current_user_id','00000000-0000-0000-0000-000000000001','true')"
+                ") SELECT t.* FROM s, expenses t"
+            ),
             "SELECT set_config('app.current_user_is_pod_admin','true',true)",
             "SELECT pg_catalog.set_config('app.current_user_is_pod_admin','true',true)",
             "SELECT SET_CONFIG('app.current_user_is_pod_admin','true',true)",
             # Buried in a subquery and in a projection expression.
-            "SELECT * FROM expenses WHERE id IN ("
-            "SELECT set_config('app.current_user_is_pod_admin','true',true)::int)",
-            "SELECT id, coalesce("
-            "set_config('app.current_user_is_pod_admin','true',true), '') FROM expenses",
+            (
+                "SELECT * FROM expenses WHERE id IN ("
+                "SELECT set_config('app.current_user_is_pod_admin','true',true)::int)"
+            ),
+            (
+                "SELECT id, coalesce("
+                "set_config('app.current_user_is_pod_admin','true',true), '') FROM expenses"
+            ),
         ],
     )
     def test_set_config_rejected_anywhere_in_the_tree(self, query):

--- a/lemma-backend/app/modules/function/tests/unit/test_function_runtime_auth_boundary.py
+++ b/lemma-backend/app/modules/function/tests/unit/test_function_runtime_auth_boundary.py
@@ -3,9 +3,11 @@ from app.core.security import EXCLUDED_PATHS
 
 def test_all_function_runtime_backend_routes_use_global_auth() -> None:
     paths = (
-        "/internal/function-runtime/functions/"
-        "019ba7e8-5115-7000-8000-000000000002/artifacts/"
-        f"sha256:{'a' * 64}",
+        (
+            "/internal/function-runtime/functions/"
+            "019ba7e8-5115-7000-8000-000000000002/artifacts/"
+            f"sha256:{'a' * 64}"
+        ),
         "/internal/function-runtime/runs/019ba7e8-5115-7000-8000-000000000001:terminal",
     )
     assert all(not path.startswith(EXCLUDED_PATHS) for path in paths)

--- a/lemma-backend/app/modules/identity/infrastructure/adapters/email_adapter.py
+++ b/lemma-backend/app/modules/identity/infrastructure/adapters/email_adapter.py
@@ -87,8 +87,10 @@ class SmtpIdentityEmailAdapter(IdentityEmailPort):
             eyebrow = "Pod invitation"
             heading = f"Use {display_pod_name}."
             body = (
-                f"{inviter_name} invited you to access {display_pod_name} "
-                f"in {display_organization_name}.",
+                (
+                    f"{inviter_name} invited you to access {display_pod_name} "
+                    f"in {display_organization_name}."
+                ),
             )
             action_label = f"Open {display_pod_name}"
             details = (
@@ -110,8 +112,10 @@ class SmtpIdentityEmailAdapter(IdentityEmailPort):
             heading = f"Join {display_organization_name} on Lemma."
             body = (
                 f"{inviter_name} invited you to the {display_organization_name} workspace.",
-                "Accept the invitation to work with the team's agents, data, "
-                "automations, and apps in one place.",
+                (
+                    "Accept the invitation to work with the team's agents, data, "
+                    "automations, and apps in one place."
+                ),
             )
             action_label = "Accept invitation"
             details = (EmailDetail("Workspace", display_organization_name),)
@@ -152,8 +156,10 @@ class SmtpIdentityEmailAdapter(IdentityEmailPort):
             eyebrow="Welcome to Lemma",
             heading=f"Welcome to Lemma{first_name_suffix}.",
             body=(
-                "Your account is ready. Describe the work, connect the tools your team "
-                "already uses, and start turning the process into a system.",
+                (
+                    "Your account is ready. Describe the work, connect the tools your team "
+                    "already uses, and start turning the process into a system."
+                ),
             ),
             action=EmailAction("Open Lemma", settings.frontend_url.rstrip("/")),
             highlights=(
@@ -186,9 +192,11 @@ class SmtpIdentityEmailAdapter(IdentityEmailPort):
             eyebrow="Workspace joined",
             heading=f"You're in {display_organization_name}.",
             body=(
-                "The workspace is now available in your Lemma account. You can open "
-                "shared pods, collaborate with the team, and connect the tools needed "
-                "for your workflows.",
+                (
+                    "The workspace is now available in your Lemma account. You can open "
+                    "shared pods, collaborate with the team, and connect the tools needed "
+                    "for your workflows."
+                ),
             ),
             action=EmailAction("Open Lemma", settings.frontend_url.rstrip("/")),
             details=(EmailDetail("Active workspace", display_organization_name),),
@@ -220,8 +228,10 @@ class SmtpIdentityEmailAdapter(IdentityEmailPort):
             eyebrow="Pod join request",
             heading=f"New request to join {display_pod_name}.",
             body=(
-                f"{requester_label} requested access to {display_pod_name} in "
-                f"{display_organization_name}.",
+                (
+                    f"{requester_label} requested access to {display_pod_name} in "
+                    f"{display_organization_name}."
+                ),
                 "Review the pending request in Lemma to approve or decline it.",
             ),
             action=EmailAction("Review requests", settings.frontend_url.rstrip("/")),

--- a/lemma-backend/app/modules/pod_bundle/infrastructure/readme.py
+++ b/lemma-backend/app/modules/pod_bundle/infrastructure/readme.py
@@ -120,8 +120,10 @@ def render_readme(
     safe_icon_url = _safe_icon_url(icon_url)
     if safe_icon_url:
         lines += [
-            f'<img src="{safe_icon_url}" width="88" height="88" '
-            f'alt="{escaped_name}" />',
+            (
+                f'<img src="{safe_icon_url}" width="88" height="88" '
+                f'alt="{escaped_name}" />'
+            ),
             "",
         ]
     lines += [
@@ -152,22 +154,30 @@ def render_readme(
     lines += [
         "## 🚀 Install",
         "",
-        f"**One click** — press **Run it on Lemma** above "
-        f"(or [open the installer]({install_target(owner, repo)})).",
+        (
+            f"**One click** — press **Run it on Lemma** above "
+            f"(or [open the installer]({install_target(owner, repo)}))."
+        ),
         "",
-        "**From inside Lemma** — go to **Settings → Share & Export → Import from "
-        f"GitHub** and paste `{owner}/{repo}`.",
+        (
+            "**From inside Lemma** — go to **Settings → Share & Export → Import from "
+            f"GitHub** and paste `{owner}/{repo}`."
+        ),
         "",
-        "Everything installs into *your own* workspace — your data, your model keys. "
-        "Connectors reconnect to *your* accounts and apps rebuild for your pod on "
-        "import, so nothing is shared but the recipe.",
+        (
+            "Everything installs into *your own* workspace — your data, your model keys. "
+            "Connectors reconnect to *your* accounts and apps rebuild for your pod on "
+            "import, so nothing is shared but the recipe."
+        ),
         "",
         "---",
         "",
         '<div align="center">',
         "",
-        "<sub>Run your apps and agents. Bring your team. "
-        '<a href="https://lemma.work">Lemma</a>.</sub>',
+        (
+            "<sub>Run your apps and agents. Bring your team. "
+            '<a href="https://lemma.work">Lemma</a>.</sub>'
+        ),
         "",
         "</div>",
         "",

--- a/lemma-backend/app/modules/schedule/handlers/schedule_notification_consumer.py
+++ b/lemma-backend/app/modules/schedule/handlers/schedule_notification_consumer.py
@@ -97,8 +97,10 @@ def render_schedule_paused_email(
         heading=f"{display_name} needs attention.",
         body=(
             explanation,
-            "Review the underlying error, then re-enable the schedule when the "
-            "cause has been addressed.",
+            (
+                "Review the underlying error, then re-enable the schedule when the "
+                "cause has been addressed."
+            ),
         ),
         action=EmailAction("Review schedule", review_url),
         details=tuple(details),

--- a/lemma-backend/app/modules/test_support/test_e2e_model_registration.py
+++ b/lemma-backend/app/modules/test_support/test_e2e_model_registration.py
@@ -13,12 +13,14 @@ def test_cold_e2e_schema_includes_request_accounting() -> None:
         [
             sys.executable,
             "-c",
-            "from app.modules.test_support.e2e_base import _import_e2e_models; "
-            "from app.core.infrastructure.db.base import Base; "
-            "_import_e2e_models(); "
-            "assert {'usage_records', 'usage_limit_counters'} "
-            "<= Base.metadata.tables.keys(), 'Usage schema is incomplete'; "
-            "assert 'request_id' in Base.metadata.tables['usage_records'].columns",
+            (
+                "from app.modules.test_support.e2e_base import _import_e2e_models; "
+                "from app.core.infrastructure.db.base import Base; "
+                "_import_e2e_models(); "
+                "assert {'usage_records', 'usage_limit_counters'} "
+                "<= Base.metadata.tables.keys(), 'Usage schema is incomplete'; "
+                "assert 'request_id' in Base.metadata.tables['usage_records'].columns"
+            ),
         ],
         capture_output=True,
         text=True,

--- a/lemma-backend/scripts/check_contracts.py
+++ b/lemma-backend/scripts/check_contracts.py
@@ -103,8 +103,10 @@ def render(module: str, rows: list[tuple[str, str, str, str]]) -> str:
     lines = [
         f"# {module} contract",
         "",
-        f"What every `{module}` API operation guarantees: who may call it, what "
-        "must be true first, what changes, what it emits, and how it refuses.",
+        (
+            f"What every `{module}` API operation guarantees: who may call it, what "
+            "must be true first, what changes, what it emits, and how it refuses."
+        ),
         "",
         (
             "The product promises these serve are in "

--- a/lemma-typescript/tsconfig.json
+++ b/lemma-typescript/tsconfig.json
@@ -5,12 +5,13 @@
     "moduleResolution": "Bundler",
     "declaration": true,
     "outDir": "dist",
+    "rootDir": "src",
     "strict": true,
     "skipLibCheck": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": false
+    "esModuleInterop": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": [


### PR DESCRIPTION
## What changes

The three Dependabot pull requests that cannot go green each stop on one
incompatibility in our code, in three different ecosystems. This fixes all
three ahead of them, plus the config gap that made a fourth job fail.

- **ruff 0.16** widened `ISC004` to every collection literal. 42 implicit string
  concatenations get parentheses.
- **TypeScript 7** removed `esModuleInterop: false` and stopped inferring
  `rootDir`. The SDK's `tsconfig.json` stops using both.
- **sha2 0.11** returns a type with no `LowerHex`. Six `format!("{:x}", …)` on a
  digest become `hex::encode(…)`.
- **Dependabot** now reads all nine directories that hold a `uv.lock`, not six.

Nothing here changes behaviour. Every hash produces the same digits, the SDK
emits byte-identical output, and the Python edits are parentheses.

## Why

The three failures look alike from the outside — a monthly dependency PR, a red
check — and are unrelated underneath. Left alone, each one blocks its ecosystem's
routine *and* security updates, because both groups share one open-PR slot.

**#634, backend quality.** ruff 0.15.11 → 0.16.5. `ISC004` used to fire only on
some collections and now fires on all of them, so `make lint` failed with 42
errors in code nobody in that PR had touched. It failed at the *first* gate,
which hid the next one.

**#634, sandbox images.** The image build runs `uv sync --locked` and the lock
was stale. Both sandbox templates depend on `lemma-cli`, `lemma-pod-bundle` and
`lemma-python` by path, and uv records a path dependency's own specifiers inside
the dependant's lock — so bumping `ruff` in `lemma-python`, a dev tool no image
installs, was enough to strand them. `lint-lockfiles` already gates on these two
directories; Dependabot never relocked them because `dependabot.yml` listed six
directories and there are nine.

**#587, TypeScript SDK and frontend.** TypeScript 5.9.3 → 7.0.2. Both are config
errors, so `tsc` refuses before reading any source. The frontend job failed with
the same two messages because `prelint` → `prepare:lemma-sdk` builds the SDK.

**#437, desktop.** sha2 0.10.9 → 0.11.0 moved `finalize()` from
`generic_array::GenericArray` to `hybrid_array::Array`, and only the former
implements `LowerHex`. Two of the six sites are in `lemma-locald`, which is why
cargo stopped before reaching the other four in `lemma-desktop`.

The four remaining Dependabot PRs — #592, #593, #594, #436 — are already green.

## How to verify

Each fix was checked against the version that breaks it *and* the version on
`main`, since this lands before the bumps do.

```bash
# ruff — the pinned 0.15.11 and the 0.16.5 that #634 installs
cd lemma-backend
uv run ruff check app migrations scripts                    # All checks passed!
uvx ruff@0.16.5 check app migrations scripts                # All checks passed!
uvx ruff@0.16.5 format --check app migrations scripts \
    sandbox_runtime load_tests standalone_app.py sitecustomize.py   # 2527 formatted

# TypeScript — pinned 5.9.3, then 7.0.2, then #587's own dependency tree
cd lemma-typescript && npm ci && npm run build               # exit 0
npx -p typescript@7.0.2 tsc -p tsconfig.json --noEmit        # clean
git checkout <587> -- package.json package-lock.json && npm ci && npm run build   # exit 0

# Rust — #437's manifests, then main's
cd desktop && cargo check --workspace --all-targets          # compiles; only the
                                                             # tauri sidecar step
                                                             # is left, as always
make desktop-lint                                            # clippy clean
make desktop-test                                            # see note below

# Everything else
make quality                                                 # ✓ quality gates pass
```

`make quality` passes end to end. `make desktop-lint` is clean and the balloon
policy is intact.

**On `make desktop-test`:** one test, `permission_flow_e2e::
an_approved_request_lets_the_agent_finish_its_turn`, timed out at 90s on the
first run — while clippy, `make quality` and an `npm ci` were running beside it.
Re-run alone it passes in 2.11s. It is in `lemma-agent-host`, which this change
does not touch and does not compile differently.

**On the TypeScript emit:** `tsc` output under the pinned 5.9.3 is byte-identical
before and after the tsconfig change (`diff -rq`, no differences), and
`npm run build` regenerated the committed `public/lemma-ui.js` with no diff. 7.0.2
accepts `esModuleInterop: true` and rejects only `false`, so setting it rather
than deleting it keeps both compilers on the same interop semantics instead of
silently flipping 5.x to the opposite default.

**On the hex encoding:** `hex::encode` takes anything `AsRef<[u8]>` and emits the
same lowercase digits `{:x}` did. That matters at the two sites in
`artifact_install.rs` that compare against a published `sha256` — an encoding
that differed would reject every download. `hex` was already in `Cargo.lock` via
`agent-host`, so this adds two dependency edges and no crate.

## Checklist

- [x] Tests cover the behavioral change — there is no behavioural change; the
      existing suites are the check, and they were run against both the current
      and the bumped dependency versions
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **API surface** — no route, schema or SDK API change. The SDK's compiler
      configuration changed; its emitted output did not.
- [x] **Security** — nothing logged, returned or queued; the digest comparisons
      in `artifact_install.rs` produce identical strings, verified above
- [x] **Rollback** — plain revert, four independent commits, no migration and no
      persisted state

## What this does not do

It does not merge the Dependabot PRs or vouch for the rest of their contents. It
removes the blockers I could reproduce and fix:

- **#437** now compiles against its own manifests — `base64` 0.23, `getrandom`
  0.4 and `rusqlite` 0.40 turned out to need nothing from us.
- **#587**'s SDK job builds against its own dependency tree. The frontend's Next
  build under those 51 bumps is *not* verified — CI never reached it, and neither
  did I.
- **#634** still needs `uv lock` run in the two sandbox template directories.
  The config change fixes the *next* group PR, not the open one, because
  Dependabot relocks a directory when it updates something there and #634 was
  opened before it owned them.

Also unaddressed, and a decision rather than an oversight: the routine groups are
`patterns: ["*"]`, which the comment at the top of `dependabot.yml` says is
deliberate — majors included. That is why one monthly PR carries a ruff minor
that is really a lint-rule change, a TypeScript major, and a hashing-library
major all at once. Excluding `version-update:semver-major` from the routine
groups would make these PRs mergeable without a human in the loop, and would move
majors to deliberate upgrades. That is a policy call, so it is not in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Developer Experience**
  - Improved TypeScript project configuration for source-directory handling and module interoperability.
  - Expanded automated dependency-update coverage for sandbox templates and test scenarios.

- **Maintenance**
  - Standardized digest encoding while preserving existing verification results.
  - Reformatted backend messages, SQL statements, email content, and test fixtures without changing their behavior.

- **Tests**
  - Updated assertions and fixtures to reflect consistent response formatting and shared-file message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->