### PR TITLE
A protocol version nothing tied together, and six ways to write a file safely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -784,6 +784,18 @@ jobs:
         working-directory: desktop
         run: cargo test -p lemma-locald -p lemma-guestd --locked
 
+      # The Rust half of the Agent Host's wire contract. This job runs on
+      # backend-only pull requests -- `lemma-backend/**` is in its filter --
+      # and it did not run the half that would notice. Both sides of
+      # `tests/fixtures/wire_contract.json` are assertions over a committed
+      # file; only the named suites, because the rest of this crate's tests
+      # spawn agents.
+      - name: Agent Host wire contract
+        working-directory: desktop
+        run: >-
+          cargo test -p lemma-agent-host --locked
+          --test wire_contract --test control_plane_contract
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2764,6 +2764,7 @@ dependencies = [
  "hex",
  "interprocess",
  "lemma-desktop-process",
+ "lemma-private-file",
  "libc",
  "objc2",
  "objc2-app-kit",
@@ -2818,6 +2819,7 @@ dependencies = [
  "interprocess",
  "keyring",
  "lemma-desktop-process",
+ "lemma-private-file",
  "lemma-runtime-manager",
  "libc",
  "qrcode",
@@ -2828,6 +2830,14 @@ dependencies = [
  "socket2 0.6.4",
  "tempfile",
  "tokio",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "lemma-private-file"
+version = "0.7.2"
+dependencies = [
+ "tempfile",
  "windows-sys 0.61.2",
 ]
 
@@ -2845,6 +2855,7 @@ version = "0.7.2"
 dependencies = [
  "getrandom 0.3.4",
  "lemma-desktop-process",
+ "lemma-private-file",
  "libc",
  "serde",
  "serde_json",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -21,6 +21,7 @@ resolver = "2"
 members = [
     "locald",
     "agent-host",
+    "private-file",
     "process",
     "local-runtime/manager",
     "local-runtime/hostctl",
@@ -74,6 +75,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 lemma-desktop-process = { path = "process" }
+lemma-private-file = { path = "private-file" }
 # macos-private-api is what gates WebviewWindowBuilder::transparent, which an
 # NSVisualEffectView has to sit behind to be visible at all. It is also what
 # makes a build ineligible for the Mac App Store — fine for the dmg/app targets

--- a/desktop/agent-host/tests/fixtures/wire_contract.json
+++ b/desktop/agent-host/tests/fixtures/wire_contract.json
@@ -22,8 +22,15 @@
     "`rawInput: {}` and sends the real arguments moments later on a",
     "status-less `tool_call_update`, which the backend dropped. Every streamed",
     "tool call rendered with empty arguments, and views built from them had",
-    "nothing to build from."
+    "nothing to build from.",
+    "",
+    "`protocol_version` is `lemma_agent_host::PROTOCOL_VERSION` and",
+    "`AGENT_HOST_PROTOCOL_VERSION`. Two literals, in two languages, that the",
+    "host sends and the backend compares against -- and nothing tied them, so",
+    "raising one and not the other makes every host of the old version look",
+    "unrecognised, silently, from the moment the backend deploys."
   ],
+  "protocol_version": 2,
   "event_types": [
     "run_state",
     "user_message",

--- a/desktop/agent-host/tests/wire_contract.rs
+++ b/desktop/agent-host/tests/wire_contract.rs
@@ -198,3 +198,24 @@ fn the_host_respects_the_bounds_the_backend_enforces() {
         "object_id is truncated to this in acp.rs; both sides read it here"
     );
 }
+
+/// The protocol version both sides send and compare, from one place.
+///
+/// `lemma_agent_host::PROTOCOL_VERSION` and the backend's
+/// `AGENT_HOST_PROTOCOL_VERSION` are two literals in two languages. The host
+/// puts its number in every identity it publishes and the backend checks it;
+/// raising one without the other makes every host of the old version look
+/// unrecognised, from the moment the backend deploys, with nothing failing on
+/// either side to say so.
+#[test]
+fn the_protocol_version_is_the_one_the_backend_expects() {
+    let declared = contract()["protocol_version"]
+        .as_u64()
+        .expect("the contract declares a protocol version");
+    assert_eq!(
+        u64::from(lemma_agent_host::PROTOCOL_VERSION),
+        declared,
+        "PROTOCOL_VERSION and the shared contract disagree; the backend reads \
+         the contract's number, so raise both or neither",
+    );
+}

--- a/desktop/local-runtime/manager/Cargo.toml
+++ b/desktop/local-runtime/manager/Cargo.toml
@@ -7,6 +7,7 @@ license = "AGPL-3.0-or-later"
 
 [dependencies]
 lemma-desktop-process = { path = "../../process" }
+lemma-private-file = { path = "../../private-file" }
 getrandom = "0.3"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/desktop/local-runtime/manager/src/private_files.rs
+++ b/desktop/local-runtime/manager/src/private_files.rs
@@ -3,6 +3,15 @@
 
 use super::*;
 
+// The implementations were here, and in five other modules, each with a
+// slightly different guarantee -- this one never fsynced the directory the
+// rename happened in, so a power cut could take back a write that had
+// already reported success.
+pub(crate) use lemma_private_file::{
+    appending_log as private_appending_log, ensure_private as ensure_private_file,
+    ensure_private_directory as set_private_directory, write_atomic as write_private_atomic,
+};
+
 #[cfg(target_os = "macos")]
 pub(crate) fn remove_if_present(path: &Path) -> io::Result<()> {
     match fs::remove_file(path) {
@@ -42,72 +51,6 @@ pub(crate) fn create_private_sparse_file(path: &Path, size: u64) -> io::Result<b
     file.sync_all()?;
     ensure_private_file(path)?;
     Ok(true)
-}
-
-pub(crate) fn write_private_atomic(path: &Path, contents: &[u8]) -> io::Result<()> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "path has no parent"))?;
-    fs::create_dir_all(parent)?;
-    let temporary = path.with_extension(format!("tmp-{}", std::process::id()));
-    let _ = fs::remove_file(&temporary);
-    let mut options = OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
-    let mut file = options.open(&temporary)?;
-    file.write_all(contents)?;
-    file.sync_all()?;
-    fs::rename(temporary, path)?;
-    ensure_private_file(path)
-}
-
-pub(crate) fn set_private_directory(path: &Path) -> io::Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
-    }
-    #[cfg(not(unix))]
-    let _ = path;
-    Ok(())
-}
-
-pub(crate) fn ensure_private_file(path: &Path) -> io::Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-        let metadata = fs::symlink_metadata(path)?;
-        if !metadata.file_type().is_file() || metadata.mode() & 0o077 != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                format!(
-                    "private runtime file has unsafe permissions: {}",
-                    path.display()
-                ),
-            ));
-        }
-    }
-    #[cfg(not(unix))]
-    let _ = path;
-    Ok(())
-}
-
-pub(crate) fn private_appending_log(path: &Path) -> io::Result<std::fs::File> {
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
-    let mut options = OpenOptions::new();
-    options.create(true).append(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
-    options.open(path)
 }
 
 pub(crate) fn rotate_log(path: &Path, max_bytes: u64) -> io::Result<()> {

--- a/desktop/locald/Cargo.toml
+++ b/desktop/locald/Cargo.toml
@@ -16,6 +16,7 @@ interprocess = "2.4"
 keyring = "4.1.5"
 lemma-runtime-manager = { path = "../local-runtime/manager" }
 lemma-desktop-process = { path = "../process" }
+lemma-private-file = { path = "../private-file" }
 qrcode = { version = "0.14", default-features = false, features = ["svg"] }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/desktop/locald/src/host_process/ledger.rs
+++ b/desktop/locald/src/host_process/ledger.rs
@@ -1,6 +1,8 @@
 //! What this installation started, written down so a replaced daemon can
 //! find it again.
 
+pub(crate) use lemma_private_file::write_atomic as write_private_atomic;
+
 use super::*;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -71,44 +73,6 @@ pub(crate) fn read_process_ledger(path: &Path) -> Option<ProcessLedger> {
 
 pub(crate) fn write_process_ledger(path: &Path, ledger: &ProcessLedger) -> io::Result<()> {
     write_private_atomic(path, &serde_json::to_vec_pretty(ledger)?)
-}
-
-pub(crate) fn write_private_atomic(path: &Path, contents: &[u8]) -> io::Result<()> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| io::Error::other("process ledger has no parent"))?;
-    fs::create_dir_all(parent)?;
-    let temporary = parent.join(format!(
-        ".processes-{}-{}.tmp",
-        std::process::id(),
-        random_generation()?
-    ));
-    let _ = fs::remove_file(&temporary);
-    let mut options = OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
-    let mut file = options.open(&temporary)?;
-    file.write_all(contents)?;
-    file.sync_all()?;
-    replace_private_file(&temporary, path)?;
-    #[cfg(unix)]
-    File::open(parent)?.sync_all()?;
-    Ok(())
-}
-
-pub(crate) fn replace_private_file(source: &Path, destination: &Path) -> io::Result<()> {
-    // No delete-then-rename on Windows. `fs::rename` is MoveFileExW with
-    // MOVEFILE_REPLACE_EXISTING and already replaces the destination, so the
-    // unlink bought nothing and cost two things: a window in which the process
-    // ledger simply did not exist -- crash there and the previous backend and
-    // frontend are never reclaimed, and keep their ports -- and a second way to
-    // fail, since removing a file anything has open (a virus scanner, moments
-    // after it was written) is a sharing violation.
-    fs::rename(source, destination)
 }
 
 pub(crate) fn reclaim_verified_processes(

--- a/desktop/locald/src/host_process/tests/ledger.rs
+++ b/desktop/locald/src/host_process/tests/ledger.rs
@@ -15,7 +15,16 @@ fn process_ledger_reclaims_only_an_exact_owned_process() {
     let ledger_path = root.path().join("processes.json");
     let installation_id = "0123456789abcdef0123456789abcdef";
     let mut child = Command::new("/bin/sleep").arg("30").spawn().unwrap();
-    let identity = process_identity(child.id()).unwrap();
+    // Settled, the way `record_child` records one, not sampled the instant
+    // after `spawn`. Between `fork` and `exec` a Linux child is a copy of its
+    // parent, so `/proc/<pid>/exe` names *this test binary* rather than
+    // `sleep` -- a plausible path that happens to be the wrong one. Recording
+    // that made the reclaim below decline to signal a record whose executable
+    // no longer matched, and this test then waited out the whole `sleep 30`
+    // and failed saying the process had exited on its own. Which is exactly
+    // the window `settled_process_identity` exists to wait out, and what its
+    // own doc comment predicts on a loaded runner.
+    let identity = settled_process_identity(&mut child).unwrap();
     let mut backend = service("backend", &[]);
     backend.command = vec!["/bin/sleep".into(), "30".into()];
     let value = manifest(vec![backend, service("frontend", &["backend"])]);
@@ -72,7 +81,11 @@ fn process_ledger_never_kills_a_pid_with_the_wrong_start_identity() {
     let ledger_path = root.path().join("processes.json");
     let installation_id = "0123456789abcdef0123456789abcdef";
     let mut child = Command::new("/bin/sleep").arg("30").spawn().unwrap();
-    let identity = process_identity(child.id()).unwrap();
+    // Settled, for the reason the guard above gives. Here it decides whether
+    // this test proves anything: an unsettled executable is a second reason
+    // not to signal, so the assertion below would pass without the start
+    // identity -- the one thing it is about -- being consulted at all.
+    let identity = settled_process_identity(&mut child).unwrap();
     let mut backend = service("backend", &[]);
     backend.command = vec!["/bin/sleep".into(), "30".into()];
     let value = manifest(vec![backend, service("frontend", &["backend"])]);

--- a/desktop/locald/src/managed_runtime/bootstrap.rs
+++ b/desktop/locald/src/managed_runtime/bootstrap.rs
@@ -1,6 +1,10 @@
 //! What the guest is handed at boot: its manifest, the infrastructure
 //! secrets, and the environment the backend reads them from.
 
+pub(crate) use lemma_private_file::{
+    ensure_private as ensure_private_file, write_atomic as write_private_atomic,
+};
+
 use super::*;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -216,47 +220,6 @@ pub(crate) fn validate_secret(name: &str, value: &str) -> io::Result<()> {
             format!("managed {name} must be a 64-character lowercase hex secret"),
         ));
     }
-    Ok(())
-}
-
-pub(crate) fn write_private_atomic(path: &Path, contents: &[u8]) -> io::Result<()> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "secret path has no parent"))?;
-    fs::create_dir_all(parent)?;
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    let temporary = parent.join(format!(".infra-secrets-{}-{nonce}.tmp", std::process::id()));
-    let mut options = OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
-    let mut file = options.open(&temporary)?;
-    file.write_all(contents)?;
-    file.sync_all()?;
-    fs::rename(&temporary, path)?;
-    ensure_private_file(path)
-}
-
-pub(crate) fn ensure_private_file(path: &Path) -> io::Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-        let metadata = fs::symlink_metadata(path)?;
-        if !metadata.file_type().is_file() || metadata.mode() & 0o077 != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                format!("managed secret file is not private: {}", path.display()),
-            ));
-        }
-    }
-    #[cfg(not(unix))]
-    let _ = path;
     Ok(())
 }
 

--- a/desktop/locald/src/managed_runtime/mod.rs
+++ b/desktop/locald/src/managed_runtime/mod.rs
@@ -5,8 +5,8 @@
 
 use std::collections::HashMap;
 use std::env;
-use std::fs::{self, OpenOptions};
-use std::io::{self, Write};
+use std::fs::{self};
+use std::io::{self};
 #[cfg(any(not(target_os = "macos"), test))]
 use std::net::TcpStream;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime};
 
 use lemma_runtime_manager::{
     ManagedRuntime, ManagedRuntimeConfig, ManagedRuntimeStatus, DEFAULT_WSL_DISTRIBUTION,

--- a/desktop/locald/src/managed_runtime/tests/forwarders.rs
+++ b/desktop/locald/src/managed_runtime/tests/forwarders.rs
@@ -1,6 +1,7 @@
 //! The forwarders that reach the guest's private services.
 
 use super::*;
+use std::io::Write;
 
 #[test]
 fn stopping_forwarder_closes_idle_connections_in_both_directions() {

--- a/desktop/locald/src/native_host_pack/mod.rs
+++ b/desktop/locald/src/native_host_pack/mod.rs
@@ -11,10 +11,9 @@
 //! rendered entirely by the durable daemon.
 
 use std::collections::BTreeMap;
-use std::fs::{self, OpenOptions};
-use std::io::{self, Write};
+use std::fs::{self};
+use std::io::{self};
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use base64::engine::general_purpose::URL_SAFE;
 use base64::Engine;

--- a/desktop/locald/src/native_host_pack/secrets.rs
+++ b/desktop/locald/src/native_host_pack/secrets.rs
@@ -1,7 +1,7 @@
 //! This installation's own secrets, and the private files holding them.
 
 pub(crate) use lemma_private_file::{
-    make_private as ensure_private_file, write_atomic as write_private_atomic,
+    ensure_private as ensure_private_file, write_atomic as write_private_atomic,
 };
 
 use super::*;
@@ -18,6 +18,7 @@ pub(crate) fn load_or_create_host_secrets(
     healed: &mut Vec<String>,
 ) -> io::Result<HostSecrets> {
     if path.is_file() {
+        narrow_exposed_secret(path, healed)?;
         match read_existing_host_secrets(path) {
             Ok(secrets) => return Ok(secrets),
             Err(reason) => {
@@ -66,6 +67,45 @@ pub(crate) fn load_or_create_host_secrets(
     };
     write_private_atomic(path, &serde_json::to_vec(&secrets)?)?;
     Ok(secrets)
+}
+
+/// Narrow a secret that more than this user can read, and say that it was.
+///
+/// Repaired rather than refused, unlike the managed runtime's secrets, and the
+/// difference is what refusing costs here. A refusal sends this file into the
+/// quarantine path above, which remints the installation secret and requires a
+/// data reset -- every encrypted row in the installation permanently
+/// unreadable, arrived at from a mode bit. `cp -R` instead of `cp -Rp` lands
+/// exactly here, and the directory holding this file is 0700, so the widened
+/// file inside it was never actually readable by anybody else.
+///
+/// Not silently, though, which is what it used to be: the mode was set on
+/// every read and nothing was recorded either way. A secret found wider than it
+/// should be is worth an operator hearing about even when nothing read it, and
+/// `healed` is where this daemon says what it had to repair to start.
+///
+/// A symlink or a directory is left to `read_existing_host_secrets`, which
+/// refuses it. That is not a permissions accident and repairing it would be the
+/// bug.
+fn narrow_exposed_secret(path: &Path, healed: &mut Vec<String>) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let metadata = fs::symlink_metadata(path)?;
+        if metadata.file_type().is_file() && metadata.mode() & 0o077 != 0 {
+            lemma_private_file::make_private(path)?;
+            healed.push(format!(
+                "this installation's secret at {} could be read by more than this user                  (mode {:o}); it has been narrowed. Nothing else was changed, and the                  secret itself still works -- but if this machine is shared, treat it as                  known to anyone who had an account on it",
+                path.display(),
+                metadata.mode() & 0o777,
+            ));
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (path, healed);
+    }
+    Ok(())
 }
 
 pub(crate) fn read_existing_host_secrets(path: &Path) -> Result<HostSecrets, String> {

--- a/desktop/locald/src/native_host_pack/secrets.rs
+++ b/desktop/locald/src/native_host_pack/secrets.rs
@@ -1,5 +1,9 @@
 //! This installation's own secrets, and the private files holding them.
 
+pub(crate) use lemma_private_file::{
+    make_private as ensure_private_file, write_atomic as write_private_atomic,
+};
+
 use super::*;
 
 /// Read the installation secret, replacing it only if unreadable.
@@ -91,41 +95,5 @@ pub(crate) fn validate_hex_secret(label: &str, value: &str) -> io::Result<()> {
             "{label} is not a 32-byte lowercase hex secret"
         )));
     }
-    Ok(())
-}
-
-pub(crate) fn write_private_atomic(path: &Path, contents: &[u8]) -> io::Result<()> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| invalid("private file has no parent directory"))?;
-    fs::create_dir_all(parent)?;
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    let temporary = parent.join(format!(".native-host-{}-{nonce}.tmp", std::process::id()));
-    let mut options = OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
-    let mut file = options.open(&temporary)?;
-    file.write_all(contents)?;
-    file.write_all(b"\n")?;
-    file.sync_all()?;
-    fs::rename(&temporary, path)?;
-    ensure_private_file(path)
-}
-
-pub(crate) fn ensure_private_file(path: &Path) -> io::Result<()> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
-    }
-    #[cfg(not(unix))]
-    let _ = path;
     Ok(())
 }

--- a/desktop/locald/src/native_host_pack/tests/secrets.rs
+++ b/desktop/locald/src/native_host_pack/tests/secrets.rs
@@ -141,11 +141,22 @@ fn a_world_readable_installation_secret_is_narrowed_and_reported_not_reminted() 
 #[cfg(unix)]
 #[test]
 fn a_symbolic_link_where_the_secret_belongs_is_not_repaired() {
+    use std::os::unix::fs::PermissionsExt;
     let root = tempfile::tempdir().unwrap();
     let root = root.path();
     std::fs::create_dir_all(root.join("data/files")).unwrap();
     let elsewhere = root.join("elsewhere.json");
-    std::fs::write(&elsewhere, br#"{"installation_secret":"00"}"#).unwrap();
+    // A secret that would be accepted in every respect if it were reached:
+    // valid hex, and private. Neither was true of the fixture this replaced,
+    // so a regression that followed the link would have been refused for one
+    // of those instead and the guard would have passed without the link
+    // mattering at all.
+    std::fs::write(
+        &elsewhere,
+        format!(r#"{{"installation_secret":"{}"}}"#, "ab".repeat(32)).as_bytes(),
+    )
+    .unwrap();
+    std::fs::set_permissions(&elsewhere, std::fs::Permissions::from_mode(0o600)).unwrap();
     let path = root.join("host.secrets.json");
     std::os::unix::fs::symlink(&elsewhere, &path).unwrap();
 

--- a/desktop/locald/src/native_host_pack/tests/secrets.rs
+++ b/desktop/locald/src/native_host_pack/tests/secrets.rs
@@ -87,3 +87,74 @@ fn a_checkout_never_reaches_for_the_keychain() {
             .unwrap_or("keychain")
     );
 }
+
+/// A secret anyone on the machine could read is narrowed, kept, and reported.
+///
+/// Three things have to be true at once, and each is a way this has been wrong.
+/// The secret must survive: refusing it sends this file into the quarantine
+/// path, which remints the key and requires a data reset -- every encrypted row
+/// in the installation, permanently unreadable, arrived at from a mode bit.
+/// The mode must be repaired, or the next start finds it exactly as wide. And
+/// it must be said out loud, which it never was: the mode was set on every read
+/// and nothing recorded that anything had been wrong.
+#[cfg(unix)]
+#[test]
+fn a_world_readable_installation_secret_is_narrowed_and_reported_not_reminted() {
+    use std::os::unix::fs::PermissionsExt;
+    let root = tempfile::tempdir().unwrap();
+    let root = root.path();
+    std::fs::create_dir_all(root.join("data/files")).unwrap();
+    let path = root.join("host.secrets.json");
+
+    let mut healed = Vec::new();
+    let original = load_or_create_host_secrets(&path, &mut healed).unwrap();
+    assert!(healed.is_empty(), "a first run says nothing: {healed:?}");
+
+    // However it got this way -- `cp -R` without `-p` is the usual answer.
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+    let mut healed = Vec::new();
+    let reopened = load_or_create_host_secrets(&path, &mut healed).unwrap();
+
+    assert_eq!(
+        reopened.installation_secret, original.installation_secret,
+        "the key must survive: reminting it makes every encrypted row unreadable",
+    );
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+    assert_eq!(mode & 0o077, 0, "mode was left at {mode:o}");
+    assert_eq!(healed.len(), 1, "{healed:?}");
+    assert!(
+        healed[0].contains("more than this user"),
+        "the operator has to be told: {}",
+        healed[0]
+    );
+    assert!(
+        crate::paths::data_reset_reason(root).is_none(),
+        "a mode bit is not a reason to destroy the data",
+    );
+}
+
+/// And a symlink where the secret should be is still refused.
+///
+/// Not a permissions accident, and following one is the bug the repair path
+/// must not introduce.
+#[cfg(unix)]
+#[test]
+fn a_symbolic_link_where_the_secret_belongs_is_not_repaired() {
+    let root = tempfile::tempdir().unwrap();
+    let root = root.path();
+    std::fs::create_dir_all(root.join("data/files")).unwrap();
+    let elsewhere = root.join("elsewhere.json");
+    std::fs::write(&elsewhere, br#"{"installation_secret":"00"}"#).unwrap();
+    let path = root.join("host.secrets.json");
+    std::os::unix::fs::symlink(&elsewhere, &path).unwrap();
+
+    let mut healed = Vec::new();
+    load_or_create_host_secrets(&path, &mut healed).unwrap();
+    assert_eq!(healed.len(), 1, "{healed:?}");
+    assert!(
+        healed[0].contains("unreadable"),
+        "a link is quarantined, not narrowed: {}",
+        healed[0]
+    );
+}

--- a/desktop/locald/src/network.rs
+++ b/desktop/locald/src/network.rs
@@ -1,11 +1,12 @@
 use std::env;
-use std::fs::{self, OpenOptions};
-use std::io::{self, Write};
+use std::fs::{self};
+use std::io::{self};
 use std::net::{Ipv4Addr, SocketAddr, TcpStream};
-use std::path::Path;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
+
+use lemma_private_file::write_atomic as write_private_atomic;
 
 use crate::paths::LocalPaths;
 use crate::port_reservation::PortReservation;
@@ -221,65 +222,6 @@ fn allocate_ports() -> io::Result<(NetworkPorts, ReservedPair)> {
         io::ErrorKind::AddrNotAvailable,
         "could not allocate high local ports for Lemma",
     ))
-}
-
-fn write_private_atomic(path: &Path, contents: &[u8]) -> io::Result<()> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "network path has no parent"))?;
-    fs::create_dir_all(parent)?;
-    let temporary = parent.join(format!(".network-{}.tmp", std::process::id()));
-    let _ = fs::remove_file(&temporary);
-    let mut options = OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
-    let mut file = options.open(&temporary)?;
-    file.write_all(contents)?;
-    file.sync_all()?;
-    replace_file(&temporary, path)?;
-    #[cfg(unix)]
-    {
-        if let Ok(directory) = fs::File::open(parent) {
-            let _ = directory.sync_all();
-        }
-    }
-    Ok(())
-}
-
-#[cfg(not(windows))]
-fn replace_file(source: &Path, destination: &Path) -> io::Result<()> {
-    fs::rename(source, destination)
-}
-
-#[cfg(windows)]
-fn replace_file(source: &Path, destination: &Path) -> io::Result<()> {
-    use std::os::windows::ffi::OsStrExt;
-    use windows_sys::Win32::Storage::FileSystem::{
-        MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
-    };
-
-    let source: Vec<u16> = source.as_os_str().encode_wide().chain(Some(0)).collect();
-    let destination: Vec<u16> = destination
-        .as_os_str()
-        .encode_wide()
-        .chain(Some(0))
-        .collect();
-    let result = unsafe {
-        MoveFileExW(
-            source.as_ptr(),
-            destination.as_ptr(),
-            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
-        )
-    };
-    if result == 0 {
-        Err(io::Error::last_os_error())
-    } else {
-        Ok(())
-    }
 }
 
 fn now_ms() -> u128 {

--- a/desktop/locald/src/operator_config/mod.rs
+++ b/desktop/locald/src/operator_config/mod.rs
@@ -4,8 +4,8 @@
 //! Was one 2,423-line file. Split by what is being done to the config.
 
 use std::collections::{BTreeMap, HashMap};
-use std::fs::{self, OpenOptions};
-use std::io::{self, Write};
+use std::fs::{self};
+use std::io::{self};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -14,6 +14,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::provider_probe::{HttpModelProviderProbe, ModelProviderProbe};
+pub(crate) use lemma_private_file::{
+    make_private as ensure_private_file, write_atomic as write_private_atomic,
+};
 
 const CONFIG_SCHEMA_VERSION: u64 = 1;
 const VAULT_SERVICE: &str = "work.lemma.local";
@@ -67,62 +70,6 @@ pub struct OperatorConfigStore {
 pub(crate) struct OperatorConfigState {
     config: OperatorConfig,
     secrets: BTreeMap<String, Option<String>>,
-}
-
-pub(crate) fn write_private_atomic(path: &Path, contents: &[u8]) -> io::Result<()> {
-    let parent = path
-        .parent()
-        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "config path has no parent"))?;
-    fs::create_dir_all(parent)?;
-    let temporary = path.with_extension(format!("next-{}", std::process::id()));
-    let _ = fs::remove_file(&temporary);
-    let mut options = OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600);
-    }
-    let mut file = options.open(&temporary)?;
-    file.write_all(contents)?;
-    file.sync_all()?;
-    fs::rename(temporary, path)?;
-    #[cfg(unix)]
-    fs::File::open(parent)?.sync_all()?;
-    ensure_private_file(path)
-}
-
-/// Make sure the config is a regular file only this user can read.
-///
-/// Over-broad permissions are *repaired* rather than rejected. Refusing to
-/// start does not make the file any less readable -- it just means the
-/// installation never runs again -- and the way this actually happens is
-/// somebody moving their state directory with `cp -R` instead of `cp -Rp`,
-/// which lands 0644 and used to be permanently fatal, silently.
-///
-/// Anything that is not a regular file still fails: a symlink or a directory
-/// here is not a permissions accident, and following one would be the bug.
-pub(crate) fn ensure_private_file(path: &Path) -> io::Result<()> {
-    let metadata = fs::symlink_metadata(path)?;
-    if !metadata.file_type().is_file() {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            format!(
-                "private configuration is not a regular file: {}",
-                path.display()
-            ),
-        ));
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::{MetadataExt, PermissionsExt};
-        if metadata.mode() & 0o077 != 0 {
-            fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
-        }
-    }
-    #[cfg(not(unix))]
-    let _ = path;
-    Ok(())
 }
 
 impl OperatorConfigStore {

--- a/desktop/locald/src/state.rs
+++ b/desktop/locald/src/state.rs
@@ -7,9 +7,25 @@ use serde_json::{json, Value};
 
 use crate::PROTOCOL_VERSION;
 
+fn default_state_schema_version() -> u64 {
+    STATE_SCHEMA_VERSION
+}
+
+/// The shape of `state.json`.
+///
+/// Written into every file and read back, so a build that changes the shape
+/// can tell "an older Lemma wrote this" from "this is corrupt". There was no
+/// version at all, and `load` falls back to the default on any parse failure
+/// -- which means a shape change would have silently reset every
+/// installation's state with nothing anywhere saying why.
+pub const STATE_SCHEMA_VERSION: u64 = 1;
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StateSnapshot {
+    /// Absent in files written before this existed, which is version 1.
+    #[serde(default = "default_state_schema_version")]
+    pub schema_version: u64,
     pub revision: u64,
     pub status: String,
     pub ready: bool,
@@ -28,6 +44,7 @@ pub struct StateSnapshot {
 impl Default for StateSnapshot {
     fn default() -> Self {
         Self {
+            schema_version: STATE_SCHEMA_VERSION,
             revision: 0,
             status: "stopped".into(),
             ready: false,
@@ -196,11 +213,16 @@ impl StateSnapshot {
         event
     }
 
+    /// Write the state, atomically and privately.
+    ///
+    /// This used to be a plain `write` to `state.json.next` and a rename: no
+    /// fsync of either the file or the directory, so a power cut could take
+    /// back a write that had already returned `Ok`; no private mode, on a file
+    /// that carries the workspace URL; and a temporary named from the path
+    /// alone, so two threads persisting at once wrote through each other.
     pub fn persist(&self, path: &Path) -> io::Result<()> {
-        let temporary = path.with_extension("json.next");
         let bytes = serde_json::to_vec_pretty(self).map_err(io::Error::other)?;
-        std::fs::write(&temporary, bytes)?;
-        std::fs::rename(temporary, path)
+        lemma_private_file::write_atomic(path, &bytes)
     }
 
     fn normalize_loaded_state(&mut self) {

--- a/desktop/private-file/Cargo.toml
+++ b/desktop/private-file/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "lemma-private-file"
+version.workspace = true
+edition = "2021"
+license = "AGPL-3.0-or-later"
+description = "Files only this user may read, written so a crash cannot leave one half-written"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.2", features = ["Win32_Storage_FileSystem"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+missing_errors_doc = "allow"
+missing_panics_doc = "allow"

--- a/desktop/private-file/src/lib.rs
+++ b/desktop/private-file/src/lib.rs
@@ -79,30 +79,57 @@ pub fn replace(source: &Path, destination: &Path) -> io::Result<()> {
     //
     // `MOVEFILE_WRITE_THROUGH` is what makes the rename itself durable on
     // Windows; `fs::rename` does not pass it.
+    //
+    // Retried, because on Windows replacing a file is not a single instant the
+    // way `rename(2)` is. The destination is opened for the duration, and
+    // anything else holding it without `FILE_SHARE_DELETE` -- another writer
+    // mid-replace, a virus scanner reading the file that was written a
+    // millisecond ago, Windows Search indexing it -- makes the call fail with
+    // "Access is denied" or a sharing violation. Neither is a permissions
+    // problem and neither lasts: the guard for two threads persisting state at
+    // once failed here on Windows and passed on every other platform, because
+    // on every other platform the second rename simply wins.
     #[cfg(windows)]
     {
         use std::os::windows::ffi::OsStrExt;
+        use std::time::{Duration, Instant};
         use windows_sys::Win32::Storage::FileSystem::{
             MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
         };
+
+        /// `ERROR_ACCESS_DENIED` and `ERROR_SHARING_VIOLATION`, spelled out
+        /// rather than pulling in another `windows-sys` feature for two
+        /// integers. These are the two the contention above produces.
+        const CONTENDED: [i32; 2] = [5, 32];
+        /// Long enough to outlast a scanner's hold on a file this size, short
+        /// enough that a real permissions failure is still reported promptly.
+        const PATIENCE: Duration = Duration::from_secs(2);
 
         let wide =
             |path: &Path| -> Vec<u16> { path.as_os_str().encode_wide().chain(Some(0)).collect() };
         let source = wide(source);
         let destination = wide(destination);
-        // SAFETY: both strings are NUL-terminated and outlive the call, and
-        // the return value is checked.
-        let result = unsafe {
-            MoveFileExW(
-                source.as_ptr(),
-                destination.as_ptr(),
-                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
-            )
-        };
-        if result == 0 {
-            Err(io::Error::last_os_error())
-        } else {
-            Ok(())
+        let deadline = Instant::now() + PATIENCE;
+        loop {
+            // SAFETY: both strings are NUL-terminated and outlive the call,
+            // and the return value is checked.
+            let result = unsafe {
+                MoveFileExW(
+                    source.as_ptr(),
+                    destination.as_ptr(),
+                    MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+                )
+            };
+            if result != 0 {
+                return Ok(());
+            }
+            let error = io::Error::last_os_error();
+            if !CONTENDED.contains(&error.raw_os_error().unwrap_or_default())
+                || Instant::now() >= deadline
+            {
+                return Err(error);
+            }
+            std::thread::sleep(Duration::from_millis(10));
         }
     }
 }

--- a/desktop/private-file/src/lib.rs
+++ b/desktop/private-file/src/lib.rs
@@ -1,0 +1,236 @@
+//! Files only this user may read, written so a crash cannot leave one
+//! half-written.
+//!
+//! There were six copies of this, one per module that needed it, and they had
+//! drifted into six different guarantees. Two never fsynced the directory, so
+//! the rename that made the file visible could be lost by a power cut that the
+//! `Ok(())` had already promised through. One picked a temporary name from the
+//! process id alone, so two daemons writing at once collided. One left the
+//! result unchecked, so a file the user had made group-readable stayed that
+//! way. The daemon's own `state.json` had none of it: no private mode, no
+//! fsync, no unique name.
+//!
+//! So there is one, and it is the strongest of the six:
+//!
+//! * the parent directory exists;
+//! * the temporary is created with `create_new` and a name no other writer can
+//!   choose, at mode 0600 where the platform has modes;
+//! * the contents are written and `fsync`ed before anything is renamed;
+//! * the rename is `MOVEFILE_WRITE_THROUGH` on Windows, which is the only form
+//!   that is durable there;
+//! * the parent directory is `fsync`ed, so the rename survives too;
+//! * and the result is checked, not assumed.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Write `contents` to `path`, atomically, readable only by this user.
+///
+/// Either the previous contents are there or the new ones are; never a prefix
+/// of either, and never nothing.
+pub fn write_atomic(path: &Path, contents: &[u8]) -> io::Result<()> {
+    let parent = path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("{} has no parent directory", path.display()),
+        )
+    })?;
+    fs::create_dir_all(parent)?;
+
+    let temporary = temporary_beside(path);
+    // `create_new`, so two writers cannot land on the same file even if the
+    // name somehow repeats; the name itself already carries a counter.
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let outcome = (|| -> io::Result<()> {
+        let mut file = options.open(&temporary)?;
+        file.write_all(contents)?;
+        file.sync_all()?;
+        drop(file);
+        replace(&temporary, path)?;
+        sync_directory(parent)
+    })();
+    if outcome.is_err() {
+        let _ = fs::remove_file(&temporary);
+        return outcome;
+    }
+    ensure_private(path)
+}
+
+/// Replace `destination` with `source`, durably.
+pub fn replace(source: &Path, destination: &Path) -> io::Result<()> {
+    #[cfg(not(windows))]
+    {
+        fs::rename(source, destination)
+    }
+    // No delete-then-rename. `MoveFileExW` with `MOVEFILE_REPLACE_EXISTING`
+    // already replaces the destination, so unlinking first bought nothing and
+    // cost two things: a window in which the file simply did not exist, and a
+    // second way to fail -- removing a file something has open, a virus scanner
+    // moments after it was written, is a sharing violation.
+    //
+    // `MOVEFILE_WRITE_THROUGH` is what makes the rename itself durable on
+    // Windows; `fs::rename` does not pass it.
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Storage::FileSystem::{
+            MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+        };
+
+        let wide =
+            |path: &Path| -> Vec<u16> { path.as_os_str().encode_wide().chain(Some(0)).collect() };
+        let source = wide(source);
+        let destination = wide(destination);
+        // SAFETY: both strings are NUL-terminated and outlive the call, and
+        // the return value is checked.
+        let result = unsafe {
+            MoveFileExW(
+                source.as_ptr(),
+                destination.as_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            )
+        };
+        if result == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// Refuse a file anyone but this user can read.
+///
+/// Checked rather than corrected: a private file that is not private is a
+/// question about how it got that way, and answering it by widening our own
+/// mode and carrying on is how a leaked credential stays leaked.
+pub fn ensure_private(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let metadata = fs::symlink_metadata(path)?;
+        if !metadata.file_type().is_file() || metadata.mode() & 0o077 != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("{} is readable by more than this user", path.display()),
+            ));
+        }
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
+/// Narrow a file's mode to this user, and refuse anything that is not a file.
+///
+/// The repairing counterpart to `ensure_private`, and the difference between
+/// them is deliberate. Some of these files are ones a person can legitimately
+/// end up owning with the wrong mode: `cp -R` instead of `cp -Rp` lands 0644
+/// on a whole state directory, and refusing there was permanently fatal, and
+/// silent. Where the exposure itself is the question -- a secret, a
+/// credential -- `ensure_private` refuses instead.
+///
+/// A symlink or a directory is refused either way. That is not a permissions
+/// accident, and following one would be the bug.
+pub fn make_private(path: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("{} is not a regular file", path.display()),
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        if metadata.mode() & 0o077 != 0 {
+            fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+        }
+    }
+    Ok(())
+}
+
+/// A directory only this user may enter.
+pub fn ensure_private_directory(path: &Path) -> io::Result<()> {
+    fs::create_dir_all(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(())
+}
+
+/// A log only this user may read, opened for appending.
+pub fn appending_log(path: &Path) -> io::Result<File> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    options.open(path)
+}
+
+/// A name beside `path` that no other writer will choose.
+///
+/// The process id is not enough on its own: one process writing the same file
+/// twice at once -- two threads persisting state, which is exactly what the
+/// daemon does -- picks the same name both times, and `create_new` then fails
+/// the second one for a reason that reads like a permissions problem.
+fn temporary_beside(path: &Path) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let sequence = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let stem = path.file_name().map_or_else(
+        || "file".to_owned(),
+        |name| name.to_string_lossy().into_owned(),
+    );
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    parent.join(format!(
+        ".{stem}.{}-{nonce}-{sequence}.tmp",
+        std::process::id()
+    ))
+}
+
+/// Make the rename durable as well as the contents.
+///
+/// A file whose bytes are on the disk but whose directory entry is not is a
+/// file that is not there. Best-effort on the platforms where a directory
+/// cannot be opened for this.
+#[cfg_attr(
+    not(unix),
+    expect(
+        clippy::unnecessary_wraps,
+        reason = "the unix arm returns a real result; the signature is one shape"
+    )
+)]
+fn sync_directory(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        File::open(path)?.sync_all()
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/desktop/private-file/src/lib.rs
+++ b/desktop/private-file/src/lib.rs
@@ -197,6 +197,18 @@ pub fn ensure_private_directory(path: &Path) -> io::Result<()> {
 }
 
 /// A log only this user may read, opened for appending.
+///
+/// Narrowed as well as created narrow. `mode` applies to a file this call
+/// brings into existence and to nothing else, so a log that already existed --
+/// written by an older build that did not set a mode, or copied without `-p` --
+/// stayed as wide as it was, for ever, while every line appended to it made it
+/// worth more. These carry `wsl.exe` output, daemon diagnostics and the
+/// occasional error message with a path or a name in it.
+///
+/// Repaired rather than refused, like the config files: a log is not the thing
+/// an attacker wants and refusing to open one takes the diagnostics away
+/// exactly when somebody is trying to work out what went wrong. A symlink is
+/// still refused, by `make_private`.
 pub fn appending_log(path: &Path) -> io::Result<File> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
@@ -208,7 +220,9 @@ pub fn appending_log(path: &Path) -> io::Result<File> {
         use std::os::unix::fs::OpenOptionsExt;
         options.mode(0o600);
     }
-    options.open(path)
+    let log = options.open(path)?;
+    make_private(path)?;
+    Ok(log)
 }
 
 /// A name beside `path` that no other writer will choose.
@@ -238,8 +252,18 @@ fn temporary_beside(path: &Path) -> PathBuf {
 /// Make the rename durable as well as the contents.
 ///
 /// A file whose bytes are on the disk but whose directory entry is not is a
-/// file that is not there. Best-effort on the platforms where a directory
-/// cannot be opened for this.
+/// file that is not there.
+///
+/// Best-effort where the filesystem will not do it, which the comment used to
+/// claim and the code did not. Not every filesystem answers `fsync` on a
+/// directory descriptor: a FUSE server that implements no `fsyncdir`, and some
+/// network mounts, return `EINVAL` or `ENOTSUP`. By the time this runs the
+/// rename has already succeeded, so returning that error failed a write that
+/// had landed -- and, because `write_atomic` returns immediately, skipped the
+/// `ensure_private` after it, leaving the file written and unchecked.
+///
+/// Only those two. Anything else -- the directory gone, permission refused, an
+/// I/O error from the device -- is a real failure and is still reported.
 #[cfg_attr(
     not(unix),
     expect(
@@ -250,13 +274,35 @@ fn temporary_beside(path: &Path) -> PathBuf {
 fn sync_directory(path: &Path) -> io::Result<()> {
     #[cfg(unix)]
     {
-        File::open(path)?.sync_all()
+        match File::open(path).and_then(|directory| directory.sync_all()) {
+            Err(error) if directory_sync_is_unsupported(&error) => Ok(()),
+            outcome => outcome,
+        }
     }
     #[cfg(not(unix))]
     {
         let _ = path;
         Ok(())
     }
+}
+
+/// Whether the filesystem declined to sync a directory at all, as opposed to
+/// failing to.
+///
+/// Its own function so the line between the two is one thing, in one place,
+/// with a test on it. Widening this is how a real durability failure -- a
+/// device error, a directory that has gone -- becomes a write that silently
+/// claims to have landed.
+///
+/// Compiled for the test on every platform and called only on unix: Windows
+/// has no directory descriptor to sync, so `sync_directory` does nothing there
+/// and this would be dead code.
+#[cfg(any(unix, test))]
+fn directory_sync_is_unsupported(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::InvalidInput | io::ErrorKind::Unsupported
+    )
 }
 
 #[cfg(test)]

--- a/desktop/private-file/src/tests.rs
+++ b/desktop/private-file/src/tests.rs
@@ -164,3 +164,60 @@ fn repairing_still_refuses_what_is_not_a_regular_file() {
     assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
     assert!(make_private(root.path()).is_err(), "nor is a directory");
 }
+
+/// A log that already existed is narrowed, not only one this call creates.
+///
+/// `OpenOptions::mode` applies to a file this call brings into existence and to
+/// nothing else, so a log written by an older build that set no mode -- or one
+/// copied without `-p` -- stayed as wide as it was while every appended line
+/// made it worth more.
+#[cfg(unix)]
+#[test]
+fn an_existing_log_is_narrowed_rather_than_left_as_it_was_found() {
+    use std::os::unix::fs::PermissionsExt;
+    let root = scratch();
+    let path = root.path().join("run.log");
+    std::fs::write(&path, b"already here\n").unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+    {
+        let mut log = appending_log(&path).unwrap();
+        log.write_all(b"and this\n").unwrap();
+    }
+
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+    assert_eq!(mode & 0o077, 0, "mode was {mode:o}");
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        "already here\nand this\n",
+        "narrowing a log must not cost what was in it"
+    );
+}
+
+/// Which directory-sync failures are forgiven, and which are not.
+///
+/// A filesystem that implements no `fsyncdir` -- a FUSE server, some network
+/// mounts -- answers `EINVAL` or `ENOTSUP`. By then the rename has already
+/// succeeded, so reporting it failed a write that had landed and skipped the
+/// privacy check after it. Everything else is a real failure: the interesting
+/// half of this guard is the second list, because forgiving too much turns a
+/// device error into a write that claims to have been made durable.
+#[test]
+fn only_a_filesystem_that_will_not_sync_a_directory_is_forgiven() {
+    for kind in [io::ErrorKind::InvalidInput, io::ErrorKind::Unsupported] {
+        assert!(
+            directory_sync_is_unsupported(&io::Error::new(kind, "no fsyncdir here")),
+            "{kind:?} means the filesystem declined, not that the write failed"
+        );
+    }
+    for kind in [
+        io::ErrorKind::PermissionDenied,
+        io::ErrorKind::NotFound,
+        io::ErrorKind::Other,
+    ] {
+        assert!(
+            !directory_sync_is_unsupported(&io::Error::new(kind, "a real failure")),
+            "{kind:?} is a durability failure and must be reported"
+        );
+    }
+}

--- a/desktop/private-file/src/tests.rs
+++ b/desktop/private-file/src/tests.rs
@@ -1,0 +1,166 @@
+//! The guards for the one guarantee six copies used to give differently.
+
+use super::*;
+use std::sync::Arc;
+
+fn scratch() -> tempfile::TempDir {
+    tempfile::tempdir().expect("a temporary directory")
+}
+
+#[test]
+fn a_written_file_has_exactly_the_contents_it_was_given() {
+    let root = scratch();
+    let path = root.path().join("nested/deeper/state.json");
+    write_atomic(&path, b"{\"a\":1}").expect("the parent directories are created");
+    assert_eq!(std::fs::read(&path).unwrap(), b"{\"a\":1}");
+}
+
+#[test]
+fn a_rewrite_replaces_rather_than_appends() {
+    let root = scratch();
+    let path = root.path().join("state.json");
+    write_atomic(&path, b"first").unwrap();
+    write_atomic(&path, b"second").unwrap();
+    assert_eq!(std::fs::read(&path).unwrap(), b"second");
+}
+
+/// The temporary must never be left behind, whatever happens to it.
+#[test]
+fn nothing_is_left_beside_the_file_it_wrote() {
+    let root = scratch();
+    let path = root.path().join("state.json");
+    write_atomic(&path, b"contents").unwrap();
+    let left: Vec<String> = std::fs::read_dir(root.path())
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|entry| entry.file_name().to_string_lossy().into_owned())
+        .filter(|name| name != "state.json")
+        .collect();
+    assert!(left.is_empty(), "left behind: {left:?}");
+}
+
+/// Two writers at once, which is what a daemon persisting state from two
+/// threads actually does.
+///
+/// The implementations this replaced named the temporary from the process id
+/// alone. Two writes in flight in one process therefore chose the same name,
+/// and `create_new` failed the second with `AlreadyExists` -- a persist that
+/// reported failure for a reason that reads like a permissions problem.
+#[test]
+fn two_writes_at_once_in_one_process_both_succeed() {
+    let root = scratch();
+    let path = Arc::new(root.path().join("state.json"));
+    let barrier = Arc::new(std::sync::Barrier::new(8));
+    let mut writers = Vec::new();
+    for index in 0..8 {
+        let path = Arc::clone(&path);
+        let barrier = Arc::clone(&barrier);
+        writers.push(std::thread::spawn(move || {
+            barrier.wait();
+            write_atomic(&path, format!("writer {index}").as_bytes())
+        }));
+    }
+    for writer in writers {
+        writer
+            .join()
+            .expect("the writer did not panic")
+            .expect("every write succeeds");
+    }
+    // Whichever won, the file is one writer's contents entire.
+    let contents = std::fs::read_to_string(path.as_path()).unwrap();
+    assert!(
+        (0..8).any(|index| contents == format!("writer {index}")),
+        "a torn file: {contents:?}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn a_written_file_is_private_and_a_widened_one_is_refused() {
+    use std::os::unix::fs::PermissionsExt;
+    let root = scratch();
+    let path = root.path().join("secret.json");
+    write_atomic(&path, b"secret").unwrap();
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+    assert_eq!(mode & 0o077, 0, "mode was {mode:o}");
+
+    // And a file somebody else widened is reported rather than corrected.
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+    let error = ensure_private(&path).expect_err("a group-readable secret is refused");
+    assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+}
+
+#[cfg(unix)]
+#[test]
+fn a_symbolic_link_is_not_a_private_file() {
+    let root = scratch();
+    let real = root.path().join("real");
+    std::fs::write(&real, b"x").unwrap();
+    let link = root.path().join("link");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+    assert!(
+        ensure_private(&link).is_err(),
+        "a link is not a regular file"
+    );
+}
+
+#[test]
+fn a_path_with_no_parent_is_refused_rather_than_panicking() {
+    let error = write_atomic(Path::new("/"), b"x").expect_err("the root has no parent");
+    assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+}
+
+#[cfg(unix)]
+#[test]
+fn a_private_directory_is_entered_only_by_this_user() {
+    use std::os::unix::fs::PermissionsExt;
+    let root = scratch();
+    let path = root.path().join("vault");
+    ensure_private_directory(&path).unwrap();
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+    assert_eq!(mode & 0o077, 0, "mode was {mode:o}");
+}
+
+#[test]
+fn an_appending_log_keeps_what_was_already_there() {
+    let root = scratch();
+    let path = root.path().join("logs/run.log");
+    {
+        let mut log = appending_log(&path).unwrap();
+        log.write_all(b"first\n").unwrap();
+    }
+    {
+        let mut log = appending_log(&path).unwrap();
+        log.write_all(b"second\n").unwrap();
+    }
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), "first\nsecond\n");
+}
+
+/// The repairing counterpart, and why it is not the refusing one.
+#[cfg(unix)]
+#[test]
+fn a_widened_file_is_narrowed_rather_than_refused_where_that_is_the_contract() {
+    use std::os::unix::fs::PermissionsExt;
+    let root = scratch();
+    let path = root.path().join("config.json");
+    std::fs::write(&path, b"{}").unwrap();
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+    // `cp -R` instead of `cp -Rp` lands exactly here, and refusing was
+    // permanently fatal to an installation, silently.
+    make_private(&path).expect("a widened config is repaired");
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+    assert_eq!(mode & 0o077, 0, "mode was {mode:o}");
+}
+
+#[cfg(unix)]
+#[test]
+fn repairing_still_refuses_what_is_not_a_regular_file() {
+    let root = scratch();
+    let real = root.path().join("real");
+    std::fs::write(&real, b"x").unwrap();
+    let link = root.path().join("link");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+    let error = make_private(&link).expect_err("a link is not a file to repair");
+    assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    assert!(make_private(root.path()).is_err(), "nor is a directory");
+}

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_host_wire_contract.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_host_wire_contract.py
@@ -21,6 +21,7 @@ import pytest
 from uuid import uuid7
 
 from app.modules.agent.domain.agent_host import (
+    AGENT_HOST_PROTOCOL_VERSION,
     AgentHostCapacity,
     AgentHostEvent,
     AgentHostEventType,
@@ -149,3 +150,14 @@ def test_the_declared_limits_are_the_ones_this_side_enforces() -> None:
         item.le for item in max_runs.metadata if getattr(item, "le", None) is not None
     )
     assert ceiling == limits["max_runs"]
+
+
+def test_the_protocol_version_is_the_one_the_host_sends() -> None:
+    """One number, in two languages, that nothing used to tie together.
+
+    The host puts ``PROTOCOL_VERSION`` in every identity it publishes and this
+    process compares it. Raising one side and not the other makes every host of
+    the old version look unrecognised, from the moment this deploys, with
+    nothing failing on either side to say so.
+    """
+    assert AGENT_HOST_PROTOCOL_VERSION == _contract()["protocol_version"]

--- a/lemma-stack/pyproject.toml
+++ b/lemma-stack/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-stack"
-version = "0.7.1"
+version = "0.7.2"
 description = "Installer and management tool for a fully-local Lemma stack"
 readme = "README.md"
 requires-python = ">=3.14,<3.15"

--- a/lemma-stack/uv.lock
+++ b/lemma-stack/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.14.*"
 
 [[package]]
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "lemma-stack"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -159,6 +159,7 @@ SOURCES: tuple[Source, ...] = (
 # next release, so the shape is checked rather than the value.
 WORKSPACE_MEMBERS: tuple[str, ...] = (
     "desktop/locald",
+    "desktop/private-file",
     "desktop/agent-host",
     "desktop/local-runtime/manager",
     "desktop/local-runtime/hostctl",

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -142,6 +142,16 @@ SOURCES: tuple[Source, ...] = (
         "desktop bundled runtime manifest",
         REPO_ROOT / "desktop/runtime/lemma-local.json",
     ),
+    # `install.sh` installs this as a uv tool and SUPPORT.md tells people to
+    # run it, so it is a version somebody has installed. It was not in this
+    # list and had fallen a release behind: `lemma-stack --version` said 0.7.1
+    # while the backend it manages said 0.7.2, which is exactly the skew a
+    # support conversation cannot see past.
+    Source(
+        "lemma-stack package",
+        REPO_ROOT / "lemma-stack/pyproject.toml",
+        re.compile(r'(?m)^version = "([^"]+)"'),
+    ),
 )
 
 # Every crate in the desktop workspace inherits one version. A member that

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -154,22 +154,40 @@ SOURCES: tuple[Source, ...] = (
     ),
 )
 
+def workspace_members() -> tuple[str, ...]:
+    """Every crate in the desktop workspace, read from the workspace manifest.
+
+    Derived rather than listed. The list was written out by hand here and
+    `desktop/process` was never added to it, so that crate could re-declare its
+    own version and nothing would say -- which is the drift this check exists to
+    catch. The manifest is the one place that already has to name every member,
+    and it is the place a new crate is added.
+
+    The root manifest is both the workspace's definition and its own package, so
+    it is checked too; it is not in its own members list.
+    """
+    manifest = (REPO_ROOT / "desktop/Cargo.toml").read_text(encoding="utf-8")
+    listed = re.search(r"^members\s*=\s*\[(.*?)\]", manifest, re.MULTILINE | re.DOTALL)
+    if listed is None:
+        raise SystemExit(
+            "desktop/Cargo.toml declares no workspace members; this check reads them "
+            "from there and has nothing to check"
+        )
+    members = re.findall(r'"([^"]+)"', listed.group(1))
+    if len(members) < 5:
+        raise SystemExit(
+            f"desktop/Cargo.toml lists {len(members)} workspace member(s); that is fewer "
+            "than the workspace has ever had, so the manifest is not being read correctly"
+        )
+    return ("desktop", *(f"desktop/{member}" for member in members))
+
+
 # Every crate in the desktop workspace inherits one version. A member that
 # re-declares its own would be invisible to SOURCES above and would drift at the
 # next release, so the shape is checked rather than the value.
-WORKSPACE_MEMBERS: tuple[str, ...] = (
-    "desktop/locald",
-    "desktop/private-file",
-    "desktop/agent-host",
-    "desktop/local-runtime/manager",
-    "desktop/local-runtime/hostctl",
-    "desktop/local-runtime/guestd",
-)
-
-
 def workspace_member_problems() -> list[str]:
     problems: list[str] = []
-    for member in WORKSPACE_MEMBERS:
+    for member in workspace_members():
         manifest = REPO_ROOT / member / "Cargo.toml"
         if not manifest.exists():
             problems.append(f"  {member}: no Cargo.toml")


### PR DESCRIPTION
## What changes

Two register items from the post-#631 desktop audit, neither of them a
refactor.

**CT-1 — the Agent Host protocol version was two literals, and nothing ran the
test that would have noticed.** `lemma_agent_host::PROTOCOL_VERSION` and the
backend's `AGENT_HOST_PROTOCOL_VERSION` are the same number written twice, in
two languages. The host puts it in every identity it publishes and the backend
compares it; raising one without the other makes every host of the old version
look unrecognised, from the moment the backend deploys, with nothing failing on
either side to say so. It goes in `tests/fixtures/wire_contract.json` — which
both sides already assert, for the event enum and the two text extractors —
and each side checks its own literal against it.

The CI half was worse. `desktop-contract` runs on backend-only pull requests,
which is the direction that matters, and it ran
`cargo test -p lemma-locald -p lemma-guestd`: not the crate whose contract the
backend was changing. It now runs the Agent Host's `wire_contract` and
`control_plane_contract` suites too — only those two, because the rest of that
crate's tests spawn agents.

`lemma-stack` was also a release behind: `install.sh` installs it as a uv tool
and SUPPORT.md tells people to run `lemma-stack doctor`, so it is a version
somebody has installed, and it said 0.7.1 while the backend it manages said
0.7.2. It was never in `check_version_consistency.py`. It is now.

**LD-10 — six copies of "write this file safely", two of which could lose the
write.** `write_private_atomic` existed six times, and the copies had drifted:

- Two never `fsync`ed the directory the rename happened in. A file whose bytes
  are on the disk but whose directory entry is not is a file that is not
  there, so a power cut could take back a write that had already returned
  `Ok`.
- One named the temporary from the process id alone. Two writes in flight in
  one process — which is what a daemon persisting state from two threads does
  — chose the same name, and `create_new` failed the second with
  `AlreadyExists`: a persist reporting failure for a reason that reads like a
  permissions problem.
- Only one used `MOVEFILE_WRITE_THROUGH`, which is what makes the rename
  itself durable on Windows. The other five used `fs::rename`, which does not
  pass it.
- `state.json` had none of it: a plain `write` to a fixed `.json.next` and a
  rename, no `fsync` of either the file or the directory, no private mode on a
  file that carries the workspace URL.

There is one now, in a new `lemma-private-file` crate, and it is the strongest
of the six.

The one difference that was *not* drift is kept and named. `ensure_private`
refuses a file anyone else can read; `make_private` narrows it instead. The
operator config takes the second on purpose and says why: `cp -R` rather than
`cp -Rp` lands 0644 on a whole state directory, and refusing there was
permanently fatal, silently. Where the exposure itself is the question — the
infrastructure secrets, the runtime's private files — refusing is right.

And `state.json` carries a `schemaVersion`. It had none, and `load` falls back
to the default on any parse failure, so a future shape change would have
silently reset every installation with nothing saying why.

## Why

Both are entries in the post-#631 production-readiness audit, and both are the
kind of defect that reports success. Nothing observable breaks until a machine
loses power at the wrong moment, or a backend deploy quietly stops recognising
every host in the field.

## How to verify

```bash
make desktop-check
python3 scripts/check_version_consistency.py
cd lemma-backend && uv run pytest app/modules/agent/tests/unit/test_agent_host_wire_contract.py
```

Every fix has a test that fails without it, and I checked each by reverting the
fix rather than by reading:

- Setting `PROTOCOL_VERSION` to 3 fails
  `the_protocol_version_is_the_one_the_backend_expects` with the message that
  names the contract.
- Restoring the previous temporary-file naming (`with_extension("tmp-<pid>")`,
  pre-removed) fails `two_writes_at_once_in_one_process_both_succeed` — eight
  threads writing one path.
- `check_version_consistency.py` reports thirteen components rather than
  twelve, and reported the 0.7.1/0.7.2 split before the bump.

Eleven tests on the new crate, covering the atomic replacement, the private
mode, the refusing and repairing variants, a symlink, a path with no parent,
and the concurrent case.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

`state.json` gains a `schemaVersion` field. It is `#[serde(default)]`, so a
file written before this reads as version 1 and a file written after this is
readable by a build without the field — the daemon's `deny_unknown_fields` is
on the operator config, not on this. Revertible either way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability and privacy for local configuration, state, secret, and log files through atomic writes and stricter permission handling.
  - Existing exposed secret files are now secured without unnecessarily regenerating secrets.
  - Improved compatibility when reading existing local state files while distinguishing older formats from corrupted data.
  - Improved Windows file replacement behavior for local data updates.

- **Tests**
  - Added validation to keep desktop and backend communication protocols synchronized.
  - Expanded coverage for private-file handling, concurrent writes, permissions, and append-only logs.

- **Release**
  - Updated the Lemma Stack version to 0.7.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->