### PR TITLE
An agent could not look at an image, and the refusal named the budget

### DIFF
--- a/.github/pytest-census.json
+++ b/.github/pytest-census.json
@@ -15,7 +15,7 @@
     "provider": 87,
     "real_llm": 18,
     "real_sandbox": 13,
-    "skip": 18,
+    "skip": 20,
     "skipif": 50,
     "slow": 26,
     "surface_live": 5,

--- a/lemma-backend/app/modules/agent/tests/e2e/test_vision_real_llm_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_vision_real_llm_e2e.py
@@ -20,6 +20,7 @@ from decimal import Decimal
 from uuid import UUID, uuid4
 
 import pytest
+from PIL import ImageFont
 from pydantic_ai.messages import (
     BinaryContent,
     ModelMessage,
@@ -61,20 +62,32 @@ pytestmark = [
 SECRET = "PLUM 47"
 
 
+def _legible_font(size: int) -> "ImageFont.FreeTypeFont | ImageFont.ImageFont":
+    """A face big enough to read, on whatever machine is running this.
+
+    `load_default` is the one that cannot fail, and since Pillow 10.1 it takes
+    a size and returns a scalable face -- so the fallback is still legible
+    rather than the 11px bitmap that made this test depend on a font macOS
+    happens to ship.
+    """
+    for name in (
+        "Helvetica",
+        "DejaVuSans.ttf",
+        "Arial.ttf",
+        "LiberationSans-Regular.ttf",
+    ):
+        try:
+            return ImageFont.truetype(name, size)
+        except OSError:
+            continue
+    return ImageFont.load_default(size=size)
+
+
 def _image_saying(text: str) -> bytes:
     from PIL import Image, ImageDraw
 
     image = Image.new("RGB", (640, 200), "white")
-    draw = ImageDraw.Draw(image)
-    for size in (14, 11, 8):
-        try:
-            from PIL import ImageFont
-
-            font = ImageFont.truetype("Helvetica", size * 4)
-            break
-        except OSError:
-            font = None
-    draw.text((40, 70), text, fill="black", font=font)
+    ImageDraw.Draw(image).text((40, 60), text, fill="black", font=_legible_font(56))
     buffer = io.BytesIO()
     image.save(buffer, format="PNG")
     return buffer.getvalue()

--- a/lemma-backend/app/modules/agent/tests/e2e/test_vision_real_llm_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_vision_real_llm_e2e.py
@@ -1,0 +1,234 @@
+"""An agent can actually look at an image, on a real provider, under a budget.
+
+Both routes are here because a monetary limit broke both and neither failure
+mentioned an image. The delegate -- a text-only model's only way to see -- was
+refused before it reached the provider, because its metering scope made its
+first and only request look like a run *starting* with an unpriceable shape.
+A model reading the image itself got through, then died at the request after
+it, reconciling spend that had been recorded unpriced.
+
+Real provider on purpose: the shape of the request is what was being judged,
+and a stand-in that accepts `BinaryContent` proves nothing about a model that
+has to price the tokens it turns into.
+"""
+
+from __future__ import annotations
+
+import io
+from collections.abc import Iterator
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic_ai.messages import (
+    BinaryContent,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+from pydantic_ai.models import ModelRequestParameters
+from sqlalchemy import select
+
+from app.core.infrastructure.db.manager import DatabaseManager
+from app.core.infrastructure.db.uow_factory import SessionUnitOfWorkFactory
+from app.modules.agent.services.vision_service import (
+    VisionImage,
+    configured_vision_model_name,
+    describe_images,
+)
+from app.modules.agent.tests.e2e.system_lemma_helpers import (
+    SYSTEM_LEMMA_SKIP_REASON,
+    system_lemma_available,
+)
+from app.modules.usage.config import usage_settings
+from app.modules.usage.infrastructure.metered_model import MeteredModel
+from app.modules.usage.infrastructure.models import UsageRecord
+from app.modules.usage.services.metering_scope import metering_execution
+from app.modules.usage.services.usage_context import UsageExecutionContext
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.real_llm,
+    pytest.mark.provider,
+    pytest.mark.skipif(not system_lemma_available(), reason=SYSTEM_LEMMA_SKIP_REASON),
+]
+
+# Short, unambiguous, and nothing a model could produce from the prompt alone.
+SECRET = "PLUM 47"
+
+
+def _image_saying(text: str) -> bytes:
+    from PIL import Image, ImageDraw
+
+    image = Image.new("RGB", (640, 200), "white")
+    draw = ImageDraw.Draw(image)
+    for size in (14, 11, 8):
+        try:
+            from PIL import ImageFont
+
+            font = ImageFont.truetype("Helvetica", size * 4)
+            break
+        except OSError:
+            font = None
+    draw.text((40, 70), text, fill="black", font=font)
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+@pytest.fixture
+def vision_model_name(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
+    """The deployment's configured vision model, declared image-capable.
+
+    Declared here rather than assumed: `LEMMA_OPENAI_VISION_MODEL_NAMES` is the
+    operator's statement about a catalog, and this test is about the code path
+    that carries an image, not about one deployment's environment file.
+    """
+    name = configured_vision_model_name()
+    if not name:
+        pytest.skip("VISION_MODEL is not configured.")
+    monkeypatch.setenv("LEMMA_OPENAI_VISION_MODEL_NAMES", name)
+    yield name
+
+
+@pytest.fixture
+def spending_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A monetary limit with plenty of room -- enough to engage the gate."""
+    monkeypatch.setattr(usage_settings, "usage_user_weekly_limit_usd", 100.0)
+
+
+async def _records(db_manager: DatabaseManager, user_id: UUID) -> list[UsageRecord]:
+    async with db_manager.session_factory() as session:
+        return list(
+            await session.scalars(
+                select(UsageRecord)
+                .where(UsageRecord.user_id == user_id)
+                .order_by(UsageRecord.occurred_at)
+            )
+        )
+
+
+async def test_a_text_only_model_sees_through_its_delegate(
+    db_manager: DatabaseManager, vision_model_name: str, spending_budget: None
+) -> None:
+    """`describe_images` from inside a run that is already under way."""
+    user_id = uuid4()
+    factory = SessionUnitOfWorkFactory(db_manager.session_factory)
+    run = UsageExecutionContext(
+        user_id=user_id, organization_id=None, pod_id=None, agent_run_id=uuid4()
+    )
+    async with metering_execution(run, factory=factory) as scope:
+        # The run has already reached the provider once; a tool call is the
+        # only thing that can ask for this, and a tool call implies a turn.
+        meter, _ = scope.meter(
+            {"profile_id": "system:lemma", "scope": "SYSTEM", "model_name": "opening"},
+            None,
+        )
+        meter.admitted = 1
+
+        description = await describe_images(
+            [
+                VisionImage(
+                    data=_image_saying(SECRET),
+                    media_type="image/png",
+                    label="image /pod/note.png",
+                )
+            ],
+            instructions="Transcribe the text in this image exactly.",
+            organization_id=None,
+            user_id=user_id,
+        )
+
+    assert SECRET.split()[0].lower() in description.lower(), description
+    assert SECRET.split()[1] in description, description
+
+    vision = await _records(db_manager, user_id)
+    assert vision, "the delegate's request was never metered"
+    assert {record.source_type for record in vision} == {"vision"}
+    # Priced, not merely admitted: the provider counted the pixels as input
+    # tokens and the rate card charged them.
+    assert all(record.input_tokens for record in vision)
+
+
+async def test_a_vision_model_reads_the_image_and_the_run_carries_on(
+    db_manager: DatabaseManager, vision_model_name: str, spending_budget: None
+) -> None:
+    """What `view_image` does when the run's own model can see."""
+    from app.core.domain.runtime import AgentRuntimeConfig
+    from app.modules.agent.services.runtime_model_factory import (
+        pydantic_ai_model_from_runtime_profile,
+    )
+    from app.modules.agent.services.runtime_profile_service import (
+        DEFAULT_SYSTEM_AGENT_RUNTIME_PROFILE_ID,
+        AgentRuntimeProfileService,
+    )
+
+    user_id = uuid4()
+    resolved = await AgentRuntimeProfileService().resolve(
+        runtime=AgentRuntimeConfig(
+            profile_id=DEFAULT_SYSTEM_AGENT_RUNTIME_PROFILE_ID,
+            model_name=vision_model_name,
+        ),
+        organization_id=None,
+        user_id=user_id,
+    )
+    # Already metered: the factory wraps what it builds, exactly as a run gets it.
+    model = pydantic_ai_model_from_runtime_profile(
+        runtime_profile=resolved.public_snapshot(),
+        runtime_credentials=resolved.credentials,
+    )
+    assert isinstance(model, MeteredModel)
+    assert model.runtime_profile.get("scope") == "SYSTEM", (
+        "only a SYSTEM profile is held to a monetary limit; this test needs one"
+    )
+
+    # The history a run has after `view_image` returned the picture itself.
+    looking: list[ModelMessage] = [
+        ModelRequest(
+            parts=[UserPromptPart(["Read /pod/note.png and repeat its text exactly."])]
+        ),
+        ModelResponse(
+            parts=[
+                ToolCallPart(
+                    "view_image", {"file_path": "/pod/note.png"}, tool_call_id="call-1"
+                )
+            ]
+        ),
+        ModelRequest(
+            parts=[
+                ToolReturnPart(
+                    "view_image",
+                    [BinaryContent(data=_image_saying(SECRET), media_type="image/png")],
+                    tool_call_id="call-1",
+                )
+            ]
+        ),
+    ]
+
+    async with metering_execution(
+        UsageExecutionContext(user_id=user_id, organization_id=None, pod_id=None),
+        factory=SessionUnitOfWorkFactory(db_manager.session_factory),
+    ):
+        seen = await model.request(looking, None, ModelRequestParameters())
+        # The request after the image is the one that used to die -- and it
+        # replays the image, because the history still holds it.
+        await model.request(
+            [*looking, seen, ModelRequest(parts=[UserPromptPart(["Now say OK."])])],
+            None,
+            ModelRequestParameters(),
+        )
+
+    answer = "".join(part.content for part in seen.parts if isinstance(part, TextPart))
+    assert SECRET.split()[1] in answer, answer
+
+    records = await _records(db_manager, user_id)
+    assert len(records) == 2
+    # Priced, both of them. Recording the image request unpriced is what set
+    # `require_reconciliation` and killed the one after it.
+    assert all(record.cost_amount is not None for record in records)
+    assert all(record.input_tokens for record in records)
+    assert sum(record.cost_amount or Decimal(0) for record in records) > 0

--- a/lemma-backend/app/modules/usage/infrastructure/metered_model.py
+++ b/lemma-backend/app/modules/usage/infrastructure/metered_model.py
@@ -34,7 +34,7 @@ from app.modules.usage.infrastructure.provider_retries import (
     confirmed_rejection,
 )
 from app.modules.usage.infrastructure.request_features import (
-    priceable_text_request,
+    priceable_request,
 )
 from app.modules.usage.services.metering_scope import current_metering_scope
 
@@ -172,8 +172,11 @@ class MeteredModel(WrapperModel):
             effective.get("max_tokens") or scope.settings.usage_request_output_ceiling
         )
         _, prepared_parameters = self.wrapped.prepare_request(effective, parameters)
-        priceable = priceable_text_request(
-            messages, prepared_parameters, effective
+        priceable = priceable_request(
+            messages,
+            prepared_parameters,
+            effective,
+            prices_images_as_text=pricing.prices_images_as_text,
         ) and not _compound_billing(effective)
         request_id, occurred_at, limited = await meter.before(priceable=priceable)
         if limited:

--- a/lemma-backend/app/modules/usage/infrastructure/price_catalog.py
+++ b/lemma-backend/app/modules/usage/infrastructure/price_catalog.py
@@ -17,6 +17,21 @@ from app.modules.usage.domain.accounting import (
 )
 
 
+# Rates that bill image input in a category of its own. `RequestUsage` reports
+# one `input_tokens` total, so a card holding any of these needs a split the
+# adapter never sees.
+IMAGE_RATE_KEYS = frozenset(
+    {
+        "input_image_mtok",
+        "input_gpixels",
+        "cache_image_read_mtok",
+        "cache_image_write_mtok",
+        "cache_image_write_5m_mtok",
+        "cache_image_write_1h_mtok",
+    }
+)
+
+
 class Rate(BaseModel):
     model_config = ConfigDict(frozen=True)
     base: Decimal = Field(ge=0)
@@ -69,6 +84,27 @@ class RateCard(BaseModel):
                 )
             )["total_price"]
         )
+
+    @property
+    def prices_images_as_text(self) -> bool:
+        """Whether image input is billed at this card's ordinary input rate.
+
+        Every chat model that accepts an image counts it into the provider's
+        own `input_tokens`, which `price` charges at `input_mtok` -- an image
+        costs input tokens, the same category as the words around it. Of the
+        1600-odd models the bundled catalog carries, the only ones stating a
+        separate image rate are image-generation, realtime and embedding
+        models, and for those the split the rate needs is one pydantic-ai's
+        normalized receipt does not report.
+
+        Treating every image as unpriceable instead cost the product its
+        eyes. Under a monetary limit a run that looked at an image was
+        recorded unpriced and stopped at the next request boundary, and a
+        text-only model's vision delegate -- whose every request carries an
+        image by definition -- was refused outright as an unpriceable first
+        request. Both were reported as a usage limit nobody had reached.
+        """
+        return not (IMAGE_RATE_KEYS & self.rates.keys())
 
     @property
     def priceable(self) -> bool:

--- a/lemma-backend/app/modules/usage/infrastructure/request_features.py
+++ b/lemma-backend/app/modules/usage/infrastructure/request_features.py
@@ -3,7 +3,9 @@
 from collections.abc import Mapping, Sequence
 
 from pydantic_ai.messages import (
+    BinaryContent,
     CachePoint,
+    ImageUrl,
     ModelMessage,
     ModelRequestPart,
     ModelResponsePart,
@@ -19,39 +21,50 @@ from pydantic_ai.messages import (
 )
 from pydantic_ai.models import ModelRequestParameters
 
+_SERVER_SIDE_SETTINGS = (
+    "openai_previous_response_id",
+    "openai_conversation_id",
+    "google_cached_content",
+    "openai_audio",
+    "audio",
+    "modalities",
+    "openai_modalities",
+)
 
-def priceable_text_request(
+
+def priceable_request(
     messages: Sequence[ModelMessage],
     parameters: ModelRequestParameters,
     settings: Mapping[str, object],
+    *,
+    prices_images_as_text: bool,
 ) -> bool:
+    """Whether every part of this request is billed at ordinary token rates.
+
+    `prices_images_as_text` is the rate card's answer about images, which is
+    the only content category whose price depends on the card rather than on
+    the request -- see `RateCard.prices_images_as_text`.
+    """
     if parameters.native_tools or parameters.allow_image_output:
         return False
     # A server-side continuation can restore content or work absent locally.
-    if any(
-        settings.get(key)
-        for key in (
-            "openai_previous_response_id",
-            "openai_conversation_id",
-            "google_cached_content",
-            "openai_audio",
-            "audio",
-            "modalities",
-            "openai_modalities",
-        )
-    ):
+    if any(settings.get(key) for key in _SERVER_SIDE_SETTINGS):
         return False
-    return all(_text_part(part) for message in messages for part in message.parts)
+    return all(
+        _priceable_part(part, prices_images_as_text)
+        for message in messages
+        for part in message.parts
+    )
 
 
-def _text_part(part: ModelRequestPart | ModelResponsePart) -> bool:
+def _priceable_part(
+    part: ModelRequestPart | ModelResponsePart, images_are_text: bool
+) -> bool:
     if isinstance(part, SystemPromptPart | TextPart | RetryPromptPart):
         return True
     if isinstance(part, UserPromptPart):
         return isinstance(part.content, str) or all(
-            isinstance(content, str | TextContent)
-            or (isinstance(content, CachePoint) and content.ttl == "5m")
-            for content in part.content
+            _priceable_content(content, images_are_text) for content in part.content
         )
     if isinstance(part, ToolAvailabilityDeltaPart):
         return True
@@ -62,7 +75,7 @@ def _text_part(part: ModelRequestPart | ModelResponsePart) -> bool:
         # `BinaryContent`/`ImageUrl`/`AudioUrl`/`DocumentUrl`/`VideoUrl` reaches
         # the provider through `model_response_str`, as ordinary text, priced by
         # `input_mtok` like any other text. Only the files need a price this
-        # rate card does not carry.
+        # rate card may not carry.
         #
         # Testing the content for JSON primitives instead treated everything
         # else as unpriceable -- and a tool returning a dataclass or a pydantic
@@ -71,13 +84,33 @@ def _text_part(part: ModelRequestPart | ModelResponsePart) -> bool:
         # was refused on the continuation carrying its first tool result, after
         # the tokens for both had been spent, and the refusal was reported as a
         # usage limit the account had not reached.
-        return not part.files
+        return all(_priceable_content(file, images_are_text) for file in part.files)
     if isinstance(part, ThinkingPart):
         # Signed or redacted reasoning still uses ordinary input/output tokens.
         return True
     # Native tool calls/results, compaction and file parts need distinct prices
     # even when they only occur in replayed history.
     return False
+
+
+def _priceable_content(content: object, images_are_text: bool) -> bool:
+    if isinstance(content, str | TextContent):
+        return True
+    if isinstance(content, CachePoint):
+        return content.ttl == "5m"
+    return images_are_text and _is_image(content)
+
+
+def _is_image(content: object) -> bool:
+    """Image input the provider counts into its ordinary input tokens.
+
+    A `BinaryContent` carrying anything else -- audio, video, a PDF -- is
+    metered by the provider in a category of its own, and pydantic-ai's
+    normalized receipt does not report the split those categories need.
+    """
+    if isinstance(content, BinaryContent):
+        return content.is_image
+    return isinstance(content, ImageUrl)
 
 
 def _json_content(value: object) -> bool:

--- a/lemma-backend/app/modules/usage/services/metering_scope.py
+++ b/lemma-backend/app/modules/usage/services/metering_scope.py
@@ -36,12 +36,35 @@ class MeteringScope:
         context: UsageExecutionContext,
         factory: UnitOfWorkFactory,
         settings: UsageSettings,
+        *,
+        parent: "MeteringScope | None" = None,
     ) -> None:
         self.context = context
         self.factory = factory
         self.settings = settings
+        self.parent = parent
         self.execution_id = uuid4()
         self.meters: dict[str, tuple[RequestMeter, RateCard]] = {}
+
+    @property
+    def inside_admitted_run(self) -> bool:
+        """Whether an enclosing execution has already put a request to a provider.
+
+        A vision delegate, a sub-agent or a title pass runs inside the scope of
+        the run that asked for it, but keeps a scope of its own so its spend is
+        metered under its own source. That scope's meters start empty, so
+        without this its first request is judged as the first request of a
+        fresh run -- and the delegate's first request always carries an image,
+        which is the one shape a run may not *start* with under a monetary
+        limit. Vision therefore failed as "usage limit exceeded" on an account
+        nowhere near its limit.
+        """
+        scope = self.parent
+        while scope is not None:
+            if any(meter.admitted for meter, _ in scope.meters.values()):
+                return True
+            scope = scope.parent
+        return False
 
     def meter(
         self, profile: Mapping[str, object], source: str | None
@@ -80,7 +103,7 @@ class MeteringScope:
                 self.factory, identity, card, self.settings
             )
             self.meters[key] = (
-                RequestMeter(gateway),
+                RequestMeter(gateway, inside_admitted_run=self.inside_admitted_run),
                 card,
             )
         return self.meters[key]
@@ -122,6 +145,7 @@ async def metering_execution(
         context,
         factory or SessionUnitOfWorkFactory(async_session_maker),
         settings or usage_settings,
+        parent=_scope.get(),
     )
     token = _scope.set(scope)
     try:

--- a/lemma-backend/app/modules/usage/services/request_meter.py
+++ b/lemma-backend/app/modules/usage/services/request_meter.py
@@ -25,7 +25,12 @@ class RequestAccountingGateway(Protocol):
 
 
 class RequestMeter:
-    def __init__(self, gateway: RequestAccountingGateway) -> None:
+    def __init__(
+        self,
+        gateway: RequestAccountingGateway,
+        *,
+        inside_admitted_run: bool = False,
+    ) -> None:
         self.gateway = gateway
         self.pending: dict[UUID, RequestReceipt] = {}
         self.closed = False
@@ -34,6 +39,12 @@ class RequestMeter:
         #: that has spent tokens must not be killed by a refusal that could
         #: only ever have been made before it started -- see `begin`.
         self.admitted = 0
+        #: The same, for spend an *enclosing* execution has already made. A
+        #: vision delegate or a sub-agent opens its own scope inside a run that
+        #: is already under way; its own counter starts at zero, and without
+        #: this its first request would be judged as the first request of a
+        #: fresh run and could be refused for work already admitted and billed.
+        self.inside_admitted_run = inside_admitted_run
 
     async def before(self, *, priceable: bool) -> tuple[UUID, datetime, bool]:
         if self.closed:
@@ -43,7 +54,10 @@ class RequestMeter:
         await self.flush()
         request_id, occurred_at = uuid4(), datetime.now(timezone.utc)
         limited = await self.gateway.begin(
-            request_id, occurred_at, priceable=priceable, in_flight=self.admitted > 0
+            request_id,
+            occurred_at,
+            priceable=priceable,
+            in_flight=self.inside_admitted_run or self.admitted > 0,
         )
         self.admitted += 1
         return request_id, occurred_at, limited

--- a/lemma-backend/app/modules/usage/tests/e2e/test_vision_accounting_e2e.py
+++ b/lemma-backend/app/modules/usage/tests/e2e/test_vision_accounting_e2e.py
@@ -1,0 +1,136 @@
+"""Looking at an image is metered work, not a run the budget has to refuse.
+
+Two paths reach a provider with an image in the request, and a monetary limit
+broke both. A vision-capable model got the image in its own history, and the
+request after it died reconciling spend that had been recorded unpriced. A
+text-only model's delegate opened a metering scope of its own, so its single
+image request looked like a run *starting* unpriceable, which `begin` refuses
+before anything is spent. Neither failure named an image; both were reported
+as a usage limit the account was nowhere near.
+"""
+
+from collections.abc import Iterator
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic_ai.messages import (
+    BinaryContent,
+    ModelMessage,
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+from pydantic_ai.models import ModelRequestParameters
+from pydantic_ai.models.function import AgentInfo, FunctionModel
+from pydantic_ai.usage import RequestUsage
+from sqlalchemy import select
+
+from app.core.infrastructure.db.manager import DatabaseManager
+from app.core.infrastructure.db.uow_factory import SessionUnitOfWorkFactory
+from app.modules.usage.config import usage_settings
+from app.modules.usage.infrastructure.metered_model import MeteredModel
+from app.modules.usage.infrastructure.models import UsageRecord
+from app.modules.usage.services.metering_scope import metering_execution
+from app.modules.usage.services.usage_context import UsageExecutionContext
+from app.modules.usage.services.usage_service import ModelPricing, UsageService
+
+pytestmark = pytest.mark.e2e
+
+IMAGE = BinaryContent(data=b"\x89PNG\r\n\x1a\n", media_type="image/png")
+TEXT: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart(["hello"])])]
+# What `view_image` hands back to a model that can read it itself.
+LOOKING: list[ModelMessage] = [
+    ModelRequest(parts=[ToolReturnPart("view_image", [IMAGE])])
+]
+
+
+@pytest.fixture
+def vision_model(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
+    """A budget with room in it, and a card that prices input and output."""
+    name = f"vision-{uuid4()}"
+    monkeypatch.setattr(usage_settings, "usage_user_weekly_limit_usd", 100.0)
+    UsageService.register_model_pricing({name: ModelPricing(1000.0, 1000.0)})
+    try:
+        yield name
+    finally:
+        UsageService._SYSTEM_MODEL_PRICING.pop(name, None)
+
+
+async def _provider(messages: list[ModelMessage], info: AgentInfo) -> ModelResponse:
+    return ModelResponse(
+        parts=[TextPart("what the image says")],
+        usage=RequestUsage(input_tokens=1000, output_tokens=100),
+    )
+
+
+def _model(name: str) -> MeteredModel:
+    return MeteredModel(
+        FunctionModel(_provider),
+        {"profile_id": "system:vision", "scope": "SYSTEM", "model_name": name},
+    )
+
+
+async def _costs(db_manager: DatabaseManager, user_id: UUID) -> list[Decimal | None]:
+    async with db_manager.session_factory() as session:
+        return [
+            record.cost_amount
+            for record in await session.scalars(
+                select(UsageRecord)
+                .where(UsageRecord.user_id == user_id)
+                .order_by(UsageRecord.occurred_at)
+            )
+        ]
+
+
+async def test_a_run_carries_on_after_the_model_looks_at_an_image(
+    db_manager: DatabaseManager, vision_model: str
+) -> None:
+    model, user_id = _model(vision_model), uuid4()
+    async with metering_execution(
+        UsageExecutionContext(user_id=user_id, organization_id=None, pod_id=None),
+        factory=SessionUnitOfWorkFactory(db_manager.session_factory),
+    ):
+        await model.request(TEXT, None, ModelRequestParameters())
+        await model.request(LOOKING, None, ModelRequestParameters())
+        await model.request(TEXT, None, ModelRequestParameters())
+
+    # Every request priced, the image one included: the provider counted its
+    # pixels into `input_tokens` and this card charges those at `input_mtok`.
+    assert await _costs(db_manager, user_id) == [Decimal("1.1")] * 3
+
+
+async def test_the_vision_delegate_is_admitted_and_billed_to_the_same_budget(
+    db_manager: DatabaseManager, vision_model: str
+) -> None:
+    """`describe_images` opens its own scope so the spend is sourced to vision."""
+    factory = SessionUnitOfWorkFactory(db_manager.session_factory)
+    model, user_id = _model(vision_model), uuid4()
+    parent = UsageExecutionContext(
+        user_id=user_id, organization_id=None, pod_id=None, agent_run_id=uuid4()
+    )
+    async with metering_execution(parent, factory=factory):
+        await model.request(TEXT, None, ModelRequestParameters())
+        async with metering_execution(
+            UsageExecutionContext(
+                user_id=user_id,
+                organization_id=None,
+                pod_id=None,
+                agent_run_id=parent.agent_run_id,
+                source_type="vision",
+            ),
+            factory=factory,
+        ):
+            await model.request(LOOKING, None, ModelRequestParameters())
+        await model.request(TEXT, None, ModelRequestParameters())
+
+    assert await _costs(db_manager, user_id) == [Decimal("1.1")] * 3
+    async with db_manager.session_factory() as session:
+        sources = set(
+            await session.scalars(
+                select(UsageRecord.source_type).where(UsageRecord.user_id == user_id)
+            )
+        )
+    assert sources == {"agent_run", "vision"}

--- a/lemma-backend/app/modules/usage/tests/unit/test_price_catalog.py
+++ b/lemma-backend/app/modules/usage/tests/unit/test_price_catalog.py
@@ -217,3 +217,38 @@ def test_a_price_that_is_not_the_gateway_s_own_cannot_enforce_a_budget() -> None
 
     assert card.rates, "a price was found"
     assert not card.priceable, "but not one this deployment may enforce against"
+
+
+def test_a_chat_model_bills_an_image_at_its_ordinary_input_rate() -> None:
+    """Which is what makes an agent able to look at one under a budget.
+
+    The provider counts image input into `input_tokens`; only a card that
+    states an image rate of its own needs a split the receipt does not carry.
+    """
+    chat = resolve_rate_card(
+        {"provider_model_name": "gpt-5.1", "config": {"base_url": None}},
+        {},
+        datetime(2026, 9, 1, tzinfo=timezone.utc),
+    )
+    assert chat.prices_images_as_text
+
+    separate = RateCard(
+        model="gpt-image-1",
+        enforceable=True,
+        rates={
+            "input_mtok": Rate(base=Decimal("1")),
+            "output_mtok": Rate(base=Decimal("1")),
+            "input_image_mtok": Rate(base=Decimal("10")),
+        },
+    )
+    assert not separate.prices_images_as_text
+
+
+def test_an_operator_stating_input_and_output_prices_has_priced_images() -> None:
+    card = resolve_rate_card(
+        {"model_name": "house-vision"},
+        {"house-vision": ModelPricing(3.0, 15.0)},
+        datetime(2026, 9, 1, tzinfo=timezone.utc),
+    )
+    assert card.priceable
+    assert card.prices_images_as_text

--- a/lemma-backend/app/modules/usage/tests/unit/test_request_features.py
+++ b/lemma-backend/app/modules/usage/tests/unit/test_request_features.py
@@ -1,6 +1,6 @@
 """Accounting distinguishes supported token usage from extra billing categories."""
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 
 import pytest
 from pydantic import BaseModel
@@ -30,8 +30,21 @@ from pydantic_ai.native_tools import WebSearchTool
 from pydantic_ai.tools import ToolDefinition
 
 from app.modules.usage.infrastructure.request_features import (
-    priceable_text_request,
+    priceable_request,
 )
+
+
+def priceable(
+    messages: Sequence[ModelMessage],
+    parameters: ModelRequestParameters,
+    settings: Mapping[str, object] | None = None,
+    *,
+    images: bool = True,
+) -> bool:
+    """Most cases do not turn on images; the card that prices them is the norm."""
+    return priceable_request(
+        messages, parameters, settings or {}, prices_images_as_text=images
+    )
 
 
 def test_plain_text_and_json_function_tools_are_supported() -> None:
@@ -50,42 +63,74 @@ def test_plain_text_and_json_function_tools_are_supported() -> None:
             ToolDefinition(name="lookup", parameters_json_schema={"type": "object"})
         ]
     )
-    assert priceable_text_request(messages, parameters, {})
+    assert priceable(messages, parameters, {})
 
 
 @pytest.mark.parametrize(
     "content",
     [
-        BinaryContent(data=b"image", media_type="image/png"),
-        ImageUrl("https://example.com/image.png"),
+        BinaryContent(data=b"audio", media_type="audio/mpeg"),
+        BinaryContent(data=b"pdf", media_type="application/pdf"),
         AudioUrl("https://example.com/audio.mp3"),
         VideoUrl("https://example.com/video.mp4"),
         DocumentUrl("https://example.com/document.pdf"),
         UploadedFile(file_id="file-example", provider_name="openai"),
     ],
 )
-def test_multimedia_input_is_not_a_text_request(content: UserContent) -> None:
+def test_media_the_provider_bills_in_its_own_category_is_not_priceable(
+    content: UserContent,
+) -> None:
+    """Audio, video and documents each have rates and counts of their own.
+
+    `RequestUsage` reports one input total, so the split those rates need is
+    not in the receipt however generous the card is about images.
+    """
     messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart([content])])]
-    assert not priceable_text_request(messages, ModelRequestParameters(), {})
+    assert not priceable(messages, ModelRequestParameters(), {})
 
 
-def test_media_inside_tool_returns_is_not_treated_as_plain_json() -> None:
+@pytest.mark.parametrize(
+    "image",
+    [
+        BinaryContent(data=b"image", media_type="image/png"),
+        ImageUrl("https://example.com/image.png"),
+    ],
+)
+def test_an_image_is_input_tokens_when_the_card_prices_it_that_way(
+    image: UserContent,
+) -> None:
+    """This is what lets an agent look at something.
+
+    A provider counts image input into `input_tokens` and bills it at
+    `input_mtok`, so a card with no image rate of its own prices the request
+    exactly. Calling every image unpriceable instead stopped a run at the
+    boundary after it looked at one, and refused a text-only model's vision
+    delegate outright -- every one of whose requests carries an image.
+    """
+    messages: list[ModelMessage] = [ModelRequest(parts=[UserPromptPart([image])])]
+    assert priceable(messages, ModelRequestParameters(), {}, images=True)
+    assert not priceable(messages, ModelRequestParameters(), {}, images=False)
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        (BinaryContent(data=b"image", media_type="image/png"), True),
+        (BinaryContent(data=b"pdf", media_type="application/pdf"), False),
+    ],
+)
+def test_a_tool_returning_an_image_is_priced_like_one_in_the_prompt(
+    content: UserContent, expected: bool
+) -> None:
+    """`view_image` hands its image back through a tool return."""
     messages: list[ModelMessage] = [
-        ModelRequest(
-            parts=[
-                ToolReturnPart(
-                    "view", [BinaryContent(data=b"image", media_type="image/png")]
-                )
-            ]
-        )
+        ModelRequest(parts=[ToolReturnPart("view", [content])])
     ]
-    assert not priceable_text_request(messages, ModelRequestParameters(), {})
+    assert priceable(messages, ModelRequestParameters(), {}) is expected
 
 
 def test_native_tools_are_rejected_even_without_results_yet() -> None:
-    assert not priceable_text_request(
-        [], ModelRequestParameters(native_tools=[WebSearchTool()]), {}
-    )
+    assert not priceable([], ModelRequestParameters(native_tools=[WebSearchTool()]), {})
 
 
 def test_native_tool_history_is_rejected_without_current_native_tools() -> None:
@@ -97,7 +142,7 @@ def test_native_tool_history_is_rejected_without_current_native_tools() -> None:
             ]
         )
     ]
-    assert not priceable_text_request(messages, ModelRequestParameters(), {})
+    assert not priceable(messages, ModelRequestParameters(), {})
 
 
 def test_reasoning_signatures_do_not_change_the_billing_category() -> None:
@@ -106,7 +151,7 @@ def test_reasoning_signatures_do_not_change_the_billing_category() -> None:
             parts=[ThinkingPart("", signature="opaque", provider_name="openai")]
         )
     ]
-    assert priceable_text_request(messages, ModelRequestParameters(), {})
+    assert priceable(messages, ModelRequestParameters(), {})
 
 
 @pytest.mark.parametrize(
@@ -121,20 +166,18 @@ def test_reasoning_signatures_do_not_change_the_billing_category() -> None:
 def test_server_continuations_and_audio_settings_are_not_text_requests(
     settings: Mapping[str, object],
 ) -> None:
-    assert not priceable_text_request([], ModelRequestParameters(), settings)
+    assert not priceable([], ModelRequestParameters(), settings)
 
 
 def test_cache_markers_cannot_sneak_one_hour_pricing_into_text_accounting() -> None:
     messages: list[ModelMessage] = [
         ModelRequest(parts=[UserPromptPart(["text", CachePoint(ttl="1h")])])
     ]
-    assert not priceable_text_request(messages, ModelRequestParameters(), {})
+    assert not priceable(messages, ModelRequestParameters(), {})
 
 
 def test_image_output_is_not_a_text_request() -> None:
-    assert not priceable_text_request(
-        [], ModelRequestParameters(allow_image_output=True), {}
-    )
+    assert not priceable([], ModelRequestParameters(allow_image_output=True), {})
 
 
 def test_a_tool_returning_a_model_is_text_because_that_is_what_is_sent() -> None:
@@ -157,4 +200,4 @@ def test_a_tool_returning_a_model_is_text_because_that_is_what_is_sent() -> None
             ]
         ),
     ]
-    assert priceable_text_request(messages, ModelRequestParameters(), {})
+    assert priceable(messages, ModelRequestParameters(), {})

--- a/lemma-backend/app/modules/usage/tests/unit/test_request_meter.py
+++ b/lemma-backend/app/modules/usage/tests/unit/test_request_meter.py
@@ -3,10 +3,14 @@
 from collections.abc import Iterator
 from datetime import datetime
 from types import ModuleType
+from typing import TYPE_CHECKING, cast
 from decimal import Decimal
 from uuid import UUID, uuid4
 
 import pytest
+
+if TYPE_CHECKING:
+    from app.core.infrastructure.db.uow_factory import UnitOfWorkFactory
 
 from app.modules.usage.domain.accounting import RequestReceipt, TokenCounts
 from app.modules.usage.domain.errors import UsageLimitExceededError
@@ -15,6 +19,10 @@ from app.modules.usage.services.request_accounting_gateway import (
     PostgresRequestAccountingGateway,
 )
 from app.modules.usage.services.request_meter import RequestMeter
+
+
+#: `inside_admitted_run` reads `meters`, never the database behind them.
+_unused_factory = cast("UnitOfWorkFactory", object())
 
 
 class Accounting:
@@ -341,3 +349,35 @@ async def test_a_delegate_inside_a_live_run_is_not_judged_as_starting_one() -> N
     await fresh.before(priceable=False)
     assert starting.in_flight_flags == [False]
     await fresh.close()
+
+
+def test_an_enclosing_run_is_looked_for_through_every_scope_between() -> None:
+    """A sub-agent's delegate is two scopes below the run that is paying.
+
+    The scope in between can legitimately have dispatched nothing yet -- it is
+    opened before its first request, and a delegate can be reached from setup
+    that runs first -- so this is a walk, not a look at the immediate parent.
+    """
+    from app.modules.usage.config import UsageSettings
+    from app.modules.usage.services.metering_scope import MeteringScope
+    from app.modules.usage.services.usage_context import UsageExecutionContext
+
+    def scope(parent: MeteringScope | None) -> MeteringScope:
+        return MeteringScope(
+            UsageExecutionContext(user_id=uuid4(), organization_id=None, pod_id=None),
+            _unused_factory,
+            UsageSettings(),
+            parent=parent,
+        )
+
+    run = scope(None)
+    sub_agent = scope(run)
+    delegate = scope(sub_agent)
+    assert not delegate.inside_admitted_run
+
+    meter = RequestMeter(Accounting())
+    meter.admitted = 1
+    run.meters["opening-request"] = (meter, RateCard(model="whatever"))
+    assert delegate.inside_admitted_run
+    assert sub_agent.inside_admitted_run
+    assert not run.inside_admitted_run

--- a/lemma-backend/app/modules/usage/tests/unit/test_request_meter.py
+++ b/lemma-backend/app/modules/usage/tests/unit/test_request_meter.py
@@ -321,3 +321,23 @@ class TestUnpriceableIsAlwaysReported:
                 gateway._report_unpriceable(priceable=True, refused=False)
 
         assert len(self._reports(caplog)) == 1
+
+
+async def test_a_delegate_inside_a_live_run_is_not_judged_as_starting_one() -> None:
+    """A vision delegate meters its own spend but is not a new run.
+
+    Its scope's counter starts at zero, so without the enclosing run's state
+    its first request -- which always carries an image -- would be judged as a
+    run *starting* with an unpriceable shape, the one case `begin` refuses.
+    """
+    gateway = Accounting()
+    delegate = RequestMeter(gateway, inside_admitted_run=True)
+    await delegate.before(priceable=False)
+    assert gateway.in_flight_flags == [True]
+    await delegate.close()
+
+    starting = Accounting()
+    fresh = RequestMeter(starting)
+    await fresh.before(priceable=False)
+    assert starting.in_flight_flags == [False]
+    await fresh.close()


### PR DESCRIPTION
## What changes

An agent can look at an image again on a deployment that has a monetary limit.
Both routes were broken and neither failure mentioned an image: a text-only
model's vision delegate was refused before it reached the provider, and a
vision-capable model could read one image and then died on the request after
it. Both were reported as a usage limit the account was nowhere near.

**Operators: this needs `LEMMA_OPENAI_VISION_MODEL_NAMES` set. See
[Configuration this depends on](#configuration-this-depends-on) below — the
code fix alone does not make vision work if that is empty.**

## Why

Whether a request can be priced was decided by testing every part for text, so
any image made the request unpriceable. Under a monetary limit that has two
consequences, and this is the first release where anything used them.

**The delegate was refused outright.** `describe_images` opens a metering scope
of its own, so the spend is sourced to `vision` rather than to the run. That
scope's meters start empty, so its one request — which carries an image by
definition — was judged as a run *starting* with a shape that cannot be priced,
which is the one case `begin` refuses before anything is spent. It surfaced to
the agent as `The vision model could not describe the image.`

**A vision-capable model broke one request later.** Its image request was
admitted in-flight but recorded unpriced, which sets `require_reconciliation`,
so the *next* request in the run raised `UsageReportingError`. The model could
look at one image and then the turn collapsed.

**An image is not unpriceable.** Every chat model that accepts one counts it
into the provider's `input_tokens` and bills it at `input_mtok` — the same
category as the words around it. Of the 1646 models in the bundled catalog, 14
state an image rate of their own, and every one of those is an image-generation,
realtime or embedding model, never a vision chat model. So the rate card answers
the question instead of a blanket rule: `RateCard.prices_images_as_text` is
false only when the card itself distinguishes images. Audio, video, documents
and uploaded files stay unpriceable, because those do have rates and counts of
their own that pydantic-ai's normalized receipt cannot split.

Separately, a nested metering scope now inherits its parent's admitted state.
A delegate, a sub-agent or a title pass is work inside a run that has already
been admitted and billed, not a run asking for budget, and it should not be
refused for a condition only a *first* request is judged on. That is the
structural half of the fix, and it holds for any future delegate whose shape is
not an image.

Only SYSTEM-scope profiles under a configured monetary limit were affected —
`budget_windows` returns nothing otherwise, so BYO-key organizations never saw
this.

## Configuration this depends on

Nothing here needs a new setting, a migration, or a deploy-order constraint. But
two existing settings decide whether vision works at all, and on the deployment
this was debugged against one of them was empty — which is a separate reason
vision was dead, and the code fix does not address it.

| Setting | What it does | What to check |
|---|---|---|
| `LEMMA_OPENAI_VISION_MODEL_NAMES` | Comma-separated subset of `LEMMA_OPENAI_MODEL_NAMES` that accepts image input. **Defaults to empty.** | Must be non-empty for any vision at all. It gates two things: which agents read images directly, and whether `VISION_MODEL` resolves — the delegate is required to be a model listed here, so an unlisted `VISION_MODEL` fails with `VisionUnavailableError` before any request. |
| `VISION_MODEL` | The model a text-only agent delegates to. Env wins over `agent_settings.vision_model`. | Must name a model that is also in `LEMMA_OPENAI_VISION_MODEL_NAMES`. There is deliberately no fallback: falling back resolves to the same text-only model that created the problem. |

The OpenAI-compatible `/models` endpoint reports no modalities, so this cannot
be auto-detected for an OpenAI-compatible provider — it has to be declared, and
declaring a text-only model hands it `BinaryContent` and the provider rejects the
whole turn. So the list has to be measured, not guessed.

Probed directly against Fireworks (2026-09-10), for the five models in this
deployment's `LEMMA_OPENAI_MODEL_NAMES`:

| Model | Image input |
|---|---|
| `accounts/fireworks/models/minimax-m3` | accepted |
| `accounts/fireworks/models/glm-5p3-flash` | accepted |
| `accounts/fireworks/models/glm-5p3` | `This model does not support image input` |
| `accounts/fireworks/models/deepseek-v4-pro-0813` | same |
| `accounts/fireworks/models/deepseek-v4-flash-0731` (the default) | same |

So for a Fireworks deployment with that catalog:

```
LEMMA_OPENAI_VISION_MODEL_NAMES=accounts/fireworks/models/minimax-m3,accounts/fireworks/models/glm-5p3-flash
VISION_MODEL=accounts/fireworks/models/minimax-m3
```

which resolves to: default model → `DELEGATED`, minimax-m3 and glm-5p3-flash →
`DIRECT`, everything else → `DELEGATED`. Re-probe before adding a model to the
list; a wrong entry breaks every turn that returns an image on that model.

Two operational notes for whoever holds the config:

- `usage_unpriced_limit_policy` is unchanged and still defaults to `allow`.
  Removing the plan's monetary limit was the only workaround before this fix and
  is no longer needed; a deployment that had dropped its dev limit to unblock
  vision can put it back.
- The degraded line `usage.request_accounting_gateway.request_not_priceable`
  is the one to watch. It is emitted once per model per metering scope and now
  fires for genuinely unpriceable shapes only. `rate_card_enforceable=false` on
  it means the deployment resells a vendor's model through a gateway and the
  catalog price is not yours — that is a pricing-configuration signal, not this
  bug.

## How to verify

The metering half runs in the PR lane; the provider half is real-LLM and local
only, since nothing in CI may reach a credential.

```bash
# Metering, real Postgres and the real accounting gateway. In the required lane.
cd lemma-backend && uv run pytest \
  app/modules/usage/tests/e2e/test_vision_accounting_e2e.py \
  app/modules/usage/tests/unit/test_request_features.py \
  app/modules/usage/tests/unit/test_price_catalog.py \
  app/modules/usage/tests/unit/test_request_meter.py -q
# 36 passed

# Both vision routes against the real provider. Needs LEMMA_OPENAI_API_KEY.
cd lemma-backend && E2E_LLM_MODE=real uv run pytest \
  app/modules/agent/tests/e2e/test_vision_real_llm_e2e.py -q
# 2 passed

# The whole module, plus the gates.
cd lemma-backend && uv run pytest app/modules/usage -q   # 193 passed, 2 skipped
make quality && make format-check && make architecture   # pass
cd lemma-backend && E2E_WORKERS=4 make test-e2e-fast     # 989 passed
```

Every new test fails on `main` with the exact production symptom —
`VisionDescriptionError` wrapping `UsageLimitExceededError` for the delegate,
`UsageReportingError` for the direct model — and passes here. The real-LLM pair
puts a rendered image of known text in front of Fireworks `minimax-m3` and
asserts the text comes back, then asserts the spend was *priced* rather than
merely admitted.

Three failures in the fast e2e lane (`test_dead_letter_e2e`,
`test_github_webhook_e2e`) reproduce identically with this branch's `usage`
changes stashed — pre-existing on that machine, not from this change.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload; no
      authorization surface touched
- [x] **Rollback** — plain revert. No migration, no schema change, no data
      written in a new shape. Reverting restores the previous behavior exactly:
      vision fails again under a monetary limit, and image requests are recorded
      unpriced rather than priced.

No migrations and no API surface change, so those sections do not apply.

## Compatibility and rollback notes

One behavioral change worth stating for anyone reading a usage report: image
requests are now **priced** rather than recorded unpriced, so spend that
previously appeared in the ledger with a null cost now carries one. That is the
correct number — the provider was always billing those tokens — but a report
comparing before and after will show vision spend appearing where there was
none. Historical rows are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Image-based requests are now correctly metered and billed when included in an active run.
  * Vision-model requests and delegated image analysis are no longer incorrectly rejected by spending limits.
  * Image inputs are recognized as billable input tokens when supported by the applicable pricing.
  * Nested vision requests now correctly share active-run accounting.

* **Tests**
  * Added end-to-end and unit coverage for vision requests, image pricing, nested metering, and usage accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->