### PR TITLE
On Windows a path is not an identity, and an installer cannot replace an open file

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -901,7 +901,20 @@ jobs:
       - name: Verify Authenticode signatures
         if: env.WINDOWS_SIGNING_AVAILABLE == 'true'
         shell: pwsh
+        env:
+          CERTIFICATE_THUMBPRINT: ${{ steps.windows-signing.outputs.thumbprint }}
         run: |
+          # Whose signature, not merely that there is one. `Status -eq "Valid"`
+          # says the chain checks out against the machine's trust store, which
+          # every certificate a GitHub runner already trusts also satisfies --
+          # so a binary signed by anyone at all passed this step. The
+          # thumbprint is the same one the signing step passed to signtool, so
+          # a mismatch means something other than our certificate signed a
+          # file we are about to ship.
+          $expected = $env:CERTIFICATE_THUMBPRINT
+          if ([string]::IsNullOrWhiteSpace($expected)) {
+            throw "Signing is available but no publisher thumbprint was published to verify against"
+          }
           $paths = @(
             "desktop/target/release/lemma-desktop.exe",
             "desktop/binaries/lemma-locald-x86_64-pc-windows-msvc.exe",
@@ -923,6 +936,10 @@ jobs:
             $signature = Get-AuthenticodeSignature $path
             if ($signature.Status -ne "Valid") {
               throw "Invalid Authenticode signature for $path`: $($signature.StatusMessage)"
+            }
+            $signer = $signature.SignerCertificate.Thumbprint
+            if ($signer -ne $expected) {
+              throw "Unexpected Authenticode signer for $path`: $signer, expected $expected"
             }
           }
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -905,6 +905,12 @@ jobs:
           $paths = @(
             "desktop/target/release/lemma-desktop.exe",
             "desktop/binaries/lemma-locald-x86_64-pc-windows-msvc.exe",
+            # The Agent Host runs the user's coding agents with their
+            # credentials and was the one shipped executable nothing here
+            # checked. It is bundled by the same `externalBin` list as the
+            # other two, so an unsigned one is a build problem, not a missing
+            # step -- which is exactly what this is for.
+            "desktop/binaries/lemma-agent-host-x86_64-pc-windows-msvc.exe",
             "desktop/binaries/lemma-runtime-x86_64-pc-windows-msvc.exe"
           )
           $installers = Get-ChildItem `

--- a/desktop/installer/hooks.nsh
+++ b/desktop/installer/hooks.nsh
@@ -1,7 +1,43 @@
 ; Lemma's NSIS hooks.
 ;
-; One thing, done at the one point where it can work.
+; Two things, each at the one point where it can work.
 ;
+; PREINSTALL stops the previous installation's background services, because
+; Windows will not replace a file that is open.
+;
+; PREUNINSTALL erases the local data when the uninstaller's checkbox asked
+; for it, which is not where Tauri would have looked.
+
+; An upgrade installs over a running installation.
+;
+; Windows will not replace a file that is open, so an installer that runs while
+; locald and the Agent Host are up either fails outright or -- because Tauri's
+; NSIS template does not stop on a failed file write -- leaves the previous
+; binaries in place and reports success. The app then launches as the new
+; version against the old daemon, which answers with the same path it always
+; did, and until the build stamp in the handshake landed there was nothing that
+; could tell the difference.
+;
+; Killed rather than asked to stop: there is no window here in which to wait,
+; and a daemon that is killed comes back when the app is next opened. Its state
+; is on disk and survives.
+
+!macro NSIS_HOOK_PREINSTALL
+  DetailPrint "Stopping Lemma's background services..."
+  ; By image name, which is wider than this installation, for the reason the
+  ; uninstall hook gives: narrowing it needs the process path, which NSIS
+  ; cannot filter on without a PowerShell round trip that nothing here can
+  ; test. Installing is explicit and rare.
+  nsExec::ExecToLog 'taskkill /F /T /IM lemma-locald.exe'
+  Pop $0
+  nsExec::ExecToLog 'taskkill /F /T /IM lemma-agent-host.exe'
+  Pop $0
+  ; Give the handles time to close. `taskkill /F` returns once the kill is
+  ; requested, not once the process is gone, and a file whose last handle
+  ; closes a moment later is still in use when the copy starts.
+  Sleep 1500
+!macroend
+
 ; Tauri's uninstaller offers to delete application data, and what it deletes is
 ; %APPDATA%\${BUNDLEID} and %LOCALAPPDATA%\${BUNDLEID} -- for Lemma,
 ; work.lemma.desktop. Lemma's data is not there. It is in %LOCALAPPDATA%\Lemma,
@@ -11,11 +47,13 @@
 ; uninstalling left a registered distribution and a multi-gigabyte disk that
 ; only `wsl --unregister` from a terminal could remove.
 ;
+;
 ; locald already knows how to do this properly: `reset --confirm=erase-local-
 ; lemma` unregisters the guest, reclaims the installation's processes and
 ; removes its state, and it refuses to touch a directory whose contents are not
 ; recognisably Lemma's. This runs it, at PREUNINSTALL, because by POSTUNINSTALL
 ; its binary has already been deleted.
+
 
 !macro NSIS_HOOK_PREUNINSTALL
   ; `reset` refuses while the daemon's socket is answering -- deliberately, so

--- a/desktop/installer/hooks.nsh
+++ b/desktop/installer/hooks.nsh
@@ -28,14 +28,48 @@
   ; uninstall hook gives: narrowing it needs the process path, which NSIS
   ; cannot filter on without a PowerShell round trip that nothing here can
   ; test. Installing is explicit and rare.
-  nsExec::ExecToLog 'taskkill /F /T /IM lemma-locald.exe'
+  ;
+  ; Waited for rather than slept over. `taskkill /F` returns once termination
+  ; has been *requested*, and a file whose last handle closes a moment later is
+  ; still open when the copy starts -- so a fixed pause was a guess about a
+  ; machine we are not on, and being wrong leaves the previous binaries in
+  ; place under an installer that reports success.
+  ;
+  ; taskkill is its own probe: it exits non-zero when there is no such image,
+  ; so "both refused" is "both are gone", and a service that respawned between
+  ; iterations is killed again rather than missed.
+  ;
+  ; The template's own registers, borrowed and given back: this hook runs
+  ; inside its install section, not beside it.
+  Push $0
+  Push $1
+  Push $2
+  StrCpy $1 0
+  ${Do}
+    nsExec::ExecToLog 'taskkill /F /T /IM lemma-locald.exe'
+    Pop $0
+    nsExec::ExecToLog 'taskkill /F /T /IM lemma-agent-host.exe'
+    Pop $2
+    ${If} $0 <> 0
+    ${AndIf} $2 <> 0
+      ${ExitDo}
+    ${EndIf}
+    Sleep 250
+    IntOp $1 $1 + 1
+  ${LoopUntil} $1 >= 40
+  ${If} $0 == 0
+  ${OrIf} $2 == 0
+    ; Ten seconds of `/F` and still answering. Said out loud rather than
+    ; aborted: nothing has been written yet, so this install is still
+    ; recoverable either way, and the handshake stamp this release adds is what
+    ; catches the daemon that survives -- the app refuses to adopt a binary
+    ; that is not the one it ships, instead of running the new shell against
+    ; the old runtime and reporting the same version on both sides.
+    DetailPrint "Lemma is still running. Close it and run this installer again if the new version does not start."
+  ${EndIf}
+  Pop $2
+  Pop $1
   Pop $0
-  nsExec::ExecToLog 'taskkill /F /T /IM lemma-agent-host.exe'
-  Pop $0
-  ; Give the handles time to close. `taskkill /F` returns once the kill is
-  ; requested, not once the process is gone, and a file whose last handle
-  ; closes a moment later is still in use when the copy starts.
-  Sleep 1500
 !macroend
 
 ; Tauri's uninstaller offers to delete application data, and what it deletes is

--- a/desktop/locald/src/daemon/handshake.rs
+++ b/desktop/locald/src/daemon/handshake.rs
@@ -1,0 +1,103 @@
+//! What the daemon says about itself before it says anything else.
+
+use super::*;
+
+impl Daemon {
+    /// The first event on every connection: which daemon this is, and which
+    /// build of it.
+    ///
+    /// Its own function because the shell decides from it whether to adopt
+    /// this daemon or replace it, and a decision that important should be
+    /// readable -- and drivable by a test -- without a socket.
+    pub(super) fn hello_event(&self) -> Value {
+        json!({
+            "v": PROTOCOL_VERSION,
+            "event": "hello",
+            "protocol": PROTOCOL_VERSION,
+            "daemon_version": DAEMON_VERSION,
+            "daemon_api_revision": DAEMON_API_REVISION,
+            "pid": std::process::id(),
+            // Which binary is actually serving this socket, resolved through
+            // the filesystem rather than argv. A replaced app bundle keeps
+            // running from wherever its executable went — ~/.Trash, in the
+            // case this was written for — and the shell has no other way to
+            // tell that the daemon answering it is not the one it ships.
+            // Same version, same API revision, different build.
+            //
+            // Read now rather than at startup, unlike the stamp below: the
+            // question this answers is where the running binary *is*, and on
+            // macOS that changes under a daemon that keeps serving.
+            "executable": std::env::current_exe()
+                .and_then(|path| std::fs::canonicalize(&path).or(Ok(path)))
+                .ok()
+                .map(|path| path.to_string_lossy().into_owned()),
+            // And which build is at that path. On Windows an in-place update
+            // writes to the *same* path, so the path alone says nothing: a
+            // daemon from the previous version answers with an identical one
+            // and gets adopted by the new shell, which then supervises the old
+            // runtime with the same version reported on both sides. Size and
+            // mtime, because an installer that writes a new file changes both
+            // and reading the whole binary on every handshake to learn the
+            // same thing is not worth it.
+            "executable_size": self.executable_stamp.map(|(size, _)| size),
+            "executable_modified_ms": self.executable_stamp
+                .map(|(_, modified)| modified.to_string()),
+            "compatibility_supervisor": self.managed_runtime.is_none(),
+            "mode": if self.managed_runtime.is_some() {
+                "managed-local"
+            } else if self.host_processes.is_some() {
+                "host-packs"
+            } else {
+                "compatibility"
+            },
+            "host_pack_release": self.host_processes.as_ref().map(|manager| manager.release()),
+            "host_pack_root": self.host_pack_root.as_deref(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::daemon;
+    use serde_json::json;
+
+    /// The handshake describes the binary this daemon started from, not
+    /// whichever file is at its path when a client happens to connect.
+    ///
+    /// Measured at handshake time it described neither. An in-place Windows
+    /// update replaces the executable under a daemon that is still running, so
+    /// the old daemon read the *new* file and answered with the identity of
+    /// the build that had just replaced it -- and the shell, finding the
+    /// path and the stamp both matching what it ships, adopted the one daemon
+    /// the stamp exists to refuse. Read once, before `serve` binds the socket,
+    /// it can only ever describe itself.
+    #[test]
+    fn the_handshake_describes_the_build_this_daemon_started_from() {
+        let (_root, mut daemon) = daemon();
+        // What a daemon whose executable was replaced underneath it still has
+        // to say. Nothing else in the process can produce these numbers, so a
+        // handshake that measures the file instead cannot report them.
+        let started_from = (4_242_u64, 1_234_567_u128);
+        std::sync::Arc::get_mut(&mut daemon)
+            .expect("the test holds the only reference")
+            .executable_stamp = Some(started_from);
+
+        let hello = daemon.hello_event();
+        assert_eq!(hello["executable_size"], json!(4_242));
+        assert_eq!(hello["executable_modified_ms"], json!("1234567"));
+    }
+
+    /// A daemon that cannot measure its own binary says so, rather than
+    /// leaving the field out and being taken for an older build that never
+    /// had it.
+    #[test]
+    fn a_daemon_that_cannot_measure_itself_reports_nothing_rather_than_guessing() {
+        let (_root, mut daemon) = daemon();
+        std::sync::Arc::get_mut(&mut daemon)
+            .expect("the test holds the only reference")
+            .executable_stamp = None;
+        let hello = daemon.hello_event();
+        assert!(hello["executable_size"].is_null());
+        assert!(hello["executable_modified_ms"].is_null());
+    }
+}

--- a/desktop/locald/src/daemon/mod.rs
+++ b/desktop/locald/src/daemon/mod.rs
@@ -32,7 +32,7 @@ use crate::PROTOCOL_VERSION;
 const DAEMON_VERSION: &str = env!("CARGO_PKG_VERSION");
 // Bump whenever Desktop must replace a durable daemon even when the public
 // app/host-pack release has not changed (for example, a test-build hotfix).
-const DAEMON_API_REVISION: u64 = 5;
+const DAEMON_API_REVISION: u64 = 6;
 
 /// Broadcasts held for a subscriber that is not keeping up.
 ///
@@ -82,7 +82,7 @@ mod supervisor;
 
 use dispatch::{error_diagnostic_source, runtime_operation_error_code};
 use environment::{compose_backend_environment, sharing_environment, validate_canonical_origin};
-use supervisor::prepare_compatibility_host_manifest;
+use supervisor::{executable_stamp, prepare_compatibility_host_manifest};
 
 impl Daemon {
     pub fn new(paths: LocalPaths) -> io::Result<Arc<Self>> {
@@ -316,6 +316,18 @@ impl Daemon {
                     .and_then(|path| std::fs::canonicalize(&path).or(Ok(path)))
                     .ok()
                     .map(|path| path.to_string_lossy().into_owned()),
+                // And which build is at that path. On Windows an in-place
+                // update writes to the *same* path, so the path alone says
+                // nothing: a daemon from the previous version answers with an
+                // identical one and gets adopted by the new shell, which then
+                // supervises the old runtime with the same version reported on
+                // both sides. Size and mtime, because an installer that writes
+                // a new file changes both and reading the whole binary on every
+                // handshake to learn the same thing is not worth it.
+                "executable_size": executable_stamp().map(|(size, _)| size),
+                "executable_modified_ms": executable_stamp()
+                    .map(|(_, modified)| modified)
+                    .map(|modified| modified.to_string()),
                 "compatibility_supervisor": self.managed_runtime.is_none(),
                 "mode": if self.managed_runtime.is_some() {
                     "managed-local"

--- a/desktop/locald/src/daemon/mod.rs
+++ b/desktop/locald/src/daemon/mod.rs
@@ -68,12 +68,23 @@ pub struct Daemon {
     /// State this daemon had to repair before it could start, in the operator's
     /// words rather than serde's. Empty on every healthy launch.
     healed: Vec<String>,
+    /// The size and modification time of the binary this daemon started from.
+    ///
+    /// Measured once, here, and not again. The case it exists for is a Windows
+    /// in-place update, which replaces the file at `current_exe()` under a
+    /// daemon that is still running -- so a stamp read at handshake time is a
+    /// measurement of the build that just replaced this one, handed to a shell
+    /// that then adopts the daemon the update was meant to retire. It is also
+    /// two metadata reads off every connection, which is two more than a value
+    /// that cannot change needs.
+    executable_stamp: Option<(u64, u128)>,
 }
 
 mod agent_host_ops;
 mod config_ops;
 mod dispatch;
 mod environment;
+mod handshake;
 mod monitors;
 mod reset_ops;
 mod sharing_ops;
@@ -221,6 +232,10 @@ impl Daemon {
             shutdown_running: AtomicBool::new(false),
             agent_host,
             healed,
+            // Before `serve` binds the socket, which is the whole point: after
+            // that a Windows installer can replace this file while this
+            // process is still answering on it.
+            executable_stamp: executable_stamp(),
         }))
     }
 
@@ -297,49 +312,7 @@ impl Daemon {
             }
         });
 
-        self.send_direct(
-            &sender,
-            json!({
-                "v": PROTOCOL_VERSION,
-                "event": "hello",
-                "protocol": PROTOCOL_VERSION,
-                "daemon_version": DAEMON_VERSION,
-                "daemon_api_revision": DAEMON_API_REVISION,
-                "pid": std::process::id(),
-                // Which binary is actually serving this socket, resolved through
-                // the filesystem rather than argv. A replaced app bundle keeps
-                // running from wherever its executable went — ~/.Trash, in the
-                // case this was written for — and the shell has no other way to
-                // tell that the daemon answering it is not the one it ships.
-                // Same version, same API revision, different build.
-                "executable": std::env::current_exe()
-                    .and_then(|path| std::fs::canonicalize(&path).or(Ok(path)))
-                    .ok()
-                    .map(|path| path.to_string_lossy().into_owned()),
-                // And which build is at that path. On Windows an in-place
-                // update writes to the *same* path, so the path alone says
-                // nothing: a daemon from the previous version answers with an
-                // identical one and gets adopted by the new shell, which then
-                // supervises the old runtime with the same version reported on
-                // both sides. Size and mtime, because an installer that writes
-                // a new file changes both and reading the whole binary on every
-                // handshake to learn the same thing is not worth it.
-                "executable_size": executable_stamp().map(|(size, _)| size),
-                "executable_modified_ms": executable_stamp()
-                    .map(|(_, modified)| modified)
-                    .map(|modified| modified.to_string()),
-                "compatibility_supervisor": self.managed_runtime.is_none(),
-                "mode": if self.managed_runtime.is_some() {
-                    "managed-local"
-                } else if self.host_processes.is_some() {
-                    "host-packs"
-                } else {
-                    "compatibility"
-                },
-                "host_pack_release": self.host_processes.as_ref().map(|manager| manager.release()),
-                "host_pack_root": self.host_pack_root.as_deref(),
-            }),
-        );
+        self.send_direct(&sender, self.hello_event());
         self.send_direct(
             &sender,
             self.state.lock().expect("state lock poisoned").event(None),

--- a/desktop/locald/src/daemon/supervisor.rs
+++ b/desktop/locald/src/daemon/supervisor.rs
@@ -340,3 +340,20 @@ pub(super) fn transitional_provider(managed_runtime_available: bool) -> String {
         _ => "podman".into(),
     }
 }
+
+/// The size and modification time of the executable this daemon is running.
+///
+/// Paired with `executable` in the handshake: see the comment there for why a
+/// path is not an identity on Windows.
+pub(super) fn executable_stamp() -> Option<(u64, u128)> {
+    let path = std::env::current_exe().ok()?;
+    let resolved = std::fs::canonicalize(&path).unwrap_or(path);
+    let metadata = std::fs::metadata(&resolved).ok()?;
+    let modified = metadata
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_millis();
+    Some((metadata.len(), modified))
+}

--- a/desktop/locald/src/daemon/tests.rs
+++ b/desktop/locald/src/daemon/tests.rs
@@ -9,7 +9,7 @@ use std::sync::mpsc;
 /// the arms that are pure protocol -- authentication, unknown commands, the
 /// stopping gate, the shapes of acks and errors -- can be driven without a
 /// VM, a backend or a tunnel. Those arms had no test at all.
-fn daemon() -> (tempfile::TempDir, std::sync::Arc<Daemon>) {
+pub(super) fn daemon() -> (tempfile::TempDir, std::sync::Arc<Daemon>) {
     let root = tempfile::tempdir().unwrap();
     let daemon = Daemon::new(LocalPaths::new(root.path().join("locald")))
         .expect("a daemon over an empty root");

--- a/desktop/scripts/desktop.ps1
+++ b/desktop/scripts/desktop.ps1
@@ -10,10 +10,11 @@
     so they cannot drift.
 
     There is deliberately no `dev` verb. Running the app from source is macOS
-    only for now: dev-local.sh has no Windows counterpart, and the WSL
-    distribution name the managed runtime uses is a global constant, so a dev
-    run in a throwaway state root would adopt and mutate the distro a real
-    install owns. On Windows, build and install the app instead — `exe`.
+    only for now: dev-local.sh has no Windows counterpart. The distribution
+    name is no longer the blocker it was — a state root other than the standard
+    one gets its own `LemmaRuntime-<hash>`, and `LEMMA_RUNTIME_WSL_DISTRIBUTION`
+    overrides it — so a dev run in a throwaway root no longer adopts the distro
+    a real install owns. On Windows, build and install the app instead — `exe`.
 
 .EXAMPLE
     pwsh desktop\scripts\desktop.ps1 test

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -100,7 +100,7 @@ const MAX_INSTALL_LOG_BYTES: u64 = 1024 * 1024;
 // Must match locald's handshake revision. This prevents a newly installed
 // Desktop hotfix from silently reusing an older durable daemon with the same
 // public release number.
-const REQUIRED_LOCALD_API_REVISION: u64 = 5;
+const REQUIRED_LOCALD_API_REVISION: u64 = 6;
 // Legacy development builds persisted a mode before the released chooser
 // contract was stable. Require that chooser once, then retain the new choice.
 const CONNECTION_MODE_PROMPT_REVISION: u64 = 1;

--- a/desktop/src/runtime_layout.rs
+++ b/desktop/src/runtime_layout.rs
@@ -272,7 +272,21 @@ pub(crate) fn locald_is_this_build(
         // whatever it built. Identity is the developer's business there.
         return true;
     };
-    hello["executable"].as_str() == Some(path_identity(expected).as_str())
+    if hello["executable"].as_str() != Some(path_identity(expected).as_str()) {
+        return false;
+    }
+    // And the same *build* at that path. On Windows an in-place update writes
+    // to the same path, so the path alone matches a daemon from the previous
+    // version -- which the shell would then adopt, supervising the old runtime
+    // under a new app with the same version reported on both sides.
+    //
+    // A file we cannot measure is not the one we ship, and neither is a daemon
+    // that will not say. Both are refused rather than assumed.
+    let Some((size, modified)) = executable_stamp(expected) else {
+        return false;
+    };
+    hello["executable_size"].as_u64() == Some(size)
+        && hello["executable_modified_ms"].as_str() == Some(modified.to_string().as_str())
 }
 
 pub(crate) fn locald_matches_host_pack(

--- a/desktop/src/shell_paths.rs
+++ b/desktop/src/shell_paths.rs
@@ -246,6 +246,36 @@ pub(crate) fn path_identity(path: &std::path::Path) -> String {
         .into_owned()
 }
 
+/// Which *build* of an executable is at a path, not just which path it is.
+///
+/// A path is not an identity when the file at it can be replaced. On macOS an
+/// update moves the old app to the Trash, so the running daemon's path changes
+/// and comparing paths is enough. On Windows an in-place update writes to the
+/// same path -- so a daemon from the previous version reports an identical
+/// path, and a shell that compares only paths adopts it: the new app
+/// supervising the old runtime, with the same version on both sides and
+/// nothing anywhere saying so.
+///
+/// Size and modification time rather than a content hash. The daemon sends
+/// this on every handshake and the shell computes it on every connect, and
+/// reading thirty megabytes to answer "is this the file I ship" is not a cost
+/// worth paying for a question a replaced file already answers: an installer
+/// that writes a new file changes both.
+///
+/// `None` when the file cannot be measured, which is itself a different
+/// daemon -- the executable it is running from is gone.
+pub(crate) fn executable_stamp(path: &std::path::Path) -> Option<(u64, u128)> {
+    let resolved = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let metadata = std::fs::metadata(&resolved).ok()?;
+    let modified = metadata
+        .modified()
+        .ok()?
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_millis();
+    Some((metadata.len(), modified))
+}
+
 /// The storage partition a server's session lives in.
 ///
 /// Lemma Cloud and a local install are different servers -- different accounts,

--- a/desktop/src/tests/locald.rs
+++ b/desktop/src/tests/locald.rs
@@ -50,26 +50,72 @@ fn a_busy_daemon_refuses_an_operation_rather_than_dropping_it() {
 
 #[test]
 fn a_daemon_from_a_replaced_app_bundle_is_not_this_build() {
-    let expected = std::path::Path::new("/Applications/Lemma.app/Contents/MacOS/lemma-locald");
+    // A real file, because identity is now the build at the path and not only
+    // the path: the shell measures the sidecar it ships.
+    let bundle = tempfile::tempdir().expect("a temporary bundle");
+    let expected = bundle.path().join("lemma-locald");
+    std::fs::write(&expected, b"the daemon this app ships").unwrap();
+    let expected = expected.as_path();
+    let (size, modified) = executable_stamp(expected).expect("the sidecar can be measured");
     let this_build = json!({
         "daemon_api_revision": REQUIRED_LOCALD_API_REVISION,
         "executable": path_identity(expected),
+        "executable_size": size,
+        "executable_modified_ms": modified.to_string(),
     });
     assert!(locald_is_this_build(&this_build, Some(expected)));
 
-    // The failure this exists for. Updating the app moves the previous
-    // bundle to the Trash; its daemon keeps running and keeps the socket,
-    // reporting the same version and the same revision as the one that
+    // The failure this exists for on macOS. Updating the app moves the
+    // previous bundle to the Trash; its daemon keeps running and keeps the
+    // socket, reporting the same version and the same revision as the one that
     // replaced it.
     let from_the_trash = json!({
         "daemon_api_revision": REQUIRED_LOCALD_API_REVISION,
         "daemon_version": env!("CARGO_PKG_VERSION"),
         "executable": "/Users/someone/.Trash/Lemma 4.23.56 PM.app/Contents/MacOS/lemma-locald",
+        "executable_size": size,
+        "executable_modified_ms": modified.to_string(),
     });
     assert!(
         !locald_is_this_build(&from_the_trash, Some(expected)),
         "a daemon running from another bundle must be replaced, not adopted",
     );
+
+    // And the failure on Windows, which the path can never catch: an in-place
+    // update writes to the *same* path, so the previous version's daemon
+    // answers with a path identical to the one the new shell expects.
+    for (label, wrong) in [
+        (
+            "a different size at the same path",
+            json!({
+                "daemon_api_revision": REQUIRED_LOCALD_API_REVISION,
+                "executable": path_identity(expected),
+                "executable_size": size + 1,
+                "executable_modified_ms": modified.to_string(),
+            }),
+        ),
+        (
+            "a different build time at the same path",
+            json!({
+                "daemon_api_revision": REQUIRED_LOCALD_API_REVISION,
+                "executable": path_identity(expected),
+                "executable_size": size,
+                "executable_modified_ms": (modified + 1).to_string(),
+            }),
+        ),
+        (
+            "a daemon that will not say which build it is",
+            json!({
+                "daemon_api_revision": REQUIRED_LOCALD_API_REVISION,
+                "executable": path_identity(expected),
+            }),
+        ),
+    ] {
+        assert!(
+            !locald_is_this_build(&wrong, Some(expected)),
+            "{label} was adopted",
+        );
+    }
 
     // Every build older than the field predates the check, so silence is a
     // mismatch rather than a pass.
@@ -79,6 +125,8 @@ fn a_daemon_from_a_replaced_app_bundle_is_not_this_build() {
     let wrong_revision = json!({
         "daemon_api_revision": REQUIRED_LOCALD_API_REVISION + 1,
         "executable": path_identity(expected),
+        "executable_size": size,
+        "executable_modified_ms": modified.to_string(),
     });
     assert!(!locald_is_this_build(&wrong_revision, Some(expected)));
 

--- a/desktop/src/tests/windows.rs
+++ b/desktop/src/tests/windows.rs
@@ -34,6 +34,29 @@ fn the_windows_uninstaller_removes_the_data_the_checkbox_promises() {
          elsewhere that can change under us"
     );
 
+    // An upgrade installs over a running installation, and Windows will not
+    // replace an open file. Without this the previous binaries survive the
+    // copy and the new app launches against the old daemon.
+    assert!(
+        hooks.contains("!macro NSIS_HOOK_PREINSTALL"),
+        "an installer that runs while locald is up cannot replace its binary"
+    );
+    let stopped = hooks
+        .find("!macro NSIS_HOOK_PREINSTALL")
+        .expect("the pre-install hook exists");
+    let preinstall = &hooks[stopped..hooks.find("!macroend").expect("it ends")];
+    for image in ["lemma-locald.exe", "lemma-agent-host.exe"] {
+        assert!(
+            preinstall.contains(&format!("taskkill /F /T /IM {image}")),
+            "{image} holds its own file open during an upgrade"
+        );
+    }
+    assert!(
+        preinstall.contains("Sleep "),
+        "`taskkill /F` returns when the kill is requested, not when the \
+         handles are closed, so the copy has to wait for them"
+    );
+
     assert!(
         hooks.contains("!macro NSIS_HOOK_PREUNINSTALL"),
         "PRE, not POST: by POSTUNINSTALL lemma-locald.exe has already been \


### PR DESCRIPTION
## What changes

Two halves of the same failure on Windows, and neither is visible on macOS.

**An in-place update leaves the old daemon answering, and the new shell adopts
it.** The handshake identifies the daemon by its executable path, which is
enough on macOS — an update moves the old bundle to the Trash, so the path
changes. On Windows the installer writes to the *same* path. The previous
version's daemon reports a path identical to the one the new shell expects and
gets adopted: **the new app supervising the old runtime, with the same version
reported on both sides and nothing anywhere saying so.**

`install_app_update` works around it by stopping locald before installing, and
its comment says exactly why. Nothing covers the other ways a stale daemon
survives an upgrade — a crash mid-install, a repair, a user replacing files.

The handshake now carries the size and modification time of the executable, and
the shell compares them against the sidecar it ships. Not a content hash: the
daemon sends this on every handshake and the shell computes it on every
connect, and reading thirty megabytes to answer "is this the file I ship" is
not worth paying for a question a replaced file already answers. A daemon that
will not say is refused, so `DAEMON_API_REVISION` moves to 6.

**And the installer ran over a live installation.** Windows will not replace a
file that is open, so an upgrade with locald and the Agent Host running either
fails outright or — because Tauri's NSIS template does not stop on a failed
file write — leaves the previous binaries in place and reports success.
`NSIS_HOOK_PREINSTALL` stops them first, with a pause afterwards because
`taskkill /F` returns when the kill is *requested*, not when the handles are
closed.

Two smaller things found on the way:

- The release workflow verified Authenticode on three of the four executables
  it ships. **The Agent Host** — which runs the user's coding agents with their
  credentials — **was the one nothing checked.** It is bundled by the same
  `externalBin` list as the others, so an unsigned one is a build problem, not
  a missing step, which is what a verification list is for.
- `desktop.ps1` still said the WSL distribution name is a global constant. That
  stopped being true when a non-standard state root started getting its own
  `LemmaRuntime-<hash>`, so the stated reason there is no `dev` verb on Windows
  was wrong. The remaining reason is that `dev-local.sh` has no counterpart.

## Why

Register entries WIN-3 and WIN-12. WIN-4 and WIN-7 turned out already done —
`record_update_attempt`/`reconcile_update_attempt` and the pinned
`installMode` plus the real `PREUNINSTALL` reset — so this is what was left.

## How to verify

```bash
make desktop-check
```

`a_daemon_from_a_replaced_app_bundle_is_not_this_build` is rewritten around a
real file, because identity is now the build at the path rather than only the
path, and it covers the three Windows shapes the path can never catch: the same
path with a different size, the same path with a different build time, and a
daemon that does not answer at all. All three are refused.

The installer hook cannot be executed from here — NSIS runs only on Windows,
during a real install — so `the_windows_uninstaller_removes_the_data_the_checkbox_promises`
asserts its shape: the hook exists, it stops both images by name, and it waits
afterwards. CI's Windows job building the installer is what proves it parses.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

`DAEMON_API_REVISION` 5 → 6, and the shell requires 6. This is the existing
mechanism for exactly this: a shell meeting an older daemon replaces it rather
than adopting it, which is the behaviour being fixed. Both halves ship in one
release, so no mixed pair exists outside a development checkout — where the
shell has no packaged sidecar to compare against and identity is the
developer's business, as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Windows upgrades now stop running desktop services before replacing their files, helping installations complete reliably.
  - The Desktop app now rejects outdated or replaced background services, even when they use the expected file path.
  - Windows release builds now verify the Agent Host executable’s signature alongside other bundled binaries.

- **Documentation**
  - Updated Windows development guidance clarifies runtime distribution naming and isolation for temporary development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->