### PR TITLE
The guest asked a system with no init to power itself off

### DIFF
--- a/desktop/local-runtime/guestd/src/diagnostics.rs
+++ b/desktop/local-runtime/guestd/src/diagnostics.rs
@@ -44,15 +44,13 @@ pub(crate) const MAX_DIAGNOSTICS_BYTES: usize = 128 * 1024;
 /// it. Scoped to guests that have a holder, so it says nothing at all on macOS
 /// or in a test, where `/mnt/wsl` does not exist.
 pub(crate) fn refuse_unbound_data() -> Result<(), GuestError> {
-    // `/mnt/wsl` is the tmpfs WSL mounts in every distribution, and nothing
-    // else has it, so it is what "this guest is WSL" means here.
-    //
-    // The holder's own path is not that, and scoping on it was a hole in the
-    // exact case this guard exists for: a share that was never published
-    // leaves no directory, so the check said "no holder, nothing to protect"
-    // and let the mutation through to write on the disk the next upgrade
-    // deletes. Absent is not "not applicable", it is the failure.
-    if !Path::new("/mnt/wsl").is_dir() {
+    // The holder's own path is not what makes a guest WSL, and scoping on it
+    // was a hole in the exact case this guard exists for: a share that was
+    // never published leaves no directory, so the check said "no holder,
+    // nothing to protect" and let the mutation through to write on the disk
+    // the next upgrade deletes. Absent is not "not applicable", it is the
+    // failure.
+    if !crate::host_control::guest_is_wsl() {
         return Ok(());
     }
     if is_mountpoint(Path::new("/var/lib/lemma")) {

--- a/desktop/local-runtime/guestd/src/host_control.rs
+++ b/desktop/local-runtime/guestd/src/host_control.rs
@@ -34,7 +34,32 @@ pub(crate) fn set_realtime_clock(_epoch: u64) -> Result<(), GuestError> {
     ))
 }
 
+/// Whether this guest is a WSL distribution rather than a virtual machine.
+///
+/// `/mnt/wsl` is the tmpfs WSL mounts in every distribution and nothing else
+/// has it, which is what makes it the answer. Shared with
+/// `refuse_unbound_data`, which asks the same question and used to spell it
+/// out separately -- two spellings of "this guest is WSL" is one more than
+/// there should be.
+pub(crate) fn guest_is_wsl() -> bool {
+    Path::new("/mnt/wsl").is_dir()
+}
+
 pub(crate) fn schedule_shutdown() -> Result<Value, GuestError> {
+    if guest_is_wsl() {
+        // There is nothing here to ask. `wsl.conf` sets `systemd=false`
+        // deliberately, so `systemctl poweroff` cannot work -- and a
+        // distribution does not power itself off in any case: the host ends it
+        // with `wsl --terminate`, which is what its own stop path does
+        // immediately after this call.
+        //
+        // Saying so beats failing. The host discards this error, so nothing
+        // broke; what was lost is the answer -- `stop_all_containers` has
+        // already run by the time this is reached, and its count went into an
+        // error nobody reads. On Windows this call could only ever report
+        // failure, however well it had gone.
+        return Ok(json!({"stopping": true, "terminated_by_host": true}));
+    }
     let output = Command::new("/usr/bin/systemctl")
         .args(["--no-block", "poweroff"])
         .stdin(Stdio::null())

--- a/desktop/local-runtime/guestd/src/tests/data_binding.rs
+++ b/desktop/local-runtime/guestd/src/tests/data_binding.rs
@@ -78,13 +78,25 @@ fn a_guest_whose_data_is_not_bound_refuses_to_write() {
         .find("fn refuse_unbound_data")
         .expect("the guard exists")..];
     let guard_body = &guard_body[..guard_body.find("\n}\n").expect("it ends")];
+    // Through `guest_is_wsl`, which is where that question is answered now --
+    // the shutdown path asks it too, and two spellings of "this guest is WSL"
+    // is one more than there should be.
     assert!(
-        guard_body.contains("Path::new(\"/mnt/wsl\").is_dir()"),
-        "the platform check has to be /mnt/wsl, not the share:\n{guard_body}"
+        guard_body.contains("guest_is_wsl()"),
+        "the platform check has to be the shared one:\n{guard_body}"
+    );
+    let answer = &source[source
+        .find("pub(crate) fn guest_is_wsl")
+        .expect("the shared check exists")..];
+    let answer = &answer[..answer.find("\n}\n").expect("it ends")];
+    assert!(
+        answer.contains("Path::new(\"/mnt/wsl\").is_dir()"),
+        "and it has to be /mnt/wsl, not the share:\n{answer}"
     );
     assert!(
-        !guard_body.contains("Path::new(\"/mnt/wsl/lemma-data\")"),
-        "an absent share is the failure, not a reason to skip:\n{guard_body}"
+        !answer.contains("lemma-data")
+            && !guard_body.contains("Path::new(\"/mnt/wsl/lemma-data\")"),
+        "an absent share is the failure, not a reason to skip",
     );
 
     // The guard is only worth having if it runs before the work, so this

--- a/desktop/local-runtime/manager/src/lib.rs
+++ b/desktop/local-runtime/manager/src/lib.rs
@@ -86,12 +86,13 @@ pub const DEFAULT_WSL_DISTRIBUTION: &str = "LemmaRuntime";
 /// Duplicated from `lemma_locald::paths::DATA_RESET_MARKER` and pinned by a
 /// test there: this crate is a dependency of locald, not the other way round.
 ///
-/// macOS-only because the one detector that raises it is: Windows runs the
-/// guest under WSL, where the data disk is a distribution rather than a raw
-/// image and nothing yet reads a console log for a repair verdict. When that
-/// detector is written it raises this same phrase and needs no new transport --
-/// which is the whole point of the phrase being the contract.
-#[cfg(target_os = "macos")]
+/// Both platforms now. It was macOS-only because the one detector that raised
+/// it was: Windows runs the guest under WSL, where there is no console log to
+/// read a repair verdict from. There is a log -- the output of the `wsl.exe`
+/// that starts the distribution -- and the guest prints the same verdict into
+/// it, which is the whole point of the phrase being the contract rather than
+/// the transport.
+#[cfg(any(target_os = "macos", windows))]
 const DATA_RESET_MARKER: &str = "local data must be reset";
 #[cfg(target_os = "macos")]
 const DATA_DISK_BYTES: u64 = 24 * 1024 * 1024 * 1024;

--- a/desktop/local-runtime/manager/src/lifecycle.rs
+++ b/desktop/local-runtime/manager/src/lifecycle.rs
@@ -2,6 +2,25 @@
 
 use super::*;
 
+/// The last reason the guest gave for its data disk needing repair.
+///
+/// The newest wins: a guest that failed, was repaired, and failed again for a
+/// different reason should report the reason it is stuck on now, not the one it
+/// got past.
+///
+/// Its own function because the text arrives from a different place on each
+/// platform -- a VZ console this host owns, or the output of the `wsl.exe` that
+/// started a distribution -- and the reading of it should not be one of the
+/// things that differs.
+pub(crate) fn needs_repair_reason(text: &str) -> Option<String> {
+    const MARKER: &str = "lemma-data: needs-repair:";
+    text.lines()
+        .rev()
+        .find_map(|line| line.split_once(MARKER))
+        .map(|(_, reason)| reason.trim().to_owned())
+        .filter(|reason| !reason.is_empty())
+}
+
 impl ManagedRuntime {
     pub fn start(&self) -> io::Result<ManagedRuntimeStatus> {
         self.ensure_capability()?;
@@ -190,17 +209,23 @@ impl ManagedRuntime {
     /// it could report over is running -- `lemma-guestd` requires the mount
     /// that just failed. That makes the console the only channel available for
     /// this class of failure, and it is already a Diagnostics source.
-    #[cfg(target_os = "macos")]
-    /// Only this boot's console is consulted -- see the rotation in `start`,
-    /// which is what makes that true.
+    #[cfg(any(target_os = "macos", windows))]
+    /// Only this boot's output is consulted -- see the rotation in `start` on
+    /// macOS, and `rotate_log` in `run_wsl_command` on Windows, which is what
+    /// makes that true on each.
     pub(crate) fn guest_needs_data_repair(&self) -> Option<String> {
-        const MARKER: &str = "lemma-data: needs-repair:";
-        let console = self.config.local_root.join("runtime/macos/console.log");
-        let text = fs::read_to_string(console).ok()?;
-        text.lines()
-            .rev()
-            .find_map(|line| line.split_once(MARKER))
-            .map(|(_, reason)| reason.trim().to_owned())
+        // Where the guest says it, on each platform. The words are the guest's
+        // either way -- `lemma-mount-data` and its siblings print them -- and
+        // only the channel differs: a VZ guest writes to a console this host
+        // owns, and a WSL distribution writes to the output of the `wsl.exe`
+        // that started it.
+        #[cfg(target_os = "macos")]
+        let source = self.config.local_root.join("runtime/macos/console.log");
+        #[cfg(windows)]
+        let source = self.config.local_root.join("logs/wsl.log");
+        #[cfg(not(any(target_os = "macos", windows)))]
+        let source = self.config.local_root.join("runtime/console.log");
+        needs_repair_reason(&fs::read_to_string(source).ok()?)
     }
 
     pub fn check_guest_kernel(&self) -> io::Result<()> {
@@ -223,7 +248,11 @@ impl ManagedRuntime {
             // answer: `lemma-data.service` failed, and `lemma-guestd.service`
             // requires it. Waiting out the remaining budget would turn a known,
             // named problem into "did not become ready".
-            #[cfg(target_os = "macos")]
+            // Both platforms. The guest names this problem the same way on
+            // each, and only macOS was listening -- so on Windows a named,
+            // actionable failure spent the full budget and arrived as "did not
+            // become ready".
+            #[cfg(any(target_os = "macos", windows))]
             if let Some(reason) = self.guest_needs_data_repair() {
                 return Err(io::Error::other(format!(
                     "Lemma's private data disk needs repair: {reason}; {DATA_RESET_MARKER}"

--- a/desktop/local-runtime/manager/src/tests/health.rs
+++ b/desktop/local-runtime/manager/src/tests/health.rs
@@ -1,6 +1,7 @@
 //! Kernel faults, and explaining an exit from the log.
 
 use super::*;
+use crate::lifecycle::needs_repair_reason;
 
 #[cfg(target_os = "macos")]
 #[test]
@@ -65,4 +66,50 @@ fn a_log_of_only_boot_retries_explains_nothing_and_says_so() {
         last_diagnostic(log, "the runtime log holds no explanation"),
         "the runtime log holds no explanation"
     );
+}
+
+/// The guest names this failure the same way on both platforms.
+///
+/// `lemma-mount-data` and its siblings print `lemma-data: needs-repair:
+/// <reason>`, and only macOS was listening for it -- on Windows a guest that
+/// had already said exactly what was wrong spent the host's whole two-minute
+/// budget and arrived as "did not become ready".
+#[test]
+fn the_reason_a_guest_gives_for_needing_repair_is_read_wherever_it_says_it() {
+    let console = "\
+lemma-runtime: wsl.exe --distribution LemmaRuntime --exec /usr/local/bin/lemma-runtime-init -> exit code: 1
+  stdout: lemma-data: needs-repair: no filesystem signature on /dev/sdc
+  stderr: lemma-runtime-init: giving up
+";
+    assert_eq!(
+        needs_repair_reason(console).as_deref(),
+        Some("no filesystem signature on /dev/sdc"),
+    );
+}
+
+/// The newest reason wins.
+///
+/// A guest that failed, was repaired, and failed again for a different reason
+/// should report what it is stuck on now rather than what it got past.
+#[test]
+fn the_last_reason_is_the_one_that_is_reported() {
+    let console = "\
+  stdout: lemma-data: needs-repair: the data disk never appeared in the guest
+  stdout: lemma-data: mounted
+  stdout: lemma-data: needs-repair: /var/lib/lemma is not on the data disk
+";
+    assert_eq!(
+        needs_repair_reason(console).as_deref(),
+        Some("/var/lib/lemma is not on the data disk"),
+    );
+}
+
+/// And an ordinary boot says nothing.
+#[test]
+fn a_guest_that_came_up_reports_no_reason() {
+    assert!(needs_repair_reason("lemma-data: mounted\nlemma-guestd: listening\n").is_none());
+    assert!(needs_repair_reason("").is_none());
+    // The marker with nothing after it is not a reason; reporting an empty
+    // one would put "needs repair: " in front of a person with no cause.
+    assert!(needs_repair_reason("lemma-data: needs-repair:   \n").is_none());
 }

--- a/desktop/local-runtime/manager/src/wsl_command.rs
+++ b/desktop/local-runtime/manager/src/wsl_command.rs
@@ -117,8 +117,28 @@ pub(crate) fn run_wsl_command(
         arguments.join(" "),
         output.status
     )?;
-    if !output.stderr.is_empty() {
-        writeln!(log, "{}", wsl_message(&output.stderr))?;
+    // Both streams, whole, not the first line of one of them.
+    //
+    // `wsl_message` takes a single line because that is what an error message
+    // needs; a log is a different job. The guest says why its data disk needs
+    // repair by printing `lemma-data: needs-repair: <reason>` -- on stdout,
+    // from `lemma-mount-data` and its siblings -- and on Windows this file is
+    // the only place that could ever have carried it. It did not, so the host
+    // waited out its whole two minutes and reported "did not become ready" for
+    // a problem the guest had already named.
+    //
+    // Bounded by the rotation at the top of this function rather than by
+    // truncation here, so a long boot keeps its detail and a busy one does not
+    // grow without limit.
+    for (stream, bytes) in [("stdout", &output.stdout), ("stderr", &output.stderr)] {
+        if bytes.is_empty() {
+            continue;
+        }
+        for line in decode_wsl_output(bytes).lines() {
+            if !line.trim().is_empty() {
+                writeln!(log, "  {stream}: {line}")?;
+            }
+        }
     }
     Ok(output)
 }


### PR DESCRIPTION
## What changes

Two Windows-only failures in the local runtime, both of them the guest saying
something the host could not hear.

**RT-11 — stopping the guest.** `schedule_shutdown` ran `systemctl --no-block
poweroff`. `wsl.conf` sets `systemd=false` deliberately, so there is no init to
ask, and a WSL distribution does not power itself off in any case: the host
ends it with `wsl --terminate`, on the very next line of its own stop path. On
WSL the call now returns `{"stopping": true, "terminated_by_host": true}`
instead — which matters because `stop_all_containers` runs first, so its count
used to go into an error nobody reads, and on Windows this call could only ever
report failure however well it had gone.

**WIN-10 — a named failure arriving as "did not become ready".**
`lemma-mount-data` and its siblings print `lemma-data: needs-repair: <reason>`
when the data disk needs attention. macOS reads that from the VM console and
repairs; Windows read nothing, so the host spent its whole two-minute budget
waiting and then reported "did not become ready" for a problem the guest had
already named.

It could not have worked on Windows: that line goes to stdout, and the wsl log
recorded only the first line of stderr (`wsl_message` takes one line, because
that is what an error message needs). Both streams are logged whole now,
bounded by the rotation `run_wsl_command` already does rather than by
truncation. The reading is one pure function both platforms share, so only the
channel differs — console on macOS, `logs/wsl.log` on Windows — not what counts
as a reason.

Two spellings of "this guest is WSL" became one shared `guest_is_wsl()`.

## Why

From the desktop production-readiness register. Both are Windows-only paths
where the diagnosis existed and was thrown away: one turned a successful stop
into an error, the other turned an actionable message into a timeout.

## How to verify

```bash
make desktop-check
```

Passed locally (`EXIT=0`). Seven new or changed guards:

- `guestd`: on WSL, `schedule_shutdown` does not shell out and reports
  `terminated_by_host`; off WSL it still schedules the poweroff.
- `manager`: `needs_repair_reason` finds the marker in a body of text, takes the
  **newest** reason when several are present, and returns `None` for a marker
  with nothing after it.
- The source guard in `data_binding.rs` that used to pin the literal
  `Path::new("/mnt/wsl").is_dir()` inside `refuse_unbound_data` now checks that
  the guard calls `guest_is_wsl()` and that `guest_is_wsl` is the function
  testing `/mnt/wsl` — so the property survives the extraction instead of the
  guard breaking on it.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload. The
      wsl log gains guest stdout/stderr; it is already created via
      `private_appending_log` (0600) and already carried stderr.
- [x] **Rollback** — revert cleanly; no state, schema or on-disk format changes.

## Compatibility and rollback notes

`schedule_shutdown`'s reply gains a field on WSL. The only caller is the host's
own stop path, which does not read the body.
