### PR TITLE
Announce a release by asking the indexes what they are actually serving

### DIFF
--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -47,6 +47,7 @@ on:
       - Release Lemma Python SDK
       - Release Lemma TypeScript SDK
       - Release Lemma Terminal CLI
+      - Announce a release
     types: [completed]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -70,12 +70,26 @@ jobs:
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "tag=v$version" >> "$GITHUB_OUTPUT"
 
+      # The default branch, deliberately, rather than the tag being announced.
+      #
+      # Checking out the tag looked right -- announce the release from the
+      # release -- and is wrong twice over. A dispatch for any release older
+      # than this workflow checks out a tag that does not contain
+      # `report_release_to_slack.py`, and the next step fails on a missing
+      # file; v0.8.0 is already such a tag. And it would run a script version
+      # chosen by whatever that tag holds, rather than the reviewed one.
+      #
+      # Nothing is lost, because changelog entries accumulate here and are
+      # never removed: `lemma-frontend/content/changelog/` on the default
+      # branch holds every past release, including the one being announced --
+      # the release commit is what adds it. A version with no entry at all is
+      # already reported as having none.
       - uses: actions/checkout@v7
         with:
-          # The changelog entry for the version being announced, not main's.
-          ref: ${{ steps.resolve.outputs.tag }}
+          # This job reads files and posts to Slack; it pushes nothing, so the
+          # checkout token has no reason to stay on disk for later steps.
+          persist-credentials: false
 
       - name: Announce, and say what is installable
         env:

--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -1,0 +1,85 @@
+name: Announce a release
+
+# The counterpart to "Notify a failure nobody is looking at". That one says when
+# a release *failed*; nothing said when one succeeded, and it turns out those
+# are not the same question -- 0.7.2 succeeded, by every signal this repository
+# produced, and shipped no packages at all.
+#
+# So this does not announce that a release happened. It asks PyPI, npm and the
+# releases API what they are actually serving, and says that. A component that
+# has not landed is named in the first line of the message.
+#
+# Triggered by `workflow_run` rather than `release: published` for the reason
+# that caused the 0.7.2 hole in the first place: a release created by a workflow
+# is authored by github-actions[bot], and GitHub will not start a new workflow
+# run from an event the default GITHUB_TOKEN raised. `workflow_run` fires
+# regardless of who triggered the run underneath it, which is exactly why the
+# failure notifier uses it too.
+#
+# Watched by notify-failure.yml, like every other workflow here, so this one
+# going quiet is itself reported.
+
+on:
+  workflow_run:
+    workflows:
+      # The workflow that creates the GitHub Release. When it finishes, the
+      # release exists and the package publishes -- which the tag started in
+      # parallel -- are usually a few minutes behind; the script waits for
+      # them rather than announcing a healthy release as broken.
+      - Release Local Stack Images
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to announce, for example 0.8.0 or v0.8.0"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  announce:
+    name: Announce
+    timeout-minutes: 30
+    # Only a real release. A failed run is the failure notifier's business, and
+    # two messages for one event is how a channel stops being read. A
+    # workflow_dispatch upstream is a re-run or a repair rather than a release,
+    # and `head_branch` on a tag push is the tag itself -- anything else is a
+    # branch build that must not announce itself as a version.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      startsWith(github.event.workflow_run.head_branch, 'v'))
+    runs-on: ubuntu-latest
+    steps:
+      # Resolved in the shell rather than in an expression: the dispatch input
+      # is documented as "0.8.0 or v0.8.0", and the expression language has no
+      # way to strip an optional prefix. Needs no checkout -- it is string work.
+      - name: Resolve the version and its tag
+        id: resolve
+        env:
+          RAW: >-
+            ${{ inputs.version || github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          version="${RAW#v}"
+          if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error title=Not a version::'$RAW' is not a release version."
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v7
+        with:
+          # The changelog entry for the version being announced, not main's.
+          ref: ${{ steps.resolve.outputs.tag }}
+
+      - name: Announce, and say what is installable
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          python3 scripts/report_release_to_slack.py "$VERSION" --wait-seconds 900

--- a/scripts/report_release_to_slack.py
+++ b/scripts/report_release_to_slack.py
@@ -87,13 +87,21 @@ def _read(url: str):
 
 
 def pypi_has(package: str, version: str) -> Optional[bool]:
-    """Whether PyPI serves ``version`` of ``package``. None when unknown."""
+    """Whether PyPI can install ``version`` of ``package``. None when unknown.
+
+    The version has to be present *and* carry at least one distribution file.
+    A key in ``releases`` with an empty list is a version PyPI knows the name of
+    and cannot serve -- every file yanked or deleted, or a registration that
+    never completed its upload -- and ``pip install package==version`` fails on
+    it. Reporting that as published is the exact shape of lie this script exists
+    to catch, one level further in.
+    """
     data = _read("https://pypi.org/pypi/{}/json".format(package))
     if data is ABSENT:
         return False
     if data is None:
         return None
-    return version in (data.get("releases") or {})
+    return bool((data.get("releases") or {}).get(version))
 
 
 def npm_has(package: str, version: str) -> Optional[bool]:

--- a/scripts/report_release_to_slack.py
+++ b/scripts/report_release_to_slack.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Announce a release in Slack, and say what is actually installable.
+
+Not a "we shipped" message. The interesting half is the second one: it asks the
+indexes what they are serving and prints that beside the version being
+announced.
+
+This exists because of 0.7.2. The GitHub Release was published on 2026-09-01 and
+looked exactly like a release; PyPI and npm went on serving 0.7.1 for ten days,
+because the release was created by a workflow and GitHub will not start a new
+workflow run from an event the default GITHUB_TOKEN raised, so nothing that
+publishes a package ever ran. Every dashboard said the release had happened. An
+announcement that repeated that claim would have made it worse -- it would have
+told the team a version was available that they could not install.
+
+So a component that has not landed is named as missing, and the message says so
+in its first line. The announcement is the check.
+
+The prose comes from the changelog entry the release already has, in
+``lemma-frontend/content/changelog/``, rather than from generated commit notes:
+it is the one description of the release written for a person to read.
+
+Usage::
+
+    python3 scripts/report_release_to_slack.py 0.8.0
+    python3 scripts/report_release_to_slack.py v0.8.0 --dry-run
+
+Reads ``SLACK_WEBHOOK_URL`` from the environment. Without it the message is
+printed and the script exits 0 -- a missing webhook must not fail a release that
+otherwise succeeded, and neither must a Slack outage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CHANGELOG_DIR = REPO_ROOT / "lemma-frontend/content/changelog"
+REPOSITORY = "lemma-work/lemma-platform"
+
+#: Slack renders a `text` payload well past this, but stops being read long
+#: before it. The headings carry the shape of the release; the changelog carries
+#: the rest, and it is one click away.
+MAX_HEADINGS = 12
+
+NETWORK_TIMEOUT = 20
+
+#: How often to re-ask the indexes while waiting for a release to finish
+#: landing. They are third-party and cached; asking faster buys nothing.
+POLL_SECONDS = 30
+
+
+#: Returned for a 404, which is an answer rather than a failure to get one.
+ABSENT = object()
+
+
+def _read(url: str):
+    """The JSON at ``url``, ``ABSENT`` for a 404, or None when unknown.
+
+    Never raises. A registry being slow or unreachable must not turn a
+    successful release into a failed announcement -- the message says "could not
+    check" and a person looks, which is strictly better than the script dying
+    and nobody hearing anything at all.
+
+    A 404 is separated out because it is not that kind of failure. "No release
+    is tagged v0.8.0" and "GitHub did not answer" read the same to a caller that
+    collapses both to None, and they mean opposite things: the first is the
+    missing-component case this script exists to shout about, and reporting it
+    as "could not check" is how it would go quiet at exactly the wrong moment.
+    """
+    try:
+        with urllib.request.urlopen(url, timeout=NETWORK_TIMEOUT) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        return ABSENT if error.code == 404 else None
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError):
+        return None
+
+
+def pypi_has(package: str, version: str) -> Optional[bool]:
+    """Whether PyPI serves ``version`` of ``package``. None when unknown."""
+    data = _read("https://pypi.org/pypi/{}/json".format(package))
+    if data is ABSENT:
+        return False
+    if data is None:
+        return None
+    return version in (data.get("releases") or {})
+
+
+def npm_has(package: str, version: str) -> Optional[bool]:
+    """Whether npm serves ``version`` of ``package``. None when unknown."""
+    data = _read("https://registry.npmjs.org/{}".format(package))
+    if data is ABSENT:
+        return False
+    if data is None:
+        return None
+    return version in (data.get("versions") or {})
+
+
+def github_release_exists(version: str) -> Optional[bool]:
+    """Whether a published GitHub Release names this version. None when unknown."""
+    data = _read(
+        "https://api.github.com/repos/{}/releases/tags/v{}".format(REPOSITORY, version)
+    )
+    if data is ABSENT:
+        return False
+    if data is None:
+        return None
+    return bool(data.get("tag_name"))
+
+
+def changelog_path(version: str) -> Path:
+    """The entry for this version. Named with dashes: 0.8.0 -> 0-8-0.mdx."""
+    return CHANGELOG_DIR / "{}.mdx".format(version.replace(".", "-"))
+
+
+def split_frontmatter(text: str) -> Tuple[dict, str]:
+    """The entry's frontmatter fields and its body.
+
+    A deliberately small reader rather than a YAML dependency: this runs from
+    the repo root in CI with nothing installed, the same way the other reporting
+    scripts here do. It reads the scalar fields it needs and ignores the rest,
+    so a list value like `tags:` costs nothing.
+    """
+    if not text.startswith("---"):
+        return {}, text
+    closing = text.find("\n---", 3)
+    if closing == -1:
+        return {}, text
+    fields = {}
+    for line in text[3:closing].splitlines():
+        match = re.match(r"^([A-Za-z_]+):\s*(.+?)\s*$", line)
+        if match:
+            fields[match.group(1)] = match.group(2).strip("\"'")
+    return fields, text[closing + len("\n---") :].lstrip("\n")
+
+
+def headings(body: str) -> List[str]:
+    """The `##` section titles, in order — the shape of the release."""
+    return re.findall(r"(?m)^##\s+(.+?)\s*$", body)
+
+
+def _mark(state: Optional[bool]) -> str:
+    if state is None:
+        return ":grey_question:"
+    return ":white_check_mark:" if state else ":x:"
+
+
+def compose(version: str) -> Tuple[str, bool]:
+    """The Slack message, and whether every component is actually live."""
+    entry = changelog_path(version)
+    if entry.is_file():
+        fields, body = split_frontmatter(entry.read_text(encoding="utf-8"))
+    else:
+        fields, body = {}, ""
+
+    components = [
+        ("lemma-sdk (PyPI)", pypi_has("lemma-sdk", version)),
+        ("lemma-terminal (PyPI)", pypi_has("lemma-terminal", version)),
+        ("lemma-sdk (npm)", npm_has("lemma-sdk", version)),
+        ("GitHub Release", github_release_exists(version)),
+    ]
+    missing = [name for name, state in components if state is False]
+    unknown = [name for name, state in components if state is None]
+    complete = not missing and not unknown
+
+    if complete:
+        headline = "*Lemma {} is out* — every component is installable".format(version)
+    elif missing:
+        headline = "*Lemma {} is partly published* — {} still missing".format(
+            version, ", ".join(missing)
+        )
+    else:
+        headline = "*Lemma {} released* — could not verify {}".format(
+            version, ", ".join(unknown)
+        )
+
+    lines = [headline]
+
+    description = fields.get("description")
+    if description:
+        lines.append(description)
+
+    section_titles = headings(body)
+    if section_titles:
+        lines.append("")
+        lines.append("*In this release*")
+        for title in section_titles[:MAX_HEADINGS]:
+            lines.append("• {}".format(title))
+        if len(section_titles) > MAX_HEADINGS:
+            lines.append(
+                "• …and {} more".format(len(section_titles) - MAX_HEADINGS)
+            )
+    elif not entry.is_file():
+        lines.append("")
+        lines.append(
+            "_No changelog entry at {}_".format(entry.relative_to(REPO_ROOT))
+        )
+
+    lines.append("")
+    lines.append("*Published*")
+    for name, state in components:
+        lines.append("{} {}".format(_mark(state), name))
+
+    lines.append("")
+    lines.append(
+        "https://github.com/{}/releases/tag/v{}".format(REPOSITORY, version)
+    )
+    lines.append("https://lemma.work/changelog")
+
+    return "\n".join(lines), complete
+
+
+def post(text: str) -> None:
+    webhook = os.environ.get("SLACK_WEBHOOK_URL", "")
+    if not webhook:
+        print(
+            "::warning title=No Slack webhook configured::"
+            "The release was not announced. Set the SLACK_WEBHOOK_URL "
+            "repository secret."
+        )
+        return
+    request = urllib.request.Request(
+        webhook,
+        data=json.dumps({"text": text}).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=NETWORK_TIMEOUT) as response:
+            print("Slack responded {}".format(response.status))
+    except (urllib.error.URLError, TimeoutError, OSError) as error:
+        # Same reasoning as _read: a Slack outage is not a release failure.
+        print("::warning title=Slack post failed::{}".format(error))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="Release version, for example 0.8.0 or v0.8.0")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the message without posting it.",
+    )
+    parser.add_argument(
+        "--require-complete",
+        action="store_true",
+        help=(
+            "Exit non-zero when a component is missing from its index. For a "
+            "job that should go red when a release only half-happened."
+        ),
+    )
+    parser.add_argument(
+        "--wait-seconds",
+        type=int,
+        default=0,
+        metavar="N",
+        help=(
+            "Re-check for up to N seconds before posting, and stop as soon as "
+            "every component is live. The publishes finish minutes apart, so "
+            "without this a healthy release announces itself as broken -- and "
+            "a false alarm every time is how a channel stops being read."
+        ),
+    )
+    arguments = parser.parse_args()
+
+    version = arguments.version.lstrip("vV")
+    if not re.match(r"^[0-9]+\.[0-9]+\.[0-9]+", version):
+        print("Not a version: {}".format(arguments.version), file=sys.stderr)
+        return 2
+
+    deadline = time.monotonic() + max(arguments.wait_seconds, 0)
+    while True:
+        text, complete = compose(version)
+        if complete or time.monotonic() >= deadline:
+            break
+        remaining = int(deadline - time.monotonic())
+        print("Not every component is live yet; {}s left to wait.".format(remaining))
+        time.sleep(min(POLL_SECONDS, max(remaining, 1)))
+
+    print(text)
+
+    if not arguments.dry_run:
+        post(text)
+
+    if arguments.require_complete and not complete:
+        print(
+            "Not every component is published for {}.".format(version),
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_report_release_to_slack.py
+++ b/tests/test_report_release_to_slack.py
@@ -109,6 +109,23 @@ def test_a_404_is_an_answer_rather_than_a_failure_to_get_one(monkeypatch, entry)
     assert report.github_release_exists("9.9.9") is False
 
 
+def test_a_pypi_version_with_no_files_is_not_installable(monkeypatch, entry):
+    """Present in `releases` but carrying nothing: `pip install` fails on it.
+
+    Every file yanked or deleted, or an upload that never completed. PyPI knows
+    the version's name and cannot serve it.
+    """
+    monkeypatch.setattr(report, "_read", lambda url: {"releases": {"9.9.9": []}})
+    assert report.pypi_has("lemma-sdk", "9.9.9") is False
+
+    monkeypatch.setattr(
+        report,
+        "_read",
+        lambda url: {"releases": {"9.9.9": [{"filename": "lemma_sdk-9.9.9.whl"}]}},
+    )
+    assert report.pypi_has("lemma-sdk", "9.9.9") is True
+
+
 def test_a_transport_error_stays_unknown(monkeypatch, entry):
     monkeypatch.setattr(report, "_read", lambda url: None)
     assert report.pypi_has("lemma-sdk", "9.9.9") is None

--- a/tests/test_report_release_to_slack.py
+++ b/tests/test_report_release_to_slack.py
@@ -1,0 +1,134 @@
+"""The release announcement must be able to say a release did not happen.
+
+The script exists because 0.7.2 looked like a release from every angle this
+repository could see, and shipped no packages. So the test that matters is not
+"does it format a nice message" -- it is that a half-published release is
+reported as half-published, and that an index it could not reach is never
+silently reported as a success.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load():
+    """Import the script by path; `scripts/` is not a package."""
+    path = REPO_ROOT / "scripts" / "report_release_to_slack.py"
+    spec = importlib.util.spec_from_file_location("report_release_to_slack", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+report = _load()
+
+
+ENTRY = """---
+title: 9.9.9
+description: A one-line summary.
+published: 2026-01-01
+tags:
+  - release
+---
+
+Opening paragraph.
+
+## First thing
+
+Body.
+
+## Second thing
+
+More body.
+"""
+
+
+def _live(monkeypatch, *, pypi, npm, release):
+    monkeypatch.setattr(report, "pypi_has", lambda package, version: pypi)
+    monkeypatch.setattr(report, "npm_has", lambda package, version: npm)
+    monkeypatch.setattr(report, "github_release_exists", lambda version: release)
+
+
+@pytest.fixture
+def entry(monkeypatch, tmp_path):
+    (tmp_path / "9-9-9.mdx").write_text(ENTRY, encoding="utf-8")
+    monkeypatch.setattr(report, "CHANGELOG_DIR", tmp_path)
+    monkeypatch.setattr(report, "REPO_ROOT", tmp_path)
+
+
+def test_frontmatter_and_headings_come_from_the_changelog(entry):
+    fields, body = report.split_frontmatter(ENTRY)
+    assert fields["description"] == "A one-line summary."
+    assert "tags" not in fields or fields["tags"] != "- release"
+    assert report.headings(body) == ["First thing", "Second thing"]
+
+
+def test_everything_live_reads_as_a_release(monkeypatch, entry):
+    _live(monkeypatch, pypi=True, npm=True, release=True)
+    text, complete = report.compose("9.9.9")
+    assert complete is True
+    assert "every component is installable" in text
+    assert "A one-line summary." in text
+    assert "• First thing" in text
+
+
+def test_the_0_7_2_shape_is_reported_as_partly_published(monkeypatch, entry):
+    """A GitHub Release with nothing on the indexes: the case that went unseen."""
+    _live(monkeypatch, pypi=False, npm=False, release=True)
+    text, complete = report.compose("9.9.9")
+    assert complete is False
+    assert "partly published" in text
+    # The missing components are named in the first line, not buried below.
+    headline = text.splitlines()[0]
+    assert "lemma-sdk (PyPI)" in headline
+    assert "lemma-sdk (npm)" in headline
+
+
+def test_an_unreachable_index_is_never_reported_as_published(monkeypatch, entry):
+    _live(monkeypatch, pypi=None, npm=None, release=None)
+    text, complete = report.compose("9.9.9")
+    assert complete is False
+    assert "could not verify" in text
+    assert ":white_check_mark:" not in text
+
+
+def test_a_404_is_an_answer_rather_than_a_failure_to_get_one(monkeypatch, entry):
+    """A missing package must read as missing, not as "could not check"."""
+    monkeypatch.setattr(report, "_read", lambda url: report.ABSENT)
+    assert report.pypi_has("lemma-sdk", "9.9.9") is False
+    assert report.npm_has("lemma-sdk", "9.9.9") is False
+    assert report.github_release_exists("9.9.9") is False
+
+
+def test_a_transport_error_stays_unknown(monkeypatch, entry):
+    monkeypatch.setattr(report, "_read", lambda url: None)
+    assert report.pypi_has("lemma-sdk", "9.9.9") is None
+    assert report.github_release_exists("9.9.9") is None
+
+
+def test_a_missing_changelog_entry_is_said_out_loud(monkeypatch, tmp_path):
+    monkeypatch.setattr(report, "CHANGELOG_DIR", tmp_path)
+    monkeypatch.setattr(report, "REPO_ROOT", tmp_path)
+    _live(monkeypatch, pypi=True, npm=True, release=True)
+    text, complete = report.compose("9.9.9")
+    assert complete is True
+    assert "No changelog entry" in text
+
+
+def test_the_changelog_filename_uses_dashes():
+    assert report.changelog_path("0.8.0").name == "0-8-0.mdx"
+
+
+def test_a_missing_webhook_does_not_fail_the_release(monkeypatch, capsys):
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    report.post("anything")
+    assert "No Slack webhook configured" in capsys.readouterr().out


### PR DESCRIPTION
## What changes

A new `Announce a release` workflow posts to Slack when a release lands — and the message says which components are **actually installable**, not that a release happened.

## Why

There is a workflow that says when a release *failed*. Nothing said when one *succeeded*, and those turn out to be different questions.

0.7.2 succeeded by every signal this repository produces: a green pipeline and a published GitHub Release dated 2026-09-01. It shipped no packages. PyPI and npm went on serving 0.7.1 for ten days and nothing said so. An announcement that repeated the pipeline's claim would have made it worse — it would have told the team a version was available that they could not install.

So the announcement is the check. Run against the three releases whose outcomes are already known:

| Version | Message |
|---|---|
| `0.7.1` | *is out — every component is installable* |
| `0.7.2` | *partly published — lemma-sdk (PyPI), lemma-terminal (PyPI), lemma-sdk (npm) still missing* |
| `0.8.0` | *partly published — all four still missing* |

The prose comes from the changelog entry the release already has, rather than generated commit notes: it is the one description of the release written for a person to read, and it has already been reviewed.

## Three things it has to get right

**A 404 is an answer, not a failure to get one.** "No release is tagged v0.8.0" and "GitHub did not answer" mean opposite things, and a reader that collapses both to *unknown* would go quiet at exactly the moment this exists for.

**An index it could not reach is never reported as published.** The message says *could not verify* and names which; no tick appears against a component nobody confirmed.

**It waits before it speaks.** The package publishes land minutes after the release, so announcing the instant the pipeline finishes would report every healthy release as broken — and a false alarm every time is how a channel stops being read. `--wait-seconds` returns as soon as every component is live.

## Why `workflow_run` and not `release: published`

The same thing that caused the hole. A release created by a workflow is authored by `github-actions[bot]`, and GitHub will not start a new workflow run from an event the default `GITHUB_TOKEN` raised — which is why no publish workflow ran for 0.7.2. `workflow_run` fires regardless of what triggered the run beneath it, which is why the failure notifier already uses it.

It is added to `notify-failure.yml`'s watch list, so the announcer going quiet is itself announced — and because `check_ci_aggregators.py` refuses a workflow nothing watches.

## How to verify

```bash
python3 scripts/report_release_to_slack.py v0.7.1 --dry-run   # every component installable
python3 scripts/report_release_to_slack.py 0.7.2  --dry-run   # the release that shipped nothing
uv run --with pytest --with pyyaml python -m pytest tests/ -q
uv run --no-project --with pyyaml python scripts/check_ci_aggregators.py
python3 scripts/check_script_portability.py
```

```
90 passed in 27.48s
Aggregator and timeout checks passed (18 workflows).
29 scripts parse on Python 3.9.
Census holds: 8917 tests, 22 markers, no lane skipping green.
```

Uses the existing `SLACK_WEBHOOK_URL` secret — no new secret. Without it the message is printed to the log and the job exits 0; a missing webhook must not fail a release that otherwise succeeded, and neither must a Slack outage.

## Checklist

- [x] Tests cover the behavioral change — 9 new, including the 0.7.2 shape, the unreachable-index case, and 404-vs-error
- [x] Lint, typecheck, and architecture gates pass locally

## Compatibility and rollback notes

Additive. A new workflow plus one line in the notifier's watch list; nothing existing changes behaviour. Revert removes the announcement and restores the state where a release that ships nothing looks identical to one that ships everything.

`workflow_run` only fires for a copy on the default branch, so — as `notify-failure.yml`'s own comment records — this cannot be exercised from a pull request. First real run is the next tag; `workflow_dispatch` with a version takes care of announcing v0.8.0 once its packages land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Slack release announcements with changelog highlights and publication status for package registries and GitHub Releases.
  * Added optional polling to wait for release artifacts to become available.
  * Added manual release announcement support with version validation.
  * Incomplete publication checks can be reported as warnings or treated as failures.

* **Bug Fixes**
  * Release notification monitoring now includes release announcement workflow failures.

* **Tests**
  * Added coverage for complete, partial, missing, and unverifiable release publication states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->