### PR TITLE
Set every component to 0.8.0, and stop three of them drifting

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -53,7 +53,7 @@ spec:
         registry_type: GHCR
         registry: lemma-work
         repository: lemma-backend
-        tag: v0.7.2
+        tag: v0.8.0
       http_port: 8000
       instance_size_slug: professional-xs
       instance_count: 1
@@ -110,7 +110,7 @@ spec:
         registry_type: GHCR
         registry: lemma-work
         repository: lemma-frontend
-        tag: v0.7.2
+        tag: v0.8.0
       http_port: 8080
       instance_size_slug: basic-xs
       instance_count: 1
@@ -128,7 +128,7 @@ spec:
         registry_type: GHCR
         registry: lemma-work
         repository: lemma-backend
-        tag: v0.7.2
+        tag: v0.8.0
       run_command: python -m app.worker
       instance_size_slug: professional-xs
       instance_count: 1
@@ -144,7 +144,7 @@ spec:
         registry_type: GHCR
         registry: lemma-work
         repository: lemma-backend
-        tag: v0.7.2
+        tag: v0.8.0
       run_command: alembic upgrade head
       instance_size_slug: basic-xs
       instance_count: 1

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2722,7 +2722,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lemma-agent-host"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
@@ -2759,7 +2759,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-desktop"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "base64 0.22.1",
  "hex",
@@ -2792,7 +2792,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-desktop-process"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "process-wrap",
  "tempfile",
@@ -2803,7 +2803,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-guestd"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "libc",
  "serde",
@@ -2813,14 +2813,14 @@ dependencies = [
 
 [[package]]
 name = "lemma-job-object"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "lemma-locald"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-private-file"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "tempfile",
  "windows-sys 0.61.2",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-runtime"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "serde_json",
  "tempfile",
@@ -2863,7 +2863,7 @@ dependencies = [
 
 [[package]]
 name = "lemma-runtime-manager"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "getrandom 0.3.4",
  "lemma-desktop-process",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -46,7 +46,7 @@ default-members = ["."]
 [workspace.package]
 # One version for six crates. Release used to rewrite desktop/Cargo.toml alone,
 # so the moment the other five moved in here they would have drifted silently.
-version = "0.7.2"
+version = "0.8.0"
 
 [workspace.dependencies]
 # Hoisted because feature unification makes the *emergent* feature set of a

--- a/desktop/runtime/lemma-local.json
+++ b/desktop/runtime/lemma-local.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "version": "0.7.2",
+  "version": "0.8.0",
   "artifact_source": "ci-build-check",
   "host_packs": {
     "aarch64-apple-darwin": {
@@ -11,7 +11,7 @@
       "format": "zip",
       "platform": "macos",
       "architecture": "aarch64",
-      "runtime_version": "0.7.2"
+      "runtime_version": "0.8.0"
     },
     "x86_64-pc-windows-msvc": {
       "url": "https://downloads.example.invalid/lemma-host-pack.zip",
@@ -21,7 +21,7 @@
       "format": "zip",
       "platform": "windows",
       "architecture": "x86_64",
-      "runtime_version": "0.7.2"
+      "runtime_version": "0.8.0"
     }
   },
   "guest_runtimes": {
@@ -33,7 +33,7 @@
       "format": "zip",
       "platform": "linux",
       "architecture": "aarch64",
-      "runtime_version": "0.7.2"
+      "runtime_version": "0.8.0"
     },
     "windows-x86_64": {
       "url": "https://downloads.example.invalid/lemma-guest-runtime.zip",
@@ -43,7 +43,7 @@
       "format": "zip",
       "platform": "linux",
       "architecture": "x86_64",
-      "runtime_version": "0.7.2"
+      "runtime_version": "0.8.0"
     }
   }
 }

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Lemma",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "identifier": "work.lemma.desktop",
   "build": {
     "frontendDist": "ui"

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,20 +1,46 @@
 # API and SDK versioning
 
-Lemma's public API schema and generated SDK packages share a compatibility
-line. While the platform is in beta, that line is the SemVer major and minor:
+Every Lemma-owned component — the API, both SDKs, the CLI, the desktop app, the
+stack tool and the packages they are built from — ships under one version
+string. That is what a release is *called*, and it is checked rather than
+trusted: `scripts/check_version_consistency.py` reads the version out of every
+component and the release workflows run it against the tag before anything is
+published.
 
-- A compatible API schema change bumps the API patch and the patch of each
-  affected generated SDK package.
-- An SDK-only change bumps only that SDK package patch. Its embedded API version
-  remains the version of the schema from which it was generated.
-- A breaking API change bumps the API and both SDK packages together to the next
-  minor, for example `0.6.x` to `0.7.0`.
-- After `1.0`, a breaking API change bumps the shared major compatibility line.
+While the platform is in beta the compatibility line is the SemVer major and
+minor:
 
-Package patches do not need to match. The API and both SDK packages must always
-share the same major and minor versions.
+- A compatible API change bumps the patch.
+- A breaking API change bumps the minor, for example `0.7.x` to `0.8.0`.
+- After `1.0`, a breaking API change bumps the major.
 
-The move from API `4.0.1` to `0.6.3` is a one-time beta normalization. It aligns
-the previously independent API counter with the Python and TypeScript SDKs
-without claiming a stable `4.x` compatibility contract before the platform has
-reached `1.0`.
+## When the number moves
+
+At release, not on the branch. Regeneration used to refuse a schema change that
+did not also bump `API_VERSION`, so a number naming a release that had not
+happened climbed once per pull request, and every schema-touching branch
+conflicted with every other one on the same handful of lines.
+
+Components are therefore free to disagree while work is in flight, and must
+agree at the moment something is published. A release is one change that sets
+every component to the new version, regenerates what embeds it — the bundled
+specs, both generated clients, the browser bundle, the lockfiles — and adds the
+changelog entry.
+
+Skew between an installed client and the server it is talking to never depended
+on this label anyway. `lemma_sdk._spec_info.SPEC_SHA256` fingerprints the schema
+itself, so `lemma doctor` reports a mismatched client whether or not anyone
+remembered to bump.
+
+## Adding a component
+
+Add it to `SOURCES` in `scripts/check_version_consistency.py` the moment it
+carries a version somebody can read — installed from an index or not. Three
+packages were left out because nothing publishes them, drifted a release behind
+without anything saying so, and were found by the next release rather than by
+the check.
+
+The move from API `4.0.1` to `0.6.3` was a one-time beta normalization. It
+aligned the previously independent API counter with the Python and TypeScript
+SDKs without claiming a stable `4.x` compatibility contract before the platform
+has reached `1.0`.

--- a/lemma-backend/app/version.py
+++ b/lemma-backend/app/version.py
@@ -29,4 +29,4 @@ Use a normal MAJOR.MINOR.PATCH string.
 
 from __future__ import annotations
 
-API_VERSION = "0.7.2"
+API_VERSION = "0.8.0"

--- a/lemma-backend/pyproject.toml
+++ b/lemma-backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-backend"
-version = "0.7.1"
+version = "0.8.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.14,<3.15"

--- a/lemma-backend/sandbox-images/templates/function-python/uv.lock
+++ b/lemma-backend/sandbox-images/templates/function-python/uv.lock
@@ -168,7 +168,7 @@ requires-dist = [
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.2"
+version = "0.8.0"
 source = { directory = "../../../../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/lemma-backend/sandbox-images/templates/workspace-python/uv.lock
+++ b/lemma-backend/sandbox-images/templates/workspace-python/uv.lock
@@ -640,12 +640,12 @@ wheels = [
 
 [[package]]
 name = "lemma-pod-bundle"
-version = "0.7.1"
+version = "0.8.0"
 source = { directory = "../../../../lemma-pod-bundle" }
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.2"
+version = "0.8.0"
 source = { directory = "../../../../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/lemma-backend/uv.lock
+++ b/lemma-backend/uv.lock
@@ -1827,7 +1827,7 @@ wheels = [
 
 [[package]]
 name = "lemma-backend"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -1995,12 +1995,12 @@ dev = [
 
 [[package]]
 name = "lemma-pod-bundle"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "../lemma-pod-bundle" }
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.2"
+version = "0.8.0"
 source = { editable = "../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/lemma-cli/lemma_cli/__init__.py
+++ b/lemma-cli/lemma_cli/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 __all__ = ["__version__"]
 
-__version__ = "0.7.2"
+__version__ = "0.8.0"
 
 if sys.platform == "win32":
     for _stream in (sys.stdout, sys.stderr):

--- a/lemma-cli/pyproject.toml
+++ b/lemma-cli/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   # — an unbounded floor lets a `pip install lemma-cli` a year from now resolve
   # a CLI against an SDK nobody ever ran it with. The release workflow rewrites
   # both halves on every tagged build.
-  "lemma-sdk>=0.7.2,<0.8",
+  "lemma-sdk>=0.8.0,<0.9",
   "click>=8.3.0",
   "typer>=0.12.5",
   "rich>=13.9.4",

--- a/lemma-cli/uv.lock
+++ b/lemma-cli/uv.lock
@@ -323,12 +323,12 @@ wheels = [
 
 [[package]]
 name = "lemma-pod-bundle"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "../lemma-pod-bundle" }
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.2"
+version = "0.8.0"
 source = { directory = "../lemma-python" }
 dependencies = [
     { name = "attrs" },

--- a/lemma-frontend/content/changelog/0-8-0.mdx
+++ b/lemma-frontend/content/changelog/0-8-0.mdx
@@ -1,0 +1,121 @@
+---
+title: 0.8.0
+description: Lemma runs on Windows, GitHub and Slack become connectors Lemma speaks natively, a run says what it costs while it runs, and three names on the wire settle on one spelling each.
+published: 2026-09-10
+tags:
+  - release
+---
+
+## Three names on the wire settle on one spelling
+
+This is the change that makes 0.8 a minor rather than a patch. Three
+inconsistencies were spread across the API, each of them harmless on its own and
+each of them something a client had to learn twice.
+
+`{org_id}` becomes `{organization_id}` in the fourteen identity and agent
+operations that still spelled it the short way; usage and connectors already
+said `organization_id`, and there was no reason for the split beyond the order
+the modules were written in. `GET /pods/organization/{organization_id}` was the
+only org-scoped collection not nested under its organization, and is now
+`GET /organizations/{organization_id}/pods`. And three routes named an action
+with a colon while twenty named it with a slash, so the slash wins on count.
+
+None of the operation ids move, so anything written against the SDKs by name is
+untouched — both SDK layers call the generated clients positionally, and a path
+rename stops at the generated signature. Two of the colon routes,
+`/agent-host/pairings:complete` and `/agent-host/events:append`, keep an alias:
+the Rust agent host hard-codes them and an installed host keeps calling what it
+shipped with, so removing them outright would strand every paired computer
+already in the field.
+
+If you call the HTTP API directly, those are the three edits. If you use
+`lemma-sdk` for Python or TypeScript, or the `lemma` CLI, upgrade the package
+and there is nothing else to do.
+
+## Lemma runs on Windows
+
+Lemma had never been run on Windows. It nearly booted after four blockers, and
+then kept not-quite-working in ways that only running it could find: a path is
+not an identity there, so a wrapper-launched agent outlived every run it
+belonged to; an installer cannot replace a file that is open; every sandbox
+start began the download the previous start was still doing; and an upgrade was
+a choice between the old release and nothing.
+
+Those are fixed, along with the shell paths that could each stop the app, and
+the nightly can now build a Windows host pack — it could not, because of an API
+nobody calls.
+
+## GitHub, Slack and Gmail are connectors Lemma speaks natively
+
+GitHub is a real GitHub App now. Lemma acts as the App against an installation,
+so a schedule keeps working after its author leaves and a triggered run has an
+identity with nobody present; and as the person for the sandbox's `git` and `gh`
+and for pod publishing, because work in someone's checkout should carry their
+name. GitHub events wake a pod. "GitHub is connected" used to be true and
+useless — authorizing is not installing — and now says which of the two it
+means. A published pod no longer carries its author's installation with it.
+
+Slack and Gmail stop going through a vendored package and become native OpenAPI
+connectors, which meant teaching the shared machinery the three things they
+need: form-encoded bodies, failure reported inside a `200`, and cursor
+pagination. Slack answering `{"ok": false}` with HTTP 200 had been reaching
+agents as a successful result, so an agent read a failure as data.
+
+An MCP server connected with an API key came up with no tools; it comes up with
+its tools, described in the server's own words, on a session that survives.
+
+## A run says what it costs, while it runs
+
+Model work that had been running for free is metered per request, budgets are
+enforced as the run proceeds rather than after it, and the usage screens say
+what a cost is made of and how much of a plan is left. A refusal now names the
+budget it hit, which is how an agent that could not look at an image explained
+itself instead of failing the whole run over one picture.
+
+## Apps and functions can be rolled back
+
+Both keep a bounded version history, and a rollback is a safe operation rather
+than a redeploy of something you hope you still have. An app's version history
+shipped in an earlier version with no way to open it; there is a way now.
+
+## Lem is a real agent
+
+The pod's assistant had no `agents` row — a conversation with a null agent id
+*was* the assistant — so it could not be scheduled, could not be a trigger's
+target, and every surface that wanted to name it faked it differently. It has
+one row, one identity and one name everywhere, and a schedule can wake it with
+an instruction for the occasion rather than an agent whose entire purpose is one
+sentence.
+
+## Self-hosting on a server
+
+There were four ways to run Lemma and none of them was "on a server".
+`deploy/compose/` is that missing path: api and worker as separate containers, a
+one-shot migrate that stops a deploy rather than crash-looping against a schema
+it cannot use, and images pinned by digest from the release manifest — so a
+compose deployment of a version runs the same bytes as a desktop install of it.
+
+## Desktop stops freezing, and stops being unreadable
+
+Five locks were held across work that waits, and the tray froze for eleven
+seconds. The splash parsed 356 KB before it could draw anything. A killed
+install left 2.2 GB behind. A guest asked a system with no init to power itself
+off. Those are gone, along with a sandbox that could quietly fill the guest's
+disk, and a settings pane that asked a dead daemon for ever.
+
+The agent host was 16,678 lines in ten files. Nothing under `desktop/` is over
+600 lines now, `daemon.rs` is not 3,261 of them, and the twenty guards that had
+been reading the wrong file read the right one.
+
+## Under the floor
+
+The composition root is empty and then gone: modules talk through contracts and
+events, and imports through the root fell from 195 to 61 on the way. The
+standard the code is held to is written down, with an id per rule and the check
+that enforces it, and the gates were changed to match what it says. A unit test
+can no longer reach production. A default a test cannot replace is a build
+failure. Both DMG pipelines verify the same things, after each had been checking
+something the other thought mattered.
+
+A forged `From:` could make a mailbox write to a stranger, and a channel could
+make an agent answer nobody. Neither can now.

--- a/lemma-frontend/package-lock.json
+++ b/lemma-frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemma-frontend",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lemma-frontend",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "@noble/hashes": "^2.2.0",
@@ -88,7 +88,7 @@
     },
     "../lemma-typescript": {
       "name": "lemma-sdk",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "supertokens-web-js": "^0.16.0"

--- a/lemma-frontend/package.json
+++ b/lemma-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemma-frontend",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "engines": {
     "node": ">=24 <25"
   },

--- a/lemma-frontend/public/openapi.json
+++ b/lemma-frontend/public/openapi.json
@@ -18457,7 +18457,7 @@
   "info": {
     "description": "Authentication API with JWT, user management, and OAuth support",
     "title": "Lemma Backend",
-    "version": "0.7.2"
+    "version": "0.8.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/lemma-pod-bundle/pyproject.toml
+++ b/lemma-pod-bundle/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-pod-bundle"
-version = "0.7.1"
+version = "0.8.0"
 description = "Shared pod bundle format vocabulary for the Lemma CLI and backend"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/lemma-pod-bundle/uv.lock
+++ b/lemma-pod-bundle/uv.lock
@@ -4,5 +4,5 @@ requires-python = "==3.14.*"
 
 [[package]]
 name = "lemma-pod-bundle"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "." }

--- a/lemma-python/lemma_sdk/_spec_info.py
+++ b/lemma-python/lemma_sdk/_spec_info.py
@@ -12,5 +12,5 @@ SDK and the server it is talking to.
 
 from __future__ import annotations
 
-API_VERSION = "0.7.2"
-SPEC_SHA256 = "080b0e75592f041ca7b7dcf5e1cc4f000839a6cd8d747e0c92caf091c063d069"
+API_VERSION = "0.8.0"
+SPEC_SHA256 = "58283611f1ae677d5bda850a0c8ac05c7ab0db1bf2458e343136ca135820b4c6"

--- a/lemma-python/lemma_sdk/openapi_spec.json
+++ b/lemma-python/lemma_sdk/openapi_spec.json
@@ -18457,7 +18457,7 @@
   "info": {
     "description": "Authentication API with JWT, user management, and OAuth support",
     "title": "Lemma Backend",
-    "version": "0.7.2"
+    "version": "0.8.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/lemma-python/pyproject.toml
+++ b/lemma-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-sdk"
-version = "0.7.2"
+version = "0.8.0"
 description = "Python SDK for Lemma"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/lemma-python/uv.lock
+++ b/lemma-python/uv.lock
@@ -160,7 +160,7 @@ wheels = [
 
 [[package]]
 name = "lemma-sdk"
-version = "0.7.2"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },

--- a/lemma-stack/pyproject.toml
+++ b/lemma-stack/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lemma-stack"
-version = "0.7.2"
+version = "0.8.0"
 description = "Installer and management tool for a fully-local Lemma stack"
 readme = "README.md"
 requires-python = ">=3.14,<3.15"

--- a/lemma-stack/uv.lock
+++ b/lemma-stack/uv.lock
@@ -31,7 +31,7 @@ wheels = [
 
 [[package]]
 name = "lemma-stack"
-version = "0.7.2"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "packaging" },

--- a/lemma-typescript/package-lock.json
+++ b/lemma-typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lemma-sdk",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lemma-sdk",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "supertokens-web-js": "^0.16.0"

--- a/lemma-typescript/package.json
+++ b/lemma-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemma-sdk",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "engines": {
     "node": ">=22"
   },

--- a/lemma-typescript/public/lemma-client.js
+++ b/lemma-typescript/public/lemma-client.js
@@ -9926,7 +9926,7 @@ var LemmaClient = (() => {
   }
 
   // src/version.ts
-  var SDK_VERSION = "0.7.2";
+  var SDK_VERSION = "0.8.0";
   var CLIENT_HEADER_NAME = "X-Lemma-Client";
   var APP_HEADER_NAME = "X-Lemma-App";
   var KNOWN_CLIENTS = [
@@ -10354,7 +10354,7 @@ var LemmaClient = (() => {
   // src/openapi_client/core/OpenAPI.ts
   var OpenAPI = {
     BASE: "",
-    VERSION: "0.7.2",
+    VERSION: "0.8.0",
     WITH_CREDENTIALS: false,
     CREDENTIALS: "include",
     TOKEN: void 0,

--- a/lemma-typescript/src/openapi_client/core/OpenAPI.ts
+++ b/lemma-typescript/src/openapi_client/core/OpenAPI.ts
@@ -21,7 +21,7 @@ export type OpenAPIConfig = {
 
 export const OpenAPI: OpenAPIConfig = {
     BASE: '',
-    VERSION: '0.7.2',
+    VERSION: '0.8.0',
     WITH_CREDENTIALS: false,
     CREDENTIALS: 'include',
     TOKEN: undefined,

--- a/lemma-typescript/src/openapi_spec.json
+++ b/lemma-typescript/src/openapi_spec.json
@@ -18457,7 +18457,7 @@
   "info": {
     "description": "Authentication API with JWT, user management, and OAuth support",
     "title": "Lemma Backend",
-    "version": "0.7.2"
+    "version": "0.8.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/lemma-typescript/src/version.ts
+++ b/lemma-typescript/src/version.ts
@@ -1,6 +1,6 @@
 // Keep SDK_VERSION in sync with package.json "version". The CI codegen/drift
 // gate (workstream A) asserts they match so this can't silently drift.
-export const SDK_VERSION = "0.7.2";
+export const SDK_VERSION = "0.8.0";
 
 /** Sent as `X-Lemma-Client` when it will not add an otherwise avoidable browser
  *  preflight, so the backend can log which client + version hit an endpoint. */

--- a/render.yaml
+++ b/render.yaml
@@ -77,7 +77,7 @@ services:
     runtime: image
     plan: standard
     image:
-      url: ghcr.io/lemma-work/lemma-backend:v0.7.2
+      url: ghcr.io/lemma-work/lemma-backend:v0.8.0
     healthCheckPath: /health/ready
     # Migrations before the new instance serves. On compose this is a separate
     # one-shot container so a failure stops the deploy; Render's equivalent is
@@ -142,7 +142,7 @@ services:
     runtime: image
     plan: standard
     image:
-      url: ghcr.io/lemma-work/lemma-backend:v0.7.2
+      url: ghcr.io/lemma-work/lemma-backend:v0.8.0
     dockerCommand: python -m app.worker
     envVars: *backend_env
 
@@ -151,7 +151,7 @@ services:
     runtime: image
     plan: starter
     image:
-      url: ghcr.io/lemma-work/lemma-frontend:v0.7.2
+      url: ghcr.io/lemma-work/lemma-frontend:v0.8.0
     envVars:
       - key: NEXT_PUBLIC_API_URL
         sync: false

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -152,6 +152,22 @@ SOURCES: tuple[Source, ...] = (
         REPO_ROOT / "lemma-stack/pyproject.toml",
         re.compile(r'(?m)^version = "([^"]+)"'),
     ),
+    # The three below are not installed from an index, which is why they were
+    # left out — and why they drifted. The 0.7.1 release moved all three; 0.7.2
+    # moved neither, and nothing said, so 0.8.0 found them a release behind.
+    # A version that is only ever read by a person reporting a bug still has to
+    # be right, and the cost of listing them here is one line each at release.
+    Source(
+        "lemma-backend package",
+        REPO_ROOT / "lemma-backend/pyproject.toml",
+        re.compile(r'(?m)^version = "([^"]+)"'),
+    ),
+    Source(
+        "lemma-pod-bundle package",
+        REPO_ROOT / "lemma-pod-bundle/pyproject.toml",
+        re.compile(r'(?m)^version = "([^"]+)"'),
+    ),
+    Source("lemma-frontend package", REPO_ROOT / "lemma-frontend/package.json"),
 )
 
 def workspace_members() -> tuple[str, ...]:


### PR DESCRIPTION
## What changes

Every Lemma-owned component moves from 0.7.2 to **0.8.0**, and the three that
had fallen a release behind join the check so it cannot happen again.

0.8 is a minor rather than a patch because #620 changed the wire:

| Before | After |
|---|---|
| `{org_id}` (14 identity/agent operations) | `{organization_id}` |
| `GET /pods/organization/{organization_id}` | `GET /organizations/{organization_id}/pods` |
| `…/messages:append`, `/agent-host/events:append`, `/agent-host/pairings:complete` | the `/` spelling the other twenty actions already used |

Per [docs/versioning.md](docs/versioning.md) that is the shared API/SDK
compatibility line moving.

Also here: the `0.8.0` changelog entry, and `docs/versioning.md` rewritten —
it still described the per-change bumping that #273 replaced, on the page that
documents this exact operation.

## Why

The version check is a release gate, not a per-PR one: components drift while
work is in flight and must agree at the moment something is published. This is
that moment.

Three of them had drifted further than that allows. `lemma-backend`,
`lemma-pod-bundle` and `lemma-frontend` all moved for 0.7.1, none moved for
0.7.2, and this release found them still at 0.7.1. They are not installed from
an index, which is why they were left out of `SOURCES` — and exactly why they
drifted, the same way `lemma-stack` did before it was added. All three are in
the check now. **Sixteen components, not thirteen.**

## How it was done

Nothing that embeds a version was hand-edited; it was regenerated:

```bash
cd lemma-backend && uv run python scripts/dump_openapi_spec.py \
  --output ../lemma-python/lemma_sdk/openapi_spec.json
cd lemma-python   && OPENAPI_FILE=lemma_sdk/openapi_spec.json bash scripts/generate_openapi_client.sh
cd lemma-typescript && OPENAPI_FILE=../lemma-python/lemma_sdk/openapi_spec.json bash scripts/generate_openapi_client.sh
node scripts/generate_l2.mjs && npm run build:bundle
node lemma-frontend/scripts/sync-openapi-spec.mjs
```

Both generated clients came back byte-identical apart from the version and
`_spec_info.SPEC_SHA256`, and the L2 hooks did not move at all.

**The lockfiles are edited, not relocked** — deliberately. `uv` on this machine
is 0.7.10 against revision-3 locks, and `npm` is 11.3.0 against a lockfile
written by a newer one. A full relock downgrades the lock format and rewrites
platform markers and `libc` blocks that have nothing to do with this release; a
reviewer would have to read 32 lines of unrelated churn to find the two that
matter. Only the eleven `version =` lines under `lemma-*` package blocks moved,
and the result is verified below.

## How to verify

```bash
python3 scripts/check_version_consistency.py --expect v0.8.0
make lint-lockfiles
(cd desktop && cargo metadata --locked --format-version 1 >/dev/null && echo "Cargo.lock OK")
(cd lemma-cli && uv sync --quiet && ./.venv/bin/lemma --version)
make quality && make quality-frontend && make codeql
(cd lemma-stack && uv run pytest tests/test_install_experience.py -q)
make test-python && make test-cli-unit && (cd lemma-typescript && npm test)
```

What they printed:

```
All 16 components declare 0.8.0.
8 lockfiles current.
Cargo.lock OK
lemma 0.8.0
lemma-sdk 0.8.0 (api schema 0.8.0, spec 58283611f1ae)
✓ quality gates pass
[openapi] public/openapi.json is current (186 paths)
CodeQL: no findings in changed files.
9 passed in 78.67s            # lemma-stack install experience
117 passed, 1 deselected      # lemma-python
780 passed, 18 deselected     # lemma-cli
321 passed (41 files)         # lemma-typescript
```

`npm ci` in both Node projects leaves the lockfiles untouched, which is the
check that matters for the hand-edit.

## Checklist

- [x] Lint, typecheck, and architecture gates pass locally
- [x] **API surface** — spec regenerated from the backend app, both SDKs
      regenerated from that spec, the published `openapi.json` and the browser
      bundle rebuilt, all committed here
- [x] **Compatibility** — see below
- [x] **Rollback** — revert the commit; nothing is published until the tag

## Compatibility and rollback notes

The wire changes landed in #620, not here; this change is what names them. For
anyone calling the HTTP API directly, the three renames above are the edits.
Anyone on `lemma-sdk` (Python or TypeScript) or the `lemma` CLI upgrades the
package and does nothing else — both SDK layers call the generated clients
positionally, so a path-parameter rename stops at the generated signature, and
no operation id moved.

`/agent-host/pairings:complete` and `/agent-host/events:append` keep their
colon aliases: the Rust agent host hard-codes them against a user-supplied
server, so removing them would strand every paired computer in the field.

**One ordering note.** `render.yaml` and `.do/deploy.template.yaml` now pin
`v0.8.0` image tags — their own comment says to bump them together — and those
tags do not exist until `release-local-images.yml` publishes them for the tag.
Between this merging and the tag being pushed, those two templates name an
image that is not there yet. That is the same window the tag itself has, and
the alternative is a follow-up PR that gets forgotten.

## Rollout, once this merges

Pushing `v0.8.0` starts everything: `release-local-images.yml` builds and
publishes the `ghcr.io` images and the GitHub Release, and the Release being
published triggers the desktop build, `lemma-sdk` to PyPI, `lemma` to PyPI, and
`lemma-sdk` to npm. Each of those runs `check_version_consistency.py --expect`
against the tag first, so a component left behind stops the publish rather than
shipping skewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows support, app and function rollback, per-request metering with budget enforcement, and a new self-hosting deployment path.
  * GitHub is now available as a native app, with Slack and Gmail available as native OpenAPI connectors.
  * The Lemma assistant now has a persistent identity.

* **Improvements**
  * Standardized API naming and route formats, while retaining compatibility aliases.
  * Improved desktop freezing and readability.

* **Release**
  * Updated all published components and deployment images to version 0.8.0.
  * Added release-wide version consistency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->