### PR TITLE
Publish the packages from the tag, not from a release nobody can trigger

### DIFF
--- a/.github/workflows/release-lemma-python.yml
+++ b/.github/workflows/release-lemma-python.yml
@@ -1,6 +1,15 @@
 name: Release Lemma Python SDK
 
 on:
+  # The tag, not the release. A release created by a workflow runs as the
+  # default GITHUB_TOKEN, and GitHub will not start a new workflow run from an
+  # event that token raised -- so `release: published` fires only when a person
+  # cuts the release by hand. v0.7.1 was cut by a person and this ran; v0.7.2
+  # was cut by release-local-images.yml and this never ran at all, which is why
+  # PyPI sat a release behind for ten days with nothing saying so.
+  push:
+    tags:
+      - "v*"
   release:
     types:
       - published
@@ -27,14 +36,21 @@ jobs:
         working-directory: lemma-python
 
     steps:
+      # Build the tag, not whatever the default branch happens to be. Without a
+      # ref a workflow_dispatch checks out main and the version input only
+      # rewrites the version string, so a dispatch run after an unrelated merge
+      # would publish a different tree under this release's name -- and a
+      # package version cannot be re-cut once it is on an index.
       - name: Checkout
         uses: actions/checkout@v7
-
-      - name: Require fresh backend protected E2E
-        uses: ./.github/actions/require-backend-protected-e2e
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sha: ${{ github.sha }}
+          ref: ${{ github.event.release.tag_name || inputs.version || github.ref }}
+
+      # The protected backend suite is not a gate on this artifact. It exercises
+      # the real Docker runtime, the document processors and the Rust agent
+      # host; none of the three is in the wheel published here, and the job
+      # already builds and tests exactly what it uploads. The desktop release
+      # keeps the gate, which is what it was written for.
 
       - name: Setup Python
         uses: actions/setup-python@v7

--- a/.github/workflows/release-lemma-terminal.yml
+++ b/.github/workflows/release-lemma-terminal.yml
@@ -1,6 +1,15 @@
 name: Release Lemma Terminal CLI
 
 on:
+  # The tag, not the release. A release created by a workflow runs as the
+  # default GITHUB_TOKEN, and GitHub will not start a new workflow run from an
+  # event that token raised -- so `release: published` fires only when a person
+  # cuts the release by hand. v0.7.1 was cut by a person and this ran; v0.7.2
+  # was cut by release-local-images.yml and this never ran at all, which is why
+  # PyPI sat a release behind for ten days with nothing saying so.
+  push:
+    tags:
+      - "v*"
   release:
     types:
       - published
@@ -24,14 +33,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # Build the tag, not whatever the default branch happens to be. Without a
+      # ref a workflow_dispatch checks out main and the version input only
+      # rewrites the version string, so a dispatch run after an unrelated merge
+      # would publish a different tree under this release's name -- and a
+      # package version cannot be re-cut once it is on an index.
       - name: Checkout
         uses: actions/checkout@v7
-
-      - name: Require fresh backend protected E2E
-        uses: ./.github/actions/require-backend-protected-e2e
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sha: ${{ github.sha }}
+          ref: ${{ github.event.release.tag_name || inputs.version || github.ref }}
+
+      # The protected backend suite is not a gate on this artifact. It exercises
+      # the real Docker runtime, the document processors and the Rust agent
+      # host; none of the three is in the wheel published here, and the job
+      # already builds and tests exactly what it uploads. The desktop release
+      # keeps the gate, which is what it was written for.
 
       - name: Setup Python
         uses: actions/setup-python@v7

--- a/.github/workflows/release-lemma-typescript.yml
+++ b/.github/workflows/release-lemma-typescript.yml
@@ -1,6 +1,15 @@
 name: Release Lemma TypeScript SDK
 
 on:
+  # The tag, not the release. A release created by a workflow runs as the
+  # default GITHUB_TOKEN, and GitHub will not start a new workflow run from an
+  # event that token raised -- so `release: published` fires only when a person
+  # cuts the release by hand. v0.7.1 was cut by a person and this ran; v0.7.2
+  # was cut by release-local-images.yml and this never ran at all, which is why
+  # npm sat a release behind for ten days with nothing saying so.
+  push:
+    tags:
+      - "v*"
   release:
     types:
       - published
@@ -31,14 +40,21 @@ jobs:
         working-directory: lemma-typescript
 
     steps:
+      # Build the tag, not whatever the default branch happens to be. Without a
+      # ref a workflow_dispatch checks out main and the version input only
+      # rewrites the version string, so a dispatch run after an unrelated merge
+      # would publish a different tree under this release's name -- and a
+      # package version cannot be re-cut once it is on an index.
       - name: Checkout
         uses: actions/checkout@v7
-
-      - name: Require fresh backend protected E2E
-        uses: ./.github/actions/require-backend-protected-e2e
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sha: ${{ github.sha }}
+          ref: ${{ github.event.release.tag_name || inputs.version || github.ref }}
+
+      # The protected backend suite is not a gate on this artifact. It exercises
+      # the real Docker runtime, the document processors and the Rust agent
+      # host; none of the three is in the package published here, and the job
+      # already builds and tests exactly what it uploads. The desktop release
+      # keeps the gate, which is what it was written for.
 
       - name: Setup Node.js
         uses: actions/setup-node@v7


### PR DESCRIPTION
## What changes

`lemma-sdk` (PyPI + npm) and `lemma-terminal` (PyPI) publish on the **tag push** rather than only on a hand-cut GitHub Release. The checkout takes a `ref`, and the protected-E2E gate comes off these three workflows.

## Why

**PyPI and npm have been a release behind since 0.7.2, and nothing said so.**

| Package | Registry | Published | Should be |
|---|---|---|---|
| `lemma-sdk` | PyPI | 0.7.1 | 0.7.2 |
| `lemma-terminal` | PyPI | 0.7.1 | 0.7.2 |
| `lemma-sdk` | npm | 0.7.1 | 0.7.2 |

The `v0.7.2` GitHub Release exists, dated 2026-09-01. There is no run of any of these three workflows for it.

**It is the token.** A release created by a workflow runs as the default `GITHUB_TOKEN`, and GitHub will not start a new workflow run from an event that token raised:

| Release | `author` | These workflows ran? |
|---|---|---|
| `v0.7.1` | `anukuljha` | yes — ran, failed, repaired by hand |
| `v0.7.2` | `github-actions[bot]` | **no runs at all** |

`release-local-images.yml` creates the release via `softprops/action-gh-release@v3` with no explicit token, so every release cut by the pipeline is invisible to `release: published`. The tag push is what actually happens on a release, so that becomes the trigger; the release trigger stays for a hand-cut one.

## Two things that go with it

**The checkout takes a ref.** It had none, so a `workflow_dispatch` checked out the *default branch* and the version input only rewrote the version string — a dispatch after an unrelated merge would publish a different tree under the release's name. A package version cannot be re-cut once it is on an index.

**The protected-E2E gate comes off these three.** It exercises the real Docker runtime, the document processors and the Rust agent host; none of the three is in a wheel or an npm tarball, and each job already builds and tests exactly what it uploads. `release-desktop.yml` and `release-local-images.yml` keep it — a DMG that ships the runtime is what it was written to protect.

That gate also **cannot currently pass at all**: #631 put `local_cli` on `test_agent_host_process_e2e.py`, pulling fourteen tests into the protected selection, and `backend-protected-e2e.yml` installs no Rust toolchain and never builds `lemma-agent-host` — so they fail on a missing binary. Confirmed on 2026-09-09 (`193968f9b`, scheduled) and 2026-09-10 (`7fa233d1c`). That is a defect in the gate, is being fixed separately, and should never have been able to block a wheel that does not contain the thing it tests.

## How to verify

```bash
python3 -c "import yaml;[print(f, sorted((lambda d: d[True] if True in d else d['on'])(yaml.safe_load(open('.github/workflows/'+f))))) for f in ('release-lemma-python.yml','release-lemma-terminal.yml','release-lemma-typescript.yml')]"
python3 scripts/check_ci_aggregators.py
```

Each of the three now reports `['push', 'release', 'workflow_dispatch']`.

## Compatibility and rollback notes

Workflow-only; no package source changes. Revert restores the previous triggers — and with them the failure mode where a pipeline-cut release publishes nothing.

Once this merges, `v0.8.0` is dispatched by hand (the tag is already pushed, so its push event has passed). From 0.8.1 on the tag push does it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Releases for the Python SDK, terminal CLI, and TypeScript package can now be published automatically when version tags are pushed.
  * Manual releases and published-release workflows continue to be supported.
  * Tagged releases now consistently use the corresponding version, helping ensure the published packages match the intended release.
* **Workflow Updates**
  * Publishing no longer depends on the protected backend end-to-end test requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->