### PR TITLE
The pod's organization was decided on this screen and never shown on it

### DIFF
--- a/lemma-frontend/components/pod/create-pod-screen.test.tsx
+++ b/lemma-frontend/components/pod/create-pod-screen.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+
+type TestOrg = { id: string; name: string };
+
+const state = vi.hoisted(() => ({
+    organizations: [] as TestOrg[],
+}));
+
+vi.mock("@/components/dashboard/org-context", () => ({
+    useOrganization: () => ({
+        organizations: state.organizations,
+        currentOrg: state.organizations[0] ?? null,
+        setCurrentOrg: vi.fn(),
+        isLoading: false,
+        hasSession: true,
+    }),
+}));
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("@tanstack/react-query", () => ({
+    useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+vi.mock("@/lib/sdk/lemma-client", () => ({
+    getLemmaClient: () => ({ pods: { create: vi.fn() } }),
+}));
+
+import { CreatePodScreen } from "./create-pod-screen";
+
+function render(organizations: TestOrg[]) {
+    state.organizations = organizations;
+    return renderToStaticMarkup(<CreatePodScreen remixSource={null} />);
+}
+
+describe("CreatePodScreen", () => {
+    it("names the organization the pod will land in when there is more than one", () => {
+        const markup = render([
+            { id: "org-1", name: "Acme" },
+            { id: "org-2", name: "Side project" },
+        ]);
+
+        expect(markup).toContain('aria-label="Organization"');
+        expect(markup).toContain("Acme");
+    });
+
+    it("leaves out the selector when there is nowhere else the pod could go", () => {
+        const markup = render([{ id: "org-1", name: "Acme" }]);
+
+        expect(markup).not.toContain('aria-label="Organization"');
+    });
+});

--- a/lemma-frontend/components/pod/create-pod-screen.tsx
+++ b/lemma-frontend/components/pod/create-pod-screen.tsx
@@ -16,6 +16,13 @@ import { WaitingScreen } from "@/components/shared/loading";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { ArrowRight, Boxes } from "@/components/ui/icons";
 import {
   buildNewPodConversationHref,
@@ -37,6 +44,11 @@ import { getLemmaClient } from "@/lib/sdk/lemma-client";
  * The chips are the same start paths as first run, minus the form. They create
  * the pod under the name in the field, then seed that composer with the start
  * of a sentence — see `startPathComposerLaunch`.
+ *
+ * A pod is created in an organization, and the screen used to pick that
+ * silently: whichever org happened to be active. Someone in two orgs could only
+ * find out afterwards, from the pod they had already made. The org now sits in
+ * the name row, so the destination is visible next to the decision.
  */
 
 const DEFAULT_POD_NAME = "Untitled pod";
@@ -54,7 +66,7 @@ type PendingAction = ComposerStartPath | "create" | "templates";
 export function CreatePodScreen({ remixSource: rawRemixSource }: { remixSource: string | null }) {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { currentOrg, isLoading } = useOrganization();
+  const { currentOrg, setCurrentOrg, organizations, isLoading } = useOrganization();
   const remixSource = normalizeRemixSource(rawRemixSource);
   const [name, setName] = useState(
     remixSource ? `Remix of ${remixSourceLabel(remixSource)}` : "",
@@ -165,12 +177,50 @@ export function CreatePodScreen({ remixSource: rawRemixSource }: { remixSource: 
               );
             }}
           >
-            <Label
-              htmlFor="create-pod-name"
-              className="text-sm text-[var(--text-secondary)]"
-            >
-              Name
-            </Label>
+            <div className="flex items-center justify-between gap-3">
+              <Label
+                htmlFor="create-pod-name"
+                className="text-sm text-[var(--text-secondary)]"
+              >
+                Name
+              </Label>
+              {/* One org is not a choice, so it gets no control — the pod can
+                  only land in the one place. The selector appears the moment
+                  there is somewhere else it could go, and switching here
+                  switches the active org, which is what opening the new pod
+                  would have done anyway. */}
+              {organizations.length > 1 ? (
+                <div className="flex min-w-0 items-center gap-2">
+                  <span className="text-xs text-[var(--text-tertiary)]">in</span>
+                  <Select
+                    value={currentOrg?.id}
+                    disabled={Boolean(pending)}
+                    onValueChange={(organizationId) => {
+                      const organization = organizations.find(
+                        (candidate) => candidate.id === organizationId,
+                      );
+                      if (organization) setCurrentOrg(organization);
+                    }}
+                  >
+                    <SelectTrigger
+                      aria-label="Organization"
+                      className="setup-detail-choice h-8 w-auto max-w-56 gap-2 px-2.5 text-sm font-normal"
+                    >
+                      <SelectValue placeholder="Choose organization">
+                        {currentOrg?.name}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                      {organizations.map((organization) => (
+                        <SelectItem key={organization.id} value={organization.id}>
+                          {organization.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              ) : null}
+            </div>
             <Input
               id="create-pod-name"
               autoFocus


### PR DESCRIPTION
## What changes

Creating a pod puts it in an organization, and `/create-pod` picked that silently — whichever org happened to be active. The name row now shows it: `Name` on the left, `in <org>` on the right, as a compact select in the same chip skin as the start paths below it. It governs the whole screen, not just the button: the four start chips and "Explore templates" create through the same call.

It renders only when there is more than one org to choose from. One org is not a choice, so it gets no control — the pod can only land in the one place either way. Choosing an org calls `setCurrentOrg`, so the selection *is* the active org rather than a second screen-local notion of "current"; opening the new pod switches the active org to the pod's org a moment later anyway ([layout.tsx](https://github.com/lemma-work/lemma-platform/blob/main/lemma-frontend/app/pod/%5Bid%5D/layout.tsx)), which would have overwritten a local-only choice.

Both "New pod" entry points — the home sidebar row and the pod switcher menu — route to `/create-pod`, so this one screen covers pod creation.

## Why

Someone who belongs to two organizations got no say and no signal. The first they learn of the destination is the pod they have already made, in the wrong org, with members who should not see it.

## How to verify

```bash
cd lemma-frontend
npx vitest run components/pod/create-pod-screen.test.tsx
npx eslint components/pod/create-pod-screen.tsx components/pod/create-pod-screen.test.tsx
npm run design:audit:changed
```

- vitest: `Test Files 1 passed (1) / Tests 2 passed (2)` — the selector names the org when there are two, and is absent when there is one.
- eslint: no output.
- design audit: all informational and advisory counts `0`.

By hand, signed in on `/create-pod` with an account in two or more orgs: the row reads `Name … in <org>`, switching it changes where `Create pod`, the start chips and `Explore templates` land, and the same account with a single org sees the row unchanged from before.

Typecheck caveat: `tsc --noEmit` in my worktree resolves `lemma-sdk` from the main checkout's `node_modules`, so 34 pre-existing errors appear in unrelated files (usage, connectors, hooks). None are in the two files here — `tsc ... | grep create-pod` is empty. CI runs it against a freshly built SDK.

## Checklist

- [x] Tests cover the behavioral change
- [ ] Lint, typecheck, and architecture gates pass locally — lint and the design audit pass; typecheck as described above

## Compatibility and rollback notes

Frontend render change only. No API, schema, or SDK surface is touched; reverting the commit is the whole rollback.

## Known gap, not addressed here

With no organization at all, submitting still fails with a toast telling you to create or join one, and offers no way to do either. That dead end predates this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pod creation now displays an organization selector when multiple organizations are available.
  - The selected organization is shown alongside the pod name and can be changed before creation.
  - The organization selector is temporarily disabled while the pod is being created.
  - Users with only one organization continue to see a streamlined pod creation experience without the selector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->