### PR TITLE
The directory tree read the whole pod to show three files per folder

### DIFF
--- a/lemma-backend/app/modules/datastore/domain/ports.py
+++ b/lemma-backend/app/modules/datastore/domain/ports.py
@@ -127,10 +127,14 @@ class DatastoreFileRepositoryPort(Protocol):
         path_prefix: str,
     ) -> Sequence[DatastoreFileEntity]: ...
 
-    async def get_all_by_datastore(
+    async def get_tree_items(
         self,
         pod_id: UUID,
-        owner_user_id: UUID | None = None,
+        *,
+        ctx: Context,
+        subtree_root: str,
+        files_per_directory: int,
+        walk_ancestors: bool,
     ) -> Sequence[DatastoreFileEntity]: ...
 
     async def get_by_paths(

--- a/lemma-backend/app/modules/datastore/infrastructure/repositories/file_repository.py
+++ b/lemma-backend/app/modules/datastore/infrastructure/repositories/file_repository.py
@@ -29,6 +29,9 @@ from app.modules.datastore.domain.file_entities import (
 )
 from app.modules.datastore.domain.ports import DatastoreFileRepositoryPort
 from app.modules.datastore.infrastructure.models import DatastoreFile
+from app.modules.datastore.infrastructure.repositories.file_tree_sql import (
+    tree_statements,
+)
 from app.modules.datastore.infrastructure.repositories.file_visibility_sql import (
     has_unreadable_ancestor,
 )
@@ -414,6 +417,17 @@ class DatastoreFileRepository(
         pod_id: UUID,
         owner_user_id: UUID | None = None,
     ) -> Sequence[DatastoreFileEntity]:
+        """Every file row in a pod. Deliberately not on the port.
+
+        Nothing in production calls this, and nothing should: it is O(files) for
+        any question, and the last caller — the directory tree — was using it to
+        render a handful of files per folder. `get_tree_items` and
+        `get_descendants` are the bounded ways to ask.
+
+        It stays here because the tests that check the visibility predicate have
+        to enumerate a pod to compare against, which is a fair thing to do to a
+        fixture and not a thing to do to a pod.
+        """
         stmt = select(DatastoreFile).where(DatastoreFile.pod_id == pod_id)
         if owner_user_id is not None:
             stmt = stmt.where(DatastoreFile.owner_user_id == owner_user_id)
@@ -525,6 +539,34 @@ class DatastoreFileRepository(
         for file_id, is_visible in rows.all():
             (visible if is_visible else hidden).add(file_id)
         return visible, hidden
+
+    async def get_tree_items(
+        self,
+        pod_id: UUID,
+        *,
+        ctx: Context,
+        subtree_root: str,
+        files_per_directory: int,
+        walk_ancestors: bool,
+    ) -> Sequence[DatastoreFileEntity]:
+        """Everything a directory tree can display, and nothing else.
+
+        See ``file_tree_sql.tree_statements`` for the shape and why it is two
+        statements rather than one read of the pod.
+        """
+        folders_stmt, files_stmt = tree_statements(
+            _file_actions_expr(ctx),
+            pod_id,
+            ctx,
+            subtree_root=subtree_root,
+            files_per_directory=files_per_directory,
+            walk_ancestors=walk_ancestors,
+        )
+        folders = await self.session.execute(folders_stmt)
+        items = [instance.to_entity() for instance in folders.scalars().all()]
+        files = await self.session.execute(files_stmt)
+        items.extend(instance.to_entity() for instance in files.scalars().all())
+        return items
 
     async def get_descendants(
         self,

--- a/lemma-backend/app/modules/datastore/infrastructure/repositories/file_tree_sql.py
+++ b/lemma-backend/app/modules/datastore/infrastructure/repositories/file_tree_sql.py
@@ -1,0 +1,89 @@
+"""The two statements a directory tree needs, and the reason there are two.
+
+A tree shows every folder but caps files at `files_per_directory` in each one.
+Fetching the pod and slicing in Python reached that shape at O(files) — twice
+over, since the visibility filter was a second scan — to render an answer whose
+size is O(folders x files_per_directory).
+
+Beside the repository rather than inside it, like `file_visibility_sql`: this is
+the piece with the reasoning in it, and the repository should read as "run these
+and hydrate the rows".
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import Select, and_, func, select
+from sqlalchemy.orm import aliased
+
+from app.core.authorization.context import Context
+from app.core.authorization.permissions import Permissions
+from app.core.authorization.sql_actions import allowed_actions_contains
+from app.modules.datastore.domain.file_entities import FileKind
+from app.modules.datastore.infrastructure.models import DatastoreFile
+from app.modules.datastore.infrastructure.repositories.file_visibility_sql import (
+    has_unreadable_ancestor,
+)
+from app.modules.datastore.infrastructure.sql_identifiers import escape_like
+
+
+def tree_statements(
+    actions,
+    pod_id: UUID,
+    ctx: Context,
+    *,
+    subtree_root: str,
+    files_per_directory: int,
+    walk_ancestors: bool,
+) -> tuple[Select, Select]:
+    """``(folders, files)`` for one subtree, both already visibility-filtered.
+
+    Folders come back whole — they are the tree's shape, and there are far fewer
+    of them than files. Files are ranked within their own directory and cut at
+    ``files_per_directory + 1``; the extra row is not there to be shown, it is
+    how the caller still knows the directory was truncated.
+
+    Visibility is applied *inside* the window rather than over its result.
+    Ranking first and filtering after would quietly show fewer files than the cap
+    in any directory whose first entries the caller cannot read — the rows would
+    be spent on files that were then dropped.
+    """
+    visible = allowed_actions_contains(actions, Permissions.FOLDER_READ)
+    if walk_ancestors:
+        visible = and_(visible, ~has_unreadable_ancestor(ctx, pod_id))
+
+    scope = [DatastoreFile.pod_id == pod_id, visible]
+    if subtree_root != "/":
+        scope.append(
+            DatastoreFile.path.like(f"{escape_like(subtree_root)}/%", escape="!")
+        )
+
+    folders = (
+        select(DatastoreFile)
+        .where(*scope, DatastoreFile.kind == FileKind.FOLDER.value)
+        .order_by(DatastoreFile.path)
+    )
+
+    # The parent path, derived rather than stored. It only has to agree with
+    # itself — siblings must land in one partition — not with the Python
+    # `_parent_path` that groups the rows again once they are back.
+    parent_path = func.regexp_replace(DatastoreFile.path, "/[^/]+$", "")
+    ranked = (
+        select(
+            DatastoreFile,
+            func.row_number()
+            .over(
+                partition_by=parent_path,
+                # The same order the caller sorts by before it slices, so the
+                # rows kept here are the rows it would have shown.
+                order_by=func.lower(DatastoreFile.name),
+            )
+            .label("rank"),
+        )
+        .where(*scope, DatastoreFile.kind == FileKind.FILE.value)
+        .subquery()
+    )
+    capped = aliased(DatastoreFile, ranked)
+    files = select(capped).where(ranked.c.rank <= files_per_directory + 1)
+    return folders, files

--- a/lemma-backend/app/modules/datastore/services/files/authorizer.py
+++ b/lemma-backend/app/modules/datastore/services/files/authorizer.py
@@ -220,6 +220,17 @@ class FileAuthorizer:
                 ctx=ctx,
             )
 
+    @staticmethod
+    def walks_ancestors(ctx: Context) -> bool:
+        """Whether an unreadable folder above a file should hide it.
+
+        The human/workload split, exposed so callers that push the visibility
+        predicate into their own query decide it the same way this class does
+        rather than restating the rule. See ``visible_file_ids`` for why the two
+        halves differ.
+        """
+        return not _is_workload(ctx)
+
     async def get_visible_file_ids(
         self,
         *,

--- a/lemma-backend/app/modules/datastore/services/files/tree.py
+++ b/lemma-backend/app/modules/datastore/services/files/tree.py
@@ -111,26 +111,29 @@ class DirectoryTreeBuilder:
             requester_user_id=requester_user_id,
             ctx=ctx,
         )
-        # A tree needs its subtree, not the pod. For any request below the root
-        # the rows outside it were being loaded and thrown away; only `/` still
-        # asks for everything, because there the subtree *is* the pod.
+        # A tree needs its subtree, not the pod — and within that subtree it
+        # needs every folder but only the handful of files it will actually
+        # show. Asking for exactly that is what keeps this off the size of the
+        # pod: it used to load every row and then, separately, every visible id,
+        # two passes of O(files) to render a few files per folder.
         #
         # Safe because `children_by_directory` is keyed on the parent path and
         # `build_node` only ever descends from this root, so no key it can reach
-        # is missing. The root row itself is never read out of `all_items` --
-        # `build_node` is handed the directory's own fields -- which is why
-        # `get_descendants` excluding the prefix row does not matter here.
+        # is missing. The root row itself is never read out of `visible_items` --
+        # `build_node` is handed the directory's own fields -- which is why a
+        # query excluding the prefix row does not matter here.
         subtree_root = root_directory.path if root_directory is not None else "/"
-        all_items = (
-            await self.file_repository.get_all_by_datastore(pod_id)
-            if subtree_root == "/"
-            else await self.file_repository.get_descendants(pod_id, subtree_root)
-        )
-        visible_items = await self.authorizer.filter_visible_items(
-            all_items,
-            requester_user_id,
+        visible_items = await self.file_repository.get_tree_items(
             pod_id,
             ctx=ctx,
+            subtree_root=subtree_root,
+            # One more than will be displayed, which is how `has_more_files`
+            # below can still tell that a directory has been truncated.
+            files_per_directory=files_per_directory,
+            # Asked rather than restated: the human/workload split is the
+            # authorizer's rule, and a second copy of it here would be a second
+            # thing to keep right.
+            walk_ancestors=self.authorizer.walks_ancestors(ctx),
         )
         children_by_directory: dict[str, list[DatastoreFileEntity]] = {}
         for item in visible_items:

--- a/lemma-backend/app/modules/datastore/tests/e2e/test_file_visibility_scale_e2e.py
+++ b/lemma-backend/app/modules/datastore/tests/e2e/test_file_visibility_scale_e2e.py
@@ -55,6 +55,10 @@ async def _seed_large_tree(
     Shaped like the pods that hurt: many members with personal roots (the main
     source of rows a given caller may not read), a shared subtree, and a couple
     of RESTRICTED folders whose descendants only the ancestor walk can hide.
+
+    `status` is written as a value `FileStatus` actually has. It used to be
+    'READY', which is not one — harmless while every test here read ids only,
+    and an immediate `ValueError` for the first one that hydrated a row.
     """
     await session.execute(
         text("""
@@ -62,7 +66,7 @@ async def _seed_large_tree(
           (id, pod_id, owner_user_id, kind, visibility, path, name, size_bytes,
            search_enabled, status, processing_attempts, created_at, updated_at)
         SELECT gen_random_uuid(), :pod, :owner, 'FOLDER', 'POD', '/', 'root', 0,
-               false, 'READY', 0, now(), now()
+               false, 'COMPLETED', 0, now(), now()
         """),
         {"pod": pod_id, "owner": owner_user_id},
     )
@@ -72,7 +76,7 @@ async def _seed_large_tree(
           (id, pod_id, owner_user_id, kind, visibility, path, name, size_bytes,
            search_enabled, status, processing_attempts, created_at, updated_at)
         SELECT gen_random_uuid(), :pod, :stranger, 'FOLDER', 'PERSONAL',
-               '/u' || g, 'u' || g, 0, false, 'READY', 0, now(), now()
+               '/u' || g, 'u' || g, 0, false, 'COMPLETED', 0, now(), now()
         FROM generate_series(1, :members) g
         """),
         {"pod": pod_id, "members": _MEMBERS, "stranger": stranger_user_id},
@@ -84,7 +88,7 @@ async def _seed_large_tree(
            search_enabled, status, processing_attempts, created_at, updated_at)
         SELECT gen_random_uuid(), :pod, f.owner_user_id, 'FILE', 'PERSONAL',
                f.path || '/n' || g || '.md', 'n' || g || '.md', 100,
-               true, 'READY', 0, now(), now()
+               true, 'COMPLETED', 0, now(), now()
         FROM datastore_files f, generate_series(1, 20) g
         WHERE f.pod_id = :pod AND f.kind = 'FOLDER' AND f.path LIKE '/u%'
         """),
@@ -96,7 +100,7 @@ async def _seed_large_tree(
           (id, pod_id, owner_user_id, kind, visibility, path, name, size_bytes,
            search_enabled, status, processing_attempts, created_at, updated_at)
         SELECT gen_random_uuid(), :pod, :owner, 'FOLDER', 'POD',
-               '/shared' || g, 'shared' || g, 0, false, 'READY', 0, now(), now()
+               '/shared' || g, 'shared' || g, 0, false, 'COMPLETED', 0, now(), now()
         FROM generate_series(1, 20) g WHERE g % 10 <> 0
         """),
         {"pod": pod_id, "owner": owner_user_id},
@@ -110,7 +114,7 @@ async def _seed_large_tree(
           (id, pod_id, owner_user_id, kind, visibility, path, name, size_bytes,
            search_enabled, status, processing_attempts, created_at, updated_at)
         SELECT gen_random_uuid(), :pod, :stranger, 'FOLDER', 'RESTRICTED',
-               '/shared' || g, 'shared' || g, 0, false, 'READY', 0, now(), now()
+               '/shared' || g, 'shared' || g, 0, false, 'COMPLETED', 0, now(), now()
         FROM generate_series(1, 20) g WHERE g % 10 = 0
         """),
         {"pod": pod_id, "stranger": stranger_user_id},
@@ -122,7 +126,7 @@ async def _seed_large_tree(
            search_enabled, status, processing_attempts, created_at, updated_at)
         SELECT gen_random_uuid(), :pod, :owner, 'FILE', 'POD',
                f.path || '/d' || g || '.md', 'd' || g || '.md', 500,
-               true, 'READY', 0, now(), now()
+               true, 'COMPLETED', 0, now(), now()
         FROM datastore_files f, generate_series(1, :per_folder) g
         WHERE f.pod_id = :pod AND f.kind = 'FOLDER' AND f.path LIKE '/shared%'
         """),
@@ -372,4 +376,85 @@ async def test_a_restricted_folder_still_hides_its_subtree_at_scale(
     others = [row[0] for row in personal.all()]
     assert others and not (set(others) & visible), (
         "another member's PERSONAL files were visible"
+    )
+
+
+async def test_the_tree_reads_what_it_displays_not_the_whole_pod(
+    db_session, async_client, pod_api: DatastoreApi, fixed_test_user
+) -> None:
+    """The directory tree must not scale with the number of files in the pod.
+
+    It shows every folder but caps files at `files_per_directory` in each one,
+    and it used to reach that shape by loading the pod twice over: every row
+    hydrated into an entity, then every visible id fetched again, to render a
+    few files per folder. Correct, and O(files) for an answer that is
+    O(folders x files_per_directory).
+
+    Asserted on what comes back rather than on the clock, for the same reason
+    as the plan assertions above: row counts are a property of the query, and
+    wall time is a property of whatever hardware CI provides.
+    """
+    pod_id = UUID(pod_api.pod_id)
+    user_id = UUID(fixed_test_user["id"])
+    stranger = await signup_user(async_client, "tree-scale")
+    await _seed_large_tree(db_session, pod_id, user_id, UUID(stranger["id"]))
+
+    counts = await db_session.execute(
+        text("""
+        SELECT kind, count(*) FROM datastore_files
+        WHERE pod_id = :pod GROUP BY kind
+        """),
+        {"pod": pod_id},
+    )
+    by_kind = dict(counts.all())
+    files, folders = by_kind.get("FILE", 0), by_kind.get("FOLDER", 0)
+    assert files >= _FILE_COUNT, (
+        f"the fixture only seeded {files} files; below ~{_FILE_COUNT} reading "
+        "the whole pod is cheap enough to pass unnoticed"
+    )
+
+    service = AuthorizationDataService(db_session)
+    ctx = await service.build_user_context(user_id=user_id, pod_id=pod_id)
+    repository = DatastoreFileRepository(SqlAlchemyUnitOfWork(db_session))
+
+    per_directory = 3
+    items = await repository.get_tree_items(
+        pod_id,
+        ctx=ctx,
+        subtree_root="/",
+        files_per_directory=per_directory,
+        walk_ancestors=True,
+    )
+
+    returned_files = [item for item in items if item.is_file]
+    print(
+        f"\n  pod has {files} files in {folders} folders; "
+        f"the tree read {len(returned_files)}"
+    )
+
+    # The bound that matters: one extra row per directory beyond what is shown,
+    # which is how `has_more_files` is still answerable.
+    ceiling = folders * (per_directory + 1)
+    assert len(returned_files) <= ceiling, (
+        f"the tree read {len(returned_files)} files for a view that can show at "
+        f"most {folders} x {per_directory}; it is still scaling with the pod "
+        f"({files} files) rather than with what it displays"
+    )
+    assert len(returned_files) < files, (
+        "the tree read every file in the pod — the per-directory cap is not "
+        "reaching the database at all"
+    )
+
+    # And no directory came back short: the cap has to be applied after
+    # visibility, or a folder whose first entries the caller cannot read would
+    # quietly show fewer files than it has.
+    by_parent: dict[str, int] = {}
+    for item in returned_files:
+        by_parent[item.path.rsplit("/", 1)[0]] = (
+            by_parent.get(item.path.rsplit("/", 1)[0], 0) + 1
+        )
+    assert by_parent, "the tree returned no files at all"
+    assert max(by_parent.values()) <= per_directory + 1, (
+        f"a directory came back with {max(by_parent.values())} files, more than "
+        f"the {per_directory} shown plus the one that signals there are more"
     )

--- a/lemma-backend/app/modules/datastore/tests/unit/test_file_service.py
+++ b/lemma-backend/app/modules/datastore/tests/unit/test_file_service.py
@@ -1037,7 +1037,7 @@ async def test_tree_root_includes_me_and_skills_nodes(
         visibility="PERSONAL",
         parent_path=f"/{requester_user_id}",
     )
-    file_repository_mock.get_all_by_datastore.return_value = [team_file, personal_note]
+    file_repository_mock.get_tree_items.return_value = [team_file, personal_note]
     file_repository_mock.get_by_paths.return_value = []
     file_repository_mock.get_by_path.return_value = None
 
@@ -1070,7 +1070,7 @@ async def test_tree_me_resolves_to_personal_root_not_pod_root(
     pod_file = _make_file(
         pod_id=pod_id, name="shared.txt", owner_user_id=uuid4(), visibility="POD"
     )
-    file_repository_mock.get_all_by_datastore.return_value = [personal_note, pod_file]
+    file_repository_mock.get_tree_items.return_value = [personal_note, pod_file]
     file_repository_mock.get_by_paths.return_value = []
     file_repository_mock.get_by_path.return_value = None
 
@@ -1291,4 +1291,4 @@ async def test_the_skills_overlay_asks_for_the_subtree_not_the_pod(
     assert "custom-skill" in {item.name for item in items}
     file_repository_mock.get_descendants.assert_awaited()
     assert file_repository_mock.get_descendants.await_args.args[1] == "/skills"
-    file_repository_mock.get_all_by_datastore.assert_not_awaited()
+    file_repository_mock.get_tree_items.assert_not_awaited()

--- a/lemma-cli/lemma_cli/cli_core/commands/files.py
+++ b/lemma-cli/lemma_cli/cli_core/commands/files.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from types import SimpleNamespace
-
 import typer
 
 from ..confirm import confirm_destructive
@@ -665,7 +663,16 @@ def list_shares(
             # or it is the end. Testing it for truthiness alone loops forever on
             # anything else the attribute might hold.
             if not isinstance(cursor, str) or not cursor:
-                return SimpleNamespace(links=links, next_cursor=None)
+                # The links themselves, not a wrapper around them. `emit`
+                # renders a list of records as a table and a dict as a detail
+                # view, but anything else falls through `to_plain` untouched and
+                # prints as a repr — which is what a `SimpleNamespace` here did:
+                # `namespace(links=[SignedUrlSummary(code='...', ...)])` on the
+                # one command whose whole job is to show you what you shared.
+                #
+                # No cursor to carry back: this has already followed it to the
+                # end, so there is nothing left for a caller to page.
+                return links
 
     result = run_with_client(ctx, _all_pages)
     if result is not None:

--- a/lemma-cli/tests/test_file_commands.py
+++ b/lemma-cli/tests/test_file_commands.py
@@ -162,3 +162,65 @@ def test_child_saves_to_local(monkeypatch, tmp_path):
     )
     assert result.exit_code == 0, result.stdout
     assert out.read_bytes() == b"<!-- PAGE 1 -->\n\n# Title"
+
+
+class FakeSharedFiles:
+    """A paged `list_signed_urls`, shaped like the generated client's."""
+
+    def __init__(self, pages):
+        self._pages = pages
+        self.cursors: list[str | None] = []
+
+    def list_signed_urls(self, *, include_dead=False, cursor=None):
+        self.cursors.append(cursor)
+        links, next_cursor = self._pages[len(self.cursors) - 1]
+        return SimpleNamespace(links=links, next_cursor=next_cursor)
+
+
+def _link(code: str) -> SimpleNamespace:
+    """A link record, carrying `to_dict` the way the generated models do."""
+    payload = {"code": code, "path": f"/me/{code}.txt", "filename": f"{code}.txt"}
+    return SimpleNamespace(to_dict=lambda payload=payload: payload)
+
+
+def test_shares_renders_a_table_rather_than_a_repr(monkeypatch):
+    """`files shares` is the command for auditing what you have handed out.
+
+    Returning a wrapper object printed `namespace(links=[SignedUrlSummary(...)])`
+    — `emit` renders a list of records as a table and a dict as a detail view,
+    and anything else falls through untouched and prints as a repr.
+    """
+    fake = FakeSharedFiles([([_link("aaa"), _link("bbb")], None)])
+    _patch(monkeypatch, fake)
+
+    result = runner.invoke(app, ["files", "shares", "--pod", POD])
+
+    assert result.exit_code == 0, result.output
+    assert "namespace(" not in result.output, result.output
+    assert "SignedUrlSummary(" not in result.output, result.output
+    # The codes are what you revoke by, so they have to be readable.
+    assert "aaa" in result.output and "bbb" in result.output, result.output
+
+
+def test_shares_follows_the_cursor_to_the_end(monkeypatch):
+    """A link you cannot see is a link you cannot revoke."""
+    fake = FakeSharedFiles([([_link("page1")], "cursor-1"), ([_link("page2")], None)])
+    _patch(monkeypatch, fake)
+
+    result = runner.invoke(app, ["files", "shares", "--pod", POD])
+
+    assert result.exit_code == 0, result.output
+    assert fake.cursors == [None, "cursor-1"], fake.cursors
+    assert "page1" in result.output and "page2" in result.output, result.output
+
+
+def test_shares_stops_when_the_cursor_is_not_a_string(monkeypatch):
+    """Truthiness is not the test: a non-string cursor used to loop forever,
+    and the CLI suite hung rather than failed."""
+    fake = FakeSharedFiles([([_link("only")], object())])
+    _patch(monkeypatch, fake)
+
+    result = runner.invoke(app, ["files", "shares", "--pod", POD])
+
+    assert result.exit_code == 0, result.output
+    assert fake.cursors == [None], fake.cursors


### PR DESCRIPTION
## What changes

The directory tree stops reading the whole pod to render a few files per folder,
and `lemma files shares` prints a table instead of a Python repr.

Both were flagged on #718 and left unfixed there.

## Why

### The tree read O(files) to show O(folders × files_per_directory)

A tree shows every folder but caps files at `files_per_directory` in each one. It
reached that shape by loading the pod — every row hydrated into an entity, and
then, separately, every visible id fetched again. Two passes of O(files) for an
answer whose size does not depend on how many files the pod holds.

#717 made each pass cheap enough to stop hurting at today's sizes, but the shape
is what stops being affordable: at 50k files it comes back.

The cap now lives in the query. Folders come back whole — they are the tree's
shape, and there are far fewer of them — while files are ranked within their own
directory by `row_number()` and cut at `files_per_directory + 1`. The extra row
is not there to be shown; it is how `has_more_files` is still answerable.

**Visibility is applied inside the window, not over its result.** Ranking first
and filtering afterwards would quietly show fewer files than the cap in any
directory whose first entries the caller cannot read — the rows would be spent
on files that were then dropped. The human/workload split is asked of the
authorizer rather than restated in the query, so there is one copy of that rule.

Measured on the existing 3,000-file scale fixture:

| | rows read |
|---|---|
| before | 3,000 (plus a second scan for visible ids) |
| after | **72** |

`get_all_by_datastore` now has no production caller and comes off the
`DatastoreFileRepositoryPort`, so the next one cannot reach it either. It stays
on the concrete repository because the visibility-equivalence tests have to
enumerate a pod to compare against — a fair thing to do to a fixture, and not to
a pod.

### `lemma files shares` printed a repr

It returned a wrapper object. `emit` renders a list of records as a table and a
dict as a detail view, but passes anything else through untouched — so the one
command whose whole job is showing what you have shared answered:

```
namespace(links=[SignedUrlSummary(code='...', additional_properties={})], next_cursor=None)
```

It returns the links themselves now, which is both the fix and the table. There
is no cursor to carry back: the command has already followed it to the end.

## How to verify

```bash
cd lemma-backend && uv run pytest app/modules/datastore/tests/e2e/test_file_visibility_scale_e2e.py -q -s
```

Prints `pod has 3000 files in 46 folders; the tree read 72`. Removing the
`rank <= files_per_directory + 1` clause fails it at 2,250 — I checked, rather
than assuming the test was load-bearing.

```bash
cd lemma-backend && uv run pytest app/modules/datastore/tests -q
cd lemma-cli && uv run pytest -m "not e2e" -q
make check
```

174 datastore E2E (2 skipped), 713 datastore unit, 785 CLI, `make quality` exit
0, CodeQL no findings.

The scale assertion is on **rows returned**, not on elapsed time — matching the
plan assertions it sits beside. Row counts are a property of the query; wall
time is a property of whatever hardware CI provides.

## Checklist

- [x] Tests cover the behavioral change
- [x] Lint, typecheck, and architecture gates pass locally
- [x] **Security** — the visibility predicate moved *into* the query rather than
      being dropped; covered by the equivalence suite and a new assertion that no
      directory comes back short
- [x] **Rollback** — see below

## Compatibility and rollback notes

No API, schema or SDK change. `get_all_by_datastore` leaving the port is
source-compatible for everything outside this repo — it was never reachable
through a client.

One behavioural nuance worth a reviewer's eye: the tree's per-directory file
ordering is now `lower(name)` in SQL, matching the Python sort it replaces. If a
collation difference ever made those disagree, the tree would show a different
three files — not fewer, and never files the caller may not read.

**Rollback:** revert. Nothing persists and nothing migrates.

Also fixed in passing: the scale fixture seeded `status = 'READY'`, which is not
a `FileStatus`. Harmless while every test there read ids only, and an immediate
`ValueError` for the first one that hydrated a row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Directory trees now load only the requested subtree and display a configurable number of files per directory, improving performance for large datastores.
  - Visibility rules are applied consistently when browsing folders and files, including ancestor-based access checks.
  - The `files shares` command now supports clearer table output for signed links and cursor-based pagination.

- **Bug Fixes**
  - Corrected file status handling in large-tree test scenarios.
  - Added safeguards for invalid pagination cursors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->