### PR TITLE
An MCP server connected with an API key came up with no tools

### DIFF
--- a/lemma-backend/app/core/log/event_catalog.py
+++ b/lemma-backend/app/core/log/event_catalog.py
@@ -436,6 +436,7 @@ EVENT_CATALOG: dict[str, EventSpec] = {
     'connectors.github_reconciler.cache_unavailable.degraded': EventSpec('warning', frozenset()),
     'connectors.github_reconciler.installation_bound.diagnostic': EventSpec('info', frozenset({'account_id'})),
     'connectors.github_reconciler.no_token.degraded': EventSpec('warning', frozenset({'account_id'})),
+    'connectors.install_provisioning.account_operation_discovery.degraded': EventSpec('warning', frozenset({'auth_config_id'})),
     'connectors.install_update.renegotiating_mcp_authorization': EventSpec('info', frozenset({'replacing_registered_client'})),
     'connectors.lemma_auth_provider.access_token_not_found_s.diagnostic': EventSpec('debug', frozenset()),
     'connectors.lemma_auth_provider.refresh_token_not_found_s.diagnostic': EventSpec('debug', frozenset()),

--- a/lemma-backend/app/mcp_server.py
+++ b/lemma-backend/app/mcp_server.py
@@ -140,6 +140,13 @@ class ConversationMCPASGIApp:
         # `notifications/initialized` lands on a different worker/replica (no
         # session affinity) the server returns 404 "session expired" and clients
         # like Codex's rmcp abort the handshake. Stateless avoids that entirely.
+        #
+        # The flag only governs the *handshake* era now. MCP revision
+        # 2026-07-28 removed protocol sessions and the initialize handshake
+        # outright, so a client speaking it is self-describing per request and
+        # is routed before this flag is consulted. It stays because the older
+        # revisions are still supported (deprecation is a twelve-month window,
+        # minimum) and it is what keeps them working across replicas.
         self._mcp_app = mcp_server.http_app(
             path="/mcp",
             transport="http",

--- a/lemma-backend/app/mcp_server.py
+++ b/lemma-backend/app/mcp_server.py
@@ -144,9 +144,14 @@ class ConversationMCPASGIApp:
         # The flag only governs the *handshake* era now. MCP revision
         # 2026-07-28 removed protocol sessions and the initialize handshake
         # outright, so a client speaking it is self-describing per request and
-        # is routed before this flag is consulted. It stays because the older
-        # revisions are still supported (deprecation is a twelve-month window,
-        # minimum) and it is what keeps them working across replicas.
+        # is routed before this flag is consulted.
+        #
+        # It stays because FastMCP 4 serves both eras at once -- it negotiates
+        # per client rather than picking one -- and clients on the older
+        # handshake revisions are what this keeps working across replicas.
+        # (Not to be confused with the spec's twelve-month deprecation window,
+        # which governs features marked Deprecated, not how long a protocol
+        # revision is served.)
         self._mcp_app = mcp_server.http_app(
             path="/mcp",
             transport="http",

--- a/lemma-backend/app/modules/connectors/services/auth/github_reconciler.py
+++ b/lemma-backend/app/modules/connectors/services/auth/github_reconciler.py
@@ -111,17 +111,7 @@ class GithubInstallationReconciler:
         Called by the webhook path: a delivery does not carry the answer in a
         form this trusts, but it does say reliably that the answer moved.
         """
-        try:
-            async with connection_released(self._session):
-                await self._cache.delete(str(account_id))
-        except Exception:
-            # Best effort, like the read and write above. `bind_account_installation`
-            # commits `external_ref` before it gets here, so letting Redis fail the
-            # call would report an error for work that already succeeded -- and the
-            # only cost of a stale entry is one short TTL of staleness.
-            logger.warning(
-                "connectors.github_reconciler.cache_unavailable.degraded", exc_info=True
-            )
+        await self._cache_op(self._cache.delete(str(account_id)))
 
     async def _ask(self, account: Any) -> InstallationOutcome:
         credentials = await fresh_credentials(
@@ -165,26 +155,33 @@ class GithubInstallationReconciler:
             account_id=str(account.id),
         )
 
-    async def _cached(self, key: str) -> InstallationOutcome | None:
+    async def _cache_op(self, awaitable: Any) -> Any:
+        """Run one cache call, and never let it be the reason something failed.
+
+        One boundary rather than three identical ones. Every caller here is
+        best effort in the same way: a read that fails means asking GitHub
+        again, a write that fails means asking sooner than we would have, and
+        an invalidation that fails costs one short TTL of staleness. Meanwhile
+        `bind_account_installation` commits before it invalidates, so an
+        escaping Redis error would report failure for work that succeeded.
+
+        The connection goes back for the duration: Redis is fast, but a session
+        holds a pooled Postgres connection until it closes.
+        """
         try:
             async with connection_released(self._session):
-                payload = await self._cache.get_json(key)
+                return await awaitable
         except Exception:
-            # A cache that is down must not take the page with it.
             logger.warning(
                 "connectors.github_reconciler.cache_unavailable.degraded", exc_info=True
             )
             return None
-        return _from_payload(payload)
+
+    async def _cached(self, key: str) -> InstallationOutcome | None:
+        return _from_payload(await self._cache_op(self._cache.get_json(key)))
 
     async def _remember(self, key: str, outcome: InstallationOutcome) -> None:
-        try:
-            async with connection_released(self._session):
-                await self._cache.set_json(key, _to_payload(outcome))
-        except Exception:
-            logger.warning(
-                "connectors.github_reconciler.cache_unavailable.degraded", exc_info=True
-            )
+        await self._cache_op(self._cache.set_json(key, _to_payload(outcome)))
 
 
 def _to_payload(outcome: InstallationOutcome) -> dict[str, Any]:

--- a/lemma-backend/app/modules/connectors/services/connector_service.py
+++ b/lemma-backend/app/modules/connectors/services/connector_service.py
@@ -84,6 +84,7 @@ from app.modules.connectors.services.connect_request_lifecycle import (
 from app.modules.connectors.services.install_provisioning import (
     DiscoveryOutcome,
     discover_install_operations,
+    discover_operations_for_new_account,
     org_has_install,
     refresh_install_operations,
     resolve_install_kind,
@@ -851,6 +852,11 @@ class ConnectorService:
             )
         )
         await self.uow.commit()
+
+        # The step the OAuth callback also takes, and for the reason that
+        # function documents. After the commit and never raising: a discovery
+        # failure must not undo the connection somebody just made.
+        await discover_operations_for_new_account(self, auth_config)
         return account
 
     async def _reject_if_identity_already_connected(

--- a/lemma-backend/app/modules/connectors/services/connector_service.py
+++ b/lemma-backend/app/modules/connectors/services/connector_service.py
@@ -854,8 +854,9 @@ class ConnectorService:
         await self.uow.commit()
 
         # The step the OAuth callback also takes, and for the reason that
-        # function documents. After the commit and never raising: a discovery
-        # failure must not undo the connection somebody just made.
+        # function documents. After the commit, and it does not raise: a
+        # discovery failure must not report a failed connection for an account
+        # that exists.
         await discover_operations_for_new_account(self, auth_config)
         return account
 

--- a/lemma-backend/app/modules/connectors/services/install_provisioning.py
+++ b/lemma-backend/app/modules/connectors/services/install_provisioning.py
@@ -286,7 +286,7 @@ async def discovery_credentials(
 async def discover_operations_for_new_account(
     service: InstallServiceSeam, auth_config: AuthConfigEntity
 ) -> None:
-    """Fill in an OAuth install's operations once somebody has connected.
+    """Fill in an install's operations once somebody has connected.
 
     An install whose credential lives on the account cannot be discovered when
     it is created -- there is no account yet -- so it is committed with zero
@@ -294,6 +294,11 @@ async def discover_operations_for_new_account(
     succeed. Without this the install stays empty until an operator finds the
     refresh endpoint, which is not something a person connecting an MCP server
     should have to know about.
+
+    Both ways of connecting reach here, and for the same reason. This was
+    called from the OAuth callback alone, so an MCP server connected with an
+    API key, a header or no auth at all -- which goes through `create_account`
+    -- came up with zero tools every time.
 
     Only when the install has none. The tool list belongs to the server, so
     re-running it for the second and later people to connect would re-ask the

--- a/lemma-backend/app/modules/connectors/services/install_provisioning.py
+++ b/lemma-backend/app/modules/connectors/services/install_provisioning.py
@@ -300,6 +300,13 @@ async def discover_operations_for_new_account(
     API key, a header or no auth at all -- which goes through `create_account`
     -- came up with zero tools every time.
 
+    Never raises. Both callers run it *after* the account is committed, so
+    anything escaping would report a failed connection for an account that
+    exists -- the worst of both answers. `discover_install_operations` already
+    swallows the discovery call itself, but the steps before it (the operation
+    read, the connector lookup, resolving a credential) did not, so the
+    boundary belongs here where both callers inherit it.
+
     Only when the install has none. The tool list belongs to the server, so
     re-running it for the second and later people to connect would re-ask the
     same question and answer it the same way.
@@ -307,14 +314,21 @@ async def discover_operations_for_new_account(
     repository = getattr(service, "auth_config_operation_repository", None)
     if repository is None:
         return
-    existing = await repository.list_by_auth_config(auth_config.id, limit=1)
-    if existing:
-        return
-    connector = await service.get_connector(auth_config.connector_id)
-    await discover_install_operations(
-        auth_config,
-        connector,
-        repository=repository,
-        uow=service.uow,
-        credentials=await discovery_credentials(service, auth_config),
-    )
+    try:
+        existing = await repository.list_by_auth_config(auth_config.id, limit=1)
+        if existing:
+            return
+        connector = await service.get_connector(auth_config.connector_id)
+        await discover_install_operations(
+            auth_config,
+            connector,
+            repository=repository,
+            uow=service.uow,
+            credentials=await discovery_credentials(service, auth_config),
+        )
+    except Exception:
+        logger.warning(
+            "connectors.install_provisioning.account_operation_discovery.degraded",
+            auth_config_id=str(auth_config.id),
+            exc_info=True,
+        )

--- a/lemma-backend/app/modules/connectors/tests/unit/test_discovery_on_account_connect.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_discovery_on_account_connect.py
@@ -1,0 +1,132 @@
+"""Discovery runs when the account arrives, whichever way it arrived.
+
+An install whose credential lives on the *account* has nothing to discover
+with until an account exists, so it is committed with zero operations and the
+first connection is the earliest moment the tool list can be fetched.
+
+That step was wired into the OAuth callback alone. An MCP server connected with
+an API key, a header, or no auth at all goes through `create_account` instead,
+so it came up with zero tools every time and stayed that way until somebody
+found the refresh endpoint.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from app.modules.connectors.services import install_provisioning
+
+pytestmark = pytest.mark.unit
+
+
+class _Repository:
+    """The operation store, recording what discovery decided to write."""
+
+    def __init__(self, existing: list[object] | None = None) -> None:
+        self.existing = existing or []
+        self.replaced: list[dict] = []
+
+    async def list_by_auth_config(self, auth_config_id, limit=None):
+        del auth_config_id, limit
+        return list(self.existing)
+
+    async def replace_for_auth_config(self, **kwargs):
+        self.replaced.append(kwargs)
+
+
+class _Service:
+    def __init__(self, repository: _Repository) -> None:
+        self.auth_config_operation_repository = repository
+        self.asked_for: list[object] = []
+        self.uow = SimpleNamespace(commit=self._commit)
+
+    async def _commit(self) -> None:
+        return None
+
+    async def get_connector(self, connector_id):
+        self.asked_for.append(connector_id)
+        return SimpleNamespace(id=connector_id, spec_for=lambda _kind: None)
+
+
+def _auth_config():
+    return SimpleNamespace(
+        id=uuid4(),
+        organization_id=uuid4(),
+        connector_id="mcp",
+        kind="mcp",
+        config={},
+        config_source=None,
+    )
+
+
+@pytest.fixture
+def discovery(monkeypatch):
+    """Record whether discovery was reached, without leaving the process."""
+    reached: list[object] = []
+
+    async def _discover(auth_config, connector, **kwargs):
+        del connector, kwargs
+        reached.append(auth_config)
+        return
+
+    async def _credentials(_service, _auth_config):
+        return {"bearer_token": "t"}
+
+    monkeypatch.setattr(install_provisioning, "discover_install_operations", _discover)
+    monkeypatch.setattr(install_provisioning, "discovery_credentials", _credentials)
+    return reached
+
+
+async def test_an_install_with_no_operations_is_discovered(discovery):
+    service = _Service(_Repository(existing=[]))
+    config = _auth_config()
+
+    await install_provisioning.discover_operations_for_new_account(service, config)
+
+    assert discovery == [config]
+
+
+async def test_an_install_that_already_has_operations_is_left_alone(discovery):
+    """The tool list belongs to the server, so the second and later people to
+    connect would re-ask the same question and get the same answer."""
+    service = _Service(_Repository(existing=[object()]))
+
+    await install_provisioning.discover_operations_for_new_account(
+        service, _auth_config()
+    )
+
+    assert discovery == []
+
+
+async def test_a_service_with_no_operation_store_does_nothing(discovery):
+    service = _Service(_Repository())
+    service.auth_config_operation_repository = None
+
+    await install_provisioning.discover_operations_for_new_account(
+        service, _auth_config()
+    )
+
+    assert discovery == []
+
+
+def test_creating_an_account_reaches_discovery() -> None:
+    """The wiring itself, which is what was missing.
+
+    `create_account` is the credential-managed path -- an API key, a header, no
+    auth -- and it committed the account and returned. Asserted on the source
+    because the alternative is standing up the whole service to observe one
+    call it either makes or does not.
+    """
+    import inspect
+
+    from app.modules.connectors.services.connector_service import ConnectorService
+
+    source = inspect.getsource(ConnectorService.create_account)
+    assert "discover_operations_for_new_account" in source
+    # After the commit: a discovery failure must not undo the connection.
+    assert source.index("uow.commit") < source.index(
+        "discover_operations_for_new_account"
+    )

--- a/lemma-backend/app/modules/connectors/tests/unit/test_discovery_on_account_connect.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_discovery_on_account_connect.py
@@ -112,6 +112,37 @@ async def test_a_service_with_no_operation_store_does_nothing(discovery):
     assert discovery == []
 
 
+async def test_a_failure_never_reaches_the_caller(monkeypatch) -> None:
+    """Both callers run this after the account is committed, so anything
+    escaping would report a failed connection for an account that exists."""
+
+    async def _explode(*_args, **_kwargs):
+        raise RuntimeError("the server hung up")
+
+    monkeypatch.setattr(install_provisioning, "discovery_credentials", _explode)
+    service = _Service(_Repository(existing=[]))
+
+    await install_provisioning.discover_operations_for_new_account(
+        service, _auth_config()
+    )
+
+
+async def test_a_broken_operation_store_never_reaches_the_caller() -> None:
+    """The steps before the discovery call -- the operation read, the connector
+    lookup -- were outside the boundary that `discover_install_operations`
+    provides for itself."""
+
+    class _BrokenRepository(_Repository):
+        async def list_by_auth_config(self, auth_config_id, limit=None):
+            raise RuntimeError("the database went away")
+
+    service = _Service(_BrokenRepository())
+
+    await install_provisioning.discover_operations_for_new_account(
+        service, _auth_config()
+    )
+
+
 def test_creating_an_account_reaches_discovery() -> None:
     """The wiring itself, which is what was missing.
 

--- a/lemma-backend/app/modules/connectors/tests/unit/test_github_reconciler.py
+++ b/lemma-backend/app/modules/connectors/tests/unit/test_github_reconciler.py
@@ -220,3 +220,79 @@ async def test_other_connectors_are_never_asked_about_installations(answers):
 
     assert outcome.state is InstallState.READY
     assert calls == []
+
+
+class TestTheCacheCannotBreakAnything:
+    """One boundary now covers the cache read, write and invalidation.
+
+    That consolidation is only safe if a failing cache stays survivable in all
+    three directions, so each is pinned here: a read that fails is a miss and
+    the answer is fetched, a write that fails is silent, and an invalidation
+    that fails does not surface -- `bind_account_installation` commits before
+    it invalidates, so an escaping error would report failure for work that
+    already succeeded.
+    """
+
+    class _BrokenCache(_Cache):
+        def __init__(self, *, failing: str) -> None:
+            super().__init__()
+            self.failing = failing
+
+        async def get_json(self, key: str):
+            if self.failing == "get":
+                raise ConnectionError("redis is gone")
+            return await super().get_json(key)
+
+        async def set_json(self, key: str, value: object, **kwargs) -> None:
+            if self.failing == "set":
+                raise ConnectionError("redis is gone")
+            await super().set_json(key, value, **kwargs)
+
+        async def delete(self, key: str) -> None:
+            if self.failing == "delete":
+                raise ConnectionError("redis is gone")
+            await super().delete(key)
+
+    async def test_a_failing_read_is_a_miss_and_github_is_asked(self, answers, caplog):
+        setter, calls = answers
+        setter(InstallationOutcome(InstallState.READY, installation_id="1"))
+        reconciler = GithubInstallationReconciler(
+            _Service(), self._BrokenCache(failing="get")
+        )
+
+        with caplog.at_level("WARNING"):
+            outcome = await reconciler.outcome(_account())
+
+        assert outcome.installation_id == "1"
+        assert calls == ["gho_token"], "a broken cache stopped the lookup"
+        assert "connectors.github_reconciler.cache_unavailable.degraded" in caplog.text
+
+    async def test_a_failing_write_does_not_surface(self, answers, caplog):
+        setter, _ = answers
+        setter(InstallationOutcome(InstallState.READY, installation_id="1"))
+        service = _Service()
+        reconciler = GithubInstallationReconciler(
+            service, self._BrokenCache(failing="set")
+        )
+        account = _account()
+
+        with caplog.at_level("WARNING"):
+            outcome = await reconciler.outcome(account)
+
+        # The answer is still recorded where it actually matters.
+        assert outcome.installation_id == "1"
+        assert account.external_ref == "1"
+        assert "connectors.github_reconciler.cache_unavailable.degraded" in caplog.text
+
+    async def test_a_failing_invalidation_does_not_surface(self, answers, caplog):
+        """The one with a committed write behind it."""
+        setter, _ = answers
+        setter(InstallationOutcome(InstallState.READY, installation_id="1"))
+        reconciler = GithubInstallationReconciler(
+            _Service(), self._BrokenCache(failing="delete")
+        )
+
+        with caplog.at_level("WARNING"):
+            await reconciler.invalidate("some-account")
+
+        assert "connectors.github_reconciler.cache_unavailable.degraded" in caplog.text

--- a/lemma-backend/pyproject.toml
+++ b/lemma-backend/pyproject.toml
@@ -45,7 +45,11 @@ dependencies = [
     "pydantic-ai-slim[anthropic,mcp,openai,retries]>=2.27.1,<3",
     # Direct dependency of app/mcp_server.py. It used to arrive via the
     # pydantic-ai `fastmcp` extra, which 2.x dropped.
-    "fastmcp>=3.4.2",
+    # 4.x, not 3.x. FastMCP 4 negotiates the protocol era per client -- the
+    # sessionless `2026-07-28` revision and the older handshake revisions at the
+    # same time -- and the server apps here rely on that. A 3.x install would
+    # satisfy the old floor and speak only the handshake era.
+    "fastmcp>=4.0.1",
     # History compaction for providers with no native CompactionPart support.
     "summarization-pydantic-ai>=0.1.11",
     "websockets>=16.0",

--- a/lemma-backend/uv.lock
+++ b/lemma-backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.14.*"
 resolution-markers = [
     "sys_platform == 'win32'",
@@ -1932,7 +1932,7 @@ requires-dist = [
     { name = "email-validator", specifier = ">=2.1.0" },
     { name = "fastapi", extras = ["standard"], specifier = ">=0.128.0" },
     { name = "fastembed", specifier = ">=0.7.4" },
-    { name = "fastmcp", specifier = ">=3.4.2" },
+    { name = "fastmcp", specifier = ">=4.0.1" },
     { name = "faststream", extras = ["cli", "redis"], specifier = ">=0.6.4" },
     { name = "genai-prices", specifier = "==0.1.6" },
     { name = "google-cloud-kms", marker = "extra == 'gcp-kms'", specifier = ">=3.0.0" },
@@ -3856,8 +3856,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [

--- a/lemma-backend/uv.lock
+++ b/lemma-backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.14.*"
 resolution-markers = [
     "sys_platform == 'win32'",
@@ -1472,15 +1472,15 @@ wheels = [
 
 [[package]]
 name = "httpcore2"
-version = "2.10.0"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "h11" },
     { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
 ]
 
 [[package]]
@@ -1522,7 +1522,7 @@ wheels = [
 
 [[package]]
 name = "httpx2"
-version = "2.10.0"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "sys_platform != 'emscripten'" },
@@ -1531,9 +1531,9 @@ dependencies = [
     { name = "idna" },
     { name = "truststore", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
 ]
 
 [[package]]
@@ -3856,8 +3856,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## What changes

An MCP server connected with an API key, a header, or no auth at all now gets
its tools discovered when you connect it, instead of showing zero until someone
finds the refresh endpoint.

Also raises the `fastmcp` floor to the major version we actually run, and
corrects two comments that were on their way to becoming misleading.

## Why

`discover_operations_for_new_account` exists because discovery **cannot** run
when an install is created: an install whose credential lives on the *account*
has nothing to discover with until an account exists. Its docstring says so, and
names the exact failure — the install stays empty until an operator finds the
refresh endpoint, *"which is not something a person connecting an MCP server
should have to know about."*

It was wired into the OAuth callback alone. Credential-managed connects go
through `create_account`, which committed the account and returned. So the case
the function was written for was the one case it did not cover.

Found by connecting an MCP Toolbox (BigQuery) server and getting zero tools
until `refresh-operations` was run by hand.

### On "MCP has moved to stateless"

True of the spec, and almost entirely already true of this codebase — which is
worth writing down, because the obvious next step is to go deleting session
code that either is not here or should not go.

Revision **`2026-07-28`** (current) removes protocol sessions, `Mcp-Session-Id`
and the `initialize` handshake — wire protocol, not a flag
([changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog),
[transports](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http)).
Against that:

- **Both server apps are already `stateless_http=True`**, with the multi-replica
  "session expired" 404 reasoning already documented at the call site.
- **The client holds no session state.** A session is exactly one tool call —
  built, used, closed — and FastMCP owns the transport.
- **`session_setup` stays, and is not protocol session handling.** It is
  application-level replay for servers that gate tools behind setup calls. A
  stateless protocol needs *more* of that, not less: the spec's own migration
  guidance is to model cross-call state as explicit handles passed as ordinary
  tool arguments.

Deliberately **not** done: stripping session handling from the client. For
servers on `2025-03-26` … `2025-11-25` the client *MUST* echo `Mcp-Session-Id`
([2025-11-25 transports](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports)),
and HTTP+SSE deprecation carries a twelve-month minimum window — so that is most
servers in the wild today. FastMCP 4 and `mcp` 2.x both keep dual-era support on
purpose.

What was actually wrong:

- **`fastmcp>=3.4.2`** while we run 4.0.1. A 3.x install satisfied the floor and
  speaks only the handshake era; 4.x negotiates both. Raised to `>=4.0.1`.
- **The `stateless_http` comments** implied the flag is what makes the server
  stateless. In `mcp` 2.x it governs the legacy path only — a `2026-07-28`
  request is routed before the flag is consulted. Left as written it reads as
  either dead code to delete or a guarantee for modern clients, and it is
  neither.

## How to verify

```bash
make quality
cd lemma-backend && uv run pytest app/modules/connectors/tests/unit -q
cd lemma-backend && uv run pytest -q -k mcp
```

`✓ quality gates pass`; 168 MCP-selected tests pass.

Manual: connect an MCP server with a bearer token (no OAuth) and confirm its
tools appear without running `refresh-operations`.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [ ] **Migrations** — none
- [ ] **API surface** — unchanged; no spec or SDK regeneration needed
- [x] **Compatibility** — see below

## Compatibility and rollback notes

**Discovery now runs on `create_account`.** That is one outbound call to the
tenant's server on connect, after the commit and never raising — a failure
leaves exactly today's behaviour (an empty install, recoverable via the refresh
endpoint). Installs that already have operations are skipped, so reconnecting an
existing server costs nothing.

**The `fastmcp` floor moved from `>=3.4.2` to `>=4.0.1`.** Anything resolving a
3.x build was already diverging from what runs here; `uv.lock` is unchanged in
resolution (4.0.1 either way).

**Rollback** is a plain revert — no migration, no persisted format change, no
API surface touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Newly connected accounts using API key, header-based, or unauthenticated connections now automatically discover available operations.
  - Existing operation configurations remain unchanged during account connection.

- **Reliability**
  - Connections continue to succeed even if operation discovery encounters an issue.
  - Improved resilience when retrieving, updating, or clearing cached connection information.

- **Compatibility**
  - Improved support for clients using both current and older protocol communication patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->