### PR TITLE
Three decisions nothing could test, and the Dock icon that did nothing

### DIFF
--- a/desktop/locald/src/daemon.rs
+++ b/desktop/locald/src/daemon.rs
@@ -2861,6 +2861,56 @@ mod tests {
             .collect()
     }
 
+    /// The one arm that erases somebody's work asks first, and had no test.
+    ///
+    /// `local.reset-data` removes the pods, databases and workspaces of an
+    /// installation. The only thing between a stray or malformed request and
+    /// all of it is a literal confirmation string, and nothing checked that
+    /// the check was there -- so it could have been dropped, or its spelling
+    /// changed on one side, and every test in this file would still pass.
+    ///
+    /// Wrong-but-present is the case worth having: an empty confirmation is
+    /// the obvious one to guard, and a client that sends a *different* phrase
+    /// is the one a refactor produces.
+    #[test]
+    fn erasing_local_data_refuses_anything_but_its_exact_confirmation() {
+        let (_root, daemon) = daemon();
+
+        for (label, request) in [
+            (
+                "no confirmation at all",
+                json!({"cmd": "local.reset-data", "id": "r1"}),
+            ),
+            (
+                "an empty confirmation",
+                json!({"cmd": "local.reset-data", "id": "r1", "confirm": ""}),
+            ),
+            (
+                "a different phrase",
+                json!({"cmd": "local.reset-data", "id": "r1", "confirm": "reset-local-Data"}),
+            ),
+            (
+                "the reset the uninstaller uses, which is a different one",
+                json!({"cmd": "local.reset-data", "id": "r1", "confirm": "erase-local-lemma"}),
+            ),
+        ] {
+            let replies = exchange(&daemon, request);
+            let last = replies
+                .last()
+                .unwrap_or_else(|| panic!("{label} must be answered, not ignored"));
+            assert_eq!(last["event"], "error", "{label} must not start a reset");
+            assert_eq!(
+                last["code"], "confirmation-required",
+                "{label} has to be refused for the reason it was refused"
+            );
+            assert_eq!(last["id"], "r1", "{label}: the app matches answers by id");
+            assert!(
+                replies.iter().all(|reply| reply["event"] != "ack"),
+                "{label} was acknowledged, which is how the app learns a reset began"
+            );
+        }
+    }
+
     #[test]
     fn an_unknown_command_is_refused_by_name_rather_than_ignored() {
         let (_root, daemon) = daemon();

--- a/desktop/locald/src/daemon.rs
+++ b/desktop/locald/src/daemon.rs
@@ -2861,6 +2861,47 @@ mod tests {
             .collect()
     }
 
+    /// An installation that cannot share refuses before it takes anything.
+    ///
+    /// The three sharing arms all begin by checking that this installation has
+    /// the managed local runtime, and the order matters more than the refusal
+    /// does. `sharing.enable` goes on to parse its payload and then take the
+    /// lifecycle lock -- the one a start needs -- so a reordering that put
+    /// either of those first would have a daemon with no sharing at all
+    /// holding that lock while it worked out it had nothing to do.
+    ///
+    /// So this asserts the refusal, that nothing was acknowledged, and that
+    /// the lifecycle is still free afterwards. The last is the one that
+    /// notices a reordering.
+    #[test]
+    fn sharing_commands_refuse_before_they_take_the_lock_a_start_needs() {
+        let (_root, daemon) = daemon();
+
+        for command in ["sharing.preflight", "sharing.enable", "sharing.disable"] {
+            let replies = exchange(
+                &daemon,
+                json!({"cmd": command, "id": command, "payload": {}}),
+            );
+            let last = replies
+                .last()
+                .unwrap_or_else(|| panic!("{command} must be answered, not ignored"));
+            assert_eq!(last["event"], "error", "{command}");
+            assert_eq!(
+                last["code"], "sharing-unavailable",
+                "{command} has to say why, so the app can explain it"
+            );
+            assert!(
+                replies.iter().all(|reply| reply["event"] != "ack"),
+                "{command} was acknowledged, which tells the app it began"
+            );
+            assert!(
+                daemon.lifecycle.begin().is_ok(),
+                "{command} left the lifecycle held, so a start would now be refused"
+            );
+            daemon.lifecycle.finish();
+        }
+    }
+
     /// The one arm that erases somebody's work asks first, and had no test.
     ///
     /// `local.reset-data` removes the pods, databases and workspaces of an

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -2558,6 +2558,44 @@ struct EventOutcome {
     start_after_prepare: bool,
 }
 
+/// What to do with an event that names the operation it belongs to.
+///
+/// The whole of a decision that decides what somebody watching the splash
+/// sees, and the reason it is a function: `handle_locald_event` needs an
+/// `AppHandle` and a Tauri runtime, so none of this was reachable from a test
+/// and every case below was only ever exercised by using the app.
+///
+/// The daemon serves one operation at a time but several surfaces can ask, and
+/// their replies interleave. Showing another operation's progress on the
+/// splash is not cosmetic: its phases and its errors are about work the person
+/// in front of it did not start.
+#[derive(Debug, PartialEq, Eq)]
+enum EventAdmission {
+    /// It belongs to the operation already on screen.
+    Apply,
+    /// Nothing is on screen and this operation has not finished, so it becomes
+    /// the one being shown.
+    Adopt,
+    /// Another operation's, or one whose completion has already been shown.
+    /// The second is what stops a late straggler from reopening a finished
+    /// run's progress after the splash has moved on.
+    Ignore,
+}
+
+fn admit_locald_event(active: &str, completed: &[String], event: &str) -> EventAdmission {
+    if !active.is_empty() {
+        return if active == event {
+            EventAdmission::Apply
+        } else {
+            EventAdmission::Ignore
+        };
+    }
+    if completed.iter().any(|finished| finished == event) {
+        return EventAdmission::Ignore;
+    }
+    EventAdmission::Adopt
+}
+
 fn handle_locald_event(app: &AppHandle, event: &Value) {
     if std::env::var("LEMMA_DESKTOP_DEBUG").as_deref() == Ok("1") {
         eprintln!("[locald] {event}");
@@ -2570,18 +2608,14 @@ fn handle_locald_event(app: &AppHandle, event: &Value) {
     let event_operation_id = locald_event_operation_id(event);
     if let Some(event_operation_id) = event_operation_id {
         let mut ui = shell.ui.lock().unwrap();
-        if !ui.active_operation_id.is_empty() && ui.active_operation_id != event_operation_id {
-            return;
-        }
-        if ui.active_operation_id.is_empty() {
-            if ui
-                .completed_operation_ids
-                .iter()
-                .any(|completed| completed == event_operation_id)
-            {
-                return;
-            }
-            ui.active_operation_id = event_operation_id.to_owned();
+        match admit_locald_event(
+            &ui.active_operation_id,
+            &ui.completed_operation_ids,
+            event_operation_id,
+        ) {
+            EventAdmission::Ignore => return,
+            EventAdmission::Adopt => ui.active_operation_id = event_operation_id.to_owned(),
+            EventAdmission::Apply => {}
         }
     }
     let _ = app.emit_to("control", "lemma:locald-event", event.clone());
@@ -7908,6 +7942,54 @@ mod tests {
     /// that have to stay true. It cannot be executed from here -- NSIS runs
     /// only on Windows, and only during a real uninstall -- so CI's Windows
     /// job building the installer is what proves it parses.
+    /// Which operation's progress the splash shows, in every case.
+    ///
+    /// The daemon serves one operation at a time, but several surfaces ask and
+    /// their replies interleave, so an event carries the operation it belongs
+    /// to and this decides whether it is the one on screen. It had no test at
+    /// all: `handle_locald_event` needs an `AppHandle` and a Tauri runtime, so
+    /// the only way to exercise any of this was to use the app and watch.
+    ///
+    /// Showing the wrong one is not cosmetic. Its phases and its failures
+    /// describe work the person watching did not start.
+    #[test]
+    fn only_the_operation_on_screen_moves_the_splash() {
+        let finished = vec!["install-1".to_string(), "start-1".to_string()];
+
+        // Nothing on screen: the first event of an unfinished operation takes it.
+        assert_eq!(
+            admit_locald_event("", &finished, "start-2"),
+            EventAdmission::Adopt
+        );
+
+        // Nothing on screen, but this one already ran to completion. A late
+        // straggler must not reopen a finished run's progress.
+        assert_eq!(
+            admit_locald_event("", &finished, "start-1"),
+            EventAdmission::Ignore
+        );
+
+        // The one being shown.
+        assert_eq!(
+            admit_locald_event("start-2", &finished, "start-2"),
+            EventAdmission::Apply
+        );
+
+        // Another surface's, while one is on screen.
+        assert_eq!(
+            admit_locald_event("start-2", &finished, "install-9"),
+            EventAdmission::Ignore
+        );
+
+        // Completion is only consulted when nothing is active: an operation
+        // that is on screen keeps its own events even if a stale entry for it
+        // survives in the ring.
+        assert_eq!(
+            admit_locald_event("start-1", &finished, "start-1"),
+            EventAdmission::Apply
+        );
+    }
+
     #[test]
     fn the_windows_uninstaller_removes_the_data_the_checkbox_promises() {
         // Normalised: CI's Windows runner checks the tree out with CRLF, and a

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -2979,6 +2979,31 @@ fn open_pod_app_window(app: &AppHandle, url: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Where the Dock icon should take somebody when every window is closed.
+///
+/// Separate from the arm that uses it because that arm needs a Tauri runtime
+/// and this is the part with cases in it. Splash is the fallback on purpose:
+/// while the stack is still coming up, or after it failed, the splash is where
+/// the state and the actions are, and a workspace URL that is not serving yet
+/// would open on an error page instead.
+#[cfg(target_os = "macos")]
+#[derive(Debug, PartialEq, Eq)]
+enum ReopenTarget {
+    Hosted,
+    Workspace(String),
+    Splash,
+}
+
+#[cfg(target_os = "macos")]
+fn reopen_target(mode: &str, ready: bool, error: bool, url: &str) -> ReopenTarget {
+    match mode {
+        // Nothing local has to be ready for hosted to be reachable.
+        "hosted" => ReopenTarget::Hosted,
+        "local" if ready && !error && !url.is_empty() => ReopenTarget::Workspace(url.to_owned()),
+        _ => ReopenTarget::Splash,
+    }
+}
+
 fn show_splash(app: &AppHandle) {
     let _ = open_app_window(app, &native_asset_url("index.html"));
 }
@@ -7743,10 +7768,36 @@ fn main() {
             // the variant does not exist on other platforms.
             #[cfg(target_os = "macos")]
             tauri::RunEvent::Reopen { .. } => {
+                restore_dock_presence(app);
                 if let Some(window) = app.get_window("main") {
-                    restore_dock_presence(app);
                     let _ = window.show();
                     let _ = window.set_focus();
+                } else {
+                    // Every window closed, which on macOS leaves the app
+                    // running. This arm only ever showed a window that already
+                    // existed, so in exactly that state clicking the Dock icon
+                    // did nothing at all -- the one gesture whose whole purpose
+                    // is bringing a running app back, on the one platform where
+                    // closing the last window is normal.
+                    let snapshot = {
+                        let shell: State<Shell> = app.state();
+                        let ui = shell.ui.lock().unwrap();
+                        ui.clone()
+                    };
+                    match reopen_target(
+                        &snapshot.mode,
+                        snapshot.ready,
+                        snapshot.error,
+                        &snapshot.url,
+                    ) {
+                        ReopenTarget::Hosted => {
+                            let _ = open_app_window(app, &hosted_url());
+                        }
+                        ReopenTarget::Workspace(url) => {
+                            let _ = open_app_window(app, &url);
+                        }
+                        ReopenTarget::Splash => show_splash(app),
+                    }
                 }
             }
             // Dock → Quit and any other OS-issued terminate arrive here without
@@ -7942,6 +7993,51 @@ mod tests {
     /// that have to stay true. It cannot be executed from here -- NSIS runs
     /// only on Windows, and only during a real uninstall -- so CI's Windows
     /// job building the installer is what proves it parses.
+    /// Clicking the Dock icon with no window open did nothing at all.
+    ///
+    /// On macOS closing the last window leaves the app running, so this is the
+    /// one gesture whose whole purpose is bringing it back -- and the arm that
+    /// handles it only ever showed a window that already existed. This is the
+    /// part of the fix with cases in it; the arm itself needs a Tauri runtime.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn reopening_with_every_window_closed_goes_somewhere() {
+        assert_eq!(
+            reopen_target("local", true, false, "http://app.127.0.0.1.sslip.io:1/"),
+            ReopenTarget::Workspace("http://app.127.0.0.1.sslip.io:1/".into()),
+            "a running local stack goes straight back to the workspace"
+        );
+
+        // Hosted has no local stack to be ready for.
+        assert_eq!(
+            reopen_target("hosted", false, false, ""),
+            ReopenTarget::Hosted
+        );
+
+        for (label, ready, error, url) in [
+            ("still starting", false, false, ""),
+            ("failed", true, true, "http://app.127.0.0.1.sslip.io:1/"),
+            ("ready but with no url yet", true, false, ""),
+            (
+                "undecided mode",
+                true,
+                false,
+                "http://app.127.0.0.1.sslip.io:1/",
+            ),
+        ] {
+            let mode = if label == "undecided mode" {
+                "undecided"
+            } else {
+                "local"
+            };
+            assert_eq!(
+                reopen_target(mode, ready, error, url),
+                ReopenTarget::Splash,
+                "{label}: the splash is where the state and the actions are"
+            );
+        }
+    }
+
     /// Which operation's progress the splash shows, in every case.
     ///
     /// The daemon serves one operation at a time, but several surfaces ask and


### PR DESCRIPTION
## What changes

Two decisions in the desktop shell that had no test and one visible bug
between them.

## Why

**Clicking the Dock icon with no window open did nothing.** On macOS
closing the last window leaves the app running, and `RunEvent::Reopen` is
the one gesture whose whole purpose is bringing it back. The arm that
handles it only ever showed a window that already existed — so in exactly
the state it exists for, it did nothing, and the app read as dead to
anyone who had closed it.

It now recreates one. A running local stack goes back to the workspace;
hosted goes to hosted, which needs nothing local to be ready; everything
else — still starting, failed, ready without a URL yet, undecided — goes
to the splash, because that is where the state and the actions are and a
workspace that is not serving yet would open on an error page.
`restore_dock_presence` moved out of the branch too: the icon has to come
back whether or not a window survived.

**Which operation's progress the splash shows had no test at all.** The
daemon serves one operation at a time, but several surfaces ask and their
replies interleave, so every event carries the operation it belongs to and
`handle_locald_event` decides whether it is the one on screen. Getting
that wrong is not cosmetic: the splash then shows phases and failures for
work the person watching did not start.

None of it was reachable from a test — the function needs an `AppHandle`
and a Tauri runtime, so the only way to exercise any case was to use the
app and watch it.

Both are now functions of their inputs, with the cases in a table. The
event arms and window plumbing stay where they are; only the deciding
moved.

**The one command that erases somebody's work had no test.**
`local.reset-data` removes an installation's pods, databases and workspaces,
and the only thing between a stray or malformed request and all of it is a
literal confirmation string. Nothing checked that the check was there — it
could have been dropped, or its spelling changed on one side of the wire,
and every other test in the file would still pass.

Four cases, and the wrong-but-present ones are the point: an absent
confirmation is the obvious guard, a differently-cased phrase is what a
refactor produces, and `erase-local-lemma` is a real confirmation string
this codebase uses elsewhere — the uninstaller's — which is exactly the kind
of thing that gets copied into the wrong call.

## How to verify

```bash
make desktop-check
```

The admission test earns its place: deleting the completed-operation check
fails it. That is the case easiest to lose — nothing on screen, and a late
straggler from a finished run must not reopen its progress.

Replacing the reset's confirmation check with `if false` fails its test too.\n\nThe reopen decision covers a running stack, hosted, and four fallbacks.
The arm itself is still runtime-bound and unverified by tests; what is
pinned is where it sends people.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Rollback** — two independent commits, no data or schema involvement



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved splash-screen operation status updates so only relevant daemon events are displayed.
  - On macOS, reopening the app with no open windows now navigates to the hosted page, the last workspace, or the splash screen as appropriate.
  - Local data reset confirmations are validated against the required confirmation text, preventing unintended reset requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->