### PR TITLE
Five locks held across work that waits, and the tray froze for eleven seconds

### DIFF
--- a/desktop/locald/src/agent_host/lifecycle.rs
+++ b/desktop/locald/src/agent_host/lifecycle.rs
@@ -12,19 +12,25 @@ impl AgentHostSupervisor {
     }
 
     pub fn start(&self) -> io::Result<()> {
-        let mut state = self.state.lock().expect("Agent Host state lock poisoned");
-        state.desired_running = true;
-        // A deliberate start forgives the past, the way `start_all` does for
-        // the host processes. Somebody pressing the button has, in effect,
-        // said the cause is fixed.
-        state.circuit_open = false;
-        state.window_restarts = 0;
-        state.window_started = Instant::now();
-        state.next_restart = Instant::now();
-        if child_running(&mut state) {
-            return Ok(());
+        let _transition = self
+            .transition
+            .lock()
+            .expect("Agent Host transition lock poisoned");
+        {
+            let mut state = self.state.lock().expect("Agent Host state lock poisoned");
+            state.desired_running = true;
+            // A deliberate start forgives the past, the way `start_all` does
+            // for the host processes. Somebody pressing the button has, in
+            // effect, said the cause is fixed.
+            state.circuit_open = false;
+            state.window_restarts = 0;
+            state.window_started = Instant::now();
+            state.next_restart = Instant::now();
+            if child_running(&mut state) {
+                return Ok(());
+            }
         }
-        self.spawn_locked(&mut state)
+        self.spawn()
     }
 
     /// Stop the process and stop wanting it back, for this daemon's lifetime.
@@ -46,21 +52,38 @@ impl AgentHostSupervisor {
     }
 
     pub(crate) fn halt(&self, keep_desire: bool) -> io::Result<()> {
-        let mut state = self.state.lock().expect("Agent Host state lock poisoned");
-        if !keep_desire {
-            state.desired_running = false;
-        }
-        if let Some(mut child) = state.child.take() {
-            state.last_exit_code = terminate_process_tree(&mut child)?;
+        // The transition lock, not the state lock, is what makes a stop and a
+        // start exclusive. The child comes out under `state`; it dies outside
+        // it, because dying takes up to eleven seconds and `status` -- which
+        // the shell polls to draw the tray -- takes the same `state`.
+        let _transition = self
+            .transition
+            .lock()
+            .expect("Agent Host transition lock poisoned");
+        let mut child = {
+            let mut state = self.state.lock().expect("Agent Host state lock poisoned");
+            if !keep_desire {
+                state.desired_running = false;
+            }
+            state.started_at = None;
+            state.started_at_ms = None;
+            state.child.take()
+        };
+
+        let exit = child.as_mut().map(terminate_process_tree).transpose();
+
+        {
+            let mut state = self.state.lock().expect("Agent Host state lock poisoned");
+            if let Ok(Some(code)) = exit {
+                state.last_exit_code = code;
+            }
         }
         // Stopped on purpose is not a leftover: clear the record whether or
         // not there was a child, so a stale one cannot outlive the thing it
         // describes and get some later daemon to kill an innocent pid.
         self.forget_running();
-        state.started_at = None;
-        state.started_at_ms = None;
         self.invalidate_details();
-        Ok(())
+        exit.map(|_| ())
     }
 
     pub fn restart(&self) -> io::Result<()> {
@@ -75,6 +98,13 @@ impl AgentHostSupervisor {
         if self.executable.is_none() {
             return Ok(());
         }
+        // Taken before `state`, and before the decision to spawn: a tick that
+        // decided to restart while a stop was still terminating the old child
+        // would put a second one on top of it.
+        let _transition = self
+            .transition
+            .lock()
+            .expect("Agent Host transition lock poisoned");
         // A healthy Agent Host is spawned once and never again, so rotating
         // only at spawn means it never rotates at all. This tick is the only
         // thing that bounds the log of a host that simply keeps running.
@@ -109,7 +139,8 @@ impl AgentHostSupervisor {
             return Ok(());
         }
         state.window_restarts = state.window_restarts.saturating_add(1);
-        self.spawn_locked(&mut state)
+        drop(state);
+        self.spawn()
     }
 
     /// Stop a sidecar this installation started and never got to stop.
@@ -189,7 +220,9 @@ impl AgentHostSupervisor {
         let _ = std::fs::remove_file(&self.record_path);
     }
 
-    pub(crate) fn spawn_locked(&self, state: &mut SupervisorState) -> io::Result<()> {
+    /// Start the sidecar. The caller holds `transition`; this takes `state`
+    /// only to record what happened.
+    pub(crate) fn spawn(&self) -> io::Result<()> {
         // Before taking the lock for ourselves, give up any we already hold.
         // A sidecar left over from a daemon that did not live to stop it holds
         // that lock against every future launch, and the new one can do
@@ -200,6 +233,7 @@ impl AgentHostSupervisor {
         match self.spawn_process() {
             Ok(mut child) => {
                 self.record_running(&mut child);
+                let mut state = self.state.lock().expect("Agent Host state lock poisoned");
                 state.child = Some(child);
                 state.restart_count = state.restart_count.saturating_add(1);
                 state.started_at = Some(Instant::now());
@@ -210,6 +244,7 @@ impl AgentHostSupervisor {
                 Ok(())
             }
             Err(error) => {
+                let mut state = self.state.lock().expect("Agent Host state lock poisoned");
                 state.last_error = Some(error.to_string());
                 state.next_restart = Instant::now() + RESTART_BACKOFF;
                 Err(error)

--- a/desktop/locald/src/agent_host/mod.rs
+++ b/desktop/locald/src/agent_host/mod.rs
@@ -62,6 +62,18 @@ pub(crate) struct SupervisorState {
 }
 
 pub struct AgentHostSupervisor {
+    /// Held by whoever is starting or stopping the sidecar; never by anyone
+    /// only reporting on it.
+    ///
+    /// Terminating the process tree is a five-second `SIGTERM` wait before it
+    /// is a `SIGKILL`, and reclaiming a leftover is another. Those used to
+    /// happen under `state`, which `status` also takes -- so stopping the
+    /// Agent Host froze the tray menu it was stopped from, for up to eleven
+    /// seconds. This serialises the transitions instead, and `state` is held
+    /// only long enough to read or write a field.
+    ///
+    /// Lock order: this one before `state`, never the other way.
+    transition: Mutex<()>,
     executable: Option<PathBuf>,
     data_dir: PathBuf,
     log_path: PathBuf,
@@ -122,6 +134,7 @@ impl AgentHostSupervisor {
         // choosing "off": the Agent Host stayed down after the stack came back.
         let desired_running = host_is_paired(&shared_root.join("config.json"));
         Self {
+            transition: Mutex::new(()),
             executable,
             data_dir: shared_root.clone(),
             log_path: shared_root.join("agent-host.log"),

--- a/desktop/locald/src/agent_host/tests/status.rs
+++ b/desktop/locald/src/agent_host/tests/status.rs
@@ -122,3 +122,71 @@ fn a_failure_never_echoes_the_pairing_code() {
     assert!(detail.contains("<pairing code>"));
     assert!(detail.contains("already paired"));
 }
+
+/// Reporting on the Agent Host must not wait for it to stop.
+///
+/// `halt` used to hold the state lock across `terminate_process_tree`, which
+/// is a five-second `SIGTERM` wait before a `SIGKILL` and another wait for the
+/// process group. `status` takes the same lock, and the shell polls `status`
+/// to draw the tray -- so stopping the Agent Host froze the menu it was
+/// stopped from, for up to eleven seconds.
+///
+/// A sidecar that ignores `SIGTERM` is the case that makes the wait real.
+#[cfg(unix)]
+#[test]
+fn status_answers_while_a_stubborn_sidecar_is_still_being_stopped() {
+    use std::io::BufRead;
+    use std::os::unix::process::CommandExt;
+
+    let home = tempdir().unwrap();
+    let supervisor = AgentHostSupervisor::discover(&home.path().join("locald"));
+    std::fs::create_dir_all(&supervisor.data_dir).unwrap();
+
+    // `trap '' TERM` is the whole point: the terminate has to spend its
+    // budget. Blocked on a pipe nothing writes to, with no child of its own --
+    // a `sleep` in the same group receives the group signal, dies, and takes
+    // the trapping shell out with it, which is not the case being tested.
+    let mut child = Command::new("/bin/sh")
+        .arg("-c")
+        .arg("trap '' TERM; echo ready; read line")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .process_group(0)
+        .spawn()
+        .unwrap();
+    let _stdin = child.stdin.take().expect("stdin is piped");
+    // Wait for the trap to be installed. A `SIGTERM` that arrives in the
+    // milliseconds before it lands on the default disposition and kills the
+    // shell outright, which would make this test pass for the wrong reason.
+    let mut ready = String::new();
+    std::io::BufReader::new(child.stdout.take().expect("stdout is piped"))
+        .read_line(&mut ready)
+        .expect("the sidecar says when its trap is installed");
+    assert_eq!(ready.trim(), "ready");
+    let pid = child.id();
+    supervisor.state.lock().unwrap().child.replace(child);
+
+    let started = Instant::now();
+    std::thread::scope(|scope| {
+        let stopping = scope.spawn(|| supervisor.stop());
+        // Long enough that the terminate is certainly in its wait, short
+        // enough that it is nowhere near finished.
+        std::thread::sleep(Duration::from_millis(200));
+        let asked = Instant::now();
+        let status = supervisor.status();
+        assert!(
+            asked.elapsed() < Duration::from_millis(500),
+            "status waited {:?} for a stop that had not finished",
+            asked.elapsed(),
+        );
+        assert_eq!(status["running"], false, "the child is on its way out");
+        stopping.join().unwrap().unwrap();
+    });
+    assert!(
+        started.elapsed() >= Duration::from_secs(1),
+        "the stop returned too fast to have waited on anything; \
+         the test is not exercising what it claims",
+    );
+    // Nothing is left behind.
+    assert_eq!(unsafe { libc::kill(-i32::try_from(pid).unwrap(), 0) }, -1);
+}

--- a/desktop/locald/src/daemon/stack_ops.rs
+++ b/desktop/locald/src/daemon/stack_ops.rs
@@ -59,12 +59,15 @@ impl Daemon {
                     failure.get_or_insert_with(|| error.to_string());
                 }
             }
-            if let Some(mut supervisor) = daemon
+            // Taken out under the lock; killed and reaped outside it. `wait`
+            // blocks until the process is gone, and every client thread that
+            // wants the supervisor takes this same lock.
+            let taken = daemon
                 .supervisor
                 .lock()
                 .expect("supervisor lock poisoned")
-                .take()
-            {
+                .take();
+            if let Some(mut supervisor) = taken {
                 let _ = supervisor.child.kill();
                 let _ = supervisor.child.wait();
             }

--- a/desktop/locald/src/lib.rs
+++ b/desktop/locald/src/lib.rs
@@ -176,6 +176,75 @@ pub(crate) fn locald_sources() -> Vec<(String, String)> {
 }
 
 #[cfg(test)]
+mod lock_scope_policy {
+    /// A lock taken in the scrutinee is held for the whole block.
+    ///
+    /// `if let Some(x) = self.thing.lock()...take() { ... }` reads like the
+    /// guard is dropped once the value is out. It is not: the temporary lives
+    /// to the end of the `if let`, so the lock is held across everything in
+    /// the body. Four places in this crate did that across work that waits --
+    /// terminating a process tree, `Child::wait`, `JoinHandle::join`, a
+    /// tunnel's shutdown -- and every one of them stalled a reader of the same
+    /// lock for as long as the work took. Stopping the Agent Host froze the
+    /// tray menu it was stopped from, for up to eleven seconds.
+    ///
+    /// The fix is always the same shape: bind the take to a `let`, which drops
+    /// the guard at the end of that statement, and use the value below.
+    ///
+    /// Two are left, and they are here rather than fixed because the body
+    /// cannot wait. Adding a third means saying which it is.
+    const HOLDS_NOTHING_THAT_WAITS: [&str; 2] = [
+        // A `HashMap` lookup, then `send` on an unbounded `mpsc::Sender`,
+        // which never blocks.
+        "daemon/supervisor.rs",
+        // A `HashMap` lookup and a `return`. The keychain read that *can*
+        // block is deliberately outside, and says so.
+        "operator_config/vault.rs",
+    ];
+
+    #[test]
+    fn no_lock_is_held_across_a_block_that_can_wait() {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let mut held = Vec::new();
+        for (name, source) in super::rust_sources(&root, "locald/src") {
+            if name.contains("tests") || HOLDS_NOTHING_THAT_WAITS.iter().any(|k| name.ends_with(k))
+            {
+                continue;
+            }
+            let lines: Vec<&str> = source.lines().collect();
+            for (index, line) in lines.iter().enumerate() {
+                let trimmed = line.trim_start();
+                if !(trimmed.starts_with("if let ")
+                    || trimmed.starts_with("while let ")
+                    || trimmed.starts_with("match "))
+                {
+                    continue;
+                }
+                // The scrutinee can span several lines; it ends at the brace.
+                let mut scrutinee = String::new();
+                for line in &lines[index..(index + 8).min(lines.len())] {
+                    scrutinee.push_str(line);
+                    scrutinee.push('\n');
+                    if line.trim_end().ends_with('{') {
+                        break;
+                    }
+                }
+                if scrutinee.contains(".lock()") {
+                    held.push(format!("{name}:{}: {}", index + 1, trimmed));
+                }
+            }
+        }
+        assert!(
+            held.is_empty(),
+            "these hold a lock for the whole block they open. Bind the value \
+             with a `let` first, or add the site to HOLDS_NOTHING_THAT_WAITS \
+             with the reason its body cannot wait:\n{}",
+            held.join("\n"),
+        );
+    }
+}
+
+#[cfg(test)]
 mod doc_comment_policy {
     /// An indented block in a doc comment is a *Rust* code block.
     ///

--- a/desktop/locald/src/managed_runtime/lifecycle.rs
+++ b/desktop/locald/src/managed_runtime/lifecycle.rs
@@ -200,20 +200,24 @@ impl ManagedRuntimeController {
         // inherit a thread that never ends.
         self.cancel_pending_requests();
         self.stop_clock_keeper();
-        if let Some(auth) = self
+        // Taken out under each lock; joined outside them. Joining a thread
+        // while holding the mutex that thread may itself want is how a
+        // shutdown turns into a deadlock, and at best it makes every reader of
+        // these two wait for work that is finishing anyway.
+        let auth = self
             .pending_auth
             .lock()
             .expect("pending auth lock poisoned")
-            .take()
-        {
+            .take();
+        if let Some(auth) = auth {
             let _ = auth.join();
         }
-        if let Some(images) = self
+        let images = self
             .pending_images
             .lock()
             .expect("pending images lock poisoned")
-            .take()
-        {
+            .take();
+        if let Some(images) = images {
             let _ = images.join();
         }
         self.clear_forwarders();

--- a/desktop/locald/src/operator_config/apply.rs
+++ b/desktop/locald/src/operator_config/apply.rs
@@ -77,8 +77,6 @@ impl OperatorConfigStore {
     /// no key is supplied the stored one is used, so an already-configured
     /// provider can be re-listed without the caller handling the secret at all.
     pub fn discover_models(&self, request: Value) -> io::Result<Vec<String>> {
-        // Pair the destination and vault read with the same committed revision.
-        let _write = self.writes.lock().expect("operator writes poisoned");
         #[derive(Deserialize)]
         #[serde(deny_unknown_fields)]
         struct DiscoverRequest {
@@ -94,17 +92,26 @@ impl OperatorConfigStore {
         }
         validate_ai_shape(&request.ai)?;
 
-        let saved = self
-            .config
-            .lock()
-            .expect("operator config poisoned")
-            .clone();
-        let api_key = match request.api_key {
-            Some(value) if !value.is_empty() => Some(value),
-            // An empty string is the page saying "no key", which is legitimate
-            // for a loopback provider. Absent means "use whatever is stored".
-            Some(_) => None,
-            None => self.saved_provider_key(&saved, &request.ai)?,
+        // The write lock pairs the destination with the vault read, off one
+        // committed revision -- and that is all it is for. It used to be held
+        // across the probe below, which is an HTTP round trip to a provider
+        // the caller chose, with a timeout measured in seconds: every settings
+        // save waited behind a model list.
+        let api_key = {
+            let _write = self.writes.lock().expect("operator writes poisoned");
+            let saved = self
+                .config
+                .lock()
+                .expect("operator config poisoned")
+                .clone();
+            match request.api_key {
+                Some(value) if !value.is_empty() => Some(value),
+                // An empty string is the page saying "no key", which is
+                // legitimate for a loopback provider. Absent means "use
+                // whatever is stored".
+                Some(_) => None,
+                None => self.saved_provider_key(&saved, &request.ai)?,
+            }
         };
         if !local_no_auth(&request.ai.base_url) && api_key.is_none() {
             return Err(invalid("this AI provider requires an API key"));

--- a/desktop/locald/src/operator_config/tests/discovery.rs
+++ b/desktop/locald/src/operator_config/tests/discovery.rs
@@ -1,6 +1,7 @@
 //! Asking a provider what it can do, and never with the wrong key.
 
 use super::*;
+use std::time::Duration;
 
 #[test]
 fn discovery_never_sends_a_saved_key_to_a_changed_destination() {
@@ -52,4 +53,110 @@ fn successful_provider_probe_discovers_default_and_marks_profile_ready() {
     );
     assert!(snapshot["config"]["ai"]["last_validated_at_unix_ms"].is_number());
     assert_eq!(snapshot["readiness"]["ai"], "ready");
+}
+
+/// A model list must not hold up a settings save.
+///
+/// `discover_models` took the write lock for the whole call, including the
+/// probe -- an HTTP round trip to a provider the caller chose, with a timeout
+/// measured in seconds. Every other write waited behind it: opening Local
+/// settings and pressing "Discover models" made the Save button do nothing
+/// until the provider answered.
+///
+/// What the lock is actually for is pairing the destination with the stored
+/// key off one committed revision, and that is done before the probe.
+#[test]
+fn discovering_models_does_not_hold_up_the_settings_that_are_being_saved() {
+    /// A probe that parks on its *first* call until the test lets it through.
+    ///
+    /// Only the first: `apply` validates a profile through the same probe, so
+    /// a probe that parked on every call would block the very save this test
+    /// is timing -- for a reason that has nothing to do with the lock.
+    struct BlockingProbe {
+        release: Mutex<std::sync::mpsc::Receiver<()>>,
+        entered: std::sync::mpsc::SyncSender<()>,
+        parked: std::sync::atomic::AtomicBool,
+    }
+    impl ModelProviderProbe for BlockingProbe {
+        fn discover(
+            &self,
+            _profile: &AiProfile,
+            _api_key: Option<&str>,
+        ) -> io::Result<Vec<String>> {
+            if !self.parked.swap(true, std::sync::atomic::Ordering::SeqCst) {
+                self.entered.send(()).expect("the test is waiting");
+                self.release
+                    .lock()
+                    .expect("probe lock poisoned")
+                    .recv()
+                    .expect("the test releases the probe");
+            }
+            Ok(vec!["alpha-model".into(), "zeta-model".into()])
+        }
+    }
+
+    let (release_sender, release) = std::sync::mpsc::channel();
+    let (entered, entered_receiver) = std::sync::mpsc::sync_channel(1);
+    let root = tempdir().unwrap();
+    let store = OperatorConfigStore::load_probing(
+        root.path().join("operator-config.json"),
+        Arc::new(MemoryVault::default()),
+        Arc::new(BlockingProbe {
+            release: Mutex::new(release),
+            entered,
+            parked: std::sync::atomic::AtomicBool::new(false),
+        }),
+    )
+    .unwrap();
+
+    std::thread::scope(|scope| {
+        let probing = scope.spawn(|| {
+            store.discover_models(json!({
+                "ai": {
+                    "protocol": "openai_compat",
+                    "base_url": "http://127.0.0.1:1234/v1",
+                    "default_model": "alpha-model",
+                    "models": ["alpha-model"],
+                    "vision_models": [],
+                },
+            }))
+        });
+        entered_receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("the probe is reached");
+
+        // The probe is now inside `discover`, going nowhere. A save must not
+        // wait for it.
+        //
+        // On its own thread with a deadline, because the failure this guards
+        // against is an unbounded wait: asserting on elapsed time in this
+        // thread would hang here rather than fail.
+        let (saved_sender, saved) = std::sync::mpsc::sync_channel(1);
+        let store_for_save = &store;
+        let saving = scope.spawn(move || {
+            let outcome = store_for_save.set_ai(json!({
+                "ai": {
+                    "protocol": "openai_compat",
+                    "base_url": "http://127.0.0.1:1234/v1",
+                    "default_model": "zeta-model",
+                    "models": ["zeta-model"],
+                    "vision_models": [],
+                },
+            }));
+            let _ = saved_sender.send(outcome.is_ok());
+        });
+        let in_time = saved.recv_timeout(Duration::from_secs(5));
+
+        // Released before anything is asserted: a panic inside the scope waits
+        // for every thread in it, and one parked on this channel never
+        // returns, so a failing assertion would hang instead of failing.
+        release_sender.send(()).expect("the probe is still waiting");
+        assert_eq!(
+            in_time,
+            Ok(true),
+            "the save waited on a model list instead of going through",
+        );
+        saving.join().unwrap();
+        probing.join().unwrap().expect("the probe finishes");
+    });
 }

--- a/desktop/locald/src/sharing/transitions.rs
+++ b/desktop/locald/src/sharing/transitions.rs
@@ -317,12 +317,17 @@ impl SharingController {
     }
 
     pub(crate) fn stop_active(&self) {
-        if let Some(mut active) = self
+        // Taken out under the lock, stopped outside it. The guard used to live
+        // to the end of the `if let`, which held it across a tunnel process's
+        // termination and the gateway's shutdown -- and `snapshot` takes the
+        // same lock to say whether sharing is on, so turning it off froze the
+        // page that turned it off.
+        let taken = self
             .active
             .lock()
             .expect("sharing active lock poisoned")
-            .take()
-        {
+            .take();
+        if let Some(mut active) = taken {
             if let Some(tunnel) = active.tunnel.as_mut() {
                 tunnel.stop();
             }


### PR DESCRIPTION
## What changes

Five locks held across work that waits. `if let Some(x) =
self.thing.lock()...take() { ... }` reads like the guard is dropped once the
value is out. It is not: the temporary lives to the end of the `if let`, so the
lock is held across everything in the body.

- **The Agent Host.** `halt` held the state lock across
  `terminate_process_tree` — a five-second `SIGTERM` wait, then whatever is
  left of that budget for the process group, then a `SIGKILL`. `status` takes
  the same lock, and the shell polls `status` to draw the tray, **so stopping
  the Agent Host froze the menu it was stopped from.** Measured at 4.8 seconds
  by the new guard, against a sidecar that ignores `SIGTERM`. `spawn` had the
  same shape around `reclaim_leftover`, which also terminates a process tree.
- **Sharing.** `stop_active` held the active lock across a tunnel process's
  termination and the gateway's shutdown, and `snapshot` takes the same lock to
  say whether sharing is on. Turning sharing off froze the page that turned it
  off.
- **The supervisor teardown** held its lock across `Child::wait`, which blocks
  until the process is gone.
- **The managed runtime** held two locks across `JoinHandle::join` — a thread
  joined while holding a mutex that thread might itself want.
- **Model discovery** held the operator write lock across the provider probe:
  an HTTP round trip to a host the caller chose, with a timeout measured in
  seconds. Every settings save waited behind a model list.

The Agent Host gets a second lock, `transition`, which is what makes a start
and a stop exclusive; `state` is now held only long enough to read or write a
field. Taking `transition` before `state`, never the other way, is the whole of
the lock order.

## Why

Register entries LD-5 and LD-7, plus three more of the same shape found while
fixing them. All four of the P2s here are user-visible: a frozen tray, a frozen
settings page, a save that does nothing until a provider answers.

## How to verify

```bash
make desktop-check
```

Two behavioural guards, each checked by reverting the fix rather than by
reading:

- `status_answers_while_a_stubborn_sidecar_is_still_being_stopped` — with the
  old shape, `status` waits **4.83 seconds**. The sidecar is a shell that traps
  `SIGTERM` and blocks on a pipe nothing writes to, and the test waits for it
  to say its trap is installed: a `SIGTERM` arriving in the milliseconds before
  that lands on the default disposition and kills it outright, which would make
  the test pass for the wrong reason.
- `discovering_models_does_not_hold_up_the_settings_that_are_being_saved` —
  with the old shape the save never returns. The save runs on its own thread
  with a deadline, because asserting on elapsed time in the test thread would
  hang there rather than fail. The probe double parks only on its *first* call,
  since `apply` validates through the same probe.

And a guard for the shape itself: `no_lock_is_held_across_a_block_that_can_wait`
walks the crate and fails on a `.lock()` in the scrutinee of an `if let`,
`while let` or `match`. Two sites are left, named with the reason their bodies
cannot wait — an unbounded `mpsc::Sender`, and a `HashMap` lookup whose
blocking neighbour is already outside. A third has to say which it is. I
confirmed it catches a reintroduced case by putting the sharing one back.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

No protocol, format or API change. One new private field on the Agent Host
supervisor. Revertible as a whole.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved responsiveness while stopping background services, preventing tray menus and status views from freezing during shutdown.
  - Settings can now be saved while model discovery is still in progress.
  - Sharing status remains accessible while sharing is being stopped.
  - Improved shutdown reliability to prevent potential hangs or deadlocks.
  - Start, stop, and recovery operations are now coordinated more reliably to avoid overlapping background-process transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->