### PR TITLE
The health probe waited behind the pull it was checking on

### DIFF
--- a/desktop/local-runtime/macos-vz/Sources/LemmaServiceBridge/RequestGate.swift
+++ b/desktop/local-runtime/macos-vz/Sources/LemmaServiceBridge/RequestGate.swift
@@ -1,0 +1,58 @@
+import Dispatch
+
+/// How many guest requests may be in flight, and what happens to the rest.
+///
+/// Extracted from the guest bridge because it is the whole of a defect and
+/// none of it needs a virtual machine to exercise.
+///
+/// The bridge used to hold one guest connection and serve one request at a
+/// time. Sharing a channel is why: two requests on one connection can hand
+/// each caller the other's reply. Serialising fixed that and bought something
+/// worse -- `core.images` may run for seventy-five minutes, because a first
+/// install really can take that long on a slow line, and every later request
+/// waited behind it. Including the health probe, which has five seconds. The
+/// host concluded its own guest had died in the middle of the pull it had
+/// asked for, tore down the database forwarders, and restarted everything.
+///
+/// A connection per request removes the reply-mixing without the queue. This
+/// is what keeps that from becoming unbounded: a bound well under the guest's
+/// own limit of 32 connections, and a queue for the rest, so a client waits
+/// rather than opening a connection nothing will read.
+public final class RequestGate<Client> {
+    private let limit: Int
+    private var waiting: [Client] = []
+    private var active = 0
+
+    public init(limit: Int) {
+        precondition(limit > 0, "a gate that admits nobody is a closed door")
+        self.limit = limit
+    }
+
+    /// Queue a client, and hand back everything that may start now.
+    ///
+    /// Returns rather than calls, so the caller decides which queue the work
+    /// runs on and this stays free of one.
+    public func admit(_ client: Client) -> [Client] {
+        waiting.append(client)
+        return drain()
+    }
+
+    /// One request finished; hand back whatever that lets in.
+    public func finish() -> [Client] {
+        precondition(active > 0, "finished a request that was never admitted")
+        active -= 1
+        return drain()
+    }
+
+    public var inFlight: Int { active }
+    public var queued: Int { waiting.count }
+
+    private func drain() -> [Client] {
+        var starting: [Client] = []
+        while active < limit, !waiting.isEmpty {
+            starting.append(waiting.removeFirst())
+            active += 1
+        }
+        return starting
+    }
+}

--- a/desktop/local-runtime/macos-vz/Sources/LemmaVZ/main.swift
+++ b/desktop/local-runtime/macos-vz/Sources/LemmaVZ/main.swift
@@ -296,11 +296,27 @@ private func unixListener(path: String) throws -> Int32 {
 private final class GuestBridge {
     private let socketDevice: VZVirtioSocketDevice
     private let listener: Int32
-    // Reuse the control channel and serialize requests so each caller receives
-    // its own reply, including after another caller abandons a slow request.
-    private var guestConnection: VZVirtioSocketConnection?
-    private var pendingClients: [Int32] = []
-    private var requestActive = false
+    // A guest connection per client, not one channel served one request at a
+    // time.
+    //
+    // Sharing a channel is why this used to serialise: two requests on one
+    // connection can hand each caller the other's reply, and a caller that
+    // abandons a slow request leaves an unread response for whoever is next.
+    // Serialising fixed that and introduced a worse one. `core.images` is
+    // allowed seventy-five minutes because a first install really can take
+    // that long on a slow line, and while it held the channel every later
+    // request waited behind it -- including the health probe, which has five
+    // seconds. So the host concluded its own guest had died in the middle of
+    // the pull it had asked for. The guest has served concurrent connections
+    // since it stopped answering them from its accept loop; this was the last
+    // place that funnelled them back into one.
+    //
+    // Bounded, and well under the guest's own limit of 32: a client that
+    // cannot be served yet waits rather than opening a connection nothing will
+    // read. That policy lives in `RequestGate`, in the library target, because
+    // it is the whole of the defect and none of it needs a virtual machine to
+    // exercise.
+    private let gate = RequestGate<Int32>(limit: 8)
 
     init(
         socketDevice: VZVirtioSocketDevice,
@@ -321,30 +337,26 @@ private final class GuestBridge {
                 }
                 _ = fcntl(client, F_SETFD, FD_CLOEXEC)
                 DispatchQueue.main.async { [self] in
-                    pendingClients.append(client)
-                    processNext()
+                    start(gate.admit(client))
                 }
             }
         }
     }
 
-    private func processNext() {
+    private func start(_ clients: [Int32]) {
         dispatchPrecondition(condition: .onQueue(.main))
-        guard !requestActive, !pendingClients.isEmpty else { return }
-        requestActive = true
-        let client = pendingClients.removeFirst()
-        if let connection = guestConnection {
-            transfer(client: client, connection: connection)
-            return
-        }
-        socketDevice.connect(toPort: guestPort) { [self] result in
-            switch result {
-            case .failure(let error):
-                fputs("lemma-vz: guest connect failed: \(error.localizedDescription)\n", stderr)
-                fail(client: client)
-            case .success(let connection):
-                guestConnection = connection
-                transfer(client: client, connection: connection)
+        for client in clients {
+            socketDevice.connect(toPort: guestPort) { [self] result in
+                switch result {
+                case .failure(let error):
+                    fputs(
+                        "lemma-vz: guest connect failed: \(error.localizedDescription)\n",
+                        stderr
+                    )
+                    fail(client: client)
+                case .success(let connection):
+                    transfer(client: client, connection: connection)
+                }
             }
         }
     }
@@ -357,12 +369,12 @@ private final class GuestBridge {
             } catch {
                 fputs("lemma-vz: client read failed: \(error.localizedDescription)\n", stderr)
                 close(client)
-                finishRequest(keepGuestConnection: true)
+                finishRequest(connection)
                 return
             }
             guard !request.isEmpty else {
                 close(client)
-                finishRequest(keepGuestConnection: true)
+                finishRequest(connection)
                 return
             }
             do {
@@ -377,19 +389,21 @@ private final class GuestBridge {
                 do {
                     try writeAll(client, response)
                 } catch {
-                    // A timed-out bridge caller may close its Unix socket while
-                    // the guest operation finishes. The persistent guest
-                    // channel remains valid and must not be discarded.
+                    // A timed-out bridge caller may close its Unix socket
+                    // while the guest operation finishes. Its answer has
+                    // nowhere to go, which is not an error worth failing over:
+                    // the guest did the work, and this connection is this
+                    // request's alone to close either way.
                     fputs("lemma-vz: client write failed: \(error.localizedDescription)\n", stderr)
                 }
                 close(client)
-                finishRequest(keepGuestConnection: true)
+                finishRequest(connection)
             } catch {
                 fputs("lemma-vz: guest bridge failed: \(error.localizedDescription)\n", stderr)
                 let payload = "{\"ok\":false,\"error\":{\"code\":\"guest_unavailable\",\"message\":\"Guest control channel is unavailable\",\"retryable\":true,\"status_code\":503}}\n"
                 _ = try? writeAll(client, Data(payload.utf8))
                 close(client)
-                finishRequest(keepGuestConnection: false)
+                finishRequest(connection)
             }
         }
     }
@@ -398,18 +412,23 @@ private final class GuestBridge {
         let payload = "{\"ok\":false,\"error\":{\"code\":\"guest_unavailable\",\"message\":\"Private guest is unavailable\",\"retryable\":true,\"status_code\":503}}\n"
         _ = try? writeAll(client, Data(payload.utf8))
         close(client)
-        requestActive = false
-        processNext()
+        finishRequest(nil)
     }
 
-    private func finishRequest(keepGuestConnection: Bool) {
+    /// One request is over: close its guest connection and admit the next.
+    ///
+    /// Closing unconditionally is the difference this rework buys. The shared
+    /// channel had to be kept alive across a caller that gave up -- discarding
+    /// it would have cost every other caller too -- so a failure had to decide
+    /// whether the channel was still good. A connection owned by one request
+    /// is simply finished with when that request is.
+    private func finishRequest(_ connection: VZVirtioSocketConnection?) {
+        // On the main queue, which is the VM's: every other Virtualization
+        // object here is touched there, and closing a connection from the
+        // worker that just used it would be the one exception.
         DispatchQueue.main.async { [self] in
-            if !keepGuestConnection {
-                guestConnection?.close()
-                guestConnection = nil
-            }
-            requestActive = false
-            processNext()
+            connection?.close()
+            start(gate.finish())
         }
     }
 }

--- a/desktop/local-runtime/macos-vz/Tests/LemmaServiceBridgeTests/RequestGateTests.swift
+++ b/desktop/local-runtime/macos-vz/Tests/LemmaServiceBridgeTests/RequestGateTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import LemmaServiceBridge
+
+final class RequestGateTests: XCTestCase {
+    /// The defect this exists to prevent: one slow request stopping the rest.
+    ///
+    /// The guest bridge served one request at a time over one shared channel.
+    /// `core.images` is allowed seventy-five minutes, and while it held that
+    /// channel the health probe -- five seconds -- waited behind it, so the
+    /// host decided its guest had died during the pull it had asked for.
+    func testASlowRequestDoesNotHoldUpTheOnesBehindIt() {
+        let gate = RequestGate<String>(limit: 8)
+
+        let slow = gate.admit("core.images")
+        XCTAssertEqual(slow, ["core.images"])
+
+        // The probe starts immediately, with the pull still in flight.
+        XCTAssertEqual(gate.admit("health"), ["health"])
+        XCTAssertEqual(gate.inFlight, 2)
+        XCTAssertEqual(gate.queued, 0)
+    }
+
+    /// Concurrency without a bound is the other way to lose a guest.
+    func testBeyondTheLimitClientsWaitRatherThanConnect() {
+        let gate = RequestGate<Int>(limit: 2)
+
+        XCTAssertEqual(gate.admit(1), [1])
+        XCTAssertEqual(gate.admit(2), [2])
+        XCTAssertEqual(gate.admit(3), [], "the third has to wait")
+        XCTAssertEqual(gate.inFlight, 2)
+        XCTAssertEqual(gate.queued, 1)
+
+        XCTAssertEqual(gate.finish(), [3], "and start as soon as there is room")
+        XCTAssertEqual(gate.inFlight, 2)
+        XCTAssertEqual(gate.queued, 0)
+    }
+
+    /// Order matters: the request that has waited longest goes first.
+    func testWaitingClientsAreAdmittedInTheOrderTheyArrived() {
+        let gate = RequestGate<Int>(limit: 1)
+        _ = gate.admit(1)
+        _ = gate.admit(2)
+        _ = gate.admit(3)
+
+        XCTAssertEqual(gate.finish(), [2])
+        XCTAssertEqual(gate.finish(), [3])
+        XCTAssertEqual(gate.finish(), [])
+        XCTAssertEqual(gate.inFlight, 0)
+    }
+}


### PR DESCRIPTION
## What changes

The macOS bridge no longer serialises every guest request behind one shared
connection. A long guest operation stops blocking the health probe that is
checking on it.

## Why

The bridge held one guest connection and served one request at a time.
Sharing a channel is why it serialised: two requests on one connection can
hand each caller the other's reply, and a caller that abandons a slow
request leaves an unread response for whoever is next.

That fix bought a worse problem. `core.images` is allowed seventy-five
minutes — because a first install really can take that long on a slow
line — and while it held the channel every later request waited behind it.
Including the health probe, which has five seconds. So during the pull it
had itself asked for, the host concluded its own guest had died.

The guest stopped answering from its accept loop some time ago and has
served concurrent connections since. This was the last place funnelling
them back into one.

A connection per request removes the reply-mixing without the queue, and
each request closes its own — the shared channel had to survive a caller
that gave up, so every failure path had to decide whether the channel was
still good, and now none of them do.

## How to verify

The bound that keeps per-request connections from becoming unbounded lives
in `RequestGate`, in the library target rather than the executable, because
it is the whole of the defect and none of it needs a virtual machine:

```bash
swift test --package-path desktop/local-runtime/macos-vz
```

Three cases, each failing without the change: a slow request does not hold
up the ones behind it, clients beyond the limit wait rather than opening a
connection nothing will read, and waiting clients are admitted in arrival
order.

On the machine, with the rebuilt helper swapped into an installed
candidate, the stack came up and reported ready *while* a sandbox image was
still downloading:

```
{"event":"sandbox-images","state":"downloading",...}
{"event":"done","cmd":"start","ok":true}
{"event":"status","status":"running","ready":true,...}
{"event":"sandbox-images","state":"ready",...}
```

Frontend served 200 (24,540 bytes), and no connection churn: the
`guest connect failed` count — the normal boot retries — stayed at 18 over
45 seconds of running.

**What I could not measure, and why.** I tried to time concurrent guest
requests against that installation and got no speedup. The reason is not
this change: the guest in that release predates the commit that made
`guestd` serve connections from threads rather than from its accept loop,
so it serialises regardless of what the bridge does. Measuring the fix
end to end needs a guest built from `main` or later; the unit tests and the
concurrent-start evidence above are what this rests on until then.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Rollback** — one commit, macOS-only, no data or schema involvement


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Multiple local service requests can now be processed concurrently, improving responsiveness when several requests are active.
  - Up to eight requests may run at once; additional requests wait in an orderly queue until capacity becomes available.

- **Reliability**
  - Request handling now cleans up each completed or failed request independently, reducing the risk that one request blocks others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->