### PR TITLE
The release gate was red for three days, and none of it was a defect

### DIFF
--- a/.github/pytest-census.json
+++ b/.github/pytest-census.json
@@ -24,7 +24,6 @@
     "workspace": 111
   },
   "empty_markers": [
-    "local_cli",
     "protected"
   ]
 }

--- a/.github/workflows/backend-protected-e2e.yml
+++ b/.github/workflows/backend-protected-e2e.yml
@@ -48,10 +48,38 @@ jobs:
         # Matches what actually ships: lemma-backend/Dockerfile and every
         # other backend workflow sync `--extra local`.
         run: uv sync --extra local
+      # Two clauses have come out of this filter, both because what they select
+      # cannot report a defect from here. Every release gate reads this run, so
+      # a red that is not a defect costs a Desktop release and a nightly DMG.
+      #
+      # `local_cli` names tests needing a locally built agent CLI -- pytest.ini
+      # says so, and says "each dedicated lane supplies its binaries". This lane
+      # supplies none: it installs no Rust toolchain and never runs
+      # `cargo build -p lemma-agent-host`, so all fourteen tests in
+      # `test_agent_host_process_e2e.py` asserted "Build lemma-agent-host first"
+      # on every run from 2026-09-08, when #631 gave that file the marker. Seven
+      # of them also want a built TypeScript SDK, a Playwright browser and a CORS
+      # override. CI's `Desktop contracts` job builds all of that and runs the
+      # same fourteen -- `make desktop-agent-host-e2e` and
+      # `make desktop-agent-host-browser-e2e` between them -- on every pull
+      # request touching `lemma-backend/**`. Building it again here would add
+      # twenty minutes to a release gate to repeat a merge gate.
+      #
+      # `not benchmark` is the function-execution benchmark, whose budgets are
+      # wall-clock p95s on a shared runner: it failed on 2026-09-09 with
+      # "platform overhead p95 3.502s exceeds 2.000s" and passed on 2026-09-10,
+      # with one deleted dead line in `sandbox_runtime/function/runner.py` the
+      # only change to function execution between the two runs. So the number
+      # moved and the code did not. `sandbox-function-benchmark.yml` runs it
+      # nightly
+      # at the timeout and provider settings it was written for, keeps the
+      # report, and is one of the workflows notify-failure.yml watches. A
+      # latency budget belongs in the lane that trends it, not in the one that
+      # decides whether a build may be cut.
       - name: Run protected suite
         run: >-
           uv run pytest
-          -m "e2e and (slow or workspace or indexing or local_cli or protected) and not provider"
+          -m "e2e and (slow or workspace or indexing or protected) and not provider and not benchmark"
           --junitxml=protected-e2e.xml
           -o timeout=300
         env:

--- a/docs/engineering/tests.md
+++ b/docs/engineering/tests.md
@@ -164,9 +164,10 @@ gating on Docker/E2B/network at runtime — ratchet
 
 A lane that selects nothing is green forever.
 
-*Today:* `empty_markers` = `identity`, `local_cli`, `pod`, `protected` — and the
-protected-e2e workflow selects `local_cli` and `protected`, both empty — hard
-once cleared
+*Today:* `empty_markers` = `protected`, named by the protected-e2e workflow and
+carried by nothing — hard once cleared. `local_cli` stopped being empty in #631,
+and the lane naming it could not build what those tests need; the protected
+workflow's comment has the story
 
 ### TST-13 — coverage floors are per module and ratcheted; the global number is advisory
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -76,7 +76,8 @@ way a scenario says, do not edit the scenario.
 | Scenarios (fast) | `make scenarios` | Nightly, on request, or with the `run-scenarios` label |
 | Scenarios (sandbox) | `make scenarios-sandbox` | Same, after building the workspace images |
 | Scenarios (live) | `make scenarios-live` | Locally, before a release. See [LIVE.md](../tests/scenarios/LIVE.md) |
-| Protected e2e | — | Weekly, via `backend-protected-e2e.yml`. Where `@pytest.mark.slow` tests go. |
+| Protected e2e | `make test-e2e-runtime` | Weekly and on every `v*` tag, via `backend-protected-e2e.yml`. Where `@pytest.mark.slow` tests go, and what every Desktop release gate reads. It builds nothing, so a test needing a compiled artifact belongs in the lane that builds it. |
+| Sandbox function benchmark | `make benchmark-functions-docker` | Nightly on Docker, weekly on E2B, via `sandbox-function-benchmark.yml`. Owns `@pytest.mark.benchmark`: wall-clock budgets are trended here and gate nothing. |
 | Real-LLM e2e | `make test-e2e-real-llm` | Locally whenever a change touches the model or pause path. Not in CI. |
 
 The real-LLM lane is worth one paragraph, because its absence used to be
@@ -115,7 +116,11 @@ Over the budget, there are three honest answers and one dishonest one:
 
 - **Mark it `@pytest.mark.slow`.** It moves to the scheduled protected lane.
   Right when the thing under test is a matrix of variations rather than a
-  contract that can break on its own.
+  contract that can break on its own. Two things do not belong there whatever
+  they cost: a test needing something compiled — the protected lane installs no
+  toolchain and builds nothing — and a wall-clock budget, which is
+  `@pytest.mark.benchmark` and belongs to the lane that trends it. Every Desktop
+  release waits on that lane, so a red there has to mean a defect.
 - **Split it.** Keep a cheap test that proves the wiring is connected, and
   move the exhaustive half to `slow`. This is usually the best answer:
   `test_kreuzberg_upload_indexes_a_document_and_makes_it_searchable` (one PDF,

--- a/lemma-backend/Makefile
+++ b/lemma-backend/Makefile
@@ -89,7 +89,7 @@ help:
 	@echo "  make test-e2e          # run all e2e tests"
 	@echo "  make test-e2e-fast     # hermetic API/worker e2e (no slow/workspace/provider/local_cli),"
 	@echo "                         #   parallel via pytest-xdist (E2E_WORKERS=$(E2E_WORKERS); auto|0 to override)"
-	@echo "  make test-e2e-runtime  # run slow worker/workspace/local/provider e2e tests (serial)"
+	@echo "  make test-e2e-runtime  # exactly what backend-protected-e2e.yml runs (serial)"
 	@echo "  make test-module MODULE=pod"
 	@echo "  make coverage-unit     # unit coverage"
 	@echo "  make coverage-e2e      # e2e coverage"
@@ -211,9 +211,14 @@ test-e2e-real-llm:
 # locally to reproduce the protected lane failed on tests CI never runs, and
 # passed on none it does. That lane once did nothing at all for eleven days and
 # blocked every Desktop release; it should be reproducible in one command.
+#
+# What it does not select is argued in the workflow: `local_cli` needs an Agent
+# Host neither this target nor that job builds (`make desktop-agent-host-e2e`
+# does), and `benchmark` is a wall-clock budget owned by
+# `make benchmark-functions-docker`.
 test-e2e-runtime:
 	E2E_REAL=1 E2E_LLM_MODE=mock uv run pytest \
-		-m "e2e and (slow or workspace or indexing or local_cli or protected) and not provider" \
+		-m "e2e and (slow or workspace or indexing or protected) and not provider and not benchmark" \
 		-o timeout=300
 
 test-module:

--- a/lemma-backend/README.md
+++ b/lemma-backend/README.md
@@ -131,8 +131,14 @@ Uses the **real model** (`LEMMA_OPENAI_API_KEY`) + the **real Docker sandbox**, 
 
 ```bash
 make test-e2e-real      # all e2e against the real model + Docker sandbox
-make test-e2e-runtime   # only the slow/worker/workspace/provider/local_cli subset
+make test-e2e-runtime   # exactly what backend-protected-e2e.yml runs
 ```
+
+`test-e2e-runtime` is byte-identical to the protected workflow, asserted by
+`test_the_protected_lane_can_be_reproduced_from_the_makefile`. It selects the
+slow/workspace/indexing subset and deliberately not `local_cli` (needs a
+cargo-built Agent Host; `make desktop-agent-host-e2e` supplies it) or
+`benchmark` (wall-clock budgets; `make benchmark-functions-docker` owns them).
 
 ### Markers & modes
 

--- a/lemma-backend/app/core/tests/unit/test_e2e_workflow_contract.py
+++ b/lemma-backend/app/core/tests/unit/test_e2e_workflow_contract.py
@@ -381,15 +381,23 @@ def test_the_protected_lane_can_be_reproduced_from_the_makefile() -> None:
     it silently did nothing for eleven days -- `--extra markitdown` had stopped
     existing -- and blocked every Desktop release while it did.
 
-    Two clauses have since come out of the filter, both because they selected
-    nothing. `not mock_sandbox_only` named two workflow tests that were excluded
-    here in #155 and given no other lane, so they ran nowhere for eight weeks --
-    and they pass in this lane's exact configuration, so the exclusion outlived
-    whatever it was for. `or surface_live` was inert by construction: that file
-    is `provider` at module level and this filter says `not provider`, so the
-    clause read like a lane and was one for nobody. Its `LEMMA_RUN_SURFACE_LIVE_E2E`
-    went with it; the smoke job in `e2e.yml` still sets it, which is where those
-    tests actually run.
+    Four clauses have since come out of the filter. Two selected nothing:
+    `not mock_sandbox_only` named two workflow tests that were excluded here in
+    #155 and given no other lane, so they ran nowhere for eight weeks -- and
+    they pass in this lane's exact configuration, so the exclusion outlived
+    whatever it was for; and `or surface_live` was inert by construction, since
+    that file is `provider` at module level and this filter says `not provider`.
+    Its `LEMMA_RUN_SURFACE_LIVE_E2E` went with it; the smoke job in `e2e.yml`
+    still sets it, which is where those tests actually run.
+
+    The other two selected something that could not report a defect from here,
+    which for a lane every release gate reads is the same failure wearing better
+    clothes. `or local_cli` selected fourteen tests needing a cargo-built
+    `lemma-agent-host` this job does not build, and CI's `Desktop contracts`
+    does; `not benchmark` drops a wall-clock p95 budget that
+    `sandbox-function-benchmark.yml` trends nightly. Both are argued at their
+    new homes, and `test_the_non_shard_lanes_match_their_workflows` is what
+    holds the planner to them.
     """
     makefile = (_REPO_ROOT / "lemma-backend/Makefile").read_text()
     workflow = (_REPO_ROOT / ".github/workflows/backend-protected-e2e.yml").read_text()
@@ -397,8 +405,8 @@ def test_the_protected_lane_can_be_reproduced_from_the_makefile() -> None:
     target = makefile.split("\ntest-e2e-runtime:\n", 1)[1].split("\n\n", 1)[0]
 
     marker = (
-        "e2e and (slow or workspace or indexing or local_cli "
-        "or protected) and not provider"
+        "e2e and (slow or workspace or indexing "
+        "or protected) and not provider and not benchmark"
     )
     assert marker in workflow, (
         "the protected workflow's marker filter changed; update this test and "
@@ -413,19 +421,31 @@ def test_the_protected_lane_can_be_reproduced_from_the_makefile() -> None:
         assert setting in target, f"{setting} missing from the target"
 
 
-def test_the_two_non_shard_lanes_match_their_workflows() -> None:
+def test_the_non_shard_lanes_match_their_workflows() -> None:
     """`--verify` decides coverage, so its copy of a lane must be the lane.
 
     The shard lanes need no such check: the gate reads their filters straight
     out of `.github/e2e-shards.json`, which is the file the workflow runs from.
-    The other two lanes are not in that file, so the planner holds a copy of
+    The other four lanes are not in that file, so the planner holds a copy of
     each -- and a stale copy would not fail loudly. It would report a test as
     covered by a lane whose filter no longer selects it, which is the exact
     shape of the bug the gate exists to catch, wearing the gate's own colours.
+
+    Three of the four own one file each, which is why each is checked here as
+    "this workflow runs this file, and runs all of it". `Desktop contracts` is
+    the strictest of those: it takes two passes to cover its file, split on
+    `agent_host_browser`, and it is only a lane at all because it builds the
+    Agent Host first.
     """
     planner = _load_planner()
     protected = (_REPO_ROOT / ".github/workflows/backend-protected-e2e.yml").read_text()
     e2e = (_REPO_ROOT / ".github/workflows/e2e.yml").read_text()
+    ci = (_REPO_ROOT / ".github/workflows/ci.yml").read_text()
+    benchmark_workflow = (
+        _REPO_ROOT / ".github/workflows/sandbox-function-benchmark.yml"
+    ).read_text()
+    root_makefile = (_REPO_ROOT / "Makefile").read_text()
+    backend_makefile = (_REPO_ROOT / "lemma-backend/Makefile").read_text()
 
     assert planner.PROTECTED_MARKERS in protected, (
         "plan_e2e_shards.PROTECTED_MARKERS no longer matches the protected "
@@ -436,6 +456,43 @@ def test_the_two_non_shard_lanes_match_their_workflows() -> None:
     )
     assert f"-m {planner.SMOKE_MARKERS}" in e2e, (
         "the surface-live smoke job's marker filter changed"
+    )
+
+    # `Desktop contracts`: two make targets, both named by ci.yml, that between
+    # them run every test in the Agent Host file. The split is the point --
+    # drop either target and half the file runs nowhere, which is exactly what
+    # the protected lane's `or local_cli` was papering over.
+    desktop_targets = {
+        name: root_makefile.split(f"\n{name}:\n", 1)[1].split("\n\n", 1)[0]
+        for name in ("desktop-agent-host-e2e", "desktop-agent-host-browser-e2e")
+    }
+    for name, recipe in desktop_targets.items():
+        assert f"make {name}" in ci, f"ci.yml no longer runs {name}"
+        assert planner.DESKTOP_CONTRACT_PATH in recipe, (
+            f"{name} no longer runs plan_e2e_shards.DESKTOP_CONTRACT_PATH"
+        )
+        assert "cargo build -p lemma-agent-host" in recipe, (
+            f"{name} no longer builds the binary its tests assert on; without "
+            f"it these tests fail on the build, not on the product"
+        )
+    plain, browser = (
+        desktop_targets["desktop-agent-host-e2e"],
+        desktop_targets["desktop-agent-host-browser-e2e"],
+    )
+    assert (
+        "-m 'not agent_host_browser'" in plain and "-m agent_host_browser" in browser
+    ), (
+        "the two Desktop contract passes no longer split on "
+        "`agent_host_browser`, so between them they may not run the whole file"
+    )
+
+    # The nightly benchmark: one target, run by its own workflow, on the file
+    # the planner credits it with.
+    assert "make benchmark-functions-docker" in benchmark_workflow, (
+        "sandbox-function-benchmark.yml no longer runs the Docker benchmark"
+    )
+    assert f"FUNCTION_BENCH_TEST = {planner.BENCHMARK_PATH}" in backend_makefile, (
+        "the benchmark target no longer runs plan_e2e_shards.BENCHMARK_PATH"
     )
 
 

--- a/lemma-backend/app/modules/agent/tests/e2e/test_workspace_tools_e2e.py
+++ b/lemma-backend/app/modules/agent/tests/e2e/test_workspace_tools_e2e.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
-from contextlib import AsyncExitStack, asynccontextmanager
+from contextlib import asynccontextmanager
 import hashlib
 import json
 import shlex
@@ -10,12 +10,12 @@ import statistics
 import time
 from uuid import UUID, uuid4
 
-import anyio
 import httpx
+import httpx2
 import pytest
 from fastapi import status
 from mcp import ClientSession
-from mcp.client.streamable_http import StreamableHTTPTransport
+from mcp.client.streamable_http import streamable_http_client
 
 from app.core.infrastructure.db.session import async_session_maker
 from app.core.infrastructure.db.uow_factory import create_uow_from_session_maker
@@ -765,47 +765,35 @@ async def test_agent_workspace_cli_tools_execute_through_a_real_sandbox(
 
 @asynccontextmanager
 async def _mcp_client_session(url: str, token: str):
-    async with httpx.AsyncClient(
-        timeout=None,
-        headers={"Authorization": f"Bearer {token}"},
-    ) as http_client:
-        read_stream_writer, read_stream = anyio.create_memory_object_stream(0)
-        write_stream, write_stream_reader = anyio.create_memory_object_stream(0)
-        transport = StreamableHTTPTransport(url)
+    """A real MCP client against the conversation's streamable-HTTP endpoint.
 
-        async with anyio.create_task_group() as task_group:
-            try:
-                async with AsyncExitStack() as stack:
-                    stack.push_async_callback(read_stream.aclose)
-                    stack.push_async_callback(read_stream_writer.aclose)
-                    stack.push_async_callback(write_stream.aclose)
-                    stack.push_async_callback(write_stream_reader.aclose)
+    Through the library's own entry point, deliberately. This used to hand-wire
+    `StreamableHTTPTransport.post_writer` onto a pair of plain
+    `anyio.create_memory_object_stream` channels -- a copy of
+    `streamable_http_client`'s body, one version behind it. The SDK's internal
+    wiring is not a contract, and `mcp` 2.x changed it: the client now carries
+    the sender's `contextvars.Context` across those channels and reads it back
+    as `write_stream_reader.last_context`, which a plain memory stream does not
+    have. Every session died in `post_writer` with an `AttributeError` the
+    caller only ever saw as `MCPError(-32000, 'Connection closed')` out of
+    `initialize()`.
 
-                    def start_get_stream() -> None:
-                        task_group.start_soon(
-                            transport.handle_get_stream,
-                            http_client,
-                            read_stream_writer,
-                        )
-
-                    task_group.start_soon(
-                        transport.post_writer,
-                        http_client,
-                        write_stream_reader,
-                        read_stream_writer,
-                        write_stream,
-                        start_get_stream,
-                        task_group,
-                    )
-
-                    async with ClientSession(read_stream, write_stream) as session:
-                        await session.initialize()
-                        yield session
-
-                    if transport.session_id:
-                        await transport.terminate_session(http_client)
-            finally:
-                task_group.cancel_scope.cancel()
+    Nothing is lost by asking the library instead: `streamable_http_client`
+    takes the authenticated client, which is the only reason to be down here.
+    """
+    async with (
+        httpx2.AsyncClient(
+            timeout=None,
+            headers={"Authorization": f"Bearer {token}"},
+        ) as http_client,
+        streamable_http_client(url, http_client=http_client) as (
+            read_stream,
+            write_stream,
+        ),
+        ClientSession(read_stream, write_stream) as session,
+    ):
+        await session.initialize()
+        yield session
 
 
 def _latency_summary(values: list[float]) -> dict[str, float]:

--- a/lemma-backend/app/modules/function/tests/perf/test_function_execution_benchmark.py
+++ b/lemma-backend/app/modules/function/tests/perf/test_function_execution_benchmark.py
@@ -17,10 +17,21 @@ from load_tests.function_execution import (
 )
 
 
+# `benchmark` says who owns this: `sandbox-function-benchmark.yml`, nightly on
+# Docker and weekly on E2B, at the 1800s timeout and the tuned environment
+# `make benchmark-functions-docker` supplies, keeping the report and telling
+# Slack when a budget moves. Everything below asserts a wall-clock p95 on a
+# shared runner, so a red here is as often the runner as the code -- the
+# protected lane failed on 2026-09-09 with "platform overhead p95 3.502s exceeds
+# 2.000s" and passed on 2026-09-10, and the only change to function execution
+# between the two runs was one deleted dead line. That is a trend to watch, not
+# a gate: the marker is what keeps it out of `backend-protected-e2e.yml`, which
+# every Desktop release waits on.
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.slow,
     pytest.mark.real_sandbox,
+    pytest.mark.benchmark,
 ]
 
 

--- a/lemma-backend/app/modules/pod_bundle/tests/e2e/test_support_inbox_real_llm_e2e.py
+++ b/lemma-backend/app/modules/pod_bundle/tests/e2e/test_support_inbox_real_llm_e2e.py
@@ -34,11 +34,20 @@ from app.modules.pod_bundle.tests.e2e.bundle_e2e_helpers import (
     provision_workspace,
 )
 
+# `provider`, which is what the module docstring above already says in prose:
+# this needs real ``system:lemma`` credentials. Saying it in a marker is what
+# stops a lane claiming it. Until now the only lane selecting this test was
+# `backend-protected-e2e.yml`, via `workspace` -- and that lane pins
+# `E2E_LLM_MODE=mock`, which the root conftest reads before any of this, so the
+# test skipped on every run it was ever selected for. A skip and a pass are the
+# same colour in a lane's summary; `plan_e2e_shards.py --verify` now counts this
+# among the `provider` tests no lane can supply, which is the true statement.
 pytestmark = [
     pytest.mark.e2e,
     pytest.mark.worker,
     pytest.mark.workspace,
     pytest.mark.real_llm,
+    pytest.mark.provider,
     pytest.mark.skipif(not system_lemma_available(), reason=SYSTEM_LEMMA_SKIP_REASON),
 ]
 

--- a/lemma-backend/pytest.ini
+++ b/lemma-backend/pytest.ini
@@ -39,6 +39,7 @@ markers =
     real_sandbox: Tests that require the real Docker sandbox (skipped in fake e2e mode)
     fast_workspace: Deterministic agent journeys that use the real sandbox but belong in the fast coverage shard
     protected: Tests requiring protected infrastructure or secrets; never run in the required hermetic PR suite
+    benchmark: Tests whose assertions are wall-clock latency or throughput budgets; owned by the lane that trends them (sandbox-function-benchmark.yml), never a merge or release gate
     connection_scope: Runtime proof that a flow holds no pooled connection across non-database work; run as a required CI gate
 
 # Async support

--- a/scripts/plan_e2e_shards.py
+++ b/scripts/plan_e2e_shards.py
@@ -571,17 +571,36 @@ def _collectors(path: str, shards: list[dict]) -> list[str]:
     return hits
 
 
-# The two lanes that are not shards. Both are kept byte-identical to the
-# workflow step that owns them, and `test_the_two_non_shard_lanes_match_their_workflows`
-# is what holds that -- the same discipline FAST_MARKERS is under, for the same
+# The lanes that are not shards. Each is kept byte-identical to the workflow
+# step that owns it, and `test_the_non_shard_lanes_match_their_workflows` is
+# what holds that -- the same discipline FAST_MARKERS is under, for the same
 # reason: this file decides whether a test counts as covered, so a stale copy
 # here would report coverage that CI does not provide.
 PROTECTED_MARKERS = (
-    "e2e and (slow or workspace or indexing or local_cli "
-    "or protected) and not provider"
+    "e2e and (slow or workspace or indexing "
+    "or protected) and not provider and not benchmark"
 )
 SMOKE_PATH = "app/modules/agent_surfaces/tests/e2e/test_surface_live_smoke_e2e.py"
 SMOKE_MARKERS = "surface_live"
+
+# Two lanes that run one file each, by path rather than by marker, because each
+# needs something built first that no marker filter can conjure.
+#
+# `Desktop contracts` in ci.yml builds `lemma-agent-host` with cargo, and for
+# the browser half the TypeScript SDK and a Playwright browser too, then runs
+# this file in two passes split on `agent_host_browser`. It is where the
+# `local_cli` tests live now; the protected lane used to select them and supply
+# none of it, so every one of them asserted "Build lemma-agent-host first".
+DESKTOP_CONTRACT_PATH = "app/modules/agent/tests/e2e/test_agent_host_process_e2e.py"
+DESKTOP_CONTRACT_MARKERS = "local_cli"
+
+# `sandbox-function-benchmark.yml` runs the function benchmark nightly on
+# Docker and weekly on E2B, with the 1800s timeout and tuned environment its
+# wall-clock budgets were written for. Those budgets are a trend, not a gate:
+# on a shared runner they fail without a defect, which is why the protected
+# lane -- the one every Desktop release waits on -- says `not benchmark`.
+BENCHMARK_PATH = "app/modules/function/tests/perf/test_function_execution_benchmark.py"
+BENCHMARK_MARKERS = "benchmark"
 
 # Collected in the subprocess below and read back here. `pytest_collection_finish`
 # rather than `pytest_collection_modifyitems`, so it cannot race the root
@@ -655,6 +674,8 @@ def _compile_lanes(shards: list[dict]) -> dict[str, object]:
     lanes = {shard["name"]: Expression.compile(shard["markers"]) for shard in shards}
     lanes["protected"] = Expression.compile(PROTECTED_MARKERS)
     lanes["surface-live-smoke"] = Expression.compile(SMOKE_MARKERS)
+    lanes["desktop-contract"] = Expression.compile(DESKTOP_CONTRACT_MARKERS)
+    lanes["sandbox-function-benchmark"] = Expression.compile(BENCHMARK_MARKERS)
     return lanes
 
 
@@ -672,10 +693,13 @@ def _lanes_for(
     ]
     if compiled["protected"].evaluate(marks.__contains__):
         lanes.append("protected")
-    if path == SMOKE_PATH and compiled["surface-live-smoke"].evaluate(
-        marks.__contains__
+    for lane, owned_path in (
+        ("surface-live-smoke", SMOKE_PATH),
+        ("desktop-contract", DESKTOP_CONTRACT_PATH),
+        ("sandbox-function-benchmark", BENCHMARK_PATH),
     ):
-        lanes.append("surface-live-smoke")
+        if path == owned_path and compiled[lane].evaluate(marks.__contains__):
+            lanes.append(lane)
     return lanes
 
 
@@ -692,9 +716,11 @@ def verify() -> int:
 
     So the check is now the claim: collect the suite once, ask each lane's real
     marker filter about each test, and require exactly one PR lane per test --
-    or the protected lane, or the labelled smoke job. `provider` tests are the
-    one accepted gap: they need live third-party credentials, no lane can
-    supply them, and saying so here is better than a proxy that never noticed.
+    or the protected lane, or one of the three lanes that own a single file:
+    the labelled smoke job, `Desktop contracts`, and the nightly sandbox
+    function benchmark. `provider` tests are the one accepted gap: they need
+    live third-party credentials, no lane can supply them, and saying so here is
+    better than a proxy that never noticed.
 
     Collection costs about ten seconds, which is why this is worth naming: the
     cheap version of this check was the reason nobody knew.
@@ -756,16 +782,19 @@ def verify() -> int:
         print(f"::error::{nodeid} is selected by {', '.join(lanes)}; expected one")
     if nowhere or twice:
         print(
-            "\nA test runs in a PR shard, in the protected lane, or in the "
-            "labelled smoke job. If its markers put it outside all three, that "
-            "is the bug -- adding a marker to a filter to hide it is how the "
-            "last two got lost."
+            "\nA test runs in a PR shard, in the protected lane, or in one of "
+            "the lanes that own a file outright -- the labelled smoke job, "
+            "`Desktop contracts`, the nightly sandbox function benchmark. If "
+            "its markers put it outside all of them, that is the bug -- adding "
+            "a marker to a filter to hide it is how the last two got lost."
         )
         return 1
     print(
         f"{covered} e2e tests each run in exactly one of {len(shards)} PR "
-        f"shards, the protected lane, or the smoke job; {provider_only} "
-        f"`provider` tests need live credentials and run in none."
+        f"shards, the protected lane, or a lane that owns a file (the smoke "
+        f"job, Desktop contracts, the sandbox function benchmark); "
+        f"{provider_only} `provider` tests need live credentials and run in "
+        f"none."
     )
     return 0
 


### PR DESCRIPTION
## What changes

`backend-protected-e2e.yml` is green again, and a red there now means a defect.

That workflow is what `.github/actions/require-backend-protected-e2e` reads, and
both `release-desktop.yml` and `release-local-images.yml` demand a successful run
for the **exact** release SHA within seven days. It has failed every run since it
came back to life on 2026-09-08, so for the last three days no Desktop release
and no nightly DMG could be built at all — again, and for a second unrelated
reason, three weeks after the `--extra markitdown` outage its own comment
records.

Fifteen tests failed. None of the fifteen was the product being wrong.

**Fourteen — the whole of `test_agent_host_process_e2e.py` — never got as far as
running.** #631 gave that file `pytest.mark.local_cli` on 2026-09-08, which put
it in this lane's `or local_cli` clause. `pytest.ini` says what that marker means:
*"Tests that require locally built or installed agent CLI binaries; each
dedicated lane supplies its binaries."* This lane supplies none — no Rust
toolchain, no `cargo build -p lemma-agent-host` — so all fourteen hit

```
AssertionError: Build lemma-agent-host first: make desktop-agent-host-e2e
```

*Deselected, because another job already runs them properly.* CI's **Desktop
contracts** job installs the toolchain, builds the host, builds the TypeScript
SDK, installs Playwright, and runs the same fourteen tests in two passes —
`make desktop-agent-host-e2e` and `make desktop-agent-host-browser-e2e`, split on
`agent_host_browser` so that between them they run the whole file. Its path
filter includes `lemma-backend/**`, so it runs on every backend pull request, and
it is inside the required `CI passed` aggregator. The proof is on the same commit
this lane failed on: run `34513856755`, SHA `7fa233d1c`, *Desktop contracts:
success* in 10m, with both `Real backend and Agent Host streaming` and `Chat UI
with JSON ACP agents` green — while run `34517070543` on that identical SHA
failed those fourteen. Building the Agent Host a second time here would add
roughly twenty minutes to a release gate in order to repeat a merge gate.

**One was a real defect, in the test.**
`test_workspace_cli_tools_execute_over_real_mcp_with_latency_summary` failed on
both 09-09 and 09-10 with `MCPError(-32000, 'Connection closed')`. The cause is
in the captured stdout, not the traceback:

```
"event": "Error in post_writer", "error_type": "AttributeError",
"error_message": "'MemoryObjectReceiveStream' object has no attribute 'last_context'"
```

`_mcp_client_session` hand-wired the SDK's internals — it drove
`StreamableHTTPTransport.post_writer` over a pair of plain
`anyio.create_memory_object_stream` channels, which is a copy of
`streamable_http_client`'s body. #634 bumped `mcp` 1.29.0 → 2.1.1 on 2026-09-07,
and 2.x carries the sender's `contextvars.Context` across those channels and
reads it back as `write_stream_reader.last_context`, which a plain memory stream
has not got. Every session died in `post_writer`, and the client saw only
"Connection closed" out of `initialize()`. It merged green because the only lane
that runs this test was itself dead at the time.

Fixed by calling `streamable_http_client(url, http_client=...)` — the library's
own entry point, which takes the authenticated client, which was the only reason
to be down there. Thirty-eight lines become eleven.

**One more clause came out, and one more test was mismarked.** Neither is in the
failure list, and both are the same shape as the first:

- `test_function_execution_quality_benchmark` failed on 09-09 with `api_write_batch
  platform overhead p95 3.502s exceeds 2.000s` and passed on 09-10. A wall-clock
  p95 on a shared runner cannot distinguish a defect from a noisy neighbour, and
  this lane decides whether a build may be cut. It now carries
  `@pytest.mark.benchmark`, and the lane says `not benchmark`.
  *Deselected, because another job already runs it properly:*
  `sandbox-function-benchmark.yml` runs it nightly on Docker and weekly on E2B
  via `make benchmark-functions-docker`, at the 1800s timeout and tuned
  environment those budgets were written for, keeps the report as an artifact,
  and is one of the workflows `notify-failure.yml` posts to Slack.
- `test_support_inbox_real_llm_e2e.py` is `real_llm`, and this lane pins
  `E2E_LLM_MODE=mock`, which `conftest.py` reads first. It was selected here (via
  `workspace`) and skipped on every single run — the `3 skipped` line in the
  evidence. Its own docstring says it needs real `system:lemma` credentials, so
  it is now marked `provider` as well, which is what the lane already excludes.
  Nothing stops running: it ran nowhere before, and `--verify` now says so out
  loud instead of a lane claiming it.

Nothing was deleted, skipped, or `xfail`ed. Every one of these tests still runs
in a job that can actually run it.

The arithmetic: the lane selected 152 tests and now selects **136** — exactly the
136 that passed on 2026-09-10, and nothing else.

Two supporting pieces, so this cannot rot:

- `plan_e2e_shards.py --verify` decides whether a test counts as covered, so it
  had to learn the two lanes that now own a file outright, beside the smoke job:
  `Desktop contracts` and the nightly function benchmark. Without that it would
  have reported fourteen tests as running in no lane, which is the correct
  complaint about the wrong thing.
- `test_the_non_shard_lanes_match_their_workflows` (renamed from
  `..._the_two_non_shard_lanes_...`) now asserts what each of those lanes claims:
  that `ci.yml` runs both make targets, that both name the file, that **both
  build the binary the tests assert on**, and that the two passes split on
  `agent_host_browser` so neither half can silently stop running. That last
  assertion is the one that would have caught this in the first place.

## Why

A gate whose red does not mean a defect is a gate people route around, and this
one blocks every Desktop artifact the project ships. Two of the three problems
were a lane selecting work it had no way to do; one was a dependency bump landing
on a test that had copied a library's private wiring. Making the lane honest is
cheaper than making it capable, when the capable job already exists and already
gates the merge.

`docs/testing.md` now says both rules in the place people read before adding a
`slow` test: nothing needing a compiled artifact, and no wall-clock budget.

## How to verify

```bash
# The real defect, against a real Docker sandbox. Fails on origin/main.
cd lemma-backend
E2E_REAL=1 E2E_LLM_MODE=mock uv run pytest \
  app/modules/agent/tests/e2e/test_workspace_tools_e2e.py::test_workspace_cli_tools_execute_over_real_mcp_with_latency_summary
# 1 passed, 1 warning in 327.60s (0:05:27)   [call: 14.23s]

# The lane now selects exactly the tests that passed on 2026-09-10.
uv run pytest --collect-only -q \
  -m "e2e and (slow or workspace or indexing or protected) and not provider and not benchmark"
# collected 8917 items / 8781 deselected / 2 skipped / 136 selected   (was 152)

# Every e2e test still runs in exactly one lane.
uv run python ../scripts/plan_e2e_shards.py --verify
# 1153 e2e tests each run in exactly one of 8 PR shards, the protected lane, or a
# lane that owns a file (the smoke job, Desktop contracts, the sandbox function
# benchmark); 51 `provider` tests need live credentials and run in none.

# The copies of the lane filter cannot drift apart.
uv run pytest app/core/tests/unit/test_e2e_workflow_contract.py
# 14 passed in 6.19s

# No suite quietly stopped running, and no lane skips green.
cd .. && python3 scripts/check_pytest_census.py
# Census holds: 8917 tests, 23 markers, no lane skipping green.

cd lemma-backend && uv run python ../scripts/check_ci_aggregators.py
# Aggregator and timeout checks passed (17 workflows).

cd .. && make quality
# (pass)
```

Evidence for the deselections, rather than an assertion that they are covered:

```bash
# Same SHA the protected lane failed those fourteen tests on.
gh run view 34513856755 --repo lemma-work/lemma-platform \
  --json jobs -q '.jobs[] | select(.name=="Desktop contracts") | .steps[] | "\(.name)\t\(.conclusion)"'
# Install Rust toolchain              success
# Real backend and Agent Host streaming   success      <- make desktop-agent-host-e2e
# Chat UI with JSON ACP agents            success      <- make desktop-agent-host-browser-e2e

gh run view 34517070543 --repo lemma-work/lemma-platform --log-failed   # the 15
gh run view 34324454514 --repo lemma-work/lemma-platform --log-failed   # + the p95
```

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally

No migrations, no API surface change, no SDK regeneration: this touches test
selection, one test helper, and the documents that describe both.

## Compatibility and rollback notes

Nothing to note. Every change is a marker, a marker filter, or a comment;
reverting the commit restores the previous selection exactly, and the only
runtime code touched is a test helper.

## Found and not fixed

- **The lane is scheduled `41 2 * * 3` — weekly — and on `v*` tags.** Both
  failures here landed on a Monday and were found by a person on Thursday. It is
  in `notify-failure.yml`'s watch list, so Slack did get told; nothing else did.
  Worth considering a nightly cron, but that is a cost decision, not a bug.
- **`check_swallowed_errors.py` reports `1 baselined violation(s) gone — run
  --update-baseline`** on `origin/main`, unrelated to anything here (no file in
  this diff appears in `swallowed-errors-baseline.json`). The ratchet is loose by
  one.
- **`test_workspace_tools_e2e.py` reads `CallToolResult.structuredContent`**,
  which `fastmcp` now deprecates in favour of `structured_content`. Left alone:
  it is a warning today, and renaming it is a separate, mechanical change. It is
  the same failure mode as the bug fixed here, one bump earlier in its life.
- **`real_llm` in a lane pinned to `E2E_LLM_MODE=mock` is a shape, not one
  test.** `make test-e2e-real-llm`'s own comment already records it. Today only
  the pod-bundle test was caught by it, and that one is marked; a general
  `not real_llm` clause on the lane would need `--verify` to accept a second
  category of gap, which is a bigger decision than this change.
- **No test asserts that the protected lane's marker filter selects a non-zero
  count per module**, so a future clause that silently empties part of the lane
  would still pass. `--verify` catches the reverse (a test in no lane), which is
  the direction that has actually bitten.
