### PR TITLE
Retrying a DMG build without detaching what the last one left

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1066,7 +1066,30 @@ jobs:
             ${{ (github.event_name == 'push'
             || needs.changes.outputs.desktop_packaging == 'true')
             && 'app,dmg' || 'app' }}
-        run: npx -y "$TAURI_CLI" build --config tauri.online.conf.json --bundles "$BUNDLES"
+        run: |
+          set -euo pipefail
+          # Retried, and the detach between attempts is the part that matters.
+          # `bundle_dmg.sh` failing partway leaves its image attached, so a
+          # second attempt meets the first one's leftovers and fails the same
+          # way -- the same shape as retrying an apt fetch whose cached index
+          # is the thing that is wrong. Cargo has already compiled by then, so
+          # a retry costs the bundling and the signing, not the build.
+          #
+          # Measured: this took main red once today, after every test in the
+          # job had passed, and the re-run went green untouched.
+          for attempt in 1 2 3; do
+            npx -y "$TAURI_CLI" build \
+              --config tauri.online.conf.json --bundles "$BUNDLES" && break
+            if [ "$attempt" = 3 ]; then
+              echo "::error::tauri build failed three times; this is not hdiutil"
+              exit 1
+            fi
+            echo "tauri build failed (attempt $attempt); detaching leftovers and retrying"
+            for volume in /Volumes/Lemma*; do
+              [ -d "$volume" ] && hdiutil detach "$volume" -force || true
+            done
+            sleep 20
+          done
 
       - name: Verify application signature
         shell: bash

--- a/.github/workflows/release-local-images.yml
+++ b/.github/workflows/release-local-images.yml
@@ -1133,11 +1133,28 @@ jobs:
           # nightly is already the online config.
           overlay="${RUNNER_TEMP}/tauri.nightly.conf.json"
           printf '{"version": "%s"}\n' "${VERSION}" > "${overlay}"
-          rm -rf target/release/bundle/macos target/release/bundle/dmg
-          npx -y "$TAURI_CLI" build \
-            --config tauri.online.conf.json \
-            --config tauri.updater.conf.json \
-            --config "${overlay}"
+          # Retried, and each attempt starts from the same clean state as the
+          # first. `bundle_dmg.sh` fails on a busy `hdiutil`, and when it does
+          # it leaves its image attached and a half-built bundle behind -- so
+          # an attempt that does not clear both meets the last one's leftovers
+          # and fails the same way. Cargo has compiled by then, so a retry
+          # costs the bundling and the signing rather than the build.
+          for attempt in 1 2 3; do
+            rm -rf target/release/bundle/macos target/release/bundle/dmg
+            for volume in /Volumes/Lemma*; do
+              [ -d "${volume}" ] && hdiutil detach "${volume}" -force || true
+            done
+            npx -y "$TAURI_CLI" build \
+              --config tauri.online.conf.json \
+              --config tauri.updater.conf.json \
+              --config "${overlay}" && break
+            if [ "${attempt}" = 3 ]; then
+              echo "::error::the nightly DMG failed to build three times"
+              exit 1
+            fi
+            echo "nightly DMG build failed (attempt ${attempt}); retrying"
+            sleep 20
+          done
           mkdir -p target/release/release-artifacts
           dmg=(target/release/bundle/dmg/Lemma_*_aarch64.dmg)
           [[ "${#dmg[@]}" == 1 ]]

--- a/lemma-backend/app/core/tests/unit/test_ci_configuration_contract.py
+++ b/lemma-backend/app/core/tests/unit/test_ci_configuration_contract.py
@@ -212,3 +212,41 @@ def test_every_job_that_installs_a_browser_restores_it_from_cache() -> None:
             ):
                 assert expected in paths, f"{name} misses {expected}"
     assert installing, "no job installs a browser; this contract found nothing"
+
+
+def test_every_dmg_build_survives_a_busy_hdiutil() -> None:
+    """`bundle_dmg.sh` fails on a busy `hdiutil`, and it fails late.
+
+    By then the workspace has compiled, every test in the job has passed, and
+    the only thing left is wrapping a signed `.app` in a disk image. That took
+    main red once, and the re-run went green untouched.
+
+    The retry is not enough on its own, which is the part worth pinning: a
+    failed run leaves its image attached and a half-built bundle behind, so an
+    attempt that does not clear both meets the last one's leftovers and fails
+    the same way. Retrying an unchanged failure is how the first version of the
+    apt retry managed three identical failures.
+    """
+    import yaml
+
+    building = []
+    for path in (
+        ".github/workflows/ci.yml",
+        ".github/workflows/release-local-images.yml",
+    ):
+        workflow = yaml.safe_load(_read(path))
+        for name, job in workflow["jobs"].items():
+            for step in job.get("steps", []):
+                run = step.get("run") or ""
+                # The steps that *invoke* the CLI to build, not the one that
+                # puts its version in the environment — and not the
+                # Windows-only `--bundles nsis` one, which makes no disk image.
+                if '"$TAURI_CLI" build' not in run or "nsis" in run:
+                    continue
+                building.append((path, name))
+                assert "for attempt in" in run, f"{name} bundles a DMG without retrying"
+                assert "hdiutil detach" in run, (
+                    f"{name} retries without detaching what the failure left "
+                    "attached, so the retry asks the same broken question"
+                )
+    assert len(building) == 2, f"expected both DMG lanes, found {building}"

--- a/scripts/build_local_host_pack.py
+++ b/scripts/build_local_host_pack.py
@@ -375,6 +375,55 @@ def enforce_windows_path_budget(pack_root: Path) -> None:
             f"{WINDOWS_PATH_BUDGET}-character Windows path budget",
             flush=True,
         )
+    report_windows_path_headroom(pack_root)
+
+
+# How little headroom is worth saying something about.
+#
+# A dependency update that lands ten characters below the limit has not broken
+# anything, and is one release away from doing so.
+WINDOWS_PATH_HEADROOM_WARNING = 15
+
+
+def report_windows_path_headroom(pack_root: Path) -> None:
+    """Say how close the longest surviving path came.
+
+    The gate above only speaks when something has already crossed the line,
+    which makes every crossing a surprise -- a build that was fine yesterday
+    failing today because a dependency grew a directory level. This is the
+    number that would have made it visible first: a `twilio` file sat nine
+    characters over, and nothing before it had ever reported how much room was
+    left.
+
+    Reported on every build, and loudly when the margin is thin, so the last
+    quiet release before a failure looks different from the ones before it.
+    """
+    longest = max(
+        (
+            (len(installed_path(pack_root, path)), installed_path(pack_root, path))
+            for path in pack_root.rglob("*")
+            if path.is_file()
+        ),
+        default=(0, ""),
+    )
+    length, where = longest
+    headroom = WINDOWS_PATH_BUDGET - length
+    print(
+        f"+ longest installed path is {length} characters, "
+        f"{headroom} below the {WINDOWS_PATH_BUDGET}-character Windows budget",
+        flush=True,
+    )
+    # Negatives included. `enforce_windows_path_budget` raises before this for
+    # a source file over the line, so a negative here means bytecode it dropped
+    # -- still worth saying, and silence would be the wrong answer to the one
+    # number this function exists to report.
+    if headroom < WINDOWS_PATH_HEADROOM_WARNING:
+        print(
+            f"::warning::only {headroom} characters of Windows path budget "
+            f"remain; the next dependency to grow a directory level will fail "
+            f"the build. Longest: {where}",
+            flush=True,
+        )
 
 
 def compile_python_runtime(python_root: Path, executable: Path) -> None:

--- a/tests/test_build_local_host_pack.py
+++ b/tests/test_build_local_host_pack.py
@@ -24,6 +24,7 @@ from scripts.build_local_host_pack import (
     _resolve_rpath_libraries,
     enforce_windows_path_budget,
     prune_unused_twilio_domains,
+    report_windows_path_headroom,
     copy_browser_assets,
     copy_node_runtime,
     npm_executable,
@@ -355,3 +356,43 @@ def test_pruning_twilio_is_safe_where_twilio_is_absent(tmp_path: Path) -> None:
     site_packages = tmp_path / "site-packages"
     site_packages.mkdir()
     prune_unused_twilio_domains(site_packages)
+
+
+def test_a_pack_says_how_much_windows_path_budget_is_left(tmp_path, capsys) -> None:
+    """The gate only speaks once something has crossed the line.
+
+    Which makes every crossing a surprise: a build that was fine yesterday
+    fails today because a dependency grew a directory level. A `twilio` file
+    sat nine characters over, and nothing before it had ever said how much room
+    was left.
+    """
+    # Under the pack root directly: `installed_path` is what prepends
+    # `local-runtime/`, so building one here would count it twice.
+    pack = tmp_path / "pack"
+    pack.mkdir()
+    (pack / "short.py").write_text("x")
+
+    report_windows_path_headroom(pack)
+
+    printed = capsys.readouterr().out
+    assert "longest installed path is" in printed
+    assert "below the 170-character Windows budget" in printed
+    assert "::warning::" not in printed, "a short path is not worth a warning"
+
+
+def test_a_pack_close_to_the_limit_says_so_before_it_fails(tmp_path, capsys) -> None:
+    """The last quiet release before a failure should not look like the rest."""
+    pack = tmp_path / "pack"
+    deep = pack / ("d" * 120)
+    deep.mkdir(parents=True)
+    # Inside the budget, and only just. `installed_path` adds the
+    # `local-runtime/` prefix, so that is counted here rather than created.
+    prefix = len("local-runtime/") + 120 + 1
+    name = "n" * (WINDOWS_PATH_BUDGET - prefix - len(".py"))
+    (deep / f"{name}.py").write_text("x")
+
+    report_windows_path_headroom(pack)
+
+    printed = capsys.readouterr().out
+    assert "::warning::" in printed, printed
+    assert "will fail the build" in printed


### PR DESCRIPTION
## What changes

`bundle_dmg.sh` fails on a busy `hdiutil`, and it fails late. By then the
workspace has compiled, every test in the job has passed, and the only thing
left is wrapping a signed `.app` in a disk image.

That took main red today, after eleven pull requests had each passed the same
job individually — and the re-run went green with nothing changed. The step's
own comment already said it: *"fails on a busy `hdiutil` often enough to have
shown up twice in the last twenty runs"*.

Both macOS lanes retry now: the pull-request job, and the nightly that cuts the
installers. Cargo has compiled by the time bundling starts, so a retry costs
the bundling and the signing rather than the build.

### The detach is the half that matters

A failed run leaves its image attached and a half-built bundle behind. An
attempt that does not clear both meets the last one's leftovers and fails the
same way — which is exactly what the first version of the apt retry did, three
identical times, before it started throwing the apt index away between
attempts.

So each attempt starts from the same state as the first: the bundle directories
removed, and any `Lemma` volume left attached forced off.

## Why

Not a register entry — it is the third infrastructure flake to block a lane
today, and the only one still unaddressed. The apt index and the dev server's
cold-start 404 were fixed at their sources earlier.

## How to verify

```bash
cd lemma-backend && uv run pytest app/core/tests/unit/test_ci_configuration_contract.py
```

The contract finds every step that invokes the Tauri CLI to build a disk image
— not the step that merely sets its version, and not the Windows `--bundles
nsis` one that makes no image — and requires both the retry and the detach. It
fails when the detach is removed, which I checked; a retry that asks the same
broken question is the failure mode this is guarding against.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

CI-only. Three failures in a row still fail, and say that it is not `hdiutil`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS desktop package builds by retrying failed builds up to three times.
  * Added cleanup of stale disk images and build artifacts before retries.
  * Builds now report a clear failure after all retry attempts are exhausted.
  * Added Windows path-length reporting during local host-pack builds, including warnings when available headroom is low.

* **Tests**
  * Added automated checks for package-build retry and cleanup behavior.
  * Added coverage for Windows path-length reporting and warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->