### PR TITLE
Telemetry that nothing called, in the crate none of its events happen in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -820,13 +820,17 @@ jobs:
           npm ci --prefix lemma-typescript
           npm ci --prefix lemma-frontend
           npm ci --prefix desktop/ui-tests
-          # Retried, because `--with-deps` runs apt, and apt fetches Google's
-          # Chrome repository index over the network. A "Hash Sum mismatch"
-          # there -- a mirror caught mid-update, which is nobody's bug and
-          # nothing this repository controls -- exits 100 and takes the whole
-          # lane down after every Rust test in it has already passed. Measured
-          # once on this job; the second attempt costs seconds and the failure
-          # it absorbs costs a re-run of everything.
+          # `--with-deps` runs apt, and apt fetches Google's Chrome repository
+          # index. "Hash Sum mismatch" there exits 100 and takes the whole lane
+          # down after every Rust test in it has already passed.
+          #
+          # The retry throws the index away first, which is the part that
+          # matters. A mismatch is apt saying its cached index does not agree
+          # with what the server just served -- so repeating the same fetch
+          # reproduces it exactly, which is what the first version of this
+          # retry did: three attempts, three identical failures, measured on
+          # this job. Clearing `/var/lib/apt/lists` is what makes the next
+          # attempt a different question.
           for attempt in 1 2 3; do
             npm exec --prefix desktop/ui-tests -- \
               playwright install --with-deps chromium && break
@@ -834,8 +838,9 @@ jobs:
               echo "playwright install failed three times; this is not transient"
               exit 1
             fi
-            echo "playwright install failed (attempt $attempt); retrying"
-            sleep 15
+            echo "playwright install failed (attempt $attempt); refetching the apt index"
+            sudo rm -rf /var/lib/apt/lists/*
+            sudo apt-get update || true
           done
 
       - name: Chat UI with JSON ACP agents

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -820,7 +820,23 @@ jobs:
           npm ci --prefix lemma-typescript
           npm ci --prefix lemma-frontend
           npm ci --prefix desktop/ui-tests
-          npm exec --prefix desktop/ui-tests -- playwright install --with-deps chromium
+          # Retried, because `--with-deps` runs apt, and apt fetches Google's
+          # Chrome repository index over the network. A "Hash Sum mismatch"
+          # there -- a mirror caught mid-update, which is nobody's bug and
+          # nothing this repository controls -- exits 100 and takes the whole
+          # lane down after every Rust test in it has already passed. Measured
+          # once on this job; the second attempt costs seconds and the failure
+          # it absorbs costs a re-run of everything.
+          for attempt in 1 2 3; do
+            npm exec --prefix desktop/ui-tests -- \
+              playwright install --with-deps chromium && break
+            if [ "$attempt" = 3 ]; then
+              echo "playwright install failed three times; this is not transient"
+              exit 1
+            fi
+            echo "playwright install failed (attempt $attempt); retrying"
+            sleep 15
+          done
 
       - name: Chat UI with JSON ACP agents
         run: make desktop-agent-host-browser-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -815,6 +815,22 @@ jobs:
             lemma-frontend/package-lock.json
             desktop/ui-tests/package-lock.json
 
+      # Chromium is ~150 MB and byte-identical between runs; the only thing
+      # that changes it is a Playwright version bump, which changes the
+      # lockfile. Restoring it turns a download into a hash check.
+      #
+      # Safe to restore stale or partial: `playwright install` still checks
+      # what it finds and fetches whatever is missing, so a bad cache costs a
+      # download rather than the wrong browser.
+      - name: Cache the Playwright browser
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            ~/AppData/Local/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('desktop/ui-tests/package-lock.json') }}
+
       - name: Install chat UI test dependencies
         run: |
           npm ci --prefix lemma-typescript
@@ -976,6 +992,22 @@ jobs:
 
       - name: Guest boot tooling tests
         run: uv run --no-project python -m unittest discover -s desktop/scripts -p 'test_*.py'
+
+      # Chromium is ~150 MB and byte-identical between runs; the only thing
+      # that changes it is a Playwright version bump, which changes the
+      # lockfile. Restoring it turns a download into a hash check.
+      #
+      # Safe to restore stale or partial: `playwright install` still checks
+      # what it finds and fetches whatever is missing, so a bad cache costs a
+      # download rather than the wrong browser.
+      - name: Cache the Playwright browser
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            ~/AppData/Local/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('desktop/ui-tests/package-lock.json') }}
 
       - name: Settings behavior tests
         working-directory: desktop/ui-tests
@@ -1324,6 +1356,22 @@ jobs:
 
       - name: Guest packaging tests
         run: uv run --no-project python -m unittest discover -s desktop/scripts -p 'test_*.py'
+
+      # Chromium is ~150 MB and byte-identical between runs; the only thing
+      # that changes it is a Playwright version bump, which changes the
+      # lockfile. Restoring it turns a download into a hash check.
+      #
+      # Safe to restore stale or partial: `playwright install` still checks
+      # what it finds and fetches whatever is missing, so a bad cache costs a
+      # download rather than the wrong browser.
+      - name: Cache the Playwright browser
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            ~/AppData/Local/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('desktop/ui-tests/package-lock.json') }}
 
       - name: Settings behavior tests
         working-directory: desktop/ui-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -836,28 +836,27 @@ jobs:
           npm ci --prefix lemma-typescript
           npm ci --prefix lemma-frontend
           npm ci --prefix desktop/ui-tests
-          # `--with-deps` runs apt, and apt fetches Google's Chrome repository
-          # index. "Hash Sum mismatch" there exits 100 and takes the whole lane
-          # down after every Rust test in it has already passed.
+          # The browser first, from the cache above, with no apt involved.
+          npm exec --prefix desktop/ui-tests -- playwright install chromium
+          # Then the system libraries it wants. This is the apt half, and it is
+          # the half that fails: `--with-deps` fetches Google's Chrome
+          # repository index, and a "Hash Sum mismatch" there exits 100 and
+          # takes the lane down after every Rust test in it has already passed.
+          # Four times in one afternoon, on an index this repository neither
+          # controls nor needs -- the browser is already downloaded.
           #
-          # The retry throws the index away first, which is the part that
-          # matters. A mismatch is apt saying its cached index does not agree
-          # with what the server just served -- so repeating the same fetch
-          # reproduces it exactly, which is what the first version of this
-          # retry did: three attempts, three identical failures, measured on
-          # this job. Clearing `/var/lib/apt/lists` is what makes the next
-          # attempt a different question.
-          for attempt in 1 2 3; do
-            npm exec --prefix desktop/ui-tests -- \
-              playwright install --with-deps chromium && break
-            if [ "$attempt" = 3 ]; then
-              echo "playwright install failed three times; this is not transient"
-              exit 1
-            fi
-            echo "playwright install failed (attempt $attempt); refetching the apt index"
-            sudo rm -rf /var/lib/apt/lists/*
-            sudo apt-get update || true
-          done
+          # Retrying it was the wrong fix and is gone: a mismatch is apt saying
+          # its cached index disagrees with the server, so the same fetch fails
+          # the same way, which is exactly what three attempts did.
+          #
+          # Not fatal now. `ubuntu-latest` ships the libraries Chromium needs,
+          # so this is belt and braces; if that ever stops being true the
+          # browser fails to launch in the next step and names the library it
+          # is missing, which is a better failure than a lane that dies on a
+          # mirror being mid-update.
+          if ! npm exec --prefix desktop/ui-tests -- playwright install-deps chromium; then
+            echo "::warning::playwright install-deps failed; continuing on the runner image's own libraries"
+          fi
 
       - name: Chat UI with JSON ACP agents
         run: make desktop-agent-host-browser-e2e

--- a/desktop/build.rs
+++ b/desktop/build.rs
@@ -45,6 +45,8 @@ const COMMANDS: &[&str] = &[
     "restart_into_recovery",
     "check_for_app_update",
     "install_app_update",
+    "telemetry_status",
+    "set_telemetry_enabled",
 ];
 
 fn main() {

--- a/desktop/capabilities/control.json
+++ b/desktop/capabilities/control.json
@@ -17,6 +17,8 @@
     "allow-repair-runtime",
     "allow-control-snapshot",
     "allow-agent-host-action",
+    "allow-telemetry-status",
+    "allow-set-telemetry-enabled",
     "allow-apply-operator-config",
     "allow-discover-provider-models",
     "allow-configure-ai-provider",

--- a/desktop/locald/src/lib.rs
+++ b/desktop/locald/src/lib.rs
@@ -16,7 +16,6 @@ pub mod reset;
 pub mod sharing;
 pub mod state;
 mod tcp_forwarder;
-pub mod telemetry;
 pub mod update_transaction;
 pub mod vault_process;
 
@@ -296,17 +295,7 @@ mod http_client_policy {
         // Assembled at compile time so this guard does not find itself: it
         // reads every file in the crate now, and this one is one of them.
         let builder = concat!("Client::", "builder()");
-        // The one client here that is not talking to the supervised stack.
-        // Telemetry posts to an ingestion host on the internet, which is
-        // exactly the traffic a system proxy exists to carry -- so it must
-        // *not* opt out. Named here because it was never in the list this
-        // rule used to read, and "not in the list" is not a decision anyone
-        // made.
-        const OUTBOUND: [&str; 1] = ["locald/src/telemetry.rs"];
         for (name, source) in &sources {
-            if OUTBOUND.contains(&name.as_str()) {
-                continue;
-            }
             for (offset, _) in source.match_indices(builder) {
                 // The builder chain runs until the `.build()` that ends it.
                 let rest = &source[offset..];

--- a/desktop/src/app.rs
+++ b/desktop/src/app.rs
@@ -80,6 +80,8 @@ pub(crate) fn run() {
             prompts::resolve_confirmation,
             diagnostics::open_developer_tools,
             local_recovery::local_recovery_options,
+            telemetry::telemetry_status,
+            telemetry::set_telemetry_enabled,
             local_recovery::reset_local_data,
             local_recovery::reset_full_reinstall,
             local_recovery::restart_into_recovery,
@@ -134,6 +136,12 @@ pub(crate) fn run() {
                 "resume: hit, opening the workspace directly"
             } else {
                 "resume: miss, falling back to the splash"
+            });
+            // Cold means this launch found nothing already serving and has to
+            // bring the stack up. It is the launch that can go wrong, and the
+            // one whose duration is worth knowing.
+            telemetry::note(telemetry::InstallEvent::Launched {
+                cold: resume.is_none(),
             });
 
             let initial_url = if mode == "hosted" {

--- a/desktop/src/connection.rs
+++ b/desktop/src/connection.rs
@@ -98,6 +98,11 @@ pub(crate) fn set_mode(app: &AppHandle, mode: &str) -> Result<(), String> {
         config["connectionMode"] = json!(mode);
         config["connectionModePromptRevision"] = json!(CONNECTION_MODE_PROMPT_REVISION);
     })?;
+    // Every path that changes the deployment choice comes through here, which
+    // is why the event is here rather than in the three callers.
+    telemetry::note(telemetry::InstallEvent::ModeSelected {
+        local: mode == "local",
+    });
     refresh_menus_for_connection_mode(app);
     let changed = {
         let shell: State<Shell> = app.state();

--- a/desktop/src/locald_events.rs
+++ b/desktop/src/locald_events.rs
@@ -151,6 +151,17 @@ pub(crate) fn apply_locald_event(ui: &mut UiState, kind: &str, event: &Value) ->
         "ready" => {
             if !ui.ready {
                 launch_trace("daemon reported ready");
+                // How long this launch took to become usable, and whether it
+                // had to install anything to get there. The first of those is
+                // the number the whole runtime install exists to keep small,
+                // and nothing was measuring it outside a developer's console.
+                telemetry::note(telemetry::InstallEvent::RuntimeReady {
+                    cached: !ui.installed_this_launch,
+                    duration_ms: u64::try_from(
+                        LAUNCH_START.get_or_init(Instant::now).elapsed().as_millis(),
+                    )
+                    .unwrap_or(u64::MAX),
+                });
             }
             ui.ready = true;
             ui.running = true;

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -37,6 +37,7 @@ mod shell_paths;
 mod shutdown;
 mod stack_control;
 mod state;
+mod telemetry;
 mod update_policy;
 mod window_placement;
 mod windowing;

--- a/desktop/src/quitting.rs
+++ b/desktop/src/quitting.rs
@@ -258,6 +258,7 @@ pub(crate) fn run_quit_watchdog(
 pub(crate) fn finish_quit(app: &AppHandle) {
     let shell: State<Shell> = app.state();
     shell.quit_confirmed.store(true, Ordering::Release);
+    note_session_length();
     let worker = app.clone();
     let exiting = app.clone();
     shell.shutdown.start(
@@ -267,7 +268,21 @@ pub(crate) fn finish_quit(app: &AppHandle) {
     );
 }
 
+/// How long this session lasted, once, however the app is quit.
+///
+/// Both quit paths end in a shutdown, and either can be reached first, so the
+/// once-only is here rather than at each call site.
+fn note_session_length() {
+    static NOTED: std::sync::Once = std::sync::Once::new();
+    NOTED.call_once(|| {
+        telemetry::note(telemetry::InstallEvent::Quit {
+            session_seconds: LAUNCH_START.get_or_init(Instant::now).elapsed().as_secs(),
+        });
+    });
+}
+
 pub(crate) fn finish_quit_after_daemon(app: &AppHandle) {
+    note_session_length();
     let worker = app.clone();
     let exiting = app.clone();
     app.state::<Shell>().shutdown.start(

--- a/desktop/src/runtime_setup.rs
+++ b/desktop/src/runtime_setup.rs
@@ -97,6 +97,15 @@ pub(crate) fn ensure_runtime_artifacts_inner(
         let mut ui = shell.ui.lock().unwrap();
         ui.active_operation_id = install_operation_id.clone();
     }
+    telemetry::note(telemetry::InstallEvent::RuntimeInstallStarted);
+    {
+        let shell: State<Shell> = app.state();
+        shell.ui.lock().unwrap().installed_this_launch = true;
+    }
+    // Where the install got to, for the failure event. A install that dies is
+    // only useful to hear about if we know which step died, and the progress
+    // callback is the only thing that knows.
+    let reached = std::sync::Arc::new(std::sync::Mutex::new("resolve"));
     emit_runtime_install_progress(
         app,
         "resolve",
@@ -119,6 +128,9 @@ pub(crate) fn ensure_runtime_artifacts_inner(
         &runtime_install_root(),
         env!("CARGO_PKG_VERSION"),
         &mut |progress| {
+            if let Some(step) = install_step(progress.stage) {
+                *reached.lock().expect("install step lock poisoned") = step;
+            }
             let fraction = progress
                 .current
                 .saturating_mul(1000)
@@ -157,7 +169,14 @@ pub(crate) fn ensure_runtime_artifacts_inner(
             );
         },
     )
-    .map_err(|error| format!("could not install the local runtime: {error}"))?;
+    .map_err(|error| {
+        let detail = format!("could not install the local runtime: {error}");
+        telemetry::note(telemetry::InstallEvent::RuntimeInstallFailed {
+            step: *reached.lock().expect("install step lock poisoned"),
+            class: runtime_install_failure_class(&detail),
+        });
+        detail
+    })?;
     stop_locald_for_runtime_maintenance(app).map_err(|error| {
         format!("could not stop the previous local runtime before activation: {error}")
     })?;
@@ -180,7 +199,53 @@ pub(crate) fn ensure_runtime_artifacts_inner(
             ui.active_operation_id.clear();
         }
     }
+    telemetry::note(telemetry::InstallEvent::RuntimeInstallCompleted);
     Ok(())
+}
+
+/// The installer's own stage names, narrowed to the ones worth reporting.
+///
+/// A closed set on purpose: the event carries this verbatim, and an unbounded
+/// string from the installer is how a path or a URL ends up in an analytics
+/// database.
+fn install_step(stage: &str) -> Option<&'static str> {
+    match stage {
+        "download" => Some("download"),
+        "verify" => Some("verify"),
+        "host-extract" => Some("host-extract"),
+        "guest-extract" => Some("guest-extract"),
+        "validate" => Some("validate"),
+        _ => None,
+    }
+}
+
+/// Why an install failed, as one of a fixed set of words.
+///
+/// The same taxonomy `actionable_runtime_install_error` uses to decide what to
+/// tell the person, reduced to something countable. Never the error text: that
+/// carries paths, hostnames and occasionally a URL with a token in it.
+fn runtime_install_failure_class(error: &str) -> &'static str {
+    let lowered = error.to_ascii_lowercase();
+    if error.contains("artifact download failed with HTTP 404") {
+        return "artifact-missing";
+    }
+    if lowered.contains("http 401") || lowered.contains("http 403") || lowered.contains("http 429")
+    {
+        return "download-blocked";
+    }
+    if lowered.contains("could not connect") || lowered.contains("dns") {
+        return "network-unreachable";
+    }
+    if lowered.contains("no space") || lowered.contains("not enough space") {
+        return "disk-full";
+    }
+    if lowered.contains("digest") || lowered.contains("signature") || lowered.contains("checksum") {
+        return "verification-failed";
+    }
+    if lowered.contains("permission denied") || lowered.contains("read-only") {
+        return "permission-denied";
+    }
+    "other"
 }
 
 /// Turn an installer failure into something the person reading it can do.

--- a/desktop/src/runtime_setup.rs
+++ b/desktop/src/runtime_setup.rs
@@ -177,10 +177,23 @@ pub(crate) fn ensure_runtime_artifacts_inner(
         });
         detail
     })?;
-    stop_locald_for_runtime_maintenance(app).map_err(|error| {
-        format!("could not stop the previous local runtime before activation: {error}")
-    })?;
-    activate_installed_runtime(&installed)?;
+    // Reported the same way as the install itself. These two run *after*
+    // `RuntimeInstallStarted`, so a failure here used to end the attempt with
+    // no terminal event at all -- an install that started and, as far as the
+    // numbers went, never finished. Install health is the one thing this
+    // telemetry is for, so the funnel has to close on every path out of it.
+    let activation = stop_locald_for_runtime_maintenance(app)
+        .map_err(|error| {
+            format!("could not stop the previous local runtime before activation: {error}")
+        })
+        .and_then(|()| activate_installed_runtime(&installed));
+    if let Err(detail) = activation {
+        telemetry::note(telemetry::InstallEvent::RuntimeInstallFailed {
+            step: "activate",
+            class: runtime_install_failure_class(&detail),
+        });
+        return Err(detail);
+    }
     emit_runtime_install_progress(
         app,
         "activate",

--- a/desktop/src/state.rs
+++ b/desktop/src/state.rs
@@ -32,6 +32,12 @@ pub(crate) struct UiState {
     pub(crate) completed_operation_ids: Vec<String>,
     #[serde(skip)]
     pub(crate) terminal_recovery_pending: bool,
+    /// Whether this launch had to install a runtime before it could start.
+    ///
+    /// Only for the readiness measurement: a first run and a warm start take
+    /// wildly different times, and a number that mixes them says nothing.
+    #[serde(skip)]
+    pub(crate) installed_this_launch: bool,
 }
 
 /// What a broken installation can still be offered.

--- a/desktop/src/telemetry.rs
+++ b/desktop/src/telemetry.rs
@@ -24,6 +24,10 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
+use crate::shell_paths::locald_root;
+use crate::{require_control_window, Webview};
+use serde_json::Value;
+
 const KEY_ENV: &str = "LEMMA_TELEMETRY_KEY";
 const HOST_ENV: &str = "LEMMA_TELEMETRY_HOST";
 const DISABLE_ENV: &str = "LEMMA_TELEMETRY";
@@ -162,9 +166,30 @@ pub fn load_state(root: &Path) -> TelemetryState {
 
 pub fn save_state(root: &Path, state: &TelemetryState) -> std::io::Result<()> {
     fs::create_dir_all(root)?;
-    let encoded = serde_json::to_string_pretty(state)
+    let encoded = serde_json::to_vec_pretty(state)
         .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-    fs::write(state_path(root), encoded)
+    // Atomically, and readable only by this user. It was a plain `write`,
+    // which can leave a truncated file: this one holds the opt-out, and a
+    // half-written opt-out reads as "never answered", which reads as consent.
+    lemma_private_file::write_atomic(&state_path(root), &encoded)
+}
+
+/// Where the install id and the opt-out live.
+///
+/// The daemon's state directory rather than the app's own, so "start over"
+/// takes them with it: somebody who erases this installation gets a new
+/// install id, which is the behaviour the identity promises.
+pub fn root() -> PathBuf {
+    locald_root()
+}
+
+/// Record an event about this installation, if the person has not opted out
+/// and this build has an ingestion key.
+///
+/// The convenience the call sites use, so none of them has to know where the
+/// state lives.
+pub fn note(event: InstallEvent) {
+    record(&root(), event);
 }
 
 /// The Local settings toggle writes through here.
@@ -342,5 +367,120 @@ mod tests {
         // No path, no host, no user-supplied string can appear: the variant
         // only accepts &'static str chosen at the call site.
         assert!(!rendered.contains('/'));
+    }
+}
+
+/// What Local settings shows for the anonymous install-health switch.
+///
+/// `available` is whether this build has an ingestion key at all. Without one
+/// nothing is ever sent, so a switch would be a control over nothing -- the
+/// page hides the whole panel rather than offering a lie.
+#[tauri::command(async)]
+pub(crate) fn telemetry_status(window: Webview) -> Result<Value, String> {
+    require_control_window(&window)?;
+    let root = root();
+    Ok(serde_json::json!({
+        "available": ingestion_key().is_some(),
+        "enabled": is_enabled(&root),
+        "host": DEFAULT_HOST,
+        "install_id": load_state(&root).install_id,
+    }))
+}
+
+/// The switch itself.
+///
+/// An explicit `false` is never overridden by anything: not by an upgrade, not
+/// by a new ingestion key. That is what makes it an opt-out rather than a
+/// preference.
+#[tauri::command(async)]
+pub(crate) fn set_telemetry_enabled(window: Webview, enabled: bool) -> Result<(), String> {
+    require_control_window(&window)?;
+    set_enabled(&root(), enabled)
+        .map_err(|error| format!("could not save your anonymous install-health choice: {error}"))
+}
+
+#[cfg(test)]
+mod wiring_tests {
+
+    /// Every event this module can express is one the app actually sends.
+    ///
+    /// The module was written, reviewed and shipped with no caller at all:
+    /// `record` was never invoked from anywhere, so the first signal that a
+    /// runtime install broke on a new macOS release stayed a GitHub issue
+    /// three weeks later -- which is the exact failure the opening comment
+    /// says this exists to prevent. A variant nobody constructs is that bug
+    /// coming back one event at a time.
+    #[test]
+    fn every_event_is_sent_from_somewhere() {
+        let source = crate::tests::shell_source();
+        let mut unsent = Vec::new();
+        for variant in [
+            "Launched",
+            "RuntimeInstallStarted",
+            "RuntimeInstallCompleted",
+            "RuntimeInstallFailed",
+            "RuntimeReady",
+            "ModeSelected",
+            "Quit",
+        ] {
+            if !source.contains(&format!("InstallEvent::{variant}")) {
+                unsent.push(variant);
+            }
+        }
+        assert!(
+            unsent.is_empty(),
+            "these events exist and nothing sends them: {unsent:?}",
+        );
+    }
+
+    /// The switch is offered to Local settings and to nothing else.
+    #[test]
+    fn the_switch_is_not_reachable_from_the_workspace() {
+        for command in ["allow-telemetry-status", "allow-set-telemetry-enabled"] {
+            assert!(
+                crate::tests::granted("control")
+                    .iter()
+                    .any(|p| p == command),
+                "{command} has to be granted to Local settings"
+            );
+            assert!(
+                !crate::tests::granted("workspace")
+                    .iter()
+                    .any(|p| p == command),
+                "{command} must not be reachable from a remote origin"
+            );
+            assert!(
+                !crate::tests::granted("main").iter().any(|p| p == command),
+                "{command} must not be reachable from the splash"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod documentation_tests {
+    /// The switch, the destination and the events are documented where a
+    /// person installing Lemma will look.
+    ///
+    /// The register's DOC-1 is exactly this gap: the module named a PostHog
+    /// endpoint that appeared in no document a user reads, and claimed a Local
+    /// settings toggle that did not exist.
+    #[test]
+    fn what_is_sent_and_how_to_stop_it_is_written_down() {
+        let installation = include_str!("../../docs/installation.md").replace("\r\n", "\n");
+        assert!(
+            installation.contains("Anonymous install health"),
+            "the switch is not documented where somebody installing Lemma reads",
+        );
+        for required in [
+            super::DEFAULT_HOST,
+            "LEMMA_TELEMETRY=0",
+            "desktop.runtime_install",
+        ] {
+            assert!(
+                installation.contains(required),
+                "{required:?} is not in the installation guide",
+            );
+        }
     }
 }

--- a/desktop/src/telemetry.rs
+++ b/desktop/src/telemetry.rs
@@ -20,6 +20,7 @@ use std::fs;
 #[cfg(unix)]
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -193,10 +194,35 @@ pub fn note(event: InstallEvent) {
 }
 
 /// The Local settings toggle writes through here.
-pub fn set_enabled(root: &Path, enabled: bool) -> std::io::Result<()> {
+/// Every read-modify-write of the telemetry state happens under this.
+///
+/// Atomic file replacement makes each *write* whole; it does nothing about two
+/// of them overlapping. `install_id` and `set_enabled` both read the file,
+/// change one field and write it back, so an opt-out saved between an event's
+/// read and its write was replaced by the state that event had read a moment
+/// earlier -- and telemetry carried on after the user had turned it off. That
+/// is the one bug this file cannot be allowed to have.
+///
+/// Process-wide, which is the scope that matters: the shell is single-instance
+/// and only it writes this file.
+static STATE: Mutex<()> = Mutex::new(());
+
+/// Read the state, change it, and write it back, with nothing in between.
+pub(crate) fn update_state<T>(
+    root: &Path,
+    change: impl FnOnce(&mut TelemetryState) -> T,
+) -> std::io::Result<T> {
+    let _guard = STATE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let mut state = load_state(root);
-    state.enabled = Some(enabled);
-    save_state(root, &state)
+    let outcome = change(&mut state);
+    save_state(root, &state)?;
+    Ok(outcome)
+}
+
+pub fn set_enabled(root: &Path, enabled: bool) -> std::io::Result<()> {
+    update_state(root, |state| state.enabled = Some(enabled))
 }
 
 /// A random per-installation id, minted once and kept.
@@ -204,14 +230,19 @@ pub fn set_enabled(root: &Path, enabled: bool) -> std::io::Result<()> {
 /// Random on purpose — never derived from hostname, MAC or machine id, which
 /// identify a person's computer rather than an installation of this app.
 pub fn install_id(root: &Path) -> String {
-    let mut state = load_state(root);
-    if let Some(existing) = state.install_id.as_ref().filter(|id| !id.is_empty()) {
-        return existing.clone();
-    }
-    let minted = random_hex();
-    state.install_id = Some(minted.clone());
-    let _ = save_state(root, &state);
-    minted
+    // Under the same lock as every other change, so minting an id cannot write
+    // back an `enabled` this call read before the user changed it.
+    let minted = update_state(root, |state| {
+        if let Some(existing) = state.install_id.as_ref().filter(|id| !id.is_empty()) {
+            return existing.clone();
+        }
+        let minted = random_hex();
+        state.install_id = Some(minted.clone());
+        minted
+    });
+    // A state file that cannot be written is not a reason to lose the turn:
+    // the id is still usable for this process, and the next start mints one.
+    minted.unwrap_or_else(|_| random_hex())
 }
 
 fn random_hex() -> String {
@@ -277,6 +308,35 @@ pub fn is_enabled(root: &Path) -> bool {
 }
 
 /// Fire and forget. Returns immediately; delivery happens on a detached thread.
+/// Whether a development override may be posted to.
+///
+/// HTTPS anywhere, or plain HTTP only to this machine. The override exists so
+/// a developer can point the app at a collector they are running locally, and
+/// that collector is `http://127.0.0.1:port` -- refusing it outright would
+/// remove the only thing the variable is for. Refusing cleartext to anywhere
+/// *else* is the part worth keeping: the payload carries the ingestion key and
+/// the install id.
+///
+/// A release build never reaches this. `record` reads the variable only under
+/// `debug_assertions`, because a baked-in key plus a settable destination is an
+/// exfiltration primitive rather than a configuration option.
+pub(crate) fn destination_is_safe(host: &str) -> bool {
+    let host = host.trim();
+    if let Some(rest) = host.strip_prefix("https://") {
+        return !rest.is_empty();
+    }
+    let Some(rest) = host.strip_prefix("http://") else {
+        return false;
+    };
+    // The authority only: a path or a query is somebody else's host smuggled
+    // past a loopback prefix.
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or_default();
+    let name = authority
+        .rsplit_once(':')
+        .map_or(authority, |(name, _)| name);
+    matches!(name, "127.0.0.1" | "localhost" | "[::1]")
+}
+
 pub fn record(root: &Path, event: InstallEvent) {
     if !is_enabled(root) {
         return;
@@ -294,7 +354,10 @@ pub fn record(root: &Path, event: InstallEvent) {
     // clear, wherever you like. Redirecting it stays available for development,
     // which is the only place it was ever for.
     let host = if cfg!(debug_assertions) {
-        std::env::var(HOST_ENV).unwrap_or_else(|_| DEFAULT_HOST.to_string())
+        std::env::var(HOST_ENV)
+            .ok()
+            .filter(|host| destination_is_safe(host))
+            .unwrap_or_else(|| DEFAULT_HOST.to_string())
     } else {
         DEFAULT_HOST.to_string()
     };
@@ -309,6 +372,13 @@ pub fn record(root: &Path, event: InstallEvent) {
     std::thread::spawn(move || {
         let client = match reqwest::blocking::Client::builder()
             .timeout(TIMEOUT)
+            // A telemetry post has no reason to follow a redirect, and one
+            // reason not to: reqwest follows HTTPS to HTTP by default, so a
+            // redirect at the far end would put the ingestion key and the
+            // install id on the wire in the clear. This applies to the built-in
+            // destination too, which is the half of that risk a shipped build
+            // has.
+            .redirect(reqwest::redirect::Policy::none())
             .build()
         {
             Ok(client) => client,

--- a/desktop/src/tests/mod.rs
+++ b/desktop/src/tests/mod.rs
@@ -149,7 +149,7 @@ fn every_included_source_is_read_with_normalised_line_endings() {
     );
 }
 
-fn granted(name: &str) -> Vec<String> {
+pub(crate) fn granted(name: &str) -> Vec<String> {
     capability(name)["permissions"]
         .as_array()
         .expect("permissions array")

--- a/desktop/src/tests/mod.rs
+++ b/desktop/src/tests/mod.rs
@@ -15,6 +15,7 @@ mod quit;
 mod quit_prompt;
 mod runtime;
 mod splash;
+mod telemetry_privacy;
 mod update_install;
 mod window_placement;
 mod windows;

--- a/desktop/src/tests/telemetry_privacy.rs
+++ b/desktop/src/tests/telemetry_privacy.rs
@@ -1,0 +1,147 @@
+//! The two telemetry promises that must not have races or holes in them.
+
+use super::*;
+use crate::telemetry::{destination_is_safe, is_enabled, set_enabled};
+
+/// An event that is mid-update holds off every other change to the file.
+///
+/// Every write of `telemetry.json` is atomic, and that says nothing about two
+/// of them overlapping. `install_id` and `set_enabled` each read the state,
+/// change one field and write it back -- so an opt-out saved between an
+/// event's read and its write was replaced by the state that event had read a
+/// moment earlier, and telemetry carried on after the user turned it off.
+///
+/// Driven rather than raced. Two threads doing this quickly enough to collide
+/// is luck, and a guard that only sometimes reproduces the bug is a guard that
+/// passes on the broken code -- which this one did, until it was written this
+/// way. Here the first update is held open on a channel, so the overlap is a
+/// fact of the test rather than a hope.
+#[test]
+fn a_change_to_the_state_file_waits_for_the_one_in_flight() {
+    let root = std::env::temp_dir().join(format!("lemma-tel-lock-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    set_enabled(&root, true).expect("opted in to begin with");
+
+    let (entered, has_entered) = std::sync::mpsc::channel();
+    let (release, may_finish) = std::sync::mpsc::channel::<()>();
+    let holding = {
+        let root = root.clone();
+        std::thread::spawn(move || {
+            crate::telemetry::update_state(&root, |state| {
+                // What an event does before it writes: it has read `enabled`,
+                // and it is about to write it back.
+                entered.send(()).expect("the test is listening");
+                let _ = may_finish.recv();
+                state.install_id = Some("0123456789abcdef0123456789abcdef".into());
+            })
+        })
+    };
+    has_entered
+        .recv_timeout(std::time::Duration::from_secs(10))
+        .expect("the first update started");
+
+    let (opted_out, has_opted_out) = std::sync::mpsc::channel();
+    let disabling = {
+        let root = root.clone();
+        std::thread::spawn(move || {
+            let outcome = set_enabled(&root, false);
+            let _ = opted_out.send(());
+            outcome
+        })
+    };
+    let blocked = has_opted_out
+        .recv_timeout(std::time::Duration::from_millis(250))
+        .is_err();
+
+    // Released before anything is asserted, so a guard that is going to fail
+    // fails rather than hanging on a thread it left parked.
+    let _ = release.send(());
+    holding.join().expect("the event thread").expect("saved");
+    disabling
+        .join()
+        .expect("the opt-out thread")
+        .expect("saved");
+
+    assert!(
+        blocked,
+        "a second change went ahead while one was mid-flight; the read and the \
+         write are not one operation",
+    );
+    assert!(
+        !is_enabled(&root),
+        "and the opt-out has to be what the file ends up saying",
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Where a development override may point, and where it may not.
+///
+/// The payload carries the ingestion key and the install id. HTTPS anywhere is
+/// fine; plain HTTP is fine only to this machine, because a local collector is
+/// the only thing this override exists for. Anything else is cleartext to
+/// somebody else's host.
+#[test]
+fn a_telemetry_destination_is_https_or_this_machine() {
+    for allowed in [
+        "https://eu.i.posthog.com",
+        "https://collector.example",
+        "http://127.0.0.1:8000",
+        "http://localhost:9000",
+        "http://[::1]:9000",
+    ] {
+        assert!(destination_is_safe(allowed), "{allowed} should be allowed");
+    }
+
+    for refused in [
+        "http://posthog.example",
+        "http://10.0.0.5:8000",
+        // A loopback name in the path rather than the authority is somebody
+        // else's host wearing it as a disguise.
+        "http://evil.example/127.0.0.1",
+        "http://evil.example?x=localhost",
+        "ftp://localhost",
+        "https://",
+        "",
+        "127.0.0.1:8000",
+    ] {
+        assert!(!destination_is_safe(refused), "{refused} should be refused");
+    }
+}
+
+/// Every way out of a started install reports how it ended.
+///
+/// `RuntimeInstallFailed` used to be recorded only where the installer itself
+/// failed. The activation that follows -- stopping the previous daemon, then
+/// swapping the runtime in -- returned its error after `RuntimeInstallStarted`
+/// with no terminal event, so an install that failed there looked, in the
+/// numbers, like one that started and never finished. Install health is the
+/// whole point of this telemetry.
+#[test]
+fn a_failed_activation_still_reports_the_install_as_failed() {
+    let source = shell_source();
+    let body = function_body(&source, "fn ensure_runtime_artifacts_inner(");
+    let started = body
+        .find("RuntimeInstallStarted")
+        .expect("the install announces itself");
+    let activation = body
+        .find("activate_installed_runtime")
+        .expect("the install activates what it fetched");
+    assert!(
+        started < activation,
+        "activation comes after the start event"
+    );
+    let reported = body[activation..]
+        .find("RuntimeInstallFailed")
+        .map(|at| activation + at);
+    let completed = body[activation..]
+        .find("RuntimeInstallCompleted")
+        .map(|at| activation + at);
+    let (reported, completed) = (
+        reported.expect("activation failure is reported"),
+        completed.expect("the install still reports success"),
+    );
+    assert!(
+        reported < completed,
+        "the failure path has to be reported before the success one is reached",
+    );
+}

--- a/desktop/src/tests/telemetry_privacy.rs
+++ b/desktop/src/tests/telemetry_privacy.rs
@@ -1,7 +1,7 @@
 //! The two telemetry promises that must not have races or holes in them.
 
 use super::*;
-use crate::telemetry::{destination_is_safe, is_enabled, set_enabled};
+use crate::telemetry::{destination_is_safe, set_enabled};
 
 /// An event that is mid-update holds off every other change to the file.
 ///
@@ -67,8 +67,14 @@ fn a_change_to_the_state_file_waits_for_the_one_in_flight() {
         "a second change went ahead while one was mid-flight; the read and the \
          write are not one operation",
     );
-    assert!(
-        !is_enabled(&root),
+    // The file, not `is_enabled`. `is_enabled` answers false whenever there is
+    // no ingestion key, and a test environment has none -- the sibling guard
+    // `disabled_without_a_key_even_when_opted_in` asserts exactly that -- so
+    // asking it here passed whether or not the opt-out had survived. Which is
+    // the same shape as the bug this test is about.
+    assert_eq!(
+        crate::telemetry::load_state(&root).enabled,
+        Some(false),
         "and the opt-out has to be what the file ends up saying",
     );
     let _ = std::fs::remove_dir_all(&root);

--- a/desktop/ui-tests/tests/settings.test.mjs
+++ b/desktop/ui-tests/tests/settings.test.mjs
@@ -210,3 +210,44 @@ test('saving one section cannot silently rebase another draft past an unseen cha
   assert.equal(context.sectionRevisions.get('ai'), 1);
   assert.equal(context.sectionRevisions.get('integrations'), 3);
 });
+
+test('the install-health switch is hidden unless this build can send anything', async () => {
+  const { context, element } = fixture();
+  // A build with no ingestion key sends nothing at all, so a switch would be a
+  // control over nothing. The whole panel stays hidden rather than offering a
+  // toggle that does not toggle anything.
+  context.invoke = async () => ({ available: false, enabled: false, host: 'https://eu.i.posthog.com' });
+  element('telemetry-panel').hidden = true;
+  load(context, 'let telemetryLoaded = false;', '\n// Matches `formatUptime`');
+  await context.loadTelemetry();
+  assert.equal(element('telemetry-panel').hidden, true);
+});
+
+test('turning the install-health switch off is sent once and kept on failure', async () => {
+  const { context, element } = fixture();
+  const listeners = [];
+  const box = element('telemetry-enabled');
+  box.addEventListener = (_event, handler) => listeners.push(handler);
+  element('telemetry-panel').hidden = true;
+  const sent = [];
+  context.invoke = async (command, args) => {
+    if (command === 'telemetry_status') {
+      return { available: true, enabled: true, host: 'https://eu.i.posthog.com', install_id: 'abcdef0123456789' };
+    }
+    sent.push(args);
+    throw new Error('the daemon said no');
+  };
+  load(context, 'let telemetryLoaded = false;', '\n// Matches `formatUptime`');
+  await context.loadTelemetry();
+
+  assert.equal(element('telemetry-panel').hidden, false);
+  assert.equal(box.checked, true, 'the stored choice is what the switch shows');
+  assert.match(element('telemetry-detail').textContent, /eu\.i\.posthog\.com/);
+  assert.match(element('telemetry-detail').textContent, /abcdef01/, 'the install id is shown, abbreviated');
+
+  box.checked = false;
+  await listeners[0]();
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].enabled, false);
+  assert.equal(box.checked, true, 'a refused save puts the switch back rather than lying');
+});

--- a/desktop/ui/control.html
+++ b/desktop/ui/control.html
@@ -318,6 +318,11 @@
             <div class="log-tabs" id="diag-log-tabs"></div>
             <pre class="log-view" id="diag-log" tabindex="0">Loading…</pre>
           </article>
+          <article class="panel span-two" id="telemetry-panel" hidden>
+            <div class="panel-heading"><div><h2>Anonymous install health</h2><p>Whether Lemma started, and whether its runtime installed. Nothing about your pods, your files, your account or your network.</p></div></div>
+            <label class="check"><input type="checkbox" id="telemetry-enabled" /> Send anonymous install health</label>
+            <p class="hint" id="telemetry-detail"></p>
+          </article>
           <article class="panel span-two"><div class="panel-heading"><div><h2>Non-destructive repair</h2><p>Replaces signed application/runtime files only. Databases, files, and workspaces are preserved.</p></div></div><div class="button-row"><button class="btn" data-action="restart">Restart application</button><button class="btn" data-action="repair-runtime">Verify &amp; repair runtime</button></div></article>
         </div>
       </section>

--- a/desktop/ui/control.js
+++ b/desktop/ui/control.js
@@ -88,8 +88,12 @@ function setPage(page) {
   $("page-subtitle").textContent = titles[page][1];
   document.querySelector(".content").scrollTo({ top: 0, behavior: "instant" });
   // Only poll while the logs are actually on screen.
-  if (page === "diagnostics") startLogPolling();
-  else stopLogPolling();
+  if (page === "diagnostics") {
+    startLogPolling();
+    loadTelemetry();
+  } else {
+    stopLogPolling();
+  }
 }
 
 /* ---------------------------------------------------------------- logs ---
@@ -938,6 +942,42 @@ function render() {
   }
   renderAgentHost(snapshot.agent_host || {});
   renderSharing(sharing);
+}
+
+// The anonymous install-health switch.
+//
+// Read once, when Local settings opens. It is not part of the operator config
+// -- it is a choice about this installation, stored beside the install id --
+// so it neither joins the dirty-section machinery nor waits for a save.
+let telemetryLoaded = false;
+async function loadTelemetry() {
+  if (telemetryLoaded) return;
+  telemetryLoaded = true;
+  let status;
+  try {
+    status = await invoke("telemetry_status");
+  } catch {
+    // A build that cannot answer offers nothing rather than a dead switch.
+    return;
+  }
+  if (!status?.available) return;
+  const panel = $("telemetry-panel");
+  const box = $("telemetry-enabled");
+  panel.hidden = false;
+  box.checked = Boolean(status.enabled);
+  $("telemetry-detail").textContent =
+    `Sent to ${status.host}, identified only by a random id for this installation`
+    + (status.install_id ? ` (${status.install_id.slice(0, 8)}…).` : ".")
+    + " Turning this off is remembered, and nothing is sent again.";
+  box.addEventListener("change", async () => {
+    const wanted = box.checked;
+    try {
+      await invoke("set_telemetry_enabled", { enabled: wanted });
+    } catch (error) {
+      box.checked = !wanted;
+      toast(String(error), "bad");
+    }
+  });
 }
 
 // Matches `formatUptime` in the workspace's own This computer card, which is

--- a/docs/design/product-analytics.md
+++ b/docs/design/product-analytics.md
@@ -4,7 +4,7 @@ The plane is built on all four edges: the backend spine (`app/core/origin.py`,
 `app/core/analytics/`, and the subscriber in
 `app/composition/analytics_consumer.py`), the web client
 (`lib/analytics/client.ts`), the CLI (`lemma_cli/cli_core/telemetry.py` and
-`lemma telemetry`), and Desktop (`locald/src/telemetry.rs`). The ClickStack sink
+`lemma telemetry`), and Desktop (`desktop/src/telemetry.rs`). The ClickStack sink
 described in §4 is not written yet.
 
 Nothing reports anywhere until an ingestion key is set, and no key is set

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -323,6 +323,39 @@ does not delete the private data disk. If a child exits during startup, Lemma
 fails immediately with its status and recent log excerpt instead of waiting
 for the health timeout.
 
+### Anonymous install health
+
+**Local settings → Diagnostics** carries one switch: *Send anonymous install
+health*. It is on in official builds and off in every build without an
+ingestion key compiled in, which includes anything you build yourself.
+
+What it sends is whether the app started and whether its runtime installed:
+`desktop.launched`, `desktop.runtime_install`, `desktop.runtime_ready`,
+`desktop.mode_selected`, `desktop.quit`. Each carries the operating system, the
+architecture, the app version, and — for the two that measure something — a
+*bucket* rather than a number, so `0-5s` rather than `3,214 ms`. An install
+failure carries which step failed and one word for why, from a fixed list.
+
+It cannot express anything else. There is no field for a pod, an organization,
+a user, a file name, a hostname, a path, or an error message, and the event
+type is a closed Rust enum rather than a map: an event this app cannot name is
+an event it does not send.
+
+It goes to `https://eu.i.posthog.com`, identified by a random id minted once
+for this installation and stored beside it. The id is random — never derived
+from your hostname, MAC address or machine id — and **Start over** takes it
+with it, so a reset installation is a new one.
+
+Three switches turn it off, and any one is enough:
+
+```bash
+LEMMA_TELEMETRY=0            # this launch
+```
+
+the toggle in Local settings, which is remembered and is never overridden by an
+upgrade; and building without an ingestion key, which is the default for a
+local build.
+
 ## Updates, data, and uninstall
 
 Local Lemma stores application data and runs Lemma services on your computer.

--- a/lemma-backend/app/core/tests/unit/test_ci_configuration_contract.py
+++ b/lemma-backend/app/core/tests/unit/test_ci_configuration_contract.py
@@ -169,3 +169,46 @@ def test_expensive_security_jobs_are_change_scoped() -> None:
     assert "if: needs.changes.outputs.javascript == 'true'" in workflow
     assert "if: needs.changes.outputs.python_dependencies == 'true'" in workflow
     assert "if: needs.changes.outputs.backend_image == 'true'" in workflow
+
+
+def test_every_job_that_installs_a_browser_restores_it_from_cache() -> None:
+    """Chromium is downloaded once per Playwright version, not once per run.
+
+    It is ~150 MB and byte-identical between runs, so three desktop jobs were
+    each fetching it on every push. The cache has to sit *before* the install
+    in the same job -- a restore afterwards is a restore of nothing -- and it
+    has to be keyed on the lockfile, because that is the file a Playwright
+    version bump changes.
+    """
+    import yaml
+
+    workflow = yaml.safe_load(_read(".github/workflows/ci.yml"))
+    installing = set()
+    for name, job in workflow["jobs"].items():
+        for index, step in enumerate(job.get("steps", [])):
+            if "playwright install" not in str(step.get("run", "")):
+                continue
+            installing.add(name)
+            cache = [
+                earlier
+                for earlier in job["steps"][:index]
+                if earlier.get("uses", "").startswith("actions/cache@")
+                and "ms-playwright" in str(earlier.get("with", {}).get("path", ""))
+            ]
+            assert cache, f"{name} downloads a browser it never restores"
+            key = cache[-1]["with"]["key"]
+            assert "desktop/ui-tests/package-lock.json" in key, (
+                f"{name} keys its browser cache on something other than the "
+                "lockfile a version bump changes"
+            )
+            paths = cache[-1]["with"]["path"]
+            # One step for three runners: the browser lives somewhere different
+            # on each, and a path that does not exist is skipped rather than
+            # failing.
+            for expected in (
+                "~/.cache/ms-playwright",
+                "~/Library/Caches/ms-playwright",
+                "~/AppData/Local/ms-playwright",
+            ):
+                assert expected in paths, f"{name} misses {expected}"
+    assert installing, "no job installs a browser; this contract found nothing"


### PR DESCRIPTION
## What changes

Desktop sends anonymous install health again — or rather, for the first time.

`locald/src/telemetry.rs` was 346 lines with **no caller**. `record` was
invoked from nowhere, the "Local settings toggle" its own header described did
not exist, and the PostHog endpoint appeared in no document a user reads. So
the thing its opening comment says it exists to prevent — the first signal that
a runtime install broke on a new macOS release being a GitHub issue three weeks
later — was exactly what still happened.

**Why it was never called is visible once you list the events.** `Launched`,
`ModeSelected`, `RuntimeInstallStarted/Completed/Failed`, `RuntimeReady`,
`Quit` — every one happens in the desktop shell, and the shell does not depend
on locald as a library. The module was in the wrong crate, and being
unreachable is what let it stay unwired. It moves to
`desktop/src/telemetry.rs`, where its call sites are.

- **Wired** at all seven points, each where the decision is made rather than in
  its callers: the mode event is in `set_mode`, which all three paths go
  through; the quit event is behind a `Once`, because both quit paths end in a
  shutdown and either can be reached first.
- **An install failure says which step and one word for why**, from the same
  taxonomy `actionable_runtime_install_error` already uses to decide what to
  tell the person. Never the error text — that carries paths, hostnames, and
  occasionally a URL with a token in it.
- **The toggle exists.** *Local settings → Diagnostics*, granted to that window
  and nothing else. The panel hides itself entirely in a build with no
  ingestion key, rather than offering a switch over nothing.
- **The state file is written atomically and privately.** It was a plain
  `write`, which can leave a truncated file — and this one holds the opt-out. A
  half-written opt-out reads as "never answered", which reads as consent.
- **Documented** in `docs/installation.md`, where somebody installing Lemma
  will look: the destination, the five event names, what each carries, what the
  shape structurally cannot express, and the three ways to turn it off.

## Why

Register entries LD-8 and DOC-1. The remedy the audit gave was "wire with
toggle + docs, or delete", and the decision to wire was the user's.

The privacy posture is unchanged and deliberate, and now it is also true:

- Nothing is sent without an ingestion key compiled in. **No key ships in this
  repo**, so nothing built from it sends anything. The key arrives later, from
  the release pipeline.
- `LEMMA_TELEMETRY=0` turns it off for a launch; the toggle turns it off for
  good and is never overridden by an upgrade or by a new key.
- The event type is a closed Rust enum, not a map. There is no field for a pod,
  an organization, a user, a file name, a hostname, a path, or an error
  message — an event this app cannot name is an event it does not send.
- Durations are buckets (`0-5s`), not numbers. The install id is random, never
  derived from hostname or MAC, and **Start over** takes it with it.

## How to verify

```bash
make desktop-check
```

Four guards, and I checked the load-bearing one by reverting rather than by
reading — deleting the `RuntimeInstallCompleted` call makes
`every_event_is_sent_from_somewhere` fail naming that event:

- **`every_event_is_sent_from_somewhere`** — a variant nobody constructs is
  this bug coming back one event at a time.
- **`the_switch_is_not_reachable_from_the_workspace`** — the two commands are
  in `control.json` and in neither `workspace.json` nor `main.json`.
- **`what_is_sent_and_how_to_stop_it_is_written_down`** — the installation
  guide names the host, `LEMMA_TELEMETRY=0`, and an event.
- Two browser tests: the panel stays hidden without a key, and a refused save
  puts the switch back rather than lying about what was stored.

Plus the module's own four, which already covered the install id, the key gate
and the opt-out.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload; the
      two new commands check the calling window and are granted to Local
      settings alone

## Compatibility and rollback notes

`telemetry.json` moves nowhere — same path, same shape — so an installation
that already has an install id keeps it. Reverting stops the events and leaves
the file; the toggle's stored value survives either direction.

Stacked on #683.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional anonymous install-health telemetry covering launches, runtime installation, readiness, mode selection, and session completion.
  - Added a Diagnostics setting to view telemetry status and enable or disable reporting.
  - Added safeguards and feedback when saving telemetry preferences fails.

- **Documentation**
  - Documented telemetry data, destination, and opt-out options.

- **Bug Fixes**
  - Improved telemetry preference persistence and restored the toggle when saving fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->