### PR TITLE
Three things the Agent Host was deciding by reading English

### DIFF
--- a/desktop/agent-host/src/adapters/manifest.rs
+++ b/desktop/agent-host/src/adapters/manifest.rs
@@ -108,11 +108,6 @@ impl AdapterManifest {
                 .ok_or_else(|| anyhow::anyhow!("adapter cache is not configured"))?;
             let command = cached_adapter_executable(cache_root, &spec);
             verify_cached_adapter(&command)?;
-            // After the cache is known good and before anything launches it.
-            // A cache installed under a Node that has since been replaced is
-            // the same problem as one installed under a Node that never
-            // qualified, and this is the one place both pass through.
-            ensure_adapter_node_runs(&spec, cache_root)?;
             command
         } else {
             resolve_executable(&spec.command).ok_or_else(|| {
@@ -121,6 +116,17 @@ impl AdapterManifest {
         };
         let upstream_command = resolve_executable(&spec.upstream_command)
             .ok_or_else(|| anyhow::anyhow!("{} executable was not found", spec.upstream_command))?;
+        // After the cache is known good and after both executables are known,
+        // because the Node this checks has to be the Node the adapter's shim
+        // will find -- and that is decided by a `PATH` with these two
+        // directories in front of it. A cache installed under a Node that has
+        // since been replaced is the same problem as one installed under a
+        // Node that never qualified, and this is where both pass through.
+        if let Some(cache_root) = self.cache_root.as_ref()
+            && spec.distribution.starts_with("npm:")
+        {
+            ensure_adapter_node_runs(&spec, cache_root, &command, &upstream_command)?;
+        }
         let probed = probe_version(&upstream_command, &spec.upstream_version_args);
         let upstream_version = probed.clone().ok();
         if let Some(minimum) = spec.minimum_upstream_version.as_deref() {

--- a/desktop/agent-host/src/adapters/manifest.rs
+++ b/desktop/agent-host/src/adapters/manifest.rs
@@ -3,10 +3,10 @@
 use super::{
     AdapterManifest, AdapterSpec, Arc, BUILTIN_MANIFEST, Digest, HarnessSnapshot, HashMap, Mutex,
     Path, PathBuf, ResolvedAdapter, Sha256, TRANSIENT_MARKER, VERSION_PROBE_TIMEOUT,
-    VersionUnknown, cached_adapter_directory, cached_adapter_executable, fingerprint_path,
-    probe_version, reason_is_transient, reason_without_marker, resolve_executable,
-    snapshot_installing, snapshot_ready, snapshot_unavailable, verify_cached_adapter,
-    version_is_at_least,
+    VersionUnknown, cached_adapter_directory, cached_adapter_executable, ensure_adapter_node_runs,
+    fingerprint_path, probe_version, reason_is_transient, reason_without_marker,
+    resolve_executable, snapshot_installing, snapshot_ready, snapshot_unavailable,
+    verify_cached_adapter, version_is_at_least,
 };
 
 impl AdapterManifest {
@@ -108,6 +108,11 @@ impl AdapterManifest {
                 .ok_or_else(|| anyhow::anyhow!("adapter cache is not configured"))?;
             let command = cached_adapter_executable(cache_root, &spec);
             verify_cached_adapter(&command)?;
+            // After the cache is known good and before anything launches it.
+            // A cache installed under a Node that has since been replaced is
+            // the same problem as one installed under a Node that never
+            // qualified, and this is the one place both pass through.
+            ensure_adapter_node_runs(&spec, cache_root)?;
             command
         } else {
             resolve_executable(&spec.command).ok_or_else(|| {

--- a/desktop/agent-host/src/adapters/mod.rs
+++ b/desktop/agent-host/src/adapters/mod.rs
@@ -23,10 +23,12 @@ use crate::protocol::{ConfigOption, HarnessCapabilities, HarnessHealth, HarnessS
 mod cache;
 mod discovery;
 mod manifest;
+mod node;
 mod snapshots;
 
 pub use cache::*;
 pub(crate) use discovery::*;
+pub(crate) use node::*;
 pub use snapshots::*;
 
 #[cfg(test)]

--- a/desktop/agent-host/src/adapters/node.rs
+++ b/desktop/agent-host/src/adapters/node.rs
@@ -14,7 +14,10 @@
 
 use std::path::Path;
 
-use super::{AdapterSpec, cached_adapter_directory, probe_version, resolve_executable};
+use super::{
+    AdapterSpec, adapter_search_paths, cached_adapter_directory, probe_version,
+    resolve_executable_in,
+};
 
 /// The Node range an adapter declares, if it declares one.
 pub(crate) fn declared_node_range(package_json: &str) -> Option<String> {
@@ -91,16 +94,24 @@ pub(crate) fn pinned_package_name(distribution: &str) -> Option<&str> {
 pub(crate) fn ensure_adapter_node_runs(
     spec: &AdapterSpec,
     cache_root: &Path,
+    command: &Path,
+    upstream_command: &Path,
 ) -> anyhow::Result<()> {
-    ensure_adapter_node_runs_with(spec, cache_root, node_version_on_this_computer)
+    ensure_adapter_node_runs_with(spec, cache_root, || {
+        node_version_on_this_computer(command, upstream_command)
+    })
 }
 
 /// The Node the adapter's own shim will pick, and what it calls itself.
 ///
-/// The same search order the shim's `#!/usr/bin/env node` resolves through, so
-/// the version checked is the version that runs.
-fn node_version_on_this_computer() -> Option<String> {
-    let node = resolve_executable("node")?;
+/// Resolved through `adapter_search_paths`, which is what
+/// `ResolvedAdapter::environment` puts in the child's `PATH` -- so this is the
+/// Node the shim's `#!/usr/bin/env node` will find. Searching only
+/// `executable_search_paths()` would have missed the two directories that
+/// environment prepends, which are precisely where a second Node would shadow
+/// the one on the ordinary path.
+fn node_version_on_this_computer(command: &Path, upstream_command: &Path) -> Option<String> {
+    let node = resolve_executable_in("node", adapter_search_paths(command, upstream_command))?;
     probe_version(&node, &["--version".to_owned()]).ok()
 }
 
@@ -176,6 +187,41 @@ mod tests {
             assert!(!node_is_excluded(range, "v16.0.0"), "{range}");
         }
         assert!(!node_is_excluded(">=20", "not-a-version"));
+    }
+
+    /// The Node this checks is the Node the shim will run.
+    ///
+    /// `ResolvedAdapter::environment` puts the adapter's own directory and the
+    /// agent's in front of everything else, so a `node` sitting in either of
+    /// them is the one `#!/usr/bin/env node` finds. The probe used to search
+    /// only the ordinary path and would have reported a different version than
+    /// the one that runs -- which is worse than not checking, because the
+    /// answer looks authoritative.
+    #[cfg(unix)]
+    #[test]
+    fn the_probe_searches_the_path_the_adapter_will_run_under() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let beside_the_adapter = root.path().join("cache/node_modules/.bin");
+        std::fs::create_dir_all(&beside_the_adapter).unwrap();
+        let shadowing_node = beside_the_adapter.join("node");
+        std::fs::write(&shadowing_node, "#!/bin/sh\necho v22.0.0\n").unwrap();
+        std::fs::set_permissions(&shadowing_node, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        let command = beside_the_adapter.join("codex-acp");
+        let upstream = root.path().join("agent/codex");
+
+        let found = super::adapter_search_paths(&command, &upstream)
+            .into_iter()
+            .find(|directory| directory.join("node").is_file());
+
+        assert_eq!(
+            found.as_deref(),
+            Some(beside_the_adapter.as_path()),
+            "the adapter's own directory has to come before the ordinary path, \
+             or the version reported is not the version that runs",
+        );
     }
 
     #[test]

--- a/desktop/agent-host/src/adapters/node.rs
+++ b/desktop/agent-host/src/adapters/node.rs
@@ -1,0 +1,266 @@
+//! Whether the Node on this computer can run the adapter that was installed.
+//!
+//! Every npm adapter states the Node it needs in its own `package.json`, and
+//! `npm install` does not enforce it: an unmet `engines` field is `EBADENGINE`,
+//! a *warning*, and the install succeeds. So on a computer with an old Node the
+//! adapter is fetched, verified, cached and launched, and the first thing the
+//! user sees is a parse error from a file inside `node_modules` -- naming a line
+//! of somebody else's code, saying nothing about Node, on a machine whose owner
+//! has no reason to suspect their Node at all.
+//!
+//! The floor is read from the adapter rather than written down here. Pinning a
+//! number in Lemma would be a second claim about the same thing, free to drift
+//! from the one the adapter actually enforces at parse time.
+
+use std::path::Path;
+
+use super::{AdapterSpec, cached_adapter_directory, probe_version, resolve_executable};
+
+/// The Node range an adapter declares, if it declares one.
+pub(crate) fn declared_node_range(package_json: &str) -> Option<String> {
+    let manifest: serde_json::Value = serde_json::from_str(package_json).ok()?;
+    let range = manifest.get("engines")?.get("node")?.as_str()?.trim();
+    (!range.is_empty()).then(|| range.to_owned())
+}
+
+/// Whether `range` definitively rules `version` out.
+///
+/// False whenever we cannot tell. npm's range syntax is wider than this
+/// parser's -- `||` alternatives above all -- and a floor nobody can read must
+/// not become a new way for a working installation to be refused. The check
+/// exists to turn one silent failure into a sentence, not to add one.
+pub(crate) fn node_is_excluded(range: &str, version: &str) -> bool {
+    // npm separates an `AND` with a space; this parser separates it with a
+    // comma. Everything else about the two agrees.
+    let normalized = range.split_whitespace().collect::<Vec<_>>().join(",");
+    let Ok(requirement) = semver::VersionReq::parse(&normalized) else {
+        return false;
+    };
+    let Ok(version) = semver::Version::parse(version.trim().trim_start_matches('v')) else {
+        return false;
+    };
+    // Prereleases are matched on the release they precede: a `24.0.0-nightly`
+    // is a 24 for the purpose of a floor, and `VersionReq` alone would say no
+    // to every one of them.
+    let release = semver::Version::new(version.major, version.minor, version.patch);
+    !requirement.matches(&release)
+}
+
+/// Refuse an adapter this computer's Node cannot run, and say why.
+///
+/// `node_version` is passed in rather than probed so the decision is a
+/// function of what was found. The caller is the one that knows which `node`
+/// the adapter's own shim will pick, and probing twice could disagree.
+pub(crate) fn ensure_node_runs(
+    package_root: &Path,
+    adapter: &str,
+    node_version: &str,
+) -> anyhow::Result<()> {
+    let manifest = package_root.join("package.json");
+    let Ok(text) = std::fs::read_to_string(&manifest) else {
+        return Ok(());
+    };
+    let Some(range) = declared_node_range(&text) else {
+        return Ok(());
+    };
+    anyhow::ensure!(
+        !node_is_excluded(&range, node_version),
+        "{adapter} needs Node {range} and this computer has Node {}. \
+         Install a newer Node, then reopen Lemma.",
+        node_version.trim()
+    );
+    Ok(())
+}
+
+/// The package an `npm:` distribution pins, without its version.
+pub(crate) fn pinned_package_name(distribution: &str) -> Option<&str> {
+    distribution
+        .strip_prefix("npm:")?
+        .rsplit_once('@')
+        .map(|(name, _)| name)
+        .filter(|name| !name.is_empty())
+}
+
+/// Check the Node that will launch this adapter against what it declares.
+///
+/// Every step here that cannot answer returns `Ok`. There is no Node on the
+/// search path, or it will not say its version, or the adapter declares
+/// nothing: in each case the shim is about to run and this check has nothing to
+/// add. It only ever converts a failure that would have happened anyway into
+/// one that says what to do about it.
+pub(crate) fn ensure_adapter_node_runs(
+    spec: &AdapterSpec,
+    cache_root: &Path,
+) -> anyhow::Result<()> {
+    ensure_adapter_node_runs_with(spec, cache_root, node_version_on_this_computer)
+}
+
+/// The Node the adapter's own shim will pick, and what it calls itself.
+///
+/// The same search order the shim's `#!/usr/bin/env node` resolves through, so
+/// the version checked is the version that runs.
+fn node_version_on_this_computer() -> Option<String> {
+    let node = resolve_executable("node")?;
+    probe_version(&node, &["--version".to_owned()]).ok()
+}
+
+/// The body, with the lookup passed in.
+///
+/// A seam rather than a probe, so the wiring -- which cached directory holds
+/// the manifest, and which name goes in the message -- is testable without a
+/// particular Node installed and without writing to this process's
+/// environment, which the rest of the suite is reading in parallel.
+pub(crate) fn ensure_adapter_node_runs_with(
+    spec: &AdapterSpec,
+    cache_root: &Path,
+    node_version: impl FnOnce() -> Option<String>,
+) -> anyhow::Result<()> {
+    let Some(package) = pinned_package_name(&spec.distribution) else {
+        return Ok(());
+    };
+    let root = cached_adapter_directory(cache_root, spec)
+        .join("node_modules")
+        .join(package);
+    let Some(reported) = node_version() else {
+        return Ok(());
+    };
+    ensure_node_runs(&root, &spec.command, &reported)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_declared_floor_is_read_and_an_absent_one_is_not_invented() {
+        assert_eq!(
+            declared_node_range(r#"{"engines":{"node":">=20"}}"#).as_deref(),
+            Some(">=20")
+        );
+        for absent in [
+            r#"{"engines":{}}"#,
+            r#"{"engines":{"node":"  "}}"#,
+            r#"{"engines":{"node":20}}"#,
+            r#"{"name":"x"}"#,
+            "not json at all",
+        ] {
+            assert_eq!(declared_node_range(absent), None, "{absent}");
+        }
+    }
+
+    /// The case this exists for: npm warns, installs anyway, and the adapter
+    /// fails later with a syntax error.
+    #[test]
+    fn a_node_below_the_declared_floor_is_ruled_out() {
+        assert!(node_is_excluded(">=20", "v18.20.4"));
+        assert!(node_is_excluded(">=20.6.0", "v20.5.1"));
+        assert!(node_is_excluded(">=18 <22", "v24.1.0"));
+        assert!(node_is_excluded("^20.0.0", "v18.0.0"));
+    }
+
+    #[test]
+    fn a_node_that_satisfies_the_floor_is_left_alone() {
+        assert!(!node_is_excluded(">=20", "v22.11.0"));
+        assert!(!node_is_excluded(">=18 <22", "v20.0.0"));
+        assert!(!node_is_excluded("*", "v18.0.0"));
+        // A nightly or release candidate is the version it precedes.
+        assert!(!node_is_excluded(">=20", "v24.0.0-nightly20260101"));
+    }
+
+    /// A range this parser does not understand must let the install through.
+    /// Refusing what we cannot read would replace a confusing failure with a
+    /// confident wrong one.
+    #[test]
+    fn a_range_we_cannot_read_never_refuses() {
+        for range in ["^18 || ^20", "18 - 22", "lts/*", "", "  "] {
+            assert!(!node_is_excluded(range, "v16.0.0"), "{range}");
+        }
+        assert!(!node_is_excluded(">=20", "not-a-version"));
+    }
+
+    #[test]
+    fn a_pinned_distribution_yields_its_package_name() {
+        assert_eq!(
+            pinned_package_name("npm:@agentclientprotocol/codex-acp@1.1.7"),
+            Some("@agentclientprotocol/codex-acp")
+        );
+        for other in ["native", "npm:@scope/name", "npm:@1.0.0", "npm:"] {
+            assert_eq!(pinned_package_name(other), None, "{other}");
+        }
+    }
+
+    /// End to end over a real cache layout: the manifest is read from the
+    /// pinned package's own directory inside the cache, which is the part of
+    /// this that a wrong join would break silently -- an unreadable manifest
+    /// declares nothing, and nothing is exactly what a passing check looks
+    /// like.
+    #[test]
+    fn the_declared_floor_is_read_from_the_cached_package_itself() {
+        let cache = tempfile::tempdir().unwrap();
+        let spec = spec_for("npm:@agentclientprotocol/codex-acp@1.1.7");
+        let package = cached_adapter_directory(cache.path(), &spec)
+            .join("node_modules/@agentclientprotocol/codex-acp");
+        std::fs::create_dir_all(&package).unwrap();
+        std::fs::write(
+            package.join("package.json"),
+            r#"{"engines":{"node":">=20"}}"#,
+        )
+        .unwrap();
+
+        let error =
+            ensure_adapter_node_runs_with(&spec, cache.path(), || Some("v18.20.4".to_owned()))
+                .unwrap_err()
+                .to_string();
+        assert!(error.contains("codex-acp"), "{error}");
+        assert!(error.contains(">=20"), "{error}");
+
+        ensure_adapter_node_runs_with(&spec, cache.path(), || Some("v22.0.0".to_owned())).unwrap();
+        // No Node to ask: the shim is about to fail on its own, and guessing
+        // here would only replace its message with a wrong one.
+        ensure_adapter_node_runs_with(&spec, cache.path(), || None).unwrap();
+        // Not an npm adapter, so there is no package manifest to consult.
+        ensure_adapter_node_runs_with(&spec_for("native"), cache.path(), || {
+            Some("v18.20.4".to_owned())
+        })
+        .unwrap();
+    }
+
+    fn spec_for(distribution: &str) -> AdapterSpec {
+        AdapterSpec {
+            key: "codex".to_owned(),
+            display_name: "Codex".to_owned(),
+            adapter_version: "1.1.7".to_owned(),
+            command: "codex-acp".to_owned(),
+            args: Vec::new(),
+            upstream_command: "codex".to_owned(),
+            upstream_version_args: vec!["--version".to_owned()],
+            upstream_path_env: None,
+            omit_optional_dependencies: true,
+            minimum_upstream_version: None,
+            distribution: distribution.to_owned(),
+            artifact_integrity: None,
+            license: "Apache-2.0".to_owned(),
+        }
+    }
+
+    #[test]
+    fn the_refusal_names_both_versions_and_a_missing_manifest_is_not_one() {
+        let root = tempfile::tempdir().unwrap();
+        // No package.json: nothing is claimed, so nothing is refused.
+        ensure_node_runs(root.path(), "codex-acp", "v18.0.0").unwrap();
+
+        std::fs::write(
+            root.path().join("package.json"),
+            r#"{"engines":{"node":">=20"}}"#,
+        )
+        .unwrap();
+        let error = ensure_node_runs(root.path(), "codex-acp", "v18.20.4")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("codex-acp"), "{error}");
+        assert!(error.contains(">=20"), "{error}");
+        assert!(error.contains("v18.20.4"), "{error}");
+
+        ensure_node_runs(root.path(), "codex-acp", "v22.0.0").unwrap();
+    }
+}

--- a/desktop/agent-host/src/adapters/snapshots.rs
+++ b/desktop/agent-host/src/adapters/snapshots.rs
@@ -2,9 +2,30 @@
 
 use super::{
     AdapterSpec, BTreeMap, ChronoDuration, ConfigOption, Digest, HarnessCapabilities,
-    HarnessHealth, HarnessSnapshot, HashSet, ResolvedAdapter, SNAPSHOT_TTL, Sha256,
+    HarnessHealth, HarnessSnapshot, HashSet, Path, PathBuf, ResolvedAdapter, SNAPSHOT_TTL, Sha256,
     TRANSIENT_MARKER, Utc, env, executable_search_paths, push_unique,
 };
+
+/// The search path an adapter runs under.
+///
+/// Its own directory first, then the agent's, then everything else. Extracted
+/// so the Node the version check probes is the Node the shim's
+/// `#!/usr/bin/env node` will actually find: the probe used to search only
+/// `executable_search_paths()`, and these two prepended directories are exactly
+/// where a second Node would shadow it.
+pub(crate) fn adapter_search_paths(command: &Path, upstream_command: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    let mut seen = HashSet::new();
+    for executable in [command, upstream_command] {
+        if let Some(parent) = executable.parent() {
+            push_unique(&mut paths, &mut seen, parent.to_path_buf());
+        }
+    }
+    for path in executable_search_paths() {
+        push_unique(&mut paths, &mut seen, path);
+    }
+    paths
+}
 
 impl ResolvedAdapter {
     #[must_use]
@@ -15,16 +36,7 @@ impl ResolvedAdapter {
     #[must_use]
     pub fn environment(&self) -> BTreeMap<String, String> {
         let mut environment = BTreeMap::new();
-        let mut paths = Vec::new();
-        let mut seen = HashSet::new();
-        for executable in [&self.command, &self.upstream_command] {
-            if let Some(parent) = executable.parent() {
-                push_unique(&mut paths, &mut seen, parent.to_path_buf());
-            }
-        }
-        for path in executable_search_paths() {
-            push_unique(&mut paths, &mut seen, path);
-        }
+        let paths = adapter_search_paths(&self.command, &self.upstream_command);
         if let Ok(joined) = env::join_paths(paths) {
             environment.insert("PATH".to_owned(), joined.to_string_lossy().into_owned());
         }

--- a/desktop/agent-host/src/conversation_directory.rs
+++ b/desktop/agent-host/src/conversation_directory.rs
@@ -56,6 +56,70 @@ fn directory(path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// `path` is the primary key, so SQLite keeps a unique index on it and both
+/// queries below are ranges of that index. Nothing else is stored, and nothing
+/// here needs a migration: this is the table that has always been written.
+const REGISTRY_SCHEMA: &str =
+    "CREATE TABLE IF NOT EXISTS directory_owners (path TEXT PRIMARY KEY, target TEXT NOT NULL)";
+
+/// One directory, by its exact path.
+const OWNER_OF: &str = "SELECT target FROM directory_owners WHERE path = ?1";
+
+/// Everything registered beneath a directory.
+const OWNERS_BENEATH: &str =
+    "SELECT path, target FROM directory_owners WHERE path > ?1 AND path < ?2";
+
+/// `a/b/c` as `a`, `a/b`, `a/b/c` -- every directory that contains it, and it.
+fn ancestors(relative: &str) -> impl Iterator<Item = &str> {
+    relative
+        .match_indices('/')
+        .map(|(index, _)| &relative[..index])
+        .chain(std::iter::once(relative))
+}
+
+/// Every registered directory that overlaps `relative`, and who owns it.
+///
+/// Overlapping means one contains the other, so the answer is the ancestors of
+/// `relative` -- itself included -- and its descendants. Both are ranges of the
+/// primary key: the ancestors are at most one point lookup per path component,
+/// and the descendants are a single scan bounded to the keys that begin
+/// `relative/`.
+///
+/// This used to be `SELECT path, target` with no `WHERE` and the prefix work
+/// done in Rust, which meant every conversation start read every directory the
+/// workspace had ever registered. The cost of opening a conversation grew with
+/// how much the workspace had been used, on the path a person is waiting on.
+///
+/// `0` is the byte after `/`, so the upper bound stops exactly where the
+/// `relative/...` keys stop. A sibling that merely shares a textual prefix --
+/// `proj` beside `project` -- sorts outside it, which is the same boundary the
+/// `format!("{path}/")` comparisons drew before.
+fn overlapping_owners(
+    transaction: &rusqlite::Transaction<'_>,
+    relative: &str,
+) -> rusqlite::Result<Vec<(String, String)>> {
+    use rusqlite::OptionalExtension;
+
+    let mut found = Vec::new();
+    let mut owner_of = transaction.prepare(OWNER_OF)?;
+    for prefix in ancestors(relative) {
+        if let Some(owner) = owner_of
+            .query_row([prefix], |row| row.get::<_, String>(0))
+            .optional()?
+        {
+            found.push((prefix.to_owned(), owner));
+        }
+    }
+    let mut beneath = transaction.prepare(OWNERS_BENEATH)?;
+    let rows = beneath.query_map([format!("{relative}/"), format!("{relative}0")], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    })?;
+    for row in rows {
+        found.push(row?);
+    }
+    Ok(found)
+}
+
 /// Bind paths to a paired workspace before opening an agent. Conversations
 /// within the same workspace can share their parent's cwd, just as in a VM.
 /// This registry prevents accidental collisions; it is not an OS sandbox.
@@ -74,24 +138,14 @@ pub fn prepare(root: &Path, target: Uuid, cwd: &str) -> anyhow::Result<PathBuf> 
     }
     let mut connection = rusqlite::Connection::open(database)?;
     connection.busy_timeout(std::time::Duration::from_secs(5))?;
-    connection.execute_batch(
-        "CREATE TABLE IF NOT EXISTS directory_owners (path TEXT PRIMARY KEY, target TEXT NOT NULL)",
-    )?;
+    connection.execute_batch(REGISTRY_SCHEMA)?;
     let transaction =
         connection.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
     let target = target.to_string();
-    let owners = transaction
-        .prepare("SELECT path, target FROM directory_owners")?
-        .query_map([], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-        })?
-        .collect::<Result<Vec<_>, _>>()?;
-    for (path, owner) in &owners {
-        let overlapping = path == relative
-            || relative.starts_with(&format!("{path}/"))
-            || path.starts_with(&format!("{relative}/"));
+    let owners = overlapping_owners(&transaction, relative)?;
+    for (_, owner) in &owners {
         anyhow::ensure!(
-            !overlapping || owner == &target,
+            owner == &target,
             "conversation directory belongs to another paired workspace"
         );
     }
@@ -181,6 +235,69 @@ mod tests {
             std::fs::read_to_string(project.join("work.txt")).unwrap(),
             "mine"
         );
+    }
+
+    /// The registry is consulted on every conversation start, so it has to be
+    /// answered from the index. A plan that says SCAN is one that reads every
+    /// directory the workspace has ever registered.
+    #[test]
+    fn overlap_is_answered_from_the_index_rather_than_by_reading_every_row() {
+        let connection = rusqlite::Connection::open_in_memory().unwrap();
+        connection.execute_batch(REGISTRY_SCHEMA).unwrap();
+        for (sql, parameters) in [(OWNER_OF, 1), (OWNERS_BENEATH, 2)] {
+            // SQLite plans a prepared statement, so the placeholders have to
+            // be bound even though nothing is read back.
+            let bound = vec!["a/b"; parameters];
+            let plan = connection
+                .prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
+                .unwrap()
+                .query_map(rusqlite::params_from_iter(bound), |row| {
+                    row.get::<_, String>(3)
+                })
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+                .join("; ");
+            assert!(plan.contains("SEARCH"), "{sql}\n{plan}");
+            assert!(!plan.contains("SCAN"), "{sql}\n{plan}");
+        }
+    }
+
+    /// The bound between "beneath" and "merely spelled similarly" is a path
+    /// separator, not a string prefix. `project` is not inside `proj`, and two
+    /// paired workspaces are entitled to one each.
+    #[test]
+    fn a_sibling_that_only_shares_a_prefix_is_not_an_overlap() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("lemma");
+        prepare(&root, Uuid::new_v4(), "/workspace/proj").unwrap();
+        prepare(&root, Uuid::new_v4(), "/workspace/project").unwrap();
+        prepare(&root, Uuid::new_v4(), "/workspace/proj0").unwrap();
+        // And the real containment is still refused.
+        assert!(prepare(&root, Uuid::new_v4(), "/workspace/proj/inside").is_err());
+    }
+
+    /// Narrowing the query must not narrow what it finds. A conflict buried
+    /// among directories that do not overlap is still a conflict, and a
+    /// descendant registered by someone else still blocks its parent.
+    #[test]
+    fn a_conflict_is_still_found_among_directories_that_do_not_overlap() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().join("lemma");
+        let mine = Uuid::new_v4();
+        for index in 0..64 {
+            prepare(&root, Uuid::new_v4(), &format!("/workspace/other-{index}")).unwrap();
+        }
+        prepare(&root, mine, "/workspace/a/b/c").unwrap();
+
+        // An ancestor of a directory somebody else owns.
+        assert!(prepare(&root, Uuid::new_v4(), "/workspace/a").is_err());
+        // A descendant of one.
+        assert!(prepare(&root, Uuid::new_v4(), "/workspace/a/b/c/d").is_err());
+        // The same directory.
+        assert!(prepare(&root, Uuid::new_v4(), "/workspace/a/b/c").is_err());
+        // And its own owner is still let back in.
+        assert!(prepare(&root, mine, "/workspace/a/b/c/d").is_ok());
     }
 
     #[cfg(unix)]

--- a/desktop/agent-host/src/runtime/commands.rs
+++ b/desktop/agent-host/src/runtime/commands.rs
@@ -6,6 +6,77 @@ use super::{
     TargetWorker, Utc, Value, redact_error, short_revision, terminal_failure,
 };
 
+/// Why a command was refused, decided where the refusal happens.
+///
+/// This used to be recovered afterwards by matching English substrings against
+/// the error's message -- and against the message *after* `redact_error` had
+/// rewritten parts of it. Two things were wrong with that. Rewording any
+/// `bail!` on the start path silently changed the machine-readable code the
+/// workspace acts on, with nothing failing when it did; and the words are not
+/// specific enough to carry the meaning, so an unrelated failure that happened
+/// to say "expired" -- a provider credential, a certificate -- was reported to
+/// Lemma as `CommandExpired`, which is not retryable, for a run that a retry
+/// would have fixed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RefusedBecause {
+    Draining,
+    CommandExpired,
+    HarnessNotFound,
+    ConfigRevisionStale,
+    CapacityLost,
+    AdapterUnavailable,
+}
+
+impl RefusedBecause {
+    /// The code the workspace stores and acts on.
+    fn code(self) -> RejectionCode {
+        match self {
+            Self::Draining => RejectionCode::Draining,
+            Self::CommandExpired => RejectionCode::CommandExpired,
+            Self::HarnessNotFound => RejectionCode::HarnessNotFound,
+            Self::ConfigRevisionStale => RejectionCode::ConfigRevisionStale,
+            Self::CapacityLost => RejectionCode::CapacityLost,
+            Self::AdapterUnavailable => RejectionCode::AdapterUnavailable,
+        }
+    }
+
+    /// Whether Lemma may mint the same run again without a person deciding.
+    ///
+    /// Only the two that describe this host being momentarily full or on its
+    /// way out. The rest need something to change first -- a revision to be
+    /// republished, an adapter to be installed -- so retrying reproduces them.
+    fn retryable(self) -> bool {
+        matches!(self, Self::Draining | Self::CapacityLost)
+    }
+}
+
+/// A refusal, carrying both the reason and the sentence a person reads.
+///
+/// The `Display` is the detail alone, so every existing log line and stored
+/// rejection detail reads exactly as it did. The reason travels beside it
+/// instead of inside it.
+#[derive(Debug)]
+pub(crate) struct Refusal {
+    because: RefusedBecause,
+    detail: String,
+}
+
+impl std::fmt::Display for Refusal {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.detail)
+    }
+}
+
+impl std::error::Error for Refusal {}
+
+/// Refuse a command for a stated reason.
+pub(crate) fn refuse(because: RefusedBecause, detail: impl std::fmt::Display) -> anyhow::Error {
+    anyhow::Error::new(Refusal {
+        because,
+        detail: detail.to_string(),
+    })
+}
+
 pub(crate) fn command_rejection(
     command: &Command,
     error: &anyhow::Error,
@@ -16,22 +87,15 @@ pub(crate) fn command_rejection(
     let run_id = command.run_id?;
     let lease_epoch = command.lease_epoch?;
     let detail = redact_error(&error.to_string());
-    let normalized = detail.to_ascii_lowercase();
-    let (code, retryable) = if normalized.contains("draining") {
-        (RejectionCode::Draining, true)
-    } else if normalized.contains("expired") {
-        (RejectionCode::CommandExpired, false)
-    } else if normalized.contains("unknown harness") {
-        (RejectionCode::HarnessNotFound, false)
-    } else if normalized.contains("revision changed") {
-        (RejectionCode::ConfigRevisionStale, false)
-    } else if normalized.contains("capacity changed") {
-        (RejectionCode::CapacityLost, true)
-    } else if normalized.contains("adapter") || normalized.contains("executable") {
-        (RejectionCode::AdapterUnavailable, false)
-    } else {
-        (RejectionCode::InvalidCommand, false)
-    };
+    // Not the message. A refusal raised anywhere on the start path says why it
+    // refused; anything else that reaches here is a failure this file did not
+    // anticipate, and the workspace can only treat that as a command it cannot
+    // act on -- which is what `InvalidCommand`, not retryable, already means.
+    let (code, retryable) = error
+        .downcast_ref::<Refusal>()
+        .map_or((RejectionCode::InvalidCommand, false), |refusal| {
+            (refusal.because.code(), refusal.because.retryable())
+        });
     Some(CommandRejection {
         command_id: command.command_id,
         run_id,
@@ -44,7 +108,9 @@ pub(crate) fn command_rejection(
 
 impl TargetWorker {
     pub(crate) fn handle_command(&mut self, command: &Command) -> anyhow::Result<()> {
-        anyhow::ensure!(command.expires_at >= Utc::now(), "command is expired");
+        if command.expires_at < Utc::now() {
+            return Err(refuse(RefusedBecause::CommandExpired, "command is expired"));
+        }
         match command.kind {
             CommandKind::StartRun => self.handle_start(command),
             CommandKind::CancelRun => self.handle_cancel(command),
@@ -82,13 +148,20 @@ impl TargetWorker {
     }
 
     pub(crate) fn handle_start(&mut self, command: &Command) -> anyhow::Result<()> {
-        anyhow::ensure!(!self.draining, "Agent Host is draining");
+        if self.draining {
+            return Err(refuse(RefusedBecause::Draining, "Agent Host is draining"));
+        }
         let spec: RunSpec = serde_json::from_value(command.payload.clone())?;
         let published = self
             .harnesses
             .get(&spec.harness_id)
             .cloned()
-            .ok_or_else(|| anyhow::anyhow!("command references an unknown harness"))?;
+            .ok_or_else(|| {
+                refuse(
+                    RefusedBecause::HarnessNotFound,
+                    "command references an unknown harness",
+                )
+            })?;
         if published.config_revision != spec.profile_revision {
             // Both revisions, because the question a reader has is always "how
             // far behind was the command?", and one hash alone cannot answer
@@ -112,13 +185,16 @@ impl TargetWorker {
             // the command, and "how far behind was it?" is the first question
             // asked of a run that died here — on a machine whose log nobody
             // reading the run will ever see.
-            anyhow::bail!(
-                "harness configuration revision changed: this computer publishes {} at {}, \
-                 and the run was minted against {}",
-                published.harness_key,
-                short_revision(&published.config_revision),
-                short_revision(&spec.profile_revision),
-            );
+            return Err(refuse(
+                RefusedBecause::ConfigRevisionStale,
+                format!(
+                    "harness configuration revision changed: this computer publishes {} at {}, \
+                     and the run was minted against {}",
+                    published.harness_key,
+                    short_revision(&published.config_revision),
+                    short_revision(&spec.profile_revision),
+                ),
+            ));
         }
         if self.active_runs.contains_key(&spec.agent_run_id) {
             let outcome = self.journal.accept_start(
@@ -138,7 +214,13 @@ impl TargetWorker {
         // ACCEPTED. Once ACCEPTED is durable, Lemma must not start a cloud
         // fallback, so waiting on the semaphore after that point can duplicate
         // provider work.
-        let adapter = self.manifest.resolve(&published.harness_key)?;
+        // Wrapped, not bubbled: the manifest reports a missing or unusable
+        // adapter in its own words, and those words are what a person needs.
+        // The reason is what Lemma needs, and only this call site knows it.
+        let adapter = self
+            .manifest
+            .resolve(&published.harness_key)
+            .map_err(|error| refuse(RefusedBecause::AdapterUnavailable, error))?;
         let probe = self.probes.get(&published.harness_key).cloned();
         let can_load_session = probe
             .as_ref()
@@ -146,7 +228,12 @@ impl TargetWorker {
         let published_config_options = probe.map(|probe| probe.config_options).unwrap_or_default();
         let permit = Arc::clone(&self.global_capacity)
             .try_acquire_owned()
-            .map_err(|_| anyhow::anyhow!("Agent Host capacity changed; command will be retried"))?;
+            .map_err(|_| {
+                refuse(
+                    RefusedBecause::CapacityLost,
+                    "Agent Host capacity changed; command will be retried",
+                )
+            })?;
         let outcome = self.journal.accept_start(
             self.target.target_id,
             command,

--- a/desktop/agent-host/src/runtime/tests/command_refusal_tests.rs
+++ b/desktop/agent-host/src/runtime/tests/command_refusal_tests.rs
@@ -1,0 +1,142 @@
+//! What the workspace is told when a run cannot be started.
+//!
+//! The reason used to be recovered by matching English substrings against the
+//! error's message, after `redact_error` had already rewritten parts of it.
+//! These guards are about the two ways that was wrong: a message that no
+//! longer carries the words, and words that carry the wrong meaning.
+
+use chrono::Utc;
+use uuid::Uuid;
+
+use super::{RefusedBecause, command_rejection, refuse};
+use crate::protocol::{Command, CommandKind, RejectionCode};
+
+fn start_command() -> Command {
+    Command {
+        command_id: Uuid::new_v4(),
+        kind: CommandKind::StartRun,
+        created_at: Utc::now(),
+        expires_at: Utc::now() + chrono::Duration::minutes(1),
+        run_id: Some(Uuid::new_v4()),
+        lease_epoch: Some(1),
+        payload: serde_json::Value::Null,
+    }
+}
+
+/// Each reason has one code, and only the two that describe a host being
+/// momentarily full or on its way out may be retried without a person.
+#[test]
+fn every_reason_reaches_the_workspace_as_its_own_code() {
+    let expected = [
+        (RefusedBecause::Draining, RejectionCode::Draining, true),
+        (
+            RefusedBecause::CommandExpired,
+            RejectionCode::CommandExpired,
+            false,
+        ),
+        (
+            RefusedBecause::HarnessNotFound,
+            RejectionCode::HarnessNotFound,
+            false,
+        ),
+        (
+            RefusedBecause::ConfigRevisionStale,
+            RejectionCode::ConfigRevisionStale,
+            false,
+        ),
+        (
+            RefusedBecause::CapacityLost,
+            RejectionCode::CapacityLost,
+            true,
+        ),
+        (
+            RefusedBecause::AdapterUnavailable,
+            RejectionCode::AdapterUnavailable,
+            false,
+        ),
+    ];
+    for (because, code, retryable) in expected {
+        let rejection = command_rejection(&start_command(), &refuse(because, "why"))
+            .expect("a refused start is reported");
+        assert_eq!(rejection.code, code, "{because:?}");
+        assert_eq!(rejection.retryable, retryable, "{because:?}");
+        assert_eq!(rejection.detail.as_deref(), Some("why"), "{because:?}");
+    }
+}
+
+/// `redact_error` truncates at the first credential marker it finds, so a
+/// message whose tail carried the meaning arrives at the classifier without
+/// it. The manifest names the registry URL it could not install from, and a
+/// registry URL is exactly where a `token=` turns up.
+#[test]
+fn a_refusal_survives_having_its_message_redacted() {
+    let error = refuse(
+        RefusedBecause::AdapterUnavailable,
+        "could not install from https://registry.example/pkg?token=abc123 -- \
+         the adapter is not on this computer",
+    );
+
+    let rejection =
+        command_rejection(&start_command(), &error).expect("a refused start is reported");
+
+    assert_eq!(rejection.code, RejectionCode::AdapterUnavailable);
+    // The detail still goes through redaction: the reason travels beside the
+    // message, it does not exempt it.
+    let detail = rejection.detail.unwrap();
+    assert!(detail.contains("[redacted]"), "{detail}");
+    assert!(!detail.contains("abc123"), "{detail}");
+    // And the truncation took the reason with it: nothing left in this string
+    // says "adapter" at all.
+    assert!(!detail.contains("adapter"), "{detail}");
+}
+
+/// The words are not specific enough to carry the meaning. An adapter whose
+/// signing certificate has expired is an unavailable adapter, not a command
+/// that arrived too late -- and the two differ in whether Lemma may retry.
+#[test]
+fn a_reason_is_not_guessed_from_words_that_mean_something_else() {
+    let error = refuse(
+        RefusedBecause::AdapterUnavailable,
+        "the adapter's signing certificate expired on 2026-01-01",
+    );
+
+    let rejection =
+        command_rejection(&start_command(), &error).expect("a refused start is reported");
+
+    assert_eq!(rejection.code, RejectionCode::AdapterUnavailable);
+    assert!(!rejection.retryable);
+}
+
+/// A failure the start path did not classify is a command the host cannot act
+/// on, whatever its message happens to mention. A serde error naming the field
+/// it could not read is the ordinary case, and `adapter_version` is a field.
+#[test]
+fn a_failure_nobody_classified_is_an_invalid_command() {
+    let error = anyhow::anyhow!("missing field `adapter_version` at line 1 column 2");
+
+    let rejection =
+        command_rejection(&start_command(), &error).expect("a failed start is reported");
+
+    assert_eq!(rejection.code, RejectionCode::InvalidCommand);
+    assert!(!rejection.retryable);
+}
+
+/// Only a start is reported this way. A cancel or a permission resolution that
+/// fails has no run to fence and nothing for Lemma to re-mint.
+#[test]
+fn only_a_start_is_reported_as_a_rejection() {
+    for kind in [
+        CommandKind::CancelRun,
+        CommandKind::ResolvePermission,
+        CommandKind::RefreshCredential,
+    ] {
+        let command = Command {
+            kind,
+            ..start_command()
+        };
+        assert!(
+            command_rejection(&command, &refuse(RefusedBecause::Draining, "why")).is_none(),
+            "{kind:?}"
+        );
+    }
+}

--- a/desktop/agent-host/src/runtime/tests/mod.rs
+++ b/desktop/agent-host/src/runtime/tests/mod.rs
@@ -7,6 +7,7 @@ use super::*;
 mod adapter_failure_message_tests;
 mod adapter_installation_tests;
 mod capability_tests;
+mod command_refusal_tests;
 mod harness_publish_scheduling_tests;
 mod stream_upsert_tests;
 mod target_worker;

--- a/desktop/agent-host/src/runtime/tests/target_worker/runs.rs
+++ b/desktop/agent-host/src/runtime/tests/target_worker/runs.rs
@@ -135,3 +135,77 @@ fn every_terminal_path_wakes_the_poll_that_reports_it() {
         "the scan found no terminal paths, so it is asserting nothing"
     );
 }
+
+/// A host on its way out refuses starts, and says so in a way Lemma may act
+/// on: this run belongs somewhere else, so re-mint it rather than failing it.
+#[tokio::test]
+async fn a_start_refused_because_the_host_is_draining_is_retryable() {
+    let mut harness = Harness::new().await;
+    harness.worker.draining = true;
+    let command = start_command(Uuid::new_v4(), Utc::now() + chrono::Duration::minutes(1));
+
+    let error = harness.worker.handle_command(&command).unwrap_err();
+    let rejection = command_rejection(&command, &error).expect("a refused start is reported");
+
+    assert_eq!(rejection.code, RejectionCode::Draining);
+    assert!(rejection.retryable);
+}
+
+/// A command that sat in a queue past its own deadline is not retried: the
+/// deadline is Lemma's, and Lemma is the one that decides whether to mint
+/// another.
+#[tokio::test]
+async fn a_start_that_arrived_too_late_is_not_retryable() {
+    let mut harness = Harness::new().await;
+    let command = start_command(Uuid::new_v4(), Utc::now() - chrono::Duration::seconds(1));
+
+    let error = harness.worker.handle_command(&command).unwrap_err();
+    let rejection = command_rejection(&command, &error).expect("a refused start is reported");
+
+    assert_eq!(rejection.code, RejectionCode::CommandExpired);
+    assert!(!rejection.retryable);
+}
+
+/// Minted against a harness this computer does not publish. Retrying cannot
+/// help until the harness exists here, so the run fails rather than looping.
+#[tokio::test]
+async fn a_start_for_a_harness_this_host_never_published_is_not_retryable() {
+    let mut harness = Harness::new().await;
+    let command = start_command(Uuid::new_v4(), Utc::now() + chrono::Duration::minutes(1));
+
+    let error = harness.worker.handle_command(&command).unwrap_err();
+    let rejection = command_rejection(&command, &error).expect("a refused start is reported");
+
+    assert_eq!(rejection.code, RejectionCode::HarnessNotFound);
+    assert!(!rejection.retryable);
+}
+
+/// A start command for `harness_id`, due at `expires_at`.
+fn start_command(harness_id: Uuid, expires_at: chrono::DateTime<Utc>) -> Command {
+    let run_id = Uuid::new_v4();
+    let spec = RunSpec {
+        agent_run_id: run_id,
+        conversation_id: Uuid::new_v4(),
+        harness_id,
+        profile_revision: "revision".into(),
+        model_name: None,
+        config_selections: JsonMap::new(),
+        system_prompt: String::new(),
+        prompt: vec![serde_json::json!({"type": "text", "text": "hi"})],
+        resume_session_id: None,
+        workspace_cwd: None,
+        context: JsonMap::new(),
+        mcp: serde_json::json!({}),
+        run_deadline: Utc::now() + chrono::Duration::minutes(5),
+        system_prompt_delivery: None,
+    };
+    Command {
+        command_id: Uuid::new_v4(),
+        kind: CommandKind::StartRun,
+        created_at: Utc::now(),
+        expires_at,
+        run_id: Some(run_id),
+        lease_epoch: Some(1),
+        payload: serde_json::to_value(&spec).unwrap(),
+    }
+}


### PR DESCRIPTION
## What changes

Three Agent Host items from the desktop production-readiness register, all of
them the same shape: a decision made by reading text that was never meant to
carry it.

**AH-17 — the rejection code was recovered from the error's English.** A start
command that cannot run is reported to the workspace as a `RejectionCode`, and
that code was chosen by matching substrings against `error.to_string()` —
*after* `redact_error` had rewritten parts of it. Two consequences, both
reachable today:

- `redact_error` truncates at the first credential marker it finds. The
  manifest names the registry URL it could not install from, and a registry URL
  is where a `token=` appears, so an adapter that is genuinely not on the
  computer arrived at the classifier as `[redacted]` and was reported as
  `InvalidCommand`.
- `"expired"` was tested before `"adapter"`. An adapter whose signing
  certificate had expired became `CommandExpired`, which is not retryable; a
  serde error naming the field `adapter_version` became `AdapterUnavailable`.

A `RefusedBecause` is now raised where the refusal happens and travels beside
the message rather than inside it. `Display` is still the detail alone, so
every log line and stored rejection detail reads exactly as before. Anything
that reaches the classifier unclassified is an `InvalidCommand`, which is what
it is.

**AH-12 — the directory registry read every row on every conversation start.**
Overlap means one directory contains the other: the ancestors of a path, and
its descendants. Both are ranges of `path`, which is the primary key and
therefore already indexed. It is now one point lookup per path component plus a
single bounded scan, so opening a conversation costs the same on the thousandth
as on the first. No schema change and no migration — this is the table that has
always been written.

**AH-16 (the Node floor half) — nothing enforced the Node the adapters need.**
Each npm adapter states it in its own `package.json`, and `npm install` does
not enforce it: an unmet `engines` is `EBADENGINE`, a *warning*. So on a
computer with an old Node the adapter is fetched, verified, cached and
launched, and the first thing the user sees is a parse error from a file inside
`node_modules` — naming somebody else's code, saying nothing about Node.

The floor is read from the adapter rather than written down in Lemma, so it
cannot drift from the one enforced at parse time. Every step that cannot answer
returns `Ok`: no Node on the search path, no version from it, no `engines`
field, or a range this parser cannot read. A floor nobody can read must not
become a new way for a working installation to be refused.

The compat matrix and offline pack halves of AH-16 remain open.

## Why

From the desktop production-readiness register (AH-12, AH-16 partial, AH-17).
AH-17 is the one with a user-visible consequence: the code decides whether
Lemma may re-mint the run, so a misread reason is a run that either fails when
a retry would have fixed it or retries something that cannot succeed.

## How to verify

```bash
make desktop-check
```

Passed locally (`EXIT=0`), 213 agent-host tests. Fifteen new guards; the ones
that fail against the code they replace:

- `a_refusal_survives_having_its_message_redacted` — the reason is gone from
  the redacted string, so the substring table said `InvalidCommand`.
- `a_reason_is_not_guessed_from_words_that_mean_something_else` — said
  `CommandExpired` for an expired *certificate*.
- `a_failure_nobody_classified_is_an_invalid_command` — said
  `AdapterUnavailable` for a serde error.
- `overlap_is_answered_from_the_index_rather_than_by_reading_every_row` —
  `EXPLAIN QUERY PLAN` must say SEARCH, not SCAN. Verified against the old
  unfiltered query, which plans as `SCAN directory_owners`.
- `a_node_below_the_declared_floor_is_ruled_out` — verified against dropping
  the space-to-comma normalisation, which is what makes npm's `>=18 <22`
  readable at all.

Each was run against the pre-change code and observed to fail with exactly the
misreading described.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Compatibility** — `RejectionCode` is unchanged on the wire; what
      changes is which one a given failure maps to. `Display` on a refusal is
      the same sentence as before, so stored details are unchanged.
- [x] **Security** — the adapter integrity and cache verification are
      untouched; the Node check runs after them and only refuses.
- [x] **Rollback** — revert cleanly; no schema, state or on-disk format
      changes.

## Compatibility and rollback notes

The directory registry's table and rows are exactly as before; only the queries
against it narrowed. An older build reading the same file sees the same data.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pre-launch validation for npm-based adapters to detect incompatible Node.js versions and provide clearer error details.
  - Added structured command refusal reporting with specific rejection reasons and retry guidance.

- **Bug Fixes**
  - Improved handling of expired commands, unavailable harnesses, draining hosts, and other start failures.
  - Prevented rejection details from being misclassified when error messages contain ambiguous wording.
  - Improved adapter startup behavior when the cached runtime is no longer compatible.
  - Ensured Node.js checks use the same executable paths as adapter launches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->