### PR TITLE
Two of three branches unwrapped the secret, and dev signed up through the third

### DIFF
--- a/lemma-backend/app/core/config.py
+++ b/lemma-backend/app/core/config.py
@@ -597,9 +597,8 @@ class Settings(BaseSettings):
             "is correct when one endpoint carries both event types."
         ),
     )
-    # No default. A fallback sender is not configuration: it makes an
-    # unconfigured deployment send password resets from a domain it may not own,
-    # which fails DMARC silently and locks people out with no error anywhere.
+    # Required alongside RESEND_API_KEY, and no default is possible: Resend only
+    # accepts a sender on a domain verified for that account.
     resend_from_email: Optional[str] = Field(
         default=None,
         description="Sender address used with the Resend SMTP relay",
@@ -1256,7 +1255,8 @@ class Settings(BaseSettings):
                 self.smtp_from_email,
             ]
         )
-        return bool(explicit_smtp or reveal_secret(self.resend_api_key))
+        resend = reveal_secret(self.resend_api_key) and self.resend_from_email
+        return bool(explicit_smtp or resend)
 
     def resolve_browser_sdk_path(self) -> Optional[Path]:
         """Locate the built browser SDK bundle served to no-build apps.

--- a/lemma-backend/app/core/email/email_sender.py
+++ b/lemma-backend/app/core/email/email_sender.py
@@ -121,7 +121,7 @@ class EmailSender:
                 smtp_port=settings.smtp_port,
                 smtp_user=settings.smtp_user or "",
                 smtp_password=reveal_secret(settings.smtp_password) or "",
-                from_email=settings.smtp_from_email or "hello@updates.lemma.work",
+                from_email=settings.smtp_from_email or "lemma@localhost",
                 from_name=settings.smtp_from_name,
                 use_tls=settings.smtp_use_tls,
                 transport="filesystem",
@@ -138,6 +138,15 @@ class EmailSender:
             )
         )
         if not explicit_smtp and resend_api_key:
+            if not settings.resend_from_email:
+                # No default is possible: Resend only accepts a sender on a
+                # domain verified for that account, which differs per
+                # deployment. Anything we picked would be rejected by the relay
+                # or fail the receiving domain's DMARC.
+                raise EmailNotConfiguredError(
+                    "RESEND_API_KEY is set but RESEND_FROM_EMAIL is not. Set it "
+                    "to an address on a domain verified in your Resend account."
+                )
             return cls(
                 smtp_host="smtp.resend.com",
                 smtp_port=465,
@@ -156,12 +165,18 @@ class EmailSender:
                 "SMTP_USER, SMTP_PASSWORD, and SMTP_FROM_EMAIL."
             )
 
+        if not settings.smtp_from_email:
+            raise EmailNotConfiguredError(
+                "SMTP is configured but SMTP_FROM_EMAIL is not, so outgoing "
+                "mail would have no sender address."
+            )
+
         return cls(
             smtp_host=settings.smtp_host,
             smtp_port=settings.smtp_port,
-            smtp_user=settings.smtp_user,  # type: ignore
-            smtp_password=settings.smtp_password,  # type: ignore
-            from_email=settings.smtp_from_email,  # type: ignore
+            smtp_user=settings.smtp_user or "",
+            smtp_password=reveal_secret(settings.smtp_password) or "",
+            from_email=settings.smtp_from_email,
             from_name=settings.smtp_from_name,
             use_tls=settings.smtp_use_tls,
             transport="smtp",

--- a/lemma-backend/app/modules/identity/tests/unit/test_email_sender.py
+++ b/lemma-backend/app/modules/identity/tests/unit/test_email_sender.py
@@ -17,6 +17,7 @@ from app.core.email.email_sender import (
 
 class _FakeSMTP:
     kwargs: dict = {}
+    credentials: tuple = ()
     fail = False
 
     def __init__(self, **kwargs):
@@ -28,9 +29,13 @@ class _FakeSMTP:
     async def __aexit__(self, *_args):
         return None
 
-    async def login(self, _user, _password):
+    async def login(self, user, password):
         if self.fail:
             raise OSError("SMTP unavailable")
+        # aiosmtplib encodes both credentials before putting them on the wire.
+        # Doing the same here is what makes a SecretStr that never got
+        # unwrapped fail in the test instead of only in production.
+        type(self).credentials = (user.encode("utf-8"), password.encode("utf-8"))
 
     async def send_message(self, _message):
         return None
@@ -142,7 +147,7 @@ def test_explicit_smtp_configuration_takes_precedence_over_resend(monkeypatch):
     monkeypatch.setattr(settings, "smtp_host", "smtp.example.com")
     monkeypatch.setattr(settings, "smtp_port", 587)
     monkeypatch.setattr(settings, "smtp_user", "explicit-user")
-    monkeypatch.setattr(settings, "smtp_password", "explicit-password")
+    monkeypatch.setattr(settings, "smtp_password", SecretStr("explicit-password"))
     monkeypatch.setattr(settings, "smtp_from_email", "mail@example.com")
     monkeypatch.setattr(settings, "resend_api_key", SecretStr("re_test_key"))
 
@@ -152,3 +157,34 @@ def test_explicit_smtp_configuration_takes_precedence_over_resend(monkeypatch):
     assert sender.smtp_port == 587
     assert sender.smtp_user == "explicit-user"
     assert sender.from_email == "mail@example.com"
+    # aiosmtplib encodes the password on login, so a SecretStr that reached
+    # this far unwrapped would fail there and nowhere else.
+    assert sender.smtp_password.encode("utf-8") == b"explicit-password"
+
+
+def test_resend_key_without_sender_address_is_rejected(monkeypatch):
+    """No sender must fail loudly. Resend only accepts a verified domain, so
+    there is no address we could default to that would actually deliver."""
+    monkeypatch.setattr(settings, "email_transport", "smtp")
+    monkeypatch.setattr(settings, "smtp_user", None)
+    monkeypatch.setattr(settings, "smtp_password", None)
+    monkeypatch.setattr(settings, "smtp_from_email", None)
+    monkeypatch.setattr(settings, "resend_api_key", SecretStr("re_test_key"))
+    monkeypatch.setattr(settings, "resend_from_email", None)
+
+    assert not settings.is_email_configured()
+    with pytest.raises(EmailNotConfiguredError):
+        EmailSender.from_settings()
+
+
+def test_explicit_smtp_without_sender_address_is_rejected(monkeypatch):
+    monkeypatch.setattr(settings, "email_transport", "smtp")
+    monkeypatch.setattr(settings, "smtp_host", "smtp.example.com")
+    monkeypatch.setattr(settings, "smtp_user", "explicit-user")
+    monkeypatch.setattr(settings, "smtp_password", SecretStr("explicit-password"))
+    monkeypatch.setattr(settings, "smtp_from_email", None)
+    monkeypatch.setattr(settings, "resend_api_key", None)
+    monkeypatch.setattr(settings, "resend_from_email", None)
+
+    with pytest.raises(EmailNotConfiguredError):
+        EmailSender.from_settings()


### PR DESCRIPTION
## What changes

Signing up on dev returns a 500 and never sends the verification email. `EmailSender.from_settings()` builds a sender three ways; two unwrap the SMTP password, the third passes the raw `SecretStr` to aiosmtplib, which calls `.encode()` on it.

A sender address is now also required wherever mail actually leaves the process. `from_email` is typed `str` but reached the relay as `None` when `RESEND_FROM_EMAIL` was unset, posting `Lemma <None>`.

## Why

Every verification email on dev fails:

```
email.send.failed  AttributeError: 'SecretStr' object has no attribute 'encode'
→ EmailDeliveryError: SMTP delivery failed   POST /st/auth/user/email/verify/token  500
```

Dev takes the explicit-SMTP branch because `SMTP_HOST`/`USER`/`FROM_EMAIL` are in `backend-config` and `SMTP_PASSWORD` is in `backend-secrets`, so `explicit_smtp` is true.

Introduced by #603, which made `smtp_password` a `SecretStr` and converted two of the three call sites. The `# type: ignore` on the third suppressed exactly the type error that would have caught it.

**Prod is not affected yet, but this blocks the release.** Its pin `07e76ebd` (2026-08-31) predates #603 (`d55eccef7`, 2026-09-03) — confirmed with `git merge-base --is-ancestor`. Prod's email config has the same shape, so it takes the same branch the moment this RC is promoted.

### Why the test suite was green

The explicit-SMTP branch *had* a test. Two things made it certify the broken half:

1. It monkeypatched `smtp_password="explicit-password"` — a plain `str`. `reveal_secret()` deliberately tolerates plain strings so tests can patch settings, which means a bare-string double **cannot distinguish a revealed secret from an unrevealed one**. The test also never asserted on the password.
2. `_FakeSMTP.login()` accepted both credentials and discarded them. Real aiosmtplib encodes them — so the one operation that fails was the one operation not exercised.

The fake now encodes what it is handed, and the test supplies the type pydantic actually produces.

### Why no default sender

`from_email` cannot be defaulted. Resend only accepts a sender on a domain verified for that account, and that differs per deployment — any hardcoded address is either rejected by the relay or fails the receiving domain's DMARC. `RESEND_FROM_EMAIL` is documented in `docs/authentication-hardening.md` as "no default; must be a domain you own"; this restores that contract in code. `is_email_configured()` previously reported a Resend key alone as configured; it no longer does.

### Scope check

Audited all 22 `SecretStr` fields and every read of them. This was the only unwrapping defect: `basedpyright` across `lemma-backend/app` reports **zero** SecretStr-assignability errors after the fix, and `lemma-cli`/`lemma-python`/`lemma-stack` use no `SecretStr`. After this change no `# type: ignore` in non-test backend code sits on a line touching a secret.

Worth flagging separately: basedpyright pinpoints this bug (`"SecretStr" is not assignable to "str"`), but the backend has no type-check gate — the gate covers only `lemma_cli`/`lemma_sdk`, and `app/` carries ~1,200 pre-existing errors. Nothing in CI would have caught the suppression.

## How to verify

```bash
cd lemma-backend
uv run pytest app/modules/identity/tests/unit/test_email_sender.py -q
uv run basedpyright app/core/email/email_sender.py
```

`8 passed`, and `0 errors, 0 warnings, 0 notes`.

Reverting just the source fix (keeping the tests) fails `test_explicit_smtp_configuration_takes_precedence_over_resend` — verified, so the guard is real rather than merely present.

Gates, from the repo root:

```bash
make format-check && make quality
```

`✓ quality gates pass`. Full lane: `1498 passed, 1 skipped` across `app/modules/identity/tests/unit` and `app/modules/agent_surfaces/tests/unit`.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — no new secret in a log, response, or queued payload. The change removes a `SecretStr` from a path that would have put plaintext on the wire only after unwrapping at the point of use.
- [x] **Rollback** — revert the commit; it touches three files and no state.

## Compatibility and rollback notes

One operator-visible change: a deployment with `RESEND_API_KEY` set but `RESEND_FROM_EMAIL` unset now fails at `EmailSender` construction with a message naming the setting, where it previously built `From: Lemma <None>` and failed at the relay. Every environment I could check already sets a sender — dev has `SMTP_FROM_EMAIL=lemma@ops.asur.work`, and prod sets an explicit `from_email` — so nothing in flight is affected.

The filesystem transport stays zero-config for local installs; its placeholder moved from `hello@updates.lemma.work` to `lemma@localhost`, since that spool never reaches a relay and the old value was a domain from a test fixture rather than one Lemma sends from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
