### PR TITLE
The nightly could not build a Windows pack, because of an API nobody calls

### DIFF
--- a/scripts/build_local_host_pack.py
+++ b/scripts/build_local_host_pack.py
@@ -281,6 +281,40 @@ def prune_python_runtime(python_root: Path) -> None:
                 continue
             for tests in sorted(root.rglob("tests"), reverse=True):
                 shutil.rmtree(tests, ignore_errors=True)
+        prune_unused_twilio_domains(site_packages)
+
+
+def prune_unused_twilio_domains(site_packages: Path) -> None:
+    """Drop the Twilio REST domains, which this product never calls.
+
+    Twilio is here by accident of the dependency graph. Nothing in `app`
+    imports it; `supertokens_python` does, at module level, so that its
+    passwordless recipe can deliver a one-time code by SMS -- a feature Lemma
+    does not enable. The package cannot simply be removed, because that
+    module-level `from twilio.rest import Client` would then fail at import.
+
+    Its `rest/` tree can. Every domain under it is imported lazily: the
+    top-level names in `twilio/rest/__init__.py` are under `TYPE_CHECKING`, and
+    `Client.api` runs `from twilio.rest.api import Api` only when something
+    reaches for it. Nothing does.
+
+    What this buys is the Windows path budget below. `twilio/rest/api/v2010/
+    account/sip/domain/auth_types/auth_type_registrations/` is a directory tree
+    describing an API nobody here calls, and a source file inside it sat nine
+    characters past the limit -- which fails the build, correctly, because a
+    source file Windows cannot open is a backend that cannot import a module
+    sitting in its own directory listing.
+
+    Verified rather than assumed: with all 39 domain trees removed,
+    `from twilio.rest import Client` and the SuperTokens SMS delivery types
+    both still import.
+    """
+    rest = site_packages / "twilio" / "rest"
+    if not rest.is_dir():
+        return
+    for domain in sorted(rest.iterdir()):
+        if domain.is_dir():
+            shutil.rmtree(domain, ignore_errors=True)
 
 
 # How long a path inside the pack may be, measured from the pack's own root.

--- a/tests/test_build_local_host_pack.py
+++ b/tests/test_build_local_host_pack.py
@@ -23,6 +23,7 @@ from scripts.build_local_host_pack import (
     WINDOWS_PATH_BUDGET,
     _resolve_rpath_libraries,
     enforce_windows_path_budget,
+    prune_unused_twilio_domains,
     copy_browser_assets,
     copy_node_runtime,
     npm_executable,
@@ -317,3 +318,40 @@ def test_the_budget_leaves_room_for_where_the_pack_is_installed():
     assert release_directory + 1 + WINDOWS_PATH_BUDGET <= usable, (
         "the budget has to fit under the directory the pack is installed into"
     )
+
+
+def test_twilio_keeps_its_client_and_loses_the_api_nobody_calls(tmp_path: Path) -> None:
+    """Twilio is here by accident of the dependency graph.
+
+    Nothing in `app` imports it. `supertokens_python` does, at module level, so
+    that its passwordless recipe can send a code by SMS -- a feature this
+    product does not enable. So the package has to stay importable while the
+    REST tree it never walks does not: that tree is where a source file sat
+    past the Windows path budget, which fails the build rather than shipping a
+    pack whose backend cannot import a module in its own directory listing.
+    """
+    site_packages = tmp_path / "site-packages"
+    rest = site_packages / "twilio" / "rest"
+    (rest / "api" / "v2010" / "account" / "sip").mkdir(parents=True)
+    (rest / "api" / "v2010" / "account" / "sip" / "domain.py").write_text("x")
+    (rest / "messaging").mkdir()
+    (rest / "__init__.py").write_text("from twilio.base.client_base import ClientBase")
+    (site_packages / "twilio" / "base").mkdir()
+    (site_packages / "twilio" / "base" / "client_base.py").write_text("class ClientBase: ...")
+    (site_packages / "twilio" / "__init__.py").write_text("")
+
+    prune_unused_twilio_domains(site_packages)
+
+    assert (rest / "__init__.py").is_file(), "the module supertokens imports has to survive"
+    assert (site_packages / "twilio" / "base" / "client_base.py").is_file(), (
+        "and everything it imports at module level with it"
+    )
+    assert not (rest / "api").exists(), "the domain holding the over-budget path is gone"
+    assert not (rest / "messaging").exists(), "and so are its siblings; none are reachable"
+
+
+def test_pruning_twilio_is_safe_where_twilio_is_absent(tmp_path: Path) -> None:
+    """A pack built without it is not a pack that fails to build."""
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    prune_unused_twilio_domains(site_packages)


### PR DESCRIPTION
## What changes

The nightly cannot build a Windows host pack. This is what stops it:

```
1 file(s) sit more than 170 characters below the pack root, so Windows cannot
open them once this is installed:
  local-runtime/backend/python/lib/python3.14/site-packages/twilio/rest/api/
  v2010/account/sip/domain/auth_types/auth_type_registrations/
  auth_registrations_credential_list_mapping.py
```

Nine characters over, and the gate is right to fail: Rust addresses files as
`\\?\` and writes them happily, and then Explorer, PowerShell and the pack's own
Python cannot open them — a backend that cannot import a module sitting in its
own directory listing.

**Twilio is here by accident of the dependency graph.** Nothing in `app`
imports it. `supertokens_python` does, at module level, so its passwordless
recipe can deliver a one-time code by SMS — a feature Lemma does not enable.
So the package cannot be removed: that `from twilio.rest import Client` would
fail at import.

**Its REST tree can be.** Every domain under it is imported lazily — the
top-level names in `twilio/rest/__init__.py` are under `TYPE_CHECKING`, and
`Client.api` runs `from twilio.rest.api import Api` only when something reaches
for it. Nothing does.

Verified rather than assumed: with all 39 domain trees removed,
`from twilio.rest import Client` and the SuperTokens SMS delivery types both
still import. I checked that against the real installed packages before writing
the prune.

## The wider fix, which this is not

Nine characters only matter because the pack's own prefix spends 58 before a
dependency has written anything: `local-runtime/backend/python/lib/python3.14/
site-packages/`. Shortening it buys headroom for every dependency rather than
this one, and it is a rename across the builder, locald's bindings, and the
installer's validation. That wants its own change, with its own care, rather
than to be folded into a build fix while a release is blocked.

## How to verify

```bash
cd lemma-backend && uv run pytest ../tests/test_build_local_host_pack.py
```

Two guards: that the module SuperTokens imports survives along with everything
it imports at module level, while the domain holding the over-budget path and
its siblings do not; and that a pack built without Twilio at all still builds.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

Removes ~2.4 MB from the host pack. The only behaviour that could depend on
what is pruned is Twilio SMS delivery through SuperTokens, which this product
does not enable; if it ever does, the prune is one function to delete and the
path budget becomes the thing to solve properly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Local host package builds now exclude unused Twilio REST domains while preserving the components required for SuperTokens.
  * Cleanup safely skips environments where Twilio is not installed.

* **Tests**
  * Added coverage confirming required Twilio modules are retained and unused domains are removed.
  * Added coverage for builds without a Twilio installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->