### PR TITLE
The log the daemon pointed at did not exist

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2766,6 +2766,7 @@ dependencies = [
  "interprocess",
  "lemma-desktop-process",
  "lemma-job-object",
+ "lemma-locald",
  "lemma-private-file",
  "libc",
  "objc2",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -115,6 +115,10 @@ tempfile = { workspace = true }
 # minisign key rather than a placeholder. A dev dependency, so it is not
 # linked into the shipped app.
 base64 = "0.22"
+# The daemon names a diagnostic log source in every startup error, and the shell
+# is what serves those sources. Only a test puts the two vocabularies in the
+# same process; the shipped app talks to locald over a socket, as before.
+lemma-locald = { path = "locald" }
 
 # A workspace ignores [profile] in anything but the root manifest — with a
 # warning that is easy to miss — so every member's release profile lives here.

--- a/desktop/locald/src/daemon/dispatch.rs
+++ b/desktop/locald/src/daemon/dispatch.rs
@@ -221,10 +221,26 @@ pub(super) fn runtime_operation_error_code(message: &str, fallback: &'static str
     }
 }
 
-pub(super) fn error_diagnostic_source(message: &str) -> (&'static str, &'static str) {
+/// Which component failed, and which diagnostic log will say why.
+///
+/// The second half is a *log source id*, and the shell serves a fixed set of
+/// them (`diagnostic_log_sources` in `desktop/src/diagnostics.rs`). It used to
+/// answer "infrastructure", which is not one of them: `read_diagnostic_log`
+/// refuses an id it does not serve, so a guest-kernel failure -- or anything
+/// mentioning a container, a registry or the guest -- selected a tab that
+/// could not be read. Those are the failures a person opens the log *for*.
+///
+/// `vm` is `logs/runtime.log`, which the runtime manager writes on both
+/// platforms and is where all of these are recorded. The first half is a label,
+/// not an id, and stays as it was.
+///
+/// `pub` so `every_log_source_the_daemon_names_is_one_the_shell_serves` can ask
+/// it. The two halves of this contract are compiled into different binaries,
+/// and nothing else can put them in the same room.
+pub fn error_diagnostic_source(message: &str) -> (&'static str, &'static str) {
     let message = message.to_ascii_lowercase();
     if message.contains("guest kernel") {
-        ("infrastructure", "infrastructure")
+        ("infrastructure", "vm")
     } else if message.contains("migration") || message.contains("alembic") {
         ("migrations", "migrations")
     } else if message.contains("frontend") || message.contains("eaddrinuse") {
@@ -236,7 +252,7 @@ pub(super) fn error_diagnostic_source(message: &str) -> (&'static str, &'static 
         || message.contains("registry")
         || message.contains("guest")
     {
-        ("infrastructure", "infrastructure")
+        ("infrastructure", "vm")
     } else {
         ("locald", "events")
     }

--- a/desktop/locald/src/daemon/error_classification_tests.rs
+++ b/desktop/locald/src/daemon/error_classification_tests.rs
@@ -1,0 +1,120 @@
+//! Turning a failure into a code the workspace acts on, and a log that says why.
+//!
+//! Split out of `tests.rs` under DES-09. One subject: every startup failure
+//! leaves the daemon as a stable error code and a diagnostic log id, and both
+//! are read by something in another process.
+
+use tempfile::tempdir;
+
+use super::{error_diagnostic_source, runtime_operation_error_code};
+
+#[test]
+fn windows_runtime_errors_have_stable_user_action_codes() {
+    assert_eq!(
+        runtime_operation_error_code(
+            "WSL 2 is required for Lemma's private runtime",
+            "host-operation-failed"
+        ),
+        "wsl-required"
+    );
+    assert_eq!(
+        runtime_operation_error_code(
+            "Windows must restart to finish enabling WSL 2",
+            "host-operation-failed"
+        ),
+        "wsl-reboot-required"
+    );
+    assert_eq!(
+        runtime_operation_error_code(
+            "Windows did not approve or complete WSL 2 setup",
+            "runtime-prepare-failed"
+        ),
+        "wsl-setup-denied"
+    );
+    assert_eq!(
+        runtime_operation_error_code("database failed", "host-operation-failed"),
+        "host-operation-failed"
+    );
+}
+
+/// Anything that says the marker phrase gets the code the reset button
+/// keys on -- however many different detectors end up raising it.
+#[test]
+fn stranded_local_data_is_reported_with_the_code_the_reset_button_uses() {
+    assert_eq!(
+        runtime_operation_error_code(
+            "this installation's secret was replaced, and anything encrypted with the \
+                 previous one can no longer be read; local data must be reset",
+            "host-operation-failed"
+        ),
+        "local-data-incompatible"
+    );
+    // The phrase is the whole contract, so a detector nobody has written
+    // yet gets the same treatment for free.
+    assert_eq!(
+        runtime_operation_error_code(
+            &format!(
+                "the workspace database was created by PostgreSQL 16 and this release \
+                     runs PostgreSQL 18; {}",
+                crate::paths::DATA_RESET_MARKER
+            ),
+            "host-operation-failed"
+        ),
+        "local-data-incompatible"
+    );
+}
+
+/// The marker is checked before the guest is touched.
+///
+/// Reaching `prepare_private_infra` would boot a VM to discover a failure
+/// already known on disk, and the failure it would then report is an opaque
+/// auth error rather than an offer to reset.
+#[test]
+fn a_recorded_data_reset_requirement_survives_until_it_is_cleared() {
+    let root = tempdir().unwrap();
+    assert!(crate::paths::data_reset_reason(root.path()).is_none());
+
+    crate::paths::require_data_reset(root.path(), "the passwords were replaced").unwrap();
+    let reason = crate::paths::data_reset_reason(root.path()).unwrap();
+    assert_eq!(reason, "the passwords were replaced");
+    assert_eq!(
+        runtime_operation_error_code(
+            &format!("{reason}; {}", crate::paths::DATA_RESET_MARKER),
+            "host-operation-failed"
+        ),
+        "local-data-incompatible"
+    );
+
+    crate::paths::clear_data_reset(root.path()).unwrap();
+    assert!(crate::paths::data_reset_reason(root.path()).is_none());
+    // Clearing twice is how a reset that retries behaves; it must not fail.
+    crate::paths::clear_data_reset(root.path()).unwrap();
+}
+
+#[test]
+fn startup_errors_select_the_relevant_diagnostic_log() {
+    // The second half of each pair is an id the shell has to serve. "vm" is
+    // logs/runtime.log; "infrastructure" was not a source at all, so the tab it
+    // selected could not be read.
+    let kernel_error = "backend health gate: Linux guest kernel crashed";
+    assert_eq!(
+        error_diagnostic_source(kernel_error),
+        ("infrastructure", "vm")
+    );
+    assert_eq!(
+        runtime_operation_error_code(kernel_error, "host-operation-failed"),
+        "guest-kernel-failed"
+    );
+    assert_eq!(
+        error_diagnostic_source("frontend failed: EADDRINUSE"),
+        ("frontend", "frontend")
+    );
+    assert_eq!(
+        error_diagnostic_source("migrations setup exited"),
+        ("migrations", "migrations")
+    );
+    assert_eq!(
+        error_diagnostic_source("registry DNS lookup failed"),
+        ("infrastructure", "vm")
+    );
+}

--- a/desktop/locald/src/daemon/mod.rs
+++ b/desktop/locald/src/daemon/mod.rs
@@ -82,7 +82,10 @@ pub struct Daemon {
 
 mod agent_host_ops;
 mod config_ops;
-mod dispatch;
+// Public for one function: `error_diagnostic_source` names a diagnostic log
+// that the *shell* has to serve, and the two halves of that contract compile
+// into different binaries. See the guard in desktop/src/tests/diagnostics.rs.
+pub mod dispatch;
 mod environment;
 mod handshake;
 mod monitors;
@@ -495,5 +498,7 @@ fn create_listener(paths: &LocalPaths) -> io::Result<LocalSocketListener> {
     }
 }
 
+#[cfg(test)]
+mod error_classification_tests;
 #[cfg(test)]
 mod tests;

--- a/desktop/locald/src/daemon/tests.rs
+++ b/desktop/locald/src/daemon/tests.rs
@@ -201,13 +201,8 @@ fn a_subscriber_that_stopped_reading_is_dropped_rather_than_queued_for_ever() {
 }
 use std::collections::HashMap;
 
-use tempfile::tempdir;
-
 use super::environment::exact_origin_regex;
-use super::{
-    compose_backend_environment, error_diagnostic_source, runtime_operation_error_code,
-    sharing_environment,
-};
+use super::{compose_backend_environment, sharing_environment};
 use crate::sharing::SharingMode;
 
 #[test]
@@ -242,114 +237,6 @@ fn operator_updates_preserve_private_runtime_endpoints() {
     assert_eq!(
         environment["SUPERTOKENS_CORE_URL"],
         "http://192.168.64.37:3567"
-    );
-}
-
-#[test]
-fn windows_runtime_errors_have_stable_user_action_codes() {
-    assert_eq!(
-        runtime_operation_error_code(
-            "WSL 2 is required for Lemma's private runtime",
-            "host-operation-failed"
-        ),
-        "wsl-required"
-    );
-    assert_eq!(
-        runtime_operation_error_code(
-            "Windows must restart to finish enabling WSL 2",
-            "host-operation-failed"
-        ),
-        "wsl-reboot-required"
-    );
-    assert_eq!(
-        runtime_operation_error_code(
-            "Windows did not approve or complete WSL 2 setup",
-            "runtime-prepare-failed"
-        ),
-        "wsl-setup-denied"
-    );
-    assert_eq!(
-        runtime_operation_error_code("database failed", "host-operation-failed"),
-        "host-operation-failed"
-    );
-}
-
-/// Anything that says the marker phrase gets the code the reset button
-/// keys on -- however many different detectors end up raising it.
-#[test]
-fn stranded_local_data_is_reported_with_the_code_the_reset_button_uses() {
-    assert_eq!(
-        runtime_operation_error_code(
-            "this installation's secret was replaced, and anything encrypted with the \
-                 previous one can no longer be read; local data must be reset",
-            "host-operation-failed"
-        ),
-        "local-data-incompatible"
-    );
-    // The phrase is the whole contract, so a detector nobody has written
-    // yet gets the same treatment for free.
-    assert_eq!(
-        runtime_operation_error_code(
-            &format!(
-                "the workspace database was created by PostgreSQL 16 and this release \
-                     runs PostgreSQL 18; {}",
-                crate::paths::DATA_RESET_MARKER
-            ),
-            "host-operation-failed"
-        ),
-        "local-data-incompatible"
-    );
-}
-
-/// The marker is checked before the guest is touched.
-///
-/// Reaching `prepare_private_infra` would boot a VM to discover a failure
-/// already known on disk, and the failure it would then report is an opaque
-/// auth error rather than an offer to reset.
-#[test]
-fn a_recorded_data_reset_requirement_survives_until_it_is_cleared() {
-    let root = tempdir().unwrap();
-    assert!(crate::paths::data_reset_reason(root.path()).is_none());
-
-    crate::paths::require_data_reset(root.path(), "the passwords were replaced").unwrap();
-    let reason = crate::paths::data_reset_reason(root.path()).unwrap();
-    assert_eq!(reason, "the passwords were replaced");
-    assert_eq!(
-        runtime_operation_error_code(
-            &format!("{reason}; {}", crate::paths::DATA_RESET_MARKER),
-            "host-operation-failed"
-        ),
-        "local-data-incompatible"
-    );
-
-    crate::paths::clear_data_reset(root.path()).unwrap();
-    assert!(crate::paths::data_reset_reason(root.path()).is_none());
-    // Clearing twice is how a reset that retries behaves; it must not fail.
-    crate::paths::clear_data_reset(root.path()).unwrap();
-}
-
-#[test]
-fn startup_errors_select_the_relevant_diagnostic_log() {
-    let kernel_error = "backend health gate: Linux guest kernel crashed";
-    assert_eq!(
-        error_diagnostic_source(kernel_error),
-        ("infrastructure", "infrastructure")
-    );
-    assert_eq!(
-        runtime_operation_error_code(kernel_error, "host-operation-failed"),
-        "guest-kernel-failed"
-    );
-    assert_eq!(
-        error_diagnostic_source("frontend failed: EADDRINUSE"),
-        ("frontend", "frontend")
-    );
-    assert_eq!(
-        error_diagnostic_source("migrations setup exited"),
-        ("migrations", "migrations")
-    );
-    assert_eq!(
-        error_diagnostic_source("registry DNS lookup failed"),
-        ("infrastructure", "infrastructure")
     );
 }
 

--- a/desktop/src/tests/diagnostics.rs
+++ b/desktop/src/tests/diagnostics.rs
@@ -183,3 +183,63 @@ fn a_credential_attached_to_its_key_is_redacted_too() {
         assert_eq!(mask_secret_shapes(ordinary.to_string()), ordinary);
     }
 }
+
+/// Every source id `locald` can name is one this shell serves.
+///
+/// `read_diagnostic_log` refuses an id it has no file for, so an unknown one is
+/// not a fallback: the log panel gets an error instead of a log. The daemon
+/// used to answer `infrastructure` for a crashed guest kernel, and for anything
+/// mentioning a container, a registry or the guest -- which are exactly the
+/// failures a person opens the log to read.
+///
+/// The two vocabularies compile into different binaries, so nothing but a test
+/// can put them in the same room. The messages below are the ones
+/// `error_diagnostic_source` branches on; the point is not that each picks a
+/// particular log, which locald's own tests already pin, but that whatever it
+/// picks exists here.
+#[test]
+fn every_log_source_the_daemon_names_is_one_the_shell_serves() {
+    let served: Vec<&str> = diagnostic_log_sources()
+        .into_iter()
+        .map(|(id, _, _)| id)
+        .collect();
+
+    for message in [
+        "backend health gate: Linux guest kernel crashed",
+        "frontend failed: EADDRINUSE",
+        "migrations setup exited",
+        "registry DNS lookup failed",
+        "containerd refused to start",
+        "the managed runtime did not come up",
+        "backend never became healthy",
+        "alembic could not upgrade",
+        "something nobody has a branch for",
+    ] {
+        let (_, source) = lemma_locald::daemon::dispatch::error_diagnostic_source(message);
+        assert!(
+            served.contains(&source),
+            "locald points {message:?} at the {source:?} log, which this shell \
+             does not serve, so the log panel shows an error instead of the \
+             log. Served: {served:?}",
+        );
+    }
+}
+
+/// The ids the daemon writes into a phase event, for the same reason.
+///
+/// Literals in `stack_ops.rs` rather than a function, so they are listed here.
+/// One added there and not here is not caught -- but one added to both, and not
+/// served, is, which is the step that would otherwise be skipped.
+#[test]
+fn the_phase_log_sources_are_served_too() {
+    let served: Vec<&str> = diagnostic_log_sources()
+        .into_iter()
+        .map(|(id, _, _)| id)
+        .collect();
+    for source in ["migrations", "backend", "frontend", "locald", "vm", "guest"] {
+        assert!(
+            served.contains(&source),
+            "a phase event names the {source:?} log, which this shell does not serve",
+        );
+    }
+}

--- a/desktop/ui-tests/drivers/splash.mjs
+++ b/desktop/ui-tests/drivers/splash.mjs
@@ -10,6 +10,30 @@
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
+// What the app itself serves, so the harness cannot pass on an asset the app
+// would refuse or refuse one the app serves. Tauri derives the type from the
+// extension (`tauri-utils::mime_type`), and `.mjs` is `text/javascript` there.
+const CONTENT_TYPES = {
+  html: 'text/html',
+  js: 'text/javascript',
+  mjs: 'text/javascript',
+  css: 'text/css',
+  json: 'application/json',
+  woff2: 'font/woff2',
+};
+
+/** The extension of `name`, refusing one nothing has a type for. */
+function extension(name) {
+  const found = name.includes('.') ? name.slice(name.lastIndexOf('.') + 1) : '';
+  if (!Object.hasOwn(CONTENT_TYPES, found)) {
+    throw new Error(
+      `no content type for .${found}: add it to CONTENT_TYPES, and check the `
+      + `app serves it too`,
+    );
+  }
+  return found;
+}
+
 export const DEFAULT_STATE = {
   mode: 'undecided',
   phaseKey: 'boot',
@@ -52,9 +76,18 @@ export async function launchSplash(browser, t, {
     const name = new URL(route.request().url()).pathname.slice(1);
     const file = new URL(name, assets);
     if (!file.href.startsWith(assets.href)) return route.abort();
-    const contentType = name.endsWith('.html') ? 'text/html'
-      : name.endsWith('.js') ? 'text/javascript'
-        : name.endsWith('.json') ? 'application/json' : 'application/octet-stream';
+    let contentType;
+    try {
+      contentType = CONTENT_TYPES[extension(name)];
+    } catch (error) {
+      // Louder than serving it as bytes. A module or a stylesheet delivered as
+      // application/octet-stream is *refused* by the browser, and the page then
+      // fails in whatever way the missing file happens to cause -- for a module
+      // the whole importing script never runs, which arrives as every assertion
+      // timing out and nothing saying why. This is how `screen-state.mjs` was
+      // found, thirty seconds at a time.
+      throw new Error(`${error.message} (requested by the page under test)`);
+    }
     try {
       await route.fulfill({ body: await readFile(file), contentType });
     } catch {

--- a/desktop/ui-tests/tests/screen-state.test.mjs
+++ b/desktop/ui-tests/tests/screen-state.test.mjs
@@ -1,0 +1,188 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  LOG_SOURCES,
+  deriveScreen,
+  diagnosticSourceForState,
+} from '../../ui/screen-state.mjs';
+
+/**
+ * The daemon saw the raw failure, before anything reshaped it for a person to
+ * read, so what it names is the answer -- as long as the shell serves it.
+ */
+test('a log source the daemon names is used, and one it cannot serve is not', () => {
+  assert.equal(diagnosticSourceForState({ logSource: 'migrations' }), 'migrations');
+
+  // `read_diagnostic_log` refuses an id it has no file for, so passing one
+  // through gives the user an error panel where the log should be. The daemon
+  // answered exactly this for a crashed guest kernel.
+  assert.equal(diagnosticSourceForState({ logSource: 'infrastructure' }), 'events');
+  assert.equal(diagnosticSourceForState({ logSource: '' }), 'events');
+  assert.equal(diagnosticSourceForState(null), 'events');
+});
+
+/**
+ * The fallback reads enumerated keys, not prose. Both of these used to be
+ * decided by searching `phaseKey + status + errorCode` for words -- after the
+ * message had already been rewritten for display.
+ */
+test('the fallback reads the error code and the phase, not the words around them', () => {
+  assert.equal(
+    diagnosticSourceForState({ errorCode: 'guest-kernel-failed' }),
+    'vm',
+  );
+  assert.equal(
+    diagnosticSourceForState({ errorCode: 'locald-start-failed' }),
+    'locald-stderr',
+  );
+  assert.equal(diagnosticSourceForState({ phaseKey: 'frontend' }), 'frontend');
+  assert.equal(diagnosticSourceForState({ phaseKey: 'download' }), 'installer');
+
+  // A status that says "install" while the runtime is what failed used to win
+  // over the error code, because "install" was tested before anything else.
+  assert.equal(
+    diagnosticSourceForState({
+      errorCode: 'guest-kernel-failed',
+      status: 'could not install the guest kernel module',
+      phaseKey: 'infra',
+    }),
+    'vm',
+  );
+
+  // And a phase with no log of its own is the events log, not a guess.
+  assert.equal(diagnosticSourceForState({ phaseKey: 'boot' }), 'events');
+  assert.equal(diagnosticSourceForState({ errorCode: 'nothing-known' }), 'events');
+});
+
+test('every log this can choose is one the shell serves', () => {
+  const states = [
+    {}, { logSource: 'guest' }, { phaseKey: 'migrations' },
+    { errorCode: 'wsl-required' }, { errorCode: 'runtime-recovery' },
+    { errorCode: 'local-data-incompatible' }, { phaseKey: 'verify' },
+    { phaseKey: 'workspace' }, { errorCode: 'locald-disconnected' },
+  ];
+  for (const state of states) {
+    assert.ok(
+      LOG_SOURCES.includes(diagnosticSourceForState(state)),
+      `${JSON.stringify(state)} chose a log the shell does not serve`,
+    );
+  }
+});
+
+test('a state with no phase keeps the last one rather than rendering nothing', () => {
+  assert.equal(deriveScreen({}, { lastPhase: 'backend' }).phaseKey, 'backend');
+  assert.equal(deriveScreen({}, {}).phaseKey, 'boot');
+});
+
+test('an undecided mode is the chooser, whatever else the snapshot says', () => {
+  const screen = deriveScreen({ mode: 'undecided', phaseKey: 'backend', progress: 40 }, {});
+  assert.equal(screen.screen, 'choosing');
+});
+
+/**
+ * Data this release cannot read: retrying reproduces it exactly, and offering
+ * Try again is how somebody learns the app has nothing for them.
+ */
+test('an unreadable data directory offers recovery instead of a retry', () => {
+  const screen = deriveScreen({ error: true, errorCode: 'local-data-incompatible', status: 'x' }, {});
+  assert.equal(screen.screen, 'error');
+  assert.equal(screen.showRetry, false);
+  assert.equal(screen.showResetData, true);
+  assert.equal(screen.showFullReinstall, true);
+});
+
+test('a Windows permission is a setup button, not a retry', () => {
+  for (const errorCode of ['wsl-required', 'wsl-setup-denied']) {
+    const screen = deriveScreen({ error: true, errorCode }, {});
+    assert.equal(screen.showPrepareWindows, true, errorCode);
+    assert.equal(screen.showRetry, false, errorCode);
+    assert.equal(screen.windowsSetup, true, errorCode);
+  }
+  const restart = deriveScreen({ error: true, errorCode: 'wsl-reboot-required' }, {});
+  assert.equal(restart.windowsRestart, true);
+  assert.equal(restart.showRetry, false);
+  assert.equal(restart.showPrepareWindows, false);
+});
+
+test('a stack that could not start offers a data reset but not a reinstall', () => {
+  for (const errorCode of ['locald-start-failed', 'locald-disconnected', 'runtime-install-failed']) {
+    const screen = deriveScreen({ error: true, errorCode }, {});
+    assert.equal(screen.showResetData, true, errorCode);
+    assert.equal(screen.showFullReinstall, false, errorCode);
+    assert.equal(screen.showRetry, true, errorCode);
+  }
+});
+
+test('an ordinary failure keeps Try again and nothing else', () => {
+  const screen = deriveScreen({ error: true, errorCode: 'host-operation-failed', status: 'boom' }, {});
+  assert.equal(screen.showRetry, true);
+  assert.equal(screen.showResetData, false);
+  assert.equal(screen.showFullReinstall, false);
+  assert.equal(screen.errorDetail, 'boom');
+});
+
+test('an error with no status still says something', () => {
+  assert.equal(deriveScreen({ error: true }, {}).errorDetail, 'startup failed');
+});
+
+/**
+ * A snapshot taken before the stop was admitted still says ready. Acting on it
+ * offers to open a workspace that is being shut down -- and the splash takes
+ * that offer on the user's behalf after a moment.
+ */
+test('ready during a shutdown is the stopping screen, and offers nothing to open', () => {
+  const screen = deriveScreen({ ready: true }, { isShuttingDown: true });
+  assert.equal(screen.screen, 'stopping');
+  assert.equal(screen.showOpen, false);
+  assert.equal(screen.primaryAction, null);
+  assert.equal(screen.progressWidth, 100);
+});
+
+test('ready opens, stopped starts, and each says which', () => {
+  const ready = deriveScreen({ ready: true, progress: 100 }, {});
+  assert.equal(ready.screen, 'ready');
+  assert.equal(ready.primaryAction, 'open');
+  assert.equal(ready.showOpen, true);
+  assert.equal(ready.progressActive, false);
+  assert.equal(ready.runInfo, '');
+
+  const stopped = deriveScreen({ phaseKey: 'stopped' }, {});
+  assert.equal(stopped.screen, 'stopped');
+  assert.equal(stopped.primaryAction, 'start');
+  assert.equal(stopped.showOpen, true);
+  assert.equal(stopped.progressActive, false);
+});
+
+test('a run that has ever been a first setup keeps saying so', () => {
+  assert.equal(deriveScreen({ setup: true, phaseKey: 'infra' }, {}).runInfo, 'first run · only once');
+  // Carried, because a later snapshot does not repeat it.
+  assert.equal(
+    deriveScreen({ phaseKey: 'backend' }, { sawSetup: true }).runInfo,
+    'first run · only once',
+  );
+  assert.equal(deriveScreen({ phaseKey: 'backend' }, {}).runInfo, 'quick start');
+  assert.equal(deriveScreen({ setup: true }, {}).sawSetup, true);
+});
+
+test('progress is clamped, and only the working screen shows a bar', () => {
+  assert.equal(deriveScreen({ phaseKey: 'backend', progress: 140 }, {}).progressWidth, 100);
+  assert.equal(deriveScreen({ phaseKey: 'backend' }, {}).progressActive, true);
+  assert.equal(deriveScreen({ error: true }, {}).progressActive, false);
+  assert.equal(deriveScreen({ phaseKey: 'stopped' }, {}).progressActive, false);
+});
+
+/** Nothing may fall through: a state nobody handles leaves the static logo up. */
+test('every snapshot resolves to a screen', () => {
+  const snapshots = [
+    {}, null, undefined, { phaseKey: 'boot' }, { running: true }, { setup: true },
+    { error: true }, { ready: true }, { phaseKey: 'stopped' }, { mode: 'undecided' },
+    { mode: 'local', phaseKey: 'verify', progress: 91 },
+  ];
+  const known = ['choosing', 'error', 'stopping', 'ready', 'stopped', 'working'];
+  for (const snapshot of snapshots) {
+    const screen = deriveScreen(snapshot, {});
+    assert.ok(known.includes(screen.screen), `${JSON.stringify(snapshot)} -> ${screen.screen}`);
+    assert.ok(LOG_SOURCES.includes(screen.logSource));
+  }
+});

--- a/desktop/ui-tests/tests/startup.browser.mjs
+++ b/desktop/ui-tests/tests/startup.browser.mjs
@@ -154,7 +154,12 @@ test('opening the log from an error preselects the log for that failure', async 
   });
   await push(page, {
     mode: 'local', phaseKey: 'error', error: true, running: false, ready: false,
+    // What the daemon actually sends. It classifies the failure from the raw
+    // error, before anything reshapes it for a person to read, and puts the
+    // answer in the event; this used to omit it and the splash re-derived the
+    // answer by searching the displayed status for words.
     status: 'A database migration failed', errorCode: 'locald-start-failed',
+    logSource: 'migrations',
   });
   await page.getByRole('button', { name: 'View log', exact: true }).click();
   await page.getByText('relation already exists', { exact: false }).waitFor();
@@ -163,6 +168,49 @@ test('opening the log from an error preselects the log for that failure', async 
     // Again, the boot read comes first; what matters is that View log then
     // asks for the source belonging to this failure rather than for events.
     ['events', 'migrations'],
+  );
+});
+
+// An error event with no `log_source` -- an older daemon, or a path that does
+// not set one. The error *code* decides, because it is an enumerated value;
+// the status text beside it is prose and used to be what decided.
+test('an error with no named log falls back to its code, not to its wording', async t => {
+  const page = await splash(t, {
+    logs: {
+      sources: [{ id: 'locald-stderr', label: 'Service manager startup' }],
+      entries: { 'locald-stderr': 'could not bind the control socket' },
+    },
+  });
+  await push(page, {
+    mode: 'local', phaseKey: 'error', error: true, running: false, ready: false,
+    status: 'A database migration failed', errorCode: 'locald-start-failed',
+  });
+  await page.getByRole('button', { name: 'View log', exact: true }).click();
+  await page.getByText('could not bind the control socket', { exact: false }).waitFor();
+  assert.deepEqual(
+    (await commandCalls(page, ['diagnostic_logs'])).map(call => call.args.source),
+    ['events', 'locald-stderr'],
+  );
+});
+
+// A source the shell does not serve is not passed through. `read_diagnostic_log`
+// refuses an id it has no file for, so the panel would show an error where the
+// log should be -- and "infrastructure" is what the daemon answered for a
+// crashed guest kernel.
+test('a log source the shell cannot serve falls back to events', async t => {
+  const page = await splash(t, {
+    logs: { sources: [{ id: 'events', label: 'Events' }], entries: { events: 'boot line' } },
+  });
+  await push(page, {
+    mode: 'local', phaseKey: 'error', error: true, running: false, ready: false,
+    status: 'the guest kernel crashed', errorCode: 'host-operation-failed',
+    logSource: 'infrastructure',
+  });
+  await page.getByRole('button', { name: 'View log', exact: true }).click();
+  await page.getByText('boot line', { exact: false }).waitFor();
+  assert.deepEqual(
+    (await commandCalls(page, ['diagnostic_logs'])).map(call => call.args.source),
+    ['events', 'events'],
   );
 });
 

--- a/desktop/ui/index.html
+++ b/desktop/ui/index.html
@@ -831,7 +831,9 @@
   </div>
 </div>
 
-<script>
+<script type="module">
+  import { deriveScreen, diagnosticSourceForState } from "./screen-state.mjs";
+
   // ---- bridge: Tauri when available, scripted demo otherwise ------------
   (function () {
     const tauri = window.__TAURI__;
@@ -1101,28 +1103,25 @@
       progressEl.classList.toggle("active", !s.error);
       return;
     }
-    // Neither of these may return silently. This function is the only thing that
-    // draws the screen and the only thing that schedules the move to the
-    // workspace, so a state it declines to handle leaves the bare static logo up
-    // for good -- which is exactly what a stuck first run looked like.
-    //
-    // A state with no phase is still a state: fall back to the boot phase rather
-    // than rendering nothing.
-    if (!s.phaseKey) s = { ...s, phaseKey: lastPhase || "boot" };
-    // Undecided means the user has not picked a connection mode. Show them the
-    // choice instead of an empty screen.
-    if (s.mode === "undecided") {
+    // `deriveScreen` may not decline a state. This function is the only thing
+    // that draws the screen and the only thing that schedules the move to the
+    // workspace, so a state nothing handles leaves the bare static logo up for
+    // good -- which is exactly what a stuck first run looked like. A state with
+    // no phase is still a state, and `lastPhase` is how it keeps one.
+    const screen = deriveScreen(s, { lastPhase, sawSetup, isShuttingDown });
+
+    if (screen.screen === "choosing") {
       showChooser();
       return;
     }
     lastState = s;
     switchModeBtn.hidden = s.mode !== "local";
     if (s.running || s.ready) hideConnectionChoice();
-    if (s.setup) sawSetup = true;
-    lastPhase = s.phaseKey;
+    sawSetup = screen.sawSetup;
+    lastPhase = screen.phaseKey;
 
-    if (s.error) {
-      if (logPanel.hidden) activeLogSource = diagnosticSourceForState(s);
+    if (screen.screen === "error") {
+      if (logPanel.hidden) activeLogSource = screen.logSource;
       clearTimeout(readyOpenTimer);
       clearPrimaryBusy();
       hideOperationStatus();
@@ -1130,30 +1129,23 @@
       window.__orb?.stall();
       scene.classList.add("stalled");
       scene.classList.remove("awake");
-      const needsWindowsSetup = ["wsl-required", "wsl-setup-denied"].includes(s.errorCode);
-      const needsWindowsRestart = s.errorCode === "wsl-reboot-required";
-      say(needsWindowsSetup
+      say(screen.windowsSetup
         ? "Windows needs one permission."
-        : needsWindowsRestart
+        : screen.windowsRestart
           ? "One restart, then Lemma continues."
           : "Something stopped.");
-      truth.textContent = needsWindowsSetup
+      truth.textContent = screen.windowsSetup
         ? "one-time Windows setup · no Docker Desktop or Ubuntu"
-        : needsWindowsRestart
+        : screen.windowsRestart
           ? "restart Windows, then reopen Lemma"
           : "";
-      errdetail.textContent = s.status || "startup failed";
+      errdetail.textContent = screen.errorDetail;
       errwrap.hidden = false;
-      prepareWindowsBtn.hidden = !needsWindowsSetup;
+      prepareWindowsBtn.hidden = !screen.showPrepareWindows;
       prepareWindowsBtn.disabled = false;
       prepareWindowsBtn.textContent = "Set up Windows runtime";
-      // Data this release cannot read: retrying reproduces it exactly, and
-      // offering Try again is how someone learns the app has nothing for them.
-      const dataIsUnreadable = s.errorCode === "local-data-incompatible";
-      const cannotStart = ["locald-start-failed", "locald-disconnected", "runtime-install-failed"]
-        .includes(s.errorCode);
-      showRecoveryButtons(dataIsUnreadable || cannotStart, dataIsUnreadable);
-      retryBtn.hidden = needsWindowsSetup || needsWindowsRestart || dataIsUnreadable;
+      showRecoveryButtons(screen.showResetData, screen.showFullReinstall);
+      retryBtn.hidden = !screen.showRetry;
       openBtn.hidden = true;
       whisper.classList.remove("on");
       return;
@@ -1165,11 +1157,8 @@
     retryBtn.hidden = false;
     showRecoveryButtons(false, false);
 
-    const voice = VOICE[s.phaseKey] || VOICE.boot;
-    // A snapshot taken before the stop was admitted still says ready. Saying
-    // so here would offer to open a workspace that is being shut down, and
-    // `scheduleReadyOpen` would then take that offer on the user's behalf.
-    if (s.ready && isShuttingDown) {
+    const voice = VOICE[screen.phaseKey] || VOICE.boot;
+    if (screen.screen === "stopping") {
       clearPrimaryBusy();
       say(VOICE.stopping[0]);
       truth.textContent = VOICE.stopping[1];
@@ -1180,20 +1169,20 @@
       bar.style.width = "100%";
       return;
     }
-    if (s.ready) {
+    if (screen.screen === "ready") {
       clearPrimaryBusy();
       hideOperationStatus();
       window.__orb?.awake();
       scene.classList.add("awake");
       say(READY_LINE);
       truth.textContent = VOICE.ready[1];
-      primaryAction = "open";
+      primaryAction = screen.primaryAction;
       openBtn.textContent = "Open Lemma";
-      openBtn.hidden = false;
+      openBtn.hidden = !screen.showOpen;
       whisper.classList.remove("on");
       stopWhispers();
       scheduleReadyOpen();
-    } else if (s.phaseKey === "stopped") {
+    } else if (screen.screen === "stopped") {
       clearTimeout(readyOpenTimer);
       clearPrimaryBusy();
       hideOperationStatus();
@@ -1201,9 +1190,9 @@
       scene.classList.add("awake");
       say(VOICE.stopped[0]);
       truth.textContent = VOICE.stopped[1];
-      primaryAction = "start";
+      primaryAction = screen.primaryAction;
       openBtn.textContent = "Start Lemma";
-      openBtn.hidden = false;
+      openBtn.hidden = !screen.showOpen;
       whisper.classList.remove("on");
     } else {
       if (scene.classList.contains("awake")) {
@@ -1225,13 +1214,9 @@
         : "local services are starting";
     }
 
-    bar.style.width = `${Math.min(100, s.progress || 0)}%`;
-    progressEl.classList.toggle("active", !s.ready && !s.error && s.phaseKey !== "stopped");
-    runinfo.textContent = s.ready
-      ? ""
-      : sawSetup
-        ? "first run · only once"
-        : "quick start";
+    bar.style.width = `${screen.progressWidth}%`;
+    progressEl.classList.toggle("active", screen.progressActive);
+    runinfo.textContent = screen.runInfo;
   }
   function formatEta(seconds) {
     return seconds >= 90 ? `${Math.round(seconds / 60)}m` : `${seconds}s`;
@@ -1282,18 +1267,6 @@
   let diagnosticLog = "";
   let diagnosticCursor = null;
   let logRefreshTimer = null;
-  function diagnosticSourceForState(s) {
-    if (s?.logSource) return s.logSource;
-    const text = `${s?.phaseKey || ""} ${s?.status || ""} ${s?.errorCode || ""}`.toLowerCase();
-    if (text.includes("migration")) return "migrations";
-    if (text.includes("frontend") || text.includes("eaddrinuse")) return "frontend";
-    if (text.includes("backend") || text.includes("health gate")) return "backend";
-    if (text.includes("download") || text.includes("artifact") || text.includes("install")) return "installer";
-    if (text.includes("runtime") || text.includes("container") || text.includes("registry") || text.includes("guest")) {
-      return "vm";
-    }
-    return "events";
-  }
   function renderLog() {
     const live = activeLogSource === "events" ? logLines.join("\n") : "";
     const sections = [diagnosticLog, live].filter(Boolean);

--- a/desktop/ui/screen-state.mjs
+++ b/desktop/ui/screen-state.mjs
@@ -1,0 +1,196 @@
+//! What a daemon snapshot means, decided in one place.
+//
+// `render()` used to be the state machine: a chain of `if`s that each mutated
+// half a dozen elements and returned early, with the screen's identity implied
+// by which branch had run and by CSS classes left on `.scene`. Nothing could
+// ask it what it thought the state was, so nothing tested it -- on the function
+// that decides what every screen shows, and that schedules the move into the
+// workspace.
+//
+// These two functions are the decisions. The copy and the DOM stay in
+// index.html; what moved is the part that has an answer worth checking.
+
+/** The diagnostic logs the shell serves. `read_diagnostic_log` refuses any
+ *  other id, so a source outside this set is an error panel, not a log. */
+export const LOG_SOURCES = [
+  "events",
+  "migrations",
+  "backend",
+  "frontend",
+  "vm",
+  "guest",
+  "locald",
+  "locald-stderr",
+  "agent-host",
+  "installer",
+  "launch",
+];
+
+/** Which log is worth opening while a given phase is running. */
+const PHASE_LOG = {
+  download: "installer",
+  check: "installer",
+  infra: "vm",
+  workspace: "vm",
+  migrations: "migrations",
+  backend: "backend",
+  frontend: "frontend",
+  verify: "backend",
+};
+
+/** Which log explains a given failure. */
+const ERROR_LOG = {
+  "wsl-required": "installer",
+  "wsl-setup-denied": "installer",
+  "wsl-reboot-required": "installer",
+  "runtime-install-failed": "installer",
+  "runtime-prepare-failed": "vm",
+  "runtime-recovery": "vm",
+  "guest-kernel-failed": "vm",
+  "managed-runtime-unavailable": "vm",
+  "managed-runtime-recovery-failed": "vm",
+  "local-data-incompatible": "vm",
+  "local-data-reset-incomplete": "vm",
+  "locald-start-failed": "locald-stderr",
+  "locald-disconnected": "locald",
+};
+
+/** Failures that a retry cannot change, because nothing has changed. */
+const UNRETRYABLE = ["local-data-incompatible"];
+
+/** Failures that mean the stack could not be brought up at all. */
+const CANNOT_START = [
+  "locald-start-failed",
+  "locald-disconnected",
+  "runtime-install-failed",
+];
+
+const NEEDS_WINDOWS_SETUP = ["wsl-required", "wsl-setup-denied"];
+
+/**
+ * The diagnostic log to open for this state.
+ *
+ * The daemon names one in its phase and error events, and that is the answer
+ * whenever it is a log the shell serves -- it saw the raw failure, before
+ * anything reshaped it for a person to read.
+ *
+ * The fallback used to be a second guess made from the same words after they
+ * had been reshaped: `phaseKey`, `status` and `errorCode` joined together and
+ * searched for "migration", "frontend", "download", "container". Both keys are
+ * enumerated values, so there is nothing to guess -- and matching prose meant
+ * an error whose *message* happened to say "install" chose the installer log
+ * over the one that recorded the failure.
+ *
+ * Anything unrecognised is the events log, which always exists.
+ */
+export function diagnosticSourceForState(state, served = LOG_SOURCES) {
+  const named = state?.logSource;
+  if (named && served.includes(named)) return named;
+  const byError = ERROR_LOG[state?.errorCode];
+  if (byError && served.includes(byError)) return byError;
+  const byPhase = PHASE_LOG[state?.phaseKey];
+  if (byPhase && served.includes(byPhase)) return byPhase;
+  return "events";
+}
+
+/**
+ * Which screen a snapshot means, and what the screen offers.
+ *
+ * `context` carries the three things that are not in the snapshot: the phase
+ * last seen (a state with no phase is still a state), whether this run has ever
+ * been a first setup, and whether the user has asked to stop.
+ */
+export function deriveScreen(state, context = {}) {
+  const { lastPhase = "boot", sawSetup = false, isShuttingDown = false } = context;
+  const phaseKey = state?.phaseKey || lastPhase || "boot";
+  const setup = sawSetup || Boolean(state?.setup);
+  const base = {
+    phaseKey,
+    sawSetup: setup,
+    logSource: diagnosticSourceForState(state),
+    errorDetail: "",
+    showOpen: false,
+    showRetry: false,
+    showPrepareWindows: false,
+    showResetData: false,
+    showFullReinstall: false,
+    primaryAction: null,
+    progressActive: false,
+    progressWidth: Math.min(100, state?.progress || 0),
+    runInfo: setup ? "first run · only once" : "quick start",
+  };
+
+  // Before anything else: a user who has not chosen a mode is shown the
+  // choice, not an empty screen behind a phase they never asked for.
+  if (state?.mode === "undecided") {
+    return { ...base, screen: "choosing", orb: "resume", whispers: "idle" };
+  }
+
+  if (state?.error) {
+    const code = state.errorCode;
+    const windowsSetup = NEEDS_WINDOWS_SETUP.includes(code);
+    const windowsRestart = code === "wsl-reboot-required";
+    const unreadable = UNRETRYABLE.includes(code);
+    return {
+      ...base,
+      screen: "error",
+      windowsSetup,
+      windowsRestart,
+      errorDetail: state.status || "startup failed",
+      // Retrying an unreadable data directory reproduces it exactly, and
+      // offering Try again is how somebody learns the app has nothing for them.
+      showRetry: !windowsSetup && !windowsRestart && !unreadable,
+      showPrepareWindows: windowsSetup,
+      showResetData: unreadable || CANNOT_START.includes(code),
+      showFullReinstall: unreadable,
+      orb: "stall",
+      whispers: "idle",
+    };
+  }
+
+  // A snapshot taken before the stop was admitted still says ready. Acting on
+  // it would offer to open a workspace that is being shut down -- and the
+  // splash takes that offer on the user's behalf after a moment.
+  if (state?.ready && isShuttingDown) {
+    return {
+      ...base,
+      screen: "stopping",
+      orb: "resume",
+      whispers: "stop",
+      progressActive: true,
+      progressWidth: 100,
+    };
+  }
+
+  if (state?.ready) {
+    return {
+      ...base,
+      screen: "ready",
+      showOpen: true,
+      primaryAction: "open",
+      orb: "awake",
+      whispers: "stop",
+      runInfo: "",
+    };
+  }
+
+  if (phaseKey === "stopped") {
+    return {
+      ...base,
+      screen: "stopped",
+      showOpen: true,
+      primaryAction: "start",
+      orb: "resume",
+      whispers: "idle",
+    };
+  }
+
+  return {
+    ...base,
+    screen: "working",
+    showRetry: true,
+    orb: "resume",
+    whispers: "run",
+    progressActive: true,
+  };
+}

--- a/lemma-frontend/components/app/app-launch.test.tsx
+++ b/lemma-frontend/components/app/app-launch.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { AppFrame } from './app-launch';
+
+const APP_URL = 'https://notes--r3.apps.lemma.localhost/';
+
+/**
+ * The frame is the only part of this that can fail invisibly.
+ *
+ * On macOS the desktop app serves the workspace from `*.localhost` and an app
+ * from its own `*.localhost` host, which WebKit treats as cross-site: the frame
+ * gets no cookies, the app loads permanently signed out, and its SDK refreshes
+ * for ever trying to fix it. Nothing errors. The user sees a spinner that never
+ * resolves, and there is no console message that says why.
+ *
+ * So the interesting assertion is a *negative* one — that no iframe is rendered
+ * at all — and it depends on globals that only exist in a browser. Hence the
+ * environment above; the rest of this suite is node-only on purpose.
+ */
+function renderFrame() {
+    const client = new QueryClient({
+        defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false } },
+    });
+    return render(
+        <QueryClientProvider client={client}>
+            <AppFrame podId="pod-1" appId="app-1" appName="Notes" title="Notes" url={APP_URL} />
+        </QueryClientProvider>,
+    );
+}
+
+/** jsdom's own location, put back after a test replaces it. */
+const REAL_LOCATION = Object.getOwnPropertyDescriptor(window, 'location')!;
+
+/** Serve the workspace from the host the desktop app serves it from. */
+function onLocalhostSubdomain() {
+    Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: { ...window.location, hostname: 'lemma.localhost', href: 'https://lemma.localhost/' },
+    });
+}
+
+function inDesktopApp(platform?: string) {
+    (window as unknown as Record<string, unknown>).__LEMMA_DESKTOP__ = platform
+        ? { platform }
+        : {};
+}
+
+afterEach(() => {
+    cleanup();
+    delete (window as unknown as Record<string, unknown>).__LEMMA_DESKTOP__;
+    Object.defineProperty(window, 'location', REAL_LOCATION);
+});
+
+describe('AppFrame', () => {
+    it('renders the app in a frame in an ordinary browser', () => {
+        renderFrame();
+
+        const frame = document.querySelector('iframe');
+        expect(frame).not.toBeNull();
+        expect(frame?.getAttribute('src')).toBe(APP_URL);
+    });
+
+    /**
+     * The sandbox is the app's containment, and every token in it was chosen.
+     * `allow-same-origin` is what gives the app its own storage; dropping
+     * `allow-top-navigation-by-user-activation` for the unqualified form would
+     * let an app navigate the workspace out from under the user.
+     */
+    it('contains the app with the sandbox it was given', () => {
+        renderFrame();
+        const sandbox = document.querySelector('iframe')?.getAttribute('sandbox') ?? '';
+
+        for (const token of [
+            'allow-same-origin',
+            'allow-scripts',
+            'allow-forms',
+            'allow-popups',
+            'allow-downloads',
+            'allow-modals',
+            'allow-top-navigation-by-user-activation',
+        ]) {
+            expect(sandbox.split(' ')).toContain(token);
+        }
+        expect(sandbox.split(' ')).not.toContain('allow-top-navigation');
+        expect(document.querySelector('iframe')?.getAttribute('referrerPolicy'))
+            .toBe('strict-origin-when-cross-origin');
+    });
+
+    /**
+     * The failure this component exists to avoid. No frame at all is the fix:
+     * the shell routes an app URL opened in a new window to its own window,
+     * where the page is first-party and the session works.
+     */
+    it('offers a window instead of a frame where the frame would have no session', () => {
+        onLocalhostSubdomain();
+        inDesktopApp('macos');
+
+        renderFrame();
+
+        expect(document.querySelector('iframe')).toBeNull();
+        expect(screen.getByText('This app opens in its own window.')).toBeTruthy();
+        const link = screen.getByRole('link', { name: /Open app/ });
+        // The marker is what tells the shell this is an app being opened rather
+        // than an arbitrary link, so a bare href would open it in a browser.
+        expect(link.getAttribute('href')).toContain('#');
+        expect(link.getAttribute('href')?.startsWith(APP_URL)).toBe(true);
+        expect(link.getAttribute('target')).toBe('_blank');
+        expect(link.getAttribute('rel')).toBe('noreferrer');
+    });
+
+    /**
+     * Windows keeps its frame: WebView2 treats `*.localhost` as same-site, so
+     * the cookie reaches the app and there is nothing to work around. Costing
+     * Windows users a window for a WebKit problem would be a real regression.
+     */
+    it('keeps the frame in the desktop app on Windows', () => {
+        onLocalhostSubdomain();
+        inDesktopApp('windows');
+
+        renderFrame();
+
+        expect(document.querySelector('iframe')).not.toBeNull();
+    });
+
+    /**
+     * A shell too old to say which platform it is. locald serves a frontend
+     * pack that updates independently of the shell, so a newer pack can run
+     * inside a shell that never injected `platform`. Assuming the permissive
+     * case brings back the signed-out frame that retries for ever; assuming the
+     * restrictive one costs a window.
+     */
+    it('assumes the restrictive case when the shell does not say what it is', () => {
+        onLocalhostSubdomain();
+        inDesktopApp();
+
+        renderFrame();
+
+        expect(document.querySelector('iframe')).toBeNull();
+    });
+});

--- a/lemma-frontend/lib/desktop/local-deployment.test.ts
+++ b/lemma-frontend/lib/desktop/local-deployment.test.ts
@@ -1,5 +1,7 @@
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
 
 const source = (path: string) =>
     readFileSync(new URL(`../../${path}`, import.meta.url), "utf8");
@@ -53,19 +55,105 @@ describe("local deployments never serve the landing page", () => {
  * computer, inside the desktop app. `useSyncExternalStore` gives React a server
  * snapshot it knows to reconcile and a client snapshot that is actually true.
  */
-describe("desktop bridge detection", () => {
-    it("is read through a store rather than called during render", () => {
-        const capabilities = source("lib/desktop/local-capabilities.ts");
+/**
+ * Run `work` with `window` and the deployment set as given, then put the
+ * globals back.
+ *
+ * Modules are reset around each one: `local-capabilities` and what it imports
+ * read both at module scope, so a cached copy answers for whatever the last
+ * test set. A `location` is supplied because a transitive import reads
+ * `window.location.hostname` while it is being evaluated.
+ */
+async function withEnvironment<T>(
+    { deployment, windowValue }: { deployment?: string; windowValue?: object },
+    work: () => Promise<T>,
+): Promise<T> {
+    const globals = globalThis as Record<string, unknown>;
+    const previousWindow = globals.window;
+    const previousDeployment = process.env.NEXT_PUBLIC_LEMMA_DEPLOYMENT;
+    const restore = (key: string, value: string | undefined) => {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+    };
+    if (windowValue === undefined) delete globals.window;
+    else globals.window = { location: { hostname: "lemma.local", port: "" }, ...windowValue };
+    restore("NEXT_PUBLIC_LEMMA_DEPLOYMENT", deployment);
+    vi.resetModules();
+    try {
+        return await work();
+    } finally {
+        if (previousWindow === undefined) delete globals.window;
+        else globals.window = previousWindow;
+        restore("NEXT_PUBLIC_LEMMA_DEPLOYMENT", previousDeployment);
+        vi.resetModules();
+    }
+}
 
-        expect(capabilities).toContain("useSyncExternalStore");
-        expect(capabilities).toMatch(/export function useDesktopBridge\(\)/);
+const SHELL = { __TAURI__: { core: { invoke: () => undefined } } };
+
+describe("desktop bridge detection", () => {
+    /**
+     * The server render is what the user reads first, and on the server the
+     * answer has to be "not in the desktop app" whatever the globals say —
+     * otherwise React reconciles a mismatch and, in between, the user is
+     * looking at HTML that contradicts where they are sitting.
+     *
+     * Rendered rather than read: `useSyncExternalStore`'s third argument is the
+     * only thing that makes this true, and its presence in the source says
+     * nothing about what it returns.
+     */
+    it("renders as unavailable on the server even inside the desktop app", async () => {
+        await withEnvironment({ deployment: "local", windowValue: SHELL }, async () => {
+            const { useDesktopBridge } = await import("./local-capabilities");
+            const Probe = () => createElement("p", null, String(useDesktopBridge()));
+
+            expect(renderToString(createElement(Probe))).toBe("<p>false</p>");
+        });
     });
 
+    /**
+     * The non-reactive form is for event handlers, where there is no server
+     * render to get wrong — and it has to be safe to call with no `window` at
+     * all, because a module that imports it is evaluated on the server too.
+     */
+    it("answers false with no window rather than throwing", async () => {
+        await withEnvironment({ deployment: "local" }, async () => {
+            const { desktopBridgeAvailable } = await import("./local-capabilities");
+
+            expect(desktopBridgeAvailable()).toBe(false);
+        });
+    });
+
+    /**
+     * Both halves are required, and each is false on its own: a LAN browser
+     * pointed at a local install has the deployment and no shell, and a desktop
+     * window showing a cloud workspace has the shell and no local stack.
+     */
+    it("requires both a local deployment and a reachable shell", async () => {
+        const cases: Array<[string | undefined, object, boolean]> = [
+            ["local", SHELL, true],
+            ["local", {}, false],
+            [undefined, SHELL, false],
+            ["cloud", SHELL, false],
+        ];
+        for (const [deployment, windowValue, expected] of cases) {
+            await withEnvironment({ deployment, windowValue }, async () => {
+                const { desktopBridgeAvailable } = await import("./local-capabilities");
+
+                expect(desktopBridgeAvailable(), `${deployment} / ${JSON.stringify(windowValue)}`)
+                    .toBe(expected);
+            });
+        }
+    });
+
+    /**
+     * The steps that gate on it must use the hook, not the bare function. This
+     * one stays a source contract on purpose: what it guards is a *call site*,
+     * and a call site's absence cannot be observed by calling anything.
+     */
     it("is not called during render by the steps that gate on it", () => {
         const steps = source("components/onboarding/local-setup-steps.tsx");
 
-        // The hook, never the bare function: the bare one is for event
-        // handlers, where there is no server render to get wrong.
         expect(steps).toContain("useDesktopBridge()");
         expect(steps).not.toContain("desktopBridgeAvailable()");
     });


### PR DESCRIPTION
## What changes

**A real defect first.** Every startup failure carries a diagnostic log id, and
the shell serves eleven of them. `error_diagnostic_source` answered
`"infrastructure"`, which is not one — `read_diagnostic_log` refuses an id it
has no file for, so a crashed guest kernel, or anything mentioning a container,
a registry or the guest, opened the log panel onto an error instead of a log.
Those are the failures a person opens the log *for*.

It answers `vm` now (`logs/runtime.log`, where all of them are recorded). The
two halves of that contract compile into different binaries, so a test puts them
in the same room: it asks locald what it would name for each message it branches
on, and checks the shell serves it.

**UI-9 — the splash made the same decision a second time, worse.** `render`
trusted whatever the daemon named, and otherwise guessed from prose:
`phaseKey`, `status` and `errorCode` joined together and searched for
"migration", "download", "container" — after the message had been reshaped for
display. An error whose status happened to say "install" chose the installer log
over the one that recorded the failure. Both keys are enumerated values, so
there is nothing to guess; and an id the shell cannot serve is no longer passed
through, so a daemon that names one gets the events log rather than an error
panel.

`render` was also the state machine: a chain of `if`s each mutating half a dozen
elements and returning early, with the screen's identity implied by which branch
had run and by classes left on `.scene`. Nothing could ask it what it thought
the state was, so nothing tested it — on the function that decides what every
screen shows, and the only thing that schedules the move into the workspace. The
decisions are now `deriveScreen` in `ui/screen-state.mjs`; the copy and the DOM
stayed in `index.html`.

**Three splash tests were passing on things that are not true.** The journey
that checks the log panel opens on the right log omitted `logSource`, which the
daemon always sends — so it was exercising the fallback and asserting the
guess's answer. It sends it now, and two new journeys cover the fallback and an
id the shell cannot serve.

And the browser harness served every extension it did not recognise as
`application/octet-stream`, which a browser *refuses* for a module or a
stylesheet. A new module arrived as four assertions timing out with nothing
saying why. It mirrors what the app serves now (Tauri derives the type from the
extension; `.mjs` is `text/javascript` there), and an unknown extension is an
error rather than bytes — which also means `control.css` has been reaching the
settings tests as a stylesheet only since this commit.

**FE-6 — `AppFrame` had no tests.** Its interesting behaviour is a negative one:
on macOS the app frame is cross-site, gets no cookies, and loads permanently
signed out while its SDK refreshes for ever. Nothing errors; the user sees a
spinner that never resolves. So the only correct rendering is *no frame*, and
asserting that needs a browser — five tests under a per-file jsdom environment,
covering the frame, its sandbox, the macOS case, Windows (which keeps its
frame), and a shell too old to say which it is.

**FE-7 — the desktop-bridge tests read their own source** for the word
`useSyncExternalStore`. They render now: the server snapshot must be `false`
even with the shell's globals present, which is the hydration mismatch the hook
exists to avoid. The one that guards a *call site* stays a source contract, and
says why.

UI-11 and UI-12 turned out to be already fixed in the tree; they are marked
verified, not changed.

## Why

From the desktop production-readiness register (UI-9, FE-6, FE-7). The log
source was found while doing UI-9 and is the reason this is a defect fix rather
than a refactor.

## How to verify

```bash
make desktop-check
```

Passed locally (`EXIT=0`): 196 desktop tests, 15 splash journeys, 76 script
tests. Frontend: `npx vitest run lib/desktop components/app` — 81 passed;
`npm run typecheck` and `eslint` clean.

Each new guard was checked against the code it replaces:

- `every_log_source_the_daemon_names_is_one_the_shell_serves` — fails on the old
  `"infrastructure"`, naming the message and listing what is served.
- `screen-state.test.mjs` (15) — the log-source cases fail on the substring
  guess; `every snapshot resolves to a screen` covers the null/undefined/empty
  cases the old chain could fall through.
- `AppFrame` — flipping `crossSiteFramesCarryCookies` to permissive fails two;
  dropping `-by-user-activation` from the sandbox fails one.
- `renders as unavailable on the server` — fails when the server snapshot is
  changed to read the live value (`<p>true</p>` vs `<p>false</p>`).

`daemon/tests.rs` was at 601 lines after a comment, so the four
error-classification tests moved to `daemon/error_classification_tests.rs` under
DES-09.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — the frame's sandbox and referrer policy are unchanged and
      now asserted. `lemma-locald` is a **dev**-dependency of the desktop crate,
      for the cross-binary test only; nothing is linked into the shipped app.
- [x] **Rollback** — revert cleanly; no state, schema or on-disk format changes.

## Compatibility and rollback notes

The splash's main script became `type="module"` so the decisions could live in
one. Tauri serves `.mjs` as `text/javascript`, and the page already used a
dynamic `import()` for the orb.

`error_diagnostic_source`'s second return value changes for two branches. Its
first value, the component label, is unchanged, and the only reader of the
second is the shell's log panel.
