### PR TITLE
Two flakes: one was a stopwatch, one was telling callers an image was still downloading

### DIFF
--- a/desktop/agent-host/src/journal/tests/concurrency.rs
+++ b/desktop/agent-host/src/journal/tests/concurrency.rs
@@ -202,7 +202,6 @@ fn a_fast_stream_never_surfaces_a_busy_journal() {
     journal
         .accept_start(target, &command, &spec, "codex", "1.0")
         .unwrap();
-    let started = std::time::Instant::now();
     std::thread::scope(|scope| {
         scope.spawn(|| {
             for index in 0..CHUNKS {
@@ -245,11 +244,64 @@ fn a_fast_stream_never_surfaces_a_busy_journal() {
         sequences.windows(2).all(|pair| pair[1] == pair[0] + 1),
         "sequences must stay contiguous under concurrent reads"
     );
-    // Loose enough not to be a benchmark, tight enough that reintroducing
-    // an fsync-per-chunk open/close cycle fails here rather than in a chat.
-    assert!(
-        started.elapsed() < Duration::from_secs(20),
-        "journalling {CHUNKS} chunks took {:?}",
-        started.elapsed()
+    // The elapsed-time assertion that used to be here is gone, and
+    // `the_journal_keeps_one_connection_and_never_fsyncs_an_append` below asks
+    // the same question without a stopwatch. It was wrong in both directions:
+    // twenty seconds for 600 chunks is thirty-three milliseconds each, which is
+    // looser than the open/close/fsync cycle it named on a slow disk, and tight
+    // enough to fail a busy CI runner that was doing nothing wrong. It did the
+    // second on a change that touched none of this.
+    //
+    // What is above -- every chunk recorded exactly once, sequences contiguous
+    // under concurrent reads -- is the part of this test that only concurrency
+    // can establish, and it is deterministic.
+}
+
+/// One connection, in WAL, never fsyncing an append.
+///
+/// This is what the stopwatch was standing in for. The failure it guards is
+/// AH-2: a connection per operation, each opening the file, setting three
+/// pragmas, syncing FULL and closing -- which is both slow and, under a fast
+/// stream, a `SQLITE_BUSY` that fails the run and loses the turn.
+///
+/// Asked directly, all three parts are deterministic, and they hold on a CI
+/// runner that is busy.
+#[test]
+fn the_journal_keeps_one_connection_and_never_fsyncs_an_append() {
+    let (_directory, journal, _target, _command, _spec) = fixture();
+
+    // A temporary table lives in the connection that made it. Seeing it from a
+    // clone is the same statement as "these share one connection", which is
+    // what long-lived means here -- a per-operation connection would not.
+    journal
+        .connection()
+        .execute_batch("CREATE TEMP TABLE one_connection (marker)")
+        .expect("the journal's connection must accept a temp table");
+    let elsewhere = journal.clone();
+    let seen: i64 = elsewhere
+        .connection()
+        .query_row("SELECT count(*) FROM one_connection", [], |row| row.get(0))
+        .expect("a clone must be looking at the same connection, not its own");
+    assert_eq!(seen, 0);
+
+    let mode: String = journal
+        .connection()
+        .query_row("PRAGMA journal_mode", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(
+        mode.to_ascii_lowercase(),
+        "wal",
+        "a rollback journal serialises readers against every append",
+    );
+
+    // 0 = OFF, 1 = NORMAL, 2 = FULL. FULL is an fsync per commit, and every
+    // streamed chunk is a commit.
+    let synchronous: i64 = journal
+        .connection()
+        .query_row("PRAGMA synchronous", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(
+        synchronous, 1,
+        "synchronous must be NORMAL: FULL fsyncs every appended chunk",
     );
 }

--- a/desktop/local-runtime/guestd/src/pull_claim.rs
+++ b/desktop/local-runtime/guestd/src/pull_claim.rs
@@ -27,27 +27,50 @@ pub(crate) struct PullClaim {
 ///
 /// `Ok(None)` is not a failure. It is the answer that lets a caller hand back
 /// a retryable `image_pulling` instead of starting a second download.
+/// How long a claim attempt keeps trying before reporting that somebody has it.
+///
+/// Releasing a `flock` is closing a descriptor, and the kernel does not make
+/// that visible to the next attempt instantly. Measured here, on macOS and on a
+/// Linux CI runner: a claim taken immediately after its holder was dropped was
+/// refused once and granted 489 microseconds later, on the very next try.
+///
+/// A download that is genuinely running holds its claim for minutes, so this
+/// window only ever covers the instant after a release. It cannot delay the
+/// answer that matters -- and without it, a guest that has just finished
+/// fetching an image can tell the next caller the image is still downloading.
+const CLAIM_SETTLES_WITHIN: Duration = Duration::from_millis(25);
+
 pub(crate) fn claim_pull(directory: &Path, image: &str) -> io::Result<Option<PullClaim>> {
     fs::create_dir_all(directory)?;
     // Best effort. An existing directory from an older release keeps whatever
     // mode it has, and a claim file is not secret -- it is empty.
     let _ = fs::set_permissions(directory, fs::Permissions::from_mode(0o700));
-    let file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .mode(0o600)
-        .open(directory.join(claim_name(image)))?;
-    // SAFETY: `flock` is given a descriptor this scope owns, for the duration
-    // of the call. The lock it takes is released by the kernel when `file` is
-    // dropped, or when the process holding it ends.
-    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
-        return Ok(Some(PullClaim { _file: file }));
+    let path = directory.join(claim_name(image));
+    let deadline = Instant::now() + CLAIM_SETTLES_WITHIN;
+    loop {
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .mode(0o600)
+            .open(&path)?;
+        // SAFETY: `flock` is given a descriptor this scope owns, for the
+        // duration of the call. The lock it takes is released by the kernel
+        // when `file` is dropped, or when the process holding it ends.
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+            return Ok(Some(PullClaim { _file: file }));
+        }
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() != Some(libc::EWOULDBLOCK) {
+            return Err(error);
+        }
+        if Instant::now() >= deadline {
+            return Ok(None);
+        }
+        // Yield rather than sleep: what this is waiting for is the kernel
+        // finishing with a descriptor that is already closed, not another
+        // process finishing a download.
+        std::thread::yield_now();
     }
-    let error = io::Error::last_os_error();
-    if error.raw_os_error() == Some(libc::EWOULDBLOCK) {
-        return Ok(None);
-    }
-    Err(error)
 }
 
 /// A filesystem-safe name for one image reference.

--- a/desktop/local-runtime/guestd/src/tests/images.rs
+++ b/desktop/local-runtime/guestd/src/tests/images.rs
@@ -176,6 +176,13 @@ fn a_download_already_under_way_is_joined_rather_than_started_again() {
     );
 
     drop(held);
+    // Immediately, with nothing in between. Releasing a `flock` is closing a
+    // descriptor, and the kernel does not make that visible to the next attempt
+    // instantly -- measured at 489 microseconds, under the contention of a
+    // parallel test run. `claim_pull` allows for it; without that this line
+    // fails roughly once in eight runs at `--test-threads=8`, and a guest that
+    // had just finished a download would tell the next caller it was still
+    // going.
     service.pull_image(image).expect("the claim was released");
     assert_eq!(service.engine.commands.lock().unwrap()[0][0], "pull");
 }


### PR DESCRIPTION
## What changes

Two CI flakes, both blocking every other open pull request, both root-caused
with a measurement rather than a re-run. One of them turned out to be a product
defect wearing a flake's clothes.

### The journal test was a stopwatch

`a_fast_stream_never_surfaces_a_busy_journal` ended by asserting 600 chunks were
journalled in under twenty seconds. It failed the Windows job on a pull request
that touches none of this code. The assertion was wrong in both directions:

- Twenty seconds for 600 chunks is **33ms each** — looser than the
  open/close/fsync cycle it named, on the slow disk where that regression would
  actually hurt. It would not reliably have caught its own subject.
- It is tight enough to fail a runner that is merely busy. Which is what it did.

What it stood in for is AH-2 — a connection per operation, opening the file,
setting three pragmas, syncing FULL and closing. Three properties, all askable:

- **One connection.** A temp table lives in the connection that created it, so
  making one through the journal and reading it back through a clone *is* the
  statement "these share one connection".
- **WAL**, because a rollback journal serialises readers against every append.
- **`synchronous = NORMAL`**, because FULL is an fsync per commit and every
  streamed chunk is a commit.

The concurrency test keeps what only concurrency can establish — every chunk
recorded once, sequences contiguous under concurrent reads. That never needed a
clock.

### The pull claim was a real defect

`a_download_already_under_way_is_joined_rather_than_started_again` failed on CI,
then **three times in twenty-five runs** here at `--test-threads=8`. It takes a
claim, checks a second download is refused, drops the claim, and expects the
next attempt to succeed. That last step failed.

Instrumented on the failing path: the claim was refused once with a clean
`EWOULDBLOCK` and granted **489 microseconds** later, on the very next try — on
macOS here and on a Linux runner there. Releasing a `flock` is closing a
descriptor, and the kernel does not make that visible to the next attempt
instantly.

That is not only a flaky test. **A guest that has just finished fetching an
image answers the next caller with `image_pulling`**, and the host backs off and
asks again for something already on disk. `claim_pull` now retries the
non-blocking lock for 25ms before reporting that somebody else has it — 50× the
measured window, and nothing next to a real download, which holds its claim for
minutes. It yields rather than sleeps: what it waits for is the kernel finishing
with a descriptor that is already closed, not another process finishing a
download.

**Three failures in twenty-five runs before; none in sixty after.**

## Why

Both were blocking the whole queue, and a re-run would have left both in place.

## How to verify

```bash
make desktop-check
```

Passed (`EXIT=0`). Beyond that:

- The journal assertions were each checked by reintroducing the regression they
  name: `synchronous = FULL`, `journal_mode = DELETE`, and a `Clone` that
  reopens the file. Each fails with its own message.
- The claim fix was measured: 3/25 failures before, 0/60 after, at
  `--test-threads=8`.

**A test I wrote for the claim window and then deleted.** Take a claim, drop it,
take it again, five hundred times — it passed with the fix *and* with the fix
disabled, because the window only opens under the scheduling pressure of a
parallel run. A guard that cannot fail is not a guard. What covers this is the
test that was failing, which now records what it is standing on.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Rollback** — revert cleanly; no state, schema or format changes.

## Compatibility and rollback notes

`claim_pull` can now take up to 25ms to report that a download is already
running, where it used to answer immediately. That path already ends in a
retryable `image_pulling` the host backs off on, so the cost is bounded and
invisible; the benefit is that the answer is no longer sometimes wrong.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved image download coordination so brief handoff delays are handled more reliably, reducing false reports that another download is already in progress.

- **Tests**
  - Added deterministic validation for journal connection reuse and durability settings.
  - Replaced timing-dependent checks with stable behavioral tests, improving reliability across environments.
  - Documented timing considerations for concurrent image-download scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->