### PR TITLE
The journal concurrency test was reporting a deadlock that was not happening

### DIFF
--- a/desktop/agent-host/src/journal.rs
+++ b/desktop/agent-host/src/journal.rs
@@ -1300,6 +1300,23 @@ mod tests {
         );
     }
 
+    /// Interleaved journal writes and reads, in a child process.
+    ///
+    /// The property is that two threads contending on the journal both make
+    /// progress. A lock cycle shows up in the first handful of interleavings,
+    /// not the two hundredth, so the loop is short on purpose: every write
+    /// commits under `synchronous = FULL`, which is an fsync each, and the cost
+    /// of those is what separates a developer SSD from a CI runner's virtual
+    /// disk. At 200 iterations this test spent over 30 seconds on Windows CI
+    /// and was killed by its own timeout, which then reported a deadlock that
+    /// was not happening.
+    const CONCURRENCY_ITERATIONS: usize = 50;
+
+    /// Generous because of what it is for. A real deadlock never finishes, so
+    /// waiting longer only delays a true failure; waiting too little invents
+    /// one. The child completes in well under a second on a developer machine.
+    const CONCURRENCY_BUDGET: Duration = Duration::from_secs(120);
+
     #[tokio::test]
     async fn concurrent_checkpoints_and_event_reads_make_progress() {
         // A SQLite mutex deadlock cannot be cancelled by a Tokio timeout on
@@ -1308,17 +1325,33 @@ mod tests {
         if std::env::var_os("LEMMA_JOURNAL_CONCURRENCY_CHILD").is_none() {
             let thread = std::thread::current();
             let test_name = thread.name().expect("the test runner names its thread");
+            // The child records how far it got. Without it a timeout cannot
+            // tell "wedged on the third write" from "still going, just slow",
+            // and those want opposite fixes.
+            let progress = TempDir::new().unwrap();
+            let progress_path = progress.path().join("iterations");
             let mut child = tokio::process::Command::new(std::env::current_exe().unwrap())
                 .args(["--exact", test_name, "--nocapture"])
                 .env("LEMMA_JOURNAL_CONCURRENCY_CHILD", "1")
+                .env("LEMMA_JOURNAL_CONCURRENCY_PROGRESS", &progress_path)
                 .kill_on_drop(true)
                 .spawn()
                 .unwrap();
-            if let Ok(status) = tokio::time::timeout(Duration::from_secs(30), child.wait()).await {
+            if let Ok(status) = tokio::time::timeout(CONCURRENCY_BUDGET, child.wait()).await {
                 assert!(status.unwrap().success());
             } else {
                 child.kill().await.unwrap();
-                panic!("concurrent journal operations deadlocked");
+                let reached = std::fs::read_to_string(&progress_path)
+                    .ok()
+                    .and_then(|text| text.trim().parse::<usize>().ok())
+                    .unwrap_or(0);
+                panic!(
+                    "concurrent journal operations did not finish within \
+                     {CONCURRENCY_BUDGET:?}: the writer completed {reached} of \
+                     {CONCURRENCY_ITERATIONS} iterations. Stuck near zero is a lock \
+                     cycle; most of the way through is a slow disk, and the budget is \
+                     what needs changing."
+                );
             }
             return;
         }
@@ -1326,9 +1359,10 @@ mod tests {
         journal
             .accept_start(target, &command, &spec, "codex", "1.0")
             .unwrap();
+        let progress_path = std::env::var_os("LEMMA_JOURNAL_CONCURRENCY_PROGRESS");
         std::thread::scope(|scope| {
             scope.spawn(|| {
-                for _ in 0..200 {
+                for iteration in 0..CONCURRENCY_ITERATIONS {
                     journal
                         .checkpoint(
                             target,
@@ -1348,10 +1382,16 @@ mod tests {
                             JsonMap::new(),
                         )
                         .unwrap();
+                    // Best effort: this is diagnostics for a failure that has
+                    // already happened, and a failed write here must not turn a
+                    // passing run into a failing one.
+                    if let Some(path) = progress_path.as_ref() {
+                        let _ = std::fs::write(path, (iteration + 1).to_string());
+                    }
                 }
             });
             scope.spawn(|| {
-                for _ in 0..200 {
+                for _ in 0..CONCURRENCY_ITERATIONS {
                     journal.pending_events(target, 256).unwrap();
                     journal.pending_control(target).unwrap();
                 }
@@ -1359,7 +1399,7 @@ mod tests {
         });
         assert_eq!(
             journal.pending_events(target, 256).unwrap()[0].events.len(),
-            200
+            CONCURRENCY_ITERATIONS
         );
     }
 


### PR DESCRIPTION
## What changes

`journal::tests::concurrent_checkpoints_and_event_reads_make_progress` stops
failing on Windows CI, and stops claiming a deadlock when what happened was a
slow disk.

## Why

The test has failed **two of the last three** Windows runs since #631 landed,
always with:

```
panicked at agent-host\src\journal.rs:1321:17:
concurrent journal operations deadlocked
test result: FAILED. 162 passed; 1 failed ... finished in 31.38s
```

It is not deadlocking. That string is the test's own `tokio::time::timeout`
branch, so it fires identically whether there is a lock cycle or the runner was
merely slow — and the evidence says slow:

- The child process completes in **0.3–1.4s** on a developer machine (measured,
  5 runs). A deadlock does not finish in 0.3s.
- It could not hang this code anyway. Every journal operation opens its own
  `Connection` with `busy_timeout(5s)`, so a lock conflict returns `SQLITE_BUSY`
  and panics with a SQLite error rather than blocking. There is no shared Rust
  mutex to cycle on.
- `connection()` sets `synchronous = FULL`, so every commit pays an fsync. 200
  iterations is 400 committed writes — nothing on an SSD, tens of seconds on a
  CI runner's virtual disk. The binary reporting `finished in 31.38s` against a
  30s budget is the child consuming all of it.

So the timeout was hiding a cost problem behind a message that reads like a
diagnosis.

## The fix

Three changes, none of which weaken the property under test:

| | Before | After |
|---|---|---|
| Iterations | 200 | 50 |
| Budget | 30s | 120s |
| On timeout | asserts "deadlocked" | reports iterations completed |

- **50 iterations.** The property is that two contending threads both make
  progress. A lock cycle shows up in the first handful of interleavings, not the
  two hundredth. Locally this takes the test from ~0.3s to ~0.10s.
- **120s budget.** A real deadlock never finishes, so waiting longer only delays
  a true failure; waiting too little invents one.
- **The child records how far it got**, and the panic reports it. A timeout
  could not previously tell "wedged on the third write" from "still going, just
  slow", and those want opposite fixes. The message now points at the evidence
  instead of asserting a conclusion.

Roughly fifteen times the headroom on the runner that was failing, and a failure
that explains itself next time.

## How to verify

```bash
cd desktop
cargo test -p lemma-agent-host --lib concurrent_checkpoints_and_event_reads_make_progress
cargo clippy -p lemma-agent-host --all-targets -- -D warnings
cargo test -p lemma-agent-host --lib
```

printed, on macOS:

```
test result: ok. 1 passed; 0 failed ... finished in 0.11s     (5 consecutive runs, all pass)
clippy: Finished `dev` profile                                 (clean under -D warnings)
test result: ok. 168 passed; 0 failed
```

The progress reporting was checked directly by running the child half and
reading the file it writes:

```
child exit=0
progress file contains: 50
```

Windows is where it mattered and where I could not run it; the arithmetic is
that the same runner which needed >30s for 200 iterations should need roughly a
quarter of that for 50, against a budget four times larger.

## The other two failures from the same window

Checked, and they do **not** share a cause — worth saying so explicitly rather
than filing them together:

- `live_unicode_text_survives_a_lost_ack_without_repeating_the_prompt`
  (`tests/support/mod.rs:876`, macOS, failed after 90.70s) is the same *class* —
  a wall-clock budget on an async workflow — but a different mechanism, an
  in-process 50ms poll loop. It already dumps published events, `start_sent`,
  event kinds and log tails on failure, so it is self-diagnosing. It has not
  recurred since.
- `every_harness_opens_and_resumes_in_the_same_saved_directory`
  (`tests/acp_process_e2e.rs:235`, Windows, failed in 0.30s) is not a timeout at
  all — it is `assert_eq!(session["params"]["cwd"], cwd.to_str().unwrap())`
  failing fast, which on Windows points at path canonicalization rather than
  timing. It has not recurred either, and it failed on #631's own branch, so it
  may already be fixed.

Neither is touched here.

## Checklist

- [x] Tests cover the behavioral change — the change *is* to a test; validated by
      running it repeatedly and by exercising the new diagnostic path directly
- [x] Lint, typecheck, and architecture gates pass locally — `cargo clippy -p
      lemma-agent-host --all-targets -- -D warnings` clean, `cargo fmt --check`
      clean, 168/168 lib tests pass

Not applicable: no migrations, no API surface, no SDK regeneration, no version
bumps, no production code changed — the diff is one test in `#[cfg(test)]`.

## Compatibility and rollback notes

Test-only. Reverting restores the previous flakiness and nothing else.

## Why this is its own pull request

It blocks any branch that merges `main` to satisfy the up-to-date requirement,
including mine (#650). A required check that fails for unrelated reasons trains
people to hit rerun without reading, which is the exact failure mode
`scripts/check_ci_aggregators.py` and the notify-failure lane were built to
prevent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved concurrency stress-test diagnostics by recording progress and reporting whether a timeout is likely due to a lock cycle or slow storage.
  - Increased the test timeout budget while reducing iteration count to make test failures more actionable and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->