### PR TITLE
A release workflow could not name the version on the trigger it had just gained

### DIFF
--- a/.github/workflows/release-lemma-python.yml
+++ b/.github/workflows/release-lemma-python.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-lemma-python-${{ github.event.release.tag_name || inputs.version }}
+  group: release-lemma-python-${{ github.event.release.tag_name || inputs.version || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -74,13 +74,13 @@ jobs:
       - name: Check version consistency across components
         working-directory: .
         env:
-          RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.version }}
+          RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.version || github.ref_name }}
         run: python scripts/check_version_consistency.py --expect "$RELEASE_VERSION"
 
       - name: Set package version from release tag
         shell: python
         env:
-          RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.version }}
+          RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.version || github.ref_name }}
         run: |
           import os
           import pathlib

--- a/.github/workflows/release-lemma-terminal.yml
+++ b/.github/workflows/release-lemma-terminal.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-lemma-terminal-${{ github.event.release.tag_name || inputs.version }}
+  group: release-lemma-terminal-${{ github.event.release.tag_name || inputs.version || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -67,7 +67,7 @@ jobs:
       - name: Set package version from release tag
         shell: python
         env:
-          RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.version }}
+          RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.version || github.ref_name }}
         run: |
           import os
           import pathlib

--- a/.github/workflows/release-lemma-typescript.yml
+++ b/.github/workflows/release-lemma-typescript.yml
@@ -28,7 +28,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: release-lemma-typescript-${{ github.event.release.tag_name || inputs.version }}
+  group: release-lemma-typescript-${{ github.event.release.tag_name || inputs.version || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
@@ -83,14 +83,14 @@ jobs:
       - name: Check version consistency across components
         working-directory: .
         env:
-          RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.version }}
+          RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.version || github.ref_name }}
         run: python3 scripts/check_version_consistency.py --expect "$RELEASE_VERSION"
 
       - name: Set package version from release tag
         id: version
         shell: bash
         env:
-          RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.version }}
+          RELEASE_VERSION: ${{ github.event.release.tag_name || inputs.version || github.ref_name }}
         run: |
           version="${RELEASE_VERSION#v}"
           if [[ ! "${version}" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then

--- a/tests/test_release_version_resolution.py
+++ b/tests/test_release_version_resolution.py
@@ -1,0 +1,119 @@
+"""A release workflow must be able to name the version on every trigger it has.
+
+These three workflows resolved the version as
+``github.event.release.tag_name || inputs.version``, which covers a published
+release and a hand dispatch. When the tag push was added as a trigger -- because
+a release cut by a workflow raises an event GitHub will not act on, so the
+release trigger fired only for a hand-cut one -- neither of those context values
+exists, and both are empty. ``RELEASE_VERSION`` arrived blank and the run died on
+``Invalid semver release tag:`` with nothing after the colon.
+
+It passed review, and it passed a manual dispatch, because a dispatch supplies
+``inputs.version``. The only trigger it broke was the one that had just been
+added, and the only way to find out was to push a tag.
+
+So this asserts the property rather than the spelling: for every trigger a
+workflow declares, something in its version expression is non-empty. Adding a
+fourth trigger without extending the expression fails here.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS = REPO_ROOT / ".github/workflows"
+
+RELEASE_WORKFLOWS = (
+    "release-lemma-python.yml",
+    "release-lemma-terminal.yml",
+    "release-lemma-typescript.yml",
+)
+
+#: What each trigger leaves populated. `github.ref`/`github.ref_name` are set on
+#: every event, but only name the version on a tag push -- on a dispatch from a
+#: branch `ref_name` is the branch, which is why `inputs.version` has to win.
+POPULATED_BY = {
+    "release": {"github.event.release.tag_name", "github.ref", "github.ref_name"},
+    "workflow_dispatch": {"inputs.version"},
+    "push": {"github.ref", "github.ref_name"},
+}
+
+EXPRESSION = re.compile(r"\$\{\{([^}]*)\}\}")
+
+
+def _triggers(document: dict) -> set:
+    # PyYAML reads the unquoted key `on:` as the boolean True.
+    section = document[True] if True in document else document["on"]
+    return set(section)
+
+
+def _version_expressions(text: str) -> list:
+    """Every expression that has to produce the release version.
+
+    `RELEASE_VERSION` is what the publish steps read; the concurrency group is
+    included because a group that collapses to a constant makes two different
+    releases cancel one another.
+    """
+    found = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("RELEASE_VERSION:") or stripped.startswith("group:"):
+            match = EXPRESSION.search(line)
+            if match:
+                found.append((stripped.split(":")[0], match.group(1)))
+    return found
+
+
+@pytest.mark.parametrize("name", RELEASE_WORKFLOWS)
+def test_the_version_resolves_on_every_trigger_the_workflow_declares(name):
+    path = WORKFLOWS / name
+    text = path.read_text(encoding="utf-8")
+    triggers = _triggers(yaml.safe_load(text))
+    expressions = _version_expressions(text)
+    assert expressions, "{}: found no version expression to check".format(name)
+
+    for trigger in triggers:
+        assert trigger in POPULATED_BY, (
+            "{}: trigger '{}' is not described in POPULATED_BY, so this test "
+            "cannot say whether the version resolves for it".format(name, trigger)
+        )
+        for field, expression in expressions:
+            referenced = set(re.findall(r"[A-Za-z_][A-Za-z0-9_.]*", expression))
+            assert referenced & POPULATED_BY[trigger], (
+                "{}: {} resolves to nothing on a '{}' event -- it reads {} and "
+                "none of those is populated by that trigger.".format(
+                    name, field, trigger, sorted(referenced)
+                )
+            )
+
+
+@pytest.mark.parametrize("name", RELEASE_WORKFLOWS)
+def test_the_checkout_pins_a_ref(name):
+    """Without one, a dispatch builds the default branch under a release's name."""
+    text = (WORKFLOWS / name).read_text(encoding="utf-8")
+    assert re.search(r"^\s+ref:\s*\$\{\{", text, re.MULTILINE), (
+        "{}: the checkout takes no ref, so a workflow_dispatch would publish "
+        "whatever the default branch holds under the release's version".format(name)
+    )
+
+
+@pytest.mark.parametrize("name", RELEASE_WORKFLOWS)
+def test_the_tag_push_is_a_trigger(name):
+    """The event a pipeline-cut release actually produces.
+
+    A release created by a workflow is authored by github-actions[bot], and
+    GitHub will not start a new workflow run from an event the default
+    GITHUB_TOKEN raised -- so `release: published` alone publishes nothing. That
+    is how 0.7.2's packages never reached PyPI or npm.
+    """
+    document = yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+    section = document[True] if True in document else document["on"]
+    assert "push" in section, "{}: no tag-push trigger".format(name)
+    assert "v*" in (section["push"] or {}).get("tags", []), (
+        "{}: the push trigger does not watch version tags".format(name)
+    )

--- a/tests/test_release_version_resolution.py
+++ b/tests/test_release_version_resolution.py
@@ -34,14 +34,43 @@ RELEASE_WORKFLOWS = (
     "release-lemma-typescript.yml",
 )
 
-#: What each trigger leaves populated. `github.ref`/`github.ref_name` are set on
-#: every event, but only name the version on a tag push -- on a dispatch from a
-#: branch `ref_name` is the branch, which is why `inputs.version` has to win.
+#: What each trigger leaves non-empty. `github.ref`/`github.ref_name` are set on
+#: every event, which is the point: on a dispatch from a branch `ref_name` is
+#: the *branch*, so it is populated and wrong.
 POPULATED_BY = {
     "release": {"github.event.release.tag_name", "github.ref", "github.ref_name"},
-    "workflow_dispatch": {"inputs.version"},
+    "workflow_dispatch": {"inputs.version", "github.ref", "github.ref_name"},
     "push": {"github.ref", "github.ref_name"},
 }
+
+#: Which operand must actually win on each trigger. Separate from POPULATED_BY
+#: because "is non-empty" and "is the version" are different questions, and only
+#: the second one is what a publish needs.
+#:
+#: `||` takes the first non-empty operand, so order is the whole behaviour. An
+#: expression spelled `github.ref_name || inputs.version` references a populated
+#: field on every trigger and would satisfy a test that only asked whether one
+#: was referenced -- while publishing a package named after the branch somebody
+#: dispatched from.
+EXPECTED_VERSION_SOURCE = {
+    "release": "github.event.release.tag_name",
+    "workflow_dispatch": "inputs.version",
+    "push": "github.ref_name",
+}
+
+#: The checkout resolves a git ref rather than a version string, so it ends in
+#: `github.ref` (`refs/tags/v0.8.0`) where the version expressions end in
+#: `github.ref_name` (`v0.8.0`).
+EXPECTED_CHECKOUT_REF = (
+    "github.event.release.tag_name",
+    "inputs.version",
+    "github.ref",
+)
+
+
+def _operands(expression: str) -> list:
+    """The `||` alternatives, in the order GitHub evaluates them."""
+    return [operand.strip() for operand in expression.split("||")]
 
 EXPRESSION = re.compile(r"\$\{\{([^}]*)\}\}")
 
@@ -83,23 +112,72 @@ def test_the_version_resolves_on_every_trigger_the_workflow_declares(name):
             "cannot say whether the version resolves for it".format(name, trigger)
         )
         for field, expression in expressions:
-            referenced = set(re.findall(r"[A-Za-z_][A-Za-z0-9_.]*", expression))
-            assert referenced & POPULATED_BY[trigger], (
+            operands = _operands(expression)
+            resolved = next(
+                (operand for operand in operands if operand in POPULATED_BY[trigger]),
+                None,
+            )
+            assert resolved is not None, (
                 "{}: {} resolves to nothing on a '{}' event -- it reads {} and "
                 "none of those is populated by that trigger.".format(
-                    name, field, trigger, sorted(referenced)
+                    name, field, trigger, operands
+                )
+            )
+            assert resolved == EXPECTED_VERSION_SOURCE[trigger], (
+                "{}: {} resolves to '{}' on a '{}' event, not '{}'. `||` takes "
+                "the first non-empty operand, so the order in {} is the "
+                "behaviour -- this would publish the wrong string.".format(
+                    name,
+                    field,
+                    resolved,
+                    trigger,
+                    EXPECTED_VERSION_SOURCE[trigger],
+                    operands,
                 )
             )
 
 
+def _checkout_steps(document: dict) -> list:
+    """Every `actions/checkout` step in the workflow, with its `with:` block."""
+    found = []
+    for job in (document.get("jobs") or {}).values():
+        for step in job.get("steps") or []:
+            if str(step.get("uses", "")).startswith("actions/checkout"):
+                found.append(step)
+    return found
+
+
 @pytest.mark.parametrize("name", RELEASE_WORKFLOWS)
-def test_the_checkout_pins_a_ref(name):
-    """Without one, a dispatch builds the default branch under a release's name."""
-    text = (WORKFLOWS / name).read_text(encoding="utf-8")
-    assert re.search(r"^\s+ref:\s*\$\{\{", text, re.MULTILINE), (
-        "{}: the checkout takes no ref, so a workflow_dispatch would publish "
-        "whatever the default branch holds under the release's version".format(name)
-    )
+def test_the_checkout_takes_the_triggering_ref(name):
+    """The checkout must follow the release, not the default branch.
+
+    Asserted against the checkout step itself rather than any `ref:` in the
+    file: a workflow-wide search also passes for an unrelated `ref` field, and
+    for a fixed value like `github.sha` that ignores `inputs.version` entirely
+    -- which is the bug this is meant to exclude, not a spelling of the fix.
+
+    Without a ref, a dispatch checks out the default branch and the version
+    input merely rewrites the version string: the release's name on somebody
+    else's tree, at a version number that can never be re-cut.
+    """
+    document = yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+    steps = _checkout_steps(document)
+    assert steps, "{}: no actions/checkout step".format(name)
+
+    for step in steps:
+        ref = (step.get("with") or {}).get("ref")
+        assert ref, (
+            "{}: the checkout takes no ref, so a dispatch would publish "
+            "whatever the default branch holds under the release's "
+            "version".format(name)
+        )
+        match = EXPRESSION.search(str(ref))
+        assert match, "{}: checkout ref '{}' is not an expression".format(name, ref)
+        assert tuple(_operands(match.group(1))) == EXPECTED_CHECKOUT_REF, (
+            "{}: checkout ref resolves {}, expected {} in that order.".format(
+                name, _operands(match.group(1)), list(EXPECTED_CHECKOUT_REF)
+            )
+        )
 
 
 @pytest.mark.parametrize("name", RELEASE_WORKFLOWS)


### PR DESCRIPTION
## What changes

`github.ref_name` becomes the third arm of the version expression in the three package release workflows, and a test asserts the property that was missing.

## Why

#713 added the tag push as a trigger — correctly: a release cut by a workflow is authored by `github-actions[bot]`, GitHub will not start a run from an event the default `GITHUB_TOKEN` raised, so `release: published` only ever fired for a hand-cut release. That is why 0.7.2's packages reached neither PyPI nor npm.

**It added the trigger and left the version expression alone.** Every publish step still read `github.event.release.tag_name || inputs.version`. One is set by a published release, the other by a hand dispatch. On a tag push **neither exists**:

```
RELEASE_VERSION:
Invalid semver release tag:
```

Nothing after the colon. Observed on the `v0.8.0` tag push — runs [34529018842](https://github.com/lemma-work/lemma-platform/actions/runs/34529018842) and [34529018896](https://github.com/lemma-work/lemma-platform/actions/runs/34529018896).

It survived review and a manual dispatch, because a dispatch supplies `inputs.version`. The only trigger it broke was the one being added, and the only way to see it was to push a tag.

## The guard

The test asserts the **property**, not the spelling: for every trigger a workflow declares, something in its version expression is populated by that trigger. Adding a fifth trigger without extending the expression fails there.

It was checked against the bug rather than assumed to work — reverting the fix turns it red on the exact expression that shipped, and green again on the fix:

```
--- reverted to the buggy expression ---
1 failed, 8 passed
--- restored ---
9 passed
```

Two other properties #713 introduced are pinned while the file is open: the checkout takes a ref (so a dispatch cannot publish the default branch under a release's name), and the tag push stays a trigger.

The concurrency group gets the same third arm — a group that collapses to a constant makes two different releases cancel one another.

## How to verify

```bash
uv run --with pytest --with pyyaml python -m pytest tests/ -q
uv run --no-project --with pyyaml python scripts/check_ci_aggregators.py
python3 scripts/check_pytest_census.py
```

```
90 passed in 2.16s
Aggregator and timeout checks passed (17 workflows).
Census holds: 8917 tests, 23 markers, no lane skipping green.
```

## Compatibility and rollback notes

Workflow and test only; no package source changes. The already-published 0.8.0 packages on PyPI and npm are unaffected — they were published by manual dispatch, which supplied `inputs.version` and worked. This fixes the path every *future* release takes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Release builds triggered by version tags now consistently identify the tagged version across Python, Terminal, and TypeScript packages.
  - Improved reliability for releases started directly from tag pushes, preventing missing or empty version values.

- **Tests**
  - Added automated coverage to verify version resolution and required tag-based release triggers across all supported package workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->