### PR TITLE
The run spec is one payload in two languages, and nothing compared them

### DIFF
--- a/desktop/agent-host/src/adapters/cache.rs
+++ b/desktop/agent-host/src/adapters/cache.rs
@@ -1,4 +1,19 @@
 //! Installing an adapter into the cache, and verifying what is there.
+//!
+//! Downloaded on first run rather than shipped inside the app, which is a
+//! decision rather than an omission. Bundling the two npm adapters would add
+//! about 67 MB to every installer, and a real no-Node path would mean shipping
+//! Node itself on top of that -- roughly doubling it -- to serve a machine
+//! that either has no Node at all or cannot reach the registry. The app
+//! already downloads on first run, so an adapter is nothing new in kind, and
+//! the size is paid by everyone to spare an edge case.
+//!
+//! What that trade needs in exchange is a failure that says so, and the path
+//! is bounded at both ends: `npm` runs under a 300-second cap that kills the
+//! process tree, and whatever went wrong is recorded per adapter in
+//! `install_failures`, which `snapshot_for` turns into a named cause instead
+//! of a "Setting up, usually under a minute" that never ends. `doctor
+//! --repair` is the retry.
 
 use super::{
     AdapterManifest, AdapterSpec, Cancellation, Command, Digest, Duration, Mutex, Path, PathBuf,

--- a/desktop/agent-host/tests/fixtures/wire_contract.json
+++ b/desktop/agent-host/tests/fixtures/wire_contract.json
@@ -220,5 +220,26 @@
     "_why": "Bounds the backend enforces on the wire. A host that exceeds one of these does not degrade: an over-long object_id gets its batch refused and the transcript discarded, and an over-large max_runs makes every poll 422 so the host reports itself offline for ever.",
     "object_id_max_length": 255,
     "max_runs": 128
+  },
+  "run_spec": {
+    "_why": "The START_RUN payload is a run spec in two languages, and only one of them declares every field. `mcp` is on the wire but is deliberately not a field of the Python model: it rests in the command row as `encrypted_mcp` and `_wire_command` decrypts it into `mcp` as the command is handed to the host, so a model field would be somewhere a run-scoped credential could be persisted in plaintext. Nothing tied the two field lists together, which made that deliberate absence indistinguishable from a field somebody forgot -- and made adding a field on one side and not the other invisible until a run behaved oddly.",
+    "fields": [
+      "agent_run_id",
+      "conversation_id",
+      "harness_id",
+      "profile_revision",
+      "model_name",
+      "config_selections",
+      "system_prompt",
+      "prompt",
+      "resume_session_id",
+      "workspace_cwd",
+      "context",
+      "run_deadline",
+      "system_prompt_delivery"
+    ],
+    "added_on_delivery": {
+      "mcp": "Run-scoped Lemma MCP configuration, decrypted from `encrypted_mcp` by AgentHostDispatchRepository._wire_command when the command is delivered."
+    }
   }
 }

--- a/desktop/agent-host/tests/wire_contract.rs
+++ b/desktop/agent-host/tests/wire_contract.rs
@@ -3,13 +3,16 @@
 //! `lemma-backend` asserts the same file from Python. Neither side can move
 //! alone: the enum has to name the same events, and the two text extractors
 //! have to agree character for character, because the host accumulates streamed
-//! text with one and the backend re-accumulates it with the other.
+//! text with one and the backend re-accumulates it with the other. The run
+//! spec is the third: both sides declare its fields, and only the fixture says
+//! which of them the backend adds as it hands the command over.
 
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 
-use lemma_agent_host::protocol::EventType;
+use lemma_agent_host::protocol::{EventType, JsonMap, RunSpec};
 use serde_json::Value;
+use uuid::Uuid;
 
 fn contract() -> Value {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/wire_contract.json");
@@ -218,4 +221,75 @@ fn the_protocol_version_is_the_one_the_backend_expects() {
         "PROTOCOL_VERSION and the shared contract disagree; the backend reads \
          the contract's number, so raise both or neither",
     );
+}
+
+/// The two `RunSpec` declarations, which only one side states in full.
+///
+/// The `START_RUN` payload is a run spec in two languages. Every field but one
+/// is declared on both; `mcp` is declared only here, because on the backend it
+/// rests in the command row as `encrypted_mcp` and is decrypted into `mcp` by
+/// `AgentHostDispatchRepository._wire_command` on the way out. A Python model
+/// field would be somewhere for a run-scoped credential to sit in plaintext,
+/// so its absence is deliberate -- and was indistinguishable from drift until
+/// this recorded which fields each side is supposed to have.
+///
+/// This half can only assert the union: `mcp` is a field of this struct whether
+/// the contract calls it shared or added on delivery. Which side of that line a
+/// field falls on is the Python half's to check, because it is the one that can
+/// see the model `mcp` is deliberately missing from.
+#[test]
+fn the_run_spec_carries_the_fields_the_contract_names() {
+    let contract = contract();
+    let run_spec = &contract["run_spec"];
+
+    let shared = run_spec["fields"]
+        .as_array()
+        .expect("run_spec.fields is a list")
+        .iter()
+        .map(|value| value.as_str().expect("a field name is a string").to_owned())
+        .collect::<BTreeSet<_>>();
+    let on_delivery = run_spec["added_on_delivery"]
+        .as_object()
+        .expect("run_spec.added_on_delivery is an object")
+        .keys()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    let ours = serde_json::to_value(sample_run_spec())
+        .expect("a run spec serializes")
+        .as_object()
+        .expect("as an object")
+        .keys()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(
+        ours,
+        shared.union(&on_delivery).cloned().collect::<BTreeSet<_>>(),
+        "this side's run spec and the contract name different fields"
+    );
+    assert!(
+        shared.is_disjoint(&on_delivery),
+        "a field cannot be both declared on both sides and added on delivery"
+    );
+}
+
+/// Every field set, so serialization cannot omit one and pass.
+fn sample_run_spec() -> RunSpec {
+    RunSpec {
+        agent_run_id: Uuid::nil(),
+        conversation_id: Uuid::nil(),
+        harness_id: Uuid::nil(),
+        profile_revision: "r1".to_owned(),
+        model_name: Some("m".to_owned()),
+        config_selections: JsonMap::new(),
+        system_prompt: "s".to_owned(),
+        prompt: vec![serde_json::json!({"type": "text", "text": "hello"})],
+        resume_session_id: Some("session".to_owned()),
+        workspace_cwd: Some("project".to_owned()),
+        context: JsonMap::new(),
+        mcp: serde_json::json!({}),
+        run_deadline: chrono::Utc::now(),
+        system_prompt_delivery: Some("NEW_SESSION_ONLY".to_owned()),
+    }
 }

--- a/lemma-backend/app/modules/agent/tests/unit/test_agent_host_wire_contract.py
+++ b/lemma-backend/app/modules/agent/tests/unit/test_agent_host_wire_contract.py
@@ -9,7 +9,11 @@ twice across the two languages and nothing used to check that the copies agree:
   and this process re-accumulates it with the other, reconciling the two
   buffers at every segment boundary. A disagreement raises nothing. It
   silently truncates a persisted message, which is precisely how the
-  seal-and-clear bug in ``Segment`` stayed invisible.
+  seal-and-clear bug in ``Segment`` stayed invisible;
+* the ``RunSpec`` field list — a field added on one side and not the other is
+  either a spec the host silently ignores or one this process cannot see, and
+  the fixture is also where ``mcp``'s deliberate absence from this side is
+  written down so nobody closes the gap by declaring it here.
 """
 
 from __future__ import annotations
@@ -25,6 +29,7 @@ from app.modules.agent.domain.agent_host import (
     AgentHostCapacity,
     AgentHostEvent,
     AgentHostEventType,
+    AgentHostRunSpec,
 )
 from app.modules.agent.domain.value_objects import AgentEventType, MessageKind
 from app.modules.agent.infrastructure.harnesses.agent_host.events import (
@@ -161,3 +166,28 @@ def test_the_protocol_version_is_the_one_the_host_sends() -> None:
     nothing failing on either side to say so.
     """
     assert AGENT_HOST_PROTOCOL_VERSION == _contract()["protocol_version"]
+
+
+def test_the_run_spec_declares_the_fields_the_contract_names() -> None:
+    """The run spec is one payload in two languages, and this side omits a field.
+
+    ``mcp`` is on the wire -- ``_wire_command`` decrypts ``encrypted_mcp`` into
+    it as the command is handed to the host -- but it is deliberately not a
+    field of this model. A model field is a place the plaintext could be
+    persisted back into the command row, which is the one thing encrypting it
+    at rest exists to prevent. Every other field is declared on both sides, and
+    nothing tied the two lists together: adding a field here and not in
+    ``protocol.rs`` gives the host a spec it silently ignores, and adding one
+    there and not here makes it a field this side cannot see.
+    """
+    run_spec = _contract()["run_spec"]
+    shared = set(run_spec["fields"])
+    on_delivery = set(run_spec["added_on_delivery"])
+
+    assert set(AgentHostRunSpec.model_fields) == shared
+    assert shared.isdisjoint(on_delivery)
+    for field in on_delivery:
+        assert field not in AgentHostRunSpec.model_fields, (
+            f"{field} is added when the command is delivered; declaring it here "
+            f"would let the plaintext be persisted with the command"
+        )


### PR DESCRIPTION
## What changes

The `RunSpec` field list is now part of the wire contract the host and the
backend already share, so a field added to one side and not the other fails a
test instead of surfacing as a run that behaves oddly.

## Why

`START_RUN` carries a run spec declared twice — `protocol.rs` in the host,
`AgentHostRunSpec` in the backend. Thirteen fields appear on both sides and
nothing compared the two lists. Adding a field to one and not the other is
either a spec the host silently ignores or one the backend cannot see, and
neither shows up until a run misbehaves.

The fourteenth field is why this was hard to read. `mcp` is declared only on
the host. It is genuinely on the wire, but it does not travel as part of the
spec: it rests in the command row as `encrypted_mcp`, and `_wire_command`
decrypts it into the payload as the command is handed over. Declaring it on
the model would be somewhere a run-scoped credential could be persisted in
plaintext — the one thing encrypting it at rest exists to prevent. So its
absence is a decision that looked exactly like an omission, and the fixture
now says which it is.

The two halves check different things, deliberately. The Rust half can only
assert the union, since `mcp` is a field of that struct whichever list the
contract puts it in; the Python half is the one that can see the model it is
missing from.

Closes the last open piece of CT-2. Not pinned: a lower bound for
`lease_epoch`. The host never mints one — it echoes the epoch it was handed —
so there is no bound for it to violate, and a number recorded here would be a
claim about nothing.

## How to verify

```bash
cd desktop && cargo test -p lemma-agent-host --test wire_contract
cd lemma-backend && uv run pytest app/modules/agent/tests/unit/test_agent_host_wire_contract.py -q
```

`7 passed` and `17 passed`.

The guard was checked against three mutations of the fixture rather than
assumed:

| mutation | Rust | Python |
|---|---|---|
| an invented field added to `fields` | caught | caught |
| `workspace_cwd` removed from `fields` | caught | caught |
| `mcp` promoted into `fields` | not caught (cannot be) | caught |

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

---

## Also here: why the adapters are downloaded rather than shipped

The register carried an offline adapter pack as open work, which made
downloading them on first run read as something nobody had got to. It is the
decision, and the second commit records it where someone would look for it.

Bundling the two npm adapters adds ~67 MB to every installer, and the no-Node
path the register describes means shipping Node on top of that — roughly
doubling it — for a machine with no Node or no route to the registry. The app
already downloads on first run, so an adapter is nothing new in kind, and the
size would be paid by everyone to spare an edge case.

What that trade needs in exchange is a failure that says so, and it already
holds: `npm` runs under a 300-second cap that kills the process tree, so a
registry that accepts the connection and never answers cannot hang setup;
the cause is recorded per adapter in `install_failures`; and `snapshot_for`
turns it into a named reason rather than a "Setting up, usually under a
minute" that never ends. `adapters/tests.rs` already covers all three states —
not yet tried, failed with the cause named, and cleared again so
`doctor --repair` is a real remedy.

No behaviour change in that commit; the reasoning lived in a working file
outside the repository, which is to say nowhere.
