### PR TITLE
An agent behind a wrapper outlived every run it belonged to, on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1082,10 +1082,13 @@ desktop-check-windows:
 	@rustup target list --installed | grep -q x86_64-pc-windows-msvc || ( \
 		echo "→ Adding the Windows target…"; \
 		rustup target add x86_64-pc-windows-msvc)
-	@echo "→ Windows compile check (locald, runtime manager, bridge, process)…"
+	@echo "→ Windows compile check (locald, runtime manager, bridge, process, job object)…"
+	# lemma-agent-host is deliberately absent: it depends on libsqlite3-sys,
+	# which needs a Windows C toolchain to cross-compile. CI's windows-latest
+	# job builds and tests it, and that is the only place it can be checked.
 	@cd $(DESKTOP_DIR) && cargo clippy \
 		-p lemma-locald -p lemma-runtime-manager \
-		-p lemma-runtime -p lemma-desktop-process \
+		-p lemma-runtime -p lemma-desktop-process -p lemma-job-object \
 		--target x86_64-pc-windows-msvc --all-targets --locked -- -D warnings
 	@echo "  ✓ the Windows code paths compile and lint"
 

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2738,6 +2738,7 @@ dependencies = [
  "getrandom 0.3.4",
  "hex",
  "lemma-desktop-process",
+ "lemma-job-object",
  "predicates",
  "reqwest",
  "rusqlite",
@@ -2764,6 +2765,7 @@ dependencies = [
  "hex",
  "interprocess",
  "lemma-desktop-process",
+ "lemma-job-object",
  "libc",
  "objc2",
  "objc2-app-kit",
@@ -2803,6 +2805,13 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+]
+
+[[package]]
+name = "lemma-job-object"
+version = "0.7.2"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -19,6 +19,7 @@ edition = "2021"
 [workspace]
 resolver = "2"
 members = [
+    "job-object",
     "locald",
     "agent-host",
     "process",
@@ -74,6 +75,7 @@ tauri-build = { version = "2", features = [] }
 
 [dependencies]
 lemma-desktop-process = { path = "process" }
+lemma-job-object = { path = "job-object" }
 # macos-private-api is what gates WebviewWindowBuilder::transparent, which an
 # NSVisualEffectView has to sit behind to be visible at all. It is also what
 # makes a build ineligible for the Mac App Store — fine for the dmg/app targets

--- a/desktop/agent-host/Cargo.toml
+++ b/desktop/agent-host/Cargo.toml
@@ -46,6 +46,7 @@ futures-util = "0.3.33"
 rustix = { version = "1", features = ["process"] }
 fs4 = { version = "1.1.0", features = ["sync"] }
 lemma-desktop-process = { path = "../process" }
+lemma-job-object = { path = "../job-object" }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/desktop/agent-host/src/acp/supervision.rs
+++ b/desktop/agent-host/src/acp/supervision.rs
@@ -28,6 +28,22 @@ pub(crate) const STDERR_TAIL_LIMIT: usize = 8 * 1024;
 /// `a_crash_mid_stream_keeps_every_chunk_the_agent_had_already_sent`.
 pub(crate) struct SupervisedAgent {
     child: async_process::Child,
+    /// Everything this agent starts, held so that dropping this ends all of
+    /// it. Windows only, and inert elsewhere: on unix the process group the
+    /// protocol crate spawns into already does this.
+    ///
+    /// `taskkill /T` walks the tree the OS still maintains, which is not the
+    /// case that matters. Agents ship behind wrapper launchers -- `npx`,
+    /// `uvx` -- and a wrapper that has already exited leaves its child in no
+    /// tree at all. That child holds the workspace open, holds the provider
+    /// credential and can still write files, after the run it belonged to has
+    /// ended. A job object has no such hole.
+    ///
+    /// `None` when the job could not be created or the child could not be
+    /// assigned. Not fatal: `kill_agent_tree` is still what it was, and
+    /// refusing to run an agent because a job object was unavailable would
+    /// trade a leak for an outage.
+    job: Option<lemma_job_object::Job>,
 }
 
 impl SupervisedAgent {
@@ -42,9 +58,10 @@ impl SupervisedAgent {
         let (stdin, stdout, stderr, child) = agent
             .spawn_process()
             .map_err(|error| anyhow::anyhow!("could not start the agent: {error}"))?;
+        let job = adopt_into_job(&child);
         // `new(outgoing, incoming)`: we write to the child's stdin and read its
         // stdout.
-        Ok((Self { child }, ByteStreams::new(stdin, stdout), stderr))
+        Ok((Self { child, job }, ByteStreams::new(stdin, stdout), stderr))
     }
 
     /// Explain a protocol failure using what the process did, now that the
@@ -84,6 +101,30 @@ impl Drop for SupervisedAgent {
     fn drop(&mut self) {
         kill_agent_tree(self.child.id());
         let _ = self.child.kill();
+        // Last, and only on Windows does it do anything: closing the job ends
+        // every process in it, including the ones no tree walk can reach.
+        drop(self.job.take());
+    }
+}
+
+/// Put a freshly spawned agent, and everything it goes on to start, in a job.
+///
+/// Best effort by design. A job object that cannot be created or assigned is
+/// a leak we already had; refusing to run the agent over it would trade that
+/// leak for an outage.
+fn adopt_into_job(child: &async_process::Child) -> Option<lemma_job_object::Job> {
+    #[cfg(windows)]
+    {
+        use std::os::windows::io::AsRawHandle;
+
+        let job = lemma_job_object::Job::new().ok()?;
+        job.adopt(child.as_raw_handle()).ok()?;
+        Some(job)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = child;
+        None
     }
 }
 

--- a/desktop/job-object/Cargo.toml
+++ b/desktop/job-object/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "lemma-job-object"
+version.workspace = true
+edition = "2021"
+license = "AGPL-3.0-or-later"
+description = "A Windows job object, so a process tree dies with the thing that started it"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.2", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_JobObjects",
+    "Win32_System_Threading",
+] }
+
+[lints.clippy]
+all = { level = "warn", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+missing_errors_doc = "allow"

--- a/desktop/job-object/src/lib.rs
+++ b/desktop/job-object/src/lib.rs
@@ -132,12 +132,27 @@ mod tests {
     /// ends it anyway.
     #[test]
     fn a_grandchild_whose_parent_has_gone_still_dies_with_the_job() {
-        let marker = std::env::temp_dir().join(format!("lemma-job-{}.txt", std::process::id()));
-        let _ = std::fs::remove_file(&marker);
+        // By process id, not by image name. `ping.exe` is a name anything on
+        // the machine may be using -- a runner builds several jobs at once --
+        // so an image-name check could watch somebody else's process and
+        // report either answer for the wrong reason.
+        let pings = || -> std::collections::BTreeSet<String> {
+            let output = Command::new("tasklist")
+                .args(["/FI", "IMAGENAME eq ping.exe", "/FO", "CSV", "/NH"])
+                .output()
+                .expect("tasklist runs");
+            String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .filter_map(|line| line.split(',').nth(1))
+                .map(|field| field.trim().trim_matches('"').to_owned())
+                .filter(|pid| pid.chars().all(|digit| digit.is_ascii_digit()) && !pid.is_empty())
+                .collect()
+        };
+        let before = pings();
 
         let job = Job::new().expect("a job object");
-        // `cmd` starts a detached `ping` that writes nothing and outlives it,
-        // then exits. `ping -t` runs until it is killed.
+        // `cmd` starts a detached `ping` that outlives it, then exits. `ping
+        // -t` runs until something kills it.
         let mut wrapper = Command::new("cmd")
             .args(["/c", "start", "/b", "ping", "-t", "127.0.0.1"])
             .stdin(Stdio::null())
@@ -149,15 +164,31 @@ mod tests {
             .expect("the wrapper joins the job");
         wrapper.wait().expect("the wrapper exits on its own");
 
-        let running = |name: &str| {
+        // Waited for, not sampled. `cmd` exits as soon as it has asked for the
+        // grandchild; the grandchild is not in the process list at that
+        // instant, and checking once there failed the assertion that is
+        // supposed to establish this test means anything.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let grandchild = loop {
+            if let Some(pid) = pings().difference(&before).next().cloned() {
+                break pid;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "the grandchild never appeared, so there is nothing here to outlive its parent"
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        };
+
+        let alive = |pid: &str| {
             let output = Command::new("tasklist")
-                .args(["/FI", &format!("IMAGENAME eq {name}")])
+                .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
                 .output()
                 .expect("tasklist runs");
-            String::from_utf8_lossy(&output.stdout).contains(name)
+            String::from_utf8_lossy(&output.stdout).contains(pid)
         };
         assert!(
-            running("ping.exe"),
+            alive(&grandchild),
             "the grandchild outlived its parent, as it must for this test to mean anything"
         );
 
@@ -165,14 +196,15 @@ mod tests {
 
         let deadline = Instant::now() + Duration::from_secs(10);
         while Instant::now() < deadline {
-            if !running("ping.exe") {
+            if !alive(&grandchild) {
                 return;
             }
             std::thread::sleep(Duration::from_millis(100));
         }
-        // Best effort cleanup before failing.
+        // Best effort cleanup before failing, so a broken run does not leave a
+        // `ping -t` behind on the runner for ever.
         let _ = Command::new("taskkill")
-            .args(["/F", "/IM", "ping.exe"])
+            .args(["/F", "/PID", &grandchild])
             .output();
         panic!("closing the job left the grandchild running");
     }

--- a/desktop/job-object/src/lib.rs
+++ b/desktop/job-object/src/lib.rs
@@ -1,0 +1,179 @@
+//! A Windows job object, so a process tree dies with the thing that started it.
+//!
+//! On unix a process group and one signal end an agent and everything it
+//! started. Windows has no equivalent. `taskkill /T` walks the tree the OS
+//! still maintains, which misses exactly the case that matters here: agents
+//! ship behind wrapper launchers -- `npx`, `uvx` -- and a wrapper that has
+//! already exited leaves its child in no tree at all. That child holds the
+//! workspace open, holds the provider credential, and can still write files,
+//! after the run it belonged to has ended.
+//!
+//! A job object does not have that hole. Every process put in one, and
+//! everything they go on to start, belongs to it for good, and closing the last
+//! handle with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` ends all of them.
+//!
+//! Its own crate because of one word. `lemma-desktop-process` is where this
+//! belongs by subject and `lemma-agent-host` is where it is needed, and both
+//! declare `unsafe_code = "forbid"` -- which cannot be lifted locally, and is
+//! not a policy worth weakening across a whole crate for four calls into
+//! `Win32`. So the `unsafe` is here, in a crate small enough to read in one
+//! sitting, and nothing else changes its mind about unsafe code.
+
+#![cfg_attr(not(windows), allow(unused))]
+
+use std::io;
+
+/// A job object that kills everything in it when it is dropped.
+///
+/// On platforms without job objects this is an empty handle that does nothing,
+/// so a caller needs no `cfg` of its own: the guarantee is Windows-only
+/// because the problem is.
+pub struct Job {
+    #[cfg(windows)]
+    handle: isize,
+}
+
+impl Job {
+    /// Create a job whose processes die when this value is dropped.
+    #[cfg(windows)]
+    pub fn new() -> io::Result<Self> {
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::JobObjects::{
+            CreateJobObjectW, JobObjectExtendedLimitInformation, SetInformationJobObject,
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        };
+
+        // SAFETY: a null name and null attributes are the documented way to
+        // create an unnamed job, and the returned handle is checked.
+        let handle = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+        if handle.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: an all-zero `JOBOBJECT_EXTENDED_LIMIT_INFORMATION` is the
+        // documented starting point; only the flags are then set.
+        let mut limits: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { std::mem::zeroed() };
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        // SAFETY: `limits` outlives the call, and the length passed is its own.
+        let configured = unsafe {
+            SetInformationJobObject(
+                handle,
+                JobObjectExtendedLimitInformation,
+                std::ptr::from_ref(&limits).cast(),
+                u32::try_from(std::mem::size_of_val(&limits)).unwrap_or(0),
+            )
+        };
+        if configured == 0 {
+            let error = io::Error::last_os_error();
+            // SAFETY: the handle was just created here and is not used again.
+            unsafe { CloseHandle(handle) };
+            return Err(error);
+        }
+        Ok(Self {
+            handle: handle as isize,
+        })
+    }
+
+    /// Everywhere else, a job that holds nothing and promises nothing.
+    #[cfg(not(windows))]
+    pub fn new() -> io::Result<Self> {
+        Ok(Self {})
+    }
+
+    /// Put a process, and everything it goes on to start, in this job.
+    ///
+    /// A freshly spawned child is never already in a job that forbids this.
+    #[cfg(windows)]
+    pub fn adopt(&self, process: std::os::windows::io::RawHandle) -> io::Result<()> {
+        use windows_sys::Win32::System::JobObjects::AssignProcessToJobObject;
+
+        // SAFETY: both handles are owned by their holders for the call.
+        let assigned = unsafe { AssignProcessToJobObject(self.handle as *mut _, process.cast()) };
+        if assigned == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+}
+
+impl Drop for Job {
+    /// Implemented on every platform, even where it does nothing.
+    ///
+    /// The type's whole contract is "dropping this ends what is in it", and a
+    /// caller writing `drop(job)` should not have to know which platform gives
+    /// that meaning -- nor be told by a lint that the value it is dropping has
+    /// no `Drop`.
+    fn drop(&mut self) {
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::Foundation::CloseHandle;
+
+            // Closing the last handle is what ends the job's processes. There
+            // is nothing useful to do with a failure: the handle goes away
+            // with this process either way.
+            // SAFETY: the handle came from `CreateJobObjectW` and is closed
+            // exactly once, here.
+            unsafe { CloseHandle(self.handle as *mut _) };
+        }
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+    use std::os::windows::io::AsRawHandle;
+    use std::process::{Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    /// The case `taskkill /T` cannot reach.
+    ///
+    /// A wrapper that starts a grandchild and exits leaves that grandchild in
+    /// no tree at all -- which is the normal shape behind `npx` and `uvx`, and
+    /// exactly how an agent survived the run it belonged to. Closing the job
+    /// ends it anyway.
+    #[test]
+    fn a_grandchild_whose_parent_has_gone_still_dies_with_the_job() {
+        let marker = std::env::temp_dir().join(format!("lemma-job-{}.txt", std::process::id()));
+        let _ = std::fs::remove_file(&marker);
+
+        let job = Job::new().expect("a job object");
+        // `cmd` starts a detached `ping` that writes nothing and outlives it,
+        // then exits. `ping -t` runs until it is killed.
+        let mut wrapper = Command::new("cmd")
+            .args(["/c", "start", "/b", "ping", "-t", "127.0.0.1"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("the wrapper starts");
+        job.adopt(wrapper.as_raw_handle())
+            .expect("the wrapper joins the job");
+        wrapper.wait().expect("the wrapper exits on its own");
+
+        let running = |name: &str| {
+            let output = Command::new("tasklist")
+                .args(["/FI", &format!("IMAGENAME eq {name}")])
+                .output()
+                .expect("tasklist runs");
+            String::from_utf8_lossy(&output.stdout).contains(name)
+        };
+        assert!(
+            running("ping.exe"),
+            "the grandchild outlived its parent, as it must for this test to mean anything"
+        );
+
+        drop(job);
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            if !running("ping.exe") {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        // Best effort cleanup before failing.
+        let _ = Command::new("taskkill")
+            .args(["/F", "/IM", "ping.exe"])
+            .output();
+        panic!("closing the job left the grandchild running");
+    }
+}

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -148,6 +148,7 @@ SOURCES: tuple[Source, ...] = (
 # re-declares its own would be invisible to SOURCES above and would drift at the
 # next release, so the shape is checked rather than the value.
 WORKSPACE_MEMBERS: tuple[str, ...] = (
+    "desktop/job-object",
     "desktop/locald",
     "desktop/agent-host",
     "desktop/local-runtime/manager",


### PR DESCRIPTION
## What changes

An agent behind a wrapper outlived every run it belonged to, on Windows.

`kill_agent_tree` already says what is wrong with it: *"a descendant whose
parent has already exited is no longer part of any tree to walk, and neither
platform can reach one of those."* On unix that is a narrow case, because the
adapter is spawned into its own process group and one signal reaches the group
whatever has exited. **On Windows it is the normal case.** Agents ship behind
`npx` and `uvx`; the wrapper starts the real agent and exits; `taskkill /T`
then has no tree to walk. The agent went on running — holding the workspace
open, holding the provider credential, still able to write files — after the
run it belonged to had ended.

A job object has no such hole. Everything put in one, and everything they go on
to start, belongs to it for good, and closing the last handle with
`JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` ends all of it. `SupervisedAgent` holds
one for the agent's lifetime and closes it last in `Drop`, after the kill it
already did.

Adopting the child is best effort. A job object that cannot be created is a
leak we already had, and refusing to run the agent over it would trade that
leak for an outage.

### Why it is its own crate

Because of one word. It belongs by subject in `lemma-desktop-process` and it is
needed in `lemma-agent-host`, and **both declare `unsafe_code = "forbid"`** —
which cannot be lifted locally, and is not a policy worth weakening across a
whole crate for four calls into Win32. So the `unsafe` is in a crate small
enough to read in one sitting, and nothing else changes its mind about unsafe
code. locald's own `create_windows_job`/`assign_child_to_windows_job` can move
there next; this leaves them alone.

## Why

Register entries AH-5 and the remaining half of WIN-5. WIN-5's first half —
`taskkill /T` instead of `Child::kill` — already landed; this closes the case
that comment names as out of reach.

## How to verify

```bash
make desktop-check          # now covers lemma-job-object on the Windows target
```

The test is the case `taskkill /T` cannot reach: a `cmd` that starts a detached
`ping` and exits, then the job closes and the ping has to be gone. It asserts
the grandchild is still running *before* the job closes, so a test that proved
nothing would fail rather than pass.

**It runs only on Windows, which is the honest limit here.** `lemma-agent-host`
cannot be cross-compiled from a Mac at all — `libsqlite3-sys` needs a Windows C
toolchain — so CI's `windows-latest` job is the only place either half is
checked. `make desktop-check-windows` now covers the job crate itself, which
has no C dependencies and does cross-compile, and the Makefile says why the
agent host is absent from that list.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

Inert everywhere but Windows: `Job` exists on every platform so callers need no
`cfg`, and off Windows it holds nothing and its `Drop` does nothing. No
protocol, format or API change.

Stacked on #682.
